### PR TITLE
fix: handle oauth_minimax in auxiliary providers

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2623,6 +2623,41 @@ def resolve_provider_client(
         return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                 else (client, final_model))
 
+    elif pconfig.auth_type == "oauth_minimax":
+        try:
+            from hermes_cli.auth import resolve_minimax_oauth_runtime_credentials
+
+            creds = resolve_minimax_oauth_runtime_credentials()
+        except Exception as exc:
+            logger.warning(
+                "resolve_provider_client: minimax-oauth requested but OAuth "
+                "credentials are unavailable (%s)",
+                exc,
+            )
+            return None, None
+
+        api_key = str(creds.get("api_key", "")).strip()
+        if not api_key:
+            logger.warning(
+                "resolve_provider_client: minimax-oauth requested but OAuth "
+                "credentials returned no access token"
+            )
+            return None, None
+
+        raw_base_url = (
+            str(creds.get("base_url", "")).strip().rstrip("/")
+            or pconfig.inference_base_url
+        )
+        base_url = _to_openai_base_url(raw_base_url)
+        default_model = _get_aux_model_for_provider(provider)
+        final_model = _normalize_resolved_model(model or default_model, provider)
+        client = OpenAI(api_key=api_key, base_url=base_url)
+        client = _wrap_if_needed(client, final_model, raw_base_url, api_key)
+
+        logger.debug("resolve_provider_client: %s (%s)", provider, final_model)
+        return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
+                else (client, final_model))
+
     if pconfig.auth_type == "external_process":
         creds = resolve_external_process_provider_credentials(provider)
         final_model = _normalize_resolved_model(

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -276,6 +276,62 @@ class TestAnthropicOAuthFlag:
         assert mock_build.call_args.args[0] == "sk-ant-oat01-pooled"
 
 
+class TestMinimaxOAuthAuxiliary:
+    def test_resolve_provider_client_builds_minimax_oauth_client(self):
+        from agent.auxiliary_client import (
+            AnthropicAuxiliaryClient,
+            resolve_provider_client,
+        )
+
+        fake_creds = {
+            "provider": "minimax-oauth",
+            "api_key": "mxp-test-token",
+            "base_url": "https://api.minimax.io/anthropic",
+            "source": "oauth",
+        }
+
+        with (
+            patch(
+                "hermes_cli.auth.resolve_minimax_oauth_runtime_credentials",
+                return_value=fake_creds,
+            ),
+            patch(
+                "agent.anthropic_adapter.build_anthropic_client",
+                return_value=MagicMock(),
+            ) as mock_build,
+        ):
+            client, model = resolve_provider_client("minimax-oauth")
+
+        assert isinstance(client, AnthropicAuxiliaryClient)
+        assert model == "MiniMax-M2.7-highspeed"
+        mock_build.assert_called_once_with(
+            "mxp-test-token",
+            "https://api.minimax.io/anthropic",
+        )
+
+    def test_resolve_provider_client_handles_missing_minimax_oauth_credentials(
+        self, caplog
+    ):
+        from hermes_cli.auth import AuthError
+
+        caplog.set_level(logging.WARNING)
+
+        with patch(
+            "hermes_cli.auth.resolve_minimax_oauth_runtime_credentials",
+            side_effect=AuthError(
+                "not logged in",
+                provider="minimax-oauth",
+                code="not_logged_in",
+            ),
+        ):
+            client, model = resolve_provider_client("minimax-oauth")
+
+        assert client is None
+        assert model is None
+        assert "unhandled auth_type oauth_minimax" not in caplog.text
+        assert "minimax-oauth requested but OAuth credentials are unavailable" in caplog.text
+
+
 class TestBuildCodexClient:
     def test_pool_without_selected_entry_falls_back_to_auth_store(self):
         with (


### PR DESCRIPTION
## Summary
- handle `auth_type: oauth_minimax` in `agent.auxiliary_client.resolve_provider_client`
- reuse `resolve_minimax_oauth_runtime_credentials()` so auxiliary MiniMax OAuth providers get the right token, base URL, and wrapped Anthropics-compatible client
- add regression tests for both the successful credential path and the missing-credentials warning path

## Root cause
`agent/auxiliary_client.py` never handled `oauth_minimax`, so every auxiliary MiniMax OAuth config fell through to the generic `unhandled auth_type` warning even though the runtime credential resolver already existed elsewhere.

## Validation
- `./scripts/run_tests.sh tests/agent/test_auxiliary_client.py -q -k 'minimax_oauth or AnthropicOAuthFlag'`
- `./scripts/run_tests.sh tests/hermes_cli/test_runtime_provider_resolution.py -q -k minimax_oauth`
- `git diff --check`
- `uv sync --frozen --extra all`
- `uv run --frozen ruff check .`
- `python scripts/lint_diff.py ...`
- `env -i ... python -m pytest tests/ --collect-only -q --ignore=tests/integration --ignore=tests/e2e -n auto`

Fixes #21521
