### PR TITLE
fix(security): honor relay-declared sender_type in Google Chat adapter to prevent BOT filter bypass

### DIFF
--- a/plugins/platforms/google_chat/adapter.py
+++ b/plugins/platforms/google_chat/adapter.py
@@ -1010,13 +1010,25 @@ class GoogleChatAdapter(BasePlatformAdapter):
                 + (sender_email or "unknown").replace("@", "_at_").replace(".", "_")
             )
             text = envelope.get("text", "") or ""
+            # Honor the relay's declared sender_type when present so the
+            # downstream BOT self-filter (sender_type == "BOT") fires for
+            # bot-originated messages forwarded by the relay. Hardcoding
+            # "HUMAN" here meant the bot would re-process its own replies
+            # if the relay forwarded them, and allowed a relay envelope to
+            # impersonate any allowlisted user without ever being marked
+            # as a bot. Default to "HUMAN" for backward compatibility when
+            # the relay does not provide the field.
+            sender_type_raw = (envelope.get("sender_type") or "HUMAN")
+            sender_type = str(sender_type_raw).strip().upper() or "HUMAN"
+            if sender_type not in {"HUMAN", "BOT"}:
+                sender_type = "HUMAN"
             msg: Dict[str, Any] = {
                 "name": envelope.get("message_name", "") or "",
                 "sender": {
                     "name": sender_name_surrogate,
                     "email": sender_email,
                     "displayName": sender_display,
-                    "type": "HUMAN",
+                    "type": sender_type,
                 },
                 "text": text,
                 "argumentText": text,


### PR DESCRIPTION
## What does this PR do?

The Google Chat adapter (`plugins/platforms/google_chat/adapter.py`)
supports three envelope formats — Pub/Sub native, Cloud Function
direct, and a "Format 3" relay/flat shape used by custom Cloud Run
relays. Format 3 hardcodes `sender.type = "HUMAN"` regardless of the
actual sender:

```python
# Before (vulnerable)
msg: Dict[str, Any] = {
    "name": envelope.get("message_name", "") or "",
    "sender": {
        "name": sender_name_surrogate,
        "email": sender_email,
        "displayName": sender_display,
        "type": "HUMAN",   # ← hardcoded, never "BOT"
    },
    ...
}
```

This breaks the downstream BOT self-filter at line 1145:

```python
sender_type = sender.get("type") or ""
...
if sender_type == "BOT":
    return  # ← never fires for relay format
```

Two related issues result:

### 1. Bot-loop DoS

If the Cloud Run relay forwards every message in a space (including
the bot's own replies — easy to misconfigure), the bot will re-process
its own output indefinitely:

1. User sends message → relay forwards → bot replies via Chat API
2. Relay sees the bot's reply in the space, forwards it as a Format 3 envelope
3. Adapter marks `type = "HUMAN"` → BOT filter doesn't fire
4. Bot processes its own reply → generates another reply → infinite loop

The dedup guard at line 1139 doesn't always catch this either, because
relay envelopes can have empty `message_name` (the relay synthesizes
an `event_type` rather than carrying a `messages/...` resource path).

### 2. Allowlist impersonation (relay-trust-boundary attack)

`GOOGLE_CHAT_ALLOWED_USERS` is checked at line 1537 against
`user_id = sender_email or sender_name`. In Format 3, `sender_email`
comes directly from the envelope:

```python
sender_email = (envelope.get("sender_email") or "").strip()
```

A caller with write access to the Pub/Sub topic the relay publishes
to (a GCP project member with the right role, or a compromised relay)
can craft an envelope claiming to be any allowlisted user:

```json
{
  "event_type": "MESSAGE",
  "sender_email": "allowlisted@company.com",
  "text": "<malicious command>",
  "space_name": "spaces/TARGET"
}
```

The adapter accepts the spoofed sender, marks it `HUMAN`, and the
allowlist check passes. The relay's trust boundary is implicit but
the adapter doesn't enforce it.

## Fix

Honor the relay's declared `sender_type` field (mirrors what Format 1
and Format 2 already do via `sender.type`). Default to `"HUMAN"` for
backward compatibility when the field is absent:

```python
sender_type_raw = (envelope.get("sender_type") or "HUMAN")
sender_type = str(sender_type_raw).strip().upper() or "HUMAN"
if sender_type not in {"HUMAN", "BOT"}:
    sender_type = "HUMAN"
msg: Dict[str, Any] = {
    "sender": {
        ...
        "type": sender_type,
    },
    ...
}
```

A correctly configured relay can now mark its forwarded bot replies
as `sender_type: "BOT"` and the existing BOT self-filter at line 1145
will reject them. Operators with relays that already mark sender type
need no behavior change; relays that don't are safe by default thanks
to the `"HUMAN"` fallback.

The relay setup documentation should call out that the relay must
forward `sender.type` from the original Chat event into the envelope
as `sender_type`, but that's a docs change rather than a code change.

## Type of Change

- [x] 🔒 Security fix (HIGH — bot-loop DoS + allowlist impersonation)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Backward compatible — default `"HUMAN"` matches previous behavior
- [x] Aligns with how Format 1 and Format 2 already read `sender.type`
- [x] Defensive coercion — only accepts `"HUMAN"` or `"BOT"`, falls back otherwise
- [x] No behavior change for relays that don't declare `sender_type`