### PR TITLE
fix(patch-tool): advertise per-mode required params in schema descriptions

### DIFF
--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -361,4 +361,49 @@ class TestSearchHints:
         assert "offset=100" in raw
 
 
+# ---------------------------------------------------------------------------
+# PATCH_SCHEMA shape tests (issue #15524)
+# ---------------------------------------------------------------------------
 
+class TestPatchSchemaShape:
+    """PATCH_SCHEMA must advertise per-mode required params so strict models
+    (e.g. kimi-k2.x) don't silently omit old_string / new_string for replace
+    mode, or patch content for patch mode."""
+
+    def test_required_only_contains_mode(self):
+        # anyOf is incompatible with several providers (Anthropic, Fireworks,
+        # Kimi/Moonshot). The only safe approach is description-level guidance.
+        assert PATCH_SCHEMA["parameters"]["required"] == ["mode"]
+
+    def test_top_level_description_documents_replace_mode_required_params(self):
+        desc = PATCH_SCHEMA["description"]
+        assert "REQUIRED PARAMETERS: mode, path, old_string, new_string" in desc
+
+    def test_top_level_description_documents_patch_mode_required_params(self):
+        desc = PATCH_SCHEMA["description"]
+        assert "REQUIRED PARAMETERS: mode, patch" in desc
+
+    def test_path_property_advertises_required_for_replace(self):
+        desc = PATCH_SCHEMA["parameters"]["properties"]["path"]["description"]
+        assert "REQUIRED when mode='replace'" in desc
+
+    def test_old_string_property_advertises_required_for_replace(self):
+        desc = PATCH_SCHEMA["parameters"]["properties"]["old_string"]["description"]
+        assert "REQUIRED when mode='replace'" in desc
+
+    def test_new_string_property_advertises_required_for_replace(self):
+        desc = PATCH_SCHEMA["parameters"]["properties"]["new_string"]["description"]
+        assert "REQUIRED when mode='replace'" in desc
+
+    def test_patch_property_advertises_required_for_patch_mode(self):
+        desc = PATCH_SCHEMA["parameters"]["properties"]["patch"]["description"]
+        assert "REQUIRED when mode='patch'" in desc
+
+    def test_no_anyof_at_parameters_level(self):
+        assert "anyOf" not in PATCH_SCHEMA["parameters"]
+        assert "oneOf" not in PATCH_SCHEMA["parameters"]
+
+    def test_schema_is_provider_compatible_object(self):
+        params = PATCH_SCHEMA["parameters"]
+        assert params["type"] == "object"
+        assert isinstance(params["properties"], dict)

--- a/tests/tools/test_file_tools.py
+++ b/tests/tools/test_file_tools.py
@@ -366,44 +366,23 @@ class TestSearchHints:
 # ---------------------------------------------------------------------------
 
 class TestPatchSchemaShape:
-    """PATCH_SCHEMA must advertise per-mode required params so strict models
-    (e.g. kimi-k2.x) don't silently omit old_string / new_string for replace
-    mode, or patch content for patch mode."""
+    """PATCH_SCHEMA must advertise per-mode required params via description
+    text (not JSON-schema ``required``), so strict models like kimi-k2.x stop
+    silently omitting old_string / new_string / patch content."""
 
-    def test_required_only_contains_mode(self):
-        # anyOf is incompatible with several providers (Anthropic, Fireworks,
-        # Kimi/Moonshot). The only safe approach is description-level guidance.
-        assert PATCH_SCHEMA["parameters"]["required"] == ["mode"]
-
-    def test_top_level_description_documents_replace_mode_required_params(self):
+    def test_per_mode_required_params_documented_in_descriptions(self):
         desc = PATCH_SCHEMA["description"]
         assert "REQUIRED PARAMETERS: mode, path, old_string, new_string" in desc
-
-    def test_top_level_description_documents_patch_mode_required_params(self):
-        desc = PATCH_SCHEMA["description"]
         assert "REQUIRED PARAMETERS: mode, patch" in desc
+        props = PATCH_SCHEMA["parameters"]["properties"]
+        for name in ("path", "old_string", "new_string"):
+            assert "REQUIRED when mode='replace'" in props[name]["description"]
+        assert "REQUIRED when mode='patch'" in props["patch"]["description"]
 
-    def test_path_property_advertises_required_for_replace(self):
-        desc = PATCH_SCHEMA["parameters"]["properties"]["path"]["description"]
-        assert "REQUIRED when mode='replace'" in desc
-
-    def test_old_string_property_advertises_required_for_replace(self):
-        desc = PATCH_SCHEMA["parameters"]["properties"]["old_string"]["description"]
-        assert "REQUIRED when mode='replace'" in desc
-
-    def test_new_string_property_advertises_required_for_replace(self):
-        desc = PATCH_SCHEMA["parameters"]["properties"]["new_string"]["description"]
-        assert "REQUIRED when mode='replace'" in desc
-
-    def test_patch_property_advertises_required_for_patch_mode(self):
-        desc = PATCH_SCHEMA["parameters"]["properties"]["patch"]["description"]
-        assert "REQUIRED when mode='patch'" in desc
-
-    def test_no_anyof_at_parameters_level(self):
-        assert "anyOf" not in PATCH_SCHEMA["parameters"]
-        assert "oneOf" not in PATCH_SCHEMA["parameters"]
-
-    def test_schema_is_provider_compatible_object(self):
+    def test_no_anyof_required_stays_mode_only(self):
+        # anyOf/oneOf at parameters level break Anthropic, Fireworks, and the
+        # Moonshot/Kimi schema sanitizer — description-level guidance is the
+        # only provider-safe signalling mechanism.
         params = PATCH_SCHEMA["parameters"]
-        assert params["type"] == "object"
-        assert isinstance(params["properties"], dict)
+        assert params["required"] == ["mode"]
+        assert "anyOf" not in params and "oneOf" not in params

--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -1055,19 +1055,48 @@ WRITE_FILE_SCHEMA = {
 
 PATCH_SCHEMA = {
     "name": "patch",
-    "description": "Targeted find-and-replace edits in files. Use this instead of sed/awk in terminal. Uses fuzzy matching (9 strategies) so minor whitespace/indentation differences won't break it. Returns a unified diff. Auto-runs syntax checks after editing.\n\nReplace mode (default): find a unique string and replace it.\nPatch mode: apply V4A multi-file patches for bulk changes.",
+    "description": (
+        "Targeted find-and-replace edits in files. Use this instead of sed/awk in terminal. "
+        "Uses fuzzy matching (9 strategies) so minor whitespace/indentation differences won't break it. "
+        "Returns a unified diff. Auto-runs syntax checks after editing.\n\n"
+        "REPLACE MODE (mode='replace', default): find a unique string and replace it. "
+        "REQUIRED PARAMETERS: mode, path, old_string, new_string.\n"
+        "PATCH MODE (mode='patch'): apply V4A multi-file patches for bulk changes. "
+        "REQUIRED PARAMETERS: mode, patch."
+    ),
     "parameters": {
         "type": "object",
         "properties": {
-            "mode": {"type": "string", "enum": ["replace", "patch"], "description": "Edit mode: 'replace' for targeted find-and-replace, 'patch' for V4A multi-file patches", "default": "replace"},
-            "path": {"type": "string", "description": "File path to edit (required for 'replace' mode)"},
-            "old_string": {"type": "string", "description": "Text to find in the file (required for 'replace' mode). Must be unique in the file unless replace_all=true. Include enough surrounding context to ensure uniqueness."},
-            "new_string": {"type": "string", "description": "Replacement text (required for 'replace' mode). Can be empty string to delete the matched text."},
-            "replace_all": {"type": "boolean", "description": "Replace all occurrences instead of requiring a unique match (default: false)", "default": False},
-            "patch": {"type": "string", "description": "V4A format patch content (required for 'patch' mode). Format:\n*** Begin Patch\n*** Update File: path/to/file\n@@ context hint @@\n context line\n-removed line\n+added line\n*** End Patch"}
+            "mode": {
+                "type": "string",
+                "enum": ["replace", "patch"],
+                "description": "Edit mode. 'replace' (default): requires path + old_string + new_string. 'patch': requires patch content only.",
+                "default": "replace",
+            },
+            "path": {
+                "type": "string",
+                "description": "REQUIRED when mode='replace'. File path to edit.",
+            },
+            "old_string": {
+                "type": "string",
+                "description": "REQUIRED when mode='replace'. Exact text to find and replace. Must be unique in the file unless replace_all=true. Include surrounding context lines to ensure uniqueness.",
+            },
+            "new_string": {
+                "type": "string",
+                "description": "REQUIRED when mode='replace'. Replacement text. Pass empty string '' to delete the matched text.",
+            },
+            "replace_all": {
+                "type": "boolean",
+                "description": "Replace all occurrences instead of requiring a unique match (default: false)",
+                "default": False,
+            },
+            "patch": {
+                "type": "string",
+                "description": "REQUIRED when mode='patch'. V4A format patch content. Format:\n*** Begin Patch\n*** Update File: path/to/file\n@@ context hint @@\n context line\n-removed line\n+added line\n*** End Patch",
+            },
         },
-        "required": ["mode"]
-    }
+        "required": ["mode"],
+    },
 }
 
 SEARCH_FILES_SCHEMA = {


### PR DESCRIPTION
Salvages #15673 (@briandevans, 1198 commits stale) onto current main.

## Summary
Strict tool callers (kimi-k2.x, and per a Slack report from Ben Eng today, llm-wiki batch edits) see only `mode` in the patch tool's JSON-schema `required`, treat `path`/`old_string`/`new_string` as optional, and emit incomplete patch calls — causing loops of "old_string and new_string required" and bulk batches that silently drop edits while the model claims success.

Fix is description-only: `required: ["mode"]` stays (Anthropic / Fireworks / Moonshot-Kimi sanitizers all reject `anyOf`/`oneOf` at the parameters level). Per-mode requirements are now called out in both the top-level tool description and each conditionally-required property's description.

## Changes
- `tools/file_tools.py`: PATCH_SCHEMA description restructured with `REPLACE MODE` / `PATCH MODE` sections listing `REQUIRED PARAMETERS`; per-property descriptions prefixed with `REQUIRED when mode='replace'` / `REQUIRED when mode='patch'`.
- `tests/tools/test_file_tools.py`: two invariant tests (one for description layers, one pinning `required == ["mode"]` with no `anyOf`/`oneOf` to prevent re-introducing the bug). Trimmed from the original 9-test block.

## Validation
`scripts/run_tests.sh tests/tools/test_file_tools.py` → 29 passed.

Closes #15524. Credit: @briandevans.