### PR TITLE
fix(security): sandbox execute_code against PYTHONPATH import of hermes internals

### DIFF
--- a/tests/tools/test_code_execution_modes.py
+++ b/tests/tools/test_code_execution_modes.py
@@ -450,6 +450,50 @@ class TestSecurityInvariantsAcrossModes(unittest.TestCase):
         self.assertIn("execute_code_available: False", result["output"])
         self.assertIn("delegate_task_available: False", result["output"])
 
+    def test_sandbox_cannot_import_hermes_internals_strict(self):
+        """Sandboxed code must not be able to import hermes-internal packages.
+
+        If the hermes-agent root were on PYTHONPATH, scripts could import
+        tools.approval to bypass the approval system or hermes_cli.auth to
+        read stored credentials.  Only the hermes_tools RPC stub (in tmpdir)
+        should be importable.
+        """
+        code = (
+            "import importlib\n"
+            "for mod in ('hermes_cli', 'hermes_cli.auth', 'agent', "
+            "'gateway', 'tools', 'tools.approval'):\n"
+            "    try:\n"
+            "        importlib.import_module(mod)\n"
+            "        print(f'IMPORTED:{mod}')\n"
+            "    except (ImportError, ModuleNotFoundError):\n"
+            "        print(f'BLOCKED:{mod}')\n"
+        )
+        result = self._run(code, mode="strict")
+        self.assertEqual(result["status"], "success")
+        for mod in ("hermes_cli", "hermes_cli.auth", "agent",
+                     "gateway", "tools", "tools.approval"):
+            self.assertNotIn(f"IMPORTED:{mod}", result["output"],
+                             f"Sandbox was able to import {mod}")
+
+    def test_sandbox_cannot_import_hermes_internals_project(self):
+        """CRITICAL: project mode does NOT expose hermes internals either."""
+        code = (
+            "import importlib\n"
+            "for mod in ('hermes_cli', 'hermes_cli.auth', 'agent', "
+            "'gateway', 'tools', 'tools.approval'):\n"
+            "    try:\n"
+            "        importlib.import_module(mod)\n"
+            "        print(f'IMPORTED:{mod}')\n"
+            "    except (ImportError, ModuleNotFoundError):\n"
+            "        print(f'BLOCKED:{mod}')\n"
+        )
+        result = self._run(code, mode="project")
+        self.assertEqual(result["status"], "success")
+        for mod in ("hermes_cli", "hermes_cli.auth", "agent",
+                     "gateway", "tools", "tools.approval"):
+            self.assertNotIn(f"IMPORTED:{mod}", result["output"],
+                             f"Sandbox was able to import {mod}")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/tools/test_env_passthrough.py
+++ b/tests/tools/test_env_passthrough.py
@@ -113,7 +113,7 @@ class TestExecuteCodeIntegration:
         """TENOR_API_KEY should be blocked without passthrough."""
         _SAFE_ENV_PREFIXES = ("PATH", "HOME", "USER", "LANG", "LC_", "TERM",
                               "TMPDIR", "TMP", "TEMP", "SHELL", "LOGNAME",
-                              "XDG_", "PYTHONPATH", "VIRTUAL_ENV", "CONDA")
+                              "XDG_", "VIRTUAL_ENV", "CONDA")
         _SECRET_SUBSTRINGS = ("KEY", "TOKEN", "SECRET", "PASSWORD", "CREDENTIAL",
                               "PASSWD", "AUTH")
 
@@ -136,7 +136,7 @@ class TestExecuteCodeIntegration:
         """TENOR_API_KEY should pass through when registered."""
         _SAFE_ENV_PREFIXES = ("PATH", "HOME", "USER", "LANG", "LC_", "TERM",
                               "TMPDIR", "TMP", "TEMP", "SHELL", "LOGNAME",
-                              "XDG_", "PYTHONPATH", "VIRTUAL_ENV", "CONDA")
+                              "XDG_", "VIRTUAL_ENV", "CONDA")
         _SECRET_SUBSTRINGS = ("KEY", "TOKEN", "SECRET", "PASSWORD", "CREDENTIAL",
                               "PASSWD", "AUTH")
 

--- a/tools/code_execution_tool.py
+++ b/tools/code_execution_tool.py
@@ -1033,7 +1033,7 @@ def execute_code(
         # (terminal.env_passthrough) are passed through.
         _SAFE_ENV_PREFIXES = ("PATH", "HOME", "USER", "LANG", "LC_", "TERM",
                               "TMPDIR", "TMP", "TEMP", "SHELL", "LOGNAME",
-                              "XDG_", "PYTHONPATH", "VIRTUAL_ENV", "CONDA",
+                              "XDG_", "VIRTUAL_ENV", "CONDA",
                               "HERMES_")
         _SECRET_SUBSTRINGS = ("KEY", "TOKEN", "SECRET", "PASSWORD", "CREDENTIAL",
                               "PASSWD", "AUTH")
@@ -1055,13 +1055,13 @@ def execute_code(
                 child_env[k] = v
         child_env["HERMES_RPC_SOCKET"] = sock_path
         child_env["PYTHONDONTWRITEBYTECODE"] = "1"
-        # Ensure the hermes-agent root is importable in the sandbox so
-        # repo-root modules are available to child scripts.  We also prepend
-        # the staging tmpdir so ``from hermes_tools import ...`` resolves even
-        # when the subprocess CWD is not tmpdir (project mode).
-        _hermes_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        # The hermes_tools.py stub module is in tmpdir, so tmpdir must be on
+        # PYTHONPATH.  The hermes-agent root is deliberately excluded: exposing
+        # it would let sandboxed scripts import internal modules (hermes_cli,
+        # agent, gateway, tools.approval) and bypass credential protection and
+        # the approval system.  See upstream security report.
         _existing_pp = child_env.get("PYTHONPATH", "")
-        _pp_parts = [tmpdir, _hermes_root]
+        _pp_parts = [tmpdir]
         if _existing_pp:
             _pp_parts.append(_existing_pp)
         child_env["PYTHONPATH"] = os.pathsep.join(_pp_parts)


### PR DESCRIPTION
## Problem (fixes #8028)

`execute_code` runs Python in a sandbox but inadvertently grants access to Hermes internals:

1. The sandbox's `PYTHONPATH` included `_hermes_root` (~/.hermes/hermes-agent), making `hermes_cli`, `agent`, `gateway`, `tools`, and all installed packages importable from sandboxed scripts
2. The `_SAFE_ENV_PREFIXES` allowed-list included `"PYTHONPATH"`, so a parent process's `PYTHONPATH` (possibly containing Hermes paths) was inherited into the sandbox

## Fix (defense in depth)

| Layer | Change |
|-------|--------|
| **Don't inject** | Remove `_hermes_root` from `_pp_parts` — only `tmpdir` (with the `hermes_tools.py` RPC stub) is added |
| **Don't inherit** | Remove `"PYTHONPATH"` from `_SAFE_ENV_PREFIXES` — parent PYTHONPATH no longer leaks in |

The `hermes_tools.py` stub in `tmpdir` is still importable, preserving backward compatibility for `from hermes_tools import terminal, …`.

## Changes

| File | Change |
|------|--------|
| `tools/code_execution_tool.py` | -2 lines: remove `_hermes_root` from PYTHONPATH; remove PYTHONPATH from safe env prefixes |
| `tests/tools/test_code_execution_modes.py` | +34 lines: 2 new security regression tests |
| `tests/tools/test_env_passthrough.py` | -2 lines: sync PYTHONPATH removal in test expectations