### PR TITLE
fix(dashboard): preserve running gateway status in dashboard

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -576,8 +576,12 @@ async def get_status():
         gateway_exit_reason = runtime.get("exit_reason")
         gateway_updated_at = runtime.get("updated_at")
         if not gateway_running:
-            gateway_state = gateway_state if gateway_state in ("stopped", "startup_failed") else "stopped"
-            gateway_platforms = {}
+            # Trust an explicit runtime "running" state even when the local PID
+            # file is missing; the dashboard should not overwrite valid runtime
+            # status with "stopped" in that case.
+            if gateway_state not in ("running",):
+                gateway_state = gateway_state if gateway_state in ("stopped", "startup_failed") else "stopped"
+                gateway_platforms = {}
         elif gateway_running and remote_health_body is not None:
             # The health probe confirmed the gateway is alive, but the local
             # runtime status file may be stale (cross-container).  Override

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -191,6 +191,44 @@ class TestWebServerEndpoints:
         assert resp.json()["gateway_state"] == "startup_failed"
         assert resp.json()["gateway_platforms"] == {}
 
+    def test_get_status_keeps_runtime_running_when_pid_file_missing(self, monkeypatch):
+        import gateway.config as gateway_config
+        import hermes_cli.web_server as web_server
+
+        class _Platform:
+            def __init__(self, value):
+                self.value = value
+
+        class _GatewayConfig:
+            def get_connected_platforms(self):
+                return [_Platform("telegram")]
+
+        monkeypatch.setattr(web_server, "get_running_pid", lambda: None)
+        monkeypatch.setattr(
+            web_server,
+            "read_runtime_status",
+            lambda: {
+                "gateway_state": "running",
+                "updated_at": "2026-04-12T00:00:00+00:00",
+                "platforms": {
+                    "telegram": {"state": "connected", "updated_at": "2026-04-12T00:00:00+00:00"},
+                    "whatsapp": {"state": "retrying", "updated_at": "2026-04-12T00:00:00+00:00"},
+                },
+            },
+        )
+        monkeypatch.setattr(web_server, "_GATEWAY_HEALTH_URL", None)
+        monkeypatch.setattr(web_server, "check_config_version", lambda: (1, 1))
+        monkeypatch.setattr(gateway_config, "load_gateway_config", lambda: _GatewayConfig())
+
+        resp = self.client.get("/api/status")
+
+        assert resp.status_code == 200
+        assert resp.json()["gateway_running"] is False
+        assert resp.json()["gateway_state"] == "running"
+        assert resp.json()["gateway_platforms"] == {
+            "telegram": {"state": "connected", "updated_at": "2026-04-12T00:00:00+00:00"},
+        }
+
     def test_get_config_schema(self):
         resp = self.client.get("/api/config/schema")
         assert resp.status_code == 200


### PR DESCRIPTION
## Summary

- Preserve dashboard `gateway_state="running"` when runtime status says the gateway is running but the local PID file is missing.
- Add a focused regression test covering the missing-PID / runtime-running case so the dashboard no longer overwrites a valid running state to `stopped`.

Fixes #21848.

## Verification

- `uv run --frozen python -m py_compile hermes_cli/web_server.py tests/hermes_cli/test_web_server.py`
- `uv run --frozen python -m pytest tests/hermes_cli/test_web_server.py -q -k "get_status_keeps_runtime_running_when_pid_file_missing or get_status_filters_unconfigured_gateway_platforms or get_status_hides_stale_platforms_when_gateway_not_running or status_falls_back_to_remote_probe"`
- `git diff --check`
- `uv sync --frozen --extra all`
- `uv run --frozen ruff check .`
- `env -i ... uv run --frozen --extra all python -m pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e --tb=short -n auto`
- `env -i ... /private/tmp/hermes-pr-e06274c4-495b-46e1-bbd8-aaf2b09dda1c-4679c45a-9c58-47ca-884f-4fd2e24492b2/.venv/bin/python -m pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e --tb=short -n auto` on latest `origin/main`
- `env -i ... /private/tmp/hermes-pr-e06274c4-495b-46e1-bbd8-aaf2b09dda1c-4679c45a-9c58-47ca-884f-4fd2e24492b2/.venv/bin/python -m pytest -q --tb=short tests/gateway/test_approve_deny_commands.py::TestBlockingApprovalE2E::test_blocking_approval_deny tests/run_agent/test_real_interrupt_subagent.py::TestRealSubagentInterrupt::test_interrupt_child_during_api_call tests/tui_gateway/test_goal_command.py::test_goal_stop_and_done_are_clear_aliases` on both candidate and latest `origin/main`
- `python3 scripts/lint_diff.py --base-ruff .paperclip_artifacts/quality-gate/her76-rebased-20260508T135459Z/lint-reports-archive/base/ruff.json --head-ruff .paperclip_artifacts/quality-gate/her76-rebased-20260508T135459Z/lint-reports-archive/head/ruff.json --base-ty .paperclip_artifacts/quality-gate/her76-rebased-20260508T135459Z/lint-reports-archive/base/ty.json --head-ty .paperclip_artifacts/quality-gate/her76-rebased-20260508T135459Z/lint-reports-archive/head/ty.json --base-ref origin/main --head-ref mainline/HER-76-aaf2b09dda1c-4fd2e24492b2 --output .paperclip_artifacts/quality-gate/her76-rebased-20260508T135459Z/lint-reports-archive/summary.md`

## Quality Firewall Proof

- `local_proof_sha`: `ed32b7dd9c849210b71a9a7c02f1e18fc52d5c71`
- `github_pr_head_sha`: `ed32b7dd9c849210b71a9a7c02f1e18fc52d5c71`
- `worktree_path`: `/private/tmp/hermes-pr-e06274c4-495b-46e1-bbd8-aaf2b09dda1c-4679c45a-9c58-47ca-884f-4fd2e24492b2`
- `branch`: `mainline/HER-76-aaf2b09dda1c-4fd2e24492b2`
- `base_origin_main_sha`: `674fad14832006bfd742c5e3183f34c24018e43a`
- `latest_fetch_at`: `2026-05-08T14:22:48Z`
- `started_at`: `2026-05-08T13:54:59Z`
- `completed_at`: `2026-05-08T14:23:14Z`
- `repair_mode`: `false`
- `commands`: see proof JSON at `.paperclip_artifacts/quality-gate/proof-ed32b7dd9c849210b71a9a7c02f1e18fc52d5c71.json`
- `exit_codes`: `py_compile=0`, `targeted_pytest=0`, `git_diff_check=0`, `uv_sync=0`, `ruff_check=0`, `pytest_clean_env_candidate=1`, `pytest_clean_env_baseline=1`, `candidate_only_node_repro_on_candidate=1`, `candidate_only_node_repro_on_baseline=1`, `lint_diff_generate_summary=0`
- `log_artifacts_or_inline_summary`:
  candidate gate dir: `.paperclip_artifacts/quality-gate/her76-rebased-20260508T135459Z`
  candidate full pytest log: `.paperclip_artifacts/quality-gate/her76-rebased-20260508T135459Z/clean_env_pytest.log`
  baseline full pytest log: `.paperclip_artifacts/quality-gate/her76-rebased-20260508T135459Z/baseline-full-clean-env-py311.log`
  lint summary: `.paperclip_artifacts/quality-gate/her76-rebased-20260508T135459Z/lint-reports-archive/summary.md`
  proof json: `.paperclip_artifacts/quality-gate/proof-ed32b7dd9c849210b71a9a7c02f1e18fc52d5c71.json`
- `baseline_attribution`:
  full suite verdict: `preexisting_unrelated`
  lint diff verdict: `preexisting_unrelated`
  candidate full suite: `68 failed, 20864 passed, 70 skipped`
  baseline full suite on latest `origin/main`: `66 failed, 20865 passed, 70 skipped`
  candidate-only nodes:
  `tests/gateway/test_approve_deny_commands.py::TestBlockingApprovalE2E::test_blocking_approval_deny`
  `tests/run_agent/test_real_interrupt_subagent.py::TestRealSubagentInterrupt::test_interrupt_child_during_api_call`
  `tests/tui_gateway/test_goal_command.py::test_goal_stop_and_done_are_clear_aliases`
  baseline-only node:
  `tests/agent/test_auxiliary_client.py::TestCodexAuxiliaryAdapterTimeout::test_enforces_total_timeout_while_stream_keeps_emitting_events`
  isolated reruns showed the first two candidate-only nodes fail the same way on latest `origin/main`, while the third passes on both candidate and baseline; no candidate-only failure is attributable to the touched dashboard files.
  archive-based lint diff reported `ruff` 0 vs 0 and unchanged touched-file `ty` diagnostics: `hermes_cli/web_server.py` 9 vs 9, `tests/hermes_cli/test_web_server.py` 44 vs 44, with `0` new and `0` fixed touched-file diagnostics.
- `baseline_compare_summary`: exact clean-env full pytest is red on both candidate and latest `origin/main`; the remaining delta is shared instability outside `hermes_cli/web_server.py` and `tests/hermes_cli/test_web_server.py`, while the touched dashboard regression coverage stays green.
- `baseline_worktree_path`: `/private/tmp/hermes-baseline-her76-20260508T135459Z`

