### PR TITLE
fix(cli): drain completion_queue on every loop iteration, not just idle

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12019,6 +12019,23 @@ class HermesCLI:
         def process_loop():
             while not self._should_exit:
                 try:
+                    # Drain background process notifications (completions
+                    # and watch pattern matches) on every iteration so they
+                    # aren't missed when the user sends a message.
+                    try:
+                        from tools.process_registry import process_registry
+                        if not process_registry.completion_queue.empty():
+                            evt = process_registry.completion_queue.get_nowait()
+                            _evt_sid = evt.get("session_id", "")
+                            if evt.get("type") == "completion" and process_registry.is_completion_consumed(_evt_sid):
+                                pass  # already delivered via tool result
+                            else:
+                                _synth = _format_process_notification(evt)
+                                if _synth:
+                                    self._pending_input.put(_synth)
+                    except Exception:
+                        pass
+
                     # Check for pending input with timeout
                     try:
                         user_input = self._pending_input.get(timeout=0.1)
@@ -12026,22 +12043,6 @@ class HermesCLI:
                         # Periodic config watcher — auto-reload MCP on mcp_servers change
                         if not self._agent_running:
                             self._check_config_mcp_changes()
-                            # Check for background process notifications (completions
-                            # and watch pattern matches) while agent is idle.
-                            try:
-                                from tools.process_registry import process_registry
-                                if not process_registry.completion_queue.empty():
-                                    evt = process_registry.completion_queue.get_nowait()
-                                    # Skip if the agent already consumed this via wait/poll/log
-                                    _evt_sid = evt.get("session_id", "")
-                                    if evt.get("type") == "completion" and process_registry.is_completion_consumed(_evt_sid):
-                                        pass  # already delivered via tool result
-                                    else:
-                                        _synth = _format_process_notification(evt)
-                                        if _synth:
-                                            self._pending_input.put(_synth)
-                            except Exception:
-                                pass
                         continue
                     
                     if not user_input:


### PR DESCRIPTION
## Fix

The completion_queue drain in process_loop() previously only ran inside the except queue.Empty branch (idle timeout). When a background process exited during an active agent turn, the notification was delayed until the post-turn drain. If poll() had been called during the turn, the _completion_consumed flag was set (see #10156), causing the post-turn drain to skip the event with continue. The notification was lost.

Move the drain to the top of every loop iteration, before checking for new user input. This ensures background process events are picked up immediately regardless of user activity, reducing the race window.

## Test

Adds a regression guard for #10156: verifies that poll() (a read-only status query) does not have the side effect of consuming completion notifications, which would silently suppress notify_on_complete watcher delivery.

Fixes #21904
Related: #10156