### PR TITLE
fix(test): handle empty args in run_tests on macOS bash

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -87,18 +87,20 @@ WORKERS="${HERMES_TEST_WORKERS:-4}"
 # ── Run pytest ──────────────────────────────────────────────────────────────
 cd "$REPO_ROOT"
 
-# If the first argument starts with `-` treat all args as pytest flags;
-# otherwise treat them as test paths.
-ARGS=("$@")
-
 echo "▶ running pytest with $WORKERS workers, hermetic env, in $REPO_ROOT"
 echo "  (TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0; all credential env vars unset)"
 
 # -o "addopts=" clears pyproject.toml's `-n auto` so our -n wins.
-exec "$PYTHON" -m pytest \
+PYTEST_ARGS=(
   -o "addopts=" \
   -n "$WORKERS" \
   --ignore=tests/integration \
   --ignore=tests/e2e \
-  -m "not integration" \
-  "${ARGS[@]}"
+  -m "not integration"
+)
+
+if [ "$#" -gt 0 ]; then
+  PYTEST_ARGS+=("$@")
+fi
+
+exec "$PYTHON" -m pytest "${PYTEST_ARGS[@]}"


### PR DESCRIPTION
## What does this PR do?

Fixes scripts/run_tests.sh when it is invoked without arguments on macOS environments where env bash resolves to Apple’s system Bash 3.2.x.

The script runs with set -euo pipefail, stores user arguments in a Bash array, and later expands that array unconditionally. On Bash 3.2, expanding an empty array under set -u can fail with:
```text
ARGS[@]: unbound variable
```
This PR avoids expanding user-provided arguments when none were provided. It preserves the existing pytest defaults and keeps pass-through behavior unchanged when test paths or pytest flags are supplied.



## Related Issue
Fixes #22011

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

-Updated scripts/run_tests.sh to build the default pytest arguments in a PYTEST_ARGS array.
-Appended user-provided arguments only when the script receives one or more arguments.
-Removed the unconditional empty ARGS[@] expansion that fails on Bash 3.2 with set -u.

## How to Test

1. On macOS with system Bash 3.2.x, run:
```bash
/bin/bash --version
scripts/run_tests.sh

```
2. Confirm the script starts pytest instead of exiting with:
```text
ARGS[@]: unbound variable

```
3.Confirm pass-through arguments still work:
```bash
scripts/run_tests.sh tests/agent/
scripts/run_tests.sh --tb=long -v
``` 
I also verified the no-argument and argument paths with a temporary fake venv/python harness to confirm the generated pytest command is correct without running the full test suite.

## Checklist


### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature 
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 / Darwin 24, Apple Silicon

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

Before this change, invoking the test runner without arguments on macOS Bash 3.2 fails before pytest runs:
```text
running pytest with 4 workers, hermetic env, in ****/NousResearch/hermes-agent
  (TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0; all credential env vars unset)
scripts/run_tests.sh: line 98: ARGS[@]: unbound variable
```
After this change, the no-argument path no longer expands an empty user-argument array under set -u, so pytest is invoked with the default runner arguments.

