### PR TITLE
fix(cron): clean up output dir when auto-removing repeat-limited job

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -738,6 +738,11 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                         # Remove the job (limit reached)
                         jobs.pop(i)
                         save_jobs(jobs)
+                        # Mirror remove_job()'s cleanup — output dirs from the
+                        # completed runs would otherwise accumulate unnoticed.
+                        job_output_dir = OUTPUT_DIR / job_id
+                        if job_output_dir.exists():
+                            shutil.rmtree(job_output_dir)
                         return
                 
                 # Compute next run

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -452,6 +452,39 @@ class TestMarkJobRun:
         assert updated["enabled"] is False
         assert updated["state"] == "completed"
 
+    def test_repeat_limit_cleans_up_output_dir(self, tmp_cron_dir):
+        """mark_job_run() must delete OUTPUT_DIR/<job_id> when auto-removing a
+        repeat-limited job, matching what remove_job() does (PR #21882 parity).
+        Without this, completed one-shot jobs leave orphaned output directories.
+        """
+        job = create_job(prompt="Once", schedule="30m", repeat=1)
+        job_id = job["id"]
+
+        # Simulate save_job_output() having written at least one output file.
+        output_dir = tmp_cron_dir / "cron" / "output" / job_id
+        output_dir.mkdir(parents=True)
+        (output_dir / "2026-05-08_12-00-00.md").write_text("output")
+
+        assert output_dir.exists()
+
+        mark_job_run(job_id, success=True)
+
+        assert get_job(job_id) is None, "job was not removed after repeat limit"
+        assert not output_dir.exists(), "output dir was not cleaned up after auto-delete"
+
+    def test_repeat_limit_no_output_dir_is_safe(self, tmp_cron_dir):
+        """mark_job_run() auto-delete is safe when no output was ever saved
+        (OUTPUT_DIR/<job_id> does not exist) — the cleanup must be a no-op.
+        """
+        job = create_job(prompt="Once", schedule="30m", repeat=1)
+        output_dir = tmp_cron_dir / "cron" / "output" / job["id"]
+
+        assert not output_dir.exists()
+
+        mark_job_run(job["id"], success=True)
+
+        assert get_job(job["id"]) is None
+
 
 class TestAdvanceNextRun:
     """Tests for advance_next_run() — crash-safety for recurring jobs."""


### PR DESCRIPTION
## What does this PR do?

`mark_job_run()` removes a job from `jobs.json` when its `repeat` limit is reached, but the corresponding `OUTPUT_DIR/<job_id>` directory (written by `save_job_output()` on every run) was never deleted. Each completed one-shot job leaves behind an orphaned output directory that accumulates indefinitely.

`remove_job()` gained the identical cleanup in PR #21882 (merged today). This PR extends that fix to `mark_job_run()`, the only other code path that deletes a job — parity with `remove_job()` lines 700–703.

One-line fix in `mark_job_run()`, scoped to the repeat-limit branch. No behavior change for recurring jobs or jobs without a repeat limit.

## Related Issue

Fixes #22065

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `cron/jobs.py`: add `shutil.rmtree(OUTPUT_DIR / job_id)` guard in the repeat-limit auto-delete branch of `mark_job_run()` (+4 lines)
- `tests/cron/test_jobs.py`: two new tests in `TestMarkJobRun` (+33 lines)
  - `test_repeat_limit_cleans_up_output_dir` — verifies the dir is removed after auto-delete
  - `test_repeat_limit_no_output_dir_is_safe` — verifies no crash when no output was saved

## How to Test

```bash
python3.11 -m pytest tests/cron/test_jobs.py::TestMarkJobRun -v --override-ini="addopts="
```

All 12 tests pass (1 skip for missing `croniter` — pre-existing on macOS).

## Checklist

### Code
- [x] Contributing Guide read
- [x] Conventional Commits
- [x] No duplicate PR
- [x] This fix only
- [x] pytest run
- [x] Tests added
- [x] Platform: macOS

### Documentation & Housekeeping
- [x] Docs updated — N/A
- [x] cli-config.yaml.example — N/A
- [x] CONTRIBUTING.md/AGENTS.md — N/A
- [x] Cross-platform impact — N/A (`shutil.rmtree` is cross-platform)
- [x] Tool descriptions — N/A