### PR TITLE
fix(security): validate media file paths + fix class prefix in extract_media

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1886,6 +1886,23 @@ class BasePlatformAdapter(ABC):
         return await self.send(chat_id=chat_id, content=text, reply_to=reply_to)
 
     @staticmethod
+    def _is_safe_media_path(path: str) -> bool:
+        """Validate that a MEDIA: path is within the Hermes cache directory.
+
+        Rejects absolute paths, parent-directory traversal, and paths outside
+        the designated media cache to prevent arbitrary file reads via prompt
+        injection.
+        """
+        cache_dir = os.path.realpath(os.path.join(
+            os.path.expanduser("~"), ".hermes", "media_cache"
+        ))
+        try:
+            resolved = os.path.realpath(os.path.expanduser(path))
+        except (ValueError, OSError):
+            return False
+        return resolved.startswith(cache_dir + os.sep) or resolved == cache_dir
+
+    @staticmethod
     def extract_media(content: str) -> Tuple[List[Tuple[str, bool]], str]:
         """
         Extract MEDIA:<path> tags and [[audio_as_voice]] directives from response text.
@@ -1932,7 +1949,7 @@ class BasePlatformAdapter(ABC):
             if len(path) >= 2 and path[0] == path[-1] and path[0] in "`\"'":
                 path = path[1:-1].strip()
             path = path.lstrip("`\"'").rstrip("`\"',.;:)}]")
-            if path:
+            if path and BasePlatformAdapter._is_safe_media_path(path):
                 media.append((os.path.expanduser(path), has_voice_tag))
 
         # Remove MEDIA tags from content (including surrounding quote/backtick wrappers)


### PR DESCRIPTION
## Summary

Combines two related fixes for the MEDIA: tag file sending system:

1. Add `_is_safe_media_path()` — validates MEDIA:<path> tags against arbitrary file read via prompt injection
2. Fix NameError: add `BasePlatformAdapter` class prefix to static method call inside `extract_media()`

## Test Plan

- [x] `_is_safe_media_path('/tmp/test.txt')` returns False
- [x] `extract_media('MEDIA:/path/file.md')` no longer raises NameError

## Related

- Original security fix: commit 1181fa76e (PR #4686)
- Class prefix fix: commit 2be688537