### PR TITLE
feat(discord): configurable reaction emojis for processing lifecycle

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -770,6 +770,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["group_allow_from"] = platform_cfg["group_allow_from"]
                 if plat in (Platform.DISCORD, Platform.SLACK) and "channel_skill_bindings" in platform_cfg:
                     bridged["channel_skill_bindings"] = platform_cfg["channel_skill_bindings"]
+                if plat == Platform.DISCORD and "reaction_emojis" in platform_cfg:
+                    bridged["reaction_emojis"] = platform_cfg["reaction_emojis"]
                 if "channel_prompts" in platform_cfg:
                     channel_prompts = platform_cfg["channel_prompts"]
                     if isinstance(channel_prompts, dict):

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1319,13 +1319,45 @@ class DiscordAdapter(BasePlatformAdapter):
         """Check if message reactions are enabled via config/env."""
         return os.getenv("DISCORD_REACTIONS", "true").lower() not in ("false", "0", "no")
 
+    _REACTION_DEFAULTS: Dict[str, str] = {
+        "thinking": "👀",
+        "done": "✅",
+        "error": "❌",
+    }
+
+    def _resolve_emoji(self, slot: str) -> Optional[str]:
+        """Resolve the emoji for a lifecycle slot, applying per-slot overrides.
+
+        Resolution semantics:
+        - Missing key in reaction_emojis → use default for the slot
+        - null / "" / whitespace-only string → disabled (returns None)
+        - Non-empty string → use trimmed value
+        """
+        reaction_emojis = {}
+        if self.config and isinstance(self.config.extra, dict):
+            reaction_emojis = self.config.extra.get("reaction_emojis") or {}
+        if not isinstance(reaction_emojis, dict):
+            reaction_emojis = {}
+
+        default = self._REACTION_DEFAULTS.get(slot, "")
+        if slot not in reaction_emojis:
+            return default if default else None
+
+        value = reaction_emojis[slot]
+        if value is None:
+            return None
+        trimmed = str(value).strip()
+        return trimmed if trimmed else None
+
     async def on_processing_start(self, event: MessageEvent) -> None:
         """Add an in-progress reaction for normal Discord message events."""
         if not self._reactions_enabled():
             return
         message = event.raw_message
         if hasattr(message, "add_reaction"):
-            await self._add_reaction(message, "👀")
+            emoji = self._resolve_emoji("thinking")
+            if emoji:
+                await self._add_reaction(message, emoji)
 
     async def on_processing_complete(self, event: MessageEvent, outcome: ProcessingOutcome) -> None:
         """Swap the in-progress reaction for a final success/failure reaction."""
@@ -1333,11 +1365,17 @@ class DiscordAdapter(BasePlatformAdapter):
             return
         message = event.raw_message
         if hasattr(message, "add_reaction"):
-            await self._remove_reaction(message, "👀")
+            thinking_emoji = self._resolve_emoji("thinking")
+            if thinking_emoji:
+                await self._remove_reaction(message, thinking_emoji)
             if outcome == ProcessingOutcome.SUCCESS:
-                await self._add_reaction(message, "✅")
+                done_emoji = self._resolve_emoji("done")
+                if done_emoji:
+                    await self._add_reaction(message, done_emoji)
             elif outcome == ProcessingOutcome.FAILURE:
-                await self._add_reaction(message, "❌")
+                error_emoji = self._resolve_emoji("error")
+                if error_emoji:
+                    await self._add_reaction(message, error_emoji)
 
     async def send(
         self,

--- a/tests/gateway/test_discord_reactions.py
+++ b/tests/gateway/test_discord_reactions.py
@@ -246,3 +246,254 @@ async def test_on_processing_complete_cancelled_removes_eyes_without_terminal_re
 
     raw_message.remove_reaction.assert_awaited_once_with("👀", adapter._client.user)
     raw_message.add_reaction.assert_not_awaited()
+
+
+def _make_adapter_with_emojis(emoji_overrides: dict) -> DiscordAdapter:
+    config = PlatformConfig(enabled=True, token="***", extra={"reaction_emojis": emoji_overrides})
+    adapter = DiscordAdapter(config)
+    adapter._client = SimpleNamespace(
+        tree=FakeTree(),
+        get_channel=lambda _id: None,
+        fetch_channel=AsyncMock(),
+        user=SimpleNamespace(id=99999, name="HermesBot"),
+    )
+    return adapter
+
+
+def test_resolve_emoji_missing_key_uses_default(adapter):
+    assert adapter._resolve_emoji("thinking") == "👀"
+    assert adapter._resolve_emoji("done") == "✅"
+    assert adapter._resolve_emoji("error") == "❌"
+
+
+def test_resolve_emoji_null_disables():
+    a = _make_adapter_with_emojis({"done": None, "error": None})
+    assert a._resolve_emoji("done") is None
+    assert a._resolve_emoji("error") is None
+
+
+def test_resolve_emoji_empty_string_disables():
+    a = _make_adapter_with_emojis({"thinking": "", "done": ""})
+    assert a._resolve_emoji("thinking") is None
+    assert a._resolve_emoji("done") is None
+
+
+def test_resolve_emoji_whitespace_only_disables():
+    a = _make_adapter_with_emojis({"done": "   "})
+    assert a._resolve_emoji("done") is None
+
+
+def test_resolve_emoji_non_empty_returns_trimmed():
+    a = _make_adapter_with_emojis({"done": " 🎉 "})
+    assert a._resolve_emoji("done") == "🎉"
+
+
+def test_resolve_emoji_no_reaction_emojis_key_uses_defaults(adapter):
+    assert adapter._resolve_emoji("thinking") == "👀"
+    assert adapter._resolve_emoji("done") == "✅"
+    assert adapter._resolve_emoji("error") == "❌"
+
+
+@pytest.mark.asyncio
+async def test_failure_path_default_behavior(adapter, monkeypatch):
+    monkeypatch.delenv("DISCORD_REACTIONS", raising=False)
+
+    raw_message = SimpleNamespace(add_reaction=AsyncMock(), remove_reaction=AsyncMock())
+    event = _make_event("10", raw_message)
+
+    await adapter.on_processing_start(event)
+    await adapter.on_processing_complete(event, ProcessingOutcome.FAILURE)
+
+    assert raw_message.add_reaction.await_args_list[0].args == ("👀",)
+    raw_message.remove_reaction.assert_awaited_once_with("👀", adapter._client.user)
+    assert raw_message.add_reaction.await_args_list[1].args == ("❌",)
+
+
+@pytest.mark.asyncio
+async def test_only_thinking_customized_done_error_use_defaults(monkeypatch):
+    monkeypatch.delenv("DISCORD_REACTIONS", raising=False)
+    a = _make_adapter_with_emojis({"thinking": "🔄"})
+
+    raw_message = SimpleNamespace(add_reaction=AsyncMock(), remove_reaction=AsyncMock())
+    event = _make_event("11", raw_message)
+
+    await a.on_processing_start(event)
+    await a.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+    calls = raw_message.add_reaction.await_args_list
+    assert calls[0].args == ("🔄",)
+    assert calls[1].args == ("✅",)
+    raw_message.remove_reaction.assert_awaited_once_with("🔄", a._client.user)
+
+
+@pytest.mark.asyncio
+async def test_done_null_disables_success_emoji(monkeypatch):
+    monkeypatch.delenv("DISCORD_REACTIONS", raising=False)
+    a = _make_adapter_with_emojis({"done": None})
+
+    raw_message = SimpleNamespace(add_reaction=AsyncMock(), remove_reaction=AsyncMock())
+    event = _make_event("12", raw_message)
+
+    await a.on_processing_start(event)
+    await a.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+    assert raw_message.add_reaction.await_count == 1
+    assert raw_message.add_reaction.await_args_list[0].args == ("👀",)
+
+
+@pytest.mark.asyncio
+async def test_done_empty_string_disables_success_emoji(monkeypatch):
+    monkeypatch.delenv("DISCORD_REACTIONS", raising=False)
+    a = _make_adapter_with_emojis({"done": ""})
+
+    raw_message = SimpleNamespace(add_reaction=AsyncMock(), remove_reaction=AsyncMock())
+    event = _make_event("13", raw_message)
+
+    await a.on_processing_start(event)
+    await a.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+    assert raw_message.add_reaction.await_count == 1
+    assert raw_message.add_reaction.await_args_list[0].args == ("👀",)
+
+
+@pytest.mark.asyncio
+async def test_error_null_disables_failure_emoji(monkeypatch):
+    monkeypatch.delenv("DISCORD_REACTIONS", raising=False)
+    a = _make_adapter_with_emojis({"error": None})
+
+    raw_message = SimpleNamespace(add_reaction=AsyncMock(), remove_reaction=AsyncMock())
+    event = _make_event("14", raw_message)
+
+    await a.on_processing_start(event)
+    await a.on_processing_complete(event, ProcessingOutcome.FAILURE)
+
+    assert raw_message.add_reaction.await_count == 1
+    assert raw_message.add_reaction.await_args_list[0].args == ("👀",)
+
+
+@pytest.mark.asyncio
+async def test_error_empty_string_disables_failure_emoji(monkeypatch):
+    monkeypatch.delenv("DISCORD_REACTIONS", raising=False)
+    a = _make_adapter_with_emojis({"error": ""})
+
+    raw_message = SimpleNamespace(add_reaction=AsyncMock(), remove_reaction=AsyncMock())
+    event = _make_event("15", raw_message)
+
+    await a.on_processing_start(event)
+    await a.on_processing_complete(event, ProcessingOutcome.FAILURE)
+
+    assert raw_message.add_reaction.await_count == 1
+    assert raw_message.add_reaction.await_args_list[0].args == ("👀",)
+
+
+@pytest.mark.asyncio
+async def test_thinking_null_skips_add_and_remove_but_done_still_fires(monkeypatch):
+    monkeypatch.delenv("DISCORD_REACTIONS", raising=False)
+    a = _make_adapter_with_emojis({"thinking": None})
+
+    raw_message = SimpleNamespace(add_reaction=AsyncMock(), remove_reaction=AsyncMock())
+    event = _make_event("16", raw_message)
+
+    await a.on_processing_start(event)
+    await a.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+    raw_message.remove_reaction.assert_not_awaited()
+    assert raw_message.add_reaction.await_count == 1
+    assert raw_message.add_reaction.await_args_list[0].args == ("✅",)
+
+
+@pytest.mark.asyncio
+async def test_thinking_empty_skips_add_and_remove_error_still_fires(monkeypatch):
+    monkeypatch.delenv("DISCORD_REACTIONS", raising=False)
+    a = _make_adapter_with_emojis({"thinking": ""})
+
+    raw_message = SimpleNamespace(add_reaction=AsyncMock(), remove_reaction=AsyncMock())
+    event = _make_event("17", raw_message)
+
+    await a.on_processing_start(event)
+    await a.on_processing_complete(event, ProcessingOutcome.FAILURE)
+
+    raw_message.remove_reaction.assert_not_awaited()
+    assert raw_message.add_reaction.await_count == 1
+    assert raw_message.add_reaction.await_args_list[0].args == ("❌",)
+
+
+@pytest.mark.asyncio
+async def test_all_three_custom_emojis(monkeypatch):
+    monkeypatch.delenv("DISCORD_REACTIONS", raising=False)
+    a = _make_adapter_with_emojis({"thinking": "⏳", "done": "🎉", "error": "💥"})
+
+    raw_message = SimpleNamespace(add_reaction=AsyncMock(), remove_reaction=AsyncMock())
+    event = _make_event("18", raw_message)
+
+    await a.on_processing_start(event)
+    await a.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+    assert raw_message.add_reaction.await_args_list[0].args == ("⏳",)
+    raw_message.remove_reaction.assert_awaited_once_with("⏳", a._client.user)
+    assert raw_message.add_reaction.await_args_list[1].args == ("🎉",)
+
+
+@pytest.mark.asyncio
+async def test_all_three_custom_emojis_failure_path(monkeypatch):
+    monkeypatch.delenv("DISCORD_REACTIONS", raising=False)
+    a = _make_adapter_with_emojis({"thinking": "⏳", "done": "🎉", "error": "💥"})
+
+    raw_message = SimpleNamespace(add_reaction=AsyncMock(), remove_reaction=AsyncMock())
+    event = _make_event("19", raw_message)
+
+    await a.on_processing_start(event)
+    await a.on_processing_complete(event, ProcessingOutcome.FAILURE)
+
+    assert raw_message.add_reaction.await_args_list[0].args == ("⏳",)
+    raw_message.remove_reaction.assert_awaited_once_with("⏳", a._client.user)
+    assert raw_message.add_reaction.await_args_list[1].args == ("💥",)
+
+
+@pytest.mark.asyncio
+async def test_call_order_add_thinking_remove_thinking_terminal(monkeypatch):
+    monkeypatch.delenv("DISCORD_REACTIONS", raising=False)
+    a = _make_adapter_with_emojis({})
+
+    call_log = []
+    raw_message = SimpleNamespace(
+        add_reaction=AsyncMock(side_effect=lambda e: call_log.append(("add", e))),
+        remove_reaction=AsyncMock(side_effect=lambda e, u: call_log.append(("remove", e))),
+    )
+    event = _make_event("20", raw_message)
+
+    await a.on_processing_start(event)
+    await a.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+    assert call_log == [("add", "👀"), ("remove", "👀"), ("add", "✅")]
+
+
+@pytest.mark.asyncio
+async def test_thinking_disabled_done_customized(monkeypatch):
+    monkeypatch.delenv("DISCORD_REACTIONS", raising=False)
+    a = _make_adapter_with_emojis({"thinking": None, "done": "🎉"})
+
+    raw_message = SimpleNamespace(add_reaction=AsyncMock(), remove_reaction=AsyncMock())
+    event = _make_event("21", raw_message)
+
+    await a.on_processing_start(event)
+    raw_message.add_reaction.assert_not_awaited()
+
+    await a.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+    raw_message.remove_reaction.assert_not_awaited()
+    assert raw_message.add_reaction.await_args_list[0].args == ("🎉",)
+
+
+@pytest.mark.asyncio
+async def test_global_reactions_disabled_overrides_emoji_config(monkeypatch):
+    monkeypatch.setenv("DISCORD_REACTIONS", "false")
+    a = _make_adapter_with_emojis({"thinking": "⏳", "done": "🎉", "error": "💥"})
+
+    raw_message = SimpleNamespace(add_reaction=AsyncMock(), remove_reaction=AsyncMock())
+    event = _make_event("22", raw_message)
+
+    await a.on_processing_start(event)
+    await a.on_processing_complete(event, ProcessingOutcome.SUCCESS)
+
+    raw_message.add_reaction.assert_not_awaited()
+    raw_message.remove_reaction.assert_not_awaited()

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -305,6 +305,10 @@ discord:
   free_response_channels: ""      # Comma-separated channel IDs (or YAML list)
   auto_thread: true               # Auto-create threads on @mention
   reactions: true                 # Add emoji reactions during processing
+  reaction_emojis:                # Override per-slot emojis (optional)
+    thinking: "👀"                # Emoji while processing (null or "" to disable)
+    done: "✅"                    # Emoji on success (null or "" to disable)
+    error: "❌"                   # Emoji on failure (null or "" to disable)
   ignored_channels: []            # Channel IDs where bot never responds
   no_thread_channels: []          # Channel IDs where bot responds without threading
   channel_prompts: {}             # Per-channel ephemeral system prompts
@@ -364,6 +368,31 @@ Controls whether the bot adds emoji reactions to messages as visual feedback:
 - ❌ added if an error occurs during processing
 
 Disable this if you find the reactions distracting or if the bot's role doesn't have the **Add Reactions** permission.
+
+#### `discord.reaction_emojis`
+
+**Type:** object — **Default:** `{}` (all slots use built-in defaults)
+
+Overrides the emoji used for each processing-lifecycle slot. Any slot you omit keeps its default. Set a slot to `null` or an empty string to disable that reaction entirely (whitespace-only strings are also treated as disabled).
+
+```yaml
+discord:
+  reaction_emojis:
+    thinking: "⏳"    # Replace 👀 with a different in-progress emoji
+    done: "🎉"        # Replace ✅ with a custom success emoji
+    error: "💥"       # Replace ❌ with a custom failure emoji
+```
+
+To disable only the success and failure reactions while keeping the in-progress indicator:
+
+```yaml
+discord:
+  reaction_emojis:
+    done: null
+    error: null
+```
+
+`discord.reactions: false` (or `DISCORD_REACTIONS=false`) still overrides everything — no reactions are added regardless of what `reaction_emojis` contains.
 
 #### `discord.ignored_channels`
 


### PR DESCRIPTION
## What does this PR do?

Adds optional `reaction_emojis` config block under `discord:` to let users override the thinking/done/error emojis used during message processing. The master `discord.reactions` switch and `DISCORD_REACTIONS` env var continue to control all reaction activity as before.

**Config shape:**
```yaml
discord:
  reactions: true
  reaction_emojis:
    thinking: "👀"   # optional; defaults to 👀
    done: "✅"        # optional; defaults to ✅
    error: "❌"       # optional; defaults to ❌
```

`reaction_emojis` is optional — omitting it preserves legacy behavior exactly.

### Resolution semantics

For each slot (`thinking`, `done`, `error`):

| Config value | Resolved behavior |
|---|---|
| Missing key | Use default emoji |
| `null` or `""` | Disabled (no reaction) |
| Whitespace-only string | Disabled |
| Non-empty string | Use trimmed value |

### Lifecycle behavior

- **On processing start**: if reactions enabled and `thinking` resolves, add it.
- **On processing complete**: remove `thinking` if it was enabled; add `done` or `error` per outcome. Cancelled path removes thinking only, adds no terminal emoji.
- Reaction API errors remain non-fatal throughout.

## Related Issue

Fixes #22365

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/discord.py` — `_resolve_emoji()` helper + updated start/complete handlers
- `gateway/config.py` — `reaction_emojis` field added to Discord config model
- `tests/gateway/test_discord_reactions.py` — 15 new/updated tests covering defaults, disable semantics, trim, cancelled path, custom emojis, and master-switch override
- `website/docs/user-guide/messaging/discord.md` — documents the new config block

## How to Test

1. Set config.yaml per this example:

```
discord:
  reaction_emojis:
    thinking: "🦄"   # optional; defaults to 👀
    done: ""        # optional; defaults to ✅
    error: "😭"       # optional; defaults to ❌
```

2. Send message in Discord
3. Notice that thinking emoji is now 🦄
4. Notice that after response, the thinking emoji is removed and a done emoji does not appear (because it is an empty string. Also `null` has the same behavior as empty string)

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [N/A] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
