### PR TITLE
fix(api-server): typed Responses input items + duplicated history on chained turns

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2092,9 +2092,22 @@ class APIServerAdapter(BasePlatformAdapter):
             if instructions is None:
                 instructions = stored.get("instructions")
 
-        # Append new input messages to history (all but the last become history)
-        for msg in input_messages[:-1]:
-            conversation_history.append(msg)
+        # When conversation_history was loaded from a prior source
+        # (body.conversation_history or previous_response_id), the request's
+        # input array's leading items are a client-side replay of the same
+        # turns we just loaded — appending them would duplicate every prior
+        # turn.  Open WebUI's Responses mode triggers this: it sends
+        # previous_response_id AND re-inlines the entire prior transcript
+        # in input[], so without this guard each chained turn doubled the
+        # stored conversation_history.
+        history_from_prior_source = bool(conversation_history)
+
+        # Append new input messages to history (all but the last become
+        # history). Skip when prior was loaded — those inlined items are a
+        # redundant client-side replay of what we already have.
+        if not history_from_prior_source:
+            for msg in input_messages[:-1]:
+                conversation_history.append(msg)
 
         # Last input message is the user_message
         user_message: Any = input_messages[-1].get("content", "") if input_messages else ""

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2020,7 +2020,19 @@ class APIServerAdapter(BasePlatformAdapter):
             previous_response_id = self._response_store.get_conversation(conversation)
             # No error if conversation doesn't exist yet — it's a new conversation
 
-        # Normalize input to message list
+        # Normalize input to message list.
+        # Responses API input arrays may contain typed items (function_call,
+        # function_call_output, reasoning, message, …) representing the prior
+        # turn's structured output.  Open WebUI Responses mode forwards these
+        # verbatim when chaining without ``previous_response_id``.  Treating
+        # every dict as a {role, content} message turns prior tool calls and
+        # tool outputs into spurious user-shaped history, which bloats context
+        # and causes the agent to re-address old user questions.
+        # We parse Responses item types explicitly: only ``message`` items
+        # (and untyped role/content dicts, for chat-style callers) become
+        # conversation messages.  Other typed items are dropped here — the
+        # agent reconstructs tool flow from ``previous_response_id`` chaining
+        # when callers want stateful tool replay.
         input_messages: List[Dict[str, Any]] = []
         if isinstance(raw_input, str):
             input_messages = [{"role": "user", "content": raw_input}]
@@ -2029,6 +2041,11 @@ class APIServerAdapter(BasePlatformAdapter):
                 if isinstance(item, str):
                     input_messages.append({"role": "user", "content": item})
                 elif isinstance(item, dict):
+                    item_type = str(item.get("type") or "").strip().lower()
+                    if item_type and item_type != "message":
+                        # function_call / function_call_output / reasoning /
+                        # other built-in tool items — not user-visible turns.
+                        continue
                     role = item.get("role", "user")
                     try:
                         content = _normalize_multimodal_content(item.get("content", ""))

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1360,6 +1360,110 @@ class TestResponsesEndpoint:
                 assert "HUGE_TOOL_OUTPUT_THAT_MUST_NOT_LEAK_INTO_HISTORY" not in str(entry.get("content", ""))
 
     @pytest.mark.asyncio
+    async def test_previous_response_id_does_not_duplicate_inlined_history(self, adapter):
+        """When ``previous_response_id`` is provided AND the client also
+        re-inlines the prior transcript in ``input[]`` (Open WebUI's
+        Responses-mode pattern), the inlined items must NOT be appended on
+        top of the loaded prior history — that doubles every prior turn.
+        """
+        # Seed a prior response in the store.
+        adapter._response_store.put(
+            "resp_prior",
+            {
+                "response": {"id": "resp_prior"},
+                "conversation_history": [
+                    {"role": "user", "content": "What is 1+1?"},
+                    {"role": "assistant", "content": "2"},
+                ],
+                "instructions": None,
+                "session_id": "sess_prior",
+            },
+        )
+        mock_result = {"final_response": "3", "messages": [], "api_calls": 1}
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "previous_response_id": "resp_prior",
+                        # Client (Open WebUI) re-inlines the prior transcript
+                        # alongside previous_response_id — these items must
+                        # be ignored, not duplicated into history.
+                        "input": [
+                            {
+                                "type": "message",
+                                "role": "user",
+                                "content": [{"type": "input_text", "text": "What is 1+1?"}],
+                            },
+                            {
+                                "type": "message",
+                                "role": "assistant",
+                                "content": [{"type": "output_text", "text": "2"}],
+                            },
+                            {
+                                "type": "message",
+                                "role": "user",
+                                "content": [{"type": "input_text", "text": "Now add 1 more"}],
+                            },
+                        ],
+                    },
+                )
+
+            assert resp.status == 200
+            call_kwargs = mock_run.call_args.kwargs
+            assert call_kwargs["user_message"] == "Now add 1 more"
+            history = call_kwargs["conversation_history"]
+            # Expect exactly the two prior messages — NOT four (which would
+            # be the loaded prior + duplicated inlined replay).
+            assert history == [
+                {"role": "user", "content": "What is 1+1?"},
+                {"role": "assistant", "content": "2"},
+            ]
+
+    @pytest.mark.asyncio
+    async def test_explicit_conversation_history_is_not_duplicated_by_input(self, adapter):
+        """When body.conversation_history is provided AND input[] re-inlines
+        the same turns, conversation_history must not be duplicated.
+        """
+        mock_result = {"final_response": "ok", "messages": [], "api_calls": 1}
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "conversation_history": [
+                            {"role": "user", "content": "Hello"},
+                            {"role": "assistant", "content": "Hi"},
+                        ],
+                        # Same turns re-inlined alongside explicit history.
+                        "input": [
+                            {"type": "message", "role": "user",
+                             "content": [{"type": "input_text", "text": "Hello"}]},
+                            {"type": "message", "role": "assistant",
+                             "content": [{"type": "output_text", "text": "Hi"}]},
+                            {"type": "message", "role": "user",
+                             "content": [{"type": "input_text", "text": "Anything new?"}]},
+                        ],
+                    },
+                )
+
+            assert resp.status == 200
+            call_kwargs = mock_run.call_args.kwargs
+            assert call_kwargs["user_message"] == "Anything new?"
+            assert call_kwargs["conversation_history"] == [
+                {"role": "user", "content": "Hello"},
+                {"role": "assistant", "content": "Hi"},
+            ]
+
+    @pytest.mark.asyncio
     async def test_instructions_as_ephemeral_prompt(self, adapter):
         """The instructions field maps to ephemeral_system_prompt."""
         mock_result = {"final_response": "Ahoy!", "messages": [], "api_calls": 1}

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1296,6 +1296,70 @@ class TestResponsesEndpoint:
             assert len(call_kwargs["conversation_history"]) == 1
 
     @pytest.mark.asyncio
+    async def test_responses_input_skips_function_call_items(self, adapter):
+        """Open WebUI Responses mode forwards prior assistant turns as a
+        sequence of typed Responses items: user message, function_call,
+        function_call_output, assistant message, then the new user message.
+
+        function_call/function_call_output items must NOT become user-shaped
+        history entries — only ``type=message`` items (and the assistant's
+        ``output_text`` reply) belong in conversation_history.  The latest
+        user message becomes ``user_message``.
+        """
+        mock_result = {"final_response": "Sure.", "messages": [], "api_calls": 1}
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": [
+                            {
+                                "type": "message",
+                                "role": "user",
+                                "content": [{"type": "input_text", "text": "What time is it?"}],
+                            },
+                            {
+                                "type": "function_call",
+                                "name": "get_time",
+                                "arguments": "{}",
+                                "call_id": "call_1",
+                            },
+                            {
+                                "type": "function_call_output",
+                                "call_id": "call_1",
+                                "output": "HUGE_TOOL_OUTPUT_THAT_MUST_NOT_LEAK_INTO_HISTORY",
+                            },
+                            {
+                                "type": "message",
+                                "role": "assistant",
+                                "content": [{"type": "output_text", "text": "It is noon."}],
+                            },
+                            {
+                                "type": "message",
+                                "role": "user",
+                                "content": [{"type": "input_text", "text": "Thanks, what about tomorrow?"}],
+                            },
+                        ],
+                    },
+                )
+
+            assert resp.status == 200
+            call_kwargs = mock_run.call_args.kwargs
+            assert call_kwargs["user_message"] == "Thanks, what about tomorrow?"
+            history = call_kwargs["conversation_history"]
+            assert history == [
+                {"role": "user", "content": "What time is it?"},
+                {"role": "assistant", "content": "It is noon."},
+            ]
+            # Sanity: tool output text never leaked into history.
+            for entry in history:
+                assert "HUGE_TOOL_OUTPUT_THAT_MUST_NOT_LEAK_INTO_HISTORY" not in str(entry.get("content", ""))
+
+    @pytest.mark.asyncio
     async def test_instructions_as_ephemeral_prompt(self, adapter):
         """The instructions field maps to ephemeral_system_prompt."""
         mock_result = {"final_response": "Ahoy!", "messages": [], "api_calls": 1}


### PR DESCRIPTION
## What does this PR do?

Fixes two related bugs in `/v1/responses` request parsing that cause Open WebUI's stateful Responses-mode multi-turn chats to corrupt their stored `conversation_history`.

### Bug 1: Typed Responses input items get coerced into `{role: "user", content: ""}` messages

The Responses API spec allows `input[]` to contain typed items: `{type: "function_call", ...}`, `{type: "function_call_output", ...}`, `{type: "reasoning", ...}`, `{type: "message", role: ..., content: ...}`. Open WebUI forwards prior assistant turns as a sequence of these typed items when chaining.

The current parser at `gateway/platforms/api_server.py:2025` treats every dict the same way:

```python
elif isinstance(item, dict):
    role = item.get("role", "user")
    ...
    input_messages.append({"role": role, "content": content})
```

`function_call` / `function_call_output` items have no `role`, so they default to `user` with empty `content`. They become spurious user-shaped history entries, bloating context and making the agent re-address old user questions.

### Bug 2: `previous_response_id` + inlined history → duplicated transcript

When `previous_response_id` is set, the server loads stored prior history from the response store (`api_server.py:2081`). It then unconditionally appends `input_messages[:-1]` to that loaded history. Open WebUI's Responses-mode connector sends *both* `previous_response_id` *and* re-inlines the entire prior transcript in `input[]`. Result: every chained turn duplicates every prior turn in stored history; long chains grow exponentially.

This is **distinct** from #18995 / #21185 ("avoid duplicated Responses history"). That fix runs at *storage* time and inspects `result["messages"]` returned by the agent. It does not catch the input-side duplication that happens *before* the agent runs.

## Related Issue

No existing issue — first reproduction is described below. Happy to file a bug-report issue separately if maintainers prefer.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/platforms/api_server.py`:
  - **Bug 1 fix** (lines 2018–2030): when iterating `input[]` dicts, skip items whose `type` is set to anything other than `"message"`. Untyped role/content dicts (chat-style callers) still pass through unchanged.
  - **Bug 2 fix** (lines 2087–2102): track whether `conversation_history` was loaded from a prior source (`body.conversation_history` or `previous_response_id`). When it was, skip the `for msg in input_messages[:-1]: conversation_history.append(msg)` loop — those inlined items are a redundant client-side replay.
- `tests/gateway/test_api_server.py`: three regression tests
  - `test_responses_input_skips_function_call_items` — Bug 1 coverage
  - `test_previous_response_id_does_not_duplicate_inlined_history` — Bug 2 coverage (`previous_response_id` path)
  - `test_explicit_conversation_history_is_not_duplicated_by_input` — Bug 2 coverage (`body.conversation_history` path)

## How to Test

### Reproduction (before fix)

Connect Open WebUI in Responses mode (`api_configs[N].api_type = "responses"`) to a Hermes api_server endpoint. Send two turns:

1. *"What is in my home folder?"* (triggers a tool call)
2. *"Which file is the largest?"* (context-dependent follow-up)

Observe the second turn's stored `conversation_history` in `~/.hermes/response_store.db`:

```
[0] user: "What is in my home folder?"
[1] user: ""                                       ← function_call item, coerced
[2] user: ""                                       ← function_call_output item, coerced
[3] assistant: "Your home folder is /home/kyle..."
[4] user: "Which file is the largest?"
[5] user: "What is in my home folder?"             ← DUPLICATE of [0]
[6] assistant: "Your home folder is..."            ← DUPLICATE of [3]
[7] user: "Which file is the largest?"             ← DUPLICATE of [4]
[8-10] current turn's tool flow
```

`hist_len = 11` for what should be a 5-message chain.

### After fix

Same two-turn sequence; second turn stores:

```
[0] user: "What is in my home folder..."
[1] assistant: "Your home folder is /home/kyle..."
[2] user: "Which file is the largest?"
```

`hist_len = 3`. Empty user messages gone. No duplication.

### Test commands

```
pytest tests/gateway/test_api_server.py -q
```

141/141 pass on my checkout (138 existing + 3 new). The three new tests fail on `main` and pass after this PR.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for existing PRs — closest is #21185 (storage-side dedupe, distinct path); #17422 (preserve tool_call_id, adjacent area)
- [x] My PR contains **only** changes related to these two bugs
- [x] I've run `pytest tests/gateway/test_api_server.py -q` and all tests pass
- [x] I've added tests for the changes
- [x] Tested on Ubuntu 24.04 against a live Open WebUI instance

### Documentation & Housekeeping

- [x] No documentation changes needed — internal request-parsing fix
- [x] No config keys added/changed
- [x] No architecture changes
- [x] No cross-platform impact — pure Python request handler logic
