### PR TITLE
feat: add agent.gateway_shutdown_notifications config option

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2587,6 +2587,10 @@ class GatewayRunner:
         messages can be delivered. Best-effort: individual send failures are
         logged and swallowed so they never block the shutdown sequence.
         """
+        # Check if shutdown notifications are disabled
+        if not cfg_get(self.config, "agent", "gateway_shutdown_notifications", default=True):
+            return
+
         active = self._snapshot_running_agents()
 
         action = "restarting" if self._restart_requested else "shutting down"


### PR DESCRIPTION
Add a configuration option to disable the 'Gateway shutting down — Your current task will be interrupted' notification that is sent to active sessions when the gateway is restarting or shutting down.

When set to false, no shutdown notifications will be sent. The default is true to maintain backward-compatible behavior.

Usage in config.yaml:
```yaml
agent:
  gateway_shutdown_notifications: false
```