### PR TITLE
feat(image-gen): support reference images in image_generate

### DIFF
--- a/agent/image_gen_provider.py
+++ b/agent/image_gen_provider.py
@@ -139,7 +139,10 @@ class ImageGenProvider(abc.ABC):
         Implementations should return the dict from :func:`success_response`
         or :func:`error_response`. ``kwargs`` may contain forward-compat
         parameters future versions of the schema will expose — implementations
-        should ignore unknown keys.
+        should ignore unknown keys. Current optional kwargs include
+        ``input_images`` (local paths, data URLs, or HTTP(S) URLs used as visual
+        references by compatible backends) and ``background`` (``transparent``,
+        ``opaque``, or ``auto`` for GPT image providers that support it).
         """
 
 

--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -14,13 +14,21 @@ Selection precedence for the tier (first hit wins):
 3. ``image_gen.model`` in ``config.yaml`` (when it's one of our tier IDs)
 4. :data:`DEFAULT_MODEL` — ``gpt-image-2-medium``
 
-Output is saved as PNG under ``$HERMES_HOME/cache/images/``.
+Output is saved as PNG under ``$HERMES_HOME/cache/images/``.  When the
+``image_generate`` tool supplies ``input_images`` (local paths, data URLs, or
+HTTP(S) URLs), they are attached to the Codex Responses message as
+``input_image`` items so GPT Image can use the full reference/crop context
+without requiring an OpenAI API key.
 """
 
 from __future__ import annotations
 
 import logging
+import base64
+import mimetypes
+from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
 
 from agent.image_gen_provider import (
     DEFAULT_ASPECT_RATIO,
@@ -78,6 +86,7 @@ _CODEX_INSTRUCTIONS = (
     "You are an assistant that must fulfill image generation requests by "
     "using the image_generation tool when provided."
 )
+_VALID_BACKGROUNDS = {"transparent", "opaque", "auto"}
 
 
 # ---------------------------------------------------------------------------
@@ -161,9 +170,82 @@ def _build_codex_client():
         return None
 
 
-def _collect_image_b64(client: Any, *, prompt: str, size: str, quality: str) -> Optional[str]:
+def _normalize_input_images(input_images: Any) -> List[str]:
+    """Normalize user/tool supplied image references into a list of strings."""
+    if input_images is None:
+        return []
+    if isinstance(input_images, str):
+        raw_items = [input_images]
+    elif isinstance(input_images, (list, tuple)):
+        raw_items = list(input_images)
+    else:
+        raise ValueError("input_images must be a string or a list of strings")
+
+    normalized: List[str] = []
+    for item in raw_items:
+        if not isinstance(item, str):
+            raise ValueError("input_images entries must be strings")
+        ref = item.strip()
+        if ref:
+            normalized.append(ref)
+    return normalized
+
+
+def _resolve_background(background: Any) -> str:
+    """Return a valid image_generation background mode."""
+    if background is None:
+        return "opaque"
+    value = str(background).strip().lower()
+    if value not in _VALID_BACKGROUNDS:
+        allowed = ", ".join(sorted(_VALID_BACKGROUNDS))
+        raise ValueError(f"background must be one of: {allowed}")
+    return value
+
+
+def _is_remote_or_data_image_ref(ref: str) -> bool:
+    if ref.startswith("data:image/"):
+        return True
+    parsed = urlparse(ref)
+    return parsed.scheme in {"http", "https"}
+
+
+def _local_image_to_data_url(ref: str) -> str:
+    path = Path(ref).expanduser()
+    if not path.is_file():
+        raise FileNotFoundError(f"input image not found: {ref}")
+    mime_type = mimetypes.guess_type(str(path))[0] or "image/png"
+    if not mime_type.startswith("image/"):
+        raise ValueError(f"input image must have an image MIME type: {ref}")
+    encoded = base64.b64encode(path.read_bytes()).decode("ascii")
+    return f"data:{mime_type};base64,{encoded}"
+
+
+def _input_image_ref_to_image_url(ref: str) -> str:
+    if _is_remote_or_data_image_ref(ref):
+        return ref
+    return _local_image_to_data_url(ref)
+
+
+def _build_response_content(prompt: str, input_images: Any = None) -> List[Dict[str, str]]:
+    """Build Responses API message content with text plus optional images."""
+    content: List[Dict[str, str]] = [{"type": "input_text", "text": prompt}]
+    for ref in _normalize_input_images(input_images):
+        content.append({"type": "input_image", "image_url": _input_image_ref_to_image_url(ref)})
+    return content
+
+
+def _collect_image_b64(
+    client: Any,
+    *,
+    prompt: str,
+    size: str,
+    quality: str,
+    input_images: Any = None,
+    background: Any = "opaque",
+) -> Optional[str]:
     """Stream a Codex Responses image_generation call and return the b64 image."""
     image_b64: Optional[str] = None
+    resolved_background = _resolve_background(background)
 
     with client.responses.stream(
         model=_CODEX_CHAT_MODEL,
@@ -172,7 +254,7 @@ def _collect_image_b64(client: Any, *, prompt: str, size: str, quality: str) -> 
         input=[{
             "type": "message",
             "role": "user",
-            "content": [{"type": "input_text", "text": prompt}],
+            "content": _build_response_content(prompt, input_images),
         }],
         tools=[{
             "type": "image_generation",
@@ -180,7 +262,7 @@ def _collect_image_b64(client: Any, *, prompt: str, size: str, quality: str) -> 
             "size": size,
             "quality": quality,
             "output_format": "png",
-            "background": "opaque",
+            "background": resolved_background,
             "partial_images": 1,
         }],
         tool_choice={
@@ -306,6 +388,8 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
 
         tier_id, meta = _resolve_model()
         size = _SIZES.get(aspect, _SIZES["square"])
+        input_images = _normalize_input_images(kwargs.get("input_images"))
+        background = _resolve_background(kwargs.get("background"))
 
         client = _build_codex_client()
         if client is None:
@@ -324,6 +408,8 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
                 prompt=prompt,
                 size=size,
                 quality=meta["quality"],
+                input_images=input_images,
+                background=background,
             )
         except Exception as exc:
             logger.debug("Codex image generation failed", exc_info=True)
@@ -364,7 +450,12 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
             prompt=prompt,
             aspect_ratio=aspect,
             provider="openai-codex",
-            extra={"size": size, "quality": meta["quality"]},
+            extra={
+                "size": size,
+                "quality": meta["quality"],
+                "background": background,
+                "input_images_count": len(input_images),
+            },
         )
 
 

--- a/tests/tools/test_image_generation.py
+++ b/tests/tools/test_image_generation.py
@@ -363,11 +363,12 @@ class TestAspectRatioNormalization:
 
 class TestRegistryIntegration:
 
-    def test_schema_exposes_only_prompt_and_aspect_ratio_to_agent(self, image_tool):
-        """The agent-facing schema must stay tight — model selection is a
-        user-level config choice, not an agent-level arg."""
+    def test_schema_exposes_reference_inputs_but_not_backend_selection_to_agent(self, image_tool):
+        """The agent-facing schema should expose generation inputs, while
+        keeping backend/model selection a user-level config choice."""
         props = image_tool.IMAGE_GENERATE_SCHEMA["parameters"]["properties"]
-        assert set(props.keys()) == {"prompt", "aspect_ratio"}
+        assert set(props.keys()) == {"prompt", "aspect_ratio", "input_images", "background"}
+        assert "model" not in props
 
     def test_aspect_ratio_enum_is_three_values(self, image_tool):
         enum = image_tool.IMAGE_GENERATE_SCHEMA["parameters"]["properties"]["aspect_ratio"]["enum"]

--- a/tests/tools/test_image_generation_input_images.py
+++ b/tests/tools/test_image_generation_input_images.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import base64
+import importlib.util
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from agent import image_gen_registry
+from agent.image_gen_provider import ImageGenProvider
+
+
+@pytest.fixture(autouse=True)
+def _reset_registry():
+    image_gen_registry._reset_for_tests()
+    yield
+    image_gen_registry._reset_for_tests()
+
+
+class _RecordingProvider(ImageGenProvider):
+    @property
+    def name(self) -> str:
+        return "recording"
+
+    def generate(self, prompt, aspect_ratio="landscape", **kwargs):
+        return {
+            "success": True,
+            "image": "/tmp/reference-aware.png",
+            "model": "test-model",
+            "prompt": prompt,
+            "aspect_ratio": aspect_ratio,
+            "provider": self.name,
+            "received_kwargs": kwargs,
+        }
+
+
+def _load_openai_codex_plugin():
+    root = Path(__file__).resolve().parents[2]
+    plugin_path = root / "plugins" / "image_gen" / "openai-codex" / "__init__.py"
+    spec = importlib.util.spec_from_file_location("openai_codex_image_gen_for_tests", plugin_path)
+    assert spec and spec.loader
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class _DummyResponses:
+    def __init__(self):
+        self.kwargs = None
+
+    def stream(self, **kwargs):
+        self.kwargs = kwargs
+
+        class _Stream:
+            def __enter__(self_inner):
+                return self_inner
+
+            def __exit__(self_inner, exc_type, exc, tb):
+                return False
+
+            def __iter__(self_inner):
+                return iter(())
+
+            def get_final_response(self_inner):
+                item = SimpleNamespace(type="image_generation_call", result="ZmFrZS1wbmc=")
+                return SimpleNamespace(output=[item])
+
+        return _Stream()
+
+
+class _DummyClient:
+    def __init__(self):
+        self.responses = _DummyResponses()
+
+
+class TestImageGenerateSchemaAndDispatch:
+    def test_schema_exposes_reference_image_inputs_to_agent(self):
+        from tools import image_generation_tool
+
+        props = image_generation_tool.IMAGE_GENERATE_SCHEMA["parameters"]["properties"]
+
+        assert set(props) == {"prompt", "aspect_ratio", "input_images", "background"}
+        assert props["input_images"]["type"] == "array"
+        assert props["input_images"]["items"]["type"] == "string"
+        assert props["background"]["enum"] == ["transparent", "opaque", "auto"]
+
+    def test_plugin_dispatch_forwards_input_images_and_background(self, monkeypatch, tmp_path):
+        from tools import image_generation_tool
+        from agent import image_gen_registry as registry_module
+        from hermes_cli import plugins as plugins_module
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        provider = _RecordingProvider()
+        image_gen_registry.register_provider(provider)
+
+        monkeypatch.setattr(image_generation_tool, "_read_configured_image_provider", lambda: "recording")
+        monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda force=False: None)
+        monkeypatch.setattr(registry_module, "get_provider", lambda name: provider if name == "recording" else None)
+
+        dispatched = image_generation_tool._dispatch_to_plugin_provider(
+            "extract the blue icon as a transparent asset",
+            "square",
+            input_images=["/tmp/reference.png", "/tmp/crop.png"],
+            background="transparent",
+        )
+        payload = json.loads(dispatched)
+
+        assert payload["success"] is True
+        assert payload["received_kwargs"]["input_images"] == ["/tmp/reference.png", "/tmp/crop.png"]
+        assert payload["received_kwargs"]["background"] == "transparent"
+
+
+class TestOpenAICodexImageInputs:
+    def test_builds_input_image_content_from_local_files(self, tmp_path):
+        module = _load_openai_codex_plugin()
+        crop = tmp_path / "crop.png"
+        raw = b"\x89PNG\r\n\x1a\nminimal-test-bytes"
+        crop.write_bytes(raw)
+
+        content = module._build_response_content("extract this icon", [str(crop)])
+
+        assert content[0] == {"type": "input_text", "text": "extract this icon"}
+        assert content[1]["type"] == "input_image"
+        assert content[1]["image_url"].startswith("data:image/png;base64,")
+        encoded = content[1]["image_url"].split(",", 1)[1]
+        assert base64.b64decode(encoded) == raw
+
+    def test_passes_remote_and_data_urls_through_as_input_images(self):
+        module = _load_openai_codex_plugin()
+
+        content = module._build_response_content(
+            "use these references",
+            ["https://example.com/ref.png", "data:image/png;base64,AAAA"],
+        )
+
+        assert content[1] == {"type": "input_image", "image_url": "https://example.com/ref.png"}
+        assert content[2] == {"type": "input_image", "image_url": "data:image/png;base64,AAAA"}
+
+    def test_collect_image_b64_sends_input_images_and_background_to_codex_responses(self, tmp_path):
+        module = _load_openai_codex_plugin()
+        crop = tmp_path / "crop.png"
+        crop.write_bytes(b"\x89PNG\r\n\x1a\nminimal-test-bytes")
+        client = _DummyClient()
+
+        image_b64 = module._collect_image_b64(
+            client,
+            prompt="extract transparent icon",
+            size="1024x1024",
+            quality="medium",
+            input_images=[str(crop)],
+            background="transparent",
+        )
+
+        assert image_b64 == "ZmFrZS1wbmc="
+        kwargs = client.responses.kwargs
+        assert kwargs["input"][0]["content"][0]["type"] == "input_text"
+        assert kwargs["input"][0]["content"][1]["type"] == "input_image"
+        assert kwargs["tools"][0]["type"] == "image_generation"
+        assert kwargs["tools"][0]["background"] == "transparent"

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -618,18 +618,21 @@ def _upscale_image(image_url: str, original_prompt: str) -> Optional[Dict[str, A
 def image_generate_tool(
     prompt: str,
     aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+    input_images: Optional[list[str]] = None,
+    background: Optional[str] = None,
     num_inference_steps: Optional[int] = None,
     guidance_scale: Optional[float] = None,
     num_images: Optional[int] = None,
     output_format: Optional[str] = None,
     seed: Optional[int] = None,
 ) -> str:
-    """Generate an image from a text prompt using the configured FAL model.
+    """Generate an image using the configured image backend.
 
-    The agent-facing schema exposes only ``prompt`` and ``aspect_ratio``; the
-    remaining kwargs are overrides for direct Python callers and are filtered
-    per-model via the ``supports`` whitelist (unsupported overrides are
-    silently dropped so legacy callers don't break when switching models).
+    The agent-facing schema exposes ``prompt``, ``aspect_ratio``, optional
+    ``input_images`` references, and an optional ``background`` preference.
+    Plugin providers receive those richer inputs when selected. The legacy
+    in-tree FAL path remains text-to-image only and fails loudly instead of
+    silently ignoring reference images.
 
     Returns a JSON string with ``{"success": bool, "image": url | None,
     "error": str, "error_type": str}``.
@@ -641,6 +644,8 @@ def image_generate_tool(
         "parameters": {
             "prompt": prompt,
             "aspect_ratio": aspect_ratio,
+            "input_images": input_images,
+            "background": background,
             "num_inference_steps": num_inference_steps,
             "guidance_scale": guidance_scale,
             "num_images": num_images,
@@ -658,6 +663,19 @@ def image_generate_tool(
     try:
         if not prompt or not isinstance(prompt, str) or len(prompt.strip()) == 0:
             raise ValueError("Prompt is required and must be a non-empty string")
+
+        if input_images:
+            raise ValueError(
+                "The built-in FAL image generation path does not support "
+                "reference input images. Set image_gen.provider to a backend "
+                "that supports input_images (for example openai-codex)."
+            )
+        if background is not None:
+            raise ValueError(
+                "The built-in FAL image generation path does not support the "
+                "background override. Use an image-gen plugin provider such as "
+                "openai-codex for transparent-background asset extraction."
+            )
 
         if not (fal_key_is_configured() or _resolve_managed_fal_gateway()):
             message = "FAL_KEY environment variable not set"
@@ -854,7 +872,9 @@ from tools.registry import registry, tool_error
 IMAGE_GENERATE_SCHEMA = {
     "name": "image_generate",
     "description": (
-        "Generate high-quality images from text prompts. The underlying "
+        "Generate high-quality images from text prompts, optionally using "
+        "reference input images when the configured backend supports them. "
+        "The underlying "
         "backend (FAL, OpenAI, etc.) and model are user-configured and not "
         "selectable by the agent. Returns either a URL or an absolute file "
         "path in the `image` field; display it with markdown "
@@ -872,6 +892,23 @@ IMAGE_GENERATE_SCHEMA = {
                 "enum": list(VALID_ASPECT_RATIOS),
                 "description": "The aspect ratio of the generated image. 'landscape' is 16:9 wide, 'portrait' is 16:9 tall, 'square' is 1:1.",
                 "default": DEFAULT_ASPECT_RATIO,
+            },
+            "input_images": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Optional local image paths, data URLs, or HTTP(S) image URLs "
+                    "to use as visual references. Only backends that support image "
+                    "inputs will honor this parameter."
+                ),
+            },
+            "background": {
+                "type": "string",
+                "enum": ["transparent", "opaque", "auto"],
+                "description": (
+                    "Optional output background preference for compatible GPT image "
+                    "backends. Use 'transparent' for isolated PNG assets."
+                ),
             },
         },
         "required": ["prompt"],
@@ -915,7 +952,13 @@ def _read_configured_image_provider():
     return None
 
 
-def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
+def _dispatch_to_plugin_provider(
+    prompt: str,
+    aspect_ratio: str,
+    *,
+    input_images: Optional[list[str]] = None,
+    background: Optional[str] = None,
+):
     """Route the call to a plugin-registered provider when one is selected.
 
     Returns a JSON string on dispatch, or ``None`` to fall through to the
@@ -968,9 +1011,13 @@ def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
         })
 
     try:
-        kwargs = {"prompt": prompt, "aspect_ratio": aspect_ratio}
+        kwargs: Dict[str, Any] = {"prompt": prompt, "aspect_ratio": aspect_ratio}
         if configured_model:
             kwargs["model"] = configured_model
+        if input_images is not None:
+            kwargs["input_images"] = input_images
+        if background is not None:
+            kwargs["background"] = background
         result = provider.generate(**kwargs)
     except Exception as exc:
         logger.warning(
@@ -998,16 +1045,25 @@ def _handle_image_generate(args, **kw):
     if not prompt:
         return tool_error("prompt is required for image generation")
     aspect_ratio = args.get("aspect_ratio", DEFAULT_ASPECT_RATIO)
+    input_images = args.get("input_images")
+    background = args.get("background")
 
     # Route to a plugin-registered provider if one is active (and it's
     # not the in-tree FAL path).
-    dispatched = _dispatch_to_plugin_provider(prompt, aspect_ratio)
+    dispatched = _dispatch_to_plugin_provider(
+        prompt,
+        aspect_ratio,
+        input_images=input_images,
+        background=background,
+    )
     if dispatched is not None:
         return dispatched
 
     return image_generate_tool(
         prompt=prompt,
         aspect_ratio=aspect_ratio,
+        input_images=input_images,
+        background=background,
     )
 
 

--- a/website/docs/developer-guide/image-gen-provider-plugin.md
+++ b/website/docs/developer-guide/image-gen-provider-plugin.md
@@ -130,6 +130,11 @@ class MyBackendImageGenProvider(ImageGenProvider):
                 aspect_ratio=aspect_ratio,
             )
 
+        # Optional schema kwargs you may support:
+        # - input_images: local paths, data URLs, or HTTP(S) reference images
+        # - background: "transparent" | "opaque" | "auto"
+        # Ignore unknown kwargs so providers stay forward-compatible.
+
         # Model selection precedence: env var → config → default. The helper
         # _resolve_model() in the built-in openai plugin is a good reference.
         model_id = kwargs.get("model") or self.default_model() or "my-model-fast"
@@ -205,7 +210,19 @@ Full contract in `agent/image_gen_provider.py`. The methods you'll typically ove
 | `list_models()` | — | `[]` | Catalog for `hermes tools` model picker |
 | `default_model()` | — | first from `list_models()` | Fallback when no model is configured |
 | `get_setup_schema()` | — | minimal | Picker metadata + env-var prompts |
-| `generate(prompt, aspect_ratio, **kwargs)` | ✅ | — | The call |
+| `generate(prompt, aspect_ratio, **kwargs)` | ✅ | — | The call; optional kwargs currently include `input_images` and `background` |
+
+### Optional reference-image inputs
+
+The `image_generate` tool may pass:
+
+- `input_images`: a list of local file paths, `data:image/...` URLs, or HTTP(S) image URLs.
+- `background`: `transparent`, `opaque`, or `auto`.
+
+Providers that support image-conditioned generation should attach those images
+to the backend request. Providers that do not support them should either ignore
+unknown kwargs or return a clear unsupported-parameter error rather than silently
+pretending the reference was used.
 
 ## Response format
 


### PR DESCRIPTION
## Summary
- Expose optional `input_images` and `background` parameters on the `image_generate` tool.
- Pass reference-image inputs through to image generation providers.
- Add `openai-codex` provider support for local paths, HTTP(S) URLs, and `data:image/...` URLs as `input_image` items for Codex image generation.
- Document optional provider kwargs and add focused tests.

## Test Plan
- `uv run pytest tests/tools/test_image_generation.py tests/tools/test_image_generation_plugin_dispatch.py tests/tools/test_image_generation_input_images.py -q -o addopts=''`
