### PR TITLE
fix(status): redact API keys in --all output

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -165,12 +165,12 @@ def show_status(args):
             continue
         value = _resolve_env(env_ref)
         has_key = bool(value)
-        display = redact_key(value) if not show_all else value
+        display = redact_key(value)
         print(f"  {name:<12}  {check_mark(has_key)} {display}")
 
     from hermes_cli.auth import get_anthropic_key
     anthropic_value = get_anthropic_key()
-    anthropic_display = redact_key(anthropic_value) if not show_all else anthropic_value
+    anthropic_display = redact_key(anthropic_value)
     print(f"  {'Anthropic':<12}  {check_mark(bool(anthropic_value))} {anthropic_display}")
 
     # =========================================================================

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -12,6 +12,37 @@ def test_show_status_includes_tavily_key(monkeypatch, capsys, tmp_path):
     output = capsys.readouterr().out
     assert "Tavily" in output
     assert "tvly...cdef" in output
+    assert "tvly-1234567890abcdef" not in output
+
+
+def test_show_status_all_redacts_tavily_key(monkeypatch, capsys, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("TAVILY_API_KEY", "tvly-1234567890abcdef")
+
+    show_status(SimpleNamespace(all=True, deep=False))
+
+    output = capsys.readouterr().out
+    assert "Tavily" in output
+    assert "tvly...cdef" in output
+    assert "tvly-1234567890abcdef" not in output
+
+
+def test_show_status_all_keeps_api_keys_redacted(monkeypatch, capsys, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    raw_openai = "sk-test-raw-secret-1234567890"
+    raw_anthropic = "sk-ant-test-raw-secret-abcdefghij"
+    monkeypatch.setenv("OPENAI_API_KEY", raw_openai)
+
+    import hermes_cli.auth as auth_mod
+    monkeypatch.setattr(auth_mod, "get_anthropic_key", lambda: raw_anthropic, raising=False)
+
+    show_status(SimpleNamespace(all=True, deep=False))
+
+    output = capsys.readouterr().out
+    assert raw_openai not in output
+    assert raw_anthropic not in output
+    assert "sk-t...7890" in output
+    assert "sk-a...ghij" in output
 
 
 def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys, tmp_path):


### PR DESCRIPTION
## What does this PR do?

This fixes a specific `hermes status --all` redaction bypass where configured API keys could be printed raw.

Previously, `--all` bypassed `redact_key()` for configured API keys. This change keeps the detailed status view while still redacting secret values before printing.

## Related Issue

No linked issue.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `hermes_cli/status.py` so API key values are always passed through `redact_key()`, including when `--all` is used.
- Added regression coverage in `tests/hermes_cli/test_status.py` for:
  - Tavily API key output
  - Tavily API key output with `--all`
  - OpenAI and Anthropic key output with `--all`

## How to Test

1. Activate the project virtual environment:
   `. venv/bin/activate`

2. Run the focused status tests:
   `python -m pytest tests/hermes_cli/test_status.py -q`

3. Confirm the result:
   `6 passed in 2.51s`

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu/Linux VM

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused test run:

```text
. venv/bin/activate
python -m pytest tests/hermes_cli/test_status.py -q

6 passed in 2.51s