### PR TITLE
feat(gateway): add configurable STT transcription echo

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -428,6 +428,7 @@ class GatewayConfig:
 
     # STT settings
     stt_enabled: bool = True  # Whether to auto-transcribe inbound voice messages
+    echo_transcription: bool = False  # Whether to echo transcriptions back to the user
 
     # Session isolation in shared chats
     group_sessions_per_user: bool = True  # Isolate group/channel sessions per participant when user IDs are available
@@ -579,6 +580,10 @@ class GatewayConfig:
         if stt_enabled is None:
             stt_enabled = data.get("stt", {}).get("enabled") if isinstance(data.get("stt"), dict) else None
 
+        echo_transcription = data.get("echo_transcription")
+        if echo_transcription is None:
+            echo_transcription = data.get("stt", {}).get("echo_transcription") if isinstance(data.get("stt"), dict) else None
+
         group_sessions_per_user = data.get("group_sessions_per_user")
         thread_sessions_per_user = data.get("thread_sessions_per_user")
         unauthorized_dm_behavior = _normalize_unauthorized_dm_behavior(
@@ -603,6 +608,7 @@ class GatewayConfig:
             sessions_dir=sessions_dir,
             always_log_local=_coerce_bool(data.get("always_log_local"), True),
             stt_enabled=_coerce_bool(stt_enabled, True),
+            echo_transcription=_coerce_bool(echo_transcription, False),
             group_sessions_per_user=_coerce_bool(group_sessions_per_user, True),
             thread_sessions_per_user=_coerce_bool(thread_sessions_per_user, False),
             unauthorized_dm_behavior=unauthorized_dm_behavior,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6120,10 +6120,28 @@ class GatewayRunner:
                     )
 
             if audio_paths:
-                message_text = await self._enrich_message_with_transcription(
+                message_text, _transcripts = await self._enrich_message_with_transcription(
                     message_text,
                     audio_paths,
                 )
+                # Echo transcriptions back to user if enabled
+                if getattr(self.config, "echo_transcription", False) and _transcripts:
+                    _echo_adapter = self.adapters.get(source.platform)
+                    _echo_meta = {"thread_id": source.thread_id} if source.thread_id else None
+                    if _echo_adapter:
+                        try:
+                            _echo_lines = [f'🎤 "{t}"' for t in _transcripts]
+                            _echo_msg = "\n".join(_echo_lines)
+                            logger.info("Sending echo transcription: %s", _echo_msg)
+                            result = await _echo_adapter.send(
+                                source.chat_id,
+                                _echo_msg,
+                                reply_to=event.message_id,
+                                metadata=_echo_meta,
+                            )
+                            logger.info("Echo send result: success=%s error=%s", result.success, result.error)
+                        except Exception as e:
+                            logger.error("Failed to send echo transcription: %s", e, exc_info=True)
                 _stt_fail_markers = (
                     "No STT provider",
                     "STT is disabled",
@@ -12187,7 +12205,7 @@ class GatewayRunner:
         self,
         user_text: str,
         audio_paths: List[str],
-    ) -> str:
+    ) -> tuple[str, list[str]]:
         """
         Auto-transcribe user voice/audio messages using the configured STT provider
         and prepend the transcript to the message text.
@@ -12197,7 +12215,7 @@ class GatewayRunner:
             audio_paths: List of local file paths to cached audio files.
 
         Returns:
-            The enriched message string with transcriptions prepended.
+            Tuple of (enriched message string, list of successful transcripts).
         """
         if not getattr(self.config, "stt_enabled", True):
             disabled_note = "[The user sent voice message(s), but transcription is disabled in config."
@@ -12208,18 +12226,20 @@ class GatewayRunner:
                 )
             disabled_note += "]"
             if user_text:
-                return f"{disabled_note}\n\n{user_text}"
-            return disabled_note
+                return f"{disabled_note}\n\n{user_text}", []
+            return disabled_note, []
 
         from tools.transcription_tools import transcribe_audio
 
         enriched_parts = []
+        successful_transcripts = []
         for path in audio_paths:
             try:
                 logger.debug("Transcribing user voice: %s", path)
                 result = await asyncio.to_thread(transcribe_audio, path)
                 if result["success"]:
                     transcript = result["transcript"]
+                    successful_transcripts.append(transcript)
                     enriched_parts.append(
                         f'[The user sent a voice message~ '
                         f'Here\'s what they said: "{transcript}"]'
@@ -12262,11 +12282,11 @@ class GatewayRunner:
             # when we successfully transcribed the audio — it's redundant.
             _placeholder = "(The user sent a message with no text content)"
             if user_text and user_text.strip() == _placeholder:
-                return prefix
+                return prefix, successful_transcripts
             if user_text:
-                return f"{prefix}\n\n{user_text}"
-            return prefix
-        return user_text
+                return f"{prefix}\n\n{user_text}", successful_transcripts
+            return prefix, successful_transcripts
+        return user_text, successful_transcripts
 
     def _build_process_event_source(self, evt: dict):
         """Resolve the canonical source for a synthetic background-process event.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -939,6 +939,7 @@ DEFAULT_CONFIG = {
     "stt": {
         "enabled": True,
         "provider": "local",  # "local" (free, faster-whisper) | "groq" | "openai" (Whisper API) | "mistral" (Voxtral Transcribe)
+        "echo_transcription": False,  # If True, sends the transcribed text back to the user before the AI responds
         "local": {
             "model": "base",  # tiny, base, small, medium, large-v3
             "language": "",  # auto-detect by default; set to "en", "es", "fr", etc. to force


### PR DESCRIPTION
## What
Adds an `echo_transcription` option to the STT config. When enabled, successful voice transcriptions are sent back to the user as a reply to the original voice message.

## Why
Users often want to see what the AI heard before it responds, especially when verifying transcription accuracy or when the voice message is long. This matches behavior seen in other Telegram bots and improves UX.

## Changes
- `gateway/config.py`: Added `echo_transcription` field to `GatewayConfig` with `from_dict` loading
- `gateway/run.py`:
  - Modified `_enrich_message_with_transcription` to return `(message_text, transcripts)` tuple
  - Added echo logic in `_prepare_inbound_message` that replies to the original voice message with the transcription
- `hermes_cli/config.py`: Added `echo_transcription: false` to default STT config

## Format
The echo appears as a reply to the voice message:
> 🎤 "Hola, probando 1 2 3."

## How to test
1. Set `stt.echo_transcription: true` in `~/.hermes/config.yaml`
2. Restart gateway
3. Send a voice message — the transcription should appear as a reply before the AI response

## Platforms tested
- Linux (Ubuntu)
- Telegram

---
