### PR TITLE
Fix DeepSeek thinking content array replay

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3387,20 +3387,16 @@ class AIAgent:
         # to inline extraction when no structured reasoning was found.
         content = getattr(assistant_message, "content", None)
         if not reasoning_parts and isinstance(content, list):
-            text_parts = []
+            assistant_message.content = ""
             for part in content:
-                # Persist only visible text; thinking blocks are stored separately.
-                if isinstance(part, dict) and part.get("type") == "text":
-                    text_parts.append(str(part.get("text", "")))
-                if isinstance(part, dict) and part.get("type") == "thinking":
-                    cleaned = str(part.get("thinking") or part.get("content") or "").strip()
-                    if cleaned and cleaned not in reasoning_parts:
-                        reasoning_parts.append(cleaned)
-            assistant_message.content = "\n".join(text_parts)
+                if not isinstance(part, dict) or part.get("type") != "thinking":
+                    continue
+                cleaned = str(part.get("thinking") or part.get("content") or "").strip()
+                if cleaned and cleaned not in reasoning_parts:
+                    reasoning_parts.append(cleaned)
         elif not reasoning_parts and isinstance(content, str) and content:
             for tag in ("think", "thinking", "thought", "reasoning", "REASONING_SCRATCHPAD"):
-                flags = re.DOTALL | re.IGNORECASE
-                for block in re.findall(rf"<{tag}>(.*?)</{tag}>", content, flags=flags):
+                for block in re.findall(rf"<{tag}>(.*?)</{tag}>", content, flags=re.DOTALL | re.IGNORECASE):
                     cleaned = block.strip()
                     if cleaned and cleaned not in reasoning_parts:
                         reasoning_parts.append(cleaned)
@@ -9017,6 +9013,10 @@ class AIAgent:
         # assistant content.  Reasoning was already captured into
         # ``reasoning_text`` above (either from structured fields or the
         # inline-block fallback), so the raw tags in content are redundant.
+        # Leaving them in place caused reasoning to leak to messaging
+        # platforms (#8878, #9568), inflate context on subsequent turns
+        # (#9306 observed 16% content-size reduction on a real MiniMax
+        # session), and pollute generated session titles.  One strip at the
         # storage boundary cleans content for every downstream consumer:
         # API replay, session transcript, gateway delivery, CLI display,
         # compression, title generation.

--- a/run_agent.py
+++ b/run_agent.py
@@ -3387,12 +3387,16 @@ class AIAgent:
         # to inline extraction when no structured reasoning was found.
         content = getattr(assistant_message, "content", None)
         if not reasoning_parts and isinstance(content, list):
+            text_parts = []
             for part in content:
-                if not isinstance(part, dict) or part.get("type") != "thinking":
-                    continue
-                cleaned = str(part.get("thinking") or part.get("content") or "").strip()
-                if cleaned and cleaned not in reasoning_parts:
-                    reasoning_parts.append(cleaned)
+                # Persist only visible text; thinking blocks are stored separately.
+                if isinstance(part, dict) and part.get("type") == "text":
+                    text_parts.append(str(part.get("text", "")))
+                if isinstance(part, dict) and part.get("type") == "thinking":
+                    cleaned = str(part.get("thinking") or part.get("content") or "").strip()
+                    if cleaned and cleaned not in reasoning_parts:
+                        reasoning_parts.append(cleaned)
+            assistant_message.content = "\n".join(text_parts)
         elif not reasoning_parts and isinstance(content, str) and content:
             for tag in ("think", "thinking", "thought", "reasoning", "REASONING_SCRATCHPAD"):
                 flags = re.DOTALL | re.IGNORECASE
@@ -9005,13 +9009,7 @@ class AIAgent:
         # Sanitize surrogates from API response — some models (e.g. Kimi/GLM via Ollama)
         # can return invalid surrogate code points that crash json.dumps() on persist.
         _raw_content = assistant_message.content or ""
-        if isinstance(_raw_content, list):
-            _raw_content = "\n".join(
-                str(p.get("text", ""))
-                for p in _raw_content
-                if isinstance(p, dict) and p.get("type") == "text"
-            )
-        _san_content = _sanitize_surrogates(str(_raw_content))
+        _san_content = _sanitize_surrogates(_raw_content)
         if reasoning_text:
             reasoning_text = _sanitize_surrogates(reasoning_text)
 
@@ -9019,10 +9017,6 @@ class AIAgent:
         # assistant content.  Reasoning was already captured into
         # ``reasoning_text`` above (either from structured fields or the
         # inline-block fallback), so the raw tags in content are redundant.
-        # Leaving them in place caused reasoning to leak to messaging
-        # platforms (#8878, #9568), inflate context on subsequent turns
-        # (#9306 observed 16% content-size reduction on a real MiniMax
-        # session), and pollute generated session titles.  One strip at the
         # storage boundary cleans content for every downstream consumer:
         # API replay, session transcript, gateway delivery, CLI display,
         # compression, title generation.

--- a/run_agent.py
+++ b/run_agent.py
@@ -3386,17 +3386,17 @@ class AIAgent:
         # instead of returning structured reasoning fields.  Only fall back
         # to inline extraction when no structured reasoning was found.
         content = getattr(assistant_message, "content", None)
-        if not reasoning_parts and isinstance(content, str) and content:
-            inline_patterns = (
-                r"<think>(.*?)</think>",
-                r"<thinking>(.*?)</thinking>",
-                r"<thought>(.*?)</thought>",
-                r"<reasoning>(.*?)</reasoning>",
-                r"<REASONING_SCRATCHPAD>(.*?)</REASONING_SCRATCHPAD>",
-            )
-            for pattern in inline_patterns:
+        if not reasoning_parts and isinstance(content, list):
+            for part in content:
+                if not isinstance(part, dict) or part.get("type") != "thinking":
+                    continue
+                cleaned = str(part.get("thinking") or part.get("content") or "").strip()
+                if cleaned and cleaned not in reasoning_parts:
+                    reasoning_parts.append(cleaned)
+        elif not reasoning_parts and isinstance(content, str) and content:
+            for tag in ("think", "thinking", "thought", "reasoning", "REASONING_SCRATCHPAD"):
                 flags = re.DOTALL | re.IGNORECASE
-                for block in re.findall(pattern, content, flags=flags):
+                for block in re.findall(rf"<{tag}>(.*?)</{tag}>", content, flags=flags):
                     cleaned = block.strip()
                     if cleaned and cleaned not in reasoning_parts:
                         reasoning_parts.append(cleaned)
@@ -9005,7 +9005,13 @@ class AIAgent:
         # Sanitize surrogates from API response — some models (e.g. Kimi/GLM via Ollama)
         # can return invalid surrogate code points that crash json.dumps() on persist.
         _raw_content = assistant_message.content or ""
-        _san_content = _sanitize_surrogates(_raw_content)
+        if isinstance(_raw_content, list):
+            _raw_content = "\n".join(
+                str(p.get("text", ""))
+                for p in _raw_content
+                if isinstance(p, dict) and p.get("type") == "text"
+            )
+        _san_content = _sanitize_surrogates(str(_raw_content))
         if reasoning_text:
             reasoning_text = _sanitize_surrogates(reasoning_text)
 

--- a/tests/run_agent/test_deepseek_reasoning_content_echo.py
+++ b/tests/run_agent/test_deepseek_reasoning_content_echo.py
@@ -318,6 +318,31 @@ class TestBuildAssistantMessageDeepSeekReasoningContent:
         assert msg["reasoning_content"] == "DeepSeek tool-call reasoning"
         assert msg["tool_calls"][0]["id"] == "call_1"
 
+    def test_deepseek_content_array_thinking_is_backfilled(self) -> None:
+        agent = _make_agent(provider="deepseek", model="deepseek-v4-pro")
+        assistant_message = SimpleNamespace(
+            content=[{"type": "thinking", "thinking": "DeepSeek array thoughts"}],
+            reasoning=None,
+            reasoning_content=None,
+            reasoning_details=None,
+            codex_reasoning_items=None,
+            codex_message_items=None,
+            tool_calls=[
+                SimpleNamespace(
+                    id="call_1",
+                    call_id=None,
+                    response_item_id=None,
+                    type="function",
+                    function=SimpleNamespace(name="terminal", arguments="{}"),
+                )
+            ],
+        )
+
+        msg = agent._build_assistant_message(assistant_message, "tool_calls")
+
+        assert msg["reasoning"] == "DeepSeek array thoughts"
+        assert msg["reasoning_content"] == "DeepSeek array thoughts"
+
     def test_deepseek_model_extra_reasoning_content_is_preserved(self) -> None:
         """OpenAI SDK stores unknown provider fields in model_extra."""
         agent = _make_agent(provider="deepseek", model="deepseek-v4-flash")


### PR DESCRIPTION
## Summary
- Extract DeepSeek/OpenAI-compatible `content` array entries with `type: thinking` into stored `reasoning`.
- Promote that captured thinking into `reasoning_content` so DeepSeek V4 Pro sessions replay with the required thinking-mode echo.
- Store only text parts from array content as visible assistant content.

Fixes #21946.

## Test plan
- `python3 -m ruff check run_agent.py tests/run_agent/test_deepseek_reasoning_content_echo.py`
- `python3 -m pytest -o addopts='' tests/run_agent/test_deepseek_reasoning_content_echo.py -q`

Made with [Cursor](https://cursor.com)