### PR TITLE
fix(webui): add platform hint for MEDIA rendering

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -529,7 +529,7 @@ PLATFORM_HINTS = {
         "controls), video, PDFs, HTML, CSV, diffs/patches, and Excalidraw files "
         "render as rich previews. Do not use Markdown image syntax like "
         "![alt](/path) for local files; local paths are not served that way. "
-        "Use MEDIA:/path instead."
+        "Use MEDIA:/absolute/path instead."
     ),
 }
 

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -519,6 +519,18 @@ PLATFORM_HINTS = {
         "code fences). Treat this like a conversation, not a document. Keep responses "
         "brief and natural."
     ),
+    "webui": (
+        "You are in the Hermes WebUI, a browser-based chat interface. "
+        "Full Markdown rendering is supported — headings, bold, italic, code "
+        "blocks, tables, math (LaTeX), and Mermaid diagrams all render natively. "
+        "To display local or remote media/files inline, include "
+        "MEDIA:/absolute/path/to/file or MEDIA:https://... in your response. "
+        "Local file paths must be absolute. Images, audio (with playback speed "
+        "controls), video, PDFs, HTML, CSV, diffs/patches, and Excalidraw files "
+        "render as rich previews. Do not use Markdown image syntax like "
+        "![alt](/path) for local files; local paths are not served that way. "
+        "Use MEDIA:/path instead."
+    ),
 }
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -789,6 +789,7 @@ class TestPromptBuilderConstants:
         assert "cron" in PLATFORM_HINTS
         assert "cli" in PLATFORM_HINTS
         assert "api_server" in PLATFORM_HINTS
+        assert "webui" in PLATFORM_HINTS
 
     def test_cli_hint_does_not_suggest_media_tags(self):
         # Regression: MEDIA:/path tags are intercepted only by messaging
@@ -825,6 +826,13 @@ class TestPromptBuilderConstants:
         assert "Feishu" in hint
         assert "MEDIA:" in hint
         assert "Markdown" in hint
+
+    def test_platform_hints_webui(self):
+        hint = PLATFORM_HINTS["webui"]
+        assert "WebUI" in hint
+        assert "MEDIA:" in hint
+        assert "Markdown" in hint
+        assert "absolute" in hint
 
 
 # =========================================================================


### PR DESCRIPTION
## What does this PR do?

Adds a `webui` entry to `PLATFORM_HINTS` so WebUI sessions get explicit guidance about the `MEDIA:` rendering path.

WebUI already supports rich local/remote media previews via `MEDIA:/absolute/path` and `MEDIA:https://...`, but `AIAgent(platform="webui")` currently receives no platform hint because `webui` is missing from `PLATFORM_HINTS` (`agent/prompt_builder.py:355`). Without the hint the agent either ignores `MEDIA:` entirely or falls back to Markdown image syntax `![alt](/path)`, which silently fails for local files because the WebUI markdown renderer does not serve local paths.

The new hint documents the `MEDIA:` path, lists the supported preview types, calls out WebUI-specific Markdown features (math/Mermaid) the messaging-platform hints don't cover, and explicitly steers the agent away from `![alt](/path)` for local files.

## Related Issue

Fixes #21883

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `"webui"` entry to `PLATFORM_HINTS` in [agent/prompt_builder.py](/mnt/d/hermes-agent/agent/prompt_builder.py) covering:
  - Markdown features (headings, bold, italic, code blocks, tables, math, Mermaid)
  - `MEDIA:/absolute/path` and `MEDIA:https://...` syntax, with local files requiring absolute paths
  - Supported preview types (images, audio with playback speed controls, video, PDF, HTML, CSV, diffs, Excalidraw)
  - Negative instruction against `![alt](/path)` for local files
- Added `test_platform_hints_webui` in [tests/agent/test_prompt_builder.py](/mnt/d/hermes-agent/tests/agent/test_prompt_builder.py) asserting the hint mentions `WebUI`, `MEDIA:`, `Markdown`, and `absolute`.
- Extended `test_platform_hints_known_platforms` in [tests/agent/test_prompt_builder.py](/mnt/d/hermes-agent/tests/agent/test_prompt_builder.py) to include `"webui"`.

## How to Test

1. Activate the repo venv.
2. Run `python -m pytest tests/agent/test_prompt_builder.py -q`
3. Confirm `test_platform_hints_webui` and `test_platform_hints_known_platforms` pass and the suite is green.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `python -m pytest tests/agent/test_prompt_builder.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL Ubuntu / Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

`python -m pytest tests/agent/test_prompt_builder.py -q`

`117 passed in 6.10s`
