### PR TITLE
fix(kanban): request default board explicitly (#21819)

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -385,7 +385,7 @@
 
     // --- load config once ---------------------------------------------------
     useEffect(function () {
-      SDK.fetchJSON(`${API}/config`)
+      SDK.fetchJSON(withBoard(`${API}/config`, board))
         .then(function (c) {
           setConfig(c);
           if (!configApplied) {
@@ -418,7 +418,7 @@
 
     // --- load list of boards for the switcher ------------------------------
     const loadBoardList = useCallback(function () {
-      return SDK.fetchJSON(`${API}/boards`)
+      return SDK.fetchJSON(withBoard(`${API}/boards`, board))
         .then(function (data) {
           const boards = (data && data.boards) || [];
           setBoardList(boards);
@@ -640,7 +640,7 @@
         if (slug && payload.switch) switchBoard(slug);
         return res;
       });
-    }, [loadBoardList, switchBoard]);
+    }, [loadBoardList, switchBoard, board]);
 
     const deleteBoard = useCallback(function (slug) {
       if (!slug || slug === "default") return Promise.resolve();

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -1683,3 +1683,43 @@ def test_specify_no_aux_client_surfaces_reason(client, monkeypatch):
     # Task must stay in triage — nothing was touched.
     detail = client.get(f"/api/plugins/kanban/tasks/{t['id']}").json()["task"]
     assert detail["status"] == "triage"
+
+
+def test_board_endpoint_accepts_explicit_board_default_param(client):
+    """GET /board?board=default must not fall through to env/current-file resolution.
+
+    The dashboard always sends ``?board=<slug>`` (including ``board=default``)
+    so that the server-side ``current`` file can never override the dashboard's
+    selected board.  This test asserts the endpoint accepts the parameter and
+    returns the default board without falling back to environment variable or
+    current-file resolution.
+    Regression: #21819.
+    """
+    # Create a task on the default board.
+    t = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "on-default-board"},
+    ).json()["task"]
+    assert t["status"] == "ready"
+
+    # Request with explicit board=default — must succeed and include the task.
+    r = client.get("/api/plugins/kanban/board?board=default")
+    assert r.status_code == 200
+    data = r.json()
+    ready = next((c for c in data["columns"] if c["name"] == "ready"), None)
+    assert ready is not None, "no 'ready' column in default board response"
+    task_ids = [task["id"] for task in ready["tasks"]]
+    assert t["id"] in task_ids, (
+        f"task {t['id']} not found in ready column of default board "
+        f"(got tasks: {task_ids}). The board=default param was likely ignored."
+    )
+
+
+def test_dashboard_requests_default_board_explicitly():
+    """Dashboard REST calls must include board=default instead of relying on server current board."""
+    repo_root = Path(__file__).resolve().parents[2]
+    dist = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text()
+
+    assert "SDK.fetchJSON(withBoard(`${API}/config`, board))" in dist
+    assert "SDK.fetchJSON(withBoard(`${API}/boards`, board))" in dist
+    assert "}, [loadBoardList, switchBoard, board]);" in dist


### PR DESCRIPTION
## What does this PR do?

Makes the Kanban dashboard request the selected board explicitly even when the selected slug is `default`. Previously some dashboard REST calls omitted `board=default`, allowing the backend's current-board pointer to leak a non-default board into the UI while the selector still showed Default.

## Related Issue

Fixes #21819

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `plugins/kanban/dashboard/dist/index.js`: route config and boards requests through `withBoard(..., board)` and include `board` in the create-board callback dependencies.
- `tests/plugins/test_kanban_dashboard_plugin.py`: verify the backend accepts `board=default` and add a static regression test that dashboard code explicitly uses `withBoard(..., board)` for default-sensitive requests.

## How to Test

1. `python3 -m pytest tests/plugins/test_kanban_dashboard_plugin.py -k 'explicit_board_default_param or dashboard_requests_default_board_explicitly' -o 'addopts=' --tb=short -q`
2. Fail-without-fix proof: with the dashboard dist change reverted, `test_dashboard_requests_default_board_explicitly` fails.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Linux / Python 3.11

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` — N/A
- [x] I've considered cross-platform impact — dashboard JS/API requests only
- [x] I've updated tool descriptions/schemas — N/A
