### PR TITLE
fix(entry-points): guard hermes_bootstrap import so partial updates don't brick hermes

### DIFF
--- a/acp_adapter/entry.py
+++ b/acp_adapter/entry.py
@@ -15,7 +15,14 @@ Usage::
 
 # IMPORTANT: hermes_bootstrap must be the very first import — UTF-8 stdio
 # on Windows.  No-op on POSIX.  See hermes_bootstrap.py for full rationale.
-import hermes_bootstrap  # noqa: F401
+try:
+    import hermes_bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    # Graceful fallback when hermes_bootstrap isn't registered in the venv
+    # yet — happens during partial ``hermes update`` where git-reset landed
+    # new code but ``uv pip install -e .`` didn't finish.  Missing bootstrap
+    # means UTF-8 stdio setup is skipped on Windows; POSIX is unaffected.
+    pass
 
 import asyncio
 import logging

--- a/batch_runner.py
+++ b/batch_runner.py
@@ -22,7 +22,14 @@ Usage:
 
 # IMPORTANT: hermes_bootstrap must be the very first import — UTF-8 stdio
 # on Windows.  No-op on POSIX.  See hermes_bootstrap.py for full rationale.
-import hermes_bootstrap  # noqa: F401
+try:
+    import hermes_bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    # Graceful fallback when hermes_bootstrap isn't registered in the venv
+    # yet — happens during partial ``hermes update`` where git-reset landed
+    # new code but ``uv pip install -e .`` didn't finish.  Missing bootstrap
+    # means UTF-8 stdio setup is skipped on Windows; POSIX is unaffected.
+    pass
 
 import json
 import logging

--- a/cli.py
+++ b/cli.py
@@ -14,7 +14,14 @@ Usage:
 
 # IMPORTANT: hermes_bootstrap must be the very first import — UTF-8 stdio
 # on Windows.  No-op on POSIX.  See hermes_bootstrap.py for full rationale.
-import hermes_bootstrap  # noqa: F401
+try:
+    import hermes_bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    # Graceful fallback when hermes_bootstrap isn't registered in the venv
+    # yet — happens during partial ``hermes update`` where git-reset landed
+    # new code but ``uv pip install -e .`` didn't finish.  Missing bootstrap
+    # means UTF-8 stdio setup is skipped on Windows; POSIX is unaffected.
+    pass
 
 import logging
 import os

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15,7 +15,14 @@ Usage:
 
 # IMPORTANT: hermes_bootstrap must be the very first import — UTF-8 stdio
 # on Windows.  No-op on POSIX.  See hermes_bootstrap.py for full rationale.
-import hermes_bootstrap  # noqa: F401
+try:
+    import hermes_bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    # Graceful fallback when hermes_bootstrap isn't registered in the venv
+    # yet — happens during partial ``hermes update`` where git-reset landed
+    # new code but ``uv pip install -e .`` didn't finish.  Missing bootstrap
+    # means UTF-8 stdio setup is skipped on Windows; POSIX is unaffected.
+    pass
 
 import asyncio
 import dataclasses

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -46,7 +46,20 @@ Usage:
 # IMPORTANT: hermes_bootstrap must be the very first import — it sets up
 # UTF-8 stdio on Windows so print()/subprocess children don't hit
 # UnicodeEncodeError with non-ASCII characters.  No-op on POSIX.
-import hermes_bootstrap  # noqa: F401
+#
+# Guarded against ModuleNotFoundError because ``hermes_bootstrap`` is a
+# top-level module registered via pyproject.toml's ``py-modules`` list.
+# When the user upgrades code via ``git pull`` (or ``hermes update``
+# crashes between ``git reset --hard`` and ``uv pip install -e .``), the
+# new code references ``hermes_bootstrap`` but the editable install's
+# ``.pth`` file still points at the old set of top-level modules.  Without
+# this guard, hermes crashes on import and the user can't run
+# ``hermes update`` to recover.  Missing the bootstrap means UTF-8 stdio
+# setup is skipped on Windows — degraded, not broken.  POSIX is unaffected.
+try:
+    import hermes_bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    pass
 
 import argparse
 import json

--- a/run_agent.py
+++ b/run_agent.py
@@ -22,7 +22,14 @@ Usage:
 
 # IMPORTANT: hermes_bootstrap must be the very first import — UTF-8 stdio
 # on Windows.  No-op on POSIX.  See hermes_bootstrap.py for full rationale.
-import hermes_bootstrap  # noqa: F401
+try:
+    import hermes_bootstrap  # noqa: F401
+except ModuleNotFoundError:
+    # Graceful fallback when hermes_bootstrap isn't registered in the venv
+    # yet — happens during partial ``hermes update`` where git-reset landed
+    # new code but ``uv pip install -e .`` didn't finish.  Missing bootstrap
+    # means UTF-8 stdio setup is skipped on Windows; POSIX is unaffected.
+    pass
 
 import asyncio
 import base64

--- a/tests/test_hermes_bootstrap.py
+++ b/tests/test_hermes_bootstrap.py
@@ -257,6 +257,15 @@ class TestEntryPointsImportBootstrap:
         We're lenient about the docstring (can be arbitrarily long) and
         about comment lines — just need to verify the first import
         statement is the bootstrap.
+
+        Also lenient about a try/except wrapper around the import: entry
+        points may guard the import against ``ModuleNotFoundError`` so a
+        half-finished ``hermes update`` (git-reset landed new code but
+        ``uv pip install -e .`` didn't finish re-registering
+        ``hermes_bootstrap`` as a top-level module) leaves hermes
+        recoverable instead of crashing on every invocation.  When the
+        first top-level node is such a guarded-import block, we peek
+        inside it to verify bootstrap is the imported module.
         """
         # Resolve relative to the hermes-agent repo root.  Tests live
         # at tests/test_hermes_bootstrap.py, so go up one dir.
@@ -269,8 +278,7 @@ class TestEntryPointsImportBootstrap:
         source = full_path.read_text(encoding="utf-8")
 
         # Find the first non-comment, non-blank line that starts with
-        # 'import ' or 'from '.  It must be 'import hermes_bootstrap'.
-        import tokenize
+        # 'import ' or 'from ', or a Try block whose body is the import.
         import ast
         tree = ast.parse(source)
 
@@ -278,6 +286,15 @@ class TestEntryPointsImportBootstrap:
         for node in ast.iter_child_nodes(tree):
             if isinstance(node, (ast.Import, ast.ImportFrom)):
                 first_import_node = node
+                break
+            # Accept a guarded-import Try block where the body is a lone
+            # Import node — this is the recovery-friendly form that lets
+            # hermes start even when hermes_bootstrap hasn't been
+            # re-registered in the venv yet.
+            if isinstance(node, ast.Try) and len(node.body) == 1 and isinstance(
+                node.body[0], (ast.Import, ast.ImportFrom)
+            ):
+                first_import_node = node.body[0]
                 break
 
         assert first_import_node is not None, (


### PR DESCRIPTION
## Summary
Guards `import hermes_bootstrap` in all 6 entry points so a partial update can't brick hermes. Cherry-picked from PR #21561 since it's independently useful.

## The bug

`hermes_bootstrap` is a top-level module registered via `pyproject.toml`'s `py-modules` list (Brooklyn's Windows UTF-8 stdio work).  It must be in the venv's editable-install `.pth` file before Python can find it as a bare `import hermes_bootstrap`.

`hermes update` handles this correctly:
1. `git reset --hard` (code now references `hermes_bootstrap`)
2. clear `__pycache__`
3. `uv pip install -e .` (re-registers the package including the new `py-modules` list)
4. restart

**If any step AFTER (1) fails** — network blip during pip install, PEP 668 on a system Python, venv locked, uv not in PATH, crash mid-update — the user is left with new code that references `hermes_bootstrap` and a venv that doesn't know about it.  Every hermes invocation after that crashes with `ModuleNotFoundError: No module named 'hermes_bootstrap'`, **including `hermes update` itself**.  No recovery path without manually running `uv pip install -e .`.

Also affects developers who `git pull` directly without running `hermes update`.

**Hit in the wild:** teknium1 hit this on both his Windows box and his Linux workstation within 24 hours.

## The fix

Wrap `import hermes_bootstrap` in `try/except ModuleNotFoundError` across all 6 entry points: `hermes_cli/main.py`, `run_agent.py`, `gateway/run.py`, `acp_adapter/entry.py`, `cli.py`, `batch_runner.py`.

On Windows, missing the bootstrap means the UTF-8 stdio setup doesn't run — Unicode chars may fail to print, but hermes doesn't crash.  POSIX is completely unaffected (the bootstrap is a no-op there anyway).

Once hermes is running again, the user can `hermes update` (or `uv pip install -e .`) to fully recover.

## Test update

`tests/test_hermes_bootstrap.py::test_entry_point_imports_bootstrap` walks the AST of each entry point to assert that `hermes_bootstrap` is the first top-level import.  Extended the check to also accept a `Try` block whose body is a lone `Import hermes_bootstrap` — the recovery-friendly form we just introduced.

## Verification

- 12/12 `test_hermes_bootstrap.py` tests pass on Linux (5 Windows-only tests skip).
- Manually verified by `mv hermes_bootstrap.py hermes_bootstrap.py.bak` and confirming `python -c "import hermes_cli.main"` now succeeds instead of crashing.

## Origin

This is commit 81f5faf1e from #21561.  Lifted into a standalone PR so users can get the robustness fix without waiting for the full Windows-support PR to land.  No conflict on merge — 4 files auto-merged, no manual resolution needed.
