### PR TITLE
fix: kill via subshell substitution bypasses self-termination guard

### DIFF
--- a/tools/approval.py
+++ b/tools/approval.py
@@ -295,6 +295,8 @@ DANGEROUS_PATTERNS = [
     (r'\bnohup\b.*gateway\s+run\b', "start gateway outside systemd (use 'systemctl --user restart hermes-gateway')"),
     # Self-termination protection: prevent agent from killing its own process
     (r'\b(pkill|killall)\b.*\b(hermes|gateway|cli\.py)\b', "kill hermes/gateway process (self-termination)"),
+    # Also catch `kill -9 $(pgrep -f hermes)` — subshell substitution form.
+    (r'\bkill\b[^\n]*\$\(\s*(pgrep|pidof)\b[^)]*\b(hermes|gateway|cli\.py)\b', "kill hermes/gateway via subshell substitution (self-termination)"),
     # Self-termination via kill + command substitution (pgrep/pidof).
     # The name-based pattern above catches `pkill hermes` but not
     # `kill -9 $(pgrep -f hermes)` because the substitution is opaque


### PR DESCRIPTION
## Bug

The self-termination guard in `tools/approval.py` matches `pkill hermes` and `killall hermes` but does not catch `kill -9 $(pgrep -f hermes)`. The subshell substitution form passes through the approval check entirely.

## Impact

A prompt injection or misguided model action can terminate the Hermes process using the `kill $(pgrep ...)` idiom without triggering the safety check.

## Fix

Add a second pattern that matches `kill ... $(pgrep|pidof ... hermes|gateway)` to the self-termination protection list.