### PR TITLE
fix(cli): preserve setup config picker writes

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -809,13 +809,12 @@ def setup_model_provider(config: dict, *, quick: bool = False):
     # Re-sync the wizard's config dict from what cmd_model saved to disk.
     # This is critical: cmd_model writes to disk via its own load/save cycle,
     # and the wizard's final save_config(config) must not overwrite those
-    # changes with stale values (#4172).
+    # changes with stale values (#4172). Refresh the dict in place so callers
+    # that keep the same object see every section the shared model picker may
+    # have changed (model, custom_providers, auxiliary, provider metadata, etc.).
     _refreshed = load_config()
-    config["model"] = _refreshed.get("model", config.get("model"))
-    if "custom_providers" in _refreshed:
-        config["custom_providers"] = _refreshed["custom_providers"]
-    else:
-        config.pop("custom_providers", None)
+    config.clear()
+    config.update(_refreshed)
 
     # Derive the selected provider for downstream steps (vision setup).
     selected_provider = None

--- a/tests/hermes_cli/test_setup_model_provider.py
+++ b/tests/hermes_cli/test_setup_model_provider.py
@@ -63,6 +63,38 @@ def _write_model_config(provider, base_url="", model_name="test-model"):
     save_config(cfg)
 
 
+def _write_aux_config(task="compression", provider="gemini", model_name="gemini-2.5-flash"):
+    """Simulate the aux picker writing a task override to disk."""
+    cfg = load_config()
+    aux = cfg.setdefault("auxiliary", {})
+    entry = aux.setdefault(task, {})
+    entry["provider"] = provider
+    entry["model"] = model_name
+    save_config(cfg)
+
+
+def test_setup_model_provider_preserves_auxiliary_choices_written_by_picker(tmp_path, monkeypatch):
+    """Aux choices made inside hermes setup must survive the wizard's final save."""
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    _clear_provider_env(monkeypatch)
+
+    config = load_config()
+    assert config["auxiliary"]["compression"]["provider"] == "auto"
+
+    def fake_select():
+        _write_aux_config("compression", "gemini", "gemini-2.5-flash")
+
+    monkeypatch.setattr("hermes_cli.main.select_provider_and_model", fake_select)
+
+    setup_model_provider(config, quick=True)
+    save_config(config)  # mirrors run_setup_wizard(section="model") final save
+
+    reloaded = load_config()
+    compression = reloaded["auxiliary"]["compression"]
+    assert compression["provider"] == "gemini"
+    assert compression["model"] == "gemini-2.5-flash"
+
+
 def test_setup_keep_current_custom_from_config_does_not_fall_through(tmp_path, monkeypatch):
     """Keep-current custom should not fall through to the generic model menu."""
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))


### PR DESCRIPTION
## What does this PR do?

Fixes a stale-config overwrite in `hermes setup`.

`setup_model_provider()` delegates to the shared model/provider picker. That picker writes to `config.yaml` using its own `load_config()` / `save_config()` cycle. The setup wizard then continues with the older in-memory `config` object and performs a final save when it exits.

The existing mitigation only copied back selected keys (`model`, `custom_providers`). This PR reloads the saved config and refreshes the caller's dict in place, so any section changed by the shared picker is preserved, including auxiliary task choices.

## Related Issue

Fixes #22073

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/setup.py`
  - After the shared picker returns, reload `config.yaml` and refresh the setup wizard's config dict in place with `clear()` + `update()`.
  - This preserves object identity while avoiding a fragile whitelist of config keys.
- `tests/hermes_cli/test_setup_model_provider.py`
  - Adds a regression test showing auxiliary choices written by the delegated picker survive the setup wizard's final save.

## How to Test

1. Start with default config where `auxiliary.compression.provider` is `auto`.
2. Simulate the shared picker writing `auxiliary.compression.provider = gemini` and `model = gemini-2.5-flash` to disk.
3. Return to `setup_model_provider()` and run the setup wizard's final save.
4. Verify the auxiliary override is still present after reloading config.

Test command run locally:

```bash
TZ=UTC LANG=C.UTF-8 LC_ALL=C.UTF-8 PYTHONHASHSEED=0 \
python -m pytest -o addopts= -n 4 \
  --ignore=tests/integration \
  --ignore=tests/e2e \
  -m 'not integration' \
  tests/hermes_cli/test_setup_model_provider.py
```

Result:

```text
15 passed in 2.64s
```

Note: I first attempted the repo-preferred wrapper:

```bash
scripts/run_tests.sh tests/hermes_cli/test_setup_model_provider.py
```

but this checkout's local `venv` is missing `pip`, so the wrapper failed while trying to install `pytest-split`:

```text
/home/alex/.hermes/hermes-agent/venv/bin/python: No module named pip
```

The direct pytest command above mirrors the wrapper's relevant hermetic settings and 4-worker xdist run for this focused test file.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation and Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

```text
============================= test session starts ==============================
platform linux -- Python 3.11.15, pytest-9.0.3, pluggy-1.6.0
created: 4/4 workers
4 workers [15 items]

...............                                                          [100%]
============================== 15 passed in 2.64s ==============================
```
