### PR TITLE
fix: _reset_allow_private_cache documented as test-only but needed for hot-reload

### DIFF
--- a/tools/url_safety.py
+++ b/tools/url_safety.py
@@ -129,7 +129,13 @@ def _global_allow_private_urls() -> bool:
 
 
 def _reset_allow_private_cache() -> None:
-    """Reset the cached toggle — only for tests."""
+    """Reset the cached allow_private_urls toggle.
+
+    Clears the module-level cache so the next call to
+    _global_allow_private_urls() re-reads config and env var.
+    Safe to call from production code after a config hot-reload,
+    not just in tests.
+    """
     global _allow_private_resolved, _cached_allow_private
     _allow_private_resolved = False
     _cached_allow_private = False


### PR DESCRIPTION
## Bug

`_reset_allow_private_cache()` in `tools/url_safety.py` has the docstring: *'Reset the cached toggle — only for tests.'* The function is, however, the only way to invalidate the module-level `_cached_allow_private` value after a config hot-reload. Production code that calls `update_config()` and expects the change to take effect immediately cannot do so because the only reset path is hidden behind a 'test-only' label.

## Impact

Config changes to `security.allow_private_urls` do not take effect until the process restarts.

## Fix

Update the docstring to document the function as safe to call from production config-reload handlers, not just tests.