### PR TITLE
fix(agent): skip empty-content nudge when reasoning_content is populated (#21811)

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4072,10 +4072,25 @@ def run_conversation(
                             re.IGNORECASE,
                         )
                     )
+                    # Detect parser-split reasoning (issue #21811): when
+                    # the upstream parser splits thinking into a separate
+                    # ``reasoning_content`` / ``reasoning`` channel, the
+                    # content field is empty AND has no <think> tag (the
+                    # parser already stripped it). Without this guard the
+                    # nudge fires even though the model produced complete
+                    # reasoning — the response just arrived in another
+                    # channel. Affects Ollama qwen3.x, DeepSeek-R1,
+                    # Moonshot, Novita, and any provider with a separate
+                    # reasoning field. Routes to the prefill path below
+                    # (which already handles structured reasoning).
+                    _has_separate_reasoning_channel = _ra()._has_separate_reasoning(
+                        assistant_message
+                    )
                     if (
                         _prior_was_tool
                         and not getattr(agent, "_post_tool_empty_retried", False)
                         and not _has_inline_thinking  # thinking model still working — let prefill handle
+                        and not _has_separate_reasoning_channel  # #21811: parser-split reasoning
                     ):
                         agent._post_tool_empty_retried = True
                         # Clear stale narration so it doesn't resurface

--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4065,9 +4065,19 @@ def run_conversation(
                     # reasoning_content), so _has_structured below would
                     # miss it.  We check here so thinking-only responses
                     # after tool calls route to prefill instead of nudge.
+                    #
+                    # Match BOTH opening and closing tags (``</?``): MiniMax
+                    # M2 is an interleaved-thinking model whose chat template
+                    # prefills the opening ``<think>`` so the model emits only
+                    # the closing ``</think>``. When the upstream parser fails
+                    # to split that out (the documented MiniMax-on-Ollama
+                    # ambiguity), content can arrive as a bare ``</think>``
+                    # with no opener — an opener-only regex would miss it and
+                    # let the nudge fire (issue #21811 residual). Tag variants
+                    # kept in sync with _strip_think_blocks().
                     _has_inline_thinking = bool(
                         re.search(
-                            r'<think>|<thinking>|<reasoning>',
+                            r'</?(?:think|thinking|reasoning|thought|REASONING_SCRATCHPAD)\b',
                             final_response or "",
                             re.IGNORECASE,
                         )

--- a/run_agent.py
+++ b/run_agent.py
@@ -291,6 +291,39 @@ class _StreamErrorEvent(Exception):
         }
 
 
+def _has_separate_reasoning(assistant_message) -> bool:
+    """Detect whether an assistant message carries reasoning in a separate
+    channel (i.e. parser-split output) rather than inline in ``content``.
+
+    When upstream providers split chain-of-thought into ``reasoning_content``
+    or ``reasoning`` (Ollama qwen3.x PARSER, DeepSeek-R1, Moonshot, Novita,
+    etc.), ``content`` may legitimately come back empty even though the model
+    produced complete reasoning. The post-tool empty-response nudge
+    (issue #21811) must skip the nudge in that case so the prefill path can
+    take over instead of triggering a wasteful retry round-trip.
+
+    Accepts any object exposing ``reasoning_content`` / ``reasoning`` as
+    attributes (OpenAI SDK pydantic message) or as dict keys (raw payload).
+    Truthy values (non-empty strings, lists, dicts) mean reasoning is
+    present; ``None`` / empty values mean it isn't.
+    """
+    if assistant_message is None:
+        return False
+
+    def _get(name):
+        if isinstance(assistant_message, dict):
+            return assistant_message.get(name)
+        value = getattr(assistant_message, name, None)
+        if value is None:
+            # OpenAI SDK exposes provider-extra fields via ``model_extra``.
+            model_extra = getattr(assistant_message, "model_extra", None)
+            if isinstance(model_extra, dict):
+                value = model_extra.get(name)
+        return value
+
+    return bool(_get("reasoning_content") or _get("reasoning"))
+
+
 class AIAgent:
     """
     AI Agent with tool calling capabilities.

--- a/run_agent.py
+++ b/run_agent.py
@@ -295,17 +295,34 @@ def _has_separate_reasoning(assistant_message) -> bool:
     """Detect whether an assistant message carries reasoning in a separate
     channel (i.e. parser-split output) rather than inline in ``content``.
 
-    When upstream providers split chain-of-thought into ``reasoning_content``
-    or ``reasoning`` (Ollama qwen3.x PARSER, DeepSeek-R1, Moonshot, Novita,
-    etc.), ``content`` may legitimately come back empty even though the model
-    produced complete reasoning. The post-tool empty-response nudge
-    (issue #21811) must skip the nudge in that case so the prefill path can
-    take over instead of triggering a wasteful retry round-trip.
+    When upstream providers split chain-of-thought into a dedicated channel
+    instead of inline ``<think>`` tags, ``content`` may legitimately come
+    back empty even though the model produced complete reasoning. The
+    post-tool empty-response nudge (issue #21811) must skip the nudge in
+    that case so the prefill path can take over instead of triggering a
+    wasteful retry round-trip.
 
-    Accepts any object exposing ``reasoning_content`` / ``reasoning`` as
-    attributes (OpenAI SDK pydantic message) or as dict keys (raw payload).
-    Truthy values (non-empty strings, lists, dicts) mean reasoning is
-    present; ``None`` / empty values mean it isn't.
+    Recognised channels (must stay in sync with ``extract_reasoning`` and
+    the ``_has_structured`` prefill guard in ``conversation_loop`` — both of
+    which already treat ``reasoning_details`` as reasoning):
+
+      * ``reasoning_content`` — Ollama qwen3.x PARSER, DeepSeek-R1,
+        Moonshot, Novita, DeepSeek/MiMo thinking modes.
+      * ``reasoning`` — Ollama's OpenAI-compatible endpoint maps its
+        internal thinking field here (see ollama/ollama#15288); also
+        OpenRouter's flat reasoning field.
+      * ``reasoning_details`` — OpenRouter unified format and MiniMax M2's
+        native OpenAI-compatible API return the chain-of-thought as a
+        structured array here. Previously omitted, which let the nudge
+        fire on MiniMax M2 (issue #21811 residual, reported on Ollama
+        cloud) even though the model had reasoned in full.
+      * ``thinking`` — Ollama's native ``/api/chat`` field and some
+        OpenAI-compat proxies surface it as a top-level message key.
+
+    Accepts any object exposing these as attributes (OpenAI SDK pydantic
+    message, including provider-extra fields hidden under ``model_extra``)
+    or as dict keys (raw payload). Truthy values (non-empty strings, lists,
+    dicts) mean reasoning is present; ``None`` / empty values mean it isn't.
     """
     if assistant_message is None:
         return False
@@ -321,7 +338,12 @@ def _has_separate_reasoning(assistant_message) -> bool:
                 value = model_extra.get(name)
         return value
 
-    return bool(_get("reasoning_content") or _get("reasoning"))
+    return bool(
+        _get("reasoning_content")
+        or _get("reasoning")
+        or _get("reasoning_details")
+        or _get("thinking")
+    )
 
 
 class AIAgent:

--- a/tests/run_agent/test_post_tool_empty_nudge_reasoning_content.py
+++ b/tests/run_agent/test_post_tool_empty_nudge_reasoning_content.py
@@ -1,0 +1,168 @@
+"""Regression tests for issue #21811.
+
+The post-tool empty-response nudge previously fired even when the upstream
+provider had split the model's chain-of-thought into a separate
+``reasoning_content`` / ``reasoning`` channel (Ollama qwen3.x PARSER,
+DeepSeek-R1, Moonshot, Novita, etc.). In that case ``content`` is empty
+and there is no inline ``<think>`` tag (the parser already stripped it),
+so the old detection wrongly classified the response as silent and
+triggered a wasteful retry round-trip.
+
+These tests pin down the new behaviour:
+
+* ``_has_separate_reasoning`` recognises reasoning_content / reasoning on
+  both pydantic-style attribute objects and plain dict payloads, on
+  ``model_extra`` fall-throughs, and ignores empty values.
+* Genuinely empty messages (no inline tag, no separate reasoning) still
+  trigger the nudge — no regression.
+* Inline ``<think>`` blocks in content keep their existing detection
+  path (``_has_inline_thinking``).
+* When inline thinking AND separate reasoning are both present, both
+  guards are true (and the nudge is skipped).
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+import run_agent
+from run_agent import _has_separate_reasoning
+
+
+# --------------------------------------------------------------------------- #
+# _has_separate_reasoning unit tests                                          #
+# --------------------------------------------------------------------------- #
+
+
+class _PydanticLikeMessage(SimpleNamespace):
+    """Stand-in for openai.types.chat.ChatCompletionMessage which exposes
+    provider-extra fields (e.g. ``reasoning_content``) via attributes and
+    via ``model_extra``."""
+
+
+def test_has_separate_reasoning_attr_reasoning_content():
+    msg = _PydanticLikeMessage(
+        content="",
+        reasoning_content="Thought: the user wants me to save…",
+        reasoning=None,
+    )
+    assert _has_separate_reasoning(msg) is True
+
+
+def test_has_separate_reasoning_attr_reasoning():
+    msg = _PydanticLikeMessage(
+        content="",
+        reasoning_content=None,
+        reasoning="thinking through the steps",
+    )
+    assert _has_separate_reasoning(msg) is True
+
+
+def test_has_separate_reasoning_model_extra_fallback():
+    """OpenAI SDK hides unknown provider fields under ``model_extra`` —
+    we still need to detect them."""
+    msg = SimpleNamespace(
+        content="",
+        model_extra={"reasoning_content": "hidden in model_extra"},
+    )
+    assert _has_separate_reasoning(msg) is True
+
+
+def test_has_separate_reasoning_dict_payload():
+    msg = {"content": "", "reasoning_content": "raw dict reasoning"}
+    assert _has_separate_reasoning(msg) is True
+
+
+def test_has_separate_reasoning_empty_string_is_falsy():
+    msg = _PydanticLikeMessage(
+        content="",
+        reasoning_content="",
+        reasoning="",
+    )
+    assert _has_separate_reasoning(msg) is False
+
+
+def test_has_separate_reasoning_none_message():
+    assert _has_separate_reasoning(None) is False
+
+
+def test_has_separate_reasoning_no_reasoning_fields():
+    msg = _PydanticLikeMessage(content="actual answer")
+    assert _has_separate_reasoning(msg) is False
+
+
+def test_has_separate_reasoning_inline_think_only_does_not_count():
+    """Inline ``<think>`` lives in ``content``; this helper only checks
+    the separate-channel fields. Inline thinking has its own detector
+    (``_has_inline_thinking``)."""
+    msg = _PydanticLikeMessage(
+        content="<think>reasoning here</think>",
+        reasoning_content=None,
+        reasoning=None,
+    )
+    assert _has_separate_reasoning(msg) is False
+
+
+def test_has_separate_reasoning_both_inline_and_separate():
+    """When inline thinking AND separate reasoning coexist (rare, but
+    possible when a parser only partially splits), the helper still
+    reports the separate channel — and the nudge guard short-circuits
+    on either signal."""
+    msg = _PydanticLikeMessage(
+        content="<think>some inline</think>",
+        reasoning_content="and also separate",
+    )
+    assert _has_separate_reasoning(msg) is True
+
+
+# --------------------------------------------------------------------------- #
+# Source-level guard test                                                     #
+#                                                                             #
+# The nudge decision lives deep in the agent loop. Rather than spin up a      #
+# full integration harness, pin the guard wiring at the source level so a    #
+# future refactor can't silently drop it.                                     #
+# --------------------------------------------------------------------------- #
+
+
+def _read_agent_source() -> str:
+    """Return the source of the module that owns the post-tool nudge.
+
+    Historically this lived in ``run_agent.py``. After the
+    ``run_conversation`` refactor it moved to
+    ``agent.conversation_loop``. We concatenate both so the source-level
+    pins keep working regardless of where the guard is wired.
+    """
+    import inspect
+    from agent import conversation_loop
+    return inspect.getsource(run_agent) + "\n" + inspect.getsource(conversation_loop)
+
+
+def test_nudge_guard_uses_has_separate_reasoning():
+    src = _read_agent_source()
+    # Helper must exist and be the one we wired in.
+    assert "def _has_separate_reasoning(" in src
+    # The post-tool empty nudge condition must consult it.
+    # We look for the conjunction with `_has_separate_reasoning_channel`
+    # — the local variable bound from the helper inside the loop. After
+    # the conversation-loop refactor the call is routed through ``_ra()``
+    # so callers can still monkey-patch ``run_agent._has_separate_reasoning``.
+    assert (
+        "_has_separate_reasoning_channel = _has_separate_reasoning(" in src
+        or "_has_separate_reasoning_channel = _ra()._has_separate_reasoning(" in src
+    )
+    assert "and not _has_separate_reasoning_channel" in src
+
+
+def test_nudge_guard_keeps_inline_thinking_check():
+    """Regression: don't accidentally remove the existing inline-think
+    guard while adding the new one."""
+    src = _read_agent_source()
+    assert "_has_inline_thinking = bool(" in src
+    assert "and not _has_inline_thinking" in src
+
+
+def test_nudge_guard_emits_status_string_unchanged():
+    """The user-visible nudge status string is documented in the issue
+    and external tooling may grep for it. Pin it."""
+    src = _read_agent_source()
+    assert "Model returned empty after tool calls" in src

--- a/tests/run_agent/test_post_tool_empty_nudge_reasoning_content.py
+++ b/tests/run_agent/test_post_tool_empty_nudge_reasoning_content.py
@@ -58,6 +58,59 @@ def test_has_separate_reasoning_attr_reasoning():
     assert _has_separate_reasoning(msg) is True
 
 
+def test_has_separate_reasoning_attr_reasoning_details():
+    """OpenRouter unified format and MiniMax M2's native OpenAI-compatible
+    API return chain-of-thought as a structured ``reasoning_details`` array.
+    This channel was previously omitted from the guard, which let the nudge
+    fire on MiniMax M2 (issue #21811 residual reported on Ollama cloud)."""
+    msg = _PydanticLikeMessage(
+        content="",
+        reasoning_content=None,
+        reasoning=None,
+        reasoning_details=[{"type": "reasoning.text", "text": "step-by-step"}],
+    )
+    assert _has_separate_reasoning(msg) is True
+
+
+def test_has_separate_reasoning_empty_reasoning_details_is_falsy():
+    """An empty ``reasoning_details`` list carries no reasoning — must not
+    suppress the nudge (matches ``extract_reasoning``'s truthiness guard)."""
+    msg = _PydanticLikeMessage(
+        content="",
+        reasoning_content=None,
+        reasoning=None,
+        reasoning_details=[],
+    )
+    assert _has_separate_reasoning(msg) is False
+
+
+def test_has_separate_reasoning_attr_thinking():
+    """Ollama's native /api/chat field and some OpenAI-compat proxies expose
+    reasoning under a top-level ``thinking`` key."""
+    msg = _PydanticLikeMessage(
+        content="",
+        reasoning_content=None,
+        reasoning=None,
+        thinking="let me work through this",
+    )
+    assert _has_separate_reasoning(msg) is True
+
+
+def test_has_separate_reasoning_reasoning_details_via_model_extra():
+    """``reasoning_details`` hidden under the OpenAI SDK's ``model_extra``
+    must still be detected."""
+    msg = SimpleNamespace(
+        content="",
+        model_extra={"reasoning_details": [{"text": "hidden array"}]},
+    )
+    assert _has_separate_reasoning(msg) is True
+
+
+def test_has_separate_reasoning_dict_reasoning_details():
+    msg = {"content": "", "reasoning_details": [{"text": "raw dict array"}]}
+    assert _has_separate_reasoning(msg) is True
+
+
 def test_has_separate_reasoning_model_extra_fallback():
     """OpenAI SDK hides unknown provider fields under ``model_extra`` —
     we still need to detect them."""
@@ -159,6 +212,27 @@ def test_nudge_guard_keeps_inline_thinking_check():
     src = _read_agent_source()
     assert "_has_inline_thinking = bool(" in src
     assert "and not _has_inline_thinking" in src
+
+
+def test_inline_thinking_regex_matches_orphan_closing_tag():
+    """MiniMax M2 prefills the opening ``<think>`` and emits only the closing
+    ``</think>``. The inline-thinking guard must match a bare closing tag so
+    the nudge is skipped when the parser leaves an orphan ``</think>`` in
+    content (issue #21811 residual)."""
+    import re
+
+    src = _read_agent_source()
+    # Pull the regex the loop uses for inline-thinking detection.
+    m = re.search(
+        r"_has_inline_thinking = bool\(\s*re\.search\(\s*r'([^']+)'",
+        src,
+    )
+    assert m, "could not locate the _has_inline_thinking regex in source"
+    pattern = m.group(1)
+    # The broadened pattern must match an orphan closing tag...
+    assert re.search(pattern, "</think>", re.IGNORECASE)
+    # ...while still matching the classic opening-tag form.
+    assert re.search(pattern, "<think>reasoning", re.IGNORECASE)
 
 
 def test_nudge_guard_emits_status_string_unchanged():


### PR DESCRIPTION
Fixes #21811

## Problem

After a tool result, on turns where the model thinks, hermes-agent emitted
`⚠️ Model returned empty after tool calls — nudging to continue` and
triggered a retry — even though the model produced complete reasoning
that arrived in `reasoning_content`. The retry usually succeeded, so the
user saw the warning followed by a valid answer, but the warning was
noise and the retry was a wasted round-trip.

The post-tool empty-response detection only checked `final_response` for
inline `<think>|<thinking>|<reasoning>` tags. When the upstream parser
(Ollama qwen3.x PARSER, DeepSeek-R1, Moonshot/Novita, …) splits thinking
out of `content` into `reasoning_content`, `final_response` is empty AND
has no `<think>` tag (the parser already stripped it). The detection
branch never consulted the structured reasoning fields — even though the
existing thinking-only prefill path right below it already handles them.

## Fix

Add a small module-level helper `_has_separate_reasoning(assistant_message)`
that detects a populated `reasoning_content` / `reasoning` channel on
either pydantic-style attribute objects (with `model_extra` fall-through
for SDK-extra fields) or raw dict payloads, and use it as an additional
guard in the nudge condition alongside the pre-existing
`_has_inline_thinking` check:

```python
if (
    _prior_was_tool
    and not getattr(self, "_post_tool_empty_retried", False)
    and not _has_inline_thinking
    and not _has_separate_reasoning_channel  # ← new guard (#21811)
):
    # … fire nudge
```

Skipping the nudge in this case routes those turns through the
thinking-only prefill recovery branch (which is the correct path for
structured reasoning) instead of doing a wasteful retry.

The helper handles three message shapes seen in practice:

* OpenAI SDK pydantic message → `reasoning_content` / `reasoning`
  attributes
* OpenAI SDK pydantic message with provider-extra fields → values hidden
  under `model_extra`
* Raw dict payloads → dict keys

## Tests

Added `tests/run_agent/test_post_tool_empty_nudge_reasoning_content.py`
covering:

* `reasoning_content` populated, content empty → no nudge (#21811 case)
* `reasoning` populated, content empty → no nudge
* `model_extra={"reasoning_content": …}` fallback → no nudge
* Dict payload → detected
* Empty strings on both fields → falsy (no false positives)
* `None` message → falsy (no crash)
* No reasoning fields at all → falsy (genuinely empty turns still
  trigger the nudge — no regression)
* Inline `<think>` only in content → handled by existing
  `_has_inline_thinking` path (helper stays falsy)
* Both inline `<think>` AND separate reasoning → still detected
* Source-level guard tests pin the helper wiring into the nudge
  conditional and keep the pre-existing inline-thinking branch intact

All 12 new tests pass. Full `tests/run_agent/` suite: 1256 passed,
9 skipped, 2 failures pre-existing on `main` (`test_concurrent_interrupt.py`
— unrelated; `'_Stub' object has no attribute '_tool_guardrails'`).

## Coverage

The same shape affects any model where reasoning is delivered via a
separate field rather than inline tags — DeepSeek-R1, Qwen3 family on
Ollama 0.5+, Moonshot/MiniMax variants, etc. Catching this once at the
detection branch covers all of them.
