### PR TITLE
fix(compression): honor custom provider context lengths

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -415,6 +415,7 @@ class ContextCompressor(ContextEngine):
         config_context_length: int | None = None,
         provider: str = "",
         api_mode: str = "",
+        custom_providers: list | None = None,
     ):
         self.model = model
         self.base_url = base_url
@@ -431,6 +432,7 @@ class ContextCompressor(ContextEngine):
             model, base_url=base_url, api_key=api_key,
             config_context_length=config_context_length,
             provider=provider,
+            custom_providers=custom_providers,
         )
         # Floor: never compress below MINIMUM_CONTEXT_LENGTH tokens even if
         # the percentage would suggest a lower value.  This prevents premature

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -415,7 +415,6 @@ class ContextCompressor(ContextEngine):
         config_context_length: int | None = None,
         provider: str = "",
         api_mode: str = "",
-        custom_providers: Any = None,
     ):
         self.model = model
         self.base_url = base_url
@@ -432,7 +431,6 @@ class ContextCompressor(ContextEngine):
             model, base_url=base_url, api_key=api_key,
             config_context_length=config_context_length,
             provider=provider,
-            custom_providers=custom_providers,
         )
         # Floor: never compress below MINIMUM_CONTEXT_LENGTH tokens even if
         # the percentage would suggest a lower value.  This prevents premature

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -415,7 +415,7 @@ class ContextCompressor(ContextEngine):
         config_context_length: int | None = None,
         provider: str = "",
         api_mode: str = "",
-        custom_providers: list | None = None,
+        custom_providers: Any = None,
     ):
         self.model = model
         self.base_url = base_url

--- a/run_agent.py
+++ b/run_agent.py
@@ -2203,11 +2203,7 @@ class AIAgent:
             _custom_providers = _agent_cfg.get("custom_providers")
             if not isinstance(_custom_providers, list):
                 _custom_providers = []
-        self._custom_providers = _custom_providers
-
-        # Store for reuse by _check_compression_model_feasibility (auxiliary
-        # compression model context-length detection needs the same list).
-        self._custom_providers = _custom_providers
+        self._custom_providers = _custom_providers  # Cache for aux compression probe.
 
         # Check custom_providers per-model context_length
         if _config_context_length is None and _custom_providers:
@@ -3247,12 +3243,10 @@ class AIAgent:
                 base_url=aux_base_url,
                 api_key=aux_api_key,
                 config_context_length=getattr(self, "_aux_compression_context_length_config", None),
-                custom_providers=getattr(self, "_custom_providers", None),
-                # Each model must be resolved with its own provider so that
-                # provider-specific paths (e.g. Bedrock static table, OpenRouter API)
+                # Resolve provider-specific paths (e.g. Bedrock static table)
                 # are invoked for the correct client, not inherited from the main model.
                 provider=(_aux_cfg_provider if _aux_cfg_provider and _aux_cfg_provider != "auto" else getattr(self, "provider", "")),
-                custom_providers=self._custom_providers,
+                custom_providers=getattr(self, "_custom_providers", None),
             )
 
             # Hard floor: the auxiliary compression model must have at least

--- a/run_agent.py
+++ b/run_agent.py
@@ -2203,6 +2203,7 @@ class AIAgent:
             _custom_providers = _agent_cfg.get("custom_providers")
             if not isinstance(_custom_providers, list):
                 _custom_providers = []
+        self._custom_providers = _custom_providers
 
         # Store for reuse by _check_compression_model_feasibility (auxiliary
         # compression model context-length detection needs the same list).
@@ -2338,6 +2339,7 @@ class AIAgent:
                 config_context_length=_config_context_length,
                 provider=self.provider,
                 api_mode=self.api_mode,
+                custom_providers=_custom_providers,
             )
         self.compression_enabled = compression_enabled
 
@@ -3246,6 +3248,7 @@ class AIAgent:
                 base_url=aux_base_url,
                 api_key=aux_api_key,
                 config_context_length=getattr(self, "_aux_compression_context_length_config", None),
+                custom_providers=getattr(self, "_custom_providers", None),
                 # Each model must be resolved with its own provider so that
                 # provider-specific paths (e.g. Bedrock static table, OpenRouter API)
                 # are invoked for the correct client, not inherited from the main model.

--- a/run_agent.py
+++ b/run_agent.py
@@ -2339,7 +2339,6 @@ class AIAgent:
                 config_context_length=_config_context_length,
                 provider=self.provider,
                 api_mode=self.api_mode,
-                custom_providers=_custom_providers,
             )
         self.compression_enabled = compression_enabled
 

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -192,8 +192,79 @@ def test_feasibility_check_passes_config_context_length(mock_get_client, mock_ct
         base_url="http://custom-endpoint:8080/v1",
         api_key="sk-custom",
         config_context_length=1_000_000,
+        custom_providers=None,
         provider="openrouter",
         custom_providers=[],
+    )
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=1_000_000)
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_feasibility_check_passes_custom_providers(mock_get_client, mock_ctx_len):
+    """Auto compression model context should honor custom_providers metadata."""
+    custom_providers = [
+        {
+            "name": "my-gateway",
+            "base_url": "https://ais.example.com/v1",
+            "models": {
+                "qwen/deepseek-v4-pro": {"context_length": 1_000_000},
+            },
+        }
+    ]
+    agent = _make_agent(main_context=1_000_000, threshold_percent=0.50)
+    agent.model = "qwen/deepseek-v4-pro"
+    agent.provider = "custom:my-gateway"
+    agent.base_url = "https://ais.example.com/v1"
+    agent._custom_providers = custom_providers
+    mock_client = MagicMock()
+    mock_client.base_url = "https://ais.example.com/v1"
+    mock_client.api_key = "sk-custom"
+    mock_get_client.return_value = (mock_client, "qwen/deepseek-v4-pro")
+
+    agent._emit_status = lambda msg: None
+    agent._check_compression_model_feasibility()
+
+    mock_ctx_len.assert_called_once_with(
+        "qwen/deepseek-v4-pro",
+        base_url="https://ais.example.com/v1",
+        api_key="sk-custom",
+        config_context_length=None,
+        custom_providers=custom_providers,
+        provider="custom:my-gateway",
+    )
+
+
+def test_context_compressor_passes_custom_providers_to_context_resolver():
+    custom_providers = [
+        {
+            "name": "my-gateway",
+            "base_url": "https://ais.example.com/v1",
+            "models": {
+                "qwen/deepseek-v4-pro": {"context_length": 1_000_000},
+            },
+        }
+    ]
+
+    with patch(
+        "agent.context_compressor.get_model_context_length", return_value=1_000_000
+    ) as mock_ctx_len:
+        compressor = ContextCompressor(
+            model="qwen/deepseek-v4-pro",
+            base_url="https://ais.example.com/v1",
+            api_key="sk-custom",
+            provider="custom:my-gateway",
+            custom_providers=custom_providers,
+            quiet_mode=True,
+        )
+
+    assert compressor.context_length == 1_000_000
+    mock_ctx_len.assert_called_once_with(
+        "qwen/deepseek-v4-pro",
+        base_url="https://ais.example.com/v1",
+        api_key="sk-custom",
+        config_context_length=None,
+        provider="custom:my-gateway",
+        custom_providers=custom_providers,
     )
 
 
@@ -216,6 +287,7 @@ def test_feasibility_check_ignores_invalid_context_length(mock_get_client, mock_
         base_url="http://custom:8080/v1",
         api_key="sk-test",
         config_context_length=None,
+        custom_providers=None,
         provider="openrouter",
         custom_providers=[],
     )
@@ -270,6 +342,7 @@ def test_init_feasibility_check_uses_aux_context_override_from_config():
         base_url="http://custom-endpoint:8080/v1",
         api_key="sk-custom",
         config_context_length=1_000_000,
+        custom_providers=[],
         provider="",
         custom_providers=[],
     )

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -234,40 +234,6 @@ def test_feasibility_check_passes_custom_providers(mock_get_client, mock_ctx_len
     )
 
 
-def test_context_compressor_passes_custom_providers_to_context_resolver():
-    custom_providers = [
-        {
-            "name": "my-gateway",
-            "base_url": "https://ais.example.com/v1",
-            "models": {
-                "qwen/deepseek-v4-pro": {"context_length": 1_000_000},
-            },
-        }
-    ]
-
-    with patch(
-        "agent.context_compressor.get_model_context_length", return_value=1_000_000
-    ) as mock_ctx_len:
-        compressor = ContextCompressor(
-            model="qwen/deepseek-v4-pro",
-            base_url="https://ais.example.com/v1",
-            api_key="sk-custom",
-            provider="custom:my-gateway",
-            custom_providers=custom_providers,
-            quiet_mode=True,
-        )
-
-    assert compressor.context_length == 1_000_000
-    mock_ctx_len.assert_called_once_with(
-        "qwen/deepseek-v4-pro",
-        base_url="https://ais.example.com/v1",
-        api_key="sk-custom",
-        config_context_length=None,
-        provider="custom:my-gateway",
-        custom_providers=custom_providers,
-    )
-
-
 @patch("agent.model_metadata.get_model_context_length", return_value=128_000)
 @patch("agent.auxiliary_client.get_text_auxiliary_client")
 def test_feasibility_check_ignores_invalid_context_length(mock_get_client, mock_ctx_len):

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -192,7 +192,6 @@ def test_feasibility_check_passes_config_context_length(mock_get_client, mock_ct
         base_url="http://custom-endpoint:8080/v1",
         api_key="sk-custom",
         config_context_length=1_000_000,
-        custom_providers=None,
         provider="openrouter",
         custom_providers=[],
     )
@@ -253,7 +252,6 @@ def test_feasibility_check_ignores_invalid_context_length(mock_get_client, mock_
         base_url="http://custom:8080/v1",
         api_key="sk-test",
         config_context_length=None,
-        custom_providers=None,
         provider="openrouter",
         custom_providers=[],
     )
@@ -308,7 +306,6 @@ def test_init_feasibility_check_uses_aux_context_override_from_config():
         base_url="http://custom-endpoint:8080/v1",
         api_key="sk-custom",
         config_context_length=1_000_000,
-        custom_providers=[],
         provider="",
         custom_providers=[],
     )


### PR DESCRIPTION
## Problem
Compression models configured with `provider: auto` and an empty model inherit the main model name, but the startup feasibility check did not inherit the `custom_providers[].models.<model>.context_length` metadata for that model. Users with custom OpenAI-compatible providers could see Hermes auto-lower the compression threshold to the 256K fallback even when config.yaml declared a larger context window.

Closes #21947

## Root cause
`get_model_context_length()` already supports `custom_providers`, and the main compressor path already resolves custom-provider context into `model.context_length` before construction. The auxiliary compression feasibility probe, however, only passed `auxiliary.compression.context_length` and did not have access to the resolved custom provider list.

## Fix
Cache the resolved custom provider metadata on the agent and pass it into `_check_compression_model_feasibility()` when resolving the inherited auxiliary compression model's context length.

## Testing
- `python3 -m py_compile run_agent.py tests/run_agent/test_compression_feasibility.py`: clean
- `python3 -m ruff check tests/run_agent/test_compression_feasibility.py --select F`: clean
- `python3 -m pytest -o addopts='' tests/run_agent/test_compression_feasibility.py -q`: 17 passed

Note: full-file `ruff --select E,W,F` on `run_agent.py` still reports pre-existing unrelated issues; the repo's CI uses the ruff diff workflow for PRs.