### PR TITLE
feat(matrix): self-sign device after cross-signing verification

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -746,6 +746,34 @@ class MatrixAdapter(BasePlatformAdapter):
                     try:
                         await olm.verify_with_recovery_key(recovery_key)
                         logger.info("Matrix: cross-signing verified via recovery key")
+
+                        # Attempt to self-sign our own device with the recovered SSK.
+                        # This is required for Element to show the green shield
+                        # (device cross-signed by owner).
+                        try:
+                            if client.device_id:
+                                own_device = await olm.get_or_fetch_device(
+                                    client.mxid, client.device_id
+                                )
+                                if own_device:
+                                    await olm.sign_own_device(own_device)
+                                    logger.info(
+                                        "Matrix: successfully self-signed device %s with cross-signing key",
+                                        client.device_id,
+                                    )
+                                else:
+                                    logger.warning(
+                                        "Matrix: could not retrieve own device identity for self-signing"
+                                    )
+                            else:
+                                logger.warning(
+                                    "Matrix: no device_id set, cannot self-sign device"
+                                )
+                        except Exception as exc:
+                            logger.warning(
+                                "Matrix: self-signing device with cross-signing key failed: %s",
+                                exc,
+                            )
                     except Exception as exc:
                         logger.warning(
                             "Matrix: recovery key verification failed: %s", exc


### PR DESCRIPTION
## Summary

This PR adds **device self-signing** immediately after cross-signing verification succeeds in the Matrix gateway.

### Problem

After a device-key rotation (fresh crypto.db, `share_keys` re-upload), the bot's device no longer has a valid self-signing signature from its own cross-signing identity. Even though `verify_with_recovery_key()` restores the self-signing key (SSK), Element clients show:

> "Encrypted by a device not verified by its owner"

This happens because the device itself was never signed with the recovered SSK. Peers therefore refuse to share Megolm sessions with the bot, breaking E2EE message reception.

### Solution

After successful recovery-key verification, attempt to:

1. Fetch the bot's own device identity (`olm.get_or_fetch_device(mxid, device_id)`)
2. Sign it with the recovered SSK (`olm.sign_own_device(device)`)
3. Log the outcome

This produces the green verification shield in Element and satisfies the cross-signing trust chain.

### Changes

- ~28 lines inserted inside the existing recovery-key verification block in `connect()`
- Nested `try/except` so self-signing failure is **non-fatal** and never propagates to the outer verification block
- Four defensive log levels:
  - `INFO` — successful self-signing
  - `WARNING` — missing `device_id`
  - `WARNING` — `get_or_fetch_device` returned `None`
  - `WARNING` — `sign_own_device` raised an exception

### Backwards Compatibility

- No new configuration or env vars
- If `MATRIX_RECOVERY_KEY` is not set, this code path is never reached
- If self-signing fails, the bot continues with degraded E2EE (same as before this PR)

### Testing

- Verified green shield appears in Element after fresh crypto.db + recovery key
- Verified bot continues to connect when `get_or_fetch_device` returns `None`
- Verified no exception propagates when `sign_own_device` raises

### Dependencies

Relies on mautrix-olm methods:
- `olm.get_or_fetch_device(mxid, device_id)`
- `olm.sign_own_device(device)`

Both are available in mautrix >= 0.20.0.
