### PR TITLE
feat(transports/codex): pass reasoning.effort to xAI Responses API

### DIFF
--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -105,6 +105,7 @@ class ResponsesApiTransport(ProviderTransport):
 
         if reasoning_enabled and is_xai_responses:
             kwargs["include"] = ["reasoning.encrypted_content"]
+            kwargs["reasoning"] = {"effort": reasoning_effort}
         elif reasoning_enabled:
             if is_github_responses:
                 github_reasoning = params.get("github_reasoning_extra")

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -149,6 +149,37 @@ class TestCodexBuildKwargs:
         # "minimal" should be clamped to "low"
         assert kw.get("reasoning", {}).get("effort") == "low"
 
+    def test_xai_reasoning_effort_passed(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="grok-4.3", messages=messages, tools=[],
+            is_xai_responses=True,
+            reasoning_config={"effort": "high"},
+        )
+        # xAI Responses must receive both encrypted reasoning content and the effort
+        assert kw.get("reasoning") == {"effort": "high"}
+        assert "reasoning.encrypted_content" in kw.get("include", [])
+
+    def test_xai_reasoning_disabled_no_reasoning_key(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="grok-4.3", messages=messages, tools=[],
+            is_xai_responses=True,
+            reasoning_config={"enabled": False},
+        )
+        # When reasoning is disabled, do not send the reasoning key at all
+        assert "reasoning" not in kw
+
+    def test_xai_minimal_effort_clamped(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="grok-4.3", messages=messages, tools=[],
+            is_xai_responses=True,
+            reasoning_config={"effort": "minimal"},
+        )
+        # "minimal" should be clamped to "low" for xAI as well
+        assert kw.get("reasoning", {}).get("effort") == "low"
+
 
 class TestCodexValidateResponse:
 


### PR DESCRIPTION
## Problem

The xAI direct path (`is_xai_responses=True`) in `agent/transports/codex.py` only forwards `include=["reasoning.encrypted_content"]` and silently drops the resolved `reasoning_effort`. The sibling non-xAI Responses branch already passes `kwargs["reasoning"] = {"effort": ..., "summary": "auto"}`.

This means `agent.reasoning_effort` (and any `reasoning_config.effort` injected by callers) is **silently ignored** on the xAI direct route. Setting `low`, `medium`, or `high` in config has zero effect — xAI receives no `reasoning` field and uses its server-side default.

## Why this matters

For agentic tool-calling on grok-4.x, xAI's docs explicitly recommend `reasoning_effort: low` ([model-capabilities/text/reasoning](https://docs.x.ai/developers/model-capabilities/text/reasoning)). When Hermes can't transmit this, users running Telegram bots / CLIs report:
- "intention without execution" patterns (model says "I'll check..." but emits no tool_call)
- inability to control thinking depth between latency-sensitive and analysis-heavy tasks

A 100-call benchmark across efforts on a real-world Alfred-style session showed pass rate variance: `none=58%, low=87%, medium=82%, high=86%` — variance that's currently inaccessible from config on the xAI direct path.

## Fix

One-line change: in the `is_xai_responses` branch, also pass `kwargs["reasoning"] = {"effort": reasoning_effort}`. We deliberately omit `summary: "auto"` (used by the OpenAI Responses branch) since xAI's Responses API documentation does not mention it — conservative posture pending confirmation.

```python
 if reasoning_enabled and is_xai_responses:
     kwargs["include"] = ["reasoning.encrypted_content"]
+    kwargs["reasoning"] = {"effort": reasoning_effort}
 elif reasoning_enabled:
     ...
```

## Tests

3 new tests in `tests/agent/transports/test_codex_transport.py::TestCodexBuildKwargs`:
- `test_xai_reasoning_effort_passed` — asserts `kw["reasoning"] == {"effort": "high"}` and the encrypted-content include remains.
- `test_xai_reasoning_disabled_no_reasoning_key` — asserts `"reasoning" not in kw` when `reasoning_config={"enabled": False}`.
- `test_xai_minimal_effort_clamped` — parity with the existing non-xAI clamp test (`minimal -> low`).

`pytest tests/agent/transports/test_codex_transport.py -v` → **29 passed**.

## Live verification

Real call to `https://api.x.ai/v1/responses` with the patched payload + a single dummy `echo` tool:

```
response.id      = 11a97f68-e8c9-92ae-8f45-0ec5403d14f7
response.model   = grok-4.3
output[0].type   = reasoning
output[1].type   = function_call
reasoning_tokens = 153    ← effort=low effectively activated
```

Without the patch, the equivalent request produces no `reasoning` output item and `reasoning_tokens=0`.

## Tangential note

While building the live test, I confirmed that xAI rejects requests with `tool_choice` set but `tools=[]` (HTTP 400 *"A tool_choice was set on the request but no tools were specified"*) — exact symptom of #20606 (still open). Independent of this PR but worth flagging.