### PR TITLE
fix: add permissive items to array tool schemas

### DIFF
--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -197,6 +197,41 @@ def test_items_sanitized_in_array_schema():
     assert items == {"type": "object", "properties": {}}
 
 
+def test_array_without_items_gets_permissive_items():
+    """Repro for OpenAI 400 'array schema missing items' (e.g. mcp_bear_edit_note).
+
+    OpenAI's function-schema validator rejects ``{"type": "array"}`` with no
+    ``items`` keyword. Symmetric to the object-without-properties rule.
+    """
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "edits": {"type": "array"},  # no items declared
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    edits = out[0]["function"]["parameters"]["properties"]["edits"]
+    assert edits["type"] == "array"
+    assert edits["items"] == {}
+
+
+def test_top_level_array_without_items_gets_items():
+    """Defensive: even if an array shows up at an unusual position, items is injected."""
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "matrix": {
+                "type": "array",
+                "items": {"type": "array"},  # inner array also missing items
+            },
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    inner = out[0]["function"]["parameters"]["properties"]["matrix"]["items"]
+    assert inner["type"] == "array"
+    assert inner["items"] == {}
+
+
 def test_empty_tools_list_returns_empty():
     assert sanitize_tool_schemas([]) == []
 

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -284,6 +284,14 @@ def _sanitize_node(node: Any, path: str) -> Any:
     if out.get("type") == "object" and not isinstance(out.get("properties"), dict):
         out["properties"] = {}
 
+    # Array nodes without items: inject permissive items schema. OpenAI's
+    # function-schema validator rejects ``{"type": "array"}`` with no
+    # ``items`` ("Invalid schema for function 'X': array schema missing
+    # items"). Malformed MCP tool schemas occasionally omit it (e.g. Bear's
+    # mcp_bear_edit_note `edits` property).
+    if out.get("type") == "array" and "items" not in out:
+        out["items"] = {}
+
     # Prune ``required`` entries that don't exist in properties (defense
     # against malformed MCP schemas; also caught upstream for MCP tools, but
     # built-in tools or plugin tools may not have been through that path).


### PR DESCRIPTION
## Summary
- Add a schema-sanitizer fallback for array nodes missing `items`
- Covers malformed MCP/tool schemas such as Bear edit-note `edits: {"type": "array"}`
- Add regression tests for direct and nested arrays without `items`

## Why
OpenAI rejects function/tool schemas where an array omits the `items` keyword with an error like:

```text
Invalid schema for function ... array schema missing items
```

Hermes already normalizes object schemas missing `properties`; this applies the same defensive approach for arrays by injecting a permissive `items: {}`.

## Test Plan
- [x] `python -m pytest tests/tools/test_schema_sanitizer.py -q`

## Safety
- Only touches schema sanitization and tests
- No credentials, config, local scripts, or user-specific files included
