### PR TITLE
fix(tui): support middle-click primary paste in Linux

### DIFF
--- a/ui-tui/src/__tests__/clipboard.test.ts
+++ b/ui-tui/src/__tests__/clipboard.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { isUsableClipboardText, readClipboardText, writeClipboardText } from '../lib/clipboard.js'
+import {
+  isUsableClipboardText,
+  readClipboardText,
+  readPrimarySelectionText,
+  writeClipboardText
+} from '../lib/clipboard.js'
 
 describe('readClipboardText', () => {
   it('reads text from pbpaste on macOS', async () => {
@@ -80,6 +85,51 @@ describe('readClipboardText', () => {
     await expect(
       readClipboardText('linux', run, { WAYLAND_DISPLAY: 'wayland-1' } as NodeJS.ProcessEnv)
     ).resolves.toBeNull()
+  })
+})
+
+describe('readPrimarySelectionText', () => {
+  it('reads Wayland PRIMARY with wl-paste before X11 PRIMARY backends', async () => {
+    const run = vi.fn().mockResolvedValue({ stdout: 'from primary\n' })
+
+    await expect(
+      readPrimarySelectionText('linux', run, { WAYLAND_DISPLAY: 'wayland-1' } as NodeJS.ProcessEnv)
+    ).resolves.toBe('from primary\n')
+    expect(run).toHaveBeenCalledWith(
+      'wl-paste',
+      ['--primary', '--type', 'text'],
+      expect.objectContaining({ encoding: 'utf8', maxBuffer: 4 * 1024 * 1024, windowsHide: true })
+    )
+  })
+
+  it('falls back from Wayland PRIMARY to X11 PRIMARY', async () => {
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('wl-paste missing'))
+      .mockResolvedValueOnce({ stdout: 'from x primary\n' })
+
+    await expect(
+      readPrimarySelectionText('linux', run, { WAYLAND_DISPLAY: 'wayland-1' } as NodeJS.ProcessEnv)
+    ).resolves.toBe('from x primary\n')
+    expect(run).toHaveBeenNthCalledWith(
+      1,
+      'wl-paste',
+      ['--primary', '--type', 'text'],
+      expect.objectContaining({ encoding: 'utf8', maxBuffer: 4 * 1024 * 1024, windowsHide: true })
+    )
+    expect(run).toHaveBeenNthCalledWith(
+      2,
+      'xclip',
+      ['-selection', 'primary', '-out'],
+      expect.objectContaining({ encoding: 'utf8', maxBuffer: 4 * 1024 * 1024, windowsHide: true })
+    )
+  })
+
+  it('returns null off Linux so callers can fall back to clipboard paste', async () => {
+    const run = vi.fn()
+
+    await expect(readPrimarySelectionText('darwin', run)).resolves.toBeNull()
+    expect(run).not.toHaveBeenCalled()
   })
 })
 

--- a/ui-tui/src/__tests__/clipboard.test.ts
+++ b/ui-tui/src/__tests__/clipboard.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { isUsableClipboardText, readClipboardText, writeClipboardText } from '../lib/clipboard.js'
+import {
+  isUsableClipboardText,
+  readClipboardText,
+  readPrimarySelectionText,
+  writeClipboardText
+} from '../lib/clipboard.js'
 
 describe('readClipboardText', () => {
   it('reads text from pbpaste on macOS', async () => {
@@ -102,6 +107,51 @@ describe('readClipboardText', () => {
     await expect(readClipboardText('linux', run, { WSL_INTEROP: '/tmp/socket' } as NodeJS.ProcessEnv)).resolves.toBe(
       cjkText
     )
+  })
+})
+
+describe('readPrimarySelectionText', () => {
+  it('reads Wayland PRIMARY with wl-paste before X11 PRIMARY backends', async () => {
+    const run = vi.fn().mockResolvedValue({ stdout: 'from primary\n' })
+
+    await expect(
+      readPrimarySelectionText('linux', run, { WAYLAND_DISPLAY: 'wayland-1' } as NodeJS.ProcessEnv)
+    ).resolves.toBe('from primary\n')
+    expect(run).toHaveBeenCalledWith(
+      'wl-paste',
+      ['--primary', '--type', 'text'],
+      expect.objectContaining({ encoding: 'utf8', maxBuffer: 4 * 1024 * 1024, windowsHide: true })
+    )
+  })
+
+  it('falls back from Wayland PRIMARY to X11 PRIMARY', async () => {
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('wl-paste missing'))
+      .mockResolvedValueOnce({ stdout: 'from x primary\n' })
+
+    await expect(
+      readPrimarySelectionText('linux', run, { WAYLAND_DISPLAY: 'wayland-1' } as NodeJS.ProcessEnv)
+    ).resolves.toBe('from x primary\n')
+    expect(run).toHaveBeenNthCalledWith(
+      1,
+      'wl-paste',
+      ['--primary', '--type', 'text'],
+      expect.objectContaining({ encoding: 'utf8', maxBuffer: 4 * 1024 * 1024, windowsHide: true })
+    )
+    expect(run).toHaveBeenNthCalledWith(
+      2,
+      'xclip',
+      ['-selection', 'primary', '-out'],
+      expect.objectContaining({ encoding: 'utf8', maxBuffer: 4 * 1024 * 1024, windowsHide: true })
+    )
+  })
+
+  it('returns null off Linux so callers can fall back to clipboard paste', async () => {
+    const run = vi.fn()
+
+    await expect(readPrimarySelectionText('darwin', run)).resolves.toBeNull()
+    expect(run).not.toHaveBeenCalled()
   })
 })
 

--- a/ui-tui/src/__tests__/textInputMiddleClick.test.tsx
+++ b/ui-tui/src/__tests__/textInputMiddleClick.test.tsx
@@ -1,0 +1,111 @@
+import { PassThrough } from 'node:stream'
+
+import { AlternateScreen, renderSync } from '@hermes/ink'
+import React from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { type PasteEvent, TextInput } from '../components/textInput.js'
+import * as clipboard from '../lib/clipboard.js'
+
+vi.mock('../lib/clipboard.js', async () => {
+  const actual = await vi.importActual<typeof clipboard>('../lib/clipboard.js')
+
+  return { ...actual, readPrimarySelectionText: vi.fn() }
+})
+
+const readPrimarySelectionTextMock = vi.mocked(clipboard.readPrimarySelectionText)
+
+function makeStdin() {
+  const stdin = new PassThrough()
+
+  Object.assign(stdin, {
+    isRaw: false,
+    isTTY: true,
+    ref: vi.fn(),
+    setRawMode: vi.fn((enabled: boolean) => {
+      Object.assign(stdin, { isRaw: enabled })
+    }),
+    unref: vi.fn()
+  })
+
+  return stdin
+}
+
+function renderTextInput(
+  onChange: (value: string) => void,
+  onPaste: (event: PasteEvent) => { cursor: number; value: string }
+) {
+  const stdin = makeStdin()
+  const stderr = new PassThrough()
+
+  Object.assign(stderr, { isTTY: false })
+  stderr.on('data', () => {})
+
+  const writeSpy = vi
+    .spyOn(process.stdout, 'write')
+    .mockImplementation((() => true) as unknown as typeof process.stdout.write)
+
+  const instance = renderSync(
+    <AlternateScreen mouseTracking="buttons">
+      <TextInput focus onChange={onChange} onPaste={onPaste} value="" />
+    </AlternateScreen>,
+    {
+      exitOnCtrlC: false,
+      patchConsole: false,
+      stderr: stderr as NodeJS.WriteStream,
+      stdin: stdin as NodeJS.ReadStream,
+      stdout: process.stdout
+    }
+  )
+
+  const cleanup = () => {
+    instance.unmount()
+    instance.cleanup()
+    writeSpy.mockRestore()
+  }
+
+  return { cleanup, stdin }
+}
+
+function middleClick(stdin: PassThrough) {
+  stdin.write('\x1b[<1;1;1M')
+}
+
+afterEach(() => {
+  readPrimarySelectionTextMock.mockReset()
+})
+
+describe('TextInput middle-click paste', () => {
+  it('does not fall back to CLIPBOARD when PRIMARY succeeds with empty text', async () => {
+    const onChange = vi.fn()
+    const onPaste = vi.fn(() => ({ cursor: 0, value: 'clipboard fallback' }))
+    readPrimarySelectionTextMock.mockResolvedValue('')
+    const { cleanup, stdin } = renderTextInput(onChange, onPaste)
+
+    try {
+      middleClick(stdin)
+      await vi.waitFor(() => expect(readPrimarySelectionTextMock).toHaveBeenCalledOnce())
+
+      expect(onChange).not.toHaveBeenCalled()
+      expect(onPaste).not.toHaveBeenCalled()
+    } finally {
+      cleanup()
+    }
+  })
+
+  it('uses the ordinary paste pipeline only when PRIMARY is unavailable', async () => {
+    const onChange = vi.fn()
+    const onPaste = vi.fn(() => ({ cursor: 8, value: 'fallback' }))
+    readPrimarySelectionTextMock.mockResolvedValue(null)
+    const { cleanup, stdin } = renderTextInput(onChange, onPaste)
+
+    try {
+      middleClick(stdin)
+      await vi.waitFor(() => expect(onPaste).toHaveBeenCalledOnce())
+
+      expect(onPaste).toHaveBeenCalledWith({ cursor: 0, hotkey: true, text: '', value: '' })
+    } finally {
+      cleanup()
+    }
+  })
+})

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -3,7 +3,7 @@ import * as Ink from '@hermes/ink'
 import { type MutableRefObject, useEffect, useMemo, useRef, useState } from 'react'
 
 import { setInputSelection } from '../app/inputSelectionStore.js'
-import { readClipboardText, writeClipboardText } from '../lib/clipboard.js'
+import { readClipboardText, readPrimarySelectionText, writeClipboardText } from '../lib/clipboard.js'
 import { cursorLayout, offsetFromPosition } from '../lib/inputMetrics.js'
 import {
   DEFAULT_VOICE_RECORD_KEY,
@@ -1228,6 +1228,22 @@ export function TextInput({
       }}
       onMouseDown={(e: MouseEventLite) => {
         if (!focus) {
+          return
+        }
+
+        // Middle-click mirrors native Linux terminal behavior: paste PRIMARY
+        // when available, including a successful empty selection. Only an
+        // unavailable PRIMARY backend falls back to the regular clipboard.
+        if (e.button === 1) {
+          e.stopImmediatePropagation?.()
+          void readPrimarySelectionText().then(text => {
+            if (text !== null) {
+              pastePlainText(text)
+            } else {
+              emitPaste({ cursor: curRef.current, hotkey: true, text: '', value: vRef.current })
+            }
+          })
+
           return
         }
 

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -4,7 +4,7 @@ import { type MutableRefObject, useEffect, useMemo, useRef, useState } from 'rea
 
 import { setInputSelection } from '../app/inputSelectionStore.js'
 import { highlightMask, highlightsStable } from '../domain/composerHighlights.js'
-import { readClipboardText, writeClipboardText } from '../lib/clipboard.js'
+import { readClipboardText, readPrimarySelectionText, writeClipboardText } from '../lib/clipboard.js'
 import { cursorLayout, offsetFromPosition } from '../lib/inputMetrics.js'
 import {
   DEFAULT_VOICE_RECORD_KEY,
@@ -1697,6 +1697,22 @@ export function TextInput({
       }}
       onMouseDown={(e: MouseEventLite) => {
         if (!focus) {
+          return
+        }
+
+        // Middle-click mirrors native Linux terminal behavior: paste PRIMARY
+        // when available, including a successful empty selection. Only an
+        // unavailable PRIMARY backend falls back to the regular clipboard.
+        if (e.button === 1) {
+          e.stopImmediatePropagation?.()
+          void readPrimarySelectionText().then(text => {
+            if (text !== null) {
+              pastePlainText(text)
+            } else {
+              emitPaste({ cursor: curRef.current, hotkey: true, text: '', value: vRef.current })
+            }
+          })
+
           return
         }
 

--- a/ui-tui/src/lib/clipboard.ts
+++ b/ui-tui/src/lib/clipboard.ts
@@ -57,22 +57,31 @@ function readClipboardCommands(
   return attempts
 }
 
-/**
- * Read plain text from the system clipboard.
- *
- * Uses native platform tools in fallback order:
- * - macOS: pbpaste
- * - Windows: PowerShell Get-Clipboard -Raw
- * - WSL: powershell.exe Get-Clipboard -Raw
- * - Linux Wayland: wl-paste --type text
- * - Linux X11: xclip -selection clipboard -out
- */
-export async function readClipboardText(
-  platform: NodeJS.Platform = process.platform,
-  run: ClipboardRun = execFileAsync,
-  env: NodeJS.ProcessEnv = process.env
+function readPrimarySelectionCommands(
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv
+): Array<{ args: readonly string[]; cmd: string }> {
+  if (platform !== 'linux') {
+    return []
+  }
+
+  const attempts: Array<{ args: readonly string[]; cmd: string }> = []
+
+  if (env.WAYLAND_DISPLAY) {
+    attempts.push({ cmd: 'wl-paste', args: ['--primary', '--type', 'text'] })
+  }
+
+  attempts.push({ cmd: 'xclip', args: ['-selection', 'primary', '-out'] })
+  attempts.push({ cmd: 'xsel', args: ['--primary', '--output'] })
+
+  return attempts
+}
+
+async function readFromCommands(
+  commands: Array<{ args: readonly string[]; cmd: string }>,
+  run: ClipboardRun
 ): Promise<string | null> {
-  for (const attempt of readClipboardCommands(platform, env)) {
+  for (const attempt of commands) {
     try {
       const result = await run(attempt.cmd, [...attempt.args], {
         encoding: 'utf8',
@@ -89,6 +98,39 @@ export async function readClipboardText(
   }
 
   return null
+}
+
+/**
+ * Read plain text from the system clipboard.
+ *
+ * Uses native platform tools in fallback order:
+ * - macOS: pbpaste
+ * - Windows: PowerShell Get-Clipboard -Raw
+ * - WSL: powershell.exe Get-Clipboard -Raw
+ * - Linux Wayland: wl-paste --type text
+ * - Linux X11: xclip -selection clipboard -out
+ */
+export async function readClipboardText(
+  platform: NodeJS.Platform = process.platform,
+  run: ClipboardRun = execFileAsync,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<string | null> {
+  return readFromCommands(readClipboardCommands(platform, env), run)
+}
+
+/**
+ * Read plain text from the Linux PRIMARY selection.
+ *
+ * This is the selection pasted by middle-click in X11/Wayland terminals,
+ * distinct from the normal clipboard used by Ctrl/Cmd+V. Non-Linux
+ * platforms return null so callers can fall back to regular clipboard paste.
+ */
+export async function readPrimarySelectionText(
+  platform: NodeJS.Platform = process.platform,
+  run: ClipboardRun = execFileAsync,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<string | null> {
+  return readFromCommands(readPrimarySelectionCommands(platform, env), run)
 }
 
 // PowerShell on Windows/WSL decodes piped stdin with the system ANSI code

--- a/ui-tui/src/lib/clipboard.ts
+++ b/ui-tui/src/lib/clipboard.ts
@@ -65,22 +65,31 @@ function readClipboardCommands(
   return attempts
 }
 
-/**
- * Read plain text from the system clipboard.
- *
- * Uses native platform tools in fallback order:
- * - macOS: pbpaste
- * - Windows: PowerShell Get-Clipboard -Raw
- * - WSL: powershell.exe Get-Clipboard -Raw
- * - Linux Wayland: wl-paste --type text
- * - Linux X11: xclip -selection clipboard -out
- */
-export async function readClipboardText(
-  platform: NodeJS.Platform = process.platform,
-  run: ClipboardRun = execFileAsync,
-  env: NodeJS.ProcessEnv = process.env
+function readPrimarySelectionCommands(
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv
+): Array<{ args: readonly string[]; cmd: string }> {
+  if (platform !== 'linux') {
+    return []
+  }
+
+  const attempts: Array<{ args: readonly string[]; cmd: string }> = []
+
+  if (env.WAYLAND_DISPLAY) {
+    attempts.push({ cmd: 'wl-paste', args: ['--primary', '--type', 'text'] })
+  }
+
+  attempts.push({ cmd: 'xclip', args: ['-selection', 'primary', '-out'] })
+  attempts.push({ cmd: 'xsel', args: ['--primary', '--output'] })
+
+  return attempts
+}
+
+async function readFromCommands(
+  commands: Array<{ args: readonly string[]; cmd: string; base64?: boolean }>,
+  run: ClipboardRun
 ): Promise<string | null> {
-  for (const attempt of readClipboardCommands(platform, env)) {
+  for (const attempt of commands) {
     try {
       const result = await run(attempt.cmd, [...attempt.args], {
         encoding: 'utf8',
@@ -101,6 +110,39 @@ export async function readClipboardText(
   }
 
   return null
+}
+
+/**
+ * Read plain text from the system clipboard.
+ *
+ * Uses native platform tools in fallback order:
+ * - macOS: pbpaste
+ * - Windows: PowerShell Get-Clipboard -Raw
+ * - WSL: powershell.exe Get-Clipboard -Raw
+ * - Linux Wayland: wl-paste --type text
+ * - Linux X11: xclip -selection clipboard -out
+ */
+export async function readClipboardText(
+  platform: NodeJS.Platform = process.platform,
+  run: ClipboardRun = execFileAsync,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<string | null> {
+  return readFromCommands(readClipboardCommands(platform, env), run)
+}
+
+/**
+ * Read plain text from the Linux PRIMARY selection.
+ *
+ * This is the selection pasted by middle-click in X11/Wayland terminals,
+ * distinct from the normal clipboard used by Ctrl/Cmd+V. Non-Linux
+ * platforms return null so callers can fall back to regular clipboard paste.
+ */
+export async function readPrimarySelectionText(
+  platform: NodeJS.Platform = process.platform,
+  run: ClipboardRun = execFileAsync,
+  env: NodeJS.ProcessEnv = process.env
+): Promise<string | null> {
+  return readFromCommands(readPrimarySelectionCommands(platform, env), run)
 }
 
 // PowerShell on Windows/WSL decodes piped stdin with the system ANSI code


### PR DESCRIPTION
Linux QoL: make middle-click in the TUI paste the PRIMARY selection, matching native terminal behavior.

## Summary
- Add a Linux PRIMARY-selection reader with Wayland (`wl-paste --primary`) and X11 (`xclip` / `xsel`) backends.
- Wire button 1 into the current `TextInput.onMouseDown` path before the non-left-button return.
- Fall back to the ordinary clipboard pipeline only when PRIMARY is unavailable (`null`), not when PRIMARY succeeds with empty text (`''`).
- Preserve current right-click copy-or-paste behavior and the newer UTF-8-safe PowerShell clipboard-write path from `main`.
- Add real SGR mouse-event coverage for successful empty PRIMARY and unavailable PRIMARY, plus helper fallback-order tests.

## Review feedback addressed
- [x] Distinguish `text !== null` from truthiness so an empty PRIMARY selection cannot paste unrelated CLIPBOARD contents.
- [x] Rename the misleading helper-test title to describe PRIMARY backend order accurately.
- [x] Add event-level middle-click coverage, including the empty-PRIMARY case.
- [x] Rebase onto current `main` and resolve the `TextInput` / clipboard conflicts semantically.

## Validation
- [x] Current-main negative control: an SGR middle-click produced no paste call (`expected once, got 0`).
- [x] `npm test -- --run src/__tests__/clipboard.test.ts src/__tests__/textInputMiddleClick.test.tsx src/__tests__/textInputRightClick.test.ts` — 31 passed.
- [x] `npm run typecheck`
- [x] Changed-file ESLint — passed.
- [x] Changed-file Prettier check — passed.
- [x] `npm run build`
- [x] `git diff --check origin/main...HEAD`
- [x] Full `npm test` — 1,120 passed, 1 skipped; four unrelated current-main failures remain (two stale status-rule expectations, one virtual-height expectation, and one existing cursor-regression timeout).

## Baseline notes
- Full `npm run lint` still reports one existing error and 15 warnings in unrelated files; changed-file lint passes cleanly.
- Rebased commit preserves the original contributor authorship and is based on `af250d84948179834820a62bfd870c0df6f264a1`.
