### PR TITLE
refactor(matrix): remove delayed reaction redaction scheduling

### DIFF
--- a/gateway/platforms/matrix.py
+++ b/gateway/platforms/matrix.py
@@ -384,12 +384,6 @@ class MatrixAdapter(BasePlatformAdapter):
             "MATRIX_REACTIONS", "true"
         ).lower() not in ("false", "0", "no")
         self._pending_reactions: dict[tuple[str, str], str] = {}
-        # Delay before redacting reactions so Matrix homeservers have time to
-        # deliver the final message event without tripping "missing event"
-        # errors in some clients.  5s is empirically safe; not user-tunable —
-        # if that changes, add a config.yaml entry rather than an env var.
-        self._reaction_redaction_delay_seconds = 5.0
-        self._reaction_redaction_tasks: Set[asyncio.Task] = set()
 
         # Proxy support — resolve once at init, reuse for all HTTP traffic.
         self._proxy_url: str | None = resolve_proxy_url(platform_env_var="MATRIX_PROXY")
@@ -876,14 +870,6 @@ class MatrixAdapter(BasePlatformAdapter):
                 await self._sync_task
             except (asyncio.CancelledError, Exception):
                 pass
-
-        redaction_tasks = list(self._reaction_redaction_tasks)
-        for task in redaction_tasks:
-            if not task.done():
-                task.cancel()
-        if redaction_tasks:
-            await asyncio.gather(*redaction_tasks, return_exceptions=True)
-        self._reaction_redaction_tasks.clear()
 
         # Close the SQLite crypto store database.
         if hasattr(self, "_crypto_db") and self._crypto_db:
@@ -1975,35 +1961,6 @@ class MatrixAdapter(BasePlatformAdapter):
         """Remove a reaction by redacting its event."""
         return await self.redact_message(room_id, reaction_event_id, reason)
 
-    def _schedule_reaction_redaction(
-        self,
-        room_id: str,
-        reaction_event_id: str,
-        reason: str = "",
-    ) -> None:
-        """Redact a reaction after a short delay so message delivery settles."""
-
-        async def _redact_later() -> None:
-            try:
-                if self._reaction_redaction_delay_seconds:
-                    await asyncio.sleep(self._reaction_redaction_delay_seconds)
-                if not await self._redact_reaction(room_id, reaction_event_id, reason):
-                    logger.debug(
-                        "Matrix: failed to redact reaction %s", reaction_event_id
-                    )
-            except asyncio.CancelledError:
-                raise
-            except Exception as exc:
-                logger.debug(
-                    "Matrix: delayed reaction redaction failed for %s: %s",
-                    reaction_event_id,
-                    exc,
-                )
-
-        task = asyncio.create_task(_redact_later())
-        self._reaction_redaction_tasks.add(task)
-        task.add_done_callback(self._reaction_redaction_tasks.discard)
-
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Add eyes reaction when the agent starts processing a message."""
         if not self._reactions_enabled:
@@ -2032,11 +1989,8 @@ class MatrixAdapter(BasePlatformAdapter):
         reaction_key = (room_id, msg_id)
         if reaction_key in self._pending_reactions:
             eyes_event_id = self._pending_reactions.pop(reaction_key)
-            self._schedule_reaction_redaction(
-                room_id,
-                eyes_event_id,
-                "processing complete",
-            )
+            if not await self._redact_reaction(room_id, eyes_event_id):
+                logger.debug("Matrix: failed to redact eyes reaction %s", eyes_event_id)
         await self._send_reaction(
             room_id,
             msg_id,
@@ -2115,8 +2069,11 @@ class MatrixAdapter(BasePlatformAdapter):
     ) -> None:
         """Redact the bot's seed ✅/❎ reactions, leaving only the user's reaction."""
         for emoji, evt_id in prompt.bot_reaction_events.items():
-            self._schedule_reaction_redaction(room_id, evt_id, "approval resolved")
-            logger.debug("Matrix: scheduled bot reaction redaction %s (%s)", emoji, evt_id)
+            try:
+                await self.redact_message(room_id, evt_id, "approval resolved")
+                logger.debug("Matrix: redacted bot reaction %s (%s)", emoji, evt_id)
+            except Exception as exc:
+                logger.debug("Matrix: failed to redact bot reaction %s: %s", emoji, exc)
 
     # ------------------------------------------------------------------
     # Text message aggregation (handles Matrix client-side splits)


### PR DESCRIPTION
## Summary

This PR removes the **delayed async reaction redaction** logic from the Matrix gateway and replaces it with immediate redaction.

### Problem

The Matrix adapter scheduled a background `asyncio.Task` for every reaction redaction, sleeping for 5 seconds first. This was intended to give homeservers time to deliver the final message event before the reaction disappeared, avoiding "missing event" errors in some clients.

In practice, the delay caused several issues:
- **Task leaks**: if the bot disconnected while tasks were pending, cancellation was best-effort
- **Stale reactions**: under load, multiple 5-second delays meant checkmark/cross reactions appeared alongside the old eyes reaction
- **Unnecessary complexity**: a non-configurable constant, a task set, and cancellation logic for a client-side edge case

### Solution

Redact reactions **immediately** via direct `await`:
- `on_processing_complete()` → `_redact_reaction()` directly
- `_redact_bot_approval_reactions()` → `redact_message()` directly

Both call sites log at `debug` level on failure, so errors are visible but non-fatal.

### Removed

- `_schedule_reaction_redaction()` method
- `_reaction_redaction_delay_seconds` constant
- `_reaction_redaction_tasks: Set[asyncio.Task]`
- Task cancellation loop in `disconnect()`
- Stale comment about the delay rationale

### Backwards Compatibility

- No configuration changes
- No API changes
- Behavior change: reactions disappear immediately instead of after ~5s — this is arguably the expected UX

### Testing

- Verified eyes reaction is replaced by checkmark/cross without lingering
- Verified approval reactions are cleaned up immediately after resolution
- Verified no exceptions propagate when redaction fails
