### PR TITLE
explicitly guard against None when checking subprocess exit code

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1297,7 +1297,7 @@ def _launch_tui(
         except KeyboardInterrupt:
             code = 130
 
-        if code in (0, 130):
+        if code is not None and code in (0, 130):
             _print_tui_exit_summary(resume_session_id, active_session_file)
     finally:
         try:


### PR DESCRIPTION
## Description
This PR addresses a logic gap where the code variable could remain None and be incorrectly evaluated when checking the process exit status, clarifying the intended behavior when a subprocess fails unexpectedly.

### Root Cause
The code variable is initialized to None and only assigned an integer value inside an inner try block. If subprocess.call raises an exception other than KeyboardInterrupt (such as FileNotFoundError or PermissionError), the assignment is bypassed, and code remains None.

Consequently, the script evaluates None in (0, 130). While this evaluates to False in Python (avoiding a direct crash on this line), it silently skips the exit summary. More importantly, the intent is ambiguous, and the unhandled exception from subprocess.call propagates upward unchecked.

### Expected Behavior & Fix
An explicit code is not None guard has been added to the condition. Now, if the process fails to execute and code is never set, the script intentionally safely bypasses the exit summary. This makes the code explicitly safe and clearly communicates the expected behavior when dealing with unhandled subprocess exceptions.