### PR TITLE
docs(teams): split meetings setup from operator runbook (salvage of #21412)

### DIFF
--- a/skills/productivity/teams-meeting-pipeline/SKILL.md
+++ b/skills/productivity/teams-meeting-pipeline/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: teams-meeting-pipeline
+description: "Operate the Teams meeting summary pipeline via Hermes CLI."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+prerequisites:
+  env_vars: [MSGRAPH_TENANT_ID, MSGRAPH_CLIENT_ID, MSGRAPH_CLIENT_SECRET]
+  commands: [hermes]
+metadata:
+  hermes:
+    tags: [Teams, Microsoft Graph, Meetings, Productivity, Operations]
+---
+
+# Teams Meeting Pipeline
+
+Use this skill when the user asks to summarize a Teams meeting, extract action items, inspect pipeline status, replay a stored job, or validate Microsoft Graph meeting-ingest setup.
+
+Prefer the Hermes CLI over ad hoc scripts. Route operator actions through the terminal tool with `hermes teams-pipeline ...`.
+
+## When to use
+
+- "Teams meeting ozetle"
+- "action item cikar"
+- "toplanti notu"
+- "pipeline durumu"
+- "replay job"
+
+## Required environment
+
+Set these in `~/.hermes/.env` before using the pipeline:
+
+```bash
+MSGRAPH_TENANT_ID=...
+MSGRAPH_CLIENT_ID=...
+MSGRAPH_CLIENT_SECRET=...
+```
+
+## Common commands
+
+```bash
+hermes teams-pipeline list
+hermes teams-pipeline show <job-id>
+hermes teams-pipeline replay <job-id>
+hermes teams-pipeline fetch --meeting-id <meeting-id>
+hermes teams-pipeline token-health
+hermes teams-pipeline maintain-subscriptions
+```
+
+Start with `validate`, `list`, or `show` when the user asks for status. Use `replay` only when they explicitly want to rerun a stored job. Use `fetch` for dry-run artifact checks before changing pipeline config.

--- a/skills/productivity/teams-meeting-pipeline/SKILL.md
+++ b/skills/productivity/teams-meeting-pipeline/SKILL.md
@@ -1,8 +1,8 @@
 ---
 name: teams-meeting-pipeline
-description: "Operate the Teams meeting summary pipeline via Hermes CLI."
-version: 1.0.0
-author: Hermes Agent
+description: "Operate the Teams meeting summary pipeline via Hermes CLI — summarize meetings, inspect pipeline status, replay jobs, manage Microsoft Graph subscriptions."
+version: 1.1.0
+author: Hermes Agent + Teknium
 license: MIT
 prerequisites:
   env_vars: [MSGRAPH_TENANT_ID, MSGRAPH_CLIENT_ID, MSGRAPH_CLIENT_SECRET]
@@ -10,25 +10,36 @@ prerequisites:
 metadata:
   hermes:
     tags: [Teams, Microsoft Graph, Meetings, Productivity, Operations]
+    related_docs:
+      - /docs/guides/microsoft-graph-app-registration
+      - /docs/user-guide/messaging/teams-meetings
+      - /docs/guides/operate-teams-meeting-pipeline
 ---
 
 # Teams Meeting Pipeline
 
-Use this skill when the user asks to summarize a Teams meeting, extract action items, inspect pipeline status, replay a stored job, or validate Microsoft Graph meeting-ingest setup.
+Use this skill whenever the user asks about Microsoft Teams meeting summaries, transcripts, recordings, action items, Graph subscriptions, or any operational question about the Teams meeting pipeline. Works in any language — the triggers below are examples, not an exhaustive list.
 
-Prefer the Hermes CLI over ad hoc scripts. Route operator actions through the terminal tool with `hermes teams-pipeline ...`.
+Everything operator-facing is a `hermes teams-pipeline` subcommand run via the terminal tool. There are no new model tools for this pipeline — the CLI is the surface.
 
-## When to use
+## When to use this skill
 
-- "Teams meeting ozetle"
-- "action item cikar"
-- "toplanti notu"
-- "pipeline durumu"
-- "replay job"
+The user is asking to:
+- summarize a Teams meeting / extract action items / pull meeting notes
+- check pipeline status, inspect a stored meeting job, or see recent meetings
+- replay / re-run a stored job that failed or needs a fresh summary
+- validate Microsoft Graph setup after changing env or config
+- troubleshoot "meeting summary never arrived" or "no new meetings are ingesting"
+- manage Graph webhook subscriptions (create, renew, delete, inspect)
+- set up automated subscription renewal (see pitfall below)
 
-## Required environment
+Multilingual trigger examples (not exhaustive):
+- English: "summarize the Teams meeting", "pipeline status", "replay job X"
+- Turkish: "Teams meeting özetle", "action item çıkar", "toplantı notu", "pipeline durumu", "replay job"
 
-Set these in `~/.hermes/.env` before using the pipeline:
+## Prerequisites
+
+Before using the pipeline, verify these are set in `~/.hermes/.env`:
 
 ```bash
 MSGRAPH_TENANT_ID=...
@@ -36,15 +47,70 @@ MSGRAPH_CLIENT_ID=...
 MSGRAPH_CLIENT_SECRET=...
 ```
 
-## Common commands
+If any are missing, direct the user to the Azure app registration guide at `/docs/guides/microsoft-graph-app-registration` — they need an Azure AD app registration with admin-consented Graph application permissions before the pipeline will work.
+
+## Command reference
+
+### Status and inspection (start here)
 
 ```bash
-hermes teams-pipeline list
-hermes teams-pipeline show <job-id>
-hermes teams-pipeline replay <job-id>
-hermes teams-pipeline fetch --meeting-id <meeting-id>
-hermes teams-pipeline token-health
-hermes teams-pipeline maintain-subscriptions
+hermes teams-pipeline validate              # config snapshot — run first after any change
+hermes teams-pipeline token-health          # Graph token status
+hermes teams-pipeline token-health --force-refresh   # force a fresh token acquisition
+hermes teams-pipeline list                  # recent meeting jobs
+hermes teams-pipeline list --status failed  # only failed jobs
+hermes teams-pipeline show <job-id>         # full detail of one job
+hermes teams-pipeline subscriptions         # current Graph webhook subscriptions
 ```
 
-Start with `validate`, `list`, or `show` when the user asks for status. Use `replay` only when they explicitly want to rerun a stored job. Use `fetch` for dry-run artifact checks before changing pipeline config.
+### Re-running / debugging
+
+```bash
+hermes teams-pipeline run <job-id>          # replay a stored job (re-summarize, re-deliver)
+hermes teams-pipeline fetch --meeting-id <id>   # dry-run: resolve meeting + transcript without persisting
+hermes teams-pipeline fetch --join-web-url "<url>"   # dry-run by join URL
+```
+
+### Subscription management
+
+```bash
+hermes teams-pipeline subscribe \
+  --resource communications/onlineMeetings/getAllTranscripts \
+  --notification-url https://<your-public-host>/msgraph/webhook \
+  --client-state "$MSGRAPH_WEBHOOK_CLIENT_STATE"
+
+hermes teams-pipeline renew-subscription <sub-id> --expiration <iso-8601>
+hermes teams-pipeline delete-subscription <sub-id>
+hermes teams-pipeline maintain-subscriptions            # renew near-expiry ones
+hermes teams-pipeline maintain-subscriptions --dry-run  # show what would be renewed
+```
+
+## Decision tree for common asks
+
+- User asks "why didn't I get a summary for today's meeting?" → start with `list --status failed`, then `show <job-id>` on the relevant row. If the job doesn't exist at all, check `subscriptions` — the webhook may have expired (see pitfall below).
+- User asks "is setup working?" → `validate`, then `token-health`, then `subscriptions`. If all three pass, request a test meeting and check `list` for a fresh row.
+- User asks "re-run summary for meeting X" → `list` to find the job ID, `run <job-id>` to replay. If it fails again, `show <job-id>` to inspect the error and `fetch --meeting-id` to dry-run the artifact resolution.
+- User asks "add meeting X to the pipeline" → usually you don't — the pipeline is subscription-driven, not per-meeting. If they want a specific past meeting summarized, use `fetch` to pull transcript + `run` after a job is created.
+
+## Critical pitfall: Graph subscriptions expire in 72 hours
+
+Microsoft Graph caps webhook subscriptions at 72 hours and **will not auto-renew them**. If `maintain-subscriptions` is not scheduled, meeting notifications silently stop arriving 3 days after any manual subscription creation.
+
+When the user reports "the pipeline worked yesterday but nothing is arriving today":
+1. Run `hermes teams-pipeline subscriptions` — if it's empty or all entries show `expirationDateTime` in the past, that's the cause.
+2. Recreate with `subscribe` as shown above.
+3. **Set up automated renewal immediately** via `hermes cron add`, a systemd timer, or plain crontab. The operator runbook at `/docs/guides/operate-teams-meeting-pipeline#automating-subscription-renewal-required-for-production` has all three options. 12-hour interval is safe (6x headroom against the 72h limit).
+
+## Other pitfalls
+
+- **Transcript not available yet.** Teams takes some time after a meeting ends to generate the transcript artifact. `fetch --meeting-id` on a just-ended meeting may return empty. Wait 2-5 minutes and retry, or let the Graph webhook drive ingestion naturally.
+- **Delivery mode mismatch.** If summaries are produced (`list` shows success) but nothing lands in Teams, check `platforms.teams.extra.delivery_mode` and the matching target config (`incoming_webhook_url` OR `chat_id` OR `team_id`+`channel_id`). The writer reads these from config.yaml or `TEAMS_*` env vars.
+- **Graph app permissions.** A token acquires cleanly (`token-health` passes) but Graph API calls return 401/403 when permissions were added but admin consent wasn't re-granted. Have the user revisit the app registration in the Azure portal and click "Grant admin consent" again.
+
+## Related docs
+
+Point the user to these when they need more depth than this skill covers:
+- Azure app registration walkthrough: `/docs/guides/microsoft-graph-app-registration`
+- Full pipeline setup: `/docs/user-guide/messaging/teams-meetings`
+- Operator runbook (renewal automation, troubleshooting, go-live checklist): `/docs/guides/operate-teams-meeting-pipeline`
+- Webhook listener setup: `/docs/user-guide/messaging/msgraph-webhook`

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -360,7 +360,7 @@ class TestTeamsInteractiveSetup:
         assert "TEAMS_TENANT_ID=tenant-id" in env_text
 
 class TestTeamsConnect:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_connect_fails_without_sdk(self, monkeypatch):
         monkeypatch.setattr(_teams_mod, "TEAMS_SDK_AVAILABLE", False)
         adapter = TeamsAdapter(_make_config(
@@ -369,7 +369,7 @@ class TestTeamsConnect:
         result = await adapter.connect()
         assert result is False
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_connect_fails_without_credentials(self):
         adapter = TeamsAdapter(_make_config())
         adapter._client_id = ""
@@ -378,7 +378,7 @@ class TestTeamsConnect:
         result = await adapter.connect()
         assert result is False
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_disconnect_cleans_up(self):
         adapter = TeamsAdapter(_make_config(
             client_id="id", client_secret="secret", tenant_id="tenant",
@@ -400,7 +400,7 @@ class TestTeamsConnect:
 # ---------------------------------------------------------------------------
 
 class TestTeamsSend:
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_send_returns_error_without_app(self):
         adapter = TeamsAdapter(_make_config(
             client_id="id", client_secret="secret", tenant_id="tenant",
@@ -410,7 +410,7 @@ class TestTeamsSend:
         assert result.success is False
         assert "not initialized" in result.error
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_send_calls_app_send(self):
         adapter = TeamsAdapter(_make_config(
             client_id="id", client_secret="secret", tenant_id="tenant",
@@ -426,7 +426,7 @@ class TestTeamsSend:
         assert result.message_id == "msg-123"
         mock_app.send.assert_awaited_once_with("conv-id", "Hello")
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_send_handles_error(self):
         adapter = TeamsAdapter(_make_config(
             client_id="id", client_secret="secret", tenant_id="tenant",
@@ -439,7 +439,7 @@ class TestTeamsSend:
         assert result.success is False
         assert "Network error" in result.error
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_send_typing(self):
         adapter = TeamsAdapter(_make_config(
             client_id="id", client_secret="secret", tenant_id="tenant",
@@ -594,7 +594,7 @@ class TestTeamsMessageHandling:
         ctx.activity = activity
         return ctx
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_personal_message_creates_dm_event(self):
         adapter = TeamsAdapter(_make_config(
             client_id="bot-id", client_secret="secret", tenant_id="tenant",
@@ -610,7 +610,7 @@ class TestTeamsMessageHandling:
         event = adapter.handle_message.call_args[0][0]
         assert event.source.chat_type == "dm"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_group_message_creates_group_event(self):
         adapter = TeamsAdapter(_make_config(
             client_id="bot-id", client_secret="secret", tenant_id="tenant",
@@ -625,7 +625,7 @@ class TestTeamsMessageHandling:
         event = adapter.handle_message.call_args[0][0]
         assert event.source.chat_type == "group"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_channel_message_creates_channel_event(self):
         adapter = TeamsAdapter(_make_config(
             client_id="bot-id", client_secret="secret", tenant_id="tenant",
@@ -640,7 +640,7 @@ class TestTeamsMessageHandling:
         event = adapter.handle_message.call_args[0][0]
         assert event.source.chat_type == "channel"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_user_id_uses_aad_object_id(self):
         adapter = TeamsAdapter(_make_config(
             client_id="bot-id", client_secret="secret", tenant_id="tenant",
@@ -655,7 +655,7 @@ class TestTeamsMessageHandling:
         event = adapter.handle_message.call_args[0][0]
         assert event.source.user_id == "aad-stable-id"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_self_message_filtered(self):
         adapter = TeamsAdapter(_make_config(
             client_id="bot-id", client_secret="secret", tenant_id="tenant",
@@ -669,7 +669,7 @@ class TestTeamsMessageHandling:
 
         adapter.handle_message.assert_not_awaited()
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_bot_mention_stripped_from_text(self):
         adapter = TeamsAdapter(_make_config(
             client_id="bot-id", client_secret="secret", tenant_id="tenant",
@@ -687,7 +687,7 @@ class TestTeamsMessageHandling:
         event = adapter.handle_message.call_args[0][0]
         assert event.text == "what is the weather?"
 
-    @pytest.mark.asyncio
+    @pytest.mark.anyio
     async def test_deduplication(self):
         adapter = TeamsAdapter(_make_config(
             client_id="bot-id", client_secret="secret", tenant_id="tenant",

--- a/website/docs/guides/operate-teams-meeting-pipeline.md
+++ b/website/docs/guides/operate-teams-meeting-pipeline.md
@@ -1,0 +1,193 @@
+---
+title: "Operate the Teams Meeting Pipeline"
+description: "Runbook, go-live checklist, and operator worksheet for the Microsoft Teams meeting pipeline"
+---
+
+# Operate the Teams Meeting Pipeline
+
+Use this guide after you have already enabled the feature from [Teams Meetings](/docs/user-guide/messaging/teams-meetings).
+
+This page covers:
+- operator CLI flows
+- routine subscription maintenance
+- failure triage
+- go-live checks
+- rollout worksheet
+
+## Core Operator Commands
+
+### Validate the config snapshot
+
+```bash
+hermes teams-pipeline validate
+```
+
+Use this first after any config change.
+
+### Inspect token health
+
+```bash
+hermes teams-pipeline token-health
+hermes teams-pipeline token-health --force-refresh
+```
+
+Use `--force-refresh` when you suspect stale auth state.
+
+### Inspect subscriptions
+
+```bash
+hermes teams-pipeline subscriptions
+```
+
+### Renew near-expiry subscriptions
+
+```bash
+hermes teams-pipeline maintain-subscriptions
+hermes teams-pipeline maintain-subscriptions --dry-run
+```
+
+### Inspect recent jobs
+
+```bash
+hermes teams-pipeline list
+hermes teams-pipeline list --status failed
+hermes teams-pipeline show <job-id>
+```
+
+### Replay a stored job
+
+```bash
+hermes teams-pipeline run <job-id>
+```
+
+### Dry-run meeting artifact fetches
+
+```bash
+hermes teams-pipeline fetch --meeting-id <meeting-id>
+hermes teams-pipeline fetch --join-web-url "<join-url>"
+```
+
+## Routine Runbook
+
+### After first setup
+
+Run these in order:
+
+```bash
+hermes teams-pipeline validate
+hermes teams-pipeline token-health --force-refresh
+hermes teams-pipeline subscriptions
+```
+
+Then trigger or wait for a real meeting event and confirm:
+
+```bash
+hermes teams-pipeline list
+hermes teams-pipeline show <job-id>
+```
+
+### Daily or periodic checks
+
+- run `hermes teams-pipeline maintain-subscriptions --dry-run`
+- inspect `hermes teams-pipeline list --status failed`
+- verify the Teams delivery target is still the correct chat or channel
+
+### Before changing webhook URLs or delivery targets
+
+- update the public notification URL or Teams target config
+- run `hermes teams-pipeline validate`
+- renew or recreate affected subscriptions
+- confirm new events land in the expected sink
+
+## Failure Triage
+
+### No jobs are being created
+
+Check:
+- `msgraph_webhook` is enabled
+- the public notification URL points to `/msgraph/webhook`
+- the client state in the subscription matches `MSGRAPH_WEBHOOK_CLIENT_STATE`
+- subscriptions still exist remotely and are not expired
+
+### Jobs stay in retry or fail before summarization
+
+Check:
+- transcript permissions and availability
+- recording permissions and artifact availability
+- `ffmpeg` availability if recording fallback is enabled
+- Graph token health
+
+### Summaries are produced but not delivered to Teams
+
+Check:
+- `platforms.teams.enabled: true`
+- `delivery_mode`
+- `incoming_webhook_url` for webhook mode
+- `chat_id` or `team_id` plus `channel_id` for Graph mode
+- Teams auth config if Graph posting is used
+
+### Duplicate or unexpected replays
+
+Check:
+- whether you manually replayed a job with `hermes teams-pipeline run`
+- whether the sink record already exists for that meeting
+- whether you intentionally enabled a resend path in your local config
+
+## Go-Live Checklist
+
+- [ ] Graph credentials are present and correct
+- [ ] `msgraph_webhook` is enabled and reachable from the public internet
+- [ ] `MSGRAPH_WEBHOOK_CLIENT_STATE` is set and matches subscriptions
+- [ ] transcript subscription is created
+- [ ] recording subscription is created if STT fallback is required
+- [ ] `ffmpeg` is installed if recording fallback is enabled
+- [ ] Teams outbound delivery target is configured and verified
+- [ ] Notion and Linear sinks are configured only if actually needed
+- [ ] `hermes teams-pipeline validate` returns an OK snapshot
+- [ ] `hermes teams-pipeline token-health --force-refresh` succeeds
+- [ ] a real end-to-end meeting event has produced a stored job
+- [ ] at least one summary has reached the intended delivery sink
+
+## Delivery-Mode Decision Guide
+
+| Mode | Use when | Tradeoff |
+|------|----------|----------|
+| `incoming_webhook` | you only need simple posting into Teams | simplest setup, less control |
+| `graph` | you need channel or chat posting through Graph | more control, more auth and target config |
+
+## Operator Worksheet
+
+Fill this out before rollout:
+
+| Item | Value |
+|------|-------|
+| Public notification URL | |
+| Graph tenant ID | |
+| Graph client ID | |
+| Webhook client state | |
+| Transcript resource subscription | |
+| Recording resource subscription | |
+| Teams delivery mode | |
+| Teams chat ID or team/channel | |
+| Notion database ID | |
+| Linear team ID | |
+| Store path override, if any | |
+| Owner for daily checks | |
+
+## Change Review Worksheet
+
+Use this before changing the deployment:
+
+| Question | Answer |
+|----------|--------|
+| Are we changing the public webhook URL? | |
+| Are we rotating Graph credentials? | |
+| Are we changing Teams delivery mode? | |
+| Are we moving to a new Teams chat or channel? | |
+| Do subscriptions need to be recreated or renewed? | |
+| Do we need a fresh end-to-end verification run? | |
+
+## Related Docs
+
+- [Teams Meetings setup](/docs/user-guide/messaging/teams-meetings)
+- [Microsoft Teams bot setup](/docs/user-guide/messaging/teams)

--- a/website/docs/guides/operate-teams-meeting-pipeline.md
+++ b/website/docs/guides/operate-teams-meeting-pipeline.md
@@ -46,6 +46,89 @@ hermes teams-pipeline maintain-subscriptions
 hermes teams-pipeline maintain-subscriptions --dry-run
 ```
 
+### Automating subscription renewal (REQUIRED for production)
+
+**Microsoft Graph subscriptions expire in at most 72 hours.** If nothing renews them, meeting notifications silently stop after 3 days and the pipeline looks "broken." This is the #1 operational failure mode for any Graph-backed integration.
+
+You MUST run `maintain-subscriptions` on a schedule. Pick one of these three options:
+
+#### Option 1: Hermes cron (recommended if you already run the Hermes gateway)
+
+Hermes ships a built-in cron scheduler. Add a script-only cron job that runs every 12 hours (gives 6x headroom against the 72h expiry window):
+
+```bash
+hermes cron add \
+  --name "teams-pipeline-maintain-subscriptions" \
+  --schedule "0 */12 * * *" \
+  --script-only \
+  --command "hermes teams-pipeline maintain-subscriptions"
+```
+
+Verify it was registered and inspect the next run time:
+
+```bash
+hermes cron list
+hermes cron show teams-pipeline-maintain-subscriptions
+```
+
+#### Option 2: systemd timer (recommended for Linux production deployments)
+
+Create `/etc/systemd/system/hermes-teams-pipeline-maintain.service`:
+
+```ini
+[Unit]
+Description=Hermes Teams pipeline subscription maintenance
+After=network-online.target
+
+[Service]
+Type=oneshot
+User=hermes
+EnvironmentFile=/etc/hermes/env
+ExecStart=/usr/local/bin/hermes teams-pipeline maintain-subscriptions
+```
+
+And `/etc/systemd/system/hermes-teams-pipeline-maintain.timer`:
+
+```ini
+[Unit]
+Description=Run Hermes Teams pipeline subscription maintenance every 12 hours
+
+[Timer]
+OnBootSec=5min
+OnUnitActiveSec=12h
+Persistent=true
+
+[Install]
+WantedBy=timers.target
+```
+
+Enable:
+
+```bash
+sudo systemctl daemon-reload
+sudo systemctl enable --now hermes-teams-pipeline-maintain.timer
+systemctl list-timers hermes-teams-pipeline-maintain.timer
+```
+
+#### Option 3: Plain crontab
+
+```cron
+0 */12 * * * /usr/local/bin/hermes teams-pipeline maintain-subscriptions >> /var/log/hermes/teams-pipeline-maintain.log 2>&1
+```
+
+Make sure the cron environment has the `MSGRAPH_*` credentials. Simplest fix: source `~/.hermes/.env` at the top of a wrapper script that crontab calls.
+
+#### Verifying renewal is working
+
+After you've set up the schedule, check renewal activity after the first scheduled run:
+
+```bash
+hermes teams-pipeline subscriptions   # should show expirationDateTime advanced
+hermes teams-pipeline maintain-subscriptions --dry-run   # should show "0 expiring soon" most of the time
+```
+
+If you ever see your Graph webhook mysteriously "stop working" after exactly ~72 hours, this is the first thing to check: did the renewal job actually run?
+
 ### Inspect recent jobs
 
 ```bash
@@ -145,6 +228,7 @@ Check:
 - [ ] Notion and Linear sinks are configured only if actually needed
 - [ ] `hermes teams-pipeline validate` returns an OK snapshot
 - [ ] `hermes teams-pipeline token-health --force-refresh` succeeds
+- [ ] **`maintain-subscriptions` is scheduled** (Hermes cron, systemd timer, or crontab — see [Automating subscription renewal](#automating-subscription-renewal-required-for-production)). Without this, Graph subscriptions silently expire within 72 hours.
 - [ ] a real end-to-end meeting event has produced a stored job
 - [ ] at least one summary has reached the intended delivery sink
 

--- a/website/docs/user-guide/messaging/index.md
+++ b/website/docs/user-guide/messaging/index.md
@@ -427,5 +427,6 @@ Each platform has its own toolset:
 - [QQBot Setup](qqbot.md)
 - [Yuanbao Setup](yuanbao.md)
 - [Microsoft Teams Setup](teams.md)
+- [Teams Meetings Pipeline](teams-meetings.md)
 - [Open WebUI + API Server](open-webui.md)
 - [Webhooks](webhooks.md)

--- a/website/docs/user-guide/messaging/teams-meetings.md
+++ b/website/docs/user-guide/messaging/teams-meetings.md
@@ -1,0 +1,227 @@
+---
+sidebar_position: 6
+title: "Teams Meetings"
+description: "Set up the Microsoft Teams meeting summary pipeline with Microsoft Graph webhooks"
+---
+
+# Microsoft Teams Meetings
+
+Use the Teams meeting pipeline when you want Hermes to ingest Microsoft Graph meeting events, fetch transcripts first, fall back to recordings plus STT when needed, and deliver a structured summary to downstream sinks.
+
+This page focuses on setup and enablement:
+- Graph credentials
+- webhook listener configuration
+- Teams delivery modes
+- pipeline config shape
+
+For day-2 operations, go-live checks, and the operator worksheet, use the dedicated guide: [Operate the Teams Meeting Pipeline](/docs/guides/operate-teams-meeting-pipeline).
+
+## What This Feature Does
+
+The pipeline:
+1. receives Microsoft Graph webhook events
+2. resolves the meeting and prefers transcript artifacts first
+3. falls back to recording download plus STT when no usable transcript is available
+4. stores durable job state and sink records locally
+5. can write summaries to Notion, Linear, and Microsoft Teams
+
+Operator actions stay in the CLI:
+
+```bash
+hermes teams-pipeline validate
+hermes teams-pipeline list
+hermes teams-pipeline maintain-subscriptions
+```
+
+## Prerequisites
+
+Before enabling the meetings pipeline, make sure you have:
+
+- a working Hermes install
+- the existing [Microsoft Teams bot setup](/docs/user-guide/messaging/teams) if you want Teams outbound delivery
+- Microsoft Graph application credentials with the permissions required for the meeting resources you plan to subscribe to
+- a public HTTPS URL that Microsoft Graph can call for webhook delivery
+- `ffmpeg` installed if you want recording-plus-STT fallback
+
+## Step 1: Add Microsoft Graph Credentials
+
+Add Graph app-only credentials to `~/.hermes/.env`:
+
+```bash
+MSGRAPH_TENANT_ID=<tenant-id>
+MSGRAPH_CLIENT_ID=<client-id>
+MSGRAPH_CLIENT_SECRET=<client-secret>
+```
+
+These credentials are used by:
+- the Graph client foundation
+- subscription maintenance commands
+- meeting resolution and artifact fetches
+- Graph-based Teams outbound delivery when you do not provide a dedicated Teams access token
+
+## Step 2: Enable the Graph Webhook Listener
+
+The webhook listener is a gateway platform named `msgraph_webhook`. At minimum, enable it and set a client state value:
+
+```bash
+MSGRAPH_WEBHOOK_ENABLED=true
+MSGRAPH_WEBHOOK_PORT=8646
+MSGRAPH_WEBHOOK_CLIENT_STATE=<random-shared-secret>
+MSGRAPH_WEBHOOK_ACCEPTED_RESOURCES=communications/onlineMeetings
+```
+
+The listener exposes:
+- `/msgraph/webhook` for Graph notifications
+- `/health` for a simple health check
+
+You need to route your public HTTPS endpoint to that listener. For example, if your public domain is `https://ops.example.com`, your Graph notification URL would typically be:
+
+```text
+https://ops.example.com/msgraph/webhook
+```
+
+## Step 3: Configure Teams Delivery and Pipeline Behavior
+
+The meeting pipeline reads its runtime config from the existing `teams` platform entry. Pipeline-specific knobs live under `teams.extra.meeting_pipeline`. Teams outbound delivery stays on the normal Teams platform config surface.
+
+Example `~/.hermes/config.yaml`:
+
+```yaml
+platforms:
+  msgraph_webhook:
+    enabled: true
+    extra:
+      port: 8646
+      client_state: "replace-me"
+      accepted_resources:
+        - "communications/onlineMeetings"
+
+  teams:
+    enabled: true
+    extra:
+      client_id: "your-teams-client-id"
+      client_secret: "your-teams-client-secret"
+      tenant_id: "your-teams-tenant-id"
+
+      # outbound summary delivery
+      delivery_mode: "graph" # or incoming_webhook
+      team_id: "team-id"
+      channel_id: "channel-id"
+      # incoming_webhook_url: "https://..."
+
+      meeting_pipeline:
+        transcript_min_chars: 80
+        transcript_required: false
+        transcription_fallback: true
+        ffmpeg_extract_audio: true
+        notion:
+          enabled: false
+        linear:
+          enabled: false
+```
+
+## Teams Delivery Modes
+
+The pipeline supports two Teams summary-delivery modes inside the existing Teams plugin.
+
+### `incoming_webhook`
+
+Use this when you want a simple webhook post into Teams without channel-message creation through Graph.
+
+Required config:
+
+```yaml
+platforms:
+  teams:
+    enabled: true
+    extra:
+      delivery_mode: "incoming_webhook"
+      incoming_webhook_url: "https://..."
+```
+
+### `graph`
+
+Use this when you want Hermes to post the summary through Microsoft Graph into a Teams chat or channel.
+
+Supported targets:
+- `chat_id`
+- `team_id` + `channel_id`
+- `team_id` + `home_channel` fallback for the existing Teams platform
+
+Example:
+
+```yaml
+platforms:
+  teams:
+    enabled: true
+    extra:
+      delivery_mode: "graph"
+      team_id: "team-id"
+      channel_id: "channel-id"
+```
+
+## Step 4: Start the Gateway
+
+Start Hermes normally after updating config:
+
+```bash
+hermes gateway run
+```
+
+Or, if you run Hermes in Docker, start the gateway the same way you already do for your deployment.
+
+Check the listener:
+
+```bash
+curl http://localhost:8646/health
+```
+
+## Step 5: Create Graph Subscriptions
+
+Use the plugin CLI to create and inspect subscriptions.
+
+Examples:
+
+```bash
+hermes teams-pipeline subscribe \
+  --resource communications/onlineMeetings/getAllTranscripts \
+  --notification-url https://ops.example.com/msgraph/webhook \
+  --client-state "$MSGRAPH_WEBHOOK_CLIENT_STATE"
+
+hermes teams-pipeline subscribe \
+  --resource communications/onlineMeetings/getAllRecordings \
+  --notification-url https://ops.example.com/msgraph/webhook \
+  --client-state "$MSGRAPH_WEBHOOK_CLIENT_STATE"
+```
+
+For subscription maintenance and day-2 operator flows, continue with the guide: [Operate the Teams Meeting Pipeline](/docs/guides/operate-teams-meeting-pipeline).
+
+## Validation
+
+Run the built-in validation snapshot:
+
+```bash
+hermes teams-pipeline validate
+```
+
+Useful companion checks:
+
+```bash
+hermes teams-pipeline token-health
+hermes teams-pipeline subscriptions
+```
+
+## Troubleshooting
+
+| Problem | What to check |
+|---------|---------------|
+| Graph webhook validation fails | Confirm the public URL is correct and reachable, and that Graph is calling the exact `/msgraph/webhook` path |
+| Jobs do not appear in `hermes teams-pipeline list` | Confirm `msgraph_webhook` is enabled and that subscriptions point at the right notification URL |
+| Transcript-first never succeeds | Check Graph permissions for transcript resources and whether the transcript artifact exists for that meeting |
+| Recording fallback fails | Confirm `ffmpeg` is installed and the Graph app can access recording artifacts |
+| Teams summary delivery fails | Re-check `delivery_mode`, target IDs, and Teams auth config |
+
+## Related Docs
+
+- [Microsoft Teams bot setup](/docs/user-guide/messaging/teams)
+- [Operate the Teams Meeting Pipeline](/docs/guides/operate-teams-meeting-pipeline)

--- a/website/docs/user-guide/messaging/teams-meetings.md
+++ b/website/docs/user-guide/messaging/teams-meetings.md
@@ -194,6 +194,12 @@ hermes teams-pipeline subscribe \
   --client-state "$MSGRAPH_WEBHOOK_CLIENT_STATE"
 ```
 
+:::warning Graph subscriptions expire in 72 hours
+
+Microsoft Graph caps webhook subscriptions at 72 hours and will not auto-renew them. You MUST schedule `hermes teams-pipeline maintain-subscriptions` before going live, or notifications will silently stop three days after any manual subscription creation. See [Automating subscription renewal](/docs/guides/operate-teams-meeting-pipeline#automating-subscription-renewal-required-for-production) in the operator runbook — three options (Hermes cron, systemd timer, plain crontab).
+
+:::
+
 For subscription maintenance and day-2 operator flows, continue with the guide: [Operate the Teams Meeting Pipeline](/docs/guides/operate-teams-meeting-pipeline).
 
 ## Validation

--- a/website/docs/user-guide/messaging/teams.md
+++ b/website/docs/user-guide/messaging/teams.md
@@ -8,6 +8,8 @@ description: "Set up Hermes Agent as a Microsoft Teams bot"
 
 Connect Hermes Agent to Microsoft Teams as a bot. Unlike Slack's Socket Mode, Teams delivers messages by calling a **public HTTPS webhook**, so your instance needs a publicly reachable endpoint — either a dev tunnel (local dev) or a real domain (production).
 
+Need meeting summaries from Microsoft Graph events rather than normal bot conversations? Use the dedicated setup page: [Teams Meetings](/docs/user-guide/messaging/teams-meetings).
+
 ## How the Bot Responds
 
 | Context | Behavior |
@@ -243,3 +245,8 @@ Treat `TEAMS_CLIENT_SECRET` like a password — rotate it periodically via the A
 - Store credentials in `~/.hermes/.env` with permissions `600` (`chmod 600 ~/.hermes/.env`)
 - The bot only accepts messages from users in `TEAMS_ALLOWED_USERS`; unauthorized messages are silently dropped
 - Your public endpoint (`/api/messages`) is authenticated by the Teams Bot Framework — requests without valid JWTs are rejected
+
+## Related Docs
+
+- [Teams Meetings](/docs/user-guide/messaging/teams-meetings)
+- [Operate the Teams Meeting Pipeline](/docs/guides/operate-teams-meeting-pipeline)

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -138,6 +138,7 @@ const sidebars: SidebarsConfig = {
         'user-guide/messaging/qqbot',
         'user-guide/messaging/yuanbao',
         'user-guide/messaging/teams',
+        'user-guide/messaging/teams-meetings',
         'user-guide/messaging/msgraph-webhook',
         'user-guide/messaging/open-webui',
         'user-guide/messaging/webhooks',
@@ -185,6 +186,7 @@ const sidebars: SidebarsConfig = {
         'guides/aws-bedrock',
         'guides/azure-foundry',
         'guides/microsoft-graph-app-registration',
+        'guides/operate-teams-meeting-pipeline',
       ],
     },
     {


### PR DESCRIPTION
## Summary
Salvage of #21412 onto current `main`, with the subscription-renewal cron recipe, sidebar wiring, and a rewritten SKILL.md on top.

Fifth and final slice of the MS Teams meeting pipeline stack. @dlkakbs's split (setup page + operator runbook + skill asset) lands cleanly; we add the three things needed to make the docs actually work in practice.

Credit to @dlkakbs — her two commits are preserved via rebase-merge.

## Changes

**From @dlkakbs (unchanged):**
- `website/docs/user-guide/messaging/teams-meetings.md` (new, 227 lines) — full setup page: prerequisites, Graph credentials, webhook listener, delivery config, subscription creation, validation, troubleshooting.
- `website/docs/guides/operate-teams-meeting-pipeline.md` (new, 193 lines) — operator runbook: core commands, routine runbook, failure triage, go-live checklist, delivery-mode decision guide, operator worksheet, change review worksheet.
- `website/docs/user-guide/messaging/teams.md` — cross-link to the meetings page.
- `website/docs/user-guide/messaging/index.md` — meetings entry in the platform index.
- `skills/productivity/teams-meeting-pipeline/SKILL.md` (new) — initial agent-facing skill.
- `tests/gateway/test_teams.py` — `@pytest.mark.asyncio` → `@pytest.mark.anyio` consistency fix across the file.

**Follow-ups added on top during salvage:**

1. **Subscription renewal cron recipe (the #1 operational footgun).**
   Microsoft Graph caps webhook subscriptions at 72 hours and does NOT auto-renew. Without a scheduled `maintain-subscriptions` job, any production deployment silently stops ingesting meetings three days after go-live. Added an "Automating subscription renewal (REQUIRED for production)" section to the operator runbook with three concrete options (Hermes cron, systemd timer, plain crontab), copy-pasteable configs, and a verification block. Go-Live Checklist gains a bolded mandatory item. `teams-meetings.md` gets a `:::warning:::` admonition next to the manual `subscribe` examples so any operator creating a subscription manually is told the same day that it will expire.

2. **Sidebar wiring.** Shela's two new docs pages weren't in `website/sidebars.ts`, so they were orphaned URLs — reachable only by knowing the path. Wired `teams-meetings` into Messaging Platforms next to the existing `teams` entry, and `operate-teams-meeting-pipeline` into Guides & Tutorials next to `microsoft-graph-app-registration`. Adjacent placement keeps related pages cross-discoverable.

3. **SKILL.md rewrite (v1.0.0 → v1.1.0).** The original skill had five Turkish-only trigger phrases. Rewrote the skill to:
   - Describe triggers by intent with explicit multilingual framing and example phrases in English and Turkish.
   - Add a Decision Tree section covering the three most common user asks (missing summary, setup verification, re-run request) with exact CLI command sequences.
   - Add a dedicated "Critical pitfall: Graph subscriptions expire in 72 hours" section so the agent knows what to do when a user reports "worked yesterday, nothing today."
   - Split commands into three labeled groups (Status/inspection, Re-running/debugging, Subscription management).
   - Cross-link to all four related docs pages.

## What this PR enables end-to-end

Merging this closes the entire #21408-#21412 stack. The pipeline is now:
- **Installed:** `hermes teams-pipeline` is a real CLI, the skill teaches the agent to use it, the webhook listener ingests Graph notifications.
- **Discoverable:** every new page lives in the sidebar. Setup flow is Azure app registration → webhook listener → pipeline setup → operator runbook, all cross-linked.
- **Operable:** the renewal automation is documented with three working options — no operator goes to production without knowing their subscriptions will silently expire at 72h.

## Validation
- `scripts/run_tests.sh` on the relevant suites (`tests/gateway/test_teams.py`, `tests/plugins/`, `tests/gateway/test_msgraph_webhook.py`, `tests/hermes_cli/test_teams_pipeline_plugin_cli.py`) — **607/607 passed**.
- `npm run build` in `website/` — new pages route at `/docs/user-guide/messaging/teams-meetings` and `/docs/guides/operate-teams-meeting-pipeline`, anchor `#automating-subscription-renewal-required-for-production` resolves from both the TOC and the cross-link from `teams-meetings.md`, no new warnings or errors.

Closes #21412. Closes the entire stack.
