### PR TITLE
gateway/discord: forward edited messages when bot is newly mentioned

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -785,6 +785,12 @@ class DiscordAdapter(BasePlatformAdapter):
                 await self._handle_message(message)
 
             @self._client.event
+            async def on_message_edit(before: DiscordMessage, after: DiscordMessage):
+                # Delegate to the adapter method so the routing logic
+                # is unit-testable without spinning up a Discord client.
+                await adapter_self._handle_message_edit(before, after)
+
+            @self._client.event
             async def on_voice_state_update(member, before, after):
                 """Track voice channel join/leave events."""
                 # Only track channels where the bot is connected
@@ -4329,6 +4335,71 @@ class DiscordAdapter(BasePlatformAdapter):
             await self.handle_message(event)
 
     # ------------------------------------------------------------------
+    async def _handle_message_edit(
+        self,
+        before: "DiscordMessage",
+        after: "DiscordMessage",
+    ) -> None:
+        """Forward an edited Discord message when a fresh @-mention is added.
+
+        Discord fires ``MESSAGE_UPDATE`` for any edit, including auto-generated
+        link-preview embeds. We treat the edit like a new user turn only when
+        the user actually changed the text AND newly @-mentioned the bot (in
+        guild channels) or simply changed content (in DMs). Without this,
+        typo-fixes on already-answered messages would trigger duplicate replies.
+
+        Edits share ``message.id`` with the original, so the existing message-id
+        dedup cannot be reused. We use a separate ``edit:<id>:<edited_at>`` key so
+        a second genuine edit can re-trigger but RESUME-replays of the same edit
+        are still suppressed.
+        """
+        if not self._ready_event.is_set():
+            try:
+                await asyncio.wait_for(self._ready_event.wait(), timeout=30.0)
+            except asyncio.TimeoutError:
+                pass
+
+        # Embed-only edit (Discord auto-resolves link previews) -> ignore.
+        if before.content == after.content:
+            return
+
+        if after.author == self._client.user:
+            return
+        if after.type not in (discord.MessageType.default, discord.MessageType.reply):
+            return
+
+        if getattr(after.author, "bot", False):
+            allow_bots = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
+            if allow_bots == "none":
+                return
+            if allow_bots == "mentions" and (
+                not self._client.user or self._client.user not in after.mentions
+            ):
+                return
+        else:
+            if not self._is_allowed_user(str(after.author.id), after.author):
+                return
+
+        # Trigger only when the bot is newly @-mentioned. In DMs every user
+        # message is for us, so any genuine content change suffices.
+        if not isinstance(after.channel, discord.DMChannel):
+            mentioned_before = (
+                self._client.user is not None
+                and self._client.user in before.mentions
+            )
+            mentioned_after = (
+                self._client.user is not None
+                and self._client.user in after.mentions
+            )
+            if mentioned_before or not mentioned_after:
+                return
+
+        edited_at = after.edited_at.isoformat() if after.edited_at else "0"
+        if self._dedup.is_duplicate(f"edit:{after.id}:{edited_at}"):
+            return
+
+        await self._handle_message(after)
+
     # Text message aggregation (handles Discord client-side splits)
     # ------------------------------------------------------------------
 

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -1357,6 +1357,12 @@ class DiscordAdapter(BasePlatformAdapter):
                 await adapter_self._dispatch_discord_message(message)
 
             @self._client.event
+            async def on_message_edit(before: DiscordMessage, after: DiscordMessage):
+                # Delegate to an adapter method so the routing rules are
+                # unit-testable without driving a real Discord client.
+                await adapter_self._handle_message_edit(before, after)
+
+            @self._client.event
             async def on_voice_state_update(member, before, after):
                 """Track voice channel join/leave events."""
                 # Only track channels where the bot is connected
@@ -1434,14 +1440,23 @@ class DiscordAdapter(BasePlatformAdapter):
         message: Any,
         *,
         claim: bool,
+        skip_id_dedup: bool = False,
     ) -> tuple[bool, bool]:
-        """Return ``(admitted, role_authorized)`` for one Discord event."""
+        """Return ``(admitted, role_authorized)`` for one Discord event.
+
+        ``skip_id_dedup`` bypasses the message-id dedup entirely. It exists for
+        ``MESSAGE_UPDATE``: an edit reuses the original ``message.id``, which
+        the first dispatch already claimed, so both the claiming and the
+        non-claiming branch would reject every edit. Callers that set it are
+        responsible for their own replay protection.
+        """
         message_id = str(getattr(message, "id", ""))
-        if claim:
-            if self._dedup.is_duplicate(message_id):
+        if not skip_id_dedup:
+            if claim:
+                if self._dedup.is_duplicate(message_id):
+                    return False, False
+            elif self._dedup.contains(message_id):
                 return False, False
-        elif self._dedup.contains(message_id):
-            return False, False
         if message.author == self._client.user:
             return False, False
         if message.type not in {discord.MessageType.default, discord.MessageType.reply}:
@@ -1502,6 +1517,69 @@ class DiscordAdapter(BasePlatformAdapter):
                     return False, False
 
         return True, role_authorized
+
+    async def _handle_message_edit(self, before: Any, after: Any) -> bool:
+        """Route a ``MESSAGE_UPDATE`` that newly addresses the bot.
+
+        Discord fires this for every edit, including the ones it generates
+        itself when it resolves a link preview. An edit is treated as a new
+        user turn only when the text actually changed *and* the edit newly
+        addresses us: not mentioned in ``before``, mentioned in ``after``.
+        Without that delta a typo fix on a message we already answered would
+        produce a second reply.
+
+        The same rule is why free-response channels, bot threads and
+        ``DISCORD_REQUIRE_MENTION=false`` need no special case here: in those
+        contexts the original message was already answered, so its edit is a
+        correction to a finished turn rather than a new one. Superseding an
+        answered turn is tracked separately in #63566.
+
+        DMs are the one exception, and deliberately so: every DM is addressed
+        to us, so there is no "newly addressed" transition to detect and any
+        genuine content change is taken as a new turn.
+        """
+        if not self._ready_event.is_set():
+            try:
+                await asyncio.wait_for(self._ready_event.wait(), timeout=30.0)
+            except asyncio.TimeoutError:
+                pass
+
+        # Discord reuses MESSAGE_UPDATE to attach link-preview embeds; those
+        # carry the original content and are not a user edit.
+        if before.content == after.content:
+            return False
+
+        # Without a timestamp every edit of this message collapses onto one
+        # dedup key, so a later genuine edit would be swallowed as a replay.
+        if not after.edited_at:
+            return False
+
+        # Author, message type, allow-list, bot policy and role authorization
+        # are exactly the inbound gates. Only the id dedup has to be skipped:
+        # the original dispatch already claimed this id, so both dedup branches
+        # would reject the edit.
+        admitted, role_authorized = self._discord_message_admission(
+            after, claim=False, skip_id_dedup=True,
+        )
+        if not admitted:
+            return False
+
+        if not isinstance(after.channel, discord.DMChannel):
+            # Use the same mention test as admission, so the two gates cannot
+            # disagree: the resolved mentions list OR a raw <@ID> / <@!ID>
+            # token in the content.
+            if self._self_is_explicitly_mentioned(before):
+                return False
+            if not self._self_is_explicitly_mentioned(after):
+                return False
+
+        # Edits share message.id with the original, so key replay protection on
+        # the edit timestamp instead: a RESUME that redelivers the same edit is
+        # suppressed while a second genuine edit still gets through.
+        if self._dedup.is_duplicate(f"edit:{after.id}:{after.edited_at.isoformat()}"):
+            return False
+
+        return await self._handle_message(after, role_authorized=role_authorized)
 
     async def _dispatch_discord_message(self, message: Any) -> bool:
         """Apply Discord ingress policy and dispatch one live event."""

--- a/tests/gateway/test_discord_on_message_edit.py
+++ b/tests/gateway/test_discord_on_message_edit.py
@@ -1,0 +1,396 @@
+"""Tests for the Discord ``on_message_edit`` handler / ``_handle_message_edit``.
+
+When a user edits an existing message to add the bot's @-mention, Discord
+fires ``MESSAGE_UPDATE`` and the original ``on_message`` handler never sees
+it - so without ``_handle_message_edit`` the bot stays silent on a flow
+that's natural for users (compose, hit edit, add the mention afterwards).
+
+These tests pin down the routing rules:
+
+  - in a guild channel: forward only when the bot is *newly* mentioned in
+    the edit (so a typo-fix on an already-answered message does NOT trigger
+    a duplicate reply)
+  - in a DM: any genuine content change is treated as a new turn
+  - embed-only updates (Discord auto-resolving link previews) are ignored
+  - bot-author / system-message / disallowed-user filters mirror
+    ``on_message`` exactly
+  - dedup is keyed on ``edit:<id>:<edited_at>`` so a RESUME-replay of the
+    same edit is suppressed but a second genuine edit re-triggers
+"""
+
+import sys
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+
+def _ensure_discord_mock():
+    """Install (or augment) a mock ``discord`` module.
+
+    Same pattern as ``test_discord_allowed_mentions.py`` - other test files
+    in this dir stub ``discord`` via ``sys.modules.setdefault``, whoever
+    imports first wins. We always force the symbols we need on top.
+    """
+    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
+        # Real discord.py is installed - leave it alone.
+        return
+
+    if sys.modules.get("discord") is None:
+        discord_mod = MagicMock()
+        discord_mod.Intents.default.return_value = MagicMock()
+        discord_mod.Client = MagicMock
+        discord_mod.File = MagicMock
+        discord_mod.DMChannel = type("DMChannel", (), {})
+        discord_mod.Thread = type("Thread", (), {})
+        discord_mod.ForumChannel = type("ForumChannel", (), {})
+        discord_mod.ui = SimpleNamespace(
+            View=object,
+            button=lambda *a, **k: (lambda fn: fn),
+            Button=object,
+        )
+        discord_mod.ButtonStyle = SimpleNamespace(
+            success=1, primary=2, danger=3,
+            green=1, blurple=2, red=3, grey=4, secondary=5,
+        )
+        discord_mod.Color = SimpleNamespace(
+            orange=lambda: 1, green=lambda: 2, blue=lambda: 3, red=lambda: 4,
+        )
+        discord_mod.Interaction = object
+        discord_mod.Embed = MagicMock
+        discord_mod.app_commands = SimpleNamespace(
+            describe=lambda **kwargs: (lambda fn: fn),
+            choices=lambda **kwargs: (lambda fn: fn),
+            Choice=lambda **kwargs: SimpleNamespace(**kwargs),
+        )
+        discord_mod.opus = SimpleNamespace(is_loaded=lambda: True)
+
+        ext_mod = MagicMock()
+        commands_mod = MagicMock()
+        commands_mod.Bot = MagicMock
+        ext_mod.commands = commands_mod
+
+        sys.modules["discord"] = discord_mod
+        sys.modules.setdefault("discord.ext", ext_mod)
+        sys.modules.setdefault("discord.ext.commands", commands_mod)
+
+_ensure_discord_mock()
+
+import discord  # noqa: E402
+
+from gateway.platforms.discord import DiscordAdapter  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+class _GuildChannel:
+    """Sentinel for any non-DM channel - isinstance(_, DMChannel) is False."""
+
+
+def _make_dm_channel():
+    return discord.DMChannel()
+
+
+def _make_user(uid=100, *, is_bot=False, name="Alice"):
+    return SimpleNamespace(id=uid, bot=is_bot, name=name)
+
+
+_DEFAULT_EDIT_TIME = datetime(2026, 5, 8, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _make_message(
+    *,
+    msg_id=555,
+    content="hi",
+    author=None,
+    mentions=None,
+    channel=None,
+    msg_type=None,
+    edited_at=_DEFAULT_EDIT_TIME,
+):
+    return SimpleNamespace(
+        id=msg_id,
+        content=content,
+        author=author if author is not None else _make_user(),
+        mentions=list(mentions or []),
+        channel=channel if channel is not None else _GuildChannel(),
+        type=msg_type if msg_type is not None else discord.MessageType.default,
+        edited_at=edited_at,
+    )
+
+
+def _make_adapter(*, bot_user=None, allow_user=True, dedup_seen=None):
+    """Build a DiscordAdapter shell with just enough state to drive
+    ``_handle_message_edit``. We bypass ``__init__`` because the real one
+    requires a token and starts the discord.py client - we only need the
+    handler's collaborators here.
+    """
+    adapter = object.__new__(DiscordAdapter)
+
+    adapter._ready_event = SimpleNamespace(
+        is_set=lambda: True,
+        wait=AsyncMock(),
+    )
+    adapter._client = SimpleNamespace(user=bot_user)
+    seen = set(dedup_seen or [])
+
+    def _is_dup(key):
+        if key in seen:
+            return True
+        seen.add(key)
+        return False
+
+    adapter._dedup = SimpleNamespace(is_duplicate=_is_dup)
+    adapter._is_allowed_user = lambda *_a, **_kw: allow_user
+    adapter._handle_message = AsyncMock()
+    return adapter
+
+
+@pytest.fixture(autouse=True)
+def _isolate_discord_env(monkeypatch):
+    """Don't let DISCORD_ALLOW_BOTS leak between tests."""
+    monkeypatch.delenv("DISCORD_ALLOW_BOTS", raising=False)
+
+
+@pytest.fixture(autouse=True)
+def _stable_message_type_and_dm_channel(monkeypatch):
+    """Per-test override of ``discord.MessageType`` + ``discord.DMChannel``.
+
+    Other test files in this directory share the same ``sys.modules["discord"]``
+    object, and the handler relies on ``MessageType.default`` / ``.reply`` being
+    *identity-comparable* (``in`` check) rather than truthy MagicMock auto-attrs.
+    We override per test and restore on teardown so we never poison sibling
+    test files that pytest-xdist co-schedules onto the same worker.
+    """
+    discord_mod = sys.modules["discord"]
+    saved = {
+        "MessageType": getattr(discord_mod, "MessageType", None),
+        "DMChannel": getattr(discord_mod, "DMChannel", None),
+    }
+    discord_mod.MessageType = SimpleNamespace(
+        default=object(),
+        reply=object(),
+        thread_starter_message=object(),
+        pins_add=object(),
+    )
+    if not isinstance(discord_mod.DMChannel, type):
+        discord_mod.DMChannel = type("DMChannel", (), {})
+    yield
+    if saved["MessageType"] is None:
+        delattr(discord_mod, "MessageType")
+    else:
+        discord_mod.MessageType = saved["MessageType"]
+    if saved["DMChannel"] is None:
+        delattr(discord_mod, "DMChannel")
+    else:
+        discord_mod.DMChannel = saved["DMChannel"]
+
+
+# ---------------------------------------------------------------------------
+# Routing rules
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_embed_only_edit_is_ignored():
+    """Discord auto-resolves link previews via MESSAGE_UPDATE - same content
+    before/after. That's not a user-initiated edit, ignore it."""
+    bot = _make_user(uid=999)
+    user = _make_user(uid=100)
+    adapter = _make_adapter(bot_user=bot)
+    same = "check https://example.com"
+    before = _make_message(content=same, author=user, mentions=[bot])
+    after = _make_message(content=same, author=user, mentions=[bot])
+
+    await adapter._handle_message_edit(before, after)
+
+    adapter._handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_channel_edit_with_newly_added_mention_triggers_reply():
+    bot = _make_user(uid=999)
+    user = _make_user(uid=100)
+    adapter = _make_adapter(bot_user=bot)
+    before = _make_message(content="some question", author=user, mentions=[])
+    after = _make_message(
+        content="<@999> some question", author=user, mentions=[bot]
+    )
+
+    await adapter._handle_message_edit(before, after)
+
+    adapter._handle_message.assert_awaited_once_with(after)
+
+
+@pytest.mark.asyncio
+async def test_channel_edit_when_mention_was_already_present_is_ignored():
+    """Typo-fix on a message we already answered must NOT duplicate the
+    reply. This is the regression we'd hit if we naively forwarded every
+    edit."""
+    bot = _make_user(uid=999)
+    user = _make_user(uid=100)
+    adapter = _make_adapter(bot_user=bot)
+    before = _make_message(content="<@999> origenal", author=user, mentions=[bot])
+    after = _make_message(content="<@999> original", author=user, mentions=[bot])
+
+    await adapter._handle_message_edit(before, after)
+
+    adapter._handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_channel_edit_that_removes_mention_is_ignored():
+    bot = _make_user(uid=999)
+    user = _make_user(uid=100)
+    adapter = _make_adapter(bot_user=bot)
+    before = _make_message(content="<@999> nvm", author=user, mentions=[bot])
+    after = _make_message(content="nvm", author=user, mentions=[])
+
+    await adapter._handle_message_edit(before, after)
+
+    adapter._handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dm_edit_with_content_change_triggers_reply():
+    """In a DM every user message is implicitly addressed to the bot, so
+    the mention check is bypassed - only the content-changed gate applies."""
+    bot = _make_user(uid=999)
+    user = _make_user(uid=100)
+    adapter = _make_adapter(bot_user=bot)
+    dm = _make_dm_channel()
+    before = _make_message(content="ple", author=user, channel=dm)
+    after = _make_message(content="please help", author=user, channel=dm)
+
+    await adapter._handle_message_edit(before, after)
+
+    adapter._handle_message.assert_awaited_once_with(after)
+
+
+# ---------------------------------------------------------------------------
+# Author / type / allowlist filters - must mirror on_message
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bots_own_edit_is_ignored():
+    bot = _make_user(uid=999)
+    adapter = _make_adapter(bot_user=bot)
+    before = _make_message(content="a", author=bot)
+    after = _make_message(content="b", author=bot)
+
+    await adapter._handle_message_edit(before, after)
+
+    adapter._handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_non_default_message_type_is_ignored():
+    """Pin notifications, member joins etc. are MessageType != default/reply
+    and should never be routed to the LLM."""
+    bot = _make_user(uid=999)
+    user = _make_user(uid=100)
+    adapter = _make_adapter(bot_user=bot)
+    pin = discord.MessageType.pins_add
+    before = _make_message(content="a", author=user, msg_type=pin)
+    after = _make_message(content="b", author=user, mentions=[bot], msg_type=pin)
+
+    await adapter._handle_message_edit(before, after)
+
+    adapter._handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_disallowed_human_user_is_ignored():
+    bot = _make_user(uid=999)
+    user = _make_user(uid=100)
+    adapter = _make_adapter(bot_user=bot, allow_user=False)
+    before = _make_message(content="hello", author=user, mentions=[])
+    after = _make_message(content="<@999> hello", author=user, mentions=[bot])
+
+    await adapter._handle_message_edit(before, after)
+
+    adapter._handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_bot_author_with_allow_bots_none_is_ignored(monkeypatch):
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "none")
+    bot = _make_user(uid=999)
+    other_bot = _make_user(uid=200, is_bot=True)
+    adapter = _make_adapter(bot_user=bot)
+    before = _make_message(content="hello", author=other_bot, mentions=[])
+    after = _make_message(
+        content="<@999> hello", author=other_bot, mentions=[bot]
+    )
+
+    await adapter._handle_message_edit(before, after)
+
+    adapter._handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_bot_author_with_allow_bots_mentions_passes_when_mentioned(monkeypatch):
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "mentions")
+    bot = _make_user(uid=999)
+    other_bot = _make_user(uid=200, is_bot=True)
+    adapter = _make_adapter(bot_user=bot)
+    before = _make_message(content="hello", author=other_bot, mentions=[])
+    after = _make_message(
+        content="<@999> hello", author=other_bot, mentions=[bot]
+    )
+
+    await adapter._handle_message_edit(before, after)
+
+    adapter._handle_message.assert_awaited_once_with(after)
+
+
+# ---------------------------------------------------------------------------
+# Dedup behavior
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_dedup_suppresses_replay_of_same_edit():
+    """Discord RESUME after reconnect re-fires events; the
+    ``edit:<id>:<edited_at>`` key blocks the duplicate."""
+    bot = _make_user(uid=999)
+    user = _make_user(uid=100)
+    adapter = _make_adapter(bot_user=bot)
+    edit_time = _DEFAULT_EDIT_TIME
+
+    before = _make_message(content="hello", author=user, mentions=[], edited_at=edit_time)
+    after = _make_message(
+        content="<@999> hello", author=user, mentions=[bot], edited_at=edit_time
+    )
+
+    await adapter._handle_message_edit(before, after)
+    await adapter._handle_message_edit(before, after)
+
+    assert adapter._handle_message.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_dedup_allows_second_genuine_edit_with_later_timestamp():
+    """The same DM message edited twice with different ``edited_at`` values
+    must trigger two replies. Dedup is keyed on edit time, not message id,
+    so genuine subsequent edits get through while RESUME-replays don't."""
+    bot = _make_user(uid=999)
+    user = _make_user(uid=100)
+    adapter = _make_adapter(bot_user=bot)
+    dm = _make_dm_channel()
+    t1 = datetime(2026, 5, 8, 12, 0, 0, tzinfo=timezone.utc)
+    t2 = datetime(2026, 5, 8, 12, 1, 0, tzinfo=timezone.utc)
+
+    msg_v1 = _make_message(content="ple", author=user, channel=dm, edited_at=t1)
+    msg_v2 = _make_message(content="please", author=user, channel=dm, edited_at=t1)
+    msg_v3 = _make_message(content="please help", author=user, channel=dm, edited_at=t2)
+
+    await adapter._handle_message_edit(msg_v1, msg_v2)
+    await adapter._handle_message_edit(msg_v2, msg_v3)
+
+    assert adapter._handle_message.await_count == 2

--- a/tests/gateway/test_discord_on_message_edit.py
+++ b/tests/gateway/test_discord_on_message_edit.py
@@ -1,0 +1,369 @@
+"""Tests for ``DiscordAdapter._handle_message_edit`` (MESSAGE_UPDATE routing).
+
+The adapter subscribes to ``on_message`` but not to ``on_message_edit``, so a
+user who edits an existing message to add the bot's @-mention gets silence -
+a natural flow when someone wants to address the bot after the fact.
+
+These tests pin the routing rules:
+
+  - guild channel: forward only when the edit *newly* addresses the bot, so a
+    typo fix on a message we already answered does not produce a second reply
+  - the mention test is ``_self_is_explicitly_mentioned`` - the same one
+    inbound admission uses - so a raw ``<@ID>`` token counts even when the
+    resolved ``mentions`` list is empty, which is exactly what happens on
+    edited messages
+  - DM: any genuine content change is a new turn (there is no "newly
+    addressed" transition to detect)
+  - embed-only updates (Discord resolving a link preview) are ignored
+  - author / type / allow-list / bot-policy gates are reused from
+    ``_discord_message_admission`` rather than reimplemented, with only the
+    message-id dedup skipped - the original dispatch already claimed that id
+  - replay protection is keyed on ``edit:<id>:<edited_at>``
+"""
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+# tests/gateway/conftest.py installs the discord mock at collection time.
+import plugins.platforms.discord.adapter as discord_platform  # noqa: E402
+from plugins.platforms.discord.adapter import DiscordAdapter  # noqa: E402
+
+
+BOT_ID = 999
+USER_ID = 7
+_EDIT_TS = datetime(2026, 5, 8, 12, 0, 0, tzinfo=timezone.utc)
+
+
+class _TextChannel:
+    """Fake guild text channel - not a DMChannel, not a Thread."""
+
+    def __init__(self, channel_id: int = 100):
+        self.id = channel_id
+        self.name = "general"
+        self.guild = SimpleNamespace(name="Test Server", id=1)
+
+
+def _dm_channel():
+    return discord_platform.discord.DMChannel()
+
+
+def _user(uid: int = USER_ID, *, bot: bool = False):
+    return SimpleNamespace(id=uid, name="Alice", display_name="Alice", bot=bot)
+
+
+def _bot_user():
+    return SimpleNamespace(id=BOT_ID, name="Bot", display_name="Bot", bot=True)
+
+
+def _message(
+    *,
+    msg_id: int = 42,
+    content: str = "hello",
+    author=None,
+    mentions=None,
+    channel=None,
+    msg_type=None,
+    edited_at=_EDIT_TS,
+):
+    channel = channel if channel is not None else _TextChannel()
+    is_dm = isinstance(channel, discord_platform.discord.DMChannel)
+    return SimpleNamespace(
+        id=msg_id,
+        content=content,
+        author=author if author is not None else _user(),
+        mentions=list(mentions or []),
+        channel=channel,
+        guild=None if is_dm else SimpleNamespace(name="Test Server", id=1),
+        type=(
+            msg_type
+            if msg_type is not None
+            else discord_platform.discord.MessageType.default
+        ),
+        edited_at=edited_at,
+    )
+
+
+@pytest.fixture
+def adapter(monkeypatch):
+    for var in (
+        "DISCORD_REQUIRE_MENTION",
+        "DISCORD_AUTO_THREAD",
+        "DISCORD_FREE_RESPONSE_CHANNELS",
+        "DISCORD_ALLOWED_CHANNELS",
+        "DISCORD_IGNORED_CHANNELS",
+        "DISCORD_ALLOW_BOTS",
+        "DISCORD_IGNORE_NO_MENTION",
+        "GATEWAY_ALLOW_ALL_USERS",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setenv("DISCORD_ALLOW_ALL_USERS", "true")
+
+    a = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    a._client = SimpleNamespace(user=_bot_user())
+    a._ready_event.set()
+    a._handle_message = AsyncMock(return_value=True)
+    return a
+
+
+# ---------------------------------------------------------------------------
+# Content / timestamp preconditions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_embed_only_edit_is_ignored(adapter):
+    """Discord reuses MESSAGE_UPDATE to attach a link preview; same content."""
+    same = "look at https://example.com"
+    bot = adapter._client.user
+    before = _message(content=same, mentions=[bot])
+    after = _message(content=same, mentions=[bot])
+
+    await adapter._handle_message_edit(before, after)
+
+    adapter._handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_edit_without_timestamp_is_ignored(adapter):
+    """No edited_at means every edit shares one dedup key, which would swallow
+    the next genuine edit. Bail out rather than guess a placeholder."""
+    bot = adapter._client.user
+    before = _message(content="question", mentions=[], edited_at=None)
+    after = _message(content=f"<@{BOT_ID}> question", mentions=[bot], edited_at=None)
+
+    await adapter._handle_message_edit(before, after)
+
+    adapter._handle_message.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# The newly-addressed delta
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_newly_added_mention_dispatches(adapter):
+    bot = adapter._client.user
+    before = _message(content="some question", mentions=[])
+    after = _message(content=f"<@{BOT_ID}> some question", mentions=[bot])
+
+    await adapter._handle_message_edit(before, after)
+
+    adapter._handle_message.assert_awaited_once()
+    assert adapter._handle_message.await_args.args[0] is after
+
+
+@pytest.mark.asyncio
+async def test_raw_mention_dispatches_when_mentions_list_is_empty(adapter):
+    """``message.mentions`` is not always populated on edited messages - see
+    ``_raw_mentioned_user_ids``. The delta must still see the raw token,
+    otherwise the exact flow this feature exists for stays broken."""
+    before = _message(content="some question", mentions=[])
+    after = _message(content=f"<@{BOT_ID}> some question", mentions=[])
+
+    await adapter._handle_message_edit(before, after)
+
+    adapter._handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_typo_fix_on_answered_message_is_ignored(adapter):
+    """The message was already mentioned before, so we already replied once."""
+    bot = adapter._client.user
+    before = _message(content=f"<@{BOT_ID}> origenal", mentions=[bot])
+    after = _message(content=f"<@{BOT_ID}> original", mentions=[bot])
+
+    await adapter._handle_message_edit(before, after)
+
+    adapter._handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_typo_fix_is_ignored_when_before_only_had_a_raw_mention(adapter):
+    """Same guard, but ``before`` carried the mention only in its content."""
+    bot = adapter._client.user
+    before = _message(content=f"<@{BOT_ID}> origenal", mentions=[])
+    after = _message(content=f"<@{BOT_ID}> original", mentions=[bot])
+
+    await adapter._handle_message_edit(before, after)
+
+    adapter._handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_edit_removing_the_mention_is_ignored(adapter):
+    bot = adapter._client.user
+    before = _message(content=f"<@{BOT_ID}> nvm", mentions=[bot])
+    after = _message(content="nvm", mentions=[])
+
+    await adapter._handle_message_edit(before, after)
+
+    adapter._handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_free_response_channel_edit_without_mention_is_ignored(adapter, monkeypatch):
+    """Deliberate: in a free-response channel the original message was already
+    answered, so its edit is a correction to a finished turn, not a new one.
+    Re-dispatching here would double-reply to every typo fix. Superseding an
+    answered turn is tracked separately."""
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "100")
+    before = _message(content="what about X", mentions=[])
+    after = _message(content="what about Y", mentions=[])
+
+    await adapter._handle_message_edit(before, after)
+
+    adapter._handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_dm_edit_with_content_change_dispatches(adapter):
+    """Every DM is addressed to us, so there is no transition to detect."""
+    dm = _dm_channel()
+    before = _message(content="ple", channel=dm)
+    after = _message(content="please help", channel=dm)
+
+    await adapter._handle_message_edit(before, after)
+
+    adapter._handle_message.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Gates reused from _discord_message_admission
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_bots_own_edit_is_ignored(adapter):
+    bot = adapter._client.user
+    before = _message(content="a", author=bot)
+    after = _message(content="b", author=bot)
+
+    await adapter._handle_message_edit(before, after)
+
+    adapter._handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_non_default_message_type_is_ignored(adapter):
+    """Pins, joins and other system messages never reach the agent."""
+    bot = adapter._client.user
+    pin = discord_platform.discord.MessageType.pins_add
+    before = _message(content="a", mentions=[], msg_type=pin)
+    after = _message(content=f"<@{BOT_ID}> b", mentions=[bot], msg_type=pin)
+
+    await adapter._handle_message_edit(before, after)
+
+    adapter._handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_disallowed_user_is_ignored(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_ALLOW_ALL_USERS", "false")
+    bot = adapter._client.user
+    before = _message(content="hello", mentions=[])
+    after = _message(content=f"<@{BOT_ID}> hello", mentions=[bot])
+
+    await adapter._handle_message_edit(before, after)
+
+    adapter._handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_bot_author_ignored_when_allow_bots_is_none(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "none")
+    bot = adapter._client.user
+    other = _user(uid=200, bot=True)
+    before = _message(content="hello", author=other, mentions=[])
+    after = _message(content=f"<@{BOT_ID}> hello", author=other, mentions=[bot])
+
+    await adapter._handle_message_edit(before, after)
+
+    adapter._handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_bot_author_dispatches_when_allow_bots_is_mentions(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_ALLOW_BOTS", "mentions")
+    bot = adapter._client.user
+    other = _user(uid=200, bot=True)
+    before = _message(content="hello", author=other, mentions=[])
+    after = _message(content=f"<@{BOT_ID}> hello", author=other, mentions=[bot])
+
+    await adapter._handle_message_edit(before, after)
+
+    adapter._handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_role_authorization_is_forwarded(adapter):
+    """``role_authorized`` comes back from admission and must reach
+    ``_handle_message``; dropping it silently downgrades role-authorized
+    users on the edit path only."""
+    adapter._allowed_role_ids = {5}
+    member = _user()
+    member.roles = [SimpleNamespace(id=5)]
+    bot = adapter._client.user
+    before = _message(content="hello", author=member, mentions=[])
+    after = _message(content=f"<@{BOT_ID}> hello", author=member, mentions=[bot])
+
+    await adapter._handle_message_edit(before, after)
+
+    adapter._handle_message.assert_awaited_once()
+    assert adapter._handle_message.await_args.kwargs["role_authorized"] is True
+
+
+# ---------------------------------------------------------------------------
+# Dedup
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_edit_is_not_blocked_by_the_original_message_id_claim(adapter):
+    """The crux: an edit reuses ``message.id``, which the original dispatch
+    already claimed. Without skipping the id dedup every edit is dropped."""
+    bot = adapter._client.user
+    before = _message(content="some question", mentions=[])
+    after = _message(content=f"<@{BOT_ID}> some question", mentions=[bot])
+
+    # Exactly what the first dispatch of this message did.
+    assert adapter._dedup.is_duplicate(str(after.id)) is False
+    assert adapter._dedup.contains(str(after.id)) is True
+
+    await adapter._handle_message_edit(before, after)
+
+    adapter._handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_replay_of_the_same_edit_is_deduped(adapter):
+    """A RESUME after reconnect redelivers MESSAGE_UPDATE."""
+    bot = adapter._client.user
+    before = _message(content="hello", mentions=[])
+    after = _message(content=f"<@{BOT_ID}> hello", mentions=[bot])
+
+    await adapter._handle_message_edit(before, after)
+    await adapter._handle_message_edit(before, after)
+
+    assert adapter._handle_message.await_count == 1
+
+
+@pytest.mark.asyncio
+async def test_second_genuine_edit_dispatches_again(adapter):
+    """Keyed on edited_at, so a later real edit still gets through."""
+    dm = _dm_channel()
+    t2 = _EDIT_TS + timedelta(minutes=1)
+
+    v1 = _message(content="ple", channel=dm, edited_at=_EDIT_TS)
+    v2 = _message(content="please", channel=dm, edited_at=_EDIT_TS)
+    v3 = _message(content="please help", channel=dm, edited_at=t2)
+
+    await adapter._handle_message_edit(v1, v2)
+    await adapter._handle_message_edit(v2, v3)
+
+    assert adapter._handle_message.await_count == 2


### PR DESCRIPTION
## Problem

The Discord adapter subscribes to `on_message` but never to `on_message_edit`.
When a user edits an existing message to add an `@bot` mention, the bot stays
silent - they have to send a fresh message instead. Adding the mention
afterwards is a natural flow: people hit edit to retry a prompt, or to address
the bot after the fact. We hit this regularly in our own deployment.

## Solution

Subscribe to `on_message_edit(before, after)` and route the edited message
through the existing pipeline when the edit *newly addresses* the bot: the text
actually changed, the bot was not mentioned in `before`, and is in `after`.
That delta is what keeps a typo fix on an already-answered message from
producing a second reply.

Admission is reused rather than reimplemented. `_discord_message_admission`
gains a `skip_id_dedup` flag and does the author, message-type, allow-list,
bot-policy and `role_authorized` work for the edit path too, so the two paths
cannot drift apart.

Only the id dedup has to be bypassed. An edit reuses the original `message.id`,
and the first dispatch already claimed it - at the top of admission, before the
mention gate can reject the message - so both the claiming and the non-claiming
branch would otherwise reject every edit. Replay protection moves to an
`edit:<id>:<edited_at>` key instead, which still suppresses a RESUME
redelivery of the same edit while letting a second genuine edit through.

The routing lives in `_handle_message_edit`, extracted so the behaviour matrix
is unit-testable without driving a real Discord client.

## Behaviour

| Scenario | Result |
|---|---|
| Add `@bot` via edit on a plain message | reply (new) |
| Same, but the mention is a raw `<@ID>` and `mentions` is empty | reply (new) |
| Fix a typo on a message we already answered | ignored |
| Edit that removes `@bot` | ignored |
| Embed-only change (Discord resolving a link preview) | ignored |
| Edit in a DM | reply (new) |
| Edit in a free-response channel / bot thread / `REQUIRE_MENTION=false` | ignored |
| RESUME redelivers the same edit | deduped on `edit:<id>:<edited_at>` |
| Edit with no `edited_at` | ignored |

Free-response channels, bot threads and `DISCORD_REQUIRE_MENTION=false` need no
special case: in those contexts the original message was already answered, so
its edit is a correction to a finished turn rather than a new one. Treating
them as "any content change re-triggers" would double-reply to every typo fix
in a busy shared channel. Superseding an answered turn is a different question,
tracked in #63566 (and #35535 for Simplex).

The mention test is `_self_is_explicitly_mentioned` on both sides of the delta,
not `user in message.mentions`. As `_raw_mentioned_user_ids` documents, the
resolved mentions list is not always populated on **edited** messages, so the
bare membership test would miss the raw `<@ID>` form in exactly the flow this
feature exists for.

## Tests

`tests/gateway/test_discord_on_message_edit.py`, 18 cases: the delta, the raw
mention form on both sides, the DM branch, every reused admission gate,
`role_authorized` passthrough, the `edited_at` guard, the free-response rule,
and that an edit survives the original message-id claim.

No new failures in `tests/gateway/test_discord_*.py`: 237 pass where unmodified
`main` passes 219, with the same four pre-existing failures on both (a missing
`wcwidth` dependency plus three order-dependent `test_discord_send` cases that
fail identically without this change).

## Out of scope

- **Uncached edits.** `on_message_edit` only fires for messages in discord.py's
  message cache. `on_raw_message_edit` carries no `before` view, so the
  newly-addressed delta cannot be evaluated there.
- **Editing a message whose run is still in flight.** Nothing here cancels or
  steers an active run; that is #63566.

## History

Opened 2026-05-08 against `gateway/platforms/discord.py`. `cc8e5ec2` moved the
adapter to `plugins/platforms/discord/adapter.py` four days later with no
back-compat shim, which is what the earlier review correctly flagged. This
revision is rebased onto current `main` and rewritten around the shared
admission helper, which made the change smaller rather than larger.
