### PR TITLE
fix(tui): persist in-flight streaming turns for dashboard resume

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1514,6 +1514,34 @@ class SessionDB:
 
         return self._execute_write(_do)
 
+    def update_message_content(
+        self,
+        message_id: int,
+        content: Any,
+        *,
+        session_id: Optional[str] = None,
+        role: Optional[str] = None,
+    ) -> bool:
+        """Update a single message's content without rewriting the transcript."""
+        stored_content = self._encode_content(content)
+
+        def _do(conn):
+            clauses = ["id = ?"]
+            params = [message_id]
+            if session_id is not None:
+                clauses.append("session_id = ?")
+                params.append(session_id)
+            if role is not None:
+                clauses.append("role = ?")
+                params.append(role)
+            cursor = conn.execute(
+                f"UPDATE messages SET content = ? WHERE {' AND '.join(clauses)}",
+                (stored_content, *params),
+            )
+            return cursor.rowcount > 0
+
+        return self._execute_write(_do)
+
     def replace_messages(self, session_id: str, messages: List[Dict[str, Any]]) -> None:
         """Atomically replace every message for a session.
 

--- a/tests/test_lazy_session_regressions.py
+++ b/tests/test_lazy_session_regressions.py
@@ -49,6 +49,172 @@ def _tui_session(agent=None, session_key="session-key-old", **extra):
 
 
 # ===========================================================================
+# Dashboard Chat: in-flight turn survives PTY/dashboard restart
+# ===========================================================================
+
+class TestPromptSubmitPersistsInflightTurn:
+    """Dashboard /chat runs the TUI behind a PTY.  If that PTY is closed
+    while a model response is still streaming, resume can only hydrate what
+    has already reached the session DB.  The gateway therefore needs to keep
+    an in-flight user+partial-assistant snapshot durable during streaming,
+    not only after run_conversation() returns."""
+
+    def test_stream_callback_persists_user_and_partial_assistant_snapshot(self, tmp_path, monkeypatch):
+        from tui_gateway import server
+
+        db = _make_session_db(tmp_path)
+        db.create_session(session_id="test-session", source="tui", model="test/model")
+        observed = {}
+
+        class _StreamingAgent:
+            session_id = "test-session"
+            model = "test/model"
+            _cached_system_prompt = ""
+
+            def run_conversation(self, prompt, conversation_history=None, stream_callback=None):
+                assert conversation_history == []
+                stream_callback("partial answer")
+                observed["during_stream"] = db.get_messages_as_conversation("test-session")
+                return {
+                    "final_response": "partial answer done",
+                    "messages": [
+                        {"role": "user", "content": prompt},
+                        {"role": "assistant", "content": "partial answer done"},
+                    ],
+                }
+
+        session = _tui_session(agent=_StreamingAgent(), session_key="test-session")
+
+        monkeypatch.setattr(server, "_get_db", lambda: db)
+        monkeypatch.setattr(server, "_emit", lambda *a, **kw: None)
+        monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
+        monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
+        monkeypatch.setattr(
+            server, "_sync_session_key_after_compress", lambda *a, **kw: None
+        )
+
+        class _ImmediateThread:
+            def __init__(self, target=None, daemon=None, **kw):
+                self._target = target
+
+            def start(self):
+                self._target()
+
+        server._sessions["sid"] = session
+        monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+
+        try:
+            server.handle_request({
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {"session_id": "sid", "text": "hello"},
+            })
+        finally:
+            server._sessions.pop("sid", None)
+
+        assert observed["during_stream"] == [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "partial answer"},
+        ]
+
+        assert db.get_messages_as_conversation("test-session") == [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "partial answer done"},
+        ]
+
+    def test_streaming_persistence_does_not_rewrite_full_history_per_delta(self, tmp_path, monkeypatch):
+        """Long streaming turns must not repeatedly DELETE+reinsert the
+        whole transcript.  A full replace touches every historical message and
+        all FTS rows; doing that once per streamed chunk would create visible DB
+        pressure on long sessions."""
+        from hermes_state import SessionDB
+        from tui_gateway import server
+
+        class _CountingDB(SessionDB):
+            def __init__(self, db_path):
+                super().__init__(db_path=db_path)
+                self.replace_calls = 0
+
+            def replace_messages(self, session_id, messages):
+                self.replace_calls += 1
+                return super().replace_messages(session_id, messages)
+
+        db = _CountingDB(tmp_path / "test_state.db")
+        db.create_session(session_id="test-session", source="tui", model="test/model")
+        history = []
+        for i in range(60):
+            history.extend([
+                {"role": "user", "content": f"user {i}"},
+                {"role": "assistant", "content": f"assistant {i}"},
+            ])
+        db.replace_messages("test-session", history)
+        db.replace_calls = 0
+        observed = {}
+
+        class _StreamingAgent:
+            session_id = "test-session"
+            model = "test/model"
+            _cached_system_prompt = ""
+
+            def run_conversation(self, prompt, conversation_history=None, stream_callback=None):
+                for chunk in ["a", "b", "c", "d", "e"]:
+                    stream_callback(chunk)
+                observed["during_stream"] = db.get_messages_as_conversation("test-session")
+                return {
+                    "final_response": "abcde",
+                    "messages": [
+                        *conversation_history,
+                        {"role": "user", "content": prompt},
+                        {"role": "assistant", "content": "abcde"},
+                    ],
+                }
+
+        session = _tui_session(
+            agent=_StreamingAgent(),
+            session_key="test-session",
+            history=history,
+        )
+
+        monotonic_values = iter([0, 1, 2, 3, 4])
+        monkeypatch.setattr(server.time, "monotonic", lambda: next(monotonic_values))
+        monkeypatch.setattr(server, "_get_db", lambda: db)
+        monkeypatch.setattr(server, "_emit", lambda *a, **kw: None)
+        monkeypatch.setattr(server, "make_stream_renderer", lambda cols: None)
+        monkeypatch.setattr(server, "render_message", lambda raw, cols: None)
+        monkeypatch.setattr(
+            server, "_sync_session_key_after_compress", lambda *a, **kw: None
+        )
+
+        class _ImmediateThread:
+            def __init__(self, target=None, daemon=None, **kw):
+                self._target = target
+
+            def start(self):
+                self._target()
+
+        server._sessions["sid"] = session
+        monkeypatch.setattr(server.threading, "Thread", _ImmediateThread)
+
+        try:
+            server.handle_request({
+                "id": "1",
+                "method": "prompt.submit",
+                "params": {"session_id": "sid", "text": "hello"},
+            })
+        finally:
+            server._sessions.pop("sid", None)
+
+        assert observed["during_stream"][-2:] == [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "abcde"},
+        ]
+        assert db.replace_calls <= 1, (
+            "streaming persistence should update only the in-flight assistant row; "
+            f"full transcript rewrites during one turn: {db.replace_calls}"
+        )
+
+
+# ===========================================================================
 # Bug #20001: _finalize_session uses stale session_key
 # ===========================================================================
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2045,6 +2045,75 @@ def _content_display_text(content: Any) -> str:
     return str(content)
 
 
+def _replace_session_messages_best_effort(
+    session_key: str,
+    messages: list[dict],
+    *,
+    model: str | None = None,
+) -> bool:
+    """Best-effort durable final transcript rewrite for TUI-owned sessions."""
+    if not session_key:
+        return False
+    db = _get_db()
+    if db is None:
+        return False
+    try:
+        db.create_session(session_id=session_key, source="tui", model=model)
+        db.replace_messages(session_key, messages)
+        return True
+    except Exception:
+        logger.debug("TUI session transcript rewrite failed", exc_info=True)
+        return False
+
+
+def _append_session_message_best_effort(
+    session_key: str,
+    role: str,
+    content: Any,
+    *,
+    model: str | None = None,
+) -> int | None:
+    """Best-effort append of one in-flight TUI message row."""
+    if not session_key:
+        return None
+    db = _get_db()
+    if db is None:
+        return None
+    try:
+        db.create_session(session_id=session_key, source="tui", model=model)
+        return db.append_message(session_key, role=role, content=content)
+    except Exception:
+        logger.debug("TUI session message append failed", exc_info=True)
+        return None
+
+
+def _update_session_message_content_best_effort(
+    session_key: str,
+    message_id: int | None,
+    content: Any,
+    *,
+    role: str | None = None,
+) -> bool:
+    """Best-effort update of one in-flight TUI message row."""
+    if not session_key or message_id is None:
+        return False
+    db = _get_db()
+    if db is None or not hasattr(db, "update_message_content"):
+        return False
+    try:
+        return bool(
+            db.update_message_content(
+                message_id,
+                content,
+                session_id=session_key,
+                role=role,
+            )
+        )
+    except Exception:
+        logger.debug("TUI session message update failed", exc_info=True)
+        return False
+
+
 def _history_to_messages(history: list[dict]) -> list[dict]:
     messages = []
     tool_call_args = {}
@@ -3138,11 +3207,57 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                 else:
                     run_message = _enrich_with_attached_images(prompt, images)
 
+            persist_session_key = session.get("session_key") or getattr(agent, "session_id", "") or sid
+            persist_model = getattr(agent, "model", None) or None
+            _append_session_message_best_effort(
+                persist_session_key,
+                "user",
+                run_message,
+                model=persist_model,
+            )
+            stream_chunks: list[str] = []
+            stream_last_persist = 0.0
+            stream_assistant_msg_id: int | None = None
+            stream_persist_interval_s = 2.0
+
+            def _persist_stream_snapshot(force: bool = False) -> None:
+                nonlocal stream_assistant_msg_id, stream_last_persist
+                if not stream_chunks:
+                    return
+                now = time.monotonic()
+                if (
+                    not force
+                    and stream_assistant_msg_id is not None
+                    and now - stream_last_persist < stream_persist_interval_s
+                ):
+                    return
+                partial_text = "".join(stream_chunks)
+                current_key = session.get("session_key") or getattr(agent, "session_id", "") or sid
+                if stream_assistant_msg_id is None:
+                    stream_assistant_msg_id = _append_session_message_best_effort(
+                        current_key,
+                        "assistant",
+                        partial_text,
+                        model=persist_model,
+                    )
+                else:
+                    _update_session_message_content_best_effort(
+                        current_key,
+                        stream_assistant_msg_id,
+                        partial_text,
+                        role="assistant",
+                    )
+                stream_last_persist = now
+
             def _stream(delta):
                 payload = {"text": delta}
                 if streamer and (r := streamer.feed(delta)) is not None:
                     payload["rendered"] = r
                 _emit("message.delta", sid, payload)
+
+                if delta:
+                    stream_chunks.append(str(delta))
+                    _persist_stream_snapshot()
 
             result = agent.run_conversation(
                 run_message,
@@ -3152,13 +3267,16 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
 
             last_reasoning = None
             status_note = None
+            result_messages_persistable = False
             if isinstance(result, dict):
-                if isinstance(result.get("messages"), list):
+                result_messages = result.get("messages")
+                if isinstance(result_messages, list):
                     with session["history_lock"]:
                         current_version = int(session.get("history_version", 0))
                         if current_version == history_version:
-                            session["history"] = result["messages"]
+                            session["history"] = result_messages
                             session["history_version"] = history_version + 1
+                            result_messages_persistable = True
                         else:
                             # History mutated externally during the turn
                             # (undo/compress/retry/rollback now guard on
@@ -3188,6 +3306,16 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                 _sync_session_key_after_compress(
                     sid, session, clear_pending_title=False, restart_slash_worker=True,
                 )
+                if result_messages_persistable:
+                    _replace_session_messages_best_effort(
+                        session.get("session_key")
+                        or getattr(agent, "session_id", "")
+                        or sid,
+                        result_messages,
+                        model=persist_model,
+                    )
+                else:
+                    _persist_stream_snapshot(force=True)
 
                 raw = result.get("final_response", "")
                 status = (


### PR DESCRIPTION
## Summary
- Persist a best-effort in-flight user + partial assistant snapshot for TUI-owned dashboard chat turns while the model is still streaming.
- Add a single-message `SessionDB.update_message_content()` path so streaming persistence updates the current assistant row instead of repeatedly rewriting the whole transcript.
- Add regression coverage for both refresh/resume durability and long-session DB write pressure.

## Why
Dashboard `/chat` runs through the TUI gateway behind a PTY. Before this change, `prompt.submit` only emitted live `message.delta` events during streaming and relied on `run_conversation()` returning before the final messages reached the session DB. If the browser, websocket, PTY, or dashboard process was rebuilt/restarted while a response was still streaming, resume/hydration had no durable user + partial assistant turn to display.

## Implementation
- Append the user message once before entering `run_conversation()`.
- Append the first partial assistant message on the first streamed delta.
- Update that same assistant row at most once every 2 seconds while streaming continues.
- Replace the transcript once with the final `result_messages` when the turn completes successfully.
- Keep all persistence best-effort so DB write failures do not interrupt the user-visible turn.

## Test Plan
- `python -m py_compile hermes_state.py tui_gateway/server.py`
- `git diff --cached --check`
- `scripts/run_tests.sh tests/test_lazy_session_regressions.py -q`
- `scripts/run_tests.sh tests/test_hermes_state.py -q`
- `scripts/run_tests.sh tests/tui_gateway -q`
