### PR TITLE
fix: avoid empty-arg bash 3.2 failure in run_tests.sh

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -95,10 +95,17 @@ echo "▶ running pytest with $WORKERS workers, hermetic env, in $REPO_ROOT"
 echo "  (TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0; all credential env vars unset)"
 
 # -o "addopts=" clears pyproject.toml's `-n auto` so our -n wins.
-exec "$PYTHON" -m pytest \
-  -o "addopts=" \
-  -n "$WORKERS" \
-  --ignore=tests/integration \
-  --ignore=tests/e2e \
-  -m "not integration" \
-  "${ARGS[@]}"
+PYTEST_CMD=(
+  "$PYTHON" -m pytest
+  -o "addopts="
+  -n "$WORKERS"
+  --ignore=tests/integration
+  --ignore=tests/e2e
+  -m "not integration"
+)
+
+if [ "$#" -gt 0 ]; then
+  PYTEST_CMD+=("${ARGS[@]}")
+fi
+
+exec "${PYTEST_CMD[@]}"

--- a/tests/test_run_tests_wrapper.py
+++ b/tests/test_run_tests_wrapper.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import os
+import shutil
+import stat
+import subprocess
+from pathlib import Path
+
+
+def _write_fake_python(path: Path, argv_log: Path) -> None:
+    path.write_text(
+        f"""#!/usr/bin/env python3
+import pathlib
+import sys
+
+args = sys.argv[1:]
+if args[:2] == ["-c", "import pytest_split"]:
+    raise SystemExit(0)
+if args[:2] == ["-m", "pytest"]:
+    pathlib.Path(r"{argv_log}").write_text("\\n".join(args[2:]) + "\\n")
+    raise SystemExit(0)
+if args[:2] == ["-m", "pip"]:
+    raise SystemExit(0)
+raise SystemExit("unexpected argv: " + " ".join(args))
+""",
+        encoding="utf-8",
+    )
+    path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+
+def test_run_tests_wrapper_handles_empty_args(tmp_path: Path) -> None:
+    repo_root = tmp_path / "repo"
+    scripts_dir = repo_root / "scripts"
+    scripts_dir.mkdir(parents=True)
+    source_script = Path(__file__).resolve().parents[1] / "scripts" / "run_tests.sh"
+    target_script = scripts_dir / "run_tests.sh"
+    shutil.copy2(source_script, target_script)
+    target_script.chmod(target_script.stat().st_mode | stat.S_IXUSR)
+
+    argv_log = tmp_path / "pytest-argv.txt"
+    fake_python = repo_root / ".venv" / "bin" / "python"
+    fake_python.parent.mkdir(parents=True)
+    (fake_python.parent / "activate").write_text("# fake activate\n", encoding="utf-8")
+    _write_fake_python(fake_python, argv_log)
+
+    env = os.environ.copy()
+    env.pop("VIRTUAL_ENV", None)
+    result = subprocess.run(
+        ["/bin/bash", str(target_script)],
+        cwd=repo_root,
+        env=env,
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert argv_log.read_text(encoding="utf-8").splitlines() == [
+        "-o",
+        "addopts=",
+        "-n",
+        "4",
+        "--ignore=tests/integration",
+        "--ignore=tests/e2e",
+        "-m",
+        "not integration",
+    ]


### PR DESCRIPTION
## Summary
- avoid expanding an empty Bash array when `scripts/run_tests.sh` is invoked with no user args
- build the pytest command first and append user args only when present
- add a regression test that exercises the wrapper with a fake venv and `/bin/bash`

Closes #22011.

## Verification
- `uv sync --frozen --extra all`
- `git diff --check`
- `./scripts/run_tests.sh tests/test_run_tests_wrapper.py -q`
- `uv run --frozen ruff check .`
- repo lint-diff semantics via `scripts/lint_diff.py`
- clean-env CI-equivalent pytest command via `env -i ... python -m pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e --tb=short -n auto`

## Full-suite attribution
The clean-env full suite is currently red on latest `origin/main`, but the failures are not attributable to this candidate.

- On `HEAD` (`c27af91252eecaf9dd9c5eac52112a60c6e787b2`), the clean-env full suite had 31 failures.
- Re-running those 31 failed selectors on latest `origin/main` (`78b0008f4451c4b3047107926e466dcfc257ae3e`) reproduced 29 of them.
- The remaining 2 `HEAD`-only failures passed when rerun in isolation on both `HEAD` and latest `origin/main`, consistent with preexisting flaky/scheduling behavior.

Proof artifact: `.paperclip_artifacts/quality-gate/proof-c27af91252eecaf9dd9c5eac52112a60c6e787b2.json`
