### PR TITLE
feat: add TinyFish as a web backend

### DIFF
--- a/tests/tools/test_web_providers_searxng.py
+++ b/tests/tools/test_web_providers_searxng.py
@@ -290,6 +290,8 @@ class TestCheckWebApiKey:
         monkeypatch.delenv("SEARXNG_URL", raising=False)
         monkeypatch.setattr(web_tools, "_is_tool_gateway_ready", lambda: False)
         monkeypatch.setattr(web_tools, "check_firecrawl_api_key", lambda: False)
+        monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: False)
+        monkeypatch.setattr(web_tools, "_is_tinyfish_available", lambda: False)
         assert web_tools.check_web_api_key() is False
 
 

--- a/tests/tools/test_web_providers_tinyfish.py
+++ b/tests/tools/test_web_providers_tinyfish.py
@@ -1,0 +1,223 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from tools import web_tools
+
+
+class _FakeEntry:
+    def __init__(self, *, handler=None, check_fn=None):
+        self.handler = handler
+        self.check_fn = check_fn
+
+
+class TestTinyFishBackendWiring:
+    def test_is_backend_available_true_when_mcp_tools_present(self, monkeypatch):
+        entries = {
+            "mcp_tinyfish_search": _FakeEntry(check_fn=lambda: True),
+            "mcp_tinyfish_fetch_content": _FakeEntry(check_fn=lambda: True),
+        }
+        monkeypatch.setattr(web_tools.registry, "get_entry", lambda name: entries.get(name))
+
+        assert web_tools._is_backend_available("tinyfish") is True
+
+    def test_tinyfish_not_available_when_registered_but_disconnected(self, monkeypatch):
+        entries = {
+            "mcp_tinyfish_search": _FakeEntry(check_fn=lambda: False),
+            "mcp_tinyfish_fetch_content": _FakeEntry(check_fn=lambda: False),
+        }
+        monkeypatch.setattr(web_tools.registry, "get_entry", lambda name: entries.get(name))
+
+        assert web_tools._is_backend_available("tinyfish") is False
+
+    def test_check_web_api_key_true_when_tinyfish_is_configured(self, monkeypatch):
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "tinyfish"})
+        monkeypatch.setattr(web_tools, "_is_tinyfish_available", lambda: True)
+
+        assert web_tools.check_web_api_key() is True
+
+
+class TestTinyFishSearch:
+    def test_web_search_tool_normalizes_tinyfish_results(self, monkeypatch):
+        monkeypatch.setattr(web_tools, "_get_search_backend", lambda: "tinyfish")
+        monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False, raising=False)
+
+        payload = {
+            "results": [
+                {
+                    "title": "TinyFish docs",
+                    "url": "https://docs.tinyfish.ai/",
+                    "snippet": "Agent docs",
+                    "position": 1,
+                    "site_name": "docs.tinyfish.ai",
+                }
+            ]
+        }
+        entry = SimpleNamespace(handler=lambda args: json.dumps({"result": json.dumps(payload)}))
+        monkeypatch.setattr(web_tools.registry, "get_entry", lambda name: entry if name == "mcp_tinyfish_search" else None)
+
+        result = json.loads(web_tools.web_search_tool("tinyfish", limit=3))
+
+        assert result["success"] is True
+        assert result["data"]["web"] == [
+            {
+                "title": "TinyFish docs",
+                "url": "https://docs.tinyfish.ai/",
+                "description": "Agent docs",
+                "position": 1,
+            }
+        ]
+
+    def test_web_search_tool_uses_structured_content_when_present(self, monkeypatch):
+        monkeypatch.setattr(web_tools, "_get_search_backend", lambda: "tinyfish")
+        monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False, raising=False)
+
+        payload = {
+            "results": [
+                {
+                    "title": "Structured TinyFish docs",
+                    "url": "https://docs.tinyfish.ai/structured",
+                    "snippet": "Structured payload",
+                    "position": 1,
+                }
+            ]
+        }
+        entry = SimpleNamespace(handler=lambda args: json.dumps({"result": "OK", "structuredContent": payload}))
+        monkeypatch.setattr(web_tools.registry, "get_entry", lambda name: entry if name == "mcp_tinyfish_search" else None)
+
+        result = json.loads(web_tools.web_search_tool("tinyfish", limit=3))
+
+        assert result["success"] is True
+        assert result["data"]["web"][0]["title"] == "Structured TinyFish docs"
+
+
+class TestTinyFishExtract:
+    @pytest.mark.asyncio
+    async def test_web_extract_tool_normalizes_tinyfish_results(self, monkeypatch):
+        monkeypatch.setattr(web_tools, "_get_extract_backend", lambda: "tinyfish")
+        monkeypatch.setattr(web_tools, "check_auxiliary_model", lambda: False)
+        monkeypatch.setattr(web_tools, "check_website_access", lambda url: None)
+        monkeypatch.setattr(web_tools, "is_safe_url", lambda url: True)
+
+        payload = {
+            "results": [
+                {
+                    "url": "https://docs.tinyfish.ai/",
+                    "final_url": "https://docs.tinyfish.ai/",
+                    "title": "TinyFish Developer Documentation",
+                    "text": "Full extracted content",
+                }
+            ],
+            "errors": [],
+        }
+        entry = SimpleNamespace(handler=lambda args: json.dumps({"result": json.dumps(payload)}))
+        monkeypatch.setattr(web_tools.registry, "get_entry", lambda name: entry if name == "mcp_tinyfish_fetch_content" else None)
+
+        result = json.loads(
+            await web_tools.web_extract_tool(["https://docs.tinyfish.ai/"], use_llm_processing=False)
+        )
+
+        assert result["results"] == [
+            {
+                "url": "https://docs.tinyfish.ai/",
+                "title": "TinyFish Developer Documentation",
+                "content": "Full extracted content",
+                "error": None,
+            }
+        ]
+
+    @pytest.mark.asyncio
+    async def test_web_extract_tool_uses_structured_content_when_present(self, monkeypatch):
+        monkeypatch.setattr(web_tools, "_get_extract_backend", lambda: "tinyfish")
+        monkeypatch.setattr(web_tools, "check_auxiliary_model", lambda: False)
+        monkeypatch.setattr(web_tools, "check_website_access", lambda url: None)
+        monkeypatch.setattr(web_tools, "is_safe_url", lambda url: True)
+
+        payload = {
+            "results": [
+                {
+                    "url": "https://docs.tinyfish.ai/structured",
+                    "final_url": "https://docs.tinyfish.ai/structured",
+                    "title": "Structured TinyFish Developer Documentation",
+                    "text": "Structured extracted content",
+                }
+            ],
+            "errors": [],
+        }
+        entry = SimpleNamespace(handler=lambda args: json.dumps({"result": "OK", "structuredContent": payload}))
+        monkeypatch.setattr(web_tools.registry, "get_entry", lambda name: entry if name == "mcp_tinyfish_fetch_content" else None)
+
+        result = json.loads(
+            await web_tools.web_extract_tool(["https://docs.tinyfish.ai/structured"], use_llm_processing=False)
+        )
+
+        assert result["results"][0]["title"] == "Structured TinyFish Developer Documentation"
+        assert result["results"][0]["content"] == "Structured extracted content"
+
+    @pytest.mark.asyncio
+    async def test_web_extract_tool_blocks_redirected_final_url(self, monkeypatch):
+        monkeypatch.setattr(web_tools, "_get_extract_backend", lambda: "tinyfish")
+        monkeypatch.setattr(web_tools, "check_auxiliary_model", lambda: False)
+        monkeypatch.setattr(web_tools, "is_safe_url", lambda url: True)
+
+        def fake_check(url):
+            if url == "https://allowed.test":
+                return None
+            if url == "https://blocked.test/final":
+                return {
+                    "host": "blocked.test",
+                    "rule": "blocked.test",
+                    "source": "config",
+                    "message": "Blocked by website policy",
+                }
+            pytest.fail(f"unexpected URL checked: {url}")
+
+        payload = {
+            "results": [
+                {
+                    "url": "https://allowed.test",
+                    "final_url": "https://blocked.test/final",
+                    "title": "Redirected TinyFish page",
+                    "text": "secret content",
+                }
+            ],
+            "errors": [],
+        }
+        entry = SimpleNamespace(handler=lambda args: json.dumps({"result": json.dumps(payload)}))
+        monkeypatch.setattr(web_tools, "check_website_access", fake_check)
+        monkeypatch.setattr(web_tools.registry, "get_entry", lambda name: entry if name == "mcp_tinyfish_fetch_content" else None)
+
+        result = json.loads(await web_tools.web_extract_tool(["https://allowed.test"], use_llm_processing=False))
+
+        assert result["results"][0]["url"] == "https://blocked.test/final"
+        assert result["results"][0]["content"] == ""
+        assert result["results"][0]["blocked_by_policy"]["rule"] == "blocked.test"
+
+    @pytest.mark.asyncio
+    async def test_web_extract_tool_short_circuits_blocked_input_url(self, monkeypatch):
+        monkeypatch.setattr(web_tools, "_get_extract_backend", lambda: "tinyfish")
+        monkeypatch.setattr(web_tools, "check_auxiliary_model", lambda: False)
+        monkeypatch.setattr(web_tools, "is_safe_url", lambda url: True)
+        monkeypatch.setattr(
+            web_tools,
+            "check_website_access",
+            lambda url: {
+                "host": "blocked.test",
+                "rule": "blocked.test",
+                "source": "config",
+                "message": "Blocked by website policy",
+            },
+        )
+        monkeypatch.setattr(
+            web_tools.registry,
+            "get_entry",
+            lambda name: pytest.fail("TinyFish MCP fetch should not be called for blocked URL"),
+        )
+
+        result = json.loads(await web_tools.web_extract_tool(["https://blocked.test"], use_llm_processing=False))
+
+        assert result["results"][0]["url"] == "https://blocked.test"
+        assert "Blocked by website policy" in result["results"][0]["error"]

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -386,7 +386,9 @@ class TestBackendSelection:
     def test_fallback_no_keys_defaults_to_firecrawl(self):
         """No keys, no config → 'firecrawl' (will fail at client init)."""
         from tools.web_tools import _get_backend
-        with patch("tools.web_tools._load_web_config", return_value={}):
+        with patch("tools.web_tools._load_web_config", return_value={}), \
+             patch("tools.web_tools._ddgs_package_importable", return_value=False), \
+             patch("tools.web_tools._is_tinyfish_available", return_value=False):
             assert _get_backend() == "firecrawl"
 
     def test_invalid_config_falls_through_to_fallback(self):
@@ -582,7 +584,9 @@ class TestCheckWebApiKey:
 
     def test_no_keys_returns_false(self):
         from tools.web_tools import check_web_api_key
-        assert check_web_api_key() is False
+        with patch("tools.web_tools._ddgs_package_importable", return_value=False), \
+             patch("tools.web_tools._is_tinyfish_available", return_value=False):
+            assert check_web_api_key() is False
 
     def test_both_keys_returns_true(self):
         with patch.dict(os.environ, {

--- a/tests/tools/test_website_policy.py
+++ b/tests/tools/test_website_policy.py
@@ -351,6 +351,7 @@ def test_browser_navigate_allows_when_shared_file_missing(monkeypatch, tmp_path)
 async def test_web_extract_short_circuits_blocked_url(monkeypatch):
     from tools import web_tools
 
+    monkeypatch.setattr(web_tools, "_get_extract_backend", lambda: "firecrawl")
     # Allow test URLs past SSRF check so website policy is what gets tested
     monkeypatch.setattr(web_tools, "is_safe_url", lambda url: True)
     monkeypatch.setattr(
@@ -399,6 +400,7 @@ def test_check_website_access_fails_open_on_malformed_config(tmp_path, monkeypat
 async def test_web_extract_blocks_redirected_final_url(monkeypatch):
     from tools import web_tools
 
+    monkeypatch.setattr(web_tools, "_get_extract_backend", lambda: "firecrawl")
     # Allow test URLs past SSRF check so website policy is what gets tested
     monkeypatch.setattr(web_tools, "is_safe_url", lambda url: True)
 

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -126,7 +126,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in ("parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs"):
+    if configured in ("parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "tinyfish"):
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -139,6 +139,7 @@ def _get_backend() -> str:
         ("parallel", _has_env("PARALLEL_API_KEY")),
         ("tavily", _has_env("TAVILY_API_KEY")),
         ("exa", _has_env("EXA_API_KEY")),
+        ("tinyfish", _is_tinyfish_available()),
         ("searxng", _has_env("SEARXNG_URL")),
         ("brave-free", _has_env("BRAVE_SEARCH_API_KEY")),
         ("ddgs", _ddgs_package_importable()),
@@ -198,6 +199,8 @@ def _is_backend_available(backend: str) -> bool:
         return check_firecrawl_api_key()
     if backend == "tavily":
         return _has_env("TAVILY_API_KEY")
+    if backend == "tinyfish":
+        return _is_tinyfish_available()
     if backend == "searxng":
         return _has_env("SEARXNG_URL")
     if backend == "brave-free":
@@ -220,6 +223,148 @@ def _ddgs_package_importable() -> bool:
         return True
     except ImportError:
         return False
+
+
+def _get_tinyfish_entry(tool_name: str):
+    """Return a TinyFish MCP registry entry, or None when unavailable."""
+    return registry.get_entry(tool_name)
+
+
+def _is_tinyfish_entry_available(tool_name: str) -> bool:
+    """Return True when a TinyFish MCP tool is registered and live."""
+    entry = _get_tinyfish_entry(tool_name)
+    if entry is None:
+        return False
+    if entry.check_fn is None:
+        return True
+    try:
+        return bool(entry.check_fn())
+    except Exception:
+        return False
+
+
+def _is_tinyfish_available() -> bool:
+    """Return True when TinyFish MCP search + fetch tools are registered."""
+    return (
+        _is_tinyfish_entry_available("mcp_tinyfish_search")
+        and _is_tinyfish_entry_available("mcp_tinyfish_fetch_content")
+    )
+
+
+def _parse_tinyfish_result(raw: str) -> Dict[str, Any]:
+    """Parse the JSON envelope returned by TinyFish MCP tool handlers."""
+    outer = json.loads(raw)
+    if "error" in outer:
+        raise ValueError(str(outer["error"]))
+
+    structured = outer.get("structuredContent")
+    payload = outer.get("result")
+
+    if isinstance(payload, dict):
+        return payload
+    if isinstance(payload, list):
+        return {"results": payload}
+    if isinstance(payload, str):
+        try:
+            parsed = json.loads(payload)
+        except json.JSONDecodeError:
+            parsed = None
+        if isinstance(parsed, dict):
+            return parsed
+        if isinstance(parsed, list):
+            return {"results": parsed}
+
+    if isinstance(structured, dict):
+        return structured
+    if isinstance(structured, list):
+        return {"results": structured}
+
+    raise ValueError("TinyFish MCP returned an unexpected payload")
+
+
+def _tinyfish_search(query: str, limit: int) -> Dict[str, Any]:
+    """Run TinyFish MCP search and normalize to Hermes web_search shape."""
+    entry = _get_tinyfish_entry("mcp_tinyfish_search")
+    if entry is None:
+        raise ValueError("TinyFish MCP search tool is not connected")
+
+    payload = _parse_tinyfish_result(entry.handler({"query": query}))
+    web_results = []
+    for idx, item in enumerate(payload.get("results", [])[:limit], start=1):
+        web_results.append({
+            "title": item.get("title", ""),
+            "url": item.get("url", ""),
+            "description": item.get("snippet", ""),
+            "position": item.get("position", idx),
+        })
+
+    return {
+        "success": True,
+        "data": {
+            "web": web_results,
+        },
+    }
+
+
+def _tinyfish_extract(urls: List[str], format: Optional[str]) -> List[Dict[str, Any]]:
+    """Run TinyFish MCP fetch and normalize to Hermes web_extract shape."""
+    entry = _get_tinyfish_entry("mcp_tinyfish_fetch_content")
+    if entry is None:
+        raise ValueError("TinyFish MCP fetch tool is not connected")
+
+    output_format = format if format in {"markdown", "html", "json"} else "markdown"
+    args = {
+        "urls": urls,
+        "format": output_format,
+        "include_html_head": False,
+        "links": False,
+        "image_links": False,
+    }
+    payload = _parse_tinyfish_result(entry.handler(args))
+
+    results: List[Dict[str, Any]] = []
+    for item in payload.get("results", []):
+        final_url = item.get("final_url") or item.get("url", "")
+        blocked = check_website_access(final_url) if final_url else None
+        if blocked:
+            results.append({
+                "url": final_url,
+                "title": item.get("title", ""),
+                "content": "",
+                "raw_content": "",
+                "error": blocked["message"],
+                "blocked_by_policy": {"host": blocked["host"], "rule": blocked["rule"], "source": blocked["source"]},
+            })
+            continue
+
+        text = item.get("text")
+        if isinstance(text, (dict, list)):
+            text = json.dumps(text, ensure_ascii=False)
+        results.append({
+            "url": final_url,
+            "title": item.get("title", ""),
+            "content": text or "",
+            "raw_content": text or "",
+            "metadata": {
+                "description": item.get("description"),
+                "author": item.get("author"),
+                "published_date": item.get("published_date"),
+                "language": item.get("language"),
+                "sourceURL": final_url,
+            },
+        })
+
+    for item in payload.get("errors", []):
+        error_url = item.get("url") or item.get("final_url") or ""
+        results.append({
+            "url": error_url,
+            "title": item.get("title", ""),
+            "content": "",
+            "raw_content": "",
+            "error": item.get("error") or item.get("message") or "TinyFish fetch failed",
+        })
+
+    return results
 
 # ─── Firecrawl Client ────────────────────────────────────────────────────────
 
@@ -1213,6 +1358,15 @@ def web_search_tool(query: str, limit: int = 5) -> str:
             _debug.save()
             return result_json
 
+        if backend == "tinyfish":
+            response_data = _tinyfish_search(query, limit)
+            debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
+            result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
+            debug_call_data["final_response_size"] = len(result_json)
+            _debug.log_call("web_search_tool", debug_call_data)
+            _debug.save()
+            return result_json
+
         if backend == "searxng":
             from tools.web_providers.searxng import SearXNGSearchProvider
             response_data = SearXNGSearchProvider().search(query, limit)
@@ -1386,6 +1540,23 @@ async def web_extract_tool(
                 results = await _parallel_extract(safe_urls)
             elif backend == "exa":
                 results = _exa_extract(safe_urls)
+            elif backend == "tinyfish":
+                allowed_urls: List[str] = []
+                tinyfish_blocked: List[Dict[str, Any]] = []
+                for url in safe_urls:
+                    blocked = check_website_access(url)
+                    if blocked:
+                        tinyfish_blocked.append({
+                            "url": url,
+                            "title": "",
+                            "content": "",
+                            "raw_content": "",
+                            "error": blocked["message"],
+                            "blocked_by_policy": {"host": blocked["host"], "rule": blocked["rule"], "source": blocked["source"]},
+                        })
+                    else:
+                        allowed_urls.append(url)
+                results = tinyfish_blocked + (_tinyfish_extract(allowed_urls, format) if allowed_urls else [])
             elif backend == "tavily":
                 logger.info("Tavily extract: %d URL(s)", len(safe_urls))
                 raw = _tavily_request("extract", {
@@ -1399,7 +1570,7 @@ async def web_extract_tool(
                 return json.dumps({
                     "success": False,
                     "error": f"{_label} is a search-only backend and cannot extract URL content. "
-                             "Set web.extract_backend to firecrawl, tavily, exa, or parallel.",
+                             "Set web.extract_backend to firecrawl, tavily, exa, tinyfish, or parallel.",
                 }, ensure_ascii=False)
             else:
                 # ── Firecrawl extraction ──
@@ -2080,11 +2251,11 @@ def check_firecrawl_api_key() -> bool:
 def check_web_api_key() -> bool:
     """Check whether the configured web backend is available."""
     configured = _load_web_config().get("backend", "").lower().strip()
-    if configured in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs"):
+    if configured in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "tinyfish"):
         return _is_backend_available(configured)
     return any(
         _is_backend_available(backend)
-        for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs")
+        for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "tinyfish")
     )
 
 


### PR DESCRIPTION
## Summary
- wire TinyFish MCP search/fetch into Hermes `web_search` and `web_extract`
- treat TinyFish as a real selectable backend, including availability checks and `structuredContent` handling
- preserve website policy enforcement for blocked input URLs and redirected final URLs
- add regression tests for TinyFish backend wiring plus env-sensitive existing tests

## Verification
- `pytest tests/tools/test_web_tools_config.py tests/tools/test_web_providers.py tests/tools/test_web_providers_brave_free.py tests/tools/test_web_providers_ddgs.py tests/tools/test_web_providers_searxng.py tests/tools/test_web_tools_tavily.py tests/tools/test_web_providers_tinyfish.py tests/tools/test_website_policy.py tests/tools/test_mcp_structured_content.py -q`
- Result: `177 passed`
- Independent review subagent: pass

## Why
TinyFish was connected as an MCP server, but Hermes could not actually use it as the default web lane. This makes TinyFish a first-class backend instead of decorative plumbing.
