### PR TITLE
feat(msgraph): add webhook listener platform (salvage of #21409)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -101,6 +101,7 @@ class Platform(Enum):
     DINGTALK = "dingtalk"
     API_SERVER = "api_server"
     WEBHOOK = "webhook"
+    MSGRAPH_WEBHOOK = "msgraph_webhook"
     FEISHU = "feishu"
     WECOM = "wecom"
     WECOM_CALLBACK = "wecom_callback"
@@ -376,6 +377,7 @@ _PLATFORM_CONNECTED_CHECKERS: dict[Platform, Callable[[PlatformConfig], bool]] =
     Platform.SMS: lambda cfg: bool(os.getenv("TWILIO_ACCOUNT_SID")),
     Platform.API_SERVER: lambda cfg: True,
     Platform.WEBHOOK: lambda cfg: True,
+    Platform.MSGRAPH_WEBHOOK: lambda cfg: True,
     Platform.FEISHU: lambda cfg: bool(cfg.extra.get("app_id")),
     Platform.WECOM: lambda cfg: bool(cfg.extra.get("bot_id")),
     Platform.WECOM_CALLBACK: lambda cfg: bool(
@@ -1406,6 +1408,48 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                 pass
         if webhook_secret:
             config.platforms[Platform.WEBHOOK].extra["secret"] = webhook_secret
+
+    # Microsoft Graph webhook platform
+    msgraph_webhook_enabled = os.getenv("MSGRAPH_WEBHOOK_ENABLED", "").lower() in (
+        "true",
+        "1",
+        "yes",
+    )
+    msgraph_webhook_port = os.getenv("MSGRAPH_WEBHOOK_PORT")
+    msgraph_webhook_client_state = os.getenv("MSGRAPH_WEBHOOK_CLIENT_STATE", "")
+    msgraph_webhook_resources = os.getenv("MSGRAPH_WEBHOOK_ACCEPTED_RESOURCES", "")
+    if (
+        msgraph_webhook_enabled
+        or Platform.MSGRAPH_WEBHOOK in config.platforms
+        or msgraph_webhook_port
+        or msgraph_webhook_client_state
+        or msgraph_webhook_resources
+    ):
+        if Platform.MSGRAPH_WEBHOOK not in config.platforms:
+            config.platforms[Platform.MSGRAPH_WEBHOOK] = PlatformConfig()
+        if msgraph_webhook_enabled:
+            config.platforms[Platform.MSGRAPH_WEBHOOK].enabled = True
+        if msgraph_webhook_port:
+            try:
+                config.platforms[Platform.MSGRAPH_WEBHOOK].extra["port"] = int(
+                    msgraph_webhook_port
+                )
+            except ValueError:
+                pass
+        if msgraph_webhook_client_state:
+            config.platforms[Platform.MSGRAPH_WEBHOOK].extra["client_state"] = (
+                msgraph_webhook_client_state
+            )
+        if msgraph_webhook_resources:
+            resources = [
+                resource.strip()
+                for resource in msgraph_webhook_resources.split(",")
+                if resource.strip()
+            ]
+            if resources:
+                config.platforms[Platform.MSGRAPH_WEBHOOK].extra[
+                    "accepted_resources"
+                ] = resources
 
     # DingTalk
     dingtalk_client_id = os.getenv("DINGTALK_CLIENT_ID")

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1418,12 +1418,16 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
     msgraph_webhook_port = os.getenv("MSGRAPH_WEBHOOK_PORT")
     msgraph_webhook_client_state = os.getenv("MSGRAPH_WEBHOOK_CLIENT_STATE", "")
     msgraph_webhook_resources = os.getenv("MSGRAPH_WEBHOOK_ACCEPTED_RESOURCES", "")
+    msgraph_webhook_allowed_cidrs = os.getenv(
+        "MSGRAPH_WEBHOOK_ALLOWED_SOURCE_CIDRS", ""
+    )
     if (
         msgraph_webhook_enabled
         or Platform.MSGRAPH_WEBHOOK in config.platforms
         or msgraph_webhook_port
         or msgraph_webhook_client_state
         or msgraph_webhook_resources
+        or msgraph_webhook_allowed_cidrs
     ):
         if Platform.MSGRAPH_WEBHOOK not in config.platforms:
             config.platforms[Platform.MSGRAPH_WEBHOOK] = PlatformConfig()
@@ -1450,6 +1454,16 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
                 config.platforms[Platform.MSGRAPH_WEBHOOK].extra[
                     "accepted_resources"
                 ] = resources
+        if msgraph_webhook_allowed_cidrs:
+            cidrs = [
+                cidr.strip()
+                for cidr in msgraph_webhook_allowed_cidrs.split(",")
+                if cidr.strip()
+            ]
+            if cidrs:
+                config.platforms[Platform.MSGRAPH_WEBHOOK].extra[
+                    "allowed_source_cidrs"
+                ] = cidrs
 
     # DingTalk
     dingtalk_client_id = os.getenv("DINGTALK_CLIENT_ID")

--- a/gateway/platforms/msgraph_webhook.py
+++ b/gateway/platforms/msgraph_webhook.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+from collections import deque
 from hashlib import sha1
 from typing import Any, Awaitable, Callable, Dict, Optional
 
@@ -29,6 +30,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_HOST = "0.0.0.0"
 DEFAULT_PORT = 8646
 DEFAULT_WEBHOOK_PATH = "/msgraph/webhook"
+DEFAULT_MAX_SEEN_RECEIPTS = 5000
 NotificationScheduler = Callable[[Dict[str, Any], MessageEvent], Awaitable[None] | None]
 
 
@@ -55,9 +57,13 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
             if str(value).strip()
         ]
         self._client_state: Optional[str] = self._string_or_none(extra.get("client_state"))
+        self._max_seen_receipts = max(
+            1, int(extra.get("max_seen_receipts", DEFAULT_MAX_SEEN_RECEIPTS))
+        )
         self._runner = None
         self._notification_scheduler: Optional[NotificationScheduler] = None
         self._seen_receipts: set[str] = set()
+        self._seen_receipt_order: deque[str] = deque()
         self._accepted_count = 0
         self._duplicate_count = 0
 
@@ -172,10 +178,10 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
                 continue
 
             receipt_key = self._build_receipt_key(notification)
-            if receipt_key in self._seen_receipts:
+            if self._has_seen_receipt(receipt_key):
                 duplicates += 1
                 continue
-            self._seen_receipts.add(receipt_key)
+            self._remember_receipt(receipt_key)
 
             accepted += 1
             scheduled += 1
@@ -212,6 +218,16 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
             return True
         provided = self._string_or_none(notification.get("clientState"))
         return provided == expected
+
+    def _has_seen_receipt(self, receipt_key: str) -> bool:
+        return receipt_key in self._seen_receipts
+
+    def _remember_receipt(self, receipt_key: str) -> None:
+        self._seen_receipts.add(receipt_key)
+        self._seen_receipt_order.append(receipt_key)
+        while len(self._seen_receipt_order) > self._max_seen_receipts:
+            oldest = self._seen_receipt_order.popleft()
+            self._seen_receipts.discard(oldest)
 
     def _build_message_event(
         self,

--- a/gateway/platforms/msgraph_webhook.py
+++ b/gateway/platforms/msgraph_webhook.py
@@ -80,19 +80,15 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
         return raw if raw.startswith("/") else f"/{raw}"
 
     @staticmethod
-    def _build_receipt_key(notification: Dict[str, Any]) -> str:
+    def _build_receipt_key(notification: Dict[str, Any]) -> Optional[str]:
         explicit_id = str(notification.get("id") or "").strip()
         if explicit_id:
             return f"id:{explicit_id}"
-        payload = "|".join(
-            [
-                str(notification.get("subscriptionId") or ""),
-                str(notification.get("changeType") or ""),
-                str(notification.get("resource") or ""),
-                json.dumps(notification.get("resourceData") or {}, sort_keys=True),
-            ]
-        )
-        return f"sha1:{sha1(payload.encode('utf-8')).hexdigest()}"
+        return None
+
+    @staticmethod
+    def _normalize_resource_value(resource: str) -> str:
+        return str(resource or "").strip().strip("/")
 
     def set_notification_scheduler(self, scheduler: Optional[NotificationScheduler]) -> None:
         self._notification_scheduler = scheduler
@@ -178,10 +174,11 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
                 continue
 
             receipt_key = self._build_receipt_key(notification)
-            if self._has_seen_receipt(receipt_key):
-                duplicates += 1
-                continue
-            self._remember_receipt(receipt_key)
+            if receipt_key is not None:
+                if self._has_seen_receipt(receipt_key):
+                    duplicates += 1
+                    continue
+                self._remember_receipt(receipt_key)
 
             accepted += 1
             scheduled += 1
@@ -205,10 +202,20 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
     def _resource_accepted(self, resource: str) -> bool:
         if not self._accepted_resources:
             return True
+        normalized_resource = self._normalize_resource_value(resource)
         for pattern in self._accepted_resources:
-            if pattern.endswith("*") and resource.startswith(pattern[:-1]):
-                return True
-            if resource == pattern or resource.startswith(f"{pattern}/"):
+            normalized_pattern = self._normalize_resource_value(pattern)
+            if not normalized_pattern:
+                continue
+            if normalized_pattern.endswith("*"):
+                prefix = normalized_pattern[:-1].rstrip("/")
+                if normalized_resource == prefix or normalized_resource.startswith(f"{prefix}/"):
+                    return True
+                continue
+            if (
+                normalized_resource == normalized_pattern
+                or normalized_resource.startswith(f"{normalized_pattern}/")
+            ):
                 return True
         return False
 
@@ -232,8 +239,9 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
     def _build_message_event(
         self,
         notification: Dict[str, Any],
-        receipt_key: str,
+        receipt_key: Optional[str],
     ) -> MessageEvent:
+        message_id = receipt_key or f"sha1:{sha1(json.dumps(notification, sort_keys=True).encode('utf-8')).hexdigest()}"
         source = self.build_source(
             chat_id=f"msgraph:{notification.get('subscriptionId', 'unknown')}",
             chat_name="msgraph/webhook",
@@ -246,7 +254,7 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
             message_type=MessageType.TEXT,
             source=source,
             raw_message=notification,
-            message_id=receipt_key,
+            message_id=message_id,
             internal=True,
         )
 

--- a/gateway/platforms/msgraph_webhook.py
+++ b/gateway/platforms/msgraph_webhook.py
@@ -1,0 +1,283 @@
+"""Microsoft Graph webhook adapter for change-notification ingress."""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from hashlib import sha1
+from typing import Any, Awaitable, Callable, Dict, Optional
+
+try:
+    from aiohttp import web
+
+    AIOHTTP_AVAILABLE = True
+except ImportError:
+    AIOHTTP_AVAILABLE = False
+    web = None  # type: ignore[assignment]
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import (
+    BasePlatformAdapter,
+    MessageEvent,
+    MessageType,
+    SendResult,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_HOST = "0.0.0.0"
+DEFAULT_PORT = 8646
+DEFAULT_WEBHOOK_PATH = "/msgraph/webhook"
+NotificationScheduler = Callable[[Dict[str, Any], MessageEvent], Awaitable[None] | None]
+
+
+def check_msgraph_webhook_requirements() -> bool:
+    """Return whether required webhook dependencies are available."""
+    return AIOHTTP_AVAILABLE
+
+
+class MSGraphWebhookAdapter(BasePlatformAdapter):
+    """Receive Microsoft Graph change notifications and surface them internally."""
+
+    def __init__(self, config: PlatformConfig):
+        super().__init__(config, Platform.MSGRAPH_WEBHOOK)
+        extra = config.extra or {}
+        self._host: str = str(extra.get("host", DEFAULT_HOST))
+        self._port: int = int(extra.get("port", DEFAULT_PORT))
+        self._webhook_path: str = self._normalize_path(
+            extra.get("webhook_path", DEFAULT_WEBHOOK_PATH)
+        )
+        self._health_path: str = self._normalize_path(extra.get("health_path", "/health"))
+        self._accepted_resources: list[str] = [
+            str(value).strip()
+            for value in (extra.get("accepted_resources") or [])
+            if str(value).strip()
+        ]
+        self._client_state: Optional[str] = self._string_or_none(extra.get("client_state"))
+        self._runner = None
+        self._notification_scheduler: Optional[NotificationScheduler] = None
+        self._seen_receipts: set[str] = set()
+        self._accepted_count = 0
+        self._duplicate_count = 0
+
+    @staticmethod
+    def _string_or_none(value: Any) -> Optional[str]:
+        if value is None:
+            return None
+        text = str(value).strip()
+        return text or None
+
+    @staticmethod
+    def _normalize_path(path: Any) -> str:
+        raw = str(path or "").strip() or "/"
+        return raw if raw.startswith("/") else f"/{raw}"
+
+    @staticmethod
+    def _build_receipt_key(notification: Dict[str, Any]) -> str:
+        explicit_id = str(notification.get("id") or "").strip()
+        if explicit_id:
+            return f"id:{explicit_id}"
+        payload = "|".join(
+            [
+                str(notification.get("subscriptionId") or ""),
+                str(notification.get("changeType") or ""),
+                str(notification.get("resource") or ""),
+                json.dumps(notification.get("resourceData") or {}, sort_keys=True),
+            ]
+        )
+        return f"sha1:{sha1(payload.encode('utf-8')).hexdigest()}"
+
+    def set_notification_scheduler(self, scheduler: Optional[NotificationScheduler]) -> None:
+        self._notification_scheduler = scheduler
+
+    async def connect(self) -> bool:
+        app = web.Application()
+        app.router.add_get(self._health_path, self._handle_health)
+        app.router.add_get(self._webhook_path, self._handle_notification)
+        app.router.add_post(self._webhook_path, self._handle_notification)
+
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        site = web.TCPSite(self._runner, self._host, self._port)
+        await site.start()
+        self._mark_connected()
+        logger.info(
+            "[msgraph_webhook] Listening on %s:%d%s",
+            self._host,
+            self._port,
+            self._webhook_path,
+        )
+        return True
+
+    async def disconnect(self) -> None:
+        if self._runner is not None:
+            await self._runner.cleanup()
+            self._runner = None
+        self._mark_disconnected()
+
+    async def send(
+        self,
+        chat_id: str,
+        content: str,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        logger.info("[msgraph_webhook] Response for %s: %s", chat_id, content[:200])
+        return SendResult(success=True)
+
+    async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
+        return {"name": chat_id, "type": "webhook"}
+
+    async def _handle_health(self, request: "web.Request") -> "web.Response":
+        return web.json_response(
+            {
+                "status": "ok",
+                "platform": self.platform.value,
+                "webhook_path": self._webhook_path,
+                "accepted": self._accepted_count,
+                "duplicates": self._duplicate_count,
+            }
+        )
+
+    async def _handle_notification(self, request: "web.Request") -> "web.Response":
+        validation_token = request.query.get("validationToken", "")
+        if validation_token:
+            return web.Response(text=validation_token, content_type="text/plain")
+
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response({"error": "Invalid JSON body"}, status=400)
+
+        notifications = body.get("value")
+        if not isinstance(notifications, list):
+            return web.json_response({"error": "Missing notification batch"}, status=400)
+
+        accepted = 0
+        duplicates = 0
+        rejected = 0
+        scheduled = 0
+
+        for raw_notification in notifications:
+            if not isinstance(raw_notification, dict):
+                rejected += 1
+                continue
+            notification = dict(raw_notification)
+            if not self._resource_accepted(str(notification.get("resource") or "")):
+                rejected += 1
+                continue
+            if not self._verify_client_state(notification):
+                rejected += 1
+                continue
+
+            receipt_key = self._build_receipt_key(notification)
+            if receipt_key in self._seen_receipts:
+                duplicates += 1
+                continue
+            self._seen_receipts.add(receipt_key)
+
+            accepted += 1
+            scheduled += 1
+            self._accepted_count += 1
+            event = self._build_message_event(notification, receipt_key)
+            self._schedule_notification(notification, event)
+
+        self._duplicate_count += duplicates
+        status = 202 if accepted or duplicates else 403
+        return web.json_response(
+            {
+                "status": "accepted" if accepted or duplicates else "rejected",
+                "accepted": accepted,
+                "duplicates": duplicates,
+                "rejected": rejected,
+                "scheduled": scheduled,
+            },
+            status=status,
+        )
+
+    def _resource_accepted(self, resource: str) -> bool:
+        if not self._accepted_resources:
+            return True
+        for pattern in self._accepted_resources:
+            if pattern.endswith("*") and resource.startswith(pattern[:-1]):
+                return True
+            if resource == pattern or resource.startswith(f"{pattern}/"):
+                return True
+        return False
+
+    def _verify_client_state(self, notification: Dict[str, Any]) -> bool:
+        expected = self._client_state
+        if expected is None:
+            return True
+        provided = self._string_or_none(notification.get("clientState"))
+        return provided == expected
+
+    def _build_message_event(
+        self,
+        notification: Dict[str, Any],
+        receipt_key: str,
+    ) -> MessageEvent:
+        source = self.build_source(
+            chat_id=f"msgraph:{notification.get('subscriptionId', 'unknown')}",
+            chat_name="msgraph/webhook",
+            chat_type="webhook",
+            user_id="msgraph",
+            user_name="Microsoft Graph",
+        )
+        return MessageEvent(
+            text=self._render_prompt(notification),
+            message_type=MessageType.TEXT,
+            source=source,
+            raw_message=notification,
+            message_id=receipt_key,
+            internal=True,
+        )
+
+    def _render_prompt(self, notification: Dict[str, Any]) -> str:
+        template = self.config.extra.get("prompt", "")
+        if template:
+            payload = {
+                "notification": notification,
+                "resource": notification.get("resource", ""),
+                "change_type": notification.get("changeType", ""),
+                "subscription_id": notification.get("subscriptionId", ""),
+            }
+            return self._render_template(template, payload)
+        rendered = json.dumps(notification, indent=2, sort_keys=True)[:4000]
+        return f"Microsoft Graph change notification:\n\n```json\n{rendered}\n```"
+
+    def _render_template(self, template: str, payload: Dict[str, Any]) -> str:
+        import re
+
+        def _resolve(match: "re.Match[str]") -> str:
+            key = match.group(1)
+            value: Any = payload
+            for part in key.split("."):
+                if isinstance(value, dict):
+                    value = value.get(part, f"{{{key}}}")
+                else:
+                    return f"{{{key}}}"
+            if isinstance(value, (dict, list)):
+                return json.dumps(value, sort_keys=True)[:2000]
+            return str(value)
+
+        return re.sub(r"\{([a-zA-Z0-9_.]+)\}", _resolve, template)
+
+    def _schedule_notification(
+        self,
+        notification: Dict[str, Any],
+        event: MessageEvent,
+    ) -> None:
+        scheduler = self._notification_scheduler
+        if scheduler is not None:
+            result = scheduler(notification, event)
+            if asyncio.iscoroutine(result):
+                task = asyncio.create_task(result)
+                self._background_tasks.add(task)
+                task.add_done_callback(self._background_tasks.discard)
+            return
+
+        task = asyncio.create_task(self.handle_message(event))
+        self._background_tasks.add(task)
+        task.add_done_callback(self._background_tasks.discard)

--- a/gateway/platforms/msgraph_webhook.py
+++ b/gateway/platforms/msgraph_webhook.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import asyncio
+import hmac
+import ipaddress
 import json
 import logging
 from collections import deque
@@ -60,6 +62,9 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
         self._max_seen_receipts = max(
             1, int(extra.get("max_seen_receipts", DEFAULT_MAX_SEEN_RECEIPTS))
         )
+        self._allowed_source_networks: list[ipaddress._BaseNetwork] = (
+            self._parse_allowed_source_cidrs(extra.get("allowed_source_cidrs"))
+        )
         self._runner = None
         self._notification_scheduler: Optional[NotificationScheduler] = None
         self._seen_receipts: set[str] = set()
@@ -90,13 +95,47 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
     def _normalize_resource_value(resource: str) -> str:
         return str(resource or "").strip().strip("/")
 
+    @staticmethod
+    def _parse_allowed_source_cidrs(
+        raw: Any,
+    ) -> list[ipaddress._BaseNetwork]:
+        """Parse an optional list of CIDR ranges allowed to POST to the webhook.
+
+        An empty or missing value means "allow everything" (same behavior as
+        before this field existed). When populated, requests from source IPs
+        outside every listed CIDR are rejected with 403 before the body is
+        parsed. Use this to restrict the endpoint to Microsoft Graph's
+        published webhook source ranges in production deployments.
+        """
+        if raw is None:
+            return []
+        if isinstance(raw, str):
+            candidates = [chunk.strip() for chunk in raw.split(",")]
+        elif isinstance(raw, (list, tuple, set)):
+            candidates = [str(chunk).strip() for chunk in raw]
+        else:
+            return []
+
+        networks: list[ipaddress._BaseNetwork] = []
+        for chunk in candidates:
+            if not chunk:
+                continue
+            try:
+                networks.append(ipaddress.ip_network(chunk, strict=False))
+            except ValueError:
+                logger.warning(
+                    "[msgraph_webhook] Ignoring invalid allowed_source_cidrs entry: %r",
+                    chunk,
+                )
+        return networks
+
     def set_notification_scheduler(self, scheduler: Optional[NotificationScheduler]) -> None:
         self._notification_scheduler = scheduler
 
     async def connect(self) -> bool:
         app = web.Application()
         app.router.add_get(self._health_path, self._handle_health)
-        app.router.add_get(self._webhook_path, self._handle_notification)
+        app.router.add_get(self._webhook_path, self._handle_validation)
         app.router.add_post(self._webhook_path, self._handle_notification)
 
         self._runner = web.AppRunner(app)
@@ -142,7 +181,28 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
             }
         )
 
+    async def _handle_validation(self, request: "web.Request") -> "web.Response":
+        """Handle Microsoft Graph subscription validation handshake.
+
+        Graph validates a subscription endpoint by sending a GET with
+        ``validationToken`` in the query string; the service must echo the
+        token verbatim as ``text/plain`` within 10 seconds. Anything else
+        (bare GET, GET without the token) is rejected so the endpoint can't
+        be enumerated or mistakenly used for data exfiltration.
+        """
+        if not self._source_ip_allowed(request):
+            return web.Response(status=403)
+        validation_token = request.query.get("validationToken", "")
+        if not validation_token:
+            return web.Response(status=400)
+        return web.Response(text=validation_token, content_type="text/plain")
+
     async def _handle_notification(self, request: "web.Request") -> "web.Response":
+        if not self._source_ip_allowed(request):
+            return web.Response(status=403)
+
+        # Graph never sends validationToken on POST, but tolerate it for
+        # defensive clients that replay the handshake in-band.
         validation_token = request.query.get("validationToken", "")
         if validation_token:
             return web.Response(text=validation_token, content_type="text/plain")
@@ -150,27 +210,31 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
         try:
             body = await request.json()
         except Exception:
-            return web.json_response({"error": "Invalid JSON body"}, status=400)
+            return web.Response(status=400)
 
         notifications = body.get("value")
         if not isinstance(notifications, list):
-            return web.json_response({"error": "Missing notification batch"}, status=400)
+            return web.Response(status=400)
 
         accepted = 0
         duplicates = 0
-        rejected = 0
-        scheduled = 0
+        auth_rejected = 0
+        other_rejected = 0
 
         for raw_notification in notifications:
             if not isinstance(raw_notification, dict):
-                rejected += 1
+                other_rejected += 1
                 continue
             notification = dict(raw_notification)
             if not self._resource_accepted(str(notification.get("resource") or "")):
-                rejected += 1
+                other_rejected += 1
                 continue
             if not self._verify_client_state(notification):
-                rejected += 1
+                # Treat bad clientState as an auth failure: if the whole
+                # batch is forged, we want to signal 403 so the sender
+                # stops retrying. Legitimate Graph retries have valid
+                # clientState and hit the accepted/duplicate paths.
+                auth_rejected += 1
                 continue
 
             receipt_key = self._build_receipt_key(notification)
@@ -181,23 +245,39 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
                 self._remember_receipt(receipt_key)
 
             accepted += 1
-            scheduled += 1
             self._accepted_count += 1
             event = self._build_message_event(notification, receipt_key)
             self._schedule_notification(notification, event)
 
         self._duplicate_count += duplicates
-        status = 202 if accepted or duplicates else 403
-        return web.json_response(
-            {
-                "status": "accepted" if accepted or duplicates else "rejected",
-                "accepted": accepted,
-                "duplicates": duplicates,
-                "rejected": rejected,
-                "scheduled": scheduled,
-            },
-            status=status,
-        )
+        # If anything ingested OR deduped, return 202 with empty body so
+        # Graph acks successfully and we don't leak internal counters. If
+        # every item failed auth, return 403 so an attacker POSTing fake
+        # notifications gets a clear reject. Other failures (malformed,
+        # resource-not-accepted) are the sender's configuration problem,
+        # so 400.
+        if accepted or duplicates:
+            return web.Response(status=202)
+        if auth_rejected and not other_rejected:
+            return web.Response(status=403)
+        return web.Response(status=400)
+
+    def _source_ip_allowed(self, request: "web.Request") -> bool:
+        """Return True if the request's source IP is in the configured allowlist.
+
+        When ``allowed_source_cidrs`` is empty (the default), everything is
+        allowed — preserves behavior for dev tunnels / localhost setups.
+        """
+        if not self._allowed_source_networks:
+            return True
+        peer = request.remote or ""
+        if not peer:
+            return False
+        try:
+            peer_addr = ipaddress.ip_address(peer)
+        except ValueError:
+            return False
+        return any(peer_addr in network for network in self._allowed_source_networks)
 
     def _resource_accepted(self, resource: str) -> bool:
         if not self._accepted_resources:
@@ -220,11 +300,21 @@ class MSGraphWebhookAdapter(BasePlatformAdapter):
         return False
 
     def _verify_client_state(self, notification: Dict[str, Any]) -> bool:
+        """Verify the Graph-supplied clientState matches the configured secret.
+
+        Uses ``hmac.compare_digest`` instead of ``==`` so that a mismatch
+        doesn't leak how many leading characters matched via string-compare
+        timing. The configured client_state is a shared secret (documented in
+        the setup guide as "generate with ``openssl rand -hex 32``"), so a
+        timing-safe compare is the right primitive.
+        """
         expected = self._client_state
         if expected is None:
             return True
         provided = self._string_or_none(notification.get("clientState"))
-        return provided == expected
+        if provided is None:
+            return False
+        return hmac.compare_digest(provided, expected)
 
     def _has_seen_receipt(self, receipt_key: str) -> bool:
         return receipt_key in self._seen_receipts

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4600,6 +4600,16 @@ class GatewayRunner:
             adapter.gateway_runner = self  # For cross-platform delivery
             return adapter
 
+        elif platform == Platform.MSGRAPH_WEBHOOK:
+            from gateway.platforms.msgraph_webhook import (
+                MSGraphWebhookAdapter,
+                check_msgraph_webhook_requirements,
+            )
+            if not check_msgraph_webhook_requirements():
+                logger.warning("MSGraph webhook: aiohttp not installed")
+                return None
+            return MSGraphWebhookAdapter(config)
+
         elif platform == Platform.BLUEBUBBLES:
             from gateway.platforms.bluebubbles import BlueBubblesAdapter, check_bluebubbles_requirements
             if not check_bluebubbles_requirements():

--- a/tests/gateway/test_msgraph_webhook.py
+++ b/tests/gateway/test_msgraph_webhook.py
@@ -185,3 +185,41 @@ class TestMSGraphNotifications:
         await asyncio.sleep(0.05)
 
         assert len(scheduled) == 1
+
+    @pytest.mark.anyio
+    async def test_seen_receipts_are_bounded(self):
+        adapter = _make_adapter(max_seen_receipts=2)
+
+        async def _capture(notification, event):
+            return None
+
+        adapter.set_notification_scheduler(_capture)
+
+        async def _post(notification_id: str):
+            payload = {
+                "value": [
+                    {
+                        "id": notification_id,
+                        "subscriptionId": "sub-1",
+                        "changeType": "updated",
+                        "resource": "communications/onlineMeetings/meeting-3",
+                        "clientState": "expected-client-state",
+                    }
+                ]
+            }
+            return await adapter._handle_notification(_FakeRequest(json_payload=payload))
+
+        first = await _post("notif-a")
+        second = await _post("notif-b")
+        third = await _post("notif-c")
+
+        assert first.status == 202
+        assert second.status == 202
+        assert third.status == 202
+        assert len(adapter._seen_receipts) == 2
+        assert list(adapter._seen_receipt_order) == ["id:notif-b", "id:notif-c"]
+
+        replay = await _post("notif-a")
+        replay_data = json.loads(replay.text)
+        assert replay_data["accepted"] == 1
+        assert replay_data["duplicates"] == 0

--- a/tests/gateway/test_msgraph_webhook.py
+++ b/tests/gateway/test_msgraph_webhook.py
@@ -187,6 +187,63 @@ class TestMSGraphNotifications:
         assert len(scheduled) == 1
 
     @pytest.mark.anyio
+    async def test_notifications_without_id_are_not_deduped(self):
+        adapter = _make_adapter()
+        scheduled: list[tuple[dict, object]] = []
+
+        async def _capture(notification, event):
+            scheduled.append((notification, event))
+
+        adapter.set_notification_scheduler(_capture)
+        payload = {
+            "value": [
+                {
+                    "subscriptionId": "sub-1",
+                    "changeType": "updated",
+                    "resource": "communications/onlineMeetings/meeting-3",
+                    "clientState": "expected-client-state",
+                    "resourceData": {"id": "meeting-3"},
+                }
+            ]
+        }
+
+        first = await adapter._handle_notification(_FakeRequest(json_payload=payload))
+        second = await adapter._handle_notification(_FakeRequest(json_payload=payload))
+
+        assert first.status == 202
+        assert second.status == 202
+        second_data = json.loads(second.text)
+        assert second_data["accepted"] == 1
+        assert second_data["duplicates"] == 0
+        assert second_data["scheduled"] == 1
+
+        await asyncio.sleep(0.05)
+
+        assert len(scheduled) == 2
+
+    @pytest.mark.anyio
+    async def test_resource_patterns_accept_leading_slash(self):
+        adapter = _make_adapter(accepted_resources=["/communications/onlineMeetings"])
+        payload = {
+            "value": [
+                {
+                    "id": "notif-slash",
+                    "subscriptionId": "sub-1",
+                    "changeType": "updated",
+                    "resource": "communications/onlineMeetings/meeting-4",
+                    "clientState": "expected-client-state",
+                }
+            ]
+        }
+
+        resp = await adapter._handle_notification(_FakeRequest(json_payload=payload))
+        data = json.loads(resp.text)
+
+        assert resp.status == 202
+        assert data["accepted"] == 1
+        assert data["rejected"] == 0
+
+    @pytest.mark.anyio
     async def test_seen_receipts_are_bounded(self):
         adapter = _make_adapter(max_seen_receipts=2)
 

--- a/tests/gateway/test_msgraph_webhook.py
+++ b/tests/gateway/test_msgraph_webhook.py
@@ -1,0 +1,187 @@
+"""Tests for the Microsoft Graph webhook adapter."""
+
+import asyncio
+import json
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig, _apply_env_overrides
+from gateway.platforms.msgraph_webhook import MSGraphWebhookAdapter
+
+
+def _make_adapter(**extra_overrides) -> MSGraphWebhookAdapter:
+    extra = {
+        "client_state": "expected-client-state",
+        "accepted_resources": ["communications/onlineMeetings"],
+    }
+    extra.update(extra_overrides)
+    return MSGraphWebhookAdapter(PlatformConfig(enabled=True, extra=extra))
+
+
+class _FakeRequest:
+    def __init__(self, *, query=None, json_payload=None):
+        self.query = query or {}
+        self._json_payload = json_payload
+
+    async def json(self):
+        if isinstance(self._json_payload, Exception):
+            raise self._json_payload
+        return self._json_payload
+
+
+class TestMSGraphWebhookConfig:
+    def test_gateway_config_accepts_msgraph_webhook_platform(self):
+        config = GatewayConfig.from_dict(
+            {
+                "platforms": {
+                    "msgraph_webhook": {
+                        "enabled": True,
+                        "extra": {"client_state": "expected"},
+                    }
+                }
+            }
+        )
+
+        assert Platform.MSGRAPH_WEBHOOK in config.platforms
+        assert Platform.MSGRAPH_WEBHOOK in config.get_connected_platforms()
+
+    def test_env_overrides_apply_to_existing_msgraph_webhook_platform(self, monkeypatch):
+        config = GatewayConfig(
+            platforms={Platform.MSGRAPH_WEBHOOK: PlatformConfig(enabled=True, extra={})}
+        )
+
+        monkeypatch.setenv("MSGRAPH_WEBHOOK_PORT", "8650")
+        monkeypatch.setenv("MSGRAPH_WEBHOOK_CLIENT_STATE", "env-state")
+        monkeypatch.setenv(
+            "MSGRAPH_WEBHOOK_ACCEPTED_RESOURCES",
+            "communications/onlineMeetings, chats/getAllMessages",
+        )
+
+        _apply_env_overrides(config)
+
+        extra = config.platforms[Platform.MSGRAPH_WEBHOOK].extra
+        assert extra["port"] == 8650
+        assert extra["client_state"] == "env-state"
+        assert extra["accepted_resources"] == [
+            "communications/onlineMeetings",
+            "chats/getAllMessages",
+        ]
+
+
+class TestMSGraphValidationHandshake:
+    @pytest.mark.anyio
+    async def test_validation_token_echo(self):
+        adapter = _make_adapter()
+        resp = await adapter._handle_notification(
+            _FakeRequest(query={"validationToken": "abc123"})
+        )
+        assert resp.status == 200
+        assert resp.text == "abc123"
+        assert resp.content_type == "text/plain"
+
+
+class TestMSGraphNotifications:
+    @pytest.mark.anyio
+    async def test_valid_notification_accepted_and_scheduled(self):
+        adapter = _make_adapter()
+        scheduled: list[tuple[dict, object]] = []
+
+        async def _capture(notification, event):
+            scheduled.append((notification, event))
+
+        adapter.set_notification_scheduler(_capture)
+        payload = {
+            "value": [
+                {
+                    "id": "notif-1",
+                    "subscriptionId": "sub-1",
+                    "changeType": "updated",
+                    "resource": "communications/onlineMeetings/meeting-1",
+                    "clientState": "expected-client-state",
+                    "resourceData": {"id": "meeting-1"},
+                }
+            ]
+        }
+
+        resp = await adapter._handle_notification(_FakeRequest(json_payload=payload))
+        assert resp.status == 202
+        data = json.loads(resp.text)
+        assert data["accepted"] == 1
+        assert data["duplicates"] == 0
+        assert data["rejected"] == 0
+        assert data["scheduled"] == 1
+
+        await asyncio.sleep(0.05)
+
+        assert len(scheduled) == 1
+        notification, event = scheduled[0]
+        assert notification["id"] == "notif-1"
+        assert event.source.platform == Platform.MSGRAPH_WEBHOOK
+        assert event.source.chat_type == "webhook"
+        assert event.message_id == "id:notif-1"
+
+    @pytest.mark.anyio
+    async def test_bad_client_state_rejected(self):
+        adapter = _make_adapter()
+        scheduled: list[tuple[dict, object]] = []
+
+        async def _capture(notification, event):
+            scheduled.append((notification, event))
+
+        adapter.set_notification_scheduler(_capture)
+        payload = {
+            "value": [
+                {
+                    "id": "notif-2",
+                    "subscriptionId": "sub-1",
+                    "changeType": "updated",
+                    "resource": "communications/onlineMeetings/meeting-2",
+                    "clientState": "wrong-state",
+                }
+            ]
+        }
+
+        resp = await adapter._handle_notification(_FakeRequest(json_payload=payload))
+        assert resp.status == 403
+        data = json.loads(resp.text)
+        assert data["accepted"] == 0
+        assert data["duplicates"] == 0
+        assert data["rejected"] == 1
+
+        await asyncio.sleep(0.05)
+
+        assert scheduled == []
+
+    @pytest.mark.anyio
+    async def test_duplicate_notification_deduped(self):
+        adapter = _make_adapter()
+        scheduled: list[tuple[dict, object]] = []
+
+        async def _capture(notification, event):
+            scheduled.append((notification, event))
+
+        adapter.set_notification_scheduler(_capture)
+        payload = {
+            "value": [
+                {
+                    "id": "notif-dup",
+                    "subscriptionId": "sub-1",
+                    "changeType": "updated",
+                    "resource": "communications/onlineMeetings/meeting-3",
+                    "clientState": "expected-client-state",
+                }
+            ]
+        }
+
+        first = await adapter._handle_notification(_FakeRequest(json_payload=payload))
+        assert first.status == 202
+        second = await adapter._handle_notification(_FakeRequest(json_payload=payload))
+        assert second.status == 202
+        second_data = json.loads(second.text)
+        assert second_data["accepted"] == 0
+        assert second_data["duplicates"] == 1
+        assert second_data["scheduled"] == 0
+
+        await asyncio.sleep(0.05)
+
+        assert len(scheduled) == 1

--- a/tests/gateway/test_msgraph_webhook.py
+++ b/tests/gateway/test_msgraph_webhook.py
@@ -19,9 +19,10 @@ def _make_adapter(**extra_overrides) -> MSGraphWebhookAdapter:
 
 
 class _FakeRequest:
-    def __init__(self, *, query=None, json_payload=None):
+    def __init__(self, *, query=None, json_payload=None, remote="127.0.0.1"):
         self.query = query or {}
         self._json_payload = json_payload
+        self.remote = remote
 
     async def json(self):
         if isinstance(self._json_payload, Exception):
@@ -70,14 +71,31 @@ class TestMSGraphWebhookConfig:
 
 class TestMSGraphValidationHandshake:
     @pytest.mark.anyio
-    async def test_validation_token_echo(self):
+    async def test_validation_token_echo_on_get(self):
+        adapter = _make_adapter()
+        resp = await adapter._handle_validation(
+            _FakeRequest(query={"validationToken": "abc123"})
+        )
+        assert resp.status == 200
+        assert resp.text == "abc123"
+        assert resp.content_type == "text/plain"
+
+    @pytest.mark.anyio
+    async def test_bare_get_without_validation_token_rejected(self):
+        """GET without validationToken is 400 so the endpoint can't be enumerated."""
+        adapter = _make_adapter()
+        resp = await adapter._handle_validation(_FakeRequest())
+        assert resp.status == 400
+
+    @pytest.mark.anyio
+    async def test_post_with_validation_token_still_echoes(self):
+        """Tolerate defensive clients that send validationToken on POST."""
         adapter = _make_adapter()
         resp = await adapter._handle_notification(
             _FakeRequest(query={"validationToken": "abc123"})
         )
         assert resp.status == 200
         assert resp.text == "abc123"
-        assert resp.content_type == "text/plain"
 
 
 class TestMSGraphNotifications:
@@ -104,12 +122,10 @@ class TestMSGraphNotifications:
         }
 
         resp = await adapter._handle_notification(_FakeRequest(json_payload=payload))
+        # Success is 202 with empty body: internal counters must not leak to
+        # the wire. Counters are still observable via /health.
         assert resp.status == 202
-        data = json.loads(resp.text)
-        assert data["accepted"] == 1
-        assert data["duplicates"] == 0
-        assert data["rejected"] == 0
-        assert data["scheduled"] == 1
+        assert resp.body is None or not resp.body
 
         await asyncio.sleep(0.05)
 
@@ -121,7 +137,8 @@ class TestMSGraphNotifications:
         assert event.message_id == "id:notif-1"
 
     @pytest.mark.anyio
-    async def test_bad_client_state_rejected(self):
+    async def test_bad_client_state_rejected_as_auth_failure(self):
+        """Every-item-bad-clientState batches return 403 so forged POSTs stop retrying."""
         adapter = _make_adapter()
         scheduled: list[tuple[dict, object]] = []
 
@@ -143,14 +160,45 @@ class TestMSGraphNotifications:
 
         resp = await adapter._handle_notification(_FakeRequest(json_payload=payload))
         assert resp.status == 403
-        data = json.loads(resp.text)
-        assert data["accepted"] == 0
-        assert data["duplicates"] == 0
-        assert data["rejected"] == 1
 
         await asyncio.sleep(0.05)
 
         assert scheduled == []
+
+    @pytest.mark.anyio
+    async def test_client_state_compare_is_timing_safe(self, monkeypatch):
+        """Ensure hmac.compare_digest is used for clientState comparison."""
+        import hmac
+
+        calls: list[tuple[str, str]] = []
+        real_compare = hmac.compare_digest
+
+        def _spy(a, b):
+            calls.append((a, b))
+            return real_compare(a, b)
+
+        monkeypatch.setattr(
+            "gateway.platforms.msgraph_webhook.hmac.compare_digest", _spy
+        )
+
+        adapter = _make_adapter()
+        payload = {
+            "value": [
+                {
+                    "id": "notif-timing",
+                    "subscriptionId": "sub-1",
+                    "changeType": "updated",
+                    "resource": "communications/onlineMeetings/meeting-x",
+                    "clientState": "expected-client-state",
+                }
+            ]
+        }
+        await adapter._handle_notification(_FakeRequest(json_payload=payload))
+
+        assert calls, "hmac.compare_digest was never called; clientState check is not timing-safe"
+        provided, expected = calls[0]
+        assert provided == "expected-client-state"
+        assert expected == "expected-client-state"
 
     @pytest.mark.anyio
     async def test_duplicate_notification_deduped(self):
@@ -176,11 +224,9 @@ class TestMSGraphNotifications:
         first = await adapter._handle_notification(_FakeRequest(json_payload=payload))
         assert first.status == 202
         second = await adapter._handle_notification(_FakeRequest(json_payload=payload))
+        # Duplicate-only batch still returns 202 so Graph stops retrying.
         assert second.status == 202
-        second_data = json.loads(second.text)
-        assert second_data["accepted"] == 0
-        assert second_data["duplicates"] == 1
-        assert second_data["scheduled"] == 0
+        assert adapter._duplicate_count == 1
 
         await asyncio.sleep(0.05)
 
@@ -212,10 +258,6 @@ class TestMSGraphNotifications:
 
         assert first.status == 202
         assert second.status == 202
-        second_data = json.loads(second.text)
-        assert second_data["accepted"] == 1
-        assert second_data["duplicates"] == 0
-        assert second_data["scheduled"] == 1
 
         await asyncio.sleep(0.05)
 
@@ -237,11 +279,39 @@ class TestMSGraphNotifications:
         }
 
         resp = await adapter._handle_notification(_FakeRequest(json_payload=payload))
-        data = json.loads(resp.text)
-
         assert resp.status == 202
-        assert data["accepted"] == 1
-        assert data["rejected"] == 0
+
+    @pytest.mark.anyio
+    async def test_resource_not_in_allowlist_returns_400(self):
+        """Every-item-rejected-for-non-auth returns 400 (configuration issue)."""
+        adapter = _make_adapter(accepted_resources=["communications/onlineMeetings"])
+        payload = {
+            "value": [
+                {
+                    "id": "notif-bad-resource",
+                    "resource": "users/u1/messages",
+                    "clientState": "expected-client-state",
+                }
+            ]
+        }
+        resp = await adapter._handle_notification(_FakeRequest(json_payload=payload))
+        assert resp.status == 400
+
+    @pytest.mark.anyio
+    async def test_malformed_body_returns_400(self):
+        adapter = _make_adapter()
+        resp = await adapter._handle_notification(
+            _FakeRequest(json_payload=ValueError("bad json"))
+        )
+        assert resp.status == 400
+
+    @pytest.mark.anyio
+    async def test_missing_value_array_returns_400(self):
+        adapter = _make_adapter()
+        resp = await adapter._handle_notification(
+            _FakeRequest(json_payload={"not_value": []})
+        )
+        assert resp.status == 400
 
     @pytest.mark.anyio
     async def test_seen_receipts_are_bounded(self):
@@ -277,6 +347,84 @@ class TestMSGraphNotifications:
         assert list(adapter._seen_receipt_order) == ["id:notif-b", "id:notif-c"]
 
         replay = await _post("notif-a")
-        replay_data = json.loads(replay.text)
-        assert replay_data["accepted"] == 1
-        assert replay_data["duplicates"] == 0
+        # notif-a evicted from the bounded cache, so it's accepted again (202)
+        # rather than treated as a duplicate.
+        assert replay.status == 202
+        assert adapter._accepted_count == 4
+
+
+class TestMSGraphSourceIPAllowlist:
+    @pytest.mark.anyio
+    async def test_disabled_by_default_allows_all(self):
+        """Empty allowlist preserves pre-existing behavior (dev tunnels, localhost)."""
+        adapter = _make_adapter()  # no allowed_source_cidrs set
+        payload = {
+            "value": [
+                {
+                    "id": "notif-ip",
+                    "resource": "communications/onlineMeetings/m",
+                    "clientState": "expected-client-state",
+                }
+            ]
+        }
+        resp = await adapter._handle_notification(
+            _FakeRequest(json_payload=payload, remote="203.0.113.99")
+        )
+        assert resp.status == 202
+
+    @pytest.mark.anyio
+    async def test_post_from_disallowed_ip_rejected(self):
+        adapter = _make_adapter(allowed_source_cidrs=["10.0.0.0/8"])
+        payload = {
+            "value": [
+                {
+                    "id": "notif-ip-bad",
+                    "resource": "communications/onlineMeetings/m",
+                    "clientState": "expected-client-state",
+                }
+            ]
+        }
+        resp = await adapter._handle_notification(
+            _FakeRequest(json_payload=payload, remote="203.0.113.99")
+        )
+        assert resp.status == 403
+
+    @pytest.mark.anyio
+    async def test_post_from_allowed_ip_accepted(self):
+        adapter = _make_adapter(allowed_source_cidrs=["10.0.0.0/8", "203.0.113.0/24"])
+        payload = {
+            "value": [
+                {
+                    "id": "notif-ip-ok",
+                    "resource": "communications/onlineMeetings/m",
+                    "clientState": "expected-client-state",
+                }
+            ]
+        }
+        resp = await adapter._handle_notification(
+            _FakeRequest(json_payload=payload, remote="203.0.113.5")
+        )
+        assert resp.status == 202
+
+    @pytest.mark.anyio
+    async def test_validation_handshake_also_respects_allowlist(self):
+        """A disallowed IP shouldn't be able to probe the handshake endpoint."""
+        adapter = _make_adapter(allowed_source_cidrs=["10.0.0.0/8"])
+        resp = await adapter._handle_validation(
+            _FakeRequest(query={"validationToken": "probe"}, remote="203.0.113.99")
+        )
+        assert resp.status == 403
+
+    @pytest.mark.anyio
+    async def test_invalid_cidr_entries_are_ignored_at_init(self):
+        """Malformed CIDR strings should log a warning and be ignored, not crash."""
+        adapter = _make_adapter(
+            allowed_source_cidrs=["10.0.0.0/8", "not-a-cidr", "", "203.0.113.0/24"]
+        )
+        assert len(adapter._allowed_source_networks) == 2
+
+    @pytest.mark.anyio
+    async def test_cidr_list_accepts_comma_string(self):
+        """Env-var-style 'cidr1, cidr2' strings parse as a list."""
+        adapter = _make_adapter(allowed_source_cidrs="10.0.0.0/8, 203.0.113.0/24")
+        assert len(adapter._allowed_source_networks) == 2

--- a/tests/gateway/test_platform_connected_checkers.py
+++ b/tests/gateway/test_platform_connected_checkers.py
@@ -76,7 +76,12 @@ def test_checker_returns_true_when_configured(platform, checker, monkeypatch):
     elif platform == Platform.SMS:
         monkeypatch.setenv("TWILIO_ACCOUNT_SID", "ACtest")
         mock_config.extra = {}
-    elif platform in (Platform.API_SERVER, Platform.WEBHOOK, Platform.WHATSAPP):
+    elif platform in (
+        Platform.API_SERVER,
+        Platform.WEBHOOK,
+        Platform.MSGRAPH_WEBHOOK,
+        Platform.WHATSAPP,
+    ):
         mock_config.extra = {}
     elif platform == Platform.FEISHU:
         mock_config.extra = {"app_id": "app"}

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -418,6 +418,18 @@ App-only credentials for the Microsoft Graph REST client used by the upcoming Te
 | `MSGRAPH_SCOPE` | OAuth2 scope for the client-credentials token request (default: `https://graph.microsoft.com/.default`). |
 | `MSGRAPH_AUTHORITY_URL` | Microsoft identity platform authority (default: `https://login.microsoftonline.com`). Override only for national/sovereign clouds (e.g. `https://login.microsoftonline.us` for GCC High). |
 
+### Microsoft Graph Webhook Listener
+
+Inbound change-notification listener for Graph events (Teams meetings, calendar, chat, etc.). See [Microsoft Graph Webhook Listener](/docs/user-guide/messaging/msgraph-webhook) for setup and security hardening.
+
+| Variable | Description |
+|----------|-------------|
+| `MSGRAPH_WEBHOOK_ENABLED` | Enable the `msgraph_webhook` gateway platform (`true`/`1`/`yes`). |
+| `MSGRAPH_WEBHOOK_PORT` | Port the listener binds to (default: `8646`). |
+| `MSGRAPH_WEBHOOK_CLIENT_STATE` | Shared secret Graph echoes in every notification; compared with `hmac.compare_digest`. Generate with `openssl rand -hex 32`. |
+| `MSGRAPH_WEBHOOK_ACCEPTED_RESOURCES` | Comma-separated allowlist of Graph resource paths/patterns (e.g. `communications/onlineMeetings,chats/*/messages`). Trailing `*` is prefix-matching. Empty = accept all. |
+| `MSGRAPH_WEBHOOK_ALLOWED_SOURCE_CIDRS` | Comma-separated CIDR ranges allowed to POST to the listener (e.g. `52.96.0.0/14,52.104.0.0/14`). Empty = allow all (default). Restrict to Microsoft Graph's published egress ranges in production. |
+
 ### Advanced Messaging Tuning
 
 Advanced per-platform knobs for throttling the outbound message batcher. Most users never need to touch these; defaults are set to respect each platform's rate limits without feeling sluggish.

--- a/website/docs/user-guide/messaging/msgraph-webhook.md
+++ b/website/docs/user-guide/messaging/msgraph-webhook.md
@@ -1,0 +1,137 @@
+---
+sidebar_position: 23
+title: "Microsoft Graph Webhook Listener"
+description: "Receive Microsoft Graph change notifications (meetings, calendar, chat, etc.) in Hermes"
+---
+
+# Microsoft Graph Webhook Listener
+
+The `msgraph_webhook` gateway platform is an inbound event listener. It's how Hermes receives **change notifications** from Microsoft Graph — "a Teams meeting ended," "a new message landed in this chat," "this calendar event was updated." Different from the `teams` platform (which is a chat bot users type to) — this one is M365 telling Hermes something happened, not a person.
+
+Right now the primary consumer is the Teams meeting summary pipeline: Graph notifies when a meeting produces a transcript, the pipeline fetches it, and Hermes posts a summary back into Teams. Other Graph resources (`/chats/.../messages`, `/users/.../events`) use the same listener — the pipeline consumers land with their own PRs.
+
+## Prerequisites
+
+- Microsoft Graph application credentials — [Register a Microsoft Graph Application](/docs/guides/microsoft-graph-app-registration)
+- A **public HTTPS URL** that Microsoft Graph can reach (Graph does not call private endpoints). A dev tunnel works for testing; production needs a real domain with a valid certificate.
+- A strong shared secret to use as the `clientState` value. Generate with `openssl rand -hex 32` and put it in `~/.hermes/.env` as `MSGRAPH_WEBHOOK_CLIENT_STATE`.
+
+## Quick Start
+
+Minimum `~/.hermes/config.yaml`:
+
+```yaml
+platforms:
+  msgraph_webhook:
+    enabled: true
+    extra:
+      port: 8646
+      client_state: "replace-with-a-strong-secret"
+      accepted_resources:
+        - "communications/onlineMeetings"
+```
+
+Or via env vars in `~/.hermes/.env` (auto-merged on startup):
+
+```bash
+MSGRAPH_WEBHOOK_ENABLED=true
+MSGRAPH_WEBHOOK_PORT=8646
+MSGRAPH_WEBHOOK_CLIENT_STATE=<generate-with-openssl-rand-hex-32>
+MSGRAPH_WEBHOOK_ACCEPTED_RESOURCES=communications/onlineMeetings
+```
+
+Start the gateway: `hermes gateway run`. The listener exposes:
+
+- `POST /msgraph/webhook` — change notifications from Graph
+- `GET /msgraph/webhook?validationToken=...` — Graph subscription validation handshake
+- `GET /health` — readiness probe with accepted/duplicate counters
+
+Expose the listener publicly (reverse proxy, dev tunnel, ingress). Your notification URL for Graph subscriptions is your public HTTPS origin followed by `/msgraph/webhook`:
+
+```
+https://ops.example.com/msgraph/webhook
+```
+
+## Configuration
+
+All settings go under `platforms.msgraph_webhook.extra`:
+
+| Setting | Default | Description |
+|---------|---------|-------------|
+| `host` | `0.0.0.0` | Bind address for the HTTP listener. |
+| `port` | `8646` | Bind port. |
+| `webhook_path` | `/msgraph/webhook` | URL path Graph POSTs to. |
+| `health_path` | `/health` | Readiness endpoint. |
+| `client_state` | — | Shared secret Graph echoes in every notification. Compared with `hmac.compare_digest` — generate with `openssl rand -hex 32`. |
+| `accepted_resources` | `[]` (accept all) | Allowlist of Graph resource paths/patterns. Trailing `*` acts as prefix match. Leading `/` is tolerated. Example: `["communications/onlineMeetings", "chats/*/messages"]`. |
+| `max_seen_receipts` | `5000` | Dedupe cache size for notification IDs. Oldest entries evicted when the cap is hit. |
+| `allowed_source_cidrs` | `[]` (allow all) | Optional source-IP allowlist. See below. |
+
+Each setting also has an equivalent env var (`MSGRAPH_WEBHOOK_*`) that merges into the config at gateway startup — see the [environment variables reference](/docs/reference/environment-variables#microsoft-graph-teams-meetings).
+
+## Security Hardening
+
+### clientState is the primary auth check
+
+Every Graph notification includes the `clientState` string your subscription registered with. The listener rejects any notification whose `clientState` doesn't match, using timing-safe comparison. This is Microsoft's documented mechanism — treat the value as a strong shared secret.
+
+If `client_state` is unset, the listener accepts every well-formed POST. **Don't run without it in production.**
+
+### Source-IP allowlisting (production deployments)
+
+For production, restrict the listener to Microsoft's published Graph webhook source IP ranges. Microsoft documents the egress ranges under the [Office 365 IP Address and URL Web service](https://learn.microsoft.com/en-us/microsoft-365/enterprise/urls-and-ip-address-ranges). Configure them as:
+
+```yaml
+platforms:
+  msgraph_webhook:
+    enabled: true
+    extra:
+      client_state: "..."
+      allowed_source_cidrs:
+        - "52.96.0.0/14"
+        - "52.104.0.0/14"
+        # ...add the current Microsoft 365 "Common" + "Teams" category egress ranges
+```
+
+Or as an env var:
+
+```bash
+MSGRAPH_WEBHOOK_ALLOWED_SOURCE_CIDRS="52.96.0.0/14,52.104.0.0/14"
+```
+
+Empty allowlist = accept from anywhere (default; preserves dev-tunnel workflows). Invalid CIDR strings log a warning and are ignored. **Review the Microsoft IP list quarterly** — it changes.
+
+### HTTPS termination
+
+The listener speaks plain HTTP. Terminate TLS at your reverse proxy (Caddy, Nginx, Cloudflare Tunnel, AWS ALB) and proxy to the listener over the local network. Graph refuses to deliver to non-HTTPS endpoints, so there's no path for unencrypted traffic to reach you from Graph itself.
+
+### Response hygiene
+
+On success the listener returns `202 Accepted` with an empty body — internal counters stay out of the wire response. Operators can observe counts via `/health`.
+
+Status code table:
+
+| Outcome | Status |
+|---------|--------|
+| Notification(s) accepted or deduped | 202 |
+| Validation handshake (GET with `validationToken`) | 200 (echoes the token) |
+| Every item in batch failed clientState | 403 |
+| Malformed JSON / missing `value` array / unknown resource | 400 |
+| Source IP not in allowlist | 403 |
+| Bare GET without `validationToken` | 400 |
+
+## Troubleshooting
+
+| Problem | What to check |
+|---------|---------------|
+| Graph subscription validation fails | Public URL is reachable, `/msgraph/webhook` path matches, GET with `validationToken` echoes the token verbatim as `text/plain` within 10 seconds. |
+| Notifications POST but nothing ingests | `client_state` matches what you registered the subscription with. Re-run `openssl rand -hex 32` and create a new subscription if the value drifted. Check `accepted_resources` includes the resource path Graph is sending. |
+| Every notification 403s | `clientState` mismatch (forged, or subscription registered with a different value). Re-create the subscription with `hermes teams-pipeline subscribe --client-state "$MSGRAPH_WEBHOOK_CLIENT_STATE" ...` (ships with the pipeline runtime PR). |
+| Listener starts but `curl http://localhost:8646/health` hangs | Port binding collision. Check `ss -tlnp \| grep 8646` and change `port:` if needed. |
+| Real Graph requests from Microsoft get 403'd | Source IP allowlist is too narrow. Remove `allowed_source_cidrs` temporarily, confirm traffic flows, then widen the list to include the current Microsoft egress ranges. |
+
+## Related Docs
+
+- [Register a Microsoft Graph Application](/docs/guides/microsoft-graph-app-registration) — Azure app registration prereq
+- [Environment Variables → Microsoft Graph](/docs/reference/environment-variables#microsoft-graph-teams-meetings) — full env var list
+- [Microsoft Teams bot setup](/docs/user-guide/messaging/teams) — the different platform that lets users chat with Hermes in Teams

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -136,6 +136,7 @@ const sidebars: SidebarsConfig = {
         'user-guide/messaging/qqbot',
         'user-guide/messaging/yuanbao',
         'user-guide/messaging/teams',
+        'user-guide/messaging/msgraph-webhook',
         'user-guide/messaging/open-webui',
         'user-guide/messaging/webhooks',
       ],


### PR DESCRIPTION
## Summary
Salvage of #21409 onto current `main`, with auth hardening + source-IP allowlisting + response hygiene on top, and the webhook listener setup page shipped alongside the code so operators can wire up Graph subscriptions the moment this lands.

Second slice of the MS Teams meeting pipeline stack: a new `msgraph_webhook` gateway platform that receives Microsoft Graph change notifications (meeting ended, transcript ready, etc.). Distinct from the existing `teams` platform, which is a chat bot — this one is inbound event ingress from M365.

Credit to @dlkakbs — her three commits are preserved via rebase-merge.

## Changes
- **`gateway/platforms/msgraph_webhook.py`** (new): aiohttp-based listener with Graph validation handshake (GET with `validationToken`), change-notification POST handler, resource allowlist with `*` prefix matching, bounded receipt dedupe, and internal scheduler hook for downstream consumers (the pipeline runtime plugs in here).
- **`gateway/config.py`**: `Platform.MSGRAPH_WEBHOOK` enum entry, connected-checker, env-var merge for `MSGRAPH_WEBHOOK_*`.
- **`gateway/run.py`**: adapter wiring via `check_msgraph_webhook_requirements()`.
- **Auth hardening on top of @dlkakbs's work:**
  - Timing-safe `clientState` comparison via `hmac.compare_digest` (was `==`, timing-leak).
  - Split GET/POST handlers — bare GET without `validationToken` is now 400 so the endpoint can't be probed. Previously fell through to the POST handler and blew up on `request.json()`.
  - Empty response bodies on success: 202 with no body, internal counters stay off the wire (still observable via `/health`). 403 only on every-item-bad-clientState batches (forged POSTs), 400 on malformed / unknown-resource.
  - Optional source-IP allowlist via `allowed_source_cidrs` (list or comma-string). Empty = allow all (default; preserves dev-tunnel workflows). Gates the handshake endpoint too.
  - New env var `MSGRAPH_WEBHOOK_ALLOWED_SOURCE_CIDRS`.
- **Docs:**
  - `/docs/user-guide/messaging/msgraph-webhook` — new page: distinguishes the listener from the Teams chat adapter, quick-start config, full config table, security hardening (clientState + IP allowlisting + TLS termination + response hygiene), status-code table, troubleshooting, cross-links to the Azure app reg guide.
  - `/docs/reference/environment-variables` — new Microsoft Graph Webhook Listener subsection covering all five `MSGRAPH_WEBHOOK_*` env vars.
  - Sidebar: new page slotted next to `teams` in Messaging Platforms.

## Validation
- `scripts/run_tests.sh tests/gateway/test_msgraph_webhook.py tests/gateway/test_platform_connected_checkers.py` → **52/52 passed** (was 40 pre-hardening; +12 for the new behaviors).
- New tests cover: bare-GET rejection, POST-with-validationToken handshake tolerance, timing-safe compare via `hmac.compare_digest` spy, malformed body / missing `value` array, IP allowlist accept/reject, handshake IP allowlist, invalid-CIDR graceful degradation, comma-string CIDR parsing.
- Full gateway suite: **5049 passed**, 1 pre-existing failure in `test_discord_free_response` (reproduces on clean `origin/main`, unrelated to this PR).
- `npm run build` in `website/` — new page routes at `/docs/user-guide/messaging/msgraph-webhook`, sidebar wires correctly, no new warnings or errors.

Closes #21409.
