### PR TITLE
fix(approval): block gateway self-termination commands to prevent app…

### DIFF
--- a/tests/tools/test_approval_plugin_hooks.py
+++ b/tests/tools/test_approval_plugin_hooks.py
@@ -156,6 +156,7 @@ class TestGatewaySelfTerminationBlock:
         monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
         monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
         monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
         monkeypatch.setattr(approval_module, "_get_approval_mode", lambda: "manual")
 
         result = check_all_command_guards("pkill -f hermes", "local")
@@ -168,6 +169,7 @@ class TestGatewaySelfTerminationBlock:
         monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
         monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
         monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
         monkeypatch.setattr(approval_module, "_get_approval_mode", lambda: "manual")
 
         result = check_all_command_guards(
@@ -198,6 +200,7 @@ class TestGatewaySelfTerminationBlock:
         monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
         monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
         monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
         monkeypatch.setattr(approval_module, "_get_approval_mode", lambda: "manual")
 
         result = check_all_command_guards("pkill -f hermes", "local")

--- a/tests/tools/test_approval_plugin_hooks.py
+++ b/tests/tools/test_approval_plugin_hooks.py
@@ -12,12 +12,13 @@ import pytest
 
 import tools.approval as approval_module
 from tools.approval import (
+    _GATEWAY_SELF_TERMINATION_DESCRIPTIONS,
     check_all_command_guards,
+    clear_session,
     register_gateway_notify,
-    unregister_gateway_notify,
     resolve_gateway_approval,
     set_current_session_key,
-    clear_session,
+    unregister_gateway_notify,
 )
 
 
@@ -142,4 +143,71 @@ class TestGatewayPathFiresHooks:
     approval event until resolve_gateway_approval() is called from another
     thread."""
 
+class TestGatewaySelfTerminationBlock:
+    """Gateway self-termination hard-block (issue #18693).
 
+    Commands that kill the gateway process itself (pkill hermes,
+    killall hermes, hermes gateway stop/restart, hermes update, etc.)
+    are hard-blocked inside gateway sessions to prevent an infinite
+    approval -> crash -> restart -> approval loop.
+    """
+
+    def test_gateway_blocks_pkill_hermes(self, isolated_session, monkeypatch):
+        monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+        monkeypatch.setattr(approval_module, "_get_approval_mode", lambda: "manual")
+
+        result = check_all_command_guards("pkill -f hermes", "local")
+
+        assert result["approved"] is False
+        assert "Self-termination blocked" in result["message"]
+
+    def test_gateway_blocks_hermes_gateway_stop(self, isolated_session, monkeypatch):
+        """hermes gateway stop restarts the gateway, killing running agents."""
+        monkeypatch.setenv("HERMES_GATEWAY_SESSION", "1")
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+        monkeypatch.setattr(approval_module, "_get_approval_mode", lambda: "manual")
+
+        result = check_all_command_guards(
+            "hermes gateway stop --replace", "local"
+        )
+
+        assert result["approved"] is False
+        assert "Self-termination blocked" in result["message"]
+
+    def test_cli_does_not_block_pkill(self, isolated_session, monkeypatch):
+        """CLI path: self-termination goes through normal approval, not hard-block."""
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+        monkeypatch.setattr(approval_module, "_get_approval_mode", lambda: "manual")
+
+        def cb(command, description, *, allow_permanent=True):
+            return "once"
+
+        result = check_all_command_guards(
+            "pkill -f hermes", "local", approval_callback=cb,
+        )
+
+        assert result["approved"] is True
+
+    def test_non_interactive_passes_through(self, isolated_session, monkeypatch):
+        """Non-CLI, non-gateway -> guard never reached, approved by fallthrough."""
+        monkeypatch.delenv("HERMES_INTERACTIVE", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
+        monkeypatch.setattr(approval_module, "_get_approval_mode", lambda: "manual")
+
+        result = check_all_command_guards("pkill -f hermes", "local")
+
+        assert result["approved"] is True
+
+    def test_all_descriptions_in_dangerous_patterns(self):
+        """Invariant: every self-termination description exists in DANGEROUS_PATTERNS."""
+        dangerous_descs = {desc for _, desc in approval_module.DANGEROUS_PATTERNS}
+        for desc in _GATEWAY_SELF_TERMINATION_DESCRIPTIONS:
+            assert desc in dangerous_descs, (
+                f"{desc!r} not in DANGEROUS_PATTERNS — fix the frozenset or the pattern list"
+            )

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -329,6 +329,18 @@ DANGEROUS_PATTERNS_COMPILED = [
     for pattern, description in DANGEROUS_PATTERNS
 ]
 
+# Descriptions of patterns that kill the gateway process itself. When any of
+# these fire inside a gateway session, the approving process IS the target,
+# so we hard-block to prevent an infinite approval->crash->restart loop (#18693).
+_GATEWAY_SELF_TERMINATION_DESCRIPTIONS: frozenset = frozenset([
+    "stop/restart hermes gateway (kills running agents)",
+    "hermes update (restarts gateway, kills running agents)",
+    "start gateway outside systemd (use 'systemctl --user restart hermes-gateway')",
+    "kill hermes/gateway process (self-termination)",
+    "kill process via pgrep expansion (self-termination)",
+    "kill process via backtick pgrep expansion (self-termination)",
+])
+
 
 def _legacy_pattern_key(pattern: str) -> str:
     """Reproduce the old regex-derived approval key for backwards compatibility."""
@@ -1035,6 +1047,16 @@ def check_all_command_guards(command: str, env_type: str,
             warnings.append((tirith_key, tirith_desc, True))
 
     if is_dangerous:
+        if is_gateway and description in _GATEWAY_SELF_TERMINATION_DESCRIPTIONS:
+            return {
+                "approved": False,
+                "message": (
+                    f"Self-termination blocked: '{description}'. "
+                    "This command would kill the gateway process. "
+                    "Run hermes gateway stop or hermes gateway restart "
+                    "from a separate terminal instead."
+                ),
+            }
         if not is_approved(session_key, pattern_key):
             warnings.append((pattern_key, description, False))
 


### PR DESCRIPTION
## Summary
Part of #18693. Fixes the infinite approval loop when gateway commands target the gateway process itself.

---

## Root cause
Approval state is session-scoped in memory. When the gateway process dies on command execution, the state is lost on restart. The restarted gateway has no memory of the previous approval and re-prompts for the same command.

---

## Reproduction scenario
1. Start hermes in gateway mode
2. In a gateway session, ask the agent to run `pkill -f hermes`
3. Before fix: approval prompt appears, user approves, gateway crashes, systemd restarts, same approval appears again. Infinite loop.
4. After fix: command is immediately rejected with "Self-termination blocked" message, no approval prompt, no crash

---

## What changed

**`tools/approval.py`**
- Added `_GATEWAY_SELF_TERMINATION_DESCRIPTIONS` frozenset containing descriptions of all patterns that kill the gateway process
- Added a hard-block guard in `check_all_command_guards`: when `is_gateway=True` and the matched pattern is in `_GATEWAY_SELF_TERMINATION_DESCRIPTIONS`, returns `approved=False` immediately with an explanatory message before reaching the approval queue

**User-visible change:** gateway now instantly rejects `pkill hermes` and similar commands with a clear message instead of entering the approval loop.

---

## What is NOT changed
- CLI path is unaffected, self-termination commands still go through normal approval outside gateway sessions
- Yolo mode and `approvals.mode=off` still bypass the guard by design
- Hardline blocklist is not touched
- Non-gateway contexts (CLI, batch, cron) are not affected

---

## Tests
5 new tests in `TestGatewaySelfTerminationBlock`. Full suite passes with no regressions.

See also #21938 which fixes the skills rglob path injection component of the same issue.