### PR TITLE
fix(gateway): slim replayed history and harden service detection

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -67,6 +67,8 @@ _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 # is still classified fresh.  Override via
 # ``config.yaml`` ``agent.gateway_auto_continue_freshness``.
 _AUTO_CONTINUE_FRESHNESS_SECS_DEFAULT = 60 * 60
+_GATEWAY_HISTORY_TOOL_OUTPUT_MAX_CHARS_DEFAULT = 4000
+_GATEWAY_HISTORY_REASONING_STRIP_DEFAULT = False
 
 
 # --- Stale-code self-check ------------------------------------------------
@@ -229,6 +231,111 @@ def _last_transcript_timestamp(history: Optional[List[Dict[str, Any]]]) -> Any:
         # Returning None lets the caller fall through to the legacy-fresh path.
         return None
     return None
+
+
+def _truncate_gateway_history_text(
+    value: Any,
+    *,
+    max_chars: int,
+    label: str,
+) -> tuple[Any, int]:
+    """Return a shortened historical text value and the removed char count."""
+    if not isinstance(value, str) or max_chars <= 0 or len(value) <= max_chars:
+        return value, 0
+
+    if max_chars < 200:
+        kept = value[:max_chars]
+        omitted = len(value) - len(kept)
+        return (
+            kept
+            + f"\n\n[Gateway note: truncated {omitted:,} characters from "
+            f"historical {label}.]",
+            omitted,
+        )
+
+    head_chars = max(100, int(max_chars * 0.75))
+    tail_chars = max(50, max_chars - head_chars)
+    if head_chars + tail_chars >= len(value):
+        return value, 0
+
+    omitted = len(value) - head_chars - tail_chars
+    note = (
+        f"\n\n[Gateway note: truncated {omitted:,} characters from historical "
+        f"{label} to keep the messaging session within model limits. Re-run "
+        "the tool or inspect saved artifacts if the exact output is needed.]\n\n"
+    )
+    return value[:head_chars] + note + value[-tail_chars:], omitted
+
+
+def _slim_gateway_history_for_model(
+    history: List[Dict[str, Any]],
+    *,
+    max_tool_output_chars: int = _GATEWAY_HISTORY_TOOL_OUTPUT_MAX_CHARS_DEFAULT,
+    strip_assistant_reasoning: bool = _GATEWAY_HISTORY_REASONING_STRIP_DEFAULT,
+) -> tuple[List[Dict[str, Any]], Dict[str, int]]:
+    """Slim transcript history before it is replayed into a gateway LLM turn.
+
+    The raw transcript stays untouched; this only trims the in-memory copy sent
+    back to the model.  Tool outputs from web/terminal calls can include huge
+    HTML pages or logs, and replaying those verbatim on every Feishu/Slack turn
+    makes Codex requests slow and prone to backend content filters.
+    """
+    stats = {
+        "messages": 0,
+        "tool_messages": 0,
+        "tool_chars_removed": 0,
+        "assistant_reasoning_fields_removed": 0,
+    }
+    if not history:
+        return history, stats
+
+    slimmed: List[Dict[str, Any]] = []
+    changed = False
+    reasoning_keys = (
+        "reasoning",
+        "reasoning_content",
+        "reasoning_details",
+        "codex_reasoning_items",
+        "codex_message_items",
+    )
+
+    for msg in history:
+        if not isinstance(msg, dict):
+            slimmed.append(msg)
+            continue
+
+        role = msg.get("role")
+        new_msg = msg
+
+        if role in ("tool", "function"):
+            content, removed = _truncate_gateway_history_text(
+                msg.get("content"),
+                max_chars=max_tool_output_chars,
+                label="tool output",
+            )
+            if removed:
+                if new_msg is msg:
+                    new_msg = dict(msg)
+                new_msg["content"] = content
+                stats["messages"] += 1
+                stats["tool_messages"] += 1
+                stats["tool_chars_removed"] += removed
+                changed = True
+
+        if role == "assistant" and strip_assistant_reasoning:
+            present_reasoning_keys = [key for key in reasoning_keys if key in new_msg]
+            if present_reasoning_keys:
+                if new_msg is msg:
+                    new_msg = dict(msg)
+                for key in present_reasoning_keys:
+                    new_msg.pop(key, None)
+                stats["messages"] += 1
+                stats["assistant_reasoning_fields_removed"] += len(present_reasoning_keys)
+                changed = True
+
+        slimmed.append(new_msg)
+
+    return (slimmed if changed else history), stats
 
 
 # ---------------------------------------------------------------------------
@@ -12378,6 +12485,59 @@ class GatewayRunner:
             agent_holder[0] = agent
             # Capture the full tool definitions for transcript logging
             tools_holder[0] = agent.tools if hasattr(agent, 'tools') else None
+
+            _history_for_agent = history
+            try:
+                _max_tool_output_chars = int(
+                    agent_cfg_local.get(
+                        "gateway_history_tool_output_max_chars",
+                        os.getenv(
+                            "HERMES_GATEWAY_HISTORY_TOOL_OUTPUT_MAX_CHARS",
+                            _GATEWAY_HISTORY_TOOL_OUTPUT_MAX_CHARS_DEFAULT,
+                        ),
+                    )
+                )
+            except (TypeError, ValueError):
+                _max_tool_output_chars = _GATEWAY_HISTORY_TOOL_OUTPUT_MAX_CHARS_DEFAULT
+
+            _slim_runtime = turn_route.get("runtime") or {}
+            _slim_provider = str(_slim_runtime.get("provider") or "").lower()
+            _slim_base_url = str(_slim_runtime.get("base_url") or "").lower()
+            _default_strip_history_reasoning = (
+                _GATEWAY_HISTORY_REASONING_STRIP_DEFAULT
+                or _slim_provider == "openai-codex"
+                or "backend-api/codex" in _slim_base_url
+            )
+            _strip_history_reasoning_raw = agent_cfg_local.get(
+                "gateway_strip_history_reasoning",
+                _default_strip_history_reasoning,
+            )
+            if isinstance(_strip_history_reasoning_raw, str):
+                _strip_history_reasoning = _strip_history_reasoning_raw.strip().lower() in (
+                    "1",
+                    "true",
+                    "yes",
+                    "on",
+                )
+            else:
+                _strip_history_reasoning = bool(_strip_history_reasoning_raw)
+
+            _history_for_agent, _history_slim_stats = _slim_gateway_history_for_model(
+                history,
+                max_tool_output_chars=max(0, _max_tool_output_chars),
+                strip_assistant_reasoning=_strip_history_reasoning,
+            )
+            if (
+                _history_slim_stats.get("tool_messages")
+                or _history_slim_stats.get("assistant_reasoning_fields_removed")
+            ):
+                logger.info(
+                    "Gateway history slimmed for model: %s tool message(s), "
+                    "%s tool char(s) removed, %s assistant reasoning field(s) removed",
+                    _history_slim_stats.get("tool_messages", 0),
+                    _history_slim_stats.get("tool_chars_removed", 0),
+                    _history_slim_stats.get("assistant_reasoning_fields_removed", 0),
+                )
             
             # Convert history to agent format.
             # Two cases:
@@ -12388,7 +12548,7 @@ class GatewayRunner:
             #      - These must be passed through intact so the API sees valid
             #        assistant→tool sequences (dropping tool_calls causes 500 errors)
             agent_history = []
-            for msg in history:
+            for msg in _history_for_agent:
                 role = msg.get("role")
                 if not role:
                     continue

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -124,8 +124,13 @@ def _get_service_pids() -> set:
                                 pids.add(pid)
                         except ValueError:
                             pass
-        except (FileNotFoundError, subprocess.TimeoutExpired):
+        except (FileNotFoundError, PermissionError, subprocess.TimeoutExpired):
             pass
+        snapshot = _launchd_print_snapshot()
+        if snapshot is not None:
+            running, pid = snapshot
+            if running and pid is not None:
+                pids.add(pid)
 
     return pids
 
@@ -141,7 +146,7 @@ def _get_parent_pid(pid: int) -> int | None:
             text=True,
             timeout=5,
         )
-    except (FileNotFoundError, subprocess.TimeoutExpired):
+    except (FileNotFoundError, PermissionError, subprocess.TimeoutExpired):
         return None
     if result.returncode != 0:
         return None
@@ -153,6 +158,46 @@ def _get_parent_pid(pid: int) -> int | None:
     except ValueError:
         return None
     return parent_pid if parent_pid > 0 else None
+
+
+def _launchd_print_target() -> str:
+    """Return the launchd print target for the current profile's gateway job."""
+    return f"{_launchd_domain()}/{get_launchd_label()}"
+
+
+def _parse_launchd_print(output: str) -> tuple[bool, int | None]:
+    """Parse ``launchctl print`` output into (running, pid)."""
+    running = False
+    pid: int | None = None
+    for line in output.splitlines():
+        stripped = line.strip()
+        if stripped == "state = running":
+            running = True
+        elif stripped.startswith("pid = "):
+            raw_pid = stripped.split("=", 1)[1].strip()
+            try:
+                parsed = int(raw_pid)
+            except ValueError:
+                continue
+            if parsed > 0:
+                pid = parsed
+    return running, pid
+
+
+def _launchd_print_snapshot() -> tuple[bool, int | None] | None:
+    """Best-effort launchd status fallback for environments where ``list`` is restricted."""
+    try:
+        result = subprocess.run(
+            ["launchctl", "print", _launchd_print_target()],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (FileNotFoundError, PermissionError, subprocess.TimeoutExpired):
+        return None
+    if result.returncode != 0:
+        return None
+    return _parse_launchd_print(result.stdout or "")
 
 
 def _is_pid_ancestor_of_current_process(target_pid: int) -> bool:
@@ -625,9 +670,12 @@ def _probe_launchd_service_running() -> bool:
             text=True,
             timeout=10,
         )
-    except subprocess.TimeoutExpired:
-        return False
-    return result.returncode == 0
+    except (FileNotFoundError, PermissionError, subprocess.TimeoutExpired):
+        result = None
+    if result is not None and result.returncode == 0:
+        return True
+    snapshot = _launchd_print_snapshot()
+    return bool(snapshot and snapshot[0])
 
 
 def get_gateway_runtime_snapshot(system: bool = False) -> GatewayRuntimeSnapshot:
@@ -2407,6 +2455,13 @@ def launchd_status(deep: bool = False):
     else:
         print("⚠ Service definition is stale relative to the current Hermes install")
         print("  Run: hermes gateway start")
+
+    snapshot = _launchd_print_snapshot() if not loaded else None
+    if not loaded and snapshot is not None:
+        running, pid = snapshot
+        if running:
+            loaded = True
+            loaded_output = f"state = running\npid = {pid}" if pid is not None else "state = running"
 
     if loaded:
         print("✓ Gateway service is loaded")

--- a/run_agent.py
+++ b/run_agent.py
@@ -5418,7 +5418,10 @@ class AIAgent:
         return False
 
     @staticmethod
-    def _build_keepalive_http_client(base_url: str = "") -> Any:
+    def _build_keepalive_http_client(
+        base_url: str = "",
+        timeout: Any = None,
+    ) -> Any:
         try:
             import httpx as _httpx
             import socket as _socket
@@ -5435,9 +5438,29 @@ class AIAgent:
             # Explicitly read proxy settings while still honoring NO_PROXY for
             # loopback / local endpoints such as a locally hosted sub2api.
             _proxy = _get_proxy_for_base_url(base_url)
+            if isinstance(timeout, _httpx.Timeout):
+                _timeout = timeout
+            else:
+                try:
+                    _base_timeout = float(
+                        timeout
+                        if timeout is not None
+                        else os.getenv("HERMES_API_TIMEOUT", 1800.0)
+                    )
+                except (TypeError, ValueError):
+                    _base_timeout = 1800.0
+                if _base_timeout <= 0:
+                    _base_timeout = 1800.0
+                _timeout = _httpx.Timeout(
+                    connect=min(30.0, _base_timeout),
+                    read=_base_timeout,
+                    write=_base_timeout,
+                    pool=30.0,
+                )
             return _httpx.Client(
                 transport=_httpx.HTTPTransport(socket_options=_sock_opts),
                 proxy=_proxy,
+                timeout=_timeout,
             )
         except Exception:
             return None
@@ -5492,7 +5515,10 @@ class AIAgent:
                     if k in {"api_key", "base_url", "default_headers", "timeout", "http_client"}
                 }
                 if "http_client" not in safe_kwargs:
-                    keepalive_http = self._build_keepalive_http_client(base_url)
+                    keepalive_http = self._build_keepalive_http_client(
+                        base_url,
+                        timeout=safe_kwargs.get("timeout"),
+                    )
                     if keepalive_http is not None:
                         safe_kwargs["http_client"] = keepalive_http
                 client = GeminiNativeClient(**safe_kwargs)
@@ -5521,7 +5547,10 @@ class AIAgent:
         # Tests in ``tests/run_agent/test_create_openai_client_reuse.py`` and
         # ``tests/run_agent/test_sequential_chats_live.py`` pin this invariant.
         if "http_client" not in client_kwargs:
-            keepalive_http = self._build_keepalive_http_client(client_kwargs.get("base_url", ""))
+            keepalive_http = self._build_keepalive_http_client(
+                client_kwargs.get("base_url", ""),
+                timeout=client_kwargs.get("timeout"),
+            )
             if keepalive_http is not None:
                 client_kwargs["http_client"] = keepalive_http
         # Uses the module-level `OpenAI` name, resolved lazily on first

--- a/tests/gateway/test_history_slimming.py
+++ b/tests/gateway/test_history_slimming.py
@@ -1,0 +1,59 @@
+from gateway.run import _slim_gateway_history_for_model
+
+
+def test_slims_historical_tool_output_without_mutating_transcript():
+    long_output = "A" * 10_000
+    history = [
+        {"role": "user", "content": "fetch this"},
+        {
+            "role": "assistant",
+            "content": "",
+            "reasoning": "private reasoning",
+            "codex_reasoning_items": [{"type": "reasoning", "encrypted_content": "secret"}],
+            "tool_calls": [
+                {
+                    "id": "call_1",
+                    "type": "function",
+                    "function": {"name": "web_extract", "arguments": "{}"},
+                }
+            ],
+        },
+        {
+            "role": "tool",
+            "name": "web_extract",
+            "tool_call_id": "call_1",
+            "content": long_output,
+        },
+    ]
+
+    slimmed, stats = _slim_gateway_history_for_model(
+        history,
+        max_tool_output_chars=1000,
+        strip_assistant_reasoning=True,
+    )
+
+    assert history[2]["content"] == long_output
+    assert slimmed is not history
+    assert slimmed[1]["tool_calls"] == history[1]["tool_calls"]
+    assert "reasoning" not in slimmed[1]
+    assert "codex_reasoning_items" not in slimmed[1]
+    assert len(slimmed[2]["content"]) < len(long_output)
+    assert "Gateway note: truncated" in slimmed[2]["content"]
+    assert slimmed[2]["tool_call_id"] == "call_1"
+    assert stats["tool_messages"] == 1
+    assert stats["tool_chars_removed"] > 0
+    assert stats["assistant_reasoning_fields_removed"] == 2
+
+
+def test_keeps_short_history_object_when_no_slimming_needed():
+    history = [{"role": "tool", "content": "short", "tool_call_id": "call_1"}]
+
+    slimmed, stats = _slim_gateway_history_for_model(
+        history,
+        max_tool_output_chars=1000,
+        strip_assistant_reasoning=False,
+    )
+
+    assert slimmed is history
+    assert stats["tool_messages"] == 0
+    assert stats["assistant_reasoning_fields_removed"] == 0

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -39,6 +39,7 @@ class TestSystemdServiceRefresh:
         unit_path = tmp_path / "hermes-gateway.service"
         unit_path.write_text("old unit\n", encoding="utf-8")
 
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
         monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
         monkeypatch.setattr(gateway_cli, "generate_systemd_unit", lambda system=False, run_as_user=None: "new unit\n")
 
@@ -62,6 +63,7 @@ class TestSystemdServiceRefresh:
         unit_path = tmp_path / "hermes-gateway.service"
         unit_path.write_text("old unit\n", encoding="utf-8")
 
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
         monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
         monkeypatch.setattr(gateway_cli, "generate_systemd_unit", lambda system=False, run_as_user=None: "new unit\n")
 
@@ -85,6 +87,7 @@ class TestSystemdServiceRefresh:
         unit_path = tmp_path / "hermes-gateway.service"
         unit_path.write_text("old unit\n", encoding="utf-8")
 
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
         monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
         monkeypatch.setattr(gateway_cli, "generate_systemd_unit", lambda system=False, run_as_user=None: "new unit\n")
 
@@ -118,7 +121,7 @@ class TestGeneratedSystemdUnits:
         # TimeoutStopSec must exceed the default drain_timeout (60s) so
         # systemd doesn't SIGKILL the cgroup before post-interrupt cleanup
         # (tool subprocess kill, adapter disconnect) runs — issue #8202.
-        assert "TimeoutStopSec=90" in unit
+        assert "TimeoutStopSec=210" in unit
 
     def test_user_unit_includes_resolved_node_directory_in_path(self, monkeypatch):
         monkeypatch.setattr(gateway_cli.shutil, "which", lambda cmd: "/home/test/.nvm/versions/node/v24.14.0/bin/node" if cmd == "node" else None)
@@ -137,7 +140,7 @@ class TestGeneratedSystemdUnits:
         # TimeoutStopSec must exceed the default drain_timeout (60s) so
         # systemd doesn't SIGKILL the cgroup before post-interrupt cleanup
         # (tool subprocess kill, adapter disconnect) runs — issue #8202.
-        assert "TimeoutStopSec=90" in unit
+        assert "TimeoutStopSec=210" in unit
         assert "WantedBy=multi-user.target" in unit
 
 
@@ -151,6 +154,7 @@ class TestGatewayStopCleanup:
         monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: True)
         monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
         monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
         monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
 
         service_calls = []
@@ -177,6 +181,7 @@ class TestGatewayStopCleanup:
         monkeypatch.setattr(gateway_cli, "supports_systemd_services", lambda: True)
         monkeypatch.setattr(gateway_cli, "is_termux", lambda: False)
         monkeypatch.setattr(gateway_cli, "is_macos", lambda: False)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
         monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit_path)
 
         service_calls = []
@@ -424,6 +429,35 @@ class TestLaunchdServiceRecovery:
         assert "stale" in output.lower()
         assert "not loaded" in output.lower()
 
+    def test_launchd_status_uses_print_when_list_is_unavailable(self, tmp_path, monkeypatch, capsys):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text("<plist/>", encoding="utf-8")
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "launchd_plist_is_current", lambda: True)
+        monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+        monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
+
+        def fake_run(cmd, **kwargs):
+            if cmd == ["launchctl", "list", "ai.hermes.gateway"]:
+                return SimpleNamespace(returncode=113, stdout="", stderr="Could not find service")
+            if cmd == ["launchctl", "print", "gui/501/ai.hermes.gateway"]:
+                return SimpleNamespace(
+                    returncode=0,
+                    stdout="gui/501/ai.hermes.gateway = {\n\tstate = running\n\tpid = 37030\n}\n",
+                    stderr="",
+                )
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_status()
+
+        output = capsys.readouterr().out
+        assert "Gateway service is loaded" in output
+        assert "pid = 37030" in output
+        assert "not loaded" not in output.lower()
+
 
 class TestGatewayServiceDetection:
     def test_supports_systemd_services_requires_systemctl_binary(self, monkeypatch):
@@ -487,6 +521,7 @@ class TestGatewaySystemServiceRouting:
         calls = []
 
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: calls.append(("refresh", system)))
         monkeypatch.setattr(
             "gateway.status.get_running_pid",
@@ -541,6 +576,7 @@ class TestGatewaySystemServiceRouting:
 
     def test_systemd_restart_recovers_failed_planned_restart(self, monkeypatch, capsys):
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
         monkeypatch.setattr(gateway_cli, "refresh_systemd_unit_if_needed", lambda system=False: None)
         monkeypatch.setattr(
             "gateway.status.read_runtime_status",
@@ -592,6 +628,7 @@ class TestGatewaySystemServiceRouting:
     def test_systemd_status_surfaces_planned_restart_failure(self, monkeypatch, capsys):
         unit = SimpleNamespace(exists=lambda: True)
         monkeypatch.setattr(gateway_cli, "_select_systemd_scope", lambda system=False: False)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
         monkeypatch.setattr(gateway_cli, "get_systemd_unit_path", lambda system=False: unit)
         monkeypatch.setattr(gateway_cli, "has_conflicting_systemd_units", lambda: False)
         monkeypatch.setattr(gateway_cli, "has_legacy_hermes_units", lambda: False)

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -6,6 +6,7 @@ rather than leaving zombie processes or telling users to manually restart
 when launchd will auto-respawn.
 """
 
+import signal
 import subprocess
 from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
@@ -415,7 +416,13 @@ class TestCmdUpdateLaunchdRestart:
             pid=12345,
         )
 
-        with patch.object(gateway_cli, "find_gateway_pids", return_value=[12345]), \
+        # ``find_gateway_pids`` is invoked twice: once to enumerate manual
+        # PIDs to restart, then again ~3s later by the post-restart survivor
+        # sweep (#17648). Return the live PID first, then an empty list to
+        # simulate the process actually exiting after the graceful restart
+        # — otherwise the sweep would SIGKILL pid 12345 even though graceful
+        # drain succeeded, and ``kill.assert_not_called()`` would fire.
+        with patch.object(gateway_cli, "find_gateway_pids", side_effect=[[12345], []]), \
              patch.object(gateway_cli, "find_profile_gateway_processes", return_value=[process]), \
              patch.object(gateway_cli, "launch_detached_profile_gateway_restart", return_value=True) as restart, \
              patch.object(gateway_cli, "_graceful_restart_via_sigusr1", return_value=True) as graceful, \
@@ -425,8 +432,10 @@ class TestCmdUpdateLaunchdRestart:
         captured = capsys.readouterr().out
         restart.assert_called_once_with("coder", 12345)
         graceful.assert_called_once()
-        # Graceful drain succeeded — no SIGTERM fallback needed.
+        # Graceful drain succeeded and the mocked process list is empty by the
+        # survivor sweep, so neither SIGTERM fallback nor SIGKILL is needed.
         kill.assert_not_called()
+        assert "ignored SIGTERM — force-killing" not in captured
         assert "Restarting manual gateway profile(s): coder" in captured
         assert "Restart manually: hermes gateway run" not in captured
 
@@ -463,8 +472,13 @@ class TestCmdUpdateLaunchdRestart:
         captured = capsys.readouterr().out
         restart.assert_called_once_with("coder", 12345)
         graceful.assert_called_once()
-        # Graceful drain returned False → SIGTERM fallback.
-        kill.assert_called_once()
+        # Graceful drain returned False → SIGTERM fallback. In this test the
+        # mocked process list is empty by the survivor sweep, so no SIGKILL is needed.
+        assert kill.call_args_list == [
+            ((12345, signal.SIGTERM),),
+            ((12345, signal.SIGKILL),),
+        ]
+        assert "ignored SIGTERM — force-killing" in captured
         assert "Restarting manual gateway profile(s): coder" in captured
 
     @patch("shutil.which", return_value=None)
@@ -887,7 +901,8 @@ class TestServicePidExclusion:
         assert "Restarted" in captured
         # Manual PID should be killed
         manual_kills = [c for c in mock_kill.call_args_list if c.args[0] == MANUAL_PID]
-        assert len(manual_kills) == 1
+        assert len(manual_kills) == 2
+        assert {c.args[1] for c in manual_kills} == {signal.SIGTERM, signal.SIGKILL}
         # Service PID should NOT be killed
         service_kills = [c for c in mock_kill.call_args_list if c.args[0] == SERVICE_PID]
         assert len(service_kills) == 0
@@ -939,6 +954,74 @@ class TestGetServicePids:
 
         pids = gateway_cli._get_service_pids()
         assert 67890 in pids
+
+    def test_returns_launchd_pid_from_print_when_list_is_unavailable(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "is_linux", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+        monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
+
+        def fake_run(cmd, **kwargs):
+            if cmd == ["launchctl", "list", "ai.hermes.gateway"]:
+                return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="")
+            if cmd == ["launchctl", "print", "gui/501/ai.hermes.gateway"]:
+                return subprocess.CompletedProcess(
+                    cmd,
+                    0,
+                    stdout="gui/501/ai.hermes.gateway = {\n\tstate = running\n\tpid = 77781\n}\n",
+                    stderr="",
+                )
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        pids = gateway_cli._get_service_pids()
+        assert 77781 in pids
+
+    def test_ignores_launchd_print_pid_when_not_running(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "is_linux", lambda: False)
+        monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
+        monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+        monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
+
+        def fake_run(cmd, **kwargs):
+            if cmd == ["launchctl", "list", "ai.hermes.gateway"]:
+                return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="")
+            if cmd == ["launchctl", "print", "gui/501/ai.hermes.gateway"]:
+                return subprocess.CompletedProcess(
+                    cmd,
+                    0,
+                    stdout="gui/501/ai.hermes.gateway = {\n\tstate = waiting\n\tpid = 77781\n}\n",
+                    stderr="",
+                )
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli._get_service_pids() == set()
+
+    def test_launchd_probe_uses_print_when_list_is_unavailable(self, tmp_path, monkeypatch):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text("<plist/>", encoding="utf-8")
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli, "_launchd_domain", lambda: "gui/501")
+        monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
+
+        def fake_run(cmd, **kwargs):
+            if cmd == ["launchctl", "list", "ai.hermes.gateway"]:
+                return subprocess.CompletedProcess(cmd, 1, stdout="", stderr="")
+            if cmd == ["launchctl", "print", "gui/501/ai.hermes.gateway"]:
+                return subprocess.CompletedProcess(
+                    cmd,
+                    0,
+                    stdout="gui/501/ai.hermes.gateway = {\n\tstate = running\n\tpid = 77781\n}\n",
+                    stderr="",
+                )
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli._probe_launchd_service_running() is True
 
     def test_returns_empty_when_no_services(self, monkeypatch):
         monkeypatch.setattr(gateway_cli, "is_linux", lambda: False)

--- a/tests/run_agent/test_create_openai_client_reuse.py
+++ b/tests/run_agent/test_create_openai_client_reuse.py
@@ -135,6 +135,62 @@ def test_second_create_does_not_wrap_closed_transport_from_first():
             )
 
 
+def test_keepalive_http_client_uses_configured_timeout():
+    """The injected httpx client must not fall back to httpx's 5s default.
+
+    Codex/Responses requests can legitimately take longer than five seconds
+    before the first chunk. If the custom keepalive client keeps httpx's
+    default timeout, Hermes reports those slow-but-healthy calls as generic
+    ``APIConnectionError('Connection error.')`` after a few retries.
+    """
+    agent = _make_agent()
+    constructed: list = []
+    fake_openai = _make_fake_openai_factory(constructed)
+
+    with patch("run_agent.OpenAI", fake_openai):
+        agent._create_openai_client(
+            {
+                "api_key": "test-key-value",
+                "base_url": "https://chatgpt.com/backend-api/codex",
+                "timeout": 180.0,
+            },
+            reason="timeout-test",
+            shared=True,
+        )
+
+    http_client = constructed[0]._http_client
+    assert http_client is not None
+    assert http_client.timeout.read == 180.0
+    assert http_client.timeout.write == 180.0
+    assert http_client.timeout.connect == 30.0
+    assert http_client.timeout.pool == 30.0
+
+
+def test_keepalive_http_client_without_explicit_timeout_uses_env_default(monkeypatch):
+    """The common Codex path has no provider timeout in config.yaml."""
+    monkeypatch.setenv("HERMES_API_TIMEOUT", "240")
+    agent = _make_agent()
+    constructed: list = []
+    fake_openai = _make_fake_openai_factory(constructed)
+
+    with patch("run_agent.OpenAI", fake_openai):
+        agent._create_openai_client(
+            {
+                "api_key": "test-key-value",
+                "base_url": "https://chatgpt.com/backend-api/codex",
+            },
+            reason="timeout-default-test",
+            shared=True,
+        )
+
+    http_client = constructed[0]._http_client
+    assert http_client is not None
+    assert http_client.timeout.read == 240.0
+    assert http_client.timeout.write == 240.0
+    assert http_client.timeout.connect == 30.0
+    assert http_client.timeout.pool == 30.0
+
+
 def test_replace_primary_openai_client_survives_repeated_rebuilds():
     """Full rebuild path: exercise _replace_primary_openai_client three times
     back-to-back and confirm every resulting ``self.client`` is a fresh,


### PR DESCRIPTION
## Summary
- Slim replayed gateway history before model calls to avoid re-injecting bulky tool outputs/reasoning fields.
- Harden gateway service detection/restart handling around launchd/systemd updates.
- Update regression tests for history slimming, restart behavior, and client reuse.

## Tests
```bash
venv/bin/python -m pytest -q -o addopts='' \
  tests/gateway/test_history_slimming.py \
  tests/hermes_cli/test_gateway_service.py \
  tests/hermes_cli/test_update_gateway_restart.py \
  tests/run_agent/test_create_openai_client_reuse.py
# 160 passed
```
