### PR TITLE
fix(cli): require user confirmation before uploading debug share data

### DIFF
--- a/hermes_cli/debug.py
+++ b/hermes_cli/debug.py
@@ -592,6 +592,15 @@ def run_debug_share(args):
 
     if not local_only:
         print(_PRIVACY_NOTICE)
+        yes = bool(getattr(args, "yes", False))
+        if not yes:
+            try:
+                answer = input("Upload debug report? [y/N] ").strip().lower()
+            except (EOFError, KeyboardInterrupt):
+                answer = ""
+            if answer not in ("y", "yes"):
+                print("Aborted.")
+                return
 
     print("Collecting debug report...")
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9814,6 +9814,11 @@ Examples:
         help="Print the report locally instead of uploading",
     )
     share_parser.add_argument(
+        "-y", "--yes",
+        action="store_true",
+        help="Skip confirmation prompt and upload immediately",
+    )
+    share_parser.add_argument(
         "--no-redact",
         action="store_true",
         help=(

--- a/tests/hermes_cli/test_debug.py
+++ b/tests/hermes_cli/test_debug.py
@@ -448,6 +448,7 @@ class TestRunDebugShare:
         args.lines = 50
         args.expire = 7
         args.local = False
+        args.yes = True
 
         with patch("hermes_cli.dump.run_dump"), \
              patch("hermes_cli.debug._sweep_expired_pastes", return_value=(0, 0)) as mock_sweep, \
@@ -466,6 +467,7 @@ class TestRunDebugShare:
         args.lines = 50
         args.expire = 7
         args.local = False
+        args.yes = True
 
         with patch("hermes_cli.dump.run_dump"), \
              patch(
@@ -503,6 +505,7 @@ class TestRunDebugShare:
         args.lines = 50
         args.expire = 7
         args.local = False
+        args.yes = True
 
         call_count = [0]
         uploaded_content = []
@@ -551,6 +554,7 @@ class TestRunDebugShare:
         args.lines = 50
         args.expire = 7
         args.local = False
+        args.yes = True
 
         uploaded_content = []
 
@@ -596,6 +600,7 @@ class TestRunDebugShare:
         args.lines = 50
         args.expire = 7
         args.local = False
+        args.yes = True
 
         call_count = [0]
         def _mock_upload(content, expiry_days=7):
@@ -620,6 +625,7 @@ class TestRunDebugShare:
         args.lines = 50
         args.expire = 7
         args.local = False
+        args.yes = True
 
         call_count = [0]
         def _mock_upload(content, expiry_days=7):
@@ -646,6 +652,7 @@ class TestRunDebugShare:
         args.lines = 50
         args.expire = 7
         args.local = False
+        args.yes = True
 
         with patch("hermes_cli.dump.run_dump"), \
              patch("hermes_cli.debug.upload_to_pastebin",
@@ -657,6 +664,47 @@ class TestRunDebugShare:
         out = capsys.readouterr()
         assert "all failed" in out.err
 
+
+
+    def test_share_aborts_on_user_decline(self, hermes_home, capsys, monkeypatch):
+        """When user declines the confirmation prompt, no upload occurs."""
+        from hermes_cli.debug import run_debug_share
+
+        args = MagicMock()
+        args.lines = 50
+        args.expire = 7
+        args.local = False
+        args.yes = False
+
+        monkeypatch.setattr("builtins.input", lambda _: "n")
+
+        with patch("hermes_cli.dump.run_dump"), \
+             patch("hermes_cli.debug.upload_to_pastebin") as mock_upload:
+            run_debug_share(args)
+
+        mock_upload.assert_not_called()
+        out = capsys.readouterr().out
+        assert "Aborted" in out
+
+    def test_share_skips_prompt_with_yes_flag(self, hermes_home, capsys):
+        """--yes flag skips the confirmation prompt and uploads directly."""
+        from hermes_cli.debug import run_debug_share
+
+        args = MagicMock()
+        args.lines = 50
+        args.expire = 7
+        args.local = False
+        args.yes = True
+
+        with patch("hermes_cli.dump.run_dump"), \
+             patch("hermes_cli.debug._sweep_expired_pastes", return_value=(0, 0)), \
+             patch("hermes_cli.debug.upload_to_pastebin",
+                    return_value="https://paste.rs/test"):
+            run_debug_share(args)
+
+        out = capsys.readouterr().out
+        assert "Debug report uploaded" in out
+        assert "Aborted" not in out
 
 # ---------------------------------------------------------------------------
 # Share-time redaction wiring + visible banner
@@ -694,6 +742,7 @@ class TestRunDebugShareRedaction:
         args.lines = 50
         args.expire = 7
         args.local = False
+        args.yes = True
         args.no_redact = False
 
         captured: list[str] = []
@@ -724,6 +773,7 @@ class TestRunDebugShareRedaction:
         args.lines = 50
         args.expire = 7
         args.local = False
+        args.yes = True
         args.no_redact = False
 
         captured: list[str] = []
@@ -752,6 +802,7 @@ class TestRunDebugShareRedaction:
         args.lines = 50
         args.expire = 7
         args.local = False
+        args.yes = True
         args.no_redact = True
 
         captured: list[str] = []
@@ -1180,6 +1231,7 @@ class TestShareIncludesAutoDelete:
         args.lines = 50
         args.expire = 7
         args.local = False
+        args.yes = True
 
         with patch("hermes_cli.dump.run_dump"), \
              patch("hermes_cli.debug.upload_to_pastebin",
@@ -1202,6 +1254,7 @@ class TestShareIncludesAutoDelete:
         args.lines = 50
         args.expire = 7
         args.local = False
+        args.yes = True
 
         with patch("hermes_cli.dump.run_dump"), \
              patch("hermes_cli.debug.upload_to_pastebin",


### PR DESCRIPTION
## What does this PR do?

`hermes debug share` uploads log files containing conversation content, user data, and tool outputs to public paste services (paste.rs, dpaste.com). While a privacy notice is printed, the upload proceeds automatically without requiring explicit user consent.

This PR adds a confirmation prompt that requires the user to type `y` or `yes` before any data is uploaded.


### Root Cause

The `run_debug_share()` function in `hermes_cli/debug.py` prints `_PRIVACY_NOTICE` but immediately proceeds to upload without waiting for user confirmation. A user who runs `hermes debug share` without reading the notice carefully may unknowingly expose private conversation data.

## Related Issue

Fixes #22016

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A