### PR TITLE
[codex] Keep named custom model switches on endpoint

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -825,7 +825,7 @@ def switch_model(
 
         # --- Step e: detect_provider_for_model() as last resort ---
         _base = current_base_url or ""
-        is_custom = current_provider in ("custom", "local") or (
+        is_custom = current_provider in ("custom", "local") or current_provider.startswith("custom:") or (
             "localhost" in _base or "127.0.0.1" in _base
         )
 

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -753,6 +753,63 @@ def test_switch_model_resolves_user_provider_credentials(monkeypatch, tmp_path):
     assert result.error_message == ""
 
 
+def test_named_custom_provider_keeps_bare_route_model_on_current_provider(monkeypatch):
+    """Bare model names on named custom providers should stay on that endpoint.
+
+    Bifrost can route aliases like ``deepseek-v4-pro`` internally. Provider
+    autodetection must not rewrite that request to the native DeepSeek provider
+    before the custom endpoint sees it.
+    """
+    custom_providers = [
+        {
+            "name": "bifrost",
+            "base_url": "https://bifrost.example.test/v1",
+            "api_key": "vk-test",
+            "model": "opencode/deepseek-v4-pro",
+        }
+    ]
+
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.resolve_alias",
+        lambda *a, **k: None,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.model_switch.list_provider_models",
+        lambda *a, **k: [],
+    )
+
+    def _detect_provider_for_model(*args, **kwargs):
+        raise AssertionError("custom:bifrost must not run provider autodetect")
+
+    monkeypatch.setattr(
+        "hermes_cli.models.detect_provider_for_model",
+        _detect_provider_for_model,
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.validate_requested_model",
+        lambda *a, **k: {
+            "accepted": True,
+            "persist": True,
+            "recognized": False,
+            "message": None,
+        },
+    )
+
+    result = switch_model(
+        raw_input="deepseek-v4-pro",
+        current_provider="custom:bifrost",
+        current_model="opencode/deepseek-v4-pro",
+        current_base_url="https://bifrost.example.test/v1",
+        current_api_key="vk-test",
+        custom_providers=custom_providers,
+    )
+
+    assert result.success is True
+    assert result.target_provider == "custom:bifrost"
+    assert result.provider_label == "bifrost"
+    assert result.new_model == "deepseek-v4-pro"
+
+
 # =============================================================================
 # Regression: providers: dict ``transport`` field must be honored
 # =============================================================================


### PR DESCRIPTION
## What changed

- Treat named custom providers (`custom:<name>`) the same as bare `custom` during `/model` provider autodetection.
- Add a regression test proving a bare route model on `custom:bifrost` stays on that endpoint instead of being rewritten to a native provider.

## Why

Named custom endpoints can be gateways/proxies with their own route aliases and fallback chains. A bare model like `deepseek-v4-pro` may be valid at the gateway even when it is not listed directly by `/v1/models`.

Before this change, Hermes skipped autodetection for `custom` and local endpoints, but not for `custom:<name>`. That let `/model deepseek-v4-pro` on `custom:bifrost` switch to native DeepSeek before Bifrost could route it.

Fixes #22216.

## Validation

- `pytest tests/hermes_cli/test_user_providers_model_switch.py::test_named_custom_provider_keeps_bare_route_model_on_current_provider -q`
- Full suite was also run with `./scripts/run_tests.sh`; it did not pass in this local environment due to unrelated pre-existing/environment failures, mainly git commit tests failing with `error: Couldn't get agent socket?`, unavailable CDP at `127.0.0.1:9222`, and several unrelated existing failures. Summary from that run: `21236 passed, 61 skipped, 30 failed, 12 errors`.
