### PR TITLE
fix(memory): route user profile writes through active providers

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -28,9 +28,10 @@ from __future__ import annotations
 import logging
 import re
 import inspect
+from dataclasses import replace as dataclass_replace
 from typing import Any, Dict, List, Optional
 
-from agent.memory_provider import MemoryProvider
+from agent.memory_provider import MemoryProvider, MemoryWriteIntent, MemoryWriteResult
 from tools.registry import tool_error
 
 logger = logging.getLogger(__name__)
@@ -453,6 +454,54 @@ class MemoryManager:
                     provider.name, e,
                 )
         return "\n\n".join(parts)
+
+    def handle_memory_write(self, intent: MemoryWriteIntent) -> MemoryWriteResult:
+        """Offer a durable generic memory-tool write to external providers.
+
+        This is provider-first routing: if an external provider claims an
+        intent, its result is authoritative. A claimed failure is returned to
+        the tool caller and must not fall back to local USER.md/MEMORY.md.
+        Unclaimed writes remain owned by the built-in local store.
+        """
+        for provider in self._providers:
+            if provider.name == "builtin":
+                continue
+            try:
+                wants_write = provider.wants_memory_write(intent)
+            except Exception as e:
+                logger.debug(
+                    "Memory provider '%s' wants_memory_write failed: %s",
+                    provider.name, e,
+                )
+                continue
+            if not wants_write:
+                continue
+
+            try:
+                result = provider.handle_memory_write(intent)
+            except Exception as e:
+                logger.warning(
+                    "Memory provider '%s' handle_memory_write failed: %s",
+                    provider.name, e,
+                )
+                return MemoryWriteResult(
+                    handled=True,
+                    success=False,
+                    provider=provider.name,
+                    error=f"{provider.name} memory write failed: {e}",
+                )
+
+            if result and result.handled:
+                if not result.provider:
+                    result = dataclass_replace(result, provider=provider.name)
+                return result
+
+            logger.debug(
+                "Memory provider '%s' claimed but did not handle memory write",
+                provider.name,
+            )
+
+        return MemoryWriteResult.not_handled()
 
     @staticmethod
     def _provider_memory_write_metadata_mode(provider: MemoryProvider) -> str:

--- a/agent/memory_provider.py
+++ b/agent/memory_provider.py
@@ -34,9 +34,53 @@ from __future__ import annotations
 
 import logging
 from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class MemoryWriteIntent:
+    """A durable write requested through the generic memory tool."""
+
+    action: str
+    target: str
+    content: str = ""
+    old_text: str = ""
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True)
+class MemoryWriteResult:
+    """Result of a provider-routed memory write."""
+
+    handled: bool
+    success: bool = False
+    provider: str = ""
+    message: str = ""
+    error: str = ""
+    details: Dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def not_handled(cls, provider: str = "") -> "MemoryWriteResult":
+        return cls(handled=False, provider=provider)
+
+    def to_tool_payload(self, intent: MemoryWriteIntent) -> Dict[str, Any]:
+        payload: Dict[str, Any] = {
+            "success": self.success,
+            "target": intent.target,
+            "action": intent.action,
+        }
+        if self.provider:
+            payload["provider"] = self.provider
+        if self.message:
+            payload["message"] = self.message
+        if self.error:
+            payload["error"] = self.error
+        if self.details:
+            payload.update(self.details)
+        return payload
 
 
 class MemoryProvider(ABC):
@@ -223,6 +267,24 @@ class MemoryProvider(ABC):
         result: the subagent's final response
         child_session_id: the subagent's session_id
         """
+
+    def wants_memory_write(self, intent: MemoryWriteIntent) -> bool:
+        """Return True when this provider wants to own a generic memory write.
+
+        This is the synchronous provider-first path used before the built-in
+        MEMORY.md/USER.md store is mutated. Providers should only return True
+        for writes they can durably commit or fail clearly.
+        """
+        return False
+
+    def handle_memory_write(self, intent: MemoryWriteIntent) -> MemoryWriteResult:
+        """Durably handle a generic memory write this provider claimed.
+
+        Default is not-handled for backwards compatibility. Providers that
+        return ``wants_memory_write(intent)`` as True should override this and
+        return a success or failure result; failures stop local fallback.
+        """
+        return MemoryWriteResult.not_handled(self.name)
 
     def get_config_schema(self) -> List[Dict[str, Any]]:
         """Return config fields this provider needs for setup.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -983,9 +983,12 @@ DEFAULT_CONFIG = {
         "memory_char_limit": 2200,   # ~800 tokens at 2.75 chars/token
         "user_char_limit": 1375,     # ~500 tokens at 2.75 chars/token
         # External memory provider plugin (empty = built-in only).
-        # Set to a provider name to activate: "openviking", "mem0",
-        # "hindsight", "holographic", "retaindb", "byterover".
+        # Set to a provider name to activate: "honcho", "openviking",
+        # "mem0", "hindsight", "holographic", "retaindb",
+        # "byterover", "supermemory".
         # Only ONE external provider is allowed at a time.
+        # Active providers may own generic target=user writes; target=memory
+        # remains the built-in local store for agent notes.
         "provider": "",
     },
 

--- a/plugins/memory/honcho/__init__.py
+++ b/plugins/memory/honcho/__init__.py
@@ -23,7 +23,7 @@ import time
 from typing import Any, Dict, List, Optional
 
 from agent.memory_manager import sanitize_context
-from agent.memory_provider import MemoryProvider
+from agent.memory_provider import MemoryProvider, MemoryWriteIntent, MemoryWriteResult
 from tools.registry import tool_error
 
 logger = logging.getLogger(__name__)
@@ -1149,6 +1149,64 @@ class HonchoMemoryProvider(MemoryProvider):
             target=_sync, daemon=True, name="honcho-sync"
         )
         self._sync_thread.start()
+
+    def wants_memory_write(self, intent: MemoryWriteIntent) -> bool:
+        """Claim generic user-profile adds as Honcho conclusions."""
+        return (
+            intent.action == "add"
+            and intent.target == "user"
+            and bool((intent.content or "").strip())
+            and not self._cron_skipped
+        )
+
+    def handle_memory_write(self, intent: MemoryWriteIntent) -> MemoryWriteResult:
+        """Persist a generic user-profile memory write as a Honcho conclusion."""
+        if not self.wants_memory_write(intent):
+            return MemoryWriteResult.not_handled(self.name)
+
+        if not self._session_initialized:
+            if not self._ensure_session():
+                return MemoryWriteResult(
+                    handled=True,
+                    success=False,
+                    provider=self.name,
+                    error="Honcho session could not be initialized.",
+                )
+
+        if not self._manager or not self._session_key:
+            return MemoryWriteResult(
+                handled=True,
+                success=False,
+                provider=self.name,
+                error="Honcho is not active for this session.",
+            )
+
+        content = intent.content.strip()
+        try:
+            ok = self._manager.create_conclusion(self._session_key, content, peer="user")
+        except Exception as e:
+            logger.debug("Honcho provider-routed memory write failed: %s", e)
+            return MemoryWriteResult(
+                handled=True,
+                success=False,
+                provider=self.name,
+                error=f"Honcho conclusion write failed: {e}",
+            )
+
+        if not ok:
+            return MemoryWriteResult(
+                handled=True,
+                success=False,
+                provider=self.name,
+                error="Honcho conclusion write failed.",
+            )
+
+        return MemoryWriteResult(
+            handled=True,
+            success=True,
+            provider=self.name,
+            message="User profile memory saved to Honcho.",
+        )
 
     def on_memory_write(
         self,

--- a/run_agent.py
+++ b/run_agent.py
@@ -3948,6 +3948,116 @@ class AIAgent:
             metadata["tool_call_id"] = tool_call_id
         return {k: v for k, v in metadata.items() if v not in (None, "")}
 
+    @staticmethod
+    def _memory_tool_args_can_route_to_provider(
+        action: Any,
+        target: Any,
+        content: Any,
+        old_text: Any,
+    ) -> bool:
+        """Return True once generic memory args pass basic runtime validation."""
+        if target not in ("memory", "user"):
+            return False
+        if action == "add":
+            return bool(content)
+        if action == "replace":
+            return bool(content) and bool(old_text)
+        if action == "remove":
+            return bool(old_text)
+        return False
+
+    @staticmethod
+    def _tool_result_success(result: str) -> bool:
+        try:
+            parsed = json.loads(result)
+        except Exception:
+            return False
+        return parsed.get("success") is True
+
+    def _execute_memory_tool_call(
+        self,
+        function_args: Dict[str, Any],
+        *,
+        task_id: Optional[str] = None,
+        tool_call_id: Optional[str] = None,
+    ) -> str:
+        """Execute the generic memory tool with provider-first write routing."""
+        action = function_args.get("action")
+        target = function_args.get("target", "memory")
+        content = function_args.get("content")
+        old_text = function_args.get("old_text")
+
+        metadata = self._build_memory_write_metadata(
+            task_id=task_id,
+            tool_call_id=tool_call_id,
+        )
+
+        if (
+            self._memory_manager
+            and self._memory_tool_args_can_route_to_provider(
+                action, target, content, old_text
+            )
+        ):
+            try:
+                from agent.memory_provider import MemoryWriteIntent
+
+                intent = MemoryWriteIntent(
+                    action=str(action or ""),
+                    target=str(target or ""),
+                    content=str(content or ""),
+                    old_text=str(old_text or ""),
+                    metadata=metadata,
+                )
+                routed = self._memory_manager.handle_memory_write(intent)
+                if routed.handled:
+                    payload = routed.to_tool_payload(intent)
+                    if routed.success:
+                        return json.dumps(payload, ensure_ascii=False)
+                    if not payload.get("error"):
+                        payload["error"] = (
+                            "Memory provider failed to store this durable write."
+                        )
+                    payload["success"] = False
+                    return json.dumps(payload, ensure_ascii=False)
+            except Exception as e:
+                return json.dumps(
+                    {
+                        "success": False,
+                        "error": f"Memory provider routing failed: {e}",
+                        "target": target,
+                    },
+                    ensure_ascii=False,
+                )
+
+        from tools.memory_tool import memory_tool as _memory_tool
+
+        result = _memory_tool(
+            action=action,
+            target=target,
+            content=content,
+            old_text=old_text,
+            store=self._memory_store,
+        )
+
+        # Legacy mirror hook: only notify providers after the local write
+        # actually succeeds. Provider-routed writes return above and are not
+        # mirrored a second time.
+        if (
+            self._memory_manager
+            and action in ("add", "replace")
+            and self._tool_result_success(result)
+        ):
+            try:
+                self._memory_manager.on_memory_write(
+                    action,
+                    target,
+                    content or "",
+                    metadata=metadata,
+                )
+            except Exception:
+                pass
+        return result
+
     def _apply_persist_user_message_override(self, messages: List[Dict]) -> None:
         """Rewrite the current-turn user message before persistence/return.
 
@@ -9868,30 +9978,11 @@ class AIAgent:
                 current_session_id=self.session_id,
             )
         elif function_name == "memory":
-            target = function_args.get("target", "memory")
-            from tools.memory_tool import memory_tool as _memory_tool
-            result = _memory_tool(
-                action=function_args.get("action"),
-                target=target,
-                content=function_args.get("content"),
-                old_text=function_args.get("old_text"),
-                store=self._memory_store,
+            return self._execute_memory_tool_call(
+                function_args,
+                task_id=effective_task_id,
+                tool_call_id=tool_call_id,
             )
-            # Bridge: notify external memory provider of built-in memory writes
-            if self._memory_manager and function_args.get("action") in ("add", "replace"):
-                try:
-                    self._memory_manager.on_memory_write(
-                        function_args.get("action", ""),
-                        target,
-                        function_args.get("content", ""),
-                        metadata=self._build_memory_write_metadata(
-                            task_id=effective_task_id,
-                            tool_call_id=tool_call_id,
-                        ),
-                    )
-                except Exception:
-                    pass
-            return result
         elif self._memory_manager and self._memory_manager.has_tool(function_name):
             return self._memory_manager.handle_tool_call(function_name, function_args)
         elif function_name == "clarify":
@@ -10495,29 +10586,11 @@ class AIAgent:
                 if self._should_emit_quiet_tool_messages():
                     self._vprint(f"  {_get_cute_tool_message_impl('session_search', function_args, tool_duration, result=function_result)}")
             elif function_name == "memory":
-                target = function_args.get("target", "memory")
-                from tools.memory_tool import memory_tool as _memory_tool
-                function_result = _memory_tool(
-                    action=function_args.get("action"),
-                    target=target,
-                    content=function_args.get("content"),
-                    old_text=function_args.get("old_text"),
-                    store=self._memory_store,
+                function_result = self._execute_memory_tool_call(
+                    function_args,
+                    task_id=effective_task_id,
+                    tool_call_id=getattr(tool_call, "id", None),
                 )
-                # Bridge: notify external memory provider of built-in memory writes
-                if self._memory_manager and function_args.get("action") in ("add", "replace"):
-                    try:
-                        self._memory_manager.on_memory_write(
-                            function_args.get("action", ""),
-                            target,
-                            function_args.get("content", ""),
-                            metadata=self._build_memory_write_metadata(
-                                task_id=effective_task_id,
-                                tool_call_id=getattr(tool_call, "id", None),
-                            ),
-                        )
-                    except Exception:
-                        pass
                 tool_duration = time.time() - tool_start_time
                 if self._should_emit_quiet_tool_messages():
                     self._vprint(f"  {_get_cute_tool_message_impl('memory', function_args, tool_duration, result=function_result)}")

--- a/tests/agent/test_memory_provider.py
+++ b/tests/agent/test_memory_provider.py
@@ -4,7 +4,7 @@ import json
 import pytest
 from unittest.mock import MagicMock, patch
 
-from agent.memory_provider import MemoryProvider
+from agent.memory_provider import MemoryProvider, MemoryWriteIntent, MemoryWriteResult
 from agent.memory_manager import MemoryManager
 
 # ---------------------------------------------------------------------------
@@ -82,6 +82,34 @@ class MetadataMemoryProvider(FakeMemoryProvider):
 
     def on_memory_write(self, action, target, content, metadata=None):
         self.memory_writes.append((action, target, content, metadata or {}))
+
+
+class ClaimingMemoryProvider(FakeMemoryProvider):
+    """Provider that can claim durable user-profile writes."""
+
+    def __init__(self, name="claiming", fail=False):
+        super().__init__(name)
+        self.fail = fail
+        self.claimed_intents = []
+
+    def wants_memory_write(self, intent: MemoryWriteIntent) -> bool:
+        return intent.action == "add" and intent.target == "user"
+
+    def handle_memory_write(self, intent: MemoryWriteIntent) -> MemoryWriteResult:
+        self.claimed_intents.append(intent)
+        if self.fail:
+            return MemoryWriteResult(
+                handled=True,
+                success=False,
+                provider=self.name,
+                error="provider write failed",
+            )
+        return MemoryWriteResult(
+            handled=True,
+            success=True,
+            provider=self.name,
+            message="User profile memory saved by provider.",
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -991,6 +1019,63 @@ class TestOnMemoryWriteBridge:
         mgr.on_memory_write("add", "user", "test")
         # Good provider still received the call despite bad provider crashing
         assert good.memory_writes == [("add", "user", "test")]
+
+
+class TestProviderAwareMemoryRouting:
+    """Provider-first durable write routing for generic memory tool intents."""
+
+    def test_provider_claims_user_profile_add(self):
+        mgr = MemoryManager()
+        provider = ClaimingMemoryProvider("external")
+        mgr.add_provider(provider)
+
+        intent = MemoryWriteIntent(
+            action="add",
+            target="user",
+            content="User prefers concise summaries.",
+            metadata={"session_id": "sess-1"},
+        )
+
+        result = mgr.handle_memory_write(intent)
+
+        assert result.handled is True
+        assert result.success is True
+        assert result.provider == "external"
+        assert provider.claimed_intents == [intent]
+
+    def test_unclaimed_agent_memory_write_falls_back_to_local_owner(self):
+        mgr = MemoryManager()
+        provider = ClaimingMemoryProvider("external")
+        mgr.add_provider(provider)
+
+        result = mgr.handle_memory_write(
+            MemoryWriteIntent(
+                action="add",
+                target="memory",
+                content="Project uses pytest.",
+            )
+        )
+
+        assert result.handled is False
+        assert provider.claimed_intents == []
+
+    def test_provider_failure_is_returned_as_handled_failure(self):
+        mgr = MemoryManager()
+        provider = ClaimingMemoryProvider("external", fail=True)
+        mgr.add_provider(provider)
+
+        result = mgr.handle_memory_write(
+            MemoryWriteIntent(
+                action="add",
+                target="user",
+                content="User prefers dark mode.",
+            )
+        )
+
+        assert result.handled is True
+        assert result.success is False
+        assert result.provider == "external"
+        assert result.error == "provider write failed"
 
 
 class TestHonchoCadenceTracking:

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -4,6 +4,7 @@ from datetime import datetime
 from types import SimpleNamespace
 from unittest.mock import MagicMock
 
+from agent.memory_provider import MemoryWriteIntent
 from plugins.memory.honcho.session import (
     HonchoSession,
     HonchoSessionManager,
@@ -395,6 +396,59 @@ class TestConcludeToolDispatch:
             "User prefers dark mode",
             peer="user",
         )
+
+    def test_honcho_claims_generic_user_profile_adds(self):
+        provider = HonchoMemoryProvider()
+        intent = MemoryWriteIntent(
+            action="add",
+            target="user",
+            content="User prefers dark mode",
+        )
+
+        assert provider.wants_memory_write(intent) is True
+
+    def test_honcho_provider_routed_write_uses_create_conclusion(self):
+        provider = HonchoMemoryProvider()
+        provider._session_initialized = True
+        provider._session_key = "telegram:123"
+        provider._manager = MagicMock()
+        provider._manager.create_conclusion.return_value = True
+
+        result = provider.handle_memory_write(
+            MemoryWriteIntent(
+                action="add",
+                target="user",
+                content="User prefers dark mode",
+            )
+        )
+
+        assert result.handled is True
+        assert result.success is True
+        assert result.provider == "honcho"
+        provider._manager.create_conclusion.assert_called_once_with(
+            "telegram:123",
+            "User prefers dark mode",
+            peer="user",
+        )
+
+    def test_honcho_provider_routed_write_reports_failure(self):
+        provider = HonchoMemoryProvider()
+        provider._session_initialized = True
+        provider._session_key = "telegram:123"
+        provider._manager = MagicMock()
+        provider._manager.create_conclusion.return_value = False
+
+        result = provider.handle_memory_write(
+            MemoryWriteIntent(
+                action="add",
+                target="user",
+                content="User prefers dark mode",
+            )
+        )
+
+        assert result.handled is True
+        assert result.success is False
+        assert "failed" in result.error.lower()
 
     def test_honcho_conclude_can_target_ai_peer(self):
         provider = HonchoMemoryProvider()

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -20,8 +20,11 @@ from agent.codex_responses_adapter import _chat_messages_to_responses_input, _no
 
 import run_agent
 from run_agent import AIAgent
+from agent.memory_provider import MemoryProvider, MemoryWriteIntent, MemoryWriteResult
 from agent.error_classifier import FailoverReason
 from agent.prompt_builder import DEFAULT_AGENT_IDENTITY
+from agent.memory_manager import MemoryManager
+from tools.memory_tool import MemoryStore
 
 
 # ---------------------------------------------------------------------------
@@ -42,6 +45,50 @@ def _make_tool_defs(*names: str) -> list:
         }
         for n in names
     ]
+
+
+class _RoutingProvider(MemoryProvider):
+    """Test provider that claims generic user-profile add intents."""
+
+    def __init__(self, *, fail: bool = False):
+        self.fail = fail
+        self.intents = []
+        self.mirrors = []
+
+    @property
+    def name(self) -> str:
+        return "routing-provider"
+
+    def is_available(self) -> bool:
+        return True
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        pass
+
+    def get_tool_schemas(self):
+        return []
+
+    def wants_memory_write(self, intent: MemoryWriteIntent) -> bool:
+        return intent.action == "add" and intent.target == "user"
+
+    def handle_memory_write(self, intent: MemoryWriteIntent) -> MemoryWriteResult:
+        self.intents.append(intent)
+        if self.fail:
+            return MemoryWriteResult(
+                handled=True,
+                success=False,
+                provider=self.name,
+                error="provider unavailable",
+            )
+        return MemoryWriteResult(
+            handled=True,
+            success=True,
+            provider=self.name,
+            message="Provider stored user profile memory.",
+        )
+
+    def on_memory_write(self, action, target, content, metadata=None):
+        self.mirrors.append((action, target, content, metadata or {}))
 
 
 def test_is_destructive_command_treats_cp_as_mutating():
@@ -93,6 +140,80 @@ def agent_with_memory_tool():
         )
         a.client = MagicMock()
         return a
+
+
+class TestProviderAwareGenericMemoryTool:
+    def _attach_memory(self, agent, tmp_path, monkeypatch, provider):
+        monkeypatch.setattr("tools.memory_tool.get_memory_dir", lambda: tmp_path)
+        store = MemoryStore(memory_char_limit=500, user_char_limit=300)
+        store.load_from_disk()
+        manager = MemoryManager()
+        manager.add_provider(provider)
+        agent._memory_store = store
+        agent._memory_manager = manager
+        return store
+
+    def test_user_profile_add_routes_to_active_provider_without_local_write(
+        self, agent_with_memory_tool, tmp_path, monkeypatch
+    ):
+        provider = _RoutingProvider()
+        store = self._attach_memory(agent_with_memory_tool, tmp_path, monkeypatch, provider)
+
+        result = json.loads(
+            agent_with_memory_tool._execute_memory_tool_call(
+                {
+                    "action": "add",
+                    "target": "user",
+                    "content": "User prefers direct answers.",
+                }
+            )
+        )
+
+        assert result["success"] is True
+        assert result["provider"] == "routing-provider"
+        assert store.user_entries == []
+        assert provider.intents[0].content == "User prefers direct answers."
+        assert provider.mirrors == []
+
+    def test_agent_memory_add_stays_local_with_external_provider(
+        self, agent_with_memory_tool, tmp_path, monkeypatch
+    ):
+        provider = _RoutingProvider()
+        store = self._attach_memory(agent_with_memory_tool, tmp_path, monkeypatch, provider)
+
+        result = json.loads(
+            agent_with_memory_tool._execute_memory_tool_call(
+                {
+                    "action": "add",
+                    "target": "memory",
+                    "content": "This project uses pytest.",
+                }
+            )
+        )
+
+        assert result["success"] is True
+        assert store.memory_entries == ["This project uses pytest."]
+        assert provider.intents == []
+
+    def test_provider_failure_does_not_fall_back_to_local_user_memory(
+        self, agent_with_memory_tool, tmp_path, monkeypatch
+    ):
+        provider = _RoutingProvider(fail=True)
+        store = self._attach_memory(agent_with_memory_tool, tmp_path, monkeypatch, provider)
+
+        result = json.loads(
+            agent_with_memory_tool._execute_memory_tool_call(
+                {
+                    "action": "add",
+                    "target": "user",
+                    "content": "User prefers dark mode.",
+                }
+            )
+        )
+
+        assert result["success"] is False
+        assert "provider unavailable" in result["error"]
+        assert store.user_entries == []
 
 
 def test_aiagent_reuses_existing_errors_log_handler():

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -518,6 +518,11 @@ MEMORY_SCHEMA = {
         "Save durable information to persistent memory that survives across sessions. "
         "Memory is injected into future turns, so keep it compact and focused on facts "
         "that will still matter later.\n\n"
+        "ROUTING: User profile facts/preferences/corrections belong in target='user'. "
+        "When an external memory provider is active, Hermes may route those user-profile "
+        "writes to that provider as the primary durable owner instead of USER.md. "
+        "Local environment, tool, project, and runtime notes belong in target='memory' "
+        "and are stored in the local agent memory file.\n\n"
         "WHEN TO SAVE (do this proactively, don't wait to be asked):\n"
         "- User corrects you or says 'remember this' / 'don't do that again'\n"
         "- User shares a preference, habit, or personal detail (name, role, timezone, coding style)\n"
@@ -528,11 +533,12 @@ MEMORY_SCHEMA = {
         "The most valuable memory prevents the user from having to repeat themselves.\n\n"
         "Do NOT save task progress, session outcomes, completed-work logs, or temporary TODO "
         "state to memory; use session_search to recall those from past transcripts.\n"
+        "Session transcripts and session_search results are recall sources, not durable curated memory.\n"
         "If you've discovered a new way to do something, solved a problem that could be "
         "necessary later, save it as a skill with the skill tool.\n\n"
         "TWO TARGETS:\n"
-        "- 'user': who the user is -- name, role, preferences, communication style, pet peeves\n"
-        "- 'memory': your notes -- environment facts, project conventions, tool quirks, lessons learned\n\n"
+        "- 'user': provider-backed user profile facts -- name, role, preferences, communication style, pet peeves\n"
+        "- 'memory': local agent notes -- environment facts, project conventions, tool quirks, lessons learned\n\n"
         "ACTIONS: add (new entry), replace (update existing -- old_text identifies it), "
         "remove (delete -- old_text identifies it).\n\n"
         "SKIP: trivial/obvious info, things easily re-discovered, raw data dumps, and temporary task state."
@@ -580,7 +586,6 @@ registry.register(
     check_fn=check_memory_requirements,
     emoji="🧠",
 )
-
 
 
 

--- a/website/docs/developer-guide/memory-provider-plugin.md
+++ b/website/docs/developer-guide/memory-provider-plugin.md
@@ -80,8 +80,49 @@ class MyMemoryProvider(MemoryProvider):
 | `sync_turn(user, assistant)` | After each completed turn | Persist conversation |
 | `on_session_end(messages)` | Conversation ends | Final extraction/flush |
 | `on_pre_compress(messages)` | Before context compression | Save insights before discard |
-| `on_memory_write(action, target, content)` | Built-in memory writes | Mirror to your backend |
+| `wants_memory_write(intent)` | Before built-in memory writes | Claim durable writes your provider should own |
+| `handle_memory_write(intent)` | After claiming a write | Commit provider-owned memory writes synchronously |
+| `on_memory_write(action, target, content)` | Successful local memory writes | Mirror local writes to your backend |
 | `shutdown()` | Process exit | Clean up connections |
+
+## Provider-Owned Generic Memory Writes
+
+The generic `memory` tool routes validated writes through `MemoryManager` before mutating MEMORY.md or USER.md. This lets an active provider own user-profile facts without keyword hacks or provider-specific prompt instructions.
+
+Use `wants_memory_write()` only for intents your backend can durably handle. If `handle_memory_write()` returns `success=False` for a claimed intent, Hermes returns that error to the model/user and does not fall back to local memory.
+
+```python
+from agent.memory_provider import MemoryProvider, MemoryWriteIntent, MemoryWriteResult
+
+class MyMemoryProvider(MemoryProvider):
+    # ...
+
+    def wants_memory_write(self, intent: MemoryWriteIntent) -> bool:
+        return (
+            intent.action == "add"
+            and intent.target == "user"
+            and bool(intent.content.strip())
+        )
+
+    def handle_memory_write(self, intent: MemoryWriteIntent) -> MemoryWriteResult:
+        try:
+            self._client.create_user_fact(intent.content.strip())
+        except Exception as exc:
+            return MemoryWriteResult(
+                handled=True,
+                success=False,
+                provider=self.name,
+                error=f"{self.name} write failed: {exc}",
+            )
+        return MemoryWriteResult(
+            handled=True,
+            success=True,
+            provider=self.name,
+            message="User profile memory saved.",
+        )
+```
+
+Keep `on_memory_write()` for mirror semantics only. It fires after a local MEMORY.md/USER.md write succeeds and is not the provider-first ownership path.
 
 ## Config Schema
 

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -861,7 +861,7 @@ See [Hooks](../user-guide/features/hooks.md) for event signatures and payload sh
 hermes memory <subcommand>
 ```
 
-Set up and manage external memory provider plugins. Available providers: honcho, openviking, mem0, hindsight, holographic, retaindb, byterover, supermemory. Only one external provider can be active at a time. Built-in memory (MEMORY.md/USER.md) is always active.
+Set up and manage external memory provider plugins. Available providers: honcho, openviking, mem0, hindsight, holographic, retaindb, byterover, supermemory. Only one external provider can be active at a time. Built-in MEMORY.md remains the local owner for agent notes; active providers may own user-profile writes from the generic memory tool.
 
 Subcommands:
 

--- a/website/docs/user-guide/features/honcho.md
+++ b/website/docs/user-guide/features/honcho.md
@@ -30,6 +30,8 @@ Honcho is integrated into the [Memory Providers](./memory-providers.md) system. 
 
 **Multi-agent profiles**: When multiple Hermes instances talk to the same user (e.g., a coding assistant and a personal assistant), Honcho maintains separate "peer" profiles. Each peer sees only its own observations and conclusions, preventing cross-contamination of context.
 
+**Provider-owned user profile writes**: When Honcho is the active memory provider, generic `memory(action="add", target="user", content="...")` calls are stored as Honcho conclusions. The model does not need to know about `honcho_conclude` for ordinary "remember this about me" requests. If Honcho cannot persist the conclusion, Hermes returns a clear tool error instead of writing a fake local USER.md success.
+
 ## Setup
 
 ```bash

--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -6,7 +6,7 @@ description: "External memory provider plugins — Honcho, OpenViking, Mem0, Hin
 
 # Memory Providers
 
-Hermes Agent ships with 8 external memory provider plugins that give the agent persistent, cross-session knowledge beyond the built-in MEMORY.md and USER.md. Only **one** external provider can be active at a time — the built-in memory is always active alongside it.
+Hermes Agent ships with 8 external memory provider plugins that give the agent persistent, cross-session knowledge beyond the built-in MEMORY.md and USER.md. Only **one** external provider can be active at a time. The built-in memory remains active for local agent notes, while the active provider can become the primary durable owner for user-profile writes.
 
 ## Quick Start
 
@@ -33,10 +33,10 @@ When a memory provider is active, Hermes automatically:
 2. **Prefetches relevant memories** before each turn (background, non-blocking)
 3. **Syncs conversation turns** to the provider after each response
 4. **Extracts memories on session end** (for providers that support it)
-5. **Mirrors built-in memory writes** to the external provider
+5. **Routes provider-owned memory writes** before local files are mutated
 6. **Adds provider-specific tools** so the agent can search, store, and manage memories
 
-The built-in memory (MEMORY.md / USER.md) continues to work exactly as before. The external provider is additive.
+The generic `memory` tool is provider-aware. User profile facts and preferences (`target="user"`) are offered to the active provider first; if the provider accepts the write and fails, Hermes returns a tool error instead of silently falling back to USER.md. Local agent notes (`target="memory"`) continue to use MEMORY.md, with legacy mirror hooks available for providers that want a copy of local writes.
 
 ## Available Providers
 

--- a/website/docs/user-guide/features/memory.md
+++ b/website/docs/user-guide/features/memory.md
@@ -8,16 +8,18 @@ description: "How Hermes Agent remembers across sessions — MEMORY.md, USER.md,
 
 Hermes Agent has bounded, curated memory that persists across sessions. This lets it remember your preferences, your projects, your environment, and things it has learned.
 
+When an external memory provider is active, Hermes routes provider-owned user profile writes through that provider first. This means a generic `memory(action="add", target="user", ...)` call can save to Honcho, Mem0, or another active backend without the model needing to call a provider-specific tool.
+
 ## How It Works
 
-Two files make up the agent's memory:
+Two files make up the built-in local memory:
 
 | File | Purpose | Char Limit |
 |------|---------|------------|
 | **MEMORY.md** | Agent's personal notes — environment facts, conventions, things learned | 2,200 chars (~800 tokens) |
 | **USER.md** | User profile — your preferences, communication style, expectations | 1,375 chars (~500 tokens) |
 
-Both are stored in `~/.hermes/memories/` and are injected into the system prompt as a frozen snapshot at session start. The agent manages its own memory via the `memory` tool — it can add, replace, or remove entries.
+Both are stored in `~/.hermes/memories/` and are injected into the system prompt as a frozen snapshot at session start. The agent manages memory via the `memory` tool — it can add, replace, or remove entries. If an external provider claims a user-profile write, that provider becomes the primary durable owner for that write and Hermes does not also fake a local USER.md success.
 
 :::info
 Character limits keep memory focused. When memory is full, the agent consolidates or replaces entries to make room for new information.
@@ -78,7 +80,6 @@ For information the agent needs to remember about the environment, workflows, an
 - Environment facts (OS, tools, project structure)
 - Project conventions and configuration
 - Tool quirks and workarounds discovered
-- Completed task diary entries
 - Skills and techniques that worked
 
 ### `user` — User Profile
@@ -91,6 +92,8 @@ For information about the user's identity, preferences, and communication style:
 - Workflow habits
 - Technical skill level
 
+With an active external memory provider, this target is provider-backed when the provider claims the write. For example, Honcho stores `add` writes to `target="user"` as persistent conclusions.
+
 ## What to Save vs Skip
 
 ### Save These (Proactively)
@@ -101,7 +104,6 @@ The agent saves automatically — you don't need to ask. It saves when it learns
 - **Environment facts:** "This server runs Debian 12 with PostgreSQL 16" → save to `memory`
 - **Corrections:** "Don't use `sudo` for Docker commands, user is in docker group" → save to `memory`
 - **Conventions:** "Project uses tabs, 120-char line width, Google-style docstrings" → save to `memory`
-- **Completed work:** "Migrated database from MySQL to PostgreSQL on 2026-01-15" → save to `memory`
 - **Explicit requests:** "Remember that my API key rotation happens monthly" → save to `memory`
 
 ### Skip These
@@ -212,6 +214,13 @@ memory:
 For deeper, persistent memory that goes beyond MEMORY.md and USER.md, Hermes ships with 8 external memory provider plugins — including Honcho, OpenViking, Mem0, Hindsight, Holographic, RetainDB, ByteRover, and Supermemory.
 
 External providers run **alongside** built-in memory (never replacing it) and add capabilities like knowledge graphs, semantic search, automatic fact extraction, and cross-session user modeling.
+
+Provider-aware routing applies at the generic `memory` tool boundary:
+
+- `target="user"` facts, preferences, and corrections are offered to the active provider first.
+- If the provider accepts the write and fails, Hermes returns a clear tool error instead of silently writing USER.md.
+- `target="memory"` remains the built-in local store for agent notes such as environment facts, project conventions, and tool/runtime lessons.
+- Session transcripts and `session_search` are recall mechanisms; they are not curated durable memory.
 
 ```bash
 hermes memory setup      # pick a provider and configure it


### PR DESCRIPTION
## Root cause

Hermes' generic `memory` tool still owned durable write intent even when an external memory provider was active. A model could correctly choose the generic tool for "remember this about me", but the generic path wrote durable user-profile facts locally while Honcho only mirrored `target=user` writes through `on_memory_write`. Direct Honcho tools worked, but the generic memory decision layer did not treat the active provider as the primary owner.

## Design

- Add provider-level memory write intent/result types so the tool boundary can ask `MemoryManager` whether an active provider wants to own a durable write.
- Route generic `memory(add, target=user, ...)` through `MemoryManager.handle_memory_write()` before falling back to local memory.
- Keep built-in/local memory as fallback for local agent notes, including `target=memory`.
- Make provider-claimed failures authoritative: provider-first user-profile writes fail loudly instead of pretending a local write succeeded.
- Implement Honcho as one provider implementation of the general contract by claiming user-profile add intents and writing them with `create_conclusion(..., peer="user")`.
- Update tool schema and docs so models distinguish provider-backed user-profile memory from local agent/runtime notes and session transcript search.

## Why this avoids keyword hacks

The routing decision is based on structured tool intent (`action`, `target`, content, metadata) and the active provider contract, not on phrases like "remember this". The model may still call the generic `memory` tool; Hermes routes the durable write according to provider ownership.

## Docs / context

- https://hermes-agent.nousresearch.com/docs/user-guide/features/honcho/
- https://hermes-agent.nousresearch.com/docs/user-guide/features/memory-providers/
- https://docs.honcho.dev/v3/guides/integrations/hermes
- Related issues searched/read where available: #553, #3943, #4889, #4052, #11199

## Tests run

- `uv run --extra dev pytest -q tests/agent/test_memory_provider.py tests/tools/test_memory_tool.py tests/tools/test_memory_tool_schema.py tests/honcho_plugin/test_session.py` - 219 passed
- `uv run --extra dev pytest -q tests/agent/test_memory_provider.py tests/agent/test_memory_user_id.py tests/agent/test_memory_session_switch.py tests/run_agent/test_memory_provider_init.py tests/run_agent/test_memory_sync_interrupted.py tests/honcho_plugin tests/plugins/memory tests/plugins/test_retaindb_plugin.py tests/tools/test_memory_tool.py tests/tools/test_memory_tool_schema.py` - 636 passed, 4 skipped
- `uv run --extra dev pytest -q tests/agent/test_memory_provider.py tests/agent/test_memory_user_id.py tests/agent/test_memory_session_switch.py tests/run_agent/test_memory_provider_init.py tests/run_agent/test_memory_sync_interrupted.py tests/run_agent/test_run_agent.py::TestProviderAwareGenericMemoryTool tests/honcho_plugin tests/plugins/memory tests/plugins/test_retaindb_plugin.py tests/tools/test_memory_tool.py tests/tools/test_memory_tool_schema.py` - 639 passed, 4 skipped
- `.venv/bin/python -m compileall agent/memory_provider.py agent/memory_manager.py plugins/memory/honcho/__init__.py run_agent.py tools/memory_tool.py hermes_cli/config.py`
- `git diff --check`

Note: the full `tests/run_agent` suite has two pre-existing unrelated failures in `tests/run_agent/test_concurrent_interrupt.py` from a stub agent missing `_tool_guardrails`; the provider-aware memory tests and widened memory/provider suites pass.
