### PR TITLE
fix(update): sync fork with upstream even when already up-to-date with origin

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7177,6 +7177,14 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
         if commit_count == 0:
             _invalidate_update_cache()
+
+            # Fork users: check if upstream has new commits even though
+            # we're current with origin.  The normal upstream-sync call
+            # only runs after a pull, but if origin already matches HEAD
+            # we skip the pull entirely and miss the sync.
+            if is_fork:
+                _sync_with_upstream_if_needed(git_cmd, PROJECT_ROOT)
+
             # Restore stash and switch back to original branch if we moved
             if auto_stash_ref is not None:
                 _restore_stashed_changes(

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7182,7 +7182,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
             # we're current with origin.  The normal upstream-sync call
             # only runs after a pull, but if origin already matches HEAD
             # we skip the pull entirely and miss the sync.
-            if is_fork:
+            if is_fork and branch == "main":
                 _sync_with_upstream_if_needed(git_cmd, PROJECT_ROOT)
 
             # Restore stash and switch back to original branch if we moved


### PR DESCRIPTION
## Summary

When `hermes update` determines the local checkout matches `origin/main`,
it returns early with `✓ Already up to date!` without ever checking
whether the upstream remote has new commits. For fork users, the upstream
sync code at `_sync_with_upstream_if_needed()` — which runs only after a
successful pull from `origin` — is never reached, and upstream updates
are silently missed.

## Fix

Added an `_sync_with_upstream_if_needed()` call to the early-return path
when `is_fork` is `True`. The call runs while we're still on `main`,
before the stash restore and branch switch-back, matching the same
structure used in the post-pull path at line 7280.

## Test Plan

- ✅ All 7 existing `test_cmd_update.py` tests pass unchanged (the mock
  returns empty `origin_url` so `is_fork` is `False` in existing
  tests — no regression)
- ✅ New code path only activates when `is_fork=True` and `commit_count == 0`
- ✅ Tested locally after syncing the fork — `hermes update` now correctly
  detects and syncs upstream commits even when local matches `origin/main`

## Testing

Tested on WSL2 (Ubuntu 24.04) with Python 3.11.14.