### PR TITLE
Fix ACP resume for missing sessions

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -983,7 +983,7 @@ class HermesACPAgent(acp.Agent):
         state = self.session_manager.update_cwd(session_id, cwd)
         if state is None:
             logger.warning("resume_session: session %s not found, creating new", session_id)
-            state = self.session_manager.create_session(cwd=cwd)
+            state = self.session_manager.create_session(cwd=cwd, session_id=session_id)
         await self._register_session_mcp_servers(state, mcp_servers)
         logger.info("Resumed session %s", state.session_id)
         self._schedule_history_replay(state)

--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -207,12 +207,18 @@ class SessionManager:
 
     # ---- public API ---------------------------------------------------------
 
-    def create_session(self, cwd: str = ".") -> SessionState:
-        """Create a new session with a unique ID and a fresh AIAgent."""
+    def create_session(self, cwd: str = ".", session_id: str | None = None) -> SessionState:
+        """Create a new session with a fresh AIAgent.
+
+        When an ACP client resumes an unknown session id, the protocol response
+        has no field for returning a replacement id.  In that case callers can
+        pass the requested id here so the subsequent prompt using that id still
+        resolves to the newly-created session.
+        """
         import threading
 
         cwd = _translate_acp_cwd(cwd)
-        session_id = str(uuid.uuid4())
+        session_id = str(session_id or uuid.uuid4()).strip() or str(uuid.uuid4())
         agent = self._make_agent(session_id=session_id, cwd=cwd)
         state = SessionState(
             session_id=session_id,

--- a/tests/acp_adapter/test_acp_resume_missing_session.py
+++ b/tests/acp_adapter/test_acp_resume_missing_session.py
@@ -1,0 +1,53 @@
+import pytest
+
+from acp_adapter.server import HermesACPAgent
+from acp_adapter.session import SessionManager
+
+
+class NoopDb:
+    def get_session(self, *_args, **_kwargs):
+        return None
+
+    def create_session(self, *_args, **_kwargs):
+        return None
+
+    def update_session(self, *_args, **_kwargs):
+        return None
+
+
+class DummyAgent:
+    def __init__(self, session_id: str, cwd: str):
+        self.session_id = session_id
+        self.cwd = cwd
+        self.model = "dummy-model"
+        self.provider = "dummy-provider"
+        self.conversation_history = []
+
+
+def make_manager() -> SessionManager:
+    return SessionManager(
+        agent_factory=lambda: DummyAgent("unused", "."),
+        db=NoopDb(),
+    )
+
+
+def test_create_session_can_use_client_supplied_session_id():
+    manager = make_manager()
+
+    state = manager.create_session(cwd="/tmp/project", session_id="client-session-id")
+
+    assert state.session_id == "client-session-id"
+    assert manager.get_session("client-session-id") is state
+
+
+@pytest.mark.asyncio
+async def test_resume_missing_session_preserves_requested_session_id():
+    manager = make_manager()
+    agent = HermesACPAgent(session_manager=manager)
+
+    await agent.resume_session(cwd="/tmp/project", session_id="client-session-id")
+
+    state = manager.get_session("client-session-id")
+    assert state is not None
+    assert state.session_id == "client-session-id"
+    assert state.cwd == "/tmp/project"

--- a/tests/acp_adapter/test_acp_resume_missing_session.py
+++ b/tests/acp_adapter/test_acp_resume_missing_session.py
@@ -1,4 +1,5 @@
 import pytest
+from acp.schema import TextContentBlock
 
 from acp_adapter.server import HermesACPAgent
 from acp_adapter.session import SessionManager
@@ -22,6 +23,14 @@ class DummyAgent:
         self.model = "dummy-model"
         self.provider = "dummy-provider"
         self.conversation_history = []
+        self.runs = []
+
+    def run_conversation(self, *, user_message, conversation_history, **_kwargs):
+        self.runs.append(user_message)
+        messages = list(conversation_history or [])
+        messages.append({"role": "user", "content": user_message})
+        messages.append({"role": "assistant", "content": "done"})
+        return {"final_response": "done", "messages": messages}
 
 
 def make_manager() -> SessionManager:
@@ -51,3 +60,11 @@ async def test_resume_missing_session_preserves_requested_session_id():
     assert state is not None
     assert state.session_id == "client-session-id"
     assert state.cwd == "/tmp/project"
+
+    response = await agent.prompt(
+        session_id="client-session-id",
+        prompt=[TextContentBlock(type="text", text="continue the task")],
+    )
+
+    assert response.stop_reason == "end_turn"
+    assert state.agent.runs == ["continue the task"]


### PR DESCRIPTION
## Summary
- preserve the ACP client-supplied session id when `session/resume` cannot find a persisted session
- ensure the next `session/prompt` against that same id resolves instead of returning `refusal`
- add regression coverage for missing-session resume behavior

## Test Plan
- `uv run ruff check acp_adapter/session.py acp_adapter/server.py tests/acp_adapter/test_acp_resume_missing_session.py`
- `uv run pytest tests/acp_adapter/test_acp_resume_missing_session.py tests/acp_adapter/test_acp_commands.py -q -o 'addopts='`

Both commands pass locally. `uv` still emits the existing `exclude-newer = "7 days"` pyproject warning before running.
