### PR TITLE
fix(deepseek): update fallback default from deepseek-chat to deepseek-v4-pro

### DIFF
--- a/hermes_cli/model_normalize.py
+++ b/hermes_cli/model_normalize.py
@@ -155,7 +155,7 @@ def _normalize_for_deepseek(model_name: str) -> str:
       (covers future ``deepseek-v5-*`` and dated variants without a release).
     - Contains a reasoner keyword (r1, think, reasoning, cot, reasoner)
       -> ``deepseek-reasoner``.
-    - Everything else -> ``deepseek-chat``.
+    - Everything else -> ``deepseek-v4-pro``.
 
     Args:
         model_name: The bare model name (vendor prefix already stripped).
@@ -177,7 +177,7 @@ def _normalize_for_deepseek(model_name: str) -> str:
         if keyword in bare:
             return "deepseek-reasoner"
 
-    return "deepseek-chat"
+    return "deepseek-v4-pro"
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -120,7 +120,7 @@ MODEL_ALIASES: dict[str, ModelIdentity] = {
     "gemini":    ModelIdentity("google", "gemini"),
 
     # DeepSeek
-    "deepseek":  ModelIdentity("deepseek", "deepseek-chat"),
+    "deepseek":  ModelIdentity("deepseek", "deepseek-v4-pro"),
 
     # X.AI
     "grok":      ModelIdentity("x-ai", "grok"),


### PR DESCRIPTION
## Problem

When using DeepSeek as the provider with `model.default: deepseek-v4-pro` in config.yaml, the model is silently downgraded to `deepseek-chat` in certain code paths.

Two hardcoded defaults predate the V4 model family:

1. `model_switch.py:123` — `MODEL_ALIASES["deepseek"]` returns `ModelIdentity("deepseek", "deepseek-chat")`. This alias is used in model resolution during session initialization.

2. `model_normalize.py:180` — `_normalize_for_deepseek()` fallback returns `"deepseek-chat"`. Empty strings or unknown inputs get downgraded.

## Fix

- `model_switch.py`: Model alias default → `deepseek-v4-pro`
- `model_normalize.py`: Fallback return → `deepseek-v4-pro` + docstring update

## Verification

- `deepseek-v4-pro` → `deepseek-v4-pro` ✓ (already canonical, unchanged)
- `deepseek-chat` → `deepseek-chat` ✓ (still in canonical set)
- `deepseek-r1` → `deepseek-reasoner` ✓ (reasoner keyword, unchanged)
- Unknown input → `deepseek-v4-pro` (was `deepseek-chat`)

## Impact

Low risk. Only affects fallback/default paths. Users explicitly using `deepseek-chat` are unaffected.