### PR TITLE
feat(gateway): add restart awareness with module, tests, and mode toggle

### DIFF
--- a/agent/restart_awareness.py
+++ b/agent/restart_awareness.py
@@ -1,0 +1,120 @@
+"""
+Restart awareness: persistent activity tracker for gateway restarts.
+
+Writes and reads a JSON activity file so the agent can recover context
+after an unplanned or intentional gateway restart.
+"""
+
+import json
+import os
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from hermes_constants import get_hermes_home
+
+
+def _activity_path() -> Path:
+    return get_hermes_home() / "state" / "current_activity.json"
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def update_activity(
+    current_task: str,
+    files_modified: Optional[List[str]] = None,
+    last_action: Optional[str] = None,
+    next_expected_step: Optional[str] = None,
+    mode: str = "simple",
+) -> None:
+    """Write current activity state to disk."""
+    path = _activity_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    data = {
+        "current_task": current_task,
+        "files_modified": files_modified or [],
+        "last_action": last_action or "",
+        "next_expected_step": next_expected_step or "",
+        "mode": mode,
+        "updated_at": _now(),
+    }
+    path.write_text(json.dumps(data, indent=2))
+
+
+def read_activity() -> Optional[Dict]:
+    """Read the last known activity state, or None if none exists."""
+    path = _activity_path()
+    if not path.exists():
+        return None
+    try:
+        return json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        return None
+
+
+def clear_activity() -> None:
+    """Clear the activity file after a clean handoff."""
+    path = _activity_path()
+    if path.exists():
+        path.unlink()
+
+
+def _compute_staleness(updated_at_str: Optional[str]) -> tuple[bool, str]:
+    """Return (is_stale, age_text) given an ISO timestamp string."""
+    if not updated_at_str:
+        return False, ""
+    try:
+        updated_at = datetime.fromisoformat(updated_at_str.replace("Z", "+00:00"))
+        if updated_at.tzinfo is None:
+            updated_at = updated_at.replace(tzinfo=timezone.utc)
+        age = datetime.now(timezone.utc) - updated_at
+        is_stale = age > timedelta(minutes=30)
+        total_minutes = age.total_seconds() // 60
+        if total_minutes >= 1440:
+            age_text = f"{int(total_minutes // 1440)}d {int((total_minutes % 1440) // 60)}h old"
+        elif total_minutes >= 60:
+            age_text = f"{int(total_minutes // 60)}h {int(total_minutes % 60)}m old"
+        else:
+            age_text = f"{int(total_minutes)}m old"
+        return is_stale, age_text
+    except Exception:
+        return False, ""
+
+
+def build_handoff(activity: Dict) -> str:
+    """Build the handoff text to inject on first message after restart."""
+    mode = activity.get("mode", "simple")
+    updated_at_str = activity.get("updated_at")
+    is_stale, age_text = _compute_staleness(updated_at_str)
+
+    handoff_lines = []
+    if mode == "verbose":
+        if is_stale:
+            handoff_lines.append(
+                f"[Restart handoff \u2014 STALE ({age_text})] Activity below is from {updated_at_str or 'unknown time'}. "
+                "Do NOT auto-execute the next step. Summarize the task and ask the user whether to continue."
+            )
+        else:
+            handoff_lines.append(
+                "[Restart handoff \u2014 FRESH] Agent restarted while working on the task below. Resume immediately."
+            )
+        handoff_lines.append(f"Task: {activity.get('current_task', '?')}")
+        if activity.get("files_modified"):
+            handoff_lines.append(f"Files touched: {', '.join(activity['files_modified'])}")
+        if activity.get("last_action"):
+            handoff_lines.append(f"Last action: {activity['last_action']}")
+        if activity.get("next_expected_step"):
+            handoff_lines.append(f"Next step: {activity['next_expected_step']}")
+    else:
+        if is_stale:
+            handoff_lines.append(
+                f"[Restart handoff \u2014 STALE ({age_text})] "
+                "Back after gateway restart. Last recorded activity is old \u2014 ask the user what to do next."
+            )
+        else:
+            handoff_lines.append(
+                "[Restart handoff \u2014 FRESH] Back after gateway restart."
+            )
+    return "\n".join(handoff_lines)

--- a/tests/agent/test_restart_awareness.py
+++ b/tests/agent/test_restart_awareness.py
@@ -1,0 +1,137 @@
+import json
+from datetime import datetime, timezone, timedelta
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from agent import restart_awareness as ra
+
+
+class TestComputeStaleness:
+    def test_fresh_data(self):
+        now = datetime.now(timezone.utc).isoformat()
+        is_stale, age_text = ra._compute_staleness(now)
+        assert is_stale is False
+        assert "m old" in age_text or age_text == "0m old"
+
+    def test_stale_data(self):
+        old = (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat()
+        is_stale, age_text = ra._compute_staleness(old)
+        assert is_stale is True
+        assert "h" in age_text
+
+    def test_missing_timestamp(self):
+        is_stale, age_text = ra._compute_staleness(None)
+        assert is_stale is False
+        assert age_text == ""
+
+    def test_malformed_timestamp(self):
+        is_stale, age_text = ra._compute_staleness("not-a-date")
+        assert is_stale is False
+        assert age_text == ""
+
+
+class TestBuildHandoff:
+    def test_simple_fresh(self):
+        activity = {
+            "current_task": "Test task",
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+            "mode": "simple",
+        }
+        handoff = ra.build_handoff(activity)
+        assert "[Restart handoff \u2014 FRESH]" in handoff
+        assert "Back after gateway restart." in handoff
+        assert "Task:" not in handoff
+
+    def test_simple_stale(self):
+        activity = {
+            "current_task": "Test task",
+            "updated_at": (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat(),
+            "mode": "simple",
+        }
+        handoff = ra.build_handoff(activity)
+        assert "[Restart handoff \u2014 STALE" in handoff
+        assert "old" in handoff
+
+    def test_verbose_fresh(self):
+        activity = {
+            "current_task": "Test task",
+            "files_modified": ["a.py", "b.py"],
+            "last_action": "Did something",
+            "next_expected_step": "Do next thing",
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+            "mode": "verbose",
+        }
+        handoff = ra.build_handoff(activity)
+        assert "[Restart handoff \u2014 FRESH]" in handoff
+        assert "Task: Test task" in handoff
+        assert "Files touched: a.py, b.py" in handoff
+        assert "Last action: Did something" in handoff
+        assert "Next step: Do next thing" in handoff
+
+    def test_verbose_stale(self):
+        activity = {
+            "current_task": "Test task",
+            "updated_at": (datetime.now(timezone.utc) - timedelta(hours=2)).isoformat(),
+            "mode": "verbose",
+        }
+        handoff = ra.build_handoff(activity)
+        assert "[Restart handoff \u2014 STALE" in handoff
+        assert "Do NOT auto-execute" in handoff
+        assert "Task: Test task" in handoff
+
+    def test_verbose_no_optional_fields(self):
+        activity = {
+            "current_task": "Test task",
+            "updated_at": datetime.now(timezone.utc).isoformat(),
+            "mode": "verbose",
+        }
+        handoff = ra.build_handoff(activity)
+        assert "Task: Test task" in handoff
+        assert "Files touched" not in handoff
+        assert "Last action" not in handoff
+        assert "Next step" not in handoff
+
+
+class TestReadWriteClear:
+    @patch.object(ra, "_activity_path")
+    def test_round_trip(self, mock_path):
+        tmp = MagicMock()
+        mock_path.return_value = tmp
+        tmp.parent = MagicMock()
+        tmp.exists.return_value = True
+
+        ra.update_activity(
+            current_task="Round trip",
+            files_modified=["x.py"],
+            last_action="wrote",
+            next_expected_step="read",
+            mode="verbose",
+        )
+        written = json.loads(tmp.write_text.call_args[0][0])
+        assert written["current_task"] == "Round trip"
+        assert written["files_modified"] == ["x.py"]
+        assert written["mode"] == "verbose"
+        assert "updated_at" in written
+
+        tmp.read_text.return_value = json.dumps(written)
+        result = ra.read_activity()
+        assert result["current_task"] == "Round trip"
+
+        ra.clear_activity()
+        assert tmp.unlink.called
+
+    @patch.object(ra, "_activity_path")
+    def test_read_missing(self, mock_path):
+        tmp = MagicMock()
+        mock_path.return_value = tmp
+        tmp.exists.return_value = False
+        assert ra.read_activity() is None
+
+    @patch.object(ra, "_activity_path")
+    def test_read_corrupt(self, mock_path):
+        tmp = MagicMock()
+        mock_path.return_value = tmp
+        tmp.exists.return_value = True
+        tmp.read_text.return_value = "not json"
+        assert ra.read_activity() is None


### PR DESCRIPTION
## Summary

On platform connect, read ~/.hermes/profiles/<profile>/state/current_activity.json and inject a handoff message into the first user message after restart.

## Problem

When the Hermes gateway restarts (crash, manual restart, system update), the agent loses all context. The user has to re-explain what was in progress. This is especially painful during iterative development where restarts happen frequently.

## Solution

A self-contained  module that any agent can call to persist activity state before a restart, and a thin hook in  that reads it back on connect.

### API

-  — write state
-  — read state
-  — delete state after clean handoff
-  — format handoff text for injection

### Modes

- **simple** (default): 
- **verbose**: full task, files, last action, next step, with explicit FRESH/STALE directive

### Staleness detection

Data older than 30 minutes is flagged STALE. The handoff text instructs the agent to summarize but NOT auto-execute the next step.

## Files changed

-  — new module (128 lines)
-  — refactored  to import from module
-  — 12 tests

## Design decisions

- Profile-aware path via  — no hardcoded profile names
- Lazy loading — file parsed once per connect, no startup penalty
- Silent no-op if file is missing or corrupt
- No config key required — works out of the box

## Backwards compatibility

- File is optional — if missing, all lookups return None gracefully
- No existing code paths are modified beyond 
- Default mode is 'simple' producing a one-line handoff

## Testing

============================= test session starts ==============================
platform darwin -- Python 3.11.15, pytest-9.0.3, pluggy-1.6.0 -- /Users/phoenix/.hermes/hermes-agent/venv/bin/python
cachedir: .pytest_cache
rootdir: /Users/phoenix/.hermes/hermes-agent
configfile: pyproject.toml
plugins: xdist-3.8.0, asyncio-1.3.0, anyio-4.13.0
asyncio: mode=Mode.STRICT, debug=False, asyncio_default_fixture_loop_scope=None, asyncio_default_test_loop_scope=function
created: 4/4 workers
4 workers [12 items]

scheduling tests via LoadScheduling

tests/agent/test_restart_awareness.py::TestComputeStaleness::test_fresh_data 
tests/agent/test_restart_awareness.py::TestBuildHandoff::test_verbose_fresh 
tests/agent/test_restart_awareness.py::TestComputeStaleness::test_missing_timestamp 
tests/agent/test_restart_awareness.py::TestBuildHandoff::test_simple_fresh 
[gw2] [  8%] PASSED tests/agent/test_restart_awareness.py::TestBuildHandoff::test_simple_fresh 
[gw1] [ 16%] PASSED tests/agent/test_restart_awareness.py::TestComputeStaleness::test_missing_timestamp 
[gw3] [ 25%] PASSED tests/agent/test_restart_awareness.py::TestBuildHandoff::test_verbose_fresh 
[gw0] [ 33%] PASSED tests/agent/test_restart_awareness.py::TestComputeStaleness::test_fresh_data 
tests/agent/test_restart_awareness.py::TestComputeStaleness::test_malformed_timestamp 
tests/agent/test_restart_awareness.py::TestBuildHandoff::test_simple_stale 
tests/agent/test_restart_awareness.py::TestBuildHandoff::test_verbose_stale 
tests/agent/test_restart_awareness.py::TestComputeStaleness::test_stale_data 
[gw1] [ 41%] PASSED tests/agent/test_restart_awareness.py::TestComputeStaleness::test_malformed_timestamp 
[gw2] [ 50%] PASSED tests/agent/test_restart_awareness.py::TestBuildHandoff::test_simple_stale 
tests/agent/test_restart_awareness.py::TestBuildHandoff::test_verbose_no_optional_fields 
tests/agent/test_restart_awareness.py::TestReadWriteClear::test_round_trip 
[gw3] [ 58%] PASSED tests/agent/test_restart_awareness.py::TestBuildHandoff::test_verbose_stale 
[gw0] [ 66%] PASSED tests/agent/test_restart_awareness.py::TestComputeStaleness::test_stale_data 
tests/agent/test_restart_awareness.py::TestReadWriteClear::test_read_missing 
tests/agent/test_restart_awareness.py::TestReadWriteClear::test_read_corrupt 
[gw1] [ 75%] PASSED tests/agent/test_restart_awareness.py::TestBuildHandoff::test_verbose_no_optional_fields 
[gw3] [ 83%] PASSED tests/agent/test_restart_awareness.py::TestReadWriteClear::test_read_missing 
[gw0] [ 91%] PASSED tests/agent/test_restart_awareness.py::TestReadWriteClear::test_read_corrupt 
[gw2] [100%] PASSED tests/agent/test_restart_awareness.py::TestReadWriteClear::test_round_trip 

============================== 12 passed in 3.63s ==============================

12 tests covering staleness computation, handoff formatting, and round-trip I/O.

## Future work (not in this PR)

- Config key  to opt out
- Proactive notification mode (agent sends first message on connect)
- Integration with memory store isolation