### PR TITLE
fix: resolve GPT context on Codex OAuth transport

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -149,10 +149,10 @@ DEFAULT_CONTEXT_LENGTHS = {
     "claude": 200000,
     # OpenAI — GPT-5 family (most have 400k; specific overrides first)
     # Source: https://developers.openai.com/api/docs/models
-    # GPT-5.5 (launched Apr 23 2026) is 1.05M on the direct OpenAI API and
-    # ChatGPT Codex OAuth caps it at 272K; both paths resolve via their own
-    # provider-aware branches (_resolve_codex_oauth_context_length + models.dev).
-    # This hardcoded value is only reached when every probe misses.
+    # GPT-5.5 (launched Apr 23 2026) is 1.05M on the direct OpenAI API.
+    # General GPT slugs on the ChatGPT/Codex OAuth transport resolve through
+    # this OpenAI model-metadata path; Codex-specialized slugs use Codex catalog
+    # metadata instead.
     "gpt-5.5": 1050000,
     "gpt-5.4-nano": 400000,           # 400k (not 1.05M like full 5.4)
     "gpt-5.4-mini": 400000,           # 400k (not 1.05M like full 5.4)
@@ -278,6 +278,19 @@ def _auth_headers(api_key: str = "") -> Dict[str, str]:
 
 def _is_openrouter_base_url(base_url: str) -> bool:
     return base_url_host_matches(base_url, "openrouter.ai")
+
+
+def _is_codex_oauth_base_url(base_url: str) -> bool:
+    """Return True for the ChatGPT/Codex OAuth backend URL."""
+    normalized = _normalize_base_url(base_url)
+    if not normalized or not base_url_host_matches(normalized, "chatgpt.com"):
+        return False
+    try:
+        parsed = urlparse(normalized if "://" in normalized else f"https://{normalized}")
+    except Exception:
+        return False
+    path = parsed.path.rstrip("/").lower()
+    return path == "/backend-api/codex" or path.startswith("/backend-api/codex/")
 
 
 def _is_custom_endpoint(base_url: str) -> bool:
@@ -1094,25 +1107,90 @@ def _query_anthropic_context_length(model: str, base_url: str, api_key: str) -> 
     return None
 
 
-# Known ChatGPT Codex OAuth context windows (observed via live
-# chatgpt.com/backend-api/codex/models probe, Apr 2026). These are the
-# `context_window` values, which are what Codex actually enforces — the
-# direct OpenAI API has larger limits for the same slugs, but Codex OAuth
-# caps lower (e.g. gpt-5.5 is 1.05M on the API, 272K on Codex).
+# Known ChatGPT Codex OAuth context windows for Codex-specialized slugs
+# (observed via live chatgpt.com/backend-api/codex/models probe, Apr 2026).
+# The same backend also lists general GPT slugs (for example gpt-5.5), but
+# those should resolve through the normal OpenAI model metadata path because
+# they are distinct from Codex-specialized models such as gpt-5.3-codex.
 #
 # Used as a fallback when the live probe fails (no token, network error).
 # Longest keys first so substring match picks the most specific entry.
 _CODEX_OAUTH_CONTEXT_FALLBACK: Dict[str, int] = {
+    "gpt-5.3-codex-spark": 128_000,
     "gpt-5.1-codex-max": 272_000,
     "gpt-5.1-codex-mini": 272_000,
     "gpt-5.3-codex": 272_000,
     "gpt-5.2-codex": 272_000,
-    "gpt-5.4-mini": 272_000,
-    "gpt-5.5": 272_000,
-    "gpt-5.4": 272_000,
-    "gpt-5.2": 272_000,
-    "gpt-5": 272_000,
+    "codex-auto-review": 272_000,
 }
+
+
+def _bare_model_slug(model: str) -> str:
+    """Return the provider/vendor-free model slug used for family checks."""
+    model_bare = _strip_provider_prefix(model or "").strip().lower()
+    if "/" in model_bare:
+        model_bare = model_bare.rsplit("/", 1)[1].strip()
+    return model_bare
+
+
+def _is_codex_specialized_model(model: str) -> bool:
+    """Return True for Codex-specific model slugs, not general GPT slugs."""
+    return "codex" in _bare_model_slug(model)
+
+
+def _codex_oauth_fallback_context_for_model(model: str) -> Optional[int]:
+    """Return the hardcoded Codex catalog fallback for a known Codex slug."""
+    model_lower = _bare_model_slug(model)
+    for slug, ctx in sorted(
+        _CODEX_OAUTH_CONTEXT_FALLBACK.items(), key=lambda x: len(x[0]), reverse=True
+    ):
+        if slug in model_lower:
+            return ctx
+    return None
+
+
+def _is_stale_codex_specialized_cache(model: str, cached: int) -> bool:
+    """Detect stale persisted context entries for Codex-specialized slugs."""
+    if cached >= 400_000:
+        return True
+    fallback_ctx = _codex_oauth_fallback_context_for_model(model)
+    # Older fallback tables could match a more general 272K Codex slug before a
+    # newer, more-specific lower-cap slug such as gpt-5.3-codex-spark (128K).
+    return fallback_ctx is not None and cached == 272_000 and cached > fallback_ctx
+
+
+def _resolve_openai_model_context_length(model: str) -> Optional[int]:
+    """Resolve the canonical OpenAI context length for a general GPT slug."""
+    try:
+        from agent.models_dev import lookup_models_dev_context
+        for candidate in dict.fromkeys([model, _bare_model_slug(model)]):
+            if not candidate:
+                continue
+            ctx = lookup_models_dev_context("openai", candidate)
+            if ctx:
+                return ctx
+    except Exception:
+        pass
+
+    model_lower = _bare_model_slug(model)
+    for default_model, length in sorted(
+        DEFAULT_CONTEXT_LENGTHS.items(), key=lambda x: len(x[0]), reverse=True
+    ):
+        if default_model in model_lower:
+            return length
+    return None
+
+
+def _codex_oauth_should_use_openai_model_metadata(model: str) -> bool:
+    """General GPT models on the Codex OAuth path use OpenAI model metadata.
+
+    `openai-codex` is the auth/transport provider. The live Codex catalog lists
+    both regular GPT slugs (gpt-5.5, gpt-5.4, etc.) and Codex-specialized slugs
+    (gpt-5.3-codex, codex-auto-review). Only the latter should use the Codex
+    catalog context values.
+    """
+    model_bare = _bare_model_slug(model)
+    return model_bare.startswith("gpt-") and not _is_codex_specialized_model(model_bare)
 
 
 _codex_oauth_context_cache: Dict[str, int] = {}
@@ -1121,11 +1199,11 @@ _CODEX_OAUTH_CONTEXT_CACHE_TTL = 3600  # 1 hour
 
 
 def _fetch_codex_oauth_context_lengths(access_token: str) -> Dict[str, int]:
-    """Probe the ChatGPT Codex /models endpoint for per-slug context windows.
+    """Probe the ChatGPT Codex /models endpoint for per-slug catalog windows.
 
-    Codex OAuth imposes its own context limits that differ from the direct
-    OpenAI API (e.g. gpt-5.5 is 1.05M on the API, 272K on Codex). The
-    `context_window` field in each model entry is the authoritative source.
+    The endpoint reports a `context_window` for every slug it exposes. Hermes
+    only treats that value as authoritative for Codex-specialized slugs; general
+    GPT slugs on the same auth transport resolve through OpenAI model metadata.
 
     Returns a ``{slug: context_window}`` dict. Empty on failure.
     """
@@ -1177,29 +1255,28 @@ def _resolve_codex_oauth_context_length(
     """Resolve a Codex OAuth model's real context window.
 
     Prefers a live probe of chatgpt.com/backend-api/codex/models (when we
-    have a bearer token), then falls back to ``_CODEX_OAUTH_CONTEXT_FALLBACK``.
+    have a bearer token), then falls back to known Codex catalog entries, then
+    to a conservative generic 272K fallback for future Codex-specialized slugs.
     """
-    model_bare = _strip_provider_prefix(model).strip()
+    model_bare = _bare_model_slug(model)
     if not model_bare:
+        return None
+    if _codex_oauth_should_use_openai_model_metadata(model_bare):
         return None
 
     if access_token:
         live = _fetch_codex_oauth_context_lengths(access_token)
-        if model_bare in live:
-            return live[model_bare]
-        # Case-insensitive match in case casing drifts
-        model_lower = model_bare.lower()
+        # Case-insensitive match in case casing drifts.
         for slug, ctx in live.items():
-            if slug.lower() == model_lower:
+            if slug.strip().lower() == model_bare:
                 return ctx
 
-    # Fallback: longest-key-first substring match over hardcoded defaults.
-    model_lower = model_bare.lower()
-    for slug, ctx in sorted(
-        _CODEX_OAUTH_CONTEXT_FALLBACK.items(), key=lambda x: len(x[0]), reverse=True
-    ):
-        if slug in model_lower:
-            return ctx
+    fallback_ctx = _codex_oauth_fallback_context_for_model(model_bare)
+    if fallback_ctx:
+        return fallback_ctx
+
+    if _is_codex_specialized_model(model_bare):
+        return 272_000
 
     return None
 
@@ -1249,6 +1326,7 @@ def get_model_context_length(
 
     Resolution order:
     0. Explicit config override (model.context_length or custom_providers per-model)
+    0b. General GPT slugs on the ChatGPT/Codex OAuth transport use OpenAI metadata
     1. Persistent cache (previously discovered via probing)
     1b. AWS Bedrock static table (must precede custom-endpoint probe)
     2. Active endpoint metadata (/models for explicit custom endpoints)
@@ -1281,10 +1359,27 @@ def get_model_context_length(
         except Exception:
             pass  # fall through to probing
 
+    provider = (provider or "").strip().lower()
+
     # Normalise provider-prefixed model names (e.g. "local:model-name" →
     # "model-name") so cache lookups and server queries use the bare ID that
     # local servers actually know about.  Ollama "model:tag" colons are preserved.
     model = _strip_provider_prefix(model)
+
+    is_codex_oauth_transport = (
+        provider == "openai-codex" or _is_codex_oauth_base_url(base_url)
+    )
+
+    # ChatGPT/Codex OAuth is a transport/auth provider, not necessarily a Codex
+    # model family. Its catalog lists both general GPT slugs and Codex-specific
+    # slugs; resolve the general GPT slugs through the normal OpenAI model
+    # metadata path before consulting stale Codex-base-url cache entries.
+    if is_codex_oauth_transport and _codex_oauth_should_use_openai_model_metadata(model):
+        openai_ctx = _resolve_openai_model_context_length(model)
+        if openai_ctx:
+            if base_url and get_cached_context_length(model, base_url) != openai_ctx:
+                save_context_length(model, base_url, openai_ctx)
+            return openai_ctx
 
     # 1. Check persistent cache (model+provider)
     # LM Studio is excluded — its loaded context length is transient (the
@@ -1293,16 +1388,18 @@ def get_model_context_length(
     if base_url and provider != "lmstudio":
         cached = get_cached_context_length(model, base_url)
         if cached is not None:
-            # Invalidate stale Codex OAuth cache entries: pre-PR #14935 builds
-            # resolved gpt-5.x to the direct-API value (e.g. 1.05M) via
-            # models.dev and persisted it. Codex OAuth caps at 272K for every
-            # slug, so any cached Codex entry at or above 400K is a leftover
-            # from the old resolution path. Drop it and fall through to the
-            # live /models probe in step 5 below.
-            if provider == "openai-codex" and cached >= 400_000:
+            # Invalidate stale Codex-specialized cache entries: older builds
+            # could persist direct-API GPT-5 defaults for Codex slugs. General
+            # GPT slugs on the Codex OAuth transport return before this cache
+            # branch; only Codex-specialized slugs should reach this guard.
+            if (
+                is_codex_oauth_transport
+                and _is_codex_specialized_model(model)
+                and _is_stale_codex_specialized_cache(model, cached)
+            ):
                 logger.info(
-                    "Dropping stale Codex cache entry %s@%s -> %s (pre-fix value); "
-                    "re-resolving via live /models probe",
+                    "Dropping stale Codex-specialized cache entry %s@%s -> %s; "
+                    "re-resolving via Codex catalog/fallback",
                     model, base_url, f"{cached:,}",
                 )
                 _invalidate_cached_context_length(model, base_url)
@@ -1370,6 +1467,8 @@ def get_model_context_length(
     # (e.g. claude-opus-4.6 is 1M on Anthropic but 128K on GitHub Copilot).
     # If provider is generic (openrouter/custom/empty), try to infer from URL.
     effective_provider = provider
+    if is_codex_oauth_transport:
+        effective_provider = "openai-codex"
     if not effective_provider or effective_provider in ("openrouter", "custom"):
         if base_url:
             inferred = _infer_provider_from_url(base_url)
@@ -1394,9 +1493,9 @@ def get_model_context_length(
         if ctx:
             return ctx
     if effective_provider == "openai-codex":
-        # Codex OAuth enforces lower context limits than the direct OpenAI
-        # API for the same slug (e.g. gpt-5.5 is 1.05M on the API but 272K
-        # on Codex). Authoritative source is Codex's own /models endpoint.
+        # General GPT slugs on this transport returned earlier via OpenAI
+        # metadata. Slugs that reach this branch are Codex-specialized and
+        # should use the Codex backend catalog/fallback.
         codex_ctx = _resolve_codex_oauth_context_length(model, access_token=api_key or "")
         if codex_ctx:
             if base_url:

--- a/cli.py
+++ b/cli.py
@@ -5838,9 +5838,10 @@ class HermesCLI:
         _cprint(f"  ✓ Model switched: {result.new_model}")
         _cprint(f"    Provider: {provider_label}")
 
-        # Context: always resolve via the provider-aware chain so Codex OAuth,
-        # Copilot, and Nous-enforced caps win over the raw models.dev entry
-        # (e.g. gpt-5.5 is 1.05M on openai but 272K on Codex OAuth).
+        # Context: always resolve via the provider-aware chain so transport-
+        # specific models (Codex-specialized slugs, Copilot, Nous, etc.) and
+        # general GPT slugs on OAuth transports display the same value the
+        # running session uses.
         mi = result.model_info
         try:
             from hermes_cli.model_switch import resolve_display_context_length
@@ -6069,9 +6070,10 @@ class HermesCLI:
         _cprint(f"  ✓ Model switched: {result.new_model}")
         _cprint(f"    Provider: {provider_label}")
 
-        # Context: always resolve via the provider-aware chain so Codex OAuth,
-        # Copilot, and Nous-enforced caps win over the raw models.dev entry
-        # (e.g. gpt-5.5 is 1.05M on openai but 272K on Codex OAuth).
+        # Context: always resolve via the provider-aware chain so transport-
+        # specific models (Codex-specialized slugs, Copilot, Nous, etc.) and
+        # general GPT slugs on OAuth transports display the same value the
+        # running session uses.
         mi = result.model_info
         from hermes_cli.model_switch import resolve_display_context_length
         ctx = resolve_display_context_length(

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -574,12 +574,12 @@ def resolve_display_context_length(
 ) -> Optional[int]:
     """Resolve the context length to show in /model output.
 
-    models.dev reports per-vendor context (e.g. gpt-5.5 = 1.05M on openai)
-    but provider-enforced limits can be lower (e.g. Codex OAuth caps the
-    same slug at 272k). The authoritative source is
-    ``agent.model_metadata.get_model_context_length`` which already knows
-    about Codex OAuth, Copilot, Nous, and falls back to models.dev for the
-    rest.
+    models.dev reports per-vendor context (e.g. gpt-5.5 = 1.05M on openai),
+    while some auth transports also expose provider-specific model catalogs.
+    The authoritative source is ``agent.model_metadata.get_model_context_length``
+    which classifies the actual model slug/provider pair: general GPT slugs on
+    ChatGPT/Codex OAuth use OpenAI metadata, Codex-specialized slugs use the
+    Codex catalog, and Copilot/Nous/custom providers keep their own overrides.
 
     When ``custom_providers`` is provided, per-model ``context_length``
     overrides from ``custom_providers[].models.<id>.context_length`` are

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -242,10 +242,12 @@ class TestDefaultContextLengths:
 # =========================================================================
 
 class TestCodexOAuthContextLength:
-    """ChatGPT Codex OAuth imposes lower context limits than the direct
-    OpenAI API for the same slugs. Verified Apr 2026 via live probe of
-    chatgpt.com/backend-api/codex/models: every model returns 272k, while
-    models.dev reports 1.05M for gpt-5.5/gpt-5.4 and 400k for the rest.
+    """ChatGPT/Codex OAuth is a transport path, not one model family.
+
+    The live catalog exposes both general GPT slugs (gpt-5.5, gpt-5.4, etc.)
+    and Codex-specialized slugs (gpt-5.3-codex, codex-auto-review). General GPT
+    slugs should use OpenAI model metadata; Codex-specialized slugs should use
+    the Codex catalog/fallback values.
     """
 
     def setup_method(self):
@@ -253,69 +255,199 @@ class TestCodexOAuthContextLength:
         mm._codex_oauth_context_cache = {}
         mm._codex_oauth_context_cache_time = 0.0
 
-    def test_fallback_table_used_without_token(self):
-        """With no access token, the hardcoded Codex fallback table wins
-        over models.dev (which reports 1.05M for gpt-5.5 but Codex is 272k).
-        """
+    def test_codex_oauth_base_url_detection_rejects_spoofed_hosts_and_paths(self):
+        from agent import model_metadata as mm
+
+        assert mm._is_codex_oauth_base_url("https://chatgpt.com/backend-api/codex")
+        assert mm._is_codex_oauth_base_url(
+            "https://chatgpt.com/backend-api/codex/models?client_version=1.0.0"
+        )
+        assert not mm._is_codex_oauth_base_url("https://evilchatgpt.com/backend-api/codex")
+        assert not mm._is_codex_oauth_base_url("https://chatgpt.com.evil/backend-api/codex")
+        assert not mm._is_codex_oauth_base_url("https://chatgpt.com/backend-api/codexevil")
+
+    def test_general_gpt_slugs_use_openai_metadata_without_token(self):
+        """General GPT slugs on the Codex OAuth transport keep OpenAI context."""
         from agent.model_metadata import get_model_context_length
 
+        expected = {
+            "gpt-5.5": 1_050_000,
+            "gpt-5.4": 1_050_000,
+            "gpt-5.4-mini": 400_000,
+        }
         with patch("agent.model_metadata.get_cached_context_length", return_value=None), \
              patch("agent.model_metadata.save_context_length"):
-            for model in (
-                "gpt-5.5",
-                "gpt-5.4",
-                "gpt-5.4-mini",
-                "gpt-5.3-codex",
-                "gpt-5.2-codex",
-                "gpt-5.1-codex-max",
-                "gpt-5.1-codex-mini",
-            ):
+            for model, expected_ctx in expected.items():
                 ctx = get_model_context_length(
                     model=model,
                     base_url="https://chatgpt.com/backend-api/codex",
                     api_key="",
                     provider="openai-codex",
                 )
-                assert ctx == 272_000, (
-                    f"Codex {model}: expected 272000 fallback, got {ctx} "
-                    "(models.dev leakage?)"
+                assert ctx == expected_ctx, (
+                    f"Codex transport {model}: expected OpenAI context "
+                    f"{expected_ctx}, got {ctx}"
                 )
 
-    def test_live_probe_overrides_fallback(self):
-        """When a token is provided, the live /models probe is preferred
-        and its context_window drives the result."""
+    def test_general_gpt_codex_base_url_ignores_stale_codex_catalog_cache(self):
+        """Codex base URL alone is enough to classify the OAuth transport.
+
+        Some callers know the runtime URL before the provider slug is fully
+        normalized. A stale Codex catalog cache entry for gpt-5.5 must not win
+        over the canonical OpenAI model context in that path.
+        """
+        from agent import model_metadata as mm
+
+        base_url = "https://chatgpt.com/backend-api/codex"
+        with patch("agent.model_metadata.get_cached_context_length", return_value=272_000), \
+             patch("agent.model_metadata.save_context_length") as mock_save, \
+             patch("agent.models_dev.lookup_models_dev_context", return_value=1_050_000) as lookup_ctx, \
+             patch("agent.model_metadata._resolve_codex_oauth_context_length", return_value=272_000) as codex_ctx:
+            ctx = mm.get_model_context_length(
+                model="gpt-5.5",
+                base_url=base_url,
+                api_key="",
+                provider="",
+            )
+
+        assert ctx == 1_050_000
+        lookup_ctx.assert_called_once_with("openai", "gpt-5.5")
+        codex_ctx.assert_not_called()
+        mock_save.assert_called_once_with("gpt-5.5", base_url, 1_050_000)
+
+    def test_namespaced_general_gpt_slug_uses_openai_metadata_on_codex_transport(self):
+        """openai/gpt-* slugs are still general GPT models on Codex OAuth."""
+        from agent import model_metadata as mm
+
+        base_url = "https://chatgpt.com/backend-api/codex"
+
+        def fake_lookup(provider, model):
+            if provider == "openai" and model == "gpt-5.5":
+                return 1_050_000
+            return None
+
+        with patch("agent.model_metadata.get_cached_context_length", return_value=272_000), \
+             patch("agent.model_metadata.save_context_length") as mock_save, \
+             patch("agent.models_dev.lookup_models_dev_context", side_effect=fake_lookup) as lookup_ctx, \
+             patch("agent.model_metadata._resolve_codex_oauth_context_length", return_value=272_000) as codex_ctx:
+            ctx = mm.get_model_context_length(
+                model="openai/gpt-5.5",
+                base_url=base_url,
+                api_key="",
+                provider="openai-codex",
+            )
+
+        assert ctx == 1_050_000
+        assert lookup_ctx.call_args_list[-1].args == ("openai", "gpt-5.5")
+        codex_ctx.assert_not_called()
+        mock_save.assert_called_once_with("openai/gpt-5.5", base_url, 1_050_000)
+
+    def test_codex_base_url_keeps_codex_specialized_catalog_context_without_provider(self):
+        """Codex-specialized slugs still use the Codex catalog when provider is blank."""
+        from agent import model_metadata as mm
+
+        base_url = "https://chatgpt.com/backend-api/codex"
+        with patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata.save_context_length") as mock_save, \
+             patch("agent.models_dev.lookup_models_dev_context", return_value=400_000) as lookup_ctx, \
+             patch("agent.model_metadata._resolve_codex_oauth_context_length", return_value=272_000) as codex_ctx:
+            ctx = mm.get_model_context_length(
+                model="gpt-5.3-codex",
+                base_url=base_url,
+                api_key="",
+                provider="",
+            )
+
+        assert ctx == 272_000
+        lookup_ctx.assert_not_called()
+        codex_ctx.assert_called_once_with("gpt-5.3-codex", access_token="")
+        mock_save.assert_called_once_with("gpt-5.3-codex", base_url, 272_000)
+
+    def test_codex_specialized_fallback_table_used_without_token(self):
+        """Codex-specialized slugs still use the Codex fallback table."""
+        from agent.model_metadata import get_model_context_length
+
+        expected = {
+            "gpt-5.3-codex-spark": 128_000,
+            "gpt-5.3-codex": 272_000,
+            "gpt-5.2-codex": 272_000,
+            "gpt-5.1-codex-max": 272_000,
+            "gpt-5.1-codex-mini": 272_000,
+            "codex-auto-review": 272_000,
+        }
+        with patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata.save_context_length"):
+            for model, expected_ctx in expected.items():
+                ctx = get_model_context_length(
+                    model=model,
+                    base_url="https://chatgpt.com/backend-api/codex",
+                    api_key="",
+                    provider="openai-codex",
+                )
+                assert ctx == expected_ctx, (
+                    f"Codex {model}: expected {expected_ctx} fallback, got {ctx}"
+                )
+
+    def test_unknown_codex_specialized_slug_uses_generic_codex_fallback(self):
+        """Future Codex slugs should not leak into broad OpenAI GPT defaults."""
+        from agent.model_metadata import get_model_context_length
+
+        with patch("agent.model_metadata.get_cached_context_length", return_value=None), \
+             patch("agent.model_metadata.save_context_length"), \
+             patch("agent.models_dev.lookup_models_dev_context", return_value=1_050_000) as lookup_ctx:
+            ctx = get_model_context_length(
+                model="gpt-5.9-codex",
+                base_url="https://chatgpt.com/backend-api/codex",
+                api_key="",
+                provider="openai-codex",
+            )
+
+        assert ctx == 272_000
+        lookup_ctx.assert_not_called()
+
+    def test_codex_catalog_helper_ignores_general_gpt_slugs(self):
+        """The Codex catalog helper is only authoritative for Codex-specialized slugs."""
+        from agent import model_metadata as mm
+
+        with patch("agent.model_metadata.requests.get") as mock_get:
+            ctx = mm._resolve_codex_oauth_context_length("gpt-5.5", access_token="fake-token")
+
+        assert ctx is None
+        mock_get.assert_not_called()
+
+    def test_live_probe_overrides_codex_specialized_fallback(self):
+        """For Codex-specialized slugs, live /models beats fallback values."""
         from agent.model_metadata import get_model_context_length
 
         fake_response = MagicMock()
         fake_response.status_code = 200
         fake_response.json.return_value = {
             "models": [
-                {"slug": "gpt-5.5", "context_window": 300_000},
-                {"slug": "gpt-5.4", "context_window": 400_000},
+                {"slug": "gpt-5.3-codex", "context_window": 300_000},
+                {"slug": "codex-auto-review", "context_window": 128_000},
             ]
         }
 
         with patch("agent.model_metadata.requests.get", return_value=fake_response), \
              patch("agent.model_metadata.get_cached_context_length", return_value=None), \
              patch("agent.model_metadata.save_context_length"):
-            ctx_55 = get_model_context_length(
-                model="gpt-5.5",
+            ctx_codex = get_model_context_length(
+                model="gpt-5.3-codex",
                 base_url="https://chatgpt.com/backend-api/codex",
                 api_key="fake-token",
                 provider="openai-codex",
             )
-            ctx_54 = get_model_context_length(
-                model="gpt-5.4",
+            ctx_review = get_model_context_length(
+                model="codex-auto-review",
                 base_url="https://chatgpt.com/backend-api/codex",
                 api_key="fake-token",
                 provider="openai-codex",
             )
-        assert ctx_55 == 300_000
-        assert ctx_54 == 400_000
+        assert ctx_codex == 300_000
+        assert ctx_review == 128_000
 
-    def test_probe_failure_falls_back_to_hardcoded(self):
-        """If the probe fails (non-200 / network error), we still return
-        the hardcoded 272k rather than leaking through to models.dev 1.05M."""
+    def test_codex_specialized_probe_failure_falls_back_to_hardcoded(self):
+        """If the Codex probe fails, Codex-specialized slugs use fallback."""
         from agent.model_metadata import get_model_context_length
 
         fake_response = MagicMock()
@@ -326,7 +458,7 @@ class TestCodexOAuthContextLength:
              patch("agent.model_metadata.get_cached_context_length", return_value=None), \
              patch("agent.model_metadata.save_context_length"):
             ctx = get_model_context_length(
-                model="gpt-5.5",
+                model="gpt-5.3-codex",
                 base_url="https://chatgpt.com/backend-api/codex",
                 api_key="expired-token",
                 provider="openai-codex",
@@ -334,15 +466,12 @@ class TestCodexOAuthContextLength:
         assert ctx == 272_000
 
     def test_non_codex_providers_unaffected(self):
-        """Resolving gpt-5.5 on non-Codex providers must NOT use the Codex
-        272k override — OpenRouter / direct OpenAI API have different limits.
-        """
+        """Resolving gpt-5.5 on non-Codex providers must keep OpenAI context."""
         from agent.model_metadata import get_model_context_length
 
         # OpenRouter — should hit its own catalog path first; when mocked
         # empty, falls through to hardcoded DEFAULT_CONTEXT_LENGTHS (1.05M,
-        # matching the real direct-API value — Codex OAuth's 272k cap is
-        # provider-specific and must not leak here).
+        # matching the real direct-API value).
         with patch("agent.model_metadata.fetch_model_metadata", return_value={}), \
              patch("agent.model_metadata.fetch_endpoint_model_metadata", return_value={}), \
              patch("agent.model_metadata.get_cached_context_length", return_value=None), \
@@ -354,17 +483,12 @@ class TestCodexOAuthContextLength:
                 provider="openrouter",
             )
         assert ctx == 1_050_000, (
-            f"Non-Codex gpt-5.5 resolved to {ctx}; Codex 272k override "
-            "leaked outside openai-codex provider"
+            f"Non-Codex gpt-5.5 resolved to {ctx}; Codex-specialized override "
+            "leaked outside its provider/model family"
         )
 
-    def test_stale_codex_cache_over_400k_is_invalidated(self, tmp_path, monkeypatch):
-        """Pre-PR #14935 builds cached gpt-5.5 at 1.05M (from models.dev)
-        before the Codex-aware branch existed. Upgrading users keep that
-        stale entry on disk and the cache-first lookup returns it forever.
-        Codex OAuth caps at 272k for every slug, so any cached Codex
-        entry >= 400k must be dropped and re-resolved via the live probe.
-        """
+    def test_stale_codex_specialized_cache_over_400k_is_invalidated(self, tmp_path, monkeypatch):
+        """Over-large cache entries for Codex-specialized slugs are re-probed."""
         from agent import model_metadata as mm
 
         # Isolate the cache file to tmp_path
@@ -372,24 +496,24 @@ class TestCodexOAuthContextLength:
         monkeypatch.setattr(mm, "_get_context_cache_path", lambda: cache_file)
 
         base_url = "https://chatgpt.com/backend-api/codex/"
-        stale_key = f"gpt-5.5@{base_url}"
+        stale_key = f"gpt-5.3-codex@{base_url}"
         other_key = "other-model@https://api.openai.com/v1/"
         import yaml as _yaml
         cache_file.write_text(_yaml.dump({"context_lengths": {
-            stale_key: 1_050_000,   # stale pre-fix value
+            stale_key: 400_000,     # stale over-large Codex-specialized value
             other_key: 128_000,     # unrelated, must survive
         }}))
 
         fake_response = MagicMock()
         fake_response.status_code = 200
         fake_response.json.return_value = {
-            "models": [{"slug": "gpt-5.5", "context_window": 272_000}]
+            "models": [{"slug": "gpt-5.3-codex", "context_window": 272_000}]
         }
 
         with patch("agent.model_metadata.requests.get", return_value=fake_response), \
              patch("agent.model_metadata.save_context_length") as mock_save:
             ctx = mm.get_model_context_length(
-                model="gpt-5.5",
+                model="gpt-5.3-codex",
                 base_url=base_url,
                 api_key="fake-token",
                 provider="openai-codex",
@@ -397,15 +521,43 @@ class TestCodexOAuthContextLength:
 
         assert ctx == 272_000, f"Stale entry should have been re-resolved to 272k, got {ctx}"
         # Live save was called with the fresh value
-        mock_save.assert_called_with("gpt-5.5", base_url, 272_000)
+        mock_save.assert_called_with("gpt-5.3-codex", base_url, 272_000)
         # The stale entry was removed from disk; unrelated entries survived
         remaining = _yaml.safe_load(cache_file.read_text()).get("context_lengths", {})
         assert stale_key not in remaining, "Stale entry was not invalidated from the cache file"
         assert remaining.get(other_key) == 128_000, "Unrelated cache entries must not be touched"
 
-    def test_fresh_codex_cache_under_400k_is_respected(self, tmp_path, monkeypatch):
-        """Codex entries at the correct 272k must NOT be invalidated —
-        only stale pre-fix values (>= 400k) get dropped."""
+    def test_stale_codex_spark_cache_from_old_fallback_table_is_invalidated(self, tmp_path, monkeypatch):
+        """Old substring fallback could cache spark at 272K; spark is now 128K."""
+        from agent import model_metadata as mm
+
+        cache_file = tmp_path / "context_length_cache.yaml"
+        monkeypatch.setattr(mm, "_get_context_cache_path", lambda: cache_file)
+
+        base_url = "https://chatgpt.com/backend-api/codex/"
+        stale_key = f"gpt-5.3-codex-spark@{base_url}"
+        import yaml as _yaml
+        cache_file.write_text(_yaml.dump({"context_lengths": {
+            stale_key: 272_000,
+        }}))
+
+        with patch("agent.model_metadata.requests.get") as mock_get, \
+             patch("agent.model_metadata.save_context_length") as mock_save:
+            ctx = mm.get_model_context_length(
+                model="gpt-5.3-codex-spark",
+                base_url=base_url,
+                api_key="",
+                provider="openai-codex",
+            )
+
+        assert ctx == 128_000
+        mock_get.assert_not_called()
+        mock_save.assert_called_with("gpt-5.3-codex-spark", base_url, 128_000)
+        remaining = _yaml.safe_load(cache_file.read_text()).get("context_lengths", {})
+        assert stale_key not in remaining, "Stale spark entry was not invalidated"
+
+    def test_fresh_codex_specialized_cache_under_400k_is_respected(self, tmp_path, monkeypatch):
+        """Correct Codex-specialized cache entries must not be invalidated."""
         from agent import model_metadata as mm
 
         cache_file = tmp_path / "context_length_cache.yaml"
@@ -414,13 +566,13 @@ class TestCodexOAuthContextLength:
         base_url = "https://chatgpt.com/backend-api/codex/"
         import yaml as _yaml
         cache_file.write_text(_yaml.dump({"context_lengths": {
-            f"gpt-5.5@{base_url}": 272_000,
+            f"gpt-5.3-codex@{base_url}": 272_000,
         }}))
 
         # If the invalidation incorrectly fired, this would be called; assert it isn't.
         with patch("agent.model_metadata.requests.get") as mock_get:
             ctx = mm.get_model_context_length(
-                model="gpt-5.5",
+                model="gpt-5.3-codex",
                 base_url=base_url,
                 api_key="fake-token",
                 provider="openai-codex",

--- a/tests/hermes_cli/test_apply_model_switch_result_context.py
+++ b/tests/hermes_cli/test_apply_model_switch_result_context.py
@@ -1,13 +1,11 @@
 """Regression test for the `/model` picker confirmation display.
 
-Bug (April 2026): after choosing a model from the interactive `/model` picker,
-``HermesCLI._apply_model_switch_result()`` printed ``ModelInfo.context_window``
-straight from models.dev, which always reports the vendor-wide value (e.g.
-gpt-5.5 = 1,050,000 on ``openai``). That ignored provider-specific caps — in
-particular, ChatGPT Codex OAuth enforces 272K on the same slug. The sibling
-``_handle_model_switch()`` (typed ``/model <name>``) was already fixed to use
-``resolve_display_context_length()``; the picker path was missed, causing
-"sometimes 1M, sometimes 272K" for the same model across sibling UI paths.
+After choosing a model from the interactive `/model` picker,
+``HermesCLI._apply_model_switch_result()`` must print the same provider-aware
+context value as the typed ``/model <name>`` path. This matters for
+ChatGPT/Codex OAuth because ``openai-codex`` is the auth/transport provider,
+while the selected slug may be a general GPT model (gpt-5.5 = 1.05M) or a
+Codex-specialized model (gpt-5.3-codex = Codex catalog value).
 
 Fix: both display paths now go through ``resolve_display_context_length()``.
 """
@@ -55,8 +53,9 @@ def _run_display(monkeypatch, result):
 
 
 def test_picker_path_uses_provider_aware_context_on_codex(monkeypatch):
-    """``_apply_model_switch_result`` must prefer the provider-aware resolver
-    (272K on Codex) over the raw models.dev value (1.05M for gpt-5.5).
+    """``_apply_model_switch_result`` must use the resolver for Codex OAuth.
+
+    For general GPT slugs, that resolver returns the OpenAI model context.
     """
     result = ModelSwitchResult(
         success=True,
@@ -75,16 +74,13 @@ def test_picker_path_uses_provider_aware_context_on_codex(monkeypatch):
     )
     with patch(
         "agent.model_metadata.get_model_context_length",
-        return_value=272_000,
+        return_value=1_050_000,
     ):
         lines = _run_display(monkeypatch, result)
 
     ctx_line = next((l for l in lines if "Context:" in l), "")
-    assert "272,000" in ctx_line, (
-        f"picker-path display must show Codex's 272K cap, got: {ctx_line!r}"
-    )
-    assert "1,050,000" not in ctx_line, (
-        f"picker-path display leaked models.dev's 1.05M for Codex: {ctx_line!r}"
+    assert "1,050,000" in ctx_line, (
+        f"picker-path display must show gpt-5.5's OpenAI context, got: {ctx_line!r}"
     )
 
 

--- a/tests/hermes_cli/test_model_switch_context_display.py
+++ b/tests/hermes_cli/test_model_switch_context_display.py
@@ -1,14 +1,10 @@
-"""Regression test for /model context-length display on provider-capped models.
+"""Regression tests for /model context-length display.
 
-Bug (April 2026): `/model gpt-5.5` on openai-codex (ChatGPT OAuth) showed
-"Context: 1,050,000 tokens" because the display code used the raw models.dev
-``ModelInfo.context_window`` (which reports the direct-OpenAI API value) instead
-of the provider-aware resolver. The agent was actually running at 272K — Codex
-OAuth's enforced cap — so the display was lying to the user.
-
-Fix: ``resolve_display_context_length()`` prefers
-``agent.model_metadata.get_model_context_length`` (which knows about Codex OAuth,
-Copilot, Nous, etc.) and falls back to models.dev only if that returns nothing.
+`resolve_display_context_length()` should report the provider-aware resolver value
+used by the running session. For ChatGPT/Codex OAuth this matters because the
+provider name describes the auth/transport path, while the selected slug may be
+a general GPT model (for example gpt-5.5) or a Codex-specialized model (for
+example gpt-5.3-codex).
 """
 from __future__ import annotations
 
@@ -23,12 +19,12 @@ class _FakeModelInfo:
 
 
 class TestResolveDisplayContextLength:
-    def test_codex_oauth_overrides_models_dev(self):
-        """gpt-5.5 on openai-codex must show Codex's 272K cap, not models.dev's 1.05M."""
-        fake_mi = _FakeModelInfo(1_050_000)  # what models.dev reports
+    def test_codex_oauth_gpt_display_uses_resolved_openai_context(self):
+        """gpt-5.5 on the Codex OAuth transport should display its GPT context."""
+        fake_mi = _FakeModelInfo(1_050_000)
         with patch(
             "agent.model_metadata.get_model_context_length",
-            return_value=272_000,  # what Codex OAuth actually enforces
+            return_value=1_050_000,
         ):
             ctx = resolve_display_context_length(
                 "gpt-5.5",
@@ -37,9 +33,23 @@ class TestResolveDisplayContextLength:
                 api_key="",
                 model_info=fake_mi,
             )
-        assert ctx == 272_000, (
-            "Codex OAuth's 272K cap must win over models.dev's 1.05M for gpt-5.5"
-        )
+        assert ctx == 1_050_000
+
+    def test_codex_specialized_display_uses_resolved_catalog_context(self):
+        """Codex-specialized slugs should display the Codex catalog context."""
+        fake_mi = _FakeModelInfo(400_000)
+        with patch(
+            "agent.model_metadata.get_model_context_length",
+            return_value=272_000,
+        ):
+            ctx = resolve_display_context_length(
+                "gpt-5.3-codex",
+                "openai-codex",
+                base_url="https://chatgpt.com/backend-api/codex",
+                api_key="",
+                model_info=fake_mi,
+            )
+        assert ctx == 272_000
 
     def test_falls_back_to_model_info_when_resolver_returns_none(self):
         fake_mi = _FakeModelInfo(1_048_576)


### PR DESCRIPTION
## Summary
- Resolve GPT-series context lengths when using Codex OAuth / ChatGPT subscription auth
- Preserve provider-specific behavior while avoiding stale/incorrect context-window display
- Add focused regression coverage for Codex OAuth context resolution and model-switch display

## Test plan
- `PYTHONPATH=. pytest tests/agent/test_model_metadata.py tests/hermes_cli/test_apply_model_switch_result_context.py tests/hermes_cli/test_model_switch_context_display.py -q`
- `PYTHONPATH=. pytest tests/hermes_cli/test_model_switch.py tests/hermes_cli/test_model_switch_context_display.py tests/hermes_cli/test_apply_model_switch_result_context.py tests/agent/test_model_metadata.py -q`
- `python -m py_compile agent/model_metadata.py cli.py hermes_cli/model_switch.py`
- `git diff --check`
