### PR TITLE
fix(cloudcode): always populate full delta schema in stream chunks

### DIFF
--- a/agent/gemini_cloudcode_adapter.py
+++ b/agent/gemini_cloudcode_adapter.py
@@ -450,9 +450,17 @@ def _make_stream_chunk(
     finish_reason: Optional[str] = None,
     reasoning: str = "",
 ) -> _GeminiStreamChunk:
-    delta_kwargs: Dict[str, Any] = {"role": "assistant"}
-    if content:
-        delta_kwargs["content"] = content
+    # Always initialize the full set of OpenAI delta keys so consumers can
+    # safely read ``delta.content`` / ``delta.tool_calls`` / ``delta.reasoning``
+    # without AttributeError on chunks that carry only a subset (e.g. a chunk
+    # with just a functionCall and no text content).
+    delta_kwargs: Dict[str, Any] = {
+        "role": "assistant",
+        "content": content if content else None,
+        "tool_calls": None,
+        "reasoning": None,
+        "reasoning_content": None,
+    }
     if tool_call_delta is not None:
         delta_kwargs["tool_calls"] = [SimpleNamespace(
             index=tool_call_delta.get("index", 0),

--- a/tests/agent/test_gemini_cloudcode.py
+++ b/tests/agent/test_gemini_cloudcode.py
@@ -850,6 +850,67 @@ class TestTranslateGeminiResponse:
         assert _map_gemini_finish_reason("RECITATION") == "content_filter"
 
 
+class TestMakeStreamChunk:
+    """``_make_stream_chunk`` must always initialize the full OpenAI delta
+    schema (``content`` / ``tool_calls`` / ``reasoning`` / ``reasoning_content``)
+    so consumers can read any of them without AttributeError, regardless of
+    which fields the upstream chunk happened to carry.
+    """
+
+    def test_chunk_with_only_tool_call_exposes_content_attribute(self):
+        """Regression: consumers do ``if delta and delta.content:`` — that
+        crashes with ``'types.SimpleNamespace' object has no attribute
+        'content'`` when the chunk is built from a Gemini event that carried
+        only a functionCall (no text part)."""
+        from agent.gemini_cloudcode_adapter import _make_stream_chunk
+
+        chunk = _make_stream_chunk(
+            model="m",
+            tool_call_delta={"name": "read_file", "arguments": '{"path":"a"}'},
+        )
+        delta = chunk.choices[0].delta
+        # All four optional keys must be addressable as attributes:
+        assert delta.content is None
+        assert delta.tool_calls is not None
+        assert delta.reasoning is None
+        assert delta.reasoning_content is None
+        # And the tool_call payload survives.
+        assert delta.tool_calls[0].function.name == "read_file"
+
+    def test_chunk_with_only_text_content_exposes_tool_calls_attribute(self):
+        from agent.gemini_cloudcode_adapter import _make_stream_chunk
+
+        chunk = _make_stream_chunk(model="m", content="hello")
+        delta = chunk.choices[0].delta
+        assert delta.content == "hello"
+        assert delta.tool_calls is None
+        assert delta.reasoning is None
+        assert delta.reasoning_content is None
+
+    def test_chunk_with_only_reasoning_exposes_other_attributes(self):
+        from agent.gemini_cloudcode_adapter import _make_stream_chunk
+
+        chunk = _make_stream_chunk(model="m", reasoning="thinking...")
+        delta = chunk.choices[0].delta
+        assert delta.content is None
+        assert delta.tool_calls is None
+        assert delta.reasoning == "thinking..."
+        assert delta.reasoning_content == "thinking..."
+
+    def test_empty_chunk_exposes_all_attributes_as_none(self):
+        """Terminal chunks (e.g. only a finish_reason) carry no payload but
+        must still expose every delta attribute as ``None``."""
+        from agent.gemini_cloudcode_adapter import _make_stream_chunk
+
+        chunk = _make_stream_chunk(model="m", finish_reason="stop")
+        delta = chunk.choices[0].delta
+        assert delta.content is None
+        assert delta.tool_calls is None
+        assert delta.reasoning is None
+        assert delta.reasoning_content is None
+        assert chunk.choices[0].finish_reason == "stop"
+
+
 class TestTranslateStreamEvent:
     def test_parallel_calls_to_same_tool_get_unique_indices(self):
         """Gemini may emit several functionCall parts with the same name in a


### PR DESCRIPTION
## Summary

Fixes `'types.SimpleNamespace' object has no attribute 'content'` (and analogous `AttributeError`s for `tool_calls` / `reasoning`) when consuming Cloud Code Assist streaming chunks. `_make_stream_chunk` builds the OpenAI-shaped delta with conditional kwargs, so any consumer that reads those attributes unconditionally (e.g. `run_agent.py`'s `if delta and delta.content:`) crashes whenever a chunk carries only a subset of the fields.

## Reproducer

In normal use this fires when streaming Code Assist responses that include parallel tool calls — upstream emits chunks containing only a `functionCall` part (no text content), so the resulting `SimpleNamespace` lacks the `content` attribute.

In production (Hermes 0.12 / 0.13, Code Assist Standard subscription via `google-gemini-cli`):

```
[subagent-0] API call failed after 3 retries.
'types.SimpleNamespace' object has no attribute 'content' | provider=google-gemini-cli
model=gemini-3.1-pro-preview msgs=2 tokens=~1,191
```

Every `delegate_task` subagent dies after 3 retries × ~90 s and the parent agent falls through to its fallback chain — even when the underlying Code Assist API request would have succeeded.

## Fix

Always seed `delta_kwargs` with all four optional keys (`content`, `tool_calls`, `reasoning`, `reasoning_content`) set to `None`, then conditionally overwrite the ones with payload. The resulting `SimpleNamespace` consistently exposes every delta attribute, matching the contract of OpenAI's `ChatCompletionChunk` delta object.

## Tests

Added `tests/agent/test_gemini_cloudcode.py::TestMakeStreamChunk`:

- `test_chunk_with_only_tool_call_exposes_content_attribute` — regression test for the original symptom (tool-call-only chunk must expose `.content` as `None`, not raise `AttributeError`).
- `test_chunk_with_only_text_content_exposes_tool_calls_attribute`
- `test_chunk_with_only_reasoning_exposes_other_attributes`
- `test_empty_chunk_exposes_all_attributes_as_none` — terminal chunks (only `finish_reason`) still expose all delta attributes.

## Test plan

- [x] `pytest tests/agent/test_gemini_cloudcode.py` — 89 passed (85 baseline + 4 new)
- [x] Live verification: `delegate_task` against Code Assist OAuth — before fix, subagents fail after 3 retries with the SimpleNamespace `AttributeError`; after fix, subagent completes the call and returns its summary.

Note: this PR is independent of #21843 (parallel tool results merge). Both fixes are in `agent/gemini_cloudcode_adapter.py` but address different bugs in the OpenAI↔Gemini translation layer.