### PR TITLE
fix(delegate-task): recover batch tasks from JSON-encoded string coer…

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -550,6 +550,16 @@ def coerce_tool_args(tool_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
                     # nullable "null" → None).
                     args[key] = coerced
                     continue
+                # If the string looks like a JSON array but _coerce_value
+                # failed to parse it, warn clearly instead of silently wrapping.
+                if value.strip().startswith("["):
+                    logger.warning(
+                        "coerce_tool_args: %s.%s looks like a JSON array string "
+                        "but could not be parsed — model may have emitted a "
+                        "JSON-encoded string instead of a native array. "
+                        "Falling back to single-element list.",
+                        tool_name, key,
+                    )
                 args[key] = [value]
                 logger.info(
                     "coerce_tool_args: wrapped bare string in list for %s.%s",
@@ -637,7 +647,12 @@ def _coerce_json(value: str, expected_python_type: type):
     """
     try:
         parsed = json.loads(value)
-    except (ValueError, TypeError):
+    except (ValueError, TypeError) as exc:
+        logger.warning(
+            "coerce_tool_args: failed to parse string as JSON for expected type %s: %s",
+            expected_python_type.__name__,
+            exc,
+        )
         return value
     if isinstance(parsed, expected_python_type):
         logger.debug(
@@ -645,6 +660,11 @@ def _coerce_json(value: str, expected_python_type: type):
             expected_python_type.__name__,
         )
         return parsed
+    logger.warning(
+        "coerce_tool_args: JSON-parsed value is %s, expected %s — skipping coercion",
+        type(parsed).__name__,
+        expected_python_type.__name__,
+    )
     return value
 
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1951,6 +1951,38 @@ def delegate_task(
 
     # Normalize to task list
     max_children = _get_max_concurrent_children()
+    # Post-coercion recovery: if coerce_tool_args wrapped a JSON array string
+    # into a single-element list, attempt to unwrap it here so batch delegation
+    # works even when models (e.g. Qwen, DeepSeek, GLM) emit tasks as a
+    # JSON-encoded string instead of a native array.
+    if (
+        tasks
+        and isinstance(tasks, list)
+        and len(tasks) == 1
+        and isinstance(tasks[0], str)
+    ):
+        import json as _json
+        try:
+            recovered = _json.loads(tasks[0])
+            if isinstance(recovered, list):
+                logger.info(
+                    "delegate_task: recovered %d tasks from JSON-encoded string "
+                    "(model emitted tasks as a JSON string instead of a native array)",
+                    len(recovered),
+                )
+                tasks = recovered
+            else:
+                return tool_error(
+                    f"tasks parameter is a JSON string that parses to "
+                    f"{type(recovered).__name__}, not an array. "
+                    f"The model should emit a native JSON array for batch delegation."
+                )
+        except _json.JSONDecodeError:
+            return tool_error(
+                "tasks parameter appears to be a malformed JSON string. "
+                "Ensure the model emits a native JSON array for batch delegation."
+            )
+
     if tasks and isinstance(tasks, list):
         if len(tasks) > max_children:
             return tool_error(


### PR DESCRIPTION
## What does this PR do?

Fixes silent batch delegation failures when open-weight models (Qwen, DeepSeek, GLM) emit the `tasks` array as a JSON-encoded string instead of a native array.

When this happens, `coerce_tool_args` silently wraps the string into a single-element list `["[{...}]"]`. The `delegate_task` function then receives a list containing one string, passes the `isinstance(tasks, list)` check, and crashes on `task.get("goal")` — or falls through to the unhelpful `"Provide either 'goal' or 'tasks'"` error.

**Three-layer fix:**
- `_coerce_json`: now logs a `WARNING` when JSON parsing fails or yields the wrong type, instead of returning the original string silently
- `coerce_tool_args`: detects strings that look like JSON arrays (start with `[`) before wrapping, and emits a clear warning to aid debugging
- `delegate_task`: adds post-coercion recovery — if `tasks` arrives as a single-element list containing a JSON string, attempt to parse and unwrap it before validation, restoring batch mode for affected models

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## References
Fixes #21933

## Checklist
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] My PR contains **only** changes related to this fix