### PR TITLE
fix: exclude checkpoint cache artifacts

### DIFF
--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -129,6 +129,34 @@ class TestStoreInit:
         assert _init_store(store, str(work_dir)) is None
         assert _init_store(store, str(work_dir)) is None
 
+    def test_existing_store_reconciles_default_excludes_before_checkpoint(
+        self, work_dir, checkpoint_base, monkeypatch,
+    ):
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base)
+        store = _store_path(checkpoint_base)
+        assert _init_store(store, str(work_dir)) is None
+
+        exclude_file = store / "info" / "exclude"
+        exclude_file.write_text("node_modules/\ncustom-local/\n", encoding="utf-8")
+        uv_cache = work_dir / ".uv-cache"
+        uv_cache.mkdir()
+        (uv_cache / "wheel").write_text("cached artifact\n")
+
+        manager = CheckpointManager(enabled=True)
+        assert manager.ensure_checkpoint(str(work_dir), "initial") is True
+
+        exclude_text = exclude_file.read_text(encoding="utf-8")
+        assert "custom-local/" in exclude_text
+        assert ".uv-cache/" in exclude_text
+
+        ok, tree_paths, err = _run_git(
+            ["ls-tree", "-r", "--name-only", _ref_name(_project_hash(str(work_dir)))],
+            store,
+            str(work_dir),
+        )
+        assert ok, err
+        assert ".uv-cache/wheel" not in tree_paths.splitlines()
+
     def test_bc_init_shadow_repo_shim(self, work_dir, checkpoint_base, monkeypatch):
         """Backward-compatible helper still works for old callers/tests."""
         monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base)
@@ -227,6 +255,48 @@ class TestTakeCheckpoint:
         assert (BASE / "store" / "HEAD").exists()
         assert (BASE / "store" / "projects" / f"{_project_hash(str(a))}.json").exists()
         assert (BASE / "store" / "projects" / f"{_project_hash(str(b))}.json").exists()
+
+    def test_new_default_excludes_drop_previously_checkpointed_paths(
+        self, work_dir, checkpoint_base, monkeypatch,
+    ):
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base)
+        old_excludes = [
+            pattern for pattern in DEFAULT_EXCLUDES if pattern != ".uv-cache/"
+        ]
+        monkeypatch.setattr("tools.checkpoint_manager.DEFAULT_EXCLUDES", old_excludes)
+
+        uv_cache = work_dir / ".uv-cache"
+        uv_cache.mkdir()
+        (uv_cache / "wheel").write_text("cached artifact\n")
+
+        manager = CheckpointManager(enabled=True)
+        assert manager.ensure_checkpoint(str(work_dir), "old excludes") is True
+
+        store = _store_path(checkpoint_base)
+        ref = _ref_name(_project_hash(str(work_dir)))
+        ok, files, err = _run_git(
+            ["ls-tree", "-r", "--name-only", ref],
+            store,
+            str(work_dir),
+        )
+        assert ok, err
+        assert ".uv-cache/wheel" in files.splitlines()
+
+        monkeypatch.setattr("tools.checkpoint_manager.DEFAULT_EXCLUDES", DEFAULT_EXCLUDES)
+        manager.new_turn()
+        (work_dir / "main.py").write_text("print('modified')\n")
+        assert manager.ensure_checkpoint(str(work_dir), "current excludes") is True
+
+        ok, files, err = _run_git(
+            ["ls-tree", "-r", "--name-only", ref],
+            store,
+            str(work_dir),
+        )
+        assert ok, err
+        names = set(files.splitlines())
+        assert "main.py" in names
+        assert "README.md" in names
+        assert ".uv-cache/wheel" not in names
 
 
 # =========================================================================
@@ -534,6 +604,71 @@ class TestDirFileCount:
 
     def test_nonexistent_dir(self, tmp_path):
         assert _dir_file_count(str(tmp_path / "nonexistent")) == 0
+
+    def test_default_excludes_include_uv_cache(self):
+        assert ".uv-cache/" in DEFAULT_EXCLUDES
+
+    def test_excluded_directories_do_not_trip_file_limit(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.checkpoint_manager._MAX_FILES", 2)
+        work = tmp_path / "work"
+        work.mkdir()
+        (work / "src.py").write_text("print('tracked')\n")
+
+        for dirname in [".venv", "venv", "env", "node_modules", ".uv-cache"]:
+            excluded = work / dirname
+            excluded.mkdir()
+            for i in range(3):
+                (excluded / f"ignored_{i}.txt").write_text("ignored\n")
+
+        assert _dir_file_count(str(work)) == 1
+
+    def test_non_excluded_files_still_trip_file_limit(self, tmp_path, monkeypatch):
+        monkeypatch.setattr("tools.checkpoint_manager._MAX_FILES", 2)
+        work = tmp_path / "work"
+        work.mkdir()
+        for i in range(3):
+            (work / f"source_{i}.py").write_text("print('tracked')\n")
+
+        assert _dir_file_count(str(work)) > 2
+
+
+class TestCheckpointFileLimit:
+    def test_checkpoint_allows_large_excluded_directories(
+        self,
+        tmp_path,
+        checkpoint_base,
+        monkeypatch,
+    ):
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base)
+        monkeypatch.setattr("tools.checkpoint_manager._MAX_FILES", 2)
+        work = tmp_path / "work"
+        work.mkdir()
+        (work / "src.py").write_text("print('tracked')\n")
+
+        for dirname in [".venv", ".uv-cache"]:
+            excluded = work / dirname
+            excluded.mkdir()
+            for i in range(3):
+                (excluded / f"ignored_{i}.txt").write_text("ignored\n")
+
+        m = CheckpointManager(enabled=True)
+        assert m.ensure_checkpoint(str(work), "initial") is True
+
+    def test_checkpoint_skips_large_non_excluded_directory(
+        self,
+        tmp_path,
+        checkpoint_base,
+        monkeypatch,
+    ):
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base)
+        monkeypatch.setattr("tools.checkpoint_manager._MAX_FILES", 2)
+        work = tmp_path / "work"
+        work.mkdir()
+        for i in range(3):
+            (work / f"source_{i}.py").write_text("print('tracked')\n")
+
+        m = CheckpointManager(enabled=True)
+        assert m.ensure_checkpoint(str(work), "initial") is False
 
 
 # =========================================================================

--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -22,6 +22,7 @@ from tools.checkpoint_manager import (
     _ref_name,
     _project_meta_path,
     _touch_project,
+    DEFAULT_EXCLUDES,
     format_checkpoint_list,
     prune_checkpoints,
     maybe_auto_prune_checkpoints,

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -56,6 +56,7 @@ import re
 import shutil
 import subprocess
 import time
+from fnmatch import fnmatch
 from pathlib import Path
 from hermes_constants import get_hermes_home
 from hermes_cli._subprocess_compat import windows_hide_flags
@@ -92,6 +93,7 @@ DEFAULT_EXCLUDES = [
     "*.pyc",
     "*.pyo",
     ".cache/",
+    ".uv-cache/",
     ".pytest_cache/",
     ".mypy_cache/",
     ".ruff_cache/",
@@ -433,6 +435,7 @@ def _init_store(store: Path, working_dir: str) -> Optional[str]:
         _migrate_legacy_store(base)
 
     if (store / "HEAD").exists():
+        _reconcile_default_excludes(store)
         return None
 
     store.mkdir(parents=True, exist_ok=True)
@@ -473,14 +476,35 @@ def _init_store(store: Path, working_dir: str) -> Optional[str]:
     _run_git(["config", "tag.gpgSign", "false"], store, cfg_wd)
     _run_git(["config", "gc.auto", "0"], store, cfg_wd)
 
-    info_dir = store / "info"
-    info_dir.mkdir(exist_ok=True)
-    (info_dir / "exclude").write_text(
-        "\n".join(DEFAULT_EXCLUDES) + "\n", encoding="utf-8"
-    )
+    _reconcile_default_excludes(store)
 
     logger.debug("Initialised checkpoint store at %s", store)
     return None
+
+
+def _reconcile_default_excludes(store: Path) -> None:
+    """Best-effort append of missing default excludes to the store exclude file."""
+    info_dir = store / "info"
+    exclude_file = info_dir / "exclude"
+    try:
+        info_dir.mkdir(exist_ok=True)
+        text = exclude_file.read_text(encoding="utf-8") if exclude_file.exists() else ""
+    except OSError as exc:
+        logger.debug("Checkpoint exclude reconcile skipped: %s", exc)
+        return
+
+    existing = {line.strip() for line in text.splitlines() if line.strip()}
+    missing = [pattern for pattern in DEFAULT_EXCLUDES if pattern not in existing]
+    if not missing:
+        return
+
+    if text and not text.endswith("\n"):
+        text += "\n"
+    text += "\n".join(missing) + "\n"
+    try:
+        exclude_file.write_text(text, encoding="utf-8")
+    except OSError as exc:
+        logger.debug("Checkpoint exclude reconcile failed: %s", exc)
 
 
 def _register_project(store: Path, working_dir: str) -> None:
@@ -545,14 +569,50 @@ def _list_projects(store: Path) -> List[Dict]:
     return out
 
 
+def _is_checkpoint_excluded(rel_path: str, *, is_dir: bool) -> bool:
+    """Return whether a relative path matches checkpoint default excludes."""
+    rel_path = rel_path.replace(os.sep, "/").strip("/")
+    if not rel_path:
+        return False
+
+    parts = rel_path.split("/")
+    for pattern in DEFAULT_EXCLUDES:
+        if pattern.endswith("/"):
+            dir_pattern = pattern.rstrip("/")
+            if is_dir and (
+                fnmatch(parts[-1], dir_pattern) or fnmatch(rel_path, dir_pattern)
+            ):
+                return True
+            if any(fnmatch(part, dir_pattern) for part in parts[:-1]):
+                return True
+        elif fnmatch(parts[-1], pattern) or fnmatch(rel_path, pattern):
+            return True
+    return False
+
+
 def _dir_file_count(path: str) -> int:
-    """Quick file count estimate (stops early if over _MAX_FILES)."""
+    """Quick file count estimate using checkpoint excludes."""
     count = 0
+    root = Path(path)
     try:
-        for _ in Path(path).rglob("*"):
-            count += 1
-            if count > _MAX_FILES:
-                return count
+        for dirpath, dirnames, filenames in os.walk(root):
+            current = Path(dirpath)
+            rel_dir = current.relative_to(root)
+
+            kept_dirs = []
+            for dirname in dirnames:
+                rel_path = rel_dir / dirname
+                if not _is_checkpoint_excluded(rel_path.as_posix(), is_dir=True):
+                    kept_dirs.append(dirname)
+            dirnames[:] = kept_dirs
+
+            for filename in filenames:
+                rel_path = rel_dir / filename
+                if _is_checkpoint_excluded(rel_path.as_posix(), is_dir=False):
+                    continue
+                count += 1
+                if count > _MAX_FILES:
+                    return count
     except (PermissionError, OSError):
         pass
     return count
@@ -928,6 +988,8 @@ class CheckpointManager:
             logger.debug("Checkpoint git-add failed: %s", err)
             return False
 
+        self._drop_default_excludes_from_index(store, working_dir, index_file)
+
         if self.max_file_size_mb > 0:
             self._drop_oversize_from_index(store, working_dir, index_file)
 
@@ -1003,6 +1065,37 @@ class CheckpointManager:
         self._enforce_size_cap(store)
 
         return True
+
+    def _drop_default_excludes_from_index(
+        self, store: Path, working_dir: str, index_file: Path,
+    ) -> None:
+        """Remove staged paths that now match checkpoint default excludes."""
+        ok, stdout, _ = _run_git(
+            ["ls-files", "--cached", "-z"],
+            store, working_dir, index_file=index_file,
+        )
+        if not ok or not stdout:
+            return
+
+        paths = [p for p in stdout.split("\x00") if p]
+        excluded = [
+            rel for rel in paths if _is_checkpoint_excluded(rel, is_dir=False)
+        ]
+        if not excluded:
+            return
+
+        logger.debug(
+            "Checkpoint: dropping %d default-excluded path(s) from index",
+            len(excluded),
+        )
+        BATCH = 200
+        for i in range(0, len(excluded), BATCH):
+            chunk = excluded[i:i + BATCH]
+            _run_git(
+                ["rm", "--cached", "--quiet", "--ignore-unmatch", "--"] + chunk,
+                store, working_dir, index_file=index_file,
+                allowed_returncodes={128},
+            )
 
     def _drop_oversize_from_index(
         self, store: Path, working_dir: str, index_file: Path,


### PR DESCRIPTION
## Rationale

Checkpoint snapshots should avoid capturing local cache and environment artifacts. Large generated directories like `.uv-cache/` can make checkpointing slow or skip otherwise small projects, and existing checkpoint stores may keep stale exclude rules or previously tracked cache files across upgrades.

## Summary

- Add `.uv-cache/` to checkpoint default excludes.
- Make the checkpoint file-count guard ignore default-excluded paths before applying the `_MAX_FILES` limit.
- Reconcile missing default excludes into existing checkpoint store `info/exclude` files without removing user custom excludes.
- Remove already-tracked default-excluded paths from the per-project checkpoint index before writing the next checkpoint tree.
- Add regression coverage for stale stores, newly added excludes, and large excluded directories.

## Test Plan

- [x] `scripts/run_tests.sh tests/tools/test_checkpoint_manager.py`
- [x] `venv/bin/ruff check tools/checkpoint_manager.py tests/tools/test_checkpoint_manager.py`
- [x] `git diff --check`
