### PR TITLE
fix(cli): include arg-required commands in Telegram setMyCommands

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -474,6 +474,19 @@ def _iter_plugin_command_entries() -> list[tuple[str, str, str]]:
     return entries
 
 
+_TG_DESCRIPTION_LIMIT = 256
+
+
+def _telegram_description(description: str, args_hint: str | None = None) -> str:
+    text = description or ""
+    hint = (args_hint or "").strip()
+    if hint:
+        suffix = f" {hint}"
+        if suffix not in text:
+            text = f"{text}{suffix}"
+    return text[:_TG_DESCRIPTION_LIMIT]
+
+
 def telegram_bot_commands() -> list[tuple[str, str]]:
     """Return (command_name, description) pairs for Telegram setMyCommands.
 
@@ -485,8 +498,8 @@ def telegram_bot_commands() -> list[tuple[str, str]]:
     are **included** because their handlers return usage text when selected
     without a payload, making them discoverable via autocomplete.
 
-    Plugin-registered slash commands that require arguments are **excluded**
-    because plugins may not provide a no-arg usage fallback.
+    Plugin-registered slash commands are likewise included so plugins get native
+    Telegram autocomplete without touching core code.
     """
     overrides = _resolve_config_gates()
     result: list[tuple[str, str]] = []
@@ -498,13 +511,11 @@ def telegram_bot_commands() -> list[tuple[str, str]]:
         # the menu hurts discoverability (issue #24312).
         tg_name = _sanitize_telegram_name(cmd.name)
         if tg_name:
-            result.append((tg_name, cmd.description))
+            result.append((tg_name, _telegram_description(cmd.description, cmd.args_hint)))
     for name, description, args_hint in _iter_plugin_command_entries():
-        if _requires_argument(args_hint):
-            continue
         tg_name = _sanitize_telegram_name(name)
         if tg_name:
-            result.append((tg_name, description))
+            result.append((tg_name, _telegram_description(description, args_hint)))
     return result
 
 

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -217,6 +217,12 @@ class TestGatewayHelpLines:
 
 
 class TestTelegramBotCommands:
+    def test_includes_commands_with_required_args(self):
+        commands = dict(telegram_bot_commands())
+        for name in ("steer", "queue", "background"):
+            assert name in commands
+            assert "<" in commands[name]
+
     def test_returns_list_of_tuples(self):
         cmds = telegram_bot_commands()
         assert len(cmds) > 10
@@ -1707,8 +1713,8 @@ class TestPluginCommandEnumeration:
         names = {name for name, _desc in telegram_bot_commands()}
         assert "metricas" in names
 
-    def test_plugin_command_with_required_args_excluded_from_telegram_menu(self, monkeypatch):
-        """Telegram BotCommand selections cannot supply required arguments."""
+    def test_plugin_command_with_required_args_appears_in_telegram_menu(self, monkeypatch):
+        """Telegram menu should include plugin commands that require arguments."""
         self._patch_plugin_commands(monkeypatch, {
             "background-job": {
                 "handler": lambda _a: "ok",
@@ -1718,7 +1724,7 @@ class TestPluginCommandEnumeration:
             }
         })
         names = {name for name, _desc in telegram_bot_commands()}
-        assert "background_job" not in names
+        assert "background_job" in names
 
     def test_plugin_command_appears_in_slack_subcommand_map(self, monkeypatch):
         """/hermes metricas must route through the Slack subcommand map."""
@@ -1804,3 +1810,36 @@ class TestPluginCommandEnumeration:
         slack_names = set(slack_subcommand_map())
         assert "status" in tg_names
         assert "status" in slack_names
+
+
+def test_plugin_command_with_required_args_included_in_telegram_menu(monkeypatch):
+    from hermes_cli import commands as cmdmod
+
+    def fake_entries():
+        yield ("plugin", "Plugin command", "<value>")
+
+    monkeypatch.setattr(cmdmod, "_iter_plugin_command_entries", fake_entries)
+    commands = dict(cmdmod.telegram_bot_commands())
+    assert "plugin" in commands
+    assert "<value>" in commands["plugin"]
+
+
+def test_telegram_bot_commands_include_required_args_regression():
+    from hermes_cli.commands import telegram_bot_commands
+
+    commands = dict(telegram_bot_commands())
+    for name in ("steer", "queue", "background"):
+        assert name in commands
+        assert "<" in commands[name]
+
+
+def test_plugin_command_with_required_args_included_in_telegram_menu(monkeypatch):
+    from hermes_cli import commands as cmdmod
+
+    def fake_entries():
+        yield ("plugin", "Plugin command", "<value>")
+
+    monkeypatch.setattr(cmdmod, "_iter_plugin_command_entries", fake_entries)
+    commands = dict(cmdmod.telegram_bot_commands())
+    assert "plugin" in commands
+    assert "<value>" in commands["plugin"]


### PR DESCRIPTION
## What does this PR do?

Telegram command registration omitted slash commands that require arguments, which made some steerable/DM commands undiscoverable in the Telegram command menu. This PR includes arg-required built-in and plugin commands in the Telegram BotCommand set while preserving Slack routing and command-priority behavior.

## Related Issue

Fixes #21790

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Include arg-required built-in commands in Telegram command enumeration.
- Include arg-required plugin commands after Telegram-safe name normalization.
- Preserve Slack subcommand mapping and built-in collision behavior.
- Add focused command enumeration regression tests.

## How to Test

1. Check out this PR branch.
2. Run: `.venv/bin/python -m pytest -o 'addopts=' tests/hermes_cli/test_commands.py -q`
3. Expected result: 147 passed

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — focused pytest passed; full suite was not run in this salvage pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux container / Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused verification:

```text
`.venv/bin/python -m pytest -o 'addopts=' tests/hermes_cli/test_commands.py -q` — 147 passed
```
