### PR TITLE
feat(kanban): add board policy layer

### DIFF
--- a/docs/examples/kanban-policy.example.json
+++ b/docs/examples/kanban-policy.example.json
@@ -1,0 +1,15 @@
+{
+  "project_root": "/path/to/projects/example-app",
+  "base_branch": "main",
+  "worktree_root": "/path/to/projects/example-app/.worktrees",
+  "denied_workspace_roots": [
+    "~/.hermes/kanban",
+    "~/.hermes/scripts",
+    "/tmp"
+  ],
+  "shared_project_root_writable": false,
+  "scratch_repo_operations_allowed": false,
+  "max_active_issue_pipelines": 1,
+  "cleanup_after_merge": true,
+  "forbid_dirty_completion": true
+}

--- a/docs/kanban-project-policy.md
+++ b/docs/kanban-project-policy.md
@@ -1,0 +1,92 @@
+# Kanban Project Policy
+
+Hermes Kanban supports per-board project policy files so project-specific workflow discipline stays out of core Hermes source code.
+
+A policy file declares the canonical project checkout, allowed task worktree root, denied control-plane/scratch roots, concurrency limits, and cleanup behavior for a board.
+
+## Location
+
+Policies live under the shared Kanban home:
+
+```text
+<hermes-root>/kanban/policies/<board>.json
+```
+
+For a standard install this is usually:
+
+```text
+~/.hermes/kanban/policies/<board>.json
+```
+
+Use:
+
+```bash
+hermes kanban --board <board> policy show --json
+hermes kanban --board <board> policy validate --json
+```
+
+## Example
+
+```json
+{
+  "project_root": "/path/to/projects/example-app",
+  "base_branch": "main",
+  "worktree_root": "/path/to/projects/example-app/.worktrees",
+  "denied_workspace_roots": [
+    "~/.hermes/kanban",
+    "~/.hermes/scripts",
+    "/tmp"
+  ],
+  "shared_project_root_writable": false,
+  "scratch_repo_operations_allowed": false,
+  "max_active_issue_pipelines": 1,
+  "cleanup_after_merge": true,
+  "forbid_dirty_completion": true
+}
+```
+
+Do not put secrets, tokens, API keys, connection strings, or credentials in policy files.
+
+## Fields
+
+- `project_root`: canonical project checkout. Workers may inspect it, but it should usually be read-only.
+- `base_branch`: expected base branch for new work.
+- `worktree_root`: allowed root for task-specific repo-editing worktrees.
+- `denied_workspace_roots`: roots where repo clone/build/install work is forbidden.
+- `shared_project_root_writable`: when false, repo-touching cards targeting `project_root` fail validation.
+- `scratch_repo_operations_allowed`: documents whether scratch/control-plane folders can run repo clone/build/install operations. Default false.
+- `max_active_issue_pipelines`: optional board-level throttle for implementation/review/QA/security/release pipelines.
+- `cleanup_after_merge`: documents that merged clean secondary worktrees should be eligible for cleanup.
+- `forbid_dirty_completion`: repo-touching cards should complete clean or block with dirty-file evidence.
+
+## Validation behavior
+
+`hermes kanban validate` loads the active board policy and emits errors when repo-touching cards:
+
+- target the shared project root while it is read-only,
+- use a worktree outside the configured `worktree_root`,
+- use a denied control-plane/scratch root,
+- omit an explicit worktree path on a policy-controlled board.
+
+## Cleanup vs teardown
+
+Conservative cleanup:
+
+```bash
+hermes kanban --board <board> cleanup --dry-run --json
+hermes kanban --board <board> cleanup --json
+```
+
+Cleanup only removes safe inactive clean secondary worktrees. Dirty, active, main, or unclear worktrees are blocked and reported.
+
+Destructive teardown:
+
+```bash
+hermes kanban --board <board> teardown --remove-all-worktrees --delete-board --yes --json
+```
+
+Teardown is intentionally explicit. It stops relevant processes, force-removes non-main registered worktrees when requested, deletes the board directory when requested, and verifies without recreating the board.
+
+## Updateability guidance
+
+Prefer policy config over source patches. If a rule is specific to one project, put it in `<board>.json`, skills, profiles, or operator prompts. Only change Hermes source for generic behavior that any board can use.

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -24,6 +24,8 @@ from pathlib import Path
 from typing import Any, Optional
 
 from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_policy as kp
+from hermes_cli import kanban_cleanup as kc
 
 
 # ---------------------------------------------------------------------------
@@ -187,6 +189,30 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         ),
     )
     sub = kanban_parser.add_subparsers(dest="kanban_action")
+
+    # --- policy ---
+    p_policy = sub.add_parser(
+        "policy",
+        help="Inspect or validate the active board's project/workspace policy",
+    )
+    policy_sub = p_policy.add_subparsers(dest="policy_action")
+    p_policy_show = policy_sub.add_parser("show", help="Show the effective board policy")
+    p_policy_show.add_argument("--json", action="store_true")
+    p_policy_validate = policy_sub.add_parser("validate", help="Validate the configured board policy")
+    p_policy_validate.add_argument("--json", action="store_true")
+
+    p_inventory = sub.add_parser("inventory", help="Show board worktrees, workspaces, processes, and policy")
+    p_inventory.add_argument("--json", action="store_true")
+
+    p_cleanup = sub.add_parser("cleanup", help="Conservatively remove safe inactive board artifacts")
+    p_cleanup.add_argument("--dry-run", action="store_true", default=False)
+    p_cleanup.add_argument("--json", action="store_true")
+
+    p_teardown = sub.add_parser("teardown", help="Explicit destructive board teardown")
+    p_teardown.add_argument("--remove-all-worktrees", action="store_true")
+    p_teardown.add_argument("--delete-board", action="store_true")
+    p_teardown.add_argument("--yes", action="store_true")
+    p_teardown.add_argument("--json", action="store_true")
 
     # --- init ---
     sub.add_parser("init", help="Create kanban.db if missing (idempotent)")
@@ -369,6 +395,24 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         help="Emit JSON (structured) instead of the default human table",
     )
 
+    # --- validate / lint ---
+    p_validate = sub.add_parser(
+        "validate",
+        aliases=["lint"],
+        help="Lint validation contracts, handoffs, QA evidence, and known-failure tracking",
+    )
+    p_validate.add_argument("--task", default=None, help="Only validate one task id")
+    p_validate.add_argument("--status", default=None, choices=sorted(kb.VALID_STATUSES))
+    p_validate.add_argument("--assignee", default=None)
+    p_validate.add_argument("--tenant", default=None)
+    p_validate.add_argument("--archived", action="store_true", help="Include archived tasks")
+    p_validate.add_argument("--json", action="store_true", help="Emit JSON")
+    p_validate.add_argument(
+        "--fail-on-warning",
+        action="store_true",
+        help="Return non-zero when warnings exist even if there are no errors",
+    )
+
     # --- link / unlink ---
     p_link = sub.add_parser("link", help="Add a parent->child dependency")
     p_link.add_argument("parent_id")
@@ -384,7 +428,7 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
     )
     p_claim.add_argument("task_id")
     p_claim.add_argument("--ttl", type=int, default=kb.DEFAULT_CLAIM_TTL_SECONDS,
-                         help="Claim TTL in seconds (default: 900)")
+                         help=f"Claim TTL in seconds (default: {kb.DEFAULT_CLAIM_TTL_SECONDS})")
 
     # --- comment / complete / block / unblock / archive ---
     p_comment = sub.add_parser("comment", help="Append a comment")
@@ -673,6 +717,8 @@ def kanban_command(args: argparse.Namespace) -> int:
     # `hermes kanban boards create …`.
     if action == "boards":
         return _dispatch_boards(args)
+    if action == "policy":
+        return _cmd_policy(args)
 
     # Auto-initialize the DB before dispatching any subcommand. init_db
     # is idempotent, so running it every invocation is cheap (one
@@ -698,6 +744,8 @@ def kanban_command(args: argparse.Namespace) -> int:
         "reassign": _cmd_reassign,
         "diagnostics": _cmd_diagnostics,
         "diag":     _cmd_diagnostics,
+        "validate": _cmd_validate,
+        "lint":     _cmd_validate,
         "link":     _cmd_link,
         "unlink":   _cmd_unlink,
         "claim":    _cmd_claim,
@@ -722,6 +770,9 @@ def kanban_command(args: argparse.Namespace) -> int:
         "context":  _cmd_context,
         "specify":  _cmd_specify,
         "gc":       _cmd_gc,
+        "inventory": _cmd_inventory,
+        "cleanup": _cmd_cleanup,
+        "teardown": _cmd_teardown,
     }
     handler = handlers.get(action)
     if not handler:
@@ -749,6 +800,73 @@ def _profile_author() -> str:
         return get_active_profile_name() or "user"
     except Exception:
         return "user"
+
+
+# ---------------------------------------------------------------------------
+# Board policy (hermes kanban policy …)
+# ---------------------------------------------------------------------------
+
+def _cmd_policy(args: argparse.Namespace) -> int:
+    action = getattr(args, "policy_action", None) or "show"
+    board = kb.get_current_board()
+    report = kp.policy_report(board)
+    if getattr(args, "json", False):
+        print(json.dumps(report, indent=2, sort_keys=True))
+    else:
+        print(f"Board:      {report['board']}")
+        print(f"Configured: {str(report['configured']).lower()}")
+        print(f"Path:       {report['path']}")
+        errors = report.get("errors") or []
+        if errors:
+            print("Errors:")
+            for error in errors:
+                print(f"  - {error}")
+        else:
+            print("Errors:     none")
+        print("Policy:")
+        for key, value in report["policy"].items():
+            print(f"  {key}: {value}")
+    if action == "validate" and report.get("errors"):
+        return 1
+    if action not in {"show", "validate"}:
+        print(f"kanban policy: unknown action {action!r}", file=sys.stderr)
+        return 2
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# Board inventory / cleanup / teardown
+# ---------------------------------------------------------------------------
+
+def _print_json_or_summary(data: dict[str, Any], *, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(data, indent=2, sort_keys=True))
+        return
+    for key, value in data.items():
+        print(f"{key}: {value}")
+
+
+def _cmd_inventory(args: argparse.Namespace) -> int:
+    data = kc.inventory_board(kb.get_current_board())
+    _print_json_or_summary(data, as_json=getattr(args, "json", False))
+    return 0
+
+
+def _cmd_cleanup(args: argparse.Namespace) -> int:
+    data = kc.cleanup_board(kb.get_current_board(), dry_run=getattr(args, "dry_run", False))
+    _print_json_or_summary(data, as_json=getattr(args, "json", False))
+    return 0 if data.get("verified") else 1
+
+
+def _cmd_teardown(args: argparse.Namespace) -> int:
+    data = kc.teardown_board(
+        kb.get_current_board(),
+        remove_all_worktrees=getattr(args, "remove_all_worktrees", False),
+        delete_board=getattr(args, "delete_board", False),
+        yes=getattr(args, "yes", False),
+    )
+    _print_json_or_summary(data, as_json=getattr(args, "json", False))
+    return 0 if data.get("verified") or data.get("refused") else 1
 
 
 # ---------------------------------------------------------------------------
@@ -1277,6 +1395,57 @@ def _cmd_show(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_validate(args: argparse.Namespace) -> int:
+    """Lint mission validation contracts and completion handoffs."""
+    from hermes_cli import kanban_validation as kv
+
+    with kb.connect() as conn:
+        if getattr(args, "task", None):
+            task = kb.get_task(conn, args.task)
+            if task is None:
+                print(f"no such task: {args.task}", file=sys.stderr)
+                return 1
+            tasks = [task]
+        else:
+            tasks = kb.list_tasks(
+                conn,
+                assignee=getattr(args, "assignee", None),
+                status=getattr(args, "status", None),
+                tenant=getattr(args, "tenant", None),
+                include_archived=bool(getattr(args, "archived", False)),
+            )
+        runs_by_task = {t.id: runs for t in tasks if (runs := kb.list_runs(conn, t.id))}
+
+    policy = kp.load_policy(kb.get_current_board())
+    findings = kv.validate_tasks(tasks, runs_by_task, policy=policy)
+    summary = kv.summarize_findings(findings)
+    if getattr(args, "json", False):
+        print(json.dumps({
+            "summary": summary,
+            "findings": [f.to_dict() for f in findings],
+        }, indent=2, ensure_ascii=False))
+    else:
+        if not findings:
+            print("Kanban validation: ok")
+        else:
+            print(
+                "Kanban validation: "
+                f"{summary.get('error', 0)} error(s), "
+                f"{summary.get('warning', 0)} warning(s)"
+            )
+            for f in findings:
+                marker = "ERROR" if f.severity == "error" else "WARN "
+                print(f"{marker} {f.task_id} {f.code}: {f.title}")
+                print(f"      {f.detail}")
+
+    if summary.get("error", 0):
+        return 1
+    if getattr(args, "fail_on_warning", False) and summary.get("warning", 0):
+        return 1
+    return 0
+
+
+
 def _cmd_assign(args: argparse.Namespace) -> int:
     profile = None if args.profile.lower() in ("none", "-", "null") else args.profile
     with kb.connect() as conn:
@@ -1537,6 +1706,35 @@ def _cmd_complete(args: argparse.Namespace) -> int:
         except (ValueError, json.JSONDecodeError) as exc:
             print(f"kanban: --metadata: {exc}", file=sys.stderr)
             return 2
+    # Completion-time linting: warn loudly before writing weak handoffs.
+    # This is non-blocking for backwards compatibility with manual repair/bulk
+    # operations, but the dedicated `kanban validate` command exits non-zero on
+    # hard errors.
+    if len(ids) == 1:
+        try:
+            from hermes_cli import kanban_validation as kv
+            with kb.connect() as conn:
+                task = kb.get_task(conn, ids[0])
+                if task is not None:
+                    class _PendingRun:
+                        def __init__(self, summary, metadata):
+                            self.summary = summary
+                            self.metadata = metadata
+                    pending = _PendingRun(summary if summary is not None else args.result, metadata)
+                    findings = kv.validate_tasks([task], {ids[0]: [pending]}, policy=kp.load_policy(kb.get_current_board()))
+                    completion_findings = [f for f in findings if f.severity == "error"]
+                    if completion_findings:
+                        print(
+                            f"kanban: completion validation warning for {ids[0]} "
+                            f"({len(completion_findings)} error-level issue(s)); "
+                            "completion will proceed, but downstream gates may block:",
+                            file=sys.stderr,
+                        )
+                        for f in completion_findings[:5]:
+                            print(f"  - {f.code}: {f.title}", file=sys.stderr)
+        except Exception as exc:
+            print(f"kanban: completion validation skipped: {exc}", file=sys.stderr)
+
     failed: list[str] = []
     with kb.connect() as conn:
         for tid in ids:

--- a/hermes_cli/kanban_cleanup.py
+++ b/hermes_cli/kanban_cleanup.py
@@ -1,0 +1,354 @@
+"""Inventory, cleanup, and teardown helpers for Kanban boards.
+
+The functions here intentionally separate classification from deletion so tests
+can exercise safety decisions without touching real worktrees or processes.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import signal
+import subprocess
+import time
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Any
+
+from hermes_cli import kanban_db as kb
+from hermes_cli.kanban_policy import BoardPolicy, load_policy
+
+
+@dataclass(frozen=True)
+class ProcessInfo:
+    pid: int
+    command: str
+    source: str = "detected"
+
+
+@dataclass(frozen=True)
+class CleanupDecision:
+    path: str
+    action: str
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+@dataclass(frozen=True)
+class WorktreeInfo:
+    path: Path
+    branch: str = ""
+    head: str = ""
+    main: bool = False
+    dirty: bool = False
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "path": str(self.path),
+            "branch": self.branch,
+            "head": self.head,
+            "main": self.main,
+            "dirty": self.dirty,
+        }
+
+
+def _run(args: list[str], *, cwd: Path | None = None) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(args, cwd=cwd, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+
+
+def list_registered_worktrees(project_root: Path | None) -> list[WorktreeInfo]:
+    if project_root is None or not (project_root / ".git").exists():
+        return []
+    proc = _run(["git", "worktree", "list", "--porcelain"], cwd=project_root)
+    if proc.returncode != 0:
+        return []
+    entries: list[dict[str, str]] = []
+    current: dict[str, str] = {}
+    for line in proc.stdout.splitlines():
+        if not line.strip():
+            if current:
+                entries.append(current)
+                current = {}
+            continue
+        if " " in line:
+            key, value = line.split(" ", 1)
+        else:
+            key, value = line, ""
+        if key == "worktree" and current:
+            entries.append(current)
+            current = {}
+        current[key] = value
+    if current:
+        entries.append(current)
+    infos: list[WorktreeInfo] = []
+    main_path = project_root.resolve(strict=False)
+    for entry in entries:
+        path = Path(entry.get("worktree", "")).expanduser().resolve(strict=False)
+        dirty = False
+        if path.exists():
+            status = _run(["git", "status", "--short"], cwd=path)
+            dirty = bool(status.stdout.strip()) if status.returncode == 0 else True
+        infos.append(WorktreeInfo(
+            path=path,
+            branch=entry.get("branch", ""),
+            head=entry.get("HEAD", ""),
+            main=path == main_path,
+            dirty=dirty,
+        ))
+    return infos
+
+
+def find_relevant_processes(board: str, policy: BoardPolicy) -> list[ProcessInfo]:
+    """Return processes that should be reported as board-related.
+
+    This intentionally reports broad matches for inventory visibility only.
+    Destructive teardown uses ``find_killable_worker_processes`` instead so a
+    common board slug/path cannot kill unrelated shells, editors, or tests.
+    """
+    proc = _run(["ps", "-eo", "pid=,args="])
+    if proc.returncode != 0:
+        return []
+    needles = [board.lower()]
+    if policy.project_root:
+        needles.append(str(policy.project_root).lower())
+    if policy.worktree_root:
+        needles.append(str(policy.worktree_root).lower())
+    own_pid = os.getpid()
+    infos: list[ProcessInfo] = []
+    for line in proc.stdout.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        pid_s, _, command = stripped.partition(" ")
+        try:
+            pid = int(pid_s)
+        except ValueError:
+            continue
+        if pid == own_pid:
+            continue
+        lower = command.lower()
+        if any(n and n in lower for n in needles) and "ps -eo" not in lower:
+            infos.append(ProcessInfo(pid=pid, command=command, source="broad_match"))
+    return infos
+
+
+def find_killable_worker_processes(board: str) -> list[ProcessInfo]:
+    """Return only DB-recorded running worker PIDs for this board.
+
+    Teardown must not kill by substring. The Kanban DB already tracks worker_pid
+    for running tasks; use that exact metadata and let ambiguous broad matches be
+    reported, not killed.
+    """
+    db_path = kb.kanban_db_path(board=board)
+    if not db_path.exists():
+        return []
+    conn = kb.connect(board=board)
+    try:
+        rows = conn.execute(
+            "SELECT id, worker_pid FROM tasks "
+            "WHERE status = 'running' AND worker_pid IS NOT NULL"
+        ).fetchall()
+    finally:
+        conn.close()
+    by_pid = {p.pid: p.command for p in find_relevant_processes(board, BoardPolicy(board=board))}
+    workers: list[ProcessInfo] = []
+    for row in rows:
+        try:
+            pid = int(row["worker_pid"])
+        except (TypeError, ValueError):
+            continue
+        command = by_pid.get(pid, f"worker_pid={pid} task={row['id']}")
+        workers.append(ProcessInfo(pid=pid, command=command, source=f"worker_pid:{row['id']}"))
+    return workers
+
+
+def classify_worktree_for_cleanup(info: WorktreeInfo, policy: BoardPolicy, processes: list[ProcessInfo]) -> CleanupDecision:
+    path_s = str(info.path)
+    if info.main or (policy.project_root and info.path == policy.project_root):
+        return CleanupDecision(path_s, "protected_main", "main project checkout is never removed by cleanup")
+    for proc in processes:
+        if path_s in proc.command:
+            return CleanupDecision(path_s, "blocked_active", f"active process pid={proc.pid}")
+    if info.dirty:
+        return CleanupDecision(path_s, "blocked_dirty", "worktree has uncommitted changes")
+    return CleanupDecision(path_s, "safe_remove", "inactive clean secondary worktree")
+
+
+def classify_workspace_dir_for_cleanup(path: Path, policy: BoardPolicy, processes: list[ProcessInfo]) -> CleanupDecision:
+    path = path.resolve(strict=False)
+    path_s = str(path)
+    if policy.project_root and path == policy.project_root:
+        return CleanupDecision(path_s, "protected_main", "main project checkout is never scratch junk")
+    for proc in processes:
+        if path_s in proc.command:
+            return CleanupDecision(path_s, "blocked_active", f"active process pid={proc.pid}")
+    return CleanupDecision(path_s, "safe_remove_scratch", "inactive board scratch/workspace directory")
+
+
+def inventory_board(board: str, policy: BoardPolicy | None = None) -> dict[str, Any]:
+    policy = policy or load_policy(board)
+    board_path = kb.board_dir(board)
+    workspace_root = kb.workspaces_root(board)
+    worktrees = list_registered_worktrees(policy.project_root)
+    processes = find_relevant_processes(board, policy)
+    workspace_dirs = []
+    if workspace_root.exists():
+        workspace_dirs = [str(p) for p in sorted(workspace_root.iterdir())]
+    return {
+        "board": board,
+        "policy": policy.to_dict(),
+        "board_path": str(board_path),
+        "board_exists": board_path.exists(),
+        "registered_worktrees": [w.to_dict() for w in worktrees],
+        "workspace_dirs": workspace_dirs,
+        "processes": [asdict(p) for p in processes],
+        "warnings": [],
+    }
+
+
+def stop_processes(processes: list[ProcessInfo], *, timeout: float = 1.0) -> list[int]:
+    stopped: list[int] = []
+    for proc in processes:
+        try:
+            os.kill(proc.pid, signal.SIGTERM)
+            stopped.append(proc.pid)
+        except ProcessLookupError:
+            pass
+        except PermissionError:
+            pass
+    if stopped:
+        time.sleep(timeout)
+    for proc in processes:
+        try:
+            os.kill(proc.pid, 0)
+        except ProcessLookupError:
+            continue
+        except PermissionError:
+            continue
+        try:
+            os.kill(proc.pid, signal.SIGKILL)
+        except Exception:
+            pass
+    return stopped
+
+
+def _remove_git_worktree(project_root: Path | None, path: str) -> tuple[bool, str]:
+    if project_root is None:
+        return False, "policy has no project_root"
+    proc = _run(["git", "worktree", "remove", "--force", path], cwd=project_root)
+    target = Path(path).expanduser().resolve(strict=False)
+    if proc.returncode == 0 and not target.exists():
+        return True, ""
+    error = (proc.stderr or proc.stdout or "worktree path still exists after remove").strip()
+    return False, error
+
+
+def _remove_tree(path: Path) -> tuple[bool, str]:
+    if not path.exists():
+        return True, ""
+    try:
+        shutil.rmtree(path)
+    except Exception as exc:
+        return False, repr(exc)
+    if path.exists():
+        return False, "path still exists after removal"
+    return True, ""
+
+
+def cleanup_board(board: str, *, dry_run: bool = True) -> dict[str, Any]:
+    policy = load_policy(board)
+    processes = find_relevant_processes(board, policy)
+    decisions = [classify_worktree_for_cleanup(w, policy, processes) for w in list_registered_worktrees(policy.project_root)]
+    removed: list[str] = []
+    errors: list[dict[str, str]] = []
+    if not dry_run:
+        for decision in decisions:
+            if decision.action == "safe_remove":
+                ok, error = _remove_git_worktree(policy.project_root, decision.path)
+                if ok:
+                    removed.append(decision.path)
+                else:
+                    errors.append({"path": decision.path, "error": error})
+        if policy.project_root:
+            prune = _run(["git", "worktree", "prune"], cwd=policy.project_root)
+            if prune.returncode != 0:
+                errors.append({"path": str(policy.project_root), "error": prune.stderr.strip() or "git worktree prune failed"})
+    return {
+        "board": board,
+        "dry_run": dry_run,
+        "decisions": [d.to_dict() for d in decisions],
+        "removed": removed,
+        "errors": errors,
+        "verified": not errors,
+    }
+
+
+def teardown_board(
+    board: str,
+    *,
+    remove_all_worktrees: bool,
+    delete_board: bool,
+    yes: bool,
+) -> dict[str, Any]:
+    policy = load_policy(board)
+    if not yes:
+        return {
+            "board": board,
+            "verified": False,
+            "refused": True,
+            "reason": "destructive teardown requires --yes",
+            "inventory": inventory_board(board, policy),
+        }
+    killable_processes = find_killable_worker_processes(board)
+    stopped = stop_processes(killable_processes)
+    ambiguous_processes = find_relevant_processes(board, policy)
+    removed_worktrees: list[str] = []
+    errors: list[dict[str, str]] = []
+    if remove_all_worktrees and policy.project_root:
+        removed_any_worktree = False
+        for wt in list_registered_worktrees(policy.project_root):
+            if wt.main:
+                continue
+            ok, error = _remove_git_worktree(policy.project_root, str(wt.path))
+            if ok:
+                removed_worktrees.append(str(wt.path))
+                removed_any_worktree = True
+            else:
+                errors.append({"path": str(wt.path), "error": error})
+        if removed_any_worktree:
+            prune = _run(["git", "worktree", "prune"], cwd=policy.project_root)
+            if prune.returncode != 0:
+                errors.append({"path": str(policy.project_root), "error": prune.stderr.strip() or "git worktree prune failed"})
+        if policy.worktree_root and policy.worktree_root.exists():
+            ok, error = _remove_tree(policy.worktree_root)
+            if not ok:
+                errors.append({"path": str(policy.worktree_root), "error": error})
+    board_removed = False
+    if delete_board:
+        board_path = kb.board_dir(board)
+        ok, error = _remove_tree(board_path)
+        board_removed = ok and not board_path.exists()
+        if not ok:
+            errors.append({"path": str(board_path), "error": error})
+    remaining_worktrees = [w.to_dict() for w in list_registered_worktrees(policy.project_root) if not w.main]
+    remaining_processes = [asdict(p) for p in find_killable_worker_processes(board)]
+    remaining_paths = []
+    if delete_board and kb.board_dir(board).exists():
+        remaining_paths.append(str(kb.board_dir(board)))
+    if remove_all_worktrees and policy.worktree_root and policy.worktree_root.exists():
+        remaining_paths.append(str(policy.worktree_root))
+    return {
+        "board": board,
+        "processes_stopped": stopped,
+        "killable_processes": [asdict(p) for p in killable_processes],
+        "ambiguous_processes_reported_only": [asdict(p) for p in ambiguous_processes if p.pid not in set(stopped)],
+        "worktrees_removed": removed_worktrees,
+        "board_removed": board_removed,
+        "remaining_worktrees": remaining_worktrees,
+        "remaining_processes": remaining_processes,
+        "remaining_paths": remaining_paths,
+        "errors": errors,
+        "verified": not remaining_worktrees and not remaining_processes and not remaining_paths and not errors,
+    }

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -83,6 +83,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable, Optional
 
+from hermes_cli import kanban_policy as kp
+
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -91,11 +93,12 @@ from typing import Any, Iterable, Optional
 VALID_STATUSES = {"triage", "todo", "ready", "running", "blocked", "done", "archived"}
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
 
-# A running task's claim is valid for 15 minutes; after that the next
-# dispatcher tick reclaims it.  Workers that outlive this window should call
-# ``heartbeat_claim(task_id)`` periodically.  In practice most kanban
-# workloads either finish within 15m or set a longer claim explicitly.
-DEFAULT_CLAIM_TTL_SECONDS = 15 * 60
+# A running task's claim is valid for 2 hours by default; after that the next
+# dispatcher tick reclaims it. Workers that outlive this window should call
+# ``heartbeat_claim(task_id)`` periodically. The longer default is intentional:
+# visual QA, browser probes, CI watches, and live-server checks regularly exceed
+# short leases, and a too-short lease causes the dispatcher to kill real progress.
+DEFAULT_CLAIM_TTL_SECONDS = 2 * 60 * 60
 
 
 # Worker-context caps so build_worker_context() stays bounded on
@@ -1250,20 +1253,24 @@ def create_task(
             cleaned.append(name)
         skills_list = cleaned
 
-    # Idempotency check — return the existing task instead of creating a
-    # duplicate. Done BEFORE entering write_txn to keep the fast path fast
-    # and to avoid holding a write lock during the lookup. Race is
-    # acceptable: two concurrent creators with the same key might both
-    # insert, at which point both rows exist but the next lookup stabilises.
-    if idempotency_key:
+    def _existing_idempotent_task_id() -> Optional[str]:
+        if not idempotency_key:
+            return None
         row = conn.execute(
             "SELECT id FROM tasks WHERE idempotency_key = ? "
             "AND status != 'archived' "
             "ORDER BY created_at DESC LIMIT 1",
             (idempotency_key,),
         ).fetchone()
-        if row:
-            return row["id"]
+        return row["id"] if row else None
+
+    # Idempotency check — return the existing task instead of creating a
+    # duplicate. Keep the fast path outside the write transaction, then
+    # repeat it after BEGIN IMMEDIATE below so concurrent creators with the
+    # same key serialize to one row instead of racing two inserts.
+    existing_id = _existing_idempotent_task_id()
+    if existing_id:
+        return existing_id
 
     now = int(time.time())
 
@@ -1272,6 +1279,10 @@ def create_task(
         task_id = _new_task_id()
         try:
             with write_txn(conn):
+                existing_id = _existing_idempotent_task_id()
+                if existing_id:
+                    return existing_id
+
                 # Determine initial status from parent status, unless the
                 # caller is parking this task in triage for a specifier.
                 if triage:
@@ -1875,7 +1886,7 @@ def heartbeat_claim(
 ) -> bool:
     """Extend a running claim.  Returns True if we still own it.
 
-    Workers that know they'll exceed 15 minutes should call this every
+    Workers that know they'll exceed the default lease should call this every
     few minutes to keep ownership.
     """
     expires = int(time.time()) + int(ttl_seconds)
@@ -2666,6 +2677,9 @@ def resolve_workspace(task: Task, *, board: Optional[str] = None) -> Path:
         return p
     if kind == "worktree":
         if not task.workspace_path:
+            policy = kp.load_policy(_normalize_board_slug(board) or get_current_board())
+            if policy.worktree_root:
+                return policy.worktree_root / task.id
             # Default: .worktrees/<id>/ under CWD.  Worker skill creates it.
             return Path.cwd() / ".worktrees" / task.id
         p = Path(task.workspace_path).expanduser()
@@ -2943,15 +2957,15 @@ def heartbeat_worker(
     with write_txn(conn):
         if expected_run_id is None:
             cur = conn.execute(
-                "UPDATE tasks SET last_heartbeat_at = ? "
+                "UPDATE tasks SET last_heartbeat_at = ?, claim_expires = ? "
                 "WHERE id = ? AND status = 'running'",
-                (now, task_id),
+                (now, now + DEFAULT_CLAIM_TTL_SECONDS, task_id),
             )
         else:
             cur = conn.execute(
-                "UPDATE tasks SET last_heartbeat_at = ? "
+                "UPDATE tasks SET last_heartbeat_at = ?, claim_expires = ? "
                 "WHERE id = ? AND status = 'running' AND current_run_id = ?",
-                (now, task_id, int(expected_run_id)),
+                (now, now + DEFAULT_CLAIM_TTL_SECONDS, task_id, int(expected_run_id)),
             )
         if cur.rowcount != 1:
             return False
@@ -2962,8 +2976,8 @@ def heartbeat_worker(
         )
         if run_id is not None:
             conn.execute(
-                "UPDATE task_runs SET last_heartbeat_at = ? WHERE id = ?",
-                (now, run_id),
+                "UPDATE task_runs SET last_heartbeat_at = ?, claim_expires = ? WHERE id = ?",
+                (now, now + DEFAULT_CLAIM_TTL_SECONDS, run_id),
             )
         _append_event(
             conn, task_id, "heartbeat",
@@ -3538,6 +3552,7 @@ def dispatch_once(
             pass
 
     result = DispatchResult()
+    policy = kp.load_policy(_normalize_board_slug(board) or get_current_board())
     result.reclaimed = release_stale_claims(conn)
     result.crashed = detect_crashed_workers(conn)
     # detect_crashed_workers stashes protocol-violation auto-blocks on
@@ -3557,12 +3572,30 @@ def dispatch_once(
         "ORDER BY priority DESC, created_at ASC"
     ).fetchall()
     spawned = 0
+    active_issue_pipeline_profiles = {
+        "backend-eng", "frontend-eng", "fullstack-eng", "data-eng", "devops-eng",
+        "reviewer", "qa-eng", "security-eng", "release-manager",
+    }
+    active_count = 0
+    if policy.max_active_issue_pipelines is not None:
+        active_count = int(conn.execute(
+            "SELECT COUNT(*) AS n FROM tasks WHERE status = 'running' AND assignee IN ("
+            "'backend-eng','frontend-eng','fullstack-eng','data-eng','devops-eng',"
+            "'reviewer','qa-eng','security-eng','release-manager')"
+        ).fetchone()["n"])
     for row in ready_rows:
         if max_spawn is not None and spawned >= max_spawn:
             break
         if not row["assignee"]:
             result.skipped_unassigned.append(row["id"])
             continue
+        if row["assignee"] in active_issue_pipeline_profiles:
+            if (
+                policy.max_active_issue_pipelines is not None
+                and active_count >= policy.max_active_issue_pipelines
+            ):
+                result.skipped_nonspawnable.append(row["id"])
+                continue
         # Skip ready tasks whose assignee is not a real Hermes profile.
         # `_default_spawn` invokes ``hermes -p <assignee>`` which fails
         # with "Profile 'X' does not exist" when the assignee names a
@@ -3587,7 +3620,17 @@ def dispatch_once(
             result.skipped_nonspawnable.append(row["id"])
             continue
         if dry_run:
-            result.spawned.append((row["id"], row["assignee"], ""))
+            workspace_preview = ""
+            try:
+                task_preview = get_task(conn, row["id"])
+                if task_preview is not None:
+                    workspace_preview = str(resolve_workspace(task_preview, board=board))
+            except Exception:
+                workspace_preview = ""
+            result.spawned.append((row["id"], row["assignee"], workspace_preview))
+            if row["assignee"] in active_issue_pipeline_profiles:
+                active_count += 1
+            spawned += 1
             continue
         claimed = claim_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
@@ -3629,6 +3672,8 @@ def dispatch_once(
             # complete_task).
             result.spawned.append((claimed.id, claimed.assignee or "", str(workspace)))
             spawned += 1
+            if claimed.assignee in active_issue_pipeline_profiles:
+                active_count += 1
         except Exception as exc:
             auto = _record_spawn_failure(
                 conn, claimed.id, str(exc),
@@ -3887,6 +3932,10 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
     if task.tenant:
         lines.append(f"Tenant:   {task.tenant}")
     lines.append(f"Workspace: {task.workspace_kind} @ {task.workspace_path or '(unresolved)'}")
+    guidance = kp.format_policy_guidance(kp.load_policy(get_current_board()))
+    if guidance:
+        lines.append("")
+        lines.append(guidance.rstrip())
     lines.append("")
 
     if task.body and task.body.strip():

--- a/hermes_cli/kanban_policy.py
+++ b/hermes_cli/kanban_policy.py
@@ -1,0 +1,251 @@
+"""Config-driven safety policy for Hermes Kanban boards.
+
+Board policies keep project-specific workflow constraints out of core Kanban
+logic: canonical project roots, allowed worktree roots, denied scratch roots,
+and worker guidance are loaded from declarative per-board JSON files.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any
+
+
+_BOARD_SLUG_RE = re.compile(r"^[a-z0-9][a-z0-9\-_]{0,63}$")
+
+
+def normalize_board_slug(board: str) -> str:
+    slug = str(board).strip().lower()
+    if not slug or not _BOARD_SLUG_RE.match(slug):
+        raise ValueError(
+            f"invalid board slug {board!r}: must be 1-64 chars, lowercase alphanumerics / hyphens / underscores"
+        )
+    return slug
+
+
+@dataclass(frozen=True)
+class BoardPolicy:
+    board: str
+    project_root: Path | None = None
+    base_branch: str = "main"
+    worktree_root: Path | None = None
+    denied_workspace_roots: list[Path] = field(default_factory=list)
+    shared_project_root_writable: bool = False
+    scratch_repo_operations_allowed: bool = False
+    max_active_issue_pipelines: int | None = None
+    cleanup_after_merge: bool = True
+    forbid_dirty_completion: bool = True
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "project_root", _norm_optional_path(self.project_root))
+        object.__setattr__(self, "worktree_root", _norm_optional_path(self.worktree_root))
+        object.__setattr__(
+            self,
+            "denied_workspace_roots",
+            [_norm_path(path) for path in self.denied_workspace_roots],
+        )
+        if self.max_active_issue_pipelines is not None:
+            try:
+                value = int(self.max_active_issue_pipelines)
+            except (TypeError, ValueError) as exc:
+                raise ValueError("max_active_issue_pipelines must be an integer") from exc
+            if value < 1:
+                raise ValueError("max_active_issue_pipelines must be >= 1")
+            object.__setattr__(self, "max_active_issue_pipelines", value)
+
+    @property
+    def configured(self) -> bool:
+        return any(
+            [
+                self.project_root,
+                self.worktree_root,
+                self.denied_workspace_roots,
+                self.max_active_issue_pipelines,
+                self.shared_project_root_writable,
+                self.scratch_repo_operations_allowed,
+            ]
+        )
+
+    def to_dict(self) -> dict[str, Any]:
+        data = asdict(self)
+        for key in ("project_root", "worktree_root"):
+            if data[key] is not None:
+                data[key] = str(data[key])
+        data["denied_workspace_roots"] = [str(path) for path in self.denied_workspace_roots]
+        return data
+
+
+@dataclass(frozen=True)
+class WorkspacePolicyFinding:
+    severity: str
+    code: str
+    message: str
+    detail: str = ""
+
+
+def _norm_optional_path(value: str | Path | None) -> Path | None:
+    if value is None or str(value).strip() == "":
+        return None
+    return _norm_path(value)
+
+
+def _norm_path(value: str | Path) -> Path:
+    return Path(value).expanduser().resolve(strict=False)
+
+
+def _kanban_home() -> Path:
+    try:
+        from hermes_cli import kanban_db as kb
+
+        return kb.kanban_home().resolve(strict=False)
+    except Exception:
+        override = os.environ.get("HERMES_KANBAN_HOME", "").strip()
+        if override:
+            return Path(override).expanduser().resolve(strict=False)
+        return Path(os.environ.get("HERMES_HOME", "~/.hermes")).expanduser().resolve(strict=False)
+
+
+def policies_root(*, home: Path | None = None) -> Path:
+    return (home.resolve(strict=False) if home else _kanban_home()) / "kanban" / "policies"
+
+
+def policy_path_for_board(board: str, *, home: Path | None = None) -> Path:
+    return policies_root(home=home) / f"{normalize_board_slug(board)}.json"
+
+
+def default_policy(board: str) -> BoardPolicy:
+    return BoardPolicy(board=board)
+
+
+def load_policy(board: str, *, home: Path | None = None) -> BoardPolicy:
+    path = policy_path_for_board(board, home=home)
+    if not path.exists():
+        return default_policy(board)
+    data = json.loads(path.read_text())
+    if not isinstance(data, dict):
+        raise ValueError(f"policy file {path} must contain a JSON object")
+    return BoardPolicy(
+        board=board,
+        project_root=data.get("project_root"),
+        base_branch=data.get("base_branch", "main"),
+        worktree_root=data.get("worktree_root"),
+        denied_workspace_roots=data.get("denied_workspace_roots", []),
+        shared_project_root_writable=bool(data.get("shared_project_root_writable", False)),
+        scratch_repo_operations_allowed=bool(data.get("scratch_repo_operations_allowed", False)),
+        max_active_issue_pipelines=data.get("max_active_issue_pipelines"),
+        cleanup_after_merge=bool(data.get("cleanup_after_merge", True)),
+        forbid_dirty_completion=bool(data.get("forbid_dirty_completion", True)),
+    )
+
+
+def policy_report(board: str, *, home: Path | None = None) -> dict[str, Any]:
+    path = policy_path_for_board(board, home=home)
+    errors: list[str] = []
+    policy = default_policy(board)
+    if path.exists():
+        try:
+            policy = load_policy(board, home=home)
+        except Exception as exc:
+            errors.append(str(exc))
+    return {
+        "board": board,
+        "configured": path.exists(),
+        "path": str(path),
+        "policy": policy.to_dict(),
+        "errors": errors,
+    }
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def validate_workspace(
+    policy: BoardPolicy,
+    *,
+    workspace_kind: str | None,
+    workspace_path: str | None,
+    repo_touching: bool,
+) -> list[WorkspacePolicyFinding]:
+    findings: list[WorkspacePolicyFinding] = []
+    if not repo_touching:
+        return findings
+    if not policy.project_root and not policy.worktree_root and not policy.denied_workspace_roots:
+        return findings
+
+    kind = workspace_kind or "scratch"
+    if kind != "worktree":
+        if policy.worktree_root:
+            findings.append(WorkspacePolicyFinding(
+                "error",
+                "repo_touching_requires_worktree",
+                "Repo-touching card must use workspace_kind=worktree under this board policy.",
+                f"workspace_kind={kind!r}; allowed worktree root is {policy.worktree_root}",
+            ))
+        return findings
+
+    if not workspace_path:
+        findings.append(WorkspacePolicyFinding(
+            "error",
+            "missing_explicit_project_worktree",
+            "Repo-touching worktree card lacks an explicit policy-compliant workspace_path.",
+            f"Use an absolute path under {policy.worktree_root}." if policy.worktree_root else "Set workspace_path explicitly.",
+        ))
+        return findings
+
+    path = _norm_path(workspace_path)
+    for denied in policy.denied_workspace_roots:
+        if _is_relative_to(path, denied):
+            findings.append(WorkspacePolicyFinding(
+                "error",
+                "workspace_under_denied_root",
+                f"Workspace is under denied root {denied}.",
+                str(path),
+            ))
+
+    if policy.project_root and path == policy.project_root and not policy.shared_project_root_writable:
+        findings.append(WorkspacePolicyFinding(
+            "error",
+            "shared_project_root_workspace",
+            "Repo-touching card targets the shared project root, which is read-only by policy.",
+            f"Use a task-specific worktree under {policy.worktree_root}." if policy.worktree_root else str(path),
+        ))
+
+    if policy.worktree_root and not _is_relative_to(path, policy.worktree_root):
+        findings.append(WorkspacePolicyFinding(
+            "error",
+            "worktree_outside_policy_root",
+            f"Worktree must be under {policy.worktree_root}.",
+            f"workspace_path={workspace_path!r}",
+        ))
+    return findings
+
+
+def format_policy_guidance(policy: BoardPolicy) -> str:
+    if not policy.configured:
+        return ""
+    lines = ["## Board policy", ""]
+    lines.append(f"Board: {policy.board}")
+    if policy.project_root:
+        access = "writable" if policy.shared_project_root_writable else "read-only inspection space"
+        lines.append(f"Canonical repo: {policy.project_root} ({access})")
+    lines.append(f"Base branch: {policy.base_branch}")
+    if policy.worktree_root:
+        lines.append(f"Allowed task worktree root: {policy.worktree_root}")
+    if policy.denied_workspace_roots:
+        lines.append("Denied workspace roots: " + ", ".join(str(p) for p in policy.denied_workspace_roots))
+    scratch = "allowed" if policy.scratch_repo_operations_allowed else "forbidden for repo clone/build/install operations"
+    lines.append(f"Scratch/control-plane repo operations: {scratch}")
+    if policy.max_active_issue_pipelines:
+        lines.append(f"Max active issue pipelines: {policy.max_active_issue_pipelines}")
+    if policy.forbid_dirty_completion:
+        lines.append("Completion must report clean git status or block with dirty-file evidence.")
+    return "\n".join(lines).rstrip() + "\n"

--- a/hermes_cli/kanban_validation.py
+++ b/hermes_cli/kanban_validation.py
@@ -1,0 +1,362 @@
+"""Validation-contract and handoff linting for Hermes Kanban boards.
+
+The rules here are intentionally conservative: they flag missing mission
+validation contracts, missing assertion coverage, weak completion handoffs,
+user-visible QA without live evidence, promissory known-failure notes, and
+repo-touching completions without clean git/commit evidence.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass, asdict
+from typing import Any, Iterable, Optional
+
+from hermes_cli.kanban_policy import BoardPolicy, WorkspacePolicyFinding, validate_workspace
+
+
+_IMPLEMENTER_PROFILES = {
+    "backend-eng",
+    "frontend-eng",
+    "fullstack-eng",
+    "data-eng",
+    "devops-eng",
+    "docs-writer",
+}
+_GATE_PROFILES = {"reviewer", "qa-eng", "security-eng", "release-manager"}
+_QA_PROFILES = {"qa-eng"}
+_REPO_TOUCHING_PROFILES = _IMPLEMENTER_PROFILES | {"security-eng", "release-manager"}
+
+_VC_RE = re.compile(r"\bVC-[A-Z0-9][A-Z0-9-]*\b", re.IGNORECASE)
+_GITHUB_ISSUE_URL_RE = re.compile(r"https://github\.com/[^\s)]+/issues/\d+", re.IGNORECASE)
+_GITHUB_ISSUE_REF_RE = re.compile(r"(?:issue\s*)?#\d+\b", re.IGNORECASE)
+_KNOWN_FAILURE_RE = re.compile(
+    r"known\s+(?:pre[- ]existing|unrelated)\s+failure|pre[- ]existing\s+failure|issue\s+(?:will\s+be|to\s+be)\s+created",
+    re.IGNORECASE,
+)
+_CREATED_PROMISE_RE = re.compile(r"issue\s+(?:will\s+be|to\s+be)\s+created", re.IGNORECASE)
+_USER_VISIBLE_RE = re.compile(
+    r"\b(ui|ux|frontend|browser|page|screen|route|modal|form|button|user-visible|live-app|playwright|e2e|screenshot)\b",
+    re.IGNORECASE,
+)
+
+@dataclass
+class ValidationFinding:
+    task_id: str
+    severity: str
+    code: str
+    title: str
+    detail: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _as_dict(value: Any) -> dict[str, Any]:
+    return value if isinstance(value, dict) else {}
+
+
+def _as_list(value: Any) -> list[Any]:
+    return value if isinstance(value, list) else []
+
+
+def _stringify(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    try:
+        return json.dumps(value, ensure_ascii=False, sort_keys=True)
+    except Exception:
+        return str(value)
+
+
+def _extract_vc_ids(*values: Any) -> set[str]:
+    found: set[str] = set()
+    for value in values:
+        for match in _VC_RE.findall(_stringify(value)):
+            found.add(match.upper())
+    return found
+
+
+def _metadata(run: Any) -> dict[str, Any]:
+    if not run:
+        return {}
+    return _as_dict(getattr(run, "metadata", None))
+
+
+def _summary(run: Any) -> str:
+    return (getattr(run, "summary", None) or "") if run else ""
+
+
+def _has_numeric_exit_codes(commands: list[Any]) -> bool:
+    if not commands:
+        return False
+    for cmd in commands:
+        if not isinstance(cmd, dict):
+            return False
+        if not str(cmd.get("command") or "").strip():
+            return False
+        exit_code = cmd.get("exit_code")
+        if isinstance(exit_code, bool) or not isinstance(exit_code, int):
+            return False
+    return True
+
+
+def _is_repo_touching(task: Any, meta: dict[str, Any]) -> bool:
+    assignee = (getattr(task, "assignee", None) or "").strip()
+    workspace_kind = getattr(task, "workspace_kind", None)
+    if workspace_kind == "worktree":
+        return True
+    if assignee in _REPO_TOUCHING_PROFILES and any(
+        meta.get(k)
+        for k in ("changed_files", "commit", "branch", "pr_url", "tests_run", "verification_commands")
+    ):
+        return True
+    return False
+
+
+def _task_is_user_visible(task: Any, meta: dict[str, Any]) -> bool:
+    blob = "\n".join(
+        [
+            getattr(task, "title", "") or "",
+            getattr(task, "body", "") or "",
+            _stringify(meta.get("changed_files")),
+            _stringify(meta.get("acceptance_criteria_checked")),
+            _stringify(meta.get("validation_assertions_checked")),
+        ]
+    )
+    return bool(_USER_VISIBLE_RE.search(blob))
+
+
+def _known_failure_is_tracked(text: str, meta: dict[str, Any]) -> bool:
+    if _GITHUB_ISSUE_URL_RE.search(text):
+        return True
+    issue_fields = [
+        meta.get("issue_url"),
+        meta.get("known_failure_issue_url"),
+        meta.get("tracking_issue_url"),
+        meta.get("tracked_issue_url"),
+        meta.get("issue_number"),
+        meta.get("known_failure_issue_number"),
+        meta.get("tracking_issue_number"),
+    ]
+    if any(issue_fields):
+        return True
+    tracked = meta.get("known_failures_tracked") or meta.get("tracked_known_failures")
+    if isinstance(tracked, list) and tracked:
+        return True
+    return False
+
+
+def _validate_contract_task(task: Any) -> list[ValidationFinding]:
+    findings: list[ValidationFinding] = []
+    body = getattr(task, "body", None) or ""
+    title = getattr(task, "title", None) or ""
+    lower_blob = f"{title}\n{body}".lower()
+    looks_like_root = any(
+        term in lower_blob
+        for term in (
+            "mission",
+            "root",
+            "workplan",
+            "prd",
+            "architecture improvement loop",
+            "issue series",
+            "multi-card",
+        )
+    )
+    if not looks_like_root:
+        return findings
+    vc_ids = _extract_vc_ids(body)
+    if "validation_contract" not in lower_blob and not vc_ids:
+        findings.append(ValidationFinding(
+            getattr(task, "id"),
+            "error",
+            "missing_validation_contract",
+            "Mission/root card lacks a validation contract",
+            "Non-trivial mission/workplan/root cards should define atomic VC-* assertions before implementation fan-out.",
+        ))
+    if "uncovered_assertions" not in lower_blob and vc_ids:
+        findings.append(ValidationFinding(
+            getattr(task, "id"),
+            "warning",
+            "missing_coverage_ledger",
+            "Validation assertions lack an explicit coverage ledger",
+            "Include uncovered_assertions/coverage_complete so dispatchers can see whether every VC-* has owner/evidence coverage.",
+        ))
+    return findings
+
+
+def _ready_repo_touching(task: Any) -> bool:
+    assignee = (getattr(task, "assignee", None) or "").strip()
+    workspace_kind = getattr(task, "workspace_kind", None)
+    if workspace_kind == "worktree":
+        return True
+    return assignee in (_REPO_TOUCHING_PROFILES | _GATE_PROFILES)
+
+
+def _policy_to_validation(task: Any, finding: WorkspacePolicyFinding) -> ValidationFinding:
+    return ValidationFinding(
+        getattr(task, "id"),
+        finding.severity,
+        finding.code,
+        finding.message,
+        finding.detail,
+    )
+
+
+def _validate_ready_task(task: Any, *, policy: BoardPolicy | None = None) -> list[ValidationFinding]:
+    findings: list[ValidationFinding] = []
+    assignee = (getattr(task, "assignee", None) or "").strip()
+    status = getattr(task, "status", None)
+    if status not in {"todo", "ready", "running"}:
+        return findings
+    body = getattr(task, "body", None) or ""
+    vc_ids = _extract_vc_ids(body)
+    if assignee in _IMPLEMENTER_PROFILES and not vc_ids:
+        findings.append(ValidationFinding(
+            getattr(task, "id"),
+            "warning",
+            "implementation_missing_vc_assertions",
+            "Implementation card does not cite VC-* assertions",
+            "Implementation cards should list validation_assertions_to_satisfy or otherwise cite parent VC-* IDs.",
+        ))
+    if assignee in _GATE_PROFILES and not vc_ids:
+        findings.append(ValidationFinding(
+            getattr(task, "id"),
+            "warning",
+            "gate_missing_vc_assertions",
+            "Gate card does not cite VC-* assertions",
+            "Review/QA/security/release cards should list validation_assertions_to_verify or otherwise cite parent VC-* IDs.",
+        ))
+
+    if policy is not None:
+        for finding in validate_workspace(
+            policy,
+            workspace_kind=getattr(task, "workspace_kind", None),
+            workspace_path=getattr(task, "workspace_path", None),
+            repo_touching=_ready_repo_touching(task),
+        ):
+            findings.append(_policy_to_validation(task, finding))
+    return findings
+
+
+def _validate_completion_handoff(task: Any, latest_run: Any) -> list[ValidationFinding]:
+    findings: list[ValidationFinding] = []
+    tid = getattr(task, "id")
+    meta = _metadata(latest_run)
+    summary = _summary(latest_run)
+    text = "\n".join([getattr(task, "result", None) or "", summary, _stringify(meta)])
+    assignee = (getattr(task, "assignee", None) or "").strip()
+
+    repo_touching = _is_repo_touching(task, meta)
+    gate_owner = assignee in _GATE_PROFILES
+    if repo_touching or gate_owner:
+        commands = _as_list(meta.get("commands_run"))
+        # Back-compat: older workers used tests_run as strings. Warn, don't fail, when tests exist but commands_run is absent.
+        if not _has_numeric_exit_codes(commands):
+            severity = "error" if repo_touching else "warning"
+            findings.append(ValidationFinding(
+                tid,
+                severity,
+                "missing_commands_run_exit_codes",
+                "Completion handoff lacks commands_run with numeric exit_code",
+                "Repo-touching and gate-owning cards should record each verification command with a numeric exit_code.",
+            ))
+
+    if repo_touching:
+        if not str(meta.get("commit") or "").strip():
+            findings.append(ValidationFinding(
+                tid,
+                "error",
+                "repo_completion_missing_commit",
+                "Repo-touching completion lacks commit SHA",
+                "Repo-writing cards should commit intended changes and report the commit SHA before completion.",
+            ))
+        git_status = str(meta.get("git_status") or "").lower()
+        if not git_status or not git_status.startswith("clean"):
+            findings.append(ValidationFinding(
+                tid,
+                "error",
+                "repo_completion_not_clean",
+                "Repo-touching completion does not report clean git status",
+                "Repo-writing cards must complete clean or explicitly block with the dirty files/reason.",
+            ))
+
+    failed = meta.get("validation_assertions_failed") or meta.get("assertions_failed") or meta.get("failed_assertions")
+    if failed:
+        has_followup = any(
+            meta.get(k)
+            for k in (
+                "corrective_cards",
+                "recommended_remediation_cards",
+                "bugs_found",
+                "issue_url",
+                "tracking_issue_url",
+                "human_decision_needed",
+                "issue_creation_blocked",
+            )
+        )
+        if not has_followup:
+            findings.append(ValidationFinding(
+                tid,
+                "error",
+                "failed_assertions_without_followup",
+                "Failed validation assertions lack corrective routing",
+                "If validation_assertions_failed/assertions_failed is non-empty, include corrective card IDs, issue URL, human_decision_needed, or issue_creation_blocked.",
+            ))
+
+    if assignee in _QA_PROFILES and _task_is_user_visible(task, meta):
+        mode = str(meta.get("qa_evidence_mode") or "").strip()
+        routes = _as_list(meta.get("urls_or_routes_checked"))
+        artifacts = _as_list(meta.get("screenshots_or_artifacts")) or _as_list(meta.get("evidence"))
+        if mode in {"", "blocked"} or not routes or not artifacts:
+            findings.append(ValidationFinding(
+                tid,
+                "warning",
+                "user_visible_qa_missing_live_evidence",
+                "User-visible QA lacks live/e2e/manual evidence fields",
+                "QA handoff should include qa_evidence_mode, urls_or_routes_checked, and screenshots/logs/artifacts unless explicitly blocked.",
+            ))
+
+    if _KNOWN_FAILURE_RE.search(text):
+        if _CREATED_PROMISE_RE.search(text) or not _known_failure_is_tracked(text, meta):
+            findings.append(ValidationFinding(
+                tid,
+                "error",
+                "known_failure_not_verified_tracked",
+                "Known/pre-existing failure is not linked to a verified issue",
+                "Do not leave promissory known-failure notes. Create/search/verify a GitHub issue and include its URL/number, or mark issue_creation_blocked and do not call release-ready.",
+            ))
+    return findings
+
+
+def validate_tasks(
+    tasks: Iterable[Any],
+    runs_by_task: Optional[dict[str, list[Any]]] = None,
+    *,
+    policy: BoardPolicy | None = None,
+) -> list[ValidationFinding]:
+    runs_by_task = runs_by_task if runs_by_task is not None else None
+    findings: list[ValidationFinding] = []
+    for task in tasks:
+        findings.extend(_validate_contract_task(task))
+        findings.extend(_validate_ready_task(task, policy=policy))
+        latest_run = None
+        task_id = getattr(task, "id", "")
+        runs = runs_by_task.get(task_id, []) if runs_by_task is not None else []
+        if runs:
+            latest_run = runs[-1]
+        if (runs_by_task is not None and task_id in runs_by_task) or getattr(task, "status", None) == "done":
+            findings.extend(_validate_completion_handoff(task, latest_run))
+    return findings
+
+
+
+def summarize_findings(findings: Iterable[ValidationFinding]) -> dict[str, int]:
+    summary = {"error": 0, "warning": 0}
+    for finding in findings:
+        summary[finding.severity] = summary.get(finding.severity, 0) + 1
+    return summary

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11471,7 +11471,9 @@ Examples:
 
     # Execute the command
     if hasattr(args, "func"):
-        args.func(args)
+        rc = args.func(args)
+        if isinstance(rc, int):
+            sys.exit(rc)
     else:
         parser.print_help()
 

--- a/tests/hermes_cli/test_kanban_cleanup.py
+++ b/tests/hermes_cli/test_kanban_cleanup.py
@@ -1,0 +1,101 @@
+from pathlib import Path
+from types import SimpleNamespace
+
+from hermes_cli import kanban_cleanup as kc
+from hermes_cli.kanban_cleanup import (
+    CleanupDecision,
+    ProcessInfo,
+    WorktreeInfo,
+    classify_workspace_dir_for_cleanup,
+    classify_worktree_for_cleanup,
+)
+from hermes_cli.kanban_policy import BoardPolicy
+
+
+def test_classify_clean_secondary_worktree_safe(tmp_path):
+    project = tmp_path / "Project"
+    policy = BoardPolicy(board="demo", project_root=project, worktree_root=project / ".worktrees")
+    info = WorktreeInfo(path=project / ".worktrees" / "task-1", main=False, dirty=False)
+
+    decision = classify_worktree_for_cleanup(info, policy, [])
+
+    assert decision.action == "safe_remove"
+
+
+def test_classify_dirty_worktree_blocked(tmp_path):
+    project = tmp_path / "Project"
+    policy = BoardPolicy(board="demo", project_root=project, worktree_root=project / ".worktrees")
+    info = WorktreeInfo(path=project / ".worktrees" / "task-1", main=False, dirty=True)
+
+    decision = classify_worktree_for_cleanup(info, policy, [])
+
+    assert decision.action == "blocked_dirty"
+
+
+def test_classify_active_worktree_blocked(tmp_path):
+    project = tmp_path / "Project"
+    wt = project / ".worktrees" / "task-1"
+    policy = BoardPolicy(board="demo", project_root=project, worktree_root=project / ".worktrees")
+    info = WorktreeInfo(path=wt, main=False, dirty=False)
+
+    decision = classify_worktree_for_cleanup(info, policy, [ProcessInfo(pid=123, command=f"pnpm dev {wt}")])
+
+    assert decision.action == "blocked_active"
+
+
+def test_classify_main_checkout_protected(tmp_path):
+    project = tmp_path / "Project"
+    policy = BoardPolicy(board="demo", project_root=project, worktree_root=project / ".worktrees")
+    info = WorktreeInfo(path=project, main=True, dirty=False)
+
+    decision = classify_worktree_for_cleanup(info, policy, [])
+
+    assert decision.action == "protected_main"
+
+
+def test_classify_scratch_dir_safe_when_inactive(tmp_path):
+    project = tmp_path / "Project"
+    scratch = tmp_path / ".hermes" / "kanban" / "boards" / "demo" / "workspaces" / "t1"
+    policy = BoardPolicy(board="demo", project_root=project, worktree_root=project / ".worktrees")
+
+    decision = classify_workspace_dir_for_cleanup(scratch, policy, [])
+
+    assert decision.action == "safe_remove_scratch"
+
+
+def test_teardown_reports_broad_matches_but_only_kills_db_workers(monkeypatch, tmp_path):
+    project = tmp_path / "Project"
+    policy = BoardPolicy(board="demo", project_root=project, worktree_root=project / ".worktrees")
+    killed = []
+
+    monkeypatch.setattr(kc, "load_policy", lambda board: policy)
+    monkeypatch.setattr(kc, "find_killable_worker_processes", lambda board: [ProcessInfo(pid=111, command="hermes worker", source="worker_pid:t1")])
+    monkeypatch.setattr(kc, "find_relevant_processes", lambda board, policy: [
+        ProcessInfo(pid=111, command="hermes worker", source="worker_pid:t1"),
+        ProcessInfo(pid=222, command="vim /projects/demo", source="broad_match"),
+    ])
+    monkeypatch.setattr(kc, "stop_processes", lambda processes: killed.extend([p.pid for p in processes]) or [p.pid for p in processes])
+    monkeypatch.setattr(kc, "list_registered_worktrees", lambda root: [])
+    monkeypatch.setattr(kc.kb, "board_dir", lambda board: tmp_path / "missing-board")
+
+    result = kc.teardown_board("demo", remove_all_worktrees=True, delete_board=True, yes=True)
+
+    assert killed == [111]
+    assert [p["pid"] for p in result["ambiguous_processes_reported_only"]] == [222]
+
+
+def test_cleanup_reports_failed_worktree_remove(monkeypatch, tmp_path):
+    project = tmp_path / "Project"
+    wt = project / ".worktrees" / "task-1"
+    policy = BoardPolicy(board="demo", project_root=project, worktree_root=project / ".worktrees")
+    monkeypatch.setattr(kc, "load_policy", lambda board: policy)
+    monkeypatch.setattr(kc, "find_relevant_processes", lambda board, policy: [])
+    monkeypatch.setattr(kc, "list_registered_worktrees", lambda root: [WorktreeInfo(path=wt, main=False, dirty=False)])
+    monkeypatch.setattr(kc, "_run", lambda *args, **kwargs: SimpleNamespace(returncode=1, stdout="", stderr="boom"))
+
+    result = kc.cleanup_board("demo", dry_run=False)
+
+    assert result["removed"] == []
+    assert {e["path"] for e in result["errors"]} == {str(wt), str(project)}
+    assert any(e["error"] == "boom" for e in result["errors"])
+    assert result["verified"] is False

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -57,6 +57,45 @@ def test_idempotency_key_returns_existing_task(kanban_home):
         conn.close()
 
 
+def test_dispatch_policy_throttle_counts_spawns_in_same_tick(kanban_home, all_assignees_spawnable):
+    policies = kanban_home / "kanban" / "policies"
+    policies.mkdir(parents=True)
+    (policies / "default.json").write_text(json.dumps({"max_active_issue_pipelines": 1}))
+    conn = kb.connect()
+    try:
+        first = kb.create_task(conn, title="first", assignee="backend-eng")
+        second = kb.create_task(conn, title="second", assignee="frontend-eng")
+
+        res = kb.dispatch_once(conn, spawn_fn=lambda task, ws: None)
+
+        assert len(res.spawned) == 1
+        assert res.spawned[0][0] == first
+        assert second in res.skipped_nonspawnable
+        assert kb.get_task(conn, first).status == "running"
+        assert kb.get_task(conn, second).status == "ready"
+    finally:
+        conn.close()
+
+
+def test_dispatch_policy_throttle_counts_dry_run_spawns_in_same_tick(kanban_home, all_assignees_spawnable):
+    policies = kanban_home / "kanban" / "policies"
+    policies.mkdir(parents=True)
+    (policies / "default.json").write_text(json.dumps({"max_active_issue_pipelines": 1}))
+    conn = kb.connect()
+    try:
+        first = kb.create_task(conn, title="first", assignee="backend-eng")
+        second = kb.create_task(conn, title="second", assignee="frontend-eng")
+
+        res = kb.dispatch_once(conn, dry_run=True, spawn_fn=lambda task, ws: None)
+
+        assert len(res.spawned) == 1
+        assert res.spawned[0][0] == first
+        assert res.spawned[0][2]
+        assert second in res.skipped_nonspawnable
+    finally:
+        conn.close()
+
+
 def test_idempotency_key_ignored_for_archived(kanban_home):
     conn = kb.connect()
     try:
@@ -1011,6 +1050,8 @@ def test_heartbeat_on_running_task(kanban_home):
         assert ok is True
         task = kb.get_task(conn, tid)
         assert task.last_heartbeat_at is not None
+        assert task.claim_expires is not None
+        assert task.claim_expires - int(time.time()) >= kb.DEFAULT_CLAIM_TTL_SECONDS - 5
         events = kb.list_events(conn, tid)
         hb = [e for e in events if e.kind == "heartbeat"]
         assert len(hb) == 1
@@ -1297,6 +1338,24 @@ def test_run_created_on_claim(kanban_home):
         assert r.outcome is None
         assert r.ended_at is None
         assert r.claim_lock is not None and r.claim_expires is not None
+    finally:
+        conn.close()
+
+
+def test_default_claim_ttl_is_long_enough_for_visual_qa(kanban_home):
+    """Default claim lease should not reclaim long Visual QA/browser work quickly."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="visual qa", assignee="qa-eng")
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+        task = kb.get_task(conn, tid)
+        now = int(time.time())
+        assert kb.DEFAULT_CLAIM_TTL_SECONDS == 2 * 60 * 60
+        assert task.claim_expires is not None
+        assert task.claim_expires - now >= (2 * 60 * 60) - 5
+        run = kb.latest_run(conn, tid)
+        assert run.claim_expires == task.claim_expires
     finally:
         conn.close()
 
@@ -2460,6 +2519,43 @@ def test_resolve_workspace_rejects_relative_worktree_path(kanban_home):
         )
         with pytest.raises(ValueError, match=r"non-absolute"):
             kb.resolve_workspace(kb.get_task(conn, tid))
+    finally:
+        conn.close()
+
+
+def test_resolve_workspace_uses_policy_worktree_root(kanban_home, tmp_path):
+    policies = kanban_home / "kanban" / "policies"
+    policies.mkdir(parents=True)
+    project = tmp_path / "Project"
+    (policies / "default.json").write_text(json.dumps({
+        "project_root": str(project),
+        "worktree_root": str(project / ".worktrees"),
+    }))
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="wt", assignee="worker", workspace_kind="worktree")
+        resolved = kb.resolve_workspace(kb.get_task(conn, tid))
+        assert resolved == (project / ".worktrees" / tid).resolve(strict=False)
+    finally:
+        conn.close()
+
+
+def test_build_worker_context_includes_board_policy_guidance(kanban_home, tmp_path):
+    policies = kanban_home / "kanban" / "policies"
+    policies.mkdir(parents=True)
+    project = tmp_path / "Project"
+    (policies / "default.json").write_text(json.dumps({
+        "project_root": str(project),
+        "worktree_root": str(project / ".worktrees"),
+        "max_active_issue_pipelines": 1,
+    }))
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="wt", assignee="worker", workspace_kind="worktree")
+        ctx = kb.build_worker_context(conn, tid)
+        assert "## Board policy" in ctx
+        assert str(project.resolve(strict=False)) in ctx
+        assert "Max active issue pipelines: 1" in ctx
     finally:
         conn.close()
 

--- a/tests/hermes_cli/test_kanban_policy.py
+++ b/tests/hermes_cli/test_kanban_policy.py
@@ -1,0 +1,170 @@
+import json
+
+import pytest
+
+from hermes_cli.kanban_policy import (
+    BoardPolicy,
+    default_policy,
+    format_policy_guidance,
+    load_policy,
+    policy_path_for_board,
+    policy_report,
+    validate_workspace,
+)
+
+
+def test_default_policy_is_safe_and_non_project_specific():
+    policy = default_policy("unknown")
+
+    assert policy.board == "unknown"
+    assert policy.project_root is None
+    assert policy.worktree_root is None
+    assert policy.shared_project_root_writable is False
+    assert policy.scratch_repo_operations_allowed is False
+    assert policy.max_active_issue_pipelines is None
+
+
+def test_policy_normalizes_paths_without_requiring_existence(tmp_path):
+    project = tmp_path / "Project"
+    worktrees = project / ".worktrees"
+
+    policy = BoardPolicy(
+        board="demo",
+        project_root=project,
+        base_branch="main",
+        worktree_root=worktrees,
+        denied_workspace_roots=[tmp_path / ".hermes"],
+    )
+
+    assert policy.project_root == project.resolve(strict=False)
+    assert policy.worktree_root == worktrees.resolve(strict=False)
+
+
+def test_load_policy_from_json_file(tmp_path, monkeypatch):
+    policies = tmp_path / "kanban" / "policies"
+    policies.mkdir(parents=True)
+    (policies / "demo.json").write_text(
+        json.dumps(
+            {
+                "project_root": str(tmp_path / "Demo"),
+                "base_branch": "development",
+                "worktree_root": str(tmp_path / "Demo" / ".worktrees"),
+                "denied_workspace_roots": [str(tmp_path / "kanban")],
+                "max_active_issue_pipelines": 1,
+            }
+        )
+    )
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(tmp_path))
+
+    policy = load_policy("demo")
+
+    assert policy.board == "demo"
+    assert policy.base_branch == "development"
+    assert policy.max_active_issue_pipelines == 1
+    assert policy.project_root == (tmp_path / "Demo").resolve(strict=False)
+
+
+def test_policy_path_rejects_path_traversal_board_slug(tmp_path):
+    with pytest.raises(ValueError, match="invalid board slug"):
+        policy_path_for_board("../evil", home=tmp_path)
+
+
+def test_missing_policy_returns_default(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(tmp_path))
+
+    policy = load_policy("missing")
+
+    assert policy.board == "missing"
+    assert policy.project_root is None
+
+
+def test_invalid_policy_reports_error(tmp_path, monkeypatch):
+    policies = tmp_path / "kanban" / "policies"
+    policies.mkdir(parents=True)
+    (policies / "demo.json").write_text(json.dumps({"max_active_issue_pipelines": 0}))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(tmp_path))
+
+    report = policy_report("demo")
+
+    assert report["configured"] is True
+    assert report["errors"]
+
+
+def test_worktree_under_policy_root_passes(tmp_path):
+    project = tmp_path / "Project"
+    policy = BoardPolicy(board="demo", project_root=project, worktree_root=project / ".worktrees")
+
+    findings = validate_workspace(
+        policy,
+        workspace_kind="worktree",
+        workspace_path=str(project / ".worktrees" / "task-1"),
+        repo_touching=True,
+    )
+
+    assert findings == []
+
+
+def test_worktree_outside_policy_root_fails(tmp_path):
+    project = tmp_path / "Project"
+    policy = BoardPolicy(board="demo", project_root=project, worktree_root=project / ".worktrees")
+
+    findings = validate_workspace(
+        policy,
+        workspace_kind="worktree",
+        workspace_path=str(tmp_path / "scratch" / "task-1"),
+        repo_touching=True,
+    )
+
+    assert any(f.code == "worktree_outside_policy_root" for f in findings)
+
+
+def test_shared_project_root_fails_for_repo_touching_card(tmp_path):
+    project = tmp_path / "Project"
+    policy = BoardPolicy(board="demo", project_root=project, worktree_root=project / ".worktrees")
+
+    findings = validate_workspace(
+        policy,
+        workspace_kind="worktree",
+        workspace_path=str(project),
+        repo_touching=True,
+    )
+
+    assert any(f.code == "shared_project_root_workspace" for f in findings)
+
+
+def test_denied_workspace_root_fails(tmp_path):
+    project = tmp_path / "Project"
+    denied = tmp_path / ".hermes" / "kanban"
+    policy = BoardPolicy(
+        board="demo",
+        project_root=project,
+        worktree_root=project / ".worktrees",
+        denied_workspace_roots=[denied],
+    )
+
+    findings = validate_workspace(
+        policy,
+        workspace_kind="worktree",
+        workspace_path=str(denied / "boards" / "demo" / "workspaces" / "t1"),
+        repo_touching=True,
+    )
+
+    assert any(f.code == "workspace_under_denied_root" for f in findings)
+
+
+def test_policy_guidance_includes_safe_roots(tmp_path):
+    project = tmp_path / "Project"
+    policy = BoardPolicy(
+        board="demo",
+        project_root=project,
+        worktree_root=project / ".worktrees",
+        denied_workspace_roots=[tmp_path / ".hermes"],
+        max_active_issue_pipelines=1,
+    )
+
+    guidance = format_policy_guidance(policy)
+
+    assert "Board policy" in guidance
+    assert str(project.resolve(strict=False)) in guidance
+    assert "read-only" in guidance
+    assert "Max active issue pipelines: 1" in guidance

--- a/tests/test_kanban_project_workspace_policy.py
+++ b/tests/test_kanban_project_workspace_policy.py
@@ -1,0 +1,63 @@
+from types import SimpleNamespace
+
+from hermes_cli.kanban_policy import BoardPolicy
+from hermes_cli.kanban_validation import validate_tasks
+
+
+def _task(**overrides):
+    data = {
+        "id": "t_policy",
+        "title": "Implement GitHub issue #123",
+        "body": "validation_assertions_to_satisfy: VC-001",
+        "assignee": "fullstack-eng",
+        "status": "ready",
+        "workspace_kind": "worktree",
+        "workspace_path": "/outside/project/task",
+    }
+    data.update(overrides)
+    return SimpleNamespace(**data)
+
+
+def _policy(tmp_path):
+    project = tmp_path / "Project"
+    return BoardPolicy(
+        board="demo",
+        project_root=project,
+        worktree_root=project / ".worktrees",
+        denied_workspace_roots=[tmp_path / ".hermes" / "kanban"],
+    )
+
+
+def test_policy_worktree_outside_project_worktrees_is_error(tmp_path):
+    findings = validate_tasks([_task()], policy=_policy(tmp_path))
+    codes = {f.code for f in findings}
+    assert "worktree_outside_policy_root" in codes
+
+
+def test_policy_shared_project_root_worktree_is_error(tmp_path):
+    policy = _policy(tmp_path)
+    findings = validate_tasks([_task(workspace_path=str(policy.project_root))], policy=policy)
+    codes = {f.code for f in findings}
+    assert "shared_project_root_workspace" in codes
+
+
+def test_policy_project_local_worktree_is_allowed_for_ready_task(tmp_path):
+    policy = _policy(tmp_path)
+    findings = validate_tasks([
+        _task(workspace_path=str(policy.worktree_root / "issue-123"))
+    ], policy=policy)
+    codes = {f.code for f in findings}
+    assert "worktree_outside_policy_root" not in codes
+    assert "shared_project_root_workspace" not in codes
+    assert "repo_completion_missing_commit" not in codes
+    assert "repo_completion_not_clean" not in codes
+    assert "missing_commands_run_exit_codes" not in codes
+
+
+def test_policy_denied_control_plane_root_is_error(tmp_path):
+    policy = _policy(tmp_path)
+    findings = validate_tasks([
+        _task(workspace_path=str(tmp_path / ".hermes" / "kanban" / "boards" / "demo" / "workspaces" / "t1"))
+    ], policy=policy)
+    codes = {f.code for f in findings}
+    assert "workspace_under_denied_root" in codes

--- a/tests/test_kanban_validation.py
+++ b/tests/test_kanban_validation.py
@@ -1,0 +1,103 @@
+import os
+from pathlib import Path
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_validation as kv
+
+
+class PendingRun:
+    def __init__(self, summary=None, metadata=None):
+        self.summary = summary
+        self.metadata = metadata
+
+
+def _isolated_board(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(tmp_path / "kanban.db"))
+    kb.init_db()
+
+
+def test_validate_flags_promissory_known_failure_without_issue(tmp_path, monkeypatch):
+    _isolated_board(tmp_path, monkeypatch)
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="Review PR", assignee="reviewer")
+        task = kb.get_task(conn, tid)
+    findings = kv.validate_tasks(
+        [task],
+        {
+            tid: [
+                PendingRun(
+                    summary="Known pre-existing failure: bootstrap still fails; issue will be created.",
+                    metadata={"commands_run": [{"command": "pytest", "exit_code": 1}]},
+                )
+            ]
+        },
+    )
+    assert any(f.code == "known_failure_not_verified_tracked" for f in findings)
+
+
+def test_validate_accepts_clean_repo_completion_with_command_exit_codes(tmp_path, monkeypatch):
+    _isolated_board(tmp_path, monkeypatch)
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="Implement UI page",
+            body="validation_assertions_to_satisfy: VC-001",
+            assignee="fullstack-eng",
+            workspace_kind="worktree",
+            workspace_path=str(tmp_path),
+        )
+        task = kb.get_task(conn, tid)
+    findings = kv.validate_tasks(
+        [task],
+        {
+            tid: [
+                PendingRun(
+                    summary="done",
+                    metadata={
+                        "commands_run": [
+                            {
+                                "command": "pytest",
+                                "exit_code": 0,
+                                "purpose": "tests",
+                                "result_summary": "passed",
+                            }
+                        ],
+                        "commit": "abc1234",
+                        "git_status": "clean",
+                        "changed_files": ["app/page.tsx"],
+                        "validation_assertions_satisfied": ["VC-001"],
+                        "validation_assertions_failed": [],
+                    },
+                )
+            ]
+        },
+    )
+    assert [f.to_dict() for f in findings] == []
+
+
+def test_validate_flags_missing_live_qa_evidence_for_user_visible_card(tmp_path, monkeypatch):
+    _isolated_board(tmp_path, monkeypatch)
+    with kb.connect() as conn:
+        tid = kb.create_task(
+            conn,
+            title="QA browser page flow VC-002",
+            body="validation_assertions_to_verify: VC-002",
+            assignee="qa-eng",
+        )
+        task = kb.get_task(conn, tid)
+    findings = kv.validate_tasks(
+        [task],
+        {
+            tid: [
+                PendingRun(
+                    summary="qa done",
+                    metadata={
+                        "commands_run": [
+                            {"command": "npm run test:e2e", "exit_code": 0}
+                        ],
+                    },
+                )
+            ]
+        },
+    )
+    assert any(f.code == "user_visible_qa_missing_live_evidence" for f in findings)

--- a/tests/tools/test_kanban_tools.py
+++ b/tests/tools/test_kanban_tools.py
@@ -332,6 +332,107 @@ def test_create_happy_path(worker_env):
         conn.close()
 
 
+
+def test_create_release_manager_auto_dedupes_by_branch(worker_env):
+    """Duplicate release cards for the same implementation branch collapse."""
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+
+    args = {
+        "title": "Release issue #68 admin course content persistence fix",
+        "assignee": "release-manager",
+        "body": "Source issue: #68\nImplementation branch/worktree: agent/issue-68-course-content-save at /tmp/wt\nMerge when gates pass.",
+    }
+    first = json.loads(kt._handle_create(args))
+    second = json.loads(kt._handle_create({
+        "title": "Release PR for issue #68 admin course edit-save-reload persistence",
+        "assignee": "release-manager",
+        "body": "QA passed. Branch: agent/issue-68-course-content-save\nCommit: abc123",
+    }))
+
+    assert first["ok"] is True
+    assert second["ok"] is True
+    assert first["task_id"] == second["task_id"]
+    assert first["idempotency_key"] == "auto:release-branch-agent/issue-68-course-content-save"
+    assert second["idempotency_key"] == first["idempotency_key"]
+
+    with kb.connect() as conn:
+        rows = conn.execute(
+            "SELECT id FROM tasks WHERE idempotency_key = ?",
+            ("auto:release-branch-agent/issue-68-course-content-save",),
+        ).fetchall()
+    assert len(rows) == 1
+
+
+def test_create_qa_cards_auto_dedupe_by_branch(worker_env):
+    """Duplicate QA gates for the same implementation branch collapse."""
+    from tools import kanban_tools as kt
+    from hermes_cli import kanban_db as kb
+
+    first = json.loads(kt._handle_create({
+        "title": "QA issue #75 admin course video title display",
+        "assignee": "qa-eng",
+        "body": "Branch: agent/issue-75-video-title\nVerify VC-75 assertions with manual/E2E evidence.",
+    }))
+    second = json.loads(kt._handle_create({
+        "title": "QA issue #75 admin video title row fix",
+        "assignee": "qa-eng",
+        "body": "Manually/E2E verify branch agent/issue-75-video-title after review passes.",
+    }))
+
+    assert first["ok"] is True
+    assert second["ok"] is True
+    assert first["task_id"] == second["task_id"]
+    assert first["idempotency_key"] == "auto:qa-branch-agent/issue-75-video-title"
+    assert second["idempotency_key"] == first["idempotency_key"]
+
+    with kb.connect() as conn:
+        rows = conn.execute(
+            "SELECT id FROM tasks WHERE idempotency_key = ?",
+            ("auto:qa-branch-agent/issue-75-video-title",),
+        ).fetchall()
+    assert len(rows) == 1
+
+
+def test_create_qa_cards_auto_dedupe_by_issue_when_no_branch(worker_env):
+    """One QA owner should aggregate validation for a single issue."""
+    from tools import kanban_tools as kt
+
+    first = json.loads(kt._handle_create({
+        "title": "QA issue #75 admin course video title display",
+        "assignee": "qa-eng",
+        "body": "Source issue: https://github.com/org/repo/issues/75\nValidation assertions to verify: VC-75-1.",
+    }))
+    second = json.loads(kt._handle_create({
+        "title": "QA issue #75 admin video title row fix",
+        "assignee": "qa-eng",
+        "body": "Manual regression for issue #75 after reviewer approval.",
+    }))
+
+    assert first["ok"] is True
+    assert second["ok"] is True
+    assert first["task_id"] == second["task_id"]
+    assert first["idempotency_key"] == "auto:qa-issue-75"
+    assert second["idempotency_key"] == first["idempotency_key"]
+
+
+def test_create_non_gate_cards_do_not_auto_dedupe(worker_env):
+    from tools import kanban_tools as kt
+
+    args = {
+        "title": "Review issue #68 admin course edit-save-reload persistence",
+        "assignee": "reviewer",
+        "body": "Branch: agent/issue-68-course-content-save",
+    }
+    first = json.loads(kt._handle_create(args))
+    second = json.loads(kt._handle_create(args))
+
+    assert first["ok"] is True
+    assert second["ok"] is True
+    assert first["task_id"] != second["task_id"]
+    assert first["idempotency_key"] is None
+    assert second["idempotency_key"] is None
+
 def test_create_rejects_no_title(worker_env):
     from tools import kanban_tools as kt
     assert json.loads(kt._handle_create({"assignee": "x"})).get("error")

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -28,8 +28,10 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 from typing import Any, Optional
 
+from hermes_cli import kanban_policy as kp
 from tools.registry import registry, tool_error
 
 logger = logging.getLogger(__name__)
@@ -249,6 +251,27 @@ def _handle_complete(args: dict, **kw) -> str:
         kb, conn = _connect()
         try:
             try:
+                # Non-blocking completion lint: surface weak handoffs before
+                # persisting them. The board-level `hermes kanban validate`
+                # command is the hard non-zero gate for operators/CI.
+                validation_warnings = []
+                try:
+                    from hermes_cli import kanban_validation as kv
+                    task = kb.get_task(conn, tid)
+                    if task is not None:
+                        class _PendingRun:
+                            def __init__(self, summary, metadata):
+                                self.summary = summary
+                                self.metadata = metadata
+                        pending = _PendingRun(summary if summary is not None else result, metadata)
+                        validation_warnings = [
+                            f.to_dict()
+                            for f in kv.validate_tasks([task], {tid: [pending]}, policy=kp.load_policy(kb.get_current_board()))
+                            if f.severity == "error"
+                        ]
+                except Exception:
+                    validation_warnings = []
+
                 ok = kb.complete_task(
                     conn, tid,
                     result=result, summary=summary, metadata=metadata,
@@ -271,7 +294,10 @@ def _handle_complete(args: dict, **kw) -> str:
                     f"could not complete {tid} (unknown id or already terminal)"
                 )
             run = kb.latest_run(conn, tid)
-            return _ok(task_id=tid, run_id=run.id if run else None)
+            payload = {"task_id": tid, "run_id": run.id if run else None}
+            if validation_warnings:
+                payload["validation_warnings"] = validation_warnings
+            return _ok(**payload)
         finally:
             conn.close()
     except Exception as e:
@@ -386,6 +412,51 @@ def _handle_comment(args: dict, **kw) -> str:
         return tool_error(f"kanban_comment: {e}")
 
 
+def _gate_dedupe_key_from_create_args(args: dict) -> Optional[str]:
+    """Infer a conservative gate-card idempotency key.
+
+    Multi-agent Kanban workers can accidentally create overlapping QA and
+    release gates for the same implementation branch/issue. Keep this guard
+    narrow: only final gate roles (`qa-eng` and `release-manager`), and only
+    when the body/title exposes a PR number, branch, or issue. Review/security
+    cards are intentionally excluded because multiple specialist reviews may
+    be valid for one branch.
+    """
+    assignee = str(args.get("assignee") or "").strip()
+    role_prefix = {
+        "release-manager": "release",
+        "qa-eng": "qa",
+    }.get(assignee)
+    if not role_prefix:
+        return None
+    text = "\n".join(str(args.get(k) or "") for k in ("title", "body"))
+    # Prefer PR number when the gate is explicitly PR-scoped.
+    m = re.search(r"(?:PR|pull request)\s*#?(\d+)", text, re.IGNORECASE)
+    if m:
+        return f"auto:{role_prefix}-pr-{m.group(1)}"
+    # Git branches are the next-best unique release/QA artifact.
+    m = re.search(r"(?:Branch|Implementation branch/worktree|branch/worktree)\s*:?\s*([^\s`]+)", text, re.IGNORECASE)
+    if m:
+        branch = m.group(1).strip().strip("`.,;)")
+        if branch:
+            return f"auto:{role_prefix}-branch-{branch}"
+    if role_prefix == "release":
+        # Fall back to issue number only for cards that are clearly release cards.
+        if re.search(r"release|merge|squash|close keyword", text, re.IGNORECASE):
+            m = re.search(r"(?:issue|fix(?:e[sd])?|close[sd]?)\s*#(\d+)", text, re.IGNORECASE)
+            if m:
+                return f"auto:{role_prefix}-issue-{m.group(1)}"
+    else:
+        # QA is the user-visible validation owner; one QA gate should aggregate
+        # all assertions/evidence for a branch/issue instead of spawning parallel
+        # browser/E2E runs. Require clear QA-ish language before issue fallback.
+        if re.search(r"\bQA\b|quality|verify|validation|manual|E2E|regression", text, re.IGNORECASE):
+            m = re.search(r"(?:issue|fix(?:e[sd])?)\s*#(\d+)", text, re.IGNORECASE)
+            if m:
+                return f"auto:{role_prefix}-issue-{m.group(1)}"
+    return None
+
+
 def _handle_create(args: dict, **kw) -> str:
     """Create a child task. Orchestrator workers use this to fan out.
 
@@ -409,6 +480,8 @@ def _handle_create(args: dict, **kw) -> str:
     workspace_path = args.get("workspace_path")
     triage = bool(args.get("triage"))
     idempotency_key = args.get("idempotency_key")
+    if not idempotency_key:
+        idempotency_key = _gate_dedupe_key_from_create_args(args)
     max_runtime_seconds = args.get("max_runtime_seconds")
     skills = args.get("skills")
     if isinstance(skills, str):
@@ -450,6 +523,7 @@ def _handle_create(args: dict, **kw) -> str:
             return _ok(
                 task_id=new_tid,
                 status=new_task.status if new_task else None,
+                idempotency_key=idempotency_key,
             )
         finally:
             conn.close()


### PR DESCRIPTION
## Summary

Adds a generic, config-driven policy layer for Hermes Kanban boards so workflow constraints can live in per-board configuration instead of hardcoded source patches.

Highlights:
- Add per-board policy loading, validation, reporting, and worker guidance.
- Add `hermes kanban --board <board> policy show|validate`.
- Add hard-gate Kanban validation/linting hooks for workspace policy errors.
- Make default worktree resolution policy-aware via configured `worktree_root`.
- Add conservative inventory/cleanup/teardown helpers for board operations.
- Harden cleanup/teardown so destructive teardown only stops DB-recorded worker PIDs, reports broad process matches without killing them, and verifies removals before reporting success.
- Add board-level `max_active_issue_pipelines` throttling, including same-tick and dry-run dispatch behavior.
- Document the policy schema with a generic example.

## Why

Kanban-backed autonomous workflows often need board-specific safety rules such as canonical project roots, task worktree roots, denied scratch/control-plane roots, concurrency limits, validation gates, and cleanup behavior. Keeping those rules in source creates fork drift. This PR moves them into explicit board policy configuration while keeping the core implementation generic.

## How to test

Example usage:

```bash
hermes kanban --board example policy show --json
hermes kanban --board example policy validate --json
hermes kanban --board example validate --json
hermes kanban --board example inventory --json
hermes kanban --board example cleanup --dry-run --json
```

Local verification run on Linux:

```bash
python -m pytest -q \
  tests/hermes_cli/test_kanban_policy.py \
  tests/hermes_cli/test_kanban_cleanup.py \
  tests/test_kanban_validation.py \
  tests/test_kanban_project_workspace_policy.py \
  tests/hermes_cli/test_kanban_db.py \
  tests/hermes_cli/test_kanban_core_functionality.py \
  tests/hermes_cli/test_kanban_cli.py \
  tests/tools/test_kanban_tools.py

python -m compileall -q hermes_cli tools agent plugins
git diff --check
```

Result:

```text
310 passed
```

The direct pytest command above passed.

## Platforms tested

- Linux local development environment

## Notes

- Commit follows the repository's Conventional Commits format: `feat(kanban): add board policy layer`.
- The PR branch is a single sanitized commit on top of `origin/main`.
