### PR TITLE
fix(kanban): tolerate races on legacy-DB column migration

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3929,10 +3929,15 @@ class GatewayRunner:
             conn = None
             try:
                 conn = _kb.connect(board=slug)
-                try:
-                    _kb.init_db(board=slug)  # idempotent, handles first-run
-                except Exception:
-                    pass
+                # `connect()` runs the schema + idempotent migration on
+                # first open per process, so an explicit `init_db()` here
+                # would be redundant. Worse: `init_db()` deliberately
+                # busts the per-process cache and re-runs the migration
+                # on a *second* connection, which races the first and
+                # used to log a benign but noisy `duplicate column name`
+                # traceback on every gateway start against a legacy DB.
+                # The migration helper now tolerates that race, but we
+                # still skip the redundant call to avoid the wasted work.
                 return _kb.dispatch_once(
                     conn,
                     board=slug,

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -959,6 +959,33 @@ def init_db(
     return path
 
 
+def _safe_add_column(conn: sqlite3.Connection, sql: str) -> bool:
+    """Run an ``ALTER TABLE … ADD COLUMN`` idempotently.
+
+    SQLite has no ``ADD COLUMN IF NOT EXISTS``. Two callers can race on the
+    same DB file (e.g. embedded gateway dispatcher's ``connect()`` plus a
+    follow-up ``init_db()`` that deliberately busts the per-process cache,
+    or a second process opening the DB during startup) and both pass the
+    pre-ALTER ``cols`` snapshot check before either ALTER lands. The loser
+    raises ``sqlite3.OperationalError: duplicate column name: <name>``.
+
+    The error is benign — by the time it fires, the column is present —
+    but it surfaces as a logged traceback on every gateway start against a
+    legacy DB. Swallow exactly that one error so the migration becomes
+    idempotent against itself; re-raise anything else.
+
+    Returns True if the ALTER ran successfully, False if it was a no-op
+    because the column already existed.
+    """
+    try:
+        conn.execute(sql)
+        return True
+    except sqlite3.OperationalError as exc:
+        if "duplicate column name" in str(exc).lower():
+            return False
+        raise
+
+
 def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     """Add columns that were introduced after v1 release to legacy DBs.
 
@@ -966,11 +993,11 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     """
     cols = {row["name"] for row in conn.execute("PRAGMA table_info(tasks)")}
     if "tenant" not in cols:
-        conn.execute("ALTER TABLE tasks ADD COLUMN tenant TEXT")
+        _safe_add_column(conn, "ALTER TABLE tasks ADD COLUMN tenant TEXT")
     if "result" not in cols:
-        conn.execute("ALTER TABLE tasks ADD COLUMN result TEXT")
+        _safe_add_column(conn, "ALTER TABLE tasks ADD COLUMN result TEXT")
     if "idempotency_key" not in cols:
-        conn.execute("ALTER TABLE tasks ADD COLUMN idempotency_key TEXT")
+        _safe_add_column(conn, "ALTER TABLE tasks ADD COLUMN idempotency_key TEXT")
         conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_tasks_idempotency "
             "ON tasks(idempotency_key)"
@@ -993,37 +1020,38 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     # the *original* snapshot; this is intentional and safe as long as
     # no step depends on a column added by a previous step in the same call.
     if "consecutive_failures" not in cols:
-        conn.execute(
+        _safe_add_column(
+            conn,
             "ALTER TABLE tasks ADD COLUMN consecutive_failures "
-            "INTEGER NOT NULL DEFAULT 0"
+            "INTEGER NOT NULL DEFAULT 0",
         )
         if "spawn_failures" in cols:
             conn.execute(
                 "UPDATE tasks SET consecutive_failures = COALESCE(spawn_failures, 0)"
             )
     if "worker_pid" not in cols:
-        conn.execute("ALTER TABLE tasks ADD COLUMN worker_pid INTEGER")
+        _safe_add_column(conn, "ALTER TABLE tasks ADD COLUMN worker_pid INTEGER")
     if "last_failure_error" not in cols:
-        conn.execute("ALTER TABLE tasks ADD COLUMN last_failure_error TEXT")
+        _safe_add_column(conn, "ALTER TABLE tasks ADD COLUMN last_failure_error TEXT")
         if "last_spawn_error" in cols:
             conn.execute(
                 "UPDATE tasks SET last_failure_error = last_spawn_error"
             )
     if "max_runtime_seconds" not in cols:
-        conn.execute("ALTER TABLE tasks ADD COLUMN max_runtime_seconds INTEGER")
+        _safe_add_column(conn, "ALTER TABLE tasks ADD COLUMN max_runtime_seconds INTEGER")
     if "last_heartbeat_at" not in cols:
-        conn.execute("ALTER TABLE tasks ADD COLUMN last_heartbeat_at INTEGER")
+        _safe_add_column(conn, "ALTER TABLE tasks ADD COLUMN last_heartbeat_at INTEGER")
     if "current_run_id" not in cols:
-        conn.execute("ALTER TABLE tasks ADD COLUMN current_run_id INTEGER")
+        _safe_add_column(conn, "ALTER TABLE tasks ADD COLUMN current_run_id INTEGER")
     if "workflow_template_id" not in cols:
-        conn.execute("ALTER TABLE tasks ADD COLUMN workflow_template_id TEXT")
+        _safe_add_column(conn, "ALTER TABLE tasks ADD COLUMN workflow_template_id TEXT")
     if "current_step_key" not in cols:
-        conn.execute("ALTER TABLE tasks ADD COLUMN current_step_key TEXT")
+        _safe_add_column(conn, "ALTER TABLE tasks ADD COLUMN current_step_key TEXT")
     if "skills" not in cols:
         # JSON array of skill names the dispatcher force-loads into the
         # worker (additive to the built-in `kanban-worker`). NULL is fine
         # for existing rows.
-        conn.execute("ALTER TABLE tasks ADD COLUMN skills TEXT")
+        _safe_add_column(conn, "ALTER TABLE tasks ADD COLUMN skills TEXT")
 
     if "max_retries" not in cols:
         # Per-task override for the consecutive-failure circuit breaker.
@@ -1031,13 +1059,13 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         # config, then ``DEFAULT_FAILURE_LIMIT``. Existing rows get NULL,
         # which is the correct default (they keep the global behaviour
         # they were getting before the column existed).
-        conn.execute("ALTER TABLE tasks ADD COLUMN max_retries INTEGER")
+        _safe_add_column(conn, "ALTER TABLE tasks ADD COLUMN max_retries INTEGER")
 
     # task_events gained a run_id column; back-fill it as NULL for
     # historical events (they predate runs and can't be attributed).
     ev_cols = {row["name"] for row in conn.execute("PRAGMA table_info(task_events)")}
     if "run_id" not in ev_cols:
-        conn.execute("ALTER TABLE task_events ADD COLUMN run_id INTEGER")
+        _safe_add_column(conn, "ALTER TABLE task_events ADD COLUMN run_id INTEGER")
         conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_events_run "
             "ON task_events(run_id, id)"

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -914,3 +914,94 @@ def test_latest_summaries_batch_omits_tasks_without_summary(kanban_home):
         assert out == {t1: "alpha", t3: "charlie"}
         # Empty input → empty dict, no SQL syntax error from "IN ()".
         assert kb.latest_summaries(conn, []) == {}
+
+
+# ---------------------------------------------------------------------------
+# Migration — concurrent / repeated invocation must not surface
+# `duplicate column name` from racing ALTER TABLE statements.
+# ---------------------------------------------------------------------------
+
+def test_migration_is_idempotent_against_itself(tmp_path):
+    """`_migrate_add_optional_columns` may be invoked twice on the same
+    DB by callers that legitimately race (the embedded gateway dispatcher
+    used to call `connect()` immediately followed by `init_db()`, and a
+    second process can open the DB during gateway startup). SQLite has
+    no `ADD COLUMN IF NOT EXISTS`, so the loser would raise
+    `OperationalError: duplicate column name`. The helper now swallows
+    exactly that error and re-raises anything else.
+    """
+    import sqlite3
+    import threading
+
+    db = tmp_path / "legacy.db"
+    # Build a pre-migration "legacy" DB: tasks table missing every
+    # optional column the migration expects to add.
+    conn = sqlite3.connect(str(db), isolation_level=None)
+    conn.row_factory = sqlite3.Row
+    conn.executescript(
+        """
+        CREATE TABLE tasks (
+          id TEXT PRIMARY KEY, title TEXT NOT NULL, body TEXT,
+          assignee TEXT, status TEXT NOT NULL, priority INTEGER DEFAULT 0,
+          created_by TEXT, created_at INTEGER NOT NULL,
+          started_at INTEGER, completed_at INTEGER,
+          workspace_kind TEXT NOT NULL DEFAULT 'scratch',
+          workspace_path TEXT, claim_lock TEXT, claim_expires INTEGER
+        );
+        CREATE TABLE task_events (id INTEGER PRIMARY KEY, kind TEXT);
+        """
+    )
+    conn.close()
+
+    errors: list[BaseException] = []
+
+    def migrate_once() -> None:
+        try:
+            cc = sqlite3.connect(str(db), isolation_level=None)
+            cc.row_factory = sqlite3.Row
+            kb._migrate_add_optional_columns(cc)
+            cc.close()
+        except BaseException as exc:  # pragma: no cover - regression guard
+            errors.append(exc)
+
+    # Four concurrent migrators against the same legacy DB. Without the
+    # helper, at least one thread would raise OperationalError.
+    threads = [threading.Thread(target=migrate_once) for _ in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert errors == []
+
+    # Final schema must contain every column the migration is supposed
+    # to add — proves the helper didn't silently drop any ALTER.
+    final = sqlite3.connect(str(db))
+    final.row_factory = sqlite3.Row
+    cols = {r["name"] for r in final.execute("PRAGMA table_info(tasks)")}
+    final.close()
+    expected = {
+        "tenant", "result", "idempotency_key", "consecutive_failures",
+        "worker_pid", "last_failure_error", "max_runtime_seconds",
+        "last_heartbeat_at", "current_run_id", "workflow_template_id",
+        "current_step_key", "skills", "max_retries",
+    }
+    assert expected <= cols
+
+
+def test_safe_add_column_reraises_unrelated_errors(tmp_path):
+    """The helper must only swallow `duplicate column name`. Any other
+    OperationalError (bad SQL, missing table, etc.) must propagate so
+    real schema bugs don't get masked.
+    """
+    import sqlite3
+
+    db = tmp_path / "tiny.db"
+    conn = sqlite3.connect(str(db), isolation_level=None)
+    try:
+        with pytest.raises(sqlite3.OperationalError):
+            kb._safe_add_column(
+                conn, "ALTER TABLE does_not_exist ADD COLUMN foo TEXT"
+            )
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary

Fixes a benign-but-noisy traceback emitted on every gateway start against a kanban DB created before the `max_retries` column was added:

```
sqlite3.OperationalError: duplicate column name: max_retries
  File "hermes_cli/kanban_db.py", line 1034, in _migrate_add_optional_columns
    conn.execute("ALTER TABLE tasks ADD COLUMN max_retries INTEGER")
ERROR gateway.run: kanban dispatcher: tick failed on board default
```

## Root cause

`_migrate_add_optional_columns` reads `PRAGMA table_info(tasks)` once into a `cols` set, then issues a series of `ALTER TABLE … ADD COLUMN`. Two callers can race on the same DB file and both pass the pre-ALTER snapshot check before either ALTER lands; the loser raises `duplicate column name`. SQLite has no `ADD COLUMN IF NOT EXISTS`, so the snapshot guard is not enough.

The race fires today inside the embedded gateway dispatcher in `_tick_once_for_board` (`gateway/run.py`), which calls `_kb.connect(board=slug)` (runs the migration) immediately followed by `_kb.init_db(board=slug)` — and `init_db` deliberately busts the per-process `_INITIALIZED_PATHS` cache and re-runs the migration. It can also fire if a second process opens the same DB during gateway startup.

The error is harmless (by the time it fires, the column is already present and the next dispatcher tick succeeds), but the traceback is logged on every gateway start against a legacy DB and obscures real failures.

## Fix

1. **Make the migration idempotent against itself.** New `_safe_add_column` helper wraps every optional-column ALTER and swallows exactly `sqlite3.OperationalError: duplicate column name`, re-raising anything else. Applied to all 13 optional-column ALTERs on `tasks` and the one on `task_events`.
2. **Drop the redundant `init_db()` call in `_tick_once_for_board`.** `connect()` already runs the schema + migration on first open per process; the explicit `init_db()` only existed to guarantee re-migration after a cache bust, which is no longer needed now that the helper is race-tolerant. Removes one source of the race entirely. The dropped call was already wrapped in `except Exception: pass`, so no callers depended on its result.

## Test Plan

New tests in `tests/hermes_cli/test_kanban_db.py`:

- `test_migration_is_idempotent_against_itself` — builds a legacy DB shape (pre-migration `tasks` schema), runs **four concurrent migrators** on it, asserts (a) no errors and (b) every expected column was actually added.
- `test_safe_add_column_reraises_unrelated_errors` — confirms the helper does NOT mask other `OperationalError` cases (e.g. ALTER on a missing table) so real schema bugs still surface.

### Test results

**Regression test fails on unpatched upstream/main** (proves the test catches the bug, not just passes vacuously):

```
$ git checkout upstream/main -- hermes_cli/kanban_db.py gateway/run.py
$ pytest tests/hermes_cli/test_kanban_db.py::test_migration_is_idempotent_against_itself \
        tests/hermes_cli/test_kanban_db.py::test_safe_add_column_reraises_unrelated_errors

FAILED test_migration_is_idempotent_against_itself
  AssertionError: assert [OperationalError('duplicate column name: tenant'), ...] == []
FAILED test_safe_add_column_reraises_unrelated_errors
  (helper does not exist on upstream/main)
```

The `duplicate column name: tenant` error is the same class of failure as the `max_retries` traceback in the bug report — the new test captures the general race, not just one column.

**With the patch applied — full kanban-db suite passes:**

```
$ pytest tests/hermes_cli/test_kanban_db.py -q
62 passed in 7.12s
```

**Broader kanban surface — 378/379 pass:**

```
$ pytest tests/hermes_cli/test_kanban_*.py tests/tools/test_kanban_tools.py -q
1 failed, 378 passed in 12.57s
```

The one failure is `tests/hermes_cli/test_kanban_boards.py::TestCLI::test_boards_create_and_switch`. I confirmed it reproduces on plain upstream/main with my changes reverted, so it is **pre-existing and unrelated** to this PR.

**End-to-end:** verified on a real legacy `kanban.db` that originally produced the traceback in the bug report. After the patch, the column is present, the dispatcher tick runs cleanly, and `gateway.log` is silent on restart.

## Risk

Low.

- `_safe_add_column` only suppresses the exact "duplicate column name" substring and re-raises everything else; the migration logic is otherwise unchanged. Regression-tested.
- The dropped `init_db()` in `_tick_once_for_board` was already inside a bare `except Exception: pass`, so no caller could have depended on its return value or side effects beyond running the migration that `connect()` had already run on first open. Outer try/except in the dispatcher is unchanged.