### PR TITLE
fix(chat-completions): pad reasoning content for fallback tool calls

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -99,6 +99,62 @@ def _is_gemini_openai_compat_base_url(base_url: Any) -> bool:
     return normalized.endswith("/openai")
 
 
+def _kimi_thinking_enabled(reasoning_config: dict | None) -> bool:
+    """Return whether Kimi/Moonshot thinking-mode request fields are active."""
+    return not (
+        reasoning_config
+        and isinstance(reasoning_config, dict)
+        and reasoning_config.get("enabled") is False
+    )
+
+
+def _pad_kimi_tool_call_reasoning_content(
+    messages: List[Dict[str, Any]],
+    reasoning_config: dict | None,
+) -> List[Dict[str, Any]]:
+    """Pad assistant tool-call turns for Kimi thinking-mode replay.
+
+    Hermes can build ``api_messages`` while the active provider is still a
+    Codex Responses backend, then switch to Kimi inside the retry/fallback
+    loop. In that shape, Codex assistant tool-call history has already had
+    Codex-only fields stripped, but it was never passed through the Kimi
+    replay guard that adds ``reasoning_content``. Kimi rejects such requests
+    with HTTP 400: "thinking is enabled but reasoning_content is missing in
+    assistant tool call message".
+
+    Add a single-space placeholder only for Kimi thinking-mode assistant
+    tool-call messages that lack a string ``reasoning_content``. The space is
+    non-empty for strict validators, but does not fabricate or leak another
+    provider's chain-of-thought.
+    """
+    if not _kimi_thinking_enabled(reasoning_config):
+        return messages
+
+    needs_copy = False
+    for msg in messages:
+        if not isinstance(msg, dict) or msg.get("role") != "assistant":
+            continue
+        if not msg.get("tool_calls"):
+            continue
+        existing = msg.get("reasoning_content")
+        if not isinstance(existing, str) or existing == "":
+            needs_copy = True
+            break
+    if not needs_copy:
+        return messages
+
+    padded = copy.deepcopy(messages)
+    for msg in padded:
+        if not isinstance(msg, dict) or msg.get("role") != "assistant":
+            continue
+        if not msg.get("tool_calls"):
+            continue
+        existing = msg.get("reasoning_content")
+        if not isinstance(existing, str) or existing == "":
+            msg["reasoning_content"] = " "
+    return padded
+
+
 class ChatCompletionsTransport(ProviderTransport):
     """Transport for api_mode='chat_completions'.
 
@@ -204,6 +260,13 @@ class ChatCompletionsTransport(ProviderTransport):
         """
         # Codex sanitization: drop reasoning_items / call_id / response_item_id
         sanitized = self.convert_messages(messages)
+        is_kimi = params.get("is_kimi", False)
+        reasoning_config = params.get("reasoning_config")
+        if is_kimi:
+            sanitized = _pad_kimi_tool_call_reasoning_content(
+                sanitized,
+                reasoning_config,
+            )
 
         # Qwen portal prep AFTER codex sanitization.  If sanitize already
         # deepcopied, reuse that copy via the in-place variant to avoid a
@@ -290,12 +353,7 @@ class ChatCompletionsTransport(ProviderTransport):
 
         # Kimi: top-level reasoning_effort (unless thinking disabled)
         if is_kimi:
-            _kimi_thinking_off = bool(
-                reasoning_config
-                and isinstance(reasoning_config, dict)
-                and reasoning_config.get("enabled") is False
-            )
-            if not _kimi_thinking_off:
+            if _kimi_thinking_enabled(reasoning_config):
                 _kimi_effort = "medium"
                 if reasoning_config and isinstance(reasoning_config, dict):
                     _e = (reasoning_config.get("effort") or "").strip().lower()
@@ -345,12 +403,8 @@ class ChatCompletionsTransport(ProviderTransport):
 
         # Kimi extra_body.thinking
         if is_kimi:
-            _kimi_thinking_enabled = True
-            if reasoning_config and isinstance(reasoning_config, dict):
-                if reasoning_config.get("enabled") is False:
-                    _kimi_thinking_enabled = False
             extra_body["thinking"] = {
-                "type": "enabled" if _kimi_thinking_enabled else "disabled",
+                "type": "enabled" if _kimi_thinking_enabled(reasoning_config) else "disabled",
             }
 
         # Reasoning. LM Studio is handled above via top-level reasoning_effort,

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -403,6 +403,96 @@ class TestChatCompletionsKimi:
         )
         assert kw["extra_body"]["thinking"] == {"type": "disabled"}
 
+    def test_kimi_fallback_pads_codex_tool_call_history_reasoning_content(self, transport):
+        """Kimi fallback can receive Codex-built api_messages.
+
+        The Codex path strips Responses-only fields before retrying on a
+        chat-completions fallback, but Kimi thinking mode still requires
+        ``reasoning_content`` on assistant tool-call messages.
+        """
+        messages = [
+            {"role": "user", "content": "Hi"},
+            {
+                "role": "assistant",
+                "content": "",
+                "codex_reasoning_items": [{"id": "rs_1"}],
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "call_id": "call_1",
+                        "response_item_id": "fc_1",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": "{}"},
+                    }
+                ],
+            },
+        ]
+        kw = transport.build_kwargs(
+            model="kimi-k2",
+            messages=messages,
+            is_kimi=True,
+            reasoning_config={"enabled": True, "effort": "high"},
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+
+        assistant_msg = kw["messages"][1]
+        assert assistant_msg["reasoning_content"] == " "
+        assert "codex_reasoning_items" not in assistant_msg
+        assert "call_id" not in assistant_msg["tool_calls"][0]
+        assert "response_item_id" not in assistant_msg["tool_calls"][0]
+        # The transport must not mutate persisted history.
+        assert "reasoning_content" not in messages[1]
+        assert "codex_reasoning_items" in messages[1]
+
+    def test_kimi_disabled_thinking_does_not_pad_reasoning_content(self, transport):
+        messages = [
+            {"role": "user", "content": "Hi"},
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": "{}"},
+                    }
+                ],
+            },
+        ]
+        kw = transport.build_kwargs(
+            model="kimi-k2",
+            messages=messages,
+            is_kimi=True,
+            reasoning_config={"enabled": False},
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        assert "reasoning_content" not in kw["messages"][1]
+
+    def test_kimi_existing_reasoning_content_is_preserved(self, transport):
+        messages = [
+            {"role": "user", "content": "Hi"},
+            {
+                "role": "assistant",
+                "content": "",
+                "reasoning_content": "provider-supplied summary",
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "terminal", "arguments": "{}"},
+                    }
+                ],
+            },
+        ]
+        kw = transport.build_kwargs(
+            model="kimi-k2",
+            messages=messages,
+            is_kimi=True,
+            reasoning_config={"enabled": True},
+            max_tokens_param_fn=lambda n: {"max_tokens": n},
+        )
+        assert kw["messages"][1]["reasoning_content"] == "provider-supplied summary"
+
     def test_moonshot_tool_schemas_are_sanitized_by_model_name(self, transport):
         """Aggregator routes (Nous, OpenRouter) hit Moonshot by model name, not base URL."""
         tools = [


### PR DESCRIPTION
## Summary
- Preserve compatibility for OpenAI-compatible chat-completions providers that reject empty assistant content around fallback tool calls.
- Add regression coverage for reasoning/tool-call fallback payloads.

## Tests
```bash
venv/bin/python -m pytest -q -o addopts='' tests/agent/transports/test_chat_completions.py
# 64 passed
```
