### PR TITLE
handle ValueError outside try-except block

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5920,14 +5920,12 @@ def _find_stale_dashboard_pids(
                     current_cmd = line[len("CommandLine=") :]
                 elif line.startswith("ProcessId="):
                     pid_str = line[len("ProcessId=") :]
-                    if (
-                        any(p in current_cmd for p in patterns)
-                        and int(pid_str) != self_pid
-                    ):
-                        try:
-                            dashboard_pids.append(int(pid_str))
-                        except ValueError:
-                            pass
+                    try:
+                        pid = int(pid_str)
+                        if any(p in current_cmd for p in patterns) and pid != self_pid:
+                            dashboard_pids.append(pid)
+                    except ValueError:
+                        pass
         else:
             # Linux / macOS: scan the process table via ps and match against
             # the same explicit patterns list used on Windows.  Using ps

--- a/tests/hermes_cli/test_update_stale_dashboard.py
+++ b/tests/hermes_cli/test_update_stale_dashboard.py
@@ -434,3 +434,68 @@ class TestWindowsWmicEncoding:
             )
             # Must not raise.
             assert _find_stale_dashboard_pids() == []
+
+
+class TestWindowsMalformedProcessId:
+    """The wmic branch must survive a malformed ``ProcessId=`` value.
+
+    ``int(pid_str)`` used to be evaluated inside the ``if`` condition, i.e.
+    *before* the ``try`` that was meant to catch it.  Any non-numeric
+    ProcessId on a line whose CommandLine matched a dashboard pattern
+    therefore raised ValueError out of ``_find_stale_dashboard_pids`` and
+    aborted `hermes update`.  wmic can emit such records: a process that
+    exits mid-scan leaves a truncated or empty field.
+
+    The guard only fires for *matching* command lines, so a non-matching
+    process with a bad ProcessId never reached the conversion and these
+    tests would have passed before the fix — hence the matching CommandLine
+    in both cases below.
+    """
+
+    def test_malformed_pid_on_matching_command_does_not_raise(self, monkeypatch):
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(os, "getpid", lambda: 999999)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=(
+                    "CommandLine=python -m hermes_cli.main dashboard\n"
+                    "ProcessId=\n"
+                ),
+                stderr="",
+            )
+            assert _find_stale_dashboard_pids() == []
+
+    def test_scan_continues_past_malformed_pid(self, monkeypatch):
+        """A bad record must be skipped, not abort the whole scan: the valid
+        dashboard process *after* it still has to be collected and killed."""
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(os, "getpid", lambda: 999999)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=(
+                    "CommandLine=python -m hermes_cli.main dashboard\n"
+                    "ProcessId=N/A\n"
+                    "CommandLine=python -m hermes_cli.main dashboard\n"
+                    "ProcessId=4321\n"
+                ),
+                stderr="",
+            )
+            assert _find_stale_dashboard_pids() == [4321]
+
+    def test_self_pid_still_excluded_after_the_fix(self, monkeypatch):
+        """Moving the conversion into the try must not drop the self-PID
+        filter — `hermes update` would otherwise kill its own process."""
+        monkeypatch.setattr(sys, "platform", "win32")
+        monkeypatch.setattr(os, "getpid", lambda: 4321)
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0,
+                stdout=(
+                    "CommandLine=python -m hermes_cli.main dashboard\n"
+                    "ProcessId=4321\n"
+                ),
+                stderr="",
+            )
+            assert _find_stale_dashboard_pids() == []


### PR DESCRIPTION
## Description
This PR fixes a critical bug where a ValueError could be raised outside its intended try-except block, causing the dashboard process scanning function to crash.

### Root Cause
Previously, int(pid_str) was called inside an if condition to compare against self_pid. However, this conversion occurred before the try-except block that was supposed to catch the ValueError (the try-except only wrapped a secondary int(pid_str) append call).

Because of this exposure, if pid_str contained a non-numeric string (such as an empty string or malformed WMI output), the unhandled ValueError would crash the entire function. This would silently break dashboard PID detection on Windows.

### Expected Behavior & Fix
The int(pid_str) conversion has been properly scoped inside the try-except block. Now, any malformed pid_str is safely caught and skipped. The ValueError is handled gracefully, allowing the loop to continue processing the remaining valid PIDs without crashing the scanner.