### PR TITLE
fix(installer): add browser install mode

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -69,6 +69,7 @@ ROOT_FHS_LAYOUT=false
 USE_VENV=true
 RUN_SETUP=true
 BRANCH="main"
+BROWSER_INSTALL_MODE="auto"
 
 # Detect non-interactive mode (e.g. curl | bash)
 # When stdin is not a terminal, read -p will fail with EOF,
@@ -94,6 +95,19 @@ while [[ $# -gt 0 ]]; do
             BRANCH="$2"
             shift 2
             ;;
+        --browser-install-mode)
+            case "${2:-}" in
+                auto|user|skip)
+                    BROWSER_INSTALL_MODE="$2"
+                    ;;
+                *)
+                    echo "Invalid value for --browser-install-mode: ${2:-}"
+                    echo "Expected one of: auto, user, skip"
+                    exit 1
+                    ;;
+            esac
+            shift 2
+            ;;
         --dir)
             INSTALL_DIR="$2"
             INSTALL_DIR_EXPLICIT=true
@@ -112,6 +126,10 @@ while [[ $# -gt 0 ]]; do
             echo "  --no-venv      Don't create virtual environment"
             echo "  --skip-setup   Skip interactive setup wizard"
             echo "  --branch NAME  Git branch to install (default: main)"
+            echo "  --browser-install-mode MODE  Playwright browser install mode:"
+            echo "                   auto = install browser + system deps when supported"
+            echo "                   user = install browser only, never use sudo/system pkg mgr"
+            echo "                   skip = skip Playwright browser install entirely"
             echo "  --dir PATH     Installation directory"
             echo "                   default (non-root):  ~/.hermes/hermes-agent"
             echo "                   default (root, Linux): /usr/local/lib/hermes-agent"
@@ -1323,59 +1341,72 @@ install_node_deps() {
         # Playwright's --with-deps only supports apt-based systems natively.
         # For Arch/Manjaro we install the system libs via pacman first.
         # Other systems must install Chromium dependencies manually.
-        log_info "Installing browser engine (Playwright Chromium)..."
-        case "$DISTRO" in
-            ubuntu|debian|raspbian|pop|linuxmint|elementary|zorin|kali|parrot)
-                log_info "Playwright may request sudo to install browser system dependencies (shared libraries)."
-                log_info "This is standard Playwright setup — Hermes itself does not require root access."
-                cd "$INSTALL_DIR" && npx playwright install --with-deps chromium 2>/dev/null || {
-                    log_warn "Playwright browser installation failed — browser tools will not work."
-                    log_warn "Try running manually: cd $INSTALL_DIR && npx playwright install --with-deps chromium"
-                }
-                ;;
-            arch|manjaro)
-                if command -v pacman &> /dev/null; then
-                    log_info "Arch/Manjaro detected — installing Chromium system dependencies via pacman..."
-                    if command -v sudo &> /dev/null && sudo -n true 2>/dev/null; then
-                        sudo NEEDRESTART_MODE=a pacman -S --noconfirm --needed \
-                            nss atk at-spi2-core cups libdrm libxkbcommon mesa pango cairo alsa-lib >/dev/null 2>&1 || true
-                    elif [ "$(id -u)" -eq 0 ]; then
-                        pacman -S --noconfirm --needed \
-                            nss atk at-spi2-core cups libdrm libxkbcommon mesa pango cairo alsa-lib >/dev/null 2>&1 || true
-                    else
-                        log_warn "Cannot install browser deps without sudo. Run manually:"
-                        log_warn "  sudo pacman -S nss atk at-spi2-core cups libdrm libxkbcommon mesa pango cairo alsa-lib"
-                    fi
-                fi
+        if [ "$BROWSER_INSTALL_MODE" = "skip" ]; then
+            log_info "Skipping browser engine install (--browser-install-mode skip)"
+        else
+            log_info "Installing browser engine (Playwright Chromium)..."
+            if [ "$BROWSER_INSTALL_MODE" = "user" ]; then
+                log_info "Installing browser only (--browser-install-mode user); system dependencies are not modified."
+                log_info "If browser tools fail later, install Playwright system dependencies separately as an admin."
                 cd "$INSTALL_DIR" && npx playwright install chromium 2>/dev/null || {
                     log_warn "Playwright browser installation failed — browser tools will not work."
+                    log_warn "Try running manually: cd $INSTALL_DIR && npx playwright install chromium"
                 }
-                ;;
-            fedora|rhel|centos|rocky|alma)
-                log_warn "Playwright does not support automatic dependency installation on RPM-based systems."
-                log_info "Install Chromium system dependencies manually before using browser tools:"
-                log_info "  sudo dnf install nss atk at-spi2-core cups-libs libdrm libxkbcommon mesa-libgbm pango cairo alsa-lib"
-                cd "$INSTALL_DIR" && npx playwright install chromium 2>/dev/null || {
-                    log_warn "Playwright browser installation failed — install dependencies above and retry."
-                }
-                ;;
-            opensuse*|sles)
-                log_warn "Playwright does not support automatic dependency installation on zypper-based systems."
-                log_info "Install Chromium system dependencies manually before using browser tools:"
-                log_info "  sudo zypper install mozilla-nss libatk-1_0-0 at-spi2-core cups-libs libdrm2 libxkbcommon0 Mesa-libgbm1 pango cairo libasound2"
-                cd "$INSTALL_DIR" && npx playwright install chromium 2>/dev/null || {
-                    log_warn "Playwright browser installation failed — install dependencies above and retry."
-                }
-                ;;
-            *)
-                log_warn "Playwright does not support automatic dependency installation on $DISTRO."
-                log_info "Install Chromium/browser system dependencies for your distribution, then run:"
-                log_info "  cd $INSTALL_DIR && npx playwright install chromium"
-                log_info "Browser tools will not work until dependencies are installed."
-                cd "$INSTALL_DIR" && npx playwright install chromium 2>/dev/null || true
-                ;;
-        esac
-        log_success "Browser engine setup complete"
+            else
+                case "$DISTRO" in
+                    ubuntu|debian|raspbian|pop|linuxmint|elementary|zorin|kali|parrot)
+                        log_info "Playwright may request sudo to install browser system dependencies (shared libraries)."
+                        log_info "This is standard Playwright setup — Hermes itself does not require root access."
+                        cd "$INSTALL_DIR" && npx playwright install --with-deps chromium 2>/dev/null || {
+                            log_warn "Playwright browser installation failed — browser tools will not work."
+                            log_warn "Try running manually: cd $INSTALL_DIR && npx playwright install --with-deps chromium"
+                        }
+                        ;;
+                    arch|manjaro)
+                        if command -v pacman &> /dev/null; then
+                            log_info "Arch/Manjaro detected — installing Chromium system dependencies via pacman..."
+                            if command -v sudo &> /dev/null && sudo -n true 2>/dev/null; then
+                                sudo NEEDRESTART_MODE=a pacman -S --noconfirm --needed \
+                                    nss atk at-spi2-core cups libdrm libxkbcommon mesa pango cairo alsa-lib >/dev/null 2>&1 || true
+                            elif [ "$(id -u)" -eq 0 ]; then
+                                pacman -S --noconfirm --needed \
+                                    nss atk at-spi2-core cups libdrm libxkbcommon mesa pango cairo alsa-lib >/dev/null 2>&1 || true
+                            else
+                                log_warn "Cannot install browser deps without sudo. Run manually:"
+                                log_warn "  sudo pacman -S nss atk at-spi2-core cups libdrm libxkbcommon mesa pango cairo alsa-lib"
+                            fi
+                        fi
+                        cd "$INSTALL_DIR" && npx playwright install chromium 2>/dev/null || {
+                            log_warn "Playwright browser installation failed — browser tools will not work."
+                        }
+                        ;;
+                    fedora|rhel|centos|rocky|alma)
+                        log_warn "Playwright does not support automatic dependency installation on RPM-based systems."
+                        log_info "Install Chromium system dependencies manually before using browser tools:"
+                        log_info "  sudo dnf install nss atk at-spi2-core cups-libs libdrm libxkbcommon mesa-libgbm pango cairo alsa-lib"
+                        cd "$INSTALL_DIR" && npx playwright install chromium 2>/dev/null || {
+                            log_warn "Playwright browser installation failed — install dependencies above and retry."
+                        }
+                        ;;
+                    opensuse*|sles)
+                        log_warn "Playwright does not support automatic dependency installation on zypper-based systems."
+                        log_info "Install Chromium system dependencies manually before using browser tools:"
+                        log_info "  sudo zypper install mozilla-nss libatk-1_0-0 at-spi2-core cups-libs libdrm2 libxkbcommon0 Mesa-libgbm1 pango cairo libasound2"
+                        cd "$INSTALL_DIR" && npx playwright install chromium 2>/dev/null || {
+                            log_warn "Playwright browser installation failed — install dependencies above and retry."
+                        }
+                        ;;
+                    *)
+                        log_warn "Playwright does not support automatic dependency installation on $DISTRO."
+                        log_info "Install Chromium/browser system dependencies for your distribution, then run:"
+                        log_info "  cd $INSTALL_DIR && npx playwright install chromium"
+                        log_info "Browser tools will not work until dependencies are installed."
+                        cd "$INSTALL_DIR" && npx playwright install chromium 2>/dev/null || true
+                        ;;
+                esac
+            fi
+            log_success "Browser engine setup complete"
+        fi
     fi
 
     # Install TUI dependencies

--- a/tests/test_install_sh_browser_install_mode.py
+++ b/tests/test_install_sh_browser_install_mode.py
@@ -1,0 +1,99 @@
+"""Regression tests for install.sh browser install modes."""
+
+from __future__ import annotations
+
+import os
+import re
+import stat
+import subprocess
+import tempfile
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def _extract_function_body(name: str) -> str:
+    text = INSTALL_SH.read_text()
+    match = re.search(
+        rf"^{re.escape(name)}\(\)\s*\{{\s*\n(?P<body>.*?)^\}}",
+        text,
+        re.MULTILINE | re.DOTALL,
+    )
+    assert match is not None, f"{name}() not found in scripts/install.sh"
+    return match.group(0)
+
+
+def _run_install_node_deps(*, distro: str, browser_install_mode: str) -> str:
+    func = _extract_function_body("install_node_deps")
+
+    with tempfile.TemporaryDirectory(prefix="hermes-install-sh-") as tmp:
+        tmp_path = Path(tmp)
+        bin_dir = tmp_path / "bin"
+        install_dir = tmp_path / "install"
+        bin_dir.mkdir()
+        install_dir.mkdir()
+        (install_dir / "package.json").write_text("{}")
+
+        for name, content in {
+            "npm": "#!/bin/bash\nexit 0\n",
+            "npx": "#!/bin/bash\nprintf '%s\\n' \"$*\" >> \"$TMP_NPX_LOG\"\nexit 0\n",
+        }.items():
+            path = bin_dir / name
+            path.write_text(content)
+            path.chmod(path.stat().st_mode | stat.S_IXUSR)
+
+        driver = tmp_path / "driver.sh"
+        driver.write_text(
+            "\n".join(
+                [
+                    "#!/bin/bash",
+                    "set -e",
+                    func,
+                    "log_info(){ :; }",
+                    "log_warn(){ :; }",
+                    "log_success(){ :; }",
+                    "HAS_NODE=true",
+                    f'DISTRO="{distro}"',
+                    f'BROWSER_INSTALL_MODE="{browser_install_mode}"',
+                    f'INSTALL_DIR="{install_dir}"',
+                    "install_node_deps",
+                ]
+            )
+            + "\n"
+        )
+        driver.chmod(driver.stat().st_mode | stat.S_IXUSR)
+
+        env = os.environ.copy()
+        env["PATH"] = f"{bin_dir}:{env['PATH']}"
+        env["TMP_NPX_LOG"] = str(tmp_path / "npx.log")
+
+        subprocess.run(["bash", str(driver)], check=True, env=env)
+
+        log_path = tmp_path / "npx.log"
+        return log_path.read_text() if log_path.exists() else ""
+
+
+def test_install_script_help_mentions_browser_install_mode() -> None:
+    text = INSTALL_SH.read_text()
+    assert "--browser-install-mode MODE" in text
+    assert "auto = install browser + system deps when supported" in text
+    assert "user = install browser only, never use sudo/system pkg mgr" in text
+    assert "skip = skip Playwright browser install entirely" in text
+
+
+def test_ubuntu_auto_mode_uses_with_deps() -> None:
+    log = _run_install_node_deps(distro="ubuntu", browser_install_mode="auto")
+    assert "playwright install --with-deps chromium" in log
+
+
+def test_ubuntu_user_mode_skips_system_dependency_install() -> None:
+    log = _run_install_node_deps(distro="ubuntu", browser_install_mode="user")
+    assert "playwright install chromium" in log
+    assert "--with-deps" not in log
+
+
+def test_skip_mode_omits_playwright_install_entirely() -> None:
+    log = _run_install_node_deps(distro="ubuntu", browser_install_mode="skip")
+    assert log == ""


### PR DESCRIPTION
## What does this PR do?

Adds a non-sudo browser install mode to the Linux/macOS installer so service-user deployments can avoid Playwright's system dependency install path.

Today `scripts/install.sh` always installs browser tooling during `install_node_deps()`, and on apt-based Linux distributions that means running `npx playwright install --with-deps chromium` (`scripts/install.sh:1360`). That path can trigger sudo / system package installation, which is a poor fit for production deployments where a human admin prepares the machine but the Hermes gateway runs under a non-privileged service account.

This change adds an explicit installer flag to control browser setup behavior:

- `auto` keeps the current behavior
- `user` installs the Playwright browser only, without `--with-deps` or package-manager side effects
- `skip` skips Playwright browser install entirely

That preserves the default local-dev experience while giving deployment automation a stable non-sudo mode.

## Related Issue

Fixes #22152

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `BROWSER_INSTALL_MODE="auto"` plus `--browser-install-mode auto|user|skip` argument parsing and help text in [scripts/install.sh](/mnt/d/hermes-agent/scripts/install.sh).
- Updated the Playwright install branch in [scripts/install.sh](/mnt/d/hermes-agent/scripts/install.sh) so:
  - `auto` preserves the existing apt-based `npx playwright install --with-deps chromium` behavior
  - `user` runs `npx playwright install chromium` and never requests system dependency installation
  - `skip` omits Playwright browser install entirely
- Added [tests/test_install_sh_browser_install_mode.py](/mnt/d/hermes-agent/tests/test_install_sh_browser_install_mode.py) to regression-test:
  - help text exposure for the new installer flag
  - Ubuntu `auto` mode still using `--with-deps`
  - Ubuntu `user` mode avoiding `--with-deps`
  - `skip` mode making no Playwright install call at all

## How to Test

1. Activate the repo venv.
2. Run `python -m pytest tests/test_install_sh_browser_install_mode.py -q`
3. Run `python -m pytest tests/test_install_sh_termux_network_prereqs.py tests/test_install_sh_setup_wizard_tty_probe.py tests/test_install_sh_pythonpath_sanitization.py -q`
4. Optionally inspect `scripts/install.sh --help` and confirm `--browser-install-mode` documents `auto`, `user`, and `skip`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `python -m pytest tests/test_install_sh_browser_install_mode.py -q` and all tests pass
- [x] I've run `python -m pytest tests/test_install_sh_termux_network_prereqs.py tests/test_install_sh_setup_wizard_tty_probe.py tests/test_install_sh_pythonpath_sanitization.py -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL Ubuntu / Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

`python -m pytest tests/test_install_sh_browser_install_mode.py -q`

`4 passed in 12.06s`

`python -m pytest tests/test_install_sh_termux_network_prereqs.py tests/test_install_sh_setup_wizard_tty_probe.py tests/test_install_sh_pythonpath_sanitization.py -q`

`10 passed in 14.06s`
