### PR TITLE
fix(update): reconcile local branches during update

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -44,6 +44,7 @@ Usage:
 """
 
 import argparse
+from dataclasses import dataclass
 import json
 import os
 import shutil
@@ -6146,6 +6147,176 @@ def _restore_stashed_changes(
     return True
 
 
+@dataclass(frozen=True)
+class _LocalPatchStatus:
+    """Patch-id comparison for commits on a local branch during update."""
+
+    already_upstream: list[str]
+    local_only: list[str]
+
+    @property
+    def has_commits(self) -> bool:
+        return bool(self.already_upstream or self.local_only)
+
+    @property
+    def fully_upstream(self) -> bool:
+        return bool(self.already_upstream) and not self.local_only
+
+    @property
+    def needs_rebase(self) -> bool:
+        return bool(self.local_only)
+
+
+def _get_local_patch_status(
+    git_cmd: list[str], cwd: Path, base_ref: str, branch: str
+) -> _LocalPatchStatus:
+    """Compare a local branch to an updated base by patch-id.
+
+    ``git cherry`` marks commits with ``-`` when an equivalent patch already
+    exists upstream, and ``+`` when the patch is still local-only.  That lets
+    ``hermes update`` tell the difference between "my fix landed upstream" and
+    "keep carrying my local fix forward" without keyword or filename guesses.
+    """
+    try:
+        result = subprocess.run(
+            git_cmd + ["cherry", base_ref, branch],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+        )
+    except Exception:
+        return _LocalPatchStatus(already_upstream=[], local_only=[])
+
+    if result.returncode != 0:
+        return _LocalPatchStatus(already_upstream=[], local_only=[])
+
+    already_upstream: list[str] = []
+    local_only: list[str] = []
+    for line in result.stdout.splitlines():
+        marker, _, sha = line.strip().partition(" ")
+        sha = sha.strip()
+        if not sha:
+            continue
+        if marker == "-":
+            already_upstream.append(sha)
+        elif marker == "+":
+            local_only.append(sha)
+
+    return _LocalPatchStatus(
+        already_upstream=already_upstream,
+        local_only=local_only,
+    )
+
+
+def _update_snapshot_branch_name(branch: str) -> str:
+    from datetime import datetime, timezone
+
+    safe_branch = "".join(ch if ch.isalnum() or ch in ("-", "_") else "-" for ch in branch)
+    safe_branch = safe_branch.strip("-") or "branch"
+    suffix = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+    return f"hermes-update-snapshot/{safe_branch}-{suffix}"
+
+
+def _create_update_snapshot_branch(
+    git_cmd: list[str], cwd: Path, branch: str
+) -> Optional[str]:
+    snapshot = _update_snapshot_branch_name(branch)
+    try:
+        result = subprocess.run(
+            git_cmd + ["branch", snapshot, branch],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+        )
+    except Exception:
+        return None
+    if result.returncode == 0:
+        return snapshot
+    return None
+
+
+def _reconcile_local_branch_after_update(
+    git_cmd: list[str],
+    cwd: Path,
+    branch: str,
+    base_branch: str,
+    patch_status: _LocalPatchStatus,
+) -> bool:
+    """Move local branch patches onto the updated base when they still matter.
+
+    Returns True when it is sensible to restore an autostash onto the current
+    checkout.  Returns False when the stash should be left alone for manual
+    recovery, usually because the local committed patch already landed upstream
+    or because an automatic rebase could not be completed cleanly.
+    """
+    if not patch_status.has_commits:
+        return True
+
+    if patch_status.fully_upstream:
+        print()
+        print(
+            f"✓ Local branch '{branch}' has {len(patch_status.already_upstream)} commit(s) already covered by upstream."
+        )
+        print("  Staying on main; the local patch branch is no longer needed for this fix.")
+        return False
+
+    if not patch_status.needs_rebase:
+        return True
+
+    print()
+    print(
+        f"→ Local branch '{branch}' still has {len(patch_status.local_only)} local-only commit(s)."
+    )
+    snapshot = _create_update_snapshot_branch(git_cmd, cwd, branch)
+    if snapshot:
+        print(f"  ✓ Safety branch created: {snapshot}")
+
+    checkout = subprocess.run(
+        git_cmd + ["checkout", branch],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+    if checkout.returncode != 0:
+        print(f"  ⚠ Could not switch back to '{branch}'.")
+        if checkout.stderr.strip():
+            print(f"  {checkout.stderr.strip()}")
+        return False
+
+    rebase = subprocess.run(
+        git_cmd + ["rebase", base_branch],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+    if rebase.returncode == 0:
+        print(f"  ✓ Rebased '{branch}' onto updated {base_branch}.")
+        return True
+
+    print(f"  ⚠ Automatic rebase of '{branch}' hit conflicts.")
+    if rebase.stdout.strip():
+        print(rebase.stdout.strip())
+    if rebase.stderr.strip():
+        print(rebase.stderr.strip())
+    subprocess.run(
+        git_cmd + ["rebase", "--abort"],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+    subprocess.run(
+        git_cmd + ["checkout", base_branch],
+        cwd=cwd,
+        capture_output=True,
+        text=True,
+    )
+    print("  Main was updated. Your branch was left untouched for manual rebase.")
+    if snapshot:
+        print(f"  Snapshot branch: {snapshot}")
+    print(f"  Try later: git checkout {branch} && git rebase {base_branch}")
+    return False
+
+
 # =========================================================================
 # Fork detection and upstream management for `hermes update`
 # =========================================================================
@@ -7138,6 +7309,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
         # Always update against main
         branch = "main"
+        local_patch_status = _LocalPatchStatus(already_upstream=[], local_only=[])
 
         # If user is on a non-main branch or detached HEAD, switch to main
         if current_branch != "main":
@@ -7147,6 +7319,21 @@ def _cmd_update_impl(args, gateway_mode: bool):
                 else f"branch '{current_branch}'"
             )
             print(f"  ⚠ Currently on {label} — switching to main for update...")
+            if current_branch != "HEAD":
+                local_patch_status = _get_local_patch_status(
+                    git_cmd,
+                    PROJECT_ROOT,
+                    f"origin/{branch}",
+                    current_branch,
+                )
+                if local_patch_status.fully_upstream:
+                    print(
+                        f"  ✓ {len(local_patch_status.already_upstream)} local commit(s) already appear in origin/{branch}."
+                    )
+                elif local_patch_status.needs_rebase:
+                    print(
+                        f"  → {len(local_patch_status.local_only)} local commit(s) will be carried forward after update."
+                    )
             # Stash before checkout so uncommitted work isn't lost
             auto_stash_ref = _stash_local_changes_if_needed(git_cmd, PROJECT_ROOT)
             subprocess.run(
@@ -7217,6 +7404,7 @@ def _cmd_update_impl(args, gateway_mode: bool):
 
         print("→ Pulling updates...")
         update_succeeded = False
+        restore_stash_after_update = True
         try:
             pull_result = subprocess.run(
                 git_cmd + ["pull", "--ff-only", "origin", branch],
@@ -7247,6 +7435,14 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     sys.exit(1)
             update_succeeded = True
         finally:
+            if update_succeeded and current_branch not in ("main", "HEAD"):
+                restore_stash_after_update = _reconcile_local_branch_after_update(
+                    git_cmd,
+                    PROJECT_ROOT,
+                    current_branch,
+                    branch,
+                    local_patch_status,
+                )
             if auto_stash_ref is not None:
                 # Don't attempt stash restore if the code update itself failed —
                 # working tree is in an unknown state.
@@ -7255,6 +7451,11 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         f"  ℹ️  Local changes preserved in stash (ref: {auto_stash_ref})"
                     )
                     print(f"  Restore manually with: git stash apply")
+                elif not restore_stash_after_update:
+                    print(
+                        f"  ℹ️  Local uncommitted changes preserved in stash (ref: {auto_stash_ref})"
+                    )
+                    print(f"  Restore manually with: git stash apply {auto_stash_ref}")
                 else:
                     _restore_stashed_changes(
                         git_cmd,

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -409,6 +409,7 @@ def test_install_heartbeat_prints_when_dependency_install_is_silent(monkeypatch,
 def _make_update_side_effect(
     current_branch="main",
     commit_count="3",
+    cherry_stdout="",
     ff_only_fails=False,
     reset_fails=False,
     fetch_fails=False,
@@ -426,6 +427,8 @@ def _make_update_side_effect(
             return SimpleNamespace(stdout="", stderr="", returncode=0)
         if "rev-parse" in joined and "--abbrev-ref" in joined:
             return SimpleNamespace(stdout=f"{current_branch}\n", stderr="", returncode=0)
+        if "cherry" in joined:
+            return SimpleNamespace(stdout=cherry_stdout, stderr="", returncode=0)
         if "checkout" in joined and "main" in joined:
             return SimpleNamespace(stdout="", stderr="", returncode=0)
         if "rev-list" in joined:
@@ -499,6 +502,83 @@ def test_cmd_update_switches_to_main_from_feature_branch(monkeypatch, tmp_path, 
     out = capsys.readouterr().out
     assert "fix/something" in out
     assert "switching to main" in out
+
+
+def test_get_local_patch_status_classifies_cherry_output(monkeypatch, tmp_path):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return SimpleNamespace(
+            stdout="- abc123\n+ def456\n",
+            stderr="",
+            returncode=0,
+        )
+
+    monkeypatch.setattr(hermes_main.subprocess, "run", fake_run)
+
+    status = hermes_main._get_local_patch_status(
+        ["git"], tmp_path, "origin/main", "fix/something"
+    )
+
+    assert status.already_upstream == ["abc123"]
+    assert status.local_only == ["def456"]
+    assert status.needs_rebase is True
+    assert calls[0][0] == ["git", "cherry", "origin/main", "fix/something"]
+
+
+def test_cmd_update_drops_local_branch_when_patch_already_upstream(
+    monkeypatch, tmp_path, capsys
+):
+    """If git cherry says the local patch is upstream-equivalent, stay on main."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+
+    side_effect, recorded = _make_update_side_effect(
+        current_branch="fix/something",
+        cherry_stdout="- abc123\n",
+    )
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    hermes_main.cmd_update(SimpleNamespace())
+
+    rebase_calls = [c for c in recorded if "rebase" in c]
+    checkout_back = [c for c in recorded if "checkout" in c and "fix/something" in c]
+    assert rebase_calls == []
+    assert checkout_back == []
+
+    out = capsys.readouterr().out
+    assert "already covered by upstream" in out
+    assert "Staying on main" in out
+
+
+def test_cmd_update_rebases_local_branch_when_patch_not_upstream(
+    monkeypatch, tmp_path, capsys
+):
+    """If local commits are still unique, carry the branch onto updated main."""
+    _setup_update_mocks(monkeypatch, tmp_path)
+    monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+    monkeypatch.setattr(
+        hermes_main,
+        "_update_snapshot_branch_name",
+        lambda branch: "hermes-update-snapshot/fix-something-test",
+    )
+
+    side_effect, recorded = _make_update_side_effect(
+        current_branch="fix/something",
+        cherry_stdout="+ abc123\n",
+    )
+    monkeypatch.setattr(hermes_main.subprocess, "run", side_effect)
+
+    hermes_main.cmd_update(SimpleNamespace())
+
+    assert ["git", "branch", "hermes-update-snapshot/fix-something-test", "fix/something"] in recorded
+    assert ["git", "checkout", "fix/something"] in recorded
+    assert ["git", "rebase", "main"] in recorded
+
+    out = capsys.readouterr().out
+    assert "local-only commit" in out
+    assert "Rebased 'fix/something' onto updated main" in out
 
 
 def test_cmd_update_switches_to_main_from_detached_head(monkeypatch, tmp_path, capsys):

--- a/website/docs/getting-started/updating.md
+++ b/website/docs/getting-started/updating.md
@@ -25,7 +25,7 @@ This pulls the latest code, updates dependencies, and prompts you to configure a
 When you run `hermes update`, the following steps occur:
 
 1. **Pairing-data snapshot** — a lightweight pre-update state snapshot is saved (covers `~/.hermes/pairing/`, Feishu comment rules, and other state files that get modified at runtime). Rollbackable via `hermes backup restore --state pre-update`.
-2. **Git pull** — pulls the latest code from the `main` branch and updates submodules
+2. **Git pull** — pulls the latest code from the `main` branch and updates submodules. If you started on a local feature/fix branch, Hermes compares your branch's commits against the updated upstream by patch-id: equivalent patches are treated as already solved upstream, while still-local patches are rebased onto the new `main` with a safety branch created first.
 3. **Dependency install** — runs `uv pip install -e ".[all]"` to pick up new or changed dependencies
 4. **Config migration** — detects new config options added since your version and prompts you to set them
 5. **Gateway auto-restart** — running gateways are refreshed after the update completes so the new code takes effect immediately. Service-managed gateways (systemd on Linux, launchd on macOS) are restarted through the service manager. Manual gateways are relaunched automatically when Hermes can map the running PID back to a profile.

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -1135,6 +1135,7 @@ Pulls the latest `hermes-agent` code and reinstalls dependencies in your venv, t
 Additional behavior:
 
 - **Pairing data snapshot.** Even when `--backup` is off, `hermes update` takes a lightweight snapshot of `~/.hermes/pairing/` and the Feishu comment rules before `git pull`. You can roll it back with `hermes backup restore --state pre-update` if a pull rewrites a file you were editing.
+- **Local branch reconciliation.** If you run `hermes update` from a local branch, Hermes checks the branch with `git cherry`. Commits whose patch already appears on upstream `main` are considered solved, so Hermes stays on `main`. Commits that are still local-only are rebased onto the updated `main`; Hermes creates a `hermes-update-snapshot/...` branch first so the pre-update branch tip is easy to recover.
 - **Legacy `hermes.service` warning.** If Hermes detects a pre-rename `hermes.service` systemd unit (instead of the current `hermes-gateway.service`), it prints a one-time migration hint so you can avoid flap-loop issues.
 - **Exit codes.** `0` on success, `1` on pull/install/post-install errors, `2` on unexpected working-tree changes that block `git pull`.
 


### PR DESCRIPTION
## Summary

Teach `hermes update` to reconcile local fix branches against the updated upstream `main`.

When a user starts on a local branch, Hermes now uses `git cherry origin/main <branch>` after fetch to compare commits by patch-id:

- commits already present upstream are treated as solved, so the update stays on `main`
- commits still local-only are carried forward by rebasing the branch onto updated `main`
- before rebasing, Hermes creates a `hermes-update-snapshot/...` safety branch
- if rebase conflicts, Hermes aborts the rebase, leaves `main` updated, and prints recovery guidance instead of leaving the install conflicted

This makes the common "I have a local hotfix; did upstream fix this yet?" flow less scary without using filename or keyword guesses.

## Docs

Updated the update guide and CLI reference to document local branch reconciliation.

## Tests run

- `/Users/niko/.hermes/hermes-agent-provider-routing/.venv/bin/pytest -q tests/hermes_cli/test_update_autostash.py` - 27 passed
- `/Users/niko/.hermes/hermes-agent-provider-routing/.venv/bin/python -m compileall hermes_cli/main.py`
- `git diff --check`
