### PR TITLE
fix(tui): preserve input_text content in /retry multipart messages

### DIFF
--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -664,6 +664,36 @@ def test_command_dispatch_retry_handles_multipart_content(server):
     assert result["message"] == "analyze this"
 
 
+def test_command_dispatch_retry_handles_input_text_multipart_content(server):
+    """command.dispatch /retry preserves input_text parts in multipart content."""
+    sid = "test-session"
+    history = [
+        {"role": "user", "content": [
+            {"type": "input_text", "text": "analyze this"},
+            {"type": "input_image", "image_url": "data:image/png;base64,..."},
+        ]},
+        {"role": "assistant", "content": "I see the image."},
+    ]
+    server._sessions[sid] = {
+        "session_key": sid,
+        "agent": None,
+        "history": history,
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+    }
+
+    resp = server.handle_request({
+        "id": "r6b",
+        "method": "command.dispatch",
+        "params": {"name": "retry", "session_id": sid},
+    })
+
+    assert "error" not in resp
+    result = resp["result"]
+    assert result["type"] == "send"
+    assert result["message"] == "analyze this"
+
+
 def test_command_dispatch_returns_skill_payload(server):
     """command.dispatch returns structured skill payload for the TUI to send()."""
     sid = "test-session"

--- a/tests/tui_gateway/test_protocol.py
+++ b/tests/tui_gateway/test_protocol.py
@@ -694,6 +694,58 @@ def test_command_dispatch_retry_handles_input_text_multipart_content(server):
     assert result["message"] == "analyze this"
 
 
+def test_command_dispatch_retry_preserves_scalar_whitespace(server):
+    """command.dispatch /retry should preserve scalar message whitespace."""
+    sid = "test-session"
+    history = [
+        {"role": "user", "content": "  analyze this  \n"},
+        {"role": "assistant", "content": "working on it"},
+    ]
+    server._sessions[sid] = {
+        "session_key": sid,
+        "agent": None,
+        "history": history,
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+    }
+
+    resp = server.handle_request({
+        "id": "r6c",
+        "method": "command.dispatch",
+        "params": {"name": "retry", "session_id": sid},
+    })
+
+    assert "error" not in resp
+    result = resp["result"]
+    assert result["type"] == "send"
+    assert result["message"] == "  analyze this  \n"
+
+
+def test_command_dispatch_retry_rejects_non_text_structured_dict_content(server):
+    """command.dispatch /retry should not resend non-text placeholders."""
+    sid = "test-session"
+    history = [
+        {"role": "user", "content": {"type": "input_image", "image_url": "data:image/png;base64,..."}},
+        {"role": "assistant", "content": "I see the image."},
+    ]
+    server._sessions[sid] = {
+        "session_key": sid,
+        "agent": None,
+        "history": history,
+        "history_lock": threading.Lock(),
+        "history_version": 0,
+    }
+
+    resp = server.handle_request({
+        "id": "r6d",
+        "method": "command.dispatch",
+        "params": {"name": "retry", "session_id": sid},
+    })
+
+    assert "error" in resp
+    assert resp["error"]["code"] == 4018
+
+
 def test_command_dispatch_returns_skill_payload(server):
     """command.dispatch returns structured skill payload for the TUI to send()."""
     sid = "test-session"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2044,6 +2044,35 @@ def _content_display_text(content: Any) -> str:
     return str(content)
 
 
+def _retry_text_part_text(part: Any) -> Optional[str]:
+    if isinstance(part, dict):
+        kind = part.get("type")
+        if kind in {"text", "input_text", "output_text"}:
+            return str(part.get("text") or part.get("content") or "")
+        if not kind and "text" in part:
+            return str(part.get("text") or "")
+        return None
+    if isinstance(part, str):
+        return part
+    if isinstance(part, (int, float)):
+        return str(part)
+    return None
+
+
+def _retry_text_content(content: Any) -> str:
+    if isinstance(content, list):
+        text_parts = []
+        for part in content:
+            text = _retry_text_part_text(part)
+            if text is not None and text.strip():
+                text_parts.append(text)
+        return " ".join(text_parts)
+    text = _retry_text_part_text(content)
+    if text is not None:
+        return text
+    return ""
+
+
 def _history_to_messages(history: list[dict]) -> list[dict]:
     messages = []
     tool_call_args = {}
@@ -4540,26 +4569,8 @@ def _(rid, params: dict) -> dict:
                 break
         if last_user_idx is None:
             return _err(rid, 4018, "no previous user message to retry")
-        content = history[last_user_idx].get("content", "")
-        if isinstance(content, list):
-            text_parts = []
-            for part in content:
-                if not isinstance(part, dict):
-                    text = _content_display_text(part).strip()
-                    if text:
-                        text_parts.append(text)
-                    continue
-                kind = part.get("type")
-                if kind in {"text", "input_text", "output_text"} or (
-                    not kind and "text" in part
-                ):
-                    text = _content_display_text(part).strip()
-                    if text:
-                        text_parts.append(text)
-            content = "\n".join(text_parts).strip()
-        else:
-            content = _content_display_text(content).strip()
-        if not content:
+        content = _retry_text_content(history[last_user_idx].get("content", ""))
+        if not content.strip():
             return _err(rid, 4018, "last user message is empty")
         # Truncate history: remove everything from the last user message onward
         # (mirrors CLI retry_last() which strips the failed exchange)

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4542,11 +4542,23 @@ def _(rid, params: dict) -> dict:
             return _err(rid, 4018, "no previous user message to retry")
         content = history[last_user_idx].get("content", "")
         if isinstance(content, list):
-            content = " ".join(
-                p.get("text", "")
-                for p in content
-                if isinstance(p, dict) and p.get("type") == "text"
-            )
+            text_parts = []
+            for part in content:
+                if not isinstance(part, dict):
+                    text = _content_display_text(part).strip()
+                    if text:
+                        text_parts.append(text)
+                    continue
+                kind = part.get("type")
+                if kind in {"text", "input_text", "output_text"} or (
+                    not kind and "text" in part
+                ):
+                    text = _content_display_text(part).strip()
+                    if text:
+                        text_parts.append(text)
+            content = "\n".join(text_parts).strip()
+        else:
+            content = _content_display_text(content).strip()
         if not content:
             return _err(rid, 4018, "last user message is empty")
         # Truncate history: remove everything from the last user message onward


### PR DESCRIPTION
## Summary

Fix TUI `/retry` handling for multipart user messages that use structured text parts such as `input_text`.

Previously, `/retry` only reconstructed text from multipart content when parts used `{"type": "text"}`. That caused retries to fail or report `last user message is empty` for valid structured messages that used `input_text`. A naive switch to the generic display formatter also pulled in non-text placeholders like `[image]`, which is not appropriate for retry input.

## What changed

- Update the TUI gateway `/retry` path to extract only text-bearing multipart parts:
  - `text`
  - `input_text`
  - `output_text`
  - untyped dicts with a `text` field
- Keep non-text parts such as images/audio out of the retried prompt
- Add a regression test covering `input_text + input_image` multipart content

## Why

The TUI already supports structured/multimodal content shapes elsewhere, so `/retry` should not silently lose the user’s textual input just because it arrived as `input_text` instead of plain `text`.

This keeps `/retry` behavior aligned with the structured-content model without leaking display placeholders into the next send.

## Testing

Ran:

- `tests/tui_gateway/test_protocol.py -k retry`

Results:

- `test_command_dispatch_retry_empty_history` passed
- `test_command_dispatch_retry_handles_input_text_multipart_content` passed
- `test_slash_exec_rejects_pending_input_commands[retry]` passed
- `test_command_dispatch_retry_finds_last_user_message` passed
- `test_command_dispatch_retry_handles_multipart_content` passed
