### PR TITLE
feat(jira): add native Jira Cloud plugin with 4 tools

### DIFF
--- a/plugins/jira/__init__.py
+++ b/plugins/jira/__init__.py
@@ -1,0 +1,46 @@
+"""Jira integration plugin — bundled, auto-loaded.
+
+Registers 4 tools (issue, search, project, comment) into the ``jira``
+toolset. Each tool's handler is gated by ``_check_jira_available()`` —
+when the user has not run ``hermes auth jira``, the tools stay registered
+(visible in ``hermes tools``) but dispatch is blocked with a clear error.
+
+Auth flow: ``hermes auth jira`` stores the Jira domain, email, and API
+token in ``~/.hermes/auth.json`` under ``providers.jira``. The client
+reads these at call time — no token refresh needed (API tokens are
+long-lived).
+"""
+
+from __future__ import annotations
+
+from plugins.jira.tools import (
+    JIRA_COMMENT_SCHEMA,
+    JIRA_ISSUE_SCHEMA,
+    JIRA_PROJECT_SCHEMA,
+    JIRA_SEARCH_SCHEMA,
+    _check_jira_available,
+    _handle_jira_comment,
+    _handle_jira_issue,
+    _handle_jira_project,
+    _handle_jira_search,
+)
+
+_TOOLS = (
+    ("jira_issue",   JIRA_ISSUE_SCHEMA,   _handle_jira_issue,   "🎫"),
+    ("jira_search",  JIRA_SEARCH_SCHEMA,  _handle_jira_search,  "🔍"),
+    ("jira_project", JIRA_PROJECT_SCHEMA, _handle_jira_project, "📁"),
+    ("jira_comment", JIRA_COMMENT_SCHEMA, _handle_jira_comment, "💬"),
+)
+
+
+def register(ctx) -> None:
+    """Register all Jira tools. Called once by the plugin loader."""
+    for name, schema, handler, emoji in _TOOLS:
+        ctx.register_tool(
+            name=name,
+            toolset="jira",
+            schema=schema,
+            handler=handler,
+            check_fn=_check_jira_available,
+            emoji=emoji,
+        )

--- a/plugins/jira/client.py
+++ b/plugins/jira/client.py
@@ -1,0 +1,304 @@
+"""Jira REST API v3 client used by Hermes native tools."""
+
+from __future__ import annotations
+
+import base64
+import json
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+# Imported at module level so tests can monkeypatch it without going through the
+# hermes_cli.auth import chain inside _resolve_runtime.
+try:
+    from hermes_cli.auth import resolve_jira_runtime_credentials
+except ImportError:
+    def resolve_jira_runtime_credentials():  # type: ignore[misc]
+        raise RuntimeError("hermes_cli not available")
+
+
+class JiraError(RuntimeError):
+    """Base Jira tool error."""
+
+
+class JiraAuthRequiredError(JiraError):
+    """Raised when the user needs to run `hermes auth jira` first."""
+
+
+class JiraAPIError(JiraError):
+    """Structured Jira API failure."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        status_code: Optional[int] = None,
+        response_body: Optional[str] = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.response_body = response_body
+
+
+class JiraClient:
+    def __init__(self) -> None:
+        self._runtime = self._resolve_runtime()
+
+    def _resolve_runtime(self) -> Dict[str, Any]:
+        try:
+            return resolve_jira_runtime_credentials()
+        except Exception as exc:
+            raise JiraAuthRequiredError(str(exc)) from exc
+
+    @property
+    def base_url(self) -> str:
+        return str(self._runtime.get("base_url") or "").rstrip("/")
+
+    def _headers(self) -> Dict[str, str]:
+        return {
+            "Authorization": f"Basic {self._runtime['basic_token']}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        }
+
+    def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: Optional[Dict[str, Any]] = None,
+        json_body: Optional[Any] = None,
+    ) -> Any:
+        url = f"{self.base_url}{path}"
+        response = httpx.request(
+            method,
+            url,
+            headers=self._headers(),
+            params={k: v for k, v in (params or {}).items() if v is not None},
+            json=json_body,
+            timeout=30.0,
+        )
+        if response.status_code == 401:
+            raise JiraAuthRequiredError(
+                "Jira authentication failed or token expired. Run `hermes auth jira` again."
+            )
+        if response.status_code >= 400:
+            self._raise_api_error(response, method=method, path=path)
+        if response.status_code == 204 or not response.content:
+            return {"success": True, "status_code": response.status_code}
+        return response.json()
+
+    def _raise_api_error(
+        self, response: httpx.Response, *, method: str, path: str
+    ) -> None:
+        try:
+            body = response.json()
+            msgs: List[str] = body.get("errorMessages") or []
+            errs: Dict[str, str] = body.get("errors") or {}
+            detail = (
+                "; ".join(msgs)
+                or "; ".join(f"{k}: {v}" for k, v in errs.items())
+                or response.text.strip()
+            )
+        except Exception:
+            detail = response.text.strip()
+        raise JiraAPIError(
+            f"Jira API error {response.status_code} [{method} {path}]: {detail}",
+            status_code=response.status_code,
+            response_body=response.text,
+        )
+
+    # -------------------------------------------------------------------------
+    # Issue operations
+    # -------------------------------------------------------------------------
+
+    def get_issue(self, issue_key: str, *, fields: Optional[str] = None) -> Any:
+        return self.request(
+            "GET",
+            f"/issue/{issue_key}",
+            params={"fields": fields or "summary,status,assignee,priority,issuetype,description,created,updated,labels,components"},
+        )
+
+    def create_issue(
+        self,
+        project_key: str,
+        issuetype: str,
+        summary: str,
+        *,
+        description: Optional[str] = None,
+        assignee_id: Optional[str] = None,
+        priority: Optional[str] = None,
+        labels: Optional[List[str]] = None,
+    ) -> Any:
+        fields: Dict[str, Any] = {
+            "project": {"key": project_key.upper()},
+            "issuetype": {"name": issuetype},
+            "summary": summary,
+        }
+        if description:
+            fields["description"] = text_to_adf(description)
+        if assignee_id:
+            fields["assignee"] = {"accountId": assignee_id}
+        if priority:
+            fields["priority"] = {"name": priority}
+        if labels:
+            fields["labels"] = labels
+        return self.request("POST", "/issue", json_body={"fields": fields})
+
+    def update_issue(
+        self,
+        issue_key: str,
+        *,
+        summary: Optional[str] = None,
+        description: Optional[str] = None,
+        assignee_id: Optional[str] = None,
+        priority: Optional[str] = None,
+        labels: Optional[List[str]] = None,
+    ) -> Any:
+        fields: Dict[str, Any] = {}
+        if summary is not None:
+            fields["summary"] = summary
+        if description is not None:
+            fields["description"] = text_to_adf(description)
+        if assignee_id is not None:
+            fields["assignee"] = {"accountId": assignee_id} if assignee_id else None
+        if priority is not None:
+            fields["priority"] = {"name": priority}
+        if labels is not None:
+            fields["labels"] = labels
+        return self.request("PUT", f"/issue/{issue_key}", json_body={"fields": fields})
+
+    def get_transitions(self, issue_key: str) -> Any:
+        return self.request("GET", f"/issue/{issue_key}/transitions")
+
+    def transition_issue(self, issue_key: str, transition_id: str) -> Any:
+        return self.request(
+            "POST",
+            f"/issue/{issue_key}/transitions",
+            json_body={"transition": {"id": str(transition_id)}},
+        )
+
+    # -------------------------------------------------------------------------
+    # Search
+    # -------------------------------------------------------------------------
+
+    def search(
+        self,
+        jql: str,
+        *,
+        max_results: int = 20,
+        fields: Optional[str] = None,
+    ) -> Any:
+        return self.request(
+            "GET",
+            "/search",
+            params={
+                "jql": jql,
+                "maxResults": max_results,
+                "fields": fields or "summary,status,assignee,priority,issuetype,created,updated",
+            },
+        )
+
+    # -------------------------------------------------------------------------
+    # Projects
+    # -------------------------------------------------------------------------
+
+    def list_projects(self, *, max_results: int = 50) -> Any:
+        return self.request(
+            "GET",
+            "/project",
+            params={"maxResults": max_results, "orderBy": "name"},
+        )
+
+    def get_project(self, project_key: str) -> Any:
+        return self.request("GET", f"/project/{project_key.upper()}")
+
+    # -------------------------------------------------------------------------
+    # Comments
+    # -------------------------------------------------------------------------
+
+    def get_comments(self, issue_key: str, *, max_results: int = 20) -> Any:
+        return self.request(
+            "GET",
+            f"/issue/{issue_key}/comment",
+            params={"maxResults": max_results},
+        )
+
+    def add_comment(self, issue_key: str, body: str) -> Any:
+        return self.request(
+            "POST",
+            f"/issue/{issue_key}/comment",
+            json_body={"body": text_to_adf(body)},
+        )
+
+    # -------------------------------------------------------------------------
+    # User / connectivity
+    # -------------------------------------------------------------------------
+
+    def get_myself(self) -> Any:
+        return self.request("GET", "/myself")
+
+
+# ---------------------------------------------------------------------------
+# Atlassian Document Format helpers
+# ---------------------------------------------------------------------------
+
+def text_to_adf(text: str) -> Dict[str, Any]:
+    """Convert plain text to Atlassian Document Format (ADF).
+
+    Splits on double newlines to create separate paragraphs.
+    Code blocks (``` delimited) are preserved as codeBlock nodes.
+    """
+    content = []
+    for para in text.split("\n\n"):
+        para = para.strip()
+        if not para:
+            continue
+        if para.startswith("```") and para.endswith("```"):
+            inner = para[3:-3]
+            lang = ""
+            if "\n" in inner:
+                first_line, rest = inner.split("\n", 1)
+                if first_line.strip() and " " not in first_line.strip():
+                    lang = first_line.strip()
+                    inner = rest
+            content.append({
+                "type": "codeBlock",
+                "attrs": {"language": lang} if lang else {},
+                "content": [{"type": "text", "text": inner}],
+            })
+        else:
+            content.append({
+                "type": "paragraph",
+                "content": [{"type": "text", "text": para}],
+            })
+    if not content:
+        content = [{"type": "paragraph", "content": [{"type": "text", "text": text}]}]
+    return {"version": 1, "type": "doc", "content": content}
+
+
+def adf_to_text(adf: Any) -> str:
+    """Extract plain text from an ADF document for display."""
+    if not isinstance(adf, dict):
+        return str(adf) if adf else ""
+    parts: List[str] = []
+
+    def _extract(node: Any) -> None:
+        if not isinstance(node, dict):
+            return
+        if node.get("type") == "text":
+            parts.append(str(node.get("text") or ""))
+        for child in node.get("content") or []:
+            _extract(child)
+        if node.get("type") in ("paragraph", "heading", "codeBlock", "bulletList", "orderedList"):
+            if parts and not parts[-1].endswith("\n"):
+                parts.append("\n")
+
+    _extract(adf)
+    return "".join(parts).strip()
+
+
+def make_basic_token(email: str, api_token: str) -> str:
+    """Return the Base64-encoded Basic Auth token for Jira API."""
+    raw = f"{email}:{api_token}"
+    return base64.b64encode(raw.encode("utf-8")).decode("ascii")

--- a/plugins/jira/plugin.yaml
+++ b/plugins/jira/plugin.yaml
@@ -1,0 +1,10 @@
+name: jira
+version: 1.0.0
+description: "Native Jira Cloud integration — 4 tools (issues, search, projects, comments) using Jira REST API v3 with API token auth. Auth via `hermes auth jira`."
+author: NousResearch
+kind: backend
+provides_tools:
+  - jira_issue
+  - jira_search
+  - jira_project
+  - jira_comment

--- a/plugins/jira/tools.py
+++ b/plugins/jira/tools.py
@@ -1,0 +1,456 @@
+"""Native Jira tools for Hermes (registered via plugins/jira)."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from hermes_cli.auth import get_auth_status
+from plugins.jira.client import (
+    JiraAPIError,
+    JiraAuthRequiredError,
+    JiraClient,
+    JiraError,
+    adf_to_text,
+)
+from tools.registry import tool_error, tool_result
+
+
+# ---------------------------------------------------------------------------
+# Availability check
+# ---------------------------------------------------------------------------
+
+def _check_jira_available() -> bool:
+    try:
+        return bool(get_auth_status("jira").get("logged_in"))
+    except Exception:
+        return False
+
+
+def _jira_client() -> JiraClient:
+    return JiraClient()
+
+
+def _jira_tool_error(exc: Exception) -> str:
+    if isinstance(exc, JiraAuthRequiredError):
+        return tool_error(
+            str(exc),
+            hint="Run `hermes auth jira` to authenticate.",
+        )
+    if isinstance(exc, JiraAPIError):
+        return tool_error(str(exc), status_code=exc.status_code)
+    if isinstance(exc, JiraError):
+        return tool_error(str(exc))
+    return tool_error(f"Jira tool failed: {type(exc).__name__}: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _coerce_int(raw: Any, default: int, minimum: int = 1, maximum: int = 100) -> int:
+    try:
+        return max(minimum, min(maximum, int(raw)))
+    except Exception:
+        return default
+
+
+def _as_list(raw: Any) -> List[str]:
+    if raw is None:
+        return []
+    if isinstance(raw, list):
+        return [str(i).strip() for i in raw if str(i).strip()]
+    return [str(raw).strip()] if str(raw).strip() else []
+
+
+def _issue_url(issue: Dict[str, Any]) -> str:
+    """Build a browse URL from the issue's self link, guarding against malformed URLs."""
+    self_link = issue.get("self") or ""
+    key = issue.get("key") or ""
+    if not self_link or not key:
+        return ""
+    parts = self_link.split("/")
+    # self link format: https://domain/rest/api/3/issue/ID → parts[2] = domain
+    if len(parts) < 3:
+        return ""
+    return f"https://{parts[2]}/browse/{key}"
+
+
+def _format_issue(issue: Dict[str, Any]) -> Dict[str, Any]:
+    """Flatten a Jira issue object for cleaner tool output."""
+    fields = issue.get("fields") or {}
+    status = (fields.get("status") or {}).get("name") or ""
+    assignee = fields.get("assignee") or {}
+    priority = (fields.get("priority") or {}).get("name") or ""
+    issuetype = (fields.get("issuetype") or {}).get("name") or ""
+    raw_desc = fields.get("description")
+    description = adf_to_text(raw_desc) if isinstance(raw_desc, dict) else (raw_desc or "")
+    return {
+        "key": issue.get("key") or "",
+        "summary": fields.get("summary") or "",
+        "status": status,
+        "issuetype": issuetype,
+        "priority": priority,
+        "assignee": assignee.get("displayName") or assignee.get("emailAddress") or "",
+        "assignee_account_id": assignee.get("accountId") or "",
+        "labels": fields.get("labels") or [],
+        "created": fields.get("created") or "",
+        "updated": fields.get("updated") or "",
+        "description": description[:500] + "…" if len(description) > 500 else description,
+        "url": _issue_url(issue),
+    }
+
+
+# ---------------------------------------------------------------------------
+# jira_issue tool
+# ---------------------------------------------------------------------------
+
+JIRA_ISSUE_SCHEMA = {
+    "name": "jira_issue",
+    "description": (
+        "Manage Jira issues: get details, create new issues, update fields, "
+        "list available status transitions, or transition an issue to a new status. "
+        "Requires Jira Cloud authentication (run `hermes auth jira` first)."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["get", "create", "update", "transitions", "transition"],
+                "description": (
+                    "get — fetch full issue details by key. "
+                    "create — create a new issue. "
+                    "update — update fields of an existing issue. "
+                    "transitions — list available status transitions for an issue. "
+                    "transition — move an issue to a new status by transition ID."
+                ),
+            },
+            "issue_key": {
+                "type": "string",
+                "description": "Issue key (e.g. PROJ-123). Required for get/update/transitions/transition.",
+            },
+            "project_key": {
+                "type": "string",
+                "description": "Project key (e.g. PROJ). Required for create.",
+            },
+            "issuetype": {
+                "type": "string",
+                "description": "Issue type name: Bug, Task, Story, Epic, Sub-task, etc. Required for create.",
+            },
+            "summary": {
+                "type": "string",
+                "description": "Issue title/summary. Required for create; optional for update.",
+            },
+            "description": {
+                "type": "string",
+                "description": "Issue description as plain text. Converted to Atlassian Document Format automatically.",
+            },
+            "assignee_id": {
+                "type": "string",
+                "description": "Atlassian account ID of the assignee. Use jira_search to find account IDs.",
+            },
+            "priority": {
+                "type": "string",
+                "description": "Priority name: Highest, High, Medium, Low, Lowest.",
+            },
+            "labels": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": "List of label strings to apply.",
+            },
+            "transition_id": {
+                "type": "string",
+                "description": "Transition ID to apply. Get available IDs from action='transitions'.",
+            },
+        },
+        "required": ["action"],
+    },
+}
+
+
+def _handle_jira_issue(args: Dict[str, Any], **kw: Any) -> str:
+    action = str(args.get("action") or "get").strip().lower()
+    client = _jira_client()
+
+    try:
+        if action == "get":
+            key = str(args.get("issue_key") or "").strip().upper()
+            if not key:
+                return tool_error("issue_key is required for action='get'")
+            raw = client.get_issue(key)
+            return tool_result(_format_issue(raw))
+
+        if action == "create":
+            project = str(args.get("project_key") or "").strip()
+            issuetype = str(args.get("issuetype") or "Task").strip()
+            summary = str(args.get("summary") or "").strip()
+            if not project:
+                return tool_error("project_key is required for action='create'")
+            if not summary:
+                return tool_error("summary is required for action='create'")
+            result = client.create_issue(
+                project,
+                issuetype,
+                summary,
+                description=args.get("description"),
+                assignee_id=args.get("assignee_id"),
+                priority=args.get("priority"),
+                labels=_as_list(args.get("labels")),
+            )
+            return tool_result({
+                "created": True,
+                "key": result.get("key") or "",
+                "id": result.get("id") or "",
+                "self": result.get("self") or "",
+            })
+
+        if action == "update":
+            key = str(args.get("issue_key") or "").strip().upper()
+            if not key:
+                return tool_error("issue_key is required for action='update'")
+            labels_raw = args.get("labels")
+            labels = _as_list(labels_raw) if labels_raw is not None else None
+            client.update_issue(
+                key,
+                summary=args.get("summary"),
+                description=args.get("description"),
+                assignee_id=args.get("assignee_id"),
+                priority=args.get("priority"),
+                labels=labels,
+            )
+            return tool_result({"updated": True, "key": key})
+
+        if action == "transitions":
+            key = str(args.get("issue_key") or "").strip().upper()
+            if not key:
+                return tool_error("issue_key is required for action='transitions'")
+            raw = client.get_transitions(key)
+            transitions = [
+                {
+                    "id": t.get("id"),
+                    "name": t.get("name"),
+                    "to_status": (t.get("to") or {}).get("name"),
+                }
+                for t in (raw.get("transitions") or [])
+            ]
+            return tool_result({"issue_key": key, "transitions": transitions})
+
+        if action == "transition":
+            key = str(args.get("issue_key") or "").strip().upper()
+            tid = str(args.get("transition_id") or "").strip()
+            if not key:
+                return tool_error("issue_key is required for action='transition'")
+            if not tid:
+                return tool_error("transition_id is required for action='transition'. Use action='transitions' to list options.")
+            client.transition_issue(key, tid)
+            return tool_result({"transitioned": True, "key": key, "transition_id": tid})
+
+        return tool_error(f"Unknown action '{action}'. Valid actions: get, create, update, transitions, transition.")
+
+    except Exception as exc:
+        return _jira_tool_error(exc)
+
+
+# ---------------------------------------------------------------------------
+# jira_search tool
+# ---------------------------------------------------------------------------
+
+JIRA_SEARCH_SCHEMA = {
+    "name": "jira_search",
+    "description": (
+        "Search Jira issues using JQL (Jira Query Language). "
+        "Examples: 'project=PROJ AND status=\"In Progress\"', "
+        "'assignee=currentUser() AND sprint in openSprints()', "
+        "'text~\"login bug\" ORDER BY created DESC'. "
+        "Returns a compact list of matching issues."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "jql": {
+                "type": "string",
+                "description": "JQL query string. See https://support.atlassian.com/jira-software-cloud/docs/use-advanced-search-with-jira-query-language-jql/",
+            },
+            "max_results": {
+                "type": "integer",
+                "description": "Maximum number of results to return (1-50, default 20).",
+                "default": 20,
+            },
+        },
+        "required": ["jql"],
+    },
+}
+
+
+def _handle_jira_search(args: Dict[str, Any], **kw: Any) -> str:
+    jql = str(args.get("jql") or "").strip()
+    if not jql:
+        return tool_error("jql is required")
+    max_results = _coerce_int(args.get("max_results"), default=20, minimum=1, maximum=50)
+    client = _jira_client()
+    try:
+        raw = client.search(jql, max_results=max_results)
+        issues = [_format_issue(i) for i in (raw.get("issues") or [])]
+        return tool_result({
+            "total": raw.get("total") or len(issues),
+            "returned": len(issues),
+            "jql": jql,
+            "issues": issues,
+        })
+    except Exception as exc:
+        return _jira_tool_error(exc)
+
+
+# ---------------------------------------------------------------------------
+# jira_project tool
+# ---------------------------------------------------------------------------
+
+JIRA_PROJECT_SCHEMA = {
+    "name": "jira_project",
+    "description": (
+        "List all accessible Jira projects or get details about a specific project. "
+        "Use this to discover project keys required for jira_issue create."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["list", "get"],
+                "description": "list — list all projects. get — get details for a specific project.",
+                "default": "list",
+            },
+            "project_key": {
+                "type": "string",
+                "description": "Project key (e.g. PROJ). Required for action='get'.",
+            },
+            "max_results": {
+                "type": "integer",
+                "description": "Max projects to return for action='list' (1-100, default 50).",
+                "default": 50,
+            },
+        },
+        "required": ["action"],
+    },
+}
+
+
+def _handle_jira_project(args: Dict[str, Any], **kw: Any) -> str:
+    action = str(args.get("action") or "list").strip().lower()
+    client = _jira_client()
+
+    try:
+        if action == "list":
+            max_results = _coerce_int(args.get("max_results"), default=50, minimum=1, maximum=100)
+            raw = client.list_projects(max_results=max_results)
+            projects = [
+                {
+                    "key": p.get("key") or "",
+                    "name": p.get("name") or "",
+                    "type": p.get("projectTypeKey") or "",
+                    "style": p.get("style") or "",
+                }
+                for p in (raw if isinstance(raw, list) else [])
+            ]
+            return tool_result({"count": len(projects), "projects": projects})
+
+        if action == "get":
+            key = str(args.get("project_key") or "").strip().upper()
+            if not key:
+                return tool_error("project_key is required for action='get'")
+            raw = client.get_project(key)
+            return tool_result({
+                "key": raw.get("key") or "",
+                "name": raw.get("name") or "",
+                "type": raw.get("projectTypeKey") or "",
+                "description": raw.get("description") or "",
+                "lead": ((raw.get("lead") or {}).get("displayName")) or "",
+                "url": raw.get("self") or "",
+            })
+
+        return tool_error(f"Unknown action '{action}'. Valid: list, get.")
+
+    except Exception as exc:
+        return _jira_tool_error(exc)
+
+
+# ---------------------------------------------------------------------------
+# jira_comment tool
+# ---------------------------------------------------------------------------
+
+JIRA_COMMENT_SCHEMA = {
+    "name": "jira_comment",
+    "description": (
+        "Read or add comments on a Jira issue. "
+        "Use action='list' to fetch existing comments and action='add' to post a new one."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": ["list", "add"],
+                "description": "list — get all comments on an issue. add — post a new comment.",
+            },
+            "issue_key": {
+                "type": "string",
+                "description": "Issue key (e.g. PROJ-123).",
+            },
+            "body": {
+                "type": "string",
+                "description": "Comment text. Required for action='add'. Plain text is accepted.",
+            },
+            "max_results": {
+                "type": "integer",
+                "description": "Max comments to return for action='list' (default 20).",
+                "default": 20,
+            },
+        },
+        "required": ["action", "issue_key"],
+    },
+}
+
+
+def _handle_jira_comment(args: Dict[str, Any], **kw: Any) -> str:
+    action = str(args.get("action") or "list").strip().lower()
+    key = str(args.get("issue_key") or "").strip().upper()
+    if not key:
+        return tool_error("issue_key is required")
+    client = _jira_client()
+
+    try:
+        if action == "list":
+            max_results = _coerce_int(args.get("max_results"), default=20, minimum=1, maximum=100)
+            raw = client.get_comments(key, max_results=max_results)
+            comments = [
+                {
+                    "id": c.get("id") or "",
+                    "author": ((c.get("author") or {}).get("displayName")) or "",
+                    "created": c.get("created") or "",
+                    "updated": c.get("updated") or "",
+                    "body": adf_to_text(c.get("body")) if isinstance(c.get("body"), dict) else str(c.get("body") or ""),
+                }
+                for c in (raw.get("comments") or [])
+            ]
+            return tool_result({
+                "issue_key": key,
+                "total": raw.get("total") or len(comments),
+                "comments": comments,
+            })
+
+        if action == "add":
+            body = str(args.get("body") or "").strip()
+            if not body:
+                return tool_error("body is required for action='add'")
+            result = client.add_comment(key, body)
+            return tool_result({
+                "added": True,
+                "issue_key": key,
+                "comment_id": result.get("id") or "",
+                "created": result.get("created") or "",
+            })
+
+        return tool_error(f"Unknown action '{action}'. Valid: list, add.")
+
+    except Exception as exc:
+        return _jira_tool_error(exc)

--- a/tests/tools/test_jira_client.py
+++ b/tests/tools/test_jira_client.py
@@ -1,0 +1,294 @@
+"""Tests for plugins/jira/client.py — JiraClient, ADF helpers, auth utilities."""
+
+import base64
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from plugins.jira.client import (
+    JiraAPIError,
+    JiraAuthRequiredError,
+    JiraClient,
+    adf_to_text,
+    make_basic_token,
+    text_to_adf,
+)
+from plugins.jira.tools import _issue_url
+
+
+# ---------------------------------------------------------------------------
+# make_basic_token
+# ---------------------------------------------------------------------------
+
+class TestMakeBasicToken:
+    def test_encodes_email_and_token(self):
+        token = make_basic_token("user@example.com", "mytoken")
+        decoded = base64.b64decode(token).decode("utf-8")
+        assert decoded == "user@example.com:mytoken"
+
+    def test_output_is_ascii(self):
+        token = make_basic_token("a@b.com", "t")
+        assert token.isascii()
+
+
+# ---------------------------------------------------------------------------
+# _issue_url
+# ---------------------------------------------------------------------------
+
+class TestIssueUrl:
+    def test_valid_self_link(self):
+        issue = {
+            "self": "https://myco.atlassian.net/rest/api/3/issue/10001",
+            "key": "PROJ-1",
+        }
+        assert _issue_url(issue) == "https://myco.atlassian.net/browse/PROJ-1"
+
+    def test_empty_self_returns_empty(self):
+        assert _issue_url({"self": "", "key": "PROJ-1"}) == ""
+
+    def test_missing_self_returns_empty(self):
+        assert _issue_url({"key": "PROJ-1"}) == ""
+
+    def test_missing_key_returns_empty(self):
+        assert _issue_url({"self": "https://myco.atlassian.net/rest/api/3/issue/10001"}) == ""
+
+    def test_malformed_self_returns_empty(self):
+        # only one slash — split gives fewer than 3 parts
+        assert _issue_url({"self": "broken", "key": "PROJ-1"}) == ""
+
+
+# ---------------------------------------------------------------------------
+# text_to_adf
+# ---------------------------------------------------------------------------
+
+class TestTextToAdf:
+    def test_single_paragraph(self):
+        adf = text_to_adf("Hello world")
+        assert adf["type"] == "doc"
+        assert adf["version"] == 1
+        assert len(adf["content"]) == 1
+        assert adf["content"][0]["type"] == "paragraph"
+        assert adf["content"][0]["content"][0]["text"] == "Hello world"
+
+    def test_double_newline_creates_two_paragraphs(self):
+        adf = text_to_adf("First paragraph\n\nSecond paragraph")
+        assert len(adf["content"]) == 2
+        assert adf["content"][0]["content"][0]["text"] == "First paragraph"
+        assert adf["content"][1]["content"][0]["text"] == "Second paragraph"
+
+    def test_empty_string_returns_empty_paragraph(self):
+        adf = text_to_adf("")
+        assert adf["type"] == "doc"
+        assert len(adf["content"]) == 1
+
+    def test_code_block_detection(self):
+        adf = text_to_adf("```python\nprint('hi')\n```")
+        assert adf["content"][0]["type"] == "codeBlock"
+        assert adf["content"][0]["attrs"]["language"] == "python"
+
+
+# ---------------------------------------------------------------------------
+# adf_to_text
+# ---------------------------------------------------------------------------
+
+class TestAdfToText:
+    def test_simple_doc(self):
+        adf = {
+            "version": 1,
+            "type": "doc",
+            "content": [
+                {
+                    "type": "paragraph",
+                    "content": [{"type": "text", "text": "Hello world"}],
+                }
+            ],
+        }
+        assert adf_to_text(adf) == "Hello world"
+
+    def test_non_dict_returns_string(self):
+        assert adf_to_text("plain text") == "plain text"
+        assert adf_to_text(None) == ""
+        assert adf_to_text(42) == "42"
+
+    def test_nested_content(self):
+        adf = {
+            "type": "doc",
+            "content": [
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {"type": "text", "text": "Line one"},
+                    ],
+                },
+                {
+                    "type": "paragraph",
+                    "content": [
+                        {"type": "text", "text": "Line two"},
+                    ],
+                },
+            ],
+        }
+        result = adf_to_text(adf)
+        assert "Line one" in result
+        assert "Line two" in result
+
+
+# ---------------------------------------------------------------------------
+# JiraClient — auth error on missing credentials
+# ---------------------------------------------------------------------------
+
+class TestJiraClientAuthError:
+    def test_raises_auth_required_when_not_authenticated(self, monkeypatch):
+        from hermes_cli.auth import AuthError
+
+        def _raise_auth_error():
+            raise AuthError("not authenticated", provider="jira", code="jira_auth_missing")
+
+        monkeypatch.setattr(
+            "plugins.jira.client.resolve_jira_runtime_credentials",
+            _raise_auth_error,
+        )
+        with pytest.raises(JiraAuthRequiredError):
+            JiraClient()
+
+
+# ---------------------------------------------------------------------------
+# JiraClient.request — HTTP layer behaviour
+# ---------------------------------------------------------------------------
+
+def _make_client(domain="myco.atlassian.net", email="user@example.com", basic_token="tok") -> JiraClient:
+    """Build a JiraClient with a fake runtime, bypassing auth."""
+    client = object.__new__(JiraClient)
+    client._runtime = {
+        "domain": domain,
+        "email": email,
+        "basic_token": basic_token,
+        "base_url": f"https://{domain}/rest/api/3",
+    }
+    return client
+
+
+class TestJiraClientRequest:
+    def _mock_response(self, status_code: int, body: dict | None = None):
+        resp = MagicMock()
+        resp.status_code = status_code
+        resp.content = b"ok" if body is not None else b""
+        resp.headers = {"content-type": "application/json"}
+        resp.json.return_value = body or {}
+        resp.text = json.dumps(body) if body else ""
+        return resp
+
+    def test_get_returns_json(self):
+        client = _make_client()
+        resp = self._mock_response(200, {"id": "1", "key": "PROJ-1"})
+        with patch("plugins.jira.client.httpx.request", return_value=resp):
+            result = client.request("GET", "/issue/PROJ-1")
+        assert result["key"] == "PROJ-1"
+
+    def test_204_returns_success(self):
+        client = _make_client()
+        resp = MagicMock()
+        resp.status_code = 204
+        resp.content = b""
+        with patch("plugins.jira.client.httpx.request", return_value=resp):
+            result = client.request("PUT", "/issue/PROJ-1")
+        assert result["success"] is True
+
+    def test_401_raises_auth_required(self):
+        client = _make_client()
+        resp = self._mock_response(401, {"errorMessages": ["Unauthorized"]})
+        with patch("plugins.jira.client.httpx.request", return_value=resp):
+            with pytest.raises(JiraAuthRequiredError):
+                client.request("GET", "/issue/PROJ-1")
+
+    def test_400_raises_api_error_with_status(self):
+        client = _make_client()
+        resp = self._mock_response(400, {"errorMessages": ["Field 'foo' is required"]})
+        with patch("plugins.jira.client.httpx.request", return_value=resp):
+            with pytest.raises(JiraAPIError) as exc_info:
+                client.request("POST", "/issue")
+        assert exc_info.value.status_code == 400
+
+    def test_404_raises_api_error(self):
+        client = _make_client()
+        resp = self._mock_response(404, {"errorMessages": ["Issue does not exist"]})
+        with patch("plugins.jira.client.httpx.request", return_value=resp):
+            with pytest.raises(JiraAPIError):
+                client.request("GET", "/issue/BAD-999")
+
+
+# ---------------------------------------------------------------------------
+# JiraClient convenience methods
+# ---------------------------------------------------------------------------
+
+class TestJiraClientMethods:
+    def _mock_response(self, body: dict):
+        resp = MagicMock()
+        resp.status_code = 200
+        resp.content = b"ok"
+        resp.headers = {"content-type": "application/json"}
+        resp.json.return_value = body
+        return resp
+
+    def test_create_issue_builds_correct_payload(self):
+        client = _make_client()
+        captured = {}
+
+        def fake_request(method, url, **kwargs):
+            captured["json"] = kwargs.get("json")
+            resp = MagicMock()
+            resp.status_code = 201
+            resp.content = b'{"key":"PROJ-1","id":"10001","self":"http://x"}'
+            resp.headers = {"content-type": "application/json"}
+            resp.json.return_value = {"key": "PROJ-1", "id": "10001", "self": "http://x"}
+            return resp
+
+        with patch("plugins.jira.client.httpx.request", side_effect=fake_request):
+            result = client.create_issue("PROJ", "Bug", "Something is broken", description="Details here")
+
+        fields = captured["json"]["fields"]
+        assert fields["project"]["key"] == "PROJ"
+        assert fields["issuetype"]["name"] == "Bug"
+        assert fields["summary"] == "Something is broken"
+        # Description must be ADF
+        assert fields["description"]["type"] == "doc"
+        assert result["key"] == "PROJ-1"
+
+    def test_search_passes_jql(self):
+        client = _make_client()
+        captured_params = {}
+
+        def fake_request(method, url, **kwargs):
+            captured_params.update(kwargs.get("params") or {})
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.content = b'{"issues":[],"total":0}'
+            resp.headers = {"content-type": "application/json"}
+            resp.json.return_value = {"issues": [], "total": 0}
+            return resp
+
+        with patch("plugins.jira.client.httpx.request", side_effect=fake_request):
+            client.search("project=PROJ AND status=Open", max_results=10)
+
+        assert captured_params["jql"] == "project=PROJ AND status=Open"
+        assert captured_params["maxResults"] == 10
+
+    def test_add_comment_converts_to_adf(self):
+        client = _make_client()
+        captured = {}
+
+        def fake_request(method, url, **kwargs):
+            captured["json"] = kwargs.get("json")
+            resp = MagicMock()
+            resp.status_code = 201
+            resp.content = b'{"id":"10001","created":"2026-01-01"}'
+            resp.headers = {"content-type": "application/json"}
+            resp.json.return_value = {"id": "10001", "created": "2026-01-01"}
+            return resp
+
+        with patch("plugins.jira.client.httpx.request", side_effect=fake_request):
+            client.add_comment("PROJ-1", "This is my comment")
+
+        assert captured["json"]["body"]["type"] == "doc"
+        assert captured["json"]["body"]["content"][0]["content"][0]["text"] == "This is my comment"

--- a/toolsets.py
+++ b/toolsets.py
@@ -291,6 +291,14 @@ TOOLSETS = {
         "includes": []
     },
 
+    "jira": {
+        "description": "Native Jira Cloud integration — create, read, update, search, and transition issues; manage projects and comments",
+        "tools": [
+            "jira_issue", "jira_search", "jira_project", "jira_comment",
+        ],
+        "includes": []
+    },
+
 
     # Scenario-specific toolsets
     


### PR DESCRIPTION
## What does this PR do?

Adds a bundled backend plugin under `plugins/jira/` that registers 4 tools into a new `jira` toolset. This is the second slice of the Jira integration — auth foundation was added in the preceding PR.

**Tools registered:**

| Tool | Description |
|------|-------------|
| `jira_issue` | Get / create / update / transition issues (action-based) |
| `jira_search` | JQL search across all accessible issues |
| `jira_project` | List all projects or get details for a specific project |
| `jira_comment` | List or add comments on an issue |

**Architecture** follows the Spotify plugin pattern exactly:
- `plugins/jira/__init__.py` — `register(ctx)` entry point, `kind: backend`, auto-loaded
- `plugins/jira/plugin.yaml` — bundled plugin manifest
- `plugins/jira/client.py` — `JiraClient` wrapping the Jira REST API v3 + ADF helpers
- `plugins/jira/tools.py` — 4 tool schemas + handlers

Text in all fields (description, comments) is automatically converted to/from Atlassian Document Format (ADF). Issue objects are flattened before returning so the agent sees a compact, readable dict rather than the full nested API response.

`toolsets.py`: adds the `jira` toolset entry alongside `spotify`.

## Related Issue

Follows `feat(jira): add hermes auth jira command` (auth foundation PR).

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests
- [ ] ♻️ Refactor
- [x] 🎯 New skill

## Changes Made

- `plugins/jira/__init__.py` — plugin registration
- `plugins/jira/plugin.yaml` — plugin manifest
- `plugins/jira/client.py` — `JiraClient`, `text_to_adf()`, `adf_to_text()`, `make_basic_token()`
- `plugins/jira/tools.py` — 4 tool handlers + schemas
- `toolsets.py` — `jira` toolset entry (+7 lines)
- `tests/tools/test_jira_client.py` — 23 tests covering client, ADF helpers, URL construction

## How to Test

```bash
python3.11 -m pytest tests/tools/test_jira_client.py -v --override-ini="addopts="
# 23 passed

# With a real Jira account:
hermes auth jira
# Then in a hermes session:
# jira_search(jql="project=MYPROJ AND status='In Progress'")
# jira_issue(action="create", project_key="MYPROJ", issuetype="Bug", summary="Test from Hermes")
```

## Checklist

### Code
- [x] Contributing Guide read
- [x] Conventional Commits
- [x] No duplicate PR
- [x] This feat only — auth is in the preceding PR
- [x] pytest run (23/23 pass)
- [x] Tests added
- [x] ruff check passes
- [x] Platform: macOS

### Documentation & Housekeeping
- [x] Docs updated — N/A (docs PR will follow)
- [x] cli-config.yaml.example — N/A
- [x] CONTRIBUTING.md/AGENTS.md — N/A
- [x] Cross-platform impact — `httpx` and `base64` are cross-platform
- [x] Tool descriptions — included in tool schemas