### PR TITLE
fix(feishu): keep markdown tables in post payload so prose still renders

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -153,9 +153,6 @@ _MARKDOWN_HINT_RE = re.compile(
     r"(^#{1,6}\s)|(^\s*[-*]\s)|(^\s*\d+\.\s)|(^\s*---+\s*$)|(```)|(`[^`\n]+`)|(\*\*[^*\n].+?\*\*)|(~~[^~\n].+?~~)|(<u>.+?</u>)|(\*[^*\n]+\*)|(\[[^\]]+\]\([^)]+\))|(^>\s)",
     re.MULTILINE,
 )
-# Detect markdown tables: a line starting with | followed by a separator line.
-# Feishu post-type 'md' elements do not render tables, so we force text mode.
-_MARKDOWN_TABLE_RE = re.compile(r"^\|.*\|\n\|[-|: ]+\|", re.MULTILINE)
 _MARKDOWN_LINK_RE = re.compile(r"\[([^\]]+)\]\(([^)]+)\)")
 _MARKDOWN_FENCE_OPEN_RE = re.compile(r"^```([^\n`]*)\s*$")
 _MARKDOWN_FENCE_CLOSE_RE = re.compile(r"^```\s*$")
@@ -4284,12 +4281,12 @@ class FeishuAdapter(BasePlatformAdapter):
     # =========================================================================
 
     def _build_outbound_payload(self, content: str) -> tuple[str, str]:
-        # Feishu post-type 'md' elements do not render markdown tables; sending
-        # table content as post causes the message to appear blank on the client.
-        # Force plain text for anything that looks like a markdown table.
-        if _MARKDOWN_TABLE_RE.search(content):
-            text_payload = {"text": content}
-            return "text", json.dumps(text_payload, ensure_ascii=False)
+        # Feishu's post-type ``md`` element does not natively render markdown
+        # tables, but sending the whole reply as plain ``text`` (#21778)
+        # leaves Feishu showing every other markdown construct as raw source
+        # too — headings, fences, bold, links, lists.  The cure is worse than
+        # the disease: tables go through ``post`` so the surrounding prose
+        # renders, and only the table itself appears as raw markdown source.
         if _MARKDOWN_HINT_RE.search(content):
             return "post", _build_markdown_post_payload(content)
         text_payload = {"text": content}

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -4885,3 +4885,42 @@ class TestFeishuMentionEndToEnd(unittest.TestCase):
         # Body: leading @Hermes stripped, Alice preserved, trailing text intact.
         self.assertIn("@Alice review the spec with Alice", event.text)
         self.assertNotIn("@Hermes @Alice", event.text)
+
+
+class TestOutboundPayloadMarkdownTables(unittest.TestCase):
+    """Markdown tables must reach Feishu via the post pipeline so the
+    surrounding prose still renders.  Forcing the entire reply to plain
+    text (#21778) leaves headings, fences, bold, links, lists all
+    appearing as raw markdown source."""
+
+    def _build(self, content: str) -> tuple[str, str]:
+        from gateway.platforms.feishu import FeishuAdapter
+        return FeishuAdapter._build_outbound_payload(None, content)  # type: ignore[arg-type]
+
+    def test_table_uses_post_payload(self):
+        content = (
+            "Here are the results:\n"
+            "\n"
+            "| Name  | Score |\n"
+            "|-------|-------|\n"
+            "| Alice | 12    |\n"
+            "| Bob   | 7     |\n"
+            "\n"
+            "**Total**: 19"
+        )
+        msg_type, payload = self._build(content)
+        self.assertEqual(msg_type, "post")
+        # Surrounding prose survives in the post structure.
+        decoded = json.loads(payload)
+        flattened = json.dumps(decoded)
+        self.assertIn("Here are the results", flattened)
+        self.assertIn("**Total**", flattened)
+
+    def test_plain_text_without_markdown_uses_text_payload(self):
+        msg_type, payload = self._build("Just a plain status update.")
+        self.assertEqual(msg_type, "text")
+        self.assertEqual(json.loads(payload), {"text": "Just a plain status update."})
+
+    def test_markdown_without_table_uses_post_payload(self):
+        msg_type, _ = self._build("# Heading\n\n**Bold** body")
+        self.assertEqual(msg_type, "post")


### PR DESCRIPTION
## What does this PR do?

v0.13.0 added a defensive fallback in `_build_outbound_payload()` that forces any reply containing a markdown table to send as plain `text`, on the rationale that Feishu's post-type `md` element doesn't render tables natively (#21778). The cure is worse than the disease — once the whole reply is plain text, **every other markdown construct** (headings, fences, bold, links, lists) renders as raw source on the Feishu client, not just the table.

This PR drops the table-detection downgrade. Replies with markdown go through the post pipeline as usual; the table itself still appears as raw markdown on the client (Feishu's `md` element limitation unchanged), but everything around it renders. Net UX is strictly better than the prior text fallback.

## Related Issue

Closes #21778

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/feishu.py` — remove table-detection branch from `_build_outbound_payload()`; remove the now-unused `_MARKDOWN_TABLE_RE` regex
- `tests/gateway/test_feishu.py` — `TestOutboundPayloadMarkdownTables` (3 tests covering table → post, plain text → text, markdown without table → post)

## How to Test

1. `pytest tests/gateway/test_feishu.py -q` — 158 passed, 43 skipped
2. `pytest tests/gateway/test_feishu.py::TestOutboundPayloadMarkdownTables -v` — 3 new tests pass
3. The new tests fail on baseline (assert `msg_type == "post"` for table content vs. baseline `"text"`)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
pytest tests/gateway/test_feishu.py -q
158 passed, 43 skipped
```
