### PR TITLE
Fix ACP memory provider shutdown flush

### DIFF
--- a/acp_adapter/entry.py
+++ b/acp_adapter/entry.py
@@ -265,6 +265,11 @@ def main(argv: list[str] | None = None) -> None:
     except Exception:
         logger.exception("ACP agent crashed")
         sys.exit(1)
+    finally:
+        try:
+            agent.shutdown()
+        except Exception:
+            logger.debug("ACP agent shutdown failed", exc_info=True)
 
 
 if __name__ == "__main__":

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -569,6 +569,10 @@ class HermesACPAgent(acp.Agent):
         policy = self._MODE_TO_EDIT_APPROVAL_POLICY.get(mode, self._EDIT_APPROVAL_POLICY_DEFAULT)
         return policy, state.cwd
 
+    def shutdown(self) -> None:
+        """Flush per-session resources before the ACP process exits."""
+        self.session_manager.shutdown_sessions()
+
     @staticmethod
     def _encode_model_choice(provider: str | None, model: str | None) -> str:
         """Encode a model selection so ACP clients can keep provider context."""

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -385,6 +385,33 @@ class SessionManager:
         if state is not None:
             self._persist(state)
 
+    def shutdown_sessions(self) -> None:
+        """Gracefully shut down every in-memory session's agent.
+
+        The ACP server can be a short-lived process (for example one-shot
+        stdio runners).  In that mode the process may exit immediately after
+        returning the final PromptResponse, while memory providers still have
+        best-effort background work queued for the completed turn.  Calling
+        AIAgent.shutdown_memory_provider() gives providers a chance to flush
+        that work and close clients before interpreter teardown.
+        """
+        with self._lock:
+            states = list(self._sessions.values())
+
+        for state in states:
+            agent = state.agent
+            shutdown = getattr(agent, "shutdown_memory_provider", None)
+            if not callable(shutdown):
+                continue
+            try:
+                shutdown(state.history)
+            except Exception:
+                logger.debug(
+                    "Failed to shut down ACP session %s memory provider",
+                    state.session_id,
+                    exc_info=True,
+                )
+
     # ---- persistence via SessionDB ------------------------------------------
 
     def _get_db(self):

--- a/tests/acp_adapter/test_acp_shutdown.py
+++ b/tests/acp_adapter/test_acp_shutdown.py
@@ -1,0 +1,110 @@
+import acp
+
+from acp_adapter import entry, server
+from acp_adapter.server import HermesACPAgent
+from acp_adapter.session import SessionManager
+
+
+class NoopDb:
+    def get_session(self, *_args, **_kwargs):
+        return None
+
+    def create_session(self, *_args, **_kwargs):
+        return None
+
+    def update_session(self, *_args, **_kwargs):
+        return None
+
+
+class ShutdownAgent:
+    def __init__(self):
+        self.model = "fake-model"
+        self.shutdown_calls = []
+
+    def shutdown_memory_provider(self, messages=None):
+        self.shutdown_calls.append(list(messages or []))
+
+
+class RaisingShutdownAgent(ShutdownAgent):
+    def shutdown_memory_provider(self, messages=None):
+        super().shutdown_memory_provider(messages)
+        raise RuntimeError("boom")
+
+
+class EntrypointAgent:
+    def __init__(self):
+        self.shutdown_calls = 0
+
+    def shutdown(self):
+        self.shutdown_calls += 1
+
+
+def prepare_entrypoint(monkeypatch, agent, run_agent):
+    monkeypatch.setattr(entry, "_setup_logging", lambda: None)
+    monkeypatch.setattr(entry, "_load_env", lambda: None)
+    monkeypatch.setattr(server, "HermesACPAgent", lambda: agent)
+    monkeypatch.setattr(acp, "run_agent", run_agent)
+
+
+def test_session_manager_shutdown_sessions_flushes_agent_memory_with_history():
+    fake = ShutdownAgent()
+    manager = SessionManager(agent_factory=lambda **_kwargs: fake, db=NoopDb())
+    state = manager.create_session(cwd=".")
+    state.history = [
+        {"role": "user", "content": "remember this"},
+        {"role": "assistant", "content": "stored"},
+    ]
+
+    manager.shutdown_sessions()
+
+    assert fake.shutdown_calls == [state.history]
+
+
+def test_acp_agent_shutdown_delegates_to_session_manager():
+    fake = ShutdownAgent()
+    manager = SessionManager(agent_factory=lambda **_kwargs: fake, db=NoopDb())
+    state = manager.create_session(cwd=".")
+    state.history = [{"role": "assistant", "content": "done"}]
+    acp_agent = HermesACPAgent(session_manager=manager)
+
+    acp_agent.shutdown()
+
+    assert fake.shutdown_calls == [state.history]
+
+
+def test_session_manager_shutdown_sessions_is_best_effort():
+    fake = RaisingShutdownAgent()
+    manager = SessionManager(agent_factory=lambda **_kwargs: fake, db=NoopDb())
+    manager.create_session(cwd=".")
+
+    manager.shutdown_sessions()
+
+    assert len(fake.shutdown_calls) == 1
+
+
+def test_entrypoint_shutdown_runs_after_normal_return(monkeypatch):
+    agent = EntrypointAgent()
+
+    async def run_agent(actual_agent, *, use_unstable_protocol):
+        assert actual_agent is agent
+        assert use_unstable_protocol is True
+
+    prepare_entrypoint(monkeypatch, agent, run_agent)
+
+    entry.main([])
+
+    assert agent.shutdown_calls == 1
+
+
+def test_entrypoint_shutdown_runs_after_keyboard_interrupt(monkeypatch):
+    agent = EntrypointAgent()
+
+    async def run_agent(_agent, *, use_unstable_protocol):
+        assert use_unstable_protocol is True
+        raise KeyboardInterrupt
+
+    prepare_entrypoint(monkeypatch, agent, run_agent)
+
+    entry.main([])
+
+    assert agent.shutdown_calls == 1


### PR DESCRIPTION
## Summary
- add a graceful ACP adapter shutdown hook that flushes every in-memory session's memory provider before process exit
- call that hook from the ACP entrypoint after `acp.run_agent(...)` returns or is interrupted
- add tests covering shutdown delegation, transcript forwarding, and best-effort exception handling

## Why
Short-lived ACP stdio runners can exit immediately after returning the final `PromptResponse`. Hindsight auto-retain runs in a background sync thread, so without ACP shutdown flushing, that thread can race Python interpreter teardown and fail with `cannot schedule new futures after interpreter shutdown` / unclosed aiohttp session warnings.

This keeps `auto_retain` enabled and gives providers a chance to finish the retain request and close clients cleanly at the actual ACP process boundary.

## Test Plan
- `uv run ruff check acp_adapter/entry.py acp_adapter/server.py acp_adapter/session.py tests/acp_adapter/test_acp_shutdown.py`
- `uv run pytest tests/acp_adapter/test_acp_shutdown.py tests/acp_adapter/test_acp_commands.py -q -o 'addopts='`
