### PR TITLE
fix(session_search): keep matched session content

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -556,7 +556,74 @@ class TestSessionSearch:
         assert result["success"] is True
         assert result["count"] == 1
         entry = result["results"][0]
-        assert entry["session_id"] == "parent_sid", "should report resolved parent session ID"
+        assert entry["session_id"] == "child_sid", "should report the session that contains the matched content"
+        assert entry["resolved_session_id"] == "parent_sid"
         assert entry["source"] == "api_server", (
             f"source should be parent's 'api_server', got {entry['source']!r}"
         )
+
+    def test_content_retrieval_uses_original_session_id(self):
+        """Fetch preview content from the matched child session, not its resolved parent."""
+        from unittest.mock import MagicMock, AsyncMock, patch as _patch
+        from tools.session_search_tool import session_search
+
+        mock_db = MagicMock()
+        mock_db.search_messages.return_value = [
+            {
+                "session_id": "child_sid",
+                "content": "headless-chatgpt match",
+                "source": "telegram",
+                "session_started": 1709400000,
+                "model": "gpt-4o-mini",
+            },
+        ]
+
+        def _get_session(session_id):
+            if session_id == "child_sid":
+                return {
+                    "id": "child_sid",
+                    "parent_session_id": "parent_sid",
+                    "source": "telegram",
+                    "started_at": 1709400000,
+                    "model": "gpt-4o-mini",
+                }
+            if session_id == "parent_sid":
+                return {
+                    "id": "parent_sid",
+                    "parent_session_id": None,
+                    "source": "api_server",
+                    "started_at": 1709300000,
+                    "model": "gpt-4o-mini",
+                }
+            return None
+
+        def _get_messages_as_conversation(session_id):
+            if session_id == "child_sid":
+                return [
+                    {"role": "user", "content": "headless-chatgpt appears here"},
+                    {"role": "assistant", "content": "ack"},
+                ]
+            if session_id == "parent_sid":
+                return [
+                    {"role": "user", "content": "parent does not contain the query"},
+                ]
+            return []
+
+        mock_db.get_session.side_effect = _get_session
+        mock_db.get_messages_as_conversation.side_effect = _get_messages_as_conversation
+
+        with _patch(
+            "tools.session_search_tool.async_call_llm",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("no provider"),
+        ):
+            result = json.loads(session_search(query="headless-chatgpt", db=mock_db))
+
+        assert result["success"] is True
+        assert result["count"] == 1
+        mock_db.get_messages_as_conversation.assert_called_once_with("child_sid")
+        entry = result["results"][0]
+        assert entry["session_id"] == "child_sid"
+        assert entry["resolved_session_id"] == "parent_sid"
+        assert "headless-chatgpt appears here" in entry["summary"]
+        assert "parent does not contain the query" not in entry["summary"]

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -426,26 +426,36 @@ def session_search(
                 continue
             if resolved_sid not in seen_sessions:
                 result = dict(result)
-                result["session_id"] = resolved_sid
+                if resolved_sid != raw_sid:
+                    result["resolved_session_id"] = resolved_sid
                 seen_sessions[resolved_sid] = result
             if len(seen_sessions) >= limit:
                 break
 
         # Prepare all sessions for parallel summarization
         tasks = []
-        for session_id, match_info in seen_sessions.items():
+        for resolved_session_id, match_info in seen_sessions.items():
+            content_session_id = match_info["session_id"]
             try:
-                messages = db.get_messages_as_conversation(session_id)
+                messages = db.get_messages_as_conversation(content_session_id)
                 if not messages:
                     continue
-                session_meta = db.get_session(session_id) or {}
+                session_meta = db.get_session(resolved_session_id) or {}
                 conversation_text = _format_conversation(messages)
                 conversation_text = _truncate_around_matches(conversation_text, query)
-                tasks.append((session_id, match_info, conversation_text, session_meta))
+                tasks.append(
+                    (
+                        content_session_id,
+                        resolved_session_id,
+                        match_info,
+                        conversation_text,
+                        session_meta,
+                    )
+                )
             except Exception as e:
                 logging.warning(
                     "Failed to prepare session %s: %s",
-                    session_id,
+                    content_session_id,
                     e,
                     exc_info=True,
                 )
@@ -462,7 +472,7 @@ def session_search(
 
             coros = [
                 _bounded_summary(text, meta)
-                for _, _, text, meta in tasks
+                for _, _, _, text, meta in tasks
             ]
             return await asyncio.gather(*coros, return_exceptions=True)
 
@@ -486,11 +496,19 @@ def session_search(
             }, ensure_ascii=False)
 
         summaries = []
-        for (session_id, match_info, conversation_text, session_meta), result in zip(tasks, results):
+        for (
+            content_session_id,
+            resolved_session_id,
+            match_info,
+            conversation_text,
+            session_meta,
+        ), result in zip(tasks, results):
             if isinstance(result, Exception):
                 logging.warning(
                     "Failed to summarize session %s: %s",
-                    session_id, result, exc_info=True,
+                    content_session_id,
+                    result,
+                    exc_info=True,
                 )
                 result = None
 
@@ -500,13 +518,15 @@ def session_search(
             # root, so session_meta has the authoritative platform/source for the
             # session the user actually cares about (#15909).
             entry = {
-                "session_id": session_id,
+                "session_id": content_session_id,
                 "when": _format_timestamp(
                     session_meta.get("started_at") or match_info.get("session_started")
                 ),
                 "source": session_meta.get("source") or match_info.get("source", "unknown"),
                 "model": session_meta.get("model") or match_info.get("model"),
             }
+            if resolved_session_id != content_session_id:
+                entry["resolved_session_id"] = resolved_session_id
 
             if result:
                 entry["summary"] = result


### PR DESCRIPTION
## Summary
- keep session_search dedup keyed by resolved/root session while preserving the original matched session for content retrieval
- surface `resolved_session_id` alongside the matched `session_id` when a child session resolves to a parent lineage
- add regression coverage for matched-child previews so parent sessions without the query are no longer summarized instead

## Testing
- `./scripts/run_tests.sh tests/tools/test_session_search.py -q`
- `uv run --frozen ruff check .`
- `env -i ... pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e --tb=short -n auto` (37 failures; 35 reproduced on latest `origin/main`, remaining 2 passed in isolated head/base reruns)
