### PR TITLE
fix(google-workspace): harden OAuth refresh and live checks

### DIFF
--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -92,6 +92,27 @@ def _format_missing_scopes(missing_scopes: list[str]) -> str:
     )
 
 
+def _extract_oauth_error_code(exc: Exception) -> str:
+    """Extract a stable OAuth error code from google-auth exceptions when possible."""
+    try:
+        from google.auth.exceptions import RefreshError
+    except Exception:
+        RefreshError = ()  # type: ignore[assignment]
+
+    if isinstance(exc, RefreshError) and len(getattr(exc, "args", ())) >= 2:
+        response_data = exc.args[1]
+        if isinstance(response_data, dict):
+            code = str(response_data.get("error") or "").strip().lower()
+            if code:
+                return code
+
+    err_str = str(exc).lower()
+    for code in ("disabled_client", "invalid_client", "token_revoked", "invalid_grant"):
+        if code in err_str:
+            return code
+    return ""
+
+
 def install_deps():
     """Install Google API packages if missing. Returns True on success."""
     try:
@@ -138,21 +159,46 @@ def check_auth_live():
         return False
     try:
         from googleapiclient.discovery import build
+        from googleapiclient.errors import HttpError
+        from google.auth.exceptions import RefreshError
         from google.oauth2.credentials import Credentials
         creds = Credentials.from_authorized_user_file(str(TOKEN_PATH))
         service = build("calendar", "v3", credentials=creds)
         service.calendarList().list(maxResults=1).execute()
         print("LIVE_CHECK_OK: Real API call succeeded.")
         return True
-    except Exception as e:
-        err_str = str(e).lower()
-        if "disabled_client" in err_str or "invalid_client" in err_str:
+    except RefreshError as e:
+        code = _extract_oauth_error_code(e)
+        if code in ("disabled_client", "invalid_client"):
             print(f"LIVE_CHECK_FAILED: OAuth client or account disabled: {e}")
             print("  1. Check Google Cloud Console for disabled OAuth client")
             print("  2. Check myaccount.google.com for account status")
             print("  3. Do NOT retry with a disabled account")
         else:
-            print(f"LIVE_CHECK_FAILED: {e}")
+            print(f"LIVE_CHECK_FAILED: {type(e).__name__}: {e}")
+        return False
+    except HttpError as e:
+        status = getattr(getattr(e, "resp", None), "status", None)
+        body = str(e).lower()
+        if status == 403 and (
+            "access_token_scope_insufficient" in body
+            or "insufficientpermissions" in body
+            or "insufficient authentication scopes" in body
+            or "scope" in body
+        ):
+            print(f"LIVE_CHECK_PARTIAL: Calendar scope not granted, but token is valid: {e}")
+            return True
+        print(f"LIVE_CHECK_FAILED: HTTP {status}: {e}")
+        return False
+    except Exception as e:
+        code = _extract_oauth_error_code(e)
+        if code in ("disabled_client", "invalid_client"):
+            print(f"LIVE_CHECK_FAILED: OAuth client or account disabled: {e}")
+            print("  1. Check Google Cloud Console for disabled OAuth client")
+            print("  2. Check myaccount.google.com for account status")
+            print("  3. Do NOT retry with a disabled account")
+        else:
+            print(f"LIVE_CHECK_FAILED: {type(e).__name__}: {e}")
         return False
 
 
@@ -205,8 +251,8 @@ def check_auth(quiet: bool = False):
                 print(f"AUTHENTICATED: Token refreshed at {TOKEN_PATH}")
             return True
         except Exception as e:
-            err_str = str(e).lower()
-            if "disabled_client" in err_str or "invalid_client" in err_str:
+            code = _extract_oauth_error_code(e)
+            if code in ("disabled_client", "invalid_client"):
                 print(f"OAUTH_CLIENT_DISABLED: {e}")
                 print("  The OAuth client or Google account has been disabled.")
                 print("  Steps to resolve:")
@@ -215,7 +261,7 @@ def check_auth(quiet: bool = False):
                 print("    3. If the account is disabled, you can appeal at accounts.google.com/signin/recovery")
                 print("    4. Do NOT retry API calls with a disabled account — this may worsen the situation")
                 print("    5. If the OAuth client is disabled, create a new one in Google Cloud Console")
-            elif "token_revoked" in err_str or "invalid_grant" in err_str:
+            elif code in ("token_revoked", "invalid_grant"):
                 print(f"TOKEN_REVOKED: {e}")
                 print("  Re-run setup to re-authenticate.")
             else:

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -26,6 +26,7 @@ from __future__ import annotations  # allow PEP 604 `X | None` on Python 3.9+
 import argparse
 import json
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -59,6 +60,12 @@ REQUIRED_PACKAGES = ["google-api-python-client", "google-auth-oauthlib", "google
 # Google deprecated OOB, so we use a localhost redirect and tell the user to
 # copy the code from the browser's URL bar (or the page body).
 REDIRECT_URI = "http://localhost:1"
+_OAUTH_ERROR_CODES = (
+    "disabled_client",
+    "invalid_client",
+    "token_revoked",
+    "invalid_grant",
+)
 
 
 def _normalize_authorized_user_payload(payload: dict) -> dict:
@@ -107,8 +114,14 @@ def _extract_oauth_error_code(exc: Exception) -> str:
                 return code
 
     err_str = str(exc).lower()
-    for code in ("disabled_client", "invalid_client", "token_revoked", "invalid_grant"):
-        if code in err_str:
+    match = re.match(r"\s*([a-z_]+)\s*:", err_str)
+    if match:
+        code = match.group(1)
+        if code in _OAUTH_ERROR_CODES:
+            return code
+
+    for code in _OAUTH_ERROR_CODES:
+        if re.search(rf'["\']error["\']\s*[:=]\s*["\']{re.escape(code)}["\']', err_str):
             return code
     return ""
 
@@ -184,7 +197,7 @@ def check_auth_live():
             "access_token_scope_insufficient" in body
             or "insufficientpermissions" in body
             or "insufficient authentication scopes" in body
-            or "scope" in body
+            or "insufficient permission" in body
         ):
             print(f"LIVE_CHECK_PARTIAL: Calendar scope not granted, but token is valid: {e}")
             return True

--- a/skills/productivity/google-workspace/scripts/setup.py
+++ b/skills/productivity/google-workspace/scripts/setup.py
@@ -26,6 +26,7 @@ from __future__ import annotations  # allow PEP 604 `X | None` on Python 3.9+
 import argparse
 import json
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -74,6 +75,12 @@ REQUIRED_PACKAGES = [
 # Google deprecated OOB, so we use a localhost redirect and tell the user to
 # copy the code from the browser's URL bar (or the page body).
 REDIRECT_URI = "http://localhost:1"
+_OAUTH_ERROR_CODES = (
+    "disabled_client",
+    "invalid_client",
+    "token_revoked",
+    "invalid_grant",
+)
 
 
 def _normalize_authorized_user_payload(payload: dict) -> dict:
@@ -123,6 +130,34 @@ def _missing_required_packages() -> list[str]:
         except Exception:
             missing.append(spec)
     return missing
+
+
+def _extract_oauth_error_code(exc: Exception) -> str:
+    """Extract a stable OAuth error code from google-auth exceptions."""
+    try:
+        from google.auth.exceptions import RefreshError
+    except Exception:
+        RefreshError = ()  # type: ignore[assignment]
+
+    if isinstance(exc, RefreshError) and len(getattr(exc, "args", ())) >= 2:
+        response_data = exc.args[1]
+        if isinstance(response_data, dict):
+            code = str(response_data.get("error") or "").strip().lower()
+            if code:
+                return code
+
+    err_str = str(exc).lower()
+    match = re.match(r"\s*([a-z_]+)\s*:", err_str)
+    if match and match.group(1) in _OAUTH_ERROR_CODES:
+        return match.group(1)
+
+    for code in _OAUTH_ERROR_CODES:
+        if re.search(
+            rf"[\"']error[\"']\s*[:=]\s*[\"']{re.escape(code)}[\"']",
+            err_str,
+        ):
+            return code
+    return ""
 
 
 def install_deps():
@@ -197,21 +232,46 @@ def check_auth_live():
         return False
     try:
         from googleapiclient.discovery import build
+        from googleapiclient.errors import HttpError
+        from google.auth.exceptions import RefreshError
         from google.oauth2.credentials import Credentials
         creds = Credentials.from_authorized_user_file(str(TOKEN_PATH))
         service = build("calendar", "v3", credentials=creds)
         service.calendarList().list(maxResults=1).execute()
         print("LIVE_CHECK_OK: Real API call succeeded.")
         return True
-    except Exception as e:
-        err_str = str(e).lower()
-        if "disabled_client" in err_str or "invalid_client" in err_str:
+    except RefreshError as e:
+        code = _extract_oauth_error_code(e)
+        if code in ("disabled_client", "invalid_client"):
             print(f"LIVE_CHECK_FAILED: OAuth client or account disabled: {e}")
             print("  1. Check Google Cloud Console for disabled OAuth client")
             print("  2. Check myaccount.google.com for account status")
             print("  3. Do NOT retry with a disabled account")
         else:
-            print(f"LIVE_CHECK_FAILED: {e}")
+            print(f"LIVE_CHECK_FAILED: {type(e).__name__}: {e}")
+        return False
+    except HttpError as e:
+        status = getattr(getattr(e, "resp", None), "status", None)
+        body = str(e).lower()
+        if status == 403 and (
+            "access_token_scope_insufficient" in body
+            or "insufficientpermissions" in body
+            or "insufficient authentication scopes" in body
+            or "insufficient permission" in body
+        ):
+            print(f"LIVE_CHECK_PARTIAL: Calendar scope not granted, but token is valid: {e}")
+            return True
+        print(f"LIVE_CHECK_FAILED: HTTP {status}: {e}")
+        return False
+    except Exception as e:
+        code = _extract_oauth_error_code(e)
+        if code in ("disabled_client", "invalid_client"):
+            print(f"LIVE_CHECK_FAILED: OAuth client or account disabled: {e}")
+            print("  1. Check Google Cloud Console for disabled OAuth client")
+            print("  2. Check myaccount.google.com for account status")
+            print("  3. Do NOT retry with a disabled account")
+        else:
+            print(f"LIVE_CHECK_FAILED: {type(e).__name__}: {e}")
         return False
 
 
@@ -264,8 +324,8 @@ def check_auth(quiet: bool = False):
                 print(f"AUTHENTICATED: Token refreshed at {TOKEN_PATH}")
             return True
         except Exception as e:
-            err_str = str(e).lower()
-            if "disabled_client" in err_str or "invalid_client" in err_str:
+            code = _extract_oauth_error_code(e)
+            if code in ("disabled_client", "invalid_client"):
                 print(f"OAUTH_CLIENT_DISABLED: {e}")
                 print("  The OAuth client or Google account has been disabled.")
                 print("  Steps to resolve:")
@@ -274,7 +334,7 @@ def check_auth(quiet: bool = False):
                 print("    3. If the account is disabled, you can appeal at accounts.google.com/signin/recovery")
                 print("    4. Do NOT retry API calls with a disabled account — this may worsen the situation")
                 print("    5. If the OAuth client is disabled, create a new one in Google Cloud Console")
-            elif "token_revoked" in err_str or "invalid_grant" in err_str:
+            elif code in ("token_revoked", "invalid_grant"):
                 print(f"TOKEN_REVOKED: {e}")
                 print("  Re-run setup to re-authenticate.")
             else:

--- a/tests/skills/test_google_oauth_setup.py
+++ b/tests/skills/test_google_oauth_setup.py
@@ -9,6 +9,7 @@ import json
 import sys
 import types
 from pathlib import Path
+from types import SimpleNamespace
 
 import pytest
 
@@ -20,6 +21,8 @@ SCRIPT_PATH = (
 
 
 class FakeCredentials:
+    from_authorized_user_file_impl = None
+
     def __init__(self, payload=None):
         self._payload = payload or {
             "token": "access-token",
@@ -38,9 +41,25 @@ class FakeCredentials:
                 "https://www.googleapis.com/auth/documents.readonly",
             ],
         }
+        self.valid = True
+        self.expired = False
+        self.refresh_token = self._payload.get("refresh_token", "refresh-token")
+        self.refresh_error = None
 
     def to_json(self):
         return json.dumps(self._payload)
+
+    def refresh(self, _request):
+        if self.refresh_error is not None:
+            raise self.refresh_error
+        self.valid = True
+        self.expired = False
+
+    @classmethod
+    def from_authorized_user_file(cls, path, scopes=None):
+        if cls.from_authorized_user_file_impl is not None:
+            return cls.from_authorized_user_file_impl(path, scopes=scopes)
+        return cls()
 
 
 class FakeFlow:
@@ -99,9 +118,16 @@ class FakeFlow:
             raise self.fetch_error
 
 
+class FakeHttpError(Exception):
+    def __init__(self, status, body):
+        super().__init__(body)
+        self.resp = SimpleNamespace(status=status)
+
+
 @pytest.fixture
 def setup_module(monkeypatch, tmp_path):
     FakeFlow.reset()
+    FakeCredentials.from_authorized_user_file_impl = None
 
     google_auth_module = types.ModuleType("google_auth_oauthlib")
     flow_module = types.ModuleType("google_auth_oauthlib.flow")
@@ -109,6 +135,53 @@ def setup_module(monkeypatch, tmp_path):
     google_auth_module.flow = flow_module
     monkeypatch.setitem(sys.modules, "google_auth_oauthlib", google_auth_module)
     monkeypatch.setitem(sys.modules, "google_auth_oauthlib.flow", flow_module)
+
+    google_module = types.ModuleType("google")
+    google_auth_pkg = types.ModuleType("google.auth")
+    google_auth_exceptions = types.ModuleType("google.auth.exceptions")
+
+    class FakeRefreshError(Exception):
+        pass
+
+    google_auth_exceptions.RefreshError = FakeRefreshError
+    google_auth_transport = types.ModuleType("google.auth.transport")
+    google_auth_transport_requests = types.ModuleType("google.auth.transport.requests")
+
+    class FakeRequest:
+        pass
+
+    google_auth_transport_requests.Request = FakeRequest
+    google_auth_transport.requests = google_auth_transport_requests
+    google_auth_pkg.exceptions = google_auth_exceptions
+    google_auth_pkg.transport = google_auth_transport
+
+    google_oauth2_pkg = types.ModuleType("google.oauth2")
+    google_oauth2_credentials = types.ModuleType("google.oauth2.credentials")
+    google_oauth2_credentials.Credentials = FakeCredentials
+    google_oauth2_pkg.credentials = google_oauth2_credentials
+
+    googleapiclient_module = types.ModuleType("googleapiclient")
+    googleapiclient_discovery = types.ModuleType("googleapiclient.discovery")
+    googleapiclient_errors = types.ModuleType("googleapiclient.errors")
+    googleapiclient_errors.HttpError = FakeHttpError
+
+    def _default_build(*_args, **_kwargs):
+        raise AssertionError("googleapiclient.discovery.build not stubbed for this test")
+
+    googleapiclient_discovery.build = _default_build
+    googleapiclient_module.discovery = googleapiclient_discovery
+    googleapiclient_module.errors = googleapiclient_errors
+
+    monkeypatch.setitem(sys.modules, "google", google_module)
+    monkeypatch.setitem(sys.modules, "google.auth", google_auth_pkg)
+    monkeypatch.setitem(sys.modules, "google.auth.exceptions", google_auth_exceptions)
+    monkeypatch.setitem(sys.modules, "google.auth.transport", google_auth_transport)
+    monkeypatch.setitem(sys.modules, "google.auth.transport.requests", google_auth_transport_requests)
+    monkeypatch.setitem(sys.modules, "google.oauth2", google_oauth2_pkg)
+    monkeypatch.setitem(sys.modules, "google.oauth2.credentials", google_oauth2_credentials)
+    monkeypatch.setitem(sys.modules, "googleapiclient", googleapiclient_module)
+    monkeypatch.setitem(sys.modules, "googleapiclient.discovery", googleapiclient_discovery)
+    monkeypatch.setitem(sys.modules, "googleapiclient.errors", googleapiclient_errors)
 
     spec = importlib.util.spec_from_file_location("google_workspace_setup_test", SCRIPT_PATH)
     module = importlib.util.module_from_spec(spec)
@@ -130,6 +203,15 @@ def setup_module(monkeypatch, tmp_path):
     }
     module.CLIENT_SECRET_PATH.write_text(json.dumps(client_secret))
     return module
+
+
+def _make_fake_creds(*, valid=True, expired=False, refresh_token="refresh-token", payload=None, refresh_error=None):
+    creds = FakeCredentials(payload=payload)
+    creds.valid = valid
+    creds.expired = expired
+    creds.refresh_token = refresh_token
+    creds.refresh_error = refresh_error
+    return creds
 
 
 class TestGetAuthUrl:
@@ -256,6 +338,132 @@ class TestExchangeAuthCode:
         assert setup_module.TOKEN_PATH.exists()
         # Pending auth is cleaned up
         assert not setup_module.PENDING_AUTH_PATH.exists()
+
+
+class TestCheckAuth:
+    def test_check_auth_refresh_disabled_client_prints_guidance(self, setup_module, capsys):
+        refresh_error = sys.modules["google.auth.exceptions"].RefreshError(
+            "disabled_client: The OAuth client was disabled.",
+            {"error": "disabled_client", "error_description": "The OAuth client was disabled."},
+        )
+        creds = _make_fake_creds(valid=False, expired=True, refresh_error=refresh_error)
+        FakeCredentials.from_authorized_user_file_impl = lambda _path, scopes=None: creds
+        setup_module.TOKEN_PATH.write_text(json.dumps({"token": "x", "refresh_token": "r"}))
+
+        assert setup_module.check_auth() is False
+
+        out = capsys.readouterr().out
+        assert "OAUTH_CLIENT_DISABLED:" in out
+        assert "accounts.google.com/signin/recovery" in out
+
+    def test_check_auth_refresh_invalid_grant_prints_reauth(self, setup_module, capsys):
+        refresh_error = sys.modules["google.auth.exceptions"].RefreshError(
+            "invalid_grant: Token has been expired or revoked.",
+            {"error": "invalid_grant", "error_description": "Token has been expired or revoked."},
+        )
+        creds = _make_fake_creds(valid=False, expired=True, refresh_error=refresh_error)
+        FakeCredentials.from_authorized_user_file_impl = lambda _path, scopes=None: creds
+        setup_module.TOKEN_PATH.write_text(json.dumps({"token": "x", "refresh_token": "r"}))
+
+        assert setup_module.check_auth() is False
+
+        out = capsys.readouterr().out
+        assert "TOKEN_REVOKED:" in out
+        assert "Re-run setup" in out
+
+    def test_check_auth_refresh_generic_error_falls_through(self, setup_module, capsys):
+        creds = _make_fake_creds(valid=False, expired=True, refresh_error=Exception("something else"))
+        FakeCredentials.from_authorized_user_file_impl = lambda _path, scopes=None: creds
+        setup_module.TOKEN_PATH.write_text(json.dumps({"token": "x", "refresh_token": "r"}))
+
+        assert setup_module.check_auth() is False
+
+        out = capsys.readouterr().out
+        assert "REFRESH_FAILED:" in out
+        assert "OAUTH_CLIENT_DISABLED" not in out
+        assert "TOKEN_REVOKED" not in out
+
+
+class TestCheckAuthLive:
+    def test_check_auth_live_success(self, setup_module, monkeypatch, capsys):
+        creds = _make_fake_creds(valid=True, expired=False)
+        FakeCredentials.from_authorized_user_file_impl = lambda _path, scopes=None: creds
+        setup_module.TOKEN_PATH.write_text(json.dumps({"token": "x", "refresh_token": "r"}))
+
+        class _FakeCalendarList:
+            def list(self, **_kwargs):
+                return self
+
+            def execute(self):
+                return {"items": []}
+
+        class _FakeService:
+            def calendarList(self):
+                return _FakeCalendarList()
+
+        monkeypatch.setattr(sys.modules["googleapiclient.discovery"], "build", lambda *_a, **_k: _FakeService())
+
+        assert setup_module.check_auth_live() is True
+
+        out = capsys.readouterr().out
+        assert "LIVE_CHECK_OK:" in out
+        assert "AUTHENTICATED:" not in out
+
+    def test_check_auth_live_disabled_client(self, setup_module, monkeypatch, capsys):
+        creds = _make_fake_creds(valid=True, expired=False)
+        FakeCredentials.from_authorized_user_file_impl = lambda _path, scopes=None: creds
+        setup_module.TOKEN_PATH.write_text(json.dumps({"token": "x", "refresh_token": "r"}))
+
+        class _FakeCalendarList:
+            def list(self, **_kwargs):
+                return self
+
+            def execute(self):
+                raise sys.modules["google.auth.exceptions"].RefreshError(
+                    "disabled_client: OAuth client disabled",
+                    {"error": "disabled_client"},
+                )
+
+        class _FakeService:
+            def calendarList(self):
+                return _FakeCalendarList()
+
+        monkeypatch.setattr(sys.modules["googleapiclient.discovery"], "build", lambda *_a, **_k: _FakeService())
+
+        assert setup_module.check_auth_live() is False
+
+        out = capsys.readouterr().out
+        assert "LIVE_CHECK_FAILED:" in out
+        assert "OAuth client or account disabled" in out
+
+    def test_check_auth_live_partial_scope_should_not_panic(self, setup_module, monkeypatch, capsys):
+        creds = _make_fake_creds(valid=True, expired=False)
+        FakeCredentials.from_authorized_user_file_impl = lambda _path, scopes=None: creds
+        setup_module.TOKEN_PATH.write_text(json.dumps({"token": "x", "refresh_token": "r"}))
+
+        class _FakeCalendarList:
+            def list(self, **_kwargs):
+                return self
+
+            def execute(self):
+                raise FakeHttpError(
+                    403,
+                    "HttpError 403 when requesting https://www.googleapis.com/calendar/v3/users/me/calendarList "
+                    "returned \"Request had insufficient authentication scopes. "
+                    "[reason: ACCESS_TOKEN_SCOPE_INSUFFICIENT]\"",
+                )
+
+        class _FakeService:
+            def calendarList(self):
+                return _FakeCalendarList()
+
+        monkeypatch.setattr(sys.modules["googleapiclient.discovery"], "build", lambda *_a, **_k: _FakeService())
+
+        assert setup_module.check_auth_live() is True
+
+        out = capsys.readouterr().out
+        assert "LIVE_CHECK_PARTIAL:" in out
+        assert "disabled" not in out.lower()
 
 
 class TestHermesConstantsFallback:

--- a/tests/skills/test_google_oauth_setup.py
+++ b/tests/skills/test_google_oauth_setup.py
@@ -341,6 +341,17 @@ class TestExchangeAuthCode:
 
 
 class TestCheckAuth:
+    def test_extract_oauth_error_code_uses_structured_refresh_error(self, setup_module):
+        refresh_error = sys.modules["google.auth.exceptions"].RefreshError(
+            "misleading invalid_client text",
+            {"error": "invalid_grant"},
+        )
+
+        assert setup_module._extract_oauth_error_code(refresh_error) == "invalid_grant"
+
+    def test_extract_oauth_error_code_does_not_match_compound_codes(self, setup_module):
+        assert setup_module._extract_oauth_error_code(Exception("invalid_grant_type: nope")) == ""
+
     def test_check_auth_refresh_disabled_client_prints_guidance(self, setup_module, capsys):
         refresh_error = sys.modules["google.auth.exceptions"].RefreshError(
             "disabled_client: The OAuth client was disabled.",
@@ -464,6 +475,30 @@ class TestCheckAuthLive:
         out = capsys.readouterr().out
         assert "LIVE_CHECK_PARTIAL:" in out
         assert "disabled" not in out.lower()
+
+    def test_check_auth_live_generic_403_still_fails(self, setup_module, monkeypatch, capsys):
+        creds = _make_fake_creds(valid=True, expired=False)
+        FakeCredentials.from_authorized_user_file_impl = lambda _path, scopes=None: creds
+        setup_module.TOKEN_PATH.write_text(json.dumps({"token": "x", "refresh_token": "r"}))
+
+        class _FakeCalendarList:
+            def list(self, **_kwargs):
+                return self
+
+            def execute(self):
+                raise FakeHttpError(403, "HttpError 403: access forbidden by policy")
+
+        class _FakeService:
+            def calendarList(self):
+                return _FakeCalendarList()
+
+        monkeypatch.setattr(sys.modules["googleapiclient.discovery"], "build", lambda *_a, **_k: _FakeService())
+
+        assert setup_module.check_auth_live() is False
+
+        out = capsys.readouterr().out
+        assert "LIVE_CHECK_FAILED: HTTP 403" in out
+        assert "LIVE_CHECK_PARTIAL" not in out
 
 
 class TestHermesConstantsFallback:

--- a/tests/skills/test_google_oauth_setup.py
+++ b/tests/skills/test_google_oauth_setup.py
@@ -1,0 +1,216 @@
+"""Regression tests for Google Workspace OAuth error handling."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+
+SETUP_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "skills/productivity/google-workspace/scripts/setup.py"
+)
+
+
+class FakeRefreshError(Exception):
+    pass
+
+
+class FakeHttpError(Exception):
+    def __init__(self, status: int, body: str):
+        super().__init__(body)
+        self.resp = SimpleNamespace(status=status)
+
+
+class FakeCredentials:
+    loader = None
+
+    def __init__(self, *, valid=True, expired=False, refresh_token="refresh-token", refresh_error=None):
+        self.valid = valid
+        self.expired = expired
+        self.refresh_token = refresh_token
+        self.refresh_error = refresh_error
+
+    @classmethod
+    def from_authorized_user_file(cls, path, scopes=None):
+        if cls.loader is not None:
+            return cls.loader(path, scopes=scopes)
+        return cls()
+
+    def refresh(self, _request):
+        if self.refresh_error is not None:
+            raise self.refresh_error
+        self.valid = True
+        self.expired = False
+
+    def to_json(self):
+        return json.dumps({"token": "refreshed", "refresh_token": self.refresh_token})
+
+
+def _install_google_fakes(monkeypatch, *, build):
+    google = types.ModuleType("google")
+    google_auth = types.ModuleType("google.auth")
+    google_auth_exceptions = types.ModuleType("google.auth.exceptions")
+    google_auth_exceptions.RefreshError = FakeRefreshError
+    google_auth_transport = types.ModuleType("google.auth.transport")
+    google_auth_requests = types.ModuleType("google.auth.transport.requests")
+    google_auth_requests.Request = type("Request", (), {})
+    google_auth_transport.requests = google_auth_requests
+    google_auth.transport = google_auth_transport
+    google_auth.exceptions = google_auth_exceptions
+
+    google_oauth2 = types.ModuleType("google.oauth2")
+    google_credentials = types.ModuleType("google.oauth2.credentials")
+    google_credentials.Credentials = FakeCredentials
+    google_oauth2.credentials = google_credentials
+
+    google_api = types.ModuleType("googleapiclient")
+    google_discovery = types.ModuleType("googleapiclient.discovery")
+    google_discovery.build = build
+    google_errors = types.ModuleType("googleapiclient.errors")
+    google_errors.HttpError = FakeHttpError
+    google_api.discovery = google_discovery
+    google_api.errors = google_errors
+
+    for name, module in {
+        "google": google,
+        "google.auth": google_auth,
+        "google.auth.exceptions": google_auth_exceptions,
+        "google.auth.transport": google_auth_transport,
+        "google.auth.transport.requests": google_auth_requests,
+        "google.oauth2": google_oauth2,
+        "google.oauth2.credentials": google_credentials,
+        "googleapiclient": google_api,
+        "googleapiclient.discovery": google_discovery,
+        "googleapiclient.errors": google_errors,
+    }.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+
+@pytest.fixture
+def setup_module(monkeypatch, tmp_path):
+    FakeCredentials.loader = None
+    _install_google_fakes(monkeypatch, build=lambda *_args, **_kwargs: None)
+    spec = importlib.util.spec_from_file_location("google_oauth_setup_test", SETUP_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    module.TOKEN_PATH = tmp_path / "google_token.json"
+    module._ensure_deps = lambda: None
+    yield module
+    FakeCredentials.loader = None
+
+
+def _write_token(module):
+    module.TOKEN_PATH.write_text(
+        json.dumps({"token": "access", "refresh_token": "refresh"}),
+        encoding="utf-8",
+    )
+
+
+def test_structured_refresh_error_wins_over_message_text(setup_module):
+    error = FakeRefreshError(
+        "invalid_client: misleading text",
+        {"error": "invalid_grant"},
+    )
+    assert setup_module._extract_oauth_error_code(error) == "invalid_grant"
+
+
+def test_compound_oauth_code_is_not_classified(setup_module):
+    assert setup_module._extract_oauth_error_code(Exception("invalid_grant_type: nope")) == ""
+
+
+@pytest.mark.parametrize(
+    ("code", "label"),
+    [("disabled_client", "OAUTH_CLIENT_DISABLED"), ("invalid_grant", "TOKEN_REVOKED")],
+)
+def test_check_auth_classifies_refresh_errors(setup_module, capsys, code, label):
+    error = FakeRefreshError(f"{code}: failure", {"error": code})
+    creds = FakeCredentials(valid=False, expired=True, refresh_error=error)
+    FakeCredentials.loader = lambda _path, scopes=None: creds
+    _write_token(setup_module)
+
+    assert setup_module.check_auth() is False
+    output = capsys.readouterr().out
+    assert f"{label}:" in output
+
+
+def test_check_auth_generic_refresh_error_is_not_misclassified(setup_module, capsys):
+    creds = FakeCredentials(valid=False, expired=True, refresh_error=RuntimeError("network down"))
+    FakeCredentials.loader = lambda _path, scopes=None: creds
+    _write_token(setup_module)
+
+    assert setup_module.check_auth() is False
+    output = capsys.readouterr().out
+    assert "REFRESH_FAILED:" in output
+    assert "OAUTH_CLIENT_DISABLED" not in output
+    assert "TOKEN_REVOKED" not in output
+
+
+def test_check_auth_live_success(setup_module, monkeypatch, capsys):
+    FakeCredentials.loader = lambda _path, scopes=None: FakeCredentials()
+    _write_token(setup_module)
+
+    class CalendarList:
+        def list(self, **_kwargs):
+            return self
+
+        def execute(self):
+            return {"items": []}
+
+    class Service:
+        def calendarList(self):
+            return CalendarList()
+
+    monkeypatch.setitem(sys.modules["googleapiclient.discovery"].__dict__, "build", lambda *_a, **_k: Service())
+
+    assert setup_module.check_auth_live() is True
+    assert "LIVE_CHECK_OK:" in capsys.readouterr().out
+
+
+def test_check_auth_live_disabled_client(setup_module, monkeypatch, capsys):
+    FakeCredentials.loader = lambda _path, scopes=None: FakeCredentials()
+    _write_token(setup_module)
+
+    class CalendarList:
+        def list(self, **_kwargs):
+            return self
+
+        def execute(self):
+            raise FakeRefreshError("disabled_client: disabled", {"error": "disabled_client"})
+
+    class Service:
+        def calendarList(self):
+            return CalendarList()
+
+    monkeypatch.setitem(sys.modules["googleapiclient.discovery"].__dict__, "build", lambda *_a, **_k: Service())
+
+    assert setup_module.check_auth_live() is False
+    assert "OAuth client or account disabled" in capsys.readouterr().out
+
+
+def test_check_auth_live_scope_failure_is_partial_success(setup_module, monkeypatch, capsys):
+    FakeCredentials.loader = lambda _path, scopes=None: FakeCredentials()
+    _write_token(setup_module)
+
+    class CalendarList:
+        def list(self, **_kwargs):
+            return self
+
+        def execute(self):
+            raise FakeHttpError(403, "access_token_scope_insufficient")
+
+    class Service:
+        def calendarList(self):
+            return CalendarList()
+
+    monkeypatch.setitem(sys.modules["googleapiclient.discovery"].__dict__, "build", lambda *_a, **_k: Service())
+
+    assert setup_module.check_auth_live() is True
+    assert "LIVE_CHECK_PARTIAL:" in capsys.readouterr().out


### PR DESCRIPTION
## What does this PR do?

Hardens Google Workspace OAuth setup error handling in `skills/productivity/google-workspace/scripts/setup.py`.

This PR fixes two related classification problems:

- `check_auth()` no longer relies only on substring matching against `str(e)` when refresh fails. It now prefers the structured OAuth error code from `RefreshError.args[1]["error"]`, with the old string fallback kept for unexpected exception shapes.
- `check_auth_live()` no longer treats a valid-but-partial token as a failed live check when the Calendar probe returns a 403 insufficient-scope error. That case now reports a partial live check and returns success because the token itself is still valid.
- The fallback classification and partial-scope detection were tightened so compound codes like `invalid_grant_type` are not misclassified, and generic 403 errors are not incorrectly treated as partial-scope success.

It also adds regression coverage for the refresh-classification and live-check branches.

## Related Issue

Fixes #21860.
Fixes #21861.
Fixes #21862.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `_extract_oauth_error_code()` in [skills/productivity/google-workspace/scripts/setup.py](/mnt/d/hermes-agent/skills/productivity/google-workspace/scripts/setup.py) to prefer structured `RefreshError` response data over raw `str(e)` matching.
- Tightened `_extract_oauth_error_code()` fallback matching so it does not misclassify compound error codes such as `invalid_grant_type`.
- Updated `check_auth()` to classify `disabled_client` / `invalid_client` / `token_revoked` / `invalid_grant` via the helper instead of direct substring checks.
- Split `check_auth_live()` exception handling into `RefreshError`, `HttpError`, and generic exception paths.
- Treated `HttpError` 403 insufficient-scope responses as `LIVE_CHECK_PARTIAL` so partial-scope tokens are not misreported as failed/disabled, while keeping generic 403 failures on the error path.
- Added regression tests in [tests/skills/test_google_oauth_setup.py](/mnt/d/hermes-agent/tests/skills/test_google_oauth_setup.py) for refresh disabled-client, refresh invalid-grant, generic refresh failure, helper fallback edge cases, live-check success, live-check disabled-client, live-check partial-scope behavior, and generic 403 failures.

## How to Test

1. Run `python -m pytest tests/skills/test_google_oauth_setup.py`
2. Verify the suite passes, including the new `TestCheckAuth` and `TestCheckAuthLive` cases.
3. Optionally inspect the live-check tests to confirm that a 403 insufficient-scope `HttpError` now produces `LIVE_CHECK_PARTIAL` rather than `LIVE_CHECK_FAILED`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu / WSL

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```text
$ python -m pytest tests/skills/test_google_oauth_setup.py
24 passed in 15.07s
```
