### PR TITLE
fix: dedup false-positive ratio 2x too loose, blocks short legitimate writes

### DIFF
--- a/tools/file_tools.py
+++ b/tools/file_tools.py
@@ -297,7 +297,7 @@ def _is_internal_file_status_text(content: str) -> bool:
     if stripped == _READ_DEDUP_STATUS_MESSAGE:
         return True
     if _READ_DEDUP_STATUS_MESSAGE in stripped and \
-            len(stripped) <= 2 * len(_READ_DEDUP_STATUS_MESSAGE):
+            len(stripped) <= 1.2 * len(_READ_DEDUP_STATUS_MESSAGE):
         return True
     return False
 


### PR DESCRIPTION
## Bug

In `tools/file_tools.py`, `_is_internal_file_status_text` uses the heuristic `len(stripped) <= 2 * len(_READ_DEDUP_STATUS_MESSAGE)` to detect when the model is echoing back the dedup message rather than writing real content. The 2x multiplier is too permissive — any write shorter than ~300 characters that happens to quote the status message (e.g. a changelog entry about this feature, a test docstring, a comment) is falsely rejected.

## Impact

Legitimate short writes to files — especially test files and documentation — are silently blocked when they quote or reference the dedup status message.

## Fix

Tighten the ratio from `2x` to `1.2x`. At 1.2x the write must be only 20% longer than the status message, making it almost impossible for it to contain meaningful content unrelated to the dedup message.