### PR TITLE
feat(cron): expose --model/--provider/--base-url on cron CLI + add `cron show`

### DIFF
--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -175,6 +175,9 @@ def cron_create(args):
         script=getattr(args, "script", None),
         workdir=getattr(args, "workdir", None),
         no_agent=getattr(args, "no_agent", False) or None,
+        model=getattr(args, "model", None),
+        provider=getattr(args, "provider", None),
+        base_url=getattr(args, "base_url", None),
     )
     if not result.get("success"):
         print(color(f"Failed to create job: {result.get('error', 'unknown error')}", Colors.RED))
@@ -231,6 +234,9 @@ def cron_edit(args):
         script=getattr(args, "script", None),
         workdir=getattr(args, "workdir", None),
         no_agent=getattr(args, "no_agent", None),
+        model=getattr(args, "model", None),
+        provider=getattr(args, "provider", None),
+        base_url=getattr(args, "base_url", None),
     )
     if not result.get("success"):
         print(color(f"Failed to update job: {result.get('error', 'unknown error')}", Colors.RED))
@@ -250,6 +256,57 @@ def cron_edit(args):
         print("  Mode: no-agent (script stdout delivered directly)")
     if updated.get("workdir"):
         print(f"  Workdir: {updated['workdir']}")
+    if updated.get("model"):
+        print(f"  Model: {updated['model']}")
+    if updated.get("provider"):
+        print(f"  Provider: {updated['provider']}")
+    if updated.get("base_url"):
+        print(f"  Base URL: {updated['base_url']}")
+    return 0
+
+
+def cron_show(args):
+    from cron.jobs import get_job
+
+    job = get_job(args.job_id)
+    if not job:
+        print(color(f"Job not found: {args.job_id}", Colors.RED))
+        return 1
+
+    repeat_info = job.get("repeat") or {}
+    repeat_times = repeat_info.get("times")
+    repeat_completed = repeat_info.get("completed", 0)
+    repeat_str = f"{repeat_completed}/{repeat_times}" if repeat_times else f"{repeat_completed}/∞"
+
+    skills = job.get("skills") or ([job["skill"]] if job.get("skill") else [])
+    state = job.get("state", "scheduled" if job.get("enabled", True) else "paused")
+
+    print()
+    print(color(f"Job {job.get('id', '?')}", Colors.CYAN))
+    fields = [
+        ("Name", job.get("name") or "(unnamed)"),
+        ("Schedule", job.get("schedule_display") or "?"),
+        ("State", state),
+        ("Skills", ", ".join(skills) if skills else "(none)"),
+        ("Deliver", job.get("deliver", "local")),
+        ("Repeat", repeat_str),
+        ("Model", job.get("model") or "(default)"),
+        ("Provider", job.get("provider") or "(default)"),
+        ("Base URL", job.get("base_url") or "(default)"),
+        ("Script", job.get("script") or "(none)"),
+        ("No-agent", "yes" if job.get("no_agent") else "no"),
+        ("Workdir", job.get("workdir") or "(none)"),
+        ("Next run", job.get("next_run_at") or "(none)"),
+        ("Last run", job.get("last_run_at") or "(never)"),
+        ("Last status", job.get("last_status") or "(none)"),
+    ]
+    for label, value in fields:
+        print(f"  {label:<12} {value}")
+    prompt = job.get("prompt") or ""
+    if prompt:
+        preview = prompt if len(prompt) <= 200 else prompt[:200] + "…"
+        print(f"  {'Prompt':<12} {preview}")
+    print()
     return 0
 
 
@@ -289,6 +346,9 @@ def cron_command(args):
 
     if subcmd == "edit":
         return cron_edit(args)
+
+    if subcmd == "show":
+        return cron_show(args)
 
     if subcmd == "pause":
         return _job_action("pause", args.job_id, "Paused")

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9109,6 +9109,19 @@ def main():
         "--workdir",
         help="Absolute path for the job to run from. Injects AGENTS.md / CLAUDE.md / .cursorrules from that directory and uses it as the cwd for terminal/file/code_exec tools. Omit to preserve old behaviour (no project context files).",
     )
+    cron_create.add_argument(
+        "--model",
+        help="Per-job model override (e.g. claude-opus-4-7). Omit to use the current default.",
+    )
+    cron_create.add_argument(
+        "--provider",
+        help="Per-job provider override (e.g. anthropic, openrouter, custom:<name>).",
+    )
+    cron_create.add_argument(
+        "--base-url",
+        dest="base_url",
+        help="Per-job base URL for OpenAI-compatible endpoints.",
+    )
 
     # cron edit
     cron_edit = cron_subparsers.add_parser(
@@ -9173,6 +9186,25 @@ def main():
         "--workdir",
         help="Absolute path for the job to run from (injects AGENTS.md etc. and sets terminal cwd). Pass empty string to clear.",
     )
+    cron_edit.add_argument(
+        "--model",
+        help="Set per-job model override. Pass empty string to clear.",
+    )
+    cron_edit.add_argument(
+        "--provider",
+        help="Set per-job provider. Pass empty string to clear.",
+    )
+    cron_edit.add_argument(
+        "--base-url",
+        dest="base_url",
+        help="Set per-job base URL. Pass empty string to clear.",
+    )
+
+    # cron show
+    cron_show_p = cron_subparsers.add_parser(
+        "show", help="Show full details of a scheduled job"
+    )
+    cron_show_p.add_argument("job_id", help="Job ID to show")
 
     # lifecycle actions
     cron_pause = cron_subparsers.add_parser("pause", help="Pause a scheduled job")

--- a/tests/hermes_cli/test_cron.py
+++ b/tests/hermes_cli/test_cron.py
@@ -105,3 +105,93 @@ class TestCronCommandLifecycle:
         assert len(jobs) == 1
         assert jobs[0]["skills"] == ["blogwatcher", "maps"]
         assert jobs[0]["name"] == "Skill combo"
+
+    def test_create_with_model_override(self, tmp_cron_dir, capsys):
+        cron_command(
+            Namespace(
+                cron_command="create",
+                schedule="every 1h",
+                prompt="Pinned routing",
+                name=None,
+                deliver=None,
+                repeat=None,
+                skill=None,
+                skills=None,
+                model="claude-opus-4-7",
+                provider="anthropic",
+                base_url=None,
+            )
+        )
+        jobs = list_jobs()
+        assert len(jobs) == 1
+        assert jobs[0]["model"] == "claude-opus-4-7"
+        assert jobs[0]["provider"] == "anthropic"
+        assert jobs[0]["base_url"] is None
+
+    def test_edit_can_set_and_clear_model_override(self, tmp_cron_dir, capsys):
+        job = create_job(prompt="Routing target", schedule="every 1h")
+
+        cron_command(
+            Namespace(
+                cron_command="edit",
+                job_id=job["id"],
+                schedule=None,
+                prompt=None,
+                name=None,
+                deliver=None,
+                repeat=None,
+                skill=None,
+                skills=None,
+                clear_skills=False,
+                model="claude-opus-4-7",
+                provider="anthropic",
+                base_url="https://api.anthropic.com",
+            )
+        )
+        updated = get_job(job["id"])
+        assert updated["model"] == "claude-opus-4-7"
+        assert updated["provider"] == "anthropic"
+        assert updated["base_url"] == "https://api.anthropic.com"
+
+        cron_command(
+            Namespace(
+                cron_command="edit",
+                job_id=job["id"],
+                schedule=None,
+                prompt=None,
+                name=None,
+                deliver=None,
+                repeat=None,
+                skill=None,
+                skills=None,
+                clear_skills=False,
+                model="",
+                provider="",
+                base_url="",
+            )
+        )
+        cleared = get_job(job["id"])
+        assert cleared["model"] is None
+        assert cleared["provider"] is None
+        assert cleared["base_url"] is None
+
+    def test_show_renders_routing_fields(self, tmp_cron_dir, capsys):
+        job = create_job(
+            prompt="Inspect me",
+            schedule="every 1h",
+            model="claude-opus-4-7",
+            provider="anthropic",
+        )
+        rc = cron_command(Namespace(cron_command="show", job_id=job["id"]))
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert job["id"] in out
+        assert "claude-opus-4-7" in out
+        assert "anthropic" in out
+        assert "Inspect me" in out
+
+    def test_show_unknown_job_returns_error(self, tmp_cron_dir, capsys):
+        rc = cron_command(Namespace(cron_command="show", job_id="bogus"))
+        assert rc == 1
+        out = capsys.readouterr().out
+        assert "not found" in out.lower()


### PR DESCRIPTION
# feat(cron): expose `--model` / `--provider` / `--base-url` on cron CLI + add `cron show`

## Problem

The cron job model already persists `model`, `provider`, and `base_url` overrides — `cron/jobs.py::create_job` accepts and stores them, and `tools/cronjob_tools.py` wires them through on the `update` action. But the user-facing `hermes cron create` and `hermes cron edit` argparsers never exposed flags for them. Users with stale routing on existing jobs (e.g. a retired provider or a renamed model id) had to either hand-edit `~/.hermes/cron/jobs.json` or delete and recreate the job — losing the `job_id` and the run history. There was also no `cron show` command, so inspecting a single job's full routing/skill/script state required reading the JSON file directly.

## Reproduce

These commands prove the gap on `main` prior to this PR (`faa13e49`):

```bash
# 1. Create a job — no way to pin model/provider at creation time
hermes cron create "ping" --schedule "0 9 * * *" --model anthropic/claude-opus-4-7
# argparse error: unrecognized arguments: --model anthropic/claude-opus-4-7

# 2. Same for provider and base-url
hermes cron create "ping" --schedule "0 9 * * *" --provider anthropic
# argparse error: unrecognized arguments: --provider anthropic

# 3. Editing a stale routing identifier on an existing job is impossible via CLI
hermes cron edit JOB_ID --model anthropic/claude-sonnet-4-6
# argparse error: unrecognized arguments: --model anthropic/claude-sonnet-4-6

# 4. There is no way to inspect a single job's full state
hermes cron show JOB_ID
# argparse error: invalid choice: 'show'

# Workaround today: hand-edit ~/.hermes/cron/jobs.json (violates the rule
# that cron state is platform-managed) or delete + recreate (loses job_id
# and run history).
```

## Proposed fix

Pure CLI plumbing — no schema change, no data-layer change.

- Add `--model`, `--provider`, `--base-url` to both `cron create` and `cron edit` argparsers.
- Forward them as kwargs through `cron_create()` and `cron_edit()` in `hermes_cli/cron.py` to the existing data-layer methods.
- Empty string clears the override on edit (`--model ""`), matching the existing `--script ""` / `--workdir ""` convention via `_normalize_optional_job_value`.
- Add a `cron show <job_id>` subcommand that prints the full job record, including the routing fields, schedule, skills, script, workdir, and recent run summary.
- Print routing fields in the `cron edit` success summary so a user who just changed routing sees confirmation.

## Why

Without this, when a model id or provider slug changes (model rename, provider deprecation, base-url migration to a different proxy), every existing cron job continues to attempt the stale identifier and dies at runtime with `No LLM provider configured` or a 404 from the wrong endpoint. Recreating the job is the only sanctioned recovery path, which also drops the human-meaningful `job_id` and the historical run log. Exposing the flags closes that loop and makes the CLI consistent with the data layer that already supports the override.

## Testing

Four new tests in `tests/hermes_cli/test_cron.py` (all passing):

- `test_create_with_model_override` — `cron create --model …` persists the override on the new job.
- `test_edit_can_set_and_clear_model_override` — `cron edit --model X` sets the override; `cron edit --model ""` clears it back to `None`.
- `test_show_renders_routing_fields` — `cron show <id>` prints `model`, `provider`, and `base_url` for a job that has them set.
- `test_show_unknown_job_returns_error` — `cron show <bad-id>` exits non-zero with a clear message.

Full file run:

```
$ ./venv/bin/python -m pytest tests/hermes_cli/test_cron.py -v
============================== 7 passed in 0.75s ===============================
```

All pre-existing tests in `test_cron.py` still pass. No other test files touched.

## Out of scope

- Provider validation (rejecting unknown provider slugs at parse time) — deferred to a separate PR; today the data layer accepts any string and the runtime is the source of truth.
- `--json` output mode for `cron show` — current implementation is human-readable only; JSON can be added later if needed.
- `--verbose` mode for `cron list` to inline the same routing fields — out of scope here; `cron show` covers the per-job inspection case.

## Risk

None of significance. Pure additive plumbing:

- No schema migration. `model`, `provider`, `base_url` columns/keys already exist on the job model.
- No change to defaults — omitting the new flags preserves today's behavior exactly.
- Empty-string-clears semantics matches the existing `--script ""` / `--workdir ""` convention, so no new mental model for users.
- `cron show` is a read-only subcommand; it cannot mutate job state.
