### PR TITLE
fix(skills): prevent path traversal in rglob calls across skills loader

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -203,13 +203,20 @@ def _build_skill_message(
             supporting.extend(entries)
 
     if not supporting and skill_dir:
-        for subdir in ("references", "templates", "scripts", "assets"):
-            subdir_path = skill_dir / subdir
-            if subdir_path.exists():
-                for f in sorted(subdir_path.rglob("*")):
-                    if f.is_file() and not f.is_symlink():
-                        rel = str(f.relative_to(skill_dir))
-                        supporting.append(rel)
+        try:
+            if not str(skill_dir.resolve()).startswith(str(SKILLS_DIR.resolve())):
+                skill_dir = None
+        except (OSError, ValueError):
+            skill_dir = None
+
+        if skill_dir:
+            for subdir in ("references", "templates", "scripts", "assets"):
+                subdir_path = skill_dir / subdir
+                if subdir_path.exists():
+                    for f in sorted(subdir_path.rglob("*")):
+                        if f.is_file() and not f.is_symlink():
+                            rel = str(f.relative_to(skill_dir))
+                            supporting.append(rel)
 
     if supporting and skill_dir:
         try:

--- a/hermes_cli/skills_hub.py
+++ b/hermes_cli/skills_hub.py
@@ -1068,6 +1068,15 @@ def do_publish(skill_path: str, target: str = "github", repo: str = "",
     # Resolve relative to skills dir if not absolute
     if not path.is_absolute():
         path = SKILLS_DIR / path
+
+    try:
+        if not str(path.resolve()).startswith(str(SKILLS_DIR.resolve())):
+            c.print(f"[bold red]Error:[/] Invalid skill path: {path}\n")
+            return
+    except (OSError, ValueError):
+        c.print(f"[bold red]Error:[/] Invalid skill path: {path}\n")
+        return
+
     if not path.exists() or not (path / "SKILL.md").exists():
         c.print(f"[bold red]Error:[/] No SKILL.md found at {path}\n")
         return
@@ -1129,6 +1138,13 @@ def _github_publish(skill_path: Path, skill_name: str, target_repo: str,
                     auth) -> tuple:
     """Create a PR to a GitHub repo with the skill. Returns (success, message)."""
     import httpx
+    from tools.skills_hub import SKILLS_DIR
+
+    try:
+        if not str(skill_path.resolve()).startswith(str(SKILLS_DIR.resolve())):
+            return False, "Invalid skill path: outside the skills directory"
+    except (OSError, ValueError):
+        return False, f"Invalid skill path: {skill_path}"
 
     headers = auth.get_headers()
 

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 
 import tools.skills_tool as skills_tool_module
 from agent.skill_commands import (
+    _build_skill_message,
     build_preloaded_skills_prompt,
     build_skill_invocation_message,
     resolve_skill_command_key,
@@ -766,3 +767,23 @@ class TestInlineShellExpansion:
         # The command's intended stdout never made it through — only the
         # timeout marker (which echoes the command text) survives.
         assert "DYN_MARKER" not in msg.replace("sleep 5 && printf DYN_MARKER", "")
+
+
+class TestBuildSkillMessageTraversalGuard:
+    """Regression tests for supporting-files rglob guard (#18693)."""
+
+    def test_supporting_files_blocked_outside_skills_dir(self, tmp_path):
+        """_build_skill_message must not rglob supporting files outside SKILLS_DIR."""
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        evil_dir = tmp_path / "evil"
+        evil_dir.mkdir()
+        (evil_dir / "references").mkdir()
+        (evil_dir / "references" / "secret.md").write_text("SECRET")
+
+        loaded_skill = {"content": "test", "linked_files": {}}
+
+        with patch("tools.skills_tool.SKILLS_DIR", skills_dir):
+            msg = _build_skill_message(loaded_skill, evil_dir, activation_note="note")
+            assert "SECRET" not in msg
+            assert "references/secret.md" not in msg

--- a/tests/hermes_cli/test_skills_hub.py
+++ b/tests/hermes_cli/test_skills_hub.py
@@ -1,11 +1,12 @@
 from io import StringIO
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 from rich.console import Console
 
 from cli import ChatConsole
-from hermes_cli.skills_hub import do_check, do_install, do_list, do_update, handle_skills_slash
+from hermes_cli.skills_hub import do_check, do_install, do_list, do_publish, do_update, handle_skills_slash
 
 
 class _DummyLockFile:
@@ -524,3 +525,21 @@ def test_existing_categories_returns_empty_when_skills_dir_missing(monkeypatch, 
 
     from hermes_cli.skills_hub import _existing_categories
     assert _existing_categories() == []
+
+
+def test_do_publish_rejects_traversal_path(hub_env, monkeypatch):
+    """do_publish must reject paths resolving outside SKILLS_DIR."""
+    sink = StringIO()
+    console = Console(file=sink, force_terminal=False, color_system=None)
+    do_publish("../../etc/passwd", target="github", repo="owner/repo", console=console)
+    assert "Invalid skill path" in sink.getvalue()
+
+
+def test_github_publish_rejects_traversal_path(hub_env, monkeypatch):
+    """_github_publish must reject skill_path outside SKILLS_DIR."""
+    from hermes_cli.skills_hub import _github_publish
+
+    auth = object()
+    success, msg = _github_publish(Path("../../etc/passwd"), "evil", "owner/repo", auth)
+    assert success is False
+    assert "Invalid skill path" in msg

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -1076,3 +1076,51 @@ Do the legacy thing.
         assert result["setup_needed"] is False
         assert result["missing_required_environment_variables"] == []
         assert result["readiness_status"] == "available"
+
+
+class TestSkillViewRglobTraversalGuard:
+    """Regression tests for rglob path injection guards (#18693)."""
+
+    def test_legacy_rglob_skips_symlink_escaping_skills_dir(self, tmp_path):
+        """rglob should skip files in subdirs that resolve outside SKILLS_DIR."""
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+        subdir = skills_dir / "category"
+        subdir.mkdir()
+
+        outside = tmp_path / "evil.md"
+        outside.write_text("SECRET")
+        symlink_file = subdir / "evil.md"
+        try:
+            symlink_file.symlink_to(outside)
+        except OSError:
+            pytest.skip("Symlinks not supported")
+
+        assert not (skills_dir / "evil.md").exists()
+
+        with patch("tools.skills_tool.SKILLS_DIR", skills_dir):
+            result = json.loads(skill_view("evil"))
+            assert result["success"] is False
+            assert "not found" in result["error"].lower()
+
+    def test_file_listing_blocks_skill_dir_outside(self, tmp_path):
+        """file listing blocks skill_dir that resolves outside SKILLS_DIR."""
+        skills_dir = tmp_path / "skills"
+        skills_dir.mkdir()
+
+        evil_target = tmp_path / "evil"
+        evil_target.mkdir()
+        (evil_target / "SKILL.md").write_text("---\nname: evil\n---")
+        (evil_target / "references").mkdir()
+        (evil_target / "references" / "secret.md").write_text("SECRET")
+
+        evil_link = skills_dir / "evil"
+        try:
+            evil_link.symlink_to(evil_target, target_is_directory=True)
+        except OSError:
+            pytest.skip("Symlinks not supported")
+
+        with patch("tools.skills_tool.SKILLS_DIR", skills_dir):
+            result = json.loads(skill_view("evil", file_path="nonexistent"))
+            assert result["success"] is False
+            assert "SECRET" not in json.dumps(result)

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -994,6 +994,11 @@ def skill_view(
         if not skill_md:
             for search_dir in all_dirs:
                 for found_md in search_dir.rglob(f"{name}.md"):
+                    try:
+                        if not str(found_md.resolve()).startswith(str(search_dir.resolve())):
+                            continue
+                    except (OSError, ValueError):
+                        continue
                     if found_md.name != "SKILL.md":
                         skill_md = found_md
                         break
@@ -1122,27 +1127,34 @@ def skill_view(
                 }
 
                 # Scan for all readable files
-                for f in skill_dir.rglob("*"):
-                    if f.is_file() and f.name != "SKILL.md":
-                        rel = str(f.relative_to(skill_dir))
-                        if rel.startswith("references/"):
-                            available_files["references"].append(rel)
-                        elif rel.startswith("templates/"):
-                            available_files["templates"].append(rel)
-                        elif rel.startswith("assets/"):
-                            available_files["assets"].append(rel)
-                        elif rel.startswith("scripts/"):
-                            available_files["scripts"].append(rel)
-                        elif f.suffix in [
-                            ".md",
-                            ".py",
-                            ".yaml",
-                            ".yml",
-                            ".json",
-                            ".tex",
-                            ".sh",
-                        ]:
-                            available_files["other"].append(rel)
+                try:
+                    if not str(skill_dir.resolve()).startswith(str(SKILLS_DIR.resolve())):
+                        skill_dir = None
+                except (OSError, ValueError):
+                    skill_dir = None
+
+                if skill_dir:
+                    for f in skill_dir.rglob("*"):
+                        if f.is_file() and f.name != "SKILL.md":
+                            rel = str(f.relative_to(skill_dir))
+                            if rel.startswith("references/"):
+                                available_files["references"].append(rel)
+                            elif rel.startswith("templates/"):
+                                available_files["templates"].append(rel)
+                            elif rel.startswith("assets/"):
+                                available_files["assets"].append(rel)
+                            elif rel.startswith("scripts/"):
+                                available_files["scripts"].append(rel)
+                            elif f.suffix in [
+                                ".md",
+                                ".py",
+                                ".yaml",
+                                ".yml",
+                                ".json",
+                                ".tex",
+                                ".sh",
+                            ]:
+                                available_files["other"].append(rel)
 
                 # Remove empty categories
                 available_files = {k: v for k, v in available_files.items() if v}


### PR DESCRIPTION
## Summary
Fixes path traversal vulnerability in skills loader rglob calls reported in #18693.

---

## Root cause
Four places in the skills loader used `rglob()` with user-controlled input without validating that resolved paths stay within `SKILLS_DIR`. An attacker could inject path patterns or symlinks to read arbitrary files outside the skills directory.

---

## Reproduction scenario
1. A user adds an external skills directory by cloning a third-party skill repo
2. The cloned repo contains a symlink inside a skill subdirectory pointing outside the skills directory: `legit-skill/escape -> /home/user/secret-project/`
3. The user or agent calls `skill_view("README")`
4. Before fix: `rglob("README.md")` follows the symlink into `/home/user/secret-project/`, finds `README.md` there, and returns its contents to the agent. File content from outside the skills directory is leaked.
5. After fix: the `resolve() + startswith()` guard detects that the resolved path is outside `SKILLS_DIR` and skips the file, returning "Skill not found"

---

## What changed

**`tools/skills_tool.py`**
- Legacy flat `.md` file discovery: skip files that resolve outside `search_dir` via `resolve() + startswith()`
- File listing scan: bounds check `skill_dir` against `SKILLS_DIR` before rglob

**`agent/skill_commands.py`**
- Supporting files scan: bounds check `skill_dir` against `SKILLS_DIR` before rglob

**`hermes_cli/skills_hub.py`**
- `do_publish`: reject skill paths resolving outside `SKILLS_DIR` before processing
- `_github_publish`: defense-in-depth guard at entry point

All fixes use the same `resolve() + startswith()` pattern already present in `tools/skills_hub.py`.

---

## Tests
5 new tests across 3 files covering all 4 fixed locations. All related test suites pass with no regressions.

Part of #18693. Fixes the skills rglob path injection component only.