### PR TITLE
fix(security): require explicit consent before uploading debug logs

### DIFF
--- a/hermes_cli/debug.py
+++ b/hermes_cli/debug.py
@@ -183,16 +183,21 @@ def _best_effort_sweep_expired_pastes() -> None:
 # ---------------------------------------------------------------------------
 
 _PRIVACY_NOTICE = """\
-⚠️  This will upload the following to a public paste service:
-  • System info (OS, Python version, Hermes version, provider, which API keys
-    are configured — NOT the actual keys)
-  • Recent log lines (agent.log, errors.log, gateway.log — may contain
-    conversation fragments and file paths)
-  • Full agent.log and gateway.log (up to 512 KB each — likely contains
-    conversation content, tool outputs, and file paths)
+⚠️  WARNING: Logs contain UNREDACTED personal data and conversation content.
 
-Pastes auto-delete after 6 hours.
+The existing redaction pipeline masks cryptographic secrets (API keys, tokens,
+passwords) but does NOT redact:
+  • Your display name and persistent platform user ID
+  • Verbatim content of your recent messages
+  • Local filesystem paths
+  • Any other PII present in logs
+
+This URL will be PUBLIC and accessible to anyone with the link.
+Pastes auto-delete after 6 hours, but may be archived by third parties.
+
+Use --local to view the report locally without uploading.
 """
+
 
 _GATEWAY_PRIVACY_NOTICE = (
     "⚠️ **Privacy notice:** This uploads system info + recent log tails "
@@ -592,6 +597,25 @@ def run_debug_share(args):
 
     if not local_only:
         print(_PRIVACY_NOTICE)
+        yes = bool(getattr(args, "yes", False))
+        if not yes:
+            # Non-interactive mode (no TTY) requires --yes to prevent
+            # accidental data exposure in scripts/CI pipelines.
+            if not sys.stdin.isatty():
+                print(
+                    "ERROR: Non-interactive mode requires --yes to confirm upload.\n"
+                    "       This prevents accidental exposure of personal data.\n"
+                    "       Use --local to view the report without uploading.",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+            try:
+                answer = input("Upload debug report? [y/N] ").strip().lower()
+            except (EOFError, KeyboardInterrupt):
+                answer = ""
+            if answer not in ("y", "yes"):
+                print("Aborted.")
+                return
 
     print("Collecting debug report...")
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9809,11 +9809,11 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""\
 Examples:
-    hermes debug share              Upload debug report and print URL
-    hermes debug share --lines 500  Include more log lines
-    hermes debug share --expire 30  Keep paste for 30 days
+    hermes debug share              Upload report (requires confirmation)
+    hermes debug share --yes        Skip confirmation (for scripts/CI)
     hermes debug share --local      Print report locally (no upload)
-    hermes debug share --no-redact  Disable upload-time secret redaction
+    hermes debug share --lines 500  Include more log lines
+    hermes debug share --no-redact  Disable secret redaction (not recommended)
     hermes debug delete <url>       Delete a previously uploaded paste
 """,
     )
@@ -9838,6 +9838,11 @@ Examples:
         "--local",
         action="store_true",
         help="Print the report locally instead of uploading",
+    )
+    share_parser.add_argument(
+        "-y", "--yes",
+        action="store_true",
+        help="Skip confirmation prompt and upload immediately",
     )
     share_parser.add_argument(
         "--no-redact",

--- a/tests/hermes_cli/test_debug.py
+++ b/tests/hermes_cli/test_debug.py
@@ -448,6 +448,7 @@ class TestRunDebugShare:
         args.lines = 50
         args.expire = 7
         args.local = False
+        args.yes = True
 
         with patch("hermes_cli.dump.run_dump"), \
              patch("hermes_cli.debug._sweep_expired_pastes", return_value=(0, 0)) as mock_sweep, \
@@ -466,6 +467,7 @@ class TestRunDebugShare:
         args.lines = 50
         args.expire = 7
         args.local = False
+        args.yes = True
 
         with patch("hermes_cli.dump.run_dump"), \
              patch(
@@ -503,6 +505,7 @@ class TestRunDebugShare:
         args.lines = 50
         args.expire = 7
         args.local = False
+        args.yes = True
 
         call_count = [0]
         uploaded_content = []
@@ -551,6 +554,7 @@ class TestRunDebugShare:
         args.lines = 50
         args.expire = 7
         args.local = False
+        args.yes = True
 
         uploaded_content = []
 
@@ -596,6 +600,7 @@ class TestRunDebugShare:
         args.lines = 50
         args.expire = 7
         args.local = False
+        args.yes = True
 
         call_count = [0]
         def _mock_upload(content, expiry_days=7):
@@ -620,6 +625,7 @@ class TestRunDebugShare:
         args.lines = 50
         args.expire = 7
         args.local = False
+        args.yes = True
 
         call_count = [0]
         def _mock_upload(content, expiry_days=7):
@@ -646,6 +652,7 @@ class TestRunDebugShare:
         args.lines = 50
         args.expire = 7
         args.local = False
+        args.yes = True
 
         with patch("hermes_cli.dump.run_dump"), \
              patch("hermes_cli.debug.upload_to_pastebin",
@@ -657,6 +664,49 @@ class TestRunDebugShare:
         out = capsys.readouterr()
         assert "all failed" in out.err
 
+
+
+    def test_share_aborts_on_user_decline(self, hermes_home, capsys, monkeypatch):
+        """When user declines the confirmation prompt, no upload occurs."""
+        from hermes_cli.debug import run_debug_share
+
+        args = MagicMock()
+        args.lines = 50
+        args.expire = 7
+        args.local = False
+        args.yes = False
+
+        # Simulate TTY for interactive prompt
+        monkeypatch.setattr("sys.stdin.isatty", lambda: True)
+        monkeypatch.setattr("builtins.input", lambda _: "n")
+
+        with patch("hermes_cli.dump.run_dump"), \
+             patch("hermes_cli.debug.upload_to_pastebin") as mock_upload:
+            run_debug_share(args)
+
+        mock_upload.assert_not_called()
+        out = capsys.readouterr().out
+        assert "Aborted" in out
+
+    def test_share_skips_prompt_with_yes_flag(self, hermes_home, capsys):
+        """--yes flag skips the confirmation prompt and uploads directly."""
+        from hermes_cli.debug import run_debug_share
+
+        args = MagicMock()
+        args.lines = 50
+        args.expire = 7
+        args.local = False
+        args.yes = True
+
+        with patch("hermes_cli.dump.run_dump"), \
+             patch("hermes_cli.debug._sweep_expired_pastes", return_value=(0, 0)), \
+             patch("hermes_cli.debug.upload_to_pastebin",
+                    return_value="https://paste.rs/test"):
+            run_debug_share(args)
+
+        out = capsys.readouterr().out
+        assert "Debug report uploaded" in out
+        assert "Aborted" not in out
 
 # ---------------------------------------------------------------------------
 # Share-time redaction wiring + visible banner
@@ -694,6 +744,7 @@ class TestRunDebugShareRedaction:
         args.lines = 50
         args.expire = 7
         args.local = False
+        args.yes = True
         args.no_redact = False
 
         captured: list[str] = []
@@ -724,6 +775,7 @@ class TestRunDebugShareRedaction:
         args.lines = 50
         args.expire = 7
         args.local = False
+        args.yes = True
         args.no_redact = False
 
         captured: list[str] = []
@@ -752,6 +804,7 @@ class TestRunDebugShareRedaction:
         args.lines = 50
         args.expire = 7
         args.local = False
+        args.yes = True
         args.no_redact = True
 
         captured: list[str] = []
@@ -1180,6 +1233,7 @@ class TestShareIncludesAutoDelete:
         args.lines = 50
         args.expire = 7
         args.local = False
+        args.yes = True
 
         with patch("hermes_cli.dump.run_dump"), \
              patch("hermes_cli.debug.upload_to_pastebin",
@@ -1202,6 +1256,7 @@ class TestShareIncludesAutoDelete:
         args.lines = 50
         args.expire = 7
         args.local = False
+        args.yes = True
 
         with patch("hermes_cli.dump.run_dump"), \
              patch("hermes_cli.debug.upload_to_pastebin",
@@ -1210,7 +1265,8 @@ class TestShareIncludesAutoDelete:
             run_debug_share(args)
 
         out = capsys.readouterr().out
-        assert "public paste service" in out
+        # Privacy notice warns about unredacted content
+        assert "UNREDACTED" in out
 
     def test_local_no_privacy_notice(self, hermes_home, capsys):
         from hermes_cli.debug import run_debug_share
@@ -1224,4 +1280,74 @@ class TestShareIncludesAutoDelete:
             run_debug_share(args)
 
         out = capsys.readouterr().out
-        assert "public paste service" not in out
+        # Should not show privacy warning in local mode
+        assert "UNREDACTED" not in out
+
+
+class TestNonInteractiveMode:
+    """Test non-interactive mode requires --yes flag."""
+
+    def test_non_interactive_requires_yes_flag(self, hermes_home, capsys, monkeypatch):
+        """Non-interactive mode (no TTY) should fail without --yes."""
+        from hermes_cli.debug import run_debug_share
+
+        # Simulate non-TTY environment
+        monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+        args = MagicMock()
+        args.lines = 50
+        args.expire = 7
+        args.local = False
+        args.yes = False
+
+        with patch("hermes_cli.dump.run_dump"):
+            with pytest.raises(SystemExit) as exc_info:
+                run_debug_share(args)
+
+        assert exc_info.value.code == 1
+        out = capsys.readouterr()
+        assert "Non-interactive mode requires --yes" in out.err
+        assert "personal data" in out.err
+
+    def test_non_interactive_with_yes_succeeds(self, hermes_home, capsys, monkeypatch):
+        """Non-interactive mode with --yes should proceed without prompting."""
+        from hermes_cli.debug import run_debug_share
+
+        # Simulate non-TTY environment
+        monkeypatch.setattr("sys.stdin.isatty", lambda: False)
+
+        args = MagicMock()
+        args.lines = 50
+        args.expire = 7
+        args.local = False
+        args.yes = True
+
+        with patch("hermes_cli.dump.run_dump"), \
+             patch("hermes_cli.debug.upload_to_pastebin",
+                    return_value="https://paste.rs/test"):
+            run_debug_share(args)
+
+        out = capsys.readouterr().out
+        assert "https://paste.rs/test" in out
+
+    def test_privacy_notice_mentions_unredacted_pii(self, hermes_home, capsys):
+        """Privacy notice should explicitly warn about unredacted PII."""
+        from hermes_cli.debug import run_debug_share
+
+        args = MagicMock()
+        args.lines = 50
+        args.expire = 7
+        args.local = False
+        args.yes = True
+
+        with patch("hermes_cli.dump.run_dump"), \
+             patch("hermes_cli.debug.upload_to_pastebin",
+                    return_value="https://paste.rs/test"), \
+             patch("hermes_cli.debug._schedule_auto_delete"):
+            run_debug_share(args)
+
+        out = capsys.readouterr().out
+        # Privacy notice should mention that PII is NOT redacted
+        assert "UNREDACTED" in out
+        assert "display name" in out
+        assert "conversation content" in out or "messages" in out


### PR DESCRIPTION
## Summary

Fixes #22016

Logs uploaded via `hermes debug share` contain **UNREDACTED personal data and conversation content**. The existing redaction pipeline (`agent/redact.py`, called with `force=True`) masks cryptographic secrets (API keys, tokens, passwords) but does **NOT** redact:
- Display name and persistent platform user ID
- Verbatim content of recent messages (prompts, responses)
- Local filesystem paths
- Any other PII present in logs

Users posting debug share URLs on GitHub were unintentionally disclosing this sensitive information publicly.

## Solution

This PR combines the approach from #22139 with additional safety for non-interactive mode:

### From PR #22139 (@liuhao1024)
- Confirmation prompt with `[y/N]` format
- `--yes/-y` flag to skip confirmation

### This PR adds
- TTY check to prevent hanging in scripts/CI
- Clear error message when `--yes` is required for non-interactive mode
- Stronger privacy notice explicitly warning about unredacted PII
- Additional tests for non-interactive mode and privacy notice content

## Privacy Notice (before/after)

**Before:**
```
⚠️  This will upload the following to a public paste service:
  • System info (OS, Python version, Hermes version, provider, which API keys
    are configured — NOT the actual keys)
  • Recent log lines (may contain conversation fragments and file paths)
  • Full agent.log and gateway.log (likely contains conversation content)
```

**After:**
```
⚠️  WARNING: Logs contain UNREDACTED personal data and conversation content.

The existing redaction pipeline masks cryptographic secrets (API keys, tokens,
passwords) but does NOT redact:
  • Your display name and persistent platform user ID
  • Verbatim content of your recent messages
  • Local filesystem paths
  • Any other PII present in logs

This URL will be PUBLIC and accessible to anyone with the link.
Pastes auto-delete after 6 hours, but may be archived by third parties.

Use --local to view the report locally without uploading.
```

## Behavior

| Mode | Behavior |
|------|----------|
| Interactive with TTY | Shows warning, prompts `Upload debug report? [y/N]` |
| Interactive, user types 'y' or 'yes' | Proceeds with upload |
| Interactive, user types anything else | Prints "Aborted." and exits |
| Non-interactive (script/CI) without `--yes` | Exits with error: "Non-interactive mode requires --yes" |
| Non-interactive with `--yes` | Proceeds without prompt |
| `--local` flag | No prompt, no upload (just prints locally) |

## Tests

- `TestRunDebugShare::test_share_aborts_on_user_decline` - User declines prompt
- `TestRunDebugShare::test_share_skips_prompt_with_yes_flag` - `--yes` skips prompt
- `TestNonInteractiveMode::test_non_interactive_requires_yes_flag` - Non-TTY fails without `--yes`
- `TestNonInteractiveMode::test_non_interactive_with_yes_succeeds` - Non-TTY works with `--yes`
- `TestNonInteractiveMode::test_privacy_notice_mentions_unredacted_pii` - Privacy notice mentions PII

## Credits

This builds on PR #22139 by the original author. The core prompt logic and `--yes` flag were introduced there; this PR adds non-interactive safety and strengthens the privacy notice.