### PR TITLE
fix: recover dashboard chat sessions after token rotation

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -806,6 +806,45 @@ async def get_sessions(limit: int = 20, offset: int = 0, resumable: bool = True)
         raise HTTPException(status_code=500, detail="Internal server error")
 
 
+@app.get("/api/sessions/most-recent")
+async def get_most_recent_session(resumable: bool = True):
+    """Return the latest human-resumable session for chat recovery.
+
+    Browser chat uses this after a dashboard auth-token refresh when the old
+    page had no explicit ?resume= target. Keep the filter aligned with the
+    session picker: hide internal/scheduled sources and empty sessions by
+    default so a freshly-created sidebar helper session does not steal recovery.
+    """
+    try:
+        from hermes_state import SessionDB
+        db = SessionDB()
+        try:
+            exclude_sources = _RESUMABLE_SESSION_EXCLUDE_SOURCES if resumable else None
+            rows = db.list_sessions_rich(
+                limit=200,
+                offset=0,
+                exclude_sources=exclude_sources,
+                resumable_only=resumable,
+            )
+            for row in rows:
+                if exclude_sources and (row.get("source") or "") in exclude_sources:
+                    continue
+                if resumable and (row.get("message_count") or 0) <= 0:
+                    continue
+                return {
+                    "session_id": row.get("id"),
+                    "title": row.get("title") or "",
+                    "started_at": row.get("started_at") or 0,
+                    "source": row.get("source") or "",
+                }
+            return {"session_id": None}
+        finally:
+            db.close()
+    except Exception:
+        _log.exception("GET /api/sessions/most-recent failed")
+        raise HTTPException(status_code=500, detail="Internal server error")
+
+
 @app.get("/api/sessions/search")
 async def search_sessions(q: str = "", limit: int = 20, resumable: bool = True):
     """Full-text search across session message content using FTS5."""

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -10,6 +10,7 @@ Usage:
 """
 
 import asyncio
+from collections import deque
 import hmac
 import importlib.util
 import json
@@ -85,6 +86,7 @@ app = FastAPI(title="Hermes Agent", version=__version__)
 # ---------------------------------------------------------------------------
 _SESSION_TOKEN = secrets.token_urlsafe(32)
 _SESSION_HEADER_NAME = "X-Hermes-Session-Token"
+_RESUMABLE_SESSION_EXCLUDE_SOURCES = ["tool", "cron"]
 
 # In-browser Chat tab (/chat, /api/pty, …).  Off unless ``hermes dashboard --tui``
 # or HERMES_DASHBOARD_TUI=1.  Set from :func:`start_server`.
@@ -773,13 +775,23 @@ async def get_action_status(name: str, lines: int = 200):
 
 
 @app.get("/api/sessions")
-async def get_sessions(limit: int = 20, offset: int = 0):
+async def get_sessions(limit: int = 20, offset: int = 0, resumable: bool = True):
     try:
         from hermes_state import SessionDB
         db = SessionDB()
         try:
-            sessions = db.list_sessions_rich(limit=limit, offset=offset)
-            total = db.session_count()
+            exclude_sources = _RESUMABLE_SESSION_EXCLUDE_SOURCES if resumable else None
+            sessions = db.list_sessions_rich(
+                limit=limit,
+                offset=offset,
+                exclude_sources=exclude_sources,
+                resumable_only=resumable,
+            )
+            total = db.session_count(
+                exclude_sources=exclude_sources,
+                resumable_only=resumable,
+                include_children=False,
+            )
             now = time.time()
             for s in sessions:
                 s["is_active"] = (
@@ -795,7 +807,7 @@ async def get_sessions(limit: int = 20, offset: int = 0):
 
 
 @app.get("/api/sessions/search")
-async def search_sessions(q: str = "", limit: int = 20):
+async def search_sessions(q: str = "", limit: int = 20, resumable: bool = True):
     """Full-text search across session message content using FTS5."""
     if not q or not q.strip():
         return {"results": []}
@@ -814,7 +826,11 @@ async def search_sessions(q: str = "", limit: int = 20):
                 else:
                     terms.append(token + "*")
             prefix_query = " ".join(terms)
-            matches = db.search_messages(query=prefix_query, limit=limit)
+            matches = db.search_messages(
+                query=prefix_query,
+                limit=limit,
+                exclude_sources=_RESUMABLE_SESSION_EXCLUDE_SOURCES if resumable else None,
+            )
             # Group by session_id — return unique sessions with their best snippet
             seen: dict = {}
             for m in matches:
@@ -3287,6 +3303,12 @@ except ImportError as _pty_import_err:  # pragma: no cover - Windows-only path
 
 _RESIZE_RE = re.compile(rb"\x1b\[RESIZE:(\d+);(\d+)\]")
 _PTY_READ_CHUNK_TIMEOUT = 0.2
+_DASHBOARD_PTY_IDLE_TTL_SECONDS = float(
+    os.environ.get("HERMES_DASHBOARD_PTY_IDLE_TTL_SECONDS", "1800")
+)
+_DASHBOARD_PTY_BUFFER_BYTES = int(
+    os.environ.get("HERMES_DASHBOARD_PTY_BUFFER_BYTES", str(2 * 1024 * 1024))
+)
 _VALID_CHANNEL_RE = re.compile(r"^[A-Za-z0-9._-]{1,128}$")
 # Starlette's TestClient reports the peer as "testclient"; treat it as
 # loopback so tests don't need to rewrite request scope.
@@ -3399,6 +3421,199 @@ def _channel_or_close_code(ws: WebSocket) -> Optional[str]:
     return channel if _VALID_CHANNEL_RE.match(channel) else None
 
 
+class _DashboardPtySession:
+    def __init__(self, bridge: PtyBridge):
+        self.bridge = bridge
+        self.ws: Optional[WebSocket] = None
+        self.reader_task: Optional[asyncio.Task] = None
+        self.cleanup_task: Optional[asyncio.Task] = None
+        self.buffer = deque()
+        self.buffer_bytes = 0
+        self.closed = False
+        self.lock = asyncio.Lock()
+
+
+_dashboard_pty_sessions: dict[str, _DashboardPtySession] = {}
+_dashboard_pty_sessions_lock = asyncio.Lock()
+
+
+def _buffer_dashboard_pty_chunk(session: _DashboardPtySession, chunk: bytes) -> None:
+    if not chunk:
+        return
+    session.buffer.append(chunk)
+    session.buffer_bytes += len(chunk)
+    while session.buffer and session.buffer_bytes > _DASHBOARD_PTY_BUFFER_BYTES:
+        old = session.buffer.popleft()
+        session.buffer_bytes -= len(old)
+
+
+async def _close_dashboard_pty_session(
+    channel: Optional[str], session: _DashboardPtySession
+) -> None:
+    if session.closed:
+        return
+    session.closed = True
+    if session.cleanup_task and session.cleanup_task is not asyncio.current_task():
+        session.cleanup_task.cancel()
+    if session.reader_task and session.reader_task is not asyncio.current_task():
+        session.reader_task.cancel()
+    async with session.lock:
+        ws = session.ws
+        session.ws = None
+        session.buffer.clear()
+        session.buffer_bytes = 0
+    if channel:
+        async with _dashboard_pty_sessions_lock:
+            if _dashboard_pty_sessions.get(channel) is session:
+                _dashboard_pty_sessions.pop(channel, None)
+    if ws is not None:
+        try:
+            await ws.close()
+        except Exception:
+            pass
+    session.bridge.close()
+
+
+async def _dashboard_pty_reader(
+    channel: Optional[str], session: _DashboardPtySession, loop: asyncio.AbstractEventLoop
+) -> None:
+    try:
+        while not session.closed:
+            chunk = await loop.run_in_executor(
+                None, session.bridge.read, _PTY_READ_CHUNK_TIMEOUT
+            )
+            if chunk is None:
+                await _close_dashboard_pty_session(channel, session)
+                return
+            if not chunk:
+                await asyncio.sleep(0)
+                continue
+            async with session.lock:
+                ws = session.ws
+            if ws is None:
+                async with session.lock:
+                    _buffer_dashboard_pty_chunk(session, chunk)
+                continue
+            try:
+                await ws.send_bytes(chunk)
+            except Exception:
+                async with session.lock:
+                    if session.ws is ws:
+                        session.ws = None
+                    _buffer_dashboard_pty_chunk(session, chunk)
+    except asyncio.CancelledError:
+        # TestClient and some ASGI lifecycles can cancel tasks created during
+        # a WebSocket request when that request exits.  Cancellation is not PTY
+        # EOF; keep the bridge alive so a later browser reconnect can reattach.
+        return
+
+
+async def _spawn_dashboard_pty_session(
+    *,
+    channel: Optional[str],
+    resume: Optional[str],
+    sidecar_url: Optional[str],
+    loop: asyncio.AbstractEventLoop,
+) -> _DashboardPtySession:
+    argv, cwd, env = await loop.run_in_executor(
+        None,
+        lambda: _resolve_chat_argv(resume=resume, sidecar_url=sidecar_url),
+    )
+    bridge = await loop.run_in_executor(
+        None,
+        lambda: PtyBridge.spawn(argv, cwd=cwd, env=env),
+    )
+    session = _DashboardPtySession(bridge)
+    session.reader_task = asyncio.create_task(
+        _dashboard_pty_reader(channel, session, loop)
+    )
+    return session
+
+
+async def _get_dashboard_pty_session(
+    *,
+    channel: Optional[str],
+    resume: Optional[str],
+    sidecar_url: Optional[str],
+    loop: asyncio.AbstractEventLoop,
+) -> _DashboardPtySession:
+    if not channel:
+        return await _spawn_dashboard_pty_session(
+            channel=None, resume=resume, sidecar_url=sidecar_url, loop=loop
+        )
+
+    async with _dashboard_pty_sessions_lock:
+        existing = _dashboard_pty_sessions.get(channel)
+        if existing and not existing.closed:
+            if existing.cleanup_task:
+                existing.cleanup_task.cancel()
+                existing.cleanup_task = None
+            if existing.reader_task is None or existing.reader_task.done():
+                existing.reader_task = asyncio.create_task(
+                    _dashboard_pty_reader(channel, existing, loop)
+                )
+            return existing
+
+    session = await _spawn_dashboard_pty_session(
+        channel=channel, resume=resume, sidecar_url=sidecar_url, loop=loop
+    )
+    async with _dashboard_pty_sessions_lock:
+        existing = _dashboard_pty_sessions.get(channel)
+        if existing and not existing.closed:
+            await _close_dashboard_pty_session(None, session)
+            return existing
+        _dashboard_pty_sessions[channel] = session
+    return session
+
+
+async def _attach_dashboard_pty_session(
+    session: _DashboardPtySession, ws: WebSocket
+) -> None:
+    async with session.lock:
+        old_ws = session.ws
+        session.ws = ws
+        buffered = list(session.buffer)
+        session.buffer.clear()
+        session.buffer_bytes = 0
+    if old_ws is not None and old_ws is not ws:
+        try:
+            await old_ws.close(code=1012)
+        except Exception:
+            pass
+    for chunk in buffered:
+        await ws.send_bytes(chunk)
+
+
+async def _schedule_dashboard_pty_cleanup(
+    channel: str, session: _DashboardPtySession
+) -> None:
+    async def _cleanup() -> None:
+        try:
+            await asyncio.sleep(max(0.0, _DASHBOARD_PTY_IDLE_TTL_SECONDS))
+            async with session.lock:
+                attached = session.ws is not None
+            if not attached:
+                await _close_dashboard_pty_session(channel, session)
+        except asyncio.CancelledError:
+            return
+
+    if session.cleanup_task:
+        session.cleanup_task.cancel()
+    session.cleanup_task = asyncio.create_task(_cleanup())
+
+
+async def _detach_dashboard_pty_session(
+    channel: Optional[str], session: _DashboardPtySession, ws: WebSocket
+) -> None:
+    async with session.lock:
+        if session.ws is ws:
+            session.ws = None
+    if channel:
+        await _schedule_dashboard_pty_cleanup(channel, session)
+    else:
+        await _close_dashboard_pty_session(None, session)
+
+
 @app.websocket("/api/pty")
 async def pty_ws(ws: WebSocket) -> None:
     if not _DASHBOARD_EMBEDDED_CHAT_ENABLED:
@@ -3430,22 +3645,26 @@ async def pty_ws(ws: WebSocket) -> None:
         await ws.close(code=1011)
         return
 
-    # --- spawn PTY ------------------------------------------------------
+    loop = asyncio.get_running_loop()
+
+    # --- spawn or reattach PTY -----------------------------------------
     resume = ws.query_params.get("resume") or None
     channel = _channel_or_close_code(ws)
     sidecar_url = _build_sidecar_url(channel) if channel else None
 
     try:
-        argv, cwd, env = _resolve_chat_argv(resume=resume, sidecar_url=sidecar_url)
+        session = await _get_dashboard_pty_session(
+            channel=channel,
+            resume=resume,
+            sidecar_url=sidecar_url,
+            loop=loop,
+        )
+        await _attach_dashboard_pty_session(session, ws)
     except SystemExit as exc:
         # _make_tui_argv calls sys.exit(1) when node/npm is missing.
         await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")
         await ws.close(code=1011)
         return
-
-
-    try:
-        bridge = PtyBridge.spawn(argv, cwd=cwd, env=env)
     except PtyUnavailableError as exc:
         await ws.send_text(f"\r\n\x1b[31mChat unavailable: {exc}\x1b[0m\r\n")
         await ws.close(code=1011)
@@ -3454,26 +3673,6 @@ async def pty_ws(ws: WebSocket) -> None:
         await ws.send_text(f"\r\n\x1b[31mChat failed to start: {exc}\x1b[0m\r\n")
         await ws.close(code=1011)
         return
-
-    loop = asyncio.get_running_loop()
-
-    # --- reader task: PTY master → WebSocket ----------------------------
-    async def pump_pty_to_ws() -> None:
-        while True:
-            chunk = await loop.run_in_executor(
-                None, bridge.read, _PTY_READ_CHUNK_TIMEOUT
-            )
-            if chunk is None:  # EOF
-                return
-            if not chunk:  # no data this tick; yield control and retry
-                await asyncio.sleep(0)
-                continue
-            try:
-                await ws.send_bytes(chunk)
-            except Exception:
-                return
-
-    reader_task = asyncio.create_task(pump_pty_to_ws())
 
     # --- writer loop: WebSocket → PTY master ----------------------------
     try:
@@ -3494,19 +3693,14 @@ async def pty_ws(ws: WebSocket) -> None:
             if match and match.end() == len(raw):
                 cols = int(match.group(1))
                 rows = int(match.group(2))
-                bridge.resize(cols=cols, rows=rows)
+                session.bridge.resize(cols=cols, rows=rows)
                 continue
 
-            bridge.write(raw)
+            session.bridge.write(raw)
     except WebSocketDisconnect:
         pass
     finally:
-        reader_task.cancel()
-        try:
-            await reader_task
-        except (asyncio.CancelledError, Exception):
-            pass
-        bridge.close()
+        await _detach_dashboard_pty_session(channel, session, ws)
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3691,6 +3691,7 @@ async def pty_ws(ws: WebSocket) -> None:
     channel = _channel_or_close_code(ws)
     sidecar_url = _build_sidecar_url(channel) if channel else None
 
+    session: Optional[_DashboardPtySession] = None
     try:
         session = await _get_dashboard_pty_session(
             channel=channel,
@@ -3710,6 +3711,16 @@ async def pty_ws(ws: WebSocket) -> None:
         return
     except (FileNotFoundError, OSError) as exc:
         await ws.send_text(f"\r\n\x1b[31mChat failed to start: {exc}\x1b[0m\r\n")
+        await ws.close(code=1011)
+        return
+    except Exception as exc:
+        if session is not None:
+            await _detach_dashboard_pty_session(channel, session, ws)
+        _log.exception("Dashboard PTY attach failed")
+        try:
+            await ws.send_text(f"\r\n\x1b[31mChat connection failed: {exc}\x1b[0m\r\n")
+        except Exception:
+            pass
         await ws.close(code=1011)
         return
 

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -1159,6 +1159,44 @@ class SessionDB:
             current = row["id"]
         return current
 
+    @staticmethod
+    def _resumable_session_predicate(alias: str = "s") -> str:
+        """SQL predicate for logical sessions that can resume to messages.
+
+        Compression roots may have ``message_count = 0`` while their live
+        continuation child holds the messages. Treat those roots as resumable
+        too so list/count callers don't hide valid compressed conversations.
+        """
+        return f"""
+            (
+                EXISTS (
+                    SELECT 1 FROM messages m
+                    WHERE m.session_id = {alias}.id
+                    LIMIT 1
+                )
+                OR EXISTS (
+                    WITH RECURSIVE compression_chain(id) AS (
+                        SELECT child.id
+                        FROM sessions child
+                        WHERE child.parent_session_id = {alias}.id
+                          AND {alias}.end_reason = 'compression'
+                          AND child.started_at >= COALESCE({alias}.ended_at, {alias}.started_at)
+                        UNION ALL
+                        SELECT child.id
+                        FROM compression_chain cc
+                        JOIN sessions parent ON parent.id = cc.id
+                        JOIN sessions child ON child.parent_session_id = parent.id
+                        WHERE parent.end_reason = 'compression'
+                          AND child.started_at >= COALESCE(parent.ended_at, parent.started_at)
+                    )
+                    SELECT 1
+                    FROM compression_chain cc
+                    JOIN messages m ON m.session_id = cc.id
+                    LIMIT 1
+                )
+            )
+        """
+
     def list_sessions_rich(
         self,
         source: str = None,
@@ -1168,6 +1206,7 @@ class SessionDB:
         include_children: bool = False,
         project_compression_tips: bool = True,
         order_by_last_active: bool = False,
+        resumable_only: bool = False,
     ) -> List[Dict[str, Any]]:
         """List sessions with preview (first user message) and last active timestamp.
 
@@ -1220,6 +1259,8 @@ class SessionDB:
             placeholders = ",".join("?" for _ in exclude_sources)
             where_clauses.append(f"s.source NOT IN ({placeholders})")
             params.extend(exclude_sources)
+        if resumable_only:
+            where_clauses.append(self._resumable_session_predicate("s"))
 
         where_sql = f"WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
         if order_by_last_active:
@@ -2415,15 +2456,41 @@ class SessionDB:
     # Utility
     # =========================================================================
 
-    def session_count(self, source: str = None) -> int:
-        """Count sessions, optionally filtered by source."""
+    def session_count(
+        self,
+        source: str = None,
+        exclude_sources: List[str] = None,
+        resumable_only: bool = False,
+        include_children: bool = True,
+    ) -> int:
+        """Count sessions, optionally using the same coarse filters as listings."""
+        where_clauses = []
+        params = []
+
+        if not include_children:
+            where_clauses.append(
+                "(s.parent_session_id IS NULL"
+                " OR EXISTS (SELECT 1 FROM sessions p"
+                "            WHERE p.id = s.parent_session_id"
+                "            AND p.end_reason = 'branched'"
+                "            AND s.started_at >= p.ended_at))"
+            )
+        if source:
+            where_clauses.append("s.source = ?")
+            params.append(source)
+        if exclude_sources:
+            placeholders = ",".join("?" for _ in exclude_sources)
+            where_clauses.append(f"s.source NOT IN ({placeholders})")
+            params.extend(exclude_sources)
+        if resumable_only:
+            where_clauses.append(self._resumable_session_predicate("s"))
+
+        where_sql = f" WHERE {' AND '.join(where_clauses)}" if where_clauses else ""
         with self._lock:
-            if source:
-                cursor = self._conn.execute(
-                    "SELECT COUNT(*) FROM sessions WHERE source = ?", (source,)
-                )
-            else:
-                cursor = self._conn.execute("SELECT COUNT(*) FROM sessions")
+            cursor = self._conn.execute(
+                f"SELECT COUNT(*) FROM sessions s{where_sql}",
+                params,
+            )
             return cursor.fetchone()[0]
 
     def message_count(self, session_id: str = None) -> int:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -125,6 +125,55 @@ class TestWebServerEndpoints:
         assert "hermes_home" in data
         assert "active_sessions" in data
 
+    def test_get_sessions_defaults_hide_cron_and_empty_sessions(self):
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(
+                session_id="visible-cli",
+                source="cli",
+                model="test-model",
+            )
+            db.set_session_title("visible-cli", "Visible CLI")
+            db.append_message("visible-cli", role="user", content="hello dashboard")
+            db.end_session("visible-cli", "test")
+
+            db.create_session(
+                session_id="cron-with-message",
+                source="cron",
+                model="test-model",
+            )
+            db.set_session_title("cron-with-message", "Cron Should Hide")
+            db.append_message("cron-with-message", role="user", content="cron output")
+            db.end_session("cron-with-message", "test")
+
+            db.create_session(
+                session_id="empty-cli",
+                source="cli",
+                model="test-model",
+            )
+            db.set_session_title("empty-cli", "Empty Should Hide")
+            db.end_session("empty-cli", "test")
+        finally:
+            db.close()
+
+        resp = self.client.get("/api/sessions?limit=20&offset=0")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        ids = [s["id"] for s in data["sessions"]]
+
+        assert ids == ["visible-cli"]
+        assert data["total"] == 1
+        assert data["limit"] == 20
+        assert data["offset"] == 0
+
+        session = data["sessions"][0]
+        assert session["source"] == "cli"
+        assert session["message_count"] == 1
+        assert session["title"] == "Visible CLI"
+
     def test_get_status_filters_unconfigured_gateway_platforms(self, monkeypatch):
         import gateway.config as gateway_config
         import hermes_cli.web_server as web_server
@@ -2082,6 +2131,13 @@ class TestPtyWebSocket:
         monkeypatch.setattr(ws, "_DASHBOARD_EMBEDDED_CHAT_ENABLED", True)
         self.token = ws._SESSION_TOKEN
         self.client = TestClient(ws.app)
+        yield
+        for session in list(getattr(ws, "_dashboard_pty_sessions", {}).values()):
+            try:
+                session.bridge.close()
+            except Exception:
+                pass
+        getattr(ws, "_dashboard_pty_sessions", {}).clear()
 
     def _url(self, token: str | None = None, **params: str) -> str:
         tok = token if token is not None else self.token
@@ -2295,6 +2351,53 @@ class TestPtyWebSocket:
         assert url.startswith("ws://127.0.0.1:9119/api/pub?")
         assert "channel=abc-123" in url
         assert "token=" in url
+
+    def test_channel_disconnect_keeps_pty_alive_for_reconnect(self, monkeypatch):
+        import time
+
+        class FakeBridge:
+            def __init__(self):
+                self.closed = 0
+                self.writes: list[bytes] = []
+                self.resizes: list[tuple[int, int]] = []
+
+            def read(self, timeout):
+                time.sleep(min(float(timeout or 0), 0.01))
+                return b""
+
+            def write(self, raw):
+                self.writes.append(raw)
+
+            def resize(self, cols, rows):
+                self.resizes.append((cols, rows))
+
+            def close(self):
+                self.closed += 1
+
+        fake = FakeBridge()
+        spawns: list[FakeBridge] = []
+        monkeypatch.setattr(
+            self.ws_module,
+            "_resolve_chat_argv",
+            lambda resume=None, sidecar_url=None: (["/bin/cat"], None, None),
+        )
+        monkeypatch.setattr(
+            self.ws_module.PtyBridge,
+            "spawn",
+            classmethod(lambda cls, *a, **k: spawns.append(fake) or fake),
+        )
+
+        with self.client.websocket_connect(self._url(channel="persist-test")) as conn:
+            conn.send_bytes(b"first\n")
+
+        time.sleep(0.05)
+        assert fake.closed == 0
+
+        with self.client.websocket_connect(self._url(channel="persist-test")) as conn:
+            conn.send_bytes(b"second\n")
+
+        assert len(spawns) == 1
+        assert fake.writes == [b"first\n", b"second\n"]
 
     def test_pub_broadcasts_to_events_subscribers(self, monkeypatch):
         """Frame written to /api/pub is rebroadcast verbatim to every

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -174,6 +174,79 @@ class TestWebServerEndpoints:
         assert session["message_count"] == 1
         assert session["title"] == "Visible CLI"
 
+    def test_get_most_recent_session_filters_internal_and_empty_rows(self):
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(
+                session_id="older-cli",
+                source="cli",
+                model="test-model",
+            )
+            db.append_message("older-cli", role="user", content="older user work")
+            db.end_session("older-cli", "test")
+
+            db.create_session(
+                session_id="newer-cron",
+                source="cron",
+                model="test-model",
+            )
+            db.append_message("newer-cron", role="user", content="cron output")
+            db.end_session("newer-cron", "test")
+
+            db.create_session(
+                session_id="newer-empty-cli",
+                source="cli",
+                model="test-model",
+            )
+            db.end_session("newer-empty-cli", "test")
+
+            db.create_session(
+                session_id="latest-cli",
+                source="cli",
+                model="test-model",
+            )
+            db.append_message("latest-cli", role="user", content="latest user work")
+            db.end_session("latest-cli", "test")
+        finally:
+            db.close()
+
+        resp = self.client.get("/api/sessions/most-recent")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert data["session_id"] == "latest-cli"
+        assert data["source"] == "cli"
+        assert data["title"] == ""
+
+    def test_get_most_recent_session_returns_null_without_resumable_rows(self):
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            db.create_session(
+                session_id="cron-only",
+                source="cron",
+                model="test-model",
+            )
+            db.append_message("cron-only", role="user", content="cron output")
+            db.end_session("cron-only", "test")
+
+            db.create_session(
+                session_id="empty-cli-only",
+                source="cli",
+                model="test-model",
+            )
+            db.end_session("empty-cli-only", "test")
+        finally:
+            db.close()
+
+        resp = self.client.get("/api/sessions/most-recent")
+
+        assert resp.status_code == 200
+        assert resp.json() == {"session_id": None}
+
     def test_get_status_filters_unconfigured_gateway_platforms(self, monkeypatch):
         import gateway.config as gateway_config
         import hermes_cli.web_server as web_server

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2425,6 +2425,38 @@ class TestPtyWebSocket:
         assert "channel=abc-123" in url
         assert "token=" in url
 
+    def test_attach_failure_detaches_dead_websocket(self, monkeypatch):
+        """A client drop during buffered replay must not leave session.ws stuck.
+
+        The next reconnect relies on session.ws being clear; otherwise the PTY
+        session can sit attached to a dead socket until a later writer failure.
+        """
+        class FakeBridge:
+            def close(self):
+                pass
+
+        session = self.ws_module._DashboardPtySession(FakeBridge())
+
+        async def fake_get_session(**_kwargs):
+            return session
+
+        async def fake_attach(sess, ws):
+            sess.ws = ws
+            raise RuntimeError("client dropped during replay")
+
+        monkeypatch.setattr(
+            self.ws_module, "_get_dashboard_pty_session", fake_get_session
+        )
+        monkeypatch.setattr(
+            self.ws_module, "_attach_dashboard_pty_session", fake_attach
+        )
+
+        with self.client.websocket_connect(self._url(channel="attach-fail")) as conn:
+            msg = conn.receive_text()
+
+        assert "Chat connection failed" in msg
+        assert session.ws is None
+
     def test_channel_disconnect_keeps_pty_alive_for_reconnect(self, monkeypatch):
         import time
 

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -2348,6 +2348,55 @@ class TestCompressionChainProjection:
         assert tip_row["ended_at"] is None  # tip is still live
         assert tip_row["end_reason"] is None
 
+    def test_resumable_only_includes_empty_compression_root_with_message_tip(self, db):
+        """A compressed root can have zero own messages while its continuation
+        has the usable transcript; resumable-only views must keep that logical
+        conversation visible.
+        """
+        import time as _time
+
+        t0 = _time.time() - 3600
+        db.create_session("empty-root", "cli")
+        db._conn.execute(
+            "UPDATE sessions SET started_at=?, ended_at=?, end_reason=? WHERE id=?",
+            (t0, t0 + 100, "compression", "empty-root"),
+        )
+        db.create_session("message-tip", "cli", parent_session_id="empty-root")
+        db._conn.execute(
+            "UPDATE sessions SET started_at=? WHERE id=?", (t0 + 101, "message-tip")
+        )
+        db.append_message("message-tip", "user", "resume me")
+        db._conn.commit()
+
+        sessions = db.list_sessions_rich(
+            source="cli", exclude_sources=["tool", "cron"], resumable_only=True
+        )
+
+        assert [s["id"] for s in sessions] == ["message-tip"]
+        assert sessions[0]["_lineage_root_id"] == "empty-root"
+        assert db.session_count(
+            source="cli",
+            exclude_sources=["tool", "cron"],
+            resumable_only=True,
+            include_children=False,
+        ) == 1
+
+    def test_resumable_only_does_not_count_empty_orphan_compression_root(self, db):
+        import time as _time
+
+        t0 = _time.time() - 3600
+        db.create_session("empty-root", "cli")
+        db._conn.execute(
+            "UPDATE sessions SET started_at=?, ended_at=?, end_reason=? WHERE id=?",
+            (t0, t0 + 100, "compression", "empty-root"),
+        )
+        db._conn.commit()
+
+        assert db.list_sessions_rich(source="cli", resumable_only=True) == []
+        assert db.session_count(
+            source="cli", resumable_only=True, include_children=False
+        ) == 0
+
     def test_list_without_projection_returns_raw_root(self, db):
         """project_compression_tips=False returns the raw parent-NULL root
         rows — useful for admin/debug UIs.

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -59,6 +59,24 @@ def test_write_json_returns_false_on_broken_pipe(monkeypatch):
     assert server.write_json({"ok": True}) is False
 
 
+def test_session_info_exposes_persistent_resume_session_id(monkeypatch):
+    agent = types.SimpleNamespace(
+        session_id="session_20260519_123456_abcd12",
+        model="test-model",
+        provider="openrouter",
+        base_url="",
+        tools=[],
+    )
+
+    monkeypatch.setattr(server, "_current_profile_name", lambda: "default")
+    monkeypatch.setattr(server, "_get_usage", lambda _agent: {})
+
+    info = server._session_info(agent)
+
+    assert info["session_id"] == "session_20260519_123456_abcd12"
+    assert info["model"] == "test-model"
+
+
 def test_dispatch_rejects_non_object_request():
     resp = server.dispatch([])
 

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3289,6 +3289,42 @@ def test_session_list_returns_clean_error_when_state_db_is_unavailable(monkeypat
     assert "state.db unavailable: locking protocol" in resp["error"]["message"]
 
 
+def test_session_list_hides_cron_tool_and_empty_rows(monkeypatch):
+    class _DB:
+        def list_sessions_rich(self, **kwargs):
+            assert kwargs["source"] is None
+            assert kwargs["exclude_sources"] == ["tool", "cron"]
+            assert kwargs["resumable_only"] is True
+            return [
+                {
+                    "id": "human-1",
+                    "source": "tui",
+                    "title": "Human chat",
+                    "preview": "hello",
+                    "started_at": 100,
+                    "message_count": 2,
+                }
+            ]
+
+    monkeypatch.setattr(server, "_get_db", lambda: _DB())
+
+    resp = server.handle_request(
+        {"id": "1", "method": "session.list", "params": {"limit": 20}}
+    )
+
+    assert "error" not in resp
+    assert resp["result"]["sessions"] == [
+        {
+            "id": "human-1",
+            "title": "Human chat",
+            "preview": "hello",
+            "started_at": 100,
+            "message_count": 2,
+            "source": "tui",
+        }
+    ]
+
+
 # --------------------------------------------------------------------------
 # session.delete — TUI resume picker `d` key
 # --------------------------------------------------------------------------
@@ -3731,9 +3767,11 @@ def test_session_most_recent_returns_first_non_denied(monkeypatch):
     """Drops `tool` rows like session.list does, returns the first hit."""
 
     class _DB:
-        def list_sessions_rich(self, *, source=None, limit=200):
+        def list_sessions_rich(self, **kwargs):
+            assert kwargs["source"] is None
+            assert kwargs["exclude_sources"] == ["tool", "cron"]
+            assert kwargs["resumable_only"] is True
             return [
-                {"id": "tool-1", "source": "tool", "title": "noise", "started_at": 100},
                 {"id": "tui-1", "source": "tui", "title": "real", "started_at": 99},
             ]
 
@@ -3750,8 +3788,10 @@ def test_session_most_recent_returns_first_non_denied(monkeypatch):
 
 def test_session_most_recent_returns_null_when_only_tool_rows(monkeypatch):
     class _DB:
-        def list_sessions_rich(self, *, source=None, limit=200):
-            return [{"id": "tool-1", "source": "tool", "started_at": 1}]
+        def list_sessions_rich(self, **kwargs):
+            assert kwargs["exclude_sources"] == ["tool", "cron"]
+            assert kwargs["resumable_only"] is True
+            return []
 
     monkeypatch.setattr(server, "_get_db", lambda: _DB())
 
@@ -3768,7 +3808,7 @@ def test_session_most_recent_folds_db_exception_into_null_result(monkeypatch):
     'no answer' (Copilot review on #17130)."""
 
     class _BrokenDB:
-        def list_sessions_rich(self, *, source=None, limit=200):
+        def list_sessions_rich(self, **kwargs):
             raise RuntimeError("db locked")
 
     monkeypatch.setattr(server, "_get_db", lambda: _BrokenDB())

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1394,6 +1394,11 @@ def _session_info(agent) -> dict:
         reasoning_effort = str(reasoning_config.get("effort", "") or "")
     service_tier = getattr(agent, "service_tier", None) or ""
     info: dict = {
+        # Persistent SessionDB id used by /resume and dashboard recovery.
+        # This is intentionally distinct from the short in-process gateway sid
+        # carried in event envelopes; the latter dies with the TUI process and
+        # must never be saved as a resume target.
+        "session_id": getattr(agent, "session_id", "") or "",
         "model": getattr(agent, "model", ""),
         "reasoning_effort": reasoning_effort,
         "service_tier": service_tier,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2180,21 +2180,30 @@ def _(rid, params: dict) -> dict:
         # user-facing surface — CLI, TUI, all gateway platforms (including new
         # ones not enumerated here), ACP adapter clients, webhook sessions,
         # custom `HERMES_SESSION_SOURCE` values, and older installs with
-        # different source labels. We deny-list only the noisy internal
-        # sources (``tool`` sub-agent runs) rather than allow-listing a
-        # fixed set of platform names that goes stale whenever a new
-        # platform is added or a user names their own source.
-        deny = frozenset({"tool"})
+        # different source labels. We deny-list only noisy internal/scheduled
+        # sources and require non-empty sessions so cron jobs, background tool
+        # rows, failed smoke tests, and accidental blank sessions do not crowd
+        # the resume picker.
+        deny = ["tool", "cron"]
 
         limit = int(params.get("limit", 200) or 200)
-        # Over-fetch modestly so per-source filtering doesn't leave us
-        # short; the compression-tip projection in ``list_sessions_rich``
-        # can also merge rows.
+        # Over-fetch modestly so compression-tip projection doesn't leave us
+        # short after rows are merged.
         fetch_limit = max(limit * 2, 200)
+        raw_rows = db.list_sessions_rich(
+            source=None,
+            exclude_sources=deny,
+            resumable_only=True,
+            limit=fetch_limit,
+        )
+        # Keep a defensive post-filter for older/stub DB implementations that
+        # may ignore newer filtering kwargs; the real DB already applies these
+        # at query time.
         rows = [
             s
-            for s in db.list_sessions_rich(source=None, limit=fetch_limit)
-            if (s.get("source") or "").strip().lower() not in deny
+            for s in raw_rows
+            if (s.get("source") or "") not in deny
+            and ("message_count" not in s or (s.get("message_count") or 0) > 0)
         ][:limit]
         return _ok(
             rid,
@@ -2221,7 +2230,8 @@ def _(rid, params: dict) -> dict:
     """Return the most recent human-facing session id, or ``None``.
 
     Mirrors ``session.list``'s deny-list behaviour (drops ``tool``
-    sub-agent rows).  Used by TUI auto-resume when
+    sub-agent rows, ``cron`` scheduled-job rows, and empty sessions).
+    Used by TUI auto-resume when
     ``display.tui_auto_resume_recent`` is on; the field is also handy
     for any CLI tooling that wants "latest session" without paginating
     the full list.
@@ -2235,16 +2245,22 @@ def _(rid, params: dict) -> dict:
     if db is None:
         return _ok(rid, {"session_id": None})
     try:
-        deny = frozenset({"tool"})
-        # Over-fetch by a generous bounded amount so heavy sub-agent
-        # users (lots of recent ``tool`` rows) don't get a false
-        # "no eligible session" answer.  ``session.list`` uses a
-        # similar over-fetch strategy.
-        rows = db.list_sessions_rich(source=None, limit=200)
+        deny = ["tool", "cron"]
+        # Over-fetch by a generous bounded amount so compression projection
+        # does not leave us with a false "no eligible session" answer.
+        raw_rows = db.list_sessions_rich(
+            source=None,
+            exclude_sources=deny,
+            resumable_only=True,
+            limit=200,
+        )
+        rows = [
+            row
+            for row in raw_rows
+            if (row.get("source") or "") not in deny
+            and ("message_count" not in row or (row.get("message_count") or 0) > 0)
+        ]
         for row in rows:
-            src = (row.get("source") or "").strip().lower()
-            if src in deny:
-                continue
             return _ok(
                 rid,
                 {

--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -44,6 +44,7 @@ interface SessionInfo {
   cwd?: string;
   model?: string;
   provider?: string;
+  session_id?: string;
   credential_warning?: string;
 }
 
@@ -208,9 +209,15 @@ export function ChatSidebar({ channel, className }: ChatSidebarProps) {
       const { type, payload, session_id: eventSessionId } = frame.params;
 
       if (type === "session.info") {
-        rememberChatSessionId(eventSessionId);
+        const infoPayload = payload as SessionInfo | undefined;
+        // eventSessionId is the short, in-process TUI gateway id. It is useful
+        // for routing live events, but it is not a durable SessionDB id and
+        // cannot be used with /resume after a dashboard reload. Prefer the
+        // persistent id included in the session.info payload; only older
+        // backends without that field fall back to the event envelope.
+        rememberChatSessionId(infoPayload?.session_id ?? eventSessionId);
         if (payload) {
-          setInfo((prev) => ({ ...prev, ...(payload as SessionInfo) }));
+          setInfo((prev) => ({ ...prev, ...infoPayload }));
         }
         return;
       }

--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -29,8 +29,12 @@ import { Card } from "@/components/ui/card";
 
 import { ModelPickerDialog } from "@/components/ModelPickerDialog";
 import { ToolCall, type ToolEntry } from "@/components/ToolCall";
-import { GatewayClient, type ConnectionState } from "@/lib/gatewayClient";
 import { HERMES_BASE_PATH } from "@/lib/api";
+import { GatewayClient, type ConnectionState } from "@/lib/gatewayClient";
+import {
+  rememberChatSessionId,
+  scheduleDashboardAuthReload,
+} from "@/lib/chatRecovery";
 
 import { cn } from "@/lib/utils";
 import { AlertCircle, ChevronDown, RefreshCw } from "lucide-react";
@@ -45,7 +49,7 @@ interface SessionInfo {
 
 interface RpcEnvelope {
   method?: string;
-  params?: { type?: string; payload?: unknown };
+  params?: { type?: string; session_id?: string; payload?: unknown };
 }
 
 const TOOL_LIMIT = 20;
@@ -174,8 +178,15 @@ export function ChatSidebar({ channel, className }: ChatSidebarProps) {
     ws.addEventListener("error", () => surface(DISCONNECTED));
 
     ws.addEventListener("close", (ev) => {
-      if (ev.code === 4401 || ev.code === 4403) {
-        surface(`events feed rejected (${ev.code}) — reload the page`);
+      if (ev.code === 4401) {
+        const reloadQueued = scheduleDashboardAuthReload();
+        surface(
+          reloadQueued
+            ? "events feed token expired — reloading dashboard"
+            : "events feed rejected (4401) — reload the page",
+        );
+      } else if (ev.code === 4403) {
+        surface("events feed rejected (4403) — reload the page");
       } else if (ev.code !== 1000) {
         surface(DISCONNECTED);
       }
@@ -194,7 +205,15 @@ export function ChatSidebar({ channel, className }: ChatSidebarProps) {
         return;
       }
 
-      const { type, payload } = frame.params;
+      const { type, payload, session_id: eventSessionId } = frame.params;
+
+      if (type === "session.info") {
+        rememberChatSessionId(eventSessionId);
+        if (payload) {
+          setInfo((prev) => ({ ...prev, ...(payload as SessionInfo) }));
+        }
+        return;
+      }
 
       if (type === "tool.start") {
         const p = payload as

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -65,6 +65,8 @@ export const api = {
   getStatus: () => fetchJSON<StatusResponse>("/api/status"),
   getSessions: (limit = 20, offset = 0) =>
     fetchJSON<PaginatedSessions>(`/api/sessions?limit=${limit}&offset=${offset}`),
+  getMostRecentSession: () =>
+    fetchJSON<MostRecentSessionResponse>("/api/sessions/most-recent"),
   getSessionMessages: (id: string) =>
     fetchJSON<SessionMessagesResponse>(`/api/sessions/${encodeURIComponent(id)}/messages`),
   getSessionLatestDescendant: (id: string) =>
@@ -404,6 +406,13 @@ export interface SessionLatestDescendantResponse {
   session_id: string;
   path: string[];
   changed: boolean;
+}
+
+export interface MostRecentSessionResponse {
+  session_id: string | null;
+  title?: string;
+  started_at?: number;
+  source?: string;
 }
 
 export interface PaginatedSessions {

--- a/web/src/lib/chatRecovery.ts
+++ b/web/src/lib/chatRecovery.ts
@@ -1,0 +1,66 @@
+const LAST_SESSION_KEY = "hermes.chat.lastSessionId";
+const RECOVER_AFTER_AUTH_RELOAD_KEY = "hermes.chat.recoverAfterAuthReload";
+const AUTH_RELOAD_AT_KEY = "hermes.chat.authReloadAt";
+
+const SESSION_ID_RE = /^[A-Za-z0-9_.:-]{1,160}$/;
+const AUTH_RELOAD_GUARD_MS = 5000;
+
+function storage(): Storage | null {
+  if (typeof window === "undefined") return null;
+  try {
+    return window.sessionStorage;
+  } catch {
+    return null;
+  }
+}
+
+function validSessionId(sessionId: string | null | undefined): sessionId is string {
+  return !!sessionId && SESSION_ID_RE.test(sessionId);
+}
+
+export function rememberChatSessionId(sessionId: string | null | undefined): void {
+  if (!validSessionId(sessionId)) return;
+  storage()?.setItem(LAST_SESSION_KEY, sessionId);
+}
+
+export function getRememberedChatSessionId(): string | null {
+  const value = storage()?.getItem(LAST_SESSION_KEY) ?? null;
+  return validSessionId(value) ? value : null;
+}
+
+export function requestChatRecoveryAfterAuthReload(
+  sessionId?: string | null,
+): void {
+  rememberChatSessionId(sessionId);
+  storage()?.setItem(RECOVER_AFTER_AUTH_RELOAD_KEY, "1");
+}
+
+export function consumeChatRecoveryAfterAuthReload(): boolean {
+  const store = storage();
+  if (!store?.getItem(RECOVER_AFTER_AUTH_RELOAD_KEY)) return false;
+  store.removeItem(RECOVER_AFTER_AUTH_RELOAD_KEY);
+  return true;
+}
+
+export function scheduleDashboardAuthReload({
+  sessionId,
+  delayMs = 600,
+}: {
+  sessionId?: string | null;
+  delayMs?: number;
+} = {}): boolean {
+  if (typeof window === "undefined") return false;
+
+  requestChatRecoveryAfterAuthReload(sessionId ?? getRememberedChatSessionId());
+
+  const store = storage();
+  const now = Date.now();
+  const lastReloadAt = Number(store?.getItem(AUTH_RELOAD_AT_KEY) ?? "0");
+  if (lastReloadAt && now - lastReloadAt < AUTH_RELOAD_GUARD_MS) {
+    return false;
+  }
+
+  store?.setItem(AUTH_RELOAD_AT_KEY, String(now));
+  window.setTimeout(() => window.location.reload(), Math.max(0, delayMs));
+  return true;
+}

--- a/web/src/lib/chatRecovery.ts
+++ b/web/src/lib/chatRecovery.ts
@@ -14,13 +14,29 @@ function storage(): Storage | null {
   }
 }
 
+function setStorageItem(key: string, value: string): void {
+  try {
+    storage()?.setItem(key, value);
+  } catch {
+    // Storage can be disabled or quota-limited in some browser modes.
+  }
+}
+
+function removeStorageItem(key: string): void {
+  try {
+    storage()?.removeItem(key);
+  } catch {
+    // Storage can be disabled or quota-limited in some browser modes.
+  }
+}
+
 function validSessionId(sessionId: string | null | undefined): sessionId is string {
   return !!sessionId && SESSION_ID_RE.test(sessionId);
 }
 
 export function rememberChatSessionId(sessionId: string | null | undefined): void {
   if (!validSessionId(sessionId)) return;
-  storage()?.setItem(LAST_SESSION_KEY, sessionId);
+  setStorageItem(LAST_SESSION_KEY, sessionId);
 }
 
 export function getRememberedChatSessionId(): string | null {
@@ -32,13 +48,13 @@ export function requestChatRecoveryAfterAuthReload(
   sessionId?: string | null,
 ): void {
   rememberChatSessionId(sessionId);
-  storage()?.setItem(RECOVER_AFTER_AUTH_RELOAD_KEY, "1");
+  setStorageItem(RECOVER_AFTER_AUTH_RELOAD_KEY, "1");
 }
 
 export function consumeChatRecoveryAfterAuthReload(): boolean {
   const store = storage();
   if (!store?.getItem(RECOVER_AFTER_AUTH_RELOAD_KEY)) return false;
-  store.removeItem(RECOVER_AFTER_AUTH_RELOAD_KEY);
+  removeStorageItem(RECOVER_AFTER_AUTH_RELOAD_KEY);
   return true;
 }
 
@@ -60,7 +76,7 @@ export function scheduleDashboardAuthReload({
     return false;
   }
 
-  store?.setItem(AUTH_RELOAD_AT_KEY, String(now));
+  setStorageItem(AUTH_RELOAD_AT_KEY, String(now));
   window.setTimeout(() => window.location.reload(), Math.max(0, delayMs));
   return true;
 }

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -67,11 +67,15 @@ function generateChannelId(): string {
 function getOrCreateChannelId(resume: string | null): string {
   if (typeof window === "undefined") return generateChannelId();
   const key = `hermes.chat.channel.${resume || "new"}`;
-  const existing = window.sessionStorage.getItem(key);
-  if (existing && /^[A-Za-z0-9._-]{1,128}$/.test(existing)) return existing;
-  const next = generateChannelId();
-  window.sessionStorage.setItem(key, next);
-  return next;
+  try {
+    const existing = window.sessionStorage.getItem(key);
+    if (existing && /^[A-Za-z0-9._-]{1,128}$/.test(existing)) return existing;
+    const next = generateChannelId();
+    window.sessionStorage.setItem(key, next);
+    return next;
+  } catch {
+    return generateChannelId();
+  }
 }
 
 // Colors for the terminal body.  Matches the dashboard's dark teal canvas
@@ -175,12 +179,20 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     const pending = consumeChatRecoveryAfterAuthReload();
     return !resumeParam && pending;
   });
-  const channel = useMemo(() => getOrCreateChannelId(resumeParam), [resumeParam]);
-
-  useEffect(() => {
-    if (!resumeParam) return;
-    rememberChatSessionId(resumeParam);
-  }, [resumeParam]);
+  const [resolvedResume, setResolvedResume] = useState<{
+    source: string | null;
+    target: string | null;
+  }>({ source: null, target: null });
+  const resumeResolutionPending = !!resumeParam && resolvedResume.source !== resumeParam;
+  const activeResumeParam = resumeParam
+    ? resumeResolutionPending
+      ? null
+      : (resolvedResume.target ?? resumeParam)
+    : null;
+  const channel = useMemo(
+    () => getOrCreateChannelId(activeResumeParam),
+    [activeResumeParam],
+  );
 
   useEffect(() => {
     if (!recoveryPending || resumeParam) return;
@@ -226,29 +238,41 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   }, [recoveryPending, resumeParam, searchParams, setSearchParams]);
 
   useEffect(() => {
-    if (!resumeParam) return;
+    if (!resumeParam) {
+      return;
+    }
+
+    if (resolvedResume.source === resumeParam) {
+      return;
+    }
 
     let cancelled = false;
 
     api
       .getSessionLatestDescendant(resumeParam)
       .then((res) => {
-        if (cancelled || !res.session_id || res.session_id === resumeParam) {
-          return;
-        }
+        if (cancelled) return;
+        const target = res.session_id || resumeParam;
+        rememberChatSessionId(target);
+        setResolvedResume({ source: resumeParam, target });
 
-        const next = new URLSearchParams(searchParams);
-        next.set("resume", res.session_id);
-        setSearchParams(next, { replace: true });
+        if (target !== resumeParam) {
+          const next = new URLSearchParams(searchParams);
+          next.set("resume", target);
+          setSearchParams(next, { replace: true });
+        }
       })
       .catch(() => {
+        if (cancelled) return;
         // Best-effort: old servers or missing sessions should not block chat.
+        rememberChatSessionId(resumeParam);
+        setResolvedResume({ source: resumeParam, target: resumeParam });
       });
 
     return () => {
       cancelled = true;
     };
-  }, [resumeParam, searchParams, setSearchParams]);
+  }, [resumeParam, resolvedResume.source, searchParams, setSearchParams]);
 
   useEffect(() => {
     const mql = window.matchMedia("(max-width: 1023px)");
@@ -341,7 +365,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     if (!token) {
       return;
     }
-    if (recoveryPending && !resumeParam) {
+    if ((recoveryPending && !resumeParam) || resumeResolutionPending) {
       return;
     }
 
@@ -622,7 +646,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
 
     const connectWebSocket = (attempt = 0) => {
       if (unmounting) return;
-      const url = buildWsUrl(token, resumeParam, channel);
+      const url = buildWsUrl(token, activeResumeParam, channel);
       const ws = new WebSocket(url);
       ws.binaryType = "arraybuffer";
       wsRef.current = ws;
@@ -646,7 +670,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         if (unmounting) return;
         if (ev.code === 4401) {
           const reloadQueued = scheduleDashboardAuthReload({
-            sessionId: resumeParam ?? getRememberedChatSessionId(),
+            sessionId: activeResumeParam ?? resumeParam ?? getRememberedChatSessionId(),
           });
           setBanner(
             reloadQueued
@@ -733,7 +757,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         copyResetRef.current = null;
       }
     };
-  }, [channel, recoveryPending, resumeParam]);
+  }, [channel, activeResumeParam, recoveryPending, resumeParam, resumeResolutionPending]);
 
   // When the user returns to the chat tab (isActive: false → true), the
   // terminal host just transitioned from display:none to display:flex.
@@ -800,7 +824,9 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   // descendants below those layers (see Toast.tsx).
   const statusBanner = banner ?? (recoveryPending && !resumeParam
     ? "Recovering previous chat session…"
-    : null);
+    : resumeResolutionPending
+      ? "Resolving chat session…"
+      : null);
 
   const mobileModelToolsPortal =
     isActive &&

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -208,29 +208,44 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       setRecoveryPending(false);
     };
 
+    const recoverFromMostRecent = () => {
+      api
+        .getMostRecentSession()
+        .then((res) => {
+          if (cancelled) return;
+          if (res.session_id) {
+            resumeTo(res.session_id);
+          } else {
+            setRecoveryPending(false);
+          }
+        })
+        .catch(() => {
+          if (!cancelled) {
+            setRecoveryPending(false);
+          }
+        });
+    };
+
     const remembered = getRememberedChatSessionId();
     if (remembered) {
-      resumeTo(remembered);
+      api
+        .getSessionLatestDescendant(remembered)
+        .then((res) => {
+          if (cancelled) return;
+          resumeTo(res.session_id || remembered);
+        })
+        .catch(() => {
+          // Older dashboard builds could save the ephemeral gateway sid in
+          // sessionStorage. If it is not a real DB session, do not resume that
+          // invalid id; fall back to the latest resumable server-side session.
+          recoverFromMostRecent();
+        });
       return () => {
         cancelled = true;
       };
     }
 
-    api
-      .getMostRecentSession()
-      .then((res) => {
-        if (cancelled) return;
-        if (res.session_id) {
-          resumeTo(res.session_id);
-        } else {
-          setRecoveryPending(false);
-        }
-      })
-      .catch(() => {
-        if (!cancelled) {
-          setRecoveryPending(false);
-        }
-      });
+    recoverFromMostRecent();
 
     return () => {
       cancelled = true;

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -49,14 +49,23 @@ function buildWsUrl(
 }
 
 // Channel id ties this chat tab's PTY child (publisher) to its sidebar
-// (subscriber).  Generated once per mount so a tab refresh starts a fresh
-// channel — the previous PTY child terminates with the old WS, and its
-// channel auto-evicts when no subscribers remain.
+// (subscriber). Persist it per resume target so a reload or transient browser
+// disconnect can reattach to the same server-side PTY while it is still alive.
 function generateChannelId(): string {
   if (typeof crypto !== "undefined" && "randomUUID" in crypto) {
     return crypto.randomUUID();
   }
   return `chat-${Math.random().toString(36).slice(2)}-${Date.now().toString(36)}`;
+}
+
+function getOrCreateChannelId(resume: string | null): string {
+  if (typeof window === "undefined") return generateChannelId();
+  const key = `hermes.chat.channel.${resume || "new"}`;
+  const existing = window.sessionStorage.getItem(key);
+  if (existing && /^[A-Za-z0-9._-]{1,128}$/.test(existing)) return existing;
+  const next = generateChannelId();
+  window.sessionStorage.setItem(key, next);
+  return next;
 }
 
 // Colors for the terminal body.  Matches the dashboard's dark teal canvas
@@ -156,7 +165,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   // treat the current resume target as part of the PTY identity and rebuild the
   // terminal session when it changes.
   const resumeParam = searchParams.get("resume");
-  const channel = useMemo(() => generateChannelId(), [resumeParam]);
+  const channel = useMemo(() => getOrCreateChannelId(resumeParam), [resumeParam]);
 
   useEffect(() => {
     if (!resumeParam) return;
@@ -544,52 +553,55 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       });
     });
 
-    // WebSocket
-    const url = buildWsUrl(token, resumeParam, channel);
-    const ws = new WebSocket(url);
-    ws.binaryType = "arraybuffer";
-    wsRef.current = ws;
-    // Suppress banner/terminal side-effects when cleanup() calls `ws.close()`
-    // (React StrictMode remount, route change) so we never write to a
-    // disposed xterm or setState on an unmounted tree.
+    // WebSocket. Keep reconnect state inside this effect so a transient
+    // browser/network close reattaches to the same channel instead of ending
+    // the PTY session immediately.
     let unmounting = false;
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
-    ws.onopen = () => {
-      setBanner(null);
-      // Send the initial RESIZE immediately so Ink has *a* size to lay
-      // out against on its first paint.  The double-rAF block above will
-      // follow up with the authoritative measurement — at worst Ink
-      // reflows once after the PTY boots, which is imperceptible.
-      ws.send(`\x1b[RESIZE:${term.cols};${term.rows}]`);
+    const connectWebSocket = (attempt = 0) => {
+      if (unmounting) return;
+      const url = buildWsUrl(token, resumeParam, channel);
+      const ws = new WebSocket(url);
+      ws.binaryType = "arraybuffer";
+      wsRef.current = ws;
+
+      ws.onopen = () => {
+        if (unmounting) return;
+        setBanner(null);
+        ws.send(`\x1b[RESIZE:${term.cols};${term.rows}]`);
+      };
+
+      ws.onmessage = (ev) => {
+        if (typeof ev.data === "string") {
+          term.write(ev.data);
+        } else {
+          term.write(new Uint8Array(ev.data as ArrayBuffer));
+        }
+      };
+
+      ws.onclose = (ev) => {
+        if (wsRef.current === ws) wsRef.current = null;
+        if (unmounting) return;
+        if (ev.code === 4401) {
+          setBanner("Auth failed. Reload the page to refresh the session token.");
+          return;
+        }
+        if (ev.code === 4403) {
+          setBanner("Chat is only reachable from localhost.");
+          return;
+        }
+        if (ev.code === 1011) {
+          // Server already wrote an ANSI error frame.
+          return;
+        }
+        const delay = Math.min(1000 * 2 ** attempt, 10_000);
+        setBanner(`Connection lost. Reconnecting in ${Math.round(delay / 1000)}s…`);
+        reconnectTimer = setTimeout(() => connectWebSocket(attempt + 1), delay);
+      };
     };
 
-    ws.onmessage = (ev) => {
-      if (typeof ev.data === "string") {
-        term.write(ev.data);
-      } else {
-        term.write(new Uint8Array(ev.data as ArrayBuffer));
-      }
-    };
-
-    ws.onclose = (ev) => {
-      wsRef.current = null;
-      if (unmounting) {
-        return;
-      }
-      if (ev.code === 4401) {
-        setBanner("Auth failed. Reload the page to refresh the session token.");
-        return;
-      }
-      if (ev.code === 4403) {
-        setBanner("Chat is only reachable from localhost.");
-        return;
-      }
-      if (ev.code === 1011) {
-        // Server already wrote an ANSI error frame.
-        return;
-      }
-      term.write("\r\n\x1b[90m[session ended]\x1b[0m\r\n");
-    };
+    connectWebSocket();
 
     // Keystrokes → PTY.
     //
@@ -608,7 +620,8 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     // eslint-disable-next-line no-control-regex -- intentional ESC byte in xterm SGR mouse report parser
     const SGR_MOUSE_RE = /^\x1b\[<(\d+);(\d+);(\d+)([Mm])$/;
     const onDataDisposable = term.onData((data) => {
-      if (ws.readyState !== WebSocket.OPEN) return;
+      const ws = wsRef.current;
+      if (!ws || ws.readyState !== WebSocket.OPEN) return;
 
       if (SGR_MOUSE_RE.test(data)) {
         return;
@@ -618,7 +631,8 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     });
 
     const onResizeDisposable = term.onResize(({ cols, rows }) => {
-      if (ws.readyState === WebSocket.OPEN) {
+      const ws = wsRef.current;
+      if (ws?.readyState === WebSocket.OPEN) {
         ws.send(`\x1b[RESIZE:${cols};${rows}]`);
       }
     });
@@ -631,6 +645,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       onDataDisposable.dispose();
       onResizeDisposable.dispose();
       if (metricsDebounce) clearTimeout(metricsDebounce);
+      if (reconnectTimer) clearTimeout(reconnectTimer);
       window.removeEventListener("resize", scheduleSyncTerminalMetrics);
       window.visualViewport?.removeEventListener(
         "resize",
@@ -640,7 +655,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       if (hostSyncRaf) cancelAnimationFrame(hostSyncRaf);
       if (settleRaf1) cancelAnimationFrame(settleRaf1);
       if (settleRaf2) cancelAnimationFrame(settleRaf2);
-      ws.close();
+      wsRef.current?.close();
       wsRef.current = null;
       term.dispose();
       termRef.current = null;

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -35,6 +35,12 @@ import { ChatSidebar } from "@/components/ChatSidebar";
 import { usePageHeader } from "@/contexts/usePageHeader";
 import { useI18n } from "@/i18n";
 import { api } from "@/lib/api";
+import {
+  consumeChatRecoveryAfterAuthReload,
+  getRememberedChatSessionId,
+  rememberChatSessionId,
+  scheduleDashboardAuthReload,
+} from "@/lib/chatRecovery";
 import { PluginSlot } from "@/plugins";
 
 function buildWsUrl(
@@ -160,12 +166,64 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
 
   // The dashboard keeps ChatPage mounted persistently so the PTY survives tab
   // switches. That is great for ordinary /chat navigation, but it means query
-  // param changes do NOT remount the component. Resume-in-chat from the
+  // changes do NOT remount the component. Resume-in-chat from the
   // Sessions page relies on `/chat?resume=<id>` changing at runtime, so we must
   // treat the current resume target as part of the PTY identity and rebuild the
   // terminal session when it changes.
   const resumeParam = searchParams.get("resume");
+  const [recoveryPending, setRecoveryPending] = useState(() => {
+    const pending = consumeChatRecoveryAfterAuthReload();
+    return !resumeParam && pending;
+  });
   const channel = useMemo(() => getOrCreateChannelId(resumeParam), [resumeParam]);
+
+  useEffect(() => {
+    if (!resumeParam) return;
+    rememberChatSessionId(resumeParam);
+  }, [resumeParam]);
+
+  useEffect(() => {
+    if (!recoveryPending || resumeParam) return;
+
+    let cancelled = false;
+
+    const resumeTo = (sessionId: string) => {
+      if (cancelled) return;
+      rememberChatSessionId(sessionId);
+      const next = new URLSearchParams(searchParams);
+      next.set("resume", sessionId);
+      setSearchParams(next, { replace: true });
+      setRecoveryPending(false);
+    };
+
+    const remembered = getRememberedChatSessionId();
+    if (remembered) {
+      resumeTo(remembered);
+      return () => {
+        cancelled = true;
+      };
+    }
+
+    api
+      .getMostRecentSession()
+      .then((res) => {
+        if (cancelled) return;
+        if (res.session_id) {
+          resumeTo(res.session_id);
+        } else {
+          setRecoveryPending(false);
+        }
+      })
+      .catch(() => {
+        if (!cancelled) {
+          setRecoveryPending(false);
+        }
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [recoveryPending, resumeParam, searchParams, setSearchParams]);
 
   useEffect(() => {
     if (!resumeParam) return;
@@ -281,6 +339,9 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     const token = window.__HERMES_SESSION_TOKEN__;
     // Banner already initialised above; just bail before wiring xterm/WS.
     if (!token) {
+      return;
+    }
+    if (recoveryPending && !resumeParam) {
       return;
     }
 
@@ -584,7 +645,14 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         if (wsRef.current === ws) wsRef.current = null;
         if (unmounting) return;
         if (ev.code === 4401) {
-          setBanner("Auth failed. Reload the page to refresh the session token.");
+          const reloadQueued = scheduleDashboardAuthReload({
+            sessionId: resumeParam ?? getRememberedChatSessionId(),
+          });
+          setBanner(
+            reloadQueued
+              ? "Dashboard restarted or token expired. Reloading and resuming chat…"
+              : "Auth failed after reload. Refresh the page to get a new dashboard token.",
+          );
           return;
         }
         if (ev.code === 4403) {
@@ -665,7 +733,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         copyResetRef.current = null;
       }
     };
-  }, [channel, resumeParam]);
+  }, [channel, recoveryPending, resumeParam]);
 
   // When the user returns to the chat tab (isActive: false → true), the
   // terminal host just transitioned from display:none to display:flex.
@@ -730,6 +798,10 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   // above the app sidebar (`z-50`) and mobile chrome (`z-40`).  The main
   // dashboard column uses `relative z-2`, which traps `position:fixed`
   // descendants below those layers (see Toast.tsx).
+  const statusBanner = banner ?? (recoveryPending && !resumeParam
+    ? "Recovering previous chat session…"
+    : null);
+
   const mobileModelToolsPortal =
     isActive &&
     narrow &&
@@ -808,9 +880,9 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       <PluginSlot name="chat:top" />
       {mobileModelToolsPortal}
 
-      {banner && (
+      {statusBanner && (
         <div className="border border-warning/50 bg-warning/10 text-warning px-3 py-2 text-xs tracking-wide">
-          {banner}
+          {statusBanner}
         </div>
       )}
 


### PR DESCRIPTION
## Summary
- Recover dashboard chat sessions after dashboard token/session-token rotation.
- Store and resume the durable SessionDB id instead of the short in-process TUI gateway sid.
- Resolve resume targets before PTY spawn, guard stale/invalid `sessionStorage`, and fall back to the latest valid server-side session.
- Harden dashboard PTY attach failure cleanup so a dropped socket during replay does not leave the PTY attached to a dead WebSocket.

## Tests
- `scripts/run_tests.sh tests/test_tui_gateway_server.py::test_session_info_exposes_persistent_resume_session_id tests/test_tui_gateway_server.py::test_session_most_recent_returns_first_non_denied tests/test_tui_gateway_server.py::test_session_most_recent_returns_null_when_only_tool_rows tests/test_tui_gateway_server.py::test_session_most_recent_folds_db_exception_into_null_result tests/test_tui_gateway_server.py::test_session_most_recent_handles_db_unavailable tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_get_most_recent_session_filters_internal_and_empty_rows tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_get_sessions_defaults_hide_cron_and_empty_sessions tests/hermes_cli/test_web_server.py::TestPtyWebSocket::test_attach_failure_detaches_dead_websocket tests/hermes_cli/test_web_server.py::TestPtyWebSocket::test_channel_disconnect_keeps_pty_alive_for_reconnect tests/test_hermes_state.py::TestCompressionChainProjection::test_resumable_only_includes_empty_compression_root_with_message_tip tests/test_hermes_state.py::TestCompressionChainProjection::test_resumable_only_does_not_count_empty_orphan_compression_root` ✅ 11 passed
- `npm --prefix web run build` ✅
- `git diff --check` ✅ for the focused branch diff before push

## Notes
- `npm --prefix web run lint` currently reports unrelated existing repo-wide lint errors outside this focused change set, so it is not used as a pass/fail signal for this PR.
