### PR TITLE
feat(tui): improve /resume picker discoverability with ? search

### DIFF
--- a/ui-tui/src/__tests__/sessionPickerSearch.test.ts
+++ b/ui-tui/src/__tests__/sessionPickerSearch.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  sessionPickerHintText,
+  sessionPickerKeyAction,
+  sessionPickerModeAfterKey,
+  sessionSearchText,
+  shouldAppendSessionFilterChar
+} from '../components/sessionPicker.js'
+
+const key = (overrides: Record<string, unknown> = {}) =>
+  ({ ctrl: false, meta: false, ...overrides }) as any
+
+describe('sessionSearchText', () => {
+  it('indexes id, title, preview, source, and message count for picker filtering', () => {
+    const text = sessionSearchText({
+      id: '20260509_001122_abc123',
+      message_count: 42,
+      preview: 'Need to create a Hermes TUI session picker PR',
+      source: 'telegram',
+      started_at: 1778265600,
+      title: 'Question mark session search'
+    })
+
+    expect(text).toContain('20260509_001122_abc123')
+    expect(text).toContain('question mark session search')
+    expect(text).toContain('hermes tui session picker')
+    expect(text).toContain('telegram')
+    expect(text).toContain('42')
+  })
+})
+
+describe('session picker filter mode', () => {
+  it('enters filter mode only from bare ? so browse shortcuts keep working', () => {
+    expect(sessionPickerModeAfterKey('browse', '?', key())).toBe('filter')
+    expect(sessionPickerModeAfterKey('browse', 'a', key())).toBe('browse')
+    expect(sessionPickerModeAfterKey('browse', '?', key({ ctrl: true }))).toBe('browse')
+    expect(sessionPickerModeAfterKey('filter', '', key({ escape: true }))).toBe('browse')
+  })
+
+  it('only appends printable search text while filter mode is active', () => {
+    expect(shouldAppendSessionFilterChar('q', key(), 'browse')).toBe(false)
+    expect(shouldAppendSessionFilterChar('d', key(), 'browse')).toBe(false)
+    expect(shouldAppendSessionFilterChar('q', key(), 'filter')).toBe(true)
+    expect(shouldAppendSessionFilterChar('d', key(), 'filter')).toBe(true)
+    expect(shouldAppendSessionFilterChar('d', key({ ctrl: true }), 'filter')).toBe(false)
+  })
+
+  it('shows the ? filter shortcut in browse footer and type-to-filter in filter footer', () => {
+    expect(sessionPickerHintText({ filterMode: false, hasQuery: false })).toContain('? filter')
+    expect(sessionPickerHintText({ filterMode: false, hasQuery: false })).toContain('1-9 quick')
+    expect(sessionPickerHintText({ filterMode: true, hasQuery: true })).toContain('type to filter')
+    expect(sessionPickerHintText({ filterMode: true, hasQuery: true })).not.toContain('1-9 quick')
+  })
+
+  it('keeps /resume browse shortcuts out of filter text handling', () => {
+    expect(sessionPickerKeyAction({ ch: '1', key: key(), mode: 'browse', query: '', visibleCount: 3 })).toEqual({
+      index: 0,
+      type: 'quick-select'
+    })
+    expect(sessionPickerKeyAction({ ch: 'q', key: key(), mode: 'browse', query: '', visibleCount: 3 })).toEqual({
+      type: 'cancel'
+    })
+    expect(sessionPickerKeyAction({ ch: 'd', key: key({ ctrl: true }), mode: 'browse', query: '', visibleCount: 3 })).toEqual({
+      type: 'delete'
+    })
+    expect(sessionPickerKeyAction({ ch: '?', key: key(), mode: 'browse', query: '', visibleCount: 3 })).toEqual({
+      type: 'enter-filter'
+    })
+  })
+
+  it('treats q, d, and digits as search text only after ? enters filter mode', () => {
+    expect(sessionPickerKeyAction({ ch: 'q', key: key(), mode: 'filter', query: '', visibleCount: 3 })).toEqual({
+      ch: 'q',
+      type: 'append-filter'
+    })
+    expect(sessionPickerKeyAction({ ch: 'd', key: key(), mode: 'filter', query: '', visibleCount: 3 })).toEqual({
+      ch: 'd',
+      type: 'append-filter'
+    })
+    expect(sessionPickerKeyAction({ ch: '1', key: key(), mode: 'filter', query: '', visibleCount: 3 })).toEqual({
+      ch: '1',
+      type: 'append-filter'
+    })
+    expect(sessionPickerKeyAction({ ch: '', key: key({ escape: true }), mode: 'filter', query: 'abc', visibleCount: 3 })).toEqual({
+      type: 'exit-filter'
+    })
+  })
+})

--- a/ui-tui/src/__tests__/textInputPassThrough.test.ts
+++ b/ui-tui/src/__tests__/textInputPassThrough.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 
-import { shouldPassThroughToGlobalHandler } from '../components/textInput.js'
+import { shouldOpenSessionPickerShortcut, shouldPassThroughToGlobalHandler } from '../components/textInput.js'
 import { DEFAULT_VOICE_RECORD_KEY, parseVoiceRecordKey } from '../lib/platform.js'
 
 const key = (overrides: Record<string, unknown> = {}) =>
@@ -39,5 +39,18 @@ describe('shouldPassThroughToGlobalHandler', () => {
     expect(shouldPassThroughToGlobalHandler('', key({ tab: true }))).toBe(true)
     expect(shouldPassThroughToGlobalHandler('', key({ pageUp: true }))).toBe(true)
     expect(shouldPassThroughToGlobalHandler('', key({ pageDown: true }))).toBe(true)
+  })
+})
+
+describe('shouldOpenSessionPickerShortcut', () => {
+  it('uses bare ? on an empty composer as the session search shortcut', () => {
+    expect(shouldOpenSessionPickerShortcut('?', key(), '', null)).toBe(true)
+    expect(shouldOpenSessionPickerShortcut('?', key({ shift: true }), '', null)).toBe(true)
+  })
+
+  it('preserves literal ? typing once the user is composing text', () => {
+    expect(shouldOpenSessionPickerShortcut('?', key(), 'why', null)).toBe(false)
+    expect(shouldOpenSessionPickerShortcut('?', key({ ctrl: true }), '', null)).toBe(false)
+    expect(shouldOpenSessionPickerShortcut('?', key(), '', { start: 0, end: 1 })).toBe(false)
   })
 })

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -299,6 +299,7 @@ const ComposerPane = memo(function ComposerPane({
                   columns={inputColumns}
                   mouseApiRef={inputMouseRef}
                   onChange={composer.updateInput}
+                  onEmptyQuestionMark={() => patchOverlayState({ picker: true })}
                   onPaste={composer.handleTextPaste}
                   onSubmit={composer.submit}
                   placeholder={composer.empty ? PLACEHOLDER : ui.busy ? 'Ctrl+C to interrupt…' : ''}

--- a/ui-tui/src/components/helpHint.tsx
+++ b/ui-tui/src/components/helpHint.tsx
@@ -6,6 +6,7 @@ import type { Theme } from '../theme.js'
 const COMMON_COMMANDS: [string, string][] = [
   ['/help', 'full list of commands + hotkeys'],
   ['/clear', 'start a new session'],
+  ['?', 'search previous sessions'],
   ['/resume', 'resume a prior session'],
   ['/details', 'control transcript detail level'],
   ['/copy', 'copy selection or last assistant message'],

--- a/ui-tui/src/components/sessionPicker.tsx
+++ b/ui-tui/src/components/sessionPicker.tsx
@@ -1,4 +1,5 @@
 import { Box, Text, useInput, useStdout } from '@hermes/ink'
+import type { Key } from '@hermes/ink'
 import { useEffect, useState } from 'react'
 
 import type { GatewayClient } from '../gatewayClient.js'
@@ -6,7 +7,7 @@ import type { SessionDeleteResponse, SessionListItem, SessionListResponse } from
 import { asRpcResult, rpcErrorMessage } from '../lib/rpc.js'
 import type { Theme } from '../theme.js'
 
-import { OverlayHint, useOverlayKeys, windowOffset } from './overlayControls.js'
+import { OverlayHint, windowOffset } from './overlayControls.js'
 
 const VISIBLE = 15
 const MIN_WIDTH = 60
@@ -26,20 +27,125 @@ const age = (ts: number) => {
   return `${Math.floor(d)}d ago`
 }
 
+export const sessionSearchText = (s: SessionListItem) =>
+  [s.id, s.title, s.preview, s.source, String(s.message_count)].filter(Boolean).join(' ').toLowerCase()
+
+export type SessionPickerMode = 'browse' | 'filter'
+
+const isPrintableSearchChar = (ch: string | undefined) => !!ch && ch.length === 1 && /^[ -~]$/.test(ch)
+
+const isBareQuestionMark = (ch: string | undefined, key: Key) =>
+  ch === '?' && !key.ctrl && !key.meta
+
+export const sessionPickerModeAfterKey = (
+  mode: SessionPickerMode,
+  ch: string | undefined,
+  key: Key
+): SessionPickerMode => {
+  if (mode === 'browse' && isBareQuestionMark(ch, key)) {
+    return 'filter'
+  }
+
+  if (mode === 'filter' && key.escape) {
+    return 'browse'
+  }
+
+  return mode
+}
+
+export const shouldAppendSessionFilterChar = (
+  ch: string | undefined,
+  key: Key,
+  mode: SessionPickerMode
+) => mode === 'filter' && !key.ctrl && !key.meta && isPrintableSearchChar(ch)
+
+export const sessionPickerHintText = ({ filterMode, hasQuery }: { filterMode: boolean; hasQuery: boolean }) =>
+  filterMode
+    ? `type to filter · ↑/↓ select · Enter resume · Backspace ${hasQuery ? 'clear' : 'exit'} · Esc exit filter`
+    : '? filter · ↑/↓ select · Enter resume · 1-9 quick · Ctrl+D delete · Esc/q cancel'
+
+export type SessionPickerKeyAction =
+  | { type: 'append-filter'; ch: string }
+  | { type: 'backspace-filter' }
+  | { type: 'cancel' }
+  | { type: 'delete' }
+  | { type: 'enter-filter' }
+  | { type: 'exit-filter' }
+  | { type: 'quick-select'; index: number }
+  | { type: 'resume-selected' }
+  | { type: 'none' }
+
+export const sessionPickerKeyAction = ({
+  ch,
+  key,
+  mode,
+  query,
+  visibleCount
+}: {
+  ch: string | undefined
+  key: Key
+  mode: SessionPickerMode
+  query: string
+  visibleCount: number
+}): SessionPickerKeyAction => {
+  const filterMode = mode === 'filter'
+
+  if (key.escape) {
+    return filterMode ? { type: 'exit-filter' } : { type: 'cancel' }
+  }
+
+  if (key.backspace && filterMode) {
+    return query ? { type: 'backspace-filter' } : { type: 'exit-filter' }
+  }
+
+  if (key.return && visibleCount > 0) {
+    return { type: 'resume-selected' }
+  }
+
+  if (!filterMode && key.ctrl && ch?.toLowerCase() === 'd' && visibleCount > 0) {
+    return { type: 'delete' }
+  }
+
+  if (!filterMode && isBareQuestionMark(ch, key)) {
+    return { type: 'enter-filter' }
+  }
+
+  if (!filterMode && ch?.toLowerCase() === 'q') {
+    return { type: 'cancel' }
+  }
+
+  const n = !filterMode ? parseInt(ch ?? '') : NaN
+
+  if (n >= 1 && n <= Math.min(9, visibleCount)) {
+    return { index: n - 1, type: 'quick-select' }
+  }
+
+  if (shouldAppendSessionFilterChar(ch, key, mode)) {
+    return { ch: ch!, type: 'append-filter' }
+  }
+
+  return { type: 'none' }
+}
+
 export function SessionPicker({ gw, onCancel, onSelect, t }: SessionPickerProps) {
   const [items, setItems] = useState<SessionListItem[]>([])
   const [err, setErr] = useState('')
   const [sel, setSel] = useState(0)
   const [loading, setLoading] = useState(true)
-  // When non-null, the user pressed `d` on this index and we're waiting for
+  const [query, setQuery] = useState('')
+  const [mode, setMode] = useState<SessionPickerMode>('browse')
+  const filterMode = mode === 'filter'
+  // When non-null, the user pressed `d` on this session and we're waiting for
   // a second `d`/`D` to confirm deletion.  Any other key cancels the prompt.
-  const [confirmDelete, setConfirmDelete] = useState<null | number>(null)
+  const [confirmDelete, setConfirmDelete] = useState<null | string>(null)
   const [deleting, setDeleting] = useState(false)
 
   const { stdout } = useStdout()
   const width = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, (stdout?.columns ?? 80) - 6))
-
-  useOverlayKeys({ onClose: onCancel })
+  const normalizedQuery = query.trim().toLowerCase()
+  const visibleItems = normalizedQuery
+    ? items.filter(s => sessionSearchText(s).includes(normalizedQuery))
+    : items
 
   useEffect(() => {
     gw.request<SessionListResponse>('session.list', { limit: 200 })
@@ -63,8 +169,12 @@ export function SessionPicker({ gw, onCancel, onSelect, t }: SessionPickerProps)
       })
   }, [gw])
 
-  const performDelete = (index: number) => {
-    const target = items[index]
+  useEffect(() => {
+    setSel(s => Math.max(0, Math.min(s, visibleItems.length - 1)))
+  }, [visibleItems.length])
+
+  const performDelete = (id: string) => {
+    const target = items.find(item => item.id === id)
 
     if (!target || deleting) {
       return
@@ -83,7 +193,7 @@ export function SessionPicker({ gw, onCancel, onSelect, t }: SessionPickerProps)
         }
 
         setItems(prev => {
-          const next = prev.filter((_, i) => i !== index)
+          const next = prev.filter(item => item.id !== id)
           setSel(s => Math.max(0, Math.min(s, next.length - 1)))
 
           return next
@@ -102,11 +212,26 @@ export function SessionPicker({ gw, onCancel, onSelect, t }: SessionPickerProps)
       return
     }
 
+    const action = sessionPickerKeyAction({ ch, key, mode, query, visibleCount: visibleItems.length })
+
+    if (action.type === 'exit-filter') {
+      setQuery('')
+      setMode('browse')
+
+      return
+    }
+
+    if (action.type === 'cancel') {
+      onCancel()
+
+      return
+    }
+
     if (confirmDelete !== null) {
       if (ch?.toLowerCase() === 'd') {
-        const idx = confirmDelete
+        const id = confirmDelete
         setConfirmDelete(null)
-        performDelete(idx)
+        performDelete(id)
       } else {
         setConfirmDelete(null)
       }
@@ -118,26 +243,45 @@ export function SessionPicker({ gw, onCancel, onSelect, t }: SessionPickerProps)
       setSel(s => s - 1)
     }
 
-    if (key.downArrow && sel < items.length - 1) {
+    if (key.downArrow && sel < visibleItems.length - 1) {
       setSel(s => s + 1)
     }
 
-    if (key.return && items[sel]) {
-      onSelect(items[sel]!.id)
+    if (action.type === 'backspace-filter') {
+      setQuery(q => q.slice(0, -1))
+      setConfirmDelete(null)
 
       return
     }
 
-    if (ch?.toLowerCase() === 'd' && items[sel]) {
-      setConfirmDelete(sel)
+    if (action.type === 'resume-selected' && visibleItems[sel]) {
+      onSelect(visibleItems[sel]!.id)
 
       return
     }
 
-    const n = parseInt(ch)
+    if (action.type === 'delete' && visibleItems[sel]) {
+      setConfirmDelete(visibleItems[sel]!.id)
 
-    if (n >= 1 && n <= Math.min(9, items.length)) {
-      onSelect(items[n - 1]!.id)
+      return
+    }
+
+    if (action.type === 'enter-filter') {
+      setMode('filter')
+      setConfirmDelete(null)
+
+      return
+    }
+
+    if (action.type === 'quick-select' && visibleItems[action.index]) {
+      onSelect(visibleItems[action.index]!.id)
+
+      return
+    }
+
+    if (action.type === 'append-filter') {
+      setQuery(q => q + action.ch)
+      setConfirmDelete(null)
     }
   })
 
@@ -149,34 +293,36 @@ export function SessionPicker({ gw, onCancel, onSelect, t }: SessionPickerProps)
     return (
       <Box flexDirection="column">
         <Text color={t.color.label}>error: {err}</Text>
-        <OverlayHint t={t}>Esc/q cancel</OverlayHint>
+        <OverlayHint t={t}>Esc cancel</OverlayHint>
       </Box>
     )
   }
 
-  if (!items.length) {
+  if (!visibleItems.length) {
     return (
       <Box flexDirection="column">
-        <Text color={t.color.muted}>no previous sessions</Text>
-        <OverlayHint t={t}>Esc/q cancel</OverlayHint>
+        <Text color={t.color.muted}>{query ? `no sessions matching "${query}"` : 'no previous sessions'}</Text>
+        {filterMode && <Text color={t.color.muted}>filter: {query || 'type to filter'}</Text>}
+        <OverlayHint t={t}>{sessionPickerHintText({ filterMode, hasQuery: !!query })}</OverlayHint>
       </Box>
     )
   }
 
-  const offset = windowOffset(items.length, sel, VISIBLE)
+  const offset = windowOffset(visibleItems.length, sel, VISIBLE)
 
   return (
     <Box flexDirection="column" width={width}>
       <Text bold color={t.color.accent}>
         Resume Session
       </Text>
+      <Text color={t.color.muted}>{filterMode ? `filter: ${query || 'type to filter'}` : 'press ? to filter'}</Text>
 
       {offset > 0 && <Text color={t.color.muted}>  ↑ {offset} more</Text>}
 
-      {items.slice(offset, offset + VISIBLE).map((s, vi) => {
+      {visibleItems.slice(offset, offset + VISIBLE).map((s, vi) => {
         const i = offset + vi
         const selected = sel === i
-        const pendingDelete = confirmDelete === i
+        const pendingDelete = confirmDelete === s.id
 
         return (
           <Box key={s.id}>
@@ -208,12 +354,14 @@ export function SessionPicker({ gw, onCancel, onSelect, t }: SessionPickerProps)
         )
       })}
 
-      {offset + VISIBLE < items.length && <Text color={t.color.muted}>  ↓ {items.length - offset - VISIBLE} more</Text>}
+      {offset + VISIBLE < visibleItems.length && (
+        <Text color={t.color.muted}>  ↓ {visibleItems.length - offset - VISIBLE} more</Text>
+      )}
       {err && <Text color={t.color.label}>error: {err}</Text>}
       {deleting ? (
         <OverlayHint t={t}>deleting…</OverlayHint>
       ) : (
-        <OverlayHint t={t}>↑/↓ select · Enter resume · 1-9 quick · d delete · Esc/q cancel</OverlayHint>
+        <OverlayHint t={t}>{sessionPickerHintText({ filterMode, hasQuery: !!query })}</OverlayHint>
       )}
     </Box>
   )

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -244,6 +244,7 @@ export function TextInput({
   onChange,
   onPaste,
   onSubmit,
+  onEmptyQuestionMark,
   mask,
   mouseApiRef,
   voiceRecordKey = DEFAULT_VOICE_RECORD_KEY,
@@ -277,9 +278,11 @@ export function TextInput({
   const cbChange = useRef(onChange)
   const cbSubmit = useRef(onSubmit)
   const cbPaste = useRef(onPaste)
+  const cbEmptyQuestionMark = useRef(onEmptyQuestionMark)
   cbChange.current = onChange
   cbSubmit.current = onSubmit
   cbPaste.current = onPaste
+  cbEmptyQuestionMark.current = onEmptyQuestionMark
 
   const raw = self.current ? vRef.current : value
   const display = mask ? raw.replace(/[^\n]/g, mask[0] ?? '*') : raw
@@ -707,6 +710,12 @@ export function TextInput({
     (inp: string, k: Key, event: InputEvent) => {
       const eventRaw = event.keypress.raw
 
+      if (shouldOpenSessionPickerShortcut(inp, k, vRef.current, selRef.current)) {
+        cbEmptyQuestionMark.current?.()
+
+        return
+      }
+
       // Configured voice shortcut wins over composer-level defaults like
       // paste/copy so users who bind voice to ctrl+v / alt+v / cmd+v
       // actually get voice toggled instead of a paste (Copilot round-7
@@ -1045,6 +1054,7 @@ interface TextInputProps {
     e: PasteEvent
   ) => { cursor: number; value: string } | Promise<{ cursor: number; value: string } | null> | null
   onSubmit?: (v: string) => void
+  onEmptyQuestionMark?: () => void
   placeholder?: string
   value: string
   voiceRecordKey?: ParsedVoiceRecordKey
@@ -1077,6 +1087,19 @@ export function decideRightClickAction(
   }
   return { action: 'paste' }
 }
+
+export const shouldOpenSessionPickerShortcut = (
+  input: string,
+  key: Key,
+  value: string,
+  selection: null | { end: number; start: number }
+): boolean =>
+  input === '?' &&
+  !key.ctrl &&
+  !key.meta &&
+  !key.return &&
+  !value.length &&
+  (!selection || selection.start === selection.end)
 
 export const shouldPassThroughToGlobalHandler = (
   input: string,


### PR DESCRIPTION
## Summary
- Adds ? as a quick shortcut to enter search/filter mode in the TUI /resume session picker, making old sessions easier to find.
- Also preserves existing browse-mode shortcuts (1-9, q, Ctrl+D) and adds tests for browse-mode vs filter-mode key behavior.
- Related to #12406 and #4988. Related broader picker work: #7880.

## Test Plan
☑ TUI targeted tests passed
☑ Type-check passed
☑ Targeted eslint passed
☑ Full TUI test suite passed: 645 tests
☑ Slash parity test passed with repo .venv
