### PR TITLE
fix(google-chat): repair setup prompt imports

### DIFF
--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -2936,15 +2936,14 @@ def interactive_setup() -> None:
     prompt for env vars, persist them to ``~/.hermes/.env`` so the next
     gateway restart picks them up.
     """
-    from hermes_cli.config import (
-        get_env_value,
-        save_env_value,
-        prompt,
-        prompt_yes_no,
+    from hermes_cli.cli_output import (
         print_info,
         print_success,
         print_warning,
+        prompt,
+        prompt_yes_no,
     )
+    from hermes_cli.config import get_env_value, save_env_value
 
     existing_sub = get_env_value("GOOGLE_CHAT_SUBSCRIPTION_NAME")
     if existing_sub:

--- a/tests/gateway/test_google_chat.py
+++ b/tests/gateway/test_google_chat.py
@@ -2409,6 +2409,61 @@ class TestADCFallback:
         assert "google_chat_service_account_json" in msg
 
 
+class TestGoogleChatInteractiveSetup:
+    def test_interactive_setup_uses_shared_cli_prompt_helpers(self, monkeypatch):
+        """Google Chat setup should not import prompt helpers from config.py."""
+        from plugins.platforms.google_chat import adapter as gc_mod
+
+        saved: dict[str, str] = {}
+        answers = {
+            "GCP project ID (e.g. my-project)": "demo-project",
+            "Pub/Sub subscription (projects/<proj>/subscriptions/<sub>)": (
+                "projects/demo-project/subscriptions/hermes-chat"
+            ),
+            "Path to Service Account JSON (or inline JSON)": "/tmp/sa.json",
+            "Allowed user emails (comma-separated)": "alice@example.com, bob@example.com",
+            "Home space for cron/notification delivery (e.g. spaces/AAAA, or empty)": (
+                "spaces/AAAA"
+            ),
+        }
+
+        def fake_get_env_value(key):
+            return saved.get(key, "")
+
+        def fake_save_env_value(key, value):
+            saved[key] = value
+
+        def fake_prompt(question, default=None, password=False):
+            return answers.get(question, default or "")
+
+        monkeypatch.setattr("hermes_cli.config.get_env_value", fake_get_env_value)
+        monkeypatch.setattr("hermes_cli.config.save_env_value", fake_save_env_value)
+        monkeypatch.setattr("hermes_cli.cli_output.prompt", fake_prompt)
+        monkeypatch.setattr(
+            "hermes_cli.cli_output.prompt_yes_no", lambda *_a, **_kw: True
+        )
+        monkeypatch.setattr(
+            "hermes_cli.cli_output.print_info", lambda *_a, **_kw: None
+        )
+        monkeypatch.setattr(
+            "hermes_cli.cli_output.print_success", lambda *_a, **_kw: None
+        )
+        monkeypatch.setattr(
+            "hermes_cli.cli_output.print_warning", lambda *_a, **_kw: None
+        )
+
+        gc_mod.interactive_setup()
+
+        assert saved["GOOGLE_CHAT_PROJECT_ID"] == "demo-project"
+        assert (
+            saved["GOOGLE_CHAT_SUBSCRIPTION_NAME"]
+            == "projects/demo-project/subscriptions/hermes-chat"
+        )
+        assert saved["GOOGLE_CHAT_SERVICE_ACCOUNT_JSON"] == "/tmp/sa.json"
+        assert saved["GOOGLE_CHAT_ALLOWED_USERS"] == "alice@example.com,bob@example.com"
+        assert saved["GOOGLE_CHAT_HOME_CHANNEL"] == "spaces/AAAA"
+
+
 # ===========================================================================
 # Supervisor reconnect (backoff + fatal)
 # ===========================================================================


### PR DESCRIPTION
## What does this PR do?

Fixes the Google Chat gateway setup crash caused by the plugin importing shared CLI prompt/output helpers from `hermes_cli.config`. Those helpers live in `hermes_cli.cli_output`, so selecting Google Chat in `hermes gateway setup` could raise `ImportError: cannot import name 'prompt' from 'hermes_cli.config'` before setup prompts were shown.

This splits the imports so env helpers still come from `hermes_cli.config` and prompt/output helpers come from `hermes_cli.cli_output`.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/platforms/google_chat/adapter.py`: import prompt/output helpers from `hermes_cli.cli_output` instead of `hermes_cli.config`.
- `tests/gateway/test_google_chat.py`: add a regression test for `interactive_setup()` that exercises the setup prompts and env persistence path.

## How to Test

1. Run `python -m pytest tests/gateway/test_google_chat.py -q`.
2. Run `python -m pytest tests/gateway/test_google_chat.py::TestGoogleChatInteractiveSetup -q`.
3. Select Google Chat in `hermes gateway setup` and confirm setup prompts appear instead of an import error.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux / WSL

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- [x] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled) — N/A
- [x] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls) — N/A
- [x] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools) — N/A
- [x] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"` — N/A

## Screenshots / Logs

Targeted tests:

- `.venv/bin/python -m pytest tests/gateway/test_google_chat.py -q`: 154 passed, 1 warning in 6.89s.
- `.venv/bin/python -m pytest tests/gateway/test_google_chat.py::TestGoogleChatInteractiveSetup -q`: 1 passed in 3.43s.
- `py_compile` for `plugins/platforms/google_chat/adapter.py` and `tests/gateway/test_google_chat.py`: passed.

Full suite:

- `scripts/run_tests.sh -n 4`: 54 failed, 20926 passed, 51 skipped, 240 warnings in 495.27s.
- `HERMES_HOME` before full suite: empty.
- `HERMES_HOME` after full suite: empty.

The full suite is not green in this checkout; the targeted Google Chat tests pass in isolation after the full-suite run.

Full-suite failure summary:

- `tests/gateway/test_api_server_runs.py::TestRunEvents::test_approval_request_event_and_response_unblock_run`
- `tests/gateway/test_config.py::TestLoadGatewayConfig::test_bridges_quoted_false_platform_enabled_from_config_yaml`
- `tests/cron/test_cron_script.py::TestBuildJobPromptWithScript::test_script_empty_output_noted`
- `tests/gateway/test_dingtalk.py::TestCardLifecycle::test_final_reply_finalizes_card`
- `tests/gateway/test_dingtalk.py::TestCardLifecycle::test_intermediate_send_stays_streaming`
- `tests/gateway/test_dingtalk.py::TestCardLifecycle::test_done_fires_only_when_reply_to_is_set`
- `tests/gateway/test_dingtalk.py::TestCardLifecycle::test_edit_message_finalize_fires_done`
- `tests/gateway/test_dingtalk.py::TestCardLifecycle::test_edit_message_finalize_false_tracks_sibling`
- `tests/gateway/test_dingtalk.py::TestCardLifecycle::test_next_send_auto_closes_sibling_streaming_cards`
- `tests/gateway/test_dingtalk.py::TestDingTalkAdapterAICards::test_send_uses_ai_card_if_configured`
- `tests/gateway/test_discord_bot_filter.py::TestDiscordBotFilter::test_default_is_none`
- `tests/agent/test_auxiliary_client.py::TestGetTextAuxiliaryClient::test_custom_endpoint_uses_codex_wrapper_when_runtime_requests_responses_api`
- `tests/agent/test_bedrock_1m_context.py::TestBedrockContext1MBeta::test_common_betas_includes_1m`
- `tests/agent/test_bedrock_1m_context.py::TestBedrockContext1MBeta::test_common_betas_for_native_anthropic_includes_1m`
- `tests/agent/test_bedrock_1m_context.py::TestBedrockContext1MBeta::test_build_anthropic_kwargs_includes_1m_for_bedrock_fastmode`
- `tests/gateway/test_discord_free_response.py::test_discord_free_channel_skips_auto_thread`
- `tests/cron/test_scheduler_mcp_init.py::test_run_job_calls_discover_mcp_tools_before_agent_construction`
- `tests/cron/test_scheduler_mcp_init.py::test_run_job_tolerates_discover_mcp_tools_failure`
- `tests/agent/test_unsupported_parameter_retry.py::TestMaxTokensRetryHardening::test_sync_max_tokens_retry_matches_generic_phrasing`
- `tests/agent/test_unsupported_parameter_retry.py::TestMaxTokensRetryHardening::test_async_max_tokens_retry_matches_generic_phrasing`
- `tests/gateway/test_api_server.py::TestAdapterInit::test_default_config`
- `tests/hermes_cli/test_backup.py::TestPreUpdateBackup::test_rotation_keeps_only_n`
- `tests/hermes_cli/test_model_validation.py::TestValidateCodexAutoCorrection::test_very_different_name_falls_to_suggestions`
- `tests/gateway/test_google_chat.py::TestEnvConfigLoading::test_project_id_primary`
- `tests/gateway/test_google_chat.py::TestEnvConfigLoading::test_project_id_falls_back_to_google_cloud_project`
- `tests/gateway/test_google_chat.py::TestEnvConfigLoading::test_subscription_accepts_legacy_alias`
- `tests/gateway/test_google_chat.py::TestEnvConfigLoading::test_sa_path_falls_back_to_google_application_credentials`
- `tests/gateway/test_google_chat.py::TestEnvConfigLoading::test_home_channel_populated`
- `tests/gateway/test_google_chat.py::TestEnvConfigLoading::test_connected_platforms_recognises_via_extras`
- `tests/hermes_cli/test_cmd_update.py::TestCmdUpdateBranchFallback::test_update_refreshes_repo_and_tui_node_dependencies`
- `tests/run_agent/test_concurrent_interrupt.py::test_concurrent_interrupt_cancels_pending`
- `tests/run_agent/test_concurrent_interrupt.py::test_running_concurrent_worker_sees_is_interrupted`
- `tests/hermes_cli/test_model_provider_persistence.py::TestProviderPersistsAfterModelSave::test_lmstudio_provider_saved_when_selected`
- `tests/hermes_cli/test_model_provider_persistence.py::TestBaseUrlValidation::test_stepfun_provider_saved_with_selected_region`
- `tests/tools/test_browser_chromium_check.py::TestChromiumInstalled::test_false_when_dir_empty`
- `tests/tools/test_browser_chromium_check.py::TestChromiumInstalled::test_false_when_only_unrelated_browsers`
- `tests/tools/test_browser_chromium_check.py::TestChromiumInstalled::test_false_when_path_not_a_dir`
- `tests/tools/test_browser_chromium_check.py::TestCheckBrowserRequirementsChromium::test_local_mode_missing_chromium_returns_false`
- `tests/tools/test_browser_chromium_check.py::TestRunBrowserCommandChromiumGuard::test_local_mode_missing_chromium_returns_error_immediately`
- `tests/tools/test_browser_chromium_check.py::TestRunBrowserCommandChromiumGuard::test_docker_hint_mentions_image_pull`
- `tests/tools/test_browser_chromium_check.py::TestRunBrowserCommandChromiumGuard::test_non_docker_hint_mentions_agent_browser_install`
- `tests/tools/test_delegate.py::TestDelegationCredentialResolution::test_nous_provider_resolves_nous_credentials`
- `tests/tools/test_delegate.py::TestDelegationCredentialResolution::test_provider_resolution_uses_runtime_model_when_config_model_missing`
- `tests/tools/test_delegate.py::TestDelegationCredentialResolution::test_provider_resolves_full_credentials`
- `tests/tools/test_delegate.py::TestDelegateHeartbeat::test_heartbeat_still_trips_idle_stale_when_no_tool`
- `tests/tools/test_skill_provenance.py::test_default_origin_is_foreground`
- `tests/tools/test_tirith_security.py::TestDiskFailureMarker::test_cosign_missing_marker_clears_when_cosign_appears`
- `tests/tools/test_vercel_sandbox_environment.py::TestExecute::test_execute_runs_command_from_workspace_root_and_updates_cwd`
- `tests/tools/test_command_guards.py::TestTirithBlock::test_tirith_block_gateway_returns_approval_required`
- `tests/tools/test_command_guards.py::TestTirithAllowDangerous::test_dangerous_only_gateway`
- `tests/tools/test_command_guards.py::TestCombinedWarnings::test_combined_gateway`
- `tests/tools/test_command_guards.py::TestWarnEmptyFindings::test_warn_empty_findings_gateway`
- `tests/tools/test_credential_pool_env_fallback.py::TestCredentialPoolSeedsFromDotEnv::test_os_environ_still_wins_over_dotenv`
- `tests/tools/test_daytona_environment.py::TestExecute::test_custom_cwd_in_command_wrapper`
