### PR TITLE
feat(scheduling): add Cal.com, Calendly, and Google Calendar plugin

### DIFF
--- a/plugins/scheduling/__init__.py
+++ b/plugins/scheduling/__init__.py
@@ -1,0 +1,50 @@
+"""Scheduling integration plugin — bundled, auto-loaded.
+
+Registers tools for Cal.com, Calendly, and Google Calendar into the
+``scheduling`` toolset. Runtime auth is handled by ``plugins.scheduling.oauth``:
+Cal.com supports either an API key or OAuth token, Calendly uses OAuth with
+PKCE, and Google Calendar reuses the existing Hermes Google token.
+"""
+
+from __future__ import annotations
+
+from plugins.scheduling.tools import (
+    SCHEDULING_CANCEL_EVENT_SCHEMA,
+    SCHEDULING_CHECK_AVAILABILITY_SCHEMA,
+    SCHEDULING_CREATE_EVENT_SCHEMA,
+    SCHEDULING_GET_EVENT_SCHEMA,
+    SCHEDULING_LIST_CALENDARS_SCHEMA,
+    SCHEDULING_LIST_EVENTS_SCHEMA,
+    SCHEDULING_OAUTH_SCHEMA,
+    _check_scheduling_available,
+    _handle_scheduling_cancel_event,
+    _handle_scheduling_check_availability,
+    _handle_scheduling_create_event,
+    _handle_scheduling_get_event,
+    _handle_scheduling_list_calendars,
+    _handle_scheduling_list_events,
+    _handle_scheduling_oauth,
+)
+
+_TOOLS = (
+    ("scheduling_list_events", SCHEDULING_LIST_EVENTS_SCHEMA, _handle_scheduling_list_events, "📅"),
+    ("scheduling_create_event", SCHEDULING_CREATE_EVENT_SCHEMA, _handle_scheduling_create_event, "➕"),
+    ("scheduling_get_event", SCHEDULING_GET_EVENT_SCHEMA, _handle_scheduling_get_event, "🔎"),
+    ("scheduling_cancel_event", SCHEDULING_CANCEL_EVENT_SCHEMA, _handle_scheduling_cancel_event, "🗑️"),
+    ("scheduling_check_availability", SCHEDULING_CHECK_AVAILABILITY_SCHEMA, _handle_scheduling_check_availability, "🕒"),
+    ("scheduling_list_calendars", SCHEDULING_LIST_CALENDARS_SCHEMA, _handle_scheduling_list_calendars, "🗓️"),
+    ("scheduling_oauth", SCHEDULING_OAUTH_SCHEMA, _handle_scheduling_oauth, "🔐"),
+)
+
+
+def register(ctx) -> None:
+    """Register all scheduling tools. Called once by the plugin loader."""
+    for name, schema, handler, emoji in _TOOLS:
+        ctx.register_tool(
+            name=name,
+            toolset="scheduling",
+            schema=schema,
+            handler=handler,
+            check_fn=_check_scheduling_available,
+            emoji=emoji,
+        )

--- a/plugins/scheduling/calcom_client.py
+++ b/plugins/scheduling/calcom_client.py
@@ -1,0 +1,100 @@
+"""Thin Cal.com API client for the scheduling plugin."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, Optional
+
+import httpx
+
+from plugins.scheduling.oauth import OAuth2Manager, OAuthError
+
+
+class SchedulingAPIError(RuntimeError):
+    """Structured scheduling API failure."""
+
+    def __init__(self, message: str, *, status_code: Optional[int] = None, response_body: Optional[str] = None) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.response_body = response_body
+
+
+def _strip_none(data: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    return {k: v for k, v in (data or {}).items() if v is not None}
+
+
+class CalComClient:
+    """Client for Cal.com v1 API using OAuth bearer tokens or API keys."""
+
+    base_url = "https://api.cal.com/v1"
+
+    def __init__(self) -> None:
+        self._oauth = OAuth2Manager("calcom")
+
+    def _headers(self) -> Dict[str, str]:
+        api_key = os.getenv("CALCOM_API_KEY")
+        if api_key:
+            return {"Authorization": f"Bearer {api_key}", "Content-Type": "application/json"}
+        try:
+            token = self._oauth.access_token()
+        except OAuthError as exc:
+            raise SchedulingAPIError(str(exc)) from exc
+        return {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        json_body: Optional[Dict[str, Any]] = None,
+        empty_response: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        """Call the Cal.com API and return decoded JSON."""
+        response = httpx.request(
+            method,
+            f"{self.base_url}{path}",
+            headers=self._headers(),
+            params=_strip_none(params),
+            json=_strip_none(json_body) if json_body is not None else None,
+            timeout=30.0,
+        )
+        if response.status_code >= 400:
+            raise SchedulingAPIError(
+                f"Cal.com API error ({response.status_code}): {response.text}",
+                status_code=response.status_code,
+                response_body=response.text,
+            )
+        if response.status_code == 204 or not response.content:
+            return empty_response or {"success": True, "status_code": response.status_code, "empty": True}
+        if "application/json" in response.headers.get("content-type", ""):
+            return response.json()
+        return {"success": True, "text": response.text}
+
+    def list_event_types(self) -> Any:
+        """List Cal.com event types."""
+        return self.request("GET", "/event-types")
+
+    def list_bookings(self, *, start_time: Optional[str] = None, end_time: Optional[str] = None, limit: Optional[int] = None) -> Any:
+        """List bookings between optional timestamps."""
+        return self.request("GET", "/bookings", params={"startTime": start_time, "endTime": end_time, "limit": limit})
+
+    def create_booking(self, payload: Dict[str, Any]) -> Any:
+        """Create a Cal.com booking."""
+        return self.request("POST", "/bookings", json_body=payload)
+
+    def get_booking(self, booking_id: str) -> Any:
+        """Fetch booking details."""
+        return self.request("GET", f"/bookings/{booking_id}")
+
+    def cancel_booking(self, booking_id: str, *, reason: Optional[str] = None) -> Any:
+        """Cancel a booking."""
+        return self.request("DELETE", f"/bookings/{booking_id}", params={"reason": reason})
+
+    def check_availability(self, *, event_type_id: Optional[str], start_time: str, end_time: str) -> Any:
+        """Check availability for an event type."""
+        return self.request("GET", "/availability", params={
+            "eventTypeId": event_type_id,
+            "startTime": start_time,
+            "endTime": end_time,
+        })

--- a/plugins/scheduling/calendly_client.py
+++ b/plugins/scheduling/calendly_client.py
@@ -1,0 +1,89 @@
+"""Thin Calendly API client for the scheduling plugin."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+import httpx
+
+from plugins.scheduling.calcom_client import SchedulingAPIError, _strip_none
+from plugins.scheduling.oauth import OAuth2Manager, OAuthError
+
+
+class CalendlyClient:
+    """Client for Calendly API using OAuth2 with PKCE."""
+
+    base_url = "https://api.calendly.com"
+
+    def __init__(self) -> None:
+        self._oauth = OAuth2Manager("calendly")
+
+    def _headers(self) -> Dict[str, str]:
+        try:
+            token = self._oauth.access_token()
+        except OAuthError as exc:
+            raise SchedulingAPIError(str(exc)) from exc
+        return {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        json_body: Optional[Dict[str, Any]] = None,
+        empty_response: Optional[Dict[str, Any]] = None,
+    ) -> Any:
+        """Call the Calendly API and return decoded JSON."""
+        response = httpx.request(
+            method,
+            f"{self.base_url}{path}",
+            headers=self._headers(),
+            params=_strip_none(params),
+            json=_strip_none(json_body) if json_body is not None else None,
+            timeout=30.0,
+        )
+        if response.status_code >= 400:
+            raise SchedulingAPIError(
+                f"Calendly API error ({response.status_code}): {response.text}",
+                status_code=response.status_code,
+                response_body=response.text,
+            )
+        if response.status_code == 204 or not response.content:
+            return empty_response or {"success": True, "status_code": response.status_code, "empty": True}
+        if "application/json" in response.headers.get("content-type", ""):
+            return response.json()
+        return {"success": True, "text": response.text}
+
+    def get_current_user(self) -> Any:
+        """Fetch the current Calendly user."""
+        return self.request("GET", "/users/me")
+
+    def list_event_types(self, *, user_uri: Optional[str] = None, limit: Optional[int] = None) -> Any:
+        """List Calendly event types."""
+        return self.request("GET", "/event_types", params={"user": user_uri, "count": limit})
+
+    def list_events(self, *, start_time: Optional[str] = None, end_time: Optional[str] = None, limit: Optional[int] = None) -> Any:
+        """List scheduled Calendly events."""
+        return self.request("GET", "/scheduled_events", params={
+            "min_start_time": start_time,
+            "max_start_time": end_time,
+            "count": limit,
+        })
+
+    def get_event(self, event_uuid: str) -> Any:
+        """Fetch event details by UUID."""
+        return self.request("GET", f"/scheduled_events/{event_uuid}")
+
+    def cancel_event(self, event_uuid: str, *, reason: Optional[str] = None) -> Any:
+        """Cancel a scheduled event."""
+        return self.request("POST", f"/scheduled_events/{event_uuid}/cancellations", json_body={"reason": reason})
+
+    def check_availability(self, *, user_uri: Optional[str], event_type_uri: Optional[str], start_time: str, end_time: str) -> Any:
+        """Check Calendly availability for a user and event type."""
+        return self.request("GET", "/availability", params={
+            "user_uri": user_uri,
+            "event_type": event_type_uri,
+            "start_time": start_time,
+            "end_time": end_time,
+        })

--- a/plugins/scheduling/google_calendar_client.py
+++ b/plugins/scheduling/google_calendar_client.py
@@ -1,0 +1,107 @@
+"""Thin Google Calendar API client for the scheduling plugin."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from plugins.scheduling.calcom_client import SchedulingAPIError, _strip_none
+from plugins.scheduling.oauth import OAuth2Manager, OAuthError
+
+
+class GoogleCalendarClient:
+    """Client for Google Calendar API using the existing Hermes Google token."""
+
+    base_url = "https://www.googleapis.com/calendar/v3"
+
+    def __init__(self, calendar_id: str = "primary") -> None:
+        self.calendar_id = calendar_id or "primary"
+        self._oauth = OAuth2Manager("google_calendar")
+
+    def _headers(self) -> Dict[str, str]:
+        try:
+            token = self._oauth.access_token()
+        except OAuthError as exc:
+            raise SchedulingAPIError(str(exc)) from exc
+        return {"Authorization": f"Bearer {token}", "Content-Type": "application/json"}
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        json_body: Optional[Dict[str, Any]] = None,
+        empty_response: Optional[Dict[str, Any]] = None,
+        allow_retry_on_401: bool = True,
+    ) -> Any:
+        """Call Google Calendar and refresh once on 401."""
+        response = httpx.request(
+            method,
+            f"{self.base_url}{path}",
+            headers=self._headers(),
+            params=_strip_none(params),
+            json=_strip_none(json_body) if json_body is not None else None,
+            timeout=30.0,
+        )
+        if response.status_code == 401 and allow_retry_on_401:
+            self._oauth.refresh_token()
+            return self.request(
+                method,
+                path,
+                params=params,
+                json_body=json_body,
+                empty_response=empty_response,
+                allow_retry_on_401=False,
+            )
+        if response.status_code >= 400:
+            raise SchedulingAPIError(
+                f"Google Calendar API error ({response.status_code}): {response.text}",
+                status_code=response.status_code,
+                response_body=response.text,
+            )
+        if response.status_code == 204 or not response.content:
+            return empty_response or {"success": True, "status_code": response.status_code, "empty": True}
+        if "application/json" in response.headers.get("content-type", ""):
+            return response.json()
+        return {"success": True, "text": response.text}
+
+    def list_calendars(self) -> Any:
+        """List Google calendars."""
+        return self.request("GET", "/users/me/calendarList")
+
+    def list_events(self, *, start_time: Optional[str] = None, end_time: Optional[str] = None, limit: Optional[int] = None) -> Any:
+        """List events on the configured calendar."""
+        return self.request("GET", f"/calendars/{self.calendar_id}/events", params={
+            "timeMin": start_time,
+            "timeMax": end_time,
+            "maxResults": limit,
+            "singleEvents": True,
+            "orderBy": "startTime",
+        })
+
+    def create_event(self, payload: Dict[str, Any]) -> Any:
+        """Create an event on the configured calendar."""
+        return self.request("POST", f"/calendars/{self.calendar_id}/events", json_body=payload)
+
+    def get_event(self, event_id: str) -> Any:
+        """Fetch one event."""
+        return self.request("GET", f"/calendars/{self.calendar_id}/events/{event_id}")
+
+    def update_event(self, event_id: str, payload: Dict[str, Any]) -> Any:
+        """Update one event."""
+        return self.request("PUT", f"/calendars/{self.calendar_id}/events/{event_id}", json_body=payload)
+
+    def delete_event(self, event_id: str) -> Any:
+        """Delete one event."""
+        return self.request("DELETE", f"/calendars/{self.calendar_id}/events/{event_id}")
+
+    def free_busy(self, *, start_time: str, end_time: str, calendar_ids: Optional[List[str]] = None) -> Any:
+        """Check free/busy for one or more calendars."""
+        ids = calendar_ids or [self.calendar_id]
+        return self.request("POST", "/freeBusy", json_body={
+            "timeMin": start_time,
+            "timeMax": end_time,
+            "items": [{"id": calendar_id} for calendar_id in ids],
+        })

--- a/plugins/scheduling/oauth.py
+++ b/plugins/scheduling/oauth.py
@@ -1,0 +1,379 @@
+"""Shared OAuth2 helpers for the scheduling plugin.
+
+The module is both importable by the scheduling clients and executable as a
+small CLI:
+
+    python -m plugins.scheduling.oauth --provider calendly --auth-url
+    python -m plugins.scheduling.oauth --provider calendly --auth-code CODE
+    python -m plugins.scheduling.oauth --provider calcom --check
+
+Google Calendar intentionally reuses the existing Hermes Google OAuth token at
+``${HERMES_HOME}/google_token.json`` instead of creating a second flow.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import hashlib
+import json
+import os
+import secrets
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+from urllib.parse import parse_qs, urlencode, urlparse
+
+import httpx
+
+from hermes_constants import get_hermes_home
+
+PROVIDERS = {"calcom", "calendly", "google_calendar"}
+DEFAULT_REDIRECT_URI = "http://localhost:1"
+
+
+class OAuthError(RuntimeError):
+    """Raised for OAuth setup, token, and refresh failures."""
+
+
+def _strip_none(data: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Return a copy without ``None`` values."""
+    return {k: v for k, v in (data or {}).items() if v is not None}
+
+
+def _now() -> int:
+    return int(time.time())
+
+
+def _client_secret_config(provider: str) -> Dict[str, str]:
+    """Resolve OAuth endpoint and client configuration for a provider."""
+    if provider == "calendly":
+        return {
+            "client_id": os.getenv("CALENDLY_CLIENT_ID", ""),
+            "client_secret": os.getenv("CALENDLY_CLIENT_SECRET", ""),
+            "authorize_url": os.getenv("CALENDLY_AUTHORIZE_URL", "https://auth.calendly.com/oauth/authorize"),
+            "token_url": os.getenv("CALENDLY_TOKEN_URL", "https://auth.calendly.com/oauth/token"),
+            "redirect_uri": os.getenv("CALENDLY_REDIRECT_URI", DEFAULT_REDIRECT_URI),
+            "scope": os.getenv("CALENDLY_SCOPE", ""),
+            "pkce": "true",
+        }
+    if provider == "calcom":
+        return {
+            "client_id": os.getenv("CALCOM_CLIENT_ID", ""),
+            "client_secret": os.getenv("CALCOM_CLIENT_SECRET", ""),
+            "authorize_url": os.getenv("CALCOM_AUTHORIZE_URL", "https://app.cal.com/oauth/authorize"),
+            "token_url": os.getenv("CALCOM_TOKEN_URL", "https://api.cal.com/v1/oauth/token"),
+            "redirect_uri": os.getenv("CALCOM_REDIRECT_URI", DEFAULT_REDIRECT_URI),
+            "scope": os.getenv("CALCOM_SCOPE", ""),
+            "pkce": os.getenv("CALCOM_OAUTH_PKCE", "false").lower(),
+        }
+    raise OAuthError(f"Unsupported OAuth provider: {provider}")
+
+
+def _google_token_path() -> Path:
+    return get_hermes_home() / "google_token.json"
+
+
+def _google_client_secret_path() -> Path:
+    return get_hermes_home() / "google_client_secret.json"
+
+
+def _token_dir() -> Path:
+    return get_hermes_home() / "scheduling_tokens"
+
+
+def _pending_path(provider: str) -> Path:
+    return _token_dir() / f"{provider}_pending.json"
+
+
+def _extract_code_and_state(code_or_url: str) -> Tuple[str, Optional[str]]:
+    """Accept either a raw authorization code or a redirect URL."""
+    if not code_or_url.startswith("http"):
+        return code_or_url, None
+    parsed = urlparse(code_or_url)
+    params = parse_qs(parsed.query)
+    code = (params.get("code") or [""])[0]
+    if not code:
+        raise OAuthError("No 'code' parameter found in callback URL.")
+    return code, (params.get("state") or [None])[0]
+
+
+def _pkce_verifier() -> str:
+    return base64.urlsafe_b64encode(secrets.token_bytes(48)).decode().rstrip("=")
+
+
+def _pkce_challenge(verifier: str) -> str:
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    return base64.urlsafe_b64encode(digest).decode().rstrip("=")
+
+
+class OAuth2Manager:
+    """Manage OAuth2 tokens for Cal.com, Calendly, and Google Calendar."""
+
+    def __init__(self, provider: str) -> None:
+        if provider not in PROVIDERS:
+            raise OAuthError(f"provider must be one of: {', '.join(sorted(PROVIDERS))}")
+        self.provider = provider
+
+    @property
+    def token_path(self) -> Path:
+        """Return the token path for this provider."""
+        if self.provider == "google_calendar":
+            return _google_token_path()
+        return _token_dir() / f"{self.provider}.json"
+
+    def check(self) -> Dict[str, Any]:
+        """Return auth status without raising for missing credentials."""
+        if self.provider == "google_calendar":
+            exists = self.token_path.exists()
+            return {
+                "success": True,
+                "provider": self.provider,
+                "authenticated": exists,
+                "token_path": str(self.token_path),
+                "message": "Using existing Google OAuth token." if exists else "No google_token.json found.",
+            }
+        if self.provider == "calcom" and os.getenv("CALCOM_API_KEY"):
+            return {
+                "success": True,
+                "provider": self.provider,
+                "authenticated": True,
+                "auth_type": "api_key",
+                "token_path": str(self.token_path),
+            }
+        token = self.load_token(refresh_if_expiring=True, raise_on_missing=False)
+        return {
+            "success": True,
+            "provider": self.provider,
+            "authenticated": bool(token),
+            "auth_type": "oauth" if token else None,
+            "token_path": str(self.token_path),
+        }
+
+    def authorization_url(self) -> Dict[str, Any]:
+        """Create and persist an OAuth state, returning the authorization URL."""
+        if self.provider == "google_calendar":
+            return {
+                "success": False,
+                "provider": self.provider,
+                "error": "Google Calendar reuses ~/.hermes/google_token.json; no scheduling OAuth flow is created.",
+            }
+
+        config = _client_secret_config(self.provider)
+        if not config["client_id"]:
+            raise OAuthError(f"{self.provider} OAuth requires a client id environment variable.")
+
+        state = secrets.token_urlsafe(24)
+        code_verifier = _pkce_verifier() if config["pkce"] in {"1", "true", "yes", "on"} else None
+        params: Dict[str, Any] = {
+            "response_type": "code",
+            "client_id": config["client_id"],
+            "redirect_uri": config["redirect_uri"],
+            "state": state,
+        }
+        if config["scope"]:
+            params["scope"] = config["scope"]
+        if code_verifier:
+            params["code_challenge"] = _pkce_challenge(code_verifier)
+            params["code_challenge_method"] = "S256"
+
+        _token_dir().mkdir(parents=True, exist_ok=True)
+        _pending_path(self.provider).write_text(json.dumps({
+            "state": state,
+            "redirect_uri": config["redirect_uri"],
+            "code_verifier": code_verifier,
+            "created_at": _now(),
+        }, indent=2))
+        return {
+            "success": True,
+            "provider": self.provider,
+            "auth_url": f"{config['authorize_url']}?{urlencode(params)}",
+            "redirect_uri": config["redirect_uri"],
+            "pkce": bool(code_verifier),
+        }
+
+    def exchange_code(self, code_or_url: str) -> Dict[str, Any]:
+        """Exchange an authorization code for tokens and store them."""
+        if self.provider == "google_calendar":
+            return {
+                "success": False,
+                "provider": self.provider,
+                "error": "Google Calendar reuses ~/.hermes/google_token.json; use the existing Google OAuth setup.",
+            }
+
+        pending_file = _pending_path(self.provider)
+        if not pending_file.exists():
+            raise OAuthError("No pending OAuth session found. Run auth_url first.")
+        pending = json.loads(pending_file.read_text())
+        code, returned_state = _extract_code_and_state(code_or_url)
+        if returned_state and returned_state != pending.get("state"):
+            raise OAuthError("OAuth state mismatch. Run auth_url again.")
+
+        config = _client_secret_config(self.provider)
+        payload = {
+            "grant_type": "authorization_code",
+            "code": code,
+            "redirect_uri": pending.get("redirect_uri") or config["redirect_uri"],
+            "client_id": config["client_id"],
+            "client_secret": config["client_secret"] or None,
+            "code_verifier": pending.get("code_verifier"),
+        }
+        token = self._token_request(config["token_url"], payload)
+        self.save_token(token)
+        pending_file.unlink(missing_ok=True)
+        return {
+            "success": True,
+            "provider": self.provider,
+            "token_path": str(self.token_path),
+            "expires_at": token.get("expires_at"),
+            "has_refresh_token": bool(token.get("refresh_token")),
+        }
+
+    def revoke(self) -> Dict[str, Any]:
+        """Delete locally stored scheduling OAuth tokens."""
+        if self.provider == "google_calendar":
+            return {
+                "success": False,
+                "provider": self.provider,
+                "error": "Refusing to delete shared google_token.json from the scheduling plugin.",
+            }
+        existed = self.token_path.exists()
+        self.token_path.unlink(missing_ok=True)
+        _pending_path(self.provider).unlink(missing_ok=True)
+        return {"success": True, "provider": self.provider, "revoked": existed}
+
+    def load_token(self, *, refresh_if_expiring: bool = True, raise_on_missing: bool = True) -> Optional[Dict[str, Any]]:
+        """Load a token and refresh it if it is expired or nearly expired."""
+        if not self.token_path.exists():
+            if raise_on_missing:
+                raise OAuthError(f"No token found for {self.provider} at {self.token_path}")
+            return None
+        try:
+            token = json.loads(self.token_path.read_text())
+        except Exception as exc:
+            raise OAuthError(f"Could not read token for {self.provider}: {exc}") from exc
+
+        if refresh_if_expiring and self._expires_soon(token):
+            token = self.refresh_token(token)
+        return token
+
+    def save_token(self, token: Dict[str, Any]) -> Dict[str, Any]:
+        """Persist a normalized token payload."""
+        normalized = dict(token)
+        if normalized.get("expires_in") and not normalized.get("expires_at"):
+            normalized["expires_at"] = _now() + int(normalized["expires_in"])
+        _token_dir().mkdir(parents=True, exist_ok=True)
+        self.token_path.write_text(json.dumps(normalized, indent=2))
+        return normalized
+
+    def refresh_token(self, token: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        """Refresh and persist an OAuth token."""
+        token = token or self.load_token(refresh_if_expiring=False)
+        if self.provider == "google_calendar":
+            refreshed = self._refresh_google_token(token or {})
+        else:
+            config = _client_secret_config(self.provider)
+            refresh_token = (token or {}).get("refresh_token")
+            if not refresh_token:
+                raise OAuthError(f"No refresh token stored for {self.provider}. Re-authenticate.")
+            refreshed = self._token_request(config["token_url"], {
+                "grant_type": "refresh_token",
+                "refresh_token": refresh_token,
+                "client_id": config["client_id"],
+                "client_secret": config["client_secret"] or None,
+            })
+            if not refreshed.get("refresh_token"):
+                refreshed["refresh_token"] = refresh_token
+        return self.save_token({**(token or {}), **refreshed})
+
+    def access_token(self) -> str:
+        """Return a current access token or raise ``OAuthError``."""
+        token = self.load_token(refresh_if_expiring=True)
+        access_token = (token or {}).get("access_token") or (token or {}).get("token")
+        if not access_token:
+            raise OAuthError(f"No access token stored for {self.provider}.")
+        return str(access_token)
+
+    def _expires_soon(self, token: Dict[str, Any]) -> bool:
+        expires_at = token.get("expires_at") or token.get("expiry")
+        if isinstance(expires_at, str):
+            try:
+                from datetime import datetime
+                expires_at = int(datetime.fromisoformat(expires_at.replace("Z", "+00:00")).timestamp())
+            except Exception:
+                return False
+        if not expires_at:
+            return False
+        return int(expires_at) <= _now() + 120
+
+    def _token_request(self, token_url: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+        response = httpx.post(
+            token_url,
+            data=_strip_none(payload),
+            headers={"Accept": "application/json"},
+            timeout=30.0,
+        )
+        if response.status_code >= 400:
+            raise OAuthError(f"Token request failed ({response.status_code}): {response.text}")
+        data = response.json()
+        if data.get("expires_in") and not data.get("expires_at"):
+            data["expires_at"] = _now() + int(data["expires_in"])
+        return data
+
+    def _refresh_google_token(self, token: Dict[str, Any]) -> Dict[str, Any]:
+        refresh_token = token.get("refresh_token")
+        if not refresh_token:
+            raise OAuthError("google_token.json does not contain a refresh_token.")
+        if not _google_client_secret_path().exists():
+            raise OAuthError(f"No Google client secret found at {_google_client_secret_path()}")
+        secret = json.loads(_google_client_secret_path().read_text())
+        client = secret.get("installed") or secret.get("web") or secret
+        client_id = client.get("client_id")
+        client_secret = client.get("client_secret")
+        token_uri = client.get("token_uri") or "https://oauth2.googleapis.com/token"
+        if not client_id or not client_secret:
+            raise OAuthError("google_client_secret.json is missing client_id/client_secret.")
+        return self._token_request(token_uri, {
+            "grant_type": "refresh_token",
+            "refresh_token": refresh_token,
+            "client_id": client_id,
+            "client_secret": client_secret,
+        })
+
+
+def run_cli(argv: Optional[list[str]] = None) -> Dict[str, Any]:
+    """Run the OAuth CLI and return a structured result."""
+    parser = argparse.ArgumentParser(description="Scheduling OAuth setup helper")
+    parser.add_argument("--provider", choices=sorted(PROVIDERS), required=True)
+    group = parser.add_mutually_exclusive_group(required=True)
+    group.add_argument("--check", action="store_true")
+    group.add_argument("--auth-url", action="store_true")
+    group.add_argument("--auth-code")
+    group.add_argument("--revoke", action="store_true")
+    args = parser.parse_args(argv)
+
+    manager = OAuth2Manager(args.provider)
+    if args.check:
+        return manager.check()
+    if args.auth_url:
+        return manager.authorization_url()
+    if args.auth_code:
+        return manager.exchange_code(args.auth_code)
+    if args.revoke:
+        return manager.revoke()
+    raise OAuthError("No OAuth action selected.")
+
+
+def main() -> None:
+    """CLI entrypoint that prints a JSON result."""
+    try:
+        result = run_cli()
+    except Exception as exc:
+        result = {"success": False, "error": str(exc)}
+        print(json.dumps(result, ensure_ascii=False))
+        raise SystemExit(1)
+    print(json.dumps(result, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/plugins/scheduling/plugin.yaml
+++ b/plugins/scheduling/plugin.yaml
@@ -1,0 +1,20 @@
+name: scheduling
+version: 1.0.0
+description: "Unified scheduling integrations for Cal.com, Calendly, and Google Calendar. Provides event listing, creation, lookup, cancellation, availability checks, calendar listing, and OAuth management."
+author: NousResearch
+kind: backend
+requires_env:
+  - name: CALCOM_API_KEY
+    optional: true
+  - name: CALENDLY_CLIENT_ID
+    optional: true
+  - name: CALENDLY_CLIENT_SECRET
+    optional: true
+provides_tools:
+  - scheduling_list_events
+  - scheduling_create_event
+  - scheduling_get_event
+  - scheduling_cancel_event
+  - scheduling_check_availability
+  - scheduling_list_calendars
+  - scheduling_oauth

--- a/plugins/scheduling/tools.py
+++ b/plugins/scheduling/tools.py
@@ -1,0 +1,347 @@
+"""Native scheduling tools for Hermes (registered via plugins/scheduling)."""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List, Optional
+
+from hermes_constants import get_hermes_home
+from plugins.scheduling.calcom_client import CalComClient, SchedulingAPIError
+from plugins.scheduling.calendly_client import CalendlyClient
+from plugins.scheduling.google_calendar_client import GoogleCalendarClient
+from plugins.scheduling.oauth import OAuth2Manager, OAuthError
+from tools.registry import tool_error, tool_result
+
+PROVIDERS = {"calcom", "calendly", "google_calendar"}
+COMMON_STRING = {"type": "string"}
+PROVIDER_SCHEMA = {"type": "string", "enum": sorted(PROVIDERS)}
+
+
+def _check_scheduling_available() -> bool:
+    """Return True when at least one scheduling provider can authenticate."""
+    try:
+        if os.getenv("CALCOM_API_KEY"):
+            return True
+        if os.getenv("CALCOM_CLIENT_ID") or os.getenv("CALENDLY_CLIENT_ID"):
+            return True
+        home = get_hermes_home()
+        if (home / "google_token.json").exists():
+            return True
+        tokens_dir = home / "scheduling_tokens"
+        return (tokens_dir / "calcom.json").exists() or (tokens_dir / "calendly.json").exists()
+    except Exception:
+        return False
+
+
+def _provider(args: Dict[str, Any]) -> str:
+    provider = str(args.get("provider") or "").strip().lower()
+    if provider not in PROVIDERS:
+        raise ValueError(f"provider must be one of: {', '.join(sorted(PROVIDERS))}")
+    return provider
+
+
+def _coerce_limit(raw: Any, *, default: int = 20, minimum: int = 1, maximum: int = 100) -> int:
+    try:
+        value = int(raw)
+    except Exception:
+        value = default
+    return max(minimum, min(maximum, value))
+
+
+def _as_list(raw: Any) -> List[str]:
+    if raw is None:
+        return []
+    if isinstance(raw, list):
+        return [str(item).strip() for item in raw if str(item).strip()]
+    return [str(raw).strip()] if str(raw).strip() else []
+
+
+def _calendar_id(args: Dict[str, Any]) -> str:
+    return str(args.get("calendar_id") or "primary").strip() or "primary"
+
+
+def _tool_failure(exc: Exception) -> str:
+    if isinstance(exc, SchedulingAPIError):
+        return tool_error(str(exc), status_code=exc.status_code)
+    if isinstance(exc, (OAuthError, ValueError)):
+        return tool_error(str(exc))
+    return tool_error(f"Scheduling tool failed: {type(exc).__name__}: {exc}")
+
+
+def _google_event_payload(args: Dict[str, Any]) -> Dict[str, Any]:
+    attendees = [{"email": email} for email in _as_list(args.get("attendees"))]
+    return {
+        "summary": args.get("title"),
+        "description": args.get("description"),
+        "location": args.get("location"),
+        "start": {"dateTime": args.get("start_time")},
+        "end": {"dateTime": args.get("end_time")},
+        "attendees": attendees or None,
+    }
+
+
+def _calcom_booking_payload(args: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "eventTypeId": args.get("event_type_id"),
+        "title": args.get("title"),
+        "start": args.get("start_time"),
+        "end": args.get("end_time"),
+        "description": args.get("description"),
+        "location": args.get("location"),
+        "attendees": _as_list(args.get("attendees")) or None,
+        "responses": args.get("responses"),
+        "metadata": args.get("metadata"),
+    }
+
+
+def _handle_scheduling_list_events(args: Dict[str, Any], **_kw: Any) -> str:
+    try:
+        provider = _provider(args)
+        limit = _coerce_limit(args.get("limit"), default=20)
+        if provider == "calcom":
+            result = CalComClient().list_bookings(
+                start_time=args.get("start_date"),
+                end_time=args.get("end_date"),
+                limit=limit,
+            )
+        elif provider == "calendly":
+            result = CalendlyClient().list_events(
+                start_time=args.get("start_date"),
+                end_time=args.get("end_date"),
+                limit=limit,
+            )
+        else:
+            result = GoogleCalendarClient(calendar_id=_calendar_id(args)).list_events(
+                start_time=args.get("start_date"),
+                end_time=args.get("end_date"),
+                limit=limit,
+            )
+        return tool_result({"success": True, "provider": provider, "result": result})
+    except Exception as exc:
+        return _tool_failure(exc)
+
+
+def _handle_scheduling_create_event(args: Dict[str, Any], **_kw: Any) -> str:
+    try:
+        provider = _provider(args)
+        if not args.get("title"):
+            return tool_error("title is required")
+        if not args.get("start_time") or not args.get("end_time"):
+            return tool_error("start_time and end_time are required")
+        if provider == "calcom":
+            result = CalComClient().create_booking(_calcom_booking_payload(args))
+        elif provider == "calendly":
+            return tool_error("Calendly API does not support creating scheduled events directly; create a booking through a scheduling link.")
+        else:
+            result = GoogleCalendarClient(calendar_id=_calendar_id(args)).create_event(_google_event_payload(args))
+        return tool_result({"success": True, "provider": provider, "result": result})
+    except Exception as exc:
+        return _tool_failure(exc)
+
+
+def _handle_scheduling_get_event(args: Dict[str, Any], **_kw: Any) -> str:
+    try:
+        provider = _provider(args)
+        event_id = str(args.get("event_id") or "").strip()
+        if not event_id:
+            return tool_error("event_id is required")
+        if provider == "calcom":
+            result = CalComClient().get_booking(event_id)
+        elif provider == "calendly":
+            result = CalendlyClient().get_event(event_id)
+        else:
+            result = GoogleCalendarClient(calendar_id=_calendar_id(args)).get_event(event_id)
+        return tool_result({"success": True, "provider": provider, "result": result})
+    except Exception as exc:
+        return _tool_failure(exc)
+
+
+def _handle_scheduling_cancel_event(args: Dict[str, Any], **_kw: Any) -> str:
+    try:
+        provider = _provider(args)
+        event_id = str(args.get("event_id") or "").strip()
+        if not event_id:
+            return tool_error("event_id is required")
+        reason = args.get("reason")
+        if provider == "calcom":
+            result = CalComClient().cancel_booking(event_id, reason=reason)
+        elif provider == "calendly":
+            result = CalendlyClient().cancel_event(event_id, reason=reason)
+        else:
+            result = GoogleCalendarClient(calendar_id=_calendar_id(args)).delete_event(event_id)
+        return tool_result({"success": True, "provider": provider, "result": result})
+    except Exception as exc:
+        return _tool_failure(exc)
+
+
+def _handle_scheduling_check_availability(args: Dict[str, Any], **_kw: Any) -> str:
+    try:
+        provider = _provider(args)
+        start_date = args.get("start_date")
+        end_date = args.get("end_date")
+        if not start_date or not end_date:
+            return tool_error("start_date and end_date are required")
+        if provider == "calcom":
+            result = CalComClient().check_availability(
+                event_type_id=args.get("event_type_id"),
+                start_time=start_date,
+                end_time=end_date,
+            )
+        elif provider == "calendly":
+            result = CalendlyClient().check_availability(
+                user_uri=args.get("user_uri"),
+                event_type_uri=args.get("event_type_uri"),
+                start_time=start_date,
+                end_time=end_date,
+            )
+        else:
+            result = GoogleCalendarClient(calendar_id=_calendar_id(args)).free_busy(
+                start_time=start_date,
+                end_time=end_date,
+                calendar_ids=_as_list(args.get("calendar_ids")) or None,
+            )
+        return tool_result({"success": True, "provider": provider, "result": result})
+    except Exception as exc:
+        return _tool_failure(exc)
+
+
+def _handle_scheduling_list_calendars(args: Dict[str, Any], **_kw: Any) -> str:
+    try:
+        provider = _provider(args)
+        if provider != "google_calendar":
+            return tool_error("scheduling_list_calendars only supports provider='google_calendar'")
+        return tool_result({"success": True, "provider": provider, "result": GoogleCalendarClient().list_calendars()})
+    except Exception as exc:
+        return _tool_failure(exc)
+
+
+def _handle_scheduling_oauth(args: Dict[str, Any], **_kw: Any) -> str:
+    try:
+        provider = _provider(args)
+        action = str(args.get("action") or "check").strip().lower()
+        manager = OAuth2Manager(provider)
+        if action == "check":
+            return tool_result(manager.check())
+        if action == "auth_url":
+            return tool_result(manager.authorization_url())
+        if action == "auth_code":
+            code = str(args.get("code") or "").strip()
+            if not code:
+                return tool_error("code is required for action='auth_code'")
+            return tool_result(manager.exchange_code(code))
+        if action == "revoke":
+            return tool_result(manager.revoke())
+        return tool_error("action must be one of: check, auth_url, auth_code, revoke")
+    except Exception as exc:
+        return _tool_failure(exc)
+
+
+SCHEDULING_LIST_EVENTS_SCHEMA: Dict[str, Any] = {
+    "name": "scheduling_list_events",
+    "description": "List scheduling events or bookings from Cal.com, Calendly, or Google Calendar.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "provider": PROVIDER_SCHEMA,
+            "start_date": COMMON_STRING,
+            "end_date": COMMON_STRING,
+            "limit": {"type": "integer"},
+            "calendar_id": COMMON_STRING,
+        },
+        "required": ["provider"],
+    },
+}
+
+SCHEDULING_CREATE_EVENT_SCHEMA: Dict[str, Any] = {
+    "name": "scheduling_create_event",
+    "description": "Create a Cal.com booking or Google Calendar event. Calendly event creation is not supported by Calendly's public API.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "provider": PROVIDER_SCHEMA,
+            "title": COMMON_STRING,
+            "start_time": COMMON_STRING,
+            "end_time": COMMON_STRING,
+            "description": COMMON_STRING,
+            "attendees": {"type": "array", "items": COMMON_STRING},
+            "location": COMMON_STRING,
+            "calendar_id": COMMON_STRING,
+            "event_type_id": COMMON_STRING,
+            "responses": {"type": "object"},
+            "metadata": {"type": "object"},
+        },
+        "required": ["provider", "title", "start_time", "end_time"],
+    },
+}
+
+SCHEDULING_GET_EVENT_SCHEMA: Dict[str, Any] = {
+    "name": "scheduling_get_event",
+    "description": "Get one scheduling event or booking by provider-specific event id.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "provider": PROVIDER_SCHEMA,
+            "event_id": COMMON_STRING,
+            "calendar_id": COMMON_STRING,
+        },
+        "required": ["provider", "event_id"],
+    },
+}
+
+SCHEDULING_CANCEL_EVENT_SCHEMA: Dict[str, Any] = {
+    "name": "scheduling_cancel_event",
+    "description": "Cancel or delete one scheduling event by provider-specific event id.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "provider": PROVIDER_SCHEMA,
+            "event_id": COMMON_STRING,
+            "reason": COMMON_STRING,
+            "calendar_id": COMMON_STRING,
+        },
+        "required": ["provider", "event_id"],
+    },
+}
+
+SCHEDULING_CHECK_AVAILABILITY_SCHEMA: Dict[str, Any] = {
+    "name": "scheduling_check_availability",
+    "description": "Check provider availability between two timestamps.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "provider": PROVIDER_SCHEMA,
+            "start_date": COMMON_STRING,
+            "end_date": COMMON_STRING,
+            "event_type_id": COMMON_STRING,
+            "event_type_uri": COMMON_STRING,
+            "user_uri": COMMON_STRING,
+            "calendar_id": COMMON_STRING,
+            "calendar_ids": {"type": "array", "items": COMMON_STRING},
+        },
+        "required": ["provider", "start_date", "end_date"],
+    },
+}
+
+SCHEDULING_LIST_CALENDARS_SCHEMA: Dict[str, Any] = {
+    "name": "scheduling_list_calendars",
+    "description": "List calendars for Google Calendar.",
+    "parameters": {
+        "type": "object",
+        "properties": {"provider": PROVIDER_SCHEMA},
+        "required": ["provider"],
+    },
+}
+
+SCHEDULING_OAUTH_SCHEMA: Dict[str, Any] = {
+    "name": "scheduling_oauth",
+    "description": "Manage scheduling OAuth status, authorization URLs, code exchange, and local token revocation.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "provider": PROVIDER_SCHEMA,
+            "action": {"type": "string", "enum": ["check", "auth_url", "auth_code", "revoke"]},
+            "code": COMMON_STRING,
+        },
+        "required": ["provider", "action"],
+    },
+}


### PR DESCRIPTION
## Summary

Unified scheduling plugin (`plugins/scheduling/`) providing 7 tools across three providers:

- **Cal.com** — OAuth or API key auth, full booking CRUD + availability checks
- **Calendly** — OAuth with PKCE, event listing/cancellation + availability
- **Google Calendar** — reuses existing `google_token.json`, full event CRUD + free/busy + calendar listing

### Tools

| Tool | Description |
|------|-------------|
| `scheduling_list_events` | List events/bookings from any provider |
| `scheduling_create_event` | Create events (Cal.com + Google Calendar) |
| `scheduling_get_event` | Get single event details |
| `scheduling_cancel_event` | Cancel/delete events |
| `scheduling_check_availability` | Check availability across providers |
| `scheduling_list_calendars` | List Google Calendar calendars |
| `scheduling_oauth` | Manage OAuth (check/auth_url/auth_code/revoke) |

### Architecture

- Follows the `plugins/spotify/` pattern exactly (`kind: backend`, auto-loaded)
- Shared `OAuth2Manager` class with PKCE support, auto-refresh, CLI interface
- Token storage in `~/.hermes/scheduling_tokens/<provider>.json`
- Google Calendar reuses existing Hermes Google OAuth — no duplicate flow
- Self-contained: only depends on `httpx` + stdlib

### Files (1,092 lines)

```
plugins/scheduling/
  plugin.yaml              — manifest
  __init__.py              — plugin registration (50 lines)
  oauth.py                 — OAuth2Manager with PKCE + CLI (379 lines)
  calcom_client.py         — Cal.com v1 API client (100 lines)
  calendly_client.py       — Calendly API client (89 lines)
  google_calendar_client.py — Google Calendar API client (107 lines)
  tools.py                 — 7 tool schemas + handlers (347 lines)
```

### Test Plan

- [ ] Verify plugin loads on startup (`hermes tools` shows scheduling toolset)
- [ ] Test Google Calendar: list events, create event, check availability (uses existing token)
- [ ] Test Cal.com OAuth flow: auth-url -> auth-code -> token exchange
- [ ] Test Calendly OAuth flow with PKCE
- [ ] Verify graceful error handling when no provider is configured