### PR TITLE
[security] fix(vision): enforce URL safety in media downloads

### DIFF
--- a/tests/tools/test_video_analyze.py
+++ b/tests/tools/test_video_analyze.py
@@ -4,6 +4,7 @@ import asyncio
 import json
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import pytest
 
 from tools.vision_tools import (
     _detect_video_mime_type,
@@ -175,6 +176,23 @@ class TestVideoAnalyzeTool:
 
     def _run(self, coro):
         return asyncio.get_event_loop().run_until_complete(coro)
+
+    def test_download_rejects_private_url_before_http_client(self, tmp_path):
+        from tools.vision_tools import _download_video
+
+        with (
+            patch("tools.vision_tools.httpx.AsyncClient") as mock_client_cls,
+            pytest.raises(ValueError, match="Blocked video download"),
+        ):
+            self._run(
+                _download_video(
+                    "http://127.0.0.1:8080/private.mp4",
+                    tmp_path / "private.mp4",
+                    max_retries=1,
+                )
+            )
+
+        mock_client_cls.assert_not_called()
 
     def test_local_file_success(self, tmp_path, monkeypatch):
         """Analyze a local video file — happy path."""

--- a/tests/tools/test_vision_tools.py
+++ b/tests/tools/test_vision_tools.py
@@ -548,6 +548,55 @@ class TestVisionSafetyGuards:
         mock_download.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_download_rejects_private_url_before_http_client(self, tmp_path):
+        from tools.vision_tools import _download_image
+
+        with (
+            patch("tools.vision_tools.httpx.AsyncClient") as mock_client_cls,
+            pytest.raises(ValueError, match="Blocked image download"),
+        ):
+            await _download_image("http://127.0.0.1:8080/private.png", tmp_path / "x.png", max_retries=1)
+
+        mock_client_cls.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_download_redirect_location_without_next_request_is_blocked(self, tmp_path):
+        from tools.vision_tools import _download_image
+
+        class FakeRedirectResponse:
+            is_redirect = True
+            headers = {"location": "http://169.254.169.254/latest/meta-data"}
+            url = "https://allowed.test/cat.png"
+            next_request = None
+
+        with (
+            patch("tools.vision_tools.check_website_access", return_value=None),
+            patch("tools.url_safety.async_is_safe_url", new_callable=AsyncMock) as mock_safe_url,
+            patch("tools.vision_tools.httpx.AsyncClient") as mock_client_cls,
+            pytest.raises(ValueError, match="Blocked image download"),
+        ):
+            mock_safe_url.side_effect = [True, False]
+            mock_client = AsyncMock()
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+
+            async def fake_get(*args, **kwargs):
+                hook = mock_client_cls.call_args.kwargs["event_hooks"]["response"][0]
+                await hook(FakeRedirectResponse())
+                raise AssertionError("redirect guard should have raised before response body")
+
+            mock_client.get = AsyncMock(side_effect=fake_get)
+            mock_client_cls.return_value = mock_client
+
+            await _download_image("https://allowed.test/cat.png", tmp_path / "cat.png", max_retries=1)
+
+        assert [call.args[0] for call in mock_safe_url.await_args_list] == [
+            "https://allowed.test/cat.png",
+            "http://169.254.169.254/latest/meta-data",
+        ]
+        assert not (tmp_path / "cat.png").exists()
+
+    @pytest.mark.asyncio
     async def test_download_blocks_redirected_final_url(self, tmp_path):
         from tools.vision_tools import _download_image
 
@@ -573,6 +622,7 @@ class TestVisionSafetyGuards:
 
         with (
             patch("tools.vision_tools.check_website_access", side_effect=fake_check),
+            patch("tools.url_safety.async_is_safe_url", new_callable=AsyncMock, return_value=True),
             patch("tools.vision_tools.httpx.AsyncClient") as mock_client_cls,
             pytest.raises(PermissionError, match="Blocked by website policy"),
         ):

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -221,6 +221,14 @@ async def _validate_image_url_async(url: str) -> bool:
     return await async_is_safe_url(url)
 
 
+async def _ensure_safe_download_url(url: str, media_type: str) -> None:
+    """Reject private/internal media download URLs before opening sockets."""
+    if not await _validate_image_url_async(url):
+        raise ValueError(
+            f"Blocked {media_type} download from private/internal address: {url}"
+        )
+
+
 def _detect_image_mime_type_from_bytes(data: bytes) -> Optional[str]:
     """Magic-byte MIME sniff on raw bytes (authoritative; no extension trust).
 
@@ -410,14 +418,13 @@ async def _download_image(image_url: str, destination: Path, max_retries: int = 
 
         Must be async because httpx.AsyncClient awaits event hooks.
         """
-        from tools.url_safety import async_is_safe_url, redirect_target_from_response
+        from tools.url_safety import redirect_target_from_response
         redirect_url = redirect_target_from_response(response)
-        if redirect_url and not await async_is_safe_url(redirect_url):
-            raise ValueError(
-                f"Blocked redirect to private/internal address: {redirect_url}"
-            )
+        if redirect_url:
+            await _ensure_safe_download_url(redirect_url, "image")
 
     last_error = None
+    await _ensure_safe_download_url(image_url, "image")
     for attempt in range(max_retries):
         try:
             blocked = check_website_access(image_url)
@@ -1561,14 +1568,13 @@ async def _download_video(video_url: str, destination: Path, max_retries: int = 
     destination.parent.mkdir(parents=True, exist_ok=True)
 
     async def _ssrf_redirect_guard(response):
-        from tools.url_safety import async_is_safe_url, redirect_target_from_response
+        from tools.url_safety import redirect_target_from_response
         redirect_url = redirect_target_from_response(response)
-        if redirect_url and not await async_is_safe_url(redirect_url):
-            raise ValueError(
-                f"Blocked redirect to private/internal address: {redirect_url}"
-            )
+        if redirect_url:
+            await _ensure_safe_download_url(redirect_url, "video")
 
     last_error = None
+    await _ensure_safe_download_url(video_url, "video")
     for attempt in range(max_retries):
         try:
             blocked = check_website_access(video_url)


### PR DESCRIPTION
## Summary

This PR hardens the vision media download boundary so the concrete download helpers enforce the same private/internal URL policy as their public validators.

It addresses a residual helper-level variant of the vision/media SSRF hardening family: the public wrappers validate with `tools.url_safety.is_safe_url()`, but the lower-level helpers that open outbound HTTP connections did not enforce that central policy before the initial request.

- Adds a shared pre-connect URL-safety guard for image and video downloads.
- Keeps redirect-target revalidation for both media types using the same guard.
- Adds regression tests proving loopback URLs are rejected before an HTTP client is opened.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Vision media download helpers did not enforce `is_safe_url()` before the initial fetch | A direct or future caller of `_download_image()` / `_download_video()` could bypass the central private/internal URL policy and fetch loopback or metadata-style targets | Medium / defense-in-depth |

## Before this PR

- `_validate_image_url()` rejected private/internal URLs with `tools.url_safety.is_safe_url()`.
- `_download_image()` and `_download_video()` only applied `check_website_access()` before the initial request.
- The helper comments described SSRF protection, but the initial helper fetch itself did not enforce the central private/internal URL policy.
- Redirect targets were checked, but the first request URL was not checked at the helper boundary.

## After this PR

- `_download_image()` rejects unsafe image URLs before constructing an `httpx.AsyncClient`.
- `_download_video()` rejects unsafe video URLs before constructing an `httpx.AsyncClient`.
- Redirect checks for both helpers use the same shared `_ensure_safe_download_url()` helper.
- Regression tests lock in that loopback URLs do not open a client connection.

## Why this matters

Hermes Agent already has a central SSRF policy for private, loopback, link-local, and metadata-style addresses. The public image/video tool wrappers currently call the validator before downloading, but the lower-level helpers are separately tested and documented as SSRF-protected. Keeping enforcement at the sink prevents future refactors or direct helper reuse from accidentally bypassing the central policy.

## How this differs from related public PRs

This patch is related to earlier public vision/media hardening, but it fixes a different layer:

- `#2679` added the original `is_safe_url()` validation and redirect revalidation for vision images.
- `#3845` added website-policy checks and image content validation.
- `#19301` added the video analysis path with similar redirect checks.

Those changes either validated at the wrapper layer or checked redirect targets. This PR adds the missing sink-level pre-connect guard for the initial image/video URL inside the helpers that actually open outbound HTTP connections. It does not replace the existing wrapper or redirect checks; it makes the sink enforce the same policy.

## Attack flow

```text
caller-controlled media URL
    -> tools.vision_tools._download_image() / _download_video()
        -> pre-patch helper checked only website policy before the initial request
            -> private/internal URL could be fetched if the helper was called directly
```

## Affected code

| Issue | Files |
|-------|-------|
| Missing helper-level initial URL-safety enforcement | `tools/vision_tools.py` |
| Regression coverage | `tests/tools/test_vision_tools.py`, `tests/tools/test_video_analyze.py` |

## Root cause

Vision media download helper boundary:

- The central `is_safe_url()` check lived in `_validate_image_url()`, outside the concrete download sink.
- `_download_image()` and the later-added `_download_video()` reused `is_safe_url()` for redirect targets, but not for the initial request URL.
- `check_website_access()` is a website policy check and should not be treated as equivalent to private/internal URL safety.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Helper-level private/internal URL fetch bypass | 5.3 Medium | `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:L/I:N/A:N` |

Rationale:

- This is bounded as medium/defense-in-depth because current public tool wrappers already perform preflight validation.
- The impact is server-side access to internal HTTP resources if these helpers are invoked directly or reused by a future path without duplicating wrapper validation.

## Safe reproduction steps

On current `origin/main`, a local harness can demonstrate that the helpers fetch loopback even while the central policy rejects it:

```text
image-helper is_safe_url False
image-helper downloaded True 69
video-helper is_safe_url False
video-helper downloaded True 13
seen ['/secret.png', '/secret.mp4']
```

After this PR, the same harness is blocked before any request reaches the local server:

```text
image-helper is_safe_url False
image-helper blocked_or_error ValueError Blocked image download from private/internal address: http://127.0.0.1:<port>/secret.png
video-helper is_safe_url False
video-helper blocked_or_error ValueError Blocked video download from private/internal address: http://127.0.0.1:<port>/secret.mp4
seen []
```

## Expected vulnerable behavior

- The central URL-safety policy rejects loopback/private media URLs.
- The concrete media download helpers should not be able to fetch a URL that the central policy rejects.
- Pre-patch, the helpers could fetch those URLs when invoked directly.

## Changes in this PR

- Imports `is_safe_url()` once at module scope.
- Adds `_ensure_safe_download_url()` as the shared media download guard.
- Calls the guard before the initial image download request.
- Calls the guard before the initial video download request.
- Reuses the guard for image and video redirect targets.
- Adds focused tests ensuring private URL downloads are rejected before `httpx.AsyncClient` is constructed.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Runtime guard | `tools/vision_tools.py` | Shared helper-level URL-safety guard for image/video initial URLs and redirects |
| Tests | `tests/tools/test_vision_tools.py` | Image helper loopback rejection regression |
| Tests | `tests/tools/test_video_analyze.py` | Video helper loopback rejection regression |

## Maintainer impact

- Narrow change limited to `tools/vision_tools.py` and focused tests.
- Public image/video wrapper behavior remains compatible for safe URLs.
- The central SSRF policy is now enforced at the download sink as well as at wrapper validation.
- No unrelated files are changed.

## Fix rationale

The safest durable boundary is the function that actually opens outbound HTTP connections. Wrapper-level validation is useful, but it is easier to regress when helpers are reused by new tool paths. Enforcing `is_safe_url()` in the download helpers makes the policy local to the sink and keeps redirect checks consistent.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Focused image/video SSRF regression tests.
- [x] Full vision and video tool test files.
- [x] Syntax check.
- [x] Ruff check on touched files.
- [x] Whitespace diff check.

Executed with:

```bash
python3.11 -m pytest -q -o addopts='' tests/tools/test_vision_tools.py::TestVisionSafetyGuards tests/tools/test_video_analyze.py::TestVideoAnalyzeTool::test_download_rejects_private_url_before_http_client
python3.11 -m pytest -q -o addopts='' tests/tools/test_vision_tools.py tests/tools/test_video_analyze.py
python3.11 -m py_compile tools/vision_tools.py tests/tools/test_vision_tools.py tests/tools/test_video_analyze.py
python3.11 -m ruff check tools/vision_tools.py tests/tools/test_vision_tools.py tests/tools/test_video_analyze.py
git diff --check
```

Results:

```text
5 passed
101 passed
All checks passed!
```

## Disclosure notes

- This PR is intentionally bounded to helper-level initial URL validation in `tools/vision_tools.py`.
- It does not claim that the public wrapper currently skips validation; it prevents the lower-level download sink from being unsafe if called directly or reused later.
- No unrelated files were changed.
