### PR TITLE
feat(run_agent): runtime intermediate-ack nudge when tool_use_enforcement=required

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1985,6 +1985,11 @@ class AIAgent:
         if not isinstance(_agent_section, dict):
             _agent_section = {}
         self._tool_use_enforcement = _agent_section.get("tool_use_enforcement", "auto")
+        # When tool_use_enforcement is set to the explicit string "required",
+        # this flag enables a runtime post-response check that nudges the
+        # model to actually invoke a tool when it produced a short narrative
+        # ack instead of a tool_call. Set in the enforcement block below.
+        self._tool_use_required_runtime = False
 
         # App-level API retry count (wraps each model API call).  Default 3,
         # overridable via agent.api_max_retries in config.yaml.  See #11616.
@@ -5338,6 +5343,15 @@ class AIAgent:
             elif isinstance(_enforce, list):
                 model_lower = (self.model or "").lower()
                 _inject = any(p.lower() in model_lower for p in _enforce if isinstance(p, str))
+            elif isinstance(_enforce, str) and _enforce.lower() == "required":
+                # "required" — inject the prompt guidance AND enable the
+                # runtime post-response check (see _tool_use_required_runtime).
+                # This goes beyond a prompt-only nudge: if the model returns a
+                # short narrative ack without any tool_call, the agent loop
+                # will append a system nudge and re-prompt instead of ending
+                # the turn on a promise. Compatible with any api_mode/model.
+                _inject = True
+                self._tool_use_required_runtime = True
             else:
                 # "auto" or any unrecognised value — use hardcoded defaults
                 model_lower = (self.model or "").lower()
@@ -14351,8 +14365,16 @@ class AIAgent:
                     self._empty_content_retries = 0
                     self._thinking_prefill_retries = 0
 
+                    # Trigger the intermediate-ack nudge when either:
+                    #   - api_mode is codex_responses (existing behaviour), OR
+                    #   - tool_use_enforcement: "required" is set (explicit
+                    #     opt-in for any model/api_mode — covers chat_completions
+                    #     paths like grok-4 via OpenRouter, DeepSeek, etc.)
                     if (
-                        self.api_mode == "codex_responses"
+                        (
+                            self.api_mode == "codex_responses"
+                            or getattr(self, "_tool_use_required_runtime", False)
+                        )
                         and self.valid_tool_names
                         and codex_ack_continuations < 2
                         and self._looks_like_codex_intermediate_ack(

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1119,6 +1119,58 @@ class TestToolUseEnforcementConfig:
             prompt = a._build_system_prompt()
             assert TOOL_USE_ENFORCEMENT_GUIDANCE not in prompt
 
+    def test_required_injects_guidance_for_any_model(self):
+        """`required` injects the prompt guidance regardless of model family."""
+        from agent.prompt_builder import TOOL_USE_ENFORCEMENT_GUIDANCE
+        agent = self._make_agent(
+            model="anthropic/claude-sonnet-4",
+            tool_use_enforcement="required",
+        )
+        prompt = agent._build_system_prompt()
+        assert TOOL_USE_ENFORCEMENT_GUIDANCE in prompt
+
+    def test_required_sets_runtime_flag(self):
+        """`required` sets the runtime flag that gates the post-response nudge."""
+        agent = self._make_agent(
+            model="x-ai/grok-4.3",
+            tool_use_enforcement="required",
+        )
+        # The flag is set inside _build_system_prompt() (which runs the
+        # enforcement block).  Trigger it by building the prompt once.
+        agent._build_system_prompt()
+        assert agent._tool_use_required_runtime is True
+
+    def test_auto_does_not_set_runtime_flag(self):
+        """`auto` (default) leaves the runtime flag off — only prompt-level guidance."""
+        agent = self._make_agent(
+            model="openai/gpt-4.1",
+            tool_use_enforcement="auto",
+        )
+        agent._build_system_prompt()
+        assert agent._tool_use_required_runtime is False
+
+    def test_required_is_case_insensitive(self):
+        """Accept `REQUIRED`, `Required`, `required` interchangeably."""
+        for value in ("required", "REQUIRED", "Required"):
+            agent = self._make_agent(
+                model="x-ai/grok-4.3",
+                tool_use_enforcement=value,
+            )
+            agent._build_system_prompt()
+            assert agent._tool_use_required_runtime is True, f"failed for value={value!r}"
+
+    def test_required_runtime_flag_independent_from_api_mode(self):
+        """The runtime flag is set purely from config, independent of api_mode.
+        This is what unlocks the post-response nudge for chat_completions models
+        (DeepSeek, OpenRouter grok, etc.) that previously fell through the
+        codex_responses-only gate."""
+        agent = self._make_agent(
+            model="deepseek/deepseek-v4-pro",  # not a codex_responses model
+            tool_use_enforcement="required",
+        )
+        agent._build_system_prompt()
+        assert agent._tool_use_required_runtime is True
+
 
 class TestInvalidateSystemPrompt:
     def test_clears_cache(self, agent):


### PR DESCRIPTION
## Problem

`agent.tool_use_enforcement: required` is currently a **silent no-op**. The string `"required"` is not recognised by the parsing block in `_build_system_prompt`:

```python
elif isinstance(_enforce, list):
    ...
else:
    # "auto" or any unrecognised value — use hardcoded defaults
    ...
```

It falls through to the default branch, so users who set `required` actually get `auto`. The prompt-level `TOOL_USE_ENFORCEMENT_GUIDANCE` is injected (via the model-substring fallback) but there is **zero runtime guarantee** that the model actually invokes a tool. A short narrative ack like `"I'll check the directory."` or `"Je vais vérifier le dossier."` ends the turn on a promise, and the user sees an *Intention Without Execution* (IWE) — the recurring failure mode reported on grok-4.x and other agentic models.

The post-response detector `_looks_like_codex_intermediate_ack` already implements the right shape of fix (append a system nudge, re-prompt) but is gated to `api_mode == "codex_responses"`. Chat-completions paths (DeepSeek, OpenRouter grok-4, etc.) get nothing.

## Fix

Make `"required"` a first-class runtime mode without any new public API surface:

1. **Init.** Add `self._tool_use_required_runtime: bool = False` next to the existing `self._tool_use_enforcement` attribute.
2. **Parsing block.** Add a branch that recognises the literal string `"required"` (case-insensitive). Sets `_inject = True` (the existing prompt-level guidance still applies) and `self._tool_use_required_runtime = True` (the new flag).
3. **Post-response gate.** The existing intermediate-ack nudge gate is extended:

```python
if (
    (
        self.api_mode == "codex_responses"
        or getattr(self, "_tool_use_required_runtime", False)
    )
    and self.valid_tool_names
    and codex_ack_continuations < 2
    and self._looks_like_codex_intermediate_ack(...)
):
    ...
```

Now the existing nudge mechanism fires for any `api_mode`/model combo when the user has explicitly opted into `required`.

## What this PR does NOT do

It deliberately does **not** flip `tool_choice` to `"required"` on the API call. Forcing a tool_call on benign turns (`"ok"`, `"merci"`, simple acknowledgements that don't need any action) would create absurd outputs. The nudge is prompt-driven: if the model legitimately cannot act, it can say so on the next turn. The `codex_ack_continuations < 2` cap caps retry storms.

## Tests

5 new cases in `TestToolUseEnforcementConfig`:

- `test_required_injects_guidance_for_any_model` — the prompt-level guidance still injects for non-default model families.
- `test_required_sets_runtime_flag` — the flag is set after `_build_system_prompt()`.
- `test_auto_does_not_set_runtime_flag` — default config leaves the flag off (no behavioural drift for users who do not opt in).
- `test_required_is_case_insensitive` — `REQUIRED`, `Required`, `required` all work.
- `test_required_runtime_flag_independent_from_api_mode` — flag set even when the model is on chat_completions (e.g. `deepseek/deepseek-v4-pro`), proving the gate now covers them.

`pytest tests/run_agent/test_run_agent.py -v -k ToolUseEnforcement` → **17 passed**.

## Pairing

Third in a small series of PRs improving IWE detection on grok-4.x and adjacent agentic stacks:

- #22055 — transmits `reasoning.effort` to xAI Responses API (otherwise `reasoning_effort` is silently dropped on the xAI direct path).
- #22059 — extends `_looks_like_codex_intermediate_ack` to French phrases and relaxes the global bail-on-prior-tool to a current-turn-only check.
- This PR — wires the existing nudge mechanism to `tool_use_enforcement: required` for any api_mode/model.

The three are independent and can land in any order.