### PR TITLE
fix(ci): install ripgrep in e2e job

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -60,6 +60,9 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
 
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
+
       - name: Install uv
         uses: astral-sh/setup-uv@d4b2f3b6ecc6e67c4457f6d3e41ec42d3d0fcb86  # v5
 


### PR DESCRIPTION
## Summary

The `test:` job installs ripgrep as a system dep but the `e2e:` job does not. If any e2e test shells out to `rg`, it fails with "command not found".

Closes #22003

## Change

Mirror the existing ripgrep install step from the `test:` job into `e2e:` (`.github/workflows/tests.yml`), placed right after Checkout and before uv setup.

## Validation

- yaml parses (`python -c "import yaml; yaml.safe_load(open(...))"`)
- diff is +3 lines (one step), no other changes