### PR TITLE
fix(gateway): stabilize platform adapter tests

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -22,13 +22,21 @@ try:
     from slack_bolt.async_app import AsyncApp
     from slack_bolt.adapter.socket_mode.async_handler import AsyncSocketModeHandler
     from slack_sdk.web.async_client import AsyncWebClient
-    import aiohttp
     SLACK_AVAILABLE = True
 except ImportError:
     SLACK_AVAILABLE = False
     AsyncApp = Any
     AsyncSocketModeHandler = Any
     AsyncWebClient = Any
+
+# aiohttp is used for slash-response_url callbacks and document downloads.
+# Keep it independent from the optional Slack SDK import so tests and partial
+# installs can patch gateway.platforms.slack.aiohttp.ClientSession even when
+# slack-bolt/slack-sdk are unavailable.
+try:
+    import aiohttp
+except ImportError:  # pragma: no cover - exercised only in minimal installs
+    aiohttp = None  # type: ignore[assignment]
 
 import sys
 from pathlib import Path as _Path

--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -520,7 +520,8 @@ class TeamsAdapter(BasePlatformAdapter):
         if not self._app:
             return
         try:
-            await self._app.send(chat_id, TypingActivityInput())
+            activity = TypingActivityInput() if callable(TypingActivityInput) else {"type": "typing"}
+            await self._app.send(chat_id, activity)
         except Exception:
             pass
 

--- a/tests/gateway/test_matrix.py
+++ b/tests/gateway/test_matrix.py
@@ -2275,6 +2275,10 @@ class TestMatrixProxyConfig:
         for key in ("HTTPS_PROXY", "HTTP_PROXY", "ALL_PROXY",
                     "https_proxy", "http_proxy", "all_proxy", "MATRIX_PROXY"):
             monkeypatch.delenv(key, raising=False)
+        # Isolate tests from macOS system proxy auto-detection (scutil --proxy).
+        # Env-proxy behavior is still covered below via explicit proxy_env.
+        import gateway.platforms.base as platform_base
+        monkeypatch.setattr(platform_base, "_detect_macos_system_proxy", lambda: None)
         if proxy_env:
             for k, v in proxy_env.items():
                 monkeypatch.setenv(k, v)


### PR DESCRIPTION
## Summary
- Stabilize adapter behavior/tests across Slack, Teams, and Matrix paths.
- Avoid test flakiness from platform-specific assumptions.

## Tests
```bash
venv/bin/python -m pytest -q -o addopts='' tests/gateway/test_matrix.py
# 141 passed
```
