### PR TITLE
fix: OAuthNonInteractiveError blames user when port is actually in conflict

### DIFF
--- a/tools/mcp_oauth.py
+++ b/tools/mcp_oauth.py
@@ -441,13 +441,16 @@ async def _wait_for_callback() -> tuple[str, str | None]:
     # Start a temporary server on the known port
     try:
         server = HTTPServer(("127.0.0.1", _oauth_port), handler_cls)
-    except OSError:
-        # Port already in use — the server from build_oauth_auth is running.
-        # Fall back to polling the server started by build_oauth_auth.
+    except OSError as _port_exc:
+        # Port is in use — either a concurrent OAuth flow with the same fixed
+        # redirect_port, or a TOCTOU race on the free-port selection. Raise a
+        # clear, actionable error instead of the misleading "complete in browser" message.
         raise OAuthNonInteractiveError(
+            f"OAuth callback server could not bind port {_oauth_port}: {_port_exc}. "
+            "If you configured a fixed redirect_port, ensure it is not in use. "
+            "Use redirect_port: 0 (the default) to auto-select a free port."
+        ) from _port_exc
             "OAuth callback timed out — could not bind callback port. "
-            "Complete the authorization in a browser first, then retry."
-        )
 
     server_thread = threading.Thread(target=server.handle_request, daemon=True)
     server_thread.start()


### PR DESCRIPTION
## Bug

When `HTTPServer` fails to bind in `_wait_for_callback` (`tools/mcp_oauth.py`), the raised `OAuthNonInteractiveError` says: *'OAuth callback timed out — could not bind callback port. Complete the authorization in a browser first, then retry.'* This message is completely wrong when the actual cause is a port conflict — it tells the user to take an action (complete browser auth) that is irrelevant to the real problem.

## Impact

Operators spend significant time trying to complete a browser flow that will never succeed because the real issue is a port conflict. The error is actively misleading.

## Fix

Replace the misleading message with one that names the conflicting port and explains that `redirect_port: 0` (the default) auto-selects a free port.