### PR TITLE
fix: preserve vision auto fallback after provider resolution

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3643,6 +3643,7 @@ def call_llm(
     """
     resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
         task, provider, model, base_url, api_key)
+    original_provider_mode = resolved_provider
     effective_extra_body = _get_task_extra_body(task)
     effective_extra_body.update(extra_body or {})
 
@@ -3879,8 +3880,13 @@ def call_llm(
         )
         # Only try alternative providers when the user didn't explicitly
         # configure this task's provider.  Explicit provider = hard constraint;
-        # auto (the default) = best-effort fallback chain.  (#7559)
-        is_auto = resolved_provider in ("auto", "", None)
+        # auto (the default) = best-effort fallback chain.  For vision calls we
+        # must key this off the ORIGINAL requested mode, not the resolved backend:
+        # resolve_vision_provider_client(auto) returns a concrete provider label
+        # like openrouter/nous/main-provider, and overwriting resolved_provider
+        # with that concrete winner previously disabled the fallback chain after
+        # 429 usage_limit_reached errors (#EMT-152).
+        is_auto = (original_provider_mode if task == "vision" else resolved_provider) in ("auto", "", None)
         if should_fallback and is_auto:
             if _is_payment_error(first_err):
                 reason = "payment error"
@@ -3980,6 +3986,7 @@ async def async_call_llm(
     """
     resolved_provider, resolved_model, resolved_base_url, resolved_api_key, resolved_api_mode = _resolve_task_provider_model(
         task, provider, model, base_url, api_key)
+    original_provider_mode = resolved_provider
     effective_extra_body = _get_task_extra_body(task)
     effective_extra_body.update(extra_body or {})
 
@@ -4175,7 +4182,7 @@ async def async_call_llm(
             or _is_connection_error(first_err)
             or _is_rate_limit_error(first_err)
         )
-        is_auto = resolved_provider in ("auto", "", None)
+        is_auto = (original_provider_mode if task == "vision" else resolved_provider) in ("auto", "", None)
         if should_fallback and is_auto:
             if _is_payment_error(first_err):
                 reason = "payment error"

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -992,6 +992,82 @@ class TestCallLlmPaymentFallback:
         # Fallback client should have been used
         assert fallback_client.chat.completions.create.called
 
+
+    def test_vision_auto_429_triggers_fallback_even_after_provider_resolution(self):
+        """Vision auto-routing should still fallback after resolve_vision_provider_client picks a concrete backend."""
+        primary_client = MagicMock()
+        rate_err = self._make_429_rate_limit_error("HTTP 429: The usage limit has been reached")
+        primary_client.chat.completions.create.side_effect = rate_err
+
+        fallback_client = MagicMock()
+        fallback_client.chat.completions.create.return_value = MagicMock(choices=[
+            MagicMock(message=MagicMock(content="vision fallback response"))
+        ])
+
+        with patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("auto", "zai/glm-5v", None, None, None)), \
+             patch("agent.auxiliary_client.resolve_vision_provider_client",
+                   return_value=("openrouter", primary_client, "zai/glm-5v")), \
+             patch("agent.auxiliary_client._try_payment_fallback",
+                   return_value=(fallback_client, "fallback-vision-model", "nous")) as mock_fallback:
+            result = call_llm(
+                task="vision",
+                messages=[{"role": "user", "content": [{"type": "text", "text": "what is in this image?"}]}],
+            )
+
+        assert result.choices[0].message.content == "vision fallback response"
+        mock_fallback.assert_called_once_with("openrouter", "vision", reason="rate limit")
+        assert fallback_client.chat.completions.create.called
+
+    def test_vision_explicit_provider_429_does_not_trigger_fallback(self):
+        """Explicit vision providers remain a hard constraint even after provider resolution picks the same backend."""
+        primary_client = MagicMock()
+        rate_err = self._make_429_rate_limit_error("HTTP 429: The usage limit has been reached")
+        primary_client.chat.completions.create.side_effect = rate_err
+
+        with patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("openrouter", "zai/glm-5v", None, None, None)), \
+             patch("agent.auxiliary_client.resolve_vision_provider_client",
+                   return_value=("openrouter", primary_client, "zai/glm-5v")), \
+             patch("agent.auxiliary_client._try_payment_fallback") as mock_fallback:
+            with pytest.raises(Exception, match="usage limit"):
+                call_llm(
+                    task="vision",
+                    messages=[{"role": "user", "content": [{"type": "text", "text": "what is in this image?"}]}],
+                )
+
+        mock_fallback.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_async_vision_auto_429_triggers_fallback_even_after_provider_resolution(self):
+        """Async vision auto-routing should fallback based on the original auto mode, not the resolved backend label."""
+        primary_client = MagicMock()
+        rate_err = self._make_429_rate_limit_error("HTTP 429: The usage limit has been reached")
+        primary_client.chat.completions.create = AsyncMock(side_effect=rate_err)
+
+        fallback_client = MagicMock()
+        async_fallback_client = MagicMock()
+        async_fallback_client.chat.completions.create = AsyncMock(return_value=MagicMock(choices=[
+            MagicMock(message=MagicMock(content="async vision fallback response"))
+        ]))
+
+        with patch("agent.auxiliary_client._resolve_task_provider_model",
+                   return_value=("auto", "zai/glm-5v", None, None, None)), \
+             patch("agent.auxiliary_client.resolve_vision_provider_client",
+                   return_value=("openrouter", primary_client, "zai/glm-5v")), \
+             patch("agent.auxiliary_client._try_payment_fallback",
+                   return_value=(fallback_client, "fallback-vision-model", "nous")) as mock_fallback, \
+             patch("agent.auxiliary_client._to_async_client",
+                   return_value=(async_fallback_client, "fallback-vision-model")):
+            result = await async_call_llm(
+                task="vision",
+                messages=[{"role": "user", "content": [{"type": "text", "text": "what is in this image?"}]}],
+            )
+
+        assert result.choices[0].message.content == "async vision fallback response"
+        mock_fallback.assert_called_once_with("openrouter", "vision", reason="rate limit")
+        assert async_fallback_client.chat.completions.create.await_count == 1
+
 # ---------------------------------------------------------------------------
 # Gate: _resolve_api_key_provider must skip anthropic when not configured
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- preserve the original requested provider mode for vision calls before provider resolution swaps `auto` to a concrete backend
- keep explicit vision providers as a hard constraint while restoring auto fallback on 429s
- add sync and async regression coverage for vision auto fallback after provider resolution

## Test Plan
- `/home/mark/.hermes/hermes-agent/venv/bin/python -m pytest tests/agent/test_auxiliary_client.py -k 'vision_auto_429_triggers_fallback or vision_explicit_provider_429_does_not_trigger_fallback' -q`
- `/home/mark/.hermes/hermes-agent/venv/bin/python -m pytest tests/agent/test_auxiliary_client.py -q`

Closes EMT-152
