### PR TITLE
fix(tui): exclude cron sessions from session.list and session.most_recent

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2155,10 +2155,10 @@ def _(rid, params: dict) -> dict:
         # ones not enumerated here), ACP adapter clients, webhook sessions,
         # custom `HERMES_SESSION_SOURCE` values, and older installs with
         # different source labels. We deny-list only the noisy internal
-        # sources (``tool`` sub-agent runs) rather than allow-listing a
-        # fixed set of platform names that goes stale whenever a new
-        # platform is added or a user names their own source.
-        deny = frozenset({"tool"})
+        # sources (``tool`` sub-agent runs, ``cron`` scheduled jobs) rather
+        # than allow-listing a fixed set of platform names that goes stale
+        # whenever a new platform is added or a user names their own source.
+        deny = frozenset({"tool", "cron"})
 
         limit = int(params.get("limit", 200) or 200)
         # Over-fetch modestly so per-source filtering doesn't leave us
@@ -2195,7 +2195,7 @@ def _(rid, params: dict) -> dict:
     """Return the most recent human-facing session id, or ``None``.
 
     Mirrors ``session.list``'s deny-list behaviour (drops ``tool``
-    sub-agent rows).  Used by TUI auto-resume when
+    sub-agent rows and ``cron`` scheduled-job rows).  Used by TUI auto-resume when
     ``display.tui_auto_resume_recent`` is on; the field is also handy
     for any CLI tooling that wants "latest session" without paginating
     the full list.
@@ -2209,7 +2209,7 @@ def _(rid, params: dict) -> dict:
     if db is None:
         return _ok(rid, {"session_id": None})
     try:
-        deny = frozenset({"tool"})
+        deny = frozenset({"tool", "cron"})
         # Over-fetch by a generous bounded amount so heavy sub-agent
         # users (lots of recent ``tool`` rows) don't get a false
         # "no eligible session" answer.  ``session.list`` uses a


### PR DESCRIPTION
## Problem

When `display.tui_auto_resume_recent` is enabled, the TUI auto-resumes the most recent session on startup. Both `session.list` and `session.most_recent` deny-list only `tool` (sub-agent) source rows, but cron scheduled jobs (source=`cron`) are also non-interactive. If a cron job ran more recently than any user session, the TUI resumes into an empty cron session instead of the user's last conversation.

## Fix

Add `cron` to the deny frozenset in both `session.list` (L2161) and `session.most_recent` (L2212), so only human-facing sessions are surfaced.

The `session.most_recent` docstring is updated to reflect the change.

## Testing

Verified against a local state.db where a cron session (`cron_7006ec1e3c63_20260509_100041`, source=`cron`) had the latest `started_at` timestamp — after the patch, `most_recent` correctly skips it and returns the next human session.