### PR TITLE
fix(dashboard): check entry-exports.js for hermes-ink staleness

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -972,7 +972,11 @@ def _tui_build_needed(tui_dir: Path) -> bool:
 
 def _hermes_ink_bundle_stale(tui_dir: Path) -> bool:
     ink_root = tui_dir / "packages" / "hermes-ink"
-    bundle = ink_root / "dist" / "ink-bundle.js"
+    # The hermes-ink build script produces entry-exports.js (not ink-bundle.js).
+    # Check entry-exports.js first; fall back to ink-bundle.js for older builds.
+    bundle = ink_root / "dist" / "entry-exports.js"
+    if not bundle.exists():
+        bundle = ink_root / "dist" / "ink-bundle.js"
     if not bundle.exists():
         return True
     bm = bundle.stat().st_mtime


### PR DESCRIPTION
## Problem

The dashboard chat tab (enabled via `hermes dashboard --tui`) renders but input is completely dead — keystrokes have no effect.

Root cause: `_hermes_ink_bundle_stale()` in `hermes_cli/main.py` checks for `packages/hermes-ink/dist/ink-bundle.js`, but the `hermes-ink` build script (`esbuild src/entry-exports.ts ... --outdir=dist`) produces `entry-exports.js`, not `ink-bundle.js`.

Because `ink-bundle.js` never exists, the staleness check always returns `True`, which causes `_find_bundled_tui()` to return `None` on every call. The `/api/pty` WebSocket endpoint then immediately rejects connections with "TUI build did not produce dist/entry.js", disconnecting before the xterm terminal in the browser can establish input.

## Fix

Check for `entry-exports.js` first (what the build actually produces), with `ink-bundle.js` as a fallback for any older builds that may have used the previous filename.

## Verification



After this fix, the `/api/pty` WebSocket connects successfully, the PTY spawns `hermes --tui`, and the chat tab is fully interactive.
