### PR TITLE
fix(transports): use PEP 604 annotation for ToolCall.extra_content

### DIFF
--- a/agent/transports/types.py
+++ b/agent/transports/types.py
@@ -62,7 +62,7 @@ class ToolCall:
         return (self.provider_data or {}).get("response_item_id")
 
     @property
-    def extra_content(self) -> Optional[Dict[str, Any]]:
+    def extra_content(self) -> dict[str, Any] | None:
         """Gemini extra_content (thought_signature) from provider_data.
 
         Gemini 3 thinking models attach ``extra_content`` with a


### PR DESCRIPTION
## Summary

`ToolCall.extra_content` in `agent/transports/types.py:65` was annotated `Optional[Dict[str, Any]]`, but neither `Optional` nor `Dict` are imported at the top of the file — only `Any` is. Every other annotation in this module uses PEP 604/585 syntax (`str | None`, `dict[str, Any] | None`).

`from __future__ import annotations` is active, so this doesn't crash class definition. But the annotation IS evaluated when anything calls `typing.get_type_hints(ToolCall)` — introspection raises `NameError: name 'Optional' is not defined`. The codebase already has `ty` and `ruff` in dev deps, and `ruff check --select F` reports it as a real error:

```
F821 Undefined name `Optional`  agent/transports/types.py:65:32
F821 Undefined name `Dict`      agent/transports/types.py:65:41
```

This PR changes the annotation to `dict[str, Any] | None` to match the style used everywhere else in the file. Single line, no new imports.

## Verification

```
> uv run ruff check --select F agent/transports/types.py
All checks passed!

> uv run python -c "import typing; from agent.transports.types import ToolCall; typing.get_type_hints(ToolCall)"
# (no error — succeeds where it raised NameError before)

> uv run pytest tests/agent/transports/ -q
166 passed in 50.10s
```

## Scope check

Searched all open / closed / merged PRs touching `agent/transports/types.py` before opening this. Two open PRs touch the file (#20918, #13481) but neither modifies line 65:

- **#20918** ("Codex native web search support") only adds new methods at line 131+.
- **#13481** ("ty type-checker cleanup") fixes similar `Optional[Dict]` patterns in *other* files (gateway/, tools/, toolsets.py) but explicitly skips `transports/types.py`. It's also stale (last activity Apr 23).

This PR is non-overlapping.

## Test plan

- [x] `ruff check --select F agent/transports/types.py` → clean
- [x] `pytest tests/agent/transports/ -q` → 166 passed
- [x] Tested on Windows 11 + Python 3.12.10
