### PR TITLE
fix(platform-hints): add missing webui entry to PLATFORM_HINTS

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -513,6 +513,20 @@ PLATFORM_HINTS = {
         "image and is the WRONG path. Bare Unicode emoji in text is also not a substitute "
         "— when a sticker is the right response, use yb_send_sticker."
     ),
+    "webui": (
+        "You are responding through the Hermes local web dashboard (WebUI). "
+        "The WebUI renders standard Markdown — headings, bold, italic, code blocks, "
+        "and tables all work. "
+        "You can send media files natively: include MEDIA:/absolute/path/to/file "
+        "in your response. Images (.png, .jpg, .gif, .svg, .avif) render inline, "
+        "audio gets an inline player with speed controls, video plays inline, "
+        "and PDF/HTML/CSV/diff files get rich previews. "
+        "Local file paths must be absolute. "
+        "You can also use MEDIA:https://... for remote images. "
+        "Do NOT use Markdown image syntax like ![alt](/path) for local files — "
+        "it will not render. Always use MEDIA:/path for local and "
+        "MEDIA:https://... for remote media."
+    ),
     "api_server": (
         "You're responding through an API server. The rendering layer is unknown — "
         "assume plain text. No markdown formatting (no asterisks, bullets, headers, "


### PR DESCRIPTION
## What does this PR do?
Adds the missing `"webui"` entry to `PLATFORM_HINTS` in `agent/prompt_builder.py`.

The WebUI creates `AIAgent` instances with `platform="webui"` (see `api/routes.py`) but `PLATFORM_HINTS` had no matching key, so the agent never received rendering guidance for the web dashboard — it silently fell through with no hint at all.

The new hint tells the agent:
- Standard Markdown renders (headings, bold, italic, code blocks, tables)
- Media files are sent via `MEDIA:/absolute/path` or `MEDIA:https://...`
- Do NOT use `![alt](/path)` Markdown image syntax for local files

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## References
Fixes #21883

## Checklist
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] My PR contains **only** changes related to this fix