### PR TITLE
fix: patch_parser silently drops empty context lines

### DIFF
--- a/tools/patch_parser.py
+++ b/tools/patch_parser.py
@@ -178,7 +178,7 @@ def parse_v4a_patch(patch_content: str) -> Tuple[List[PatchOperation], Optional[
                 hint = hint_match.group(1) if hint_match else None
                 current_hunk = Hunk(context_hint=hint)
                 
-        elif current_op and line:
+        elif current_op and line is not None:
             # Parse hunk line
             if current_hunk is None:
                 current_hunk = Hunk()


### PR DESCRIPTION
## Bug

`_assemble_patch_context` in `tools/patch_parser.py` uses a truthy check on each context line before appending it to the result. An empty context line (a literal blank line that is part of the diff context) is falsy in Python, so it gets silently discarded.

## Impact

Patches that include blank lines as context fail to apply correctly. The blank line is missing from the output, shifting every subsequent line by one and causing `apply_patch` to reject the hunk or silently produce a corrupted file.

## Fix

Replace the implicit boolean check with an explicit `is not None` guard so empty strings are preserved.