### PR TITLE
fix(gateway): surface Windows Scheduled Task in get_gateway_runtime_snapshot()

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -978,6 +978,16 @@ def get_gateway_runtime_snapshot(system: bool = False) -> GatewayRuntimeSnapshot
             service_scope="launchd",
         )
 
+    if is_windows():
+        from hermes_cli import gateway_windows
+        return GatewayRuntimeSnapshot(
+            manager="Scheduled Task",
+            service_installed=gateway_windows.is_installed(),
+            service_running=bool(gateway_pids),
+            gateway_pids=gateway_pids,
+            service_scope="Scheduled Task",
+        )
+
     return GatewayRuntimeSnapshot(
         manager="manual process",
         gateway_pids=gateway_pids,

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -682,6 +682,49 @@ class TestGatewayServiceDetection:
 
         assert gateway_cli._is_service_running() is False
 
+    def test_get_gateway_runtime_snapshot_windows_installed(self, monkeypatch):
+        """On Windows with a Scheduled Task installed and the gateway running,
+        get_gateway_runtime_snapshot() must report manager='Scheduled Task',
+        service_installed=True, and service_running=True.
+
+        Before the fix, the Windows branch was absent and the function fell
+        through to manager='manual process' with service_installed=False.
+        """
+        import hermes_cli.gateway_windows as gw
+
+        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_windows", lambda: True)
+        monkeypatch.setattr(gateway_cli, "find_gateway_pids", lambda: [12345])
+        monkeypatch.setattr(gw, "is_installed", lambda: True)
+
+        snapshot = gateway_cli.get_gateway_runtime_snapshot()
+
+        assert snapshot.manager == "Scheduled Task"
+        assert snapshot.service_installed is True
+        assert snapshot.service_running is True
+        assert 12345 in snapshot.gateway_pids
+
+    def test_get_gateway_runtime_snapshot_windows_not_installed(self, monkeypatch):
+        """When the Scheduled Task is not installed and no gateway PIDs exist,
+        service_installed and service_running must both be False."""
+        import hermes_cli.gateway_windows as gw
+
+        monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
+        monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_windows", lambda: True)
+        monkeypatch.setattr(gateway_cli, "find_gateway_pids", lambda: [])
+        monkeypatch.setattr(gw, "is_installed", lambda: False)
+
+        snapshot = gateway_cli.get_gateway_runtime_snapshot()
+
+        assert snapshot.manager == "Scheduled Task"
+        assert snapshot.service_installed is False
+        assert snapshot.service_running is False
+        assert snapshot.running is False
+
 class TestGatewaySystemServiceRouting:
     def test_systemd_restart_gracefully_restarts_running_service_and_waits(self, monkeypatch, capsys):
         calls = []


### PR DESCRIPTION
## What does this PR do?

`get_gateway_runtime_snapshot()` in `hermes_cli/gateway.py` branches on systemd → launchd → manual process, but has no Windows branch. On Windows the gateway runs as a Scheduled Task (managed by `gateway_windows`), so the function silently fell through to `manager='manual process'` with `service_installed=False` — even when the Scheduled Task was installed and the gateway was running.

PR #22099 wired the Windows service branch into both setup wizards (`hermes setup` and `hermes gateway setup`). This PR extends the same fix to `get_gateway_runtime_snapshot()`, which is the source of truth for:
- `hermes status` → gateway status section
- `hermes dump` → diagnostic snapshot
- `hermes gateway setup` wizard → service-detection logic

One-line fix: add `elif is_windows()` branch that mirrors the macOS (launchd) branch, symmetric with the existing pattern.

`service_running` uses `bool(gateway_pids)` — the Scheduled Task status field is only `"Running"` during the brief launch window, not while the gateway process is alive. Using PIDs matches what `snapshot.running` tests for in all other code paths.

## Related Issue

Parity with #22099 (`fix(setup): offer gateway service install on Windows`).

## Type of Change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `hermes_cli/gateway.py`: add `elif is_windows()` branch in `get_gateway_runtime_snapshot()` (+10 lines)
- `tests/hermes_cli/test_gateway_service.py`: two new tests in `TestGatewayServiceDetection` (+43 lines)
  - `test_get_gateway_runtime_snapshot_windows_installed` — installed + running → Scheduled Task, service_installed=True
  - `test_get_gateway_runtime_snapshot_windows_not_installed` — not installed, no PIDs → service_installed=False, running=False

## How to Test

```bash
python3.11 -m pytest tests/hermes_cli/test_gateway_service.py::TestGatewayServiceDetection -v --override-ini="addopts="
```

All 6 tests pass (4 existing + 2 new).

## Checklist

### Code
- [x] Contributing Guide read
- [x] Conventional Commits
- [x] No duplicate PR
- [x] This fix only
- [x] pytest run
- [x] Tests added
- [x] Platform: macOS

### Documentation & Housekeeping
- [x] Docs updated — N/A
- [x] cli-config.yaml.example — N/A
- [x] CONTRIBUTING.md/AGENTS.md — N/A
- [x] Cross-platform impact — Windows-only branch, guarded by is_windows()
- [x] Tool descriptions — N/A