### PR TITLE
fix(profiles): pass encoding=utf-8 to distribution.yaml open

### DIFF
--- a/hermes_cli/profiles.py
+++ b/hermes_cli/profiles.py
@@ -375,7 +375,7 @@ def _read_distribution_meta(profile_dir: Path) -> tuple:
         return None, None, None
     try:
         import yaml
-        with open(mf_path, "r") as f:
+        with open(mf_path, "r", encoding="utf-8") as f:
             data = yaml.safe_load(f) or {}
         if not isinstance(data, dict):
             return None, None, None


### PR DESCRIPTION
## Summary
Single-line fix: `_distribution_metadata()` in hermes_cli/profiles.py opens the profile's distribution.yaml without an explicit encoding. Matches the sibling `_read_config_model()` site which already passes `encoding='utf-8'`.

## Why now
PR #21561 (native Windows support) adds a blocking `ruff check .` step that enforces PLW1514 (unspecified-encoding). That's what surfaced this one remaining violation — but the bug is pre-existing on main: without the encoding argument, reading a distribution.yaml that contains non-ASCII on Windows gets mojibake via cp1252/mbcs.

## Changes
- `hermes_cli/profiles.py` — one line, `open(mf_path, "r")` → `open(mf_path, "r", encoding="utf-8")`.

## Validation
- `ruff check hermes_cli/profiles.py` — clean.
- Unblocks the `ruff enforcement (blocking)` and `Windows footguns (blocking)` jobs on PR #21561.