### PR TITLE
docs(discord): clarify install contexts for slash command discovery

### DIFF
--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -159,11 +159,15 @@ This method requires **Public Bot** to be set to **ON** in Step 2. If you set Pu
 :::
 
 1. In the left sidebar, click **Installation**.
-2. Under **Installation Contexts**, enable **Guild Install**.
+2. Under **Installation Contexts**, enable **Guild Install** and **User Install** if you want slash commands to work in both servers and DMs.
 3. For **Install Link**, select **Discord Provided Link**.
 4. Under **Default Install Settings** for Guild Install:
    - **Scopes**: select `bot` and `applications.commands`
    - **Permissions**: select the permissions listed below.
+
+:::warning[Important: installation contexts are separate authorizations]
+If you enabled both **Guild Install** and **User Install**, you must complete **both** installs. Open the install link once to add the bot to your server (Guild Install), then open it again to add the app to your own account (User Install). If you only complete one install, the other context may not show the full slash-command autocomplete experience. That means users may not be able to discover installed Hermes skill commands by typing `/` and searching, which makes everyday use much harder.
+:::
 
 ### Option B: Manual URL
 
@@ -209,6 +213,10 @@ You need the **Manage Server** permission on the Discord server to invite a bot.
 :::
 
 After authorizing, the bot will appear in your server's member list (it will show as offline until you start the Hermes gateway).
+
+:::warning[Post-install security hardening]
+After you finish installation, go back to **Bot → Authorization Flow** and set **Public Bot** back to **OFF**. Existing installs remain active. Leaving Public Bot ON makes your app discoverable and installable by anyone with the application ID.
+:::
 
 ## Step 7: Find Your Discord User ID
 
@@ -482,6 +490,8 @@ Hermes automatically registers installed skills as **native Discord Application 
 
 No extra configuration is needed — any skill installed via `hermes skills install` is automatically registered as a Discord slash command on the next gateway restart.
 
+If skill commands do not appear in autocomplete, double-check the dual-install flow in [Step 5: Generate the Invite URL](#step-5-generate-the-invite-url), then see ["Unknown integration" when running slash commands](#unknown-integration-when-running-slash-commands).
+
 ### Disabling Slash Command Registration
 
 If you run multiple Hermes gateways against the same Discord application (e.g. staging + production), only one of them should own the global slash-command registration — otherwise the last startup wins and the registrations flap. Turn slash registration off on the "follower" gateway:
@@ -577,6 +587,16 @@ Refreshing the directory (`/channels refresh` on platforms that expose it, or a 
 **Cause**: The bot is missing required permissions.
 
 **Fix**: Re-invite the bot with the correct permissions using the URL from Step 5, or manually adjust the bot's role permissions in Server Settings → Roles.
+
+### "Unknown integration" when running slash commands
+
+**Cause**: The app was installed in only one context (server or user account). The other context can miss expected slash-command behavior, including command discovery/autocomplete for installed Hermes skills, and may return **Unknown integration** for some interactions.
+
+**Fix**: In the Developer Portal, ensure both **Guild Install** and **User Install** are enabled, then run the install link twice:
+1. complete **Guild Install** (add to server)
+2. complete **User Install** (add to your apps)
+
+After both installs, users get the expected slash-command experience in both DMs and servers, including better discovery of installed Hermes skills via autocomplete.
 
 ### Bot is offline
 


### PR DESCRIPTION
## Summary
- clarify that Guild Install and User Install are separate authorizations in Discord setup
- document the quality-of-life impact when only one context is installed (missing slash-command autocomplete/discoverability for Hermes skills in the other context)
- add troubleshooting and a direct cross-reference from Native Slash Commands for Skills to install-context debugging
- add post-install guidance to set Public Bot back to OFF for safer defaults

Fixes #21949

## Test plan
- [x] Reviewed `website/docs/user-guide/messaging/discord.md` for targeted edits only
- [x] Verified markdown links/anchors for Step 5 and troubleshooting cross-reference
- [x] Confirmed no unrelated file changes are included

Made with [Cursor](https://cursor.com)