### PR TITLE
fix(mcp): include mcp_serve module in built wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,7 +217,7 @@ hermes-agent = "run_agent:main"
 hermes-acp = "acp_adapter.entry:main"
 
 [tool.setuptools]
-py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_bootstrap", "hermes_constants", "hermes_state", "hermes_time", "hermes_logging", "utils"]
+py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_bootstrap", "hermes_constants", "hermes_state", "hermes_time", "hermes_logging", "utils", "mcp_serve"]
 
 [tool.setuptools.package-data]
 hermes_cli = ["web_dist/**/*", "tui_dist/**/*", "scripts/install.sh", "scripts/install.ps1"]


### PR DESCRIPTION
## What does this PR do?

`hermes mcp serve` fails on NixOS and any other non-editable install with `ModuleNotFoundError: No module named 'mcp_serve'`. Root cause: the top-level `mcp_serve.py` module is not listed under `[tool.setuptools] py-modules` in `pyproject.toml`, so it is omitted from the built wheel. This PR adds it.

`hermes_cli/mcp_config.py:749` does a top-level `from mcp_serve import run_mcp_server`. `mcp_serve.py` lives at the repo root and defines `run_mcp_server` at line 866. Setuptools' wheel build only includes top-level modules listed in `py-modules`. Every other top-level module that production code imports (`run_agent`, `cli`, `batch_runner`, `hermes_bootstrap`, …) is in that list — `mcp_serve` was the lone omission. Editable installs (`pip install -e .`) are unaffected because the repo root is on `sys.path`, which is why dev and CI did not catch it.

## Related Issue

Fixes #22110

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `pyproject.toml` — add `"mcp_serve"` to `[tool.setuptools] py-modules`. Same fix shape as PR #2098 (`minisweagent_path`).

## How to Test

1. Build the wheel from a clean checkout: `uv build --wheel`
2. Inspect the artifact contains the module: `unzip -l dist/hermes_agent-*.whl | grep mcp_serve.py`
3. Inspect `top_level.txt` lists it: `unzip -p dist/hermes_agent-*.whl hermes_agent-*.dist-info/top_level.txt | grep mcp_serve`
4. Install into a fresh non-editable env and run `hermes mcp serve` — the `ModuleNotFoundError` is gone.

Before/after of the wheel artifact:

```
# Before
unzip -l hermes_agent-*.whl | grep mcp_serve.py    # no output
unzip -p hermes_agent-*.whl ...top_level.txt | grep -c mcp_serve    # 0

# After
unzip -l hermes_agent-*.whl | grep mcp_serve.py    # 31690 ... mcp_serve.py
unzip -p hermes_agent-*.whl ...top_level.txt | grep mcp_serve    # mcp_serve
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run focused verification (wheel inspection — there is no pytest path for this packaging bug)
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features) — N/A, packaging-only fix verified via wheel inspection
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — packaging fix is platform-independent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Related / Positioning

- Fixes #22110.
- Same fix shape as PR #2098 (`minisweagent_path`) — top-level module omitted from `py-modules`, broke in non-editable installs.

> Audited siblings: confirmed every other top-level `.py` module that production code imports (`run_agent`, `cli`, `batch_runner`, `hermes_bootstrap`, `mcp_serve` after this change, …) is now present in `[tool.setuptools] py-modules`. No widening needed.

## Screenshots / Logs

```
File ".../site-packages/hermes_cli/mcp_config.py", line 749, in mcp_command
    from mcp_serve import run_mcp_server
ModuleNotFoundError: No module named 'mcp_serve'
```
