### PR TITLE
feat(cli): refine custom provider model picker lists

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -11773,7 +11773,11 @@ class HermesCLI:
                 provider_data = state.get("provider_data") or {}
                 model_list = state.get("model_list") or []
                 title = f"⚙ Model Picker — {provider_data.get('name', provider_data.get('slug', 'Provider'))}"
-                choices = list(model_list) + ["← Back", "Cancel"]
+                model_labels = provider_data.get("model_labels") or {}
+                choices = [
+                    model_labels.get(model, model)
+                    for model in model_list
+                ] + ["← Back", "Cancel"]
                 if model_list:
                     hint = f"Select a model ({len(model_list)} available)"
                 else:

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -4849,9 +4849,11 @@ if DISCORD_AVAILABLE:
                 return
 
             models = provider.get("models", [])
+            model_labels = provider.get("model_labels", {}) or {}
             options = []
             for model_id in models[:25]:
-                short = model_id.split("/")[-1] if "/" in model_id else model_id
+                label = model_labels.get(model_id) or model_id
+                short = label.split("/")[-1] if "/" in label else label
                 options.append(
                     discord.SelectOption(
                         label=short[:100],

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1690,12 +1690,18 @@ class TelegramAdapter(BasePlatformAdapter):
 
     _MODEL_PAGE_SIZE = 8
 
-    def _build_model_keyboard(self, models: list, page: int) -> tuple:
+    def _build_model_keyboard(
+        self,
+        models: list,
+        page: int,
+        model_labels: Optional[Dict[str, str]] = None,
+    ) -> tuple:
         """Build paginated model buttons. Returns (keyboard, page_info_text)."""
         page_size = self._MODEL_PAGE_SIZE
         total = len(models)
         total_pages = max(1, (total + page_size - 1) // page_size)
         page = max(0, min(page, total_pages - 1))
+        model_labels = model_labels or {}
 
         start = page * page_size
         end = min(start + page_size, total)
@@ -1704,7 +1710,8 @@ class TelegramAdapter(BasePlatformAdapter):
         buttons: list = []
         for i, model_id in enumerate(page_models):
             abs_idx = start + i
-            short = model_id.split("/")[-1] if "/" in model_id else model_id
+            label = model_labels.get(model_id) or model_id
+            short = label.split("/")[-1] if "/" in label else label
             if len(short) > 38:
                 short = short[:35] + "..."
             buttons.append(
@@ -1761,9 +1768,11 @@ class TelegramAdapter(BasePlatformAdapter):
             state["selected_provider"] = provider_slug
             state["selected_provider_name"] = provider.get("name", provider_slug)
             state["model_list"] = models
+            model_labels = provider.get("model_labels", {}) or {}
+            state["model_labels"] = model_labels
             state["model_page"] = 0
 
-            keyboard, page_info = self._build_model_keyboard(models, 0)
+            keyboard, page_info = self._build_model_keyboard(models, 0, model_labels)
 
             pname = provider.get("name", provider_slug)
             total = provider.get("total_models", len(models))
@@ -1792,7 +1801,8 @@ class TelegramAdapter(BasePlatformAdapter):
             models = state.get("model_list", [])
             state["model_page"] = page
 
-            keyboard, page_info = self._build_model_keyboard(models, page)
+            model_labels = state.get("model_labels", {}) or {}
+            keyboard, page_info = self._build_model_keyboard(models, page, model_labels)
 
             pname = state.get("selected_provider_name", "")
             provider_slug = state.get("selected_provider", "")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8135,7 +8135,10 @@ class GatewayRunner:
                     tag = " (current)" if p["is_current"] else ""
                     lines.append(f"**{p['name']}** `--provider {p['slug']}`{tag}:")
                     if p["models"]:
-                        model_strs = ", ".join(f"`{m}`" for m in p["models"])
+                        model_labels = p.get("model_labels") or {}
+                        model_strs = ", ".join(
+                            f"`{model_labels.get(m, m)}`" for m in p["models"]
+                        )
                         extra = f" (+{p['total_models'] - len(p['models'])} more)" if p["total_models"] > len(p["models"]) else ""
                         lines.append(f"  {model_strs}{extra}")
                     elif p.get("api_url"):

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2665,7 +2665,7 @@ def _normalize_custom_provider_entry(
     _KNOWN_KEYS = {
         "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env",
         "api_mode", "transport", "model", "default_model", "models",
-        "context_length", "rate_limit_delay",
+        "context_length", "rate_limit_delay", "discover_models",
         "request_timeout_seconds", "stale_timeout_seconds",
     }
     for camel, snake in _CAMEL_ALIASES.items():
@@ -2756,6 +2756,9 @@ def _normalize_custom_provider_entry(
     rate_limit_delay = entry.get("rate_limit_delay")
     if isinstance(rate_limit_delay, (int, float)) and rate_limit_delay >= 0:
         normalized["rate_limit_delay"] = rate_limit_delay
+
+    if "discover_models" in entry:
+        normalized["discover_models"] = entry.get("discover_models")
 
     return normalized
 
@@ -2917,7 +2920,7 @@ _KNOWN_ROOT_KEYS = {
 # Valid fields inside a custom_providers list entry
 _VALID_CUSTOM_PROVIDER_FIELDS = {
     "name", "base_url", "api_key", "api_mode", "model", "models",
-    "context_length", "rate_limit_delay",
+    "context_length", "rate_limit_delay", "discover_models",
     # key_env is read at runtime by runtime_provider.py and auxiliary_client.py
     # — include it here so the set accurately describes the supported schema.
     "key_env",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2244,6 +2244,14 @@ def _aux_select_for_task(task: str) -> None:
             current_provider=current_provider,
             current_model=current_model,
             current_base_url=current_base_url,
+            user_providers=(
+                cfg.get("providers") if isinstance(cfg.get("providers"), dict) else {}
+            ),
+            custom_providers=(
+                cfg.get("custom_providers")
+                if isinstance(cfg.get("custom_providers"), list)
+                else []
+            ),
         )
     except Exception as exc:
         print(f"Could not detect authenticated providers: {exc}")

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1085,6 +1085,27 @@ def list_authenticated_providers(
     results: List[dict] = []
     seen_slugs: set = set()  # lowercase-normalized to catch case variants (#9545)
     seen_mdev_ids: set = set()  # prevent duplicate entries for aliases (e.g. kimi-coding + kimi-coding-cn)
+    # ``providers.only_configured`` means picker surfaces must stop expanding
+    # the menu from detected credentials or live /models catalogs and only show
+    # provider/model IDs explicitly called out in config.yaml. WebUI, CLI, and
+    # gateway pickers all flow through this function, so apply the policy here.
+    def _truthy_config(value) -> bool:
+        if isinstance(value, str):
+            return value.strip().lower() in {"1", "true", "yes", "on"}
+        return bool(value)
+
+    only_configured = False
+    if isinstance(user_providers, dict):
+        only_configured = _truthy_config(user_providers.get("only_configured", False))
+    else:
+        try:
+            from hermes_cli.config import load_config
+            _cfg_providers = load_config().get("providers", {})
+            if isinstance(_cfg_providers, dict):
+                only_configured = _truthy_config(_cfg_providers.get("only_configured", False))
+        except Exception:
+            only_configured = False
+
     # Effective base URLs of every built-in row we emit (normalized lower+rstrip).
     # Section 4 uses this to hide ``custom_providers`` entries that point at the
     # same endpoint as a built-in (e.g. a user-defined "my-dashscope" on
@@ -1199,6 +1220,8 @@ def list_authenticated_providers(
 
     # --- 1. Check Hermes-mapped providers ---
     for hermes_id, mdev_id in PROVIDER_TO_MODELS_DEV.items():
+        if only_configured:
+            break
         # Skip aliases that map to the same models.dev provider (e.g.
         # kimi-coding and kimi-coding-cn both → kimi-for-coding).
         # The first one with valid credentials wins (#10526).
@@ -1273,6 +1296,8 @@ def list_authenticated_providers(
     _mdev_to_hermes = {v: k for k, v in PROVIDER_TO_MODELS_DEV.items()}
 
     for pid, overlay in HERMES_OVERLAYS.items():
+        if only_configured:
+            break
         if pid.lower() in seen_slugs:
             continue
 
@@ -1386,6 +1411,8 @@ def list_authenticated_providers(
         _canon_provs = []
 
     for _cp in _canon_provs:
+        if only_configured:
+            break
         if _cp.slug.lower() in seen_slugs:
             continue
 
@@ -1478,8 +1505,12 @@ def list_authenticated_providers(
             # custom_providers entries use, so accept either.
             default_model = ep_cfg.get("default_model", "") or ep_cfg.get("model", "")
 
-            # Build models list from both default_model and full models array
+            # Build models list from both default_model and full models array.
+            # Keep per-model display labels separate so the picker can show a
+            # friendly name while switch_model still receives the provider's
+            # exact model id.
             models_list = []
+            model_labels = {}
             if default_model:
                 models_list.append(default_model)
             # Also include the full models list from config.
@@ -1488,9 +1519,13 @@ def list_authenticated_providers(
             # configs or hand-edited files may still use a list.
             cfg_models = ep_cfg.get("models", [])
             if isinstance(cfg_models, dict):
-                for m in cfg_models:
+                for m, meta in cfg_models.items():
                     if m and m not in models_list:
                         models_list.append(m)
+                    if isinstance(meta, dict):
+                        label = meta.get("display_name") or meta.get("label") or meta.get("name")
+                        if isinstance(label, str) and label.strip():
+                            model_labels[m] = label.strip()
             elif isinstance(cfg_models, list):
                 for m in cfg_models:
                     if m and m not in models_list:
@@ -1513,7 +1548,7 @@ def list_authenticated_providers(
             if not api_key:
                 key_env = str(ep_cfg.get("key_env", "") or "").strip()
                 api_key = os.environ.get(key_env, "").strip() if key_env else ""
-            discover = ep_cfg.get("discover_models", True)
+            discover = False if only_configured else ep_cfg.get("discover_models", True)
             if isinstance(discover, str):
                 discover = discover.lower() not in ("false", "no", "0")
             if api_url and api_key and discover:
@@ -1531,6 +1566,7 @@ def list_authenticated_providers(
                 "is_current": ep_name == current_provider,
                 "is_user_defined": True,
                 "models": models_list,
+                "model_labels": model_labels,
                 "total_models": len(models_list) if models_list else 0,
                 "source": "user-config",
                 "api_url": api_url,
@@ -1615,6 +1651,7 @@ def list_authenticated_providers(
                     "name": display_name,
                     "api_url": api_url,
                     "models": [],
+                    "discover_models": entry.get("discover_models", True),
                 }
 
             # The singular ``model:`` field only holds the currently
@@ -1625,12 +1662,17 @@ def list_authenticated_providers(
             default_model = (entry.get("model") or "").strip()
             if default_model and default_model not in groups[group_key]["models"]:
                 groups[group_key]["models"].append(default_model)
+            groups[group_key].setdefault("model_labels", {})
 
             cfg_models = entry.get("models", {})
             if isinstance(cfg_models, dict):
-                for m in cfg_models:
+                for m, meta in cfg_models.items():
                     if m and m not in groups[group_key]["models"]:
                         groups[group_key]["models"].append(m)
+                    if isinstance(meta, dict):
+                        label = meta.get("display_name") or meta.get("label") or meta.get("name")
+                        if isinstance(label, str) and label.strip():
+                            groups[group_key]["model_labels"][m] = label.strip()
             elif isinstance(cfg_models, list):
                 for m in cfg_models:
                     if m and m not in groups[group_key]["models"]:
@@ -1677,8 +1719,13 @@ def list_authenticated_providers(
             if _grp_url_norm and _grp_url_norm in _builtin_endpoints:
                 continue
             # Live model discovery from custom provider endpoints (matches
-            # Section 3 behavior for user ``providers:`` entries).
-            if api_url and api_key:
+            # Section 3 behavior for user ``providers:`` entries). Disabled
+            # when ``providers.only_configured`` is set so every picker only
+            # shows explicitly configured model IDs.
+            discover = False if only_configured else grp.get("discover_models", True)
+            if isinstance(discover, str):
+                discover = discover.strip().lower() not in ("false", "no", "0")
+            if api_url and api_key and discover:
                 try:
                     from hermes_cli.models import fetch_api_models
 
@@ -1694,6 +1741,7 @@ def list_authenticated_providers(
                 "is_current": slug == current_provider,
                 "is_user_defined": True,
                 "models": grp["models"],
+                "model_labels": grp.get("model_labels", {}),
                 "total_models": len(grp["models"]),
                 "source": "user-config",
                 "api_url": grp["api_url"],
@@ -1748,7 +1796,7 @@ def list_picker_providers(
     filtered: List[dict] = []
     for p in providers:
         slug = str(p.get("slug", "")).lower()
-        if slug == "openrouter":
+        if slug == "openrouter" and not p.get("is_user_defined"):
             try:
                 live = fetch_openrouter_models()
                 live_ids = [mid for mid, _ in live]

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -528,6 +528,7 @@ def get_authenticated_provider_slugs(
     current_provider: str = "",
     user_providers: dict = None,
     custom_providers: list | None = None,
+    only_configured: bool | None = None,
 ) -> list[str]:
     """Return slugs of providers that have credentials.
 
@@ -540,6 +541,7 @@ def get_authenticated_provider_slugs(
             user_providers=user_providers,
             custom_providers=custom_providers,
             max_models=0,
+            only_configured=only_configured,
         )
         return [p["slug"] for p in providers]
     except Exception:
@@ -1052,6 +1054,7 @@ def list_authenticated_providers(
     custom_providers: list | None = None,
     max_models: int = 8,
     current_model: str = "",
+    only_configured: bool | None = None,
 ) -> List[dict]:
     """Detect which providers have credentials and list their curated models.
 
@@ -1094,17 +1097,13 @@ def list_authenticated_providers(
             return value.strip().lower() in {"1", "true", "yes", "on"}
         return bool(value)
 
-    only_configured = False
-    if isinstance(user_providers, dict):
-        only_configured = _truthy_config(user_providers.get("only_configured", False))
-    else:
-        try:
-            from hermes_cli.config import load_config
-            _cfg_providers = load_config().get("providers", {})
-            if isinstance(_cfg_providers, dict):
-                only_configured = _truthy_config(_cfg_providers.get("only_configured", False))
-        except Exception:
+    if only_configured is None:
+        if isinstance(user_providers, dict):
+            only_configured = _truthy_config(user_providers.get("only_configured", False))
+        else:
             only_configured = False
+    else:
+        only_configured = _truthy_config(only_configured)
 
     # Effective base URLs of every built-in row we emit (normalized lower+rstrip).
     # Section 4 uses this to hide ``custom_providers`` entries that point at the
@@ -1550,7 +1549,7 @@ def list_authenticated_providers(
                 api_key = os.environ.get(key_env, "").strip() if key_env else ""
             discover = False if only_configured else ep_cfg.get("discover_models", True)
             if isinstance(discover, str):
-                discover = discover.lower() not in ("false", "no", "0")
+                discover = discover.strip().lower() not in ("false", "no", "0", "off")
             if api_url and api_key and discover:
                 try:
                     from hermes_cli.models import fetch_api_models
@@ -1762,6 +1761,7 @@ def list_picker_providers(
     custom_providers: list | None = None,
     max_models: int = 8,
     current_model: str = "",
+    only_configured: bool | None = None,
 ) -> List[dict]:
     """Interactive-picker variant of :func:`list_authenticated_providers`.
 
@@ -1791,6 +1791,7 @@ def list_picker_providers(
         custom_providers=custom_providers,
         max_models=max_models,
         current_model=current_model,
+        only_configured=only_configured,
     )
 
     filtered: List[dict] = []

--- a/tests/gateway/test_discord_model_picker.py
+++ b/tests/gateway/test_discord_model_picker.py
@@ -80,3 +80,35 @@ async def test_model_picker_clears_controls_before_running_switch_callback():
     interaction.response.edit_message.assert_awaited_once()
     interaction.response.defer.assert_not_called()
     interaction.edit_original_response.assert_awaited_once()
+
+
+def test_model_picker_uses_friendly_model_labels_but_preserves_raw_values():
+    async def on_model_selected(chat_id: str, model_id: str, provider_slug: str) -> str:
+        return "Model switched"
+
+    view = ModelPickerView(
+        providers=[
+            {
+                "slug": "fireworks-firepass",
+                "name": "Fireworks Firepass",
+                "models": ["accounts/fireworks/routers/kimi-k2p5-turbo"],
+                "model_labels": {
+                    "accounts/fireworks/routers/kimi-k2p5-turbo": "kimi-k2p5-turbo",
+                },
+                "total_models": 1,
+                "is_current": True,
+            }
+        ],
+        current_model="accounts/fireworks/routers/kimi-k2p5-turbo",
+        current_provider="fireworks-firepass",
+        session_key="session-1",
+        on_model_selected=on_model_selected,
+        allowed_user_ids=set(),
+    )
+
+    view._build_model_select("fireworks-firepass")
+
+    select = next(child for child in view.children if child.custom_id == "model_model_select")
+    option = select.options[0]
+    assert option.label == "kimi-k2p5-turbo"
+    assert option.value == "accounts/fireworks/routers/kimi-k2p5-turbo"

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -441,3 +441,33 @@ class TestTelegramApprovalCallback:
         query.answer.assert_called_once()
         query.edit_message_text.assert_called_once()
         assert (tmp_path / ".update_response").read_text() == "n"
+
+
+def test_model_keyboard_uses_friendly_model_labels_but_keeps_raw_callbacks():
+    adapter = _make_adapter()
+    created_buttons = []
+
+    class FakeButton:
+        def __init__(self, text, callback_data):
+            self.text = text
+            self.callback_data = callback_data
+            created_buttons.append(self)
+
+    class FakeMarkup:
+        def __init__(self, rows):
+            self.rows = rows
+
+    with patch("gateway.platforms.telegram.InlineKeyboardButton", FakeButton):
+        with patch("gateway.platforms.telegram.InlineKeyboardMarkup", FakeMarkup):
+            keyboard, page_info = adapter._build_model_keyboard(
+                ["accounts/fireworks/routers/kimi-k2p5-turbo"],
+                0,
+                {
+                    "accounts/fireworks/routers/kimi-k2p5-turbo": "kimi-k2p5-turbo",
+                },
+            )
+
+    assert page_info == ""
+    assert keyboard.rows[0][0].text == "kimi-k2p5-turbo"
+    assert keyboard.rows[0][0].callback_data == "mm:0"
+    assert created_buttons[0].text == "kimi-k2p5-turbo"

--- a/tests/hermes_cli/test_list_picker_providers.py
+++ b/tests/hermes_cli/test_list_picker_providers.py
@@ -89,6 +89,34 @@ def test_openrouter_empty_live_catalog_drops_row(monkeypatch):
     assert result == []
 
 
+def test_user_defined_openrouter_keeps_configured_models(monkeypatch):
+    """Configured OpenRouter endpoints should not be live-expanded.
+
+    This covers ``providers.only_configured`` paths where a user explicitly
+    configures an ``openrouter`` row and expects the picker to show only the
+    models listed in config.yaml.
+    """
+    base = [
+        _make_provider(
+            "openrouter",
+            models=["configured/model"],
+            is_user_defined=True,
+            source="user-config",
+            api_url="https://openrouter.ai/api/v1",
+        ),
+    ]
+
+    monkeypatch.setattr(model_switch, "list_authenticated_providers",
+                        lambda **kw: list(base))
+    monkeypatch.setattr("hermes_cli.models.fetch_openrouter_models",
+                        lambda *a, **kw: pytest.fail("should not be called"))
+
+    result = model_switch.list_picker_providers(max_models=50)
+
+    assert len(result) == 1
+    assert result[0]["models"] == ["configured/model"]
+
+
 def test_non_openrouter_rows_passed_through_unchanged(monkeypatch):
     """Non-OpenRouter providers keep their curated ``models`` as-is."""
     base = [

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -180,6 +180,60 @@ def test_list_authenticated_providers_uses_live_models_for_user_provider(monkeyp
     assert user_prov["total_models"] == 2
 
 
+def test_only_configured_limits_picker_to_configured_user_provider_models(monkeypatch):
+    """providers.only_configured makes /model use only configured models.
+
+    Even when API keys are present for built-ins and the custom endpoint's
+    /models would return additional IDs, CLI/gateway pickers should only show
+    the providers and models explicitly called out in config.yaml.
+    """
+    monkeypatch.setenv("OPENROUTER_API_KEY", "dummy-openrouter-key")
+    monkeypatch.setenv("CRS_TEST_KEY", "sk-test")
+    monkeypatch.setattr(
+        "agent.models_dev.fetch_models_dev",
+        lambda: {
+            "openrouter": {
+                "env": ["OPENROUTER_API_KEY"],
+                "models": {"openai/gpt-live": {}},
+            }
+        },
+    )
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    calls = []
+
+    def fake_fetch_api_models(api_key, base_url):
+        calls.append((api_key, base_url))
+        return ["configured-model", "unconfigured-live-model"]
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fake_fetch_api_models)
+
+    user_providers = {
+        "only_configured": True,
+        "crs-henkee": {
+            "name": "CRS Henkee",
+            "base_url": "http://127.0.0.1:3000/api/v1",
+            "key_env": "CRS_TEST_KEY",
+            "default_model": "configured-model",
+            "models": {
+                "configured-model": {"context_length": 200000},
+            },
+        },
+    }
+
+    providers = list_authenticated_providers(
+        current_provider="crs-henkee",
+        user_providers=user_providers,
+        custom_providers=[],
+        max_models=50,
+    )
+
+    assert calls == []
+    assert [p["slug"] for p in providers] == ["crs-henkee"]
+    assert providers[0]["models"] == ["configured-model"]
+    assert providers[0]["total_models"] == 1
+
+
 def test_list_authenticated_providers_dict_models_without_default_model(monkeypatch):
     """Dict-format ``models:`` without a ``default_model`` must still expose
     every dict key, not collapse to an empty list."""
@@ -256,7 +310,7 @@ def test_openai_native_curated_catalog_is_non_empty():
 
 def test_list_authenticated_providers_openai_built_in_nonzero_total(monkeypatch):
     """Built-in openai row must not report total_models=0 when creds exist."""
-    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("OPENAI_API_KEY", "dummy-openai-key")
     monkeypatch.setattr(
         "agent.models_dev.fetch_models_dev",
         lambda: {"openai": {"env": ["OPENAI_API_KEY"]}},

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -234,6 +234,82 @@ def test_only_configured_limits_picker_to_configured_user_provider_models(monkey
     assert providers[0]["total_models"] == 1
 
 
+def test_discover_models_false_string_strips_whitespace(monkeypatch):
+    """discover_models string values should parse like booleans even with whitespace."""
+    monkeypatch.setenv("CRS_TEST_KEY", "sk-test")
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    calls = []
+
+    def fake_fetch_api_models(api_key, base_url):
+        calls.append((api_key, base_url))
+        return ["live-model"]
+
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models", fake_fetch_api_models)
+
+    providers = list_authenticated_providers(
+        current_provider="crs-henkee",
+        user_providers={
+            "crs-henkee": {
+                "name": "CRS Henkee",
+                "base_url": "http://127.0.0.1:3000/api/v1",
+                "key_env": "CRS_TEST_KEY",
+                "default_model": "configured-model",
+                "discover_models": " false ",
+            },
+        },
+        custom_providers=[],
+        max_models=50,
+    )
+
+    assert calls == []
+    assert providers[0]["models"] == ["configured-model"]
+
+
+def test_list_authenticated_providers_does_not_load_config_implicitly(monkeypatch):
+    """Callers pass loaded config; the provider lister should not reload it."""
+    monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    def fail_load_config():
+        raise AssertionError("list_authenticated_providers should not call load_config")
+
+    monkeypatch.setattr("hermes_cli.config.load_config", fail_load_config)
+
+    providers = list_authenticated_providers(
+        current_provider="",
+        user_providers=None,
+        custom_providers=[],
+    )
+
+    assert isinstance(providers, list)
+
+
+def test_list_authenticated_providers_accepts_explicit_only_configured_flag(monkeypatch):
+    """Callers can pass only_configured separately from providers config."""
+    monkeypatch.setenv("OPENROUTER_API_KEY", "dummy-openrouter-key")
+    monkeypatch.setattr(
+        "agent.models_dev.fetch_models_dev",
+        lambda: {"openrouter": {"env": ["OPENROUTER_API_KEY"]}},
+    )
+    monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
+
+    providers = list_authenticated_providers(
+        current_provider="configured-provider",
+        user_providers={
+            "configured-provider": {
+                "api": "https://example.invalid/v1",
+                "default_model": "configured-model",
+            }
+        },
+        custom_providers=[],
+        only_configured=True,
+    )
+
+    assert [p["slug"] for p in providers] == ["configured-provider"]
+
+
 def test_list_authenticated_providers_dict_models_without_default_model(monkeypatch):
     """Dict-format ``models:`` without a ``default_model`` must still expose
     every dict key, not collapse to an empty list."""


### PR DESCRIPTION
## Summary

- Add per-model display labels for custom provider entries in the `/model` picker.
  - Config can now include `display_name`, `label`, or `name` metadata for each configured model.
  - Picker UI displays the friendly label while preserving the raw provider model ID for selection and API calls.
- Apply `providers.only_configured: true` consistently to shared picker logic used by CLI and gateway pickers.
  - Suppresses provider rows discovered only from credentials when configured-only mode is enabled.
  - Suppresses live `/models` expansion for configured providers when configured-only mode is enabled.
  - Prevents user-defined OpenRouter rows from being replaced by the live OpenRouter catalog.
- Preserve and validate `discover_models` in custom provider normalization.

## Why

Custom provider model IDs can be long provider-specific paths, such as:

```yaml
accounts/fireworks/routers/kimi-k2p5-turbo
```

Users should be able to show a short readable picker label like `kimi-k2p5-turbo` without changing the exact model string sent to the provider.

Also, `providers.only_configured: true` previously did not consistently constrain every `/model` picker surface. This makes CLI/gateway picker behavior match the configured-only intent: only explicitly configured providers and models are shown.

## Example

```yaml
providers:
  fireworks-firepass:
    api: https://api.fireworks.ai/inference/v1
    name: Fireworks Fire Pass
    api_key: ${CUSTOM_FIREWORKS_API_KEY}
    default_model: accounts/fireworks/routers/kimi-k2p5-turbo
    api_mode: chat_completions
    models:
      accounts/fireworks/routers/kimi-k2p5-turbo:
        display_name: kimi-k2p5-turbo
        context_length: 262144
```

The picker shows `kimi-k2p5-turbo`, while selection still passes `accounts/fireworks/routers/kimi-k2p5-turbo` to `switch_model()`.

## Test Plan

- [x] Syntax check:
  - `python -m py_compile hermes_cli/model_switch.py hermes_cli/config.py cli.py tests/hermes_cli/test_user_providers_model_switch.py tests/hermes_cli/test_list_picker_providers.py`
- [x] Focused changed-path regression suite:
  - `scripts/run_tests.sh tests/hermes_cli/test_user_providers_model_switch.py tests/hermes_cli/test_list_picker_providers.py tests/hermes_cli/test_model_switch_custom_providers.py tests/gateway/test_discord_model_picker.py tests/gateway/test_telegram_approval_buttons.py tests/test_tui_gateway_server.py -q`
  - Result: `249 passed in 5.37s`
- [x] Broader full-suite attempt:
  - `scripts/run_tests.sh`
  - The full suite currently fails on this machine with failures that reproduce on clean `origin/main` in unrelated areas (Bedrock 1M beta, auxiliary max-token retry, cron script prompt, Discord free-response, and other existing environment/order-sensitive tests). The changed-path suite above is green after rebasing onto current `origin/main`.

## Platforms tested

- Linux, Python 3.11.14, Hermes project venv
- CLI/gateway shared picker logic via unit/regression tests
