### PR TITLE
fix(discord): register goal slash command (#21589)

### DIFF
--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -3038,6 +3038,10 @@ class DiscordAdapter(BasePlatformAdapter):
         async def slash_update(interaction: discord.Interaction):
             await self._run_simple_slash(interaction, "/update", "Update initiated~")
 
+        @tree.command(name="goal", description="Create or manage a goal for this session")
+        async def slash_goal(interaction: discord.Interaction):
+            await self._run_simple_slash(interaction, "/goal")
+
         @tree.command(name="restart", description="Gracefully restart the Hermes gateway")
         async def slash_restart(interaction: discord.Interaction):
             await self._run_simple_slash(interaction, "/restart", "Restart requested~")

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -142,6 +142,27 @@ async def test_registers_native_thread_slash_command(adapter):
 
 
 @pytest.mark.asyncio
+async def test_registers_native_goal_slash_command(adapter):
+    """Regression test: /goal slash command must be registered."""
+    adapter._run_simple_slash = AsyncMock()
+    adapter._register_slash_commands()
+
+    assert "goal" in adapter._client.tree.commands, (
+        "/goal not found in registered slash commands — issue #21589"
+    )
+
+    interaction = SimpleNamespace(
+        response=SimpleNamespace(send_message=AsyncMock()),
+    )
+    await adapter._client.tree.commands["goal"](interaction)
+
+    adapter._run_simple_slash.assert_awaited_once_with(
+        interaction,
+        "/goal",
+    )
+
+
+@pytest.mark.asyncio
 async def test_registers_native_restart_slash_command(adapter):
     adapter._run_simple_slash = AsyncMock()
     adapter._register_slash_commands()


### PR DESCRIPTION
## What does this PR do?

Registers Discord's native `/goal` slash command so Discord interactions route to the existing gateway `/goal` command instead of timing out with "Application did not respond". The fix reuses the existing simple slash-command dispatch path and does not change goal command semantics.

## Related Issue

Fixes #21589

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/discord.py`: add the missing `slash_goal` registration.
- `tests/gateway/test_discord_slash_commands.py`: verify `/goal` is registered and invokes `_run_simple_slash(interaction, "/goal")`.

## How to Test

1. `python3 -m pytest tests/gateway/test_discord_slash_commands.py -k 'goal_slash_command' -o 'addopts=' --tb=short -q`
2. Broader focused file: `python3 -m pytest tests/gateway/test_discord_slash_commands.py -o 'addopts=' --tb=short -q`
3. Fail-without-fix proof: with the `discord.py` handler reverted, the new goal slash command test fails.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (Darwin 24.6.0)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

```
python3 -m pytest tests/gateway/test_discord_slash_commands.py -o 'addopts=' --tb=short -q
# slash_goal test passes; revert source → fails (fail-without-fix proof)
```
