### PR TITLE
fix(slack): enable writable app home DMs in manifest

### DIFF
--- a/hermes_cli/slack_cli.py
+++ b/hermes_cli/slack_cli.py
@@ -48,6 +48,11 @@ def _build_full_manifest(bot_name: str, bot_description: str) -> dict:
             "background_color": "#1a1a2e",
         },
         "features": {
+            "app_home": {
+                "home_tab_enabled": False,
+                "messages_tab_enabled": True,
+                "messages_tab_read_only_enabled": False,
+            },
             "bot_user": {
                 "display_name": bot_name[:80],
                 "always_online": True,
@@ -69,6 +74,7 @@ def _build_full_manifest(bot_name: str, bot_description: str) -> dict:
                     "files:read",
                     "files:write",
                     "groups:history",
+                    "groups:read",
                     "im:history",
                     "im:read",
                     "im:write",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -53,6 +53,7 @@ AUTHOR_MAP = {
     "harish.kukreja@gmail.com": "counterposition",
     "cleo@edaphic.xyz": "curiouscleo",
     "hirokazu.ogawa@kwansei.ac.jp": "hrkzogw",
+    "datapod.k@gmail.com": "dandacompany",
     "127238744+teknium1@users.noreply.github.com": "teknium1",
     "128259593+Gutslabs@users.noreply.github.com": "Gutslabs",
     "50326054+nocturnum91@users.noreply.github.com": "nocturnum91",

--- a/tests/hermes_cli/test_slack_cli.py
+++ b/tests/hermes_cli/test_slack_cli.py
@@ -1,0 +1,30 @@
+"""Tests for Slack CLI helpers."""
+
+from hermes_cli.slack_cli import _build_full_manifest
+
+
+class TestSlackFullManifest:
+    """Generated full Slack app manifest used by `hermes slack manifest`."""
+
+    def test_app_home_messages_are_writable(self):
+        manifest = _build_full_manifest("Hermes", "Your Hermes agent on Slack")
+
+        assert manifest["features"]["app_home"] == {
+            "home_tab_enabled": False,
+            "messages_tab_enabled": True,
+            "messages_tab_read_only_enabled": False,
+        }
+
+    def test_private_channel_directory_scope_is_included(self):
+        manifest = _build_full_manifest("Hermes", "Your Hermes agent on Slack")
+
+        bot_scopes = manifest["oauth_config"]["scopes"]["bot"]
+        assert "groups:read" in bot_scopes
+
+    def test_assistant_features_remain_enabled(self):
+        manifest = _build_full_manifest("Hermes", "Your Hermes agent on Slack")
+
+        assert "assistant_view" in manifest["features"]
+        assert "assistant:write" in manifest["oauth_config"]["scopes"]["bot"]
+        bot_events = manifest["settings"]["event_subscriptions"]["bot_events"]
+        assert "assistant_thread_started" in bot_events


### PR DESCRIPTION
Salvages #20503 onto current main.

Cherry-picks @dandacompany's fix that makes `hermes slack manifest --write` produce a manifest Slack will actually accept for the App Home Messages tab + private channel enumeration.

### Changes
- `hermes_cli/slack_cli.py`: `_build_full_manifest()` now sets `features.app_home` (`messages_tab_enabled=True`, `messages_tab_read_only_enabled=False`) and adds `groups:read` to bot scopes.
- `tests/hermes_cli/test_slack_cli.py`: 3 new tests pin the behavior.
- `scripts/release.py`: AUTHOR_MAP entry for datapod.k@gmail.com → dandacompany.

### Validation
`scripts/run_tests.sh tests/hermes_cli/test_slack_cli.py` → 3/3 pass.

Closes #20503 — credit to @dandacompany, authorship preserved via rebase-merge.