### PR TITLE
fix: detect Chromium installed by agent-browser 0.26+

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -3289,6 +3289,8 @@ def _chromium_search_roots() -> List[str]:
     3. ``~/Library/Caches/ms-playwright`` — Playwright's default on macOS.
     4. ``%USERPROFILE%\\AppData\\Local\\ms-playwright`` — Playwright's default
        on Windows.
+    5. ``~/.agent-browser/browsers/`` — agent-browser's own browser cache
+       (0.26+).  Downloads Chrome for Testing here on ``agent-browser install``.
     """
     roots: List[str] = []
     env_path = os.environ.get("PLAYWRIGHT_BROWSERS_PATH", "").strip()
@@ -3303,6 +3305,9 @@ def _chromium_search_roots() -> List[str]:
             home, "AppData", "Local"
         )
         roots.append(os.path.join(local, "ms-playwright"))
+    # agent-browser (0.26+) stores Chrome for Testing builds here
+    # (e.g. chrome-148.0.7778.56/) instead of the Playwright cache.
+    roots.append(os.path.join(home, ".agent-browser", "browsers"))
     return roots
 
 
@@ -3351,11 +3356,12 @@ def _chromium_installed() -> bool:
         except OSError:
             continue
         # Playwright names them ``chromium-<build>`` and
-        # ``chromium_headless_shell-<build>``; agent-browser accepts either.
+        # ``chromium_headless_shell-<build>``; agent-browser (0.26+)
+        # uses ``chrome-<build>`` (Chrome for Testing).  Accept all variants.
         for entry in entries:
             if entry.startswith("chromium-") or entry.startswith(
                 "chromium_headless_shell-"
-            ):
+            ) or entry.startswith("chrome-"):
                 _cached_chromium_installed = True
                 return True
 


### PR DESCRIPTION
## Problem

`hermes doctor` reports `browser (system dependency not met)` even when `agent-browser` and Chrome are fully functional.

`agent-browser doctor` shows all green, but `_chromium_installed()` in `tools/browser_tool.py` returns `False` because it only searches:

1. `AGENT_BROWSER_EXECUTABLE_PATH` env var
2. System PATH for `google-chrome`/`chromium-browser`/`chrome`
3. Playwright cache dirs (`~/.cache/ms-playwright/`) for `chromium-*` directories

agent-browser 0.26+ downloads **Chrome for Testing** into `~/.agent-browser/browsers/` as `chrome-<build>/` (e.g. `chrome-148.0.7778.56/`). This path was missed on both counts — wrong directory and wrong prefix (`chrome-*` vs `chromium-*`).

## Fix

- Add `~/.agent-browser/browsers/` to `_chromium_search_roots()`
- Match `chrome-*` prefix alongside `chromium-*` and `chromium_headless_shell-*`

## Before / After

```
# Before
⚠ browser (system dependency not met)

# After  
✓ browser
```

All 315 browser-related tests pass.