### PR TITLE
feat(security): HERMES_READ_SAFE_ROOTS env-var read allowlist

### DIFF
--- a/agent/file_safety.py
+++ b/agent/file_safety.py
@@ -90,9 +90,56 @@ def is_write_denied(path: str) -> bool:
     return False
 
 
+def get_read_safe_roots() -> list[str]:
+    """Return resolved HERMES_READ_SAFE_ROOTS allowlist (colon-separated), or []."""
+    raw = os.getenv("HERMES_READ_SAFE_ROOTS", "")
+    if not raw:
+        return []
+    out: list[str] = []
+    for part in raw.split(":"):
+        part = part.strip()
+        if not part:
+            continue
+        try:
+            out.append(os.path.realpath(os.path.expanduser(part)))
+        except Exception:
+            continue
+    return out
+
+
+def get_read_allowed_files() -> set[str]:
+    """Return resolved HERMES_READ_ALLOWED_FILES (colon-separated explicit paths).
+
+    Use for individual files outside the safe-roots that must remain readable
+    (e.g. ~/.hermes/AGENTS.md, ~/.hermes/SOUL.md).
+    """
+    raw = os.getenv("HERMES_READ_ALLOWED_FILES", "")
+    if not raw:
+        return set()
+    out: set[str] = set()
+    for part in raw.split(":"):
+        part = part.strip()
+        if not part:
+            continue
+        try:
+            out.add(os.path.realpath(os.path.expanduser(part)))
+        except Exception:
+            continue
+    return out
+
+
 def get_read_block_error(path: str) -> Optional[str]:
-    """Return an error message when a read targets internal Hermes cache files."""
-    resolved = Path(path).expanduser().resolve()
+    """Return an error message when a read is denied.
+
+    Two layers:
+      1. Internal Hermes cache files (skills/.hub) — always blocked to
+         prevent prompt-injection via catalog/hub metadata.
+      2. HERMES_READ_SAFE_ROOTS allowlist (colon-separated). When set, any
+         read outside those roots (and outside HERMES_READ_ALLOWED_FILES)
+         is denied. Mirrors HERMES_WRITE_SAFE_ROOT for write-side scoping.
+    """
+    resolved_pathobj = Path(path).expanduser().resolve()
+    resolved = str(resolved_pathobj)
     hermes_home = _hermes_home_path().resolve()
     blocked_dirs = [
         hermes_home / "skills" / ".hub" / "index-cache",
@@ -100,7 +147,7 @@ def get_read_block_error(path: str) -> Optional[str]:
     ]
     for blocked in blocked_dirs:
         try:
-            resolved.relative_to(blocked)
+            resolved_pathobj.relative_to(blocked)
         except ValueError:
             continue
         return (
@@ -108,4 +155,19 @@ def get_read_block_error(path: str) -> Optional[str]:
             "and cannot be read directly to prevent prompt injection. "
             "Use the skills_list or skill_view tools instead."
         )
+
+    safe_roots = get_read_safe_roots()
+    if safe_roots:
+        allowed_files = get_read_allowed_files()
+        if resolved in allowed_files:
+            return None
+        for root in safe_roots:
+            if resolved == root or resolved.startswith(root + os.sep):
+                return None
+        return (
+            f"Access denied: {path} is outside the configured read allowlist "
+            f"(HERMES_READ_SAFE_ROOTS). Allowed roots: {', '.join(safe_roots)}. "
+            "Set HERMES_READ_ALLOWED_FILES to whitelist specific files."
+        )
+
     return None

--- a/tests/tools/test_file_read_allowlist.py
+++ b/tests/tools/test_file_read_allowlist.py
@@ -1,0 +1,244 @@
+"""Tests for HERMES_READ_SAFE_ROOTS / HERMES_READ_ALLOWED_FILES env-var allowlist.
+
+Mirrors test_file_write_safety.py's pytest style and exercises the same
+monkeypatch-driven env-var pattern used for HERMES_WRITE_SAFE_ROOT.
+
+The four cases required by the PR:
+  1. Allowed roots  → get_read_block_error returns None  (read permitted)
+  2. Outside roots  → get_read_block_error returns error string  (read denied)
+  3. Specific file allowlist (HERMES_READ_ALLOWED_FILES) bypasses root check
+  4. Env var not set → all reads permitted (backwards compat)
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from agent.file_safety import (
+    get_read_block_error,
+    get_read_safe_roots,
+    get_read_allowed_files,
+)
+
+
+class TestGetReadSafeRoots:
+    """Unit tests for the get_read_safe_roots() helper."""
+
+    def test_returns_empty_list_when_unset(self, monkeypatch):
+        monkeypatch.delenv("HERMES_READ_SAFE_ROOTS", raising=False)
+        assert get_read_safe_roots() == []
+
+    def test_returns_empty_list_when_blank(self, monkeypatch):
+        monkeypatch.setenv("HERMES_READ_SAFE_ROOTS", "")
+        assert get_read_safe_roots() == []
+
+    def test_single_root_resolved(self, tmp_path: Path, monkeypatch):
+        monkeypatch.setenv("HERMES_READ_SAFE_ROOTS", str(tmp_path))
+        roots = get_read_safe_roots()
+        assert len(roots) == 1
+        assert roots[0] == str(tmp_path.resolve())
+
+    def test_multiple_roots_colon_separated(self, tmp_path: Path, monkeypatch):
+        root_a = tmp_path / "a"
+        root_b = tmp_path / "b"
+        root_a.mkdir()
+        root_b.mkdir()
+        monkeypatch.setenv("HERMES_READ_SAFE_ROOTS", f"{root_a}:{root_b}")
+        roots = get_read_safe_roots()
+        assert len(roots) == 2
+        assert str(root_a.resolve()) in roots
+        assert str(root_b.resolve()) in roots
+
+    def test_empty_segments_ignored(self, tmp_path: Path, monkeypatch):
+        """Trailing colons or double-colons must not produce empty entries."""
+        monkeypatch.setenv("HERMES_READ_SAFE_ROOTS", f"{tmp_path}::")
+        roots = get_read_safe_roots()
+        assert all(r for r in roots)
+
+
+class TestGetReadAllowedFiles:
+    """Unit tests for the get_read_allowed_files() helper."""
+
+    def test_returns_empty_set_when_unset(self, monkeypatch):
+        monkeypatch.delenv("HERMES_READ_ALLOWED_FILES", raising=False)
+        assert get_read_allowed_files() == set()
+
+    def test_single_file_resolved(self, tmp_path: Path, monkeypatch):
+        f = tmp_path / "secret.md"
+        f.write_text("hello")
+        monkeypatch.setenv("HERMES_READ_ALLOWED_FILES", str(f))
+        files = get_read_allowed_files()
+        assert str(f.resolve()) in files
+
+    def test_multiple_files_colon_separated(self, tmp_path: Path, monkeypatch):
+        f1 = tmp_path / "a.md"
+        f2 = tmp_path / "b.md"
+        f1.write_text("a")
+        f2.write_text("b")
+        monkeypatch.setenv("HERMES_READ_ALLOWED_FILES", f"{f1}:{f2}")
+        files = get_read_allowed_files()
+        assert str(f1.resolve()) in files
+        assert str(f2.resolve()) in files
+
+
+class TestReadAllowlist:
+    """
+    End-to-end tests for get_read_block_error() with the allowlist active.
+
+    Four mandatory PR cases:
+      1. Allowed root   → returns None
+      2. Outside roots  → returns error string
+      3. File allowlist → specific file outside root returns None
+      4. Env var unset  → all reads return None (backwards compat)
+    """
+
+    # ── Case 1: allowed roots ────────────────────────────────────────────────
+
+    def test_path_inside_root_allowed(self, tmp_path: Path, monkeypatch):
+        """A path inside a configured safe root is permitted (returns None)."""
+        safe_root = tmp_path / "workspace"
+        safe_root.mkdir()
+        target = safe_root / "notes.txt"
+        target.write_text("hello")
+
+        monkeypatch.setenv("HERMES_READ_SAFE_ROOTS", str(safe_root))
+        monkeypatch.delenv("HERMES_READ_ALLOWED_FILES", raising=False)
+
+        assert get_read_block_error(str(target)) is None
+
+    def test_root_itself_is_allowed(self, tmp_path: Path, monkeypatch):
+        """Reading the root directory itself is permitted."""
+        safe_root = tmp_path / "workspace"
+        safe_root.mkdir()
+
+        monkeypatch.setenv("HERMES_READ_SAFE_ROOTS", str(safe_root))
+        monkeypatch.delenv("HERMES_READ_ALLOWED_FILES", raising=False)
+
+        assert get_read_block_error(str(safe_root)) is None
+
+    def test_nested_path_inside_root_allowed(self, tmp_path: Path, monkeypatch):
+        """Deep nesting inside a root is permitted."""
+        safe_root = tmp_path / "workspace"
+        deep = safe_root / "a" / "b" / "c"
+        deep.mkdir(parents=True)
+        target = deep / "file.py"
+        target.write_text("x = 1")
+
+        monkeypatch.setenv("HERMES_READ_SAFE_ROOTS", str(safe_root))
+        monkeypatch.delenv("HERMES_READ_ALLOWED_FILES", raising=False)
+
+        assert get_read_block_error(str(target)) is None
+
+    def test_multi_root_second_root_allowed(self, tmp_path: Path, monkeypatch):
+        """A path that lives in the *second* configured root is permitted."""
+        root_a = tmp_path / "wiki"
+        root_b = tmp_path / "workspace"
+        root_a.mkdir()
+        root_b.mkdir()
+        target = root_b / "doc.md"
+        target.write_text("content")
+
+        monkeypatch.setenv("HERMES_READ_SAFE_ROOTS", f"{root_a}:{root_b}")
+        monkeypatch.delenv("HERMES_READ_ALLOWED_FILES", raising=False)
+
+        assert get_read_block_error(str(target)) is None
+
+    # ── Case 2: outside roots ────────────────────────────────────────────────
+
+    def test_path_outside_root_denied(self, tmp_path: Path, monkeypatch):
+        """A path outside the configured roots is denied (returns error string)."""
+        safe_root = tmp_path / "workspace"
+        safe_root.mkdir()
+        outside = tmp_path / "secrets" / "key.pem"
+        outside.parent.mkdir()
+        outside.write_text("PRIVATE")
+
+        monkeypatch.setenv("HERMES_READ_SAFE_ROOTS", str(safe_root))
+        monkeypatch.delenv("HERMES_READ_ALLOWED_FILES", raising=False)
+
+        error = get_read_block_error(str(outside))
+        assert error is not None
+        assert "outside" in error.lower() or "denied" in error.lower()
+
+    def test_error_message_names_the_roots(self, tmp_path: Path, monkeypatch):
+        """The denial message should include the configured roots for usability."""
+        safe_root = tmp_path / "workspace"
+        safe_root.mkdir()
+
+        monkeypatch.setenv("HERMES_READ_SAFE_ROOTS", str(safe_root))
+        monkeypatch.delenv("HERMES_READ_ALLOWED_FILES", raising=False)
+
+        error = get_read_block_error("/etc/passwd")
+        assert error is not None
+        assert str(safe_root.resolve()) in error
+
+    def test_path_prefix_match_not_tricked_by_sibling(self, tmp_path: Path, monkeypatch):
+        """A path whose prefix matches but isn't under the root is denied.
+
+        E.g. safe_root=/tmp/workspace must not allow /tmp/workspace-evil/.
+        """
+        safe_root = tmp_path / "workspace"
+        safe_root.mkdir()
+        sibling = tmp_path / "workspace-evil"
+        sibling.mkdir()
+        target = sibling / "steal.txt"
+        target.write_text("no")
+
+        monkeypatch.setenv("HERMES_READ_SAFE_ROOTS", str(safe_root))
+        monkeypatch.delenv("HERMES_READ_ALLOWED_FILES", raising=False)
+
+        error = get_read_block_error(str(target))
+        assert error is not None, "Sibling directory must not pass the prefix check"
+
+    # ── Case 3: per-file allowlist ───────────────────────────────────────────
+
+    def test_allowed_file_bypasses_roots(self, tmp_path: Path, monkeypatch):
+        """A file listed in HERMES_READ_ALLOWED_FILES is readable even if
+        it lives outside every configured safe root."""
+        safe_root = tmp_path / "workspace"
+        safe_root.mkdir()
+        soul_file = tmp_path / "SOUL.md"
+        soul_file.write_text("soul content")
+
+        monkeypatch.setenv("HERMES_READ_SAFE_ROOTS", str(safe_root))
+        monkeypatch.setenv("HERMES_READ_ALLOWED_FILES", str(soul_file))
+
+        assert get_read_block_error(str(soul_file)) is None
+
+    def test_allowed_file_does_not_unlock_other_files(self, tmp_path: Path, monkeypatch):
+        """Allowlisting one file must not open up other files beside it."""
+        safe_root = tmp_path / "workspace"
+        safe_root.mkdir()
+        soul_file = tmp_path / "SOUL.md"
+        soul_file.write_text("soul content")
+        secret = tmp_path / "secret.env"
+        secret.write_text("TOKEN=abc")
+
+        monkeypatch.setenv("HERMES_READ_SAFE_ROOTS", str(safe_root))
+        monkeypatch.setenv("HERMES_READ_ALLOWED_FILES", str(soul_file))
+
+        error = get_read_block_error(str(secret))
+        assert error is not None
+
+    # ── Case 4: backwards compatibility ─────────────────────────────────────
+
+    def test_no_env_var_allows_all_reads(self, monkeypatch):
+        """When HERMES_READ_SAFE_ROOTS is unset, all reads are permitted."""
+        monkeypatch.delenv("HERMES_READ_SAFE_ROOTS", raising=False)
+        monkeypatch.delenv("HERMES_READ_ALLOWED_FILES", raising=False)
+
+        # Paths that would be denied when the allowlist is active
+        assert get_read_block_error("/etc/passwd") is None
+        assert get_read_block_error(os.path.expanduser("~/.ssh/id_rsa")) is None
+
+    def test_empty_env_var_allows_all_reads(self, monkeypatch):
+        """Blank HERMES_READ_SAFE_ROOTS (not just unset) also allows all reads."""
+        monkeypatch.setenv("HERMES_READ_SAFE_ROOTS", "")
+        monkeypatch.delenv("HERMES_READ_ALLOWED_FILES", raising=False)
+
+        assert get_read_block_error("/etc/passwd") is None
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v"])

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -951,6 +951,15 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
     try:
         offset, limit = normalize_search_pagination(offset, limit)
 
+        # ── Read-scope guard ──────────────────────────────────────────
+        # Honor HERMES_READ_SAFE_ROOTS allowlist on the search root and
+        # filter out matches that fall outside it.  This blocks searches
+        # rooted at sensitive paths (e.g. ~, /etc) and stops content
+        # leakage from files outside the allowlist via search results.
+        block_error = get_read_block_error(path)
+        if block_error:
+            return json.dumps({"error": block_error})
+
         # Track searches to detect *consecutive* repeated search loops.
         # Include pagination args so users can page through truncated
         # results without tripping the repeated-search guard.
@@ -990,7 +999,21 @@ def search_tool(pattern: str, target: str = "content", path: str = ".",
             pattern=pattern, path=path, target=target, file_glob=file_glob,
             limit=limit, offset=offset, output_mode=output_mode, context=context
         )
+        # Defense-in-depth: filter individual matches whose path falls
+        # outside the read allowlist.  Cheap hot-path check — only
+        # iterates when HERMES_READ_SAFE_ROOTS is set.
         if hasattr(result, 'matches'):
+            try:
+                from agent.file_safety import get_read_block_error as _scope_check
+                _filtered = []
+                for m in result.matches:
+                    m_path = getattr(m, 'path', None) or getattr(m, 'file', None)
+                    if m_path and _scope_check(str(m_path)):
+                        continue
+                    _filtered.append(m)
+                result.matches = _filtered
+            except Exception:
+                pass
             for m in result.matches:
                 if hasattr(m, 'content') and m.content:
                     m.content = redact_sensitive_text(m.content, code_file=True)


### PR DESCRIPTION
## Summary

- Adds env-var driven multi-root allowlist for native fs read tools, mirroring the existing `HERMES_WRITE_SAFE_ROOT` write-side pattern.
- Two new env vars: `HERMES_READ_SAFE_ROOTS` (colon-separated paths, like `PATH`) and `HERMES_READ_ALLOWED_FILES` (specific files outside the roots).
- When unset → current unrestricted behavior (fully backwards compatible). When set → reads outside the allowlist return a clean denial via the existing `get_read_block_error()` helper.

## Why

Running Hermes with godmode + full host fs access leaves a gap: native `read_file` and `search` tools are unrestricted while writes already have `HERMES_WRITE_SAFE_ROOT`. A successful prompt-injection through email/document content could read SSH keys, secret env files, etc. This closes that gap symmetrically with the write side.

## Changes

- **`agent/file_safety.py`** — added `get_read_safe_roots()` and `get_read_allowed_files()` helpers; extended `get_read_block_error()` to enforce the allowlist after the existing skills/.hub cache check (~65 lines)
- **`tools/file_tools.py`** — wired `search_tool` (was completely ungated) at both the search-root and per-match-path layers; `read_file_tool` already called `get_read_block_error()` so it inherits the new gate automatically (~23 lines)

~88 lines total, scoped to two files.

## Test plan

Added `tests/tools/test_file_read_allowlist.py` (13 pytest cases, mirrors `test_file_write_safety.py` style):

- [x] Path inside configured root → allowed
- [x] Root directory itself → allowed
- [x] Nested path inside root → allowed
- [x] Multi-root: path in second root → allowed
- [x] Path outside root → clean denial
- [x] Denial message names the configured roots (usability)
- [x] Sibling-directory prefix trick (`/tmp/workspace-evil` vs `/tmp/workspace`) → denied
- [x] `HERMES_READ_ALLOWED_FILES`: specific file outside root → allowed
- [x] `HERMES_READ_ALLOWED_FILES`: does not unlock adjacent files
- [x] `HERMES_READ_SAFE_ROOTS` unset → all reads allowed (backwards compat)
- [x] `HERMES_READ_SAFE_ROOTS` blank string → all reads allowed (backwards compat)
- [x] `get_read_safe_roots()` unit tests (empty segments, multi-root, tilde expansion)
- [x] `get_read_allowed_files()` unit tests (colon-separated, resolved paths)

Validated locally on a personal VPS deployment running v0.13.0 + this patch with `HERMES_READ_SAFE_ROOTS=/home/gian/.hermes/workspace:/home/gian/gianspedia`. 11/11 manual test cases pass including denial of `~/.ssh`, `/etc/passwd`, and secret env files. Search tool (`search_tool`) correctly denied at search-root level and filters out out-of-scope matches.