### PR TITLE
WIP: Use Nous JWTs for inference entitlements

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -8,6 +8,7 @@ import httpx
 
 from agent.anthropic_adapter import _is_oauth_token, resolve_anthropic_token
 from hermes_cli.auth import _read_codex_tokens, resolve_codex_runtime_credentials
+from hermes_cli.nous_account import get_nous_account_status
 from hermes_cli.runtime_provider import resolve_runtime_provider
 
 
@@ -305,6 +306,51 @@ def _fetch_openrouter_account_usage(base_url: Optional[str], api_key: Optional[s
     )
 
 
+def _money_detail(label: str, value: Optional[float]) -> Optional[str]:
+    if value is None:
+        return None
+    return f"{label}: ${value:.2f}"
+
+
+def _fetch_nous_account_usage() -> Optional[AccountUsageSnapshot]:
+    status = get_nous_account_status(force_refresh=True)
+    if not status.available:
+        return AccountUsageSnapshot(
+            provider="nous",
+            source="nas_account",
+            fetched_at=_utc_now(),
+            title="Nous account",
+            unavailable_reason=status.unavailable_reason or "NAS account status unavailable",
+        )
+
+    details: list[str] = [
+        f"Paid access: {'yes' if status.paid_access else 'no'}",
+    ]
+    if status.has_active_subscription is not None:
+        details.append(
+            f"Active subscription: {'yes' if status.has_active_subscription else 'no'}"
+        )
+    for item in (
+        _money_detail("Usable credits", status.total_usable_credits),
+        _money_detail("Subscription credits", status.subscription_credits_remaining),
+        _money_detail("Purchased credits", status.purchased_credits_remaining),
+    ):
+        if item:
+            details.append(item)
+    if status.reason:
+        details.append(f"Entitlement reason: {status.reason}")
+
+    plan = status.subscription_plan or status.subscription_tier
+    return AccountUsageSnapshot(
+        provider="nous",
+        source="nas_account",
+        fetched_at=_utc_now(),
+        title="Nous account",
+        plan=_title_case_slug(plan),
+        details=tuple(details),
+    )
+
+
 def fetch_account_usage(
     provider: Optional[str],
     *,
@@ -321,6 +367,8 @@ def fetch_account_usage(
             return _fetch_anthropic_account_usage()
         if normalized == "openrouter":
             return _fetch_openrouter_account_usage(base_url, api_key)
+        if normalized == "nous":
+            return _fetch_nous_account_usage()
     except Exception:
         return None
     return None

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1395,7 +1395,7 @@ def _try_nous(vision: bool = False) -> Tuple[Optional[OpenAI], Optional[str]]:
 
     # Ask the Portal which model it currently recommends for this task type.
     # The /api/nous/recommended-models endpoint is the authoritative source:
-    # it distinguishes paid vs free tier recommendations, and get_nous_recommended_aux_model
+    # it distinguishes paid-access vs free recommendations, and get_nous_recommended_aux_model
     # auto-detects the caller's tier via check_nous_free_tier().  Fall back to
     # _NOUS_MODEL (google/gemini-3-flash-preview) when the Portal is unreachable
     # or returns a null recommendation for this task type.

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -958,9 +958,6 @@ def build_nous_subscription_prompt(valid_tool_names: "set[str] | None" = None) -
         logger.debug("Failed to import Nous subscription helper: %s", exc)
         return ""
 
-    if not managed_nous_tools_enabled():
-        return ""
-
     valid_names = set(valid_tool_names or set())
     relevant_tool_names = {
         "web_search",
@@ -985,31 +982,40 @@ def build_nous_subscription_prompt(valid_tool_names: "set[str] | None" = None) -
         return ""
 
     features = get_nous_subscription_features()
+    if not (
+        managed_nous_tools_enabled()
+        or features.nous_auth_present
+        or features.provider_is_nous
+        or features.subscribed
+    ):
+        return ""
 
     def _status_line(feature) -> str:
         if feature.managed_by_nous:
-            return f"- {feature.label}: active via Nous subscription"
+            return f"- {feature.label}: active via Nous paid access"
         if feature.active:
             current = feature.current_provider or "configured provider"
             return f"- {feature.label}: currently using {current}"
         if feature.included_by_default and features.nous_auth_present:
-            return f"- {feature.label}: included with Nous subscription, not currently selected"
+            return f"- {feature.label}: available with Nous paid access, not currently selected"
         if feature.key == "modal" and features.nous_auth_present:
-            return f"- {feature.label}: optional via Nous subscription"
+            return f"- {feature.label}: optional with Nous paid access"
         return f"- {feature.label}: not currently available"
 
     lines = [
-        "# Nous Subscription",
-        "Nous subscription includes managed web tools (Firecrawl), image generation (FAL), OpenAI TTS, and browser automation (Browser Use) by default. Modal execution is optional.",
+        "# Nous Account Access",
+        "Nous paid access means NAS reports positive usable credits. An active subscription with zero usable credits is not enough for paid Nous services.",
+        "Nous paid access can include managed web tools (Firecrawl), image generation (FAL), OpenAI TTS, and browser automation (Browser Use). Modal execution is optional.",
         "Current capability status:",
     ]
     lines.extend(_status_line(feature) for feature in features.items())
     lines.extend(
         [
             "When a Nous-managed feature is active, do not ask the user for Firecrawl, FAL, OpenAI TTS, or Browser-Use API keys.",
-            "If the user is not subscribed and asks for a capability that Nous subscription would unlock or simplify, suggest Nous subscription as one option alongside direct setup or local alternatives.",
-            "Do not mention subscription unless the user asks about it or it directly solves the current missing capability.",
-            "Useful commands: hermes setup, hermes setup tools, hermes setup terminal, hermes status.",
+            "If a Nous API returns 402, payment_required, insufficient credits, or SUBSCRIPTION_REQUIRED, inspect live account status via /usage or hermes status before recommending a fix.",
+            "If there is no active subscription, suggest Nous subscription as one option. If there is an active subscription but no usable credits, recommend topping up credits.",
+            "Do not mention subscription unless the user asks about it or it directly solves the current Nous access failure; do not mention top-up unless credits are the blocker.",
+            "Useful commands: /usage, hermes setup, hermes setup tools, hermes setup terminal, hermes status.",
         ]
     )
     return "\n".join(lines)

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -9,7 +9,7 @@ Architecture:
 - ProviderConfig registry defines known OAuth providers
 - Auth store (auth.json) holds per-provider credential state
 - resolve_provider() picks the active provider via priority chain
-- resolve_*_runtime_credentials() handles token refresh and key minting
+- resolve_*_runtime_credentials() handles token refresh and runtime credentials
 - logout_command() is the CLI entry point for clearing auth
 """
 
@@ -2818,7 +2818,7 @@ def _poll_for_token(
 
 
 # =============================================================================
-# Nous Portal — token refresh, agent key minting, model discovery
+# Nous Portal — token refresh, JWT runtime aliasing, model discovery
 # =============================================================================
 
 # -----------------------------------------------------------------------------
@@ -2886,7 +2886,7 @@ def _nous_shared_store_lock(timeout_seconds: float = AUTH_LOCK_TIMEOUT_SECONDS):
     to be held, acquire ``_auth_store_lock`` FIRST. All runtime refresh
     paths follow this order. The one exception is
     ``_try_import_shared_nous_state``, which holds this lock alone for
-    the entire refresh+mint cycle so concurrent imports on sibling
+    the entire refresh cycle so concurrent imports on sibling
     profiles can't race on the single-use shared refresh token; that
     helper must NOT be called with ``_auth_store_lock`` already held.
     """
@@ -2948,8 +2948,9 @@ def _write_shared_nous_state(state: Dict[str, Any]) -> None:
     is a convenience layer; the per-profile auth.json remains the source
     of truth.
 
-    We deliberately omit the short-lived ``agent_key`` (24h TTL, profile-
-    specific) — only the long-lived OAuth tokens are cross-profile useful.
+    We deliberately omit the legacy ``agent_key`` compatibility alias.  The
+    NAS access JWT is already shared as ``access_token`` and gets copied into
+    ``agent_key`` in each profile when runtime credentials are resolved.
     """
     refresh_token = state.get("refresh_token")
     access_token = state.get("access_token")
@@ -3047,8 +3048,8 @@ def _try_import_shared_nous_state(
 ) -> Optional[Dict[str, Any]]:
     """Attempt to rehydrate Nous OAuth state from the shared store.
 
-    Reads the shared file (if present), runs a forced refresh+mint using
-    the stored refresh_token to produce a fresh access_token + agent_key
+    Reads the shared file (if present), runs a forced refresh using
+    the stored refresh_token to produce a fresh access_token/JWT alias
     scoped to this profile, and returns the full auth_state dict ready
     for ``persist_nous_credentials()``.
 
@@ -3065,7 +3066,8 @@ def _try_import_shared_nous_state(
 
             # Build a full state dict so refresh_nous_oauth_from_state has every
             # field it needs. force_refresh=True gets us a fresh access_token
-            # for this profile; force_mint=True gets us a fresh agent_key.
+            # for this profile; force_mint=True is kept as a compatibility
+            # alias for forcing a JWT refresh.
             state: Dict[str, Any] = {
                 "access_token": shared.get("access_token"),
                 "refresh_token": shared.get("refresh_token"),
@@ -3172,30 +3174,17 @@ def _mint_agent_key(
     access_token: str,
     min_ttl_seconds: int,
 ) -> Dict[str, Any]:
-    """Mint (or reuse) a short-lived inference API key."""
-    response = client.post(
-        f"{portal_base_url}/api/oauth/agent-key",
-        headers={"Authorization": f"Bearer {access_token}"},
-        json={"min_ttl_seconds": max(60, int(min_ttl_seconds))},
+    """Legacy stub retained for older tests/extensions.
+
+    Hermes no longer mints opaque Nous inference keys.  Runtime auth uses the
+    NAS OAuth access JWT directly and aliases it into the historical
+    ``agent_key`` storage fields for compatibility.
+    """
+    raise AuthError(
+        "Nous opaque agent-key minting has been removed; use the NAS access JWT.",
+        provider="nous",
+        code="agent_key_mint_removed",
     )
-
-    if response.status_code == 200:
-        payload = response.json()
-        if "api_key" not in payload:
-            raise AuthError("Mint response missing api_key",
-                            provider="nous", code="server_error")
-        return payload
-
-    try:
-        error_payload = response.json()
-    except Exception as exc:
-        raise AuthError("Agent key mint request failed",
-                        provider="nous", code="server_error") from exc
-
-    code = str(error_payload.get("error", "server_error"))
-    description = str(error_payload.get("error_description") or "Agent key mint request failed")
-    relogin = code in {"invalid_token", "invalid_grant"}
-    raise AuthError(description, provider="nous", code=code, relogin_required=relogin)
 
 
 def fetch_nous_models(
@@ -3262,6 +3251,29 @@ def _agent_key_is_usable(state: Dict[str, Any], min_ttl_seconds: int) -> bool:
     return not _is_expiring(state.get("agent_key_expires_at"), min_ttl_seconds)
 
 
+def _alias_nous_access_jwt_as_agent_key(
+    state: Dict[str, Any],
+    *,
+    obtained_at: Optional[str] = None,
+) -> None:
+    """Copy the NAS access JWT into legacy inference-key fields."""
+    access_token = state.get("access_token")
+    if not isinstance(access_token, str) or not access_token.strip():
+        return
+    state["agent_key"] = access_token.strip()
+    state["agent_key_expires_at"] = state.get("expires_at")
+    state["agent_key_expires_in"] = _coerce_ttl_seconds(state.get("expires_in"))
+    state["agent_key_reused"] = False
+    state["agent_key_obtained_at"] = (
+        obtained_at
+        or state.get("obtained_at")
+        or datetime.now(timezone.utc).isoformat()
+    )
+    claims = _decode_jwt_claims(access_token)
+    token_id = claims.get("jti") or claims.get("sid") or claims.get("sub")
+    state["agent_key_id"] = str(token_id) if token_id not in (None, "") else None
+
+
 def resolve_nous_access_token(
     *,
     timeout_seconds: float = 15.0,
@@ -3302,7 +3314,8 @@ def resolve_nous_access_token(
                 )
 
             if not _is_expiring(state.get("expires_at"), refresh_skew_seconds):
-                if merged_shared:
+                if merged_shared or state.get("agent_key") != access_token:
+                    _alias_nous_access_jwt_as_agent_key(state)
                     _save_provider_state(auth_store, "nous", state)
                     _save_auth_store(auth_store)
                 return access_token
@@ -3345,6 +3358,7 @@ def resolve_nous_access_token(
                 "insecure": verify is False,
                 "ca_bundle": verify if isinstance(verify, str) else None,
             }
+            _alias_nous_access_jwt_as_agent_key(state)
             _save_provider_state(auth_store, "nous", state)
             _save_auth_store(auth_store)
             _write_shared_nous_state(state)
@@ -3393,7 +3407,7 @@ def refresh_nous_oauth_pure(
     timeout = httpx.Timeout(timeout_seconds if timeout_seconds else 15.0)
 
     with httpx.Client(timeout=timeout, headers={"Accept": "application/json"}, verify=verify) as client:
-        if force_refresh or _is_expiring(state.get("expires_at"), ACCESS_TOKEN_REFRESH_SKEW_SECONDS):
+        if force_refresh or force_mint or _is_expiring(state.get("expires_at"), ACCESS_TOKEN_REFRESH_SKEW_SECONDS):
             refreshed = _refresh_access_token(
                 client=client,
                 portal_base_url=state["portal_base_url"],
@@ -3415,23 +3429,7 @@ def refresh_nous_oauth_pure(
                 now.timestamp() + access_ttl, tz=timezone.utc
             ).isoformat()
 
-        if force_mint or not _agent_key_is_usable(state, max(60, int(min_key_ttl_seconds))):
-            mint_payload = _mint_agent_key(
-                client=client,
-                portal_base_url=state["portal_base_url"],
-                access_token=state["access_token"],
-                min_ttl_seconds=min_key_ttl_seconds,
-            )
-            now = datetime.now(timezone.utc)
-            state["agent_key"] = mint_payload.get("api_key")
-            state["agent_key_id"] = mint_payload.get("key_id")
-            state["agent_key_expires_at"] = mint_payload.get("expires_at")
-            state["agent_key_expires_in"] = mint_payload.get("expires_in")
-            state["agent_key_reused"] = bool(mint_payload.get("reused", False))
-            state["agent_key_obtained_at"] = now.isoformat()
-            minted_url = _optional_base_url(mint_payload.get("inference_base_url"))
-            if minted_url:
-                state["inference_base_url"] = minted_url
+        _alias_nous_access_jwt_as_agent_key(state)
 
     return state
 
@@ -3475,7 +3473,7 @@ def persist_nous_credentials(
     *,
     label: Optional[str] = None,
 ):
-    """Persist minted Nous OAuth credentials as the singleton provider state
+    """Persist Nous OAuth credentials as the singleton provider state
     and ensure the credential pool is in sync.
 
     Nous credentials are read at runtime from two independent locations:
@@ -3486,7 +3484,7 @@ def persist_nous_credentials(
     - ``credential_pool.nous``: used by the runtime ``pool.select()`` path.
 
     Historically ``hermes auth add nous`` wrote a ``manual:device_code`` pool
-    entry only, skipping ``providers.nous``.  When the 24h agent_key TTL
+    entry only, skipping ``providers.nous``.  When the runtime credential
     expired, the recovery path read the empty singleton state and raised
     ``AuthError`` silently (``logger.debug`` at INFO level).
 
@@ -3508,6 +3506,7 @@ def persist_nous_credentials(
     from agent.credential_pool import load_pool
 
     state = dict(creds)
+    _alias_nous_access_jwt_as_agent_key(state)
     if label and str(label).strip():
         state["label"] = str(label).strip()
 
@@ -3540,8 +3539,8 @@ def resolve_nous_runtime_credentials(
     """
     Resolve Nous inference credentials for runtime use.
 
-    Ensures access_token is valid (refreshes if needed) and a short-lived
-    inference key is present with minimum TTL (mints/reuses as needed).
+    Ensures the NAS OAuth access JWT is valid (refreshes if needed) and stores
+    that JWT in the legacy agent_key fields expected by older runtime paths.
     Concurrent processes coordinate through the auth store file lock.
 
     Returns dict with: provider, base_url, api_key, key_id, expires_at,
@@ -3606,6 +3605,7 @@ def resolve_nous_runtime_credentials(
             refresh_token_fp=_token_fingerprint(state.get("refresh_token")),
         )
 
+        refreshed_runtime_token = False
         with httpx.Client(timeout=timeout, headers={"Accept": "application/json"}, verify=verify) as client:
             access_token = state.get("access_token")
             refresh_token = state.get("refresh_token")
@@ -3614,15 +3614,17 @@ def resolve_nous_runtime_credentials(
                 raise AuthError("No access token found for Nous Portal login.",
                                 provider="nous", relogin_required=True)
 
-            # Step 1: refresh access token if expiring
-            if _is_expiring(state.get("expires_at"), ACCESS_TOKEN_REFRESH_SKEW_SECONDS):
+            # Refresh the NAS access JWT if expiring. force_mint is a public
+            # compatibility flag from the old opaque-key path; now it means
+            # "force a fresh JWT".
+            if force_mint or _is_expiring(state.get("expires_at"), ACCESS_TOKEN_REFRESH_SKEW_SECONDS):
                 with _nous_shared_store_lock(timeout_seconds=max(timeout_seconds + 5.0, AUTH_LOCK_TIMEOUT_SECONDS)):
                     if _merge_shared_nous_oauth_state(state):
                         access_token = state.get("access_token")
                         refresh_token = state.get("refresh_token")
                         _persist_state("post_shared_merge_access_expiring")
 
-                    if _is_expiring(state.get("expires_at"), ACCESS_TOKEN_REFRESH_SKEW_SECONDS):
+                    if force_mint or _is_expiring(state.get("expires_at"), ACCESS_TOKEN_REFRESH_SKEW_SECONDS):
                         if not isinstance(refresh_token, str) or not refresh_token:
                             raise AuthError("Session expired and no refresh token is available.",
                                             provider="nous", relogin_required=True)
@@ -3654,6 +3656,7 @@ def resolve_nous_runtime_credentials(
                         ).isoformat()
                         access_token = state["access_token"]
                         refresh_token = state["refresh_token"]
+                        refreshed_runtime_token = True
                         _oauth_trace(
                             "refresh_success",
                             sequence_id=sequence_id,
@@ -3661,107 +3664,13 @@ def resolve_nous_runtime_credentials(
                             previous_refresh_token_fp=_token_fingerprint(previous_refresh_token),
                             new_refresh_token_fp=_token_fingerprint(refresh_token),
                         )
-                        # Persist immediately so downstream mint failures cannot drop rotated refresh tokens.
+                        # Persist immediately so downstream failures cannot drop rotated refresh tokens.
                         _persist_state("post_refresh_access_expiring")
 
-            # Step 2: mint agent key if missing/expiring
-            used_cached_key = False
-            mint_payload: Optional[Dict[str, Any]] = None
+            _alias_nous_access_jwt_as_agent_key(state)
+            used_cached_key = not refreshed_runtime_token and not force_mint
 
-            if not force_mint and _agent_key_is_usable(state, min_key_ttl_seconds):
-                used_cached_key = True
-                _oauth_trace("agent_key_reuse", sequence_id=sequence_id)
-            else:
-                try:
-                    _oauth_trace(
-                        "mint_start",
-                        sequence_id=sequence_id,
-                        access_token_fp=_token_fingerprint(access_token),
-                    )
-                    mint_payload = _mint_agent_key(
-                        client=client, portal_base_url=portal_base_url,
-                        access_token=access_token, min_ttl_seconds=min_key_ttl_seconds,
-                    )
-                except AuthError as exc:
-                    _oauth_trace(
-                        "mint_error",
-                        sequence_id=sequence_id,
-                        code=exc.code,
-                    )
-                    # Retry path: access token may be stale server-side despite local checks
-                    latest_refresh_token = state.get("refresh_token")
-                    if (
-                        exc.code in {"invalid_token", "invalid_grant"}
-                        and isinstance(latest_refresh_token, str)
-                        and latest_refresh_token
-                    ):
-                        with _nous_shared_store_lock(timeout_seconds=max(timeout_seconds + 5.0, AUTH_LOCK_TIMEOUT_SECONDS)):
-                            if _merge_shared_nous_oauth_state(state):
-                                access_token = state.get("access_token")
-                                latest_refresh_token = state.get("refresh_token")
-                                _persist_state("post_shared_merge_mint_retry")
-                            else:
-                                _oauth_trace(
-                                    "refresh_start",
-                                    sequence_id=sequence_id,
-                                    reason="mint_retry_after_invalid_token",
-                                    refresh_token_fp=_token_fingerprint(latest_refresh_token),
-                                )
-                                refreshed = _refresh_access_token(
-                                    client=client, portal_base_url=portal_base_url,
-                                    client_id=client_id, refresh_token=latest_refresh_token,
-                                )
-                                now = datetime.now(timezone.utc)
-                                access_ttl = _coerce_ttl_seconds(refreshed.get("expires_in"))
-                                state["access_token"] = refreshed["access_token"]
-                                state["refresh_token"] = refreshed.get("refresh_token") or latest_refresh_token
-                                state["token_type"] = refreshed.get("token_type") or state.get("token_type") or "Bearer"
-                                state["scope"] = refreshed.get("scope") or state.get("scope")
-                                refreshed_url = _optional_base_url(refreshed.get("inference_base_url"))
-                                if refreshed_url:
-                                    inference_base_url = refreshed_url
-                                state["obtained_at"] = now.isoformat()
-                                state["expires_in"] = access_ttl
-                                state["expires_at"] = datetime.fromtimestamp(
-                                    now.timestamp() + access_ttl, tz=timezone.utc
-                                ).isoformat()
-                                access_token = state["access_token"]
-                                refresh_token = state["refresh_token"]
-                                _oauth_trace(
-                                    "refresh_success",
-                                    sequence_id=sequence_id,
-                                    reason="mint_retry_after_invalid_token",
-                                    previous_refresh_token_fp=_token_fingerprint(latest_refresh_token),
-                                    new_refresh_token_fp=_token_fingerprint(refresh_token),
-                                )
-                                # Persist retry refresh immediately for crash safety and cross-process visibility.
-                                _persist_state("post_refresh_mint_retry")
-
-                        mint_payload = _mint_agent_key(
-                            client=client, portal_base_url=portal_base_url,
-                            access_token=access_token, min_ttl_seconds=min_key_ttl_seconds,
-                        )
-                    else:
-                        raise
-
-            if mint_payload is not None:
-                now = datetime.now(timezone.utc)
-                state["agent_key"] = mint_payload.get("api_key")
-                state["agent_key_id"] = mint_payload.get("key_id")
-                state["agent_key_expires_at"] = mint_payload.get("expires_at")
-                state["agent_key_expires_in"] = mint_payload.get("expires_in")
-                state["agent_key_reused"] = bool(mint_payload.get("reused", False))
-                state["agent_key_obtained_at"] = now.isoformat()
-                minted_url = _optional_base_url(mint_payload.get("inference_base_url"))
-                if minted_url:
-                    inference_base_url = minted_url
-                _oauth_trace(
-                    "mint_success",
-                    sequence_id=sequence_id,
-                    reused=bool(mint_payload.get("reused", False)),
-                )
-
-            # Persist routing and TLS metadata for non-interactive refresh/mint
+            # Persist routing and TLS metadata for non-interactive refresh
             state["portal_base_url"] = portal_base_url
             state["inference_base_url"] = inference_base_url
             state["client_id"] = client_id
@@ -3774,7 +3683,7 @@ def resolve_nous_runtime_credentials(
 
     api_key = state.get("agent_key")
     if not isinstance(api_key, str) or not api_key:
-        raise AuthError("Failed to resolve a Nous inference API key",
+        raise AuthError("Failed to resolve a Nous inference JWT",
                         provider="nous", code="server_error")
 
     expires_at = state.get("agent_key_expires_at")
@@ -3815,8 +3724,7 @@ def _snapshot_nous_pool_status() -> Dict[str, Any]:
     """Best-effort status from the credential pool.
 
     This is a fallback only. The auth-store provider state is the runtime source
-    of truth because it is what ``resolve_nous_runtime_credentials()`` refreshes
-    and mints against.
+    of truth because it is what ``resolve_nous_runtime_credentials()`` refreshes.
     """
     try:
         from agent.credential_pool import load_pool
@@ -3863,7 +3771,7 @@ def get_nous_auth_status() -> Dict[str, Any]:
     """Status snapshot for Nous auth.
 
     Prefer the auth-store provider state, because that is the live source of
-    truth for refresh + mint operations. When provider state exists, validate it
+    truth for refresh operations. When provider state exists, validate it
     by resolving runtime credentials so revoked refresh sessions do not show up
     as a healthy login. If provider state is absent, fall back to the credential
     pool for the just-logged-in / not-yet-promoted case.
@@ -5130,7 +5038,7 @@ def _nous_device_code_login(
             min_key_ttl_seconds=min_key_ttl_seconds,
             timeout_seconds=timeout_seconds,
             force_refresh=False,
-            force_mint=True,
+            force_mint=False,
         )
     except AuthError as exc:
         if exc.code == "subscription_required":

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -511,36 +511,60 @@ def fetch_nous_account_tier(access_token: str, portal_base_url: str = "") -> dic
 
     Returns an empty dict on any failure (network, auth, parse).
     """
-    base = (portal_base_url or "https://portal.nousresearch.com").rstrip("/")
-    url = f"{base}/api/oauth/account"
-    headers = {
-        "Authorization": f"Bearer {access_token}",
-        "Accept": "application/json",
-    }
     try:
-        req = urllib.request.Request(url, headers=headers)
-        with urllib.request.urlopen(req, timeout=8) as resp:
-            return json.loads(resp.read().decode())
+        from hermes_cli.nous_account import fetch_nous_account_info
+
+        return fetch_nous_account_info(access_token, portal_base_url)
     except Exception:
         return {}
 
 
 def is_nous_free_tier(account_info: dict[str, Any]) -> bool:
-    """Return True if the account info indicates a free (unpaid) tier.
+    """Return True when NAS says the account lacks paid service access."""
+    paid_service = account_info.get("paid_service_access")
+    if isinstance(paid_service, dict):
+        raw = paid_service.get("paid_access")
+        if raw is None:
+            raw = paid_service.get("allowed")
+        if isinstance(raw, bool):
+            return not raw
+        if isinstance(raw, str):
+            lowered = raw.strip().lower()
+            if lowered in {"true", "1", "yes", "on"}:
+                return False
+            if lowered in {"false", "0", "no", "off"}:
+                return True
 
-    Checks ``subscription.monthly_charge == 0``.  Returns False when
-    the field is missing or unparseable (assumes paid — don't block users).
-    """
+        total = paid_service.get("total_usable_credits")
+        if total is not None:
+            try:
+                return float(total) <= 0
+            except (TypeError, ValueError):
+                pass
+
     sub = account_info.get("subscription")
-    if not isinstance(sub, dict):
-        return False
-    charge = sub.get("monthly_charge")
-    if charge is None:
-        return False
-    try:
-        return float(charge) == 0
-    except (TypeError, ValueError):
-        return False
+    if isinstance(sub, dict):
+        charge = sub.get("monthly_charge")
+        if charge is not None:
+            try:
+                return float(charge) == 0
+            except (TypeError, ValueError):
+                return False
+
+    purchased = account_info.get("purchased_credits_remaining")
+    has_credit_fields = (
+        isinstance(sub, dict)
+        and "credits_remaining" in sub
+    ) or purchased is not None
+    if has_credit_fields:
+        try:
+            sub_credits = float((sub or {}).get("credits_remaining") or 0)
+            purchased_credits = float(purchased or 0)
+            return (sub_credits + purchased_credits) <= 0
+        except (TypeError, ValueError):
+            return False
+
+    return False
 
 
 def partition_nous_models_by_tier(
@@ -575,7 +599,7 @@ def partition_nous_models_by_tier(
 # TTL cache for free-tier detection — avoids repeated API calls within a
 # session while still picking up upgrades quickly.
 # ---------------------------------------------------------------------------
-_FREE_TIER_CACHE_TTL: int = 180  # seconds (3 minutes)
+_FREE_TIER_CACHE_TTL: int = 60  # seconds
 _free_tier_cache: tuple[bool, float] | None = None  # (result, timestamp)
 
 
@@ -598,7 +622,7 @@ def check_nous_free_tier() -> bool:
     try:
         from hermes_cli.auth import get_provider_auth_state, resolve_nous_runtime_credentials
 
-        # Ensure we have a fresh token (triggers refresh if needed)
+        # Ensure we have a fresh NAS JWT (triggers refresh if needed)
         resolve_nous_runtime_credentials(min_key_ttl_seconds=60)
 
         state = get_provider_auth_state("nous")

--- a/hermes_cli/nous_account.py
+++ b/hermes_cli/nous_account.py
@@ -1,0 +1,245 @@
+"""Nous account entitlement helpers backed by NAS."""
+
+from __future__ import annotations
+
+import json
+import time
+import urllib.request
+from dataclasses import dataclass
+from typing import Any, Optional
+
+
+DEFAULT_NOUS_PORTAL_URL = "https://portal.nousresearch.com"
+_ACCOUNT_CACHE_TTL_SECONDS = 60
+_account_cache: tuple["NousAccountStatus", float] | None = None
+
+
+@dataclass(frozen=True)
+class NousAccountStatus:
+    available: bool
+    portal_base_url: str
+    paid_access: bool = False
+    has_active_subscription: Optional[bool] = None
+    active_subscription_is_paid: Optional[bool] = None
+    subscription_tier: Optional[str] = None
+    subscription_plan: Optional[str] = None
+    subscription_monthly_charge: Optional[float] = None
+    subscription_credits_remaining: Optional[float] = None
+    purchased_credits_remaining: Optional[float] = None
+    total_usable_credits: Optional[float] = None
+    reason: str = ""
+    unavailable_reason: str = ""
+    account_info: Optional[dict[str, Any]] = None
+    source: str = "nas_account"
+
+    @property
+    def free_tier(self) -> bool:
+        return self.available and not self.paid_access
+
+    @property
+    def has_usable_credits(self) -> Optional[bool]:
+        if self.total_usable_credits is None:
+            return None
+        return self.total_usable_credits > 0
+
+
+def _to_float(value: Any) -> Optional[float]:
+    if value in (None, ""):
+        return None
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _to_bool(value: Any) -> Optional[bool]:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"true", "1", "yes", "on"}:
+            return True
+        if lowered in {"false", "0", "no", "off"}:
+            return False
+    return None
+
+
+def fetch_nous_account_info(
+    access_token: str,
+    portal_base_url: str = "",
+    *,
+    timeout_seconds: float = 8.0,
+) -> dict[str, Any]:
+    """Fetch raw Nous account info from NAS ``/api/oauth/account``."""
+    token = str(access_token or "").strip()
+    if not token:
+        return {}
+    base = (portal_base_url or DEFAULT_NOUS_PORTAL_URL).rstrip("/")
+    req = urllib.request.Request(
+        f"{base}/api/oauth/account",
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/json",
+        },
+    )
+    with urllib.request.urlopen(req, timeout=timeout_seconds) as resp:
+        payload = json.loads(resp.read().decode())
+    return payload if isinstance(payload, dict) else {}
+
+
+def parse_nous_account_status(
+    account_info: dict[str, Any] | None,
+    *,
+    portal_base_url: str = "",
+    unavailable_reason: str = "",
+) -> NousAccountStatus:
+    """Normalize NAS account JSON into entitlement fields Hermes uses."""
+    base = (portal_base_url or DEFAULT_NOUS_PORTAL_URL).rstrip("/")
+    if not isinstance(account_info, dict) or not account_info:
+        return NousAccountStatus(
+            available=False,
+            portal_base_url=base,
+            unavailable_reason=unavailable_reason or "Account information unavailable",
+            account_info=account_info if isinstance(account_info, dict) else None,
+        )
+
+    paid_service = account_info.get("paid_service_access")
+    if not isinstance(paid_service, dict):
+        paid_service = {}
+    subscription = account_info.get("subscription")
+    if not isinstance(subscription, dict):
+        subscription = {}
+
+    raw_paid = _to_bool(paid_service.get("paid_access"))
+    if raw_paid is None:
+        raw_paid = _to_bool(paid_service.get("allowed"))
+    total_usable = _to_float(paid_service.get("total_usable_credits"))
+    if total_usable is None:
+        sub_credits = _to_float(
+            paid_service.get("subscription_credits_remaining")
+            if "subscription_credits_remaining" in paid_service
+            else subscription.get("credits_remaining")
+        ) or 0.0
+        purchased = _to_float(
+            paid_service.get("purchased_credits_remaining")
+            if "purchased_credits_remaining" in paid_service
+            else account_info.get("purchased_credits_remaining")
+        ) or 0.0
+        total_usable = sub_credits + purchased
+
+    paid_access = bool(raw_paid) if raw_paid is not None else total_usable > 0
+
+    subscription_tier = paid_service.get("subscription_tier")
+    if subscription_tier in (None, ""):
+        subscription_tier = subscription.get("tier")
+
+    subscription_plan = subscription.get("plan")
+    if subscription_plan in (None, "") and subscription_tier not in (None, ""):
+        subscription_plan = str(subscription_tier)
+
+    return NousAccountStatus(
+        available=True,
+        portal_base_url=base,
+        paid_access=paid_access,
+        has_active_subscription=_to_bool(paid_service.get("has_active_subscription")),
+        active_subscription_is_paid=_to_bool(paid_service.get("active_subscription_is_paid")),
+        subscription_tier=str(subscription_tier) if subscription_tier not in (None, "") else None,
+        subscription_plan=str(subscription_plan) if subscription_plan not in (None, "") else None,
+        subscription_monthly_charge=_to_float(
+            paid_service.get("subscription_monthly_charge")
+            if "subscription_monthly_charge" in paid_service
+            else subscription.get("monthly_charge")
+        ),
+        subscription_credits_remaining=_to_float(
+            paid_service.get("subscription_credits_remaining")
+            if "subscription_credits_remaining" in paid_service
+            else subscription.get("credits_remaining")
+        ),
+        purchased_credits_remaining=_to_float(
+            paid_service.get("purchased_credits_remaining")
+            if "purchased_credits_remaining" in paid_service
+            else account_info.get("purchased_credits_remaining")
+        ),
+        total_usable_credits=total_usable,
+        reason=str(paid_service.get("reason") or ""),
+        account_info=account_info,
+    )
+
+
+def get_nous_account_status(
+    *,
+    force_refresh: bool = False,
+    timeout_seconds: float = 8.0,
+) -> NousAccountStatus:
+    """Return the current user's live NAS entitlement status."""
+    global _account_cache
+    now = time.monotonic()
+    if not force_refresh and _account_cache is not None:
+        cached, cached_at = _account_cache
+        if now - cached_at < _ACCOUNT_CACHE_TTL_SECONDS:
+            return cached
+
+    try:
+        from hermes_cli.auth import DEFAULT_NOUS_PORTAL_URL as _AUTH_DEFAULT_PORTAL
+        from hermes_cli.auth import get_provider_auth_state, resolve_nous_access_token
+
+        state = get_provider_auth_state("nous") or {}
+        portal_base_url = str(
+            state.get("portal_base_url") or _AUTH_DEFAULT_PORTAL or DEFAULT_NOUS_PORTAL_URL
+        ).rstrip("/")
+        token = resolve_nous_access_token(timeout_seconds=timeout_seconds)
+        info = fetch_nous_account_info(
+            token,
+            portal_base_url,
+            timeout_seconds=timeout_seconds,
+        )
+        status = parse_nous_account_status(info, portal_base_url=portal_base_url)
+        _account_cache = (status, now)
+        return status
+    except Exception as exc:
+        try:
+            from hermes_cli.auth import get_provider_auth_state
+
+            state = get_provider_auth_state("nous") or {}
+            portal_base_url = str(
+                state.get("portal_base_url") or DEFAULT_NOUS_PORTAL_URL
+            ).rstrip("/")
+        except Exception:
+            portal_base_url = DEFAULT_NOUS_PORTAL_URL
+        return NousAccountStatus(
+            available=False,
+            portal_base_url=portal_base_url,
+            unavailable_reason=str(exc) or type(exc).__name__,
+        )
+
+
+def format_nous_billing_guidance_lines(
+    status: NousAccountStatus | None = None,
+    *,
+    force_refresh: bool = True,
+) -> list[str]:
+    """Return user-facing guidance for Nous 402/payment-required errors."""
+    if status is None:
+        status = get_nous_account_status(force_refresh=force_refresh)
+    portal = (status.portal_base_url or DEFAULT_NOUS_PORTAL_URL).rstrip("/")
+    billing_url = f"{portal}/billing"
+    if not status.available:
+        return [
+            "Check your Nous billing and credits in Nous Portal.",
+            f"Billing: {billing_url}",
+        ]
+    if not status.has_active_subscription:
+        return [
+            "Your Nous account does not have an active subscription for paid services.",
+            f"Subscribe: {billing_url}",
+        ]
+    if status.has_usable_credits is False or not status.paid_access:
+        return [
+            "Your Nous account has an active subscription but no usable credits for paid services.",
+            f"Top up credits: {billing_url}",
+        ]
+    return [
+        "Nous reported a payment or entitlement error even though your account shows paid access.",
+        f"Check billing details: {billing_url}",
+    ]
+

--- a/hermes_cli/nous_subscription.py
+++ b/hermes_cli/nous_subscription.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Dict, Iterable, Optional, Set
 
 from hermes_cli.auth import get_nous_auth_status
+from hermes_cli.nous_account import NousAccountStatus, get_nous_account_status
 from hermes_cli.config import get_env_value, load_config
 from tools.managed_tool_gateway import is_managed_tool_gateway_ready
 from utils import is_truthy_value
@@ -53,6 +54,12 @@ class NousSubscriptionFeatures:
     nous_auth_present: bool
     provider_is_nous: bool
     features: Dict[str, NousFeatureState]
+    paid_access: bool = False
+    has_active_subscription: Optional[bool] = None
+    active_subscription_is_paid: Optional[bool] = None
+    total_usable_credits: Optional[float] = None
+    account_source: str = ""
+    account_unavailable_reason: str = ""
 
     @property
     def web(self) -> NousFeatureState:
@@ -239,9 +246,16 @@ def get_nous_subscription_features(
     except Exception:
         nous_status = {}
 
-    managed_tools_flag = managed_nous_tools_enabled()
     nous_auth_present = bool(nous_status.get("logged_in"))
-    subscribed = provider_is_nous or nous_auth_present
+    account_status: Optional[NousAccountStatus] = None
+    if nous_auth_present:
+        try:
+            account_status = get_nous_account_status()
+        except Exception:
+            account_status = None
+    paid_access = bool(account_status and account_status.available and account_status.paid_access)
+    managed_tools_flag = paid_access
+    subscribed = paid_access
 
     web_tool_enabled = _toolset_enabled(config, "web")
     image_tool_enabled = _toolset_enabled(config, "image_gen")
@@ -483,6 +497,12 @@ def get_nous_subscription_features(
         nous_auth_present=nous_auth_present,
         provider_is_nous=provider_is_nous,
         features=features,
+        paid_access=paid_access,
+        has_active_subscription=account_status.has_active_subscription if account_status else None,
+        active_subscription_is_paid=account_status.active_subscription_is_paid if account_status else None,
+        total_usable_credits=account_status.total_usable_credits if account_status else None,
+        account_source=account_status.source if account_status else "",
+        account_unavailable_reason=account_status.unavailable_reason if account_status else "",
     )
 
 
@@ -601,7 +621,7 @@ def get_gateway_eligible_tools(
     - has_direct: tools where the user has their own API keys
     - already_managed: tools already routed through the gateway
 
-    All lists are empty when the user is not a paid Nous subscriber or
+    All lists are empty when NAS does not report Nous paid access or the user
     is not using Nous as their provider.
     """
     if not managed_nous_tools_enabled():
@@ -717,7 +737,7 @@ def prompt_enable_tool_gateway(config: Dict[str, object]) -> set[str]:
     desc_parts: list[str] = [
         "",
         "  The Tool Gateway gives you access to web search, image generation,",
-        "  text-to-speech, and browser automation through your Nous subscription.",
+        "  text-to-speech, and browser automation through your Nous paid access.",
         "  No need to sign up for separate API keys — just pick the tools you want.",
         "",
     ]
@@ -766,7 +786,7 @@ def prompt_enable_tool_gateway(config: Dict[str, object]) -> set[str]:
 
     try:
         idx = prompt_choice(
-            "Your Nous subscription includes the Tool Gateway.",
+            "Your Nous paid access includes the Tool Gateway.",
             choices,
             default_idx,
             description=description,
@@ -793,7 +813,7 @@ def prompt_enable_tool_gateway(config: Dict[str, object]) -> set[str]:
         newly_switched = changed - set(already_managed)
         for key in sorted(newly_switched):
             label = _GATEWAY_TOOL_LABELS.get(key, key)
-            print(f"  ✓ {label}: enabled via Nous subscription")
+            print(f"  ✓ {label}: enabled via Nous paid access")
         if already_managed and not newly_switched:
             print("  (all tools already using Tool Gateway)")
     return changed

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -16,7 +16,6 @@ from hermes_cli.auth import (
     DEFAULT_CODEX_BASE_URL,
     DEFAULT_QWEN_BASE_URL,
     PROVIDER_REGISTRY,
-    _agent_key_is_usable,
     format_auth_error,
     resolve_provider,
     resolve_nous_runtime_credentials,
@@ -810,11 +809,9 @@ def _resolve_explicit_runtime(
             explicit_base_url
             or str(state.get("inference_base_url") or auth_mod.DEFAULT_NOUS_INFERENCE_URL).strip().rstrip("/")
         )
-        # Only use agent_key for inference — access_token is an OAuth token for the
-        # portal API (minting keys, refreshing tokens), not for the inference API.
-        # Falling back to access_token sends an OAuth bearer token to the inference
-        # endpoint, which returns 404 because it is not a valid inference credential.
-        api_key = explicit_api_key or str(state.get("agent_key") or "").strip()
+        # The inference API now accepts the NAS OAuth access JWT directly.
+        # ``agent_key`` is retained as a compatibility alias for the same JWT.
+        api_key = explicit_api_key or str(state.get("agent_key") or state.get("access_token") or "").strip()
         expires_at = state.get("agent_key_expires_at") or state.get("expires_at")
         if not api_key:
             creds = resolve_nous_runtime_credentials(
@@ -1004,20 +1001,15 @@ def resolve_runtime_provider(
                 getattr(entry, "runtime_api_key", None)
                 or getattr(entry, "access_token", "")
             )
-        # For Nous, the pool entry's runtime_api_key is the agent_key — a
-        # short-lived inference credential (~30 min TTL).  The pool doesn't
-        # refresh it during selection (that would trigger network calls in
-        # non-runtime contexts like `hermes auth list`).  If the key is
-        # expired, clear pool_api_key so we fall through to
-        # resolve_nous_runtime_credentials() which handles refresh + mint.
+        # For Nous, runtime_api_key is the NAS JWT (mirrored through the
+        # legacy agent_key field).  If the JWT is expiring, fall through to
+        # resolve_nous_runtime_credentials() so it can refresh and re-alias it.
         if provider == "nous" and entry is not None and pool_api_key:
-            min_ttl = max(60, int(os.getenv("HERMES_NOUS_MIN_KEY_TTL_SECONDS", "1800")))
-            nous_state = {
-                "agent_key": getattr(entry, "agent_key", None),
-                "agent_key_expires_at": getattr(entry, "agent_key_expires_at", None),
-            }
-            if not _agent_key_is_usable(nous_state, min_ttl):
-                logger.debug("Nous pool entry agent_key expired/missing, falling through to runtime resolution")
+            from hermes_cli.auth import _is_expiring, ACCESS_TOKEN_REFRESH_SKEW_SECONDS
+
+            expires_at = getattr(entry, "agent_key_expires_at", None) or getattr(entry, "expires_at", None)
+            if _is_expiring(expires_at, ACCESS_TOKEN_REFRESH_SKEW_SECONDS):
+                logger.debug("Nous pool entry JWT expired/expiring, falling through to runtime resolution")
                 pool_api_key = ""
         if entry is not None and pool_api_key:
             return _resolve_runtime_from_pool_entry(

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -387,7 +387,7 @@ def _print_setup_summary(config: dict, hermes_home):
 
     # Web tools (Exa, Parallel, Firecrawl, or Tavily)
     if subscription_features.web.managed_by_nous:
-        tool_status.append(("Web Search & Extract (Nous subscription)", True, None))
+        tool_status.append(("Web Search & Extract (Nous paid access)", True, None))
     elif subscription_features.web.available:
         label = "Web Search & Extract"
         if subscription_features.web.current_provider:
@@ -427,7 +427,7 @@ def _print_setup_summary(config: dict, hermes_home):
     # Image generation — FAL (direct or via Nous), or any plugin-registered
     # provider (OpenAI, etc.)
     if subscription_features.image_gen.managed_by_nous:
-        tool_status.append(("Image Generation (Nous subscription)", True, None))
+        tool_status.append(("Image Generation (Nous paid access)", True, None))
     elif subscription_features.image_gen.available:
         tool_status.append(("Image Generation", True, None))
     else:
@@ -458,7 +458,7 @@ def _print_setup_summary(config: dict, hermes_home):
     # TTS — show configured provider
     tts_provider = cfg_get(config, "tts", "provider", default="edge")
     if subscription_features.tts.managed_by_nous:
-        tool_status.append(("Text-to-Speech (OpenAI via Nous subscription)", True, None))
+        tool_status.append(("Text-to-Speech (OpenAI via Nous paid access)", True, None))
     elif tts_provider == "elevenlabs" and get_env_value("ELEVENLABS_API_KEY"):
         tool_status.append(("Text-to-Speech (ElevenLabs)", True, None))
     elif tts_provider == "openai" and (
@@ -494,14 +494,14 @@ def _print_setup_summary(config: dict, hermes_home):
         tool_status.append(("Text-to-Speech (Edge TTS)", True, None))
 
     if subscription_features.modal.managed_by_nous:
-        tool_status.append(("Modal Execution (Nous subscription)", True, None))
+        tool_status.append(("Modal Execution (Nous paid access)", True, None))
     elif cfg_get(config, "terminal", "backend") == "modal":
         if subscription_features.modal.direct_override:
             tool_status.append(("Modal Execution (direct Modal)", True, None))
         else:
             tool_status.append(("Modal Execution", False, "run 'hermes setup terminal'"))
     elif managed_nous_tools_enabled() and subscription_features.nous_auth_present:
-        tool_status.append(("Modal Execution (optional via Nous subscription)", True, None))
+        tool_status.append(("Modal Execution (optional via Nous paid access)", True, None))
 
     # Tinker + WandB (RL training)
     if get_env_value("TINKER_API_KEY") and get_env_value("WANDB_API_KEY"):
@@ -1420,7 +1420,7 @@ def setup_terminal_backend(config: dict):
         use_managed_modal = False
         if managed_modal_available:
             modal_choices = [
-                "Use my Nous subscription",
+                "Use my Nous paid access",
                 "Use my own Modal account",
             ]
             if modal_mode == "managed":

--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -16,6 +16,7 @@ from hermes_cli.auth import AuthError, resolve_provider
 from hermes_cli.colors import Colors, color
 from hermes_cli.config import get_env_path, get_env_value, get_hermes_home, load_config
 from hermes_cli.models import provider_label
+from hermes_cli.nous_account import format_nous_billing_guidance_lines, get_nous_account_status
 from hermes_cli.nous_subscription import get_nous_subscription_features
 from hermes_cli.runtime_provider import resolve_requested_provider
 from hermes_cli.vercel_auth import describe_vercel_auth
@@ -212,7 +213,7 @@ def show_status(args):
     if nous_logged_in or nous_status.get("access_expires_at"):
         print(f"    Access exp: {access_exp}")
     if nous_logged_in or nous_status.get("agent_key_expires_at"):
-        print(f"    Key exp:    {key_exp}")
+        print(f"    JWT exp:    {key_exp}")
     if nous_logged_in or nous_status.get("has_refresh_token"):
         print(f"    Refresh:    {refresh_label}")
     if nous_error and not nous_logged_in:
@@ -264,6 +265,13 @@ def show_status(args):
     # =========================================================================
     # Nous Subscription Features
     # =========================================================================
+    nous_account_status = None
+    if nous_logged_in:
+        try:
+            nous_account_status = get_nous_account_status(force_refresh=True)
+        except Exception:
+            nous_account_status = None
+
     if managed_nous_tools_enabled():
         features = get_nous_subscription_features(config)
         print()
@@ -271,32 +279,34 @@ def show_status(args):
         if not features.nous_auth_present:
             print("  Nous Portal   ✗ not logged in")
         else:
-            print("  Nous Portal   ✓ managed tools available")
+            print("  Nous Portal   ✓ paid access verified")
+            if features.total_usable_credits is not None:
+                print(f"  Credits       ${features.total_usable_credits:.2f} usable")
         for feature in features.items():
             if feature.managed_by_nous:
-                state = "active via Nous subscription"
+                state = "active via Nous paid access"
             elif feature.active:
                 current = feature.current_provider or "configured provider"
                 state = f"active via {current}"
             elif feature.included_by_default and features.nous_auth_present:
-                state = "included by subscription, not currently selected"
+                state = "available with paid access, not currently selected"
             elif feature.key == "modal" and features.nous_auth_present:
-                state = "available via subscription (optional)"
+                state = "available with paid access (optional)"
             else:
                 state = "not configured"
             print(f"  {feature.label:<15} {check_mark(feature.available or feature.active or feature.managed_by_nous)} {state}")
     elif nous_logged_in:
-        # Logged into Nous but on the free tier — show upgrade nudge
         print()
         print(color("◆ Nous Tool Gateway", Colors.CYAN, Colors.BOLD))
-        print("  Your free-tier Nous account does not include Tool Gateway access.")
-        print("  Upgrade your subscription to unlock managed web, image, TTS, and browser tools.")
-        try:
-            portal_url = nous_status.get("portal_base_url", "").rstrip("/")
+        if nous_account_status and nous_account_status.available:
+            print("  Nous paid access is not currently available for managed tools.")
+            for line in format_nous_billing_guidance_lines(nous_account_status, force_refresh=False):
+                print(f"  {line}")
+        else:
+            print("  Could not verify Nous paid access from NAS.")
+            portal_url = str(nous_status.get("portal_base_url") or "").rstrip("/")
             if portal_url:
-                print(f"  Upgrade: {portal_url}")
-        except Exception:
-            pass
+                print(f"  Check billing: {portal_url}/billing")
 
     # =========================================================================
     # API-Key Providers

--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -368,7 +368,7 @@ TIPS = [
     # --- Credential Pools & Routing ---
     'hermes auth reset <provider> clears all cooldowns and exhaustion flags on a credential pool.',
     'credential_pool_strategies.<provider>: round_robin cycles keys evenly instead of the fill_first default.',
-    'use_gateway: true per-tool routes web, image, tts, or browser through your Nous subscription — no extra keys.',
+    'use_gateway: true per-tool routes web, image, tts, or browser through your Nous paid access — no extra keys.',
     'provider_routing.data_collection: deny excludes data-storing providers on OpenRouter.',
     'provider_routing.require_parameters: true only routes to providers that support every param in your request.',
 
@@ -483,5 +483,4 @@ def get_random_tip(exclude_recent: int = 0) -> str:
             deduplication across sessions.
     """
     return random.choice(TIPS)
-
 

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -1740,7 +1740,7 @@ def _configure_provider(provider: dict, config: dict):
             _run_post_setup(provider["post_setup"])
         _print_success(f"  {provider['name']} - no configuration needed!")
         if managed_feature:
-            _print_info("  Requests for this tool will be billed to your Nous subscription.")
+            _print_info("  Requests for this tool will use your Nous paid access.")
         # Plugin-registered image_gen provider: write image_gen.provider
         # and route model selection to the plugin's own catalog.
         plugin_name = provider.get("image_gen_plugin_name")
@@ -2014,7 +2014,7 @@ def _reconfigure_provider(provider: dict, config: dict):
             _run_post_setup(provider["post_setup"])
         _print_success(f"  {provider['name']} - no configuration needed!")
         if managed_feature:
-            _print_info("  Requests for this tool will be billed to your Nous subscription.")
+            _print_info("  Requests for this tool will use your Nous paid access.")
         plugin_name = provider.get("image_gen_plugin_name")
         if plugin_name:
             _select_plugin_image_gen_provider(plugin_name, config)
@@ -2159,7 +2159,7 @@ def tools_command(args=None, first_install: bool = False, config: dict = None):
             if managed_nous_tools_enabled():
                 for ts_key in sorted(auto_configured):
                     label = next((l for k, l, _ in CONFIGURABLE_TOOLSETS if k == ts_key), ts_key)
-                    print(color(f"  ✓ {label}: using your Nous subscription defaults", Colors.GREEN))
+                    print(color(f"  ✓ {label}: using your Nous paid-access defaults", Colors.GREEN))
 
             # Walk through ALL selected tools that have provider options or
             # need API keys.  This ensures browser (Local vs Browserbase),

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -1926,7 +1926,8 @@ def _nous_poller(session_id: str) -> None:
                 expires_in=expires_in,
                 poll_interval=interval,
             )
-        # Same post-processing as _nous_device_code_login (mint agent key)
+        # Same post-processing as _nous_device_code_login (alias access JWT
+        # into legacy runtime-key fields)
         now = datetime.now(timezone.utc)
         token_ttl = int(token_data.get("expires_in") or 0)
         auth_state = {
@@ -1946,7 +1947,7 @@ def _nous_poller(session_id: str) -> None:
         }
         full_state = refresh_nous_oauth_from_state(
             auth_state, min_key_ttl_seconds=300, timeout_seconds=15.0,
-            force_refresh=False, force_mint=True,
+            force_refresh=False, force_mint=False,
         )
         from hermes_cli.auth import persist_nous_credentials
         persist_nous_credentials(full_state)

--- a/run_agent.py
+++ b/run_agent.py
@@ -11480,6 +11480,31 @@ class AIAgent:
             oauth_1m_beta_retry_attempted = False
             llama_cpp_grammar_retry_attempted = False
             has_retried_429 = False
+            nous_billing_guidance_printed = False
+
+            def _is_current_nous_runtime(provider: object, base_url: object) -> bool:
+                provider_l = str(provider or "").strip().lower()
+                return provider_l == "nous" or base_url_host_matches(str(base_url or ""), "nousresearch.com")
+
+            def _nous_billing_guidance_lines() -> list[str]:
+                try:
+                    from hermes_cli.nous_account import format_nous_billing_guidance_lines
+
+                    return format_nous_billing_guidance_lines(force_refresh=True)
+                except Exception:
+                    return [
+                        "Check your Nous billing and credits in Nous Portal.",
+                        "Billing: https://portal.nousresearch.com/billing",
+                    ]
+
+            def _print_nous_billing_guidance(provider: object, base_url: object) -> None:
+                nonlocal nous_billing_guidance_printed
+                if nous_billing_guidance_printed or not _is_current_nous_runtime(provider, base_url):
+                    return
+                nous_billing_guidance_printed = True
+                self._vprint(f"{self.log_prefix}   💡 Nous account guidance:", force=True)
+                for line in _nous_billing_guidance_lines():
+                    self._vprint(f"{self.log_prefix}      • {line}", force=True)
             restart_with_compressed_messages = False
             restart_with_length_continuation = False
 
@@ -12497,11 +12522,11 @@ class AIAgent:
                     ):
                         nous_auth_retry_attempted = True
                         if self._try_refresh_nous_client_credentials(force=True):
-                            print(f"{self.log_prefix}🔐 Nous agent key refreshed after 401. Retrying request...")
+                            print(f"{self.log_prefix}🔐 Nous JWT refreshed after 401. Retrying request...")
                             continue
                         # Credential refresh didn't help — show diagnostic info.
                         # Most common causes: Portal OAuth expired/revoked,
-                        # account out of credits, or agent key blocked.
+                        # account out of credits, or JWT rejected.
                         from hermes_constants import display_hermes_home as _dhh_fn
                         _dhh = _dhh_fn()
                         _body_text = ""
@@ -12514,10 +12539,10 @@ class AIAgent:
                         print(f"{self.log_prefix}🔐 Nous 401 — Portal authentication failed.")
                         if _body_text:
                             print(f"{self.log_prefix}   Response: {_body_text}")
-                        print(f"{self.log_prefix}   Most likely: Portal OAuth expired, account out of credits, or agent key revoked.")
+                        print(f"{self.log_prefix}   Most likely: Portal OAuth expired, account out of credits, or JWT rejected.")
                         print(f"{self.log_prefix}   Troubleshooting:")
                         print(f"{self.log_prefix}     • Re-authenticate: hermes login --provider nous")
-                        print(f"{self.log_prefix}     • Check credits / billing: https://portal.nousresearch.com")
+                        print(f"{self.log_prefix}     • Check credits / billing: https://portal.nousresearch.com/billing")
                         print(f"{self.log_prefix}     • Verify stored credentials: {_dhh}/auth.json")
                         print(f"{self.log_prefix}     • Switch providers temporarily: /model <model> --provider openrouter")
                     if (
@@ -12657,6 +12682,8 @@ class AIAgent:
                         _err_body_str = str(_err_body)[:300] if _err_body else None
                         if _err_body_str:
                             self._vprint(f"{self.log_prefix}   📋 Details: {_err_body_str}", force=True)
+                    if classified.reason == FailoverReason.billing:
+                        _print_nous_billing_guidance(_provider, _base)
                     self._vprint(f"{self.log_prefix}   ⏱️  Elapsed: {elapsed_time:.2f}s  Context: {len(api_messages)} msgs, ~{approx_tokens:,} tokens")
 
                     # Actionable hint for OpenRouter "no tool endpoints" error.
@@ -13237,6 +13264,8 @@ class AIAgent:
                                 "execute_code with Python's open() for large "
                                 "files, or to write in smaller sections."
                             )
+                        if classified.reason == FailoverReason.billing and _is_current_nous_runtime(_provider, _base):
+                            _final_response += "\n\n" + "\n".join(_nous_billing_guidance_lines())
                         return {
                             "final_response": _final_response,
                             "messages": messages,

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -155,17 +155,17 @@ def test_auth_add_nous_oauth_persists_pool_entry(tmp_path, monkeypatch):
     assert not any(item["source"] == "manual:device_code" for item in entries)
     entry = device_code_entries[0]
     assert entry["source"] == "device_code"
-    assert entry["agent_key"] == "ak-test"
+    assert entry["agent_key"] == token
     assert entry["portal_base_url"] == "https://portal.example.com"
 
     # `hermes auth add nous` must also populate providers.nous so the
-    # 401-recovery path (resolve_nous_runtime_credentials) can mint a fresh
-    # agent_key when the 24h TTL expires. If this mirror is missing, recovery
-    # raises "Hermes is not logged into Nous Portal" and the agent dies.
+    # 401-recovery path (resolve_nous_runtime_credentials) can refresh the
+    # NAS JWT when it expires. If this mirror is missing, recovery raises
+    # "Hermes is not logged into Nous Portal" and the agent dies.
     singleton = payload["providers"]["nous"]
     assert singleton["access_token"] == token
     assert singleton["refresh_token"] == "refresh-token"
-    assert singleton["agent_key"] == "ak-test"
+    assert singleton["agent_key"] == token
     assert singleton["portal_base_url"] == "https://portal.example.com"
     assert singleton["inference_base_url"] == "https://inference.example.com/v1"
 

--- a/tests/hermes_cli/test_auth_nous_provider.py
+++ b/tests/hermes_cli/test_auth_nous_provider.py
@@ -1,10 +1,8 @@
-"""Regression tests for Nous OAuth refresh + agent-key mint interactions."""
+"""Regression tests for Nous OAuth refresh + JWT runtime aliasing."""
 
 import json
-from datetime import datetime, timezone
 from pathlib import Path
 
-import httpx
 import pytest
 
 from hermes_cli.auth import AuthError, get_provider_auth_state, resolve_nous_runtime_credentials
@@ -154,16 +152,6 @@ def _setup_nous_auth(
     (hermes_home / "auth.json").write_text(json.dumps(auth_store, indent=2))
 
 
-def _mint_payload(api_key: str = "agent-key") -> dict:
-    return {
-        "api_key": api_key,
-        "key_id": "key-id-1",
-        "expires_at": datetime.now(timezone.utc).isoformat(),
-        "expires_in": 1800,
-        "reused": False,
-    }
-
-
 def test_get_nous_auth_status_checks_credential_pool(tmp_path, monkeypatch):
     """get_nous_auth_status() should find Nous credentials in the pool
     even when the auth store has no Nous provider entry — this is the
@@ -304,7 +292,7 @@ def test_get_nous_auth_status_empty_returns_not_logged_in(tmp_path, monkeypatch)
     assert status["logged_in"] is False
 
 
-def test_refresh_token_persisted_when_mint_returns_insufficient_credits(tmp_path, monkeypatch):
+def test_refresh_token_persisted_and_jwt_aliased_without_agent_key_mint(tmp_path, monkeypatch):
     hermes_home = tmp_path / "hermes"
     _setup_nous_auth(hermes_home, refresh_token="refresh-old")
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
@@ -324,28 +312,24 @@ def test_refresh_token_persisted_when_mint_returns_insufficient_credits(tmp_path
 
     def _fake_mint_agent_key(*, client, portal_base_url, access_token, min_ttl_seconds):
         mint_calls["count"] += 1
-        if mint_calls["count"] == 1:
-            raise AuthError("credits exhausted", provider="nous", code="insufficient_credits")
-        return _mint_payload(api_key="agent-key-2")
+        raise AssertionError("opaque agent-key minting should not be called")
 
     monkeypatch.setattr("hermes_cli.auth._refresh_access_token", _fake_refresh_access_token)
     monkeypatch.setattr("hermes_cli.auth._mint_agent_key", _fake_mint_agent_key)
 
-    with pytest.raises(AuthError) as exc:
-        resolve_nous_runtime_credentials(min_key_ttl_seconds=300)
-    assert exc.value.code == "insufficient_credits"
+    creds = resolve_nous_runtime_credentials(min_key_ttl_seconds=300)
+    assert creds["api_key"] == "access-1"
+    assert mint_calls["count"] == 0
 
     state_after_failure = get_provider_auth_state("nous")
     assert state_after_failure is not None
     assert state_after_failure["refresh_token"] == "refresh-1"
     assert state_after_failure["access_token"] == "access-1"
-
-    creds = resolve_nous_runtime_credentials(min_key_ttl_seconds=300)
-    assert creds["api_key"] == "agent-key-2"
-    assert refresh_calls == ["refresh-old", "refresh-1"]
+    assert state_after_failure["agent_key"] == "access-1"
+    assert refresh_calls == ["refresh-old"]
 
 
-def test_refresh_token_persisted_when_mint_times_out(tmp_path, monkeypatch):
+def test_refresh_token_persisted_when_jwt_refresh_succeeds(tmp_path, monkeypatch):
     hermes_home = tmp_path / "hermes"
     _setup_nous_auth(hermes_home, refresh_token="refresh-old")
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
@@ -359,21 +343,22 @@ def test_refresh_token_persisted_when_mint_times_out(tmp_path, monkeypatch):
         }
 
     def _fake_mint_agent_key(*, client, portal_base_url, access_token, min_ttl_seconds):
-        raise httpx.ReadTimeout("mint timeout")
+        raise AssertionError("opaque agent-key minting should not be called")
 
     monkeypatch.setattr("hermes_cli.auth._refresh_access_token", _fake_refresh_access_token)
     monkeypatch.setattr("hermes_cli.auth._mint_agent_key", _fake_mint_agent_key)
 
-    with pytest.raises(httpx.ReadTimeout):
-        resolve_nous_runtime_credentials(min_key_ttl_seconds=300)
+    creds = resolve_nous_runtime_credentials(min_key_ttl_seconds=300)
+    assert creds["api_key"] == "access-1"
 
     state_after_failure = get_provider_auth_state("nous")
     assert state_after_failure is not None
     assert state_after_failure["refresh_token"] == "refresh-1"
     assert state_after_failure["access_token"] == "access-1"
+    assert state_after_failure["agent_key"] == "access-1"
 
 
-def test_mint_retry_uses_latest_rotated_refresh_token(tmp_path, monkeypatch):
+def test_runtime_refresh_uses_rotated_access_jwt_without_mint_retry(tmp_path, monkeypatch):
     hermes_home = tmp_path / "hermes"
     _setup_nous_auth(hermes_home, refresh_token="refresh-old")
     monkeypatch.setenv("HERMES_HOME", str(hermes_home))
@@ -393,16 +378,15 @@ def test_mint_retry_uses_latest_rotated_refresh_token(tmp_path, monkeypatch):
 
     def _fake_mint_agent_key(*, client, portal_base_url, access_token, min_ttl_seconds):
         mint_calls["count"] += 1
-        if mint_calls["count"] == 1:
-            raise AuthError("stale access token", provider="nous", code="invalid_token")
-        return _mint_payload(api_key="agent-key")
+        raise AssertionError("opaque agent-key minting should not be called")
 
     monkeypatch.setattr("hermes_cli.auth._refresh_access_token", _fake_refresh_access_token)
     monkeypatch.setattr("hermes_cli.auth._mint_agent_key", _fake_mint_agent_key)
 
     creds = resolve_nous_runtime_credentials(min_key_ttl_seconds=300)
-    assert creds["api_key"] == "agent-key"
-    assert refresh_calls == ["refresh-old", "refresh-1"]
+    assert creds["api_key"] == "access-1"
+    assert refresh_calls == ["refresh-old"]
+    assert mint_calls["count"] == 0
 
 
 # =============================================================================
@@ -593,7 +577,7 @@ def test_persist_nous_credentials_writes_both_pool_and_providers(tmp_path, monke
     """Helper must populate BOTH credential_pool.nous AND providers.nous.
 
     Regression guard: before this helper existed, `hermes auth add nous`
-    wrote only the pool. After the Nous agent_key's 24h TTL expired, the
+    wrote only the pool. After the Nous runtime JWT expired, the
     401-recovery path in run_agent.py called resolve_nous_runtime_credentials
     which reads providers.nous, found it empty, raised AuthError, and the
     agent failed with "Non-retryable client error". Both stores must stay
@@ -620,15 +604,15 @@ def test_persist_nous_credentials_writes_both_pool_and_providers(tmp_path, monke
     singleton = payload["providers"]["nous"]
     assert singleton["access_token"] == "access-tok"
     assert singleton["refresh_token"] == "refresh-tok"
-    assert singleton["agent_key"] == "agent-key-value"
-    assert singleton["agent_key_expires_at"] == "2026-04-18T22:00:00+00:00"
+    assert singleton["agent_key"] == "access-tok"
+    assert singleton["agent_key_expires_at"] == "2026-04-17T22:15:00+00:00"
 
     # credential_pool.nous has exactly one canonical device_code entry
     pool_entries = payload["credential_pool"]["nous"]
     assert len(pool_entries) == 1, pool_entries
     pool_entry = pool_entries[0]
     assert pool_entry["source"] == NOUS_DEVICE_CODE_SOURCE
-    assert pool_entry["agent_key"] == "agent-key-value"
+    assert pool_entry["agent_key"] == "access-tok"
     assert pool_entry["inference_base_url"] == "https://inference.example.com/v1"
 
 
@@ -663,13 +647,13 @@ def test_persist_nous_credentials_allows_recovery_from_401(tmp_path, monkeypatch
         }
 
     def _fake_mint_agent_key(*, client, portal_base_url, access_token, min_ttl_seconds):
-        return _mint_payload(api_key="new-agent-key")
+        raise AssertionError("opaque agent-key minting should not be called")
 
     monkeypatch.setattr("hermes_cli.auth._refresh_access_token", _fake_refresh_access_token)
     monkeypatch.setattr("hermes_cli.auth._mint_agent_key", _fake_mint_agent_key)
 
     creds = resolve_nous_runtime_credentials(min_key_ttl_seconds=300, force_mint=True)
-    assert creds["api_key"] == "new-agent-key"
+    assert creds["api_key"] == "access-new"
 
 
 def test_persist_nous_credentials_idempotent_no_duplicate_pool_entries(tmp_path, monkeypatch):
@@ -703,13 +687,13 @@ def test_persist_nous_credentials_idempotent_no_duplicate_pool_entries(tmp_path,
 
     # providers.nous reflects the latest write (singleton semantics)
     assert payload["providers"]["nous"]["access_token"] == "access-second"
-    assert payload["providers"]["nous"]["agent_key"] == "agent-key-second"
+    assert payload["providers"]["nous"]["agent_key"] == "access-second"
 
-    # credential_pool.nous has exactly one entry, carrying the latest agent_key
+    # credential_pool.nous has exactly one entry, carrying the latest JWT alias
     pool_entries = payload["credential_pool"]["nous"]
     assert len(pool_entries) == 1, pool_entries
     assert pool_entries[0]["source"] == NOUS_DEVICE_CODE_SOURCE
-    assert pool_entries[0]["agent_key"] == "agent-key-second"
+    assert pool_entries[0]["agent_key"] == "access-second"
     # And no stray `manual:device_code` / `manual:dashboard_device_code` rows
     assert not any(
         e["source"].startswith("manual:") for e in pool_entries
@@ -736,7 +720,7 @@ def test_persist_nous_credentials_reloads_pool_after_singleton_write(tmp_path, m
     # Label derived by _seed_from_singletons via label_from_token; we don't
     # assert its exact value, just that the helper returned a real entry.
     assert entry.access_token == "access-tok"
-    assert entry.agent_key == "agent-key-value"
+    assert entry.agent_key == "access-tok"
 
 
 def test_persist_nous_credentials_embeds_custom_label(tmp_path, monkeypatch):
@@ -1246,16 +1230,21 @@ def test_runtime_refresh_uses_newer_shared_token_before_local_stale_token(
     shared_state["expires_at"] = "2099-01-01T00:00:00+00:00"
     auth_mod._write_shared_nous_state(shared_state)
 
-    def _refresh_should_not_happen(**_kwargs):
-        raise AssertionError("stale profile-local refresh token was used")
+    refresh_tokens: list[str] = []
 
-    minted_with: list[str] = []
+    def _fake_refresh_access_token(*, client, portal_base_url, client_id, refresh_token):
+        refresh_tokens.append(refresh_token)
+        return {
+            "access_token": "access-from-shared-refresh",
+            "refresh_token": "refresh-from-shared-refresh",
+            "expires_in": 900,
+            "token_type": "Bearer",
+        }
 
     def _fake_mint_agent_key(*, client, portal_base_url, access_token, min_ttl_seconds):
-        minted_with.append(access_token)
-        return _mint_payload(api_key="agent-key-from-shared-token")
+        raise AssertionError("opaque agent-key minting should not be called")
 
-    monkeypatch.setattr(auth_mod, "_refresh_access_token", _refresh_should_not_happen)
+    monkeypatch.setattr(auth_mod, "_refresh_access_token", _fake_refresh_access_token)
     monkeypatch.setattr(auth_mod, "_mint_agent_key", _fake_mint_agent_key)
 
     creds = auth_mod.resolve_nous_runtime_credentials(
@@ -1263,13 +1252,14 @@ def test_runtime_refresh_uses_newer_shared_token_before_local_stale_token(
         force_mint=True,
     )
 
-    assert creds["api_key"] == "agent-key-from-shared-token"
-    assert minted_with == ["shared-fresh-access"]
+    assert creds["api_key"] == "access-from-shared-refresh"
+    assert refresh_tokens == ["shared-fresh-refresh"]
 
     profile_state = auth_mod.get_provider_auth_state("nous")
     assert profile_state is not None
-    assert profile_state["refresh_token"] == "shared-fresh-refresh"
-    assert profile_state["access_token"] == "shared-fresh-access"
+    assert profile_state["refresh_token"] == "refresh-from-shared-refresh"
+    assert profile_state["access_token"] == "access-from-shared-refresh"
+    assert profile_state["agent_key"] == "access-from-shared-refresh"
 
 
 def test_managed_gateway_access_token_uses_newer_shared_token(

--- a/tests/hermes_cli/test_nous_account.py
+++ b/tests/hermes_cli/test_nous_account.py
@@ -1,0 +1,67 @@
+from hermes_cli.nous_account import (
+    format_nous_billing_guidance_lines,
+    parse_nous_account_status,
+)
+
+
+def test_paid_access_requires_positive_usable_credits_even_with_subscription():
+    status = parse_nous_account_status(
+        {
+            "subscription": {"plan": "Plus", "monthly_charge": 20, "credits_remaining": 0},
+            "purchased_credits_remaining": 0,
+            "paid_service_access": {
+                "paid_access": False,
+                "has_active_subscription": True,
+                "active_subscription_is_paid": True,
+                "total_usable_credits": 0,
+                "subscription_credits_remaining": 0,
+                "purchased_credits_remaining": 0,
+            },
+        },
+        portal_base_url="https://portal.example.com",
+    )
+
+    assert status.available is True
+    assert status.paid_access is False
+    assert status.has_active_subscription is True
+    assert status.total_usable_credits == 0
+    assert any("Top up credits" in line for line in format_nous_billing_guidance_lines(status))
+
+
+def test_purchased_credits_grant_paid_access_without_subscription():
+    status = parse_nous_account_status(
+        {
+            "subscription": None,
+            "purchased_credits_remaining": 12.5,
+            "paid_service_access": {
+                "paid_access": True,
+                "has_active_subscription": False,
+                "total_usable_credits": 12.5,
+                "purchased_credits_remaining": 12.5,
+            },
+        }
+    )
+
+    assert status.paid_access is True
+    assert status.has_active_subscription is False
+    assert status.total_usable_credits == 12.5
+
+
+def test_billing_guidance_recommends_subscription_when_none_active():
+    status = parse_nous_account_status(
+        {
+            "subscription": None,
+            "purchased_credits_remaining": 0,
+            "paid_service_access": {
+                "paid_access": False,
+                "has_active_subscription": False,
+                "total_usable_credits": 0,
+            },
+        },
+        portal_base_url="https://portal.example.com",
+    )
+
+    lines = format_nous_billing_guidance_lines(status)
+
+    assert any("does not have an active subscription" in line for line in lines)
+    assert "https://portal.example.com/billing" in "\n".join(lines)

--- a/tests/hermes_cli/test_nous_subscription.py
+++ b/tests/hermes_cli/test_nous_subscription.py
@@ -3,6 +3,16 @@
 from hermes_cli import nous_subscription as ns
 
 
+def _paid_account_status():
+    return ns.NousAccountStatus(
+        available=True,
+        portal_base_url="https://portal.example.com",
+        paid_access=True,
+        has_active_subscription=True,
+        total_usable_credits=10.0,
+    )
+
+
 def test_get_nous_subscription_features_recognizes_direct_exa_backend(monkeypatch):
     env = {"EXA_API_KEY": "exa-test"}
 
@@ -27,6 +37,7 @@ def test_get_nous_subscription_features_prefers_managed_modal_in_auto_mode(monke
     monkeypatch.setattr("tools.tool_backend_helpers.managed_nous_tools_enabled", lambda: True)
     monkeypatch.setattr(ns, "get_env_value", lambda name: "")
     monkeypatch.setattr(ns, "get_nous_auth_status", lambda: {"logged_in": True})
+    monkeypatch.setattr(ns, "get_nous_account_status", lambda: _paid_account_status())
     monkeypatch.setattr(ns, "managed_nous_tools_enabled", lambda: True)
     monkeypatch.setattr(ns, "_toolset_enabled", lambda config, key: key == "terminal")
     monkeypatch.setattr(ns, "_has_agent_browser", lambda: False)
@@ -47,6 +58,7 @@ def test_get_nous_subscription_features_prefers_managed_modal_in_auto_mode(monke
 def test_get_nous_subscription_features_marks_browser_use_as_managed_when_gateway_ready(monkeypatch):
     monkeypatch.setattr(ns, "get_env_value", lambda name: "")
     monkeypatch.setattr(ns, "get_nous_auth_status", lambda: {"logged_in": True})
+    monkeypatch.setattr(ns, "get_nous_account_status", lambda: _paid_account_status())
     monkeypatch.setattr(ns, "managed_nous_tools_enabled", lambda: True)
     monkeypatch.setattr(ns, "_toolset_enabled", lambda config, key: key == "browser")
     monkeypatch.setattr(ns, "_has_agent_browser", lambda: True)

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -78,7 +78,7 @@ def test_show_status_reports_nous_auth_error(monkeypatch, capsys, tmp_path):
     assert "Nous Portal   ✗ not logged in (run: hermes auth add nous --type oauth)" in output
     assert "Error:      Refresh session has been revoked" in output
     assert "Access exp:" in output
-    assert "Key exp:" in output
+    assert "JWT exp:" in output
 
 
 def test_show_status_reports_vercel_backend_contract(monkeypatch, capsys, tmp_path):

--- a/tests/hermes_cli/test_status_model_provider.py
+++ b/tests/hermes_cli/test_status_model_provider.py
@@ -100,7 +100,7 @@ def test_show_status_reports_managed_nous_features(monkeypatch, capsys, tmp_path
     out = capsys.readouterr().out
     assert "Nous Tool Gateway" in out
     assert "Browser automation" in out
-    assert "active via Nous subscription" in out
+    assert "active via Nous paid access" in out
 
 
 def test_show_status_hides_nous_subscription_section_when_feature_flag_is_off(monkeypatch, capsys, tmp_path):

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -201,3 +201,30 @@ def test_fetch_account_usage_openrouter_omits_quota_window_when_key_has_no_limit
     assert snapshot.windows == ()
     assert "Credits balance: $74.50" in snapshot.details
     assert "API key usage: $25.50 total • $1.25 today • $4.50 this week • $18.00 this month" in snapshot.details
+
+
+def test_fetch_account_usage_nous_renders_paid_access_and_credits(monkeypatch):
+    from hermes_cli.nous_account import NousAccountStatus
+
+    monkeypatch.setattr(
+        "agent.account_usage.get_nous_account_status",
+        lambda force_refresh=True: NousAccountStatus(
+            available=True,
+            portal_base_url="https://portal.example.com",
+            paid_access=True,
+            has_active_subscription=False,
+            subscription_plan="Plus",
+            total_usable_credits=12.5,
+            subscription_credits_remaining=0,
+            purchased_credits_remaining=12.5,
+        ),
+    )
+
+    snapshot = fetch_account_usage("nous")
+
+    assert snapshot is not None
+    assert snapshot.title == "Nous account"
+    assert snapshot.plan == "Plus"
+    assert "Paid access: yes" in snapshot.details
+    assert "Usable credits: $12.50" in snapshot.details
+    assert "Purchased credits: $12.50" in snapshot.details

--- a/tests/tools/test_managed_browserbase_and_modal.py
+++ b/tests/tools/test_managed_browserbase_and_modal.py
@@ -51,11 +51,14 @@ def _enable_managed_nous_tools(monkeypatch):
 
     The _install_fake_tools_package() helper resets and reimports tool modules,
     so a simple monkeypatch on tool_backend_helpers doesn't survive.  We patch
-    the *source* modules that the reimported modules will import from — both
-    hermes_cli.auth and hermes_cli.models — so the function body returns True.
+    the *source* modules that the reimported modules will import from so the
+    function body returns True.
     """
     monkeypatch.setattr("hermes_cli.auth.get_nous_auth_status", lambda: {"logged_in": True})
-    monkeypatch.setattr("hermes_cli.models.check_nous_free_tier", lambda: False)
+    monkeypatch.setattr(
+        "hermes_cli.nous_account.get_nous_account_status",
+        lambda: type("Status", (), {"available": True, "paid_access": True})(),
+    )
 
 
 def _install_fake_tools_package():

--- a/tests/tools/test_managed_media_gateways.py
+++ b/tests/tools/test_managed_media_gateways.py
@@ -49,7 +49,10 @@ def _enable_managed_nous_tools(monkeypatch):
     """Patch the source modules so managed_nous_tools_enabled() returns True
     even after tool modules are dynamically reloaded."""
     monkeypatch.setattr("hermes_cli.auth.get_nous_auth_status", lambda: {"logged_in": True})
-    monkeypatch.setattr("hermes_cli.models.check_nous_free_tier", lambda: False)
+    monkeypatch.setattr(
+        "hermes_cli.nous_account.get_nous_account_status",
+        lambda: type("Status", (), {"available": True, "paid_access": True})(),
+    )
 
 
 def _install_fake_tools_package():

--- a/tests/tools/test_terminal_requirements.py
+++ b/tests/tools/test_terminal_requirements.py
@@ -170,7 +170,7 @@ def test_modal_backend_managed_mode_does_not_fall_back_to_direct(monkeypatch, ca
 
     assert ok is False
     assert any(
-        "paid Nous subscription is required" in record.getMessage()
+            "Nous paid access is required" in record.getMessage()
         for record in caplog.records
     )
 
@@ -188,7 +188,7 @@ def test_modal_backend_managed_mode_without_feature_flag_logs_clear_error(monkey
 
     assert ok is False
     assert any(
-        "paid Nous subscription is required" in record.getMessage()
+            "Nous paid access is required" in record.getMessage()
         for record in caplog.records
     )
 

--- a/tests/tools/test_tool_backend_helpers.py
+++ b/tests/tools/test_tool_backend_helpers.py
@@ -51,8 +51,8 @@ class TestManagedNousToolsEnabled:
             lambda: {"logged_in": True},
         )
         monkeypatch.setattr(
-            "hermes_cli.models.check_nous_free_tier",
-            lambda: True,
+            "hermes_cli.nous_account.get_nous_account_status",
+            lambda: type("Status", (), {"available": True, "paid_access": False})(),
         )
         assert managed_nous_tools_enabled() is False
 
@@ -62,8 +62,8 @@ class TestManagedNousToolsEnabled:
             lambda: {"logged_in": True},
         )
         monkeypatch.setattr(
-            "hermes_cli.models.check_nous_free_tier",
-            lambda: False,
+            "hermes_cli.nous_account.get_nous_account_status",
+            lambda: type("Status", (), {"available": True, "paid_access": True})(),
         )
         assert managed_nous_tools_enabled() is True
 

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1179,7 +1179,7 @@ def _create_environment(env_type: str, image: str, cwd: str, timeout: int,
             if modal_state["managed_mode_blocked"]:
                 raise ValueError(
                     "Modal backend is configured for managed mode, but "
-                    "a paid Nous subscription is required for the Tool Gateway and no direct "
+                    "Nous paid access is required for the Tool Gateway and no direct "
                     "Modal credentials/config were found. Log in with `hermes model` or "
                     "choose TERMINAL_MODAL_MODE=direct/auto."
                 )
@@ -2156,7 +2156,7 @@ def check_terminal_requirements() -> bool:
                 if modal_state["managed_mode_blocked"]:
                     logger.error(
                         "Modal backend selected with TERMINAL_MODAL_MODE=managed, but "
-                        "a paid Nous subscription is required for the Tool Gateway and no direct "
+                        "Nous paid access is required for the Tool Gateway and no direct "
                         "Modal credentials/config were found. Log in with `hermes model` "
                         "or choose TERMINAL_MODAL_MODE=direct/auto."
                     )

--- a/tools/tool_backend_helpers.py
+++ b/tools/tool_backend_helpers.py
@@ -15,11 +15,11 @@ _VALID_MODAL_MODES = {"auto", "direct", "managed"}
 
 
 def managed_nous_tools_enabled() -> bool:
-    """Return True when the user has an active paid Nous subscription.
+    """Return True when NAS reports paid access for managed Nous tools.
 
-    The Tool Gateway is available to any Nous subscriber who is NOT on
-    the free tier.  We intentionally catch all exceptions and return
-    False — never block the agent startup path.
+    Paid access means positive usable credits, not just an active
+    subscription.  We intentionally catch all exceptions and return False —
+    never block the agent startup path.
     """
     try:
         from hermes_cli.auth import get_nous_auth_status
@@ -28,11 +28,10 @@ def managed_nous_tools_enabled() -> bool:
         if not status.get("logged_in"):
             return False
 
-        from hermes_cli.models import check_nous_free_tier
+        from hermes_cli.nous_account import get_nous_account_status
 
-        if check_nous_free_tier():
-            return False  # free-tier users don't get gateway access
-        return True
+        account = get_nous_account_status()
+        return bool(account.available and account.paid_access)
     except Exception:
         return False
 

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -267,8 +267,8 @@ def _raise_web_backend_configuration_error() -> None:
     )
     if managed_nous_tools_enabled():
         message += (
-            " With your Nous subscription you can also use the Tool Gateway — "
-            "run `hermes tools` and select Nous Subscription as the web provider."
+            " With Nous paid access you can also use the Tool Gateway — "
+            "run `hermes tools` and select Nous paid access as the web provider."
         )
     raise ValueError(message)
 
@@ -278,7 +278,7 @@ def _firecrawl_backend_help_suffix() -> str:
     if not managed_nous_tools_enabled():
         return ""
     return (
-        ", or use the Nous Tool Gateway via your subscription "
+        ", or use the Nous Tool Gateway via paid access "
         "(FIRECRAWL_GATEWAY_URL or TOOL_GATEWAY_DOMAIN)"
     )
 


### PR DESCRIPTION
**Do not merge:** this is dependent on an Inference API change that is not in prod yet.

## Summary

- Use the NAS OAuth access JWT directly as the Nous inference bearer token and mirror it into the existing `agent_key` compatibility fields.
- Add live NAS account entitlement parsing so free/paid decisions use `paid_service_access` and usable credits instead of subscription price alone.
- Improve Nous 402/payment-required guidance, `/usage`, status/setup/tool messaging, and built-in prompts to recommend subscription vs credit top-up based on account state.

## Validation

- `python -m py_compile ...` for changed Python modules
- `git diff --check`
- `./scripts/run_tests.sh tests/hermes_cli/test_nous_account.py tests/hermes_cli/test_models.py tests/tools/test_tool_backend_helpers.py tests/test_account_usage.py tests/agent/test_prompt_builder.py tests/hermes_cli/test_auth_nous_provider.py tests/hermes_cli/test_auth_commands.py tests/agent/test_credential_pool.py tests/hermes_cli/test_runtime_provider_resolution.py tests/hermes_cli/test_nous_subscription.py tests/hermes_cli/test_status.py tests/hermes_cli/test_status_model_provider.py tests/tools/test_managed_media_gateways.py tests/tools/test_managed_browserbase_and_modal.py tests/tools/test_terminal_requirements.py tests/run_agent/test_run_agent.py`

Result: 841 passed, 1 skipped.

-------------------------
# Full agent plan

## Summary

Update Hermes to use the NAS OAuth access JWT directly as the Nous inference bearer token, matching the [RS256 JWT entitlement design](https://nousresearch.atlassian.net/wiki/spaces/PM/pages/487424790/Actual+implementation+RS256+JWTs+and+entitlement+cache). Hermes will stop minting opaque inference tokens, persist the JWT through the existing `agent_key` compatibility paths, and make free/paid decisions from live NAS account entitlement data.

Source contracts checked:
- NAS account endpoint: `/Users/rewbs/code/nous-account-service/src/app/api/oauth/account/route.ts`
- NAS paid-access rule: `paid_access = total_usable_credits > 0`
- Inference JWT auth: `/Users/rewbs/code/api/src/middleware/nas_jwt_auth.ts`

## Key Changes

- Replace `/api/oauth/agent-key` minting in `hermes_cli/auth.py` with JWT aliasing:
  - refresh the NAS OAuth access token as needed;
  - return `access_token` as the runtime `api_key`;
  - persist the same JWT into existing `agent_key`, `agent_key_expires_at`, `agent_key_obtained_at`, and credential-pool fields so existing key readers keep working.
- Keep public helper signatures compatible:
  - `resolve_nous_runtime_credentials(..., force_mint=True)` becomes a compatibility path that forces a JWT refresh rather than minting an opaque key.
  - Shared auth state continues to omit `agent_key`; the JWT is already present there as `access_token`, and opaque keys were not shared previously.
- Update runtime provider resolution and credential-pool freshness checks to use JWT access-token expiry/skew, not the old opaque-key minimum TTL.
- Rename user-facing diagnostics from “agent key” to “JWT”, “OAuth token”, or “Nous inference token” where appropriate.

## Entitlement And Menus

- Add a small shared NAS account-status helper that fetches `GET {portal}/api/oauth/account` using the NAS access JWT and parses:
  - `paid_service_access.paid_access` / `allowed`
  - `has_active_subscription`
  - `active_subscription_is_paid`
  - `subscription_tier`
  - `total_usable_credits`
  - subscription and purchased credit balances.
- Change all free/paid branching to use live NAS entitlement status:
  - `free_tier = not paid_access`
  - paid subscription alone is not enough if usable credits are zero.
- Update model selection, setup flows, `/model nous`, status output, managed-tool gating, and recommended auxiliary model selection to use this entitlement helper.
- Default behavior:
  - model menus: if NAS account fetch fails, do not hide paid models, but mark account status unknown;
  - managed paid services: if NAS account fetch fails, do not claim the service is available.

## 402 And Prompt Guidance

- Add Nous-specific billing guidance for `402` and relevant `SUBSCRIPTION_REQUIRED`/credit errors:
  - no active subscription: recommend subscribing;
  - active subscription with no usable credits: recommend top-up;
  - unknown account status: recommend checking Nous billing/credits.
- Wire this into:
  - main agent provider error handling in `run_agent.py`;
  - managed Tool Gateway error translation;
  - auxiliary Nous model fallback paths when a Nous 402 exhausts fallbacks.
- Add Nous support to `/usage` via `agent/account_usage.py`, rendering live subscription tier, paid-access state, and usable credit balances from NAS.
- Update the built-in Nous prompt context so Hermes knows paid access means positive usable credits, and that 402s should trigger live account inspection before suggesting subscription or top-up.

## Tests

- Auth/runtime tests:
  - no POST to `/api/oauth/agent-key`;
  - runtime `api_key` equals the access JWT;
  - JWT is persisted through existing `agent_key` provider and credential-pool fields;
  - forced mint paths now force JWT refresh.
- Entitlement tests:
  - active paid subscription with zero usable credits is treated as no paid access;
  - purchased credits without subscription grant paid access;
  - unavailable NAS status follows the planned menu and managed-tool defaults.
- Error-message tests:
  - Nous 402 with no subscription recommends subscription;
  - Nous 402 with active subscription and zero credits recommends top-up.
- Prompt and usage tests:
  - prompt contains the live account/credits workflow;
  - `/usage` renders Nous subscription and credit state.
- Run targeted suites through `scripts/run_tests.sh` for auth, runtime provider resolution, models, setup/status menus, account usage, prompt builder, managed tools, and run-agent billing handling.

## Assumptions

- Hermes keeps the existing OAuth scope unless NAS requires a new one; the inference API already accepts RS256 NAS JWTs directly.
- Existing config/file compatibility is preserved by aliasing the JWT into `agent_key` fields, not by introducing a new required storage key.
- Entitlement truth comes from NAS `/api/oauth/account`; JWT claims are only a fallback for runtime authentication, not for fresh menu decisions.
