### PR TITLE
fix: _CMDPOS regex misses brace-group commands { dangerous_cmd; }

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -176,7 +176,7 @@ _COMMAND_TAIL = r'(?:\s*(?:&&|\|\||;).*)?$'
 # after subshell openers ( `$(` or backtick ), optionally consuming
 # leading wrapper commands (sudo, env VAR=VAL, exec, nohup, setsid).
 _CMDPOS = (
-    r'(?:^|[;&|\n`]|\$\()'         # start position
+    r'(?:^|[;&|\n`{]|\$\()'         # start position; '{' catches brace-group commands
     r'\s*'                          # optional whitespace
     r'(?:sudo\s+(?:-[^\s]+\s+)*)?'  # optional sudo with flags
     r'(?:env\s+(?:\w+=\S*\s+)*)?'   # optional env with VAR=VAL pairs


### PR DESCRIPTION
## Bug

The `_CMDPOS` pattern in `tools/approval.py` defines command-start positions as `(?:^|[;&|
`]|`. The opening brace `{` used in Bash brace-groups (`{ rm -rf /important; }`) is not in the character class, so the regex engine does not recognise `rm` inside a brace-group as starting at a command position.

## Impact

Commands wrapped in brace-groups are not matched by the approval safety patterns, bypassing the destructive-command check.

## Fix

Add `{` to the `_CMDPOS` character class.