### PR TITLE
fix(skills): exclude .archive/.git/.github/.hub from _find_skill rglob (supersedes #18902)

### DIFF
--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -283,11 +283,13 @@ def _find_skill(name: str) -> Optional[Dict[str, Any]]:
     external dirs configured via skills.external_dirs.  Returns
     {"path": Path} or None.
     """
-    from agent.skill_utils import get_all_skills_dirs
+    from agent.skill_utils import get_all_skills_dirs, EXCLUDED_SKILL_DIRS
     for skills_dir in get_all_skills_dirs():
         if not skills_dir.exists():
             continue
         for skill_md in skills_dir.rglob("SKILL.md"):
+            if any(part in EXCLUDED_SKILL_DIRS for part in skill_md.parent.parts):
+                continue
             if skill_md.parent.name == name:
                 return {"path": skill_md.parent}
     return None


### PR DESCRIPTION
This PR resolves the merge conflicts on #18902 and supersedes it.

**What changed:**
- The `_find_skill` function in `tools/skill_manager_tool.py` now excludes `.archive`, `.git`, `.github`, and `.hub` directories from its `rglob("SKILL.md")` search.
- This prevents the `skill_manage` tool from accidentally mutating archived or VCS copies of skills.

**Conflict resolution:**
- Trivial import-order conflict: kept the PR's order (`get_all_skills_dirs, EXCLUDED_SKILL_DIRS`).
- Semantics conflict: `skill_md.parts` (entire path) vs `skill_md.parent.parts` (directory path only). Kept the PR's `parent.parts` — it's more correct because `skill_md` is a file path; we only want to check directory segments, not the filename itself.

**Supersedes #18902.**
