### PR TITLE
fix(status): recognize ZAI API key aliases

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -131,7 +131,7 @@ def show_status(args):
         "DeepSeek": "DEEPSEEK_API_KEY",
         "xAI / Grok": "XAI_API_KEY",
         "NVIDIA NIM": "NVIDIA_API_KEY",
-        "Z.AI / GLM": "GLM_API_KEY",
+        "Z.AI / GLM": ("GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY"),
         "Kimi": "KIMI_API_KEY",
         "StepFun Step Plan": "STEPFUN_API_KEY",
         "MiniMax": "MINIMAX_API_KEY",

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -14,6 +14,18 @@ def test_show_status_includes_tavily_key(monkeypatch, capsys, tmp_path):
     assert "tvly...cdef" in output
 
 
+def test_show_status_accepts_zai_api_key_alias(monkeypatch, capsys, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("GLM_API_KEY", raising=False)
+    monkeypatch.setenv("ZAI_API_KEY", "zai-1234567890abcdef")
+
+    show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    assert "Z.AI / GLM" in output
+    assert "zai-...cdef" in output
+
+
 def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys, tmp_path):
     from hermes_cli import status as status_mod
     import hermes_cli.auth as auth_mod


### PR DESCRIPTION
## Summary
- Let the top-level `hermes status` API-key summary recognize `ZAI_API_KEY` and `Z_AI_API_KEY` for Z.AI / GLM.
- Add regression coverage for `ZAI_API_KEY` so vault-materialized credentials show as configured.

Fixes #21990.

## Test plan
- `python3 -m ruff check hermes_cli/status.py tests/hermes_cli/test_status.py`
- `python3 -m pytest -o addopts='' tests/hermes_cli/test_status.py -q`

Made with [Cursor](https://cursor.com)