### PR TITLE
test(tui): assert /quit exits locally via session.die()

### DIFF
--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -26,6 +26,14 @@ describe('createSlashHandler', () => {
     expect(ctx.transcript.sys).toHaveBeenCalledWith('ui redrawn')
   })
 
+  it('exits locally for /quit', () => {
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)('/quit')).toBe(true)
+    expect(ctx.session.die).toHaveBeenCalledTimes(1)
+    expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
+  })
+
   it('routes /status to live session.status instead of slash worker', async () => {
     patchUiState({ sid: 'sid-abc' })
     const rpc = vi.fn(() => Promise.resolve({ output: 'Hermes TUI Status' }))


### PR DESCRIPTION
Salvage of #22026 by @adybag14-cyber onto current main.

## Summary
Adds a test that /quit dispatches locally via `session.die()` without hitting the slash worker.

## Changes
- `ui-tui/src/__tests__/createSlashHandler.test.ts`: +8 lines, one new `it()` case.

## Validation
- `npx vitest run src/__tests__/createSlashHandler.test.ts` → 52/52 passing.

Behavior on main was already correct (`ui-tui/src/app/slash/commands/core.ts` registers `quit` with `run: (_arg, ctx) => ctx.session.die()`); this just locks it in.

Closes #22026.