### PR TITLE
remove redundant return None after finally block

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -650,7 +650,6 @@ def _resolve_last_session(source: str = "cli") -> Optional[str]:
                 db.close()
             except Exception:
                 pass
-    return None
 
 
 def _probe_container(cmd: list, backend: str, via_sudo: bool = False):


### PR DESCRIPTION
## Description
This PR cleans up the control flow in _resolve_last_session by removing an explicit but unnecessary return None statement that was placed after a finally block, improving overall code readability.

### Root Cause
In _resolve_last_session, the try block either successfully returns a value (return sessions[0]["id"]) or falls through to an except Exception: pass on failure. After the finally block runs, there was a bare return None.

While technically reachable during a caught exception, its presence was highly misleading. It falsely implied that the function might reach that line during a normal execution flow, obscuring the fact that the "happy path" already returns inside the try block. This resulted in redundant code on the success path and confusing flow on the failure path.

### Expected Behavior & Fix
The explicit return None has been removed. The control flow is now perfectly clear: a successful execution returns directly from the try block, while a failure falls through the except and finally blocks, resulting in Python implicitly returning None by default. This change makes the code leaner without altering the underlying functionality.