### PR TITLE
Clarify context window display

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5843,7 +5843,7 @@ class HermesCLI:
         _cprint(f"  ✓ Model switched: {result.new_model}")
         _cprint(f"    Provider: {provider_label}")
 
-        # Context: always resolve via the provider-aware chain so Codex OAuth,
+        # Context window: always resolve via the provider-aware chain so Codex OAuth,
         # Copilot, and Nous-enforced caps win over the raw models.dev entry
         # (e.g. gpt-5.5 is 1.05M on openai but 272K on Codex OAuth).
         mi = result.model_info
@@ -5858,7 +5858,7 @@ class HermesCLI:
                 config_context_length=getattr(self.agent, "_config_context_length", None) if self.agent else None,
             )
             if ctx:
-                _cprint(f"    Context: {ctx:,} tokens")
+                _cprint(f"    Context window: {ctx:,} tokens")
         except Exception:
             pass
         if mi:
@@ -6074,7 +6074,7 @@ class HermesCLI:
         _cprint(f"  ✓ Model switched: {result.new_model}")
         _cprint(f"    Provider: {provider_label}")
 
-        # Context: always resolve via the provider-aware chain so Codex OAuth,
+        # Context window: always resolve via the provider-aware chain so Codex OAuth,
         # Copilot, and Nous-enforced caps win over the raw models.dev entry
         # (e.g. gpt-5.5 is 1.05M on openai but 272K on Codex OAuth).
         mi = result.model_info
@@ -6088,7 +6088,7 @@ class HermesCLI:
             config_context_length=getattr(self.agent, "_config_context_length", None) if self.agent else None,
         )
         if ctx:
-            _cprint(f"    Context: {ctx:,} tokens")
+            _cprint(f"    Context window: {ctx:,} tokens")
         if mi:
             if mi.max_output:
                 _cprint(f"    Max output: {mi.max_output:,} tokens")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7311,7 +7311,8 @@ class GatewayRunner:
         else:
             ctx_source = "detected"
 
-        # Format context length for display
+        # Format context window for display. This is the model/provider's
+        # available window, not the amount of conversation currently used.
         if context_length >= 1_000_000:
             ctx_display = f"{context_length / 1_000_000:.1f}M"
         elif context_length >= 1_000:
@@ -7322,7 +7323,7 @@ class GatewayRunner:
         lines = [
             f"◆ Model: `{model}`",
             f"◆ Provider: {provider or 'openrouter'}",
-            f"◆ Context: {ctx_display} tokens ({ctx_source})",
+            f"◆ Context window: {ctx_display} tokens ({ctx_source})",
         ]
 
         # Show endpoint for local/custom setups
@@ -8149,7 +8150,7 @@ class GatewayRunner:
                             config_context_length=_sw_config_ctx,
                         )
                         if ctx:
-                            lines.append(f"Context: {ctx:,} tokens")
+                            lines.append(f"Context window: {ctx:,} tokens")
                         if mi:
                             if mi.max_output:
                                 lines.append(f"Max output: {mi.max_output:,} tokens")
@@ -8285,7 +8286,7 @@ class GatewayRunner:
         lines = [f"Model switched to `{result.new_model}`"]
         lines.append(f"Provider: {provider_label}")
 
-        # Context: always resolve via the provider-aware chain so Codex OAuth,
+        # Context window: always resolve via the provider-aware chain so Codex OAuth,
         # Copilot, and Nous-enforced caps win over the raw models.dev entry.
         mi = result.model_info
         from hermes_cli.model_switch import resolve_display_context_length
@@ -8309,7 +8310,7 @@ class GatewayRunner:
             config_context_length=_sw2_config_ctx,
         )
         if ctx:
-            lines.append(f"Context: {ctx:,} tokens")
+            lines.append(f"Context window: {ctx:,} tokens")
         if mi:
             if mi.max_output:
                 lines.append(f"Max output: {mi.max_output:,} tokens")

--- a/tests/gateway/test_session_info.py
+++ b/tests/gateway/test_session_info.py
@@ -96,7 +96,7 @@ class TestFormatSessionInfo:
         with p1, p2, p3:
             info = runner._format_session_info()
         assert "Model" in info
-        assert "Context" in info
+        assert "Context window" in info
 
     def test_runtime_resolution_failure_doesnt_crash(self, runner, tmp_path):
         """If runtime resolution raises, should still produce output."""

--- a/tests/hermes_cli/test_apply_model_switch_result_context.py
+++ b/tests/hermes_cli/test_apply_model_switch_result_context.py
@@ -79,7 +79,7 @@ def test_picker_path_uses_provider_aware_context_on_codex(monkeypatch):
     ):
         lines = _run_display(monkeypatch, result)
 
-    ctx_line = next((l for l in lines if "Context:" in l), "")
+    ctx_line = next((l for l in lines if "Context window:" in l), "")
     assert "272,000" in ctx_line, (
         f"picker-path display must show Codex's 272K cap, got: {ctx_line!r}"
     )
@@ -114,7 +114,7 @@ def test_picker_path_shows_vendor_value_when_no_provider_cap(monkeypatch):
     ):
         lines = _run_display(monkeypatch, result)
 
-    ctx_line = next((l for l in lines if "Context:" in l), "")
+    ctx_line = next((l for l in lines if "Context window:" in l), "")
     assert "1,050,000" in ctx_line, (
         f"OpenRouter gpt-5.5 should show 1.05M context, got: {ctx_line!r}"
     )
@@ -146,7 +146,7 @@ def test_picker_path_falls_back_to_model_info_when_resolver_empty(monkeypatch):
     ):
         lines = _run_display(monkeypatch, result)
 
-    ctx_line = next((l for l in lines if "Context:" in l), "")
+    ctx_line = next((l for l in lines if "Context window:" in l), "")
     assert "1,050,000" in ctx_line, (
         f"resolver-empty path should fall back to ModelInfo, got: {ctx_line!r}"
     )


### PR DESCRIPTION
## Summary
- rename ambiguous context display labels to `Context window` in gateway and CLI model messages
- clarify in code that the value is the available model/provider window, not current conversation usage
- update focused tests for the new wording

## Tests
- `python -m pytest tests/gateway/test_session_info.py tests/hermes_cli/test_apply_model_switch_result_context.py -q`
