### PR TITLE
fix: skip canonical providers when user has config-defined models

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1434,6 +1434,14 @@ def list_authenticated_providers(
         else:
             _cp_model_ids = curated.get(_cp.slug, [])
         _cp_total = len(_cp_model_ids)
+        # If this slug is defined in user_providers (config's providers:), skip
+        # so section 3 can provide the models list from config. This takes
+        # precedence over any curated models from _PROVIDER_MODELS — the user's
+        # explicit base_url / api_key / models: config always wins.
+        if user_providers and isinstance(user_providers, dict):
+            _slug_lower = _cp.slug.lower()
+            if any(k.lower() == _slug_lower for k in user_providers):
+                continue
         _cp_top = _cp_model_ids[:max_models]
 
         results.append({


### PR DESCRIPTION
fix: skip canonical providers when user has config-defined models

## What does this PR do?

**Problem**

Plugin-registered providers (e.g. `free-nvidia`, `free-router`) auto-enter `CANONICAL_PROVIDERS` via the auto-extension at line 826–841 of `models.py`. When Section 2b of `list_authenticated_providers()` processes them:

1. It looks for curated models in `_PROVIDER_MODELS` — finds **none** (plugin providers have no curated entry)
2. Sets `models = []` and adds slug to `seen_slugs`
3. Section 3 (user-config from `providers:` in `config.yaml`) skips because slug is already `seen`
4. **Result: the provider appears in `/model` with 0 models**

**Fix**

Before emitting a canonical row in Section 2b, check if the slug is defined in `user_providers` (the `providers:` section of `config.yaml`). If so, skip and let Section 3 handle it — the user's explicit `base_url` / `api_key` / `models` config always wins.

## Related Issue

Fixes a regression introduced by the CANONICAL_PROVIDERS auto-extension feature.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `hermes_cli/model_switch.py`: In `list_authenticated_providers()`, Section 2b — added a guard before emitting the results entry: if the slug exists in `user_providers`, skip and let Section 3 provide the models list from config.

## How to Test

1. Create a model-provider plugin: `~/.hermes/plugins/model-providers/free-nvidia/` with a `ProviderProfile`
2. Add `free-nvidia:` under `providers:` in `config.yaml` with 3 models + `discover_models: false`
3. **Before fix**: `/model` shows `free-nvidia` with **0 models**
4. **After fix**: `/model` shows `free-nvidia` with **3 models**

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: macOS

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — N/A