### PR TITLE
fix(cron): respect per-schedule timezones

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -18,6 +18,7 @@ from datetime import datetime, timedelta
 from pathlib import Path
 from hermes_constants import get_hermes_home
 from typing import Optional, Dict, List, Any, Union
+from zoneinfo import ZoneInfo
 
 logger = logging.getLogger(__name__)
 
@@ -142,6 +143,17 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
     """
     schedule = schedule.strip()
     original = schedule
+
+    timezone_name = None
+    timezone_match = re.match(r'^(?:CRON_TZ|TZ)=(\S+)\s+(.+)$', schedule, flags=re.IGNORECASE)
+    if timezone_match:
+        timezone_name = timezone_match.group(1)
+        try:
+            ZoneInfo(timezone_name)
+        except Exception as e:
+            raise ValueError(f"Invalid timezone '{timezone_name}' in schedule '{original}': {e}") from e
+        schedule = timezone_match.group(2).strip()
+
     schedule_lower = schedule.lower()
     
     # "every X" pattern → recurring interval
@@ -167,11 +179,14 @@ def parse_schedule(schedule: str) -> Dict[str, Any]:
             croniter(schedule)
         except Exception as e:
             raise ValueError(f"Invalid cron expression '{schedule}': {e}")
-        return {
+        result = {
             "kind": "cron",
             "expr": schedule,
-            "display": schedule
+            "display": original if timezone_name else schedule,
         }
+        if timezone_name:
+            result["timezone"] = timezone_name
+        return result
     
     # ISO timestamp (contains T or looks like date)
     if 'T' in schedule or re.match(r'^\d{4}-\d{2}-\d{2}', schedule):
@@ -230,6 +245,27 @@ def _ensure_aware(dt: datetime) -> datetime:
     return dt.astimezone(target_tz)
 
 
+def _schedule_cron_timezone(schedule: Dict[str, Any]) -> Optional[ZoneInfo]:
+    """Return an optional ZoneInfo for cron schedules with CRON_TZ/TZ.
+
+    Stored jobs may contain a `timezone` field from previous Hermes versions or
+    manual repair. Invalid stored values should not crash the scheduler; fall
+    back to the Hermes timezone after logging.
+    """
+    timezone_name = schedule.get("timezone")
+    if not timezone_name:
+        return None
+    try:
+        return ZoneInfo(str(timezone_name))
+    except Exception as exc:
+        logger.warning(
+            "Ignoring invalid cron timezone %r for schedule %r: %s",
+            timezone_name,
+            schedule.get("expr"),
+            exc,
+        )
+        return None
+
 def _recoverable_oneshot_run_at(
     schedule: Dict[str, Any],
     now: datetime,
@@ -277,7 +313,9 @@ def _compute_grace_seconds(schedule: dict) -> int:
     if kind == "cron" and HAS_CRONITER:
         try:
             now = _hermes_now()
-            cron = croniter(schedule["expr"], now)
+            cron_tz = _schedule_cron_timezone(schedule)
+            base_time = now.astimezone(cron_tz) if cron_tz else now
+            cron = croniter(schedule["expr"], base_time)
             first = cron.get_next(datetime)
             second = cron.get_next(datetime)
             period_seconds = int((second - first).total_seconds())
@@ -328,8 +366,14 @@ def compute_next_run(schedule: Dict[str, Any], last_run_at: Optional[str] = None
         base_time = now
         if last_run_at:
             base_time = _ensure_aware(datetime.fromisoformat(last_run_at))
-        cron = croniter(schedule["expr"], base_time)
+        cron_tz = _schedule_cron_timezone(schedule)
+        cron_base = base_time.astimezone(cron_tz) if cron_tz else base_time
+        cron = croniter(schedule["expr"], cron_base)
         next_run = cron.get_next(datetime)
+        if cron_tz:
+            if next_run.tzinfo is None:
+                next_run = next_run.replace(tzinfo=cron_tz)
+            next_run = next_run.astimezone(now.tzinfo)
         return next_run.isoformat()
 
     return None

--- a/tests/cron/test_compute_next_run_last_run_at.py
+++ b/tests/cron/test_compute_next_run_last_run_at.py
@@ -9,7 +9,7 @@ from zoneinfo import ZoneInfo
 
 pytest.importorskip("croniter")
 
-from cron.jobs import compute_next_run
+from cron.jobs import compute_next_run, parse_schedule
 
 
 class TestCronComputeNextRunUsesLastRunAt:
@@ -64,6 +64,40 @@ class TestCronComputeNextRunUsesLastRunAt:
             f"Expected next run on Apr 11 (from now), got {next_dt}"
         )
         assert next_dt.hour == 0
+
+    def test_cron_with_schedule_timezone_uses_that_zone_not_hermes_zone(self, monkeypatch):
+        """A New York cron should advance in New York wall time even when
+        Hermes itself runs in Bangkok.
+
+        Regression: Alpaca jobs stored timezone=America/New_York but computed
+        next_run_at as 12:45 Bangkok instead of 12:45 New York.
+        """
+        bangkok = ZoneInfo("Asia/Bangkok")
+
+        now = datetime(2026, 5, 7, 12, 53, 0, tzinfo=bangkok)
+        last_run = datetime(2026, 5, 6, 23, 51, 54, tzinfo=bangkok)
+        monkeypatch.setattr("cron.jobs._hermes_now", lambda: now)
+
+        schedule = {
+            "kind": "cron",
+            "expr": "45 12 * * 1-5",
+            "timezone": "America/New_York",
+        }
+
+        result = compute_next_run(schedule, last_run_at=last_run.isoformat())
+        assert result is not None
+        next_dt = datetime.fromisoformat(result)
+
+        assert next_dt.tzinfo is not None
+        assert next_dt.astimezone(bangkok).isoformat() == "2026-05-07T23:45:00+07:00"
+
+    def test_parse_schedule_accepts_cron_tz_prefix(self):
+        schedule = parse_schedule("CRON_TZ=America/New_York 45 12 * * 1-5")
+
+        assert schedule["kind"] == "cron"
+        assert schedule["expr"] == "45 12 * * 1-5"
+        assert schedule["timezone"] == "America/New_York"
+        assert schedule["display"] == "CRON_TZ=America/New_York 45 12 * * 1-5"
 
     def test_cron_weekly_consistent_with_interval(self, monkeypatch):
         """Both cron and interval jobs should anchor to last_run_at when


### PR DESCRIPTION
## Summary
- Add support for `CRON_TZ=` / `TZ=` prefixes in Hermes cron schedules by storing a per-schedule timezone.
- Use a cron schedule's stored timezone when computing `next_run_at`, including when anchoring from `last_run_at`.
- Add regression coverage for a New York cron running from a Bangkok Hermes timezone and for parsing `CRON_TZ=` schedules.

## Intent / use case
This is not intended to replace the default/user timezone behavior for ordinary cron jobs. Normal schedules continue to use the existing Hermes/system timezone.

The purpose is to support **per-job timezone overrides** when the job's correct wall-clock time is tied to a different region than the user or Hermes host. Examples:
- A stock-trading / market-open cron that must run at `America/New_York` market hours while Hermes itself is running in `Asia/Bangkok`.
- A regional business-hours report that needs to follow a customer or office timezone while other jobs keep the local/default timezone.

Using the standard `CRON_TZ=` / `TZ=` prefix keeps that exceptional timezone requirement explicit and local to the schedule, while preserving backward compatibility for all existing schedules. A future user-level default timezone setting could still be layered on top for the common onboarding case.

## Test Plan
- `venv/bin/python -m pytest tests/cron/test_compute_next_run_last_run_at.py -q -o 'addopts='` → 5 passed
- `venv/bin/python -m py_compile cron/jobs.py tests/cron/test_compute_next_run_last_run_at.py`
- `git diff --check -- cron/jobs.py tests/cron/test_compute_next_run_last_run_at.py`

## Notes
- This was recovered from the cron timezone patch staged on the Janna / Chat Hermes hosts.
- A full local `tests/cron` run on this checkout has unrelated existing failures around script empty-output handling and MCP cron auth setup; the targeted timezone regression test passes.