### PR TITLE
fix(setup): offer gateway service install on Windows

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -4717,6 +4717,9 @@ def gateway_setup():
                         systemd_restart()
                     elif is_macos():
                         launchd_restart()
+                    elif is_windows():
+                        from hermes_cli import gateway_windows
+                        gateway_windows.restart()
                     else:
                         stop_profile_gateway()
                         print_info("Start manually: hermes gateway")
@@ -4738,6 +4741,9 @@ def gateway_setup():
                         systemd_start()
                     elif is_macos():
                         launchd_start()
+                    elif is_windows():
+                        from hermes_cli import gateway_windows
+                        gateway_windows.start()
                 except UserSystemdUnavailableError as e:
                     print_error("  Start failed — user systemd not reachable:")
                     for line in str(e).splitlines():
@@ -4749,20 +4755,34 @@ def gateway_setup():
                     print_error(f"  Start failed: {e}")
         else:
             print()
-            if supports_systemd_services() or is_macos():
-                platform_name = "systemd" if supports_systemd_services() else "launchd"
+            if supports_systemd_services() or is_macos() or is_windows():
+                if supports_systemd_services():
+                    platform_name = "systemd"
+                elif is_macos():
+                    platform_name = "launchd"
+                else:
+                    platform_name = "Scheduled Task"
                 wsl_note = " (note: services may not survive WSL restarts)" if is_wsl() else ""
                 if prompt_yes_no(f"  Install the gateway as a {platform_name} service?{wsl_note} (runs in background, starts on boot)", True):
                     try:
                         installed_scope = None
                         did_install = False
+                        started_inline = False
                         if supports_systemd_services():
                             installed_scope, did_install = install_linux_gateway_from_setup(force=False)
-                        else:
+                        elif is_macos():
                             launchd_install(force=False)
                             did_install = True
+                        else:
+                            # gateway_windows.install() registers the Scheduled
+                            # Task AND starts it (schtasks /Run or direct-spawn
+                            # fallback), so no separate start prompt is needed.
+                            from hermes_cli import gateway_windows
+                            gateway_windows.install(force=False)
+                            did_install = True
+                            started_inline = True
                         print()
-                        if did_install and prompt_yes_no("  Start the service now?", True):
+                        if did_install and not started_inline and prompt_yes_no("  Start the service now?", True):
                             try:
                                 if supports_systemd_services():
                                     systemd_start(system=installed_scope == "system")

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2446,6 +2446,7 @@ def setup_gateway(config: dict):
 
         _is_linux = _platform.system() == "Linux"
         _is_macos = _platform.system() == "Darwin"
+        _is_windows = _platform.system() == "Windows"
 
         from hermes_cli.gateway import (
             _is_service_installed,
@@ -2470,7 +2471,7 @@ def setup_gateway(config: dict):
         service_installed = _is_service_installed()
         service_running = _is_service_running()
         supports_systemd = supports_systemd_services()
-        supports_service_manager = supports_systemd or _is_macos
+        supports_service_manager = supports_systemd or _is_macos or _is_windows
 
         print()
         if supports_systemd and has_conflicting_systemd_units():
@@ -2490,6 +2491,9 @@ def setup_gateway(config: dict):
                         systemd_restart()
                     elif _is_macos:
                         launchd_restart()
+                    elif _is_windows:
+                        from hermes_cli import gateway_windows
+                        gateway_windows.restart()
                 except UserSystemdUnavailableError as e:
                     print_error("  Restart failed — user systemd not reachable:")
                     for line in str(e).splitlines():
@@ -2512,6 +2516,9 @@ def setup_gateway(config: dict):
                         systemd_start()
                     elif _is_macos:
                         launchd_start()
+                    elif _is_windows:
+                        from hermes_cli import gateway_windows
+                        gateway_windows.start()
                 except UserSystemdUnavailableError as e:
                     print_error("  Start failed — user systemd not reachable:")
                     for line in str(e).splitlines():
@@ -2522,7 +2529,12 @@ def setup_gateway(config: dict):
                 except Exception as e:
                     print_error(f"  Start failed: {e}")
         elif supports_service_manager:
-            svc_name = "systemd" if supports_systemd else "launchd"
+            if supports_systemd:
+                svc_name = "systemd"
+            elif _is_macos:
+                svc_name = "launchd"
+            else:
+                svc_name = "Scheduled Task"
             if prompt_yes_no(
                 f"  Install the gateway as a {svc_name} service? (runs in background, starts on boot)",
                 True,
@@ -2530,13 +2542,23 @@ def setup_gateway(config: dict):
                 try:
                     installed_scope = None
                     did_install = False
+                    started_inline = False
                     if supports_systemd:
                         installed_scope, did_install = install_linux_gateway_from_setup(force=False)
-                    else:
+                    elif _is_macos:
                         launchd_install(force=False)
                         did_install = True
+                    else:
+                        # gateway_windows.install() registers the Scheduled
+                        # Task AND starts it immediately (via schtasks /Run
+                        # or a direct spawn fallback), so no separate start
+                        # prompt is needed here.
+                        from hermes_cli import gateway_windows
+                        gateway_windows.install(force=False)
+                        did_install = True
+                        started_inline = True
                     print()
-                    if did_install and prompt_yes_no("  Start the service now?", True):
+                    if did_install and not started_inline and prompt_yes_no("  Start the service now?", True):
                         try:
                             if supports_systemd:
                                 systemd_start(system=installed_scope == "system")


### PR DESCRIPTION
## Summary
Windows users now get offered the gateway Scheduled Task install during `hermes setup` and `hermes gateway setup`, matching the systemd/launchd prompts on Linux/macOS. Previously both wizards fell through to a 'run in foreground' info print on Windows because the service-manager gate checked only `supports_systemd or is_macos()`, even though `_is_service_installed()` / `_is_service_running()` already call `gateway_windows` and the Windows backend has a full install/start/stop/restart contract.

## Changes
- `hermes_cli/setup.py`: Windows branch in the main setup wizard's service-manager block.
- `hermes_cli/gateway.py`: Windows branch in `hermes gateway setup`'s post-platform service-manager block.
- `supports_service_manager` now includes `is_windows()`; install-offer label reads 'Scheduled Task service' on Windows.
- `gateway_windows.install()` starts the task inline (schtasks /Run or direct-spawn fallback), so the redundant 'Start the service now?' prompt is skipped on Windows (tracked via a `started_inline` flag).
- Start / Restart on Windows delegate to `gateway_windows.start()` / `.restart()`.

## Validation
`py_compile` clean on both files. Verified on Linux: imports succeed, `is_windows()` is False so Windows branches never execute, existing systemd/launchd logic is unchanged.