### PR TITLE
feat(tools): add Gemini (Google AI Studio) as a free STT provider

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -938,10 +938,14 @@ DEFAULT_CONFIG = {
     
     "stt": {
         "enabled": True,
-        "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "mistral" (Voxtral Transcribe)
+        "provider": "local",  # "local" (free, faster-whisper) | "gemini" (free, AI Studio) | "groq" | "openai" (Whisper API) | "mistral" (Voxtral Transcribe)
         "local": {
             "model": "base",  # tiny, base, small, medium, large-v3
             "language": "",  # auto-detect by default; set to "en", "es", "fr", etc. to force
+        },
+        "gemini": {
+            "model": "gemini-3.1-flash-lite",  # or gemini-3.1-flash-lite-preview, gemini-3-flash-preview
+            "language": "",  # optional language hint; leave empty for auto-detect
         },
         "openai": {
             "model": "whisper-1",  # whisper-1, gpt-4o-mini-transcribe, gpt-4o-transcribe
@@ -1449,6 +1453,14 @@ OPTIONAL_ENV_VARS = {
         "password": False,
         "category": "provider",
         "advanced": True,
+    },
+    "GEMINI_STT_API_KEY": {
+        "description": "Dedicated Gemini API key for STT (falls back to GEMINI_API_KEY / GOOGLE_API_KEY)",
+        "prompt": "Gemini STT API key (optional — get a free key at https://aistudio.google.com/app/apikey)",
+        "url": "https://aistudio.google.com/app/apikey",
+        "password": True,
+        "category": "provider",
+        "advanced": False,
     },
     "XAI_API_KEY": {
         "description": "xAI API key",

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -273,7 +273,7 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
     "stt.provider": {
         "type": "select",
         "description": "Speech-to-text provider",
-        "options": ["local", "openai", "mistral"],
+        "options": ["local", "gemini", "openai", "mistral"],
     },
     "display.skin": {
         "type": "select",

--- a/tests/tools/test_transcription_tools.py
+++ b/tests/tools/test_transcription_tools.py
@@ -49,6 +49,9 @@ def clean_env(monkeypatch):
     monkeypatch.delenv("OPENAI_API_KEY", raising=False)
     monkeypatch.delenv("GROQ_API_KEY", raising=False)
     monkeypatch.delenv("MISTRAL_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_STT_API_KEY", raising=False)
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
     monkeypatch.delenv("HERMES_LOCAL_STT_COMMAND", raising=False)
     monkeypatch.delenv("HERMES_LOCAL_STT_LANGUAGE", raising=False)
 
@@ -1346,3 +1349,251 @@ class TestTranscribeAudioXAIDispatch:
             transcribe_audio(sample_ogg, model="custom-stt")
 
         assert mock_xai.call_args[0][1] == "custom-stt"
+
+
+# ============================================================================
+# _transcribe_gemini
+# ============================================================================
+
+class TestTranscribeGemini:
+    """Gemini STT provider tests."""
+
+    def test_no_key(self, monkeypatch):
+        monkeypatch.delenv("GEMINI_STT_API_KEY", raising=False)
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        from tools.transcription_tools import _transcribe_gemini
+        result = _transcribe_gemini("/tmp/test.ogg", "gemini-3.1-flash-lite")
+        assert result["success"] is False
+        assert "Gemini STT requires an API key" in result["error"]
+
+    def test_successful_transcription(self, monkeypatch, sample_ogg):
+        monkeypatch.setenv("GEMINI_API_KEY", "gemini-test-key")
+
+        fake_response = {
+            "candidates": [{
+                "content": {
+                    "parts": [{"text": "hello world"}],
+                },
+            }],
+        }
+
+        class FakeResponse:
+            def read(self):
+                import json
+                return json.dumps(fake_response).encode("utf-8")
+
+        class FakeUrlopen:
+            def __enter__(self):
+                return FakeResponse()
+            def __exit__(self, *args):
+                return False
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("urllib.request.urlopen", return_value=FakeUrlopen()) as mock_urlopen:
+            from tools.transcription_tools import _transcribe_gemini
+            result = _transcribe_gemini(sample_ogg, "gemini-3.1-flash-lite")
+
+        assert result["success"] is True
+        assert result["transcript"] == "hello world"
+        assert result["provider"] == "gemini"
+
+        # Verify the URL contains the model and key
+        call_args = mock_urlopen.call_args
+        req = call_args[0][0]
+        assert "gemini-3.1-flash-lite" in req.full_url
+        assert "gemini-test-key" in req.full_url
+
+    def test_empty_candidates(self, monkeypatch, sample_ogg):
+        monkeypatch.setenv("GOOGLE_API_KEY", "google-test-key")
+
+        fake_response = {
+            "candidates": [],
+            "promptFeedback": {"blockReason": "SAFETY"},
+        }
+
+        class FakeResponse:
+            def read(self):
+                import json
+                return json.dumps(fake_response).encode("utf-8")
+
+        class FakeUrlopen:
+            def __enter__(self):
+                return FakeResponse()
+            def __exit__(self, *args):
+                return False
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("urllib.request.urlopen", return_value=FakeUrlopen()):
+            from tools.transcription_tools import _transcribe_gemini
+            result = _transcribe_gemini(sample_ogg, "gemini-3.1-flash-lite")
+
+        assert result["success"] is False
+        assert "SAFETY" in result["error"]
+
+    def test_http_error(self, monkeypatch, sample_ogg):
+        monkeypatch.setenv("GEMINI_STT_API_KEY", "gemini-test-key")
+
+        import urllib.error
+        import io
+
+        error_body = b'{"error": {"message": "rate limit exceeded"}}'
+        fake_fp = io.BytesIO(error_body)
+        http_error = urllib.error.HTTPError(
+            "url", 429, "Too Many Requests", {}, fake_fp
+        )
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("urllib.request.urlopen", side_effect=http_error):
+            from tools.transcription_tools import _transcribe_gemini
+            result = _transcribe_gemini(sample_ogg, "gemini-3.1-flash-lite")
+
+        assert result["success"] is False
+        assert "rate limit exceeded" in result["error"]
+
+    def test_language_hint_from_config(self, monkeypatch, sample_ogg):
+        monkeypatch.setenv("GEMINI_API_KEY", "gemini-test-key")
+
+        fake_response = {
+            "candidates": [{"content": {"parts": [{"text": "hola mundo"}]}}],
+        }
+
+        class FakeResponse:
+            def read(self):
+                import json
+                return json.dumps(fake_response).encode("utf-8")
+
+        class FakeUrlopen:
+            def __enter__(self):
+                return FakeResponse()
+            def __exit__(self, *args):
+                return False
+
+        config = {"gemini": {"language": "es"}}
+        with patch("tools.transcription_tools._load_stt_config", return_value=config), \
+             patch("urllib.request.urlopen", return_value=FakeUrlopen()) as mock_urlopen:
+            from tools.transcription_tools import _transcribe_gemini
+            _transcribe_gemini(sample_ogg, "gemini-3.1-flash-lite")
+
+        req = mock_urlopen.call_args[0][0]
+        body = req.data.decode("utf-8")
+        assert "es" in body
+
+    def test_custom_base_url(self, monkeypatch, sample_ogg):
+        monkeypatch.setenv("GEMINI_API_KEY", "gemini-test-key")
+        monkeypatch.setenv("GEMINI_STT_BASE_URL", "https://custom.gemini.com/v1")
+
+        fake_response = {
+            "candidates": [{"content": {"parts": [{"text": "test"}]}}],
+        }
+
+        class FakeResponse:
+            def read(self):
+                import json
+                return json.dumps(fake_response).encode("utf-8")
+
+        class FakeUrlopen:
+            def __enter__(self):
+                return FakeResponse()
+            def __exit__(self, *args):
+                return False
+
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("urllib.request.urlopen", return_value=FakeUrlopen()) as mock_urlopen:
+            from tools.transcription_tools import _transcribe_gemini
+            _transcribe_gemini(sample_ogg, "gemini-3.1-flash-lite")
+
+        req = mock_urlopen.call_args[0][0]
+        assert "custom.gemini.com" in req.full_url
+
+    def test_fallback_keys(self, monkeypatch):
+        """GEMINI_STT_API_KEY > GEMINI_API_KEY > GOOGLE_API_KEY."""
+        from tools.transcription_tools import _resolve_gemini_stt_api_key
+
+        monkeypatch.setenv("GOOGLE_API_KEY", "google-key")
+        assert _resolve_gemini_stt_api_key() == "google-key"
+
+        monkeypatch.setenv("GEMINI_API_KEY", "gemini-key")
+        assert _resolve_gemini_stt_api_key() == "gemini-key"
+
+        monkeypatch.setenv("GEMINI_STT_API_KEY", "stt-key")
+        assert _resolve_gemini_stt_api_key() == "stt-key"
+
+
+# ============================================================================
+# _get_provider — Gemini
+# ============================================================================
+
+class TestGetProviderGemini:
+    """Gemini-specific provider selection tests."""
+
+    def test_gemini_when_key_set(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_API_KEY", "gemini-test")
+        from tools.transcription_tools import _get_provider
+        assert _get_provider({"provider": "gemini"}) == "gemini"
+
+    def test_gemini_explicit_no_key_returns_none(self, monkeypatch):
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        monkeypatch.delenv("GEMINI_STT_API_KEY", raising=False)
+        from tools.transcription_tools import _get_provider
+        assert _get_provider({"provider": "gemini"}) == "none"
+
+    def test_auto_detect_gemini_before_groq(self, monkeypatch):
+        """Auto-detect: gemini (free) is preferred over groq (free tier)."""
+        monkeypatch.setenv("GEMINI_API_KEY", "gemini-test")
+        monkeypatch.setenv("GROQ_API_KEY", "gsk-test")
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
+             patch("tools.transcription_tools._has_local_command", return_value=False):
+            from tools.transcription_tools import _get_provider
+            assert _get_provider({}) == "gemini"
+
+    def test_auto_detect_groq_when_no_gemini_key(self, monkeypatch):
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        monkeypatch.setenv("GROQ_API_KEY", "gsk-test")
+        with patch("tools.transcription_tools._HAS_FASTER_WHISPER", False), \
+             patch("tools.transcription_tools._has_local_command", return_value=False), \
+             patch("tools.transcription_tools._HAS_OPENAI", True):
+            from tools.transcription_tools import _get_provider
+            assert _get_provider({}) == "groq"
+
+
+# ============================================================================
+# transcribe_audio — Gemini dispatch
+# ============================================================================
+
+class TestTranscribeAudioGeminiDispatch:
+    def test_dispatches_to_gemini(self, sample_ogg):
+        with patch("tools.transcription_tools._load_stt_config", return_value={"provider": "gemini"}), \
+             patch("tools.transcription_tools._get_provider", return_value="gemini"), \
+             patch("tools.transcription_tools._transcribe_gemini",
+                   return_value={"success": True, "transcript": "hi", "provider": "gemini"}) as mock_gemini:
+            from tools.transcription_tools import transcribe_audio
+            result = transcribe_audio(sample_ogg)
+
+        assert result["success"] is True
+        assert result["provider"] == "gemini"
+        mock_gemini.assert_called_once()
+
+    def test_model_default_from_config(self, sample_ogg):
+        with patch("tools.transcription_tools._load_stt_config",
+                   return_value={"provider": "gemini", "gemini": {"model": "gemini-3.1-flash-lite"}}), \
+             patch("tools.transcription_tools._get_provider", return_value="gemini"), \
+             patch("tools.transcription_tools._transcribe_gemini",
+                   return_value={"success": True, "transcript": "hi"}) as mock_gemini:
+            from tools.transcription_tools import transcribe_audio
+            transcribe_audio(sample_ogg, model=None)
+
+        assert mock_gemini.call_args[0][1] == "gemini-3.1-flash-lite"
+
+    def test_model_override_passed_to_gemini(self, sample_ogg):
+        with patch("tools.transcription_tools._load_stt_config", return_value={}), \
+             patch("tools.transcription_tools._get_provider", return_value="gemini"), \
+             patch("tools.transcription_tools._transcribe_gemini",
+                   return_value={"success": True, "transcript": "hi"}) as mock_gemini:
+            from tools.transcription_tools import transcribe_audio
+            transcribe_audio(sample_ogg, model="custom-gemini-model")
+
+        assert mock_gemini.call_args[0][1] == "custom-gemini-model"
+

--- a/tools/transcription_tools.py
+++ b/tools/transcription_tools.py
@@ -2,10 +2,13 @@
 """
 Transcription Tools Module
 
-Provides speech-to-text transcription with six providers:
+Provides speech-to-text transcription with seven providers:
 
   - **local** (default, free) — faster-whisper running locally, no API key needed.
     Auto-downloads the model (~150 MB for ``base``) on first use.
+  - **gemini** (free) — Google Gemini 3.1 Flash Lite via AI Studio. Free tier:
+    15 req/min, 250K tokens/min, 500 req/day. Requires ``GEMINI_API_KEY`` or
+    ``GOOGLE_API_KEY``. Get one at https://aistudio.google.com/app/apikey
   - **groq** (free tier) — Groq Whisper API, requires ``GROQ_API_KEY``.
   - **openai** (paid) — OpenAI Whisper API, requires ``VOICE_TOOLS_OPENAI_KEY``.
   - **mistral** — Mistral Voxtral Transcribe API, requires ``MISTRAL_API_KEY``.
@@ -84,6 +87,7 @@ DEFAULT_LOCAL_STT_LANGUAGE = "en"
 DEFAULT_STT_MODEL = os.getenv("STT_OPENAI_MODEL", "whisper-1")
 DEFAULT_GROQ_STT_MODEL = os.getenv("STT_GROQ_MODEL", "whisper-large-v3-turbo")
 DEFAULT_MISTRAL_STT_MODEL = os.getenv("STT_MISTRAL_MODEL", "voxtral-mini-latest")
+DEFAULT_GEMINI_STT_MODEL = os.getenv("STT_GEMINI_MODEL", "gemini-3.1-flash-lite")
 LOCAL_STT_COMMAND_ENV = "HERMES_LOCAL_STT_COMMAND"
 LOCAL_STT_LANGUAGE_ENV = "HERMES_LOCAL_STT_LANGUAGE"
 COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
@@ -91,6 +95,7 @@ COMMON_LOCAL_BIN_DIRS = ("/opt/homebrew/bin", "/usr/local/bin")
 GROQ_BASE_URL = os.getenv("GROQ_BASE_URL", "https://api.groq.com/openai/v1")
 OPENAI_BASE_URL = os.getenv("STT_OPENAI_BASE_URL", "https://api.openai.com/v1")
 XAI_STT_BASE_URL = os.getenv("XAI_STT_BASE_URL", "https://api.x.ai/v1")
+GEMINI_STT_BASE_URL = os.getenv("GEMINI_STT_BASE_URL", "https://generativelanguage.googleapis.com/v1beta")
 
 SUPPORTED_FORMATS = {".mp3", ".mp4", ".mpeg", ".mpga", ".m4a", ".wav", ".webm", ".ogg", ".aac", ".flac"}
 LOCAL_NATIVE_AUDIO_FORMATS = {".wav", ".aiff", ".aif"}
@@ -268,14 +273,26 @@ def _get_provider(stt_config: dict) -> str:
             )
             return "none"
 
+        if provider == "gemini":
+            if _resolve_gemini_stt_api_key():
+                return "gemini"
+            logger.warning(
+                "STT provider 'gemini' configured but no Gemini API key found "
+                "(set GEMINI_STT_API_KEY, GEMINI_API_KEY, or GOOGLE_API_KEY)"
+            )
+            return "none"
+
         return provider  # Unknown — let it fail downstream
 
-    # --- Auto-detect (no explicit provider): local > groq > openai > mistral > xai -
+    # --- Auto-detect (no explicit provider): local > gemini (free) > groq (free) > openai > mistral > xai -
 
     if _HAS_FASTER_WHISPER:
         return "local"
     if _has_local_command():
         return "local_command"
+    if _resolve_gemini_stt_api_key():
+        logger.info("No local STT available, using Gemini STT API (free tier)")
+        return "gemini"
     if _HAS_OPENAI and get_env_value("GROQ_API_KEY"):
         logger.info("No local STT available, using Groq Whisper API")
         return "groq"
@@ -321,6 +338,153 @@ def _validate_audio_file(file_path: str) -> Optional[Dict[str, Any]]:
         return {"success": False, "transcript": "", "error": f"Failed to access file: {e}"}
 
     return None
+
+# ---------------------------------------------------------------------------
+# Provider: gemini (Google AI Studio — free tier)
+# ---------------------------------------------------------------------------
+
+
+def _resolve_gemini_stt_api_key() -> Optional[str]:
+    """Resolve Gemini STT API key from dedicated env or generic Gemini/Google keys."""
+    return (
+        get_env_value("GEMINI_STT_API_KEY")
+        or get_env_value("GEMINI_API_KEY")
+        or get_env_value("GOOGLE_API_KEY")
+    )
+
+
+_GEMINI_AUDIO_MIME_TYPES = {
+    ".wav": "audio/wav",
+    ".mp3": "audio/mpeg",
+    ".m4a": "audio/mp4",
+    ".ogg": "audio/ogg",
+    ".oga": "audio/ogg",
+    ".webm": "audio/webm",
+    ".aac": "audio/aac",
+    ".flac": "audio/flac",
+    ".aiff": "audio/aiff",
+    ".aif": "audio/aiff",
+}
+
+
+def _transcribe_gemini(file_path: str, model_name: str) -> Dict[str, Any]:
+    """Transcribe using Google Gemini via the AI Studio API (free tier).
+
+    Uses the ``generateContent`` REST endpoint with inline audio data.
+    Supports up to 15 req/min and 500 req/day on the free tier.
+    Requires ``GEMINI_STT_API_KEY``, ``GEMINI_API_KEY``, or ``GOOGLE_API_KEY``.
+    Get a free key at https://aistudio.google.com/app/apikey
+    """
+    api_key = _resolve_gemini_stt_api_key()
+    if not api_key:
+        return {
+            "success": False,
+            "transcript": "",
+            "error": (
+                "Gemini STT requires an API key. Set GEMINI_STT_API_KEY, "
+                "GEMINI_API_KEY, or GOOGLE_API_KEY. Get a free key at "
+                "https://aistudio.google.com/app/apikey"
+            ),
+        }
+
+    stt_config = _load_stt_config()
+    gemini_cfg = stt_config.get("gemini", {})
+    base_url = str(
+        gemini_cfg.get("base_url")
+        or get_env_value("GEMINI_STT_BASE_URL")
+        or GEMINI_STT_BASE_URL
+    ).strip().rstrip("/")
+
+    audio_path = Path(file_path)
+    mime_type = _GEMINI_AUDIO_MIME_TYPES.get(audio_path.suffix.lower(), "audio/ogg")
+
+    try:
+        import base64
+        import json
+        import urllib.request
+
+        with open(file_path, "rb") as f:
+            audio_b64 = base64.b64encode(f.read()).decode("utf-8")
+
+        # Language hint from config (optional — Gemini auto-detects well)
+        language = str(
+            gemini_cfg.get("language")
+            or os.getenv(LOCAL_STT_LANGUAGE_ENV)
+            or ""
+        ).strip()
+
+        prompt_text = (
+            "Transcribe this audio accurately. "
+            "Output ONLY the transcript text, preserving the original language."
+        )
+        if language:
+            prompt_text += f" The audio is in {language}."
+
+        body = json.dumps({
+            "contents": [{
+                "parts": [
+                    {"inline_data": {"mime_type": mime_type, "data": audio_b64}},
+                    {"text": prompt_text},
+                ],
+            }],
+        }).encode("utf-8")
+
+        url = f"{base_url}/models/{model_name}:generateContent?key={api_key}"
+        req = urllib.request.Request(
+            url,
+            data=body,
+            headers={"Content-Type": "application/json"},
+            method="POST",
+        )
+
+        with urllib.request.urlopen(req, timeout=60) as resp:
+            result = json.loads(resp.read().decode("utf-8"))
+
+        # Extract text from Gemini response
+        candidates = result.get("candidates", [])
+        if not candidates:
+            feedback = result.get("promptFeedback", {})
+            block_reason = feedback.get("blockReason", "")
+            safety = feedback.get("safetyRatings", [])
+            detail = block_reason or str(safety) or "Empty candidates list"
+            return {
+                "success": False,
+                "transcript": "",
+                "error": f"Gemini STT returned no candidates: {detail}",
+            }
+
+        parts = candidates[0].get("content", {}).get("parts", [])
+        transcript_text = "".join(
+            part.get("text", "") for part in parts if "text" in part
+        ).strip()
+
+        if not transcript_text:
+            return {
+                "success": False,
+                "transcript": "",
+                "error": "Gemini STT returned empty transcript",
+            }
+
+        logger.info(
+            "Transcribed %s via Gemini API (%s, %d chars)",
+            audio_path.name, model_name, len(transcript_text),
+        )
+        return {"success": True, "transcript": transcript_text, "provider": "gemini"}
+
+    except PermissionError:
+        return {"success": False, "transcript": "", "error": f"Permission denied: {file_path}"}
+    except urllib.error.HTTPError as e:
+        detail = ""
+        try:
+            err_body = json.loads(e.read().decode("utf-8"))
+            detail = err_body.get("error", {}).get("message", "") or str(err_body)
+        except Exception:
+            detail = e.reason or f"HTTP {e.code}"
+        logger.error("Gemini STT HTTP error: %s", detail)
+        return {"success": False, "transcript": "", "error": f"Gemini STT API error: {detail}"}
+    except Exception as e:
+        logger.error("Gemini transcription failed: %s", e, exc_info=True)
+        return {"success": False, "transcript": "", "error": f"Gemini transcription failed: {e}"}
 
 # ---------------------------------------------------------------------------
 # Provider: local (faster-whisper)
@@ -792,7 +956,7 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
 
     Provider priority:
       1. User config (``stt.provider`` in config.yaml)
-      2. Auto-detect: local faster-whisper (free) > Groq (free tier) > OpenAI (paid)
+      2. Auto-detect: local faster-whisper (free) > Gemini (free) > Groq (free tier) > OpenAI (paid)
 
     Args:
         file_path: Absolute path to the audio file to transcribe.
@@ -854,6 +1018,11 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         model_name = model or "grok-stt"
         return _transcribe_xai(file_path, model_name)
 
+    if provider == "gemini":
+        gemini_cfg = stt_config.get("gemini", {})
+        model_name = model or gemini_cfg.get("model", DEFAULT_GEMINI_STT_MODEL)
+        return _transcribe_gemini(file_path, model_name)
+
     # No provider available
     return {
         "success": False,
@@ -861,6 +1030,7 @@ def transcribe_audio(file_path: str, model: Optional[str] = None) -> Dict[str, A
         "error": (
             "No STT provider available. Install faster-whisper for free local "
             f"transcription, configure {LOCAL_STT_COMMAND_ENV} or install a local whisper CLI, "
+            "set GEMINI_API_KEY or GOOGLE_API_KEY for free Gemini STT, "
             "set GROQ_API_KEY for free Groq Whisper, set MISTRAL_API_KEY for Mistral "
             "Voxtral Transcribe, set XAI_API_KEY for xAI Grok STT, or set VOICE_TOOLS_OPENAI_KEY "
             "or OPENAI_API_KEY for the OpenAI Whisper API."


### PR DESCRIPTION
## What
Adds Google AI Studio (Gemini) as a free speech-to-text provider alongside the existing local (faster-whisper), Groq, OpenAI, and Mistral options.

## Why
Gemini offers a generous free tier for audio transcription via the `generateContent` API, making it a cost-effective alternative for users who don't want to run local models or pay for API access.

## Changes
- `tools/transcription_tools.py`: `_transcribe_gemini()` provider using `google-genai`
- `hermes_cli/config.py`: `GEMINI_STT_API_KEY` env var + gemini defaults in `DEFAULT_CONFIG`
- `hermes_cli/web_server.py`: Added "gemini" to the STT provider dropdown
- `tests/tools/test_transcription_tools.py`: 10 new tests covering success, missing key, unsupported formats, API errors, and fallback

## How to test
1. Get a free API key from https://aistudio.google.com/app/apikey
2. Set `GEMINI_STT_API_KEY` in `~/.hermes/.env`
3. Set `stt.provider: gemini` in `~/.hermes/config.yaml`
4. Restart gateway and send a voice message

## Platforms tested
- Linux (Ubuntu)

---
