### PR TITLE
fix(dashboard): connect PTY sidecar via loopback

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3066,7 +3066,7 @@ def _build_sidecar_url(channel: str) -> Optional[str]:
 
     if not host or not port:
         return None
-
+    host = {"0.0.0.0": "127.0.0.1", "::": "::1"}.get(host, host)
     netloc = f"[{host}]:{port}" if ":" in host and not host.startswith("[") else f"{host}:{port}"
     qs = urllib.parse.urlencode({"token": _SESSION_TOKEN, "channel": channel})
 


### PR DESCRIPTION
## Summary
- Convert wildcard dashboard bind hosts (`0.0.0.0`, `::`) to loopback targets for PTY sidecar connections.
- Keep the patch line-neutral in `web_server.py` so lint-diff avoids unrelated line-sensitive type diagnostics.

Replaces #21980.
Fixes #21948.

## Test plan
- `python3 -m ruff check hermes_cli/web_server.py`
- `git diff --check`

Made with [Cursor](https://cursor.com)