### PR TITLE
fix(bluebubbles): add GUID-based dedup to prevent duplicate replies

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -13,6 +13,7 @@ import json
 import logging
 import os
 import re
+import time
 import uuid
 from datetime import datetime
 from typing import Any, Dict, List, Optional
@@ -129,6 +130,8 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         self._private_api_enabled: Optional[bool] = None
         self._helper_connected: bool = False
         self._guid_cache: Dict[str, str] = {}
+        self._seen_message_guids: Dict[str, float] = {}  # guid -> timestamp
+        self._DEDUP_TTL = 30.0  # seconds
 
     # ------------------------------------------------------------------
     # API helpers
@@ -818,6 +821,22 @@ class BlueBubblesAdapter(BasePlatformAdapter):
             **_TAPBACK_REMOVED,
         }:
             return web.Response(text="ok")
+
+        # Dedup: BB fires multiple webhooks per message (status updates, etc.)
+        msg_guid = self._value(
+            record.get("guid"),
+            record.get("messageGuid"),
+            record.get("id"),
+        )
+        now = time.time()
+        self._seen_message_guids = {
+            k: v for k, v in self._seen_message_guids.items()
+            if now - v < self._DEDUP_TTL
+        }
+        if msg_guid and msg_guid in self._seen_message_guids:
+            return web.Response(text="ok")
+        if msg_guid:
+            self._seen_message_guids[msg_guid] = now
 
         text = (
             self._value(


### PR DESCRIPTION
## Problem

BlueBubbles sends multiple webhook events per incoming message (5-10 POSTs in rapid succession as iMessage status updates fire: delivered, read, etc.). The `_handle_webhook` method in `bluebubbles.py` spawns `asyncio.create_task(self.handle_message(event))` for every webhook hit.

Although `handle_message()` in `base.py` has an `_active_sessions` guard, the tasks are spawned synchronously but run asynchronously, creating a race window where multiple tasks pass the guard before the first one sets it. Net result: every iMessage gets 2+ duplicate replies from the agent.

## Fix

Three changes in `gateway/platforms/bluebubbles.py`:

1. Add `import time` to imports
2. Add `_seen_message_guids` dict and `_DEDUP_TTL = 30.0` to `__init__`
3. Add GUID-based dedup check in `_handle_webhook` — before the `handle_message` spawn, checks if the message GUID was seen within the last 30 seconds. If so, returns `ok` immediately. Periodically prunes expired entries.

The dedup runs after the existing `isFromMe` and tapback filters, so those are unaffected.

## Test Plan

- [ ] Verify single reply per iMessage on macOS with BlueBubbles private API enabled
- [ ] Verify dedup cache prunes stale entries (no unbounded growth)
- [ ] Verify `isFromMe` and tapback messages still silently dropped