### PR TITLE
fix(tui): trim markdown wrap spaces

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/render-node-to-output.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/render-node-to-output.ts
@@ -260,23 +260,6 @@ function applyStylesToWrappedText(
   for (let lineIdx = 0; lineIdx < lines.length; lineIdx++) {
     const line = lines[lineIdx]!
 
-    // In trim mode, skip leading whitespace that was trimmed from this line.
-    // Only skip if the original has whitespace but the output line doesn't start
-    // with whitespace (meaning it was trimmed). If both have whitespace, the
-    // whitespace was preserved and we shouldn't skip.
-    if (trimEnabled && line.length > 0) {
-      const lineStartsWithWhitespace = /\s/.test(line[0]!)
-
-      const originalHasWhitespace = charIndex < originalPlain.length && /\s/.test(originalPlain[charIndex]!)
-
-      // Only skip if original has whitespace but line doesn't
-      if (originalHasWhitespace && !lineStartsWithWhitespace) {
-        while (charIndex < originalPlain.length && /\s/.test(originalPlain[charIndex]!)) {
-          charIndex++
-        }
-      }
-    }
-
     let styledLine = ''
     let runStart = 0
     let runSegmentIndex = charToSegment[charIndex] ?? 0
@@ -333,26 +316,10 @@ function applyStylesToWrappedText(
     // split lines.
     if (charIndex < originalPlain.length && originalPlain[charIndex] === '\n') {
       charIndex++
-    }
-
-    // In trim mode, skip whitespace that was replaced by newline when wrapping.
-    // We skip whitespace in the original until we reach a character that matches
-    // the first character of the next line. This handles cases like:
-    // - "AB   \tD" wrapped to "AB\n\tD" - skip spaces until we hit the tab
-    // In non-trim mode, whitespace is preserved so no skipping is needed.
-    if (trimEnabled && lineIdx < lines.length - 1) {
-      const nextLine = lines[lineIdx + 1]!
-      const nextLineFirstChar = nextLine.length > 0 ? nextLine[0] : null
-
-      // Skip whitespace until we hit a char that matches the next line's first char
-      while (charIndex < originalPlain.length && /\s/.test(originalPlain[charIndex]!)) {
-        // Stop if we found the character that starts the next line
-        if (nextLineFirstChar !== null && originalPlain[charIndex] === nextLineFirstChar) {
-          break
-        }
-
-        charIndex++
-      }
+    } else if (trimEnabled && lineIdx < lines.length - 1 && /\s/.test(originalPlain[charIndex] ?? '')) {
+      // wrap-trim removes exactly one whitespace cell at each soft-wrap boundary.
+      // Keep the style map aligned without eating preserved indentation/spaces.
+      charIndex++
     }
   }
 

--- a/ui-tui/packages/hermes-ink/src/ink/render-node-to-output.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/render-node-to-output.ts
@@ -317,7 +317,7 @@ function applyStylesToWrappedText(
     if (charIndex < originalPlain.length && originalPlain[charIndex] === '\n') {
       charIndex++
     } else if (trimEnabled && lineIdx < lines.length - 1 && /\s/.test(originalPlain[charIndex] ?? '')) {
-      // wrap-trim removes exactly one whitespace cell at each soft-wrap boundary.
+      // wrap-trim removes exactly one whitespace character at each soft-wrap boundary.
       // Keep the style map aligned without eating preserved indentation/spaces.
       charIndex++
     }

--- a/ui-tui/packages/hermes-ink/src/ink/wrap-text.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/wrap-text.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest'
+
+import wrapText from './wrap-text.js'
+
+describe('wrapText wrap-trim', () => {
+  it('removes a single soft-wrap boundary space', () => {
+    expect(wrapText('Let me', 5, 'wrap-trim')).toBe('Let\nme')
+  })
+
+  it('preserves extra original spacing at soft-wrap boundaries', () => {
+    expect(wrapText('foo  bar', 5, 'wrap-trim')).toBe('foo \nbar')
+  })
+
+  it('preserves leading whitespace on unwrapped source lines', () => {
+    expect(wrapText('  indented', 20, 'wrap-trim')).toBe('  indented')
+  })
+})

--- a/ui-tui/packages/hermes-ink/src/ink/wrap-text.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/wrap-text.ts
@@ -87,13 +87,18 @@ function trimSoftWrapBoundaries(text: string, maxWidth: number): string {
         return pieces[0]!
       }
 
-      return pieces
-        .map((piece, index) => {
-          const withoutLeadingWrapSpace = index === 0 ? piece : piece.trimStart()
+      for (let index = 0; index < pieces.length - 1; index++) {
+        const current = pieces[index]!
+        const next = pieces[index + 1]!
 
-          return index === pieces.length - 1 ? withoutLeadingWrapSpace : withoutLeadingWrapSpace.trimEnd()
-        })
-        .join('\n')
+        if (/\s$/.test(current)) {
+          pieces[index] = current.replace(/\s$/, '')
+        } else if (/^\s/.test(next)) {
+          pieces[index + 1] = next.replace(/^\s/, '')
+        }
+      }
+
+      return pieces.join('\n')
     })
     .join('\n')
 }

--- a/ui-tui/packages/hermes-ink/src/ink/wrap-text.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/wrap-text.ts
@@ -77,6 +77,27 @@ function truncate(text: string, columns: number, position: 'start' | 'middle' | 
   return sliceFit(text, 0, columns - 1) + ELLIPSIS
 }
 
+function trimSoftWrapBoundaries(text: string, maxWidth: number): string {
+  return text
+    .split('\n')
+    .map(line => {
+      const pieces = wrapAnsi(line, maxWidth, { trim: false, hard: true }).split('\n')
+
+      if (pieces.length === 1) {
+        return pieces[0]!
+      }
+
+      return pieces
+        .map((piece, index) => {
+          const withoutLeadingWrapSpace = index === 0 ? piece : piece.trimStart()
+
+          return index === pieces.length - 1 ? withoutLeadingWrapSpace : withoutLeadingWrapSpace.trimEnd()
+        })
+        .join('\n')
+    })
+    .join('\n')
+}
+
 function computeWrap(text: string, maxWidth: number, wrapType: Styles['textWrap']): string {
   if (wrapType === 'wrap') {
     return wrapAnsi(text, maxWidth, { trim: false, hard: true })
@@ -87,7 +108,7 @@ function computeWrap(text: string, maxWidth: number, wrapType: Styles['textWrap'
   }
 
   if (wrapType === 'wrap-trim') {
-    return wrapAnsi(text, maxWidth, { trim: true, hard: true })
+    return trimSoftWrapBoundaries(text, maxWidth)
   }
 
   if (wrapType!.startsWith('truncate')) {

--- a/ui-tui/src/__tests__/markdown.test.ts
+++ b/ui-tui/src/__tests__/markdown.test.ts
@@ -190,4 +190,18 @@ describe('Md wrapping', () => {
     expect(lines).toContain('me')
     expect(lines).not.toContain(' me')
   })
+
+  it('keeps nested list and quote indentation out of trim-sensitive text', () => {
+    const lines = renderPlain(
+      React.createElement(
+        Box,
+        { flexDirection: 'column', width: 24 },
+        React.createElement(Md, { t: DEFAULT_THEME, text: '  - nested bullet' }),
+        React.createElement(Md, { t: DEFAULT_THEME, text: '>> nested quote' })
+      )
+    )
+
+    expect(lines).toContain('  • nested bullet')
+    expect(lines).toContain('  │ nested quote')
+  })
 })

--- a/ui-tui/src/__tests__/markdown.test.ts
+++ b/ui-tui/src/__tests__/markdown.test.ts
@@ -9,7 +9,10 @@ import { stripAnsi } from '../lib/text.js'
 import { DEFAULT_THEME } from '../theme.js'
 
 const matches = (text: string) => [...text.matchAll(INLINE_RE)].map(m => m[0])
-const CSI_RE = new RegExp(`${String.fromCharCode(27)}\\[[0-?]*[ -/]*[@-~]`, 'g')
+const BEL = String.fromCharCode(7)
+const ESC = String.fromCharCode(27)
+const CSI_RE = new RegExp(`${ESC}\\[[0-?]*[ -/]*[@-~]`, 'g')
+const OSC_RE = new RegExp(`${ESC}\\][\\s\\S]*?(?:${BEL}|${ESC}\\\\)`, 'g')
 
 const renderPlain = (node: React.ReactNode) => {
   const stdout = new PassThrough()
@@ -36,7 +39,7 @@ const renderPlain = (node: React.ReactNode) => {
 
   return stripAnsi(output)
     .split('\n')
-    .map(line => line.replace(CSI_RE, '').trimEnd())
+    .map(line => line.replace(OSC_RE, '').replace(CSI_RE, '').trimEnd())
 }
 
 describe('INLINE_RE emphasis', () => {

--- a/ui-tui/src/__tests__/markdown.test.ts
+++ b/ui-tui/src/__tests__/markdown.test.ts
@@ -204,4 +204,12 @@ describe('Md wrapping', () => {
     expect(lines).toContain('  • nested bullet')
     expect(lines).toContain('  │ nested quote')
   })
+
+  it('preserves original inline-code edge spaces', () => {
+    const lines = renderPlain(
+      React.createElement(Box, { width: 24 }, React.createElement(Md, { t: DEFAULT_THEME, text: '` hi ` ok' }))
+    )
+
+    expect(lines.some(line => line.startsWith(' hi  ok'))).toBe(true)
+  })
 })

--- a/ui-tui/src/__tests__/markdown.test.ts
+++ b/ui-tui/src/__tests__/markdown.test.ts
@@ -1,8 +1,43 @@
+import { PassThrough } from 'stream'
+
+import { Box, renderSync } from '@hermes/ink'
+import React from 'react'
 import { describe, expect, it } from 'vitest'
 
-import { AUDIO_DIRECTIVE_RE, INLINE_RE, MEDIA_LINE_RE, stripInlineMarkup } from '../components/markdown.js'
+import { AUDIO_DIRECTIVE_RE, INLINE_RE, Md, MEDIA_LINE_RE, stripInlineMarkup } from '../components/markdown.js'
+import { stripAnsi } from '../lib/text.js'
+import { DEFAULT_THEME } from '../theme.js'
 
 const matches = (text: string) => [...text.matchAll(INLINE_RE)].map(m => m[0])
+const CSI_RE = new RegExp(`${String.fromCharCode(27)}\\[[0-?]*[ -/]*[@-~]`, 'g')
+
+const renderPlain = (node: React.ReactNode) => {
+  const stdout = new PassThrough()
+  const stdin = new PassThrough()
+  const stderr = new PassThrough()
+  let output = ''
+
+  Object.assign(stdout, { columns: 80, isTTY: false, rows: 24 })
+  Object.assign(stdin, { isTTY: false })
+  Object.assign(stderr, { isTTY: false })
+  stdout.on('data', chunk => {
+    output += chunk.toString()
+  })
+
+  const instance = renderSync(node, {
+    patchConsole: false,
+    stderr: stderr as NodeJS.WriteStream,
+    stdin: stdin as NodeJS.ReadStream,
+    stdout: stdout as NodeJS.WriteStream
+  })
+
+  instance.unmount()
+  instance.cleanup()
+
+  return stripAnsi(output)
+    .split('\n')
+    .map(line => line.replace(CSI_RE, '').trimEnd())
+}
 
 describe('INLINE_RE emphasis', () => {
   it('matches word-boundary italic/bold', () => {
@@ -142,5 +177,17 @@ describe('protocol sentinels', () => {
     expect(AUDIO_DIRECTIVE_RE.test('[[audio_as_voice]]')).toBe(true)
     expect(AUDIO_DIRECTIVE_RE.test('  [[audio_as_voice]]  ')).toBe(true)
     expect(AUDIO_DIRECTIVE_RE.test('audio_as_voice')).toBe(false)
+  })
+})
+
+describe('Md wrapping', () => {
+  it('trims spaces from word-wrap continuation lines', () => {
+    const lines = renderPlain(
+      React.createElement(Box, { width: 5 }, React.createElement(Md, { t: DEFAULT_THEME, text: 'Let me' }))
+    )
+
+    expect(lines).toContain('Let')
+    expect(lines).toContain('me')
+    expect(lines).not.toContain(' me')
   })
 })

--- a/ui-tui/src/__tests__/markdown.test.ts
+++ b/ui-tui/src/__tests__/markdown.test.ts
@@ -37,9 +37,10 @@ const renderPlain = (node: React.ReactNode) => {
   instance.unmount()
   instance.cleanup()
 
-  return stripAnsi(output)
+  return output
+    .replace(OSC_RE, '')
     .split('\n')
-    .map(line => line.replace(OSC_RE, '').replace(CSI_RE, '').trimEnd())
+    .map(line => stripAnsi(line).replace(CSI_RE, '').trimEnd())
 }
 
 describe('INLINE_RE emphasis', () => {

--- a/ui-tui/src/components/markdown.tsx
+++ b/ui-tui/src/components/markdown.tsx
@@ -216,7 +216,11 @@ function MdInline({ t, text }: { t: Theme; text: string }) {
     const k = parts.length
 
     if (i > last) {
-      parts.push(<Text key={k}>{text.slice(last, i)}</Text>)
+      parts.push(
+        <Text key={k} wrap="wrap-trim">
+          {text.slice(last, i)}
+        </Text>
+      )
     }
 
     if (m[1] && m[2]) {
@@ -299,7 +303,11 @@ function MdInline({ t, text }: { t: Theme; text: string }) {
       parts.push(renderAutolink(parts.length, t, url))
 
       if (url.length < m[16].length) {
-        parts.push(<Text key={parts.length}>{m[16].slice(url.length)}</Text>)
+        parts.push(
+          <Text key={parts.length} wrap="wrap-trim">
+            {m[16].slice(url.length)}
+          </Text>
+        )
       }
     } else if (m[17] ?? m[18]) {
       // Inline math is run through `texToUnicode` (Greek letters, ℕℤℚℝ,
@@ -320,10 +328,24 @@ function MdInline({ t, text }: { t: Theme; text: string }) {
   }
 
   if (last < text.length) {
-    parts.push(<Text key={parts.length}>{text.slice(last)}</Text>)
+    parts.push(
+      <Text key={parts.length} wrap="wrap-trim">
+        {text.slice(last)}
+      </Text>
+    )
   }
 
-  return <Text>{parts.length ? parts : <Text>{text}</Text>}</Text>
+  return (
+    <Text wrap="wrap-trim">
+      {parts.length ? (
+        parts
+      ) : (
+        <Text wrap="wrap-trim">
+          {text}
+        </Text>
+      )}
+    </Text>
+  )
 }
 
 // Cross-instance parsed-children cache: useMemo's per-instance cache dies
@@ -420,7 +442,7 @@ function MdImpl({ compact, t, text }: MdProps) {
       if (media) {
         start('paragraph')
         nodes.push(
-          <Text color={t.color.muted} key={key}>
+          <Text color={t.color.muted} key={key} wrap="wrap-trim">
             {'▸ '}
 
             <Link url={/^(?:\/|[a-z]:[\\/])/i.test(media) ? `file://${media}` : media}>
@@ -594,7 +616,7 @@ function MdImpl({ compact, t, text }: MdProps) {
       if (heading) {
         start('heading')
         nodes.push(
-          <Text bold color={t.color.accent} key={key}>
+          <Text bold color={t.color.accent} key={key} wrap="wrap-trim">
             <MdInline t={t} text={heading} />
           </Text>
         )
@@ -606,7 +628,7 @@ function MdImpl({ compact, t, text }: MdProps) {
       if (i + 1 < lines.length && SETEXT_RE.test(lines[i + 1]!)) {
         start('heading')
         nodes.push(
-          <Text bold color={t.color.accent} key={key}>
+          <Text bold color={t.color.accent} key={key} wrap="wrap-trim">
             <MdInline t={t} text={line.trim()} />
           </Text>
         )
@@ -632,7 +654,7 @@ function MdImpl({ compact, t, text }: MdProps) {
       if (footnote) {
         start('list')
         nodes.push(
-          <Text color={t.color.muted} key={key}>
+          <Text color={t.color.muted} key={key} wrap="wrap-trim">
             [{footnote[1]}] <MdInline t={t} text={footnote[2] ?? ''} />
           </Text>
         )
@@ -641,7 +663,7 @@ function MdImpl({ compact, t, text }: MdProps) {
         while (i < lines.length && /^\s{2,}\S/.test(lines[i]!)) {
           nodes.push(
             <Box key={`${key}-cont-${i}`} paddingLeft={2}>
-              <Text color={t.color.muted}>
+              <Text color={t.color.muted} wrap="wrap-trim">
                 <MdInline t={t} text={lines[i]!.trim()} />
               </Text>
             </Box>
@@ -655,7 +677,7 @@ function MdImpl({ compact, t, text }: MdProps) {
       if (i + 1 < lines.length && DEF_RE.test(lines[i + 1]!)) {
         start('list')
         nodes.push(
-          <Text bold key={key}>
+          <Text bold key={key} wrap="wrap-trim">
             {line.trim()}
           </Text>
         )
@@ -774,7 +796,7 @@ function MdImpl({ compact, t, text }: MdProps) {
       if (summary) {
         start('paragraph')
         nodes.push(
-          <Text color={t.color.muted} key={key}>
+          <Text color={t.color.muted} key={key} wrap="wrap-trim">
             ▶ {summary}
           </Text>
         )
@@ -786,7 +808,7 @@ function MdImpl({ compact, t, text }: MdProps) {
       if (/^<\/?[^>]+>$/.test(line.trim())) {
         start('paragraph')
         nodes.push(
-          <Text color={t.color.muted} key={key}>
+          <Text color={t.color.muted} key={key} wrap="wrap-trim">
             {line.trim()}
           </Text>
         )

--- a/ui-tui/src/components/markdown.tsx
+++ b/ui-tui/src/components/markdown.tsx
@@ -216,11 +216,7 @@ function MdInline({ t, text }: { t: Theme; text: string }) {
     const k = parts.length
 
     if (i > last) {
-      parts.push(
-        <Text key={k} wrap="wrap-trim">
-          {text.slice(last, i)}
-        </Text>
-      )
+      parts.push(<Text key={k}>{text.slice(last, i)}</Text>)
     }
 
     if (m[1] && m[2]) {
@@ -303,11 +299,7 @@ function MdInline({ t, text }: { t: Theme; text: string }) {
       parts.push(renderAutolink(parts.length, t, url))
 
       if (url.length < m[16].length) {
-        parts.push(
-          <Text key={parts.length} wrap="wrap-trim">
-            {m[16].slice(url.length)}
-          </Text>
-        )
+        parts.push(<Text key={parts.length}>{m[16].slice(url.length)}</Text>)
       }
     } else if (m[17] ?? m[18]) {
       // Inline math is run through `texToUnicode` (Greek letters, ℕℤℚℝ,
@@ -328,24 +320,10 @@ function MdInline({ t, text }: { t: Theme; text: string }) {
   }
 
   if (last < text.length) {
-    parts.push(
-      <Text key={parts.length} wrap="wrap-trim">
-        {text.slice(last)}
-      </Text>
-    )
+    parts.push(<Text key={parts.length}>{text.slice(last)}</Text>)
   }
 
-  return (
-    <Text wrap="wrap-trim">
-      {parts.length ? (
-        parts
-      ) : (
-        <Text wrap="wrap-trim">
-          {text}
-        </Text>
-      )}
-    </Text>
-  )
+  return <Text wrap="wrap-trim">{parts.length ? parts : text}</Text>
 }
 
 // Cross-instance parsed-children cache: useMemo's per-instance cache dies

--- a/ui-tui/src/components/markdown.tsx
+++ b/ui-tui/src/components/markdown.tsx
@@ -689,14 +689,12 @@ function MdImpl({ compact, t, text }: MdProps) {
         const marker = task ? (task[1]!.toLowerCase() === 'x' ? '☑' : '☐') : '•'
 
         nodes.push(
-          <Text key={key} wrap="wrap-trim">
-            <Text color={t.color.muted}>
-              {' '.repeat(indentDepth(bullet[1]!) * 2)}
-              {marker}{' '}
+          <Box key={key} paddingLeft={indentDepth(bullet[1]!) * 2}>
+            <Text wrap="wrap-trim">
+              <Text color={t.color.muted}>{marker} </Text>
+              <MdInline t={t} text={task ? task[2]! : bullet[2]!} />
             </Text>
-
-            <MdInline t={t} text={task ? task[2]! : bullet[2]!} />
-          </Text>
+          </Box>
         )
         i++
 
@@ -708,14 +706,12 @@ function MdImpl({ compact, t, text }: MdProps) {
       if (numbered) {
         start('list')
         nodes.push(
-          <Text key={key} wrap="wrap-trim">
-            <Text color={t.color.muted}>
-              {' '.repeat(indentDepth(numbered[1]!) * 2)}
-              {numbered[2]}.{' '}
+          <Box key={key} paddingLeft={indentDepth(numbered[1]!) * 2}>
+            <Text wrap="wrap-trim">
+              <Text color={t.color.muted}>{numbered[2]}. </Text>
+              <MdInline t={t} text={numbered[3]!} />
             </Text>
-
-            <MdInline t={t} text={numbered[3]!} />
-          </Text>
+          </Box>
         )
         i++
 
@@ -737,11 +733,11 @@ function MdImpl({ compact, t, text }: MdProps) {
         nodes.push(
           <Box flexDirection="column" key={key}>
             {quoteLines.map((ql, qi) => (
-              <Text color={t.color.muted} key={qi} wrap="wrap-trim">
-                {' '.repeat(Math.max(0, ql.depth - 1) * 2)}
-                {'│ '}
-                <MdInline t={t} text={ql.text} />
-              </Text>
+              <Box key={qi} paddingLeft={Math.max(0, ql.depth - 1) * 2}>
+                <Text color={t.color.muted} wrap="wrap-trim">
+                  │ <MdInline t={t} text={ql.text} />
+                </Text>
+              </Box>
             ))}
           </Box>
         )

--- a/ui-tui/src/components/markdown.tsx
+++ b/ui-tui/src/components/markdown.tsx
@@ -689,7 +689,7 @@ function MdImpl({ compact, t, text }: MdProps) {
         const marker = task ? (task[1]!.toLowerCase() === 'x' ? '☑' : '☐') : '•'
 
         nodes.push(
-          <Text key={key}>
+          <Text key={key} wrap="wrap-trim">
             <Text color={t.color.muted}>
               {' '.repeat(indentDepth(bullet[1]!) * 2)}
               {marker}{' '}
@@ -708,7 +708,7 @@ function MdImpl({ compact, t, text }: MdProps) {
       if (numbered) {
         start('list')
         nodes.push(
-          <Text key={key}>
+          <Text key={key} wrap="wrap-trim">
             <Text color={t.color.muted}>
               {' '.repeat(indentDepth(numbered[1]!) * 2)}
               {numbered[2]}.{' '}
@@ -737,7 +737,7 @@ function MdImpl({ compact, t, text }: MdProps) {
         nodes.push(
           <Box flexDirection="column" key={key}>
             {quoteLines.map((ql, qi) => (
-              <Text color={t.color.muted} key={qi}>
+              <Text color={t.color.muted} key={qi} wrap="wrap-trim">
                 {' '.repeat(Math.max(0, ql.depth - 1) * 2)}
                 {'│ '}
                 <MdInline t={t} text={ql.text} />

--- a/ui-tui/src/components/markdown.tsx
+++ b/ui-tui/src/components/markdown.tsx
@@ -669,7 +669,7 @@ function MdImpl({ compact, t, text }: MdProps) {
           }
 
           nodes.push(
-            <Text key={`${key}-def-${i}`}>
+            <Text key={`${key}-def-${i}`} wrap="wrap-trim">
               <Text color={t.color.muted}> · </Text>
               <MdInline t={t} text={def} />
             </Text>


### PR DESCRIPTION
## Summary
- Use trim-aware wrapping for TUI markdown prose so continuation lines do not preserve word-boundary spaces.
- Add a narrow-width markdown render regression test for `Let me` wrapping as `Let` / `me`.

## Test plan
- `npm run build --prefix packages/hermes-ink`
- `npm test -- markdown.test.ts`
- `npx eslint src/components/markdown.tsx src/__tests__/markdown.test.ts`
- `npm run type-check`