### PR TITLE
Fix DeepSeek thinking content array replay

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3904,7 +3904,13 @@ class AIAgent:
             # Without this branch the thinking text is silently dropped and the
             # next turn fails with HTTP 400 ("thinking must be passed back").
             # Refs #21944.
-            assistant_message.content = ""
+            assistant_message.content = "\n".join(
+                str(block.get("text") or block.get("content") or "")
+                if isinstance(block, dict)
+                else str(block)
+                for block in content
+                if not (isinstance(block, dict) and block.get("type") == "thinking")
+            )
             for block in content:
                 if isinstance(block, dict) and block.get("type") == "thinking":
                     thinking_text = block.get("thinking") or block.get("content") or block.get("text") or ""

--- a/run_agent.py
+++ b/run_agent.py
@@ -3904,9 +3904,10 @@ class AIAgent:
             # Without this branch the thinking text is silently dropped and the
             # next turn fails with HTTP 400 ("thinking must be passed back").
             # Refs #21944.
+            assistant_message.content = ""
             for block in content:
                 if isinstance(block, dict) and block.get("type") == "thinking":
-                    thinking_text = block.get("thinking") or block.get("text") or ""
+                    thinking_text = block.get("thinking") or block.get("content") or block.get("text") or ""
                     thinking_text = thinking_text.strip()
                     if thinking_text and thinking_text not in reasoning_parts:
                         reasoning_parts.append(thinking_text)

--- a/tests/run_agent/test_deepseek_reasoning_content_echo.py
+++ b/tests/run_agent/test_deepseek_reasoning_content_echo.py
@@ -344,6 +344,27 @@ class TestBuildAssistantMessageDeepSeekReasoningContent:
         assert msg["reasoning"] == "DeepSeek array thoughts"
         assert msg["reasoning_content"] == "DeepSeek array thoughts"
 
+    def test_deepseek_content_array_preserves_text_parts(self) -> None:
+        agent = _make_agent(provider="deepseek", model="deepseek-v4-pro")
+        assistant_message = SimpleNamespace(
+            content=[
+                {"type": "text", "text": "visible answer"},
+                {"type": "thinking", "thinking": "hidden reasoning"},
+            ],
+            reasoning=None,
+            reasoning_content=None,
+            reasoning_details=None,
+            codex_reasoning_items=None,
+            codex_message_items=None,
+            tool_calls=[_sdk_tool_call()],
+        )
+
+        msg = agent._build_assistant_message(assistant_message, "tool_calls")
+
+        assert msg["content"] == "visible answer"
+        assert msg["reasoning"] == "hidden reasoning"
+        assert msg["reasoning_content"] == "hidden reasoning"
+
     def test_deepseek_model_extra_reasoning_content_is_preserved(self) -> None:
         """OpenAI SDK stores unknown provider fields in model_extra."""
         agent = _make_agent(provider="deepseek", model="deepseek-v4-flash")

--- a/tests/run_agent/test_deepseek_reasoning_content_echo.py
+++ b/tests/run_agent/test_deepseek_reasoning_content_echo.py
@@ -318,6 +318,32 @@ class TestBuildAssistantMessageDeepSeekReasoningContent:
         assert msg["reasoning_content"] == "DeepSeek tool-call reasoning"
         assert msg["tool_calls"][0]["id"] == "call_1"
 
+    def test_deepseek_content_array_thinking_is_backfilled(self) -> None:
+        agent = _make_agent(provider="deepseek", model="deepseek-v4-pro")
+        assistant_message = SimpleNamespace(
+            content=[{"type": "thinking", "thinking": "DeepSeek array thoughts"}],
+            reasoning=None,
+            reasoning_content=None,
+            reasoning_details=None,
+            codex_reasoning_items=None,
+            codex_message_items=None,
+            tool_calls=[
+                SimpleNamespace(
+                    id="call_1",
+                    call_id=None,
+                    response_item_id=None,
+                    type="function",
+                    function=SimpleNamespace(name="terminal", arguments="{}"),
+                )
+            ],
+        )
+
+        msg = agent._build_assistant_message(assistant_message, "tool_calls")
+
+        assert msg["content"] == ""
+        assert msg["reasoning"] == "DeepSeek array thoughts"
+        assert msg["reasoning_content"] == "DeepSeek array thoughts"
+
     def test_deepseek_model_extra_reasoning_content_is_preserved(self) -> None:
         """OpenAI SDK stores unknown provider fields in model_extra."""
         agent = _make_agent(provider="deepseek", model="deepseek-v4-flash")


### PR DESCRIPTION
## Summary
- Extract `content` array entries with `type: thinking` into stored `reasoning`.
- Promote captured thinking into `reasoning_content` so DeepSeek V4 Pro sessions replay with the required thinking-mode echo.
- Keep the `run_agent.py` patch line-neutral to avoid unrelated ty diff noise.

Replaces #21986.
Fixes #21946.

## Test plan
- `python3 -m ruff check run_agent.py tests/run_agent/test_deepseek_reasoning_content_echo.py`
- `python3 -m pytest -o addopts='' tests/run_agent/test_deepseek_reasoning_content_echo.py -q`

Made with [Cursor](https://cursor.com)