### PR TITLE
feat(jira): wire hermes auth jira into setup wizard and tool status

### DIFF
--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -524,6 +524,15 @@ def _print_setup_summary(config: dict, hermes_home):
     except Exception:
         pass
 
+    # Jira (API token via hermes auth jira — check auth.json, not env vars)
+    try:
+        from hermes_cli.auth import get_provider_auth_state
+        _jira_state = get_provider_auth_state("jira") or {}
+        if _jira_state.get("basic_token"):
+            tool_status.append(("Jira Cloud (API token)", True, None))
+    except Exception:
+        pass
+
     # Skills Hub
     if get_env_value("GITHUB_TOKEN"):
         tool_status.append(("Skills Hub (GitHub)", True, None))

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -72,6 +72,7 @@ CONFIGURABLE_TOOLSETS = [
     ("rl",              "🧪 RL Training",               "Tinker-Atropos training tools"),
     ("homeassistant",    "🏠 Home Assistant",           "smart home device control"),
     ("spotify",          "🎵 Spotify",                  "playback, search, playlists, library"),
+    ("jira",             "🎫 Jira",                     "create, search, update, and transition issues"),
     ("discord",         "💬 Discord (read/participate)", "fetch messages, search members, create thread"),
     ("discord_admin",   "🛡️  Discord Server Admin",    "list channels/roles, pin, assign roles"),
     ("yuanbao",          "🤖 Yuanbao",                  "group info, member queries, DM"),
@@ -81,7 +82,7 @@ CONFIGURABLE_TOOLSETS = [
 # Toolsets that are OFF by default for new installs.
 # They're still in _HERMES_CORE_TOOLS (available at runtime if enabled),
 # but the setup checklist won't pre-select them for first-time users.
-_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "rl", "spotify", "discord", "discord_admin", "video"}
+_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "rl", "spotify", "jira", "discord", "discord_admin", "video"}
 
 # Platform-scoped toolsets: only appear in the `hermes tools` checklist for
 # these platforms, and only resolve/save for these platforms.  A toolset
@@ -444,6 +445,18 @@ TOOL_CATEGORIES = {
                 "tag": "PKCE OAuth — opens the setup wizard",
                 "env_vars": [],
                 "post_setup": "spotify",
+            },
+        ],
+    },
+    "jira": {
+        "name": "Jira",
+        "icon": "🎫",
+        "providers": [
+            {
+                "name": "Jira Cloud (API token)",
+                "tag": "API token auth — runs hermes auth jira",
+                "env_vars": [],
+                "post_setup": "jira",
             },
         ],
     },
@@ -816,6 +829,28 @@ def _run_post_setup(post_setup_key: str):
         except Exception as exc:
             _print_warning(f"    Spotify login failed: {exc}")
             _print_info("    Run manually: hermes auth spotify")
+
+    elif post_setup_key == "jira":
+        # Run the full `hermes auth jira` flow — prompts for domain, email,
+        # and API token, validates against /rest/api/3/myself, then persists
+        # credentials to auth.json. Users can retry with `hermes auth jira`.
+        from types import SimpleNamespace
+        try:
+            from hermes_cli.auth import login_jira_command
+        except Exception as exc:
+            _print_warning(f"    Could not load Jira auth: {exc}")
+            _print_info("    Run manually: hermes auth jira")
+            return
+        _print_info("    Starting Jira authentication...")
+        try:
+            login_jira_command(SimpleNamespace(domain=None, email=None, token=None))
+            _print_success("    Jira authenticated")
+        except SystemExit as exc:
+            _print_warning(f"    Jira login did not complete: {exc}")
+            _print_info("    Run later: hermes auth jira")
+        except Exception as exc:
+            _print_warning(f"    Jira login failed: {exc}")
+            _print_info("    Run manually: hermes auth jira")
 
     elif post_setup_key == "rl_training":
         try:


### PR DESCRIPTION
## What does this PR do?

Wires the Jira integration into `hermes setup` and `hermes tools`, following the Spotify pattern exactly. All four integration points that Spotify uses are replicated for Jira:

| Location | Change |
|----------|--------|
| `CONFIGURABLE_TOOLSETS` | Adds `("jira", "🎫 Jira", "create, search, update, and transition issues")` so Jira appears in `hermes setup tools` / `hermes tools` checklist |
| `_DEFAULT_OFF_TOOLSETS` | Adds `"jira"` so the toolset is opt-in, not pre-selected for new installs |
| `TOOL_CATEGORIES["jira"]` | Provider entry with `env_vars=[]` and `post_setup="jira"` — tells the configurator to run `hermes auth jira` when the user enables the toolset |
| `_run_post_setup("jira")` | New branch that calls `login_jira_command()` interactively, mirroring the Spotify branch line-for-line |

`setup.py`: adds Jira to the tool-status block in `_print_setup_summary()` so `hermes setup` displays `✓ Jira Cloud (API token)` when the user is authenticated.

**User experience after all three Jira PRs are merged:**
```
hermes setup tools
→ [ ] 🎫 Jira — check to enable
→ starts hermes auth jira interactively

hermes status
→ ✓ Jira Cloud (API token)
```

## Related Issue

Third slice of the Jira integration series:
1. `feat(jira): add hermes auth jira command` — auth foundation
2. `feat(jira): add native Jira Cloud plugin with 4 tools` — plugin
3. **This PR** — setup wizard wiring

## Type of Change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests
- [ ] ♻️ Refactor
- [ ] 🎯 New skill

## Changes Made

- `hermes_cli/tools_config.py`: +28 lines (CONFIGURABLE_TOOLSETS, _DEFAULT_OFF_TOOLSETS, TOOL_CATEGORIES, _run_post_setup)
- `hermes_cli/setup.py`: +9 lines (tool status display)

## How to Test

```bash
# Verify Jira appears in the toolset list
python3 -c "
from hermes_cli.tools_config import CONFIGURABLE_TOOLSETS, TOOL_CATEGORIES, _DEFAULT_OFF_TOOLSETS
assert any(k == 'jira' for k,_,_ in CONFIGURABLE_TOOLSETS)
assert 'jira' in _DEFAULT_OFF_TOOLSETS
assert 'jira' in TOOL_CATEGORIES
assert TOOL_CATEGORIES['jira']['providers'][0]['post_setup'] == 'jira'
print('All OK')
"

# Full flow (requires auth PR + plugin PR)
hermes setup tools  # Jira appears in checklist
hermes auth jira    # authenticate
hermes status       # shows ✓ Jira Cloud (API token)
```

## Checklist

### Code
- [x] Contributing Guide read
- [x] Conventional Commits
- [x] No duplicate PR
- [x] This feat only
- [x] ruff passes
- [x] Platform: macOS

### Documentation & Housekeeping
- [x] Docs updated — N/A (docs PR will follow)
- [x] cli-config.yaml.example — N/A
- [x] Cross-platform impact — no platform-specific code
- [x] Tool descriptions — in CONFIGURABLE_TOOLSETS entry