### PR TITLE
fix: include dev deps when building web ui

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5523,6 +5523,7 @@ def _run_npm_install_deterministic(
     *,
     extra_args: tuple[str, ...] = (),
     capture_output: bool = True,
+    include_dev: bool = False,
 ) -> subprocess.CompletedProcess:
     """Run a deterministic npm install that does not mutate ``package-lock.json``.
 
@@ -5532,10 +5533,17 @@ def _run_npm_install_deterministic(
     rewrites committed lockfiles (stripping ``"peer": true`` etc.), which leaves
     the working tree dirty and causes the next ``hermes update`` to stash the
     lockfile — repeatedly.
+
+    ``include_dev=True`` forces devDependencies to be installed even when the
+    parent environment exports ``NODE_ENV=production``.  This matters for build
+    steps such as the Web UI, where TypeScript/Vite live in devDependencies and
+    npm would otherwise omit them, causing build failures like ``tsc: command not
+    found`` during ``hermes update``.
     """
+    install_mode_args = ("--include=dev",) if include_dev else ()
     lockfile = cwd / "package-lock.json"
     if lockfile.exists():
-        ci_cmd = [npm, "ci", *extra_args]
+        ci_cmd = [npm, "ci", *install_mode_args, *extra_args]
         ci_result = subprocess.run(
             ci_cmd,
             cwd=cwd,
@@ -5547,7 +5555,7 @@ def _run_npm_install_deterministic(
             return ci_result
         # Fall through to `npm install` — lockfile may be out of sync on a
         # WIP fork/branch, or `npm ci` may not be available on very old npm.
-    install_cmd = [npm, "install", *extra_args]
+    install_cmd = [npm, "install", *install_mode_args, *extra_args]
     return subprocess.run(
         install_cmd,
         cwd=cwd,
@@ -5580,7 +5588,12 @@ def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
             print("Install Node.js, then run:  cd web && npm install && npm run build")
         return not fatal
     print("→ Building web UI...")
-    r1 = _run_npm_install_deterministic(npm, web_dir, extra_args=("--silent",))
+    r1 = _run_npm_install_deterministic(
+        npm,
+        web_dir,
+        extra_args=("--silent",),
+        include_dev=True,
+    )
     if r1.returncode != 0:
         print(
             f"  {'✗' if fatal else '⚠'} Web UI npm install failed"

--- a/tests/hermes_cli/test_web_ui_build.py
+++ b/tests/hermes_cli/test_web_ui_build.py
@@ -13,7 +13,11 @@ from unittest.mock import patch
 
 import pytest
 
-from hermes_cli.main import _web_ui_build_needed, _build_web_ui
+from hermes_cli.main import (
+    _build_web_ui,
+    _run_npm_install_deterministic,
+    _web_ui_build_needed,
+)
 
 
 def _touch(path: Path, offset: float = 0.0) -> None:
@@ -96,6 +100,48 @@ class TestWebUIBuildNeeded:
         assert _web_ui_build_needed(web_dir) is False
 
 
+class TestDeterministicNpmInstall:
+
+    def test_include_dev_adds_flag_to_npm_ci(self, tmp_path):
+        web_dir, _ = _make_web_dir(tmp_path)
+        (web_dir / "package-lock.json").touch()
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return __import__("subprocess").CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with patch("hermes_cli.main.subprocess.run", side_effect=fake_run):
+            result = _run_npm_install_deterministic(
+                "/usr/bin/npm",
+                web_dir,
+                extra_args=("--silent",),
+                include_dev=True,
+            )
+
+        assert result.returncode == 0
+        assert calls == [["/usr/bin/npm", "ci", "--include=dev", "--silent"]]
+
+    def test_include_dev_adds_flag_to_npm_install_fallback(self, tmp_path):
+        web_dir, _ = _make_web_dir(tmp_path)
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return __import__("subprocess").CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with patch("hermes_cli.main.subprocess.run", side_effect=fake_run):
+            result = _run_npm_install_deterministic(
+                "/usr/bin/npm",
+                web_dir,
+                extra_args=("--silent",),
+                include_dev=True,
+            )
+
+        assert result.returncode == 0
+        assert calls == [["/usr/bin/npm", "install", "--include=dev", "--silent"]]
+
+
 class TestBuildWebUISkipsWhenFresh:
 
     def test_skips_npm_when_dist_is_fresh(self, tmp_path):
@@ -112,10 +158,18 @@ class TestBuildWebUISkipsWhenFresh:
     def test_runs_npm_when_dist_missing(self, tmp_path):
         web_dir, _ = _make_web_dir(tmp_path)
 
-        mock_cp = __import__("subprocess").CompletedProcess([], 0, stdout=b"", stderr=b"")
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return __import__("subprocess").CompletedProcess(cmd, 0, stdout="", stderr="")
+
         with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
-             patch("hermes_cli.main.subprocess.run", return_value=mock_cp) as mock_run:
+             patch("hermes_cli.main.subprocess.run", side_effect=fake_run):
             result = _build_web_ui(web_dir)
 
         assert result is True
-        assert mock_run.call_count == 2  # npm install + npm run build
+        assert calls == [
+            ["/usr/bin/npm", "install", "--include=dev", "--silent"],
+            ["/usr/bin/npm", "run", "build"],
+        ]


### PR DESCRIPTION
## Bug Description

`hermes update` could fail to rebuild the WebUI when the parent environment exported `NODE_ENV=production`.

In that scenario, npm omitted `devDependencies`, so the frontend build failed with `tsc: command not found` and the update finished with the WebUI unavailable.

## Root Cause

The WebUI build path used deterministic npm install logic without explicitly including dev dependencies.

That was unsafe because the frontend build depends on tooling from `devDependencies` (notably TypeScript/Vite), while `NODE_ENV=production` causes npm to omit them by default.

## Fix

- add an `include_dev` flag to `_run_npm_install_deterministic()`
- force `npm ci --include=dev` / `npm install --include=dev` for the WebUI build path
- add regression coverage for both install paths and the WebUI build invocation

## How to Verify

1. Export `NODE_ENV=production`
2. Run the WebUI build flow
3. Confirm the build succeeds instead of failing with `tsc: command not found`

## Test Plan

- [x] Added regression test for this bug
- [x] Existing focused tests pass
- [x] Manual verification of the fix

Validation performed:
- `NODE_ENV=production npm run build` passed after the fix
- `python -m pytest tests/hermes_cli/test_web_ui_build.py -q -o addopts=''` → `13 passed`

## Risk Assessment

Low — the change only affects the frontend build dependency install path and makes the WebUI build explicit and deterministic under production-like environments.
