### PR TITLE
fix(gateway/weixin): bound TCPConnector to prevent fd exhaustion

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -132,7 +132,19 @@ def _make_ssl_connector() -> Optional["aiohttp.TCPConnector"]:
     if not AIOHTTP_AVAILABLE:
         return None
     ssl_ctx = ssl.create_default_context(cafile=certifi.where())
-    return aiohttp.TCPConnector(ssl=ssl_ctx)
+    # Bound socket usage. Default aiohttp connector keeps up to 100 connections
+    # alive (keepalive_timeout=15s) which, combined with the poll + send sessions
+    # and bursty CDN fetches for images/voice, easily blows past macOS launchd's
+    # 256 soft-fd cap and surfaces as `[Errno 24] Too many open files` across the
+    # whole gateway (sqlite, telegram httpx, channel directory writes, etc.).
+    # enable_cleanup_closed reaps SSL sockets that the peer half-closes — without
+    # it those linger as TIME_WAIT-style fd leaks on macOS.
+    return aiohttp.TCPConnector(
+        ssl=ssl_ctx,
+        limit=20,
+        limit_per_host=8,
+        enable_cleanup_closed=True,
+    )
 
 ITEM_TEXT = 1
 ITEM_IMAGE = 2


### PR DESCRIPTION
The Weixin platform creates two long-lived aiohttp ClientSessions (poll + send) plus opens additional sessions for image/voice CDN fetches. The default TCPConnector keeps up to 100 idle connections per session with a 15s keepalive, and on macOS launchd's 256 soft-fd cap that pool routinely overruns the limit during bursty traffic.

When that happens it surfaces as cascading [Errno 24] Too many open files errors across the whole gateway: telegram httpx send fails with NetworkError(All connection attempts failed), the kanban dispatcher hits sqlite3.OperationalError: unable to open database file, and channel directory writes fail. Reproduced on a Mac running the launchd-managed gateway with weixin enabled — fd count climbs over hours until everything breaks and a restart is required.

Cap the connector at 20 total / 8 per-host (well above the platform's working set) and enable_cleanup_closed=True so half-closed SSL sockets get reaped instead of lingering as fd leaks.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

## Summary

Bounds the aiohttp `TCPConnector` used by the Weixin platform so it can't exhaust the gateway process's file descriptors.

The Weixin adapter holds two long-lived `ClientSession`s (poll + send) and opens additional ones for image/voice CDN fetches. The current `TCPConnector` is created with default settings, which keeps up to **100 idle connections per session** with a 15-second keepalive. Combined with bursty traffic, that pool can climb past macOS launchd's default 256 soft-fd cap.

When it does, the failure isn't isolated to Weixin — every other subsystem in the gateway starts failing too because no new socket or temp file can be opened:

- `gateway.platforms.telegram` → `httpx.ConnectError: All connection attempts failed` (Telegram replies stop going out)
- `gateway.run` kanban dispatcher → `sqlite3.OperationalError: unable to open database file`
- `gateway.channel_directory` → `[Errno 24] Too many open files` writing the directory tmp file
- `_save_sync_buf` → `[Errno 24] Too many open files: '...sync_<rand>.tmp'` (this is the one that surfaces in logs even though the leak is in the connector, not in the atomic write)

Once that state is hit the only remediation is a `hermes gateway restart`.

## Fix

Cap the connector's connection pool and enable cleanup of half-closed SSL sockets, which otherwise linger as TIME_WAIT-style fd leaks on macOS:

```python
return aiohttp.TCPConnector(
    ssl=ssl_ctx,
    limit=20,
    limit_per_host=8,
    enable_cleanup_closed=True,
)
```

`limit=20` is well above the platform's working set (poll long-poll + a handful of concurrent sends/uploads) but small enough that the two sessions together can never approach the 256-fd ceiling, even with an unrelated burst of activity from telegram/kanban/etc.

## Repro

Mac running the launchd-managed gateway (`~/Library/LaunchAgents/ai.hermes.gateway.plist`), Weixin platform enabled, sustained traffic for several hours:

```
launchctl limit maxfiles
    maxfiles    256            unlimited
```

fd count climbs over time; once it hits 256 the cascading errors above all start firing in `gateway.log`. Reproduced reliably on this setup before the patch; after the patch fd count holds steady around 45 on a freshly restarted gateway with the same workload.

## Test Plan

- [x] Restarted the gateway with the patch applied — Weixin connects, polls successfully, no `Too many open files` errors observed
- [x] Telegram polling reconnects cleanly and replies flow again
- [x] Sustained workload over ~30 minutes shows fd count stable (~45) instead of monotonically increasing

## Notes

The `_save_sync_buf` traceback in the logs is a red herring — it's just the most visible victim because every poll cycle calls `atomic_json_write`, which uses `tempfile.mkstemp`. The actual leak is the connector pool keeping idle SSL sockets around past their useful life.

A follow-up could also bump `SoftResourceLimits.NumberOfFiles` in the launchd plist as a defense-in-depth measure, but that's a packaging change; this PR is the minimal code fix.


## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

