### PR TITLE
fix(cron): clean up job output dir in remove_job

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -8,6 +8,7 @@ Output is saved to ~/.hermes/cron/output/{job_id}/{timestamp}.md
 import copy
 import json
 import logging
+import shutil
 import tempfile
 import threading
 import os
@@ -696,6 +697,10 @@ def remove_job(job_id: str) -> bool:
     jobs = [j for j in jobs if j["id"] != job_id]
     if len(jobs) < original_len:
         save_jobs(jobs)
+        # Clean up output directory to prevent orphaned dirs accumulating
+        job_output_dir = OUTPUT_DIR / job_id
+        if job_output_dir.exists():
+            shutil.rmtree(job_output_dir)
         return True
     return False
 


### PR DESCRIPTION
## Summary
`remove_job()` now removes the per-job output directory at `~/.hermes/cron/output/{job_id}/` so deleted jobs don't leave orphaned dirs accumulating forever.

## Changes
- `cron/jobs.py`: after `save_jobs(jobs)` in `remove_job`, `shutil.rmtree` the job's output dir if it exists.

## Context
Salvaged from #13510 by @hekaru-agent. The honcho RLock half of that PR was already merged as commit dad021745; this lands the remaining cron cleanup hunk on its own with authorship preserved.

## Validation
E2E: seeded a job, wrote output, called `remove_job` — job + output dir both gone. Nonexistent id still returns False. Job that never produced output removes cleanly without crashing.

Closes #13510.