### PR TITLE
feat: add Windows backend for dashboard PTY bridge

### DIFF
--- a/hermes_cli/pty_bridge.py
+++ b/hermes_cli/pty_bridge.py
@@ -1,27 +1,23 @@
-"""PTY bridge for `hermes dashboard` chat tab.
+"""PTY bridge for the Hermes dashboard chat tab.
 
 Wraps a child process behind a pseudo-terminal so its ANSI output can be
 streamed to a browser-side terminal emulator (xterm.js) and typed
 keystrokes can be fed back in.  The only caller today is the
-``/api/pty`` WebSocket endpoint in ``hermes_cli.web_server``.
+api/pty WebSocket endpoint in hermes_cli.web_server.
 
 Design constraints:
 
-* **POSIX-only.**  This module depends on ``fcntl``, ``termios``, and
-  ``ptyprocess``, none of which exist on native Windows Python.  Native
-  Windows ConPTY is a different API (Windows 10 build 17763+) and would
-  need a separate Windows implementation (``pywinpty``) — that's tracked
-  as a future enhancement.  On native Windows, importing this module
-  raises :class:`ImportError` and the dashboard's ``/chat`` tab shows a
-  WSL-recommended banner instead of crashing.  Every other feature in the
-  dashboard (sessions, jobs, metrics, config editor) works natively.
-* **Zero Node dependency on the server side.**  We use :mod:`ptyprocess`,
+* **Backend-isolated.**  The public PtyBridge API stays stable while
+  platform-specific PTY details live behind a backend seam.  The POSIX
+  backend is the only enabled backend today; Windows support can be added by
+  implementing the same byte-oriented contract.
+* **Zero Node dependency on the server side.**  We use ptyprocess,
   which is a pure-Python wrapper around the OS calls.  The browser talks
-  to the same ``hermes --tui`` binary it would launch from the CLI, so
+  to the same hermes --tui binary it would launch from the CLI, so
   every TUI feature (slash popover, model picker, tool rows, markdown,
   skin engine, clarify/sudo/approval prompts) ships automatically.
-* **Byte-safe I/O.**  Reads and writes go through the PTY master fd
-  directly — we avoid :class:`ptyprocess.PtyProcessUnicode` because
+* **Byte-safe I/O.**  Reads and writes go through a byte-oriented bridge
+  interface, avoiding Unicode wrappers because
   streaming ANSI is inherently byte-oriented and UTF-8 boundaries may land
   mid-read.
 """
@@ -35,7 +31,7 @@ import signal
 import struct
 import sys
 import time
-from typing import Optional, Sequence
+from typing import Optional, Protocol, Sequence
 
 try:
     import fcntl  # type: ignore[import-not-found]
@@ -52,12 +48,13 @@ try:
 except ImportError:  # pragma: no cover - dev env without ptyprocess
     ptyprocess = None  # type: ignore[assignment]
 
-_PTY_AVAILABLE = (
+_POSIX_PTY_AVAILABLE = (
     ptyprocess is not None
     and fcntl is not None
     and termios is not None
     and not sys.platform.startswith("win")
 )
+_PTY_AVAILABLE = _POSIX_PTY_AVAILABLE
 
 
 def _pty_unavailable_message() -> str:
@@ -96,33 +93,35 @@ class PtyUnavailableError(RuntimeError):
     """Raised when a PTY cannot be created on this platform.
 
     Today this means native Windows (no ConPTY bindings) or a dev
-    environment missing the ``ptyprocess`` dependency.  The dashboard
+    environment missing the ptyprocess dependency.  The dashboard
     surfaces the message to the user as a chat-tab banner.
     """
 
 
-class PtyBridge:
-    """Thin wrapper around ``ptyprocess.PtyProcess`` for byte streaming.
+class _PtyBackend(Protocol):
+    """Byte-oriented backend contract used by PtyBridge."""
 
-    Not thread-safe.  A single bridge is owned by the WebSocket handler
-    that spawned it; the reader runs in an executor thread while writes
-    happen on the event-loop thread.  Both sides are OK because the
-    kernel PTY is the actual synchronization point — we never call
-    :mod:`ptyprocess` methods concurrently, we only call ``os.read`` and
-    ``os.write`` on the master fd, which is safe.
-    """
+    @property
+    def pid(self) -> int: ...
+
+    def is_alive(self) -> bool: ...
+
+    def read(self, timeout: float = 0.2) -> Optional[bytes]: ...
+
+    def write(self, data: bytes) -> None: ...
+
+    def resize(self, cols: int, rows: int) -> None: ...
+
+    def close(self) -> None: ...
+
+
+class _PosixPtyBackend:
+    """POSIX implementation backed by ptyprocess plus raw fd I/O."""
 
     def __init__(self, proc: "ptyprocess.PtyProcess"):  # type: ignore[name-defined]
         self._proc = proc
         self._fd: int = proc.fd
         self._closed = False
-
-    # -- lifecycle --------------------------------------------------------
-
-    @classmethod
-    def is_available(cls) -> bool:
-        """True if a PTY can be spawned on this platform."""
-        return bool(_PTY_AVAILABLE)
 
     @classmethod
     def spawn(
@@ -133,18 +132,10 @@ class PtyBridge:
         env: Optional[dict] = None,
         cols: int = 80,
         rows: int = 24,
-    ) -> "PtyBridge":
-        """Spawn ``argv`` behind a new PTY and return a bridge.
-
-        Raises :class:`PtyUnavailableError` if the platform can't host a
-        PTY.  Raises :class:`FileNotFoundError` or :class:`OSError` for
-        ordinary exec failures (missing binary, bad cwd, etc.).
-        """
-        if not _PTY_AVAILABLE:
-            raise PtyUnavailableError(_pty_unavailable_message())
+    ) -> "_PosixPtyBackend":
         # PTY-hosted programs expect TERM to describe the terminal type.
         # CI often runs without TERM in the parent process, which makes
-        # simple terminal probes like `tput cols` fail before winsize reads.
+        # simple terminal probes like tput cols fail before winsize reads.
         # Preserve explicit caller overrides, but backfill a sensible default
         # when TERM is missing or blank.
         spawn_env = (os.environ.copy() if env is None else env.copy())
@@ -170,19 +161,8 @@ class PtyBridge:
         except Exception:
             return False
 
-    # -- I/O --------------------------------------------------------------
-
     def read(self, timeout: float = 0.2) -> Optional[bytes]:
-        """Read up to 64 KiB of raw bytes from the PTY master.
-
-        Returns:
-            * bytes — zero or more bytes of child output
-            * empty bytes (``b""``) — no data available within ``timeout``
-            * None — child has exited and the master fd is at EOF
-
-        Never blocks longer than ``timeout`` seconds.  Safe to call after
-        :meth:`close`; returns ``None`` in that case.
-        """
+        """Read up to 64 KiB of raw bytes from the PTY master."""
         if self._closed:
             return None
         try:
@@ -220,7 +200,7 @@ class PtyBridge:
             view = view[n:]
 
     def resize(self, cols: int, rows: int) -> None:
-        """Forward a terminal resize to the child via ``TIOCSWINSZ``."""
+        """Forward a terminal resize to the child via TIOCSWINSZ."""
         if self._closed:
             return
         # struct winsize: rows, cols, xpixel, ypixel (all unsigned short)
@@ -230,14 +210,8 @@ class PtyBridge:
         except OSError:
             pass
 
-    # -- teardown ---------------------------------------------------------
-
     def close(self) -> None:
-        """Terminate the child (SIGTERM → 0.5s grace → SIGKILL) and close fds.
-
-        Idempotent.  Reaping the child is important so we don't leak
-        zombies across the lifetime of the dashboard process.
-        """
+        """Terminate the child and close fds. Idempotent."""
         if self._closed:
             return
         self._closed = True
@@ -259,6 +233,90 @@ class PtyBridge:
             self._proc.close(force=True)
         except Exception:
             pass
+
+
+class PtyBridge:
+    """Thin, byte-oriented facade over a platform-specific PTY backend.
+
+    Not thread-safe.  A single bridge is owned by the WebSocket handler
+    that spawned it; the reader runs in an executor thread while writes
+    happen on the event-loop thread.  Backend implementations must preserve
+    the byte-oriented read/write contract used by /api/pty.
+    """
+
+    def __init__(self, backend: _PtyBackend):
+        self._backend = backend
+
+    # -- lifecycle --------------------------------------------------------
+
+    @classmethod
+    def is_available(cls) -> bool:
+        """True if a PTY can be spawned on this platform."""
+        return bool(_PTY_AVAILABLE)
+
+    @classmethod
+    def spawn(
+        cls,
+        argv: Sequence[str],
+        *,
+        cwd: Optional[str] = None,
+        env: Optional[dict] = None,
+        cols: int = 80,
+        rows: int = 24,
+    ) -> "PtyBridge":
+        """Spawn argv behind a new PTY and return a bridge.
+
+        Raises PtyUnavailableError if the platform cannot host a
+        PTY. Raises FileNotFoundError or OSError for ordinary exec failures
+        such as a missing binary or bad cwd.
+        """
+        if not _PTY_AVAILABLE:
+            raise PtyUnavailableError(_pty_unavailable_message())
+
+        backend = _PosixPtyBackend.spawn(
+            argv,
+            cwd=cwd,
+            env=env,
+            cols=cols,
+            rows=rows,
+        )
+        return cls(backend)
+
+    @property
+    def pid(self) -> int:
+        return self._backend.pid
+
+    def is_alive(self) -> bool:
+        return self._backend.is_alive()
+
+    # -- I/O --------------------------------------------------------------
+
+    def read(self, timeout: float = 0.2) -> Optional[bytes]:
+        """Read up to 64 KiB of raw bytes from the PTY master.
+
+        Returns:
+            * bytes — zero or more bytes of child output
+            * empty bytes (b empty) — no data available within timeout
+            * None — child has exited and the master fd is at EOF
+
+        Never blocks longer than timeout seconds. Safe to call after close;
+        returns None in that case.
+        """
+        return self._backend.read(timeout)
+
+    def write(self, data: bytes) -> None:
+        """Write raw bytes to the PTY master (i.e. the child's stdin)."""
+        self._backend.write(data)
+
+    def resize(self, cols: int, rows: int) -> None:
+        """Forward a terminal resize to the child."""
+        self._backend.resize(cols=cols, rows=rows)
+
+    # -- teardown ---------------------------------------------------------
+
+    def close(self) -> None:
+        """Terminate the child and close fds. Idempotent."""
+        self._backend.close()
 
     # Context-manager sugar — handy in tests and ad-hoc scripts.
     def __enter__(self) -> "PtyBridge":

--- a/hermes_cli/pty_bridge.py
+++ b/hermes_cli/pty_bridge.py
@@ -48,13 +48,21 @@ try:
 except ImportError:  # pragma: no cover - dev env without ptyprocess
     ptyprocess = None  # type: ignore[assignment]
 
+try:
+    from winpty import ptyprocess as winpty_ptyprocess  # type: ignore
+except ImportError:  # pragma: no cover - non-Windows or missing pywinpty
+    winpty_ptyprocess = None  # type: ignore[assignment]
+
 _POSIX_PTY_AVAILABLE = (
     ptyprocess is not None
     and fcntl is not None
     and termios is not None
     and not sys.platform.startswith("win")
 )
-_PTY_AVAILABLE = _POSIX_PTY_AVAILABLE
+_WINDOWS_PTY_AVAILABLE = (
+    winpty_ptyprocess is not None and sys.platform.startswith("win")
+)
+_PTY_AVAILABLE = _POSIX_PTY_AVAILABLE or _WINDOWS_PTY_AVAILABLE
 
 
 def _pty_unavailable_message() -> str:
@@ -235,6 +243,102 @@ class _PosixPtyBackend:
             pass
 
 
+class _WindowsPtyBackend:
+    """Windows implementation backed by pywinpty winpty.ptyprocess."""
+
+    def __init__(self, proc):
+        self._proc = proc
+        self._closed = False
+
+    @classmethod
+    def spawn(
+        cls,
+        argv: Sequence[str],
+        *,
+        cwd: Optional[str] = None,
+        env: Optional[dict] = None,
+        cols: int = 80,
+        rows: int = 24,
+    ) -> "_WindowsPtyBackend":
+        spawn_env = (os.environ.copy() if env is None else env.copy())
+        if not spawn_env.get("TERM"):
+            spawn_env["TERM"] = "xterm-256color"
+        proc = winpty_ptyprocess.PtyProcess.spawn(  # type: ignore[union-attr]
+            list(argv),
+            cwd=cwd,
+            env=spawn_env,
+            dimensions=(rows, cols),
+        )
+        return cls(proc)
+
+    @property
+    def pid(self) -> int:
+        return int(self._proc.pid)
+
+    def is_alive(self) -> bool:
+        if self._closed:
+            return False
+        try:
+            return bool(self._proc.isalive())
+        except Exception:
+            return False
+
+    def read(self, timeout: float = 0.2) -> Optional[bytes]:
+        if self._closed:
+            return None
+        try:
+            data = self._proc.read()
+        except EOFError:
+            return None
+        except OSError as exc:
+            if exc.errno in (errno.EIO, errno.EBADF, errno.EPIPE):
+                return None
+            raise
+        if data is None:
+            return None
+        if data == "" or data == b"":
+            return b""
+        if isinstance(data, bytes):
+            return data
+        return str(data).encode("utf-8")
+
+    def write(self, data: bytes) -> None:
+        if self._closed or not data:
+            return
+        if isinstance(data, bytes):
+            text = data.decode("utf-8", "replace")
+        else:
+            text = str(data)
+        try:
+            self._proc.write(text)
+        except OSError as exc:
+            if exc.errno in (errno.EIO, errno.EBADF, errno.EPIPE):
+                return
+            raise
+
+    def resize(self, cols: int, rows: int) -> None:
+        if self._closed:
+            return
+        try:
+            self._proc.setwinsize(max(1, rows), max(1, cols))
+        except Exception:
+            pass
+
+    def close(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        try:
+            self._proc.close(force=True)
+            return
+        except Exception:
+            pass
+        try:
+            self._proc.terminate(force=True)
+        except Exception:
+            pass
+
+
 class PtyBridge:
     """Thin, byte-oriented facade over a platform-specific PTY backend.
 
@@ -273,14 +377,27 @@ class PtyBridge:
         if not _PTY_AVAILABLE:
             raise PtyUnavailableError(_pty_unavailable_message())
 
-        backend = _PosixPtyBackend.spawn(
-            argv,
-            cwd=cwd,
-            env=env,
-            cols=cols,
-            rows=rows,
-        )
-        return cls(backend)
+        if _POSIX_PTY_AVAILABLE:
+            backend = _PosixPtyBackend.spawn(
+                argv,
+                cwd=cwd,
+                env=env,
+                cols=cols,
+                rows=rows,
+            )
+            return cls(backend)
+
+        if _WINDOWS_PTY_AVAILABLE:
+            backend = _WindowsPtyBackend.spawn(
+                argv,
+                cwd=cwd,
+                env=env,
+                cols=cols,
+                rows=rows,
+            )
+            return cls(backend)
+
+        raise PtyUnavailableError("Pseudo-terminals are unavailable.")
 
     @property
     def pid(self) -> int:

--- a/hermes_cli/pty_bridge.py
+++ b/hermes_cli/pty_bridge.py
@@ -29,22 +29,35 @@ Design constraints:
 from __future__ import annotations
 
 import errno
-import fcntl
 import os
 import select
 import signal
 import struct
 import sys
-import termios
 import time
 from typing import Optional, Sequence
 
 try:
+    import fcntl  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover - native Windows
+    fcntl = None  # type: ignore[assignment]
+
+try:
+    import termios  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover - native Windows
+    termios = None  # type: ignore[assignment]
+
+try:
     import ptyprocess  # type: ignore
-    _PTY_AVAILABLE = not sys.platform.startswith("win")
 except ImportError:  # pragma: no cover - dev env without ptyprocess
-    ptyprocess = None  # type: ignore
-    _PTY_AVAILABLE = False
+    ptyprocess = None  # type: ignore[assignment]
+
+_PTY_AVAILABLE = (
+    ptyprocess is not None
+    and fcntl is not None
+    and termios is not None
+    and not sys.platform.startswith("win")
+)
 
 
 __all__ = ["PtyBridge", "PtyUnavailableError"]

--- a/hermes_cli/pty_bridge.py
+++ b/hermes_cli/pty_bridge.py
@@ -60,6 +60,35 @@ _PTY_AVAILABLE = (
 )
 
 
+def _pty_unavailable_message() -> str:
+    """Return an actionable reason for spawn-time PTY unavailability."""
+    if sys.platform.startswith("win"):
+        return (
+            "Pseudo-terminals are unavailable on native Windows for the "
+            "dashboard chat/TUI path. Run Hermes Agent inside WSL to use "
+            "the dashboard chat tab."
+        )
+
+    missing_modules = [
+        name
+        for name, module in (
+            ("ptyprocess", ptyprocess),
+            ("fcntl", fcntl),
+            ("termios", termios),
+        )
+        if module is None
+    ]
+    if missing_modules:
+        return (
+            "Pseudo-terminals are unavailable because this Python environment "
+            f"is missing Unix PTY module(s): {', '.join(missing_modules)}. "
+            "On Windows, run Hermes Agent inside WSL for POSIX PTY support; "
+            "otherwise install the PTY extra with: pip install -e '.[pty]'."
+        )
+
+    return "Pseudo-terminals are unavailable."
+
+
 __all__ = ["PtyBridge", "PtyUnavailableError"]
 
 
@@ -112,18 +141,7 @@ class PtyBridge:
         ordinary exec failures (missing binary, bad cwd, etc.).
         """
         if not _PTY_AVAILABLE:
-            if sys.platform.startswith("win"):
-                raise PtyUnavailableError(
-                    "Pseudo-terminals are unavailable on this platform. "
-                    "Hermes Agent supports Windows only via WSL."
-                )
-            if ptyprocess is None:
-                raise PtyUnavailableError(
-                    "The `ptyprocess` package is missing. "
-                    "Install with: pip install ptyprocess "
-                    "(or pip install -e '.[pty]')."
-                )
-            raise PtyUnavailableError("Pseudo-terminals are unavailable.")
+            raise PtyUnavailableError(_pty_unavailable_message())
         # PTY-hosted programs expect TERM to describe the terminal type.
         # CI often runs without TERM in the parent process, which makes
         # simple terminal probes like `tput cols` fail before winsize reads.

--- a/hermes_cli/pty_bridge.py
+++ b/hermes_cli/pty_bridge.py
@@ -8,11 +8,11 @@ api/pty WebSocket endpoint in hermes_cli.web_server.
 Design constraints:
 
 * **Backend-isolated.**  The public PtyBridge API stays stable while
-  platform-specific PTY details live behind a backend seam.  The POSIX
-  backend is the only enabled backend today; Windows support can be added by
-  implementing the same byte-oriented contract.
-* **Zero Node dependency on the server side.**  We use ptyprocess,
-  which is a pure-Python wrapper around the OS calls.  The browser talks
+  platform-specific PTY details live behind a backend seam.  POSIX uses
+  ptyprocess plus Unix PTY modules; native Windows uses pywinpty/winpty
+  when the optional PTY extra is installed.
+* **Zero Node dependency on the server side.**  We use Python PTY
+  bindings on the server side.  The browser talks
   to the same hermes --tui binary it would launch from the CLI, so
   every TUI feature (slash popover, model picker, tool rows, markdown,
   skin engine, clarify/sudo/approval prompts) ships automatically.
@@ -26,10 +26,12 @@ from __future__ import annotations
 
 import errno
 import os
+import queue
 import select
 import signal
 import struct
 import sys
+import threading
 import time
 from typing import Optional, Protocol, Sequence
 
@@ -70,8 +72,9 @@ def _pty_unavailable_message() -> str:
     if sys.platform.startswith("win"):
         return (
             "Pseudo-terminals are unavailable on native Windows for the "
-            "dashboard chat/TUI path. Run Hermes Agent inside WSL to use "
-            "the dashboard chat tab."
+            "dashboard chat/TUI path because pywinpty/winpty is missing. "
+            "Install the PTY extra with: pip install -e '.[pty]', or run "
+            "Hermes Agent inside WSL for POSIX PTY support."
         )
 
     missing_modules = [
@@ -100,9 +103,8 @@ __all__ = ["PtyBridge", "PtyUnavailableError"]
 class PtyUnavailableError(RuntimeError):
     """Raised when a PTY cannot be created on this platform.
 
-    Today this means native Windows (no ConPTY bindings) or a dev
-    environment missing the ptyprocess dependency.  The dashboard
-    surfaces the message to the user as a chat-tab banner.
+    The dashboard surfaces the message to the user as a chat-tab banner
+    when no supported PTY backend is available for the current platform.
     """
 
 
@@ -244,11 +246,23 @@ class _PosixPtyBackend:
 
 
 class _WindowsPtyBackend:
-    """Windows implementation backed by pywinpty winpty.ptyprocess."""
+    """Windows implementation backed by pywinpty winpty.ptyprocess.
+
+    pywinpty exposes a blocking read API.  Keep that blocking call isolated
+    to a per-bridge daemon reader thread so PtyBridge.read(timeout) can
+    preserve the facade's timeout contract for the WebSocket executor path.
+    """
 
     def __init__(self, proc):
         self._proc = proc
         self._closed = False
+        self._read_queue: queue.Queue[Optional[bytes]] = queue.Queue()
+        self._reader_thread = threading.Thread(
+            target=self._reader_loop,
+            name=f"HermesWinptyReader-{int(proc.pid)}",
+            daemon=True,
+        )
+        self._reader_thread.start()
 
     @classmethod
     def spawn(
@@ -271,6 +285,34 @@ class _WindowsPtyBackend:
         )
         return cls(proc)
 
+    @staticmethod
+    def _normalize_read(data) -> Optional[bytes]:
+        if data is None:
+            return None
+        if data == "" or data == b"":
+            return b""
+        if isinstance(data, bytes):
+            return data
+        return str(data).encode("utf-8")
+
+    def _reader_loop(self) -> None:
+        while True:
+            try:
+                item = self._normalize_read(self._proc.read())
+            except EOFError:
+                item = None
+            except OSError as exc:
+                if exc.errno not in (errno.EIO, errno.EBADF, errno.EPIPE):
+                    item = None
+                else:
+                    item = None
+            except Exception:
+                item = None
+
+            self._read_queue.put(item)
+            if item is None:
+                return
+
     @property
     def pid(self) -> int:
         return int(self._proc.pid)
@@ -284,23 +326,12 @@ class _WindowsPtyBackend:
             return False
 
     def read(self, timeout: float = 0.2) -> Optional[bytes]:
-        if self._closed:
+        if self._closed and self._read_queue.empty():
             return None
         try:
-            data = self._proc.read()
-        except EOFError:
-            return None
-        except OSError as exc:
-            if exc.errno in (errno.EIO, errno.EBADF, errno.EPIPE):
-                return None
-            raise
-        if data is None:
-            return None
-        if data == "" or data == b"":
+            return self._read_queue.get(timeout=max(0.0, timeout))
+        except queue.Empty:
             return b""
-        if isinstance(data, bytes):
-            return data
-        return str(data).encode("utf-8")
 
     def write(self, data: bytes) -> None:
         if self._closed or not data:
@@ -337,6 +368,7 @@ class _WindowsPtyBackend:
             self._proc.terminate(force=True)
         except Exception:
             pass
+        self._reader_thread.join(timeout=1.0)
 
 
 class PtyBridge:
@@ -412,12 +444,13 @@ class PtyBridge:
         """Read up to 64 KiB of raw bytes from the PTY master.
 
         Returns:
-            * bytes — zero or more bytes of child output
-            * empty bytes (b empty) — no data available within timeout
-            * None — child has exited and the master fd is at EOF
+            * bytes — one or more bytes of child output
+            * b"" — no data available within timeout
+            * None — child has exited and the PTY is at EOF
 
-        Never blocks longer than timeout seconds. Safe to call after close;
-        returns None in that case.
+        Backend implementations keep blocking platform reads out of this
+        facade path so callers can poll with a bounded timeout. Safe to call
+        after close; returns None once buffered output is drained.
         """
         return self._backend.read(timeout)
 

--- a/tests/hermes_cli/test_pty_bridge.py
+++ b/tests/hermes_cli/test_pty_bridge.py
@@ -177,3 +177,36 @@ class TestPtyBridgeUnavailable:
     def test_error_carries_user_message(self):
         err = PtyUnavailableError("platform not supported")
         assert "platform" in str(err)
+
+    def test_spawn_error_names_missing_unix_pty_modules(self, monkeypatch):
+        import hermes_cli.pty_bridge as pty_bridge
+
+        monkeypatch.setattr(pty_bridge, "_PTY_AVAILABLE", False)
+        monkeypatch.setattr(pty_bridge, "ptyprocess", object())
+        monkeypatch.setattr(pty_bridge, "fcntl", None)
+        monkeypatch.setattr(pty_bridge, "termios", None)
+        monkeypatch.setattr(pty_bridge.sys, "platform", "linux")
+
+        with pytest.raises(PtyUnavailableError) as exc_info:
+            PtyBridge.spawn(["/bin/sh"])
+
+        message = str(exc_info.value)
+        assert "fcntl" in message
+        assert "termios" in message
+        assert "Unix PTY module" in message
+        assert "Windows" in message
+        assert "WSL" in message
+
+    def test_spawn_error_names_native_windows_wsl_path(self, monkeypatch):
+        import hermes_cli.pty_bridge as pty_bridge
+
+        monkeypatch.setattr(pty_bridge, "_PTY_AVAILABLE", False)
+        monkeypatch.setattr(pty_bridge.sys, "platform", "win32")
+
+        with pytest.raises(PtyUnavailableError) as exc_info:
+            PtyBridge.spawn(["cmd.exe"])
+
+        message = str(exc_info.value)
+        assert "native Windows" in message
+        assert "WSL" in message
+        assert "dashboard" in message

--- a/tests/hermes_cli/test_pty_bridge.py
+++ b/tests/hermes_cli/test_pty_bridge.py
@@ -210,3 +210,90 @@ class TestPtyBridgeUnavailable:
         assert "native Windows" in message
         assert "WSL" in message
         assert "dashboard" in message
+
+class TestWindowsPtyBackendAdapter:
+    def test_spawn_and_io_normalize_winpty_text_api(self, monkeypatch):
+        import types
+
+        import hermes_cli.pty_bridge as pty_bridge
+
+        created = []
+
+        class FakeWinptyProc:
+            def __init__(self):
+                self.pid = 4242
+                self.alive = True
+                self.writes = []
+                self.resizes = []
+                self.closed = []
+
+            def isalive(self):
+                return self.alive
+
+            def read(self):
+                return "héllo"
+
+            def write(self, data):
+                self.writes.append(data)
+
+            def setwinsize(self, rows, cols):
+                self.resizes.append((rows, cols))
+
+            def close(self, force=False):
+                self.closed.append(("close", force))
+                self.alive = False
+
+            def terminate(self, force=False):
+                self.closed.append(("terminate", force))
+                self.alive = False
+
+        class FakePtyProcess:
+            @staticmethod
+            def spawn(argv, cwd=None, env=None, dimensions=(24, 80), backend=None):
+                proc = FakeWinptyProc()
+                created.append(
+                    {
+                        "argv": argv,
+                        "cwd": cwd,
+                        "env": env,
+                        "dimensions": dimensions,
+                        "backend": backend,
+                        "proc": proc,
+                    }
+                )
+                return proc
+
+        monkeypatch.setattr(
+            pty_bridge,
+            "winpty_ptyprocess",
+            types.SimpleNamespace(PtyProcess=FakePtyProcess),
+            raising=False,
+        )
+
+        backend = pty_bridge._WindowsPtyBackend.spawn(
+            ["node", "entry.js"],
+            cwd="C:/hermes",
+            env={"A": "B"},
+            cols=100,
+            rows=40,
+        )
+
+        assert created[0]["argv"] == ["node", "entry.js"]
+        assert created[0]["cwd"] == "C:/hermes"
+        assert created[0]["env"]["A"] == "B"
+        assert created[0]["env"]["TERM"] == "xterm-256color"
+        assert created[0]["dimensions"] == (40, 100)
+        assert backend.pid == 4242
+        assert backend.is_alive() is True
+        assert backend.read() == "héllo".encode("utf-8")
+
+        backend.write("input".encode("utf-8"))
+        backend.resize(cols=120, rows=50)
+        backend.close()
+        backend.close()
+
+        proc = created[0]["proc"]
+        assert proc.writes == ["input"]
+        assert proc.resizes == [(50, 120)]
+        assert proc.closed
+        assert backend.is_alive() is False

--- a/tests/hermes_cli/test_pty_bridge.py
+++ b/tests/hermes_cli/test_pty_bridge.py
@@ -7,18 +7,22 @@ printf) to verify it behaves like a PTY you can read/write/resize/close.
 from __future__ import annotations
 
 import os
+import queue
 import sys
 import time
+from importlib.util import find_spec
 
 import pytest
-
-pytest.importorskip("ptyprocess", reason="ptyprocess not installed")
 
 from hermes_cli.pty_bridge import PtyBridge, PtyUnavailableError
 
 
 skip_on_windows = pytest.mark.skipif(
-    sys.platform.startswith("win"), reason="PTY bridge is POSIX-only"
+    sys.platform.startswith("win"), reason="POSIX PTY tests require non-Windows"
+)
+skip_without_posix_pty = pytest.mark.skipif(
+    sys.platform.startswith("win") or find_spec("ptyprocess") is None,
+    reason="POSIX PTY tests require ptyprocess on non-Windows",
 )
 
 
@@ -36,7 +40,7 @@ def _read_until(bridge: PtyBridge, needle: bytes, timeout: float = 5.0) -> bytes
     return bytes(buf)
 
 
-@skip_on_windows
+@skip_without_posix_pty
 class TestPtyBridgeSpawn:
     def test_is_available_on_posix(self):
         assert PtyBridge.is_available() is True
@@ -53,7 +57,7 @@ class TestPtyBridgeSpawn:
             PtyBridge.spawn([str(tmp_path / "definitely-not-a-real-binary")])
 
 
-@skip_on_windows
+@skip_without_posix_pty
 class TestPtyBridgeIO:
     def test_reads_child_stdout(self):
         bridge = PtyBridge.spawn(["/bin/sh", "-c", "printf hermes-ok"])
@@ -93,7 +97,7 @@ class TestPtyBridgeIO:
             bridge.close()
 
 
-@skip_on_windows
+@skip_without_posix_pty
 class TestPtyBridgeResize:
     def test_resize_updates_child_winsize(self):
         # Query the TTY ioctl directly instead of using tput, which requires
@@ -120,7 +124,7 @@ class TestPtyBridgeResize:
             bridge.close()
 
 
-@skip_on_windows
+@skip_without_posix_pty
 class TestPtyBridgeClose:
     def test_close_is_idempotent(self):
         bridge = PtyBridge.spawn(["/bin/sh", "-c", "sleep 30"])
@@ -145,7 +149,7 @@ class TestPtyBridgeClose:
         assert reaped, f"pid {pid} still running after close()"
 
 
-@skip_on_windows
+@skip_without_posix_pty
 class TestPtyBridgeEnv:
     def test_cwd_is_respected(self, tmp_path):
         bridge = PtyBridge.spawn(
@@ -226,12 +230,17 @@ class TestWindowsPtyBackendAdapter:
                 self.writes = []
                 self.resizes = []
                 self.closed = []
+                self.read_items = queue.Queue()
+                self.read_items.put("héllo")
 
             def isalive(self):
                 return self.alive
 
             def read(self):
-                return "héllo"
+                item = self.read_items.get()
+                if isinstance(item, BaseException):
+                    raise item
+                return item
 
             def write(self, data):
                 self.writes.append(data)
@@ -242,10 +251,12 @@ class TestWindowsPtyBackendAdapter:
             def close(self, force=False):
                 self.closed.append(("close", force))
                 self.alive = False
+                self.read_items.put(EOFError())
 
             def terminate(self, force=False):
                 self.closed.append(("terminate", force))
                 self.alive = False
+                self.read_items.put(EOFError())
 
         class FakePtyProcess:
             @staticmethod
@@ -278,22 +289,59 @@ class TestWindowsPtyBackendAdapter:
             rows=40,
         )
 
-        assert created[0]["argv"] == ["node", "entry.js"]
-        assert created[0]["cwd"] == "C:/hermes"
-        assert created[0]["env"]["A"] == "B"
-        assert created[0]["env"]["TERM"] == "xterm-256color"
-        assert created[0]["dimensions"] == (40, 100)
-        assert backend.pid == 4242
-        assert backend.is_alive() is True
-        assert backend.read() == "héllo".encode("utf-8")
+        try:
+            assert created[0]["argv"] == ["node", "entry.js"]
+            assert created[0]["cwd"] == "C:/hermes"
+            assert created[0]["env"]["A"] == "B"
+            assert created[0]["env"]["TERM"] == "xterm-256color"
+            assert created[0]["dimensions"] == (40, 100)
+            assert backend.pid == 4242
+            assert backend.is_alive() is True
+            assert backend.read(timeout=1.0) == "héllo".encode("utf-8")
+            assert backend.read(timeout=0.01) == b""
 
-        backend.write("input".encode("utf-8"))
-        backend.resize(cols=120, rows=50)
-        backend.close()
-        backend.close()
+            backend.write("input".encode("utf-8"))
+            backend.resize(cols=120, rows=50)
+        finally:
+            backend.close()
+            backend.close()
 
         proc = created[0]["proc"]
         assert proc.writes == ["input"]
         assert proc.resizes == [(50, 120)]
         assert proc.closed
         assert backend.is_alive() is False
+
+    def test_read_timeout_does_not_call_blocking_winpty_read_on_caller(self):
+        import hermes_cli.pty_bridge as pty_bridge
+
+        class BlockingFakeWinptyProc:
+            pid = 4343
+
+            def __init__(self):
+                self.alive = True
+                self.read_items = queue.Queue()
+
+            def isalive(self):
+                return self.alive
+
+            def read(self):
+                item = self.read_items.get()
+                if isinstance(item, BaseException):
+                    raise item
+                return item
+
+            def close(self, force=False):
+                self.alive = False
+                self.read_items.put(EOFError())
+
+            def terminate(self, force=False):
+                self.close(force=force)
+
+        backend = pty_bridge._WindowsPtyBackend(BlockingFakeWinptyProc())
+        try:
+            start = time.monotonic()
+            assert backend.read(timeout=0.01) == b""
+            assert time.monotonic() - start < 0.5
+        finally:
+            backend.close()

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1940,6 +1940,43 @@ class TestDashboardPluginManifestExtensions:
         ]
 
 
+
+class TestNativeWindowsPtyImportFallback:
+    def test_web_server_imports_when_unix_pty_modules_are_missing(self, monkeypatch):
+        """Dashboard import should not fail just because PTY support is unavailable.
+
+        Native Windows lacks Unix-only modules such as fcntl/termios. The dashboard
+        should still import and expose non-PTY routes, while the PTY bridge reports
+        itself unavailable.
+        """
+        import builtins
+        import importlib
+        import sys
+
+        real_import = builtins.__import__
+
+        def reject_unix_pty_modules(name, globals=None, locals=None, fromlist=(), level=0):
+            importing_module = (globals or {}).get("__name__")
+            if importing_module == "hermes_cli.pty_bridge" and name in {"fcntl", "termios"}:
+                raise ModuleNotFoundError(f"No module named '{name}'")
+            return real_import(name, globals, locals, fromlist, level)
+
+        monkeypatch.setattr(builtins, "__import__", reject_unix_pty_modules)
+        sys.modules.pop("hermes_cli.web_server", None)
+        sys.modules.pop("hermes_cli.pty_bridge", None)
+
+        try:
+            ws = importlib.import_module("hermes_cli.web_server")
+
+            assert ws.app is not None
+            assert ws.PtyBridge.is_available() is False
+            with pytest.raises(ws.PtyUnavailableError):
+                ws.PtyBridge.spawn(["hermes"])
+        finally:
+            sys.modules.pop("hermes_cli.web_server", None)
+            sys.modules.pop("hermes_cli.pty_bridge", None)
+
+
 # ---------------------------------------------------------------------------
 # /api/pty WebSocket — terminal bridge for the dashboard "Chat" tab.
 #
@@ -2104,6 +2141,8 @@ class TestPtyWebSocket:
             assert b"99" in buf and b"41" in buf
 
     def test_unavailable_platform_closes_with_message(self, monkeypatch):
+        from starlette.websockets import WebSocketDisconnect
+
         from hermes_cli.pty_bridge import PtyUnavailableError
 
         def _raise(argv, **kwargs):
@@ -2117,12 +2156,21 @@ class TestPtyWebSocket:
         # Patch PtyBridge.spawn at the web_server module's binding.
         import hermes_cli.web_server as ws_mod
 
-        monkeypatch.setattr(ws_mod.PtyBridge, "spawn", classmethod(lambda cls, *a, **k: _raise(*a, **k)))
+        monkeypatch.setattr(
+            ws_mod.PtyBridge,
+            "spawn",
+            classmethod(lambda cls, *a, **k: _raise(*a, **k)),
+        )
 
         with self.client.websocket_connect(self._url()) as conn:
-            # Expect a final text frame with the error message, then close.
+            # Expect a final text frame with the error message, then a clean
+            # endpoint-level close. The dashboard server must stay alive even
+            # when the embedded chat PTY cannot start.
             msg = conn.receive_text()
             assert "pty missing" in msg or "unavailable" in msg.lower() or "pty" in msg.lower()
+            with pytest.raises(WebSocketDisconnect) as exc:
+                conn.receive_text()
+            assert exc.value.code == 1011
 
     def test_resume_parameter_is_forwarded_to_argv(self, monkeypatch):
         captured: dict = {}

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1943,11 +1943,12 @@ class TestDashboardPluginManifestExtensions:
 
 class TestNativeWindowsPtyImportFallback:
     def test_web_server_imports_when_unix_pty_modules_are_missing(self, monkeypatch):
-        """Dashboard import should not fail just because PTY support is unavailable.
+        """Dashboard import should not fail without Unix PTY modules.
 
         Native Windows lacks Unix-only modules such as fcntl/termios. The dashboard
-        should still import and expose non-PTY routes, while the PTY bridge reports
-        itself unavailable.
+        should still import and expose non-PTY routes. If a Windows backend is
+        available, the bridge may legitimately remain available; otherwise it
+        should report graceful unavailability at spawn time.
         """
         import builtins
         import importlib
@@ -1969,9 +1970,9 @@ class TestNativeWindowsPtyImportFallback:
             ws = importlib.import_module("hermes_cli.web_server")
 
             assert ws.app is not None
-            assert ws.PtyBridge.is_available() is False
-            with pytest.raises(ws.PtyUnavailableError):
-                ws.PtyBridge.spawn(["hermes"])
+            if not ws.PtyBridge.is_available():
+                with pytest.raises(ws.PtyUnavailableError):
+                    ws.PtyBridge.spawn(["hermes"])
         finally:
             sys.modules.pop("hermes_cli.web_server", None)
             sys.modules.pop("hermes_cli.pty_bridge", None)


### PR DESCRIPTION
## Summary

Draft stacked PR for the dashboard PTY Windows backend experiment.

Native Windows is now documented as an early-beta runtime, with the dashboard /chat embedded terminal pane called out as the major remaining native limitation. This PR targets that specific gap by wiring the existing pywinpty dependency from the pty extra into the existing dashboard api/pty bridge. It does not claim installer support, broad Windows support-policy changes, or production-ready browser chat support.

Stacking note: this branch is based on #21770, which keeps the dashboard/web_server importable when Unix PTY modules are missing. If #21770 changes or merges, this branch should be rebased before final review.

## What changed

- Refactor PtyBridge into a stable byte-oriented facade plus backend implementations.
- Preserve the POSIX backend behavior behind _PosixPtyBackend.
- Add _WindowsPtyBackend using winpty.ptyprocess.PtyProcess from pywinpty.
- Keep the public PtyBridge contract used by api/pty:
  - read returns bytes, empty bytes, or None
  - write accepts bytes
  - resize accepts cols and rows
  - pid, is_alive, and close remain available
- Add a unit test with a fake winpty process to verify Windows backend mapping:
  - spawn argv/cwd/env/dimensions
  - str read normalized to UTF-8 bytes
  - bytes write decoded for winpty
  - resize maps to setwinsize(rows, cols)
  - close is idempotent

## Validation

Linux/WSL automated checks:

- .venv/bin/python -m pytest tests/hermes_cli/test_pty_bridge.py tests/hermes_cli/test_web_server.py -q -o addopts=
  - 151 passed
- .venv/bin/ruff check hermes_cli/pty_bridge.py tests/hermes_cli/test_pty_bridge.py tests/hermes_cli/test_web_server.py
  - All checks passed
- git diff --check
  - passed

Native Windows smoke checks from WSL using the Windows Hermes venv:

- Loaded branch hermes_cli.pty_bridge.py by UNC file path under native Windows Python.
- winpty module available.
- PtyBridge.is_available() returned true on native Windows.
- api/pty in-process WebSocket smoke using branch hermes_cli.web_server.py and branch hermes_cli.pty_bridge.py:
  - cmd.exe /c echo API_PTY_WIN_OK spawned through the Windows backend.
  - WebSocket received API_PTY_WIN_OK as binary frames.
- api/pty Node TTY probe smoke:
  - Node ran behind api/pty through winpty.
  - After sending minimal terminal responses for ESC[1t and ESC[c, frames contained:
    - stdin_isTTY=true
    - stdout_isTTY=true
    - platform=win32
  - no hermes-tui: no TTY output observed.
- Cleanup check:
  - no leftover node.exe from smoke runs remained; only the pre-existing OpenClaw gateway node process was present.

## Browser smoke evidence

Native Windows real-browser smoke now passes against the #21982 backend copy without modifying the live main install.

- Runtime under test:
  - copied this PR branch into a disposable Windows temp directory
  - served dashboard on http://127.0.0.1:9120/chat with HERMES_WEB_DIST pointing at packaged dashboard assets
  - verified hermes_cli.pty_bridge and hermes_cli.web_server imported from the temp branch copy, not the live install
  - verified PtyBridge.is_available() returned true on win32
- Real browser smoke:
  - Chrome / Playwright loaded /chat with HTTP 200
  - xterm rendered: .xterm count 1, helper textarea count 1, canvas count 3
  - /api/ws opened and session.create returned a session id
  - /api/pty opened, sent 1 frame, received 1 binary frame, and closed cleanly
  - no WSL/POSIX/no-TTY unavailable text was observed
- Evidence artifacts were saved locally for review:
  - %LOCALAPPDATA%\Temp\hermes-pr21982-smoke-evidence\chat-smoke-result-rerun.json
  - %LOCALAPPDATA%\Temp\hermes-pr21982-smoke-evidence\chat-smoke-rerun.png

This removes the earlier browser-smoke caveat that only the narrower API PTY probe had passed. The PR should still remain draft until #21770 lands and this branch is rebased, because it is stacked on that import/fallback PR.

## Limitations / follow-up

- This is a backend bridge MVP for the documented native-Windows /chat gap, not a broad Windows support-policy or production-readiness claim.
- pywinpty read is blocking and does not provide the same clean timeout behavior as the POSIX fd/select implementation. api/pty runs reads in an executor and close should unblock the child, but this deserves more manual browser/dashboard validation.
- A full real ui-tui/dist/entry.js TestClient smoke hung in the harness and was manually cleaned up. The narrower api/pty Node TTY probe passed. Full browser xterm.js validation should be a follow-up before marking this ready.
- The isolated WSL clone does not have ui-tui/dist or node_modules built; real TUI smoke used the native Windows install tree for evidence.

## Related

- Builds on the embedded dashboard chat path from #13379.
- Stacked on / depends on #21770 for native-Windows import-time PTY fallback behavior.
- Related to #21465 for PTY import/platform handling.
- Complements the native Windows early-beta direction and broader Windows work such as #21561; this PR is limited to the dashboard PTY backend.
- Does not pursue the API-proxy chat approach from #9903; this keeps the existing PTY/TUI embedding design.
