### PR TITLE
Wire Kanban Codex/Claude observability

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -182,6 +182,16 @@ SKILLS_GUIDANCE = (
     "Skills that aren't maintained become liabilities."
 )
 
+REPO_CODE_INTAKE_GUIDANCE = (
+    "# Repository code intake\n"
+    "When a user asks Hermes to implement, fix, refactor, or otherwise change "
+    "code in a git repository, create or use a Kanban task for the work before "
+    "execution. Do not run Codex directly from normal chat. Repository code "
+    "execution must go through the Kanban worker path and "
+    "`/home/ubuntu/.hermes/scripts/hermes-codex-phase` so progress, logs, "
+    "blocked state, completion, and notifications remain observable."
+)
+
 KANBAN_GUIDANCE = (
     "# Kanban task execution protocol\n"
     "You have been assigned ONE task from "
@@ -227,6 +237,15 @@ KANBAN_GUIDANCE = (
     "express dependencies. Then `kanban_complete` your own task with a summary "
     "of the decomposition. Do NOT execute the work yourself; your job is "
     "routing, not implementation.\n"
+    "\n"
+    "## Repository code tasks\n"
+    "\n"
+    "For implementation work in a git repository, use the `prd-phased-codex` "
+    "workflow and run every Codex execution through "
+    "`/home/ubuntu/.hermes/scripts/hermes-codex-phase`. Direct `codex ...` "
+    "commands bypass durable Kanban state and are blocked. The phase wrapper "
+    "records start/finish events, log paths, blocked/complete state, and "
+    "notification handoff back to this board.\n"
     "\n"
     "## Do NOT\n"
     "\n"

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1237,6 +1237,26 @@ class TelegramAdapter(BasePlatformAdapter):
             
             message_ids = []
             thread_id = self._metadata_thread_id(metadata)
+            reply_markup = None
+            if metadata and isinstance(metadata.get("inline_keyboard"), list):
+                rows = []
+                for row in metadata.get("inline_keyboard") or []:
+                    if not isinstance(row, list):
+                        continue
+                    buttons = []
+                    for button in row:
+                        if not isinstance(button, dict):
+                            continue
+                        text = str(button.get("text") or "").strip()
+                        callback_data = str(button.get("callback_data") or "").strip()
+                        if text and callback_data:
+                            buttons.append(
+                                InlineKeyboardButton(text, callback_data=callback_data)
+                            )
+                    if buttons:
+                        rows.append(buttons)
+                if rows:
+                    reply_markup = InlineKeyboardMarkup(rows)
             
             try:
                 from telegram.error import NetworkError as _NetErr
@@ -1269,6 +1289,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                 parse_mode=ParseMode.MARKDOWN_V2,
                                 reply_to_message_id=reply_to_id,
                                 message_thread_id=effective_thread_id,
+                                reply_markup=reply_markup if i == len(chunks) - 1 else None,
                                 **self._link_preview_kwargs(),
                             )
                         except Exception as md_error:
@@ -1282,6 +1303,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                     parse_mode=None,
                                     reply_to_message_id=reply_to_id,
                                     message_thread_id=effective_thread_id,
+                                    reply_markup=reply_markup if i == len(chunks) - 1 else None,
                                     **self._link_preview_kwargs(),
                                 )
                             else:
@@ -2062,6 +2084,50 @@ class TelegramAdapter(BasePlatformAdapter):
                     logger.error("[%s] slash-confirm callback failed: %s", self.name, exc, exc_info=True)
             return
 
+        # --- Kanban task action callbacks (kb:choice:task_id) ---
+        if data.startswith("kb:"):
+            parts = data.split(":")
+            if len(parts) not in (3, 4):
+                await query.answer(text="Invalid Kanban action.")
+                return
+            choice, task_id = parts[1], parts[2]
+            board = parts[3] if len(parts) == 4 else None
+            caller_id = str(getattr(query.from_user, "id", ""))
+            if not self._is_callback_user_authorized(
+                caller_id,
+                chat_id=query_chat_id,
+                chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                user_name=query_user_name,
+            ):
+                await query.answer(text="⛔ You are not authorized to update this task.")
+                return
+
+            result_text = self._handle_kanban_callback_action(
+                task_id=task_id,
+                choice=choice,
+                board=board,
+                user_display=getattr(query.from_user, "first_name", "Telegram user"),
+                chat_id=str(query_chat_id) if query_chat_id is not None else "",
+            )
+            await query.answer(text=result_text[:180])
+            try:
+                await query.edit_message_reply_markup(reply_markup=None)
+            except Exception:
+                pass
+            if query.message:
+                thread_id = getattr(query.message, "message_thread_id", None)
+                send_kwargs: Dict[str, Any] = {
+                    "chat_id": int(query.message.chat_id),
+                    "text": result_text,
+                    "parse_mode": ParseMode.MARKDOWN,
+                    **self._link_preview_kwargs(),
+                }
+                if thread_id is not None:
+                    send_kwargs["message_thread_id"] = thread_id
+                await self._bot.send_message(**send_kwargs)
+            return
+
         # --- Update prompt callbacks ---
         if not data.startswith("update_prompt:"):
             return
@@ -2099,6 +2165,120 @@ class TelegramAdapter(BasePlatformAdapter):
                         answer, getattr(query.from_user, "id", "unknown"))
         except Exception as exc:
             logger.error("Failed to write update response from callback: %s", exc)
+
+    def _handle_kanban_callback_action(
+        self,
+        *,
+        task_id: str,
+        choice: str,
+        user_display: str,
+        chat_id: str,
+        board: Optional[str] = None,
+    ) -> str:
+        from datetime import datetime, timezone
+
+        from hermes_cli import kanban_db as _kb
+
+        conn = _kb.connect(board=board)
+        try:
+            task = _kb.get_task(conn, task_id)
+            if not task:
+                return f"Kanban task {task_id} not found."
+
+            run = _kb.latest_run(conn, task_id)
+            meta = getattr(run, "metadata", None) if run else None
+            if not isinstance(meta, dict):
+                meta = {}
+            repo = meta.get("repo") or task.workspace_path
+
+            if choice == "ap":
+                if not repo:
+                    return f"Task {task_id} has no repo/workspace path to approve."
+                phase = str(meta.get("phase") or "").strip()
+                if phase == "post-prd":
+                    approval_path = _Path(str(repo)) / ".hermes" / "verification-answers.json"
+                else:
+                    approval_path = _Path(str(repo)) / ".hermes" / "approval-pre-planning.json"
+                approval_path.parent.mkdir(parents=True, exist_ok=True)
+                approval = {
+                    "approved": True,
+                    "approvedBy": user_display,
+                    "approvedVia": "telegram",
+                    "approvedAt": datetime.now(timezone.utc).isoformat(),
+                    "taskId": task_id,
+                }
+                if phase == "post-prd":
+                    approval["answers"] = [
+                        "Approved from Telegram; no extra verification notes provided."
+                    ]
+                tmp = approval_path.with_suffix(".json.tmp")
+                tmp.write_text(json.dumps(approval, indent=2) + "\n", encoding="utf-8")
+                tmp.replace(approval_path)
+                _kb.add_comment(
+                    conn,
+                    task_id,
+                    author="telegram",
+                    body=f"Approved by {user_display}; wrote {approval_path}",
+                )
+                _kb.add_notify_sub(
+                    conn,
+                    task_id=task_id,
+                    platform="telegram",
+                    chat_id=chat_id,
+                    user_id="kanban-approval",
+                )
+                if task.status == "blocked":
+                    _kb.unblock_task(conn, task_id)
+                return (
+                    f"✅ Approved {task_id}. Wrote `{approval_path}` and unblocked "
+                    "the task for the next dispatcher pass."
+                )
+
+            if choice == "rj":
+                reason = f"Rejected from Telegram by {user_display}."
+                _kb.add_comment(conn, task_id, author="telegram", body=reason)
+                _kb.block_task(conn, task_id, reason=reason)
+                return f"❌ Rejected {task_id}. It remains blocked."
+
+            if choice == "op":
+                return (
+                    f"💬 To add an opinion/comment, reply with:\n"
+                    f"`/kanban comment {task_id} your feedback here`\n\n"
+                    "I kept the task blocked."
+                )
+
+            if choice == "pr":
+                _kb.add_comment(
+                    conn,
+                    task_id,
+                    author="telegram",
+                    body=f"{user_display} requested PR publication from Telegram.",
+                )
+                return (
+                    f"🚀 PR requested for {task_id}.\n\n"
+                    "Reply to Hermes with:\n"
+                    f"`create a PR for Kanban task {task_id}`\n\n"
+                    "The task stays done; this button records intent and gives the exact next command."
+                )
+
+            if choice == "fu":
+                return (
+                    f"🔁 Follow-up for {task_id}.\n\n"
+                    "Reply with:\n"
+                    f"`follow up on Kanban task {task_id}: <what should change>`"
+                )
+
+            if choice == "ar":
+                if _kb.archive_task(conn, task_id):
+                    return f"📦 Archived {task_id}."
+                return f"Could not archive {task_id}; check its current state in Kanban."
+
+            return f"Unknown Kanban action for {task_id}."
+        except Exception as exc:
+            logger.error("Kanban callback failed for %s: %s", task_id, exc, exc_info=True)
+            return f"Kanban action failed for {task_id}: {exc}"
+        finally:
+            conn.close()
 
     def _missing_media_path_error(self, label: str, path: str) -> str:
         """Build an actionable file-not-found error for gateway MEDIA delivery.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -23,6 +23,7 @@ import re
 import shlex
 import sys
 import signal
+import subprocess
 import tempfile
 import threading
 import time
@@ -3656,6 +3657,163 @@ class GatewayRunner:
         )
         self._kanban_sub_fail_counts = sub_fail_counts
 
+        def _run_metadata(run: Any) -> dict[str, Any]:
+            meta = getattr(run, "metadata", None) if run else None
+            return meta if isinstance(meta, dict) else {}
+
+        def _summary_from_event(ev: Any, task: Any, run: Any) -> str:
+            if ev.payload and ev.payload.get("summary"):
+                return str(ev.payload["summary"]).strip()
+            if getattr(run, "summary", None):
+                return str(run.summary).strip()
+            if task and getattr(task, "result", None):
+                return str(task.result).strip()
+            return ""
+
+        def _changed_files(task: Any, run: Any) -> list[str]:
+            meta = _run_metadata(run)
+            files = meta.get("changed_files") or meta.get("files") or []
+            if isinstance(files, str):
+                files = [files]
+            if isinstance(files, list):
+                return [str(f) for f in files if str(f).strip()][:12]
+            return []
+
+        def _artifact_files(run: Any) -> list[str]:
+            meta = _run_metadata(run)
+            artifacts = meta.get("artifacts") or meta.get("artifact_paths") or []
+            if isinstance(artifacts, str):
+                artifacts = [artifacts]
+            result: list[str] = []
+            if isinstance(artifacts, list):
+                for artifact in artifacts:
+                    path = str(artifact).strip()
+                    if path and os.path.isfile(path):
+                        result.append(path)
+            return result[:5]
+
+        def _repo_path(task: Any, run: Any) -> str:
+            meta = _run_metadata(run)
+            repo = meta.get("repo") or meta.get("workspace") or ""
+            if not repo and task is not None:
+                repo = getattr(task, "workspace_path", "") or ""
+            return str(repo)
+
+        def _branch_name(repo: str) -> str:
+            if not repo or not os.path.isdir(repo):
+                return ""
+            try:
+                proc = subprocess.run(
+                    ["git", "branch", "--show-current"],
+                    cwd=repo,
+                    text=True,
+                    capture_output=True,
+                    timeout=3,
+                    check=False,
+                )
+                return proc.stdout.strip()
+            except Exception:
+                return ""
+
+        def _is_code_task(task: Any, run: Any) -> bool:
+            meta = _run_metadata(run)
+            if any(k in meta for k in ("changed_files", "repo", "branch", "artifacts")):
+                return True
+            if task is None:
+                return False
+            if getattr(task, "workspace_kind", "") in {"dir", "worktree"}:
+                return True
+            skills = getattr(task, "skills", None) or []
+            return "prd-phased-codex" in skills
+
+        def _kanban_link(board_slug: Optional[str]) -> str:
+            for path in (
+                _hermes_home / "kanban-dashboard-url",
+                _hermes_home / "dashboard-url",
+                _hermes_home / "kanban" / "dashboard-url",
+            ):
+                try:
+                    if path.exists():
+                        base = path.read_text(encoding="utf-8").strip().rstrip("/")
+                        if base:
+                            if not base.endswith("/kanban"):
+                                base = f"{base}/kanban"
+                            if board_slug and board_slug != "default":
+                                return f"{base}?board={board_slug}"
+                            return base
+                except OSError:
+                    pass
+            return ""
+
+        def _plain_change_explanation(task: Any, run: Any) -> str:
+            meta = _run_metadata(run)
+            explanation = meta.get("plain_explanation") or meta.get("change_explanation")
+            if explanation:
+                return str(explanation).strip()[:900]
+            summary = str(getattr(run, "summary", "") or "").strip()
+            if summary:
+                return summary[:900]
+            if task and getattr(task, "result", None):
+                return str(task.result).strip()[:900]
+            return "A task finished and produced changes/artifacts. Review the listed files before publishing."
+
+        def _text_artifact_preview(task: Any, run: Any) -> str:
+            if _is_code_task(task, run):
+                return ""
+            text = str(getattr(task, "result", "") or "").strip()
+            if not text:
+                text = str(getattr(run, "summary", "") or "").strip()
+            if not text:
+                return ""
+            return text[:1600]
+
+        def _kanban_action_keyboard(task_id: str, board_slug: Optional[str]) -> list[list[dict[str, str]]]:
+            suffix = f":{board_slug}" if board_slug else ""
+            return [[
+                {"text": "Approve", "callback_data": f"kb:ap:{task_id}{suffix}"},
+                {"text": "Reject", "callback_data": f"kb:rj:{task_id}{suffix}"},
+                {"text": "Opinar", "callback_data": f"kb:op:{task_id}{suffix}"},
+            ]]
+
+        def _kanban_done_keyboard(task_id: str, board_slug: Optional[str]) -> list[list[dict[str, str]]]:
+            suffix = f":{board_slug}" if board_slug else ""
+            return [[
+                {"text": "PR", "callback_data": f"kb:pr:{task_id}{suffix}"},
+                {"text": "Follow-up", "callback_data": f"kb:fu:{task_id}{suffix}"},
+                {"text": "Archive", "callback_data": f"kb:ar:{task_id}{suffix}"},
+            ]]
+
+        def _base_lines(
+            status_label: str,
+            sub: dict,
+            task: Any,
+            ev: Any,
+            run: Any,
+            board_slug: Optional[str],
+        ) -> list[str]:
+            repo = _repo_path(task, run)
+            branch = str(_run_metadata(run).get("branch") or "") or _branch_name(repo)
+            link = _kanban_link(board_slug)
+            title = getattr(task, "title", None) or sub["task_id"]
+            assignee = getattr(task, "assignee", None) or "unassigned"
+            summary = _summary_from_event(ev, task, run)
+            lines = [
+                "Hermes Kanban update",
+                f"Task: {sub['task_id']}",
+                f"Status: {status_label}",
+                f"Title: {str(title)[:160]}",
+                f"Assignee: {assignee}",
+            ]
+            if repo:
+                lines.append(f"Repo: {repo}")
+            if branch:
+                lines.append(f"Branch: {branch}")
+            if link:
+                lines.append(f"Kanban: {link}")
+            if summary:
+                lines.extend(["", f"Summary: {summary[:900]}"])
+            return lines
+
         # Initial delay so the gateway can finish wiring adapters.
         await asyncio.sleep(5)
 
@@ -3694,11 +3852,13 @@ class GatewayRunner:
                                 if not events:
                                     continue
                                 task = _kb.get_task(conn, sub["task_id"])
+                                run = _kb.latest_run(conn, sub["task_id"])
                                 deliveries.append({
                                     "sub": sub,
                                     "cursor": cursor,
                                     "events": events,
                                     "task": task,
+                                    "run": run,
                                     "board": slug,
                                 })
                         finally:
@@ -3709,6 +3869,7 @@ class GatewayRunner:
                 for d in deliveries:
                     sub = d["sub"]
                     task = d["task"]
+                    run = d.get("run")
                     board_slug = d.get("board")
                     platform_str = (sub["platform"] or "").lower()
                     try:
@@ -3723,7 +3884,6 @@ class GatewayRunner:
                     adapter = self.adapters.get(plat)
                     if adapter is None:
                         continue  # platform not currently connected
-                    title = (task.title if task else sub["task_id"])[:120]
                     for ev in d["events"]:
                         kind = ev.kind
                         # Identity prefix: attribute terminal pings to the
@@ -3732,30 +3892,65 @@ class GatewayRunner:
                         who = (task.assignee if task and task.assignee else None)
                         tag = f"@{who} " if who else ""
                         if kind == "completed":
-                            # Prefer the run's summary (the worker's
-                            # intentional human-facing handoff, carried
-                            # in the event payload), then fall back to
-                            # task.result for legacy rows written before
-                            # runs shipped.
-                            handoff = ""
-                            payload_summary = None
-                            if ev.payload and ev.payload.get("summary"):
-                                payload_summary = str(ev.payload["summary"])
-                            if payload_summary:
-                                h = payload_summary.strip().splitlines()[0][:200]
-                                handoff = f"\n{h}"
-                            elif task and task.result:
-                                r = task.result.strip().splitlines()[0][:160]
-                                handoff = f"\n{r}"
-                            msg = (
-                                f"✔ {tag}Kanban {sub['task_id']} done"
-                                f" — {title}{handoff}"
-                            )
+                            lines = _base_lines("done", sub, task, ev, run, board_slug)
+                            if _is_code_task(task, run):
+                                repo = _repo_path(task, run)
+                                lines.extend([
+                                    "",
+                                    "What this means:",
+                                    "- This Kanban task is finished; no approval is pending.",
+                                    "- Review the changed files and artifacts before publishing.",
+                                    "",
+                                    "Plain English:",
+                                    _plain_change_explanation(task, run),
+                                ])
+                                changed = _changed_files(task, run)
+                                if changed:
+                                    lines.extend(["", "Files:"])
+                                    lines.extend(f"- {path}" for path in changed)
+                                if repo:
+                                    lines.extend([
+                                        "",
+                                        "Validate:",
+                                        f"cd {repo} && git status --short && git diff --stat",
+                                    ])
+                                lines.extend([
+                                    "",
+                                    "Next options:",
+                                    "- Use PR to publish the branch.",
+                                    "- Use Follow-up to ask for changes.",
+                                    "- Use Archive if satisfied.",
+                                ])
+                            else:
+                                preview = _text_artifact_preview(task, run)
+                                if preview:
+                                    lines.extend(["", "Result:", preview])
+                            artifacts = _artifact_files(run)
+                            if artifacts:
+                                lines.extend(["", "Artifacts:"])
+                                lines.extend(f"- {path}" for path in artifacts)
+                            msg = "\n".join(lines)
                         elif kind == "blocked":
-                            reason = ""
-                            if ev.payload and ev.payload.get("reason"):
-                                reason = f": {str(ev.payload['reason'])[:160]}"
-                            msg = f"⏸ {tag}Kanban {sub['task_id']} blocked{reason}"
+                            lines = _base_lines("blocked", sub, task, ev, run, board_slug)
+                            reason = str((ev.payload or {}).get("reason") or "").strip()
+                            if reason:
+                                lines.extend(["", f"Blocker: {reason[:900]}"])
+                            lines.extend([
+                                "",
+                                "What this means:",
+                                "- Work is paused and waiting for your decision.",
+                                "- The worker should not continue until this is approved or rejected.",
+                                "",
+                                "Next:",
+                                "- Approve to unblock the task.",
+                                "- Reject to keep it blocked with a rejection note.",
+                                "- Opinar to add feedback before continuing.",
+                            ])
+                            artifacts = _artifact_files(run)
+                            if artifacts:
+                                lines.extend(["", "Artifacts:"])
+                                lines.extend(f"- {path}" for path in artifacts)
+                            msg = "\n".join(lines)
                         elif kind == "gave_up":
                             err = ""
                             if ev.payload and ev.payload.get("error"):
@@ -3782,6 +3977,14 @@ class GatewayRunner:
                         metadata: dict[str, Any] = {}
                         if sub.get("thread_id"):
                             metadata["thread_id"] = sub["thread_id"]
+                        if kind == "completed" and _is_code_task(task, run):
+                            metadata["inline_keyboard"] = _kanban_done_keyboard(
+                                sub["task_id"], board_slug,
+                            )
+                        elif kind == "blocked":
+                            metadata["inline_keyboard"] = _kanban_action_keyboard(
+                                sub["task_id"], board_slug,
+                            )
                         sub_key = (
                             sub["task_id"], sub["platform"],
                             sub["chat_id"], sub.get("thread_id") or "",
@@ -3790,6 +3993,20 @@ class GatewayRunner:
                             await adapter.send(
                                 sub["chat_id"], msg, metadata=metadata,
                             )
+                            for artifact in _artifact_files(run):
+                                try:
+                                    await adapter.send_document(
+                                        sub["chat_id"],
+                                        artifact,
+                                        caption=f"Kanban {sub['task_id']} artifact",
+                                        metadata=metadata,
+                                    )
+                                except TypeError:
+                                    await adapter.send_document(
+                                        sub["chat_id"],
+                                        artifact,
+                                        caption=f"Kanban {sub['task_id']} artifact",
+                                    )
                             # Reset the failure counter on success.
                             sub_fail_counts.pop(sub_key, None)
                         except Exception as exc:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -96,6 +96,11 @@ VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
 # ``heartbeat_claim(task_id)`` periodically.  In practice most kanban
 # workloads either finish within 15m or set a longer claim explicitly.
 DEFAULT_CLAIM_TTL_SECONDS = 15 * 60
+CODEX_PHASE_WRAPPER = "/home/ubuntu/.hermes/scripts/hermes-codex-phase"
+CLAUDE_KANBAN_WRAPPER = (
+    str(Path(__file__).resolve().parents[1] / "scripts" / "hermes-claude-kanban")
+)
+CLAUDE_CLI_ASSIGNEES = {"claude", "claude-eng", "claude-dev", "codex-claude"}
 
 
 # Worker-context caps so build_worker_context() stays bounded on
@@ -2415,6 +2420,7 @@ def block_task(
     *,
     reason: Optional[str] = None,
     expected_run_id: Optional[int] = None,
+    metadata: Optional[dict] = None,
 ) -> bool:
     """Transition ``running -> blocked``."""
     with write_txn(conn):
@@ -2427,7 +2433,7 @@ def block_task(
                        claim_expires= NULL,
                        worker_pid   = NULL
                  WHERE id = ?
-                   AND status IN ('running', 'ready')
+                   AND status IN ('running', 'ready', 'blocked')
                 """,
                 (task_id,),
             )
@@ -2451,6 +2457,7 @@ def block_task(
             conn, task_id,
             outcome="blocked", status="blocked",
             summary=reason,
+            metadata=metadata,
         )
         # Synthesize a run when blocking a never-claimed task so the
         # reason is preserved in attempt history.
@@ -2459,6 +2466,7 @@ def block_task(
                 conn, task_id,
                 outcome="blocked",
                 summary=reason,
+                metadata=metadata,
             )
         _append_event(conn, task_id, "blocked", {"reason": reason}, run_id=run_id)
         return True
@@ -3097,7 +3105,11 @@ def set_max_runtime(
     return cur.rowcount == 1
 
 
-def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
+def detect_crashed_workers(
+    conn: sqlite3.Connection,
+    *,
+    crash_limit: Optional[int] = None,
+) -> list[str]:
     """Reclaim ``running`` tasks whose worker PID is no longer alive.
 
     Appends a ``crashed`` event and drops the task back to ``ready``.
@@ -3209,7 +3221,7 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
             conn, tid,
             error=error_text,
             outcome="crashed",
-            failure_limit=(1 if protocol_violation else None),
+            failure_limit=(1 if protocol_violation else crash_limit),
             release_claim=False,
             end_run=False,
             event_payload_extra={"pid": pid, "claimer": claimer},
@@ -3651,6 +3663,28 @@ def _rotate_worker_log(log_path: Path, max_bytes: int) -> None:
         pass
 
 
+def _next_prd_phase(workspace: str) -> Optional[str]:
+    """Return the first incomplete PRD phased-Codex phase for ``workspace``."""
+    hermes_dir = Path(workspace) / ".hermes"
+    candidates = [
+        hermes_dir / "plans" / "phases",
+        hermes_dir / "phases",
+    ]
+    events_dir = Path(workspace) / ".hermes" / "events"
+    for phases_dir in candidates:
+        if not phases_dir.is_dir():
+            continue
+        try:
+            for phase_path in sorted(phases_dir.glob("phase-*.md")):
+                phase_name = phase_path.stem
+                event_path = events_dir / f"{phase_name}-complete.json"
+                if not event_path.exists():
+                    return str(phase_path.relative_to(Path(workspace)))
+        except OSError:
+            return None
+    return None
+
+
 def _default_spawn(
     task: Task,
     workspace: str,
@@ -3706,34 +3740,40 @@ def _default_spawn(
     # attributed correctly regardless of how the child loads config.
     env["HERMES_PROFILE"] = profile_arg
 
-    cmd = [
-        "hermes",
-        "-p", profile_arg,
-        # Auto-load the kanban-worker skill so every dispatched worker
-        # has the pattern library (good summary/metadata shapes, retry
-        # diagnostics, block-reason examples) in its context, even if
-        # the profile hasn't wired it into skills config. The MANDATORY
-        # lifecycle is already in the system prompt via KANBAN_GUIDANCE;
-        # this skill is the deeper reference. Users can point a profile
-        # at a different/additional skill via config if they want —
-        # --skills is additive to the profile's default skill set.
-        "--skills", "kanban-worker",
-    ]
-    # Per-task force-loaded skills. Each name goes in its own
-    # `--skills X` pair rather than a single comma-joined arg: the CLI
-    # accepts both forms (action='append' + comma-split), but
-    # per-name pairs are easier to read in `ps` output and avoid any
-    # quoting ambiguity if a skill name ever contains unusual chars.
-    # Dedupe against the built-in so we don't double-load kanban-worker
-    # if a task author asks for it explicitly.
-    if task.skills:
-        for sk in task.skills:
+    task_skills = task.skills or []
+    phase = _next_prd_phase(workspace) if "prd-phased-codex" in task_skills else None
+    if phase:
+        cmd = [CODEX_PHASE_WRAPPER, workspace, phase, "45"]
+    elif profile_arg in CLAUDE_CLI_ASSIGNEES:
+        cmd = [CLAUDE_KANBAN_WRAPPER, task.id, workspace]
+    else:
+        cmd = [
+            "hermes",
+            "-p", profile_arg,
+            # Auto-load the kanban-worker skill so every dispatched worker
+            # has the pattern library (good summary/metadata shapes, retry
+            # diagnostics, block-reason examples) in its context, even if
+            # the profile hasn't wired it into skills config. The MANDATORY
+            # lifecycle is already in the system prompt via KANBAN_GUIDANCE;
+            # this skill is the deeper reference. Users can point a profile
+            # at a different/additional skill via config if they want —
+            # --skills is additive to the profile's default skill set.
+            "--skills", "kanban-worker",
+        ]
+        # Per-task force-loaded skills. Each name goes in its own
+        # `--skills X` pair rather than a single comma-joined arg: the CLI
+        # accepts both forms (action='append' + comma-split), but
+        # per-name pairs are easier to read in `ps` output and avoid any
+        # quoting ambiguity if a skill name ever contains unusual chars.
+        # Dedupe against the built-in so we don't double-load kanban-worker
+        # if a task author asks for it explicitly.
+        for sk in task_skills:
             if sk and sk != "kanban-worker":
                 cmd.extend(["--skills", sk])
-    cmd.extend([
-        "chat",
-        "-q", prompt,
-    ])
+        cmd.extend([
+            "chat",
+            "-q", prompt,
+        ])
     # Redirect output to a per-task log under <board-root>/logs/.
     # Anchored at the board root (not the shared kanban root), so
     # `hermes kanban log` on a specific board reads its own file and
@@ -4091,13 +4131,17 @@ def add_notify_sub(
     for ``task_id``. Idempotent on (task, platform, chat, thread)."""
     now = int(time.time())
     with write_txn(conn):
+        current_event_id = conn.execute(
+            "SELECT COALESCE(MAX(id), 0) FROM task_events WHERE task_id = ?",
+            (task_id,),
+        ).fetchone()[0]
         conn.execute(
             """
             INSERT OR IGNORE INTO kanban_notify_subs
-                (task_id, platform, chat_id, thread_id, user_id, created_at)
-            VALUES (?, ?, ?, ?, ?, ?)
+                (task_id, platform, chat_id, thread_id, user_id, created_at, last_event_id)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
             """,
-            (task_id, platform, chat_id, thread_id or "", user_id, now),
+            (task_id, platform, chat_id, thread_id or "", user_id, now, int(current_event_id)),
         )
 
 
@@ -4326,10 +4370,68 @@ def list_profiles_on_disk() -> list[str]:
     return sorted(names)
 
 
+def profile_config_status(name: str) -> dict:
+    """Return a dashboard-friendly health summary for an assignee profile."""
+    normalized = (name or "").strip()
+    if normalized in CLAUDE_CLI_ASSIGNEES:
+        claude_bin = Path("/home/ubuntu/.hermes/node/bin/claude")
+        if claude_bin.exists():
+            return {
+                "healthy": True,
+                "reason": "claude cli configured",
+                "executor": "claude-cli",
+            }
+        return {
+            "healthy": False,
+            "reason": f"claude cli not found at {claude_bin}",
+            "executor": "claude-cli",
+        }
+
+    try:
+        import yaml
+        from hermes_constants import get_default_hermes_root
+
+        default_root = get_default_hermes_root()
+        if normalized == "default":
+            config_path = default_root / "config.yaml"
+        else:
+            config_path = default_root / "profiles" / normalized / "config.yaml"
+        if not config_path.is_file():
+            return {
+                "healthy": False,
+                "reason": "profile config not found",
+                "executor": "hermes-profile",
+            }
+        data = yaml.safe_load(config_path.read_text(encoding="utf-8")) or {}
+        model_config = data.get("model")
+        if isinstance(model_config, dict):
+            model_name = model_config.get("default")
+        else:
+            model_name = model_config
+        if model_name:
+            return {
+                "healthy": True,
+                "reason": f"model configured: {model_name}",
+                "executor": "hermes-profile",
+            }
+        return {
+            "healthy": False,
+            "reason": "profile has no default model configured",
+            "executor": "hermes-profile",
+        }
+    except Exception as exc:
+        return {
+            "healthy": False,
+            "reason": f"profile health check failed: {exc}",
+            "executor": "hermes-profile",
+        }
+
+
 def known_assignees(conn: sqlite3.Connection) -> list[dict]:
     """Return every assignee name known to the board or on disk.
 
-    Each entry is ``{"name": str, "on_disk": bool, "counts": {status: n}}``.
+    Each entry is ``{"name": str, "on_disk": bool, "healthy": bool,
+    "health_reason": str, "executor": str, "counts": {status: n}}``.
     A name is included when it's a configured profile on disk OR when
     any non-archived task has it as the assignee. Used by:
 
@@ -4350,15 +4452,28 @@ def known_assignees(conn: sqlite3.Connection) -> list[dict]:
     ):
         counts.setdefault(row["assignee"], {})[row["status"]] = int(row["n"])
 
-    names = sorted(on_disk | set(counts.keys()))
-    return [
-        {
-            "name": name,
-            "on_disk": name in on_disk,
-            "counts": counts.get(name, {}),
-        }
-        for name in names
-    ]
+    names = sorted(on_disk | set(counts.keys()) | CLAUDE_CLI_ASSIGNEES)
+    assignees: list[dict] = []
+    for name in names:
+        if name in on_disk or name in CLAUDE_CLI_ASSIGNEES:
+            status = profile_config_status(name)
+        else:
+            status = {
+                "healthy": False,
+                "reason": "profile config not found",
+                "executor": "hermes-profile",
+            }
+        assignees.append(
+            {
+                "name": name,
+                "on_disk": name in on_disk,
+                "healthy": bool(status.get("healthy")),
+                "health_reason": str(status.get("reason") or ""),
+                "executor": str(status.get("executor") or ""),
+                "counts": counts.get(name, {}),
+            }
+        )
+    return assignees
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/orchestration_observer.py
+++ b/hermes_cli/orchestration_observer.py
@@ -1,0 +1,378 @@
+"""Observe Hermes phase events and mirror them into durable Kanban state.
+
+The architecture says Codex phase execution hands events/logs back to Hermes.
+This module is the narrow bridge used by the guarded phase wrapper: it turns
+repo-local ``.hermes/events`` JSON files into Kanban comments and terminal task
+state so the dashboard/gateway notifier can see what happened even if the
+interactive agent is busy or gone.
+"""
+
+from __future__ import annotations
+
+import argparse
+import html
+import json
+import subprocess
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+from hermes_cli import kanban_db as kb
+
+
+def _load_json(path: Path) -> dict[str, Any]:
+    with path.open("r", encoding="utf-8") as fh:
+        data = json.load(fh)
+    if not isinstance(data, dict):
+        raise ValueError(f"{path} did not contain a JSON object")
+    return data
+
+
+def _event_summary(event: dict[str, Any]) -> str:
+    summary = str(event.get("summary") or "").strip()
+    if summary:
+        return summary
+    question = str(event.get("question") or "").strip()
+    if question:
+        return question
+    tail = str(event.get("tail") or "").strip()
+    if tail:
+        return tail.splitlines()[-1][:400]
+    return str(event.get("type") or "phase event")
+
+
+def _find_terminal_event(event_dir: Path, phase_id: str) -> Optional[Path]:
+    preferred = [
+        event_dir / f"{phase_id}-complete.json",
+        event_dir / f"{phase_id}-needs-input.json",
+    ]
+    for path in preferred:
+        if path.exists():
+            return path
+
+    process_events = sorted(event_dir.glob(f"*-{phase_id}-process-*.json"))
+    if process_events:
+        return process_events[-1]
+    return None
+
+
+def _has_incomplete_later_phase(repo: Path, phase_id: str) -> bool:
+    phase_dir = repo / ".hermes" / "phases"
+    event_dir = repo / ".hermes" / "events"
+    if not phase_dir.is_dir():
+        return False
+
+    seen_current = False
+    for phase in sorted(phase_dir.glob("*.md")):
+        candidate = phase.stem
+        if candidate == phase_id:
+            seen_current = True
+            continue
+        if not seen_current:
+            continue
+        if not (event_dir / f"{candidate}-complete.json").exists():
+            return True
+    return False
+
+
+def _git_value(repo: Path, args: list[str]) -> str:
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(repo), *args],
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.DEVNULL,
+            timeout=5,
+            check=False,
+        )
+    except Exception:
+        return ""
+    return proc.stdout.strip() if proc.returncode == 0 else ""
+
+
+def _phase_order(repo: Path) -> list[str]:
+    phase_dir = repo / ".hermes" / "phases"
+    if not phase_dir.is_dir():
+        return []
+    return [p.stem for p in sorted(phase_dir.glob("*.md"))]
+
+
+def _write_flow_graph(
+    *,
+    task_id: str,
+    repo: Path,
+    phase_id: str,
+    event_type: str,
+    summary: str,
+    metadata: dict[str, Any],
+) -> Optional[Path]:
+    """Write an SVG artifact that explains where the change enters the project."""
+    artifact_dir = Path("/home/ubuntu/.hermes/kanban/artifacts")
+    try:
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        return None
+
+    branch = metadata.get("branch") or _git_value(repo, ["branch", "--show-current"])
+    remote = metadata.get("remote_url") or _git_value(repo, ["remote", "get-url", "origin"])
+    changed = metadata.get("changed_files") if isinstance(metadata.get("changed_files"), list) else []
+
+    def esc(value: Any) -> str:
+        return html.escape(str(value or ""), quote=True)
+
+    def file_exists(rel: str) -> bool:
+        return (repo / rel).exists()
+
+    def classify_file(rel: str) -> tuple[str, str]:
+        name = Path(rel).name
+        if "await-pre-planning-approval" in name:
+            return ("Pre-planning gate", "New executable guard before Planner")
+        if name == "pending-input.json":
+            return ("Pending input state", "Blocked request envelope")
+        if name.startswith("approval-pre-planning"):
+            return ("Developer approval", "Approval artifact")
+        if rel.startswith(".hermes/events/"):
+            return ("Phase event", "Codex/Hermes handoff event")
+        if rel.startswith(".hermes/phases/"):
+            return ("Phase plan", "Bounded implementation phase")
+        return ("Changed file", rel)
+
+    change_nodes = []
+    for rel in changed[:6]:
+        label, detail = classify_file(str(rel))
+        change_nodes.append((str(rel), label, detail))
+    if not change_nodes:
+        change_nodes.append(("(none reported)", "Changed file", "No changed_files reported"))
+
+    has_approval = file_exists(".hermes/approval-pre-planning.json")
+    approval_label = "approved" if has_approval else "missing -> block"
+
+    changed_lines = []
+    for file_name in changed[:8]:
+        changed_lines.append(str(file_name))
+    if not changed_lines:
+        changed_lines = ["(no changed_files reported)"]
+
+    svg = [
+        '<svg xmlns="http://www.w3.org/2000/svg" width="1280" height="820" viewBox="0 0 1280 820">',
+        "<defs><style>",
+        ".bg{fill:#0f172a}.band{fill:#111827;stroke:#334155;stroke-width:2}.source{fill:#172554;stroke:#60a5fa;stroke-width:2}.gate{fill:#78350f;stroke:#f59e0b;stroke-width:2}.state{fill:#064e3b;stroke:#10b981;stroke-width:2}.next{fill:#312e81;stroke:#818cf8;stroke-width:2}.file{fill:#1f2937;stroke:#64748b;stroke-width:2}",
+        ".title{fill:#f8fafc;font:700 28px ui-sans-serif,system-ui}.text{fill:#e5e7eb;font:18px ui-sans-serif,system-ui}.small{fill:#cbd5e1;font:14px ui-sans-serif,system-ui}.mono{fill:#cbd5e1;font:14px ui-monospace,SFMono-Regular,Menlo,monospace}.arrow{stroke:#94a3b8;stroke-width:3;marker-end:url(#arrow);fill:none}.dash{stroke:#64748b;stroke-width:2;stroke-dasharray:7 7;fill:none}",
+        "</style><marker id=\"arrow\" markerWidth=\"12\" markerHeight=\"8\" refX=\"10\" refY=\"4\" orient=\"auto\"><path d=\"M0,0 L12,4 L0,8 Z\" fill=\"#94a3b8\"/></marker></defs>",
+        '<rect class="bg" x="0" y="0" width="1280" height="820"/>',
+        f'<text class="title" x="48" y="56">Project Change Flow - {esc(task_id)}</text>',
+        f'<text class="small" x="48" y="86">Repo: {esc(repo)} | Branch: {esc(branch)} | Remote: {esc(remote or "(none)")}</text>',
+        f'<text class="small" x="48" y="112">Feature slice: {esc(phase_id)} - pre-planning review pause</text>',
+    ]
+
+    svg.extend([
+        '<rect class="source" x="60" y="170" width="220" height="112" rx="14"/>',
+        '<text class="text" x="82" y="210">User request</text>',
+        '<text class="small" x="82" y="240">Design URL / screenshot / brief</text>',
+        '<text class="small" x="82" y="264">enters Hermes intake</text>',
+
+        '<rect class="gate" x="360" y="170" width="260" height="112" rx="14"/>',
+        '<text class="text" x="382" y="210">Pre-planning gate</text>',
+        '<text class="small" x="382" y="240">await-pre-planning-approval.ts</text>',
+        '<text class="small" x="382" y="264">runs before Planner starts</text>',
+
+        '<rect class="state" x="700" y="170" width="250" height="112" rx="14"/>',
+        '<text class="text" x="722" y="210">Pending input state</text>',
+        '<text class="small" x="722" y="240">.hermes/pending-input.json</text>',
+        '<text class="small" x="722" y="264">status=blocked, phase=pre-planning</text>',
+
+        '<rect class="next" x="1030" y="170" width="190" height="112" rx="14"/>',
+        '<text class="text" x="1052" y="210">Planner</text>',
+        f'<text class="small" x="1052" y="240">approval: {esc(approval_label)}</text>',
+        '<text class="small" x="1052" y="264">only proceeds if approved</text>',
+
+        '<path class="arrow" d="M280 226 H350"/>',
+        '<path class="arrow" d="M620 226 H690"/>',
+        '<path class="arrow" d="M950 226 H1020"/>',
+        '<path class="dash" d="M1125 282 V330"/>',
+        '<text class="small" x="1012" y="326">without approval, workflow stops here</text>',
+
+        '<rect class="band" x="60" y="360" width="1160" height="156" rx="14"/>',
+        '<text class="text" x="82" y="400">What changed in the project</text>',
+        f'<text class="small" x="82" y="430">Summary: {esc(summary[:250])}</text>',
+    ])
+
+    x_positions = [82, 432, 782]
+    y_positions = [456, 456, 456, 560, 560, 560]
+    for idx, (rel, label, detail) in enumerate(change_nodes[:6]):
+        x = x_positions[idx % 3]
+        y = y_positions[idx]
+        svg.append(f'<rect class="file" x="{x}" y="{y}" width="310" height="72" rx="10"/>')
+        svg.append(f'<text class="small" x="{x + 14}" y="{y + 28}">{esc(label)}</text>')
+        svg.append(f'<text class="mono" x="{x + 14}" y="{y + 52}">{esc(rel[:38])}</text>')
+
+    svg.extend([
+        '<rect class="band" x="60" y="640" width="1160" height="104" rx="14"/>',
+        '<text class="text" x="82" y="678">Runtime decision</text>',
+        '<text class="small" x="82" y="708">If .hermes/approval-pre-planning.json has approved=true, the script exits 0 and Planner may continue.</text>',
+        '<text class="small" x="82" y="732">If approval is missing, it preserves request metadata, writes blocked pending input, exits non-zero, and prevents looped execution.</text>',
+    ])
+    svg.append("</svg>")
+
+    path = artifact_dir / f"{task_id}-{phase_id}-flow.svg"
+    try:
+        path.write_text("\n".join(svg), encoding="utf-8")
+    except OSError:
+        return None
+    return path
+
+
+def record_phase_started(
+    *,
+    task_id: str,
+    repo: Path,
+    phase_id: str,
+    branch: str,
+    log_path: Path,
+    author: str = "hermes-codex-phase",
+) -> None:
+    """Append a Kanban comment that a bounded Codex phase started."""
+    kb.init_db()
+    with kb.connect() as conn:
+        kb.add_comment(
+            conn,
+            task_id,
+            author,
+            (
+                f"PHASE STARTED: {phase_id}\n"
+                f"repo: {repo}\n"
+                f"branch: {branch}\n"
+                f"log: {log_path}"
+            ),
+        )
+
+
+def record_phase_finished(
+    *,
+    task_id: str,
+    repo: Path,
+    phase_id: str,
+    event_dir: Path,
+    log_path: Path,
+    exit_code: int,
+    author: str = "hermes-codex-phase",
+) -> str:
+    """Mirror the final phase event into Kanban and return the action taken."""
+    kb.init_db()
+    event_path = _find_terminal_event(event_dir, phase_id)
+    event: dict[str, Any] = {}
+    if event_path is not None:
+        event = _load_json(event_path)
+
+    event_type = str(event.get("type") or "")
+    summary = _event_summary(event) if event else f"phase exited with code {exit_code}"
+    metadata = {
+        "repo": str(repo),
+        "phase": phase_id,
+        "event_path": str(event_path) if event_path else None,
+        "log_path": str(log_path),
+        "exit_code": exit_code,
+        "event_type": event_type or None,
+        "branch": _git_value(repo, ["branch", "--show-current"]),
+        "remote_url": _git_value(repo, ["remote", "get-url", "origin"]),
+    }
+    if isinstance(event.get("changed_files"), list):
+        metadata["changed_files"] = event["changed_files"]
+    if isinstance(event.get("commands_run"), list):
+        metadata["commands_run"] = event["commands_run"]
+    if isinstance(event.get("tests"), dict):
+        metadata["tests"] = event["tests"]
+
+    flow_graph = _write_flow_graph(
+        task_id=task_id,
+        repo=repo,
+        phase_id=phase_id,
+        event_type=event_type,
+        summary=summary,
+        metadata=metadata,
+    )
+    if flow_graph is not None:
+        metadata["flow_graph"] = str(flow_graph)
+        metadata["artifacts"] = [str(flow_graph)]
+
+    with kb.connect() as conn:
+        kb.add_comment(
+            conn,
+            task_id,
+            author,
+            (
+                f"PHASE FINISHED: {phase_id}\n"
+                f"type: {event_type or 'missing_event'}\n"
+                f"exit_code: {exit_code}\n"
+                f"event: {event_path or '(none)'}\n"
+                f"log: {log_path}\n"
+                f"summary: {summary}"
+            ),
+        )
+
+        if event_type == "phase_complete" and exit_code == 0:
+            if _has_incomplete_later_phase(repo, phase_id):
+                reason = f"phase complete, review before next phase: {summary}"
+                kb.block_task(conn, task_id, reason=reason, metadata=metadata)
+                return "blocked"
+            kb.complete_task(
+                conn,
+                task_id,
+                result=summary,
+                summary=summary,
+                metadata=metadata,
+            )
+            return "completed"
+
+        reason = summary
+        if event_type == "needs_input":
+            reason = f"needs input: {summary}"
+        elif exit_code != 0:
+            reason = f"phase failed: {summary}"
+        kb.block_task(conn, task_id, reason=reason, metadata=metadata)
+        return "blocked"
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(prog="hermes-orchestration-observer")
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    started = sub.add_parser("phase-started")
+    started.add_argument("--task-id", required=True)
+    started.add_argument("--repo", required=True)
+    started.add_argument("--phase", required=True)
+    started.add_argument("--branch", required=True)
+    started.add_argument("--log-path", required=True)
+
+    finished = sub.add_parser("phase-finished")
+    finished.add_argument("--task-id", required=True)
+    finished.add_argument("--repo", required=True)
+    finished.add_argument("--phase", required=True)
+    finished.add_argument("--event-dir", required=True)
+    finished.add_argument("--log-path", required=True)
+    finished.add_argument("--exit-code", required=True, type=int)
+
+    args = parser.parse_args(argv)
+    if args.command == "phase-started":
+        record_phase_started(
+            task_id=args.task_id,
+            repo=Path(args.repo),
+            phase_id=args.phase,
+            branch=args.branch,
+            log_path=Path(args.log_path),
+        )
+    else:
+        action = record_phase_finished(
+            task_id=args.task_id,
+            repo=Path(args.repo),
+            phase_id=args.phase,
+            event_dir=Path(args.event_dir),
+            log_path=Path(args.log_path),
+            exit_code=args.exit_code,
+        )
+        print(action)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -46,6 +46,67 @@ log = logging.getLogger(__name__)
 router = APIRouter()
 
 
+def _auto_subscribe_telegram_home(conn: sqlite3.Connection, task_id: str) -> bool:
+    """Subscribe dashboard-created work to the Telegram home channel if set."""
+    try:
+        from hermes_cli.env_loader import load_hermes_dotenv
+        from hermes_constants import get_hermes_home
+
+        load_hermes_dotenv(hermes_home=get_hermes_home())
+    except Exception:
+        pass
+
+    chat_id = os.environ.get("TELEGRAM_HOME_CHANNEL", "").strip()
+    if not chat_id:
+        return False
+
+    kanban_db.add_notify_sub(
+        conn,
+        task_id=task_id,
+        platform="telegram",
+        chat_id=chat_id,
+        user_id="dashboard",
+    )
+    return True
+
+
+def _reject_unhealthy_ready_assignee(assignee: Optional[str]) -> None:
+    if not assignee:
+        return
+    health = kanban_db.profile_config_status(assignee)
+    if health.get("healthy"):
+        return
+    reason = str(health.get("reason") or "")
+    # Historical dashboard behavior allowed free-form assignee names. Keep
+    # that for not-yet-created profiles; only reject profiles that exist but
+    # are unusable, such as config.yaml with an empty model.
+    if reason.startswith("profile config not found"):
+        return
+    raise HTTPException(
+        status_code=400,
+        detail=(
+            f"assignee {assignee!r} is not runnable: "
+            f"{reason or 'profile health check failed'}"
+        ),
+    )
+
+
+def _create_payload_would_be_ready(
+    conn: sqlite3.Connection, payload: "CreateTaskBody",
+) -> bool:
+    if payload.triage:
+        return False
+    parents = [p for p in payload.parents if p]
+    if not parents:
+        return True
+    rows = conn.execute(
+        "SELECT status FROM tasks WHERE id IN "
+        "(" + ",".join("?" * len(parents)) + ")",
+        parents,
+    ).fetchall()
+    return len(rows) == len(parents) and all(r["status"] == "done" for r in rows)
+
+
 # ---------------------------------------------------------------------------
 # Auth helper — WebSocket only (HTTP routes live behind the dashboard's
 # existing plugin-bypass; this is documented above).
@@ -82,6 +143,8 @@ def _resolve_board(board: Optional[str]) -> Optional[str]:
     through to the active board inside ``kb.connect()``).
     """
     if board is None or board == "":
+        return None
+    if board.__class__.__name__ == "Query":
         return None
     try:
         normed = kanban_db._normalize_board_slug(board)
@@ -510,6 +573,8 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
+        if payload.assignee and _create_payload_would_be_ready(conn, payload):
+            _reject_unhealthy_ready_assignee(payload.assignee)
         task_id = kanban_db.create_task(
             conn,
             title=payload.title,
@@ -528,6 +593,13 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
         )
         task = kanban_db.get_task(conn, task_id)
         body: dict[str, Any] = {"task": _task_dict(task) if task else None}
+        if task and task.assignee and _auto_subscribe_telegram_home(conn, task_id):
+            body["notify"] = {"platform": "telegram", "target": "home"}
+        if task and task.status == "ready" and not task.assignee:
+            body["warning"] = (
+                "Task is ready but unassigned; the dispatcher will not spawn "
+                "a worker until an assignee/profile is set."
+            )
         # Surface a dispatcher-presence warning so the UI can show a
         # banner when a `ready` task would otherwise sit idle because no
         # gateway is running (or dispatch_in_gateway=false). Only emit
@@ -573,12 +645,15 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
+        response: dict[str, Any] = {}
         task = kanban_db.get_task(conn, task_id)
         if task is None:
             raise HTTPException(status_code=404, detail=f"task {task_id} not found")
 
         # --- assignee ----------------------------------------------------
         if payload.assignee is not None:
+            if payload.assignee and task.status == "ready":
+                _reject_unhealthy_ready_assignee(payload.assignee)
             try:
                 ok = kanban_db.assign_task(
                     conn, task_id, payload.assignee or None,
@@ -587,6 +662,8 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                 raise HTTPException(status_code=409, detail=str(e))
             if not ok:
                 raise HTTPException(status_code=404, detail="task not found")
+            if payload.assignee and _auto_subscribe_telegram_home(conn, task_id):
+                response["notify"] = {"platform": "telegram", "target": "home"}
 
         # --- status -------------------------------------------------------
         if payload.status is not None:
@@ -604,6 +681,16 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
             elif s == "ready":
                 # Re-open a blocked task, or just an explicit status set.
                 current = kanban_db.get_task(conn, task_id)
+                if current and not current.assignee:
+                    raise HTTPException(
+                        status_code=400,
+                        detail=(
+                            "ready tasks require an assignee; set an assignee "
+                            "before moving this task to ready"
+                        ),
+                    )
+                if current:
+                    _reject_unhealthy_ready_assignee(current.assignee)
                 if current and current.status == "blocked":
                     ok = kanban_db.unblock_task(conn, task_id)
                 else:
@@ -663,7 +750,8 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                 )
 
         updated = kanban_db.get_task(conn, task_id)
-        return {"task": _task_dict(updated) if updated else None}
+        response["task"] = _task_dict(updated) if updated else None
+        return response
     finally:
         conn.close()
 
@@ -851,6 +939,24 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                         ok = kanban_db.block_task(conn, tid)
                     elif s == "ready":
                         cur = kanban_db.get_task(conn, tid)
+                        if cur and not cur.assignee and not payload.assignee:
+                            entry.update(
+                                ok=False,
+                                error=(
+                                    "ready tasks require an assignee; set an "
+                                    "assignee before moving this task to ready"
+                                ),
+                            )
+                            results.append(entry)
+                            continue
+                        if cur:
+                            target_assignee = payload.assignee if payload.assignee is not None else cur.assignee
+                            try:
+                                _reject_unhealthy_ready_assignee(target_assignee)
+                            except HTTPException as exc:
+                                entry.update(ok=False, error=str(exc.detail))
+                                results.append(entry)
+                                continue
                         if cur and cur.status == "blocked":
                             ok = kanban_db.unblock_task(conn, tid)
                         else:
@@ -864,6 +970,13 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                     if not ok:
                         entry.update(ok=False, error=f"transition to {s!r} refused")
                 if payload.assignee is not None:
+                    if payload.assignee and task.status == "ready":
+                        try:
+                            _reject_unhealthy_ready_assignee(payload.assignee)
+                        except HTTPException as exc:
+                            entry.update(ok=False, error=str(exc.detail))
+                            results.append(entry)
+                            continue
                     try:
                         if not kanban_db.assign_task(
                             conn, tid, payload.assignee or None,

--- a/run_agent.py
+++ b/run_agent.py
@@ -59,6 +59,52 @@ from pathlib import Path
 
 from hermes_constants import get_hermes_home
 
+_REPO_CODE_INTAKE_VERBS = (
+    "implemente", "implementa", "implementar", "implement",
+    "conserte", "corrija", "corrigir", "fix",
+    "refatore", "refatorar", "refactor",
+    "adicione", "adicionar", "add",
+    "altere", "alterar", "change",
+    "crie", "criar", "build",
+)
+_REPO_PATH_RE = re.compile(r"(/home/ubuntu/repos/[^\s'\"`]+)")
+
+
+def _clean_repo_path_candidate(raw: str) -> Optional[Path]:
+    if not raw:
+        return None
+    candidate = raw.rstrip(".,;:) ]}")
+    path = Path(candidate).expanduser()
+    if path.is_file():
+        path = path.parent
+    for current in [path, *path.parents]:
+        try:
+            if (current / ".git").exists():
+                return current.resolve()
+        except OSError:
+            return None
+        if str(current) == "/home/ubuntu/repos":
+            break
+    return None
+
+
+def _detect_repo_code_intake(message: Any) -> Optional[Path]:
+    """Return repo path when a normal user turn should be routed to Kanban."""
+    if os.environ.get("HERMES_KANBAN_TASK"):
+        return None
+    if os.environ.get("HERMES_DISABLE_REPO_CODE_INTAKE_ROUTER"):
+        return None
+    if not isinstance(message, str):
+        return None
+    lowered = message.lower()
+    if not any(verb in lowered for verb in _REPO_CODE_INTAKE_VERBS):
+        return None
+    for match in _REPO_PATH_RE.finditer(message):
+        repo = _clean_repo_path_candidate(match.group(1))
+        if repo is not None:
+            return repo
+    return None
+
 
 _OPENAI_CLS_CACHE: Optional[type] = None
 
@@ -135,6 +181,7 @@ from agent.prompt_builder import (
     DEFAULT_AGENT_IDENTITY, PLATFORM_HINTS,
     MEMORY_GUIDANCE, SESSION_SEARCH_GUIDANCE, SKILLS_GUIDANCE,
     HERMES_AGENT_HELP_GUIDANCE,
+    REPO_CODE_INTAKE_GUIDANCE,
     KANBAN_GUIDANCE,
     build_nous_subscription_prompt,
 )
@@ -5294,6 +5341,7 @@ class AIAgent:
 
         # Pointer to the hermes-agent skill + docs for user questions about Hermes itself.
         prompt_parts.append(HERMES_AGENT_HELP_GUIDANCE)
+        prompt_parts.append(REPO_CODE_INTAKE_GUIDANCE)
 
         # Tool-aware behavioral guidance: only inject when the tools are loaded
         tool_guidance = []
@@ -11095,6 +11143,83 @@ class AIAgent:
 
         # Initialize conversation (copy to avoid mutating the caller's list)
         messages = list(conversation_history) if conversation_history else []
+
+        routed_repo = _detect_repo_code_intake(user_message)
+        if routed_repo is not None:
+            try:
+                from hermes_cli import kanban_db as _kanban_db
+
+                with _kanban_db.connect() as conn:
+                    assignees = {
+                        entry.get("name")
+                        for entry in _kanban_db.known_assignees(conn)
+                        if entry.get("name")
+                    }
+                    assignee = "codex" if "codex" in assignees else "default"
+                    task_title = _summarize_user_message_for_log(user_message)
+                    if len(task_title) > 96:
+                        task_title = task_title[:93].rstrip() + "..."
+                    task_id = _kanban_db.create_task(
+                        conn,
+                        title=task_title or f"repo code task: {routed_repo.name}",
+                        body=str(user_message),
+                        assignee=assignee,
+                        created_by="repo-code-intake",
+                        workspace_kind="dir",
+                        workspace_path=str(routed_repo),
+                        skills=["prd-phased-codex"],
+                    )
+                    if (self.platform or "").lower() == "telegram" and self._chat_id:
+                        _kanban_db.add_notify_sub(
+                            conn,
+                            task_id=task_id,
+                            platform="telegram",
+                            chat_id=str(self._chat_id),
+                            thread_id=str(self._thread_id or ""),
+                            user_id=str(self._user_id or "repo-code-intake"),
+                        )
+                final_response = (
+                    "Roteei essa tarefa de código para o Kanban antes de mexer "
+                    f"no repositório.\n\n"
+                    f"Task: `{task_id}`\n"
+                    f"Assignee: `{assignee}`\n"
+                    f"Workspace: `{routed_repo}`\n\n"
+                    "O dispatcher do gateway deve pegar a task como `ready`. "
+                    "Acompanhe no dashboard Kanban ou com "
+                    f"`hermes kanban tail {task_id}`."
+                )
+                messages.append({"role": "user", "content": user_message})
+                self._persist_user_message_idx = len(messages) - 1
+                messages.append({"role": "assistant", "content": final_response})
+                self._persist_session(messages, conversation_history)
+                return {
+                    "final_response": final_response,
+                    "last_reasoning": None,
+                    "messages": messages,
+                    "api_calls": 0,
+                    "completed": True,
+                    "turn_exit_reason": "repo_code_intake_routed",
+                    "partial": False,
+                    "interrupted": False,
+                    "response_previewed": False,
+                    "model": self.model,
+                    "provider": self.provider,
+                    "base_url": self.base_url,
+                    "input_tokens": self.session_input_tokens,
+                    "output_tokens": self.session_output_tokens,
+                    "cache_read_tokens": self.session_cache_read_tokens,
+                    "cache_write_tokens": self.session_cache_write_tokens,
+                    "reasoning_tokens": self.session_reasoning_tokens,
+                    "prompt_tokens": self.session_prompt_tokens,
+                    "completion_tokens": self.session_completion_tokens,
+                    "total_tokens": self.session_total_tokens,
+                    "last_prompt_tokens": 0,
+                    "estimated_cost_usd": self.session_estimated_cost_usd,
+                    "cost_status": self.session_cost_status,
+                    "cost_source": self.session_cost_source,
+                }
+            except Exception as exc:
+                logger.warning("repo code intake routing failed: %s", exc)
 
         # Hydrate todo store from conversation history (gateway creates a fresh
         # AIAgent per message, so the in-memory store is empty -- we need to

--- a/scripts/hermes-claude-kanban
+++ b/scripts/hermes-claude-kanban
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+TASK_ID="${1:?task id required}"
+WORKSPACE="${2:?workspace required}"
+HERMES_AGENT="${HERMES_AGENT:-/home/ubuntu/.hermes/hermes-agent}"
+CLAUDE_BIN="${CLAUDE_BIN:-/home/ubuntu/.hermes/node/bin/claude}"
+
+mkdir -p "$WORKSPACE"
+cd "$WORKSPACE"
+
+RUN_DIR="/home/ubuntu/.hermes/kanban/claude-runs/$TASK_ID"
+mkdir -p "$RUN_DIR"
+CONTEXT_FILE="$RUN_DIR/context.md"
+PROMPT_FILE="$RUN_DIR/prompt.md"
+STDOUT_FILE="$RUN_DIR/stdout.md"
+STDERR_FILE="$RUN_DIR/stderr.log"
+MARKER="$RUN_DIR/start.marker"
+
+touch "$MARKER"
+
+PYTHONPATH="$HERMES_AGENT" "$HERMES_AGENT/venv/bin/python" - "$TASK_ID" > "$CONTEXT_FILE" <<'PY'
+import sys
+from hermes_cli import kanban_db as kb
+
+task_id = sys.argv[1]
+conn = kb.connect()
+try:
+    print(kb.build_worker_context(conn, task_id))
+finally:
+    conn.close()
+PY
+
+{
+  printf 'You are executing a Hermes Kanban task via Claude Code CLI.\n\n'
+  printf 'Work in the current workspace only unless the task explicitly names another path.\n'
+  printf 'For writing/content tasks, create a clear deliverable file in the workspace.\n'
+  printf 'For code tasks, edit the repository files directly and run focused validation when practical.\n'
+  printf 'Do not call Hermes Kanban tools. The wrapper will update task status after you exit.\n'
+  printf 'Return a concise summary followed by any files changed.\n\n'
+  printf '%s\n' '--- Kanban context ---'
+  cat "$CONTEXT_FILE"
+} > "$PROMPT_FILE"
+
+set +e
+"$CLAUDE_BIN" \
+  --print \
+  --permission-mode acceptEdits \
+  --output-format text \
+  "$(cat "$PROMPT_FILE")" \
+  > "$STDOUT_FILE" 2> "$STDERR_FILE"
+EXIT_CODE=$?
+set -e
+
+if [ "$EXIT_CODE" -ne 0 ]; then
+  PYTHONPATH="$HERMES_AGENT" "$HERMES_AGENT/venv/bin/python" - "$TASK_ID" "$EXIT_CODE" "$STDERR_FILE" <<'PY'
+import sys
+from pathlib import Path
+from hermes_cli import kanban_db as kb
+
+task_id, exit_code, stderr_path = sys.argv[1], sys.argv[2], Path(sys.argv[3])
+stderr = stderr_path.read_text(encoding="utf-8", errors="replace") if stderr_path.exists() else ""
+reason = f"Claude CLI exited {exit_code}: {stderr.strip()[:700]}"
+conn = kb.connect()
+try:
+    kb.block_task(
+        conn,
+        task_id,
+        reason=reason,
+        metadata={"executor": "claude-cli", "stderr": str(stderr_path)},
+    )
+finally:
+    conn.close()
+PY
+  exit "$EXIT_CODE"
+fi
+
+if [ ! -s "$STDOUT_FILE" ]; then
+  printf 'Claude CLI completed without textual output.\n' > "$STDOUT_FILE"
+fi
+
+if ! find . -type f -newer "$MARKER" \
+  ! -path './.git/*' \
+  ! -path './node_modules/*' \
+  ! -path './.hermes/codex-logs/*' \
+  | grep -q .; then
+  cp "$STDOUT_FILE" "$WORKSPACE/claude-output.md"
+fi
+
+PYTHONPATH="$HERMES_AGENT" "$HERMES_AGENT/venv/bin/python" - "$TASK_ID" "$WORKSPACE" "$STDOUT_FILE" "$MARKER" <<'PY'
+import subprocess
+import sys
+from pathlib import Path
+from hermes_cli import kanban_db as kb
+
+task_id, workspace, stdout_path, marker = sys.argv[1:5]
+workspace_path = Path(workspace)
+stdout = Path(stdout_path).read_text(encoding="utf-8", errors="replace").strip()
+summary = stdout.splitlines()[0][:500] if stdout else "Claude CLI completed task."
+
+changed: list[str] = []
+if (workspace_path / ".git").exists():
+    try:
+        out = subprocess.check_output(
+            ["git", "status", "--short"],
+            cwd=workspace,
+            text=True,
+            stderr=subprocess.DEVNULL,
+        )
+        for line in out.splitlines():
+            if line.strip():
+                changed.append(line[3:].strip())
+    except Exception:
+        pass
+if not changed:
+    marker_mtime = Path(marker).stat().st_mtime
+    for path in workspace_path.rglob("*"):
+        if not path.is_file():
+            continue
+        rel = path.relative_to(workspace_path)
+        if rel.parts and rel.parts[0] in {".git", "node_modules"}:
+            continue
+        try:
+            if path.stat().st_mtime >= marker_mtime:
+                changed.append(str(rel))
+        except OSError:
+            continue
+
+conn = kb.connect()
+try:
+    kb.complete_task(
+        conn,
+        task_id,
+        summary=summary,
+        metadata={
+            "executor": "claude-cli",
+            "stdout": stdout_path,
+            "changed_files": changed[:20],
+        },
+    )
+finally:
+    conn.close()
+PY

--- a/skills/autonomous-ai-agents/codex/SKILL.md
+++ b/skills/autonomous-ai-agents/codex/SKILL.md
@@ -66,6 +66,20 @@ process(action="submit", session_id="<id>", data="yes")
 process(action="kill", session_id="<id>")
 ```
 
+## Hermes Background Repo Work
+
+For user-owned repositories managed by Hermes, do not call `codex ...`
+directly from normal chat. Create or use a Kanban task and run Codex through
+the guarded phase wrapper so progress is observable:
+
+```bash
+/home/ubuntu/.hermes/scripts/hermes-codex-phase /absolute/repo/path .hermes/phases/phase-001-name.md 45
+```
+
+The wrapper captures `.hermes/codex-logs`, writes `.hermes/events`, and mirrors
+start/finish/block state back to Kanban when the worker was spawned from a
+Kanban task.
+
 ## Key Flags
 
 | Flag | Effect |

--- a/skills/software-development/prd-phased-codex/SKILL.md
+++ b/skills/software-development/prd-phased-codex/SKILL.md
@@ -1,0 +1,383 @@
+---
+name: prd-phased-codex
+description: "Default workflow for user repo work from a task or PRD: Hermes creates/updates a PRD, slices it into phases, uses Kanban for durable orchestration, and runs Codex one phase at a time through the guarded hermes-codex-phase wrapper."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [prd, planning, codex, kanban, orchestration, github, autonomous-coding]
+    related_skills: [writing-plans, plan, subagent-driven-development, kanban-orchestrator, kanban-worker, codex, github-repo-management]
+---
+
+# PRD Phased Codex
+
+Use this workflow whenever the user gives a repository, product request, PRD,
+implementation idea, or asks Hermes to work independently on a code project.
+Do this even if the user does not explicitly name this skill.
+
+## Ownership
+
+- Hermes is the orchestrator: clarify, plan, split, schedule, review, and ask the user when risk is high.
+- Repo Recon is the first worker: map the target repo with evidence only; no planning, no implementation.
+- Codex is the implementation worker: execute exactly one phase in an isolated repo/worktree.
+- Kanban is the durable state: tasks, dependencies, blocks, comments, handoffs, and retry history.
+- GitHub is the audit trail: private origin, feature branches, commits, draft PRs.
+
+## Scope Disambiguation
+
+Before planning, decide what "the workflow", "the PRD", "the planner", or "the
+tool" refers to.
+
+Default assumption for repo tasks: the user is asking about the target
+repository, not Hermes's own `prd-phased-codex` workflow.
+
+If the repo itself contains PRD/planner/builder concepts, treat those as
+product-domain concepts inside the repo. Do not rewrite Hermes skills, Codex
+skills, dashboard services, or global orchestration unless the user explicitly
+asks to change Hermes itself.
+
+Bad response pattern:
+
+- User asks for a feature in a cloned repo.
+- Hermes asks generic implementation questions about language, script location,
+  and interface without first reading the repo.
+
+Correct response pattern:
+
+- Map the repo.
+- Identify existing workflow terms from repo docs/code.
+- Restate the task using repo-native vocabulary.
+- Only then write a PRD/plan.
+
+## Mandatory Phase 0: Repo Map
+
+Do not create or update a PRD, implementation plan, phase files, or Codex prompt
+until this file exists and contains repo-specific facts:
+
+```text
+.hermes/repo-map.md
+```
+
+Repos under `/home/ubuntu/repos/` and `/home/ubuntu/work/hermes-repos/` are
+observed by `hermes-repo-watch.service`, which runs the deterministic repo map
+in the background after a repo becomes stable. Still verify the artifact exists
+and is current before planning; if the user request points to a new subsystem,
+regenerate it manually. The watcher also runs a lightweight `project-rag` recon
+index for docs/config/workflow files and writes `.hermes/rag-index.json`. Full
+code indexing is intentionally manual because it can be expensive.
+
+Preferred context stack:
+
+1. If `project-rag` MCP is available, index the target repo and run semantic
+   searches for the user's request, repo-native workflows, PRD/planner/builder
+   terms, validation commands, state files, and stop/block mechanisms.
+2. If `context-mode` MCP is available, keep the active working context scoped to
+   the target repo, user request, repo map, recon brief, and current phase.
+3. Always create the deterministic repo map below as the durable source artifact.
+
+Deterministic command:
+
+```bash
+/home/ubuntu/.hermes/scripts/hermes-repo-map <repo-path>
+```
+
+Treat this as the output of the "Repo Recon" agent. The recon artifact is
+evidence, not a plan. It should be regenerated when the repo changes
+substantially or when the user's request points at a new area of the codebase.
+
+The repo map must cite concrete files and include:
+
+- purpose of the project
+- stack and package manager
+- important scripts from `package.json`, `Makefile`, or equivalent
+- workflow described in `CLAUDE.md`, `AGENTS.md`, `README.md`, and `docs/`
+- existing PRD/planner/builder concepts in the repo
+- state files and stop/block mechanisms already present
+- where the requested change most likely belongs
+- open questions that remain after reading the repo
+
+Minimum orientation commands:
+
+```bash
+pwd
+git status --short --branch
+git remote -v
+find . -maxdepth 3 -type f | sort | sed -n '1,240p'
+test -f package.json && cat package.json
+test -f CLAUDE.md && sed -n '1,220p' CLAUDE.md
+test -f AGENTS.md && sed -n '1,220p' AGENTS.md
+test -f README.md && sed -n '1,220p' README.md
+find docs -maxdepth 2 -type f -name '*.md' -print 2>/dev/null | sort
+```
+
+For Node/TS repos, also inspect likely CLI and engine entrypoints:
+
+```bash
+find engine scripts src cli -maxdepth 3 -type f 2>/dev/null | sort | sed -n '1,240p'
+```
+
+If the repo map is generic or lacks file citations, stop and redo mapping. Do
+not ask Codex to "review the plan" until the plan was built from the repo map.
+
+If `project-rag` and deterministic reads disagree, trust concrete repository
+files over semantic summaries. Use `project-rag` to find the right files faster,
+not as permission to skip file citations.
+
+## Recon Agent Contract
+
+When the user asks for a PRD, enhancement, feature plan, or implementation in a
+repo, the first task is always:
+
+```text
+Recon: map the target repository for <user request>
+```
+
+Recon must produce:
+
+```text
+.hermes/repo-map.md
+.hermes/recon-brief.md
+```
+
+`repo-map.md` is generated by the script and contains raw evidence. `recon-brief.md`
+is Hermes's short synthesis from that evidence:
+
+```markdown
+# Recon Brief
+
+User request:
+
+Repo-native interpretation:
+
+Relevant existing workflow:
+
+Files/scripts likely involved:
+
+Existing state/block/review mechanisms:
+
+Validation commands:
+
+What NOT to change:
+
+Open questions:
+```
+
+The Planner may only start after `recon-brief.md` exists. If the brief cannot
+answer where the change belongs, ask targeted questions or run deeper grep/read
+passes; do not write a generic PRD.
+
+## External Reviewer Rule: Codex or Claude
+
+Codex is installed on this VPS; Claude CLI may or may not be installed. Treat
+Claude as optional. Never require Claude for this workflow.
+
+Before using any external reviewer (Codex, Claude, OpenCode, etc.):
+
+1. Confirm the tool exists (`command -v codex`, `command -v claude`).
+2. Provide the reviewer with:
+   - the original user request
+   - `.hermes/repo-map.md`
+   - the draft PRD/plan
+   - explicit instruction: "Review the plan against the repo map. Do not infer
+     from Hermes's global workflow unless the repo map says so."
+3. Ask for findings only, not implementation, unless executing a phase through
+   `hermes-codex-phase`.
+
+Reviewer prompt shape:
+
+```text
+You are reviewing a plan for the target repository, not Hermes itself.
+Source of truth:
+1. User request below
+2. Repo map below
+3. Draft plan below
+
+Find repo-specific gaps, wrong assumptions, missing files/scripts, and
+terminology contamination. Do not propose generic implementation questions if
+the repo map answers them.
+```
+
+If Claude is unavailable, use Codex. If both are unavailable, perform the review
+locally from the repo map and say no external reviewer was available.
+
+## Required Workspace Rules
+
+Before autonomous work:
+
+1. The repo must live under `/home/ubuntu/work/hermes-repos/`.
+   `/home/ubuntu/repos/` is also allowed as the default Telegram clone/inbox path.
+2. The repo must be a Git repo.
+3. `origin` must point to `github.com/nicolaregattieri/...`.
+4. Work must happen on a feature branch, never `main` or `master`.
+5. If the repo came from a third party, use `github-repo-management` to rename/remove the old remote and push to a private repo first.
+
+## Repository Layout
+
+Create these files inside the repo:
+
+```text
+PRD.md                         # If user did not provide one, Hermes writes it.
+.hermes/repo-map.md            # Required before PRD/planning.
+.hermes/recon-brief.md         # Required synthesis before PRD/planning.
+.hermes/plans/                 # Implementation plans.
+.hermes/phases/                # One phase file per execution unit.
+.hermes/events/                # Codex writes phase_complete / needs_input events.
+.hermes/codex-logs/            # Wrapper captures Codex logs.
+```
+
+## PRD Quality Gate
+
+A PRD is invalid if it could apply to many repositories.
+
+Every repo-derived PRD must include:
+
+- exact existing workflow from repo docs
+- exact files/scripts that will change
+- current behavior, using repo terminology
+- proposed behavior, using repo terminology
+- interaction with existing state/block/QA mechanisms
+- non-goals, especially what should not change
+- validation commands already used by the repo
+
+If the user request mentions "PRD", "planner", "builder", "Figma", "task", or
+"review pause", first check whether those terms already exist in repo docs/code.
+Use the repo's meaning, not Hermes's meaning.
+
+## Phase Rules
+
+Each phase must be small enough for one Codex run. Prefer 15-45 minutes of work.
+Good phases:
+
+- `phase-001-discover-and-run.md`
+- `phase-002-data-model.md`
+- `phase-003-api-slice.md`
+- `phase-004-ui-slice.md`
+- `phase-005-tests-and-polish.md`
+
+Every phase file must include:
+
+```markdown
+# Phase N: Name
+
+Objective:
+
+Scope:
+- In:
+- Out:
+
+Acceptance criteria:
+- ...
+
+Allowed files:
+- ...
+
+Validation:
+- Command:
+- Expected:
+
+Stop and ask if:
+- ...
+```
+
+## Execution
+
+Hermes must not call `codex --yolo` directly. Use:
+
+```bash
+/home/ubuntu/.hermes/scripts/hermes-codex-phase /home/ubuntu/work/hermes-repos/<repo> .hermes/phases/phase-001-discover-and-run.md 45
+```
+
+For repos cloned by Telegram commands, `/home/ubuntu/repos/<repo>` is valid too:
+
+```bash
+/home/ubuntu/.hermes/scripts/hermes-codex-phase /home/ubuntu/repos/<repo> .hermes/phases/phase-001-discover-and-run.md 45
+```
+
+The wrapper validates path, remote, branch, secret-like strings, timeout, logs,
+and event paths before running Codex.
+
+## Event Protocol
+
+Codex writes one of these events under `.hermes/events/`.
+
+Complete:
+
+```json
+{
+  "type": "phase_complete",
+  "phase": "phase-001-discover-and-run",
+  "summary": "Project runs locally",
+  "changed_files": ["README.md"],
+  "commands_run": ["npm install", "npm test"],
+  "tests": {"status": "passed", "details": "npm test"},
+  "next_request": "review_and_continue"
+}
+```
+
+Blocked:
+
+```json
+{
+  "type": "needs_input",
+  "phase": "phase-001-discover-and-run",
+  "question": "Which database should this project use?",
+  "options": ["SQLite for MVP", "Postgres now"],
+  "risk": "medium"
+}
+```
+
+Wrapper failure:
+
+```json
+{
+  "type": "process_failed",
+  "phase": "phase-001-discover-and-run",
+  "exit_code": 1,
+  "log_path": ".hermes/codex-logs/..."
+}
+```
+
+## Hermes Review Loop
+
+After every phase:
+
+```bash
+git status --short
+git diff --stat
+find .hermes/events -type f -maxdepth 1 | sort | tail
+```
+
+Then:
+
+1. Read the newest event and Codex log.
+2. Run the phase validation command or focused tests.
+3. If `phase_complete` and validation passes, commit and move to the next phase or open/update a draft PR.
+4. If `needs_input`, ask the user through the active channel and block the Kanban task.
+5. If `process_failed` or timeout, summarize the last log lines, create a smaller retry phase, or block if risky.
+
+## Risk Gates
+
+Autonomous continuation is allowed for:
+
+- setup discovery
+- docs
+- tests
+- isolated UI/API slices
+- refactors with tests
+
+Ask the user before continuing when a phase touches:
+
+- auth, billing, payments, permissions
+- deployment, DNS, systemd, firewall, infrastructure
+- secrets, `.env`, SSH, GitHub credentials
+- destructive migrations or data deletion
+- public visibility or license changes
+
+## Kanban Integration
+
+For multi-phase work, create a parent Kanban task for the PRD/project and one
+child task per phase. Phase tasks depend on the previous phase unless they are
+safe to run in parallel. Use `kanban_block` for user decisions and
+`kanban_complete` with metadata containing phase, branch, commit, event path,
+tests, and PR URL.

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -414,6 +414,34 @@ def test_detect_crashed_workers_reclaims(kanban_home):
         conn.close()
 
 
+def test_detect_crashed_workers_auto_blocks_after_limit(kanban_home, monkeypatch):
+    """Repeated dead workers are deterministic failures, not useful retries."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="broken worker", assignee="worker")
+        monkeypatch.setattr(kb, "_pid_alive", lambda pid: False)
+
+        for _ in range(2):
+            kb.claim_task(conn, tid)
+            kb._set_worker_pid(conn, tid, 98765)
+            kb.detect_crashed_workers(conn, crash_limit=3)
+            assert kb.get_task(conn, tid).status == "ready"
+
+        kb.claim_task(conn, tid)
+        kb._set_worker_pid(conn, tid, 98765)
+        kb.detect_crashed_workers(conn, crash_limit=3)
+
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked"
+        assert task.current_run_id is None
+        runs = kb.list_runs(conn, tid)
+        assert [r.outcome for r in runs] == ["crashed", "crashed", "crashed"]
+        kinds = [e.kind for e in kb.list_events(conn, tid)]
+        assert "gave_up" in kinds
+    finally:
+        conn.close()
+
+
 # ---------------------------------------------------------------------------
 # Daemon loop
 # ---------------------------------------------------------------------------
@@ -1836,6 +1864,88 @@ def test_dashboard_direct_status_change_within_same_state_is_noop_for_runs(kanba
         conn.close()
 
 
+def test_dashboard_create_ready_unassigned_returns_warning(kanban_home):
+    from plugins.kanban.dashboard.plugin_api import CreateTaskBody, create_task
+
+    response = create_task(CreateTaskBody(title="unassigned"))
+
+    assert response["task"]["status"] == "ready"
+    assert response["task"]["assignee"] is None
+    assert "unassigned" in response["warning"]
+    assert "will not spawn" in response["warning"]
+
+
+def test_dashboard_create_assigned_task_subscribes_telegram_home(kanban_home, monkeypatch):
+    from plugins.kanban.dashboard.plugin_api import CreateTaskBody, create_task
+
+    monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "12345")
+
+    response = create_task(CreateTaskBody(title="notify me", assignee="codex"))
+    task_id = response["task"]["id"]
+
+    assert response["notify"] == {"platform": "telegram", "target": "home"}
+    conn = kb.connect()
+    try:
+        subs = kb.list_notify_subs(conn, task_id)
+    finally:
+        conn.close()
+    assert len(subs) == 1
+    assert subs[0]["platform"] == "telegram"
+    assert subs[0]["chat_id"] == "12345"
+    assert subs[0]["user_id"] == "dashboard"
+
+
+def test_dashboard_assign_task_subscribes_telegram_home(kanban_home, monkeypatch):
+    from plugins.kanban.dashboard.plugin_api import UpdateTaskBody, update_task
+
+    monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "12345")
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="notify on assign", triage=True)
+    finally:
+        conn.close()
+
+    response = update_task(tid, UpdateTaskBody(assignee="codex"))
+
+    assert response["notify"] == {"platform": "telegram", "target": "home"}
+    conn = kb.connect()
+    try:
+        subs = kb.list_notify_subs(conn, tid)
+    finally:
+        conn.close()
+    assert len(subs) == 1
+    assert subs[0]["chat_id"] == "12345"
+
+
+def test_dashboard_refuses_ready_without_assignee(kanban_home):
+    from fastapi import HTTPException
+    from plugins.kanban.dashboard.plugin_api import UpdateTaskBody, update_task
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="unassigned", triage=True)
+    finally:
+        conn.close()
+
+    with pytest.raises(HTTPException) as exc:
+        update_task(tid, UpdateTaskBody(status="ready"))
+
+    assert exc.value.status_code == 400
+    assert "require an assignee" in str(exc.value.detail)
+
+
+def test_known_assignees_includes_default_profile(kanban_home):
+    (kanban_home / "config.yaml").write_text("model: {}\n", encoding="utf-8")
+
+    conn = kb.connect()
+    try:
+        names = [entry["name"] for entry in kb.known_assignees(conn)]
+    finally:
+        conn.close()
+
+    assert "default" in names
+
+
 def test_cli_bulk_complete_with_summary_rejects(kanban_home):
     conn = kb.connect()
     try:
@@ -2598,6 +2708,102 @@ def test_default_spawn_auto_loads_kanban_worker_skill(kanban_home, monkeypatch):
     env = captured["env"]
     assert env.get("HERMES_KANBAN_TASK") == tid
     assert env.get("HERMES_PROFILE") == "some-profile"
+    assert env.get("HERMES_KANBAN_DB") == str(kanban_home / "kanban.db")
+
+
+def test_default_spawn_uses_codex_phase_wrapper_when_phases_exist(kanban_home, monkeypatch, tmp_path):
+    captured = {}
+
+    class FakeProc:
+        pid = 12345
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["env"] = kwargs.get("env", {})
+        captured["cwd"] = kwargs.get("cwd")
+        return FakeProc()
+
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+
+    repo = tmp_path / "repo"
+    phase_dir = repo / ".hermes" / "phases"
+    event_dir = repo / ".hermes" / "events"
+    phase_dir.mkdir(parents=True)
+    event_dir.mkdir(parents=True)
+    (phase_dir / "phase-001-setup.md").write_text("# done\n", encoding="utf-8")
+    (phase_dir / "phase-002-code.md").write_text("# next\n", encoding="utf-8")
+    (event_dir / "phase-001-setup-complete.json").write_text(
+        '{"type":"phase_complete"}\n',
+        encoding="utf-8",
+    )
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="phase worker",
+            assignee="codex",
+            workspace_kind="dir",
+            workspace_path=str(repo),
+            skills=["prd-phased-codex"],
+        )
+        task = kb.get_task(conn, tid)
+        pid = kb._default_spawn(task, str(repo))
+        assert pid == 12345
+    finally:
+        conn.close()
+
+    assert captured["cmd"] == [
+        "/home/ubuntu/.hermes/scripts/hermes-codex-phase",
+        str(repo),
+        ".hermes/phases/phase-002-code.md",
+        "45",
+    ]
+    assert captured["cwd"] == str(repo)
+    assert captured["env"]["HERMES_KANBAN_TASK"] == tid
+    assert captured["env"]["HERMES_KANBAN_DB"] == str(kanban_home / "kanban.db")
+
+
+def test_default_spawn_routes_claude_assignee_to_claude_cli_wrapper(kanban_home, monkeypatch, tmp_path):
+    captured = {}
+
+    class FakeProc:
+        pid = 23456
+
+    def fake_popen(cmd, **kwargs):
+        captured["cmd"] = cmd
+        captured["env"] = kwargs.get("env", {})
+        captured["cwd"] = kwargs.get("cwd")
+        return FakeProc()
+
+    monkeypatch.setattr("subprocess.Popen", fake_popen)
+
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(
+            conn,
+            title="claude worker",
+            assignee="claude",
+            workspace_kind="dir",
+            workspace_path=str(workspace),
+        )
+        task = kb.get_task(conn, tid)
+        pid = kb._default_spawn(task, str(workspace))
+        assert pid == 23456
+    finally:
+        conn.close()
+
+    assert captured["cmd"] == [
+        str(Path(kb.__file__).resolve().parents[1] / "scripts" / "hermes-claude-kanban"),
+        tid,
+        str(workspace),
+    ]
+    assert captured["cwd"] == str(workspace)
+    assert captured["env"]["HERMES_KANBAN_TASK"] == tid
+    assert captured["env"]["HERMES_PROFILE"] == "claude"
+    assert captured["env"]["HERMES_KANBAN_DB"] == str(kanban_home / "kanban.db")
 
 
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -47,6 +47,43 @@ def test_init_creates_expected_tables(kanban_home):
     assert {"tasks", "task_links", "task_comments", "task_events"} <= names
 
 
+def test_notify_subscribe_starts_at_current_task_event(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="notify", assignee="worker")
+        kb.claim_task(conn, tid)
+        kb.block_task(conn, tid, reason="old blocker")
+
+        kb.add_notify_sub(
+            conn,
+            task_id=tid,
+            platform="telegram",
+            chat_id="12345",
+            user_id="dashboard",
+        )
+        _, events = kb.unseen_events_for_sub(
+            conn,
+            task_id=tid,
+            platform="telegram",
+            chat_id="12345",
+            kinds=["blocked"],
+        )
+
+    assert events == []
+
+
+def test_kanban_db_path_honors_shared_db_override(kanban_home, tmp_path, monkeypatch):
+    shared = tmp_path / "shared-board.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(shared))
+
+    with kb.connect() as conn:
+        kb.create_task(conn, title="shared board")
+
+    assert shared.exists()
+    with kb.connect() as conn:
+        tasks = kb.list_tasks(conn)
+    assert [t.title for t in tasks] == ["shared board"]
+
+
 # ---------------------------------------------------------------------------
 # Task creation + status inference
 # ---------------------------------------------------------------------------

--- a/tests/orchestration/test_codex_phase_wiring.py
+++ b/tests/orchestration/test_codex_phase_wiring.py
@@ -1,0 +1,338 @@
+import json
+import os
+import shutil
+import subprocess
+import textwrap
+import uuid
+from types import SimpleNamespace
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+WRAPPER = Path("/home/ubuntu/.hermes/scripts/hermes-codex-phase")
+WORK_ROOT = Path("/home/ubuntu/work/hermes-repos")
+
+
+def _run(cmd, *, cwd, env=None):
+    return subprocess.run(
+        cmd,
+        cwd=cwd,
+        env=env,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    )
+
+
+def _make_repo() -> Path:
+    if not WRAPPER.exists():
+        pytest.skip(f"missing wrapper: {WRAPPER}")
+    try:
+        WORK_ROOT.mkdir(parents=True, exist_ok=True)
+    except OSError as exc:
+        pytest.skip(f"cannot create Hermes work root {WORK_ROOT}: {exc}")
+
+    repo = WORK_ROOT / f"pytest-codex-phase-{uuid.uuid4().hex}"
+    repo.mkdir(parents=True)
+    _run(["git", "init"], cwd=repo)
+    _run(["git", "config", "user.email", "test@example.com"], cwd=repo)
+    _run(["git", "config", "user.name", "Hermes Test"], cwd=repo)
+    (repo / "README.md").write_text("test repo\n", encoding="utf-8")
+    phase_dir = repo / ".hermes" / "phases"
+    phase_dir.mkdir(parents=True)
+    (phase_dir / "phase-001.md").write_text(
+        "# Phase 001\n\nDo one bounded thing.\n",
+        encoding="utf-8",
+    )
+    _run(["git", "add", "."], cwd=repo)
+    _run(["git", "commit", "-m", "initial"], cwd=repo)
+    _run(
+        ["git", "remote", "add", "origin", "git@github.com:nicolaregattieri/test.git"],
+        cwd=repo,
+    )
+    _run(["git", "checkout", "-b", "feature/test"], cwd=repo)
+    return repo
+
+
+def _make_fake_codex(bin_dir: Path, event_body: dict, exit_code: int = 0) -> None:
+    script = bin_dir / "codex"
+    script.write_text(
+        textwrap.dedent(
+            f"""\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            mkdir -p .hermes/events
+            cat > .hermes/events/phase-001-complete.json <<'JSON'
+            {json.dumps(event_body)}
+            JSON
+            echo "fake codex wrote phase event"
+            exit {exit_code}
+            """
+        ),
+        encoding="utf-8",
+    )
+    script.chmod(0o755)
+
+
+def _make_fake_codex_needs_input(bin_dir: Path) -> None:
+    script = bin_dir / "codex"
+    script.write_text(
+        textwrap.dedent(
+            """\
+            #!/usr/bin/env bash
+            set -euo pipefail
+            mkdir -p .hermes/events
+            cat > .hermes/events/phase-001-needs-input.json <<'JSON'
+            {"type":"needs_input","phase":"phase-001","question":"Approve scope?","options":["yes","no"],"risk":"medium"}
+            JSON
+            echo "fake codex needs input"
+            exit 0
+            """
+        ),
+        encoding="utf-8",
+    )
+    script.chmod(0o755)
+
+
+def _create_task(hermes_home: Path, repo: Path) -> str:
+    os.environ["HERMES_HOME"] = str(hermes_home)
+    kb.init_db()
+    with kb.connect() as conn:
+        return kb.create_task(
+            conn,
+            title="Run phase 001",
+            body="exercise wrapper wiring",
+            assignee="codex",
+            workspace_kind="dir",
+            workspace_path=str(repo),
+            created_by="pytest",
+        )
+
+
+def _task_snapshot(task_id: str):
+    with kb.connect() as conn:
+        task = kb.get_task(conn, task_id)
+        comments = kb.list_comments(conn, task_id)
+        events = kb.list_events(conn, task_id)
+    return task, comments, events
+
+
+def test_codex_phase_wrapper_marks_kanban_task_done(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    repo = _make_repo()
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _make_fake_codex(
+        fake_bin,
+        {
+            "type": "phase_complete",
+            "phase": "phase-001",
+            "summary": "Phase finished cleanly.",
+            "changed_files": ["README.md"],
+            "commands_run": ["fake"],
+            "tests": {"status": "passed", "details": "fake"},
+            "next_request": "review_and_continue",
+        },
+    )
+    task_id = _create_task(hermes_home, repo)
+
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(hermes_home)
+    env["HERMES_KANBAN_TASK"] = task_id
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+
+    try:
+        result = subprocess.run(
+            [str(WRAPPER), str(repo), ".hermes/phases/phase-001.md", "1"],
+            cwd=repo,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+        assert ".hermes/codex-logs/" in result.stdout
+
+        task, comments, events = _task_snapshot(task_id)
+        assert task.status == "done"
+        assert "Phase finished cleanly." in (task.result or "")
+        assert any("PHASE STARTED: phase-001" in c.body for c in comments)
+        assert any("PHASE FINISHED: phase-001" in c.body for c in comments)
+        assert any(e.kind == "completed" for e in events)
+    finally:
+        shutil.rmtree(repo, ignore_errors=True)
+
+
+def test_codex_phase_wrapper_blocks_for_review_when_later_phase_exists(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    repo = _make_repo()
+    (repo / ".hermes" / "phases" / "phase-002.md").write_text(
+        "# Phase 002\n\nNext bounded thing.\n",
+        encoding="utf-8",
+    )
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _make_fake_codex(
+        fake_bin,
+        {
+            "type": "phase_complete",
+            "phase": "phase-001",
+            "summary": "Phase one finished.",
+            "changed_files": ["README.md"],
+            "commands_run": ["fake"],
+            "tests": {"status": "passed", "details": "fake"},
+            "next_request": "review_and_continue",
+        },
+    )
+    task_id = _create_task(hermes_home, repo)
+
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(hermes_home)
+    env["HERMES_KANBAN_TASK"] = task_id
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+
+    try:
+        subprocess.run(
+            [str(WRAPPER), str(repo), ".hermes/phases/phase-001.md", "1"],
+            cwd=repo,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+
+        task, comments, events = _task_snapshot(task_id)
+        assert task.status == "blocked"
+        conn = kb.connect()
+        try:
+            run = kb.latest_run(conn, task_id)
+        finally:
+            conn.close()
+        assert run is not None
+        assert run.metadata
+        assert run.metadata.get("flow_graph", "").endswith("-phase-001-flow.svg")
+        assert Path(run.metadata["flow_graph"]).exists()
+        assert any("PHASE FINISHED: phase-001" in c.body for c in comments)
+        assert any(
+            e.kind == "blocked"
+            and e.payload
+            and "review before next phase" in e.payload.get("reason", "")
+            for e in events
+        )
+    finally:
+        shutil.rmtree(repo, ignore_errors=True)
+
+
+def test_codex_phase_wrapper_blocks_kanban_task_on_needs_input(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    repo = _make_repo()
+    fake_bin = tmp_path / "bin"
+    fake_bin.mkdir()
+    _make_fake_codex_needs_input(fake_bin)
+    task_id = _create_task(hermes_home, repo)
+
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(hermes_home)
+    env["HERMES_KANBAN_TASK"] = task_id
+    env["PATH"] = f"{fake_bin}:{env['PATH']}"
+
+    try:
+        subprocess.run(
+            [str(WRAPPER), str(repo), ".hermes/phases/phase-001.md", "1"],
+            cwd=repo,
+            env=env,
+            text=True,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            check=True,
+        )
+
+        task, comments, events = _task_snapshot(task_id)
+        assert task.status == "blocked"
+        assert any("summary: Approve scope?" in c.body for c in comments)
+        assert any(
+            e.kind == "blocked"
+            and e.payload
+            and e.payload.get("reason") == "needs input: Approve scope?"
+            for e in events
+        )
+    finally:
+        shutil.rmtree(repo, ignore_errors=True)
+
+
+def test_gateway_notifier_delivers_phase_terminal_kanban_event(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    kb.init_db()
+
+    with kb.connect() as conn:
+        task_id = kb.create_task(
+            conn,
+            title="Phase task",
+            body="notify me",
+            assignee="codex",
+            created_by="pytest",
+        )
+        kb.add_notify_sub(
+            conn,
+            task_id=task_id,
+            platform="telegram",
+            chat_id="12345",
+            thread_id=None,
+            user_id="nicola",
+        )
+        kb.complete_task(
+            conn,
+            task_id,
+            result="phase done",
+            summary="phase done",
+            metadata={"phase": "phase-001"},
+        )
+
+    from gateway.config import Platform
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    sent = []
+
+    class FakeAdapter:
+        async def send(self, chat_id, content, metadata=None):
+            sent.append((chat_id, content, metadata))
+            runner._running = False
+            return SimpleNamespace(success=True, message_id="m1")
+
+    runner.adapters = {Platform.TELEGRAM: FakeAdapter()}
+
+    async def fast_sleep(_seconds):
+        return None
+
+    monkeypatch.setattr("gateway.run.asyncio.sleep", fast_sleep)
+
+    import asyncio
+
+    asyncio.run(runner._kanban_notifier_watcher(interval=1))
+
+    assert sent
+    chat_id, content, metadata = sent[0]
+    assert chat_id == "12345"
+    assert "Hermes Kanban update" in content
+    assert f"Task: {task_id}" in content
+    assert "Status: done" in content
+    assert "phase done" in content
+    assert metadata == {}

--- a/tests/run_agent/test_repo_code_intake_router.py
+++ b/tests/run_agent/test_repo_code_intake_router.py
@@ -1,0 +1,45 @@
+from pathlib import Path
+
+from hermes_cli import kanban_db as kb
+
+
+def test_repo_code_intake_routes_to_kanban_without_model_call(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "config.yaml").write_text("model: {}\n", encoding="utf-8")
+    codex_profile = home / "profiles" / "codex"
+    codex_profile.mkdir(parents=True)
+    (codex_profile / "config.yaml").write_text("model: {}\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    (repo / ".git").mkdir()
+
+    import run_agent
+
+    monkeypatch.setattr(run_agent, "_detect_repo_code_intake", lambda _msg: repo)
+
+    agent = run_agent.AIAgent(
+        api_key="test",
+        base_url="https://openrouter.ai/api/v1",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+    result = agent.run_conversation("implemente algo em /home/ubuntu/repos/example")
+
+    assert result["api_calls"] == 0
+    assert result["turn_exit_reason"] == "repo_code_intake_routed"
+    assert "Roteei essa tarefa de código para o Kanban" in result["final_response"]
+
+    with kb.connect() as conn:
+        tasks = kb.list_tasks(conn)
+    assert len(tasks) == 1
+    task = tasks[0]
+    assert task.assignee == "codex"
+    assert task.workspace_kind == "dir"
+    assert task.workspace_path == str(repo)
+    assert task.skills == ["prd-phased-codex"]

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -11,6 +11,7 @@ from tools.approval import (
     _smart_approve,
     approve_session,
     detect_dangerous_command,
+    detect_hardline_command,
     is_approved,
     load_permanent,
     prompt_dangerous_approval,
@@ -124,6 +125,41 @@ class TestSafeCommand:
         is_dangerous, key, desc = detect_dangerous_command("git status")
         assert is_dangerous is False
         assert key is None
+        assert desc is None
+
+
+class TestDirectCodexHardline:
+    def test_direct_codex_is_blocked(self):
+        blocked, desc = detect_hardline_command("codex --yolo exec 'implement this'")
+        assert blocked is True
+        assert "direct Codex execution" in desc
+
+    def test_direct_codex_after_shell_separator_is_blocked(self):
+        blocked, desc = detect_hardline_command(
+            "cd /home/ubuntu/repos/pivotree-liquid-flow && codex exec 'work'"
+        )
+        assert blocked is True
+        assert "direct Codex execution" in desc
+
+    def test_direct_codex_by_absolute_path_is_blocked(self):
+        blocked, desc = detect_hardline_command(
+            "/home/ubuntu/.hermes/node/bin/codex --yolo exec 'work'"
+        )
+        assert blocked is True
+        assert "direct Codex execution" in desc
+
+    def test_hermes_codex_phase_wrapper_is_allowed_by_codex_guard(self):
+        blocked, desc = detect_hardline_command(
+            "/home/ubuntu/.hermes/scripts/hermes-codex-phase "
+            "/home/ubuntu/repos/pivotree-liquid-flow "
+            ".hermes/phases/phase-002-pre-planning-pause.md 45"
+        )
+        assert blocked is False
+        assert desc is None
+
+    def test_text_search_for_codex_is_not_blocked(self):
+        blocked, desc = detect_hardline_command("rg codex /home/ubuntu/.hermes")
+        assert blocked is False
         assert desc is None
 
 

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -527,6 +527,8 @@ def test_kanban_guidance_not_in_normal_prompt(monkeypatch, tmp_path):
     prompt = a._build_system_prompt()
     assert "You are a Kanban worker" not in prompt
     assert "kanban_show()" not in prompt
+    assert "Repository code intake" in prompt
+    assert "/home/ubuntu/.hermes/scripts/hermes-codex-phase" in prompt
 
 
 def test_kanban_guidance_in_worker_prompt(monkeypatch, tmp_path):
@@ -555,6 +557,9 @@ def test_kanban_guidance_in_worker_prompt(monkeypatch, tmp_path):
     assert "kanban_complete" in prompt
     assert "kanban_block" in prompt
     assert "kanban_create" in prompt
+    assert "prd-phased-codex" in prompt
+    assert "/home/ubuntu/.hermes/scripts/hermes-codex-phase" in prompt
+    assert "Direct `codex ...` commands" in prompt
     # Anti-shell guidance
     assert "Do not shell out" in prompt or "tools — they work" in prompt
 

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -220,6 +220,19 @@ HARDLINE_PATTERNS_COMPILED = [
     for pattern, description in HARDLINE_PATTERNS
 ]
 
+DIRECT_CODEX_PATTERN_COMPILED = re.compile(
+    _CMDPOS + r'(?:\S*/)?codex(?:\s|$)',
+    _RE_FLAGS,
+)
+CODEX_PHASE_WRAPPER = "/home/ubuntu/.hermes/scripts/hermes-codex-phase"
+
+
+def _is_direct_codex_command(normalized_command: str) -> bool:
+    """Return True when a shell command invokes Codex outside Hermes orchestration."""
+    if CODEX_PHASE_WRAPPER in normalized_command:
+        return False
+    return bool(DIRECT_CODEX_PATTERN_COMPILED.search(normalized_command))
+
 
 def detect_hardline_command(command: str) -> tuple:
     """Check if a command matches the unconditional hardline blocklist.
@@ -228,6 +241,11 @@ def detect_hardline_command(command: str) -> tuple:
         (is_hardline, description) or (False, None)
     """
     normalized = _normalize_command_for_detection(command).lower()
+    if _is_direct_codex_command(normalized):
+        return (
+            True,
+            "direct Codex execution outside Hermes Kanban/Codex phase wrapper",
+        )
     for pattern_re, description in HARDLINE_PATTERNS_COMPILED:
         if pattern_re.search(normalized):
             return (True, description)


### PR DESCRIPTION
## Summary
- routes repository code intake into Kanban with `prd-phased-codex` and Telegram subscriptions
- wires Kanban assignees for Codex phase execution and Claude CLI execution
- improves Kanban observability with rich Telegram done/blocked messages, inline action buttons, artifacts, and code-change flow graph metadata
- adds dashboard assignee health, safer ready transitions, and focused wiring tests

## Validation
- `python3 -m py_compile hermes_cli/kanban_db.py gateway/run.py gateway/platforms/telegram.py run_agent.py plugins/kanban/dashboard/plugin_api.py hermes_cli/orchestration_observer.py`
- `bash -n scripts/hermes-claude-kanban`
- `/home/ubuntu/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py tests/orchestration/test_codex_phase_wiring.py tests/run_agent/test_repo_code_intake_router.py tests/tools/test_approval.py tests/tools/test_kanban_tools.py tests/gateway/test_telegram_approval_buttons.py -q`

Result: 415 passed, 4 warnings.
