### PR TITLE
fix: _safe_parse_import_env rejects float strings like 600.5 for int params

### DIFF
--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -92,6 +92,13 @@ def _safe_parse_import_env(
     try:
         return converter(raw)
     except (TypeError, ValueError):
+        # Second attempt: float strings (e.g. "600.5") are valid for int params.
+        # int("600.5") raises ValueError; int(float("600.5")) returns 600.
+        if converter is int:
+            try:
+                return int(float(raw))
+            except (TypeError, ValueError):
+                pass
         logger.warning(
             "Invalid value for %s: %r (expected %s). Falling back to %r.",
             name,


### PR DESCRIPTION
## Bug

`_safe_parse_import_env` in `tools/terminal_tool.py` calls `converter(raw)` directly. When `converter=int` and the environment variable contains a float string such as `600.5` (from shell arithmetic), Python raises `ValueError` and the function falls back to the default value instead of using 600.

## Impact

Users who set timeout environment variables via scripts that produce float strings silently get the default timeout, with a confusing WARNING.

## Fix

Add a second attempt: if `converter is int` and the first call fails, try `int(float(raw))` before falling back to the default.