### PR TITLE
fix(gateway): stop retrying permanent Discord auth failures

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -832,10 +832,51 @@ class DiscordAdapter(BasePlatformAdapter):
 
         except asyncio.TimeoutError:
             logger.error("[%s] Timeout waiting for connection to Discord", self.name, exc_info=True)
+            # The background bot task may have already failed with a
+            # permanent auth error (e.g. LoginFailure) while we were
+            # waiting for the READY event. Check the task's exception
+            # and classify accordingly — otherwise the gateway will
+            # misclassify a bad token as a transient timeout and
+            # keep restart-looping.
+            _permanent = False
+            if self._bot_task and self._bot_task.done():
+                _exc = self._bot_task.exception()
+                if _exc is not None:
+                    if DISCORD_AVAILABLE:
+                        import discord as _discord
+                        _permanent_errs = (
+                            _discord.errors.LoginFailure,
+                            _discord.errors.PrivilegedIntentsRequired,
+                        )
+                        _permanent = isinstance(_exc, _permanent_errs)
+                    if _permanent:
+                        self._set_fatal_error(
+                            type(_exc).__name__, str(_exc), retryable=False
+                        )
+                    else:
+                        logger.error(
+                            "[%s] Background bot task failed: %s",
+                            self.name, _exc,
+                        )
             self._release_platform_lock()
             return False
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error("[%s] Failed to connect to Discord: %s", self.name, e, exc_info=True)
+            # Classify permanent auth/config errors as non-retryable so the
+            # gateway won't restart-loop when a token is invalid/missing.
+            # Network blips and other transient errors remain retryable.
+            _permanent_error = False
+            if DISCORD_AVAILABLE:
+                import discord as _discord
+                _permanent = (
+                    _discord.errors.LoginFailure,
+                    _discord.errors.PrivilegedIntentsRequired,
+                )
+                _permanent_error = isinstance(e, _permanent)
+            if _permanent_error:
+                self._set_fatal_error(
+                    type(e).__name__, str(e), retryable=False
+                )
             self._release_platform_lock()
             return False
 
@@ -861,10 +902,72 @@ class DiscordAdapter(BasePlatformAdapter):
             except asyncio.CancelledError:
                 pass
 
+        # Cancel the background bot task (e.g. client.start()) to prevent
+        # orphaned LoginFailure errors from accumulating in the event loop
+        # after a failed connect() attempt. Also inspect the task's
+        # exception — if it's a permanent auth error, flag it so the
+        # gateway startup logic can correctly treat it as non-retryable
+        # instead of restart-looping.
+        if self._bot_task:
+            # Give the bot task a brief window to finish on its own
+            # (e.g. if it's about to raise LoginFailure). Then inspect
+            # its exception before cancelling.
+            if not self._bot_task.done():
+                try:
+                    await asyncio.wait_for(
+                        asyncio.shield(self._bot_task), timeout=2.0
+                    )
+                except (asyncio.TimeoutError, asyncio.CancelledError):
+                    pass
+                except Exception as e:
+                    # The wait is only a grace window so we can inspect the
+                    # background task. If it completes with an exception during
+                    # that window, suppress it here and classify/log it below.
+                    logger.debug(
+                        "[%s] Bot task ended during disconnect: %s",
+                        self.name,
+                        e,
+                    )
+            _exc = None
+            if self._bot_task.done():
+                try:
+                    _exc = self._bot_task.exception()
+                except asyncio.CancelledError:
+                    _exc = None
+            if _exc is not None:
+                _permanent = False
+                if DISCORD_AVAILABLE:
+                    import discord as _discord
+                    _permanent_errs = (
+                        _discord.errors.LoginFailure,
+                        _discord.errors.PrivilegedIntentsRequired,
+                    )
+                    _permanent = isinstance(_exc, _permanent_errs)
+                if _permanent:
+                    self._set_fatal_error(
+                        type(_exc).__name__, str(_exc), retryable=False
+                    )
+            if not self._bot_task.done():
+                self._bot_task.cancel()
+            try:
+                await self._bot_task
+            except asyncio.CancelledError:
+                pass
+            except Exception as e:
+                # If the bot task already ended with an error, the exception
+                # was inspected above. Do not let disconnect() re-raise it;
+                # disconnect must be best-effort cleanup after failed connect().
+                logger.debug(
+                    "[%s] Bot task exception suppressed during disconnect: %s",
+                    self.name,
+                    e,
+                )
+
         self._running = False
         self._client = None
         self._ready_event.clear()
         self._post_connect_task = None
+        self._bot_task = None
 
         self._release_platform_lock()
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3265,19 +3265,45 @@ class GatewayRunner:
                 # that raised mid-connect may still have a live
                 # aiohttp.ClientSession or child subprocess.
                 await self._safe_adapter_disconnect(adapter, platform)
-                self._update_platform_runtime_status(
-                    platform.value,
-                    platform_state="retrying",
-                    error_code=None,
-                    error_message=str(e),
-                )
-                startup_retryable_errors.append(f"{platform.value}: {e}")
-                # Unexpected exceptions are typically transient — queue for retry
-                self._failed_platforms[platform] = {
-                    "config": platform_config,
-                    "attempts": 1,
-                    "next_retry": time.monotonic() + 30,
-                }
+                # re-check: disconnect() may have detected a permanent
+                # auth error from the adapter's background task
+                # (e.g. Discord _bot_task LoginFailure) and called
+                # _set_fatal_error. Honour that classification instead
+                # of blindly treating every exception as retryable.
+                if adapter.has_fatal_error:
+                    self._update_platform_runtime_status(
+                        platform.value,
+                        platform_state="retrying" if adapter.fatal_error_retryable else "fatal",
+                        error_code=adapter.fatal_error_code,
+                        error_message=adapter.fatal_error_message,
+                    )
+                    if adapter.fatal_error_retryable:
+                        startup_retryable_errors.append(
+                            f"{platform.value}: {adapter.fatal_error_message}"
+                        )
+                        self._failed_platforms[platform] = {
+                            "config": platform_config,
+                            "attempts": 1,
+                            "next_retry": time.monotonic() + 30,
+                        }
+                    else:
+                        startup_nonretryable_errors.append(
+                            f"{platform.value}: {adapter.fatal_error_message}"
+                        )
+                else:
+                    self._update_platform_runtime_status(
+                        platform.value,
+                        platform_state="retrying",
+                        error_code=None,
+                        error_message=str(e),
+                    )
+                    startup_retryable_errors.append(f"{platform.value}: {e}")
+                    # Unexpected exceptions are typically transient — queue for retry
+                    self._failed_platforms[platform] = {
+                        "config": platform_config,
+                        "attempts": 1,
+                        "next_retry": time.monotonic() + 30,
+                    }
         
         if connected_count == 0:
             if startup_nonretryable_errors:

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -31,6 +31,17 @@ def _ensure_discord_mock():
     """
     if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
         sys.modules["discord"].AllowedMentions = _FakeAllowedMentions
+        # Ensure error classes are available for auth-error classification tests.
+        # When discord.py is installed, the real errors module is already present;
+        # when it's mocked by another test, attach the mock classes.
+        try:
+            import discord as _real_discord
+            if not hasattr(sys.modules["discord"], "errors") or not hasattr(
+                getattr(sys.modules["discord"], "errors", None), "LoginFailure"
+            ):
+                sys.modules["discord"].errors = _real_discord.errors
+        except ImportError:
+            pass
         return
 
     if sys.modules.get("discord") is None:
@@ -53,6 +64,16 @@ def _ensure_discord_mock():
         )
         discord_mod.opus = SimpleNamespace(is_loaded=lambda: True)
 
+        # Use real discord.errors classes if available, otherwise mock them
+        try:
+            import discord as _real_discord
+            discord_mod.errors = _real_discord.errors
+        except ImportError:
+            discord_mod.errors = SimpleNamespace(
+                LoginFailure=type("LoginFailure", (Exception,), {}),
+                PrivilegedIntentsRequired=type("PrivilegedIntentsRequired", (Exception,), {}),
+            )
+
         ext_mod = MagicMock()
         commands_mod = MagicMock()
         commands_mod.Bot = MagicMock
@@ -69,6 +90,31 @@ _ensure_discord_mock()
 
 import gateway.platforms.discord as discord_platform  # noqa: E402
 from gateway.platforms.discord import DiscordAdapter  # noqa: E402
+
+
+# Test exception classes for auth-error classification tests.
+# These mirror discord.errors.LoginFailure / PrivilegedIntentsRequired
+# but are proper Exception subclasses that work regardless of whether
+# the real discord.py or a MagicMock is in sys.modules.
+class _TestLoginFailure(Exception):
+    pass
+
+
+class _TestPrivilegedIntentsRequired(Exception):
+    pass
+
+
+def _patch_discord_errors(monkeypatch):
+    """Make discord.errors.LoginFailure and PrivilegedIntentsRequired
+    available on discord_platform.discord for auth-error tests.
+    Patches both the adapter module's reference AND sys.modules so
+    local 'import discord as _discord' inside disconnect() works."""
+    _err_mod = type("errors", (), {
+        "LoginFailure": _TestLoginFailure,
+        "PrivilegedIntentsRequired": _TestPrivilegedIntentsRequired,
+    })()
+    monkeypatch.setattr(discord_platform.discord, "errors", _err_mod)
+    monkeypatch.setattr(sys.modules["discord"], "errors", _err_mod)
 
 
 @pytest.fixture(autouse=True)
@@ -905,3 +951,119 @@ async def test_safe_sync_detects_contexts_drift():
     fake_http.edit_global_command.assert_not_awaited()
     fake_http.delete_global_command.assert_awaited_once_with(999, 77)
     fake_http.upsert_global_command.assert_awaited_once_with(999, desired)
+
+
+# ── Permanent auth error classification tests ──────────────────────────
+
+
+class LoginFailingBot(FakeBot):
+    """Bot whose start() raises LoginFailure (bad/missing token)."""
+    async def start(self, token):
+        raise _TestLoginFailure("Improper token has been passed.")
+
+
+@pytest.mark.asyncio
+async def test_connect_sets_fatal_error_on_LoginFailure(monkeypatch):
+    """connect() except Exception should call _set_fatal_error(retryable=False)
+    when Bot.start() raises LoginFailure (caught via background task check)."""
+    _patch_discord_errors(monkeypatch)
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="bad-token"))
+
+    monkeypatch.setattr("gateway.status.acquire_scoped_lock", lambda scope, identity, metadata=None: (True, None))
+    monkeypatch.setattr("gateway.status.release_scoped_lock", lambda scope, identity: None)
+
+    intents = SimpleNamespace(message_content=False, dm_messages=False, guild_messages=False, members=False, voice_states=False)
+    monkeypatch.setattr(discord_platform.Intents, "default", lambda: intents)
+
+    monkeypatch.setattr(
+        discord_platform.commands,
+        "Bot",
+        lambda **kwargs: LoginFailingBot(
+            intents=kwargs["intents"],
+            proxy=kwargs.get("proxy"),
+            allowed_mentions=kwargs.get("allowed_mentions"),
+        ),
+    )
+
+    # Bypass the 30s READY timeout — give the bot task one tick to fail
+    async def fake_wait_for(awaitable, timeout):
+        await asyncio.sleep(0)
+        if hasattr(awaitable, "close"):
+            awaitable.close()
+        raise asyncio.TimeoutError()
+
+    monkeypatch.setattr(discord_platform.asyncio, "wait_for", fake_wait_for)
+
+    ok = await adapter.connect()
+
+    assert ok is False
+    assert adapter.has_fatal_error is True
+    assert adapter.fatal_error_retryable is False
+    assert "Improper token" in (adapter.fatal_error_message or "")
+    assert "_TestLoginFailure" in (adapter.fatal_error_code or "")
+
+
+@pytest.mark.asyncio
+async def test_connect_timeout_checks_bot_task_for_LoginFailure(monkeypatch):
+    """When the READY timeout fires and _bot_task already has LoginFailure,
+    connect() should call _set_fatal_error(retryable=False)."""
+    _patch_discord_errors(monkeypatch)
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="bad-token"))
+
+    monkeypatch.setattr("gateway.status.acquire_scoped_lock", lambda scope, identity, metadata=None: (True, None))
+    monkeypatch.setattr("gateway.status.release_scoped_lock", lambda scope, identity: None)
+
+    intents = SimpleNamespace(message_content=False, dm_messages=False, guild_messages=False, members=False, voice_states=False)
+    monkeypatch.setattr(discord_platform.Intents, "default", lambda: intents)
+
+    monkeypatch.setattr(
+        discord_platform.commands,
+        "Bot",
+        lambda **kwargs: LoginFailingBot(
+            intents=kwargs["intents"],
+            proxy=kwargs.get("proxy"),
+            allowed_mentions=kwargs.get("allowed_mentions"),
+        ),
+    )
+
+    # Replace asyncio.wait_for so the 30s READY timeout fires immediately.
+    # Give the event loop one tick first so _bot_task gets created and fails.
+    async def fake_wait_for(awaitable, timeout):
+        await asyncio.sleep(0)  # let bot task start and fail
+        if hasattr(awaitable, "close"):
+            awaitable.close()
+        raise asyncio.TimeoutError()
+
+    monkeypatch.setattr(discord_platform.asyncio, "wait_for", fake_wait_for)
+
+    ok = await adapter.connect()
+
+    assert ok is False
+    assert adapter.has_fatal_error is True
+    assert adapter.fatal_error_retryable is False
+    assert "Improper token" in (adapter.fatal_error_message or "")
+    assert "_TestLoginFailure" in (adapter.fatal_error_code or "")
+
+
+@pytest.mark.asyncio
+async def test_disconnect_cancels_bot_task_and_detects_LoginFailure(monkeypatch):
+    """disconnect() cancels _bot_task and properly nulls the reference."""
+    _patch_discord_errors(monkeypatch)
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="bad-token"))
+
+    monkeypatch.setattr("gateway.status.acquire_scoped_lock", lambda scope, identity, metadata=None: (True, None))
+    monkeypatch.setattr("gateway.status.release_scoped_lock", lambda scope, identity: None)
+
+    # Inject a failing _bot_task
+    async def failing_start(_token):
+        raise _TestLoginFailure("Improper token has been passed.")
+    adapter._bot_task = asyncio.create_task(failing_start("bad-token"))
+    await asyncio.sleep(0)
+
+    assert adapter._bot_task.done()
+
+    await adapter.disconnect()
+
+    # Verify task cleanup
+    assert adapter._bot_task is None
+    assert adapter._post_connect_task is None


### PR DESCRIPTION
## What does this PR do?

    Fixes a Discord gateway startup failure mode where permanent Discord authentication/configuration errors were misclassified as retryable transient startup failures.

    When Discord fails with discord.errors.LoginFailure or discord.errors.PrivilegedIntentsRequired while the adapter is waiting for READY, the gateway previously only saw the READY wait timeout. That made it treat the failure as transient, queue reconnect attempts, and potentially enter a gateway/systemd restart loop. In practice this could also interrupt the cron ticker and produce noisy orphaned asyncio warnings such as Task exception was never retrieved.

    This PR makes those Discord auth/config failures fatal and non-retryable across the startup paths where they can surface:

    - direct exception from Discord connect/startup
    - background bot task exception discovered after READY timeout
    - background bot task exception discovered during disconnect/startup cleanup

    It also updates GatewayRunner to re-check adapter.has_fatal_error after startup cleanup, because disconnect() can discover the underlying permanent Discord failure after the initial timeout path.

    This approach keeps transient Discord/network startup errors retryable, but stops retrying permanent credential/intent configuration errors that require operator action.

## Related Issue

issue #21831

## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made
- gateway/platforms/discord.py
   - Classify discord.errors.LoginFailure and discord.errors.PrivilegedIntentsRequired as fatal, non-retryable adapter errors.
   - Detect those permanent Discord errors from:
        - direct connect/startup exceptions
        - background bot task exceptions after READY timeout
        - disconnect/startup-cleanup paths
    - Make disconnect() consume and suppress already-inspected background bot task exceptions so failed startup cleanup does not leave orphaned Task exception was never retrieved warnings.

- gateway/run.py
  - Re-check adapter.has_fatal_error after startup cleanup.
  - Honor fatal errors discovered during disconnect() cleanup instead of putting the adapter into the retry queue.
  - Route non-retryable startup failures to startup error handling instead of reconnect scheduling.

- tests/gateway/test_discord_connect.py
  - Add regression tests for permanent Discord auth/intent error classification.
  - Cover the READY-timeout path where the underlying Discord bot task fails with a permanent auth/config exception.
  - Cover disconnect cleanup behavior for failed background bot tasks.
  - Close mocked wait_for awaitables so the targeted test run remains warning-free.

## How to Test

1. Run the targeted Discord gateway regression tests:

```bash
scripts/run_tests.sh tests/gateway/test_discord_connect.py -q
```
Expected result:
       19 passed

2. Manual gateway smoke test with an isolated test gateway profile and intentionally bad Discord token:

```bash
PYTHONPATH=/path/to/hermes-agent \
HERMES_HOME=~/.hermes/profiles/test-gateway \
python -m hermes_cli.main gateway run
```


Configure the test profile with Discord enabled and a bad DISCORD_BOT_TOKEN.

3. Verify the fixed behavior:
- Bad Discord credentials are reported as a startup error.
- The Discord adapter does not repeatedly log reconnect attempts such as Reconnect discord error ... next retry in ....
- The gateway does not enter a Discord-driven restart loop.
- Task exception was never retrieved is not emitted for the inspected Discord bot task failure.
- Cron/no-agent cron smoke continues to run instead of being interrupted by the Discord startup failure loop.
---
## Checklist
### Code
- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (fix(scope):, feat(scope):, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [x] I've run pytest tests/ -q and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04
### Documentation & Housekeeping
- [x] I've updated relevant documentation (README, docs/, docstrings) — N/A, behavior is covered by tests and no user-facing docs need updating
- [x] I've updated cli-config.yaml.example if I added/changed config keys — N/A, no config keys changed
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — N/A, no architecture/workflow docs changed
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — N/A, gateway async error classification change only; no OS-specific paths/process behavior added
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A, no tool schemas or tool behavior changed
### Screenshots / Logs

#### cron test
```bash
# test command
mkdir -p ~/.hermes/scripts && cat > ~/.hermes/profiles/test-gateway/scripts/cron-tick.sh << 'EOF'
#!/bin/bash
echo "tick $(date)" >> /tmp/hermes-cron-test.log
EOF
chmod +x ~/.hermes/scripts/cron-tick.sh
	
PYTHONPATH=hermes-agent \
HERMES_HOME=~/.hermes/profiles/test-gateway \
hermes cron create "every 1m" --no-agent --script cron-tick.sh --name "cron-smoke-test"

PYTHONPATH=hermes-agent \
HERMES_HOME=~/.hermes/profiles/test-gateway \
hermes cron list --all

# result
> grep -i "cron\|cron-smoke\|cron-tick" ~/.hermes/profiles/test-gateway/logs/gateway.log | tail -50
2026-05-09 09:18:04,882 INFO gateway.run: Cron ticker started (interval=60s)

> sleep 120 && cat /tmp/hermes-cron-test.log
cat /tmp/hermes-cron-test.log
tick 2026年 05月 09日 星期六 09:18:04 CST
```
#### integrated test
```bash
# before modify
┌─────────────────────────────────────────────────────────┐
│           ⚕ Hermes Gateway Starting...                 │
├─────────────────────────────────────────────────────────┤
│  Messaging platforms + cron scheduler                    │
│  Press Ctrl+C to stop                                   │
└─────────────────────────────────────────────────────────┘

ERROR gateway.run: ✗ discord error: discord connect timed out after 30s
[Lark] [2026-05-09 08:35:10,838] [INFO] connected to wss://msg-frontier.feishu.cn/ws/v2?fpid=493&aid=xxx&device_id=xxx&access_key=xxx&service_id=33554678&ticket=xxx [conn_id=xxx]
WARNING gateway.run: Reconnect discord error: discord connect timed out after 30s, next retry in 120s
WARNING gateway.run: Reconnect discord error: discord connect timed out after 30s, next retry in 240s


# after modify
[Lark] [2026-05-09 09:18:04,019] [INFO] connected to wss://msg-frontier.feishu.cn/ws/v2?fpid=493&aid=xx&device_id=xxx&access_key=xxx&service_id=33554678&ticket=xxx [conn_id=xxx]
2026-05-09 09:18:02,160 ERROR gateway.run: ✗ discord error: discord connect timed out after 30s
```
#### Targeted test run
```bash
scripts/run_tests.sh tests/gateway/test_discord_connect.py -q
▶ running pytest with 4 workers, hermetic env, in hermes-agent
  (TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0; all credential env vars unset)
bringing up nodes...
...................                                                                                                                [100%]
19 passed in 3.16s



scripts/run_tests.sh tests/gateway/test_discord_connect.py::test_disconnect_cancels_bot_task_and_detects_LoginFailure -q --tb=short
▶ running pytest with 4 workers, hermetic env, in hermes-agent
  (TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0; all credential env vars unset)
bringing up nodes...
.                                                                                                                                  [100%]
1 passed in 5.04s
```

Manual gateway smoke summary:
- Bad Discord token is reported as a startup error without repeated reconnect-loop logs.
- The inspected Discord bot task exception is consumed during cleanup.
- Cron ticker / no_agent cron smoke continued to run.

Impact summary:
- Gateway: Discord startup and retry behavior changed.
- CLI: no impact.
- TUI: no impact.
- Tools: no impact.
- Config schema: no impact.