### PR TITLE
Add ambient mode for cron jobs

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -437,6 +437,8 @@ def create_job(
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
     no_agent: bool = False,
+    ambient: bool = False,
+    max_messages: int = 3,
 ) -> Dict[str, Any]:
     """
     Create a new cron job.
@@ -481,6 +483,9 @@ def create_job(
                 and deliver its stdout directly. Empty stdout = silent (no
                 delivery). Requires ``script`` to be set. Ideal for classic
                 watchdogs and periodic alerts that don't need LLM reasoning.
+        ambient: When True, use ambient initiative cron semantics: the scheduled
+                wake is low priority and may report nothing via ``[SILENT]``.
+        max_messages: Soft visible-message budget for ambient jobs.
 
     Returns:
         The created job dict
@@ -515,6 +520,11 @@ def create_job(
     normalized_toolsets = normalized_toolsets or None
     normalized_workdir = _normalize_workdir(workdir)
     normalized_no_agent = bool(no_agent)
+    normalized_ambient = bool(ambient)
+    try:
+        normalized_max_messages = max(0, int(max_messages))
+    except (TypeError, ValueError):
+        normalized_max_messages = 3
 
     # no_agent jobs are meaningless without a script — the script IS the job.
     # Surface this as a clear ValueError at create time so bad configs never
@@ -545,6 +555,8 @@ def create_job(
         "base_url": normalized_base_url,
         "script": normalized_script,
         "no_agent": normalized_no_agent,
+        "ambient": normalized_ambient,
+        "max_messages": normalized_max_messages,
         "context_from": context_from,
         "schedule": parsed_schedule,
         "schedule_display": parsed_schedule.get("display", schedule),

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -903,17 +903,35 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
 
     # Always prepend cron execution guidance so the agent knows how
     # delivery works and can suppress delivery when appropriate.
-    cron_hint = (
-        "[IMPORTANT: You are running as a scheduled cron job. "
-        "DELIVERY: Your final response will be automatically delivered "
-        "to the user — do NOT use send_message or try to deliver "
-        "the output yourself. Just produce your report/output as your "
-        "final response and the system handles the rest. "
-        "SILENT: If there is genuinely nothing new to report, respond "
-        "with exactly \"[SILENT]\" (nothing else) to suppress delivery. "
-        "Never combine [SILENT] with content — either report your "
-        "findings normally, or say [SILENT] and nothing more.]\n\n"
-    )
+    if job.get("ambient"):
+        try:
+            max_messages = max(0, int(job.get("max_messages", 3)))
+        except (TypeError, ValueError):
+            max_messages = 3
+        cron_hint = (
+            "[IMPORTANT: You are running as an ambient initiative cron wake. "
+            "This is a low-priority scheduled check, not a mandatory report. "
+            "First decide whether any action is natural and useful from persona, "
+            "memory, recent context, and the job prompt. "
+            f"VISIBLE MESSAGE BUDGET: {max_messages}. "
+            "The scheduler will automatically deliver your final response, so do "
+            "NOT use send_message or try to deliver output yourself. "
+            "If nothing should be sent, respond with exactly \"[SILENT]\" "
+            "(nothing else) to suppress delivery. Never combine [SILENT] with "
+            "content. Do not send content just to use the budget.]\n\n"
+        )
+    else:
+        cron_hint = (
+            "[IMPORTANT: You are running as a scheduled cron job. "
+            "DELIVERY: Your final response will be automatically delivered "
+            "to the user — do NOT use send_message or try to deliver "
+            "the output yourself. Just produce your report/output as your "
+            "final response and the system handles the rest. "
+            "SILENT: If there is genuinely nothing new to report, respond "
+            "with exactly \"[SILENT]\" (nothing else) to suppress delivery. "
+            "Never combine [SILENT] with content — either report your "
+            "findings normally, or say [SILENT] and nothing more.]\n\n"
+        )
     prompt = cron_hint + prompt
     if skills is None:
         legacy = job.get("skill")

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -247,6 +247,9 @@ def _format_job(job: Dict[str, Any]) -> Dict[str, Any]:
         result["script"] = job["script"]
     if job.get("no_agent"):
         result["no_agent"] = True
+    if job.get("ambient"):
+        result["ambient"] = True
+        result["max_messages"] = job.get("max_messages", 3)
     if job.get("enabled_toolsets"):
         result["enabled_toolsets"] = job["enabled_toolsets"]
     if job.get("workdir"):
@@ -274,6 +277,8 @@ def cronjob(
     enabled_toolsets: Optional[List[str]] = None,
     workdir: Optional[str] = None,
     no_agent: Optional[bool] = None,
+    ambient: Optional[bool] = None,
+    max_messages: Optional[int] = None,
     task_id: str = None,
 ) -> str:
     """Unified cron job management tool."""
@@ -341,6 +346,8 @@ def cronjob(
                 enabled_toolsets=enabled_toolsets or None,
                 workdir=_normalize_optional_job_value(workdir),
                 no_agent=_no_agent,
+                ambient=bool(ambient),
+                max_messages=3 if max_messages is None else max_messages,
             )
             return json.dumps(
                 {
@@ -468,6 +475,13 @@ def cronjob(
                             success=False,
                         )
                 updates["no_agent"] = target_no_agent
+            if ambient is not None:
+                updates["ambient"] = bool(ambient)
+            if max_messages is not None:
+                try:
+                    updates["max_messages"] = max(0, int(max_messages))
+                except (TypeError, ValueError):
+                    return tool_error("max_messages must be an integer", success=False)
             if repeat is not None:
                 # Normalize: treat 0 or negative as None (infinite)
                 normalized_repeat = None if repeat <= 0 else repeat
@@ -584,6 +598,14 @@ Important safety rule: cron-run sessions should not recursively schedule more cr
                     "WHEN TO USE True: recurring script-only pings where the script itself produces the exact message text (memory/disk/GPU watchdogs, threshold alerts, heartbeats, CI notifications, API pollers with a fixed output shape). "
                     "WHEN TO USE False (default): anything that needs reasoning — summarize a feed, draft a daily briefing, pick interesting items, rephrase data for a human, follow conditional logic based on content."
                 ),
+            },
+            "ambient": {
+                "type": "boolean",
+                "description": "When true, run this as an ambient initiative wake on the normal cron scheduler. The agent decides whether to report anything; [SILENT] suppresses delivery.",
+            },
+            "max_messages": {
+                "type": "integer",
+                "description": "Soft visible-message budget for ambient cron jobs. Default: 3. The scheduler still delivers through the normal cron delivery path.",
             },
             "context_from": {
                 "type": "array",

--- a/website/docs/user-guide/features/cron.md
+++ b/website/docs/user-guide/features/cron.md
@@ -17,6 +17,8 @@ Cron jobs can:
 - attach zero, one, or multiple skills to a job
 - deliver results back to the origin chat, local files, or configured platform targets
 - run in fresh agent sessions with the normal static tool list
+- run in **ambient mode** — a low-priority initiative wake where the agent can
+  decide to send nothing by returning `[SILENT]`
 - run in **no-agent mode** — a script on a schedule, its stdout delivered verbatim, zero LLM involvement (see the [no-agent mode](#no-agent-mode-script-only-jobs) section below)
 
 All of this is available to Hermes itself through the `cronjob` tool, so you can create, pause, edit, and remove jobs by asking in plain language — no CLI required.
@@ -88,6 +90,25 @@ cronjob(
 ```
 
 This is useful when you want a scheduled agent to inherit reusable workflows without stuffing the full skill text into the cron prompt itself.
+
+## Ambient cron jobs
+
+Ambient cron jobs reuse the normal scheduler, agent run, delivery, and audit
+paths, but change the prompt contract from "produce a scheduled report" to
+"wake, inspect context, and decide whether anything should be sent." If nothing
+should be visible, the agent returns exactly `[SILENT]` and delivery is
+suppressed.
+
+```python
+cronjob(
+    action="create",
+    schedule="every 2h",
+    name="Ambient check-in",
+    prompt="Use persona, memory, and recent context to decide whether a natural check-in or light update would be useful.",
+    ambient=True,
+    max_messages=3,
+)
+```
 
 ## Running a job inside a project directory
 


### PR DESCRIPTION
## Summary

- add `ambient=True` cron jobs that reuse the existing scheduler, agent run, delivery, and audit paths
- let the model decide on each cron wake whether to proactively send a natural message or return `[SILENT]`, enabling model-driven proactive outreach without forcing every scheduled wake to produce a user-visible message
- add `max_messages` as a soft visible-message budget for ambient cron wakes, so the agent can send a concise burst when context makes it useful
- change the scheduler prompt contract only for ambient jobs so `[SILENT]` suppresses delivery when no natural update is needed
- document ambient cron jobs in the user guide

## Behavior

Ambient cron jobs are for low-priority initiative checks rather than guaranteed reminders. The existing cron scheduler still decides when to wake the agent, but after wake-up the model reads the job prompt and context, then chooses between:

- returning `[SILENT]` when nothing should be sent
- sending one or more natural messages within `max_messages` when a proactive update is actually useful

That makes this closer to an ambient agent loop: timing comes from Hermes' scheduler, while the decision to speak comes from the model and current context.

## Testing

- `python -m py_compile cron/jobs.py cron/scheduler.py tools/cronjob_tools.py`
- smoke-tested `_build_job_prompt` for ambient prompt contract
- smoke-tested `create_job` / `update_job` for `ambient` and `max_messages` fields
