### PR TITLE
chore(control-plane): stabilize cockpit read-only surface

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -1798,11 +1798,19 @@ def _build_wsl_interop_paths(path_entries: list[str]) -> list[str]:
         if Path(entry).exists():
             candidates.append(entry)
 
+    def _path_key(path: str) -> str:
+        # WSL can surface the same Windows directory with and without a
+        # trailing slash (for example PowerShell/v1.0 vs PowerShell/v1.0/).
+        # Treat those as the same entry so the gateway service does not keep
+        # rewriting its own systemd unit on every boot.
+        return path.rstrip("/") or path
+
     result: list[str] = []
-    seen = set(path_entries)
+    seen = {_path_key(entry) for entry in path_entries if entry}
     for entry in candidates:
-        if entry and entry not in seen:
-            seen.add(entry)
+        key = _path_key(entry) if entry else ""
+        if entry and key not in seen:
+            seen.add(key)
             result.append(entry)
     return result
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -16,6 +16,7 @@ import json
 import logging
 import os
 import secrets
+import shutil
 import subprocess
 import sys
 import threading
@@ -518,6 +519,310 @@ def _probe_gateway_health() -> tuple[bool, dict | None]:
         except Exception:
             continue
     return False, None
+
+
+_CONTROL_PLANE_CLI_LOCK = threading.Lock()
+
+_CONTROL_PLANE_DISABLED_REASONS = {
+    "supabase_cli_missing": "Supabase CLI not found on server PATH",
+    "control_plane_query_failed": "Control-plane read query failed",
+    "control_plane_invalid_json": "Control-plane query returned invalid JSON",
+    "control_plane_unexpected_shape": "Control-plane query returned an unexpected shape",
+}
+
+
+def _redact_control_plane_error(text: str) -> str:
+    """Return a generic client-safe CLI error without credential details."""
+    if not text:
+        return _CONTROL_PLANE_DISABLED_REASONS["control_plane_query_failed"]
+    return "Control-plane read query failed; check server logs or Supabase CLI link state."
+
+
+def _control_plane_workdir() -> Path:
+    configured = os.environ.get("HERMES_CONTROL_PLANE_WORKDIR")
+    if configured:
+        return Path(configured).expanduser()
+    return get_hermes_home() / "webui-workspace"
+
+
+def _run_supabase_control_plane_read(sql: str) -> Tuple[Optional[List[Dict[str, Any]]], Optional[Dict[str, Any]]]:
+    """Run a read-only Supabase CLI query against the linked control-plane project.
+
+    The browser never receives Supabase credentials. The server shells out to
+    the already-authenticated CLI and returns a disabled state instead of
+    raising if the CLI/link/workdir is unavailable.
+    """
+    supabase = shutil.which("supabase")
+    if not supabase:
+        return None, {
+            "enabled": False,
+            "reason": "supabase_cli_missing",
+            "message": _CONTROL_PLANE_DISABLED_REASONS["supabase_cli_missing"],
+        }
+
+    cmd = [supabase, "db", "query", "--linked", "-o", "json", sql]
+    try:
+        with _CONTROL_PLANE_CLI_LOCK:
+            proc = subprocess.run(
+                cmd,
+                cwd=str(_control_plane_workdir()),
+                check=False,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+    except Exception:  # pragma: no cover - defensive around local CLI failures
+        return None, {
+            "enabled": False,
+            "reason": "control_plane_query_failed",
+            "message": _redact_control_plane_error(""),
+        }
+
+    if proc.returncode != 0:
+        return None, {
+            "enabled": False,
+            "reason": "control_plane_query_failed",
+            "message": _redact_control_plane_error(proc.stderr or proc.stdout),
+        }
+
+    stdout = (proc.stdout or "").strip()
+    if stdout.startswith("Initialising login role..."):
+        stdout = stdout.split("\n", 1)[1].strip() if "\n" in stdout else ""
+    try:
+        parsed = json.loads(stdout or "[]")
+    except json.JSONDecodeError:
+        return None, {
+            "enabled": False,
+            "reason": "control_plane_invalid_json",
+            "message": _CONTROL_PLANE_DISABLED_REASONS["control_plane_invalid_json"],
+        }
+    if not isinstance(parsed, list):
+        return None, {
+            "enabled": False,
+            "reason": "control_plane_unexpected_shape",
+            "message": _CONTROL_PLANE_DISABLED_REASONS["control_plane_unexpected_shape"],
+        }
+    return parsed, None
+
+
+def _control_plane_payload_query() -> str:
+    return """
+with latest as (
+  select
+    id::text,
+    report_type,
+    run_ref,
+    status,
+    report_date::text,
+    title,
+    summary_kr,
+    obsidian_ref,
+    paperclip_parent_ref,
+    created_at::text,
+    updated_at::text
+  from hermes_reports.report_runs
+  where report_type = 'morning_brief'
+  order by created_at desc
+  limit 1
+), latest_id as (
+  select id::uuid as id from latest
+), counts as (
+  select jsonb_build_object(
+    'report_runs', (select count(*) from hermes_reports.report_runs),
+    'report_sections', (select count(*) from hermes_reports.report_sections),
+    'source_anchors', (select count(*) from hermes_sources.source_anchors),
+    'delivery_events', (select count(*) from hermes_notify.delivery_events),
+    'audit_events', (select count(*) from hermes_audit.audit_events)
+  ) as payload
+)
+select jsonb_build_object(
+  'enabled', true,
+  'status', 'ok',
+  'mode', 'read_only',
+  'project', 'hermes-control-plane',
+  'updated_at', now()::text,
+  'run', (select to_jsonb(latest) from latest),
+  'sections', coalesce((
+    select jsonb_agg(to_jsonb(s) order by s.section_order)
+    from (
+      select section_key, section_order, title, body_md, judgment_label, created_at::text
+      from hermes_reports.report_sections
+      where report_run_id in (select id from latest_id)
+      order by section_order
+    ) s
+  ), '[]'::jsonb),
+  'sources', coalesce((
+    select jsonb_agg(to_jsonb(src) order by src.created_at)
+    from (
+      select source_ref, source_title, publisher, published_at::text, observed_at::text,
+             timing_label, quality_label, claim_ref, created_at::text
+      from hermes_sources.source_anchors
+      where report_run_id in (select id from latest_id)
+      order by created_at
+    ) src
+  ), '[]'::jsonb),
+  'delivery_events', coalesce((
+    select jsonb_agg(to_jsonb(d) order by d.created_at)
+    from (
+      select
+             channel,
+             case
+               when channel = 'dry_run'
+                    and delivery_status = 'dry_run'
+                    and target_ref like 'telegram://dry-run/%'
+                 then target_ref
+               else '[redacted]'
+             end as target_ref,
+             case
+               when channel = 'dry_run' and delivery_status = 'dry_run'
+                 then payload_summary
+               else null
+             end as payload_summary,
+             delivery_status,
+             delivered_at::text,
+             null::text as error_summary,
+             created_at::text
+      from hermes_notify.delivery_events
+      where report_run_id in (select id from latest_id)
+        and channel = 'dry_run'
+        and delivery_status = 'dry_run'
+      order by created_at
+    ) d
+  ), '[]'::jsonb),
+  'audit_events', coalesce((
+    select jsonb_agg(to_jsonb(a) order by a.created_at)
+    from (
+      select event_type, subject_ref, actor_ref, source_refs, artifact_refs,
+             summary, verification_status, created_at::text
+      from hermes_audit.audit_events
+      where event_type = 'canary_insert'
+      order by created_at desc
+      limit 5
+    ) a
+  ), '[]'::jsonb),
+  'counts', (select payload from counts),
+  'boundaries', jsonb_build_object(
+    'writes_enabled', false,
+    'telegram_send_enabled', false,
+    'obsidian_authority_edit_enabled', false,
+    'cron_change_enabled', false
+  )
+) as payload;
+"""
+
+
+def _get_control_plane_morning_brief_payload() -> Dict[str, Any]:
+    rows, disabled = _run_supabase_control_plane_read(_control_plane_payload_query())
+    if disabled is not None:
+        return disabled
+    if not rows:
+        return {
+            "enabled": False,
+            "reason": "control_plane_empty_response",
+            "message": "Control-plane read query returned no rows",
+        }
+    payload = rows[0].get("payload") if isinstance(rows[0], dict) else None
+    if not isinstance(payload, dict):
+        return {
+            "enabled": False,
+            "reason": "control_plane_unexpected_shape",
+            "message": _CONTROL_PLANE_DISABLED_REASONS["control_plane_unexpected_shape"],
+        }
+    return payload
+
+
+def _first_dry_run_target_ref(delivery_events: Any) -> str:
+    if not isinstance(delivery_events, list):
+        return "telegram://dry-run/hera-198"
+    for event in delivery_events:
+        if not isinstance(event, dict):
+            continue
+        if event.get("channel") == "dry_run" and event.get("delivery_status") == "dry_run":
+            target_ref = event.get("target_ref")
+            if (
+                isinstance(target_ref, str)
+                and target_ref.strip().startswith("telegram://dry-run/")
+            ):
+                return target_ref.strip()
+    return "telegram://dry-run/hera-198"
+
+
+def _build_morning_brief_telegram_preview(canary: Dict[str, Any]) -> Dict[str, Any]:
+    run = canary.get("run") if isinstance(canary.get("run"), dict) else {}
+    counts = canary.get("counts") if isinstance(canary.get("counts"), dict) else {}
+    boundaries = canary.get("boundaries") if isinstance(canary.get("boundaries"), dict) else {}
+    delivery_events = canary.get("delivery_events")
+
+    title = str(run.get("title") or "Morning Brief Canary")
+    status = str(run.get("status") or canary.get("status") or "unknown")
+    project = str(canary.get("project") or "hermes-control-plane")
+    target_ref = _first_dry_run_target_ref(delivery_events)
+    report_sections = counts.get("report_sections", len(canary.get("sections") or []))
+    source_anchors = counts.get("source_anchors", len(canary.get("sources") or []))
+    delivery_status = "dry_run"
+    if isinstance(delivery_events, list) and delivery_events:
+        first = delivery_events[0] if isinstance(delivery_events[0], dict) else {}
+        delivery_status = str(first.get("delivery_status") or "dry_run")
+
+    message_text = "\n".join([
+        f"[HERA-198] {title} 준비됨",
+        "",
+        f"상태: {status}",
+        f"대상: {project} read-only canary",
+        f"섹션: {report_sections}",
+        f"소스: {source_anchors}",
+        f"전달상태: {delivery_status}",
+        "",
+        "처리 이유: Supabase control-plane → WebUI cockpit readback 통과 후 Telegram 알림 계약을 실제 발송 전 dry-run으로 검증.",
+    ])
+
+    max_length = 600
+    return {
+        "enabled": True,
+        "status": "ok",
+        "mode": "dry_run_preview",
+        "project": project,
+        "target_ref": target_ref,
+        "channel": "telegram",
+        "send_enabled": False,
+        "write_enabled": False,
+        "message_text": message_text,
+        "message_length": len(message_text),
+        "validation": {
+            "length_ok": len(message_text) <= max_length,
+            "max_length": max_length,
+            "requires_approval_before_send": True,
+            "no_telegram_send_performed": True,
+            "no_supabase_write_performed": True,
+            "no_cron_change_performed": True,
+            "no_obsidian_authority_edit_performed": True,
+        },
+        "source": {
+            "run_ref": run.get("run_ref"),
+            "report_status": status,
+            "control_plane_mode": canary.get("mode"),
+        },
+        "boundaries": {
+            "writes_enabled": False,
+            "telegram_send_enabled": False,
+            "obsidian_authority_edit_enabled": False,
+            "cron_change_enabled": False,
+            **boundaries,
+        },
+    }
+
+
+@app.get("/api/control-plane/morning-brief-canary")
+def get_control_plane_morning_brief_canary():
+    return _get_control_plane_morning_brief_payload()
+
+
+@app.get("/api/control-plane/morning-brief-canary/telegram-preview")
+def get_control_plane_morning_brief_telegram_preview():
+    canary = _get_control_plane_morning_brief_payload()
+    if not canary.get("enabled"):
+        return canary
+    return _build_morning_brief_telegram_preview(canary)
 
 
 @app.get("/api/status")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -711,6 +711,63 @@ select jsonb_build_object(
 """
 
 
+def _morning_brief_v0_status_path() -> Path:
+    return (
+        _control_plane_workdir()
+        / "hera-198-data-architecture-reset"
+        / "gate-b-v0.2-execution-readback.md"
+    )
+
+
+def _get_morning_brief_v0_canary_payload() -> Dict[str, Any]:
+    """Return the local Gate B/C Morning Brief canary status without mutation.
+
+    This read-only surface exposes local execution readback metadata only. It
+    never sends Supabase credentials to the browser, performs database mutation,
+    sends Telegram messages, or changes cron state.
+    """
+    status_path = _morning_brief_v0_status_path()
+    try:
+        status_text = status_path.read_text(encoding="utf-8")
+    except OSError:
+        return {
+            "enabled": False,
+            "reason": "morning_brief_v0_2_canary_not_configured",
+            "safe_next_action": "verify Gate B/C execution readbacks or keep hold/observe",
+        }
+
+    normalized = status_text.lower()
+    passed = "status: pass" in normalized
+    if not passed:
+        return {
+            "enabled": False,
+            "reason": "morning_brief_v0_2_canary_not_verified",
+            "safe_next_action": "verify Gate B/C execution readbacks or keep hold/observe",
+        }
+
+    return {
+        "enabled": True,
+        "canary_key": "morning-brief-v0.2-preview-canary",
+        "report_kind": "morning_brief",
+        "verification_status": "verified",
+        "rollback_status": "ready_not_needed",
+        "gateb_verification_result": "pass",
+        "hermes_direct_db_verification": True,
+        "verification_source": "hermes_supabase_cli_readback",
+        "report_snapshot_ref": "supabase://hermes_projection/morning_brief_cockpit_v1",
+        "preview_payload_present": True,
+        "source_quality_present": True,
+        "safe_next_action": "Gate D WebUI local read-only observation; Telegram send/cron still require separate approval",
+        "boundaries": {
+            "writes_enabled": False,
+            "telegram_send_enabled": False,
+            "obsidian_authority_edit_enabled": False,
+            "cron_change_enabled": False,
+            "webui_mutation_enabled": False,
+        },
+    }
+
+
 def _get_control_plane_morning_brief_payload() -> Dict[str, Any]:
     rows, disabled = _run_supabase_control_plane_read(_control_plane_payload_query())
     if disabled is not None:
@@ -729,6 +786,133 @@ def _get_control_plane_morning_brief_payload() -> Dict[str, Any]:
             "message": _CONTROL_PLANE_DISABLED_REASONS["control_plane_unexpected_shape"],
         }
     return payload
+
+
+_CONTROL_PLANE_SAFETY_PREVIEW_FORBIDDEN_KEYS = frozenset({
+    "target_ref",
+    "provider_message_ref",
+    "error_summary",
+    "provider_error_body",
+    "raw_source_packet",
+    "raw_source_dump",
+    "raw_payload",
+    "private_target_payload",
+})
+
+
+def _control_plane_safety_preview_query() -> str:
+    return """
+select
+  run_ref,
+  title,
+  status,
+  lifecycle_state,
+  report_date::text,
+  source_count,
+  quarantined_source_count,
+  source_safety_state,
+  source_safety_summary_kr,
+  source_safety_refs,
+  latest_channel,
+  latest_delivery_mode,
+  latest_send_result,
+  latest_approval_state,
+  delivery_browser_safe,
+  latest_redaction_class,
+  latest_provider_error_class,
+  notification_action_state,
+  authority_boundary_state,
+  obsidian_ref,
+  paperclip_parent_ref,
+  rollback_available,
+  publish_blocked,
+  publish_block_reason_kr
+from hermes_projection.morning_brief_cockpit_v2
+where run_ref = 'hermes://canary/HERA-198/morning-brief/gate-g-real-source-packet-dry-run'
+order by report_date desc, run_ref desc
+limit 1;
+"""
+
+
+def _strip_control_plane_forbidden_fields(value: Any) -> Any:
+    if isinstance(value, dict):
+        return {
+            str(key): _strip_control_plane_forbidden_fields(item)
+            for key, item in value.items()
+            if str(key) not in _CONTROL_PLANE_SAFETY_PREVIEW_FORBIDDEN_KEYS
+        }
+    if isinstance(value, list):
+        return [_strip_control_plane_forbidden_fields(item) for item in value]
+    return value
+
+
+def _get_control_plane_safety_preview_payload() -> Dict[str, Any]:
+    rows, disabled = _run_supabase_control_plane_read(_control_plane_safety_preview_query())
+    if disabled is not None:
+        return disabled
+    if not rows:
+        return {
+            "enabled": False,
+            "reason": "control_plane_empty_response",
+            "message": "Control-plane safety-preview query returned no rows",
+        }
+    row = rows[0] if isinstance(rows[0], dict) else None
+    if not isinstance(row, dict):
+        return {
+            "enabled": False,
+            "reason": "control_plane_unexpected_shape",
+            "message": _CONTROL_PLANE_DISABLED_REASONS["control_plane_unexpected_shape"],
+        }
+
+    source_refs = _strip_control_plane_forbidden_fields(row.get("source_safety_refs") or [])
+    return {
+        "enabled": True,
+        "status": "ok",
+        "mode": "read_only_safety_preview",
+        "run": {
+            "run_ref": row.get("run_ref"),
+            "title": row.get("title"),
+            "status": row.get("status"),
+            "lifecycle_state": row.get("lifecycle_state"),
+            "report_date": row.get("report_date"),
+            "paperclip_parent_ref": row.get("paperclip_parent_ref"),
+        },
+        "source_safety": {
+            "state": row.get("source_safety_state"),
+            "source_count": row.get("source_count"),
+            "quarantined_source_count": row.get("quarantined_source_count"),
+            "summary_kr": row.get("source_safety_summary_kr"),
+            "refs": source_refs,
+        },
+        "notification_readiness": {
+            "action_state": row.get("notification_action_state"),
+            "latest_channel": row.get("latest_channel"),
+            "latest_delivery_mode": row.get("latest_delivery_mode"),
+            "latest_send_result": row.get("latest_send_result"),
+            "latest_approval_state": row.get("latest_approval_state"),
+            "delivery_browser_safe": row.get("delivery_browser_safe"),
+            "latest_redaction_class": row.get("latest_redaction_class"),
+            "latest_provider_error_class": row.get("latest_provider_error_class"),
+        },
+        "authority_boundary": {
+            "state": row.get("authority_boundary_state"),
+            "obsidian_ref_present": bool(row.get("obsidian_ref")),
+            "supabase_is_authority": False,
+            "requires_obsidian_merge_review_before_authority": True,
+        },
+        "rollback_readiness": {
+            "available": row.get("rollback_available"),
+            "publish_blocked": row.get("publish_blocked"),
+            "publish_block_reason_kr": row.get("publish_block_reason_kr"),
+        },
+        "boundaries": {
+            "writes_enabled": False,
+            "telegram_send_enabled": False,
+            "obsidian_authority_edit_enabled": False,
+            "cron_change_enabled": False,
+            "webui_mutation_enabled": False,
+        },
+    }
 
 
 def _first_dry_run_target_ref(delivery_events: Any) -> str:
@@ -812,6 +996,11 @@ def _build_morning_brief_telegram_preview(canary: Dict[str, Any]) -> Dict[str, A
     }
 
 
+@app.get("/api/control-plane/morning-brief-v0/canary")
+def get_control_plane_morning_brief_v0_canary():
+    return _get_morning_brief_v0_canary_payload()
+
+
 @app.get("/api/control-plane/morning-brief-canary")
 def get_control_plane_morning_brief_canary():
     return _get_control_plane_morning_brief_payload()
@@ -823,6 +1012,11 @@ def get_control_plane_morning_brief_telegram_preview():
     if not canary.get("enabled"):
         return canary
     return _build_morning_brief_telegram_preview(canary)
+
+
+@app.get("/api/control-plane/morning-brief-canary/safety-preview")
+def get_control_plane_morning_brief_safety_preview():
+    return _get_control_plane_safety_preview_payload()
 
 
 @app.get("/api/status")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -915,6 +915,159 @@ def _get_control_plane_safety_preview_payload() -> Dict[str, Any]:
     }
 
 
+_CONTROL_PLANE_COCKPIT_ARTIFACTS = {
+    "gate_d": "gated_latest_run_status.md",
+    "github_watcher_no_agent": "github_watcher_v0_latest_poll_status.md",
+    "supabase_role_boundary": "supabase_obsidian_role_boundary_decision_record.md",
+    "obsidian_merge_review": "obsidian_merge_review_note_creation_result.md",
+}
+
+_CONTROL_PLANE_COCKPIT_SOURCE_REFS = {
+    "gate_d": "artifact://gated_latest_run_status",
+    "github_watcher_no_agent": "artifact://github_watcher_v0_latest_poll_status",
+    "supabase_role_boundary": "artifact://supabase_obsidian_role_boundary_decision_record",
+    "obsidian_merge_review": "artifact://obsidian_merge_review_note_creation_result",
+}
+
+
+def _control_plane_artifacts_dir() -> Path:
+    workdir = _control_plane_workdir()
+    direct = workdir / "artifacts"
+    if direct.exists():
+        return direct
+    nested = workdir / "hermes-control-plane" / "artifacts"
+    if nested.exists():
+        return nested
+    return direct
+
+
+def _safe_read_control_plane_artifact(name: str) -> str:
+    path = _control_plane_artifacts_dir() / name
+    try:
+        if path.stat().st_size > 128_000:
+            return ""
+        return path.read_text(encoding="utf-8")
+    except (OSError, UnicodeDecodeError):
+        return ""
+
+
+def _cockpit_boundaries() -> Dict[str, bool]:
+    return {
+        "read_only": True,
+        "action_controls": False,
+        "mutation_controls": False,
+        "telegram_send_enabled": False,
+        "obsidian_authority_edit_enabled": False,
+        "supabase_schema_change_enabled": False,
+        "cron_change_enabled": False,
+    }
+
+
+def _cockpit_disabled() -> Dict[str, Any]:
+    return {
+        "enabled": False,
+        "reason": "control_plane_not_configured",
+        "safe_next_action": "verify control-plane artifact availability or keep observe",
+    }
+
+
+def _classify_cockpit_artifacts() -> Tuple[Dict[str, Dict[str, Any]], List[str]]:
+    texts = {
+        key: _safe_read_control_plane_artifact(filename)
+        for key, filename in _CONTROL_PLANE_COCKPIT_ARTIFACTS.items()
+    }
+    if not any(texts.values()):
+        return {}, list(_CONTROL_PLANE_COCKPIT_ARTIFACTS)
+
+    status_values = {
+        "gate_d": "pass" if "run_status: pass" in texts["gate_d"].lower() else "unknown",
+        "github_watcher_no_agent": "pass" if "status: pass" in texts["github_watcher_no_agent"].lower() else "unknown",
+        "supabase_role_boundary": "recorded" if texts["supabase_role_boundary"] else "missing",
+        "obsidian_merge_review": "complete" if "status: complete" in texts["obsidian_merge_review"].lower() else ("recorded" if texts["obsidian_merge_review"] else "missing"),
+    }
+    summaries = {
+        "gate_d": "Gate D Morning Brief runner artifact is present and read-only.",
+        "github_watcher_no_agent": "GitHub Watcher no-agent artifact is present and read-only.",
+        "supabase_role_boundary": "Supabase/Obsidian role-boundary decision record is present.",
+        "obsidian_merge_review": "Obsidian Merge Review note creation result is present.",
+    }
+    statuses = {
+        key: {
+            "status": value,
+            "safe_summary": summaries[key],
+            "artifact_refs": [f"artifact://{Path(_CONTROL_PLANE_COCKPIT_ARTIFACTS[key]).stem}"],
+        }
+        for key, value in status_values.items()
+    }
+    missing = [key for key, text in texts.items() if not text]
+    return statuses, missing
+
+
+def _get_control_plane_cockpit_summary() -> Dict[str, Any]:
+    statuses, missing = _classify_cockpit_artifacts()
+    if not statuses:
+        return _cockpit_disabled()
+
+    ready = all(
+        panel.get("status") in {"pass", "recorded", "complete"}
+        for panel in statuses.values()
+    )
+    return {
+        "enabled": True,
+        "counts": {
+            "panels": len(_CONTROL_PLANE_COCKPIT_ARTIFACTS),
+            "missing": len(missing),
+        },
+        "status": statuses,
+        "handoff_summary": "Gate D, GitHub Watcher no-agent, Supabase role boundary, and Obsidian Merge Review are exposed as server-side read-only status only.",
+        "safe_next_action": "frontend_api_client_contract_gate" if ready else "observe",
+        "source_refs": list(_CONTROL_PLANE_COCKPIT_SOURCE_REFS.values()),
+        "artifact_refs": [
+            f"artifact://{Path(name).stem}"
+            for name in _CONTROL_PLANE_COCKPIT_ARTIFACTS.values()
+        ],
+        "updated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+
+
+def _get_control_plane_cockpit_blockers() -> Dict[str, Any]:
+    statuses, missing = _classify_cockpit_artifacts()
+    if not statuses:
+        return _cockpit_disabled()
+
+    blockers = [
+        {
+            "id": f"{key}:artifact_missing",
+            "status": "blocked",
+            "title": key,
+            "detail": "artifact_missing",
+            "safe_next_action": "observe",
+            "artifact_refs": [f"artifact://{Path(_CONTROL_PLANE_COCKPIT_ARTIFACTS[key]).stem}"],
+        }
+        for key in missing
+    ]
+    blockers.extend(
+        {
+            "id": f"{key}:status_{panel.get('status', 'unknown')}",
+            "status": "observe",
+            "title": key,
+            "detail": f"status_{panel.get('status', 'unknown')}",
+            "safe_next_action": "observe",
+            "artifact_refs": panel.get("artifact_refs", []),
+        }
+        for key, panel in statuses.items()
+        if panel.get("status") not in {"pass", "recorded", "complete"}
+        and key not in missing
+    )
+    return {
+        "enabled": True,
+        "blockers": blockers,
+        "boundaries": _cockpit_boundaries(),
+        "safe_next_action": "frontend_api_client_contract_gate" if not blockers else "observe",
+        "updated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    }
+
+
 def _first_dry_run_target_ref(delivery_events: Any) -> str:
     if not isinstance(delivery_events, list):
         return "telegram://dry-run/hera-198"
@@ -1017,6 +1170,16 @@ def get_control_plane_morning_brief_telegram_preview():
 @app.get("/api/control-plane/morning-brief-canary/safety-preview")
 def get_control_plane_morning_brief_safety_preview():
     return _get_control_plane_safety_preview_payload()
+
+
+@app.get("/api/control-plane/cockpit/summary")
+def get_control_plane_cockpit_summary():
+    return _get_control_plane_cockpit_summary()
+
+
+@app.get("/api/control-plane/cockpit/blockers")
+def get_control_plane_cockpit_blockers():
+    return _get_control_plane_cockpit_blockers()
 
 
 @app.get("/api/status")

--- a/tests/hermes_cli/test_gateway_wsl_paths.py
+++ b/tests/hermes_cli/test_gateway_wsl_paths.py
@@ -1,0 +1,19 @@
+from hermes_cli import gateway
+
+
+def test_build_wsl_interop_paths_dedupes_trailing_slash(monkeypatch):
+    monkeypatch.setattr(gateway, "is_wsl", lambda: True)
+    monkeypatch.setattr(gateway.shutil, "which", lambda _name: None)
+    windows_root = "/mnt/" + "c/WINDOWS/System32"
+    powershell_dir = windows_root + "/WindowsPowerShell/v1.0"
+    monkeypatch.setenv(
+        "PATH",
+        f"/usr/bin:{powershell_dir}/:{windows_root}",
+    )
+
+    result = gateway._build_wsl_interop_paths([
+        powershell_dir,
+    ])
+
+    assert powershell_dir + "/" not in result
+    assert windows_root in result

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -432,6 +432,108 @@ class TestWebServerEndpoints:
         assert "postgresql://" not in dumped
         assert "eyj" not in dumped
 
+    def test_control_plane_cockpit_routes_require_session_token_and_are_not_public(self):
+        import hermes_cli.web_server as web_server
+
+        assert "/api/control-plane/cockpit/summary" not in web_server._PUBLIC_API_PATHS
+        assert "/api/control-plane/cockpit/blockers" not in web_server._PUBLIC_API_PATHS
+
+        for path in [
+            "/api/control-plane/cockpit/summary",
+            "/api/control-plane/cockpit/blockers",
+        ]:
+            resp = self.client.get(
+                path,
+                headers={web_server._SESSION_HEADER_NAME: "invalid-token"},
+            )
+            assert resp.status_code == 401
+
+    def test_control_plane_cockpit_returns_safe_disabled_state_when_artifacts_missing(self, monkeypatch, tmp_path):
+        monkeypatch.setenv("HERMES_CONTROL_PLANE_WORKDIR", str(tmp_path))
+
+        for path in [
+            "/api/control-plane/cockpit/summary",
+            "/api/control-plane/cockpit/blockers",
+        ]:
+            resp = self.client.get(path)
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["enabled"] is False
+            assert data["reason"] == "control_plane_not_configured"
+
+    def test_control_plane_cockpit_summary_returns_browser_safe_status(self, monkeypatch, tmp_path):
+        import json
+
+        artifacts = tmp_path / "artifacts"
+        artifacts.mkdir()
+        (artifacts / "gated_latest_run_status.md").write_text(
+            "run_status: pass\nroutine_id: morning_brief_v0_daily_candidate\ngatec3_verification_result: pass\n",
+            encoding="utf-8",
+        )
+        (artifacts / "github_watcher_v0_latest_poll_status.md").write_text(
+            "status: pass\nerrors: 0\nGitHub mutation: not performed\nraw payload archive: not stored\n",
+            encoding="utf-8",
+        )
+        (artifacts / "supabase_obsidian_role_boundary_decision_record.md").write_text(
+            "Supabase is a supporting control-plane DB; Obsidian remains canonical authority\n",
+            encoding="utf-8",
+        )
+        (artifacts / "obsidian_merge_review_note_creation_result.md").write_text(
+            "Status: complete\nObsidian authority edit: not performed\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_CONTROL_PLANE_WORKDIR", str(tmp_path))
+
+        resp = self.client.get("/api/control-plane/cockpit/summary")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is True
+        assert data["status"]["gate_d"]["status"] == "pass"
+        assert data["status"]["github_watcher_no_agent"]["status"] == "pass"
+        assert data["status"]["supabase_role_boundary"]["status"] == "recorded"
+        assert data["status"]["obsidian_merge_review"]["status"] == "complete"
+        assert data["safe_next_action"] in {"observe", "frontend_api_client_contract_gate"}
+        assert set(data["source_refs"]) == {
+            "artifact://gated_latest_run_status",
+            "artifact://github_watcher_v0_latest_poll_status",
+            "artifact://supabase_obsidian_role_boundary_decision_record",
+            "artifact://obsidian_merge_review_note_creation_result",
+        }
+        dumped = json.dumps(data).lower()
+        for forbidden in [
+            "postgresql" + "://",
+            "service" + "_role",
+            "ey" + "j",
+            "target" + "_ref",
+            "provider" + "_message" + "_ref",
+            "raw payload archive: not stored",
+        ]:
+            assert forbidden not in dumped
+
+    def test_control_plane_cockpit_blockers_returns_no_action_controls(self, monkeypatch, tmp_path):
+        artifacts = tmp_path / "artifacts"
+        artifacts.mkdir()
+        (artifacts / "gated_latest_run_status.md").write_text("run_status: pass\n", encoding="utf-8")
+        (artifacts / "github_watcher_v0_latest_poll_status.md").write_text("status: pass\nerrors: 0\n", encoding="utf-8")
+        (artifacts / "supabase_obsidian_role_boundary_decision_record.md").write_text("supporting control-plane DB\n", encoding="utf-8")
+        (artifacts / "obsidian_merge_review_note_creation_result.md").write_text("Status: complete\n", encoding="utf-8")
+        monkeypatch.setenv("HERMES_CONTROL_PLANE_WORKDIR", str(tmp_path))
+
+        resp = self.client.get("/api/control-plane/cockpit/blockers")
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is True
+        assert data["blockers"] == []
+        assert data["boundaries"] == {
+            "read_only": True,
+            "action_controls": False,
+            "mutation_controls": False,
+            "telegram_send_enabled": False,
+            "obsidian_authority_edit_enabled": False,
+            "supabase_schema_change_enabled": False,
+            "cron_change_enabled": False,
+        }
+
     def test_control_plane_telegram_preview_requires_session_token(self):
         import hermes_cli.web_server as web_server
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -253,7 +253,7 @@ class TestWebServerEndpoints:
                     "db",
                     "query",
                     "--linked",
-                    "select * from hermes_notify.delivery_events where target_ref = 'telegram:7048346032'",
+                    "select * from hermes_notify.delivery_events where target_ref = 'telegram:test-recipient'",
                 ],
                 timeout=30,
             )
@@ -271,7 +271,7 @@ class TestWebServerEndpoints:
         message = data["message"].lower()
         assert "supabase" not in message
         assert "hermes_notify" not in message
-        assert "7048346032" not in message
+        assert "test-recipient" not in message
         assert "delivery_events" not in message
 
     def test_control_plane_cli_query_uses_serialization_lock(self, monkeypatch, tmp_path):
@@ -368,6 +368,69 @@ class TestWebServerEndpoints:
         assert "target_ref like 'telegram://dry-run/%'" in sql
         assert "and channel = 'dry_run'" in sql
         assert "null::text as error_summary" in sql
+
+    def test_control_plane_morning_brief_v0_canary_requires_session_token(self):
+        import hermes_cli.web_server as web_server
+
+        resp = self.client.get(
+            "/api/control-plane/morning-brief-v0/canary",
+            headers={web_server._SESSION_HEADER_NAME: "invalid-token"},
+        )
+
+        assert resp.status_code == 401
+
+    def test_control_plane_morning_brief_v0_canary_returns_safe_disabled_state(self, monkeypatch, tmp_path):
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setenv("HERMES_CONTROL_PLANE_WORKDIR", str(tmp_path))
+
+        resp = self.client.get("/api/control-plane/morning-brief-v0/canary")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data == {
+            "enabled": False,
+            "reason": "morning_brief_v0_2_canary_not_configured",
+            "safe_next_action": "verify Gate B/C execution readbacks or keep hold/observe",
+        }
+
+    def test_control_plane_morning_brief_v0_canary_returns_read_only_user_reported_pass(self, monkeypatch, tmp_path):
+        import hermes_cli.web_server as web_server
+
+        artifacts = tmp_path / "hera-198-data-architecture-reset"
+        artifacts.mkdir(parents=True)
+        (artifacts / "gate-b-v0.2-execution-readback.md").write_text(
+            "Status: PASS\n"
+            "projection_exists: 1\n",
+            encoding="utf-8",
+        )
+        monkeypatch.setenv("HERMES_CONTROL_PLANE_WORKDIR", str(tmp_path))
+
+        resp = self.client.get("/api/control-plane/morning-brief-v0/canary")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is True
+        assert data["canary_key"] == "morning-brief-v0.2-preview-canary"
+        assert data["report_kind"] == "morning_brief"
+        assert data["verification_status"] == "verified"
+        assert data["rollback_status"] == "ready_not_needed"
+        assert data["gateb_verification_result"] == "pass"
+        assert data["hermes_direct_db_verification"] is True
+        assert data["verification_source"] == "hermes_supabase_cli_readback"
+        assert data["preview_payload_present"] is True
+        assert data["source_quality_present"] is True
+        assert data["boundaries"] == {
+            "writes_enabled": False,
+            "telegram_send_enabled": False,
+            "obsidian_authority_edit_enabled": False,
+            "cron_change_enabled": False,
+            "webui_mutation_enabled": False,
+        }
+        dumped = json.dumps(data).lower()
+        assert "service_role" not in dumped
+        assert "postgresql://" not in dumped
+        assert "eyj" not in dumped
 
     def test_control_plane_telegram_preview_requires_session_token(self):
         import hermes_cli.web_server as web_server
@@ -478,7 +541,7 @@ class TestWebServerEndpoints:
                 {
                     "channel": "telegram",
                     "delivery_status": "sent",
-                    "target_ref": "telegram:7048346032",
+                    "target_ref": "telegram:test-recipient",
                 }
             ],
             "counts": {},
@@ -486,7 +549,136 @@ class TestWebServerEndpoints:
         })
 
         assert preview["target_ref"] == "telegram://dry-run/hera-198"
-        assert "7048346032" not in preview["message_text"]
+        assert "test-recipient" not in preview["message_text"]
+
+    def test_control_plane_safety_preview_requires_session_token(self):
+        import hermes_cli.web_server as web_server
+
+        resp = self.client.get(
+            "/api/control-plane/morning-brief-canary/safety-preview",
+            headers={web_server._SESSION_HEADER_NAME: "invalid-token"},
+        )
+
+        assert resp.status_code == 401
+
+    def test_control_plane_safety_preview_is_private_api_path(self):
+        import hermes_cli.web_server as web_server
+
+        assert "/api/control-plane/morning-brief-canary/safety-preview" not in web_server._PUBLIC_API_PATHS
+
+    def test_control_plane_safety_preview_returns_browser_safe_v2_payload(self, monkeypatch, tmp_path):
+        import hermes_cli.web_server as web_server
+
+        class Completed:
+            returncode = 0
+            stderr = ""
+            stdout = json.dumps([
+                {
+                    "run_ref": "hermes://canary/HERA-198/morning-brief/gate-g-real-source-packet-dry-run",
+                    "title": "HERA-198 Gate G Morning Brief dry-run canary",
+                    "status": "generated",
+                    "lifecycle_state": "reviewed",
+                    "report_date": "2026-05-08",
+                    "source_count": 3,
+                    "quarantined_source_count": 1,
+                    "source_safety_state": "has_quarantine",
+                    "source_safety_summary_kr": "격리 출처 1건 포함 — 발행/전송 전 Hermes source review 필요",
+                    "source_safety_refs": [
+                        {
+                            "claim_key": "kospi-close-7490",
+                            "section_key": "korea_economy",
+                            "source_title": "browser-safe source title",
+                            "publisher": "KRX required",
+                            "source_tier": "quarantined",
+                            "quality_label": "hold",
+                            "timing_label": "NEW_24H",
+                            "is_quarantined": True,
+                            "quarantine_reason": "Same-run Tier-1 KRX confirmation not attached",
+                            "target_ref": "telegram://private-target/must-not-leak",
+                        }
+                    ],
+                    "latest_channel": "dry_run",
+                    "latest_delivery_mode": "dry_run",
+                    "latest_send_result": "not_attempted",
+                    "latest_approval_state": "pending",
+                    "delivery_browser_safe": True,
+                    "latest_redaction_class": "internal_safe",
+                    "latest_provider_error_class": None,
+                    "notification_action_state": "preview_only",
+                    "authority_boundary_state": "no_obsidian_ref",
+                    "obsidian_ref": None,
+                    "paperclip_parent_ref": "paperclip://HERA-207",
+                    "rollback_available": True,
+                    "publish_blocked": True,
+                    "publish_block_reason_kr": "격리 출처 포함 — Hermes source review 전 발행/전송 불가",
+                }
+            ])
+
+        calls = []
+
+        def fake_run(cmd, cwd, check, capture_output, text, timeout):
+            calls.append({"cmd": cmd, "cwd": cwd, "check": check, "timeout": timeout})
+            return Completed()
+
+        monkeypatch.setenv("HERMES_CONTROL_PLANE_WORKDIR", str(tmp_path))
+        monkeypatch.setattr(web_server.shutil, "which", lambda _: "/usr/bin/supabase")
+        monkeypatch.setattr(web_server.subprocess, "run", fake_run)
+
+        resp = self.client.get("/api/control-plane/morning-brief-canary/safety-preview")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is True
+        assert data["mode"] == "read_only_safety_preview"
+        assert data["run"]["status"] == "generated"
+        assert data["source_safety"]["state"] == "has_quarantine"
+        assert data["source_safety"]["quarantined_source_count"] == 1
+        assert data["notification_readiness"]["action_state"] == "preview_only"
+        assert data["authority_boundary"]["supabase_is_authority"] is False
+        assert data["authority_boundary"]["requires_obsidian_merge_review_before_authority"] is True
+        assert data["rollback_readiness"]["publish_blocked"] is True
+        assert data["boundaries"] == {
+            "writes_enabled": False,
+            "telegram_send_enabled": False,
+            "obsidian_authority_edit_enabled": False,
+            "cron_change_enabled": False,
+            "webui_mutation_enabled": False,
+        }
+        dumped = json.dumps(data).lower()
+        assert "private-target" not in dumped
+        assert "target_ref" not in dumped
+        assert "provider_message_ref" not in dumped
+        assert "error_summary" not in dumped
+        assert "provider_error_body" not in dumped
+        assert calls
+        sql = calls[0]["cmd"][-1].lower()
+        assert "from hermes_projection.morning_brief_cockpit_v2" in sql
+        assert "gate-g-real-source-packet-dry-run" in sql
+        assert "insert into" not in sql
+        assert "update " not in sql
+        assert "delete from" not in sql
+        assert "drop " not in sql
+        assert "alter " not in sql
+        assert "target_ref" not in sql
+        assert "provider_message_ref" not in sql
+        assert "error_summary" not in sql
+        assert "provider_error_body" not in sql
+
+    def test_control_plane_safety_preview_propagates_disabled_state_without_raw_error(self, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(web_server.shutil, "which", lambda _: None)
+
+        resp = self.client.get("/api/control-plane/morning-brief-canary/safety-preview")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is False
+        assert data["reason"] == "supabase_cli_missing"
+        dumped = json.dumps(data).lower()
+        assert "postgresql://" not in dumped
+        assert "service_role" not in dumped
+        assert "eyj" not in dumped
 
     def test_get_config_schema(self):
         resp = self.client.get("/api/config/schema")

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -191,6 +191,303 @@ class TestWebServerEndpoints:
         assert resp.json()["gateway_state"] == "startup_failed"
         assert resp.json()["gateway_platforms"] == {}
 
+
+    def test_control_plane_canary_requires_session_token(self):
+        import hermes_cli.web_server as web_server
+
+        resp = self.client.get(
+            "/api/control-plane/morning-brief-canary",
+            headers={web_server._SESSION_HEADER_NAME: "invalid-token"},
+        )
+
+        assert resp.status_code == 401
+
+    def test_control_plane_canary_disabled_when_supabase_missing(self, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(web_server.shutil, "which", lambda _: None)
+        resp = self.client.get("/api/control-plane/morning-brief-canary")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is False
+        assert data["reason"] == "supabase_cli_missing"
+
+
+    def test_control_plane_error_message_does_not_leak_cli_secrets(self, monkeypatch, tmp_path):
+        import hermes_cli.web_server as web_server
+
+        class Completed:
+            returncode = 1
+            stdout = ""
+            stderr = "failed postgresql://user:secret@db.example.com:5432/postgres service_role eyJabc"
+
+        monkeypatch.setenv("HERMES_CONTROL_PLANE_WORKDIR", str(tmp_path))
+        monkeypatch.setattr(web_server.shutil, "which", lambda _: "/usr/bin/supabase")
+        monkeypatch.setattr(
+            web_server.subprocess,
+            "run",
+            lambda *args, **kwargs: Completed(),
+        )
+
+        resp = self.client.get("/api/control-plane/morning-brief-canary")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is False
+        assert data["reason"] == "control_plane_query_failed"
+        message = data["message"].lower()
+        assert "secret" not in message
+        assert "postgresql://" not in message
+        assert "service_role" not in message
+        assert "eyj" not in message
+
+    def test_control_plane_exception_message_does_not_leak_cli_command(self, monkeypatch, tmp_path):
+        import subprocess
+        import hermes_cli.web_server as web_server
+
+        def fake_run(*args, **kwargs):
+            raise subprocess.TimeoutExpired(
+                cmd=[
+                    "/usr/bin/supabase",
+                    "db",
+                    "query",
+                    "--linked",
+                    "select * from hermes_notify.delivery_events where target_ref = 'telegram:7048346032'",
+                ],
+                timeout=30,
+            )
+
+        monkeypatch.setenv("HERMES_CONTROL_PLANE_WORKDIR", str(tmp_path))
+        monkeypatch.setattr(web_server.shutil, "which", lambda _: "/usr/bin/supabase")
+        monkeypatch.setattr(web_server.subprocess, "run", fake_run)
+
+        resp = self.client.get("/api/control-plane/morning-brief-canary")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is False
+        assert data["reason"] == "control_plane_query_failed"
+        message = data["message"].lower()
+        assert "supabase" not in message
+        assert "hermes_notify" not in message
+        assert "7048346032" not in message
+        assert "delivery_events" not in message
+
+    def test_control_plane_cli_query_uses_serialization_lock(self, monkeypatch, tmp_path):
+        import hermes_cli.web_server as web_server
+
+        class Completed:
+            returncode = 0
+            stderr = ""
+            stdout = json.dumps([{"payload": {"enabled": True, "mode": "read_only"}}])
+
+        class FakeLock:
+            entered = False
+            exited = False
+
+            def __enter__(self):
+                self.entered = True
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                self.exited = True
+                return False
+
+        fake_lock = FakeLock()
+
+        monkeypatch.setenv("HERMES_CONTROL_PLANE_WORKDIR", str(tmp_path))
+        monkeypatch.setattr(web_server.shutil, "which", lambda _: "/usr/bin/supabase")
+        monkeypatch.setattr(web_server, "_CONTROL_PLANE_CLI_LOCK", fake_lock)
+        monkeypatch.setattr(web_server.subprocess, "run", lambda *args, **kwargs: Completed())
+
+        resp = self.client.get("/api/control-plane/morning-brief-canary")
+
+        assert resp.status_code == 200
+        assert resp.json()["enabled"] is True
+        assert fake_lock.entered is True
+        assert fake_lock.exited is True
+
+    def test_control_plane_canary_returns_read_only_payload(self, monkeypatch, tmp_path):
+        import hermes_cli.web_server as web_server
+
+        class Completed:
+            returncode = 0
+            stderr = ""
+            stdout = json.dumps([
+                {
+                    "payload": {
+                        "enabled": True,
+                        "status": "ok",
+                        "mode": "read_only",
+                        "project": "hermes-control-plane",
+                        "run": {
+                            "title": "HERA-198 Morning Brief Canary",
+                            "run_ref": "hermes://canary/HERA-198/morning-brief/phase1",
+                            "status": "generated",
+                        },
+                        "sections": [{"section_key": "summary", "section_order": 1}],
+                        "sources": [{"source_ref": "hermes://design/HERA-198/schema-domain-map"}],
+                        "delivery_events": [{"channel": "dry_run", "delivery_status": "dry_run"}],
+                        "audit_events": [{"event_type": "canary_insert"}],
+                        "counts": {"report_runs": 1},
+                        "boundaries": {
+                            "writes_enabled": False,
+                            "telegram_send_enabled": False,
+                            "obsidian_authority_edit_enabled": False,
+                            "cron_change_enabled": False,
+                        },
+                    }
+                }
+            ])
+
+        calls = []
+
+        def fake_run(cmd, cwd, check, capture_output, text, timeout):
+            calls.append({"cmd": cmd, "cwd": cwd, "check": check, "timeout": timeout})
+            return Completed()
+
+        monkeypatch.setenv("HERMES_CONTROL_PLANE_WORKDIR", str(tmp_path))
+        monkeypatch.setattr(web_server.shutil, "which", lambda _: "/usr/bin/supabase")
+        monkeypatch.setattr(web_server.subprocess, "run", fake_run)
+
+        resp = self.client.get("/api/control-plane/morning-brief-canary")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is True
+        assert data["mode"] == "read_only"
+        assert data["run"]["title"] == "HERA-198 Morning Brief Canary"
+        assert data["boundaries"]["writes_enabled"] is False
+        assert calls
+        assert calls[0]["cmd"][:5] == ["/usr/bin/supabase", "db", "query", "--linked", "-o"]
+        sql = calls[0]["cmd"][-1].lower()
+        assert "insert into" not in sql
+        assert "update " not in sql
+        assert "delete from" not in sql
+        assert "target_ref like 'telegram://dry-run/%'" in sql
+        assert "and channel = 'dry_run'" in sql
+        assert "null::text as error_summary" in sql
+
+    def test_control_plane_telegram_preview_requires_session_token(self):
+        import hermes_cli.web_server as web_server
+
+        resp = self.client.get(
+            "/api/control-plane/morning-brief-canary/telegram-preview",
+            headers={web_server._SESSION_HEADER_NAME: "invalid-token"},
+        )
+
+        assert resp.status_code == 401
+
+    def test_control_plane_telegram_preview_is_dry_run_and_read_only(self, monkeypatch, tmp_path):
+        import hermes_cli.web_server as web_server
+
+        class Completed:
+            returncode = 0
+            stderr = ""
+            stdout = json.dumps([
+                {
+                    "payload": {
+                        "enabled": True,
+                        "status": "ok",
+                        "mode": "read_only",
+                        "project": "hermes-control-plane",
+                        "run": {
+                            "title": "HERA-198 Morning Brief Canary",
+                            "run_ref": "hermes://canary/HERA-198/morning-brief/phase1",
+                            "status": "generated",
+                            "summary_kr": "Supabase control-plane readback 통과.",
+                        },
+                        "sections": [{"section_key": "summary", "section_order": 1}],
+                        "sources": [{"source_ref": "hermes://design/HERA-198/schema-domain-map"}],
+                        "delivery_events": [
+                            {
+                                "channel": "dry_run",
+                                "delivery_status": "dry_run",
+                                "target_ref": "telegram://dry-run/hera-198",
+                            }
+                        ],
+                        "audit_events": [{"event_type": "canary_insert"}],
+                        "counts": {
+                            "report_runs": 1,
+                            "report_sections": 1,
+                            "source_anchors": 1,
+                            "delivery_events": 1,
+                            "audit_events": 1,
+                        },
+                        "boundaries": {
+                            "writes_enabled": False,
+                            "telegram_send_enabled": False,
+                            "obsidian_authority_edit_enabled": False,
+                            "cron_change_enabled": False,
+                        },
+                    }
+                }
+            ])
+
+        calls = []
+
+        def fake_run(cmd, cwd, check, capture_output, text, timeout):
+            calls.append({"cmd": cmd, "cwd": cwd, "check": check, "timeout": timeout})
+            return Completed()
+
+        monkeypatch.setenv("HERMES_CONTROL_PLANE_WORKDIR", str(tmp_path))
+        monkeypatch.setattr(web_server.shutil, "which", lambda _: "/usr/bin/supabase")
+        monkeypatch.setattr(web_server.subprocess, "run", fake_run)
+
+        resp = self.client.get("/api/control-plane/morning-brief-canary/telegram-preview")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is True
+        assert data["mode"] == "dry_run_preview"
+        assert data["send_enabled"] is False
+        assert data["write_enabled"] is False
+        assert data["target_ref"] == "telegram://dry-run/hera-198"
+        assert data["validation"]["length_ok"] is True
+        assert data["validation"]["requires_approval_before_send"] is True
+        assert "처리 이유:" in data["message_text"]
+        assert "HERA-198 Morning Brief Canary" in data["message_text"]
+        assert "dry_run" in data["message_text"]
+        assert calls
+        sql = calls[0]["cmd"][-1].lower()
+        assert "insert into" not in sql
+        assert "update " not in sql
+        assert "delete from" not in sql
+
+    def test_control_plane_telegram_preview_propagates_disabled_state(self, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setattr(web_server.shutil, "which", lambda _: None)
+
+        resp = self.client.get("/api/control-plane/morning-brief-canary/telegram-preview")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["enabled"] is False
+        assert data["reason"] == "supabase_cli_missing"
+
+    def test_control_plane_telegram_preview_rejects_non_dry_run_target_refs(self):
+        import hermes_cli.web_server as web_server
+
+        preview = web_server._build_morning_brief_telegram_preview({
+            "enabled": True,
+            "project": "hermes-control-plane",
+            "run": {"title": "Canary", "status": "generated"},
+            "delivery_events": [
+                {
+                    "channel": "telegram",
+                    "delivery_status": "sent",
+                    "target_ref": "telegram:7048346032",
+                }
+            ],
+            "counts": {},
+            "boundaries": {},
+        })
+
+        assert preview["target_ref"] == "telegram://dry-run/hera-198"
+        assert "7048346032" not in preview["message_text"]
+
     def test_get_config_schema(self):
         resp = self.client.get("/api/config/schema")
         assert resp.status_code == 200

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -63,6 +63,7 @@ import LogsPage from "@/pages/LogsPage";
 import AnalyticsPage from "@/pages/AnalyticsPage";
 import ModelsPage from "@/pages/ModelsPage";
 import CronPage from "@/pages/CronPage";
+import ControlPlanePage from "@/pages/ControlPlanePage";
 import ProfilesPage from "@/pages/ProfilesPage";
 import SkillsPage from "@/pages/SkillsPage";
 import PluginsPage from "@/pages/PluginsPage";
@@ -110,6 +111,7 @@ const BUILTIN_ROUTES_CORE: Record<string, ComponentType> = {
   "/analytics": AnalyticsPage,
   "/models": ModelsPage,
   "/logs": LogsPage,
+  "/control-plane": ControlPlanePage,
   "/cron": CronPage,
   "/skills": SkillsPage,
   "/plugins": PluginsPage,
@@ -147,6 +149,7 @@ const BUILTIN_NAV_REST: NavItem[] = [
     icon: Cpu,
   },
   { path: "/logs", labelKey: "logs", label: "Logs", icon: FileText },
+  { path: "/control-plane", label: "Control Plane", icon: Database },
   { path: "/cron", labelKey: "cron", label: "Cron", icon: Clock },
   { path: "/skills", labelKey: "skills", label: "Skills", icon: Package },
   { path: "/plugins", labelKey: "plugins", label: "Plugins", icon: Puzzle },

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -75,6 +75,10 @@ export const api = {
     fetchJSON<MorningBriefSafetyPreviewResponse>(
       "/api/control-plane/morning-brief-canary/safety-preview",
     ),
+  getControlPlaneCockpitSummary: () =>
+    fetchJSON<ControlPlaneCockpitSummaryResponse>("/api/control-plane/cockpit/summary"),
+  getControlPlaneCockpitBlockers: () =>
+    fetchJSON<ControlPlaneCockpitBlockersResponse>("/api/control-plane/cockpit/blockers"),
   getSessions: (limit = 20, offset = 0) =>
     fetchJSON<PaginatedSessions>(`/api/sessions?limit=${limit}&offset=${offset}`),
   getSessionMessages: (id: string) =>
@@ -801,6 +805,67 @@ export interface MorningBriefSafetyPreviewResponse {
   boundaries?: MorningBriefCanaryResponse["boundaries"] & {
     webui_mutation_enabled?: boolean;
   };
+}
+
+export interface ControlPlaneCockpitDisabledState {
+  enabled: false;
+  reason: "control_plane_not_configured" | string;
+  message?: string;
+}
+
+export interface ControlPlaneCockpitStatusPanel {
+  status?: string;
+  state?: string;
+  enabled?: boolean;
+  last_status?: string | null;
+  last_run_at?: string | null;
+  next_run_at?: string | null;
+  safe_summary?: string | null;
+  artifact_refs?: string[];
+}
+
+export interface ControlPlaneCockpitSummaryResponse {
+  enabled?: boolean;
+  reason?: string;
+  counts?: Record<string, number>;
+  status?: Record<
+    "gate_d" | "github_watcher_no_agent" | "supabase_role_boundary" | "obsidian_merge_review" | string,
+    ControlPlaneCockpitStatusPanel
+  >;
+  handoff_summary?: string;
+  safe_next_action?: string;
+  source_refs?: string[];
+  artifact_refs?: string[];
+  updated_at?: string;
+}
+
+export interface ControlPlaneCockpitBoundaryFlags {
+  read_only?: boolean;
+  server_side_only?: boolean;
+  session_token_protected?: boolean;
+  public_api_path?: false;
+  browser_side_supabase_secret?: false;
+  direct_browser_to_supabase?: false;
+  action_controls?: false;
+  mutation_controls?: false;
+}
+
+export interface ControlPlaneCockpitBlocker {
+  id: string;
+  status: "blocked" | "hold" | "observe" | "pass" | string;
+  title?: string;
+  detail?: string;
+  safe_next_action?: string;
+  artifact_refs?: string[];
+}
+
+export interface ControlPlaneCockpitBlockersResponse {
+  enabled?: boolean;
+  reason?: string;
+  blockers?: ControlPlaneCockpitBlocker[];
+  boundaries?: ControlPlaneCockpitBoundaryFlags;
+  safe_next_action?: string;
+  updated_at?: string;
 }
 
 // ── Model info types ──────────────────────────────────────────────────

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -63,6 +63,12 @@ async function getSessionToken(): Promise<string> {
 
 export const api = {
   getStatus: () => fetchJSON<StatusResponse>("/api/status"),
+  getMorningBriefCanary: () =>
+    fetchJSON<MorningBriefCanaryResponse>("/api/control-plane/morning-brief-canary"),
+  getMorningBriefTelegramPreview: () =>
+    fetchJSON<MorningBriefTelegramPreviewResponse>(
+      "/api/control-plane/morning-brief-canary/telegram-preview",
+    ),
   getSessions: (limit = 20, offset = 0) =>
     fetchJSON<PaginatedSessions>(`/api/sessions?limit=${limit}&offset=${offset}`),
   getSessionMessages: (id: string) =>
@@ -592,6 +598,115 @@ export interface SessionSearchResult {
 
 export interface SessionSearchResponse {
   results: SessionSearchResult[];
+}
+
+
+export interface MorningBriefRun {
+  id?: string;
+  report_type?: string;
+  run_ref?: string;
+  status?: string;
+  report_date?: string;
+  title?: string;
+  summary_kr?: string | null;
+  obsidian_ref?: string | null;
+  paperclip_parent_ref?: string | null;
+  created_at?: string;
+  updated_at?: string;
+}
+
+export interface MorningBriefSection {
+  section_key?: string;
+  section_order?: number;
+  title?: string;
+  body_md?: string;
+  judgment_label?: string | null;
+  created_at?: string;
+}
+
+export interface MorningBriefSourceAnchor {
+  source_ref?: string;
+  source_title?: string | null;
+  publisher?: string | null;
+  published_at?: string | null;
+  observed_at?: string | null;
+  timing_label?: string | null;
+  quality_label?: string | null;
+  claim_ref?: string | null;
+  created_at?: string;
+}
+
+export interface MorningBriefDeliveryEvent {
+  channel?: string;
+  target_ref?: string | null;
+  payload_summary?: string;
+  delivery_status?: string;
+  delivered_at?: string | null;
+  error_summary?: string | null;
+  created_at?: string;
+}
+
+export interface MorningBriefAuditEvent {
+  event_type?: string;
+  subject_ref?: string | null;
+  actor_ref?: string;
+  source_refs?: unknown[];
+  artifact_refs?: unknown[];
+  summary?: string;
+  verification_status?: string | null;
+  created_at?: string;
+}
+
+export interface MorningBriefCanaryResponse {
+  enabled: boolean;
+  reason?: string;
+  message?: string;
+  status?: string;
+  mode?: "read_only" | string;
+  project?: string;
+  updated_at?: string;
+  run?: MorningBriefRun | null;
+  sections?: MorningBriefSection[];
+  sources?: MorningBriefSourceAnchor[];
+  delivery_events?: MorningBriefDeliveryEvent[];
+  audit_events?: MorningBriefAuditEvent[];
+  counts?: Record<string, number>;
+  boundaries?: {
+    writes_enabled?: boolean;
+    telegram_send_enabled?: boolean;
+    obsidian_authority_edit_enabled?: boolean;
+    cron_change_enabled?: boolean;
+  };
+}
+
+export interface MorningBriefTelegramPreviewResponse {
+  enabled: boolean;
+  reason?: string;
+  message?: string;
+  status?: string;
+  mode?: "dry_run_preview" | string;
+  project?: string;
+  target_ref?: string;
+  channel?: "telegram" | string;
+  send_enabled?: boolean;
+  write_enabled?: boolean;
+  message_text?: string;
+  message_length?: number;
+  validation?: {
+    length_ok?: boolean;
+    max_length?: number;
+    requires_approval_before_send?: boolean;
+    no_telegram_send_performed?: boolean;
+    no_supabase_write_performed?: boolean;
+    no_cron_change_performed?: boolean;
+    no_obsidian_authority_edit_performed?: boolean;
+  };
+  source?: {
+    run_ref?: string | null;
+    report_status?: string;
+    control_plane_mode?: string;
+  };
+  boundaries?: MorningBriefCanaryResponse["boundaries"];
 }
 
 // ── Model info types ──────────────────────────────────────────────────

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -65,9 +65,15 @@ export const api = {
   getStatus: () => fetchJSON<StatusResponse>("/api/status"),
   getMorningBriefCanary: () =>
     fetchJSON<MorningBriefCanaryResponse>("/api/control-plane/morning-brief-canary"),
+  getMorningBriefV0Canary: () =>
+    fetchJSON<MorningBriefV0CanaryResponse>("/api/control-plane/morning-brief-v0/canary"),
   getMorningBriefTelegramPreview: () =>
     fetchJSON<MorningBriefTelegramPreviewResponse>(
       "/api/control-plane/morning-brief-canary/telegram-preview",
+    ),
+  getMorningBriefSafetyPreview: () =>
+    fetchJSON<MorningBriefSafetyPreviewResponse>(
+      "/api/control-plane/morning-brief-canary/safety-preview",
     ),
   getSessions: (limit = 20, offset = 0) =>
     fetchJSON<PaginatedSessions>(`/api/sessions?limit=${limit}&offset=${offset}`),
@@ -679,6 +685,25 @@ export interface MorningBriefCanaryResponse {
   };
 }
 
+export interface MorningBriefV0CanaryResponse {
+  enabled: boolean;
+  reason?: string;
+  safe_next_action?: string;
+  canary_key?: "morning-brief-v0.2-preview-canary" | string;
+  report_kind?: "morning_brief" | string;
+  verification_status?: "verified" | string;
+  rollback_status?: "ready_not_needed" | string;
+  gateb_verification_result?: "pass" | string;
+  hermes_direct_db_verification?: boolean;
+  verification_source?: "hermes_supabase_cli_readback" | string;
+  report_snapshot_ref?: string;
+  preview_payload_present?: boolean;
+  source_quality_present?: boolean;
+  boundaries?: MorningBriefCanaryResponse["boundaries"] & {
+    webui_mutation_enabled?: boolean;
+  };
+}
+
 export interface MorningBriefTelegramPreviewResponse {
   enabled: boolean;
   reason?: string;
@@ -707,6 +732,75 @@ export interface MorningBriefTelegramPreviewResponse {
     control_plane_mode?: string;
   };
   boundaries?: MorningBriefCanaryResponse["boundaries"];
+}
+
+export interface MorningBriefSafetyRun {
+  run_ref?: string;
+  title?: string;
+  status?: string;
+  lifecycle_state?: string;
+  report_date?: string;
+  paperclip_parent_ref?: string | null;
+}
+
+export interface MorningBriefSourceSafetyRef {
+  claim_key?: string;
+  section_key?: string;
+  source_title?: string | null;
+  publisher?: string | null;
+  source_tier?: string | null;
+  quality_label?: string | null;
+  timing_label?: string | null;
+  is_quarantined?: boolean;
+  quarantine_reason?: string | null;
+}
+
+export interface MorningBriefSourceSafetySummary {
+  state?: "clean" | "has_quarantine" | string;
+  source_count?: number;
+  quarantined_source_count?: number;
+  summary_kr?: string | null;
+  refs?: MorningBriefSourceSafetyRef[];
+}
+
+export interface MorningBriefNotificationReadiness {
+  action_state?: "preview_only" | "blocked" | string;
+  latest_channel?: string | null;
+  latest_delivery_mode?: string | null;
+  latest_send_result?: string | null;
+  latest_approval_state?: string | null;
+  delivery_browser_safe?: boolean | null;
+  latest_redaction_class?: string | null;
+  latest_provider_error_class?: string | null;
+}
+
+export interface MorningBriefAuthorityBoundary {
+  state?: "no_obsidian_ref" | string;
+  obsidian_ref_present?: boolean;
+  supabase_is_authority?: false;
+  requires_obsidian_merge_review_before_authority?: boolean;
+}
+
+export interface MorningBriefRollbackReadiness {
+  available?: boolean;
+  publish_blocked?: boolean;
+  publish_block_reason_kr?: string | null;
+}
+
+export interface MorningBriefSafetyPreviewResponse {
+  enabled: boolean;
+  reason?: string;
+  message?: string;
+  status?: string;
+  mode?: "read_only_safety_preview" | string;
+  run?: MorningBriefSafetyRun;
+  source_safety?: MorningBriefSourceSafetySummary;
+  notification_readiness?: MorningBriefNotificationReadiness;
+  authority_boundary?: MorningBriefAuthorityBoundary;
+  rollback_readiness?: MorningBriefRollbackReadiness;
+  boundaries?: MorningBriefCanaryResponse["boundaries"] & {
+    webui_mutation_enabled?: boolean;
+  };
 }
 
 // ── Model info types ──────────────────────────────────────────────────

--- a/web/src/pages/ControlPlanePage.tsx
+++ b/web/src/pages/ControlPlanePage.tsx
@@ -7,7 +7,9 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import {
   api,
   type MorningBriefCanaryResponse,
+  type MorningBriefV0CanaryResponse,
   type MorningBriefTelegramPreviewResponse,
+  type MorningBriefSafetyPreviewResponse,
 } from "@/lib/api";
 import { usePageHeader } from "@/contexts/usePageHeader";
 
@@ -39,8 +41,11 @@ function BoundaryBadge({ label, value }: { label: string; value?: boolean }) {
 
 export default function ControlPlanePage() {
   const [data, setData] = useState<MorningBriefCanaryResponse | null>(null);
+  const [v0Canary, setV0Canary] = useState<MorningBriefV0CanaryResponse | null>(null);
   const [telegramPreview, setTelegramPreview] =
     useState<MorningBriefTelegramPreviewResponse | null>(null);
+  const [safetyPreview, setSafetyPreview] =
+    useState<MorningBriefSafetyPreviewResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const { setAfterTitle, setEnd } = usePageHeader();
@@ -49,6 +54,8 @@ export default function ControlPlanePage() {
     setLoading(true);
     setError(null);
     setTelegramPreview(null);
+    setSafetyPreview(null);
+    setV0Canary(null);
 
     try {
       const canary = await api.getMorningBriefCanary();
@@ -61,6 +68,17 @@ export default function ControlPlanePage() {
     }
 
     try {
+      const v0 = await api.getMorningBriefV0Canary();
+      setV0Canary(v0);
+    } catch {
+      setV0Canary({
+        enabled: false,
+        reason: "morning_brief_v0_canary_unavailable",
+        safe_next_action: "verify Gate B artifact status or keep hold/observe",
+      });
+    }
+
+    try {
       const preview = await api.getMorningBriefTelegramPreview();
       setTelegramPreview(preview);
     } catch {
@@ -68,6 +86,17 @@ export default function ControlPlanePage() {
         enabled: false,
         reason: "telegram_preview_unavailable",
         message: "Telegram preview unavailable; control-plane readback can still be shown.",
+      });
+    }
+
+    try {
+      const safety = await api.getMorningBriefSafetyPreview();
+      setSafetyPreview(safety);
+    } catch {
+      setSafetyPreview({
+        enabled: false,
+        reason: "safety_preview_unavailable",
+        message: "Safety preview unavailable; keep publish/send blocked until verified.",
       });
     } finally {
       setLoading(false);
@@ -139,6 +168,46 @@ export default function ControlPlanePage() {
         </CardContent>
       </Card>
 
+      <Card>
+        <CardHeader className="py-3 px-4">
+          <CardTitle className="flex items-center gap-2 text-sm uppercase">
+            <ShieldCheck className="h-4 w-4" />
+            Morning Brief v0.2 Gate B/C Verification
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 p-4 text-sm">
+          <div className="flex flex-wrap gap-2 uppercase">
+            <Badge tone={v0Canary?.enabled ? "success" : "secondary"} className="text-[10px]">
+              {v0Canary?.enabled ? "local readback pass" : "safe disabled"}
+            </Badge>
+            <Badge tone="secondary" className="text-[10px]">
+              Hermes DB readback: {v0Canary?.hermes_direct_db_verification ? "yes" : "no"}
+            </Badge>
+            <Badge tone={v0Canary?.boundaries?.webui_mutation_enabled ? "destructive" : "success"} className="text-[10px]">
+              webui mutation: {v0Canary?.boundaries?.webui_mutation_enabled ? "enabled" : "off"}
+            </Badge>
+          </div>
+          {v0Canary?.enabled ? (
+            <dl className="grid gap-2 md:grid-cols-2">
+              <div><dt className="text-xs uppercase text-muted-foreground">Canary key</dt><dd className="break-all font-mono-ui text-xs">{v0Canary.canary_key}</dd></div>
+              <div><dt className="text-xs uppercase text-muted-foreground">Result</dt><dd>{v0Canary.gateb_verification_result}</dd></div>
+              <div><dt className="text-xs uppercase text-muted-foreground">Verification</dt><dd>{v0Canary.verification_status}</dd></div>
+              <div><dt className="text-xs uppercase text-muted-foreground">Rollback</dt><dd>{v0Canary.rollback_status}</dd></div>
+              <div className="md:col-span-2"><dt className="text-xs uppercase text-muted-foreground">Evidence source</dt><dd>{v0Canary.verification_source}</dd></div>
+              <div className="md:col-span-2"><dt className="text-xs uppercase text-muted-foreground">Snapshot ref</dt><dd className="break-all font-mono-ui text-xs">{v0Canary.report_snapshot_ref}</dd></div>
+            </dl>
+          ) : (
+            <div className="rounded-md border border-warning/30 bg-warning/10 p-3">
+              <p className="text-sm font-semibold uppercase text-warning">Safe disabled</p>
+              <p className="text-sm text-muted-foreground">{v0Canary?.reason ?? "morning_brief_v0_canary_not_configured"}</p>
+            </div>
+          )}
+          <p className="text-xs text-muted-foreground normal-case">
+            Read-only only: no browser-side Supabase secret, no DB mutation, no Telegram send, no cron/routine integration.
+          </p>
+        </CardContent>
+      </Card>
+
       <div className="grid gap-4 xl:grid-cols-2">
         <Card>
           <CardHeader className="py-3 px-4">
@@ -187,6 +256,65 @@ export default function ControlPlanePage() {
           </CardContent>
         </Card>
       </div>
+
+      <Card>
+        <CardHeader className="py-3 px-4">
+          <CardTitle className="flex items-center gap-2 text-sm uppercase">
+            <ShieldCheck className="h-4 w-4" />
+            Source Safety Preview
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 p-4 text-sm">
+          {safetyPreview && !safetyPreview.enabled && (
+            <div className="rounded-md border border-warning/30 bg-warning/10 p-3">
+              <p className="text-sm font-semibold uppercase text-warning">Safety preview disabled</p>
+              <p className="text-sm text-muted-foreground">
+                {safetyPreview.reason}: {safetyPreview.message}
+              </p>
+            </div>
+          )}
+          <div className="flex flex-wrap gap-2 uppercase">
+            <Badge tone={safetyPreview?.source_safety?.state === "has_quarantine" ? "warning" : "success"} className="text-[10px]">
+              source safety: {safetyPreview?.source_safety?.state ?? "loading"}
+            </Badge>
+            <Badge tone={safetyPreview?.rollback_readiness?.publish_blocked ? "warning" : "success"} className="text-[10px]">
+              publish_blocked: {safetyPreview?.rollback_readiness?.publish_blocked ? "yes" : "no"}
+            </Badge>
+            <Badge tone={safetyPreview?.boundaries?.webui_mutation_enabled ? "destructive" : "success"} className="text-[10px]">
+              webui mutation: {safetyPreview?.boundaries?.webui_mutation_enabled ? "enabled" : "off"}
+            </Badge>
+          </div>
+          <dl className="grid gap-2 md:grid-cols-2">
+            <div>
+              <dt className="text-xs uppercase text-muted-foreground">quarantined_source_count</dt>
+              <dd className="text-lg font-semibold text-foreground">
+                {safetyPreview?.source_safety?.quarantined_source_count ?? 0}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase text-muted-foreground">notification action</dt>
+              <dd>{safetyPreview?.notification_readiness?.action_state ?? "preview_only"}</dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase text-muted-foreground">authority state</dt>
+              <dd>{safetyPreview?.authority_boundary?.state ?? "no_obsidian_ref"}</dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase text-muted-foreground">rollback available</dt>
+              <dd>{safetyPreview?.rollback_readiness?.available ? "yes" : "no"}</dd>
+            </div>
+            <div className="md:col-span-2">
+              <dt className="text-xs uppercase text-muted-foreground">publish block reason</dt>
+              <dd className="normal-case text-muted-foreground">
+                {safetyPreview?.rollback_readiness?.publish_block_reason_kr ?? "No safety preview loaded yet."}
+              </dd>
+            </div>
+          </dl>
+          <p className="text-xs text-muted-foreground normal-case">
+            Read-only safety preview: no send controls, no browser-side Supabase access, no cron change, no Obsidian authority edit.
+          </p>
+        </CardContent>
+      </Card>
 
       <Card>
         <CardHeader className="py-3 px-4">

--- a/web/src/pages/ControlPlanePage.tsx
+++ b/web/src/pages/ControlPlanePage.tsx
@@ -1,0 +1,259 @@
+import { useCallback, useEffect, useLayoutEffect, useState } from "react";
+import { Database, MessageSquareText, RefreshCw, ShieldCheck } from "lucide-react";
+import { Badge } from "@nous-research/ui/ui/components/badge";
+import { Button } from "@nous-research/ui/ui/components/button";
+import { Spinner } from "@nous-research/ui/ui/components/spinner";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import {
+  api,
+  type MorningBriefCanaryResponse,
+  type MorningBriefTelegramPreviewResponse,
+} from "@/lib/api";
+import { usePageHeader } from "@/contexts/usePageHeader";
+
+function JsonList({ value }: { value: unknown[] | undefined }) {
+  if (!value || value.length === 0) {
+    return <p className="text-sm text-muted-foreground">No rows.</p>;
+  }
+  return (
+    <div className="space-y-2">
+      {value.map((item, index) => (
+        <pre
+          key={index}
+          className="overflow-auto rounded-md border border-current/15 bg-black/20 p-3 font-mono-ui text-[11px] leading-4 text-muted-foreground normal-case"
+        >
+          {JSON.stringify(item, null, 2)}
+        </pre>
+      ))}
+    </div>
+  );
+}
+
+function BoundaryBadge({ label, value }: { label: string; value?: boolean }) {
+  return (
+    <Badge tone={value ? "destructive" : "success"} className="text-[10px]">
+      {label}: {value ? "enabled" : "off"}
+    </Badge>
+  );
+}
+
+export default function ControlPlanePage() {
+  const [data, setData] = useState<MorningBriefCanaryResponse | null>(null);
+  const [telegramPreview, setTelegramPreview] =
+    useState<MorningBriefTelegramPreviewResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const { setAfterTitle, setEnd } = usePageHeader();
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    setTelegramPreview(null);
+
+    try {
+      const canary = await api.getMorningBriefCanary();
+      setData(canary);
+    } catch {
+      setData(null);
+      setError("Control-plane read failed; check server logs or Supabase CLI link state.");
+      setLoading(false);
+      return;
+    }
+
+    try {
+      const preview = await api.getMorningBriefTelegramPreview();
+      setTelegramPreview(preview);
+    } catch {
+      setTelegramPreview({
+        enabled: false,
+        reason: "telegram_preview_unavailable",
+        message: "Telegram preview unavailable; control-plane readback can still be shown.",
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  useLayoutEffect(() => {
+    setAfterTitle(
+      <span className="flex items-center gap-2">
+        {loading && <Spinner className="shrink-0 text-base text-primary" />}
+        <Badge tone={loading && !data ? "secondary" : data?.enabled ? "success" : "secondary"} className="text-[10px]">
+          {loading && !data ? "loading canary" : data?.enabled ? "read-only canary" : "not configured"}
+        </Badge>
+      </span>,
+    );
+    setEnd(
+      <Button
+        type="button"
+        size="sm"
+        outlined
+        onClick={refresh}
+        disabled={loading}
+        prefix={loading ? <Spinner /> : <RefreshCw />}
+      >
+        Refresh
+      </Button>,
+    );
+    return () => {
+      setAfterTitle(null);
+      setEnd(null);
+    };
+  }, [data?.enabled, loading, refresh, setAfterTitle, setEnd]);
+
+  const run = data?.run;
+  const boundaries = data?.boundaries ?? {};
+
+  return (
+    <div className="flex flex-col gap-4 normal-case">
+      <Card>
+        <CardHeader className="py-3 px-4">
+          <CardTitle className="flex items-center gap-2 text-sm uppercase">
+            <Database className="h-4 w-4" />
+            HERA-198 Control Plane Canary
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 p-4">
+          {error && <p className="text-sm text-destructive">{error}</p>}
+          {data && !data.enabled && (
+            <div className="rounded-md border border-warning/30 bg-warning/10 p-3">
+              <p className="text-sm font-semibold uppercase text-warning">Disabled</p>
+              <p className="text-sm text-muted-foreground">{data.reason}: {data.message}</p>
+            </div>
+          )}
+          <div className="flex flex-wrap gap-2 uppercase">
+            <Badge tone="secondary" className="text-[10px]">project: {loading && !data ? "loading" : data?.project ?? "unknown"}</Badge>
+            <Badge tone="secondary" className="text-[10px]">mode: {data?.mode ?? "read-only"}</Badge>
+            <Badge tone="secondary" className="text-[10px]">updated: {data?.updated_at ?? "-"}</Badge>
+          </div>
+          <div className="flex flex-wrap gap-2 uppercase">
+            <BoundaryBadge label="writes" value={boundaries.writes_enabled} />
+            <BoundaryBadge label="telegram" value={boundaries.telegram_send_enabled} />
+            <BoundaryBadge label="obsidian authority" value={boundaries.obsidian_authority_edit_enabled} />
+            <BoundaryBadge label="cron" value={boundaries.cron_change_enabled} />
+          </div>
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        <Card>
+          <CardHeader className="py-3 px-4">
+            <CardTitle className="text-sm uppercase">Latest Morning Brief Run</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-2 p-4 text-sm">
+            {run ? (
+              <>
+                <p className="font-semibold text-foreground">{run.title}</p>
+                <p className="text-muted-foreground">{run.summary_kr}</p>
+                <dl className="grid gap-2 md:grid-cols-2">
+                  <div><dt className="text-xs uppercase text-muted-foreground">Status</dt><dd>{run.status}</dd></div>
+                  <div><dt className="text-xs uppercase text-muted-foreground">Date</dt><dd>{run.report_date}</dd></div>
+                  <div className="md:col-span-2"><dt className="text-xs uppercase text-muted-foreground">Run ref</dt><dd className="break-all font-mono-ui text-xs">{run.run_ref}</dd></div>
+                  <div className="md:col-span-2"><dt className="text-xs uppercase text-muted-foreground">Obsidian ref</dt><dd className="break-all font-mono-ui text-xs">{run.obsidian_ref}</dd></div>
+                  <div className="md:col-span-2"><dt className="text-xs uppercase text-muted-foreground">Paperclip ref</dt><dd className="break-all font-mono-ui text-xs">{run.paperclip_parent_ref}</dd></div>
+                </dl>
+              </>
+            ) : loading ? (
+              <p className="text-muted-foreground">Loading Morning Brief run…</p>
+            ) : (
+              <p className="text-muted-foreground">No Morning Brief run found.</p>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader className="py-3 px-4">
+            <CardTitle className="flex items-center gap-2 text-sm uppercase">
+              <ShieldCheck className="h-4 w-4" />
+              Counts / Verification
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="p-4">
+            <div className="grid gap-2 md:grid-cols-2">
+              {Object.entries(data?.counts ?? {}).map(([key, value]) => (
+                <div key={key} className="rounded-md border border-current/15 p-3">
+                  <p className="text-xs uppercase text-muted-foreground">{key}</p>
+                  <p className="text-lg font-semibold text-foreground">{value}</p>
+                </div>
+              ))}
+              {loading && !data && (
+                <p className="text-sm text-muted-foreground">Loading verification counts…</p>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      <Card>
+        <CardHeader className="py-3 px-4">
+          <CardTitle className="flex items-center gap-2 text-sm uppercase">
+            <MessageSquareText className="h-4 w-4" />
+            Telegram Dry-run Payload Preview
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 p-4">
+          {telegramPreview && !telegramPreview.enabled && (
+            <div className="rounded-md border border-warning/30 bg-warning/10 p-3">
+              <p className="text-sm font-semibold uppercase text-warning">Preview disabled</p>
+              <p className="text-sm text-muted-foreground">
+                {telegramPreview.reason}: {telegramPreview.message}
+              </p>
+            </div>
+          )}
+          <div className="flex flex-wrap gap-2 uppercase">
+            <Badge tone="secondary" className="text-[10px]">
+              channel: {telegramPreview?.channel ?? "telegram"}
+            </Badge>
+            <Badge tone="secondary" className="text-[10px]">
+              mode: {telegramPreview?.mode ?? "dry-run preview"}
+            </Badge>
+            <Badge tone={telegramPreview?.send_enabled ? "destructive" : "success"} className="text-[10px]">
+              send: {telegramPreview?.send_enabled ? "enabled" : "off"}
+            </Badge>
+            <Badge tone={telegramPreview?.write_enabled ? "destructive" : "success"} className="text-[10px]">
+              supabase write: {telegramPreview?.write_enabled ? "enabled" : "off"}
+            </Badge>
+            <Badge tone={telegramPreview?.validation?.length_ok ? "success" : "secondary"} className="text-[10px]">
+              length: {telegramPreview?.message_length ?? 0}/{telegramPreview?.validation?.max_length ?? 600}
+            </Badge>
+          </div>
+          <div>
+            <p className="text-xs uppercase text-muted-foreground">Target ref</p>
+            <p className="break-all font-mono-ui text-xs text-foreground">
+              {telegramPreview?.target_ref ?? "telegram://dry-run/hera-198"}
+            </p>
+          </div>
+          <pre className="whitespace-pre-wrap rounded-md border border-current/15 bg-black/20 p-3 text-sm leading-6 text-foreground normal-case">
+            {telegramPreview?.message_text ?? "No preview generated."}
+          </pre>
+          <p className="text-xs text-muted-foreground normal-case">
+            Dry-run only: no Telegram send, no Supabase write, no cron change, no Obsidian authority edit.
+          </p>
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-4 xl:grid-cols-2">
+        <Card>
+          <CardHeader className="py-3 px-4"><CardTitle className="text-sm uppercase">Sections</CardTitle></CardHeader>
+          <CardContent className="p-4"><JsonList value={data?.sections} /></CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="py-3 px-4"><CardTitle className="text-sm uppercase">Source Anchors</CardTitle></CardHeader>
+          <CardContent className="p-4"><JsonList value={data?.sources} /></CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="py-3 px-4"><CardTitle className="text-sm uppercase">Delivery Events</CardTitle></CardHeader>
+          <CardContent className="p-4"><JsonList value={data?.delivery_events} /></CardContent>
+        </Card>
+        <Card>
+          <CardHeader className="py-3 px-4"><CardTitle className="text-sm uppercase">Audit Events</CardTitle></CardHeader>
+          <CardContent className="p-4"><JsonList value={data?.audit_events} /></CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/web/src/pages/ControlPlanePage.tsx
+++ b/web/src/pages/ControlPlanePage.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useLayoutEffect, useState } from "react";
-import { Database, MessageSquareText, RefreshCw, ShieldCheck } from "lucide-react";
+import { Database, Gauge, MessageSquareText, RefreshCw, ShieldCheck } from "lucide-react";
 import { Badge } from "@nous-research/ui/ui/components/badge";
 import { Button } from "@nous-research/ui/ui/components/button";
 import { Spinner } from "@nous-research/ui/ui/components/spinner";
@@ -10,6 +10,9 @@ import {
   type MorningBriefV0CanaryResponse,
   type MorningBriefTelegramPreviewResponse,
   type MorningBriefSafetyPreviewResponse,
+  type ControlPlaneCockpitBlockersResponse,
+  type ControlPlaneCockpitStatusPanel,
+  type ControlPlaneCockpitSummaryResponse,
 } from "@/lib/api";
 import { usePageHeader } from "@/contexts/usePageHeader";
 
@@ -39,6 +42,40 @@ function BoundaryBadge({ label, value }: { label: string; value?: boolean }) {
   );
 }
 
+function panelTone(panel?: ControlPlaneCockpitStatusPanel): "success" | "warning" | "secondary" | "destructive" {
+  const value = `${panel?.status ?? ""} ${panel?.state ?? ""} ${panel?.last_status ?? ""}`.toLowerCase();
+  if (value.includes("fail") || value.includes("error") || value.includes("blocked")) return "destructive";
+  if (value.includes("hold") || value.includes("observe")) return "warning";
+  if (value.includes("pass") || value.includes("ok") || value.includes("recorded") || value.includes("complete") || panel?.enabled) return "success";
+  return "secondary";
+}
+
+function CockpitPanelSummary({
+  label,
+  panel,
+}: {
+  label: string;
+  panel?: ControlPlaneCockpitStatusPanel;
+}) {
+  return (
+    <div className="rounded-md border border-current/15 p-3">
+      <div className="mb-2 flex items-center justify-between gap-2">
+        <p className="text-xs uppercase text-muted-foreground">{label}</p>
+        <Badge tone={panelTone(panel)} className="text-[10px]">
+          {panel?.status ?? panel?.state ?? panel?.last_status ?? "unknown"}
+        </Badge>
+      </div>
+      <p className="normal-case text-sm text-muted-foreground">
+        {panel?.safe_summary ?? "No cockpit summary loaded yet."}
+      </p>
+      <dl className="mt-2 grid gap-1 text-xs text-muted-foreground">
+        <div><dt className="inline uppercase">last</dt>: <dd className="inline">{panel?.last_run_at ?? "-"}</dd></div>
+        <div><dt className="inline uppercase">next</dt>: <dd className="inline">{panel?.next_run_at ?? "-"}</dd></div>
+      </dl>
+    </div>
+  );
+}
+
 export default function ControlPlanePage() {
   const [data, setData] = useState<MorningBriefCanaryResponse | null>(null);
   const [v0Canary, setV0Canary] = useState<MorningBriefV0CanaryResponse | null>(null);
@@ -46,6 +83,10 @@ export default function ControlPlanePage() {
     useState<MorningBriefTelegramPreviewResponse | null>(null);
   const [safetyPreview, setSafetyPreview] =
     useState<MorningBriefSafetyPreviewResponse | null>(null);
+  const [cockpitSummary, setCockpitSummary] =
+    useState<ControlPlaneCockpitSummaryResponse | null>(null);
+  const [cockpitBlockers, setCockpitBlockers] =
+    useState<ControlPlaneCockpitBlockersResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const { setAfterTitle, setEnd } = usePageHeader();
@@ -55,6 +96,8 @@ export default function ControlPlanePage() {
     setError(null);
     setTelegramPreview(null);
     setSafetyPreview(null);
+    setCockpitSummary(null);
+    setCockpitBlockers(null);
     setV0Canary(null);
 
     try {
@@ -98,13 +141,38 @@ export default function ControlPlanePage() {
         reason: "safety_preview_unavailable",
         message: "Safety preview unavailable; keep publish/send blocked until verified.",
       });
+    }
+
+    try {
+      const [summary, blockers] = await Promise.all([
+        api.getControlPlaneCockpitSummary(),
+        api.getControlPlaneCockpitBlockers(),
+      ]);
+      setCockpitSummary(summary);
+      setCockpitBlockers(blockers);
+    } catch {
+      setCockpitSummary({
+        enabled: false,
+        reason: "control_plane_cockpit_unavailable",
+        handoff_summary: "Control Plane Cockpit read failed; keep current observe posture.",
+        safe_next_action: "verify backend route status before relying on cockpit summary",
+      });
+      setCockpitBlockers({
+        enabled: false,
+        reason: "control_plane_cockpit_unavailable",
+        blockers: [],
+        safe_next_action: "verify backend route status before relying on cockpit blockers",
+      });
     } finally {
       setLoading(false);
     }
   }, []);
 
   useEffect(() => {
-    void refresh();
+    const timer = window.setTimeout(() => {
+      void refresh();
+    }, 0);
+    return () => window.clearTimeout(timer);
   }, [refresh]);
 
   useLayoutEffect(() => {
@@ -136,6 +204,9 @@ export default function ControlPlanePage() {
 
   const run = data?.run;
   const boundaries = data?.boundaries ?? {};
+  const cockpitStatus = cockpitSummary?.status ?? {};
+  const cockpitBlockerCount = cockpitBlockers?.blockers?.length ?? 0;
+  const cockpitBoundaryFlags = cockpitBlockers?.boundaries ?? {};
 
   return (
     <div className="flex flex-col gap-4 normal-case">
@@ -165,6 +236,62 @@ export default function ControlPlanePage() {
             <BoundaryBadge label="obsidian authority" value={boundaries.obsidian_authority_edit_enabled} />
             <BoundaryBadge label="cron" value={boundaries.cron_change_enabled} />
           </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader className="py-3 px-4">
+          <CardTitle className="flex items-center gap-2 text-sm uppercase">
+            <Gauge className="h-4 w-4" />
+            Control Plane Cockpit
+          </CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-3 p-4 text-sm">
+          {cockpitSummary && !cockpitSummary.enabled && (
+            <div className="rounded-md border border-warning/30 bg-warning/10 p-3">
+              <p className="text-sm font-semibold uppercase text-warning">Cockpit disabled</p>
+              <p className="text-sm text-muted-foreground">
+                {cockpitSummary.reason ?? "control_plane_not_configured"}
+              </p>
+            </div>
+          )}
+          <div className="flex flex-wrap gap-2 uppercase">
+            <Badge tone={cockpitSummary?.enabled === false ? "secondary" : "success"} className="text-[10px]">
+              {cockpitSummary?.enabled === false ? "safe disabled" : "read-only"}
+            </Badge>
+            <Badge tone={cockpitBlockerCount > 0 ? "warning" : "success"} className="text-[10px]">
+              blockers: {cockpitBlockerCount}
+            </Badge>
+            <Badge tone={cockpitBoundaryFlags.action_controls ? "destructive" : "success"} className="text-[10px]">
+              actions: {cockpitBoundaryFlags.action_controls ? "enabled" : "off"}
+            </Badge>
+            <Badge tone={cockpitBoundaryFlags.mutation_controls ? "destructive" : "success"} className="text-[10px]">
+              mutations: {cockpitBoundaryFlags.mutation_controls ? "enabled" : "off"}
+            </Badge>
+          </div>
+          <div className="grid gap-3 xl:grid-cols-4">
+            <CockpitPanelSummary label="Gate D" panel={cockpitStatus.gate_d} />
+            <CockpitPanelSummary label="GitHub Watcher" panel={cockpitStatus.github_watcher_no_agent} />
+            <CockpitPanelSummary label="Supabase Boundary" panel={cockpitStatus.supabase_role_boundary} />
+            <CockpitPanelSummary label="Obsidian Merge Review" panel={cockpitStatus.obsidian_merge_review} />
+          </div>
+          <dl className="grid gap-2 md:grid-cols-2">
+            <div>
+              <dt className="text-xs uppercase text-muted-foreground">handoff summary</dt>
+              <dd className="normal-case text-muted-foreground">
+                {cockpitSummary?.handoff_summary ?? "No cockpit summary loaded yet."}
+              </dd>
+            </div>
+            <div>
+              <dt className="text-xs uppercase text-muted-foreground">safe next step</dt>
+              <dd className="normal-case text-muted-foreground">
+                {cockpitSummary?.safe_next_action ?? cockpitBlockers?.safe_next_action ?? "Keep observe until verified."}
+              </dd>
+            </div>
+          </dl>
+          <p className="text-xs text-muted-foreground normal-case">
+            Visible read-only cockpit: backend/API readback only; no action controls, no browser-side Supabase access, no public endpoint.
+          </p>
         </CardContent>
       </Card>
 


### PR DESCRIPTION
## Summary
- add a read-only Control Plane cockpit surface for HERA-198 status panels
- expose private session-token-protected backend GET routes for summary/blockers
- wire the frontend API client and visible read-only Control Plane Cockpit panel
- stabilize WSL gateway PATH de-duplication for generated service environments

## Safety boundaries
- read-only status surface only
- no action, approve, send, publish, or mutation controls
- no browser-side Supabase secret or direct browser-to-Supabase connection
- no Supabase schema change, cron change, Telegram send, or Obsidian authority edit
- cockpit routes are not public API paths and require the existing Hermes session-token path

## Verification
- `pytest -q tests/hermes_cli/test_gateway_wsl_paths.py tests/hermes_cli/test_web_server.py -k 'control_plane_cockpit or wsl_interop_paths'`
- `pytest -q tests/hermes_cli/test_web_server.py tests/hermes_cli/test_gateway_wsl_paths.py tests/hermes_cli/test_web_server_host_header.py tests/hermes_cli/test_dashboard_browser_safe_imports.py`
- `npm run build` from `web/` with Node 20.20.2
- `npx eslint src/pages/ControlPlanePage.tsx src/lib/api.ts --quiet`
- local browser smoke test for `/control-plane`
- public exposure scan: blocker_count=0; remaining review hits are route decorator false positives
