### PR TITLE
feat(run_agent): extend codex intermediate-ack detection to French + relax prior-tool bail

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3407,7 +3407,18 @@ class AIAgent:
         messages: List[Dict[str, Any]],
     ) -> bool:
         """Detect a planning/ack message that should continue instead of ending the turn."""
-        if any(isinstance(msg, dict) and msg.get("role") == "tool" for msg in messages):
+        # Only bail if a tool was already called in the *current* user turn
+        # (i.e. since the most recent user message). A tool earlier in the
+        # session does not invalidate detection of a fresh narration-only
+        # turn — common on long Telegram/CLI sessions.
+        _last_user_idx = -1
+        for _i in range(len(messages) - 1, -1, -1):
+            _m = messages[_i]
+            if isinstance(_m, dict) and _m.get("role") == "user":
+                _last_user_idx = _i
+                break
+        _current_turn = messages[_last_user_idx + 1:] if _last_user_idx >= 0 else messages
+        if any(isinstance(msg, dict) and msg.get("role") == "tool" for msg in _current_turn):
             return False
 
         assistant_text = self._strip_think_blocks(assistant_content or "").strip().lower()
@@ -3417,7 +3428,14 @@ class AIAgent:
             return False
 
         has_future_ack = bool(
-            re.search(r"\b(i['’]ll|i will|let me|i can do that|i can help with that)\b", assistant_text)
+            re.search(
+                r"\b(i['’]ll|i will|let me|i can do that|i can help with that"
+                r"|je vais|on va|je m'en occupe|je corrige|je relance|je fais"
+                r"|je v[ée]rifie|d'accord|je m'y mets|je m'att[èe]le"
+                r"|c'est not[ée]|not[ée]|je regarde|je lance|je teste"
+                r"|je m'occupe|je vais lancer|je vais v[ée]rifier|je m'en charge)\b",
+                assistant_text,
+            )
         )
         if not has_future_ack:
             return False
@@ -3442,6 +3460,23 @@ class AIAgent:
             "walkthrough",
             "report back",
             "summarize",
+            # French equivalents (substring match handles conjugations)
+            "vérifi",
+            "corrig",
+            "relanc",
+            "examin",
+            "cherch",
+            "analys",
+            "exécut",
+            "lanc",
+            "regard",
+            "parcour",
+            "lir",
+            "ouvr",
+            "explor",
+            "résum",
+            "diagnostiqu",
+            "répar",
         )
         workspace_markers = (
             "directory",
@@ -3457,6 +3492,15 @@ class AIAgent:
             "file tree",
             "files",
             "path",
+            # French equivalents
+            "répertoire",
+            "dossier",
+            "arborescence",
+            "base de code",
+            "projet",
+            "fichier",
+            "chemin",
+            "code",
         )
 
         user_text = (user_message or "").strip().lower()

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5187,3 +5187,106 @@ class TestMemoryProviderTurnStart:
         import inspect
         src = inspect.getsource(AIAgent.run_conversation)
         assert "on_turn_start(self._user_turn_count" in src
+
+
+class TestLooksLikeCodexIntermediateAck:
+    """Cover the codex/xAI intermediate-ack heuristic, including the FR i18n extension
+    and the relaxed prior-tool bail (only the current turn counts)."""
+
+    def test_english_ack_with_workspace_action(self, agent):
+        """Regression: classic English 'I will check the directory' triggers detection."""
+        assert agent._looks_like_codex_intermediate_ack(
+            user_message="show me the project structure",
+            assistant_content="I'll check the directory and report back.",
+            messages=[],
+        ) is True
+
+    def test_french_ack_je_vais_verifier_dossier(self, agent):
+        """FR: 'Je vais vérifier le dossier' is the canonical IWE pattern from Telegram."""
+        assert agent._looks_like_codex_intermediate_ack(
+            user_message="vérifie le projet",
+            assistant_content="Je vais vérifier le dossier maintenant.",
+            messages=[],
+        ) is True
+
+    def test_french_je_corrige_le_binding(self, agent):
+        """FR: from real Alfred session #12 — 'Je corrige le binding du dashboard'.
+        Includes 'projet' as the workspace anchor (multi-condition guard)."""
+        assert agent._looks_like_codex_intermediate_ack(
+            user_message="le dashboard du projet ne répond pas, fix le binding",
+            assistant_content="Je corrige le binding du dashboard maintenant.",
+            messages=[],
+        ) is True
+
+    def test_french_je_relance_le_dashboard(self, agent):
+        """FR: 'Je relance le dashboard' with workspace anchor in assistant text."""
+        assert agent._looks_like_codex_intermediate_ack(
+            user_message="relance le dashboard du projet",
+            assistant_content="Je relance le dashboard, action en cours.",
+            messages=[],
+        ) is True
+
+    def test_french_no_action_no_workspace_returns_false(self, agent):
+        """FR negative: opinion-style 'Je vais réfléchir à ça' has no action+workspace combo."""
+        assert agent._looks_like_codex_intermediate_ack(
+            user_message="qu'en penses-tu ?",
+            assistant_content="Je vais réfléchir à ça calmement.",
+            messages=[],
+        ) is False
+
+    def test_french_no_future_ack_returns_false(self, agent):
+        """FR negative: present-tense statement without future-intent verb."""
+        assert agent._looks_like_codex_intermediate_ack(
+            user_message="quoi de neuf",
+            assistant_content="Je trouve ça intéressant comme question.",
+            messages=[],
+        ) is False
+
+    def test_prior_tool_outside_current_turn_does_not_bail(self, agent):
+        """Regression: a tool earlier in the session (before the latest user turn)
+        must not invalidate ack detection for the current narration-only turn.
+        This is the long-Telegram-session case that was previously broken."""
+        messages = [
+            {"role": "user", "content": "lis test.txt"},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "1"}]},
+            {"role": "tool", "content": "hello world", "tool_call_id": "1"},
+            {"role": "assistant", "content": "lu."},
+            {"role": "user", "content": "vérifie le dossier maintenant"},
+            # current turn starts here, no tool yet
+        ]
+        assert agent._looks_like_codex_intermediate_ack(
+            user_message="vérifie le dossier maintenant",
+            assistant_content="Je vais vérifier le dossier.",
+            messages=messages,
+        ) is True
+
+    def test_tool_in_current_turn_bails(self, agent):
+        """If a tool was already executed in the *current* turn, bail (no nudge)."""
+        messages = [
+            {"role": "user", "content": "vérifie le dossier"},
+            {"role": "assistant", "content": "", "tool_calls": [{"id": "2"}]},
+            {"role": "tool", "content": "['a', 'b']", "tool_call_id": "2"},
+            # next assistant message would be the ack, current turn already has a tool
+        ]
+        assert agent._looks_like_codex_intermediate_ack(
+            user_message="vérifie le dossier",
+            assistant_content="Je vais vérifier le dossier.",
+            messages=messages,
+        ) is False
+
+    def test_french_action_diagnostiquer_arborescence(self, agent):
+        """FR: 'diagnostiquer l'arborescence' — verb+workspace combo."""
+        assert agent._looks_like_codex_intermediate_ack(
+            user_message="il y a un souci avec mon projet",
+            assistant_content="Je vais diagnostiquer l'arborescence du projet.",
+            messages=[],
+        ) is True
+
+    def test_french_action_examiner_repertoire(self, agent):
+        """FR: 'examiner le répertoire'."""
+        assert agent._looks_like_codex_intermediate_ack(
+            user_message="explore le code",
+            assistant_content="Je vais examiner le répertoire racine.",
+            messages=[],
+        ) is True
+


### PR DESCRIPTION
## Problem

`_looks_like_codex_intermediate_ack` re-routes narrative acknowledgement turns ("I'll check the directory") into the post-tool nudge so the agent keeps working instead of ending the turn on a promise. Two coverage gaps were limiting it on real-world sessions:

**1. English-only patterns.** The future-ack regex and the `action_markers` / `workspace_markers` tuples only knew English. French Telegram/CLI users routinely produce IWE patterns that fall through detection:

- *"Je vais vérifier le dossier."*
- *"Je corrige le binding du dashboard."*
- *"Je relance le dashboard."*
- *"Je m'occupe du fichier."*

These are direct French equivalents of *"I'll check..."*, *"Let me fix..."* — same intent, same need for nudge re-routing, but the detector returned `False` and the turn ended on a narration-only response, leaving the user in an IWE spiral.

**2. Global bail on prior tool.** The current implementation bails as soon as **any** message in `messages` has `role == "tool"`:

```python
if any(isinstance(msg, dict) and msg.get("role") == "tool" for msg in messages):
    return False
```

On long Telegram/CLI sessions (60–90 turns), the first tool call permanently disables detection for the rest of the conversation, even when the *current* user turn has produced zero tools. Captured from a real Alfred session: a fresh narration-only turn at message #150 was masked because a `terminal` call had executed at message #9.

## Fix

**A. Localize the bail to the current turn only.** Walk back from the end of `messages` to the most recent `user` message; only that slice counts as the "current turn". A tool earlier in the session no longer invalidates detection.

**B. Extend the future-ack regex** with French intent verbs:

```
je vais | on va | je m'en occupe | je corrige | je relance | je fais
| je vérifie | d'accord | je m'y mets | je m'attèle | c'est noté
| noté | je regarde | je lance | je teste | je m'occupe
| je vais lancer | je vais vérifier | je m'en charge
```

**C. Extend `action_markers`** with French verb stems (substring match handles conjugations):

```
vérifi, corrig, relanc, examin, cherch, analys, exécut, lanc,
regard, parcour, lir, ouvr, explor, résum, diagnostiqu, répar
```

**D. Extend `workspace_markers`** with French nouns:

```
répertoire, dossier, arborescence, base de code, projet,
fichier, chemin, code
```

The multi-condition guard (`(user_targets_workspace or assistant_targets_workspace) and assistant_mentions_action`) is unchanged — false-positive risk on opinion-style French ("Je vais réfléchir à ça") remains contained.

## Tests

New `TestLooksLikeCodexIntermediateAck` class in `tests/run_agent/test_run_agent.py` with 10 cases:

- `test_english_ack_with_workspace_action` — regression
- `test_french_ack_je_vais_verifier_dossier` — canonical FR IWE
- `test_french_je_corrige_le_binding` — from a real Alfred Telegram session
- `test_french_je_relance_le_dashboard` — same
- `test_french_action_diagnostiquer_arborescence`
- `test_french_action_examiner_repertoire`
- `test_french_no_action_no_workspace_returns_false` — opinion ("Je vais réfléchir") stays out
- `test_french_no_future_ack_returns_false` — no future-tense verb stays out
- `test_prior_tool_outside_current_turn_does_not_bail` — relaxed bail regression
- `test_tool_in_current_turn_bails` — relaxed bail still bails when correct

`pytest tests/run_agent/test_run_agent.py -v -k LooksLikeCodexIntermediateAck` → **10 passed**.

## Why now

Pairs naturally with the existing English narration coverage and PR #6757 (which generalizes intermediate-ack detection to all `api_modes`). Whether #6757 lands first or this PR does, the regex/markers extension here applies orthogonally. The relaxed bail also helps any agent stack where a single session legitimately interleaves productive tool turns with narration-only ones — common on Telegram/CLI gateways.

This is the second of a small series of PRs improving IWE detection on grok-4.x via xAI direct (paired with #22055 which transmits `reasoning.effort` to xAI Responses).