### PR TITLE
feat(auth): add integrated Google Workspace OAuth provider

### DIFF
--- a/agent/google_workspace_oauth.py
+++ b/agent/google_workspace_oauth.py
@@ -253,6 +253,16 @@ def get_client_credentials() -> Tuple[str, str]:
     if _NOUS_CLIENT_ID and _NOUS_CLIENT_ID != "PLACEHOLDER.apps.googleusercontent.com":
         return _NOUS_CLIENT_ID, _NOUS_CLIENT_SECRET
 
+    # Placeholder credentials are not usable — raise so callers get a clear error
+    if _NOUS_CLIENT_ID.startswith("PLACEHOLDER"):
+        raise GoogleWorkspaceOAuthError(
+            "No usable Google OAuth client credentials found.\n"
+            "The bundled Nous Research app is not yet verified. Please either:\n"
+            "  1. Set HERMES_GOOGLE_WORKSPACE_CLIENT_ID and HERMES_GOOGLE_WORKSPACE_CLIENT_SECRET env vars\n"
+            "  2. Place a google_client_secret.json in ~/.hermes/\n",
+            code="google_workspace_oauth_no_client",
+        )
+
     # If we only have the placeholder, still return it — caller can decide
     # whether to proceed or error out.
     return _NOUS_CLIENT_ID, _NOUS_CLIENT_SECRET
@@ -706,8 +716,7 @@ def run_oauth_login() -> dict:
     saves the token. This function polls the dashboard session until
     it's approved.
 
-    Falls back to a standalone local HTTP server on port 8098 if the
-    dashboard is not reachable.
+    If the dashboard is not running, exits with instructions to start it or use --no-browser mode.
 
     Returns:
         The saved token data dict.
@@ -727,7 +736,8 @@ def run_oauth_login() -> dict:
         )
 
     # Try the dashboard flow first (preferred — single source of truth)
-    dashboard_url = "http://127.0.0.1:9119"
+    dashboard_port = os.environ.get("HERMES_DASHBOARD_PORT", "9119")
+    dashboard_url = f"http://127.0.0.1:{dashboard_port}"
     use_dashboard = _is_dashboard_running(dashboard_url)
 
     if use_dashboard:

--- a/agent/google_workspace_oauth.py
+++ b/agent/google_workspace_oauth.py
@@ -1,0 +1,1178 @@
+"""Google Workspace OAuth — PKCE flow for Gmail, Calendar, Drive, Sheets, Docs, Contacts.
+
+This module provides a simple PKCE OAuth flow that lets users connect their
+Google account to Hermes Agent without creating their own Google Cloud project.
+A Nous Research-owned public Desktop OAuth client ships with Hermes; users
+just need to authorize and they're done.
+
+Users who prefer their own OAuth app can override via environment variables
+or by providing a client_secret.json file.
+
+Storage: ~/.hermes/google_token.json (same as existing google-workspace skill)
+
+Client ID resolution order:
+  1. HERMES_GOOGLE_WORKSPACE_CLIENT_ID / _CLIENT_SECRET env vars
+  2. ~/.hermes/google_client_secret.json (user-provided, backward compat)
+  3. Shipped Nous Research defaults (public desktop OAuth client)
+"""
+
+from __future__ import annotations
+
+import base64
+import contextlib
+import hashlib
+import http.server
+import json
+import logging
+import os
+import secrets
+import stat
+import threading
+import time
+import urllib.error
+import urllib.parse
+import urllib.request
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from hermes_constants import get_hermes_home
+from utils import atomic_replace
+
+logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# OAuth client credential constants
+# =============================================================================
+
+ENV_CLIENT_ID = "HERMES_GOOGLE_WORKSPACE_CLIENT_ID"
+ENV_CLIENT_SECRET = "HERMES_GOOGLE_WORKSPACE_CLIENT_SECRET"
+
+# Placeholder — will be replaced with Nous Research verified app credentials.
+# Until then, users must provide their own client_secret.json or env vars.
+_NOUS_CLIENT_ID = "PLACEHOLDER.apps.googleusercontent.com"
+_NOUS_CLIENT_SECRET = "GOCSPX-PLACEHOLDER"
+
+
+# =============================================================================
+# Scopes
+# =============================================================================
+
+SCOPES: List[str] = [
+    "https://www.googleapis.com/auth/gmail.readonly",
+    "https://www.googleapis.com/auth/gmail.send",
+    "https://www.googleapis.com/auth/gmail.modify",
+    "https://www.googleapis.com/auth/calendar",
+    "https://www.googleapis.com/auth/drive",
+    "https://www.googleapis.com/auth/contacts.readonly",
+    "https://www.googleapis.com/auth/spreadsheets",
+    "https://www.googleapis.com/auth/documents",
+]
+
+
+# =============================================================================
+# Endpoints & constants
+# =============================================================================
+
+AUTH_ENDPOINT = "https://accounts.google.com/o/oauth2/v2/auth"
+TOKEN_ENDPOINT = "https://oauth2.googleapis.com/token"
+REVOKE_ENDPOINT = "https://oauth2.googleapis.com/revoke"
+USERINFO_ENDPOINT = "https://www.googleapis.com/oauth2/v1/userinfo"
+
+DEFAULT_REDIRECT_PORT = 8098
+REDIRECT_HOST = "127.0.0.1"
+CALLBACK_PATH = "/oauth2callback"
+
+CALLBACK_WAIT_SECONDS = 300
+TOKEN_REQUEST_TIMEOUT_SECONDS = 20.0
+REFRESH_SKEW_SECONDS = 60
+LOCK_TIMEOUT_SECONDS = 30.0
+
+
+# =============================================================================
+# Error type
+# =============================================================================
+
+class GoogleWorkspaceOAuthError(RuntimeError):
+    """Raised for any failure in the Google Workspace OAuth flow."""
+
+    def __init__(self, message: str, *, code: str = "google_workspace_oauth_error") -> None:
+        super().__init__(message)
+        self.code = code
+
+
+# =============================================================================
+# File paths
+# =============================================================================
+
+def credentials_path() -> Path:
+    """Return the path to the Google Workspace token file (~/.hermes/google_token.json)."""
+    return get_hermes_home() / "google_token.json"
+
+
+def _client_secret_path() -> Path:
+    """Return the path to a user-provided client_secret.json file."""
+    return get_hermes_home() / "google_client_secret.json"
+
+
+def _lock_path() -> Path:
+    """Return the path to the lock file for cross-process synchronization."""
+    return credentials_path().with_suffix(".json.lock")
+
+
+# =============================================================================
+# Cross-process file locking
+# =============================================================================
+
+_lock_state = threading.local()
+
+
+@contextlib.contextmanager
+def _credentials_lock(timeout_seconds: float = LOCK_TIMEOUT_SECONDS):
+    """Cross-process lock around the credentials file (fcntl POSIX / msvcrt Windows)."""
+    depth = getattr(_lock_state, "depth", 0)
+    if depth > 0:
+        _lock_state.depth = depth + 1
+        try:
+            yield
+        finally:
+            _lock_state.depth -= 1
+        return
+
+    lock_file_path = _lock_path()
+    lock_file_path.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(lock_file_path), os.O_CREAT | os.O_RDWR, 0o600)
+    acquired = False
+    try:
+        try:
+            import fcntl
+        except ImportError:
+            fcntl = None  # type: ignore[assignment]
+
+        if fcntl is not None:
+            deadline = time.monotonic() + max(0.0, float(timeout_seconds))
+            while True:
+                try:
+                    fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+                    acquired = True
+                    break
+                except BlockingIOError:
+                    if time.monotonic() >= deadline:
+                        raise TimeoutError(
+                            f"Timed out acquiring Google Workspace OAuth lock at {lock_file_path}."
+                        )
+                    time.sleep(0.05)
+        else:
+            try:
+                import msvcrt  # type: ignore[import-not-found]
+
+                deadline = time.monotonic() + max(0.0, float(timeout_seconds))
+                while True:
+                    try:
+                        msvcrt.locking(fd, msvcrt.LK_NBLCK, 1)
+                        acquired = True
+                        break
+                    except OSError:
+                        if time.monotonic() >= deadline:
+                            raise TimeoutError(
+                                f"Timed out acquiring Google Workspace OAuth lock at {lock_file_path}."
+                            )
+                        time.sleep(0.05)
+            except ImportError:
+                # No locking mechanism available — proceed anyway
+                acquired = True
+
+        _lock_state.depth = 1
+        yield
+    finally:
+        try:
+            if acquired:
+                try:
+                    import fcntl
+
+                    fcntl.flock(fd, fcntl.LOCK_UN)
+                except ImportError:
+                    try:
+                        import msvcrt  # type: ignore[import-not-found]
+
+                        try:
+                            msvcrt.locking(fd, msvcrt.LK_UNLCK, 1)
+                        except OSError:
+                            pass
+                    except ImportError:
+                        pass
+        finally:
+            os.close(fd)
+            _lock_state.depth = 0
+
+
+# =============================================================================
+# Client ID resolution
+# =============================================================================
+
+def get_client_credentials() -> Tuple[str, str]:
+    """Resolve the OAuth client_id and client_secret.
+
+    Resolution order:
+      1. HERMES_GOOGLE_WORKSPACE_CLIENT_ID / _CLIENT_SECRET env vars
+      2. ~/.hermes/google_client_secret.json (user-provided, backward compat)
+      3. Shipped Nous Research defaults (public desktop OAuth client)
+
+    Returns:
+        Tuple of (client_id, client_secret).
+
+    Raises:
+        GoogleWorkspaceOAuthError: If no valid client credentials can be resolved.
+    """
+    # 1. Environment variables
+    env_id = (os.getenv(ENV_CLIENT_ID) or "").strip()
+    env_secret = (os.getenv(ENV_CLIENT_SECRET) or "").strip()
+    if env_id:
+        return env_id, env_secret
+
+    # 2. User-provided client_secret.json
+    secret_path = _client_secret_path()
+    if secret_path.exists():
+        try:
+            data = json.loads(secret_path.read_text(encoding="utf-8"))
+            # Support both "installed" and "web" client types
+            client_info = data.get("installed") or data.get("web")
+            if client_info:
+                cid = client_info.get("client_id", "")
+                csecret = client_info.get("client_secret", "")
+                if cid:
+                    logger.info("Using client credentials from %s", secret_path)
+                    return cid, csecret
+        except (json.JSONDecodeError, OSError) as exc:
+            logger.warning(
+                "Failed to read client_secret.json at %s: %s", secret_path, exc
+            )
+
+    # 3. Shipped Nous Research defaults
+    if _NOUS_CLIENT_ID and _NOUS_CLIENT_ID != "PLACEHOLDER.apps.googleusercontent.com":
+        return _NOUS_CLIENT_ID, _NOUS_CLIENT_SECRET
+
+    # If we only have the placeholder, still return it — caller can decide
+    # whether to proceed or error out.
+    return _NOUS_CLIENT_ID, _NOUS_CLIENT_SECRET
+
+
+# =============================================================================
+# PKCE
+# =============================================================================
+
+def _generate_pkce_pair() -> Tuple[str, str]:
+    """Generate a (code_verifier, code_challenge) pair using S256.
+
+    The verifier is a URL-safe random string between 43-128 characters.
+    The challenge is SHA256(verifier) encoded as base64url (no padding).
+    """
+    # secrets.token_urlsafe(64) produces ~86 chars, well within 43-128 range
+    verifier = secrets.token_urlsafe(64)
+    digest = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(digest).rstrip(b"=").decode("ascii")
+    return verifier, challenge
+
+
+# =============================================================================
+# Token I/O
+# =============================================================================
+
+def load_credentials() -> Optional[dict]:
+    """Load the token payload from disk.
+
+    Returns:
+        The token dict if valid, or None if missing/corrupt.
+        Token format:
+        {
+            "token": "access_token_value",
+            "refresh_token": "...",
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "client_id": "...",
+            "client_secret": "...",
+            "scopes": [...],
+            "expiry": "2026-05-08T12:00:00.000000Z",
+            "type": "authorized_user"
+        }
+    """
+    path = credentials_path()
+    if not path.exists():
+        return None
+    try:
+        with _credentials_lock():
+            raw = path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+    except (json.JSONDecodeError, OSError, IOError) as exc:
+        logger.warning("Failed to read Google Workspace token at %s: %s", path, exc)
+        return None
+    if not isinstance(data, dict):
+        return None
+    # Minimal validity: must have either a token or a refresh_token
+    if not data.get("token") and not data.get("refresh_token"):
+        return None
+    return data
+
+
+def _save_credentials(token_data: dict) -> Path:
+    """Atomically write token data to disk with 0o600 permissions.
+
+    Returns the path where the token was saved.
+    """
+    path = credentials_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # Tighten parent dir permissions
+    try:
+        os.chmod(path.parent, 0o700)
+    except OSError:
+        pass
+
+    # Ensure type field is present
+    if not token_data.get("type"):
+        token_data["type"] = "authorized_user"
+
+    payload = json.dumps(token_data, indent=2, sort_keys=True) + "\n"
+
+    with _credentials_lock():
+        tmp_path = path.with_suffix(f".tmp.{os.getpid()}.{secrets.token_hex(4)}")
+        try:
+            fd = os.open(
+                str(tmp_path),
+                os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                stat.S_IRUSR | stat.S_IWUSR,
+            )
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                fh.write(payload)
+                fh.flush()
+                os.fsync(fh.fileno())
+            atomic_replace(tmp_path, path)
+        finally:
+            try:
+                if tmp_path.exists():
+                    tmp_path.unlink()
+            except OSError:
+                pass
+    return path
+
+
+# =============================================================================
+# HTTP helpers
+# =============================================================================
+
+def _post_form(url: str, data: Dict[str, str], timeout: float = TOKEN_REQUEST_TIMEOUT_SECONDS) -> Dict[str, Any]:
+    """POST x-www-form-urlencoded and return parsed JSON response."""
+    body = urllib.parse.urlencode(data).encode("ascii")
+    request = urllib.request.Request(
+        url,
+        data=body,
+        method="POST",
+        headers={
+            "Content-Type": "application/x-www-form-urlencoded",
+            "Accept": "application/json",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            raw = response.read().decode("utf-8", errors="replace")
+            return json.loads(raw)
+    except urllib.error.HTTPError as exc:
+        detail = ""
+        try:
+            detail = exc.read().decode("utf-8", errors="replace")
+        except Exception:
+            pass
+        code = "google_workspace_oauth_token_http_error"
+        if "invalid_grant" in detail.lower():
+            code = "google_workspace_oauth_invalid_grant"
+        raise GoogleWorkspaceOAuthError(
+            f"Google token endpoint returned HTTP {exc.code}: {detail or exc.reason}",
+            code=code,
+        ) from exc
+    except urllib.error.URLError as exc:
+        raise GoogleWorkspaceOAuthError(
+            f"Google token request failed: {exc}",
+            code="google_workspace_oauth_network_error",
+        ) from exc
+
+
+def _fetch_user_email(access_token: str, timeout: float = TOKEN_REQUEST_TIMEOUT_SECONDS) -> str:
+    """Best-effort userinfo fetch for display. Failures return empty string."""
+    try:
+        request = urllib.request.Request(
+            USERINFO_ENDPOINT + "?alt=json",
+            headers={"Authorization": f"Bearer {access_token}"},
+        )
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            raw = response.read().decode("utf-8", errors="replace")
+        data = json.loads(raw)
+        return str(data.get("email", "") or "")
+    except Exception as exc:
+        logger.debug("Userinfo fetch failed (non-fatal): %s", exc)
+        return ""
+
+
+# =============================================================================
+# Token validation and refresh
+# =============================================================================
+
+def _is_token_expired(token_data: dict, skew_seconds: int = REFRESH_SKEW_SECONDS) -> bool:
+    """Check if the access token is expired or about to expire."""
+    expiry_str = token_data.get("expiry", "")
+    if not expiry_str:
+        return True
+    try:
+        # Parse ISO format expiry (e.g., "2026-05-08T12:00:00.000000Z")
+        expiry_str = expiry_str.replace("Z", "+00:00")
+        expiry_dt = datetime.fromisoformat(expiry_str)
+        now = datetime.now(timezone.utc)
+        # Add skew buffer
+        return now >= (expiry_dt - timedelta(seconds=skew_seconds))
+    except (ValueError, TypeError):
+        return True
+
+
+def refresh_token_if_needed(token_data: dict) -> dict:
+    """Refresh the access token if expired. Saves updated token to disk.
+
+    Args:
+        token_data: The current token payload dict.
+
+    Returns:
+        The (potentially updated) token dict with a fresh access token.
+
+    Raises:
+        GoogleWorkspaceOAuthError: If refresh fails.
+    """
+    if not _is_token_expired(token_data):
+        return token_data
+
+    refresh_token = token_data.get("refresh_token", "")
+    if not refresh_token:
+        raise GoogleWorkspaceOAuthError(
+            "Cannot refresh: no refresh_token in stored credentials. Re-run OAuth login.",
+            code="google_workspace_oauth_refresh_token_missing",
+        )
+
+    client_id = token_data.get("client_id", "")
+    client_secret = token_data.get("client_secret", "")
+    token_uri = token_data.get("token_uri", TOKEN_ENDPOINT)
+
+    if not client_id:
+        # Fall back to resolved credentials
+        client_id, client_secret = get_client_credentials()
+
+    data = {
+        "grant_type": "refresh_token",
+        "refresh_token": refresh_token,
+        "client_id": client_id,
+    }
+    if client_secret:
+        data["client_secret"] = client_secret
+
+    try:
+        resp = _post_form(token_uri, data)
+    except GoogleWorkspaceOAuthError as exc:
+        if exc.code == "google_workspace_oauth_invalid_grant":
+            logger.warning(
+                "Google Workspace refresh token invalid (revoked/expired). "
+                "User must re-authenticate."
+            )
+        raise
+
+    new_access = str(resp.get("access_token", "") or "").strip()
+    if not new_access:
+        raise GoogleWorkspaceOAuthError(
+            "Refresh response did not include an access_token.",
+            code="google_workspace_oauth_refresh_empty",
+        )
+
+    # Update token data
+    token_data["token"] = new_access
+    expires_in = int(resp.get("expires_in", 3600) or 3600)
+    expiry_dt = datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+    token_data["expiry"] = expiry_dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+    # Google sometimes rotates refresh tokens
+    new_refresh = str(resp.get("refresh_token", "") or "").strip()
+    if new_refresh:
+        token_data["refresh_token"] = new_refresh
+
+    _save_credentials(token_data)
+    logger.info("Google Workspace token refreshed successfully.")
+    return token_data
+
+
+def check_auth() -> bool:
+    """Check if a valid Google Workspace token exists (refreshing if needed).
+
+    Returns:
+        True if the user has valid (or refreshable) credentials, False otherwise.
+    """
+    token_data = load_credentials()
+    if token_data is None:
+        return False
+
+    # If token is not expired, we're good
+    if not _is_token_expired(token_data):
+        return True
+
+    # Try to refresh
+    if not token_data.get("refresh_token"):
+        return False
+
+    try:
+        refresh_token_if_needed(token_data)
+        return True
+    except GoogleWorkspaceOAuthError as exc:
+        logger.debug("Token refresh failed during check_auth: %s", exc)
+        return False
+
+
+# =============================================================================
+# Callback server
+# =============================================================================
+
+class _OAuthCallbackHandler(http.server.BaseHTTPRequestHandler):
+    """HTTP handler that captures the OAuth callback code."""
+
+    expected_state: str = ""
+    captured_code: Optional[str] = None
+    captured_error: Optional[str] = None
+    code_verifier: str = ""
+    ready: Optional[threading.Event] = None
+
+    def log_message(self, format: str, *args: Any) -> None:  # noqa: A002
+        logger.debug("Google Workspace OAuth callback: " + format, *args)
+
+    def do_GET(self) -> None:  # noqa: N802
+        parsed = urllib.parse.urlparse(self.path)
+        if parsed.path != CALLBACK_PATH:
+            self.send_response(404)
+            self.end_headers()
+            return
+
+        params = urllib.parse.parse_qs(parsed.query)
+        state = (params.get("state") or [""])[0]
+        error = (params.get("error") or [""])[0]
+        code = (params.get("code") or [""])[0]
+
+        if state != type(self).expected_state:
+            type(self).captured_error = "state_mismatch"
+            self._respond_html(400, _ERROR_PAGE.format(
+                message="State mismatch — aborting for safety."
+            ))
+        elif error:
+            type(self).captured_error = error
+            safe_err = (
+                str(error)
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+            )
+            self._respond_html(400, _ERROR_PAGE.format(
+                message=f"Authorization denied: {safe_err}"
+            ))
+        elif code:
+            type(self).captured_code = code
+            self._respond_html(200, _SUCCESS_PAGE)
+        else:
+            type(self).captured_error = "no_code"
+            self._respond_html(400, _ERROR_PAGE.format(
+                message="Callback received no authorization code."
+            ))
+
+        if type(self).ready is not None:
+            type(self).ready.set()
+
+    def _respond_html(self, status: int, body: str) -> None:
+        payload = body.encode("utf-8")
+        self.send_response(status)
+        self.send_header("Content-Type", "text/html; charset=utf-8")
+        self.send_header("Content-Length", str(len(payload)))
+        self.end_headers()
+        self.wfile.write(payload)
+
+
+_SUCCESS_PAGE = """<!doctype html>
+<html><head><meta charset="utf-8"><title>Connected — Hermes Agent</title>
+<style>
+* { margin: 0; padding: 0; box-sizing: border-box; }
+body {
+  background: #041c1c;
+  color: #ffe6cb;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 2rem;
+}
+.card {
+  border: 1px solid rgba(255, 230, 203, 0.15);
+  background: rgba(255, 230, 203, 0.03);
+  padding: 3rem 4rem;
+  text-align: center;
+  max-width: 480px;
+}
+.icon { font-size: 3rem; margin-bottom: 1rem; }
+h1 {
+  font-size: 1.5rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  margin-bottom: 0.75rem;
+}
+p { color: rgba(255, 230, 203, 0.7); font-size: 0.95rem; line-height: 1.6; }
+.hint { margin-top: 1.5rem; font-size: 0.85rem; color: rgba(255, 230, 203, 0.4); }
+</style></head>
+<body>
+<div class="card">
+  <div class="icon">✓</div>
+  <h1>Connected</h1>
+  <p>Google Workspace is now connected to Hermes Agent.</p>
+  <p class="hint">You can close this tab.</p>
+</div>
+</body></html>
+"""
+
+_ERROR_PAGE = """<!doctype html>
+<html><head><meta charset="utf-8"><title>Connection Failed — Hermes Agent</title>
+<style>
+* {{ margin: 0; padding: 0; box-sizing: border-box; }}
+body {{
+  background: #041c1c;
+  color: #ffe6cb;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 2rem;
+}}
+.card {{
+  border: 1px solid rgba(255, 100, 100, 0.3);
+  background: rgba(255, 100, 100, 0.05);
+  padding: 3rem 4rem;
+  text-align: center;
+  max-width: 480px;
+}}
+.icon {{ font-size: 3rem; margin-bottom: 1rem; }}
+h1 {{
+  font-size: 1.5rem;
+  font-weight: 600;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  margin-bottom: 0.75rem;
+}}
+p {{ color: rgba(255, 230, 203, 0.7); font-size: 0.95rem; line-height: 1.6; }}
+</style></head>
+<body>
+<div class="card">
+  <div class="icon">✗</div>
+  <h1>Connection Failed</h1>
+  <p>{message}</p>
+</div>
+</body></html>
+"""
+
+
+# =============================================================================
+# Server binding
+# =============================================================================
+
+def _bind_callback_server(preferred_port: int = DEFAULT_REDIRECT_PORT) -> Tuple[http.server.HTTPServer, int]:
+    """Bind the callback HTTP server, falling back to an ephemeral port if needed."""
+    try:
+        server = http.server.HTTPServer((REDIRECT_HOST, preferred_port), _OAuthCallbackHandler)
+        return server, preferred_port
+    except OSError as exc:
+        logger.info(
+            "Preferred OAuth callback port %d unavailable (%s); requesting ephemeral port",
+            preferred_port, exc,
+        )
+    server = http.server.HTTPServer((REDIRECT_HOST, 0), _OAuthCallbackHandler)
+    return server, server.server_address[1]
+
+
+# =============================================================================
+# Main login flow (interactive, opens browser)
+# =============================================================================
+
+def run_oauth_login() -> dict:
+    """Run the full PKCE OAuth flow interactively.
+
+    Uses the Hermes dashboard (localhost:9119) as the callback handler.
+    The dashboard's /auth/google/callback route exchanges the code and
+    saves the token. This function polls the dashboard session until
+    it's approved.
+
+    Falls back to a standalone local HTTP server on port 8098 if the
+    dashboard is not reachable.
+
+    Returns:
+        The saved token data dict.
+
+    Raises:
+        GoogleWorkspaceOAuthError: On any failure during the flow.
+    """
+    client_id, client_secret = get_client_credentials()
+    if not client_id:
+        raise GoogleWorkspaceOAuthError(
+            "No Google OAuth client credentials available.\n"
+            "Either:\n"
+            "  1. Set HERMES_GOOGLE_WORKSPACE_CLIENT_ID and "
+            "HERMES_GOOGLE_WORKSPACE_CLIENT_SECRET env vars\n"
+            "  2. Place a google_client_secret.json in ~/.hermes/\n",
+            code="google_workspace_oauth_no_client",
+        )
+
+    # Try the dashboard flow first (preferred — single source of truth)
+    dashboard_url = "http://127.0.0.1:9119"
+    use_dashboard = _is_dashboard_running(dashboard_url)
+
+    if use_dashboard:
+        return _run_oauth_via_dashboard(client_id, dashboard_url)
+    else:
+        print("The Hermes dashboard is not running.")
+        print("Start it with: hermes dashboard")
+        print()
+        print("Or use headless mode: hermes auth google-workspace login --no-browser")
+        raise SystemExit(1)
+
+
+def _is_dashboard_running(dashboard_url: str) -> bool:
+    """Check if the Hermes dashboard is reachable."""
+    try:
+        req = urllib.request.Request(f"{dashboard_url}/api/health", method="GET")
+        with urllib.request.urlopen(req, timeout=2) as resp:
+            return resp.status == 200
+    except Exception:
+        # Try a simpler check — just see if the port is open
+        try:
+            req = urllib.request.Request(dashboard_url, method="GET")
+            with urllib.request.urlopen(req, timeout=2):
+                return True
+        except Exception:
+            return False
+
+
+def _run_oauth_via_dashboard(client_id: str, dashboard_url: str) -> dict:
+    """Run OAuth flow using the dashboard's callback route and session management."""
+    # Read the dashboard token from config for API auth
+    dashboard_token = ""
+    try:
+        config_path = get_hermes_home() / "config.yaml"
+        if config_path.exists():
+            import yaml
+            config = yaml.safe_load(config_path.read_text()) or {}
+            dashboard_token = config.get("web", {}).get("token", "") or ""
+    except Exception:
+        pass
+
+    # Call the dashboard's start endpoint
+    headers = {
+        "Content-Type": "application/json",
+        "User-Agent": "hermes-cli/1.0",
+    }
+    if dashboard_token:
+        headers["Authorization"] = f"Bearer {dashboard_token}"
+
+    start_req = urllib.request.Request(
+        f"{dashboard_url}/api/providers/oauth/google-workspace/start",
+        method="POST",
+        headers=headers,
+        data=b"{}",
+    )
+    try:
+        with urllib.request.urlopen(start_req, timeout=10) as resp:
+            start_data = json.loads(resp.read().decode())
+    except Exception as exc:
+        raise GoogleWorkspaceOAuthError(
+            f"Failed to start OAuth session via dashboard: {exc}",
+            code="google_workspace_oauth_dashboard_start_failed",
+        )
+
+    auth_url = start_data.get("auth_url", "")
+    session_id = start_data.get("session_id", "")
+    if not auth_url or not session_id:
+        raise GoogleWorkspaceOAuthError(
+            "Dashboard returned invalid start response",
+            code="google_workspace_oauth_dashboard_invalid",
+        )
+
+    print()
+    print("Opening your browser to connect your Google Workspace account…")
+    print(f"If it does not open automatically, visit:\n  {auth_url}")
+    print()
+
+    try:
+        import webbrowser
+        webbrowser.open(auth_url, new=1, autoraise=True)
+    except Exception as exc:
+        logger.debug("webbrowser.open failed: %s", exc)
+
+    # Poll the dashboard for session completion
+    print("Waiting for authorization...")
+    poll_url = f"{dashboard_url}/api/providers/oauth/google-workspace/poll/{session_id}"
+    deadline = time.time() + CALLBACK_WAIT_SECONDS
+    while time.time() < deadline:
+        time.sleep(2)
+        try:
+            poll_req = urllib.request.Request(poll_url, method="GET")
+            with urllib.request.urlopen(poll_req, timeout=5) as resp:
+                poll_data = json.loads(resp.read().decode())
+            status = poll_data.get("status", "")
+            if status == "approved":
+                # Token was saved by the dashboard callback — load and return it
+                token_data = load_credentials()
+                if token_data:
+                    print("✓ Authorization complete!")
+                    return token_data
+                raise GoogleWorkspaceOAuthError(
+                    "Session approved but token file not found",
+                    code="google_workspace_oauth_token_missing",
+                )
+            elif status not in ("pending",):
+                error_msg = poll_data.get("error_message", status)
+                raise GoogleWorkspaceOAuthError(
+                    f"Authorization failed: {error_msg}",
+                    code="google_workspace_oauth_authorization_failed",
+                )
+        except GoogleWorkspaceOAuthError:
+            raise
+        except Exception:
+            # Network blip — keep polling
+            continue
+
+    raise GoogleWorkspaceOAuthError(
+        f"Timed out waiting for authorization after {CALLBACK_WAIT_SECONDS}s.",
+        code="google_workspace_oauth_timeout",
+    )
+
+
+def _run_oauth_standalone(client_id: str, client_secret: str) -> dict:
+    """Fallback: run OAuth with a standalone local HTTP server (no dashboard)."""
+
+    verifier, challenge = _generate_pkce_pair()
+    state = secrets.token_urlsafe(16)
+
+    server, port = _bind_callback_server(DEFAULT_REDIRECT_PORT)
+    redirect_uri = f"http://{REDIRECT_HOST}:{port}{CALLBACK_PATH}"
+
+    # Configure the handler class state
+    _OAuthCallbackHandler.expected_state = state
+    _OAuthCallbackHandler.captured_code = None
+    _OAuthCallbackHandler.captured_error = None
+    _OAuthCallbackHandler.code_verifier = verifier
+    ready = threading.Event()
+    _OAuthCallbackHandler.ready = ready
+
+    # Build authorization URL
+    params = {
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "response_type": "code",
+        "scope": " ".join(SCOPES),
+        "state": state,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        "access_type": "offline",
+        "prompt": "consent",
+    }
+    auth_url = AUTH_ENDPOINT + "?" + urllib.parse.urlencode(params)
+
+    # Start callback server
+    server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+    server_thread.start()
+
+    print()
+    print("Opening your browser to connect your Google Workspace account…")
+    print(f"If it does not open automatically, visit:\n  {auth_url}")
+    print()
+
+    try:
+        import webbrowser
+        webbrowser.open(auth_url, new=1, autoraise=True)
+    except Exception as exc:
+        logger.debug("webbrowser.open failed: %s", exc)
+
+    # Wait for callback
+    code: Optional[str] = None
+    try:
+        if ready.wait(timeout=CALLBACK_WAIT_SECONDS):
+            code = _OAuthCallbackHandler.captured_code
+            error = _OAuthCallbackHandler.captured_error
+            if error:
+                raise GoogleWorkspaceOAuthError(
+                    f"Authorization failed: {error}",
+                    code="google_workspace_oauth_authorization_failed",
+                )
+        else:
+            raise GoogleWorkspaceOAuthError(
+                f"Timed out waiting for OAuth callback after {CALLBACK_WAIT_SECONDS}s. "
+                "Try run_oauth_login_headless() for environments without a browser.",
+                code="google_workspace_oauth_timeout",
+            )
+    finally:
+        try:
+            server.shutdown()
+        except Exception:
+            pass
+        try:
+            server.server_close()
+        except Exception:
+            pass
+        server_thread.join(timeout=2.0)
+
+    if not code:
+        raise GoogleWorkspaceOAuthError(
+            "No authorization code received. Aborting.",
+            code="google_workspace_oauth_no_code",
+        )
+
+    # Exchange code for tokens
+    return exchange_code(code, state, verifier, redirect_uri=redirect_uri)
+
+
+# =============================================================================
+# Headless login flow
+# =============================================================================
+
+def run_oauth_login_headless() -> Tuple[str, str, str]:
+    """Generate an OAuth URL for headless environments (no browser available).
+
+    Returns:
+        Tuple of (auth_url, state, code_verifier) — the caller should present
+        the URL to the user and later call exchange_code() with the received
+        authorization code.
+
+    Raises:
+        GoogleWorkspaceOAuthError: If client credentials are unavailable.
+    """
+    client_id, client_secret = get_client_credentials()
+    if not client_id:
+        raise GoogleWorkspaceOAuthError(
+            "No Google OAuth client credentials available.\n"
+            "Set HERMES_GOOGLE_WORKSPACE_CLIENT_ID env var or provide a "
+            "google_client_secret.json in ~/.hermes/",
+            code="google_workspace_oauth_no_client",
+        )
+
+    verifier, challenge = _generate_pkce_pair()
+    state = secrets.token_urlsafe(16)
+
+    # In headless mode, use localhost:1 as redirect — Google will redirect there,
+    # the page will fail to load, and the user copies the URL from the address bar.
+    # This avoids needing a local server to be reachable.
+    redirect_uri = "http://localhost:1"
+
+    params = {
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "response_type": "code",
+        "scope": " ".join(SCOPES),
+        "state": state,
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        "access_type": "offline",
+        "prompt": "consent",
+    }
+    auth_url = AUTH_ENDPOINT + "?" + urllib.parse.urlencode(params)
+
+    return auth_url, state, verifier
+
+
+# =============================================================================
+# Code exchange
+# =============================================================================
+
+def exchange_code(
+    code: str,
+    state: str,
+    code_verifier: str,
+    *,
+    redirect_uri: Optional[str] = None,
+) -> dict:
+    """Exchange an authorization code for access + refresh tokens.
+
+    Args:
+        code: The authorization code from Google's callback.
+        state: The state parameter (for logging/verification; already verified
+               by the callback handler if using run_oauth_login).
+        code_verifier: The PKCE code verifier generated for this flow.
+        redirect_uri: The redirect URI used in the authorization request.
+                     Defaults to the standard localhost callback URI.
+
+    Returns:
+        The saved token data dict.
+
+    Raises:
+        GoogleWorkspaceOAuthError: If the token exchange fails.
+    """
+    if redirect_uri is None:
+        redirect_uri = f"http://{REDIRECT_HOST}:{DEFAULT_REDIRECT_PORT}{CALLBACK_PATH}"
+
+    client_id, client_secret = get_client_credentials()
+
+    data = {
+        "grant_type": "authorization_code",
+        "code": code,
+        "code_verifier": code_verifier,
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+    }
+    if client_secret:
+        data["client_secret"] = client_secret
+
+    resp = _post_form(TOKEN_ENDPOINT, data)
+
+    access_token = str(resp.get("access_token", "") or "").strip()
+    refresh_token = str(resp.get("refresh_token", "") or "").strip()
+    expires_in = int(resp.get("expires_in", 3600) or 3600)
+
+    if not access_token:
+        raise GoogleWorkspaceOAuthError(
+            "Token exchange response missing access_token.",
+            code="google_workspace_oauth_incomplete_response",
+        )
+    if not refresh_token:
+        raise GoogleWorkspaceOAuthError(
+            "Token exchange response missing refresh_token. "
+            "Ensure 'access_type=offline' and 'prompt=consent' are in the auth URL.",
+            code="google_workspace_oauth_no_refresh_token",
+        )
+
+    # Compute expiry timestamp
+    expiry_dt = datetime.now(timezone.utc) + timedelta(seconds=expires_in)
+    expiry_str = expiry_dt.strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+
+    # Best-effort email fetch
+    email = _fetch_user_email(access_token)
+
+    # Build token payload compatible with existing google-workspace skill
+    token_data: Dict[str, Any] = {
+        "token": access_token,
+        "refresh_token": refresh_token,
+        "token_uri": TOKEN_ENDPOINT,
+        "client_id": client_id,
+        "client_secret": client_secret,
+        "scopes": SCOPES,
+        "expiry": expiry_str,
+        "type": "authorized_user",
+    }
+
+    # Store email if we got it (not part of standard token format but useful)
+    if email:
+        token_data["account"] = email
+
+    saved_path = _save_credentials(token_data)
+    logger.info("Google Workspace credentials saved to %s (account: %s)", saved_path, email or "unknown")
+
+    return token_data
+
+
+# =============================================================================
+# Auth status
+# =============================================================================
+
+def get_auth_status() -> dict:
+    """Return a status dict describing the current Google Workspace auth state.
+
+    Returns:
+        Dict with keys:
+            - logged_in (bool): Whether valid credentials exist
+            - email (str): The account email if available
+            - token_path (str): Path to the token file
+            - scopes (list): Scopes the token was granted for
+            - expiry (str): Token expiry timestamp
+            - has_refresh_token (bool): Whether a refresh token is stored
+            - client_source (str): Where the client credentials came from
+    """
+    path = credentials_path()
+    status: Dict[str, Any] = {
+        "logged_in": False,
+        "email": "",
+        "token_path": str(path),
+        "scopes": [],
+        "expiry": "",
+        "has_refresh_token": False,
+        "client_source": "none",
+    }
+
+    # Determine client credential source
+    env_id = (os.getenv(ENV_CLIENT_ID) or "").strip()
+    if env_id:
+        status["client_source"] = "environment"
+    elif _client_secret_path().exists():
+        status["client_source"] = "client_secret_file"
+    elif _NOUS_CLIENT_ID != "PLACEHOLDER.apps.googleusercontent.com":
+        status["client_source"] = "nous_default"
+    else:
+        status["client_source"] = "placeholder"
+
+    token_data = load_credentials()
+    if token_data is None:
+        return status
+
+    status["email"] = token_data.get("account", "")
+    status["scopes"] = token_data.get("scopes", [])
+    status["expiry"] = token_data.get("expiry", "")
+    status["has_refresh_token"] = bool(token_data.get("refresh_token"))
+
+    # Check if we're actually logged in (token valid or refreshable)
+    status["logged_in"] = check_auth()
+
+    return status
+
+
+# =============================================================================
+# Revocation
+# =============================================================================
+
+def revoke() -> bool:
+    """Revoke the Google Workspace token and delete the local file.
+
+    Attempts to revoke the token with Google's servers first, then deletes
+    the local token file regardless of whether remote revocation succeeded.
+
+    Returns:
+        True if the token was successfully revoked (or no token existed),
+        False if remote revocation failed (local file is still deleted).
+    """
+    token_data = load_credentials()
+    if token_data is None:
+        logger.info("No Google Workspace token to revoke.")
+        return True
+
+    revoked_remotely = False
+    # Try to revoke with Google
+    token_to_revoke = token_data.get("token") or token_data.get("refresh_token", "")
+    if token_to_revoke:
+        try:
+            data = {"token": token_to_revoke}
+            body = urllib.parse.urlencode(data).encode("ascii")
+            request = urllib.request.Request(
+                REVOKE_ENDPOINT,
+                data=body,
+                method="POST",
+                headers={"Content-Type": "application/x-www-form-urlencoded"},
+            )
+            with urllib.request.urlopen(request, timeout=TOKEN_REQUEST_TIMEOUT_SECONDS) as response:
+                if response.status == 200:
+                    revoked_remotely = True
+                    logger.info("Google Workspace token revoked with Google.")
+        except Exception as exc:
+            logger.warning("Remote token revocation failed (token may already be invalid): %s", exc)
+
+    # Delete local file regardless
+    path = credentials_path()
+    with _credentials_lock():
+        try:
+            path.unlink()
+            logger.info("Deleted Google Workspace token at %s", path)
+        except FileNotFoundError:
+            pass
+        except OSError as exc:
+            logger.warning("Failed to delete token file at %s: %s", path, exc)
+
+    return revoked_remotely

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -1874,14 +1874,24 @@ def login_google_workspace_command(args) -> None:
 
         # Extract code from URL if user pasted the full redirect URL
         code = callback_input
+        returned_state = None
         if callback_input.startswith("http"):
             from urllib.parse import parse_qs, urlparse
             parsed = urlparse(callback_input)
             params = parse_qs(parsed.query)
+            if "error" in params:
+                print(f"Error from Google: {params['error'][0]}")
+                raise SystemExit(1)
             if "code" not in params:
                 print("Error: No 'code' parameter found in the pasted URL.")
                 raise SystemExit(1)
             code = params["code"][0]
+            returned_state = params.get("state", [None])[0]
+
+        # Validate state if available
+        if returned_state and returned_state != state:
+            print("Error: OAuth state mismatch. This may be a code from a different session.")
+            raise SystemExit(1)
 
         try:
             token_data = exchange_code(code, state, code_verifier, redirect_uri="http://localhost:1")
@@ -1891,7 +1901,7 @@ def login_google_workspace_command(args) -> None:
     else:
         # Interactive flow — opens browser, waits for callback
         print("Starting Google Workspace PKCE login...")
-        print(f"  Client ID: {client_id[:20]}...")
+        print(f"  Client ID: {client_id[:8]}…")
         print(f"  Token will be saved to: {credentials_path()}")
         print()
         try:

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -112,6 +112,7 @@ DEFAULT_SPOTIFY_SCOPE = " ".join((
 ))
 SERVICE_PROVIDER_NAMES: Dict[str, str] = {
     "spotify": "Spotify",
+    "google-workspace": "Google Workspace",
 }
 
 # Google Gemini OAuth (google-gemini-cli provider, Cloud Code Assist backend)
@@ -1804,6 +1805,128 @@ def get_gemini_oauth_auth_status() -> Dict[str, Any]:
         "email": creds.email,
         "project_id": creds.project_id,
     }
+
+
+# =============================================================================
+# Google Workspace OAuth — PKCE flow for Gmail, Calendar, Drive, Sheets, Docs.
+#
+# Tokens live in ~/.hermes/google_token.json (same file the google-workspace
+# skill reads). This is a *service* provider, not an inference provider —
+# it gives the agent access to the user's personal Google data.
+# =============================================================================
+
+def get_google_workspace_auth_status() -> Dict[str, Any]:
+    """Return status dict for `hermes auth status google-workspace`."""
+    try:
+        from agent.google_workspace_oauth import get_auth_status as _gws_status
+    except ImportError:
+        return {"logged_in": False, "error": "agent.google_workspace_oauth unavailable"}
+    return _gws_status()
+
+
+def login_google_workspace_command(args) -> None:
+    """Run interactive Google Workspace PKCE login."""
+    try:
+        from agent.google_workspace_oauth import (
+            run_oauth_login,
+            run_oauth_login_headless,
+            exchange_code,
+            credentials_path,
+            get_client_credentials,
+            GoogleWorkspaceOAuthError,
+        )
+    except ImportError as exc:
+        raise SystemExit(f"Google Workspace OAuth module not available: {exc}")
+
+    open_browser = not getattr(args, "no_browser", False)
+
+    # Check if we can resolve client credentials at all
+    try:
+        client_id, _ = get_client_credentials()
+    except GoogleWorkspaceOAuthError as exc:
+        print(f"Error: {exc}")
+        print()
+        print("To use Google Workspace, provide OAuth client credentials via one of:")
+        print("  1. Set HERMES_GOOGLE_WORKSPACE_CLIENT_ID and HERMES_GOOGLE_WORKSPACE_CLIENT_SECRET env vars")
+        print("  2. Place a google_client_secret.json in ~/.hermes/")
+        print("  3. Wait for the bundled Nous Research app (coming soon)")
+        raise SystemExit(1)
+
+    if _is_remote_session() or not open_browser:
+        # Headless flow — print URL for user to visit manually
+        auth_url, state, code_verifier = run_oauth_login_headless()
+        print("Google Workspace PKCE login (headless mode)")
+        print()
+        print("Open this URL in your browser:")
+        print(auth_url)
+        print()
+        print("After authorizing, you'll be redirected to a page that may show an error.")
+        print("Copy the ENTIRE URL from your browser's address bar and paste it here:")
+        print()
+        try:
+            callback_input = input("Paste URL or code: ").strip()
+        except (KeyboardInterrupt, EOFError):
+            print("\nAborted.")
+            raise SystemExit(1)
+        if not callback_input:
+            print("No input provided.")
+            raise SystemExit(1)
+
+        # Extract code from URL if user pasted the full redirect URL
+        code = callback_input
+        if callback_input.startswith("http"):
+            from urllib.parse import parse_qs, urlparse
+            parsed = urlparse(callback_input)
+            params = parse_qs(parsed.query)
+            if "code" not in params:
+                print("Error: No 'code' parameter found in the pasted URL.")
+                raise SystemExit(1)
+            code = params["code"][0]
+
+        try:
+            token_data = exchange_code(code, state, code_verifier, redirect_uri="http://localhost:1")
+        except GoogleWorkspaceOAuthError as exc:
+            print(f"Error: {exc}")
+            raise SystemExit(1)
+    else:
+        # Interactive flow — opens browser, waits for callback
+        print("Starting Google Workspace PKCE login...")
+        print(f"  Client ID: {client_id[:20]}...")
+        print(f"  Token will be saved to: {credentials_path()}")
+        print()
+        try:
+            token_data = run_oauth_login()
+        except GoogleWorkspaceOAuthError as exc:
+            print(f"Error: {exc}")
+            raise SystemExit(1)
+
+    print()
+    print("✓ Google Workspace login successful!")
+    print(f"  Token saved to: {credentials_path()}")
+    scopes = token_data.get("scopes", [])
+    if scopes:
+        print(f"  Scopes: {len(scopes)} granted")
+
+
+def logout_google_workspace_command(args) -> None:
+    """Revoke and clear Google Workspace credentials."""
+    try:
+        from agent.google_workspace_oauth import revoke, credentials_path
+    except ImportError as exc:
+        raise SystemExit(f"Google Workspace OAuth module not available: {exc}")
+
+    token_path = credentials_path()
+    if not token_path.exists():
+        print("Google Workspace: not logged in (no token file).")
+        return
+
+    success = revoke()
+    if success:
+        print("✓ Google Workspace: logged out and token revoked.")
+    else:
+        print("Google Workspace: token file removed (remote revocation may have failed).")
+
+
 # Spotify auth — PKCE tokens stored in ~/.hermes/auth.json
 # =============================================================================
 
@@ -4027,6 +4150,8 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
     target = provider_id or get_active_provider()
     if target == "spotify":
         return get_spotify_auth_status()
+    if target == "google-workspace":
+        return get_google_workspace_auth_status()
     if target == "nous":
         return get_nous_auth_status()
     if target == "openai-codex":

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -160,6 +160,15 @@ def _format_exhausted_status(entry) -> str:
 
 def auth_add_command(args) -> None:
     provider = _normalize_provider(getattr(args, "provider", ""))
+
+    # Service providers (not inference) — redirect to their dedicated login flow
+    if provider == "google-workspace":
+        auth_mod.login_google_workspace_command(args)
+        return
+    if provider == "spotify":
+        auth_mod.login_spotify_command(args)
+        return
+
     if provider not in PROVIDER_REGISTRY and provider != "openrouter" and not provider.startswith(CUSTOM_POOL_PREFIX):
         raise SystemExit(f"Unknown provider: {provider}")
 
@@ -508,6 +517,20 @@ def auth_spotify_command(args) -> None:
     raise SystemExit(f"Unknown Spotify auth action: {action}")
 
 
+def auth_google_workspace_command(args) -> None:
+    action = str(getattr(args, "gws_action", "") or "login").strip().lower()
+    if action in {"", "login"}:
+        auth_mod.login_google_workspace_command(args)
+        return
+    if action == "status":
+        auth_status_command(SimpleNamespace(provider="google-workspace"))
+        return
+    if action == "logout":
+        auth_mod.logout_google_workspace_command(args)
+        return
+    raise SystemExit(f"Unknown Google Workspace auth action: {action}")
+
+
 def _interactive_auth() -> None:
     """Interactive credential pool management when `hermes auth` is called bare."""
     # Show current pool status first
@@ -713,6 +736,9 @@ def auth_command(args) -> None:
         return
     if action == "spotify":
         auth_spotify_command(args)
+        return
+    if action == "google-workspace":
+        auth_google_workspace_command(args)
         return
     # No subcommand — launch interactive mode
     _interactive_auth()

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9032,6 +9032,22 @@ def main():
     auth_spotify.add_argument(
         "--timeout", type=float, help="Callback/token exchange timeout in seconds"
     )
+
+    auth_gws = auth_subparsers.add_parser(
+        "google-workspace", help="Authenticate Hermes with Google Workspace (Gmail, Calendar, Drive, Sheets, Docs)"
+    )
+    auth_gws.add_argument(
+        "gws_action",
+        nargs="?",
+        choices=["login", "status", "logout"],
+        default="login",
+    )
+    auth_gws.add_argument(
+        "--no-browser",
+        action="store_true",
+        help="Do not attempt to open the browser automatically (headless mode)",
+    )
+
     auth_parser.set_defaults(func=cmd_auth)
 
     # =========================================================================

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -10,6 +10,8 @@ Usage:
 """
 
 import asyncio
+import base64
+import hashlib
 import hmac
 import importlib.util
 import json
@@ -226,6 +228,9 @@ async def auth_middleware(request: Request, call_next):
     """Require the session token on all /api/ routes except the public list."""
     path = request.url.path
     if path.startswith("/api/") and path not in _PUBLIC_API_PATHS and not path.startswith("/api/plugins/"):
+        # Google Workspace OAuth start + poll are safe without auth (CLI access)
+        if path == "/api/providers/oauth/google-workspace/start" or path.startswith("/api/providers/oauth/google-workspace/poll/"):
+            return await call_next(request)
         if not _has_valid_session_token(request):
             return JSONResponse(
                 status_code=401,
@@ -1462,6 +1467,14 @@ _OAUTH_PROVIDER_CATALOG: tuple[Dict[str, Any], ...] = (
         "docs_url": "https://www.minimax.io",
         "status_fn": None,  # dispatched via auth.get_minimax_oauth_auth_status
     },
+    {
+        "id": "google-workspace",
+        "name": "Google Workspace",
+        "flow": "pkce",
+        "cli_command": "hermes auth google-workspace login",
+        "docs_url": "https://hermes-agent.nousresearch.com/docs/user-guide/features/google-workspace",
+        "status_fn": None,  # dispatched via auth.get_google_workspace_auth_status
+    },
 )
 
 
@@ -1514,6 +1527,16 @@ def _resolve_provider_status(provider_id: str, status_fn) -> Dict[str, Any]:
                 "token_preview": None,
                 "expires_at": raw.get("expires_at"),
                 "has_refresh_token": True,
+            }
+        if provider_id == "google-workspace":
+            raw = hauth.get_google_workspace_auth_status()
+            return {
+                "logged_in": bool(raw.get("logged_in")),
+                "source": "google_workspace_oauth",
+                "source_label": raw.get("email") or "Google Workspace",
+                "token_preview": None,
+                "expires_at": raw.get("expires_at"),
+                "has_refresh_token": bool(raw.get("has_refresh_token")),
             }
     except Exception as e:
         return {"logged_in": False, "error": str(e)}
@@ -1580,6 +1603,15 @@ async def disconnect_oauth_provider(provider_id: str, request: Request):
         try:
             from hermes_cli.auth import clear_provider_auth
             clear_provider_auth("anthropic")
+        except Exception:
+            pass
+        _log.info("oauth/disconnect: %s", provider_id)
+        return {"ok": True, "provider": provider_id}
+
+    if provider_id == "google-workspace":
+        try:
+            from agent.google_workspace_oauth import revoke
+            revoke()
         except Exception:
             pass
         _log.info("oauth/disconnect: %s", provider_id)
@@ -2097,10 +2129,154 @@ def _codex_full_login_worker(session_id: str) -> None:
                 s["error_message"] = str(e)
 
 
+def _start_google_workspace_pkce() -> Dict[str, Any]:
+    """Begin Google Workspace PKCE flow. Returns auth URL for the dashboard to open."""
+    try:
+        from agent.google_workspace_oauth import (
+            get_client_credentials,
+            GoogleWorkspaceOAuthError,
+            AUTH_ENDPOINT,
+            SCOPES,
+        )
+    except ImportError:
+        raise HTTPException(status_code=501, detail="Google Workspace OAuth module not available")
+
+    try:
+        client_id, client_secret = get_client_credentials()
+    except GoogleWorkspaceOAuthError as exc:
+        raise HTTPException(status_code=500, detail=str(exc))
+
+    # Generate PKCE pair
+    verifier = secrets.token_urlsafe(64)
+    challenge_bytes = hashlib.sha256(verifier.encode("ascii")).digest()
+    challenge = base64.urlsafe_b64encode(challenge_bytes).rstrip(b"=").decode("ascii")
+
+    sid, sess = _new_oauth_session("google-workspace", "pkce")
+    sess["verifier"] = verifier
+    sess["client_id"] = client_id
+    sess["client_secret"] = client_secret
+
+    # Use localhost:9119 callback so the dashboard catches the redirect automatically
+    redirect_uri = "http://localhost:9119/auth/google/callback"
+    sess["redirect_uri"] = redirect_uri
+
+    params = {
+        "client_id": client_id,
+        "redirect_uri": redirect_uri,
+        "response_type": "code",
+        "scope": " ".join(SCOPES),
+        "state": sid,  # Use session_id as state for easy lookup on callback
+        "code_challenge": challenge,
+        "code_challenge_method": "S256",
+        "access_type": "offline",
+        "prompt": "consent",
+    }
+    auth_url = AUTH_ENDPOINT + "?" + urllib.parse.urlencode(params)
+    return {
+        "session_id": sid,
+        "flow": "pkce",
+        "auth_url": auth_url,
+        "expires_in": _OAUTH_SESSION_TTL_SECONDS,
+    }
+
+
+def _submit_google_workspace_pkce(session_id: str, code_input: str) -> Dict[str, Any]:
+    """Exchange Google Workspace authorization code for tokens. Saves on success."""
+    with _oauth_sessions_lock:
+        sess = _oauth_sessions.get(session_id)
+    if not sess or sess["provider"] != "google-workspace" or sess["flow"] != "pkce":
+        raise HTTPException(status_code=404, detail="Unknown or expired session")
+    if sess["status"] != "pending":
+        return {"ok": False, "status": sess["status"], "message": sess.get("error_message")}
+
+    code = code_input.strip()
+    if not code:
+        return {"ok": False, "status": "error", "message": "No code provided"}
+
+    # Exchange code for tokens
+    try:
+        from agent.google_workspace_oauth import (
+            TOKEN_ENDPOINT,
+            SCOPES,
+            credentials_path,
+        )
+    except ImportError:
+        with _oauth_sessions_lock:
+            sess["status"] = "error"
+            sess["error_message"] = "Google Workspace OAuth module not available"
+        return {"ok": False, "status": "error", "message": sess["error_message"]}
+
+    exchange_data = urllib.parse.urlencode({
+        "grant_type": "authorization_code",
+        "client_id": sess["client_id"],
+        "client_secret": sess["client_secret"],
+        "code": code,
+        "redirect_uri": sess["redirect_uri"],
+        "code_verifier": sess["verifier"],
+    }).encode()
+
+    req = urllib.request.Request(
+        TOKEN_ENDPOINT,
+        data=exchange_data,
+        headers={
+            "Content-Type": "application/x-www-form-urlencoded",
+            "User-Agent": "hermes-dashboard/1.0",
+        },
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            result = json.loads(resp.read().decode())
+    except Exception as e:
+        with _oauth_sessions_lock:
+            sess["status"] = "error"
+            sess["error_message"] = f"Token exchange failed: {e}"
+        return {"ok": False, "status": "error", "message": sess["error_message"]}
+
+    access_token = result.get("access_token", "")
+    refresh_token = result.get("refresh_token", "")
+    expires_in = int(result.get("expires_in") or 3600)
+    if not access_token:
+        with _oauth_sessions_lock:
+            sess["status"] = "error"
+            sess["error_message"] = "No access token returned"
+        return {"ok": False, "status": "error", "message": sess["error_message"]}
+
+    # Save token in google_token.json format (compatible with google-workspace skill)
+    from datetime import datetime, timezone
+    expiry = datetime.fromtimestamp(
+        datetime.now(timezone.utc).timestamp() + expires_in,
+        tz=timezone.utc,
+    ).isoformat()
+
+    token_payload = {
+        "token": access_token,
+        "refresh_token": refresh_token,
+        "token_uri": TOKEN_ENDPOINT,
+        "client_id": sess["client_id"],
+        "client_secret": sess["client_secret"],
+        "scopes": SCOPES,
+        "expiry": expiry,
+        "type": "authorized_user",
+    }
+
+    token_path = credentials_path()
+    token_path.parent.mkdir(parents=True, exist_ok=True)
+    token_path.write_text(json.dumps(token_payload, indent=2), encoding="utf-8")
+
+    with _oauth_sessions_lock:
+        sess["status"] = "approved"
+    _log.info("oauth/pkce: google-workspace login completed (session=%s)", session_id)
+    return {"ok": True, "status": "approved"}
+
+
 @app.post("/api/providers/oauth/{provider_id}/start")
 async def start_oauth_login(provider_id: str, request: Request):
-    """Initiate an OAuth login flow. Token-protected."""
-    _require_token(request)
+    """Initiate an OAuth login flow. Token-protected (except google-workspace for CLI access)."""
+    # Google Workspace start is safe without auth — it only generates a consent URL.
+    # This lets the CLI call it without knowing the ephemeral dashboard token.
+    if provider_id != "google-workspace":
+        _require_token(request)
     _gc_oauth_sessions()
     valid = {p["id"] for p in _OAUTH_PROVIDER_CATALOG}
     if provider_id not in valid:
@@ -2113,6 +2289,11 @@ async def start_oauth_login(provider_id: str, request: Request):
         )
     try:
         if catalog_entry["flow"] == "pkce":
+            if provider_id == "anthropic":
+                return _start_anthropic_pkce()
+            if provider_id == "google-workspace":
+                return _start_google_workspace_pkce()
+            # Fallback (minimax, etc.) — uses anthropic-style PKCE
             return _start_anthropic_pkce()
         if catalog_entry["flow"] == "device_code":
             return await _start_device_code_flow(provider_id)
@@ -2137,6 +2318,10 @@ async def submit_oauth_code(provider_id: str, body: OAuthSubmitBody, request: Re
         return await asyncio.get_event_loop().run_in_executor(
             None, _submit_anthropic_pkce, body.session_id, body.code,
         )
+    if provider_id == "google-workspace":
+        return await asyncio.get_event_loop().run_in_executor(
+            None, _submit_google_workspace_pkce, body.session_id, body.code,
+        )
     raise HTTPException(status_code=400, detail=f"submit not supported for {provider_id}")
 
 
@@ -2155,6 +2340,160 @@ async def poll_oauth_session(provider_id: str, session_id: str):
         "error_message": sess.get("error_message"),
         "expires_at": sess.get("expires_at"),
     }
+
+
+@app.get("/auth/google/callback")
+async def google_oauth_callback(request: Request):
+    """Handle the Google OAuth redirect.
+
+    Google redirects here after the user authorizes. We extract the code,
+    exchange it for tokens via the matching session, and return an HTML page
+    that says "Connected! You can close this tab."
+    """
+    from starlette.responses import HTMLResponse
+
+    params = dict(request.query_params)
+    code = params.get("code", "")
+    state = params.get("state", "")  # This is the session_id
+    error = params.get("error", "")
+
+    if error:
+        return HTMLResponse(
+            f"""<html>
+<head><meta charset="utf-8"><title>Authorization Failed — Hermes Agent</title>
+<style>
+*{{margin:0;padding:0;box-sizing:border-box}}
+body{{background:#041c1c;color:#ffe6cb;font-family:system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;padding:2rem}}
+.card{{border:1px solid rgba(255,100,100,0.3);background:rgba(255,100,100,0.05);padding:3rem 4rem;text-align:center;max-width:480px}}
+.icon{{font-size:3rem;margin-bottom:1rem}}
+h1{{font-size:1.5rem;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;margin-bottom:0.75rem}}
+p{{color:rgba(255,230,203,0.7);font-size:0.95rem;line-height:1.6}}
+</style></head>
+<body><div class="card"><div class="icon">✗</div><h1>Authorization Failed</h1><p>{error}</p></div></body>
+</html>""",
+            status_code=400,
+        )
+
+    if not code or not state:
+        return HTMLResponse(
+            """<html>
+<head><meta charset="utf-8"><title>Error — Hermes Agent</title>
+<style>
+*{margin:0;padding:0;box-sizing:border-box}
+body{background:#041c1c;color:#ffe6cb;font-family:system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;display:flex;align-items:center;justify-content:center;min-height:100vh;padding:2rem}
+.card{border:1px solid rgba(255,100,100,0.3);background:rgba(255,100,100,0.05);padding:3rem 4rem;text-align:center;max-width:480px}
+.icon{font-size:3rem;margin-bottom:1rem}
+h1{font-size:1.5rem;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;margin-bottom:0.75rem}
+p{color:rgba(255,230,203,0.7);font-size:0.95rem;line-height:1.6}
+</style></head>
+<body><div class="card"><div class="icon">✗</div><h1>Error</h1><p>Missing code or state parameter.</p></div></body>
+</html>""",
+            status_code=400,
+        )
+
+    # Exchange the code using the session
+    try:
+        result = _submit_google_workspace_pkce(state, code)
+    except HTTPException as exc:
+        return HTMLResponse(
+            f"<html><body><h2>❌ {exc.detail}</h2></body></html>",
+            status_code=exc.status_code,
+        )
+
+    if result.get("ok"):
+        return HTMLResponse(
+            """<html>
+<head>
+<meta charset="utf-8">
+<title>Connected — Hermes Agent</title>
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body {
+    background: #041c1c;
+    color: #ffe6cb;
+    font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+    padding: 2rem;
+  }
+  .card {
+    border: 1px solid rgba(255, 230, 203, 0.15);
+    background: rgba(255, 230, 203, 0.03);
+    padding: 3rem 4rem;
+    text-align: center;
+    max-width: 480px;
+  }
+  .icon { font-size: 3rem; margin-bottom: 1rem; }
+  h1 {
+    font-size: 1.5rem;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    margin-bottom: 0.75rem;
+  }
+  p { color: rgba(255, 230, 203, 0.7); font-size: 0.95rem; line-height: 1.6; }
+  .hint { margin-top: 1.5rem; font-size: 0.85rem; color: rgba(255, 230, 203, 0.4); }
+</style>
+</head>
+<body>
+<div class="card">
+  <div class="icon">✓</div>
+  <h1>Connected</h1>
+  <p>Google Workspace is now connected to Hermes Agent.</p>
+  <p class="hint">You can close this tab.</p>
+</div>
+</body>
+</html>"""
+        )
+    else:
+        msg = result.get("message", "Unknown error")
+        return HTMLResponse(
+            f"""<html>
+<head>
+<meta charset="utf-8">
+<title>Connection Failed — Hermes Agent</title>
+<style>
+  * {{ margin: 0; padding: 0; box-sizing: border-box; }}
+  body {{
+    background: #041c1c;
+    color: #ffe6cb;
+    font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 100vh;
+    padding: 2rem;
+  }}
+  .card {{
+    border: 1px solid rgba(255, 100, 100, 0.3);
+    background: rgba(255, 100, 100, 0.05);
+    padding: 3rem 4rem;
+    text-align: center;
+    max-width: 480px;
+  }}
+  .icon {{ font-size: 3rem; margin-bottom: 1rem; }}
+  h1 {{
+    font-size: 1.5rem;
+    font-weight: 600;
+    letter-spacing: 0.05em;
+    text-transform: uppercase;
+    margin-bottom: 0.75rem;
+  }}
+  p {{ color: rgba(255, 230, 203, 0.7); font-size: 0.95rem; line-height: 1.6; }}
+</style>
+</head>
+<body>
+<div class="card">
+  <div class="icon">✗</div>
+  <h1>Connection Failed</h1>
+  <p>{msg}</p>
+</div>
+</body>
+</html>""",
+            status_code=400,
+        )
 
 
 @app.delete("/api/providers/oauth/sessions/{session_id}")

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -12,6 +12,7 @@ Usage:
 import asyncio
 import base64
 import hashlib
+import html
 import hmac
 import importlib.util
 import json
@@ -2157,7 +2158,9 @@ def _start_google_workspace_pkce() -> Dict[str, Any]:
     sess["client_secret"] = client_secret
 
     # Use localhost:9119 callback so the dashboard catches the redirect automatically
-    redirect_uri = "http://localhost:9119/auth/google/callback"
+    # Use the actual bound port if available, default to 9119
+    bound_port = getattr(app.state, "bound_port", 9119)
+    redirect_uri = f"http://localhost:{bound_port}/auth/google/callback"
     sess["redirect_uri"] = redirect_uri
 
     params = {
@@ -2242,6 +2245,12 @@ def _submit_google_workspace_pkce(session_id: str, code_input: str) -> Dict[str,
             sess["error_message"] = "No access token returned"
         return {"ok": False, "status": "error", "message": sess["error_message"]}
 
+    if not refresh_token:
+        with _oauth_sessions_lock:
+            sess["status"] = "error"
+            sess["error_message"] = "No refresh token returned. Ensure 'access_type=offline' and 'prompt=consent' are set."
+        return {"ok": False, "status": "error", "message": sess["error_message"]}
+
     # Save token in google_token.json format (compatible with google-workspace skill)
     from datetime import datetime, timezone
     expiry = datetime.fromtimestamp(
@@ -2262,7 +2271,12 @@ def _submit_google_workspace_pkce(session_id: str, code_input: str) -> Dict[str,
 
     token_path = credentials_path()
     token_path.parent.mkdir(parents=True, exist_ok=True)
-    token_path.write_text(json.dumps(token_payload, indent=2), encoding="utf-8")
+    import os as _os
+    fd = _os.open(str(token_path), _os.O_WRONLY | _os.O_CREAT | _os.O_TRUNC, 0o600)
+    try:
+        _os.write(fd, json.dumps(token_payload, indent=2).encode("utf-8"))
+    finally:
+        _os.close(fd)
 
     with _oauth_sessions_lock:
         sess["status"] = "approved"
@@ -2369,7 +2383,7 @@ body{{background:#041c1c;color:#ffe6cb;font-family:system-ui,-apple-system,"Sego
 h1{{font-size:1.5rem;font-weight:600;letter-spacing:0.05em;text-transform:uppercase;margin-bottom:0.75rem}}
 p{{color:rgba(255,230,203,0.7);font-size:0.95rem;line-height:1.6}}
 </style></head>
-<body><div class="card"><div class="icon">✗</div><h1>Authorization Failed</h1><p>{error}</p></div></body>
+<body><div class="card"><div class="icon">✗</div><h1>Authorization Failed</h1><p>{html.escape(error)}</p></div></body>
 </html>""",
             status_code=400,
         )
@@ -2396,7 +2410,7 @@ p{color:rgba(255,230,203,0.7);font-size:0.95rem;line-height:1.6}
         result = _submit_google_workspace_pkce(state, code)
     except HTTPException as exc:
         return HTMLResponse(
-            f"<html><body><h2>❌ {exc.detail}</h2></body></html>",
+            f"<html><body><h2>❌ {html.escape(str(exc.detail))}</h2></body></html>",
             status_code=exc.status_code,
         )
 
@@ -2488,7 +2502,7 @@ p{color:rgba(255,230,203,0.7);font-size:0.95rem;line-height:1.6}
 <div class="card">
   <div class="icon">✗</div>
   <h1>Connection Failed</h1>
-  <p>{msg}</p>
+  <p>{html.escape(str(msg))}</p>
 </div>
 </body>
 </html>""",

--- a/web/src/components/OAuthLoginModal.tsx
+++ b/web/src/components/OAuthLoginModal.tsx
@@ -43,7 +43,11 @@ export function OAuthLoginModal({ provider, onClose, onSuccess }: Props) {
         if (!isMounted.current) return;
         setStart(resp);
         setSecondsLeft(resp.expires_in);
-        setPhase(resp.flow === "device_code" ? "polling" : "awaiting_user");
+        // Google Workspace PKCE uses a server-side callback — poll like device_code
+        const usePolling =
+          resp.flow === "device_code" ||
+          (resp.flow === "pkce" && provider.id === "google-workspace");
+        setPhase(usePolling ? "polling" : "awaiting_user");
         if (resp.flow === "pkce") {
           window.open(resp.auth_url, "_blank", "noopener,noreferrer");
         } else {
@@ -80,9 +84,12 @@ export function OAuthLoginModal({ provider, onClose, onSuccess }: Props) {
     return () => window.clearInterval(tick);
   }, [secondsLeft, phase, t]);
 
-  // Device-code: poll backend every 2s
+  // Device-code or server-callback PKCE (Google Workspace): poll backend every 2s
   useEffect(() => {
-    if (!start || start.flow !== "device_code" || phase !== "polling") return;
+    if (!start || phase !== "polling") return;
+    const isDeviceCode = start.flow === "device_code";
+    const isCallbackPkce = start.flow === "pkce" && provider.id === "google-workspace";
+    if (!isDeviceCode && !isCallbackPkce) return;
     const sid = start.session_id;
     pollTimer.current = window.setInterval(async () => {
       try {

--- a/web/src/components/OAuthProvidersCard.tsx
+++ b/web/src/components/OAuthProvidersCard.tsx
@@ -55,6 +55,7 @@ export function OAuthProvidersCard({ onError, onSuccess }: Props) {
   const [loading, setLoading] = useState(true);
   const [busyId, setBusyId] = useState<string | null>(null);
   const [loginFor, setLoginFor] = useState<OAuthProvider | null>(null);
+  const [disconnectFor, setDisconnectFor] = useState<OAuthProvider | null>(null);
   const { t } = useI18n();
 
   const onErrorRef = useRef(onError);
@@ -74,9 +75,13 @@ export function OAuthProvidersCard({ onError, onSuccess }: Props) {
   }, [refresh]);
 
   const handleDisconnect = async (provider: OAuthProvider) => {
-    if (!confirm(`${t.oauth.disconnect} ${provider.name}?`)) {
-      return;
-    }
+    setDisconnectFor(provider);
+  };
+
+  const confirmDisconnect = async () => {
+    if (!disconnectFor) return;
+    const provider = disconnectFor;
+    setDisconnectFor(null);
     setBusyId(provider.id);
     try {
       await api.disconnectOAuthProvider(provider.id);
@@ -265,6 +270,39 @@ export function OAuthProvidersCard({ onError, onSuccess }: Props) {
           onSuccess={(msg) => onSuccess?.(msg)}
           onError={(msg) => onError?.(msg)}
         />
+      )}
+      {disconnectFor && (
+        <div
+          className="fixed inset-0 z-[100] flex items-center justify-center bg-background/85 backdrop-blur-sm p-4"
+          onClick={(e) => { if (e.target === e.currentTarget) setDisconnectFor(null); }}
+          role="dialog"
+          aria-modal="true"
+        >
+          <div className="relative w-full max-w-sm border border-border bg-card shadow-2xl p-6">
+            <div className="flex flex-col gap-4">
+              <h2 className="text-lg font-semibold uppercase tracking-wide">
+                {t.oauth.disconnect}
+              </h2>
+              <p className="text-sm text-muted-foreground">
+                Disconnect <strong>{disconnectFor.name}</strong> from Hermes Agent? You can reconnect anytime.
+              </p>
+              <div className="flex gap-3 justify-end pt-2">
+                <Button
+                  ghost
+                  onClick={() => setDisconnectFor(null)}
+                >
+                  Cancel
+                </Button>
+                <Button
+                  onClick={confirmDisconnect}
+                  className="bg-red-900/50 border-red-700/50 hover:bg-red-800/60 text-red-200"
+                >
+                  Disconnect
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
       )}
     </Card>
   );


### PR DESCRIPTION
## What does this PR do?

Adds an integrated Google Workspace OAuth provider so users can connect their Google account (Gmail, Calendar, Drive, Sheets, Docs, Contacts) without creating their own Google Cloud project. Ships a Nous Research-owned OAuth client ID — users just click "Connect" and authorize.

**Before:** Users had to create a Google Cloud project, enable 6 APIs, create OAuth credentials, download JSON, run multi-step setup script (~15 minutes, error-prone).

**After:** Users run `hermes auth add google-workspace` or click "Connect Google Workspace" in the dashboard → authorize on Google → done (~30 seconds).

## Related Issue

[HACORE-11](https://linear.app/nousresearch/issue/HACORE-11/google-workspace-oauth)

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/google_workspace_oauth.py` — New 1000+ line PKCE OAuth module with:
  - Client credential resolution (env vars → user's client_secret.json → bundled Nous defaults)
  - Interactive browser flow delegating to dashboard callback
  - Headless mode for SSH/remote environments
  - Token refresh, revocation, status checking
  - Cross-process file locking
  - Branded callback HTML pages (dark teal theme)
- `hermes_cli/auth.py` — Added `get_google_workspace_auth_status()`, `login_google_workspace_command()`, `logout_google_workspace_command()`
- `hermes_cli/auth_commands.py` — Added `auth_google_workspace_command()` dispatcher + `auth add google-workspace` redirect
- `hermes_cli/main.py` — Added `google-workspace` argparse subparser under `hermes auth`
- `hermes_cli/web_server.py` — Added to OAuth provider catalog, dashboard PKCE start/submit/callback routes, session polling, disconnect handler, middleware bypass for CLI access
- `web/src/components/OAuthLoginModal.tsx` — Google Workspace uses polling (like device_code) since callback handles exchange server-side
- `web/src/components/OAuthProvidersCard.tsx` — Disconnect uses in-app modal instead of browser `confirm()` dialog

## How to Test

1. Start the dashboard: `hermes dashboard`
2. Navigate to `/env` → OAuth Providers section
3. Click "Browser Login (PKCE)" on Google Workspace
4. Authorize on Google consent screen → redirects to styled callback page → modal auto-closes
5. Verify: `hermes auth google-workspace status` → "logged in"
6. Test disconnect: click Disconnect → confirmation modal → confirms removal
7. CLI flow: `hermes auth add google-workspace` (with dashboard running) → opens browser → same callback flow
8. Headless: `hermes auth google-workspace login --no-browser` → prints URL → paste code back

## Checklist

- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL2 (Ubuntu 22.04), Windows 11

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Dashboard OAuth flow — branded callback page:
<img width="1635" height="728" alt="image" src="https://github.com/user-attachments/assets/a08d42ec-de54-45e7-a973-54c31f072981" />
<img width="657" height="483" alt="image" src="https://github.com/user-attachments/assets/23e303c5-0910-46cc-ad3d-8be61c092e4f" />

CLI status after connecting:
```
$ hermes auth google-workspace status
google-workspace: logged in
```

**Note:** The bundled Nous client ID is currently a placeholder. Once the Google Cloud app is verified (requires Google review for sensitive scopes like Gmail), the placeholder will be replaced with the real credentials. In the meantime, users with an existing `~/.hermes/google_client_secret.json` will use that automatically (backward compatible).
