### PR TITLE
fix(email): fetch iCloud messages with BODY.PEEK[]

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -358,11 +358,22 @@ class EmailAdapter(BasePlatformAdapter):
                     if len(self._seen_uids) > self._seen_uids_max:
                         self._trim_seen_uids()
 
-                    status, msg_data = imap.uid("fetch", uid, "(RFC822)")
+                    # Use BODY.PEEK[] instead of RFC822 for better server compatibility.
+                    # iCloud IMAP (imap.mail.me.com) can return only metadata for
+                    # UID FETCH (RFC822), while BODY.PEEK[] returns the full RFC 822
+                    # message without marking it as read.
+                    status, msg_data = imap.uid("fetch", uid, "(BODY.PEEK[])")
                     if status != "OK":
                         continue
 
-                    raw_email = msg_data[0][1]
+                    raw_email = None
+                    for item in msg_data or []:
+                        if isinstance(item, tuple) and len(item) > 1 and isinstance(item[1], (bytes, bytearray)):
+                            raw_email = item[1]
+                            break
+                    if not raw_email:
+                        logger.warning("[Email] IMAP fetch returned no message bytes for uid %r: %r", uid, msg_data)
+                        continue
                     msg = email_lib.message_from_bytes(raw_email)
 
                     sender_raw = msg.get("From", "")

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -850,6 +850,58 @@ class TestFetchNewMessages(unittest.TestCase):
         self.assertEqual(results[0]["sender_addr"], "user@test.com")
         self.assertIn(b"3", adapter._seen_uids)
 
+    def test_fetch_uses_body_peek_for_icloud_compatibility(self):
+        """Fetch should use BODY.PEEK[] because iCloud returns no body for RFC822."""
+        adapter = self._make_adapter()
+
+        raw_email = MIMEText("Hello", "plain", "utf-8")
+        raw_email["From"] = "user@test.com"
+        raw_email["Subject"] = "Test"
+        raw_email["Message-ID"] = "<msg@test.com>"
+
+        mock_imap = MagicMock()
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"1"])
+            if command == "fetch":
+                # iCloud-style behavior: RFC822 returns only metadata, BODY.PEEK[] works.
+                if args == (b"1", "(RFC822)"):
+                    return ("OK", [b"1 (UID 1)"])
+                if args == (b"1", "(BODY.PEEK[])"):
+                    return ("OK", [(b"1 (UID 1 BODY[] {123})", raw_email.as_bytes()), b")"])
+            return ("NO", [])
+
+        mock_imap.uid.side_effect = uid_handler
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+            results = adapter._fetch_new_messages()
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["sender_addr"], "user@test.com")
+        mock_imap.uid.assert_any_call("fetch", b"1", "(BODY.PEEK[])")
+
+    def test_fetch_skips_metadata_only_fetch_response(self):
+        """Metadata-only fetch responses should be skipped instead of crashing."""
+        adapter = self._make_adapter()
+
+        mock_imap = MagicMock()
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"1"])
+            if command == "fetch":
+                return ("OK", [b"1 (UID 1)"])
+            return ("NO", [])
+
+        mock_imap.uid.side_effect = uid_handler
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+            results = adapter._fetch_new_messages()
+
+        self.assertEqual(results, [])
+        self.assertIn(b"1", adapter._seen_uids)
+
     def test_fetch_no_unseen_messages(self):
         """No unseen messages returns empty list."""
         adapter = self._make_adapter()


### PR DESCRIPTION
## Summary
- Fetch email messages with `BODY.PEEK[]` instead of `RFC822` for better IMAP server compatibility.
- Guard metadata-only fetch responses so the email poller skips them instead of crashing.
- Add regression tests for iCloud-style metadata-only `RFC822` responses and successful `BODY.PEEK[]` fetches.

## Why
Some IMAP servers, notably iCloud (`imap.mail.me.com`), can return only metadata for `UID FETCH (RFC822)` while returning the full message for `BODY.PEEK[]`. This caused Hermes Email gateway polling to see the unseen message but fail to read its body.

Related public reports:
- https://github.com/bradsjm/mail-imap-mcp-rs/issues/1
- https://github.com/Boonanpro/done/pull/53
- https://github.com/Webklex/php-imap/issues/510

## Test plan
- `python -m py_compile gateway/platforms/email.py`
- `python -m pytest tests/gateway/test_email.py -q -o 'addopts='`
