### PR TITLE
fix(deepseek): add native thinking/reasoning_effort support

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -187,6 +187,7 @@ class ChatCompletionsTransport(ProviderTransport):
             is_github_models: bool
             is_nvidia_nim: bool
             is_kimi: bool
+            is_deepseek: bool
             is_tokenhub: bool
             is_lmstudio: bool
             is_custom_provider: bool
@@ -331,6 +332,17 @@ class ChatCompletionsTransport(ProviderTransport):
                     _kimi_thinking_enabled = False
             extra_body["thinking"] = {
                 "type": "enabled" if _kimi_thinking_enabled else "disabled",
+            }
+
+        # DeepSeek extra_body.thinking (same protocol as Kimi)
+        is_deepseek = params.get("is_deepseek", False)
+        if is_deepseek:
+            _ds_thinking_enabled = True
+            if reasoning_config and isinstance(reasoning_config, dict):
+                if reasoning_config.get("enabled") is False:
+                    _ds_thinking_enabled = False
+            extra_body["thinking"] = {
+                "type": "enabled" if _ds_thinking_enabled else "disabled",
             }
 
         # Reasoning. LM Studio is handled above via top-level reasoning_effort,

--- a/plugins/model-providers/deepseek/__init__.py
+++ b/plugins/model-providers/deepseek/__init__.py
@@ -1,9 +1,51 @@
-"""DeepSeek provider profile."""
+"""DeepSeek provider profile.
+
+DeepSeek V4+ thinking mode uses ``extra_body.thinking`` + top-level
+``reasoning_effort`` (same protocol as Kimi/Z.AI, NOT OpenRouter's
+``extra_body.reasoning``).
+"""
+
+from typing import Any
 
 from providers import register_provider
 from providers.base import ProviderProfile
 
-deepseek = ProviderProfile(
+
+class DeepSeekProfile(ProviderProfile):
+    """DeepSeek — extra_body.thinking + reasoning_effort (native protocol)."""
+
+    def build_api_kwargs_extras(
+        self, *, reasoning_config: dict | None = None, **context
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        extra_body: dict[str, Any] = {}
+        top_level: dict[str, Any] = {}
+
+        if not reasoning_config or not isinstance(reasoning_config, dict):
+            # No config → thinking enabled, default effort (high for DeepSeek)
+            extra_body["thinking"] = {"type": "enabled"}
+            top_level["reasoning_effort"] = "high"
+            return extra_body, top_level
+
+        enabled = reasoning_config.get("enabled", True)
+        if enabled is False:
+            extra_body["thinking"] = {"type": "disabled"}
+            return extra_body, top_level
+
+        # Enabled — map Hermes effort levels to DeepSeek's accepted values.
+        # DeepSeek only accepts "high" and "max"; low/medium → high, xhigh → max.
+        extra_body["thinking"] = {"type": "enabled"}
+        effort = (reasoning_config.get("effort") or "").strip().lower()
+        if effort in ("low", "medium", "high"):
+            top_level["reasoning_effort"] = "high"
+        elif effort == "xhigh":
+            top_level["reasoning_effort"] = "max"
+        else:
+            top_level["reasoning_effort"] = "high"
+
+        return extra_body, top_level
+
+
+deepseek = DeepSeekProfile(
     name="deepseek",
     aliases=("deepseek-chat",),
     env_vars=("DEEPSEEK_API_KEY",),

--- a/run_agent.py
+++ b/run_agent.py
@@ -8882,6 +8882,7 @@ class AIAgent:
             or base_url_host_matches(self.base_url, "moonshot.ai")
             or base_url_host_matches(self.base_url, "moonshot.cn")
         )
+        _is_deepseek = base_url_host_matches(self.base_url, "api.deepseek.com")
         _is_tokenhub = base_url_host_matches(self._base_url_lower, "tokenhub.tencentmaas.com")
         _is_lmstudio = (self.provider or "").strip().lower() == "lmstudio"
 
@@ -8992,6 +8993,7 @@ class AIAgent:
             is_github_models=_is_gh,
             is_nvidia_nim=_is_nvidia,
             is_kimi=_is_kimi,
+            is_deepseek=_is_deepseek,
             is_tokenhub=_is_tokenhub,
             is_lmstudio=_is_lmstudio,
             is_custom_provider=self.provider == "custom",

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -201,3 +201,25 @@ class TestBaseProfile:
         eb, tl = p.build_api_kwargs_extras()
         assert eb == {}
         assert tl == {}
+
+
+class TestDeepSeekProfile:
+    def test_thinking_enabled(self):
+        p = get_provider_profile("deepseek")
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": True, "effort": "medium"},
+        )
+        assert eb["thinking"] == {"type": "enabled"}
+
+    def test_thinking_disabled(self):
+        p = get_provider_profile("deepseek")
+        eb, tl = p.build_api_kwargs_extras(
+            reasoning_config={"enabled": False},
+        )
+        assert eb["thinking"] == {"type": "disabled"}
+
+    def test_no_config_defaults_enabled(self):
+        """When reasoning_config is None, thinking defaults to enabled."""
+        p = get_provider_profile("deepseek")
+        eb, tl = p.build_api_kwargs_extras(reasoning_config=None)
+        assert eb["thinking"] == {"type": "enabled"}

--- a/tests/providers/test_transport_parity.py
+++ b/tests/providers/test_transport_parity.py
@@ -256,3 +256,31 @@ class TestCustomOllamaParity:
             reasoning_config={"enabled": False, "effort": "none"},
         )
         assert kw["extra_body"]["think"] is False
+
+
+class TestDeepSeekParity:
+    """DeepSeek native API: thinking via extra_body.thinking (transport fallback)."""
+    # Note: is_deepseek=True triggers the transport-layer fallback;
+    # the DeepSeekProfile also handles thinking via build_api_kwargs_extras.
+
+    def test_thinking_enabled(self, transport):
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro",
+            messages=_simple_messages(),
+            tools=None,
+            provider_profile=get_provider_profile("deepseek"),
+            reasoning_config={"enabled": True, "effort": "medium"},
+            is_deepseek=True,
+        )
+        assert kw["extra_body"]["thinking"] == {"type": "enabled"}
+
+    def test_thinking_disabled(self, transport):
+        kw = transport.build_kwargs(
+            model="deepseek-v4-pro",
+            messages=_simple_messages(),
+            tools=None,
+            provider_profile=get_provider_profile("deepseek"),
+            reasoning_config={"enabled": False},
+            is_deepseek=True,
+        )
+        assert kw["extra_body"]["thinking"] == {"type": "disabled"}


### PR DESCRIPTION
## Summary

- Enable DeepSeek V4+ native thinking mode via `extra_body.thinking` + top-level `reasoning_effort`
- Previously the generic code path never sent these parameters for the deepseek provider so `/reasoning` had zero effect

## Motivation

DeepSeek uses its own protocol for reasoning (`extra_body.thinking={"type":"enabled"}` + `reasoning_effort="high"/"max"`), NOT OpenRouter-style `extra_body.reasoning`. The codebase only emitted the OpenRouter protocol. This meant `/reasoning low/medium/high/xhigh` were all no-ops for the deepseek provider.

Closes #15700, #21577

## Changes

- Introduce `DeepSeekProfile` (subclass of `ProviderProfile`) in `plugins/model-providers/deepseek/__init__.py`
- Add `build_api_kwargs_extras()` that emits the correct parameter shape per effort level:
  | Hermes `/reasoning` | `extra_body.thinking` | `reasoning_effort` |
  |---|---|---|
  | default / unset | `{type: enabled}` | `high` |
  | `none` (disabled) | `{type: disabled}` | *(omitted)* |
  | `low`, `medium`, `high` | `{type: enabled}` | `high` |
  | `xhigh` | `{type: enabled}` | `max` |
- Follows the same pattern as the existing Kimi provider

## Test Plan

- [x] Unit-level: Python snippet directly testing `build_api_kwargs_extras()` for all effort levels confirmed correct parameter shape
- [x] End-to-end: `/reasoning xhigh` in Feishu with deepseek-v4-pro confirmed thinking mode active (response detail length increased from ~30 to ~185 chars)
- [x] `/reasoning high` and `/reasoning max` both confirmed through Feishu handler
- [x] No regressions: default behavior (no reasoning config) adds thinking+effort=high, matching DeepSeek defaults

## Notes for Reviewers

- This is the exact same pattern as `plugins/model-providers/kimi/__init__.py` — Z.AI/Kimi uses the same protocol
- Issue #16533 (Z.AI/GLM missing thinking) is the same root cause and can use the same approach