### PR TITLE
fix(telegram): send Direct Messages topics with direct_messages_topic_id

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -368,6 +368,47 @@ class TelegramAdapter(BasePlatformAdapter):
         return int(thread_id)
 
     @classmethod
+    def _is_direct_messages_topic(
+        cls,
+        chat_id: str,
+        metadata: Optional[Dict[str, Any]],
+    ) -> bool:
+        """Return True when thread_id refers to a Telegram DM-topic id.
+
+        Telegram now has two unrelated topic id fields:
+        - forum/group topics: ``message_thread_id``;
+        - Direct Messages topics: ``direct_messages_topic_id``.
+
+        Hermes stores both as ``source.thread_id`` for session routing, so the
+        send path must choose the Telegram API field from chat context.  Prefer
+        explicit ``chat_type=dm`` metadata; fall back to Telegram's id shape
+        because private chats are positive and groups/supergroups are negative.
+        """
+        chat_type = str((metadata or {}).get("chat_type") or "").lower()
+        if chat_type in {"dm", "private", "direct"}:
+            return True
+        if chat_type in {"group", "forum", "supergroup", "channel"}:
+            return False
+        return not str(chat_id).strip().startswith("-")
+
+    @classmethod
+    def _topic_send_kwargs(
+        cls,
+        chat_id: str,
+        thread_id: Optional[str],
+        metadata: Optional[Dict[str, Any]],
+    ) -> Dict[str, Optional[int]]:
+        message_thread_id = cls._message_thread_id_for_send(thread_id)
+        if message_thread_id is None:
+            return {"message_thread_id": None}
+        if cls._is_direct_messages_topic(chat_id, metadata):
+            return {
+                "message_thread_id": None,
+                "direct_messages_topic_id": message_thread_id,
+            }
+        return {"message_thread_id": message_thread_id}
+
+    @classmethod
     def _message_thread_id_for_typing(cls, thread_id: Optional[str]) -> Optional[int]:
         # Asymmetric with _message_thread_id_for_send on purpose. Telegram's
         # sendMessage and sendChatAction treat thread id "1" (the forum General
@@ -1256,7 +1297,8 @@ class TelegramAdapter(BasePlatformAdapter):
             for i, chunk in enumerate(chunks):
                 should_thread = self._should_thread_reply(reply_to, i)
                 reply_to_id = int(reply_to) if should_thread else None
-                effective_thread_id = self._message_thread_id_for_send(thread_id)
+                topic_kwargs = self._topic_send_kwargs(chat_id, thread_id, metadata)
+                effective_thread_id = topic_kwargs.get("message_thread_id")
 
                 msg = None
                 for _send_attempt in range(3):
@@ -1268,7 +1310,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                 text=chunk,
                                 parse_mode=ParseMode.MARKDOWN_V2,
                                 reply_to_message_id=reply_to_id,
-                                message_thread_id=effective_thread_id,
+                                **topic_kwargs,
                                 **self._link_preview_kwargs(),
                             )
                         except Exception as md_error:
@@ -1281,7 +1323,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                     text=plain_chunk,
                                     parse_mode=None,
                                     reply_to_message_id=reply_to_id,
-                                    message_thread_id=effective_thread_id,
+                                    **topic_kwargs,
                                     **self._link_preview_kwargs(),
                                 )
                             else:
@@ -1302,6 +1344,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                     self.name, effective_thread_id,
                                 )
                                 effective_thread_id = None
+                                topic_kwargs = {"message_thread_id": None}
                                 continue
                             err_lower = str(send_err).lower()
                             if "message to be replied not found" in err_lower and reply_to_id is not None:

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -224,7 +224,7 @@ async def test_send_retries_without_thread_on_thread_not_found():
     result = await adapter.send(
         chat_id="123",
         content="test message",
-        metadata={"thread_id": "99999"},
+        metadata={"thread_id": "99999", "chat_type": "group"},
     )
 
     assert result.success is True
@@ -233,6 +233,65 @@ async def test_send_retries_without_thread_on_thread_not_found():
     assert len(call_log) == 2
     assert call_log[0]["message_thread_id"] == 99999
     assert call_log[1]["message_thread_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_send_to_dm_topic_uses_direct_messages_topic_id_not_forum_thread_id():
+    """Telegram Direct Messages topics are not forum topics.
+
+    Bot API/ptb expose them as ``direct_messages_topic_id``. Sending the same
+    id as ``message_thread_id`` makes Telegram reject it with "Thread not
+    found", after which Hermes used to fall back to the root DM/global view.
+    """
+    adapter = _make_adapter()
+    call_log = []
+
+    async def mock_send_message(**kwargs):
+        call_log.append(dict(kwargs))
+        return SimpleNamespace(message_id=43)
+
+    adapter._bot = SimpleNamespace(send_message=mock_send_message)
+
+    result = await adapter.send(
+        chat_id="1009248010",
+        content="test message",
+        metadata={"thread_id": "281962", "chat_type": "dm"},
+    )
+
+    assert result.success is True
+    assert result.message_id == "43"
+    assert len(call_log) == 1
+    assert call_log[0]["message_thread_id"] is None
+    assert call_log[0]["direct_messages_topic_id"] == 281962
+
+
+@pytest.mark.asyncio
+async def test_send_to_positive_chat_thread_defaults_to_dm_topic_for_gateway_metadata():
+    """Gateway stream metadata currently carries thread_id without chat_type.
+
+    Telegram private/direct chats have positive ids while groups are negative,
+    so a positive chat id with a thread id must be treated as a Direct Messages
+    topic to keep current deployments working before metadata is enriched.
+    """
+    adapter = _make_adapter()
+    call_log = []
+
+    async def mock_send_message(**kwargs):
+        call_log.append(dict(kwargs))
+        return SimpleNamespace(message_id=44)
+
+    adapter._bot = SimpleNamespace(send_message=mock_send_message)
+
+    result = await adapter.send(
+        chat_id="1009248010",
+        content="test message",
+        metadata={"thread_id": "281962"},
+    )
+
+    assert result.success is True
+    assert result.message_id == "44"
+    assert call_log[0]["message_thread_id"] is None
+    assert call_log[0]["direct_messages_topic_id"] == 281962
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes Telegram Direct Messages topic delivery after Bot API/PTB split topic routing into separate fields.\n\nRoot cause: Hermes stored Telegram Direct Messages topic ids in source.thread_id and sent them as message_thread_id, which is for forum/group topics. Telegram rejects that with 'Thread not found'; the existing fallback retried without thread_id, so replies landed in the root/global DM view.\n\nChange:\n- route positive private/direct chat topic ids via direct_messages_topic_id;\n- preserve message_thread_id for group/forum topics;\n- keep General forum-topic send behavior unchanged;\n- add regressions for explicit dm metadata and current gateway metadata shape.\n\nValidation:\n- .venv/bin/python -m pytest tests/gateway/test_telegram_thread_fallback.py -q → 13 passed\n- .venv/bin/python -m compileall -q gateway/platforms/telegram.py\n- .venv/bin/python -m py_compile gateway/platforms/telegram.py tests/gateway/test_telegram_thread_fallback.py\n- git diff --check