### PR TITLE
docs: add Brazilian Portuguese README and documentation (pt-BR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   <a href="https://github.com/NousResearch/hermes-agent/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License: MIT"></a>
   <a href="https://nousresearch.com"><img src="https://img.shields.io/badge/Built%20by-Nous%20Research-blueviolet?style=for-the-badge" alt="Built by Nous Research"></a>
   <a href="README.zh-CN.md"><img src="https://img.shields.io/badge/Lang-中文-red?style=for-the-badge" alt="中文"></a>
+  <a href="README.pt-BR.md"><img src="https://img.shields.io/badge/Lang-Português%20BR-009C3B?style=for-the-badge" alt="Português (Brasil)"></a>
 </p>
 
 **The self-improving AI agent built by [Nous Research](https://nousresearch.com).** It's the only agent with a built-in learning loop — it creates skills from experience, improves them during use, nudges itself to persist knowledge, searches its own past conversations, and builds a deepening model of who you are across sessions. Run it on a $5 VPS, a GPU cluster, or serverless infrastructure that costs nearly nothing when idle. It's not tied to your laptop — talk to it from Telegram while it works on a cloud VM.

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -1,0 +1,196 @@
+<p align="center">
+  <img src="assets/banner.png" alt="Hermes Agent" width="100%">
+</p>
+
+# Hermes Agent ☤
+
+<p align="center">
+  <a href="https://hermes-agent.nousresearch.com/docs/"><img src="https://img.shields.io/badge/Docs-hermes--agent.nousresearch.com-FFD700?style=for-the-badge" alt="Documentação"></a>
+  <a href="https://discord.gg/NousResearch"><img src="https://img.shields.io/badge/Discord-5865F2?style=for-the-badge&logo=discord&logoColor=white" alt="Discord"></a>
+  <a href="https://github.com/NousResearch/hermes-agent/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="Licença: MIT"></a>
+  <a href="https://nousresearch.com"><img src="https://img.shields.io/badge/Built%20by-Nous%20Research-blueviolet?style=for-the-badge" alt="Feito por Nous Research"></a>
+  <a href="README.md"><img src="https://img.shields.io/badge/Lang-English-lightgrey?style=for-the-badge" alt="English"></a>
+  <a href="README.zh-CN.md"><img src="https://img.shields.io/badge/Lang-中文-red?style=for-the-badge" alt="中文"></a>
+</p>
+
+**O agente de IA autoaperfeiçoante criado pela [Nous Research](https://nousresearch.com).** É o único agente com um loop de aprendizado embutido — ele cria habilidades a partir da experiência, aprimora elas durante o uso, se autoincentiva a persistir conhecimento, busca nas próprias conversas anteriores e constrói um modelo cada vez mais profundo de quem você é ao longo das sessões. Roda num VPS de $5, num cluster de GPU ou em infraestrutura serverless que custa quase nada quando ociosa. Não fica preso ao seu notebook — fale com ele pelo Telegram enquanto ele trabalha numa VM na nuvem.
+
+Use qualquer modelo que quiser — [Nous Portal](https://portal.nousresearch.com), [OpenRouter](https://openrouter.ai) (200+ modelos), [NVIDIA NIM](https://build.nvidia.com) (Nemotron), [Xiaomi MiMo](https://platform.xiaomimimo.com), [z.ai/GLM](https://z.ai), [Kimi/Moonshot](https://platform.moonshot.ai), [MiniMax](https://www.minimax.io), [Hugging Face](https://huggingface.co), OpenAI ou seu próprio endpoint. Troque com `hermes model` — sem mudar código, sem aprisionamento.
+
+<table>
+<tr><td><b>Interface de terminal de verdade</b></td><td>TUI completa com edição multilinha, autocompletar de slash commands, histórico de conversa, interromper-e-redirecionar e saída de ferramenta em streaming.</td></tr>
+<tr><td><b>Vive onde você está</b></td><td>Telegram, Discord, Slack, WhatsApp, Signal e CLI — tudo a partir de um único processo de gateway. Transcrição de mensagem de voz, continuidade de conversa entre plataformas.</td></tr>
+<tr><td><b>Loop de aprendizado fechado</b></td><td>Memória curada pelo agente com lembretes periódicos. Criação autônoma de habilidades depois de tarefas complexas. Habilidades se aprimoram durante o uso. Busca de sessão FTS5 com sumarização por LLM para resgate entre sessões. Modelagem dialética de usuário com <a href="https://github.com/plastic-labs/honcho">Honcho</a>. Compatível com o padrão aberto <a href="https://agentskills.io">agentskills.io</a>.</td></tr>
+<tr><td><b>Automações agendadas</b></td><td>Agendador cron embutido com entrega para qualquer plataforma. Relatórios diários, backups noturnos, auditorias semanais — tudo em linguagem natural, rodando sem supervisão.</td></tr>
+<tr><td><b>Delega e paraleliza</b></td><td>Cria subagentes isolados para fluxos de trabalho paralelos. Escreva scripts Python que chamam ferramentas via RPC, comprimindo pipelines de múltiplos passos em turnos com custo de contexto zero.</td></tr>
+<tr><td><b>Roda em qualquer lugar, não só no seu notebook</b></td><td>Sete backends de terminal — local, Docker, SSH, Singularity, Modal, Daytona e Vercel Sandbox. Daytona e Modal oferecem persistência serverless — o ambiente do seu agente hiberna quando ocioso e acorda sob demanda, custando quase nada entre sessões. Roda num VPS de $5 ou num cluster de GPU.</td></tr>
+<tr><td><b>Pronto para pesquisa</b></td><td>Geração em lote de trajetórias, ambientes de RL Atropos, compressão de trajetórias para treinar a próxima geração de modelos com tool calling.</td></tr>
+</table>
+
+---
+
+## Instalação rápida
+
+### Linux, macOS, WSL2, Termux
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+```
+
+### Windows (nativo, PowerShell) — Beta inicial
+
+> **Atenção:** O suporte nativo ao Windows está em **beta inicial**. Instala e roda, mas ainda não foi testado tão amplamente quanto os caminhos Linux/macOS/WSL2. Por favor [abra issues](https://github.com/NousResearch/hermes-agent/issues) quando encontrar problemas. Para o setup mais estável no Windows hoje, rode o one-liner de Linux/macOS acima dentro do **WSL2**.
+
+Execute no PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1 | iex
+```
+
+O instalador cuida de tudo: uv, Python 3.11, Node.js, ripgrep, ffmpeg **e um Git Bash portátil** (MinGit, descompactado em `%LOCALAPPDATA%\hermes\git` — sem precisar de admin, completamente isolado de qualquer instalação de Git do sistema). O Hermes usa esse Git Bash empacotado para rodar comandos shell.
+
+Se você já tem Git instalado, o instalador detecta e usa esse. Caso contrário, um download de ~45MB do MinGit é tudo que você precisa — e ele não toca nem interfere em nenhum Git do sistema.
+
+> **Android / Termux:** O caminho manual testado está documentado no [guia do Termux](https://hermes-agent.nousresearch.com/docs/getting-started/termux). No Termux, o Hermes instala um extra `.[termux]` curado, porque o extra completo `.[all]` puxa dependências de voz incompatíveis com Android.
+>
+> **Windows:** O Windows nativo é suportado como **beta inicial** — o one-liner do PowerShell acima instala tudo, mas espere imperfeições e por favor abra issues quando encontrar. Se preferir usar WSL2 (nosso caminho de Windows mais testado), o comando do Linux funciona lá também. A instalação nativa do Windows fica em `%LOCALAPPDATA%\hermes`; instalações WSL2 ficam em `~/.hermes` como no Linux. A única feature do Hermes que precisa especificamente de WSL2 hoje é o painel de chat baseado em navegador (usa um PTY POSIX — o CLI clássico e o gateway rodam ambos nativamente).
+
+Após a instalação:
+
+```bash
+source ~/.bashrc    # recarrega o shell (ou: source ~/.zshrc)
+hermes              # comece a conversar!
+```
+
+---
+
+## Primeiros passos
+
+```bash
+hermes              # CLI interativo — comece uma conversa
+hermes model        # Escolha o provedor de LLM e o modelo
+hermes tools        # Configure quais ferramentas estão habilitadas
+hermes config set   # Defina valores de configuração individuais
+hermes gateway      # Inicia o gateway de mensagens (Telegram, Discord, etc.)
+hermes setup        # Roda o assistente de setup completo (configura tudo de uma vez)
+hermes claw migrate # Migra do OpenClaw (se estiver vindo do OpenClaw)
+hermes update       # Atualiza para a versão mais recente
+hermes doctor       # Diagnostica problemas
+```
+
+📖 **[Documentação completa →](https://hermes-agent.nousresearch.com/docs/)**
+
+## Referência rápida: CLI x Mensagens
+
+O Hermes tem dois pontos de entrada: inicie a UI do terminal com `hermes`, ou rode o gateway e fale com ele pelo Telegram, Discord, Slack, WhatsApp, Signal ou Email. Uma vez dentro da conversa, muitos slash commands funcionam igual nas duas interfaces.
+
+| Ação | CLI | Plataformas de mensagem |
+|---------|-----|---------------------|
+| Começar a conversar | `hermes` | Rode `hermes gateway setup` + `hermes gateway start`, depois mande mensagem para o bot |
+| Iniciar conversa nova | `/new` ou `/reset` | `/new` ou `/reset` |
+| Trocar modelo | `/model [provider:model]` | `/model [provider:model]` |
+| Definir personalidade | `/personality [name]` | `/personality [name]` |
+| Refazer ou desfazer último turno | `/retry`, `/undo` | `/retry`, `/undo` |
+| Comprimir contexto / ver uso | `/compress`, `/usage`, `/insights [--days N]` | `/compress`, `/usage`, `/insights [days]` |
+| Listar habilidades | `/skills` ou `/<skill-name>` | `/<skill-name>` |
+| Interromper trabalho atual | `Ctrl+C` ou enviar nova mensagem | `/stop` ou enviar nova mensagem |
+| Status específico da plataforma | `/platforms` | `/status`, `/sethome` |
+
+Para a lista completa de comandos, veja o [guia do CLI](https://hermes-agent.nousresearch.com/docs/user-guide/cli) e o [guia do Gateway de Mensagens](https://hermes-agent.nousresearch.com/docs/user-guide/messaging).
+
+---
+
+## Documentação
+
+Toda a documentação fica em **[hermes-agent.nousresearch.com/docs](https://hermes-agent.nousresearch.com/docs/)**:
+
+| Seção | O que cobre |
+|---------|---------------|
+| [Quickstart](https://hermes-agent.nousresearch.com/docs/getting-started/quickstart) | Instalar → configurar → primeira conversa em 2 minutos |
+| [Uso do CLI](https://hermes-agent.nousresearch.com/docs/user-guide/cli) | Comandos, atalhos de teclado, personalidades, sessões |
+| [Configuração](https://hermes-agent.nousresearch.com/docs/user-guide/configuration) | Arquivo de config, provedores, modelos, todas as opções |
+| [Gateway de Mensagens](https://hermes-agent.nousresearch.com/docs/user-guide/messaging) | Telegram, Discord, Slack, WhatsApp, Signal, Home Assistant |
+| [Segurança](https://hermes-agent.nousresearch.com/docs/user-guide/security) | Aprovação de comandos, pareamento via DM, isolamento por container |
+| [Ferramentas e Toolsets](https://hermes-agent.nousresearch.com/docs/user-guide/features/tools) | 40+ ferramentas, sistema de toolsets, backends de terminal |
+| [Sistema de Habilidades](https://hermes-agent.nousresearch.com/docs/user-guide/features/skills) | Memória procedural, Skills Hub, criação de habilidades |
+| [Memória](https://hermes-agent.nousresearch.com/docs/user-guide/features/memory) | Memória persistente, perfis de usuário, boas práticas |
+| [Integração MCP](https://hermes-agent.nousresearch.com/docs/user-guide/features/mcp) | Conecte qualquer servidor MCP para ampliar capacidades |
+| [Agendamento Cron](https://hermes-agent.nousresearch.com/docs/user-guide/features/cron) | Tarefas agendadas com entrega entre plataformas |
+| [Arquivos de Contexto](https://hermes-agent.nousresearch.com/docs/user-guide/features/context-files) | Contexto de projeto que molda cada conversa |
+| [Arquitetura](https://hermes-agent.nousresearch.com/docs/developer-guide/architecture) | Estrutura do projeto, loop do agente, classes principais |
+| [Contribuir](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing) | Setup de dev, processo de PR, estilo de código |
+| [Referência do CLI](https://hermes-agent.nousresearch.com/docs/reference/cli-commands) | Todos os comandos e flags |
+| [Variáveis de Ambiente](https://hermes-agent.nousresearch.com/docs/reference/environment-variables) | Referência completa de variáveis de ambiente |
+
+---
+
+## Migração do OpenClaw
+
+Se você está vindo do OpenClaw, o Hermes pode importar automaticamente suas configurações, memórias, habilidades e chaves de API.
+
+**Durante o setup inicial:** O assistente de setup (`hermes setup`) detecta `~/.openclaw` automaticamente e oferece migrar antes da configuração começar.
+
+**A qualquer momento depois da instalação:**
+
+```bash
+hermes claw migrate              # Migração interativa (preset completo)
+hermes claw migrate --dry-run    # Visualiza o que seria migrado
+hermes claw migrate --preset user-data   # Migra sem segredos
+hermes claw migrate --overwrite  # Sobrescreve conflitos existentes
+```
+
+O que é importado:
+- **SOUL.md** — arquivo de persona
+- **Memórias** — entradas de MEMORY.md e USER.md
+- **Habilidades** — habilidades criadas pelo usuário → `~/.hermes/skills/openclaw-imports/`
+- **Allowlist de comandos** — padrões de aprovação
+- **Configurações de mensagem** — configs por plataforma, usuários permitidos, diretório de trabalho
+- **Chaves de API** — segredos da allowlist (Telegram, OpenRouter, OpenAI, Anthropic, ElevenLabs)
+- **Assets de TTS** — arquivos de áudio do workspace
+- **Instruções de workspace** — AGENTS.md (com `--workspace-target`)
+
+Veja `hermes claw migrate --help` para todas as opções, ou use a habilidade `openclaw-migration` para uma migração guiada por agente em modo interativo, com prévia em dry-run.
+
+---
+
+## Contribuir
+
+Contribuições são bem-vindas! Veja o [Guia de Contribuição](https://hermes-agent.nousresearch.com/docs/developer-guide/contributing) para setup de desenvolvimento, estilo de código e processo de PR.
+
+Início rápido para quem vai contribuir — clone e siga com `setup-hermes.sh`:
+
+```bash
+git clone https://github.com/NousResearch/hermes-agent.git
+cd hermes-agent
+./setup-hermes.sh     # instala uv, cria venv, instala .[all], cria symlink ~/.local/bin/hermes
+./hermes              # detecta o venv automaticamente, sem precisar `source`
+```
+
+Caminho manual (equivalente ao acima):
+
+```bash
+curl -LsSf https://astral.sh/uv/install.sh | sh
+uv venv .venv --python 3.11
+source .venv/bin/activate
+uv pip install -e ".[all,dev]"
+scripts/run_tests.sh
+```
+
+> **Treinamento RL (opcional):** Para a integração com RL/Atropos (`environments/`) — veja [`CONTRIBUTING.md`](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#development-setup) para o setup completo.
+
+---
+
+## Comunidade
+
+- 💬 [Discord](https://discord.gg/NousResearch)
+- 📚 [Skills Hub](https://agentskills.io)
+- 🐛 [Issues](https://github.com/NousResearch/hermes-agent/issues)
+- 🔌 [HermesClaw](https://github.com/AaronWong1999/hermesclaw) — Bridge comunitário para WeChat: rode Hermes Agent e OpenClaw na mesma conta de WeChat.
+
+---
+
+## Licença
+
+MIT — veja [LICENSE](LICENSE).
+
+Feito pela [Nous Research](https://nousresearch.com).

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -10,6 +10,7 @@
   <a href="https://github.com/NousResearch/hermes-agent/blob/main/LICENSE"><img src="https://img.shields.io/badge/License-MIT-green?style=for-the-badge" alt="License: MIT"></a>
   <a href="https://nousresearch.com"><img src="https://img.shields.io/badge/Built%20by-Nous%20Research-blueviolet?style=for-the-badge" alt="Built by Nous Research"></a>
   <a href="README.md"><img src="https://img.shields.io/badge/Lang-English-lightgrey?style=for-the-badge" alt="English"></a>
+  <a href="README.pt-BR.md"><img src="https://img.shields.io/badge/Lang-Português%20BR-009C3B?style=for-the-badge" alt="Português (Brasil)"></a>
 </p>
 
 **由 [Nous Research](https://nousresearch.com) 构建的自进化 AI 代理。** 它是唯一内置学习闭环的智能代理——从经验中创建技能，在使用中改进技能，主动持久化知识，搜索过往对话，并在跨会话中逐步构建对你的深度理解。可以在 $5 的 VPS 上运行，也可以在 GPU 集群上运行，或者使用几乎零成本的 Serverless 基础设施。它不绑定你的笔记本——你可以在 Telegram 上与它对话，而它在云端 VM 上工作。

--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -24,7 +24,7 @@ const config: Config = {
 
   i18n: {
     defaultLocale: 'en',
-    locales: ['en', 'zh-Hans'],
+    locales: ['en', 'zh-Hans', 'pt-BR'],
     localeConfigs: {
       en: {
         label: 'English',
@@ -32,6 +32,10 @@ const config: Config = {
       'zh-Hans': {
         label: '简体中文',
         htmlLang: 'zh-Hans',
+      },
+      'pt-BR': {
+        label: 'Português (Brasil)',
+        htmlLang: 'pt-BR',
       },
     },
   },

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/user-guide/features/image-generation.md
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/user-guide/features/image-generation.md
@@ -1,0 +1,156 @@
+---
+title: Geração de Imagens
+description: Gere imagens via FAL.ai — 9 modelos incluindo FLUX 2, GPT Image (1.5 e 2), Nano Banana Pro, Ideogram, Recraft V4 Pro e mais, selecionáveis em `hermes tools`.
+sidebar_label: Geração de Imagens
+sidebar_position: 6
+---
+
+# Geração de Imagens
+
+O Hermes Agent gera imagens a partir de prompts de texto via FAL.ai. Nove modelos são suportados de fábrica, cada um com diferentes trade-offs de velocidade, qualidade e custo. O modelo ativo é configurável pelo usuário via `hermes tools` e fica persistido em `config.yaml`.
+
+## Modelos Suportados
+
+| Modelo | Velocidade | Pontos fortes | Preço |
+|---|---|---|---|
+| `fal-ai/flux-2/klein/9b` *(padrão)* | `<1s` | Rápido, texto nítido | $0,006/MP |
+| `fal-ai/flux-2-pro` | ~6s | Fotorrealismo de estúdio | $0,03/MP |
+| `fal-ai/z-image/turbo` | ~2s | Bilíngue EN/CN, 6B parâmetros | $0,005/MP |
+| `fal-ai/nano-banana-pro` | ~8s | Gemini 3 Pro, raciocínio profundo, renderização de texto | $0,15/imagem (1K) |
+| `fal-ai/gpt-image-1.5` | ~15s | Aderência ao prompt | $0,034/imagem |
+| `fal-ai/gpt-image-2` | ~20s | Renderização de texto SOTA + CJK, fotorrealismo com noção de mundo | $0,04–0,06/imagem |
+| `fal-ai/ideogram/v3` | ~5s | Melhor tipografia | $0,03–0,09/imagem |
+| `fal-ai/recraft/v4/pro/text-to-image` | ~8s | Design, sistemas de marca, pronto pra produção | $0,25/imagem |
+| `fal-ai/qwen-image` | ~12s | Baseado em LLM, texto complexo | $0,02/MP |
+
+Os preços são da FAL no momento desta escrita; consulte [fal.ai](https://fal.ai/) para os valores atuais.
+
+## Setup
+
+:::tip Assinantes Nous
+Se você tem uma assinatura paga do [Nous Portal](https://portal.nousresearch.com), pode usar geração de imagens pelo **[Tool Gateway](tool-gateway.md)** sem chave de API da FAL. Sua escolha de modelo persiste nos dois caminhos.
+
+Se o gateway gerenciado retornar `HTTP 4xx` para um modelo específico, esse modelo ainda não está sendo proxiado pelo lado do portal — o agente vai te avisar, com passos de remediação (defina `FAL_KEY` para acesso direto, ou escolha outro modelo).
+:::
+
+### Obtenha uma chave de API da FAL
+
+1. Cadastre-se em [fal.ai](https://fal.ai/)
+2. Gere uma chave de API no seu dashboard
+
+### Configure e escolha um modelo
+
+Rode o comando de tools:
+
+```bash
+hermes tools
+```
+
+Navegue até **🎨 Image Generation**, escolha seu backend (Nous Subscription ou FAL.ai) e o seletor mostra todos os modelos suportados numa tabela alinhada por colunas — setas pra navegar, Enter pra selecionar:
+
+```
+  Modelo                         Velocidade  Pontos fortes               Preço
+  fal-ai/flux-2/klein/9b         <1s         Rápido, texto nítido        $0,006/MP   ← em uso
+  fal-ai/flux-2-pro              ~6s         Fotorrealismo de estúdio    $0,03/MP
+  fal-ai/z-image/turbo           ~2s         Bilíngue EN/CN, 6B          $0,005/MP
+  ...
+```
+
+Sua seleção é salva em `config.yaml`:
+
+```yaml
+image_gen:
+  model: fal-ai/flux-2/klein/9b
+  use_gateway: false            # true se estiver usando Nous Subscription
+```
+
+### Qualidade do GPT-Image
+
+A qualidade da requisição em `fal-ai/gpt-image-1.5` e `fal-ai/gpt-image-2` está fixada em `medium` (~$0,034–$0,06/imagem em 1024×1024). Não expomos os tiers `low` / `high` como opção visível ao usuário pra que o billing do Nous Portal fique previsível pra todo mundo — a diferença de custo entre tiers é de 3–22×. Se quiser uma opção mais barata, escolha Klein 9B ou Z-Image Turbo; se quiser maior qualidade, use Nano Banana Pro ou Recraft V4 Pro.
+
+## Uso
+
+O schema voltado pro agente é intencionalmente minimalista — o modelo pega o que você configurou:
+
+```
+Gere uma imagem de uma paisagem montanhosa serena com cerejeiras em flor
+```
+
+```
+Crie um retrato quadrado de uma coruja velha e sábia — use o modelo de tipografia
+```
+
+```
+Faz uma cidade futurista, orientação landscape
+```
+
+## Proporções (Aspect Ratios)
+
+Todo modelo aceita as mesmas três proporções da perspectiva do agente. Internamente, a especificação nativa de tamanho de cada modelo é preenchida automaticamente:
+
+| Entrada do agente | image_size (flux/z-image/qwen/recraft/ideogram) | aspect_ratio (nano-banana-pro) | image_size (gpt-image-1.5) | image_size (gpt-image-2) |
+|---|---|---|---|---|
+| `landscape` | `landscape_16_9` | `16:9` | `1536x1024` | `landscape_4_3` (1024×768) |
+| `square` | `square_hd` | `1:1` | `1024x1024` | `square_hd` (1024×1024) |
+| `portrait` | `portrait_16_9` | `9:16` | `1024x1536` | `portrait_4_3` (768×1024) |
+
+GPT Image 2 mapeia pra presets 4:3 em vez de 16:9 porque sua contagem mínima de pixels é 655.360 — o preset `landscape_16_9` (1024×576 = 589.824) seria rejeitado.
+
+Essa tradução acontece em `_build_fal_payload()` — o código do agente nunca precisa saber as diferenças de schema por modelo.
+
+## Upscaling Automático
+
+O upscaling via **Clarity Upscaler** da FAL é controlado por modelo:
+
+| Modelo | Upscale? | Por quê |
+|---|---|---|
+| `fal-ai/flux-2-pro` | ✓ | Compatibilidade pra trás (era o padrão antes do seletor) |
+| Todos os outros | ✗ | Modelos rápidos perderiam o valor de subsegundos; modelos hi-res não precisam |
+
+Quando o upscaling roda, ele usa estas configurações:
+
+| Configuração | Valor |
+|---|---|
+| Fator de upscale | 2× |
+| Criatividade | 0,35 |
+| Resemblance | 0,6 |
+| Escala de guidance | 4 |
+| Passos de inferência | 18 |
+
+Se o upscaling falhar (problema de rede, rate limit), a imagem original é retornada automaticamente.
+
+## Como Funciona Internamente
+
+1. **Resolução do modelo** — `_resolve_fal_model()` lê `image_gen.model` do `config.yaml`, faz fallback pra variável de ambiente `FAL_IMAGE_MODEL` e depois pra `fal-ai/flux-2/klein/9b`.
+2. **Construção do payload** — `_build_fal_payload()` traduz seu `aspect_ratio` pro formato nativo do modelo (preset enum, enum de aspect-ratio ou literal do GPT), mescla os parâmetros padrão do modelo, aplica overrides do chamador e depois filtra pela whitelist `supports` do modelo, então chaves não suportadas nunca são enviadas.
+3. **Submissão** — `_submit_fal_request()` roteia via credenciais diretas da FAL ou pelo gateway gerenciado da Nous.
+4. **Upscaling** — só roda se o metadata do modelo tiver `upscale: True`.
+5. **Entrega** — URL final da imagem retornada ao agente, que emite uma tag `MEDIA:<url>` que os adaptadores de plataforma convertem em mídia nativa.
+
+## Debugging
+
+Habilite logs de debug:
+
+```bash
+export IMAGE_TOOLS_DEBUG=true
+```
+
+Os logs de debug vão pra `./logs/image_tools_debug_<session_id>.json` com detalhes por chamada (modelo, parâmetros, timing, erros).
+
+## Entrega por Plataforma
+
+| Plataforma | Entrega |
+|---|---|
+| **CLI** | URL da imagem impressa em markdown `![](url)` — clique pra abrir |
+| **Telegram** | Mensagem de foto com o prompt como legenda |
+| **Discord** | Embed numa mensagem |
+| **Slack** | URL desdobrada pelo Slack |
+| **WhatsApp** | Mensagem de mídia |
+| **Outros** | URL em texto puro |
+
+## Limitações
+
+- **Requer credenciais da FAL** (`FAL_KEY` direta ou Nous Subscription)
+- **Apenas text-to-image** — sem inpainting, img2img ou edição por essa ferramenta
+- **URLs temporárias** — a FAL retorna URLs hospedadas que expiram em horas/dias; salve localmente se precisar
+- **Restrições por modelo** — alguns modelos não suportam `seed`, `num_inference_steps` etc. O filtro `supports` descarta silenciosamente parâmetros não suportados; isso é comportamento esperado

--- a/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/user-guide/features/tool-gateway.md
+++ b/website/i18n/pt-BR/docusaurus-plugin-content-docs/current/user-guide/features/tool-gateway.md
@@ -1,0 +1,176 @@
+---
+title: "Nous Tool Gateway"
+description: "Uma assinatura, todas as ferramentas. Busca web, geração de imagens, TTS e browsers em nuvem — tudo roteado pelo Nous Portal sem chaves de API extras."
+sidebar_label: "Tool Gateway"
+sidebar_position: 2
+---
+
+# Nous Tool Gateway
+
+**Uma assinatura. Todas as ferramentas integradas.**
+
+O Tool Gateway está incluído em toda assinatura paga do [Nous Portal](https://portal.nousresearch.com). Ele roteia as chamadas de ferramentas do Hermes — busca web, geração de imagens, conversão de texto em fala e automação de browsers em nuvem — pela infraestrutura que a Nous já opera, então você não precisa se cadastrar no Firecrawl, FAL, OpenAI, Browser Use ou em qualquer outro serviço só pra deixar seu agente útil.
+
+<div style={{display: 'flex', gap: '1rem', flexWrap: 'wrap', margin: '1.5rem 0'}}>
+  <a href="https://portal.nousresearch.com/manage-subscription" style={{background: 'var(--ifm-color-primary)', color: 'white', padding: '0.75rem 1.5rem', borderRadius: '6px', textDecoration: 'none', fontWeight: 'bold'}}>Iniciar ou gerenciar assinatura →</a>
+</div>
+
+## O que está incluído
+
+| | Ferramenta | O que você ganha |
+|---|---|---|
+| 🔍 | **Busca e extração web** | Busca web e extração de página inteira de qualidade para agentes via Firecrawl. Sem se preocupar com rate limits — o gateway cuida do escalonamento. |
+| 🎨 | **Geração de imagens** | Nove modelos sob um único endpoint: **FLUX 2 Klein 9B**, **FLUX 2 Pro**, **Z-Image Turbo**, **Nano Banana Pro** (Gemini 3 Pro Image), **GPT Image 1.5**, **GPT Image 2**, **Ideogram V3**, **Recraft V4 Pro**, **Qwen Image**. Escolha por geração com uma flag, ou deixe o Hermes usar FLUX 2 Klein como padrão. |
+| 🔊 | **Texto para fala** | Vozes do OpenAI TTS conectadas à ferramenta `text_to_speech`. Mande áudios pelo Telegram, gere áudio pra pipelines, narre o que quiser. |
+| 🌐 | **Automação de browser em nuvem** | Sessões headless do Chromium via Browser Use. `browser_navigate`, `browser_click`, `browser_type`, `browser_vision` — todos os primitivos pra dirigir o agente, sem precisar de conta no Browserbase. |
+
+Os quatro são cobrados sob demanda na sua assinatura Nous. Use qualquer combinação — rode o gateway pra web e imagens enquanto mantém sua chave do ElevenLabs pra TTS, ou roteie tudo pela Nous.
+
+## Por que isso existe
+
+Construir um agente que de fato *faça coisas* significa juntar 5+ assinaturas de API — cada uma com seu próprio cadastro, rate limits, cobrança e particularidades. O gateway colapsa isso numa única conta:
+
+- **Uma fatura.** Pague à Nous; nós cuidamos do resto.
+- **Um cadastro.** Sem contas no Firecrawl, FAL, Browser Use ou OpenAI audio pra gerenciar.
+- **Uma chave.** Seu OAuth do Nous Portal cobre todas as ferramentas.
+- **Mesma qualidade.** Os mesmos backends usados pelo caminho de chave direta — só que com a Nous na frente.
+
+Traga suas próprias chaves quando quiser — por ferramenta, a qualquer momento. O gateway não é lock-in, é atalho.
+
+## Comece a usar
+
+```bash
+hermes model          # Escolha Nous Portal como provider
+```
+
+Ao selecionar o Nous Portal, o Hermes oferece ativar o Tool Gateway. Aceite, e pronto — toda ferramenta suportada fica viva na próxima execução.
+
+Confira o que está ativo a qualquer momento:
+
+```bash
+hermes status
+```
+
+Você verá uma seção como:
+
+```
+◆ Nous Tool Gateway
+  Nous Portal     ✓ managed tools available
+  Web tools       ✓ active via Nous subscription
+  Image gen       ✓ active via Nous subscription
+  TTS             ✓ active via Nous subscription
+  Browser         ○ active via Browser Use key
+```
+
+Ferramentas marcadas com "active via Nous subscription" estão indo pelo gateway. Qualquer outra está usando suas próprias chaves.
+
+## Elegibilidade
+
+O Tool Gateway é um recurso **de assinatura paga**. Contas Nous gratuitas podem usar o Portal pra inferência mas não incluem ferramentas gerenciadas — [faça upgrade do plano](https://portal.nousresearch.com/manage-subscription) pra desbloquear o gateway.
+
+## Misture e combine
+
+O gateway é por ferramenta. Ative só pra o que você quer:
+
+- **Tudo via Nous** — mais fácil; uma assinatura, e acabou.
+- **Gateway pra web + imagens, TTS próprio** — mantenha sua voz do ElevenLabs, deixe a Nous cuidar do resto.
+- **Gateway só pra coisas que você não tem chave** — "já pago Browserbase, mas não quero conta no Firecrawl" funciona perfeitamente.
+
+Troque qualquer ferramenta a qualquer momento via:
+
+```bash
+hermes tools          # Seletor interativo por categoria de ferramenta
+```
+
+Selecione a ferramenta, escolha **Nous Subscription** como provider (ou qualquer provider direto que preferir). Sem editar config na mão.
+
+## Usando modelos individuais de imagem
+
+A geração de imagens usa FLUX 2 Klein 9B como padrão, por velocidade. Sobrescreva por chamada passando o ID do modelo pra ferramenta `image_generate`:
+
+| Modelo | ID | Melhor pra |
+|---|---|---|
+| FLUX 2 Klein 9B | `fal-ai/flux-2/klein/9b` | Rápido, bom padrão |
+| FLUX 2 Pro | `fal-ai/flux-2/pro` | FLUX de fidelidade maior |
+| Z-Image Turbo | `fal-ai/z-image/turbo` | Estilizado, rápido |
+| Nano Banana Pro | `fal-ai/gemini-3-pro-image` | Google Gemini 3 Pro Image |
+| GPT Image 1.5 | `fal-ai/gpt-image-1/5` | Geração de imagem da OpenAI, texto+imagem |
+| GPT Image 2 | `fal-ai/gpt-image-2` | OpenAI mais recente |
+| Ideogram V3 | `fal-ai/ideogram/v3` | Boa aderência a prompt + tipografia |
+| Recraft V4 Pro | `fal-ai/recraft/v4/pro` | Estilo vetorial, design gráfico |
+| Qwen Image | `fal-ai/qwen-image` | Multimodal da Alibaba |
+
+O conjunto evolui — `hermes tools` → Image Generation mostra a lista atual ao vivo.
+
+---
+
+## Referência de configuração
+
+A maioria dos usuários nunca precisa mexer aqui — `hermes model` e `hermes tools` cobrem todo workflow de forma interativa. Esta seção é pra quem edita `config.yaml` direto ou roteiriza setups.
+
+### Flag `use_gateway` por ferramenta
+
+O bloco de config de cada ferramenta aceita um booleano `use_gateway`:
+
+```yaml
+web:
+  backend: firecrawl
+  use_gateway: true
+
+image_gen:
+  use_gateway: true
+
+tts:
+  provider: openai
+  use_gateway: true
+
+browser:
+  cloud_provider: browser-use
+  use_gateway: true
+```
+
+Precedência: `use_gateway: true` roteia pela Nous independentemente de chaves diretas no `.env`. `use_gateway: false` (ou ausente) usa chaves diretas se disponíveis e só faz fallback pro gateway quando nenhuma existe.
+
+### Desativando o gateway
+
+```yaml
+web:
+  use_gateway: false   # Hermes agora usa FIRECRAWL_API_KEY do .env
+```
+
+`hermes tools` limpa a flag automaticamente quando você escolhe um provider que não é o gateway, então isso geralmente acontece sozinho.
+
+### Gateway self-hosted (avançado)
+
+Rodando seu próprio gateway compatível com a Nous? Sobrescreva os endpoints em `~/.hermes/.env`:
+
+```bash
+TOOL_GATEWAY_DOMAIN=seu-dominio.exemplo.com
+TOOL_GATEWAY_SCHEME=https
+TOOL_GATEWAY_USER_TOKEN=seu-token        # normalmente preenchido automaticamente pelo login do Portal
+FIRECRAWL_GATEWAY_URL=https://...         # sobrescrever um endpoint específico
+```
+
+Esses parâmetros existem pra setups de infraestrutura customizada (deploys enterprise, ambientes de dev). Assinantes regulares nunca precisam definir.
+
+## FAQ
+
+### Funciona com Telegram / Discord / outros gateways de mensagem?
+
+Sim. O Tool Gateway opera na camada de execução de ferramentas, não no CLI. Toda interface que pode chamar uma ferramenta — CLI, Telegram, Discord, Slack, IRC, Teams, o servidor de API, qualquer coisa — se beneficia dele de forma transparente.
+
+### O que acontece se minha assinatura expirar?
+
+Ferramentas roteadas pelo gateway param de funcionar até você renovar ou trocar por chaves de API diretas via `hermes tools`. O Hermes mostra um erro claro apontando pro portal.
+
+### Dá pra ver uso ou custos por ferramenta?
+
+Sim — o [dashboard do Nous Portal](https://portal.nousresearch.com) quebra o uso por ferramenta pra você ver o que está pesando na sua conta.
+
+### O Modal (terminal serverless) está incluído?
+
+O Modal está disponível como **add-on opcional** da assinatura Nous, não faz parte do bundle padrão do Tool Gateway. Configure via `hermes setup terminal` ou direto no `config.yaml` quando quiser uma sandbox remota pra execução de shell.
+
+### Preciso apagar minhas chaves de API existentes ao ativar o gateway?
+
+Não — mantenha elas no `.env`. Quando `use_gateway: true`, o Hermes ignora chaves diretas e usa o gateway. Volta a flag pra `false` e suas chaves voltam a ser a fonte. O gateway não é lock-in.


### PR DESCRIPTION
## What does this PR do?

Adds Brazilian Portuguese (pt-BR) documentation surfaces — root README and Docusaurus docs site locale — to complement the in-flight pt-BR work.

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- Standardizes the PR description to the same review format used in #29640.
- Preserves the original detailed description below so no context is lost.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

- Related to #15737. - Related to #20443. - Related to #22063.

<details>
<summary>Original body</summary>

## Summary

Adds Brazilian Portuguese (pt-BR) documentation surfaces — root README and Docusaurus docs site locale — to complement the in-flight pt-BR work.

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Summary

Adds Brazilian Portuguese (pt-BR) documentation surfaces — root README and Docusaurus docs site locale — to complement the in-flight pt-BR work.

### What's included

- **`README.pt-BR.md`** — full native translation of `README.md` (mirrors the structural template of `README.zh-CN.md`). Not a machine translation: idiomatic pt-BR, consistent terminology with the existing `agentskills.io` / Hermes vocabulary, code blocks and command names left untouched.
- **Bidirectional language badges** in `README.md` and `README.zh-CN.md` linking to `README.pt-BR.md`, matching the existing badge pattern.
- **Docusaurus pt-BR locale** registered in `website/docusaurus.config.ts` alongside `en` and `zh-Hans`, with localized label `Português (Brasil)` and `htmlLang: pt-BR`.
- **Seed website translation** at `website/i18n/pt-BR/docusaurus-plugin-content-docs/current/user-guide/features/image-generation.md`, mirroring the parity approach used by `zh-Hans` (which currently has 3 translated docs). Additional pages can be added incrementally without further config changes.

### Coordination with existing pt-BR PRs

Before opening this PR I checked the three open pt-BR PRs to make sure I wasn't duplicating work:

| PR | Surface | Files |
|---|---|---|
| #15737 (carloshenriquecarniatto) | Web UI | `web/src/i18n/pt.ts`, `web/src/components/LanguageSwitcher.tsx`, `web/src/i18n/context.tsx`, `web/src/i18n/types.ts` |
| #20443 (pedroborges) | CLI runtime catalog | `agent/i18n.py`, `hermes_cli/config.py`, `locales/pt.yaml`, `locales/pt_BR.yaml`, `tests/agent/test_i18n.py`, `website/docs/user-guide/configuration.md` |
| #22063 (Magaav) | Web UI | `web/src/i18n/pt-BR.ts`, `web/src/components/LanguageSwitcher.tsx`, `web/src/i18n/context.tsx`, `web/src/i18n/types.ts`, `web/src/i18n/{en,zh}.ts` |

**This PR touches none of those files.** It targets the documentation surfaces (`README.md`, `README.pt-BR.md`, `README.zh-CN.md`, `website/docusaurus.config.ts`, `website/i18n/pt-BR/**`) which are orthogonal to the runtime catalog and Web UI work in flight, so it can land independently of any of those PRs without conflict.

If maintainers prefer to consolidate, this PR is small enough to fold into one of the others — but it can also stand alone.

## Test plan

- [x] `README.pt-BR.md` renders correctly on GitHub (links, badges, tables, code blocks)
- [x] `README.md` and `README.zh-CN.md` show the new pt-BR badge linking to `README.pt-BR.md`
- [x] `website/docusaurus.config.ts` parses cleanly — `pt-BR` added to `locales` array and `localeConfigs` block follows the existing structure for `zh-Hans`
- [x] `website/i18n/pt-BR/docusaurus-plugin-content-docs/current/user-guide/features/image-generation.md` follows the file-path convention used by `zh-Hans` and will be picked up by `npm run start -- --locale pt-BR` in `website/`
- [ ] Maintainer to confirm pt-BR locale builds with `cd website && npm run build` (no Docusaurus locale assets required beyond the page overrides; missing pages fall back to English, same as `zh-Hans` today)

## Notes

- Translations target Brazilian Portuguese specifically (matches the existing `pt_BR.yaml` naming used by #20443). The Docusaurus locale code `pt-BR` is the canonical BCP-47 form for this dialect.
- I deliberately translated only the smallest of the three `zh-Hans` parity docs (`image-generation.md`) to keep this PR reviewable. Happy to follow up with `tool-gateway.md` and `windows-wsl-quickstart.md` in a separate PR once this lands, or extend this PR if maintainers prefer.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_