### PR TITLE
fix(gateway): skip stale pre-connect messages in Feishu adapter

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1393,6 +1393,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._sent_message_id_order: List[str] = []  # LRU order for _sent_message_ids_to_chat
         self._chat_info_cache: Dict[str, Dict[str, Any]] = {}
         self._message_text_cache: Dict[str, Optional[str]] = {}
+        self._connect_time: Optional[float] = None  # set in connect(); used to skip stale events on restart
         self._app_lock_identity: Optional[str] = None
         self._text_batch_state = FeishuBatchState()
         self._pending_text_batches = self._text_batch_state.events
@@ -1603,6 +1604,7 @@ class FeishuAdapter(BasePlatformAdapter):
 
             self._loop = asyncio.get_running_loop()
             await self._connect_with_retry()
+            self._connect_time = time.time()
             self._mark_connected()
             logger.info("[Feishu] Connected in %s mode (%s)", self._connection_mode, self._domain_name)
             return True
@@ -2255,6 +2257,23 @@ class FeishuAdapter(BasePlatformAdapter):
         if not message or not sender or not getattr(sender, "sender_id", None):
             logger.debug("[Feishu] Dropping malformed inbound event: missing message/sender")
             return
+
+        # Skip stale events that predate this adapter instance (e.g. queued
+        # before a gateway restart).  Feishu delivers create_time as a
+        # millisecond-precision Unix timestamp string.
+        create_time_raw = getattr(message, "create_time", None)
+        if create_time_raw is not None and self._connect_time is not None:
+            try:
+                create_ts = int(str(create_time_raw)) / 1000.0
+                if create_ts < self._connect_time:
+                    logger.info(
+                        "[Feishu] Dropping stale pre-connect message %s (created %.1fs before connect)",
+                        getattr(message, "message_id", "?"),
+                        self._connect_time - create_ts,
+                    )
+                    return
+            except (ValueError, TypeError):
+                pass  # unparseable — let it through
 
         message_id = getattr(message, "message_id", None)
         if not message_id or self._is_duplicate(message_id):

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -4823,3 +4823,101 @@ class TestFeishuMentionEndToEnd(unittest.TestCase):
         # Body: leading @Hermes stripped, Alice preserved, trailing text intact.
         self.assertIn("@Alice review the spec with Alice", event.text)
         self.assertNotIn("@Hermes @Alice", event.text)
+
+    def test_stale_pre_connect_message_is_dropped(self):
+        """Messages created before adapter connect() are skipped on restart."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._connect_time = 1700000010.0  # adapter connected at this time
+
+        class _Loop:
+            def is_closed(self):
+                return False
+
+        adapter._loop = _Loop()
+
+        # Message created 60 seconds BEFORE connect → stale
+        message = SimpleNamespace(
+            message_id="om_stale",
+            chat_type="p2p",
+            chat_id="oc_chat",
+            message_type="text",
+            content='{"text":"old message"}',
+            create_time="1700000000000",  # 1700000000s < 1700000010s connect
+        )
+        sender_id = SimpleNamespace(open_id="ou_user", user_id=None, union_id=None)
+        sender = SimpleNamespace(sender_id=sender_id, sender_type="user")
+        data = SimpleNamespace(event=SimpleNamespace(message=message, sender=sender))
+
+        # The _on_message_event path goes through _handle_message_event_data;
+        # we test the async path directly for precision.
+        import asyncio
+
+        async def _run():
+            await adapter._handle_message_event_data(data)
+
+        with patch.object(adapter, "_process_inbound_message", new_callable=AsyncMock) as proc:
+            asyncio.run(_run())
+        proc.assert_not_called()
+
+    def test_fresh_post_connect_message_is_accepted(self):
+        """Messages created after adapter connect() are processed normally."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._connect_time = 1700000000.0
+
+        # Message created 60 seconds AFTER connect → fresh
+        message = SimpleNamespace(
+            message_id="om_fresh",
+            chat_type="p2p",
+            chat_id="oc_chat",
+            message_type="text",
+            content='{"text":"new message"}',
+            create_time="1700000060000",  # 1700000060s > 1700000000s connect
+        )
+        sender_id = SimpleNamespace(open_id="ou_user", user_id=None, union_id=None)
+        sender = SimpleNamespace(sender_id=sender_id, sender_type="user")
+        data = SimpleNamespace(event=SimpleNamespace(message=message, sender=sender))
+
+        import asyncio
+
+        async def _run():
+            await adapter._handle_message_event_data(data)
+
+        with patch.object(adapter, "_process_inbound_message", new_callable=AsyncMock) as proc:
+            asyncio.run(_run())
+        proc.assert_called_once()
+        self.assertEqual(proc.call_args.kwargs["message_id"], "om_fresh")
+
+    def test_message_without_create_time_is_accepted(self):
+        """Events without create_time (older SDK) are not blocked."""
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        adapter._connect_time = 1700000000.0
+
+        message = SimpleNamespace(
+            message_id="om_no_ts",
+            chat_type="p2p",
+            chat_id="oc_chat",
+            message_type="text",
+            content='{"text":"no timestamp"}',
+            # no create_time attribute
+        )
+        sender_id = SimpleNamespace(open_id="ou_user", user_id=None, union_id=None)
+        sender = SimpleNamespace(sender_id=sender_id, sender_type="user")
+        data = SimpleNamespace(event=SimpleNamespace(message=message, sender=sender))
+
+        import asyncio
+
+        async def _run():
+            await adapter._handle_message_event_data(data)
+
+        with patch.object(adapter, "_process_inbound_message", new_callable=AsyncMock) as proc:
+            asyncio.run(_run())
+        proc.assert_called_once()


### PR DESCRIPTION
## Summary

On gateway restart, the Feishu SDK re-delivers queued WebSocket events without checking timestamps. Old messages from before the restart are processed as new, which can create infinite restart loops (e.g. user sends "restart" while gateway is down -> gateway replays it on startup -> restarts again).

Replaces #21712 (orphan branch with unrelated file changes mixed in).

## Root Cause

The `FeishuAdapter._handle_message_event_data()` method checks for duplicate `message_id` and self-sent messages, but never checks the message's `create_time` against the adapter's startup time. The Feishu SDK's WebSocket client delivers all queued events on reconnect, including those that predate the current gateway instance.

## Fix

1. Record `self._connect_time = time.time()` in `connect()` after successful connection
2. In `_handle_message_event_data`, extract `message.create_time` (millisecond Unix timestamp string from Feishu SDK) and compare against `_connect_time`
3. Skip messages created before the adapter connected, logging at INFO level
4. Messages without `create_time` (older SDK versions) pass through for backward compatibility

## Regression Coverage

Three new tests in `tests/gateway/test_feishu.py`:

- `test_stale_pre_connect_message_is_dropped` — verifies pre-connect messages are rejected
- `test_fresh_post_connect_message_is_accepted` — verifies post-connect messages are processed
- `test_message_without_create_time_is_accepted` — verifies backward compatibility when `create_time` is absent

All 192 Feishu tests pass (189 existing + 3 new).

## Testing

```bash
scripts/run_tests.sh tests/gateway/test_feishu.py
```

Fixes #21651
