### PR TITLE
fix(ci): bump e2e job timeout to 15 minutes

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -55,7 +55,7 @@ jobs:
 
   e2e:
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - name: Checkout code
         uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4


### PR DESCRIPTION
## Summary

The `e2e:` job has a 10-minute timeout while the `test:` job has 20. Bumping to 15 splits the difference, giving slower runners headroom without doubling CI cost.

Closes #22006

## Change

`.github/workflows/tests.yml`: `jobs.e2e.timeout-minutes: 10 → 15`. One-character delta.

## Validation

- yaml parses
- diff is +1/-1 line