### PR TITLE
feat(jira): add hermes auth jira command with API token auth

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -112,7 +112,11 @@ DEFAULT_SPOTIFY_SCOPE = " ".join((
 ))
 SERVICE_PROVIDER_NAMES: Dict[str, str] = {
     "spotify": "Spotify",
+    "jira": "Jira",
 }
+
+JIRA_API_TOKEN_URL = "https://id.atlassian.com/manage-profile/security/api-tokens"
+JIRA_DOCS_URL = "https://support.atlassian.com/atlassian-account/docs/manage-api-tokens-for-your-atlassian-account/"
 
 # Google Gemini OAuth (google-gemini-cli provider, Cloud Code Assist backend)
 DEFAULT_GEMINI_CLOUDCODE_BASE_URL = "cloudcode-pa://google"
@@ -4038,6 +4042,8 @@ def get_auth_status(provider_id: Optional[str] = None) -> Dict[str, Any]:
     target = provider_id or get_active_provider()
     if target == "spotify":
         return get_spotify_auth_status()
+    if target == "jira":
+        return get_jira_auth_status()
     if target == "nous":
         return get_nous_auth_status()
     if target == "openai-codex":
@@ -5350,3 +5356,163 @@ def logout_command(args) -> None:
             print("Model provider configuration was unchanged.")
     else:
         print(f"No auth state found for {provider_name}.")
+
+
+# =============================================================================
+# Jira authentication (API token — no OAuth redirect needed)
+# =============================================================================
+
+def resolve_jira_runtime_credentials() -> Dict[str, Any]:
+    """Return stored Jira credentials from auth.json.
+
+    Raises AuthError when the user has not run ``hermes auth jira``.
+    """
+    with _auth_store_lock():
+        auth_store = _load_auth_store()
+        state = _load_provider_state(auth_store, "jira")
+
+    if not state:
+        raise AuthError(
+            "Jira is not authenticated. Run `hermes auth jira` first.",
+            provider="jira",
+            code="jira_auth_missing",
+            relogin_required=True,
+        )
+
+    domain = str(state.get("domain") or "").strip()
+    email = str(state.get("email") or "").strip()
+    basic_token = str(state.get("basic_token") or "").strip()
+
+    if not domain or not email or not basic_token:
+        raise AuthError(
+            "Jira credentials are incomplete. Run `hermes auth jira` again.",
+            provider="jira",
+            code="jira_credentials_incomplete",
+            relogin_required=True,
+        )
+
+    base_url = f"https://{domain}/rest/api/3"
+    return {
+        "provider": "jira",
+        "domain": domain,
+        "email": email,
+        "basic_token": basic_token,
+        "base_url": base_url,
+    }
+
+
+def get_jira_auth_status() -> Dict[str, Any]:
+    """Return Jira authentication status for ``hermes auth status``."""
+    state = get_provider_auth_state("jira")
+    if not state:
+        return {"logged_in": False, "provider": "jira"}
+    domain = str(state.get("domain") or "").strip()
+    email = str(state.get("email") or "").strip()
+    return {
+        "logged_in": bool(domain and email and state.get("basic_token")),
+        "provider": "jira",
+        "domain": domain,
+        "email": email,
+        "auth_type": "api_token",
+    }
+
+
+def login_jira_command(args) -> None:
+    """Interactive Jira authentication via API token.
+
+    Prompts for domain, email, and API token, validates the token against
+    /rest/api/3/myself, then persists credentials to auth.json.
+    """
+    import getpass
+
+    print()
+    print("=" * 60)
+    print("Jira Authentication")
+    print("=" * 60)
+    print()
+    print("API tokens are generated at:")
+    print(f"  {JIRA_API_TOKEN_URL}")
+    print()
+
+    existing_state = get_provider_auth_state("jira") or {}
+
+    # Domain
+    existing_domain = existing_state.get("domain") or ""
+    raw_domain = getattr(args, "domain", None) or ""
+    if not raw_domain.strip():
+        prompt_domain = f"Jira domain [{existing_domain}]: " if existing_domain else "Jira domain (e.g. mycompany.atlassian.net): "
+        raw_domain = input(prompt_domain).strip() or existing_domain
+    domain = raw_domain.strip().lower().removeprefix("https://").removeprefix("http://").rstrip("/")
+    if not domain:
+        raise SystemExit("Jira domain is required.")
+
+    # Email
+    existing_email = existing_state.get("email") or ""
+    raw_email = getattr(args, "email", None) or ""
+    if not raw_email.strip():
+        prompt_email = f"Atlassian email [{existing_email}]: " if existing_email else "Atlassian email: "
+        raw_email = input(prompt_email).strip() or existing_email
+    email = raw_email.strip()
+    if not email:
+        raise SystemExit("Email is required.")
+
+    # API token (always re-prompt for security)
+    raw_token = getattr(args, "token", None) or ""
+    if not raw_token.strip():
+        print(f"API token (hidden, generate at {JIRA_API_TOKEN_URL}):")
+        raw_token = getpass.getpass("  API token: ").strip()
+    api_token = raw_token.strip()
+    if not api_token:
+        raise SystemExit("API token is required.")
+
+    # Build Basic Auth token (email:api_token base64-encoded) and validate
+    import base64
+    basic_token = base64.b64encode(f"{email}:{api_token}".encode("utf-8")).decode("ascii")
+
+    print()
+    print(f"Connecting to https://{domain}...")
+    try:
+        import httpx
+        resp = httpx.get(
+            f"https://{domain}/rest/api/3/myself",
+            headers={
+                "Authorization": f"Basic {basic_token}",
+                "Accept": "application/json",
+            },
+            timeout=15.0,
+        )
+        if resp.status_code == 401:
+            raise SystemExit(
+                "Authentication failed: invalid email or API token. "
+                f"Generate a new token at {JIRA_API_TOKEN_URL}"
+            )
+        if resp.status_code >= 400:
+            raise SystemExit(f"Jira API error {resp.status_code}: {resp.text.strip()[:200]}")
+        user_data = resp.json()
+    except SystemExit:
+        raise
+    except Exception as exc:
+        raise SystemExit(f"Could not connect to Jira: {exc}") from exc
+
+    display_name = user_data.get("displayName") or user_data.get("name") or email
+
+    jira_state: Dict[str, Any] = {
+        "domain": domain,
+        "email": email,
+        "basic_token": basic_token,
+        "auth_type": "api_token",
+        "display_name": display_name,
+        "account_id": user_data.get("accountId") or "",
+    }
+
+    with _auth_store_lock():
+        auth_store = _load_auth_store()
+        _store_provider_state(auth_store, "jira", jira_state, set_active=False)
+        saved_to = _save_auth_store(auth_store)
+
+    print(f"✓ Authenticated as {display_name} ({email})")
+    print(f"  Domain:     https://{domain}")
+    print(f"  Auth state: {saved_to}")
+    print(f"  Docs:       {JIRA_DOCS_URL}")
+    print()
+    print("You can now use jira_issue, jira_search, jira_project, and jira_comment tools.")

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -508,6 +508,20 @@ def auth_spotify_command(args) -> None:
     raise SystemExit(f"Unknown Spotify auth action: {action}")
 
 
+def auth_jira_command(args) -> None:
+    action = str(getattr(args, "jira_action", "") or "login").strip().lower()
+    if action in {"", "login"}:
+        auth_mod.login_jira_command(args)
+        return
+    if action == "status":
+        auth_status_command(SimpleNamespace(provider="jira"))
+        return
+    if action == "logout":
+        auth_logout_command(SimpleNamespace(provider="jira"))
+        return
+    raise SystemExit(f"Unknown Jira auth action: {action}")
+
+
 def _interactive_auth() -> None:
     """Interactive credential pool management when `hermes auth` is called bare."""
     # Show current pool status first
@@ -713,6 +727,9 @@ def auth_command(args) -> None:
         return
     if action == "spotify":
         auth_spotify_command(args)
+        return
+    if action == "jira":
+        auth_jira_command(args)
         return
     # No subcommand — launch interactive mode
     _interactive_auth()

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9469,6 +9469,27 @@ def main():
     auth_spotify.add_argument(
         "--timeout", type=float, help="Callback/token exchange timeout in seconds"
     )
+    auth_jira = auth_subparsers.add_parser(
+        "jira", help="Authenticate Hermes with Jira Cloud via API token"
+    )
+    auth_jira.add_argument(
+        "jira_action",
+        nargs="?",
+        choices=["login", "status", "logout"],
+        default="login",
+    )
+    auth_jira.add_argument(
+        "--domain",
+        help="Jira Cloud domain (e.g. mycompany.atlassian.net)",
+    )
+    auth_jira.add_argument(
+        "--email",
+        help="Atlassian account email address",
+    )
+    auth_jira.add_argument(
+        "--token",
+        help="Jira API token (generate at https://id.atlassian.com/manage-profile/security/api-tokens)",
+    )
     auth_parser.set_defaults(func=cmd_auth)
 
     # =========================================================================


### PR DESCRIPTION
## What does this PR do?

Adds `hermes auth jira` to authenticate against Jira Cloud using an Atlassian API token. No browser redirect or OAuth PKCE flow is needed — Jira API tokens are long-lived and generated at https://id.atlassian.com/manage-profile/security/api-tokens.

This is the auth foundation for the upcoming native Jira plugin (jira_issue, jira_search, jira_project, jira_comment tools). Follows the same pattern used by the Spotify integration.

**Auth flow (`hermes auth jira`):**
1. Prompts for Jira Cloud domain, Atlassian email, and API token
2. Validates credentials against `GET /rest/api/3/myself`
3. Persists `Basic <base64(email:token)>` in `auth.json` under `providers.jira`

**Subcommands:** `hermes auth jira login` · `hermes auth jira status` · `hermes auth jira logout`

**CLI flags:** `--domain` · `--email` · `--token` (for non-interactive use)

## Related Issue

N/A — foundation PR for the Jira plugin series.

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `hermes_cli/auth.py`: `resolve_jira_runtime_credentials()`, `get_jira_auth_status()`, `login_jira_command()` + `"jira"` in `SERVICE_PROVIDER_NAMES` and `get_auth_status()` dispatcher (+164 lines)
- `hermes_cli/auth_commands.py`: `auth_jira_command()` with login/status/logout dispatch (+17 lines)
- `hermes_cli/main.py`: `hermes auth jira` subparser with `--domain`, `--email`, `--token` flags (+21 lines)

## How to Test

```bash
# Requires a real Jira Cloud account and API token
hermes auth jira --domain myco.atlassian.net --email user@example.com --token <token>
hermes auth jira status
hermes auth jira logout
```

## Checklist

### Code
- [x] Contributing Guide read
- [x] Conventional Commits
- [x] No duplicate PR
- [x] This fix only — auth foundation, no tools yet
- [x] Platform: macOS

### Documentation & Housekeeping
- [x] Docs updated — N/A (docs PR will follow with the full plugin)
- [x] cli-config.yaml.example — N/A
- [x] CONTRIBUTING.md/AGENTS.md — N/A
- [x] Cross-platform impact — `base64` and `httpx` are cross-platform
- [x] Tool descriptions — N/A