### PR TITLE
Test/hermes constants helpers

### DIFF
--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -10,10 +10,14 @@ import hermes_constants
 from hermes_constants import (
     VALID_REASONING_EFFORTS,
     display_hermes_home,
+    get_config_path,
     get_default_hermes_root,
+    get_env_path,
     get_hermes_dir,
     get_optional_skills_dir,
+    get_skills_dir,
     is_container,
+    is_termux,
     parse_reasoning_effort,
 )
 
@@ -284,3 +288,85 @@ class TestDisplayHermesHome:
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         monkeypatch.setenv("HERMES_HOME", str(non_default))
         assert display_hermes_home() == "~/myhermes-data"
+
+
+class TestIsTermux:
+    """Tests for is_termux() — Android/Termux runtime detection."""
+
+    def test_detects_via_termux_version(self, monkeypatch):
+        """TERMUX_VERSION env var is the canonical Termux marker."""
+        monkeypatch.setenv("TERMUX_VERSION", "0.118.0")
+        monkeypatch.delenv("PREFIX", raising=False)
+        assert is_termux() is True
+
+    def test_detects_via_prefix_path(self, monkeypatch):
+        """The Termux-specific PREFIX path also triggers detection."""
+        monkeypatch.delenv("TERMUX_VERSION", raising=False)
+        monkeypatch.setenv("PREFIX", "/data/data/com.termux/files/usr")
+        assert is_termux() is True
+
+    def test_negative_when_neither_marker_present(self, monkeypatch):
+        """Regular Linux: no env signals → False."""
+        monkeypatch.delenv("TERMUX_VERSION", raising=False)
+        monkeypatch.delenv("PREFIX", raising=False)
+        assert is_termux() is False
+
+    def test_negative_for_unrelated_prefix(self, monkeypatch):
+        """A non-Termux PREFIX must not trigger a false positive."""
+        monkeypatch.delenv("TERMUX_VERSION", raising=False)
+        monkeypatch.setenv("PREFIX", "/usr/local")
+        assert is_termux() is False
+
+    def test_empty_termux_version_falls_back_to_prefix(self, monkeypatch):
+        """Empty TERMUX_VERSION is falsy — PREFIX still gets a chance."""
+        monkeypatch.setenv("TERMUX_VERSION", "")
+        monkeypatch.setenv("PREFIX", "/data/data/com.termux/files/usr")
+        assert is_termux() is True
+
+    def test_empty_termux_version_and_unrelated_prefix_is_false(
+        self, monkeypatch
+    ):
+        """Both empty/unrelated → False, not crash."""
+        monkeypatch.setenv("TERMUX_VERSION", "")
+        monkeypatch.setenv("PREFIX", "/usr")
+        assert is_termux() is False
+
+
+class TestWellKnownPaths:
+    """Tests for the get_*_path / get_*_dir helpers under HERMES_HOME."""
+
+    @pytest.mark.parametrize(
+        "func, suffix",
+        [
+            (get_config_path, "config.yaml"),
+            (get_skills_dir, "skills"),
+            (get_env_path, ".env"),
+        ],
+        ids=["config_path", "skills_dir", "env_path"],
+    )
+    def test_resolves_under_hermes_home(
+        self, tmp_path, monkeypatch, func, suffix
+    ):
+        """Each helper appends its own suffix to the current HERMES_HOME."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        assert func() == tmp_path / suffix
+
+    @pytest.mark.parametrize(
+        "func", [get_config_path, get_skills_dir, get_env_path]
+    )
+    def test_falls_back_to_default_home(self, tmp_path, monkeypatch, func):
+        """With HERMES_HOME unset, helpers anchor at ~/.hermes."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        assert func().parent == tmp_path / ".hermes"
+
+    def test_helpers_track_hermes_home_changes(self, tmp_path, monkeypatch):
+        """Changing HERMES_HOME shifts every helper to the new root."""
+        first = tmp_path / "first"
+        second = tmp_path / "second"
+        monkeypatch.setenv("HERMES_HOME", str(first))
+        assert get_config_path() == first / "config.yaml"
+        monkeypatch.setenv("HERMES_HOME", str(second))
+        assert get_config_path() == second / "config.yaml"
+        assert get_skills_dir() == second / "skills"
+        assert get_env_path() == second / ".env"

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -10,6 +10,7 @@ import hermes_constants
 from hermes_constants import (
     VALID_REASONING_EFFORTS,
     get_default_hermes_root,
+    get_optional_skills_dir,
     is_container,
     parse_reasoning_effort,
 )
@@ -171,3 +172,39 @@ class TestParseReasoningEffort:
         """
         documented = {"minimal", "low", "medium", "high", "xhigh"}
         assert documented.issubset(set(VALID_REASONING_EFFORTS))
+
+
+class TestGetOptionalSkillsDir:
+    """Tests for get_optional_skills_dir() — env override + default fallback."""
+
+    def test_env_override_wins(self, tmp_path, monkeypatch):
+        """HERMES_OPTIONAL_SKILLS, when set, takes precedence over everything."""
+        override = tmp_path / "custom-optional"
+        monkeypatch.setenv("HERMES_OPTIONAL_SKILLS", str(override))
+        assert get_optional_skills_dir() == override
+        assert get_optional_skills_dir(default=tmp_path / "ignored") == override
+
+    def test_env_override_is_stripped(self, tmp_path, monkeypatch):
+        """Surrounding whitespace in the env var is trimmed before use."""
+        override = tmp_path / "whitespace-optional"
+        monkeypatch.setenv("HERMES_OPTIONAL_SKILLS", f"  {override}\t\n")
+        assert get_optional_skills_dir() == override
+
+    @pytest.mark.parametrize("blank", ["", "   ", "\t", "\n"])
+    def test_blank_env_falls_through(self, tmp_path, monkeypatch, blank):
+        """Empty / whitespace-only env var is treated as unset."""
+        monkeypatch.setenv("HERMES_OPTIONAL_SKILLS", blank)
+        default = tmp_path / "from-default"
+        assert get_optional_skills_dir(default=default) == default
+
+    def test_default_used_when_env_unset(self, tmp_path, monkeypatch):
+        """When env is unset and default provided, default wins."""
+        monkeypatch.delenv("HERMES_OPTIONAL_SKILLS", raising=False)
+        default = tmp_path / "packaged-optional"
+        assert get_optional_skills_dir(default=default) == default
+
+    def test_falls_back_to_hermes_home(self, tmp_path, monkeypatch):
+        """No env, no default → HERMES_HOME / 'optional-skills'."""
+        monkeypatch.delenv("HERMES_OPTIONAL_SKILLS", raising=False)
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        assert get_optional_skills_dir() == tmp_path / "optional-skills"

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -10,6 +10,7 @@ import hermes_constants
 from hermes_constants import (
     VALID_REASONING_EFFORTS,
     get_default_hermes_root,
+    get_hermes_dir,
     get_optional_skills_dir,
     is_container,
     parse_reasoning_effort,
@@ -208,3 +209,44 @@ class TestGetOptionalSkillsDir:
         monkeypatch.delenv("HERMES_OPTIONAL_SKILLS", raising=False)
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         assert get_optional_skills_dir() == tmp_path / "optional-skills"
+
+
+class TestGetHermesDir:
+    """Tests for get_hermes_dir() — backward-compatible subdir resolver."""
+
+    def test_returns_new_path_when_neither_exists(self, tmp_path, monkeypatch):
+        """Fresh install: nothing on disk → new layout wins."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        result = get_hermes_dir("cache/images", "image_cache")
+        assert result == tmp_path / "cache/images"
+
+    def test_returns_old_path_when_legacy_dir_exists(self, tmp_path, monkeypatch):
+        """Legacy install: old dir on disk → old layout preserved."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        legacy = tmp_path / "image_cache"
+        legacy.mkdir()
+        result = get_hermes_dir("cache/images", "image_cache")
+        assert result == legacy
+
+    def test_legacy_wins_even_if_new_path_also_exists(self, tmp_path, monkeypatch):
+        """When both exist, the legacy path keeps winning — no migration."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        legacy = tmp_path / "image_cache"
+        legacy.mkdir()
+        (tmp_path / "cache/images").mkdir(parents=True)
+        result = get_hermes_dir("cache/images", "image_cache")
+        assert result == legacy
+
+    def test_legacy_file_at_old_path_also_counts(self, tmp_path, monkeypatch):
+        """``exists()`` matches files too — a stray file pins the old path."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "image_cache").write_text("legacy data")
+        result = get_hermes_dir("cache/images", "image_cache")
+        assert result == tmp_path / "image_cache"
+
+    def test_returned_path_is_absolute(self, tmp_path, monkeypatch):
+        """Result is always rooted at HERMES_HOME, regardless of cwd."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        result = get_hermes_dir("nested/deep/dir", "old_dir")
+        assert result.is_absolute()
+        assert result == tmp_path / "nested/deep/dir"

--- a/tests/test_hermes_constants.py
+++ b/tests/test_hermes_constants.py
@@ -9,6 +9,7 @@ import pytest
 import hermes_constants
 from hermes_constants import (
     VALID_REASONING_EFFORTS,
+    display_hermes_home,
     get_default_hermes_root,
     get_hermes_dir,
     get_optional_skills_dir,
@@ -250,3 +251,36 @@ class TestGetHermesDir:
         result = get_hermes_dir("nested/deep/dir", "old_dir")
         assert result.is_absolute()
         assert result == tmp_path / "nested/deep/dir"
+
+
+class TestDisplayHermesHome:
+    """Tests for display_hermes_home() — user-facing path formatter."""
+
+    def test_default_home_uses_tilde_shorthand(self, tmp_path, monkeypatch):
+        """No HERMES_HOME set → renders as ``~/.hermes``."""
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        assert display_hermes_home() == "~/.hermes"
+
+    def test_profile_path_uses_tilde_shorthand(self, tmp_path, monkeypatch):
+        """Profile under ~/ renders with the ``~/`` prefix preserved."""
+        profile = tmp_path / ".hermes" / "profiles" / "coder"
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(profile))
+        assert display_hermes_home() == "~/.hermes/profiles/coder"
+
+    def test_custom_path_outside_home_returns_full_path(
+        self, tmp_path, monkeypatch
+    ):
+        """Docker / custom installs fall back to the absolute path."""
+        custom = tmp_path / "opt" / "hermes-custom"
+        monkeypatch.setattr(Path, "home", lambda: tmp_path / "user")
+        monkeypatch.setenv("HERMES_HOME", str(custom))
+        assert display_hermes_home() == str(custom)
+
+    def test_arbitrary_subdir_under_home(self, tmp_path, monkeypatch):
+        """Any path under home (not just ``.hermes``) gets the shorthand."""
+        non_default = tmp_path / "myhermes-data"
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(non_default))
+        assert display_hermes_home() == "~/myhermes-data"


### PR DESCRIPTION
## What does this PR do?

Adds dedicated unit-test coverage for five helpers in `hermes_constants` that previously had no direct tests:

- `get_optional_skills_dir()` — `HERMES_OPTIONAL_SKILLS` env override
- `get_hermes_dir()` — backward-compatible legacy/new path resolution
- `display_hermes_home()` — user-facing `~/`-shorthand formatter
- `is_termux()` — Android/Termux runtime detection
- `get_config_path()` / `get_skills_dir()` / `get_env_path()` — well-known paths under `HERMES_HOME`

These functions are imported across the codebase (config loading, profile setup, skill resolution, gateway init) but were only exercised transitively by higher-level integration tests, so regressions to their contracts could go unnoticed. The new tests pin the documented behavior of each function in isolation, with no production code touched.

## Related Issue

N/A — proactive test-coverage improvement, no open issue.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `tests/test_hermes_constants.py` — added file test classes (30 new test cases, +199 lines):
  - `TestGetOptionalSkillsDir` — 8 cases covering env precedence, whitespace stripping, default-arg fallback, and the implicit `HERMES_HOME / "optional-skills"` fallback.
  - `TestGetHermesDir` — 5 cases pinning the no-migration contract: legacy directory wins when present, new layout used otherwise; `Path.exists()` matches files too.
  - `TestDisplayHermesHome` — 4 cases for the three rendering branches (default `~/.hermes`, profile under `~/`, custom path outside `~/`).
  - `TestIsTermux` — 6 cases covering both detection signals (`TERMUX_VERSION`, Termux-specific `PREFIX`) and the negative paths.
  - `TestWellKnownPaths` — 7 cases parametrized over `get_config_path` / `get_skills_dir` / `get_env_path`.

No production code modified.

## How to Test

1. Check out this branch and ensure `.venv` is set up: `python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[all,dev]"`
2. Run the new tests on their own:
   ```
   scripts/run_tests.sh tests/test_hermes_constants.py -v
   ```
   Expected: 64 passed (34 pre-existing + 30 new).
3. Run the full `hermes_constants`-related suite to confirm no cross-file regressions:
   ```
   scripts/run_tests.sh tests/test_hermes_constants.py tests/test_hermes_home_profile_warning.py tests/test_subprocess_home_isolation.py tests/test_ipv4_preference.py
   ```
   Expected: 90 passed.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`test(hermes_constants): ...` for all four commits)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/test_hermes_constants.py` and all tests pass
- [x] I've added tests for my changes (this PR is itself test additions)
- [x] I've tested on my platform: macOS 15.2 (Darwin 24.6.0), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (no behavior change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — tests are hermetic (`tmp_path` + `monkeypatch`), no real filesystem or platform-specific calls
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/test_hermes_constants.py -v
4 workers [64 items]
============================== 64 passed in 1.27s ==============================

$ scripts/run_tests.sh tests/test_hermes_constants.py tests/test_hermes_home_profile_warning.py tests/test_subprocess_home_isolation.py tests/test_ipv4_preference.py
4 workers [90 items]
============================== 90 passed in 1.25s ==============================
```
