### PR TITLE
feat(tui_gateway): add image.attach_bytes and pdf.attach methods

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -2128,6 +2128,218 @@ def test_image_attach_accepts_unquoted_screenshot_path_with_spaces(monkeypatch):
     assert len(server._sessions["sid"]["attached_images"]) == 1
 
 
+# ---------------------------------------------------------------------------
+# image.attach_bytes
+# ---------------------------------------------------------------------------
+
+
+def _make_png(width=4, height=4):
+    """Tiny valid PNG (no PIL needed)."""
+    import struct
+    import zlib
+
+    sig = b"\x89PNG\r\n\x1a\n"
+
+    def chunk(tag, data):
+        crc = zlib.crc32(tag + data) & 0xFFFFFFFF
+        return struct.pack(">I", len(data)) + tag + data + struct.pack(">I", crc)
+
+    ihdr = struct.pack(">IIBBBBB", width, height, 8, 2, 0, 0, 0)
+    raw = b""
+    for _ in range(height):
+        raw += b"\x00" + (b"\xff\x00\x00" * width)
+    idat = zlib.compress(raw)
+    return sig + chunk(b"IHDR", ihdr) + chunk(b"IDAT", idat) + chunk(b"IEND", b"")
+
+
+def test_image_attach_bytes_accepts_raw_base64(tmp_path, monkeypatch):
+    import base64
+
+    fake_cli = types.ModuleType("cli")
+    fake_cli._IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp"}
+    monkeypatch.setitem(sys.modules, "cli", fake_cli)
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+
+    server._sessions["sid"] = _session()
+    png = _make_png()
+    b64 = base64.b64encode(png).decode()
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "image.attach_bytes",
+            "params": {"session_id": "sid", "content_base64": b64},
+        }
+    )
+
+    assert resp["result"]["attached"] is True
+    assert resp["result"]["bytes"] == len(png)
+    assert resp["result"]["path"].endswith(".png")
+    assert Path(resp["result"]["path"]).read_bytes() == png
+    assert len(server._sessions["sid"]["attached_images"]) == 1
+
+
+def test_image_attach_bytes_strips_data_url_prefix(tmp_path, monkeypatch):
+    import base64
+
+    fake_cli = types.ModuleType("cli")
+    fake_cli._IMAGE_EXTENSIONS = {".png", ".jpg", ".jpeg", ".gif", ".webp", ".bmp"}
+    monkeypatch.setitem(sys.modules, "cli", fake_cli)
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+
+    server._sessions["sid"] = _session()
+    png = _make_png()
+    data_url = "data:image/png;base64," + base64.b64encode(png).decode()
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "image.attach_bytes",
+            "params": {"session_id": "sid", "content_base64": data_url},
+        }
+    )
+
+    assert resp["result"]["attached"] is True
+
+
+def test_image_attach_bytes_rejects_invalid_base64(monkeypatch):
+    fake_cli = types.ModuleType("cli")
+    fake_cli._IMAGE_EXTENSIONS = {".png"}
+    monkeypatch.setitem(sys.modules, "cli", fake_cli)
+
+    server._sessions["sid"] = _session()
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "image.attach_bytes",
+            "params": {"session_id": "sid", "content_base64": "not-base64!!!"},
+        }
+    )
+    assert resp["error"]["code"] == 4017
+
+
+def test_image_attach_bytes_rejects_oversized(tmp_path, monkeypatch):
+    import base64
+
+    fake_cli = types.ModuleType("cli")
+    fake_cli._IMAGE_EXTENSIONS = {".png"}
+    monkeypatch.setitem(sys.modules, "cli", fake_cli)
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+
+    server._sessions["sid"] = _session()
+    huge = base64.b64encode(b"\x00" * (26 * 1024 * 1024)).decode()
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "image.attach_bytes",
+            "params": {"session_id": "sid", "content_base64": huge},
+        }
+    )
+    assert resp["error"]["code"] == 4018
+
+
+# ---------------------------------------------------------------------------
+# pdf.attach
+# ---------------------------------------------------------------------------
+
+
+def _make_pdf():
+    """Tiny valid 1-page PDF that pdftoppm can render."""
+    return (
+        b"%PDF-1.4\n"
+        b"1 0 obj<</Type/Catalog/Pages 2 0 R>>endobj\n"
+        b"2 0 obj<</Type/Pages/Kids[3 0 R]/Count 1>>endobj\n"
+        b"3 0 obj<</Type/Page/Parent 2 0 R/MediaBox[0 0 612 792]/Contents 4 0 R>>endobj\n"
+        b"4 0 obj<</Length 23>>stream\nBT /F1 24 Tf 100 700 Td (hi) Tj ET\nendstream endobj\n"
+        b"xref\n0 5\n0000000000 65535 f \n0000000009 00000 n \n0000000052 00000 n \n"
+        b"0000000098 00000 n \n0000000160 00000 n \n"
+        b"trailer<</Size 5/Root 1 0 R>>\nstartxref\n230\n%%EOF\n"
+    )
+
+
+def test_pdf_attach_renders_pages_when_pdftoppm_available(tmp_path, monkeypatch):
+    import shutil
+
+    if shutil.which("pdftoppm") is None:
+        import pytest
+        pytest.skip("pdftoppm not installed; integration-test only")
+
+    fake_cli = types.ModuleType("cli")
+    fake_cli._resolve_attachment_path = lambda raw: Path(raw)
+    monkeypatch.setitem(sys.modules, "cli", fake_cli)
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+
+    pdf = tmp_path / "in.pdf"
+    pdf.write_bytes(_make_pdf())
+
+    server._sessions["sid"] = _session()
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "pdf.attach",
+            "params": {"session_id": "sid", "path": str(pdf)},
+        }
+    )
+
+    assert resp["result"]["attached"] is True
+    assert resp["result"]["pages_attached"] >= 1
+    for page in resp["result"]["pages"]:
+        assert page["path"].endswith(".png")
+        assert Path(page["path"]).is_file()
+
+
+def test_pdf_attach_rejects_non_pdf_payload(monkeypatch):
+    import base64
+
+    fake_cli = types.ModuleType("cli")
+    monkeypatch.setitem(sys.modules, "cli", fake_cli)
+
+    server._sessions["sid"] = _session()
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "pdf.attach",
+            "params": {
+                "session_id": "sid",
+                "content_base64": base64.b64encode(b"not a pdf").decode(),
+            },
+        }
+    )
+    # Either 4017 (bad magic bytes) or 5028 (no pdftoppm) is fine — both refuse cleanly.
+    assert "error" in resp
+
+
+def test_pdf_attach_rejects_oversized_page_range(tmp_path, monkeypatch):
+    import shutil
+
+    if shutil.which("pdftoppm") is None:
+        import pytest
+        pytest.skip("pdftoppm not installed")
+
+    fake_cli = types.ModuleType("cli")
+    fake_cli._resolve_attachment_path = lambda raw: Path(raw)
+    monkeypatch.setitem(sys.modules, "cli", fake_cli)
+    monkeypatch.setattr(server, "_hermes_home", tmp_path)
+
+    pdf = tmp_path / "in.pdf"
+    pdf.write_bytes(_make_pdf())
+
+    server._sessions["sid"] = _session()
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "pdf.attach",
+            "params": {
+                "session_id": "sid",
+                "path": str(pdf),
+                "first_page": 1,
+                "last_page": 100,
+            },
+        }
+    )
+    assert resp["error"]["code"] == 4019
+
+
 def test_commands_catalog_surfaces_quick_commands(monkeypatch):
     monkeypatch.setattr(
         server,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3470,6 +3470,273 @@ def _(rid, params: dict) -> dict:
         return _err(rid, 5027, str(e))
 
 
+_ATTACH_BYTES_MAX_BYTES = 25 * 1024 * 1024  # 25 MB cap (matches Anthropic image limits)
+
+
+@method("image.attach_bytes")
+def _(rid, params: dict) -> dict:
+    """Attach an image to the session by base64-encoded bytes.
+
+    Lets a remote client (e.g. a web dashboard) upload an image without first
+    transferring the file onto the host filesystem. Writes to the same
+    ``~/.hermes/images/`` directory that ``image.attach`` reads from and
+    queues into ``session["attached_images"]`` so the next ``prompt.submit``
+    picks it up via the existing native-image-attach pipeline.
+
+    Params:
+      content_base64 (str, required): Base64 of the raw image bytes.
+        Accepts a ``data:image/...;base64,`` URL prefix and/or embedded
+        whitespace.
+      filename (str, optional): Filename hint, used to derive the file
+        extension. If absent, magic-byte sniffing identifies PNG/JPEG/GIF/
+        WebP/BMP, falling back to ``.png``.
+
+    Response shape matches ``image.attach`` (``attached``, ``path``,
+    ``count``, ``remainder``, ``text``, plus ``bytes`` and ``_image_meta``
+    keys).
+    """
+    import base64
+    import re as _re
+
+    session, err = _sess(params, rid)
+    if err:
+        return err
+
+    raw_b64 = str(params.get("content_base64", "") or "").strip()
+    if not raw_b64:
+        return _err(rid, 4015, "content_base64 required")
+
+    # Allow data URL prefix (browser clients often have these).
+    m = _re.match(r"^data:image/[a-zA-Z0-9.+-]+;base64,(.*)$", raw_b64, _re.DOTALL)
+    if m:
+        raw_b64 = m.group(1)
+    raw_b64 = _re.sub(r"\s+", "", raw_b64)
+
+    try:
+        img_bytes = base64.b64decode(raw_b64, validate=True)
+    except Exception as e:
+        return _err(rid, 4017, f"invalid base64: {e}")
+
+    if not img_bytes:
+        return _err(rid, 4017, "decoded payload is empty")
+    if len(img_bytes) > _ATTACH_BYTES_MAX_BYTES:
+        mb = _ATTACH_BYTES_MAX_BYTES // (1024 * 1024)
+        return _err(rid, 4018, f"image too large ({len(img_bytes)} bytes; cap is {mb} MB)")
+
+    raw_filename = str(params.get("filename", "") or "").strip()
+    ext = ""
+    if raw_filename:
+        suffix = Path(raw_filename).suffix.lower()
+        if suffix:
+            ext = suffix
+
+    if not ext:
+        head = img_bytes[:16]
+        if head.startswith(b"\x89PNG\r\n\x1a\n"):
+            ext = ".png"
+        elif head.startswith(b"\xff\xd8\xff"):
+            ext = ".jpg"
+        elif head[:6] in (b"GIF87a", b"GIF89a"):
+            ext = ".gif"
+        elif head.startswith(b"RIFF") and head[8:12] == b"WEBP":
+            ext = ".webp"
+        elif head.startswith(b"BM"):
+            ext = ".bmp"
+        else:
+            ext = ".png"
+
+    from cli import _IMAGE_EXTENSIONS
+    if ext not in _IMAGE_EXTENSIONS:
+        return _err(rid, 4016, f"unsupported image extension: {ext}")
+
+    session["image_counter"] = session.get("image_counter", 0) + 1
+    img_dir = _hermes_home / "images"
+    img_dir.mkdir(parents=True, exist_ok=True)
+    img_path = (
+        img_dir
+        / f"upload_{datetime.now().strftime('%Y%m%d_%H%M%S')}_{session['image_counter']}{ext}"
+    )
+    try:
+        img_path.write_bytes(img_bytes)
+    except Exception as e:
+        session["image_counter"] = max(0, session["image_counter"] - 1)
+        return _err(rid, 5027, f"write failed: {e}")
+
+    session.setdefault("attached_images", []).append(str(img_path))
+    return _ok(
+        rid,
+        {
+            "attached": True,
+            "path": str(img_path),
+            "count": len(session["attached_images"]),
+            "remainder": "",
+            "text": f"[User attached image: {img_path.name}]",
+            "bytes": len(img_bytes),
+            **_image_meta(img_path),
+        },
+    )
+
+
+_PDF_ATTACH_MAX_PAGES = 25
+_PDF_ATTACH_MAX_BYTES = 50 * 1024 * 1024  # 50 MB cap
+
+
+@method("pdf.attach")
+def _(rid, params: dict) -> dict:
+    """Attach a PDF to the session by rendering each page to PNG.
+
+    Anthropic's vision pipeline accepts images, not PDFs, so this method
+    runs ``pdftoppm`` (poppler-utils) to convert the PDF to per-page PNGs
+    at 150 DPI and queues each as an attached image. Useful for dashboard
+    clients that want to drop a PDF into a chat session.
+
+    Params (one of ``path`` or ``content_base64`` is required):
+      path (str): Filesystem path to a PDF on the host.
+      content_base64 (str): Base64-encoded PDF bytes (accepts
+        ``data:application/pdf;base64,`` prefix).
+      filename (str, optional): Display filename when uploading via
+        ``content_base64``.
+      first_page (int, optional, default 1): First page to render.
+      last_page (int, optional): Last page to render. Defaults to
+        ``first_page + ${_PDF_ATTACH_MAX_PAGES} - 1``. Page range cap of
+        25 pages per call to keep one drop from blowing context budget.
+
+    Requires ``pdftoppm`` on $PATH (``apt install poppler-utils`` on
+    Debian/Ubuntu). Returns 5028 if missing.
+    """
+    import base64
+    import re as _re
+    import shutil
+    import subprocess
+    import tempfile
+
+    session, err = _sess(params, rid)
+    if err:
+        return err
+
+    if shutil.which("pdftoppm") is None:
+        return _err(
+            rid,
+            5028,
+            "pdftoppm not installed (poppler-utils package required)",
+        )
+
+    raw_path = str(params.get("path", "") or "").strip()
+    raw_b64 = str(params.get("content_base64", "") or "").strip()
+    if not raw_path and not raw_b64:
+        return _err(rid, 4015, "path or content_base64 required")
+
+    with tempfile.TemporaryDirectory(prefix="pdf_attach_") as td:
+        td_path = Path(td)
+        if raw_b64:
+            m = _re.match(r"^data:application/pdf;base64,(.*)$", raw_b64, _re.DOTALL)
+            if m:
+                raw_b64 = m.group(1)
+            raw_b64 = _re.sub(r"\s+", "", raw_b64)
+            try:
+                pdf_bytes = base64.b64decode(raw_b64, validate=True)
+            except Exception as e:
+                return _err(rid, 4017, f"invalid base64: {e}")
+            if not pdf_bytes:
+                return _err(rid, 4017, "decoded PDF is empty")
+            if len(pdf_bytes) > _PDF_ATTACH_MAX_BYTES:
+                mb = _PDF_ATTACH_MAX_BYTES // (1024 * 1024)
+                return _err(
+                    rid,
+                    4018,
+                    f"PDF too large ({len(pdf_bytes)} bytes; cap is {mb} MB)",
+                )
+            if pdf_bytes[:5] != b"%PDF-":
+                return _err(rid, 4017, "payload is not a PDF (missing %PDF- magic bytes)")
+            pdf_path = td_path / "input.pdf"
+            pdf_path.write_bytes(pdf_bytes)
+            display_name = str(params.get("filename", "") or "uploaded.pdf")
+        else:
+            try:
+                from cli import _resolve_attachment_path
+                resolved = _resolve_attachment_path(raw_path)
+            except Exception:
+                resolved = None
+            if resolved is None or not Path(resolved).is_file():
+                return _err(rid, 4016, f"PDF not found: {raw_path}")
+            if Path(resolved).suffix.lower() != ".pdf":
+                return _err(rid, 4016, f"not a PDF: {Path(resolved).name}")
+            if Path(resolved).stat().st_size > _PDF_ATTACH_MAX_BYTES:
+                mb = _PDF_ATTACH_MAX_BYTES // (1024 * 1024)
+                return _err(rid, 4018, f"PDF too large; cap is {mb} MB")
+            pdf_path = Path(resolved)
+            display_name = pdf_path.name
+
+        try:
+            first_page = int(params.get("first_page") or 1)
+            last_page_param = params.get("last_page")
+            last_page = int(last_page_param) if last_page_param is not None else None
+        except (TypeError, ValueError):
+            return _err(rid, 4015, "first_page/last_page must be integers")
+
+        if last_page is None:
+            last_page = first_page + _PDF_ATTACH_MAX_PAGES - 1
+        if last_page - first_page + 1 > _PDF_ATTACH_MAX_PAGES:
+            return _err(
+                rid,
+                4019,
+                f"page range exceeds cap of {_PDF_ATTACH_MAX_PAGES} pages per attach call",
+            )
+
+        out_prefix = td_path / "page"
+        argv = [
+            "pdftoppm",
+            "-png",
+            "-r", "150",
+            "-f", str(first_page),
+            "-l", str(last_page),
+            str(pdf_path),
+            str(out_prefix),
+        ]
+        try:
+            res = subprocess.run(argv, capture_output=True, text=True, timeout=120)
+        except subprocess.TimeoutExpired:
+            return _err(rid, 5028, "pdftoppm timed out (>120s)")
+        if res.returncode != 0:
+            tail = (res.stderr or res.stdout or "").strip().splitlines()[-3:]
+            return _err(rid, 5028, "pdftoppm failed: " + " | ".join(tail))
+
+        img_dir = _hermes_home / "images"
+        img_dir.mkdir(parents=True, exist_ok=True)
+        ts = datetime.now().strftime("%Y%m%d_%H%M%S")
+        rendered = sorted(td_path.glob("page-*.png"))
+        if not rendered:
+            return _err(rid, 5028, "pdftoppm produced no pages (corrupt PDF?)")
+
+        attached_pages = []
+        for src in rendered:
+            session["image_counter"] = session.get("image_counter", 0) + 1
+            page_num = src.stem.split("-", 1)[-1]
+            dst = img_dir / f"pdf_{ts}_{session['image_counter']}_p{page_num}.png"
+            try:
+                src.replace(dst)
+            except Exception:
+                dst.write_bytes(src.read_bytes())
+            session.setdefault("attached_images", []).append(str(dst))
+            attached_pages.append({
+                "path": str(dst),
+                "page": int(page_num),
+                **_image_meta(dst),
+            })
+
+        return _ok(
+            rid,
+            {
+                "attached": True,
+                "filename": display_name,
+                "pages_attached": len(attached_pages),
+                "pages": attached_pages,
+                "count": len(session["attached_images"]),
+                "text": f"[User attached PDF: {display_name} ({len(attached_pages)} page(s))]",
+            },
+        )
+
+
 @method("input.detect_drop")
 def _(rid, params: dict) -> dict:
     session, err = _sess_nowait(params, rid)


### PR DESCRIPTION
## Summary

Adds two JSON-RPC methods to the TUI gateway so clients (web dashboards, mobile apps, etc.) can attach images and PDFs to a session in a single round-trip without first transferring the file onto the host filesystem via SCP/SFTP.

- **`image.attach_bytes`** — base64 image upload
- **`pdf.attach`** — PDF → per-page PNGs via `pdftoppm`, queued as image attachments

Both methods reuse the existing `_image_meta()`, `_IMAGE_EXTENSIONS` allowlist, `_hermes_home` paths, and `image_counter` logic. The next `prompt.submit` picks the queued attachments up via the existing native-image-attach pipeline — no changes to attachment delivery downstream.

## Why

Today, the only way for a remote client to attach an image to a Hermes session is `image.attach`, which expects a path on the host filesystem. That requires SCP/SFTP first. For a web dashboard the round-trip is awkward — every user upload becomes `POST → server-side SCP → JSON-RPC image.attach`. Hermie's dashboard hit this and we ended up writing a local patch.

PDFs have a related gap: Anthropic's vision pipeline accepts images, not PDFs. A user can't drop a PDF into chat and have Claude read it without page-rendering server-side. `pdf.attach` does that with `pdftoppm` (poppler-utils), 150 DPI per page, which is readable for vision without being absurdly large.

## Method shapes

### `image.attach_bytes`

```jsonc
{
  "method": "image.attach_bytes",
  "params": {
    "session_id": "<sid>",
    "content_base64": "iVBORw0KGgo...",        // raw OR data:image/png;base64,...
    "filename": "screenshot.png"                 // optional, drives extension
  }
}
// → { attached, path, count, remainder, text, bytes, name, width, height, token_estimate }
```

- 25 MB cap (matches Anthropic image limits)
- Strips `data:image/...;base64,` prefix and embedded whitespace
- Magic-byte sniffing for PNG / JPEG / GIF / WebP / BMP if no filename
- Defense-in-depth extension allowlist (writes to `~/.hermes/images/`)

### `pdf.attach`

```jsonc
{
  "method": "pdf.attach",
  "params": {
    "session_id": "<sid>",
    "path": "/path/to.pdf",                      // OR
    "content_base64": "JVBERi0xLjQK...",         // OR data:application/pdf;base64,...
    "filename": "report.pdf",                    // optional, for display
    "first_page": 1,                             // optional
    "last_page": 10                              // optional, default = first + 24
  }
}
// → { attached, filename, pages_attached, pages: [{path, page, name, width, height, token_estimate}, ...], count, text }
```

- 50 MB PDF cap, 25 pages per call cap
- Validates `%PDF-` magic bytes for base64 input
- Returns a clean `5028` error if `pdftoppm` is not on PATH
- Each page auto-queues into `attached_images` so `prompt.submit` picks them up

## Tests

7 new pytest cases in `tests/test_tui_gateway_server.py`:

- `test_image_attach_bytes_accepts_raw_base64`
- `test_image_attach_bytes_strips_data_url_prefix`
- `test_image_attach_bytes_rejects_invalid_base64` (4017)
- `test_image_attach_bytes_rejects_oversized` (4018)
- `test_pdf_attach_renders_pages_when_pdftoppm_available` (skips if poppler not installed)
- `test_pdf_attach_rejects_non_pdf_payload`
- `test_pdf_attach_rejects_oversized_page_range` (4019)

All 9 `image_attach`/`pdf_attach` tests pass on Python 3.12 with poppler-utils 24.02.0:

```
9 passed in 4.76s
```

## Out-of-band testing

This patch has been running on a 5-VPS production fleet for ~1 hour as of this PR. No regressions observed.

## Dependencies

- `pdf.attach` requires `pdftoppm` (`apt install poppler-utils` on Debian/Ubuntu, `brew install poppler` on macOS)
- No new Python dependencies — uses only stdlib (`base64`, `re`, `subprocess`, `tempfile`, `shutil`)
- No changes to `AGENTS.md` slash-command registry, gateway hooks, or platform adapters

## Error codes

Reuses existing convention from `image.attach` and `clipboard.paste`. New codes:

- `4017` — invalid base64 / not a PDF
- `4018` — payload exceeds size cap
- `4019` — page range exceeds cap
- `5028` — `pdftoppm` not installed / failed / timed out
