### PR TITLE
docs(qqbot): use qqbot config key

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -6,7 +6,7 @@ REST API (``api.sgroup.qq.com``) for outbound messages and media uploads.
 
 Configuration in config.yaml:
     platforms:
-      qq:
+      qqbot:
         enabled: true
         extra:
           app_id: "your-app-id"            # or QQ_APP_ID env var

--- a/website/docs/user-guide/messaging/qqbot.md
+++ b/website/docs/user-guide/messaging/qqbot.md
@@ -64,7 +64,7 @@ For fine-grained control, add platform settings to `~/.hermes/config.yaml`:
 
 ```yaml
 platforms:
-  qq:
+  qqbot:
     enabled: true
     extra:
       app_id: "your-app-id"


### PR DESCRIPTION
## Summary
- update the QQBot advanced configuration example to use the runtime platform key `qqbot`
- keep the adapter docstring example in sync with the same platform key

## Why
`Platform.QQBOT` and the shared platform registry expose the QQ Bot adapter as `qqbot`, but the advanced YAML example still showed `platforms.qq`. Users copying that example would configure a stale key that does not match the existing runtime platform name.

## Tests
- `python3 -m py_compile gateway/platforms/qqbot/adapter.py`
- `git diff --check`
- local assertion that the QQBot docs/docstring examples now contain `qqbot` and no longer contain the stale `qq` key
