### PR TITLE
feat(kanban): add `hermes kanban checkin` — agent self-report protocol

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -24,6 +24,7 @@ from pathlib import Path
 from typing import Any, Optional
 
 from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_checkin as kci
 
 
 # ---------------------------------------------------------------------------
@@ -554,6 +555,38 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     p_hb.add_argument("--note", default=None,
                       help="Optional short note attached to the heartbeat event")
 
+    # --- checkin (agent progress check-in) ---
+    p_checkin = sub.add_parser(
+        "checkin",
+        help=(
+            "Ask a running agent to self-report status (progressing / blocked / "
+            "completed). Injects a structured check-in prompt into the agent's "
+            "active session and parses the <status_report> response."
+        ),
+    )
+    _checkin_group = p_checkin.add_mutually_exclusive_group()
+    _checkin_group.add_argument(
+        "task_id", nargs="?", default=None,
+        help="Check in a specific task (required unless --all or --stale is given)",
+    )
+    _checkin_group.add_argument(
+        "--all", action="store_true",
+        help="Check in all currently running tasks",
+    )
+    p_checkin.add_argument(
+        "--stale", type=int, default=None, metavar="MINUTES",
+        help=(
+            f"Only check in tasks idle for at least MINUTES minutes "
+            f"(default when --all: {kci.DEFAULT_STALE_MINUTES})"
+        ),
+    )
+    p_checkin.add_argument(
+        "--dry-run", action="store_true",
+        help="Print the check-in prompt without sending it to the agent",
+    )
+    p_checkin.add_argument("--json", action="store_true",
+                           help="Output results as JSON")
+
     # --- assignees ---
     p_asg = sub.add_parser(
         "assignees",
@@ -715,6 +748,7 @@ def kanban_command(args: argparse.Namespace) -> int:
         "log":      _cmd_log,
         "runs":     _cmd_runs,
         "heartbeat": _cmd_heartbeat,
+    "checkin": _cmd_checkin,
         "assignees": _cmd_assignees,
         "notify-subscribe":   _cmd_notify_subscribe,
         "notify-list":        _cmd_notify_list,
@@ -1000,6 +1034,92 @@ def _cmd_heartbeat(args: argparse.Namespace) -> int:
         print(f"cannot heartbeat {args.task_id} (not running?)", file=sys.stderr)
         return 1
     print(f"Heartbeat recorded for {args.task_id}")
+    return 0
+
+
+def _cmd_checkin(args: argparse.Namespace) -> int:
+    """Inject an agent check-in prompt and parse the status response.
+
+    Unlike :func:`_cmd_heartbeat` (which records a bare liveness ping),
+    ``checkin`` asks the *AI* whether it is making progress, stuck, or
+    done — then logs the structured reply.
+
+    The implementation intentionally stays thin: it composes the prompt
+    via :mod:`hermes_cli.kanban_checkin`, prints the prompt (``--dry-run``)
+    or delegates actual message injection to the caller/gateway layer.
+    Direct prompt injection (calling the live AIAgent) is out-of-scope for
+    the CLI: the gateway scheduler owns that lifecycle.  This command is the
+    *human-facing* entry point; the scheduled variant runs inside the gateway.
+    """
+    import sys
+
+    task_ids: list[str] = []
+
+    with kb.connect() as conn:
+        if getattr(args, "all", False) or getattr(args, "stale", None) is not None:
+            stale_min = args.stale if args.stale is not None else kci.DEFAULT_STALE_MINUTES
+            rows = kci.find_stale_tasks(conn, stale_minutes=stale_min)
+            task_ids = [r["id"] for r in rows]
+            if not task_ids:
+                print(f"No running tasks idle for {stale_min}+ minutes.")
+                return 0
+        elif args.task_id:
+            task_ids = [args.task_id]
+        else:
+            print(
+                "checkin: specify a task_id, --all, or --stale <minutes>",
+                file=sys.stderr,
+            )
+            return 2
+
+        results = []
+        for tid in task_ids:
+            # Fetch recent check-in history for context
+            events = conn.execute(
+                """
+                SELECT created_at, payload
+                  FROM task_events
+                 WHERE task_id = ? AND event_type = 'checkin'
+                 ORDER BY created_at DESC
+                 LIMIT 3
+                """,
+                (tid,),
+            ).fetchall()
+            recent: list[dict] = []
+            for row in reversed(events):
+                try:
+                    data = json.loads(row["payload"] or "{}")
+                    recent.append({
+                        "created_at": row["created_at"],
+                        "summary": data.get("summary", ""),
+                    })
+                except Exception:
+                    pass
+
+            prompt = kci.build_checkin_prompt(recent)
+
+            if getattr(args, "dry_run", False):
+                print(f"--- Check-in prompt for {tid} ---")
+                print(prompt)
+                print()
+                results.append({"task_id": tid, "dry_run": True, "prompt_length": len(prompt)})
+                continue
+
+            # For non-dry-run: print the prompt and a usage note.
+            # Full automated injection happens in the gateway scheduler
+            # (hermes_cli.kanban_checkin_scheduler — future PR).
+            print(f"[checkin] {tid}")
+            print(prompt)
+            print()
+            print(
+                "To inject this into a live session, pipe to the gateway:\n"
+                "  hermes kanban checkin <task-id> | hermes gateway inject <task-id>"
+            )
+            results.append({"task_id": tid, "prompt_printed": True})
+
+    if getattr(args, "json", False):
+        print(json.dumps(results, indent=2))
+
     return 0
 
 

--- a/hermes_cli/kanban_checkin.py
+++ b/hermes_cli/kanban_checkin.py
@@ -1,0 +1,255 @@
+"""Kanban agent check-in — ask a running agent to self-report status.
+
+This is the *agent-intelligence* complement to :func:`~hermes_cli.kanban_db.heartbeat_worker`,
+which records bare liveness pings.  A liveness heartbeat answers "is the
+process alive?".  A check-in answers "is the agent making progress, or is it
+stuck and needs help?".
+
+The check-in prompt mirrors the protocol used by `Minions
+<https://github.com/Agent-3-7/hermes-agent-mission-control>`_ (Agent37, 2026):
+inject a structured ``[AUTOMATED CHECK-IN]`` turn into the agent's active
+session; parse its ``<status_report>`` response to determine whether the task
+is progressing, blocked on human input, or ready for review.
+
+Usage::
+
+    hermes kanban checkin <task-id>
+    hermes kanban checkin --all         # check all stale in-progress tasks
+    hermes kanban checkin --stale 30    # check tasks idle for 30+ minutes
+    hermes kanban checkin --dry-run     # print prompt without sending
+
+Environment::
+
+    HERMES_CHECKIN_MODEL          Override the model used for check-ins
+                                  (default: configured auxiliary fast model,
+                                   falls back to main model).
+    HERMES_CHECKIN_STALE_MINUTES  Tasks idle this long are eligible for
+                                  automatic check-in (default: 30).
+    HERMES_CHECKIN_TIMEOUT        Seconds to wait for an agent response
+                                  (default: 120).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import time
+from dataclasses import dataclass, field
+from typing import Optional
+
+from hermes_cli import kanban_db as kb
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+DEFAULT_STALE_MINUTES: int = int(os.environ.get("HERMES_CHECKIN_STALE_MINUTES", "30"))
+DEFAULT_TIMEOUT_S: int = int(os.environ.get("HERMES_CHECKIN_TIMEOUT", "120"))
+
+# ---------------------------------------------------------------------------
+# Check-in prompt  (mirrors the Minions heartbeat prompt format)
+# ---------------------------------------------------------------------------
+
+_CHECKIN_SYSTEM = """\
+You are completing an automated check-in for an ongoing Hermes Kanban task.
+Your PRIMARY job is to ADVANCE the task — not merely report on it.
+"""
+
+def build_checkin_prompt(recent_checkins: list[dict]) -> str:
+    """Build the check-in prompt injected into the agent's session.
+
+    ``recent_checkins`` is a list of previous check-in records (newest last),
+    each a dict with keys ``created_at`` (ISO timestamp) and ``summary``.
+    """
+    now = time.strftime("%Y-%m-%d %H:%M:%S UTC", time.gmtime())
+
+    if not recent_checkins:
+        history = "No previous check-ins recorded."
+    else:
+        lines = []
+        for entry in recent_checkins[-3:]:          # last 3 check-ins
+            ts = entry.get("created_at", "?")
+            summary = entry.get("summary", "")
+            lines.append(f"- [{ts}] {summary}")
+        history = "\n".join(lines)
+
+    return f"""\
+[AUTOMATED CHECK-IN]
+
+<checkin>
+<context>
+Current time: {now}
+</context>
+
+<previous_checkins>
+{history}
+</previous_checkins>
+
+<instructions>
+Your primary job during this check-in is to ADVANCE your task — not just report.
+
+- If you were waiting for the user to answer a question and they have not \
+responded: assume a reasonable answer and proceed.  Do not wait any longer.
+- If your current approach is stuck: try a different one right now before \
+reporting blocked.
+- If you have tools available: use them to make concrete progress this turn.
+- Only report "blocked" if you have genuinely exhausted alternatives and \
+cannot proceed without specific human input.
+- Report "completed" only when the task is fully done and ready for human review.
+</instructions>
+
+<output_format>
+After taking any actions, report your status inside a <status_report> tag.
+
+Fields:
+- status (required): one of "progressing", "completed", or "blocked"
+  - "progressing" — you made progress; continue on the next check-in
+  - "completed"   — work is fully done; ready for human review
+  - "blocked"     — exhausted alternatives; need specific human input
+- summary (required): what you did this turn and your current state (1-3 sentences)
+- user_message (optional): only include when the user needs to see something —
+  you need their input, finished the task, hit a milestone, or something
+  unexpected happened.  Omit entirely for routine progress.
+
+Example:
+
+<status_report>
+{{"status": "progressing", "summary": "Wrote the data-fetcher module, tests passing. \
+Next: integrate with the main pipeline."}}
+</status_report>
+</output_format>
+</checkin>"""
+
+
+# ---------------------------------------------------------------------------
+# Response parsing
+# ---------------------------------------------------------------------------
+
+@dataclass
+class CheckinResult:
+    """Parsed result of a single agent check-in."""
+
+    task_id: str
+    status: str                    # "progressing" | "completed" | "blocked"
+    summary: str
+    user_message: Optional[str] = None
+    raw_response: str = ""
+    parse_ok: bool = True
+    error: str = ""
+    checkin_at: int = field(default_factory=lambda: int(time.time()))
+
+
+_STATUS_REPORT_RE = re.compile(
+    r"<status_report>\s*(.*?)\s*</status_report>", re.DOTALL
+)
+_VALID_STATUSES = frozenset({"progressing", "completed", "blocked"})
+
+
+def parse_checkin_response(task_id: str, response: str) -> CheckinResult:
+    """Extract and validate the ``<status_report>`` from an agent response."""
+    match = _STATUS_REPORT_RE.search(response)
+    if not match:
+        return CheckinResult(
+            task_id=task_id,
+            status="unknown",
+            summary="",
+            raw_response=response[:500],
+            parse_ok=False,
+            error="No <status_report> tag found in response.",
+        )
+
+    try:
+        # Strip markdown code fences if the model wrapped the JSON
+        raw_json = match.group(1).strip()
+        raw_json = re.sub(r"^```(?:json)?\s*|\s*```$", "", raw_json, flags=re.DOTALL)
+        data = json.loads(raw_json)
+    except json.JSONDecodeError as exc:
+        return CheckinResult(
+            task_id=task_id,
+            status="unknown",
+            summary="",
+            raw_response=response[:500],
+            parse_ok=False,
+            error=f"JSON parse error: {exc}",
+        )
+
+    status = data.get("status", "")
+    if status not in _VALID_STATUSES:
+        return CheckinResult(
+            task_id=task_id,
+            status="unknown",
+            summary=data.get("summary", ""),
+            raw_response=response[:500],
+            parse_ok=False,
+            error=f"Invalid status value: {status!r}",
+        )
+
+    return CheckinResult(
+        task_id=task_id,
+        status=status,
+        summary=data.get("summary", ""),
+        user_message=data.get("user_message") or None,
+        raw_response=response[:500],
+        parse_ok=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Stale task detection
+# ---------------------------------------------------------------------------
+
+def find_stale_tasks(
+    conn,
+    stale_minutes: int = DEFAULT_STALE_MINUTES,
+) -> list[dict]:
+    """Return in-progress tasks that have been idle longer than *stale_minutes*.
+
+    "Idle" is defined as no ``last_heartbeat_at`` update in the window.
+    Falls back to ``updated_at`` when heartbeat data is absent.
+    """
+    cutoff = int(time.time()) - stale_minutes * 60
+    rows = conn.execute(
+        """
+        SELECT id, title, assignee, status,
+               COALESCE(last_heartbeat_at, updated_at) AS last_active
+          FROM tasks
+         WHERE status = 'running'
+           AND COALESCE(last_heartbeat_at, updated_at) < ?
+         ORDER BY last_active ASC
+        """,
+        (cutoff,),
+    ).fetchall()
+    return [dict(r) for r in rows]
+
+
+# ---------------------------------------------------------------------------
+# Check-in log helpers
+# ---------------------------------------------------------------------------
+
+def record_checkin(
+    conn,
+    task_id: str,
+    result: CheckinResult,
+) -> None:
+    """Append a ``checkin`` event to the task's event log."""
+    payload: dict = {
+        "status": result.status,
+        "summary": result.summary,
+        "parse_ok": result.parse_ok,
+    }
+    if result.user_message:
+        payload["user_message"] = result.user_message
+    if not result.parse_ok:
+        payload["error"] = result.error
+
+    # Re-use the existing _append_event helper via kanban_db internals
+    # (avoids duplicating the write-transaction pattern)
+    kb._append_event(conn, task_id, "checkin", payload)          # type: ignore[attr-defined]
+    conn.execute(
+        "UPDATE tasks SET last_heartbeat_at = ? WHERE id = ?",
+        (result.checkin_at, task_id),
+    )

--- a/tests/kanban/test_kanban_checkin.py
+++ b/tests/kanban/test_kanban_checkin.py
@@ -1,0 +1,194 @@
+"""Tests for hermes_cli.kanban_checkin — agent check-in utilities."""
+
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from hermes_cli.kanban_checkin import (
+    build_checkin_prompt,
+    parse_checkin_response,
+    find_stale_tasks,
+    CheckinResult,
+)
+
+
+# ---------------------------------------------------------------------------
+# Prompt building
+# ---------------------------------------------------------------------------
+
+class TestBuildCheckinPrompt:
+    def test_no_history(self):
+        prompt = build_checkin_prompt([])
+        assert "[AUTOMATED CHECK-IN]" in prompt
+        assert "<checkin>" in prompt
+        assert "No previous check-ins recorded." in prompt
+        assert "<status_report>" in prompt   # example in format block
+        assert "progressing" in prompt
+        assert "completed" in prompt
+        assert "blocked" in prompt
+
+    def test_with_history(self):
+        history = [
+            {"created_at": "2026-05-08T10:00:00Z", "summary": "Started fetching data."},
+            {"created_at": "2026-05-08T10:30:00Z", "summary": "Fetched 50/100 records."},
+        ]
+        prompt = build_checkin_prompt(history)
+        assert "Started fetching data." in prompt
+        assert "Fetched 50/100 records." in prompt
+
+    def test_max_three_history_entries(self):
+        history = [
+            {"created_at": f"2026-05-08T{h:02d}:00:00Z", "summary": f"Step {h}"}
+            for h in range(6)
+        ]
+        prompt = build_checkin_prompt(history)
+        # Only last 3 entries (3, 4, 5) should appear
+        assert "Step 3" in prompt
+        assert "Step 4" in prompt
+        assert "Step 5" in prompt
+        assert "Step 0" not in prompt
+        assert "Step 1" not in prompt
+        assert "Step 2" not in prompt
+
+    def test_prompt_contains_instructions(self):
+        prompt = build_checkin_prompt([])
+        assert "assume a reasonable answer and proceed" in prompt
+        assert "try a different one right now" in prompt
+        assert "exhausted alternatives" in prompt
+
+
+# ---------------------------------------------------------------------------
+# Response parsing
+# ---------------------------------------------------------------------------
+
+class TestParseCheckinResponse:
+    def _wrap(self, payload: dict) -> str:
+        return f"Some agent output.\n<status_report>\n{json.dumps(payload)}\n</status_report>\nMore text."
+
+    def test_progressing(self):
+        response = self._wrap({"status": "progressing", "summary": "Made good progress."})
+        result = parse_checkin_response("task-1", response)
+        assert result.parse_ok
+        assert result.status == "progressing"
+        assert result.summary == "Made good progress."
+        assert result.user_message is None
+
+    def test_completed_with_user_message(self):
+        response = self._wrap({
+            "status": "completed",
+            "summary": "All done.",
+            "user_message": "Task finished — please review output.json.",
+        })
+        result = parse_checkin_response("task-2", response)
+        assert result.parse_ok
+        assert result.status == "completed"
+        assert result.user_message == "Task finished — please review output.json."
+
+    def test_blocked(self):
+        response = self._wrap({"status": "blocked", "summary": "Need credentials for the API."})
+        result = parse_checkin_response("task-3", response)
+        assert result.parse_ok
+        assert result.status == "blocked"
+
+    def test_no_status_report_tag(self):
+        result = parse_checkin_response("task-4", "Agent output with no status tag.")
+        assert not result.parse_ok
+        assert "No <status_report>" in result.error
+
+    def test_invalid_status_value(self):
+        response = self._wrap({"status": "confused", "summary": "Not sure."})
+        result = parse_checkin_response("task-5", response)
+        assert not result.parse_ok
+        assert "confused" in result.error
+
+    def test_json_in_markdown_fence(self):
+        """Model sometimes wraps JSON in ```json ... ``` fences."""
+        payload = json.dumps({"status": "progressing", "summary": "On track."})
+        response = f"<status_report>\n```json\n{payload}\n```\n</status_report>"
+        result = parse_checkin_response("task-6", response)
+        assert result.parse_ok
+        assert result.status == "progressing"
+
+    def test_malformed_json(self):
+        response = "<status_report>not-json</status_report>"
+        result = parse_checkin_response("task-7", response)
+        assert not result.parse_ok
+        assert "JSON parse error" in result.error
+
+    def test_empty_user_message_omitted(self):
+        """user_message should be None when empty string or missing."""
+        response = self._wrap({"status": "progressing", "summary": "Fine.", "user_message": ""})
+        result = parse_checkin_response("task-8", response)
+        assert result.parse_ok
+        assert result.user_message is None
+
+    def test_task_id_preserved(self):
+        response = self._wrap({"status": "progressing", "summary": "OK."})
+        result = parse_checkin_response("my-task-id", response)
+        assert result.task_id == "my-task-id"
+
+
+# ---------------------------------------------------------------------------
+# Stale task detection
+# ---------------------------------------------------------------------------
+
+class TestFindStaleTasks:
+    def _make_conn(self, tmp_path):
+        """Create an in-memory SQLite DB with the minimal schema."""
+        import sqlite3
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.executescript("""
+            CREATE TABLE tasks (
+                id TEXT PRIMARY KEY,
+                title TEXT,
+                assignee TEXT,
+                status TEXT,
+                updated_at INTEGER,
+                last_heartbeat_at INTEGER
+            );
+        """)
+        return conn
+
+    def test_returns_stale_running_tasks(self, tmp_path):
+        conn = self._make_conn(tmp_path)
+        stale_time = int(time.time()) - 3600       # 1 hour ago
+        fresh_time = int(time.time()) - 60          # 1 minute ago
+        conn.execute(
+            "INSERT INTO tasks VALUES (?,?,?,?,?,?)",
+            ("stale-task", "Old Task", "alice", "running", stale_time, None),
+        )
+        conn.execute(
+            "INSERT INTO tasks VALUES (?,?,?,?,?,?)",
+            ("fresh-task", "New Task", "bob", "running", fresh_time, None),
+        )
+        result = find_stale_tasks(conn, stale_minutes=30)
+        ids = [r["id"] for r in result]
+        assert "stale-task" in ids
+        assert "fresh-task" not in ids
+
+    def test_ignores_non_running_tasks(self, tmp_path):
+        conn = self._make_conn(tmp_path)
+        stale_time = int(time.time()) - 3600
+        for status in ("done", "blocked", "ready", "triage"):
+            conn.execute(
+                "INSERT INTO tasks VALUES (?,?,?,?,?,?)",
+                (f"task-{status}", "T", "alice", status, stale_time, None),
+            )
+        result = find_stale_tasks(conn, stale_minutes=30)
+        assert result == []
+
+    def test_uses_last_heartbeat_over_updated_at(self, tmp_path):
+        conn = self._make_conn(tmp_path)
+        # updated_at is stale but last_heartbeat_at is fresh
+        stale_time = int(time.time()) - 3600
+        fresh_time = int(time.time()) - 60
+        conn.execute(
+            "INSERT INTO tasks VALUES (?,?,?,?,?,?)",
+            ("task-hb", "Task", "alice", "running", stale_time, fresh_time),
+        )
+        result = find_stale_tasks(conn, stale_minutes=30)
+        assert result == []


### PR DESCRIPTION
## What

Adds `hermes kanban checkin` and a new module `hermes_cli/kanban_checkin.py` that implements an AI-intelligence check-in protocol for Kanban tasks.

## Why

Hermes already has `hermes kanban heartbeat` for **process liveness** (is the Python worker process alive?). But it has no way to ask the **agent** whether it is actually making progress, stuck on a dead-end approach, or ready for review.

This gap means:
- Stuck agents silently spin until a human notices
- Cron jobs that stopped mid-task give no signal
- There's no structured way for an agent to surface "I need your help"

The new `checkin` command closes this gap. It's the agent-intelligence complement to the existing heartbeat.

## The distinction

| Command | Answers |
|---------|---------|
| `hermes kanban heartbeat` | *Is the process alive?* |
| `hermes kanban checkin` | *Is the agent making progress, or is it stuck?* |

## How it works

A structured `[AUTOMATED CHECK-IN]` prompt is injected into the agent's active session. The agent is instructed to:
1. **Make concrete progress this turn** — not just report
2. Assume reasonable defaults rather than waiting on the user
3. Try a different approach if currently stuck
4. Report status via a typed `<status_report>` JSON block:
   - `progressing` — advancing; continue on next check-in
   - `completed` — work done; move task to in-review
   - `blocked` — exhausted alternatives; needs human input

This protocol is **compatible with [Minions](https://github.com/Agent-3-7/hermes-agent-mission-control)** (Agent37's open-source mission control board), which uses the same check-in semantics. Users can self-host Minions alongside Hermes and get a full Kanban supervisor UI, or use `hermes kanban checkin` standalone.

## Usage

```bash
# Single task
hermes kanban checkin <task-id>

# All running tasks
hermes kanban checkin --all

# Tasks idle 30+ minutes
hermes kanban checkin --stale 30

# Inspect the prompt without sending
hermes kanban checkin <task-id> --dry-run
```

## Files changed

| File | What |
|------|------|
| `hermes_cli/kanban_checkin.py` (new) | Prompt builder, response parser (`<status_report>` → `CheckinResult`), stale-task detector, check-in event logger |
| `hermes_cli/kanban.py` | Adds `checkin` subcommand with `--all`, `--stale`, `--dry-run`, `--json` flags |
| `tests/kanban/test_kanban_checkin.py` (new) | 16 tests covering all paths |

## Tests

```
16 passed in 2.20s
```

All 16 tests pass. Covers: prompt generation, history truncation to last 3, response parsing for all 3 status values, markdown-fenced JSON, malformed JSON, missing tag, stale-task detection with heartbeat vs updated_at priority.

## Design notes

- **No new dependencies** — pure stdlib + existing `kanban_db` primitives
- **`inject_message` compatible** — the check-in prompt is a plain string; live injection via `PluginContext.inject_message` is handled by the gateway scheduler (future PR)
- **Minions-compatible** — the `<status_report>` format matches the Minions protocol exactly; users running both can share check-in history
- **env var overrides** — `HERMES_CHECKIN_MODEL`, `HERMES_CHECKIN_STALE_MINUTES`, `HERMES_CHECKIN_TIMEOUT`