### PR TITLE
fix(registry): tolerate plugin handlers without **kw

### DIFF
--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -47,6 +47,49 @@ class TestRegisterAndDispatch:
         result = json.loads(reg.dispatch("echo", {"msg": "hi"}))
         assert result == {"msg": "hi"}
 
+    def test_dispatch_tolerates_handler_without_kwargs(self):
+        """A handler declared as ``def handler(args)`` must not raise
+        ``TypeError`` when the dispatcher injects kwargs like
+        ``task_id`` / ``user_task``. Plugin authors who omit ``**kw``
+        get the natural behavior instead of an error.
+        """
+        reg = ToolRegistry()
+
+        def naive_handler(args):
+            return json.dumps({"got": args})
+
+        reg.register(
+            name="naive",
+            toolset="core",
+            schema=_make_schema("naive"),
+            handler=naive_handler,
+        )
+        result = json.loads(
+            reg.dispatch("naive", {"x": 1}, task_id="t1", user_task="u1")
+        )
+        assert result == {"got": {"x": 1}}
+
+    def test_dispatch_passes_named_kwargs_when_handler_accepts_them(self):
+        """When a handler explicitly names a context kwarg (e.g.
+        ``task_id``), the dispatcher must still pass it through after
+        filtering — only unknown kwargs are dropped.
+        """
+        reg = ToolRegistry()
+
+        def named_handler(args, task_id=None):
+            return json.dumps({"task_id": task_id})
+
+        reg.register(
+            name="named",
+            toolset="core",
+            schema=_make_schema("named"),
+            handler=named_handler,
+        )
+        result = json.loads(
+            reg.dispatch("named", {}, task_id="t42", user_task="ignored")
+        )
+        assert result == {"task_id": "t42"}
+
 
 class TestGetDefinitions:
     def test_returns_openai_format(self):

--- a/tools/registry.py
+++ b/tools/registry.py
@@ -16,6 +16,7 @@ Import chain (circular-import safe):
 
 import ast
 import importlib
+import inspect
 import json
 import logging
 import threading
@@ -344,10 +345,41 @@ class ToolRegistry:
     # Dispatch
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _filter_kwargs_for_handler(handler: Callable, kwargs: dict) -> dict:
+        """Pass only kwargs the handler accepts.
+
+        Lets a handler declare ``def handler(args)`` instead of
+        ``def handler(args, **kw)`` and still be dispatched safely. The
+        bundled tool/plugin handlers all accept ``**kw``; this only
+        affects third-party plugins where authors wrote the natural
+        signature without knowing the dispatcher injects ``task_id`` /
+        ``user_task`` / ``parent_agent`` etc.
+        """
+        try:
+            sig = inspect.signature(handler)
+        except (TypeError, ValueError):
+            return kwargs
+        params = sig.parameters.values()
+        if any(p.kind == inspect.Parameter.VAR_KEYWORD for p in params):
+            return kwargs
+        accepted = {
+            n for n, p in sig.parameters.items()
+            if p.kind in (
+                inspect.Parameter.KEYWORD_ONLY,
+                inspect.Parameter.POSITIONAL_OR_KEYWORD,
+            )
+        }
+        return {k: v for k, v in kwargs.items() if k in accepted}
+
     def dispatch(self, name: str, args: dict, **kwargs) -> str:
         """Execute a tool handler by name.
 
         * Async handlers are bridged automatically via ``_run_async()``.
+        * Handler receives only the kwargs its signature accepts (see
+          ``_filter_kwargs_for_handler``); plugin handlers that omit
+          ``**kw`` no longer raise ``TypeError`` on injected context
+          kwargs like ``task_id``.
         * All exceptions are caught and returned as ``{"error": "..."}``
           for consistent error format.
         """
@@ -355,10 +387,11 @@ class ToolRegistry:
         if not entry:
             return json.dumps({"error": f"Unknown tool: {name}"})
         try:
+            passed = self._filter_kwargs_for_handler(entry.handler, kwargs)
             if entry.is_async:
                 from model_tools import _run_async
-                return _run_async(entry.handler(args, **kwargs))
-            return entry.handler(args, **kwargs)
+                return _run_async(entry.handler(args, **passed))
+            return entry.handler(args, **passed)
         except Exception as e:
             logger.exception("Tool %s dispatch error: %s", name, e)
             return json.dumps({"error": f"Tool execution failed: {type(e).__name__}: {e}"})


### PR DESCRIPTION
## Summary

The dispatcher in \`tools/registry.py\` injects context kwargs (\`task_id\`, \`user_task\`, \`parent_agent\`) into every tool handler. Every bundled handler — \`tools/file_tools.py\` (\`_handle_read_file\`), \`plugins/spotify/tools.py\` (\`_handle_spotify_search\`), etc. — accepts \`**kw\` to swallow them, but this convention is **undocumented**.

Third-party plugin authors who write the natural \`def handler(args)\` signature (matching the JSON schema, no extra noise) get a baffling \`TypeError: got an unexpected keyword argument 'task_id'\` on the very first dispatch. The error points at the handler line, but nothing in the schema or the docs hints that the dispatcher injects extra kwargs.

This patch makes the dispatcher signature-aware: it passes only kwargs the handler actually accepts. Backward-compatible — handlers that already declare \`**kw\` still receive every kwarg; handlers that explicitly name a context kwarg (\`def handler(args, task_id=None)\`) still get it; handlers that want neither now just work.

## Repro (before the patch)

\`\`\`python
from tools.registry import ToolRegistry

reg = ToolRegistry()
reg.register(name="naive", toolset="core",
             schema={"name":"naive","description":"","parameters":{"type":"object","properties":{}}},
             handler=lambda args: '{\"ok\":true}')

reg.dispatch("naive", {}, task_id="t1")
# {"error": "Tool execution failed: TypeError: <lambda>() got an unexpected keyword argument 'task_id'"}
\`\`\`

After the patch the same dispatch returns \`{\"ok\": true}\`.

I hit this while authoring an external plugin (a Hermes port of an existing identity SDK). The bug only surfaces for plugins written outside this repo, since every in-tree handler already accepts \`**kw\`.

## Changes

- \`tools/registry.py\`: add \`ToolRegistry._filter_kwargs_for_handler\` (uses \`inspect.signature\`); call it from \`dispatch()\` before invoking the handler. Tolerates \`**kw\`-style handlers (passes everything), explicitly-named-kwarg handlers (passes the matching ones, drops the rest), and signature-less callables (falls back to passing all kwargs).
- \`tests/tools/test_registry.py\`: two new tests — \`test_dispatch_tolerates_handler_without_kwargs\` and \`test_dispatch_passes_named_kwargs_when_handler_accepts_them\`.

## Test plan

- [x] \`pytest tests/tools/test_registry.py\` — passes (was 31 tests, +2 new)
- [x] \`pytest tests/test_model_tools.py tests/tools/\` — 896 pass; 2 unrelated failures pre-existing on \`main\`, neither touches the registry
- [x] End-to-end: external plugin with \`def handler(args)\` (no \`**kw\`) registers and dispatches cleanly under \`hermes chat\`

## Production validation

This patch was merged into a downstream fork (\`HumanjavaEnterprises/hermes-agent\` PR #1, commit dcc43ef6) on 2026-05-08 and has been running in production since — eight third-party plugins authored against the patched dispatcher all dispatch cleanly without needing \`**kw\` boilerplate.