### PR TITLE
fix(security): add Linear personal API key pattern to redact.py

### DIFF
--- a/agent/redact.py
+++ b/agent/redact.py
@@ -103,6 +103,9 @@ _PREFIX_PATTERNS = [
     r"hsk-[A-Za-z0-9]{10,}",            # Hindsight API key
     r"mem0_[A-Za-z0-9]{10,}",           # Mem0 Platform API key
     r"brv_[A-Za-z0-9]{10,}",            # ByteRover API key
+    r"ntn_[A-Za-z0-9]{10,}",            # Notion integration token
+    r"xai-[A-Za-z0-9_-]{10,}",          # xAI (Grok) API key
+    r"nvapi-[A-Za-z0-9_-]{10,}",        # NVIDIA NIM API key
 ]
 
 # ENV assignment patterns: KEY=value where KEY contains a secret-like name

--- a/agent/redact.py
+++ b/agent/redact.py
@@ -116,6 +116,7 @@ _PREFIX_PATTERNS = [
     r"brv_[A-Za-z0-9]{10,}",            # ByteRover API key
     r"xai-[A-Za-z0-9]{30,}",            # xAI (Grok) API key
     r"ntn_[A-Za-z0-9]{10,}",            # Notion internal integration token
+    r"lin_api_[A-Za-z0-9]{10,}",        # Linear personal API key (follow-up invited in #4541)
     r"fw-[A-Za-z0-9]{30,}",             # Fireworks AI API key
     r"fw_[A-Za-z0-9]{30,}",             # Fireworks AI API key
     r"fpk_[A-Za-z0-9]{30,}",            # Fireworks AI project key

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -37,6 +37,18 @@ class TestKnownPrefixes:
         result = redact_sensitive_text("github_pat_abc123def456ghi789jklmno")
         assert "abc123def456" not in result
 
+    def test_notion_integration_token(self):
+        result = redact_sensitive_text("ntn_abc123def456ghi789jklmno012345678901234")
+        assert "abc123def456" not in result
+
+    def test_xai_api_key(self):
+        result = redact_sensitive_text("xai-abc123def456ghi789jklmno012345678901234")
+        assert "abc123def456" not in result
+
+    def test_nvidia_nim_api_key(self):
+        result = redact_sensitive_text("nvapi-abc123def456ghi789jklmno012345678901234")
+        assert "abc123def456" not in result
+
     def test_slack_token(self):
         token = "xoxb-" + "0" * 12 + "-" + "a" * 14
         result = redact_sensitive_text(token)

--- a/tests/agent/test_redact.py
+++ b/tests/agent/test_redact.py
@@ -84,6 +84,17 @@ class TestKnownPrefixes:
         text = "fw-tooshort fw_tooshort fpk_tooshort"
         assert redact_sensitive_text(text) == text
 
+    def test_linear_api_key(self):
+        """Linear personal API key. Follow-up invited in #4541."""
+        token = "lin_api_" + "AbCdEfGhIjKlMnOpQrSt"
+        result = redact_sensitive_text(f"leaked {token} in output")
+        assert token not in result
+        assert "..." in result
+
+    def test_short_linear_like_word_unchanged(self):
+        text = "lin_api_tooshort"
+        assert redact_sensitive_text(text) == text
+
 
 
 


### PR DESCRIPTION
## What does this PR do?

Adds the missing `lin_api_` prefix (Linear personal API key) to `_PREFIX_PATTERNS` in `agent/redact.py`, so a Linear key printed or logged in plain text gets redacted.

### Scope note — this PR was rebased and narrowed

This branch is ~3.5 months old. When I went to rebase it, I checked whether each of its original patterns was still a genuine gap on current `main`:

- **Notion (`ntn_`)** — already added independently since this PR opened (identical pattern, already on `main`).
- **xAI (`xai-`)** — already added independently since this PR opened, with a *different* regex than this branch originally proposed (`main` uses `{30,}` min length, no underscore/dash in the char class).
- **NVIDIA NIM (`nvapi-`)** — genuinely still missing from detection, but `main` has since grown a plugin-registration mechanism (`register_redaction_patterns()` in `agent/redact.py`, with `tests/test_redaction_registry.py` explicitly documenting `nvapi-` as the gap that mechanism exists to close) specifically intended for provider-specific patterns like this one — nobody has actually wired the NVIDIA NIM provider through it yet. That's a different, slightly bigger fix (touching the provider module, not this hardcoded list) than anything this PR ever contained, so I left it out rather than bolt on an architecturally-wrong fix.
- **Linear (`lin_api_`)** — this is the one pattern that was in this PR's *title* but, on inspection, was never actually in its *diff* (title/code had drifted out of sync at some point). It's still a genuine gap, so this PR is now scoped to just this.

This exact addition was also independently proposed (bundled with Slack `xapp-` and GitLab `glpat-`, both since added separately) in #4541, which the maintainer closed with: *"The GitLab/Deepgram/Linear additions bundled here weren't included; feel free to open a focused follow-up for those."* This PR is that focused follow-up for Linear specifically (Deepgram's proposed `dp-` prefix is too short/generic to safely pattern-match without risking false positives on ordinary prose, so I left it out).

## Changes Made

- `agent/redact.py`: add `r"lin_api_[A-Za-z0-9]{10,}"` to `_PREFIX_PATTERNS`.
- `tests/agent/test_redact.py`: `test_linear_api_key` (positive detection) and `test_short_linear_like_word_unchanged` (false-positive guard for a too-short match), following the same pair pattern as the existing Fireworks key tests.

## How to Test

```bash
uv run --frozen pytest tests/agent/test_redact.py -k linear -v
```

## Checklist

- [x] Mutation-verified: stashed the `redact.py` change, confirmed `test_linear_api_key` fails with the exact pre-fix symptom (token survives redaction); restored, both new tests pass.
- [x] Full `tests/agent/test_redact.py` suite passes (99/99), no regressions.
- [x] `ruff check` passes on both changed files.
- [x] Verified via `git show upstream/main:agent/redact.py` (not a possibly-stale local checkout) which of the original four patterns are already covered before deciding what to keep in scope.