### PR TITLE
fix(tui): visual-line aware HOME/END/UP/DOWN navigation

### DIFF
--- a/ui-tui/src/__tests__/visualLineNav.test.ts
+++ b/ui-tui/src/__tests__/visualLineNav.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  isOnFirstVisualLine,
+  isOnLastVisualLine,
+  visualLineBounds,
+  visualLineNav
+} from '../lib/inputMetrics.js'
+
+describe('visualLineBounds — word-wrap-aware HOME/END (issue #22008)', () => {
+  it('returns whole-string bounds for an unwrapped single line', () => {
+    expect(visualLineBounds('hello world', 6, 40)).toEqual({ end: 11, start: 0 })
+  })
+
+  it('isolates the wrapped row when the cursor sits on row two', () => {
+    // 'hello world' at cols=8 wraps after the space → row 0 = 'hello ' (0..6),
+    // row 1 = 'world' (6..11). Cursor at offset 9 (the 'r') lives on row 1.
+    expect(visualLineBounds('hello world', 9, 8)).toEqual({ end: 11, start: 6 })
+  })
+
+  it('respects logical newlines as hard row boundaries', () => {
+    // 'one\ntwo' → row 0 = 'one' (0..3), row 1 = 'two' (4..7). Cursor in 'two'.
+    expect(visualLineBounds('one\ntwo', 5, 40)).toEqual({ end: 7, start: 4 })
+  })
+
+  it('reports the first row when the cursor sits at offset 0', () => {
+    expect(visualLineBounds('hello world', 0, 8)).toEqual({ end: 6, start: 0 })
+  })
+
+  it('clamps to last row when cursor is past the end', () => {
+    expect(visualLineBounds('abcdefgh', 99, 4)).toEqual({ end: 8, start: 4 })
+  })
+
+  it('handles an empty string without throwing', () => {
+    expect(visualLineBounds('', 0, 10)).toEqual({ end: 0, start: 0 })
+  })
+})
+
+describe('visualLineNav — word-wrap-aware UP/DOWN (issue #22009)', () => {
+  it('returns null on UP when already on the first visual row', () => {
+    expect(visualLineNav('hello world', 2, 8, -1)).toBeNull()
+  })
+
+  it('returns null on DOWN when already on the last visual row', () => {
+    expect(visualLineNav('hello world', 9, 8, 1)).toBeNull()
+  })
+
+  it('moves UP one visual row across a wrapped single logical line', () => {
+    // 'hello world' at cols=8: row 0 = 'hello ' (col 0..5), row 1 starts at 'world'.
+    // Cursor at offset 9 ('r' of world) sits at column 3 of row 1; UP → column 3 of row 0 = 'l'.
+    expect(visualLineNav('hello world', 9, 8, -1)).toBe(3)
+  })
+
+  it('moves DOWN one visual row across a wrapped single logical line', () => {
+    // Cursor at offset 3 ('l' of hello) on row 0; DOWN → row 1 starting at 'world'.
+    // Column 3 lands on 'l' of 'world' (offset 9).
+    expect(visualLineNav('hello world', 3, 8, 1)).toBe(9)
+  })
+
+  it('clamps cursor column when the destination visual row is shorter', () => {
+    // 'hello world abc' at cols=8 wraps as 'hello ' / 'world ' / 'abc'.
+    // Cursor at offset 8 (column 2 of row 1 'world'); DOWN → 'abc' clamped at column 2.
+    expect(visualLineNav('hello world abc', 8, 8, 1)).toBe(14)
+  })
+
+  it('descends through a logical newline as a regular visual boundary', () => {
+    // 'one\ntwo' at cols=40: row 0 = 'one', row 1 = 'two'. Cursor at offset 1 → DOWN to col 1 of 'two' (offset 5).
+    expect(visualLineNav('one\ntwo', 1, 40, 1)).toBe(5)
+  })
+
+  it('preserves column on UP through a logical newline', () => {
+    expect(visualLineNav('one\ntwo', 5, 40, -1)).toBe(1)
+  })
+})
+
+describe('isOnFirstVisualLine / isOnLastVisualLine (issue #22009 — history boundary)', () => {
+  it('treats a single unwrapped line as both first and last row', () => {
+    expect(isOnFirstVisualLine('hello', 3, 40)).toBe(true)
+    expect(isOnLastVisualLine('hello', 3, 40)).toBe(true)
+  })
+
+  it('returns false on a middle visual row of a wrapped one-liner', () => {
+    // 'hello world abc def' at cols=8 wraps to 3 rows. Cursor on the middle row.
+    const text = 'hello world abc def'
+    const middleCursor = 8
+
+    expect(isOnFirstVisualLine(text, middleCursor, 8)).toBe(false)
+    expect(isOnLastVisualLine(text, middleCursor, 8)).toBe(false)
+  })
+
+  it('detects the first row of a multiline block', () => {
+    expect(isOnFirstVisualLine('one\ntwo\nthree', 1, 40)).toBe(true)
+    expect(isOnFirstVisualLine('one\ntwo\nthree', 5, 40)).toBe(false)
+  })
+
+  it('detects the last row of a multiline block', () => {
+    expect(isOnLastVisualLine('one\ntwo\nthree', 11, 40)).toBe(true)
+    expect(isOnLastVisualLine('one\ntwo\nthree', 1, 40)).toBe(false)
+  })
+})

--- a/ui-tui/src/app/interfaces.ts
+++ b/ui-tui/src/app/interfaces.ts
@@ -201,6 +201,12 @@ export interface InputHandlerContext {
     refs: ComposerRefs
     state: ComposerState
   }
+  /**
+   * Live width of the composer's word-wrapped input area (issue #22009 — used
+   * to decide whether <Up>/<Down> should cycle history vs. move the cursor by
+   * one visual line). Defaults to terminal width when absent.
+   */
+  composerColsRef?: MutableRefObject<number>
   gateway: GatewayServices
   terminal: {
     hasSelection: boolean

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -10,6 +10,7 @@ import type {
   SudoRespondResponse,
   VoiceRecordResponse
 } from '../gatewayTypes.js'
+import { isOnFirstVisualLine, isOnLastVisualLine } from '../lib/inputMetrics.js'
 import { isAction, isCopyShortcut, isMac, isVoiceToggleKey } from '../lib/platform.js'
 import { computePrecisionWheelStep, initPrecisionWheel } from '../lib/precisionWheel.js'
 import { computeWheelStep, initWheelAccelForHost } from '../lib/wheelAccel.js'
@@ -374,12 +375,18 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
       return clearSelection()
     }
 
+    // Issue #22009: defer history cycling to the boundary of the *visual*
+    // composer area, not just the logical \n boundaries. A wrapped one-liner
+    // spans multiple rows, so middle rows must let the cursor move instead of
+    // jumping to a previous prompt.
+    const composerCols = ctx.composerColsRef?.current ?? terminal.stdout?.columns ?? 80
+
     if (key.upArrow && !cState.inputBuf.length) {
       const inputSel = getInputSelection()
       const cursor = inputSel && inputSel.start === inputSel.end ? inputSel.start : null
 
       const noLineAbove =
-        !cState.input || (cursor !== null && cState.input.lastIndexOf('\n', Math.max(0, cursor - 1)) < 0)
+        !cState.input || (cursor !== null && isOnFirstVisualLine(cState.input, cursor, composerCols))
 
       if (noLineAbove) {
         cycleQueue(1) || cycleHistory(-1)
@@ -391,7 +398,8 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
     if (key.downArrow && !cState.inputBuf.length) {
       const inputSel = getInputSelection()
       const cursor = inputSel && inputSel.start === inputSel.end ? inputSel.start : null
-      const noLineBelow = !cState.input || (cursor !== null && cState.input.indexOf('\n', cursor) < 0)
+      const noLineBelow =
+        !cState.input || (cursor !== null && isOnLastVisualLine(cState.input, cursor, composerCols))
 
       if (noLineBelow || cState.historyIdx !== null) {
         cycleQueue(-1) || cycleHistory(1)

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -247,7 +247,14 @@ export function useMainApp(gw: GatewayClient) {
 
   const detailsVisible = detailsLayoutKey !== 'hidden:hidden'
   const userPromptWidth = composerPromptWidth(ui.theme.brand.prompt)
-  const composerInputCols = stableComposerColumns(cols, userPromptWidth)
+  // Mirror ComposerPane: shell-mode (`!`-prefixed input) renders a `$` prompt
+  // instead of the brand prompt, which can change the wrap width used by
+  // TextInput. Compute the active prompt width from the same source so the
+  // global Up/Down handler stays in sync with the composer.
+  const composerShellMode = (composerState.inputBuf[0] ?? composerState.input).startsWith('!')
+  const composerPromptText = composerShellMode ? '$' : ui.theme.brand.prompt
+  const composerActivePromptWidth = composerPromptWidth(composerPromptText)
+  const composerInputCols = stableComposerColumns(cols, composerActivePromptWidth)
   const composerColsRef = useRef(composerInputCols)
   composerColsRef.current = composerInputCols
   const heightCacheKey = `${ui.sid ?? 'draft'}:${cols}:${userPromptWidth}:${ui.compact ? '1' : '0'}:${detailsLayoutKey}`

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -16,7 +16,7 @@ import type {
 } from '../gatewayTypes.js'
 import { useGitBranch } from '../hooks/useGitBranch.js'
 import { useVirtualHistory } from '../hooks/useVirtualHistory.js'
-import { composerPromptWidth } from '../lib/inputMetrics.js'
+import { composerPromptWidth, stableComposerColumns } from '../lib/inputMetrics.js'
 import { appendTranscriptMessage } from '../lib/messages.js'
 import { DEFAULT_VOICE_RECORD_KEY, isMac, type ParsedVoiceRecordKey } from '../lib/platform.js'
 import { asRpcResult, rpcErrorMessage } from '../lib/rpc.js'
@@ -247,6 +247,9 @@ export function useMainApp(gw: GatewayClient) {
 
   const detailsVisible = detailsLayoutKey !== 'hidden:hidden'
   const userPromptWidth = composerPromptWidth(ui.theme.brand.prompt)
+  const composerInputCols = stableComposerColumns(cols, userPromptWidth)
+  const composerColsRef = useRef(composerInputCols)
+  composerColsRef.current = composerInputCols
   const heightCacheKey = `${ui.sid ?? 'draft'}:${cols}:${userPromptWidth}:${ui.compact ? '1' : '0'}:${detailsLayoutKey}`
 
   const heightCache = useMemo(() => {
@@ -542,6 +545,7 @@ export function useMainApp(gw: GatewayClient) {
       sys
     },
     composer: { actions: composerActions, refs: composerRefs, state: composerState },
+    composerColsRef,
     gateway,
     terminal: { hasSelection, scrollRef, scrollWithSelection, selection, stdout },
     voice: {

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -4,7 +4,7 @@ import { type MutableRefObject, useEffect, useMemo, useRef, useState } from 'rea
 
 import { setInputSelection } from '../app/inputSelectionStore.js'
 import { readClipboardText, writeClipboardText } from '../lib/clipboard.js'
-import { cursorLayout, offsetFromPosition } from '../lib/inputMetrics.js'
+import { cursorLayout, offsetFromPosition, visualLineBounds, visualLineNav } from '../lib/inputMetrics.js'
 import {
   DEFAULT_VOICE_RECORD_KEY,
   isActionMod,
@@ -750,7 +750,8 @@ export function TextInput({
       }
 
       if (k.upArrow || k.downArrow) {
-        const next = lineNav(vRef.current, curRef.current, k.upArrow ? -1 : 1)
+        const dir = k.upArrow ? -1 : 1
+        const next = visualLineNav(vRef.current, curRef.current, columns, dir)
 
         if (next !== null) {
           moveCursor(next, k.shift)
@@ -798,12 +799,24 @@ export function TextInput({
       }
 
       if (actionHome) {
-        c = 0
+        // Issue #22008: HOME jumps to the start of the current visual line so
+        // wrapped prompts behave like every other shell. A second press from
+        // the same row collapses to logical 0; explicit Ctrl/Meta also forces
+        // the logical-start jump for keyboards without a dedicated shortcut.
+        const bounds = visualLineBounds(v, c, columns)
+        const visualStart = bounds.start
+        const target = wordMod || c === visualStart ? 0 : visualStart
+        c = target
         moveCursor(c, k.shift)
 
         return
       } else if (actionEnd) {
-        c = v.length
+        // Issue #22008 mirror: END jumps to the end of the current visual
+        // line; a second press snaps to logical end.
+        const bounds = visualLineBounds(v, c, columns)
+        const visualEnd = bounds.end
+        const target = wordMod || c === visualEnd ? v.length : visualEnd
+        c = target
         moveCursor(c, k.shift)
 
         return

--- a/ui-tui/src/lib/inputMetrics.ts
+++ b/ui-tui/src/lib/inputMetrics.ts
@@ -160,6 +160,56 @@ export function inputVisualHeight(value: string, columns: number) {
   return cursorLayout(value, value.length, columns).line + 1
 }
 
+/**
+ * Word-wrap-aware bounds for the visual line containing `cursor`. `start` is
+ * the offset of the first grapheme on the row; `end` is one past the last
+ * grapheme on the row (excluding the trailing newline, if any).
+ */
+export function visualLineBounds(value: string, cursor: number, cols: number) {
+  const pos = Math.max(0, Math.min(cursor, value.length))
+  const lines = visualLines(value, Math.max(1, cols))
+  let line = lines[0]!
+
+  for (const candidate of lines) {
+    if (candidate.start <= pos) {
+      line = candidate
+    } else {
+      break
+    }
+  }
+
+  return { end: line.end, start: line.start }
+}
+
+/**
+ * Move cursor up or down by one *visual* row, preserving the cursor's column
+ * (clamped to the destination row's length). Returns `null` when the cursor is
+ * already on the first row (dir === -1) or last row (dir === 1) — callers use
+ * that signal to fall through to history cycling instead of consuming the key.
+ */
+export function visualLineNav(value: string, cursor: number, cols: number, dir: -1 | 1): null | number {
+  const w = Math.max(1, cols)
+  const layout = cursorLayout(value, cursor, w)
+  const lines = visualLines(value, w)
+  const target = layout.line + dir
+
+  if (target < 0 || target >= lines.length) {
+    return null
+  }
+
+  return offsetFromPosition(value, target, layout.column, w)
+}
+
+export function isOnFirstVisualLine(value: string, cursor: number, cols: number) {
+  return cursorLayout(value, cursor, Math.max(1, cols)).line === 0
+}
+
+export function isOnLastVisualLine(value: string, cursor: number, cols: number) {
+  const w = Math.max(1, cols)
+
+  return cursorLayout(value, cursor, w).line >= visualLines(value, w).length - 1
+}
+
 export function composerPromptWidth(promptText: string) {
   return Math.max(1, stringWidth(promptText)) + COMPOSER_PROMPT_GAP_WIDTH
 }


### PR DESCRIPTION
## What does this PR do?

When word-wrap is active in the TUI composer, cursor navigation keys operated on **logical** lines (separated by `
`) instead of **visual** rows. This made HOME/END jump past the visible row boundary and UP/DOWN cycle history when the user expected intra-line cursor motion.

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- `ui-tui/src/lib/inputMetrics.ts` — new helpers: `visualLineBounds`, `visualLineNav`, `isOnFirstVisualLine`, `isOnLastVisualLine`. Built on existing `visualLines` / `cursorLayout` / `offsetFromPosition` so word-wrap geometry stays in one place.
- `ui-tui/src/components/textInput.tsx` — HOME/END use `visualLineBounds`; UP/DOWN use `visualLineNav`. Legacy `lineNav` export kept for the existing `textInputLineNav.test.ts`.
- `ui-tui/src/app/useInputHandlers.ts` + `useMainApp.ts` + `interfaces.ts` — plumbs the live composer column width through `composerColsRef` so the global UP/DOWN handler uses the same visual-row check as the composer (avoids double-firing where the cursor moves AND history cycles on the same key).

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

- Related to #22008. - Related to #22009.

<details>
<summary>Original body</summary>

## Summary

When word-wrap is active in the TUI composer, cursor navigation keys operated on **logical** lines (separated by `
`) instead of **visual** rows. This made HOME/END jump past the visible row boundary and UP/DOWN cycle history when the user expected intra-line cursor motion.

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Summary

When word-wrap is active in the TUI composer, cursor navigation keys operated on **logical** lines (separated by `
`) instead of **visual** rows. This made HOME/END jump past the visible row boundary and UP/DOWN cycle history when the user expected intra-line cursor motion.

This PR makes HOME / END / UP / DOWN word-wrap aware, with a small additive surface and full test coverage.

Closes #22008
Closes #22009

## Behavior

### Before
- **HOME / END** — jumped to start/end of the entire logical line, even when the line was wrapped across many visual rows.
- **UP / DOWN** — only moved by logical lines. On a wrapped one-liner, UP/DOWN immediately fell through to history cycling, losing the cursor position.

### After
- **HOME** — moves to the start of the current **visual** row. Pressing HOME again (when already at visual start) escalates to logical line start. `Ctrl+HOME` / word-modifier still forces logical start.
- **END** — mirrors HOME (visual end → second press → logical end).
- **UP / DOWN** — moves one visual row, preserving the visual column (clamped when destination row is shorter). Only defers to history cycling when the cursor is on the first / last visual row.
- Logical newlines (`
`) continue to act as hard row boundaries.

## Changes

- `ui-tui/src/lib/inputMetrics.ts` — new helpers: `visualLineBounds`, `visualLineNav`, `isOnFirstVisualLine`, `isOnLastVisualLine`. Built on existing `visualLines` / `cursorLayout` / `offsetFromPosition` so word-wrap geometry stays in one place.
- `ui-tui/src/components/textInput.tsx` — HOME/END use `visualLineBounds`; UP/DOWN use `visualLineNav`. Legacy `lineNav` export kept for the existing `textInputLineNav.test.ts`.
- `ui-tui/src/app/useInputHandlers.ts` + `useMainApp.ts` + `interfaces.ts` — plumbs the live composer column width through `composerColsRef` so the global UP/DOWN handler uses the same visual-row check as the composer (avoids double-firing where the cursor moves AND history cycles on the same key).

## Validation

- `ui-tui/src/__tests__/visualLineNav.test.ts` — 17 new tests covering: wrapped one-liners, logical newline boundaries, cursor at offset 0, clamping past end, empty string, column preservation across UP/DOWN, column clamping when destination row is shorter, first/last visual row detection on multiline blocks.
- Full suite: **665 tests / 62 files passing** (no regressions).
- Type-check clean. No new lint errors.
- Manual TUI screenshots not feasible (terminal app); covered via Vitest unit tests on the pure layout helpers.

## Scope

Additive only. No behavior change for unwrapped single-line input, no API removed, no unrelated refactors.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_