### PR TITLE
feat(docker): bootstrap auth.json from env on first boot

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -81,6 +81,20 @@ if [ ! -f "$HERMES_HOME/SOUL.md" ]; then
     cp "$INSTALL_DIR/docker/SOUL.md" "$HERMES_HOME/SOUL.md"
 fi
 
+# auth.json: bootstrap from env on first boot only.  Used by orchestrators
+# (e.g. provisioning a Hermes VPS from an account-management service) that
+# need to seed the OAuth refresh credential non-interactively, instead of
+# walking the user through `hermes setup` + the device-flow login dance.
+# Subsequent token rotations write back to the same file, which lives on a
+# persistent volume — so this env var is consumed exactly once at first
+# boot.  The `[ ! -f ... ]` guard is critical: without it, a container
+# restart would clobber a rotated refresh token with the now-stale value
+# the orchestrator originally seeded.
+if [ ! -f "$HERMES_HOME/auth.json" ] && [ -n "$HERMES_AUTH_JSON_BOOTSTRAP" ]; then
+    printf '%s' "$HERMES_AUTH_JSON_BOOTSTRAP" > "$HERMES_HOME/auth.json"
+    chmod 600 "$HERMES_HOME/auth.json"
+fi
+
 # Sync bundled skills (manifest-based so user edits are preserved)
 if [ -d "$INSTALL_DIR/skills" ]; then
     python3 "$INSTALL_DIR/tools/skills_sync.py"


### PR DESCRIPTION
Salvage of #20900 (@pefontana) cherry-picked onto current main with authorship preserved.

## Summary

Lets orchestrators seed Hermes' OAuth refresh credential into a freshly provisioned container non-interactively. If `HERMES_AUTH_JSON_BOOTSTRAP` is set and `$HERMES_HOME/auth.json` doesn't already exist, the entrypoint writes the env var's contents to `auth.json` (mode 600). Matches the existing first-boot-only pattern used for `.env`, `config.yaml`, and `SOUL.md`.

The `[ ! -f auth.json ]` guard is critical: it prevents container restarts from clobbering the rotated refresh token Hermes wrote back to the persistent volume with the now-stale value the orchestrator originally seeded.

Enables the managed Hermes VPS feature in nous-account-service (companion PR NousResearch/nous-account-service#42). Env var name is intentionally generic so it's reusable by any orchestrator.

Closes #20900.