### PR TITLE
fix(model-switch): refresh custom runtime credentials

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -885,14 +885,14 @@ def switch_model(
                 requested=current_provider,
                 target_model=new_model,
             )
-            # If resolution fell through to "custom" (e.g. named custom provider like
-            # "ollama-launch" that resolve_runtime_provider doesn't know), keep existing
-            # credentials. Otherwise use the resolved values (picks up credential rotation,
-            # base_url adjustments for OpenCode, etc.).
-            if runtime.get("provider") != "custom":
-                api_key = runtime.get("api_key", "")
-                base_url = runtime.get("base_url", "")
-                api_mode = runtime.get("api_mode", "")
+            # Same-provider switches still need fresh runtime credentials:
+            # credential pools may rotate, provider-specific base URLs/api modes
+            # may be model-dependent, and named custom providers resolve to the
+            # generic runtime label "custom" while still carrying the correct
+            # base_url/api_key for the selected provider.
+            api_key = runtime.get("api_key", "")
+            base_url = runtime.get("base_url", "")
+            api_mode = runtime.get("api_mode", "")
         except Exception:
             pass
 

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -104,6 +104,50 @@ def test_switch_model_accepts_explicit_named_custom_provider(monkeypatch):
     assert result.api_key == "no-key-required"
 
 
+def test_switch_model_refreshes_custom_runtime_when_provider_unchanged(monkeypatch):
+    """In-provider switches for named custom providers should use fresh runtime credentials.
+
+    ``resolve_runtime_provider`` intentionally returns provider="custom" for
+    named custom providers.  A same-provider /model switch must still consume
+    its resolved api_key/base_url instead of preserving stale session values.
+    """
+    monkeypatch.setattr(
+        "hermes_cli.runtime_provider.resolve_runtime_provider",
+        lambda **kwargs: {
+            "provider": "custom",
+            "api_key": "fresh-custom-key",
+            "base_url": "https://fresh.example/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+    monkeypatch.setattr("hermes_cli.models.validate_requested_model", lambda *a, **k: _MOCK_VALIDATION)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_info", lambda *a, **k: None)
+    monkeypatch.setattr("hermes_cli.model_switch.get_model_capabilities", lambda *a, **k: None)
+
+    result = switch_model(
+        raw_input="fresh-model",
+        current_provider="custom:my-provider",
+        current_model="old-model",
+        current_base_url="https://stale.example/v1",
+        current_api_key="stale-custom-key",
+        explicit_provider="",
+        user_providers={},
+        custom_providers=[
+            {
+                "name": "My Provider",
+                "base_url": "https://fresh.example/v1",
+                "model": "fresh-model",
+            }
+        ],
+    )
+
+    assert result.success is True
+    assert result.provider_changed is False
+    assert result.api_key == "fresh-custom-key"
+    assert result.base_url == "https://fresh.example/v1"
+    assert result.api_mode == "chat_completions"
+
+
 def test_list_groups_same_name_custom_providers_into_one_row(monkeypatch):
     """Multiple custom_providers entries sharing a name should produce one row
     with all models collected, not N duplicate rows."""


### PR DESCRIPTION
## Summary
- refresh runtime api_key/base_url/api_mode during same-provider /model switches
- cover named custom providers whose runtime provider resolves to the generic `custom` label
- prevent stale session credentials from being reused for validation/execution

## Test plan
- `python -m pytest tests/hermes_cli/test_model_switch_custom_providers.py::test_switch_model_refreshes_custom_runtime_when_provider_unchanged tests/hermes_cli/test_model_switch_custom_providers.py -q`
- `python -m pytest tests/hermes_cli/test_model_switch_*.py tests/gateway/test_model_switch_persistence.py -q`
- `python -m pytest tests/hermes_cli/test_runtime_provider_resolution.py -q`
