### PR TITLE
fix(mcp): validate string tool arguments

### DIFF
--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -885,19 +885,19 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
             id: The approval ID from permissions_list_open
             decision: One of "allow-once", "allow-always", or "deny"
         """
-        id, error = _require_str(id, "id")
+        approval_id, error = _require_str(id, "id")
         if error:
             return json.dumps({"error": error})
-        decision, error = _require_str(decision, "decision")
+        decision_value, error = _require_str(decision, "decision")
         if error:
             return json.dumps({"error": error})
-        if decision not in {"allow-once", "allow-always", "deny"}:
+        if decision_value not in {"allow-once", "allow-always", "deny"}:
             return json.dumps({
-                "error": f"Invalid decision: {decision}. "
+                "error": f"Invalid decision: {decision_value}. "
                          f"Must be allow-once, allow-always, or deny"
             })
 
-        result = bridge.respond_to_approval(id, decision)
+        result = bridge.respond_to_approval(approval_id, decision_value)
         return json.dumps(result, indent=2)
 
     return mcp

--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -140,12 +140,12 @@ def _coerce_optional_str(value) -> Optional[str]:
     return str(value)
 
 
-def _require_str(value, field: str) -> tuple[Optional[str], Optional[str]]:
+def _require_str(value, field: str) -> tuple[str, Optional[str]]:
     if isinstance(value, (list, dict)):
-        return None, f"{field} must be a string"
+        return "", f"{field} must be a string"
     coerced = "" if value is None else str(value)
     if not coerced:
-        return None, f"{field} is required"
+        return "", f"{field} is required"
     return coerced, None
 
 

--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -134,6 +134,21 @@ def _coerce_int(
     return max(minimum, min(coerced, maximum))
 
 
+def _coerce_optional_str(value) -> Optional[str]:
+    if value is None or isinstance(value, (list, dict)):
+        return None
+    return str(value)
+
+
+def _require_str(value, field: str) -> tuple[Optional[str], Optional[str]]:
+    if isinstance(value, (list, dict)):
+        return None, f"{field} must be a string"
+    coerced = "" if value is None else str(value)
+    if not coerced:
+        return None, f"{field} is required"
+    return coerced, None
+
+
 def _extract_message_content(msg: dict) -> str:
     """Extract text content from a message, handling multi-part content."""
     content = msg.get("content", "")
@@ -484,6 +499,8 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
             limit: Maximum number of conversations to return (default 50)
             search: Optional text to filter conversations by name
         """
+        platform = _coerce_optional_str(platform)
+        search = _coerce_optional_str(search)
         limit = _coerce_int(limit, default=50, minimum=1, maximum=200)
         entries = _load_sessions_index()
         conversations = []
@@ -532,6 +549,9 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
         Args:
             session_key: The session key from conversations_list
         """
+        session_key, error = _require_str(session_key, "session_key")
+        if error:
+            return json.dumps({"error": error})
         entries = _load_sessions_index()
         entry = entries.get(session_key)
 
@@ -572,6 +592,9 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
             session_key: The session key from conversations_list
             limit: Maximum number of messages to return (default 50, most recent)
         """
+        session_key, error = _require_str(session_key, "session_key")
+        if error:
+            return json.dumps({"error": error})
         limit = _coerce_int(limit, default=50, minimum=1, maximum=200)
         entries = _load_sessions_index()
         entry = entries.get(session_key)
@@ -629,6 +652,12 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
             session_key: The session key from conversations_list
             message_id: The message ID from messages_read
         """
+        session_key, error = _require_str(session_key, "session_key")
+        if error:
+            return json.dumps({"error": error})
+        message_id, error = _require_str(message_id, "message_id")
+        if error:
+            return json.dumps({"error": error})
         entries = _load_sessions_index()
         entry = entries.get(session_key)
         if not entry:
@@ -685,6 +714,7 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
             session_key: Optional filter to one conversation
             limit: Maximum events to return (default 20)
         """
+        session_key = _coerce_optional_str(session_key)
         after_cursor = _coerce_int(after_cursor, default=0, minimum=0, maximum=10**18)
         limit = _coerce_int(limit, default=20, minimum=1, maximum=200)
         result = bridge.poll_events(
@@ -712,6 +742,7 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
             session_key: Optional filter to one conversation
             timeout_ms: Maximum wait time in milliseconds (default 30000)
         """
+        session_key = _coerce_optional_str(session_key)
         after_cursor = _coerce_int(after_cursor, default=0, minimum=0, maximum=10**18)
         timeout_ms = _coerce_int(
             timeout_ms,
@@ -750,6 +781,12 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
             target: Platform target in "platform:identifier" format
             message: The message text to send
         """
+        target, error = _require_str(target, "target")
+        if error:
+            return json.dumps({"error": error})
+        message, error = _require_str(message, "message")
+        if error:
+            return json.dumps({"error": error})
         if not target or not message:
             return json.dumps({"error": "Both target and message are required"})
 
@@ -776,6 +813,7 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
         Args:
             platform: Filter by platform name (telegram, discord, slack, etc.)
         """
+        platform = _coerce_optional_str(platform)
         directory = _load_channel_directory()
         if not directory:
             entries = _load_sessions_index()
@@ -847,6 +885,12 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
             id: The approval ID from permissions_list_open
             decision: One of "allow-once", "allow-always", or "deny"
         """
+        id, error = _require_str(id, "id")
+        if error:
+            return json.dumps({"error": error})
+        decision, error = _require_str(decision, "decision")
+        if error:
+            return json.dumps({"error": error})
         if decision not in {"allow-once", "allow-always", "deny"}:
             return json.dumps({
                 "error": f"Invalid decision: {decision}. "

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -790,6 +790,57 @@ class TestMCPToolParameterCoercion:
         assert result["event"] is not None
         assert result["event"]["content"] == "waiting for this"
 
+    def test_optional_string_filters_ignore_structured_values(
+        self,
+        fake_mcp_server,
+        _event_loop,
+    ):
+        from mcp_serve import QueueEvent
+
+        server, bridge = fake_mcp_server
+        bridge._enqueue(QueueEvent(cursor=0, type="message", session_key="a"))
+
+        conversations = _run_tool(
+            server,
+            "conversations_list",
+            {"platform": ["slack"], "search": ["Alice"]},
+        )
+        channels = _run_tool(server, "channels_list", {"platform": ["slack"]})
+        events = _run_tool(server, "events_poll", {"session_key": []})
+
+        assert conversations["count"] == 3
+        assert channels["count"] == 3
+        assert len(events["events"]) == 1
+
+    def test_required_string_args_reject_structured_values(
+        self,
+        fake_mcp_server,
+        _event_loop,
+    ):
+        server, bridge = fake_mcp_server
+        bridge._pending_approvals["a1"] = {"id": "a1", "kind": "exec"}
+
+        message_read = _run_tool(server, "messages_read", {"session_key": []})
+        attachments = _run_tool(
+            server,
+            "attachments_fetch",
+            {
+                "session_key": "agent:main:telegram:dm:123456",
+                "message_id": [],
+            },
+        )
+        send = _run_tool(server, "messages_send", {"target": [], "message": "hi"})
+        approval = _run_tool(
+            server,
+            "permissions_respond",
+            {"id": [], "decision": "deny"},
+        )
+
+        assert message_read["error"] == "session_key must be a string"
+        assert attachments["error"] == "message_id must be a string"
+        assert send["error"] == "target must be a string"
+        assert approval["error"] == "id must be a string"
+
 
 class TestE2EMessagesSend:
     def test_send_missing_args(self, mcp_server_e2e, _event_loop):


### PR DESCRIPTION
## Problem
Closes #21960.

Malformed external MCP clients can pass structured JSON values like `[]` for string-shaped `mcp_serve.py` parameters. Some handlers then call string methods, perform dict lookups, or pass the values downstream before validating them, which can raise instead of returning a structured tool error.

## Root cause
`mcp_serve.py` only hardened numeric parameters with `_coerce_int`. Required string parameters and optional string filters trusted the MCP SDK annotations and did not defend against list/dict values crossing the external tool boundary.

## Fix
Add small string boundary helpers: required string parameters now reject list/dict values with JSON error responses, while optional filter strings ignore structured values and continue without filtering. Apply the helpers to conversations, message reads, attachment fetches, event filters, send targets/messages, channel filters, and approval responses.

## Testing
- `python3 -m py_compile mcp_serve.py tests/test_mcp_serve.py`: clean
- `python3 -m pytest -o addopts='' tests/test_mcp_serve.py::TestMCPToolParameterCoercion -q`: 6 passed
- `git diff --check`: clean

Made with [Cursor](https://cursor.com)