### PR TITLE
fix(memory): normalize replace/remove alias forwarding

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -9713,12 +9713,23 @@ class AIAgent:
             )
         elif function_name == "memory":
             target = function_args.get("target", "memory")
+            old_text = function_args.get("old_text")
+            if old_text is None:
+                old_text = function_args.get("old_string")
+            content = function_args.get("content")
+            if content is None:
+                content = function_args.get("new_text")
+            if content is None:
+                content = function_args.get("new_string")
             from tools.memory_tool import memory_tool as _memory_tool
             result = _memory_tool(
                 action=function_args.get("action"),
                 target=target,
-                content=function_args.get("content"),
-                old_text=function_args.get("old_text"),
+                content=content,
+                old_text=old_text,
+                new_text=function_args.get("new_text"),
+                old_string=function_args.get("old_string"),
+                new_string=function_args.get("new_string"),
                 store=self._memory_store,
             )
             # Bridge: notify external memory provider of built-in memory writes
@@ -9727,7 +9738,7 @@ class AIAgent:
                     self._memory_manager.on_memory_write(
                         function_args.get("action", ""),
                         target,
-                        function_args.get("content", ""),
+                        content or "",
                         metadata=self._build_memory_write_metadata(
                             task_id=effective_task_id,
                             tool_call_id=tool_call_id,
@@ -10320,12 +10331,23 @@ class AIAgent:
                     self._vprint(f"  {_get_cute_tool_message_impl('session_search', function_args, tool_duration, result=function_result)}")
             elif function_name == "memory":
                 target = function_args.get("target", "memory")
+                old_text = function_args.get("old_text")
+                if old_text is None:
+                    old_text = function_args.get("old_string")
+                content = function_args.get("content")
+                if content is None:
+                    content = function_args.get("new_text")
+                if content is None:
+                    content = function_args.get("new_string")
                 from tools.memory_tool import memory_tool as _memory_tool
                 function_result = _memory_tool(
                     action=function_args.get("action"),
                     target=target,
-                    content=function_args.get("content"),
-                    old_text=function_args.get("old_text"),
+                    content=content,
+                    old_text=old_text,
+                    new_text=function_args.get("new_text"),
+                    old_string=function_args.get("old_string"),
+                    new_string=function_args.get("new_string"),
                     store=self._memory_store,
                 )
                 # Bridge: notify external memory provider of built-in memory writes
@@ -10334,7 +10356,7 @@ class AIAgent:
                         self._memory_manager.on_memory_write(
                             function_args.get("action", ""),
                             target,
-                            function_args.get("content", ""),
+                            content or "",
                             metadata=self._build_memory_write_metadata(
                                 task_id=effective_task_id,
                                 tool_call_id=getattr(tool_call, "id", None),

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2072,6 +2072,32 @@ class TestConcurrentToolExecution:
         assert starts == [("c1", "web_search", {"query": "hello"})]
         assert completes == [("c1", "web_search", {"query": "hello"}, '{"success": true}')]
 
+    def test_sequential_memory_tool_forwards_aliases(self, agent):
+        agent._memory_store = object()
+        tool_call = _mock_tool_call(
+            name="memory",
+            arguments='{"action":"remove","target":"memory","old_string":"legacy"}',
+            call_id="c1",
+        )
+        mock_msg = _mock_assistant_msg(content="", tool_calls=[tool_call])
+        messages = []
+
+        with patch("tools.memory_tool.memory_tool", return_value='{"success": true}') as mock_memory:
+            agent._execute_tool_calls_sequential(mock_msg, messages, "task-1")
+
+        mock_memory.assert_called_once_with(
+            action="remove",
+            target="memory",
+            content=None,
+            old_text="legacy",
+            new_text=None,
+            old_string="legacy",
+            new_string=None,
+            store=agent._memory_store,
+        )
+        assert len(messages) == 1
+        assert json.loads(messages[0]["content"]) == {"success": True}
+
     def test_concurrent_tool_callbacks_fire_for_each_tool(self, agent):
         tc1 = _mock_tool_call(name="web_search", arguments='{"query":"one"}', call_id="c1")
         tc2 = _mock_tool_call(name="web_search", arguments='{"query":"two"}', call_id="c2")
@@ -2099,6 +2125,32 @@ class TestConcurrentToolExecution:
             result = agent._invoke_tool("todo", {"todos": []}, "task-1")
             mock_todo.assert_called_once()
         assert "ok" in result
+
+    def test_invoke_tool_forwards_memory_aliases(self, agent):
+        agent._memory_store = object()
+        with patch("tools.memory_tool.memory_tool", return_value='{"ok":true}') as mock_memory:
+            result = agent._invoke_tool(
+                "memory",
+                {
+                    "action": "replace",
+                    "target": "memory",
+                    "old_string": "before",
+                    "new_text": "after",
+                },
+                "task-1",
+            )
+
+        mock_memory.assert_called_once_with(
+            action="replace",
+            target="memory",
+            content="after",
+            old_text="before",
+            new_text="after",
+            old_string="before",
+            new_string=None,
+            store=agent._memory_store,
+        )
+        assert result == '{"ok":true}'
 
     def test_invoke_tool_blocked_returns_error_and_skips_execution(self, agent, monkeypatch):
         """_invoke_tool should return error JSON when a plugin blocks the tool."""

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -4,6 +4,7 @@ import json
 import pytest
 from pathlib import Path
 
+from tools.registry import registry
 from tools.memory_tool import (
     MemoryStore,
     memory_tool,
@@ -252,6 +253,32 @@ class TestMemoryToolDispatcher:
         result = json.loads(memory_tool(action="replace", content="new", store=store))
         assert result["success"] is False
 
+    def test_replace_accepts_edit_tool_aliases(self, store):
+        store.add("memory", "legacy value")
+        result = json.loads(
+            memory_tool(
+                action="replace",
+                target="memory",
+                old_string="legacy value",
+                new_text="updated value",
+                store=store,
+            )
+        )
+        assert result["success"] is True
+        assert "updated value" in result["entries"]
+
     def test_remove_requires_old_text(self, store):
         result = json.loads(memory_tool(action="remove", store=store))
         assert result["success"] is False
+
+    def test_registry_handler_forwards_memory_aliases(self, store):
+        store.add("memory", "remove me")
+        entry = registry.get_entry("memory")
+        result = json.loads(
+            entry.handler(
+                {"action": "remove", "target": "memory", "old_string": "remove me"},
+                store=store,
+            )
+        )
+        assert result["success"] is True
+        assert "remove me" not in result["entries"]

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -274,6 +274,7 @@ class TestMemoryToolDispatcher:
     def test_registry_handler_forwards_memory_aliases(self, store):
         store.add("memory", "remove me")
         entry = registry.get_entry("memory")
+        assert entry is not None
         result = json.loads(
             entry.handler(
                 {"action": "remove", "target": "memory", "old_string": "remove me"},

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -467,6 +467,9 @@ def memory_tool(
     target: str = "memory",
     content: str = None,
     old_text: str = None,
+    new_text: str = None,
+    old_string: str = None,
+    new_string: str = None,
     store: Optional[MemoryStore] = None,
 ) -> str:
     """
@@ -476,6 +479,15 @@ def memory_tool(
     """
     if store is None:
         return tool_error("Memory is not available. It may be disabled in config or this environment.", success=False)
+
+    # Accept common edit-tool aliases without changing the canonical schema.
+    if old_text is None:
+        old_text = old_string
+    if content is None:
+        if new_text is not None:
+            content = new_text
+        elif new_string is not None:
+            content = new_string
 
     if target not in ("memory", "user"):
         return tool_error(f"Invalid target '{target}'. Use 'memory' or 'user'.", success=False)
@@ -576,11 +588,13 @@ registry.register(
         target=args.get("target", "memory"),
         content=args.get("content"),
         old_text=args.get("old_text"),
+        new_text=args.get("new_text"),
+        old_string=args.get("old_string"),
+        new_string=args.get("new_string"),
         store=kw.get("store")),
     check_fn=check_memory_requirements,
     emoji="🧠",
 )
-
 
 
 


### PR DESCRIPTION
## Summary
- normalize memory tool alias forwarding for replace/remove paths
- carry old_text/new_text and old_string/new_string aliases through run_agent and memory bridge entrypoints
- add targeted regression coverage for dispatcher, registry handler, and agent-loop paths

## Verification
- uv sync --frozen --extra all
- uv run --frozen pytest tests/tools/test_memory_tool.py -q -k "edit_tool_aliases or registry_handler_forwards_memory_aliases"
- uv run --frozen pytest tests/run_agent/test_run_agent.py -q -k "forwards_memory_aliases or sequential_memory_tool_forwards_aliases"

Closes #21844