### PR TITLE
fix(cli): skip output-history replay on terminal resize

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2521,9 +2521,16 @@ class HermesCLI:
             pass
 
     def _recover_after_resize(self, app, original_on_resize) -> None:
-        """Recover a resized classic CLI without desynchronizing cursor state."""
+        """Recover a resized classic CLI without desynchronizing cursor state.
+
+        Only clears the screen and resets the renderer — does NOT replay
+        output history.  Replaying on every resize causes jarring
+        "re-streaming" of entire conversation.  Users who want history
+        restored can press Ctrl+L (/redraw) which calls _force_full_redraw.
+        """
         self._clear_prompt_toolkit_screen(app, rebuild_scrollback=True)
-        _replay_output_history()
+        # Deliberately NOT calling _replay_output_history() here.
+        # See docstring above.
         original_on_resize()
 
     def _schedule_resize_recovery(self, app, original_on_resize, delay: float = 0.12) -> None:

--- a/tests/cli/test_cli_force_redraw.py
+++ b/tests/cli/test_cli_force_redraw.py
@@ -72,6 +72,10 @@ class TestForceFullRedraw:
         ]
 
     def test_resize_rebuilds_scrollback_before_prompt_toolkit_redraw(self, bare_cli, monkeypatch):
+        """Resize recovery clears screen, rebuilds scrollback, resets renderer,
+        then hands off to prompt_toolkit WITHOUT replaying output history.
+        (Replay on every resize is too jarring — users can Ctrl+L instead.)
+        """
         app = MagicMock()
         out = app.renderer.output
         events = []
@@ -86,6 +90,8 @@ class TestForceFullRedraw:
 
         bare_cli._recover_after_resize(app, original_on_resize)
 
+        # _recover_after_resize clears screen + resets renderer, then
+        # calls original_on_resize directly — NO output history replay.
         assert events == [
             "reset_attrs",
             "erase",
@@ -93,7 +99,6 @@ class TestForceFullRedraw:
             "home",
             "flush",
             "renderer_reset",
-            "replay",
             "original_resize",
         ]
         app.invalidate.assert_not_called()


### PR DESCRIPTION
## Problem

#20444 引入的 `_resize_clear_ghosts` 机制在每次终端窗口 resize 时重放 `_OUTPUT_HISTORY`，导致一个严重体验问题：

**最大化/还原终端窗口时，所有历史输出行（包括流式 token、spinner 帧）被快速重放一遍**，视觉效果如同对话从头"重新流式输出"。

macOS 上用户习惯用 Command+Enter 切换窗口大小，这个重放非常突兀。

## Root Cause

`_recover_after_resize` → `_replay_output_history()` 把 `_OUTPUT_HISTORY` 缓冲区（最多200行，包含 callable 条目如历史面板 lambda）全部重新送给 prompt_toolkit 输出。

## Fix

删除 `_recover_after_resize` 中的 `self._replay_output_history()` 调用，只保留：

1. `self._clear_prompt_toolkit_screen()` — 清除 SIGWINCH 后的鬼影
2. `self.renderer.reset()` — 重置渲染器状态

prompt_toolkit 原生的 `_on_resize` 会自行重绘输入区和状态栏。

Ctrl+L 仍可手动恢复完整历史（`_force_full_redraw` 路径未受影响）。

## Testing

- 更新 `tests/cli/test_cli_force_redraw.py` 中的 resize 测试，不再期望 `"replay"` event
- 57/57 相关测试通过

## Related

- Fixes symptom reported in #19280
- #20444 (original resize-recovery implementation)