### PR TITLE
[security] fix(api_server): reject rebinding Host headers

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -447,7 +447,7 @@ class ResponseStore:
 
 
 # ---------------------------------------------------------------------------
-# CORS middleware
+# Host / CORS middleware
 # ---------------------------------------------------------------------------
 
 _CORS_HEADERS = {
@@ -455,8 +455,48 @@ _CORS_HEADERS = {
     "Access-Control-Allow-Headers": "Authorization, Content-Type, Idempotency-Key",
 }
 
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "localhost", "::1"})
+
+
+def _normalize_host_header(value: str) -> str:
+    """Return the hostname portion of a Host header for exact comparison."""
+    host = (value or "").strip().lower().rstrip(".")
+    if not host:
+        return ""
+    # A comma is never valid in a single Host field value; fail closed by
+    # returning the whole invalid value, which will not match the allowlist.
+    if "," in host:
+        return host
+    if host.startswith("["):
+        end = host.find("]")
+        if end == -1:
+            return host
+        return host[1:end].rstrip(".")
+    if host.count(":") == 1:
+        host, port = host.rsplit(":", 1)
+        if port.isdigit():
+            return host.rstrip(".")
+    return host
+
 
 if AIOHTTP_AVAILABLE:
+    @web.middleware
+    async def host_header_middleware(request, handler):
+        """Reject DNS-rebinding Host headers on unauthenticated local servers."""
+        adapter = request.app.get("api_server_adapter")
+        host_allowed = adapter is None or adapter._host_header_allowed(
+            request.headers.get("Host", "")
+        )
+        if not host_allowed:
+            return web.json_response(
+                _openai_error(
+                    "Invalid Host header for unauthenticated local API server.",
+                    code="invalid_host_header",
+                ),
+                status=403,
+            )
+        return await handler(request)
+
     @web.middleware
     async def cors_middleware(request, handler):
         """Add CORS headers for explicitly allowed origins; handle OPTIONS preflight."""
@@ -478,6 +518,7 @@ if AIOHTTP_AVAILABLE:
             response.headers.update(cors_headers)
         return response
 else:
+    host_header_middleware = None  # type: ignore[assignment]
     cors_middleware = None  # type: ignore[assignment]
 
 
@@ -734,6 +775,30 @@ class APIServerAdapter(BasePlatformAdapter):
             return False
 
         return "*" in self._cors_origins or origin in self._cors_origins
+
+    def _host_header_allowed(self, host_header: str) -> bool:
+        """Allow local/bound Host headers when the local API server has no key.
+
+        The no-key mode is intended for loopback-only clients. CORS blocks
+        ordinary cross-origin browser requests, but DNS rebinding can make an
+        attacker-controlled hostname resolve to 127.0.0.1 and issue same-origin
+        requests with no Origin header. In no-key mode, accept only the normal
+        loopback hostnames plus the explicitly configured bind hostname.
+        Authenticated/network deployments keep their existing Host behavior.
+        """
+        if self._api_key:
+            return True
+
+        host = _normalize_host_header(host_header)
+        if not host:
+            return True
+
+        allowed = set(_LOOPBACK_HOSTS)
+        configured = _normalize_host_header(str(self._host or ""))
+        if configured and configured not in {"0.0.0.0", "::"}:
+            allowed.add(configured)
+
+        return host in allowed
 
     # ------------------------------------------------------------------
     # Auth helper
@@ -3394,7 +3459,16 @@ class APIServerAdapter(BasePlatformAdapter):
             return False
 
         try:
-            mws = [mw for mw in (cors_middleware, body_limit_middleware, security_headers_middleware) if mw is not None]
+            mws = [
+                mw
+                for mw in (
+                    host_header_middleware,
+                    cors_middleware,
+                    body_limit_middleware,
+                    security_headers_middleware,
+                )
+                if mw is not None
+            ]
             self._app = web.Application(middlewares=mws, client_max_size=MAX_REQUEST_BYTES)
             self._app["api_server_adapter"] = self
             self._app.router.add_get("/health", self._handle_health)

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -31,6 +31,7 @@ from gateway.platforms.api_server import (
     _derive_chat_session_id,
     check_api_server_requirements,
     cors_middleware,
+    host_header_middleware,
     security_headers_middleware,
 )
 
@@ -359,9 +360,13 @@ class TestAuth:
 # ---------------------------------------------------------------------------
 
 
-def _make_adapter(api_key: str = "", cors_origins=None) -> APIServerAdapter:
+def _make_adapter(
+    api_key: str = "",
+    cors_origins=None,
+    host: str = "127.0.0.1",
+) -> APIServerAdapter:
     """Create an adapter with optional API key."""
-    extra = {}
+    extra = {"host": host}
     if api_key:
         extra["key"] = api_key
     if cors_origins is not None:
@@ -372,7 +377,11 @@ def _make_adapter(api_key: str = "", cors_origins=None) -> APIServerAdapter:
 
 def _create_app(adapter: APIServerAdapter) -> web.Application:
     """Create the aiohttp app from the adapter (without starting the full server)."""
-    mws = [mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
+    mws = [
+        mw
+        for mw in (host_header_middleware, cors_middleware, security_headers_middleware)
+        if mw is not None
+    ]
     app = web.Application(middlewares=mws)
     app["api_server_adapter"] = adapter
     app.router.add_get("/health", adapter._handle_health)
@@ -2866,6 +2875,50 @@ class TestCORS:
             )
             assert resp.status == 200
             assert resp.headers.get("Access-Control-Max-Age") == "600"
+
+
+# ---------------------------------------------------------------------------
+# Host header / DNS rebinding guard
+# ---------------------------------------------------------------------------
+
+
+class TestHostHeaderGuard:
+    def test_host_header_allows_loopback_names_without_key(self, adapter):
+        assert adapter._host_header_allowed("127.0.0.1:8642") is True
+        assert adapter._host_header_allowed("localhost:8642") is True
+        assert adapter._host_header_allowed("[::1]:8642") is True
+
+    def test_host_header_rejects_untrusted_host_without_key(self, adapter):
+        assert adapter._host_header_allowed("evil.example:8642") is False
+
+    def test_host_header_preserves_authenticated_network_clients(self):
+        adapter = _make_adapter(api_key="sk-secret", host="0.0.0.0")
+        assert adapter._host_header_allowed("open-webui.internal:8642") is True
+
+    @pytest.mark.asyncio
+    async def test_no_origin_untrusted_host_is_rejected_by_default(self, adapter):
+        """DNS-rebinding requests can omit Origin but still carry attacker Host."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get(
+                "/v1/models",
+                headers={"Host": "evil.example:8642"},
+            )
+            assert resp.status == 403
+            data = await resp.json()
+            assert data["error"]["code"] == "invalid_host_header"
+
+    @pytest.mark.asyncio
+    async def test_loopback_host_still_allows_local_clients(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.get(
+                "/v1/models",
+                headers={"Host": "127.0.0.1:8642"},
+            )
+            assert resp.status == 200
+
+
 # ---------------------------------------------------------------------------
 # Conversation parameter
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

This PR hardens the local API server boundary by rejecting untrusted `Host` headers when the server is running without an API key in loopback mode.

The existing CORS checks reject ordinary cross-origin browser requests, but they do not cover DNS-rebinding-style same-origin requests that arrive without an `Origin` header and with an attacker-controlled `Host` value. This patch adds an explicit Host header guard for unauthenticated local API servers while preserving normal loopback clients and authenticated/network deployments.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Missing Host header validation on unauthenticated local API server | A DNS-rebinding-style request can reach local API routes with an attacker-controlled Host header and no Origin header | Medium |

## Before this PR

- The API server can run without `API_SERVER_KEY` when bound to loopback.
- CORS middleware rejects untrusted browser `Origin` values, but requests with no `Origin` header continue to handlers.
- A request such as `Host: evil.example:8642` with no `Origin` could reach `/v1/models` in no-key local mode.
- There was no regression coverage for Host-header/DNS-rebinding behavior on `gateway/platforms/api_server.py`.

## After this PR

- No-key local API servers only accept Host headers for normal loopback names:
  - `127.0.0.1`
  - `localhost`
  - `::1`
  - the explicitly configured non-wildcard bind host
- Untrusted Host headers are rejected with `403` and `invalid_host_header` before route handlers run.
- Authenticated or explicitly networked deployments keep their existing Host behavior.
- Regression tests cover both rejected attacker Host headers and allowed loopback clients.

## Why this matters

The local API server exposes OpenAI-compatible endpoints intended for local integrations. In no-key mode, the trust boundary is the loopback bind plus browser protections. DNS rebinding attacks target exactly this kind of assumption: an attacker-controlled hostname can resolve to loopback and cause same-origin browser requests that do not carry an untrusted `Origin` header.

A Host header guard gives the local/no-key mode a server-side admission check that does not depend on browser CORS behavior.

## How this differs from related issue/PR

This is related to, but distinct from, earlier API-server browser-origin and bind/auth hardening work.

| Public context | What it covers | Why this PR is different |
|----------------|----------------|--------------------------|
| `#2451` / `#2108` | API server CORS/browser-origin hardening | CORS blocks ordinary cross-origin browser requests, but does not validate the inbound `Host` header for no-Origin DNS-rebinding-style requests. |
| `#6439`, `#6477`, `#6760`, `#7455` | Non-loopback bind/auth guard family | Those changes focus on network bind/auth requirements. This PR covers the remaining loopback no-key Host-header admission boundary. |
| `#13530` and related dashboard/web-server Host hardening | Dashboard/web server Host header behavior | This patch is specifically for `gateway/platforms/api_server.py`, not the dashboard server. |
| `#8033` / `#8053` | DNS rebinding in outbound URL/SSRF validation | This PR covers inbound API server requests rather than outbound URL fetch validation. |

## Attack flow

```text
attacker-controlled hostname resolves to 127.0.0.1
    -> browser sends same-origin request with Host: evil.example:8642 and no Origin
        -> local no-key API server accepts the request
            -> API route handlers are reachable across the loopback trust boundary
```

## Affected code

| Issue | Files |
|-------|-------|
| Missing Host header admission check for no-key local API server | `gateway/platforms/api_server.py` |
| Missing regression coverage | `tests/gateway/test_api_server.py` |

## Root cause

Host header validation on no-key local API server:
- The API server relied on loopback binding and CORS origin checks for local/no-key safety.
- Requests without an `Origin` header were still allowed through CORS middleware, and no separate Host-header allowlist existed for DNS-rebinding-style traffic.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| DNS-rebinding-style Host header bypass for local no-key API server | 5.3 Medium | `CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:L/I:L/A:N` |

Rationale:
- Exploitation requires a browser/user interaction and a DNS-rebinding-style setup, so attack complexity and user interaction are not zero.
- Impact is bounded to API routes exposed by the local no-key server and depends on deployment/configuration.
- The patch prevents attacker-controlled hostnames from reaching handlers in the local/no-key mode.

## Safe reproduction steps

1. Start from current `origin/main` with the API server configured for loopback/no-key mode.
2. Exercise the real `/v1/models` handler with an attacker-controlled Host header and no Origin header:

   ```python
   resp = await cli.get('/v1/models', headers={'Host': 'evil.example:8642'})
   ```

3. Observe that the vulnerable code accepts the request and returns `200`.
4. Apply this patch and rerun the same request.
5. Observe that the patched code returns `403` with `invalid_host_header`.
6. Verify that normal loopback clients still work:

   ```python
   resp = await cli.get('/v1/models', headers={'Host': '127.0.0.1:8642'})
   ```

## Expected vulnerable behavior

On vulnerable code, a no-key local API server accepts an untrusted Host header with no Origin:

```text
origin_main_status 200
origin_main_models ['hermes-agent']
```

After this patch, the same untrusted Host request is rejected while loopback hosts still work:

```text
patched_bad_status 403
patched_loopback_status 200
```

## Changes in this PR

- Adds `_normalize_host_header()` to parse exact hostnames from common Host header forms.
- Adds `host_header_middleware` before API route handlers.
- Adds `APIServerAdapter._host_header_allowed()` for the no-key local API server policy.
- Allows loopback names and the explicitly configured non-wildcard bind host in no-key mode.
- Preserves existing behavior for authenticated/network deployments.
- Adds focused regression tests for accepted loopback hosts, rejected attacker hosts, and authenticated network clients.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| API server hardening | `gateway/platforms/api_server.py` | Added Host normalization, no-key local Host allowlist, and middleware wiring. |
| Regression tests | `tests/gateway/test_api_server.py` | Added Host-header guard tests and included the middleware in the test app helper. |

## Maintainer impact

- The change is narrow to the API server adapter and its regression tests.
- Existing authenticated API deployments continue to accept their previous Host headers.
- Local clients using `127.0.0.1`, `localhost`, or `::1` continue to work without configuration changes.
- The new helper centralizes the local/no-key Host policy so future API routes inherit the same boundary.

## Fix rationale

The no-key local mode should only be reachable through local names the operator intended to use. CORS is still useful for ordinary browser-origin checks, but Host validation is the correct server-side boundary for DNS-rebinding-style traffic where the browser may consider the attacker domain same-origin and omit an untrusted `Origin` header.

The allowlist is intentionally small in no-key mode and automatically includes the configured non-wildcard bind host so explicitly configured local deployments remain usable.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Checked patch whitespace with `git diff --check`.
- [x] Byte-compiled touched files.
- [x] Ran focused Host/CORS/bind guard tests.
- [x] Ran broader API server regression tests with a raised file-descriptor limit.

Executed with:

```bash
git diff --check
python3.11 -m py_compile gateway/platforms/api_server.py tests/gateway/test_api_server.py
python3.11 -m pytest -q -o addopts='' tests/gateway/test_api_server.py::TestHostHeaderGuard tests/gateway/test_api_server.py::TestCORS tests/gateway/test_api_server_bind_guard.py
ulimit -n 4096 && python3.11 -m pytest -q -o addopts='' tests/gateway/test_api_server.py tests/gateway/test_api_server_bind_guard.py
```

Observed results:

```text
36 passed
160 passed
```

Note: the broader API server suite hit local `Too many open files` errors under the default shell file-descriptor limit. With `ulimit -n 4096`, the same suite passed.

## Disclosure notes

- This PR is bounded to inbound Host header validation for `gateway/platforms/api_server.py` in no-key local mode.
- It does not claim a bypass of authenticated/network API deployments.
- It does not change dashboard/web-server Host validation or outbound URL safety logic.
- No unrelated files were changed.
