### PR TITLE
fix(discord): add typing indicator toggle

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -824,6 +824,8 @@ def load_gateway_config() -> GatewayConfig:
                     os.environ["DISCORD_AUTO_THREAD"] = str(discord_cfg["auto_thread"]).lower()
                 if "reactions" in discord_cfg and not os.getenv("DISCORD_REACTIONS"):
                     os.environ["DISCORD_REACTIONS"] = str(discord_cfg["reactions"]).lower()
+                if "typing" in discord_cfg and not os.getenv("DISCORD_TYPING"):
+                    os.environ["DISCORD_TYPING"] = str(discord_cfg["typing"]).lower()
                 # ignored_channels: channels where bot never responds (even when mentioned)
                 ic = discord_cfg.get("ignored_channels")
                 if ic is not None and not os.getenv("DISCORD_IGNORED_CHANNELS"):

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -2368,6 +2368,8 @@ class DiscordAdapter(BasePlatformAdapter):
         8 seconds (typing indicator lasts ~10s).  The loop is cancelled when
         stop_typing() is called (after the response is sent).
         """
+        if os.getenv("DISCORD_TYPING", "true").lower() in ("false", "0", "no"):
+            return
         if not self._client:
             return
         # Don't start a duplicate loop

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1107,6 +1107,7 @@ DEFAULT_CONFIG = {
         "allowed_channels": "",        # If set, bot ONLY responds in these channel IDs (whitelist)
         "auto_thread": True,           # Auto-create threads on @mention in channels (like Slack)
         "reactions": True,             # Add 👀/✅/❌ reactions to messages during processing
+        "typing": True,                # Show Discord typing indicators while processing
         "channel_prompts": {},         # Per-channel ephemeral system prompts (forum parents apply to child threads)
         # discord / discord_admin tools: restrict which actions the agent may call.
         # Default (empty) = all actions allowed (subject to bot privileged intents).

--- a/tests/e2e/test_discord_typing_config.py
+++ b/tests/e2e/test_discord_typing_config.py
@@ -1,0 +1,44 @@
+"""Discord typing indicator configuration tests."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gateway.config import PlatformConfig
+from gateway.platforms.discord import DiscordAdapter
+from gateway.platforms.helpers import ThreadParticipationTracker
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture()
+def adapter():
+    config = PlatformConfig(enabled=True, token="e2e-test-token")
+    with patch.object(ThreadParticipationTracker, "_load", return_value=set()):
+        adapter = DiscordAdapter(config)
+    adapter._client = SimpleNamespace(http=SimpleNamespace(request=AsyncMock()))
+    return adapter
+
+
+async def test_discord_typing_disabled_by_env(adapter, monkeypatch):
+    """DISCORD_TYPING=false suppresses Discord typing REST calls."""
+    monkeypatch.setenv("DISCORD_TYPING", "false")
+
+    await adapter.send_typing("12345")
+    await asyncio.sleep(0)
+
+    adapter._client.http.request.assert_not_awaited()
+    assert adapter._typing_tasks == {}
+
+
+async def test_discord_typing_enabled_by_default(adapter, monkeypatch):
+    """Typing remains enabled unless DISCORD_TYPING is explicitly false/0/no."""
+    monkeypatch.delenv("DISCORD_TYPING", raising=False)
+
+    await adapter.send_typing("12345")
+    await asyncio.sleep(0)
+
+    adapter._client.http.request.assert_awaited_once()
+    await adapter.stop_typing("12345")

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -779,6 +779,29 @@ def test_discord_auto_thread_config_bridge(monkeypatch, tmp_path):
     assert os.getenv("DISCORD_AUTO_THREAD") == "true"
 
 
+def test_discord_typing_config_bridge(monkeypatch, tmp_path):
+    """discord.typing in config.yaml should be bridged to DISCORD_TYPING env var."""
+    import yaml
+    from pathlib import Path
+
+    hermes_dir = tmp_path / ".hermes"
+    hermes_dir.mkdir()
+    config_path = hermes_dir / "config.yaml"
+    config_path.write_text(yaml.dump({
+        "discord": {"typing": False},
+    }))
+
+    monkeypatch.delenv("DISCORD_TYPING", raising=False)
+    monkeypatch.setenv("HERMES_HOME", str(hermes_dir))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+
+    from gateway.config import load_gateway_config
+    load_gateway_config()
+
+    import os
+    assert os.getenv("DISCORD_TYPING") == "false"
+
+
 # ------------------------------------------------------------------
 # /skill command registration (flat + autocomplete)
 # ------------------------------------------------------------------

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -102,6 +102,7 @@ def _build_provider_env_blocklist() -> frozenset:
         "DISCORD_REQUIRE_MENTION",
         "DISCORD_FREE_RESPONSE_CHANNELS",
         "DISCORD_AUTO_THREAD",
+        "DISCORD_TYPING",
         "SLACK_HOME_CHANNEL",
         "SLACK_HOME_CHANNEL_NAME",
         "SLACK_ALLOWED_USERS",


### PR DESCRIPTION
## Summary
- add a `DISCORD_TYPING` environment toggle for Discord typing indicators
- bridge `discord.typing` from `config.yaml` to `DISCORD_TYPING`, matching the existing `auto_thread` / `reactions` pattern
- add tests for disabling typing via env and for the config-to-env bridge

## Intent / context
Discord typing indicators are cosmetic, but they hit the Discord REST route:

`POST /channels/{channel_id}/typing`

In live gateway usage, repeated typing refreshes during long-running agent responses can contribute to Discord 429/resource-rate-limit behavior, especially when combined with auto-thread creation and reaction add/remove calls. Once Discord starts returning 429s, retries/reconnects can make the bot appear silent or unstable even though message handling itself is fine.

This change lets operators disable only the typing indicator traffic while keeping Discord message replies working normally:

```env
DISCORD_TYPING=false
```

or:

```yaml
discord:
  typing: false
```

The default remains unchanged: typing indicators stay enabled unless explicitly disabled with `false`, `0`, or `no`.

## Test plan
- `python -m pytest tests/e2e/test_discord_typing_config.py tests/gateway/test_discord_slash_commands.py::test_discord_typing_config_bridge -q -o 'addopts='`
