### PR TITLE
fix: MCP stderr log fallback to /dev/null logs only at DEBUG level

### DIFF
--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -138,7 +138,16 @@ def _get_mcp_stderr_log() -> Any:
             fh.fileno()
             _mcp_stderr_log_fh = fh
         except Exception as exc:  # pragma: no cover — best-effort fallback
-            logger.debug("Failed to open MCP stderr log, using devnull: %s", exc)
+            # Emit a WARNING (not just DEBUG) so operators who check logs
+            # know that all MCP server output is being silently discarded.
+            # This is especially important when debugging why an MCP server
+            # fails to start — without this warning the logs are invisible.
+            logger.warning(
+                "Failed to open MCP stderr log (%s); MCP server output will be "
+                "discarded to /dev/null. Check that %s is writable.",
+                exc,
+                "~/.hermes/logs/mcp-stderr.log",
+            )
             try:
                 _mcp_stderr_log_fh = open(os.devnull, "w", encoding="utf-8")
             except Exception:


### PR DESCRIPTION
## Bug

In `tools/mcp_tool.py`, when opening the MCP stderr log file fails, the fallback to `/dev/null` is logged only at DEBUG level. All subsequent MCP server stderr output is silently discarded.

## Impact

When debugging why an MCP server fails to start, its output is completely invisible. The only hint is a DEBUG message most deployments never surface.

## Fix

Upgrade the log call from `logger.debug` to `logger.warning` and include the expected log file path, so operators know immediately where to look.