### PR TITLE
test(tui): add CJK + emoji + multi-line edge cases for inputMetrics

### DIFF
--- a/ui-tui/src/__tests__/inputMetricsEdgeCases.test.ts
+++ b/ui-tui/src/__tests__/inputMetricsEdgeCases.test.ts
@@ -1,3 +1,4 @@
+import { stringWidth } from '@hermes/ink'
 import { describe, expect, it } from 'vitest'
 
 import {
@@ -37,8 +38,11 @@ describe('inputMetrics — CJK / emoji / multi-line edge cases', () => {
     it('treats multi-codepoint emoji ZWJ sequence as a single grapheme', () => {
       const family = '👨‍👩‍👧'
       const layout = cursorLayout(family, family.length, 80)
-      expect(layout.line).toBe(0)
-      expect(layout.column).toBeGreaterThanOrEqual(2)
+      // If the ZWJ sequence were segmented into multiple graphemes, the
+      // cumulative column would exceed the grapheme's stringWidth. Assert
+      // the exact column matches stringWidth(family) so any regression in
+      // grapheme segmentation fails this test.
+      expect(layout).toEqual({ column: stringWidth(family), line: 0 })
     })
 
     it('handles \\n with row increment', () => {

--- a/ui-tui/src/__tests__/inputMetricsEdgeCases.test.ts
+++ b/ui-tui/src/__tests__/inputMetricsEdgeCases.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  cursorLayout,
+  inputVisualHeight,
+  offsetFromPosition
+} from '../lib/inputMetrics.js'
+
+describe('inputMetrics — CJK / emoji / multi-line edge cases', () => {
+  describe('cursorLayout', () => {
+    it('places cursor on row 0 col 0 for empty input', () => {
+      expect(cursorLayout('', 0, 80)).toEqual({ column: 0, line: 0 })
+    })
+
+    it('clamps cursor below 0 to start', () => {
+      expect(cursorLayout('hello', -5, 80)).toEqual({ column: 0, line: 0 })
+    })
+
+    it('clamps cursor past end to last position', () => {
+      expect(cursorLayout('hi', 999, 80)).toEqual({ column: 2, line: 0 })
+    })
+
+    it('treats cols<=0 as width 1', () => {
+      const result = cursorLayout('abc', 3, 0)
+      expect(result.line).toBeGreaterThanOrEqual(2)
+    })
+
+    it('counts CJK chars as width 2', () => {
+      expect(cursorLayout('你好', 2, 10)).toEqual({ column: 4, line: 0 })
+    })
+
+    it('wraps when CJK char would overflow', () => {
+      const result = cursorLayout('你好', 2, 3)
+      expect(result.line).toBeGreaterThanOrEqual(1)
+    })
+
+    it('treats multi-codepoint emoji ZWJ sequence as a single grapheme', () => {
+      const family = '👨‍👩‍👧'
+      const layout = cursorLayout(family, family.length, 80)
+      expect(layout.line).toBe(0)
+      expect(layout.column).toBeGreaterThanOrEqual(2)
+    })
+
+    it('handles \\n with row increment', () => {
+      const v = 'a\nb\nc'
+      expect(cursorLayout(v, 0, 80)).toEqual({ column: 0, line: 0 })
+      expect(cursorLayout(v, 2, 80)).toEqual({ column: 0, line: 1 })
+      expect(cursorLayout(v, 4, 80)).toEqual({ column: 0, line: 2 })
+    })
+
+    it('cursor at end of first line lands at trailing column', () => {
+      expect(cursorLayout('abc\ndef', 3, 80)).toEqual({ column: 3, line: 0 })
+    })
+
+    it('overflows trailing cursor to next visual row at exact wrap column', () => {
+      const layout = cursorLayout('abcde', 5, 5)
+      expect(layout).toEqual({ column: 0, line: 1 })
+    })
+  })
+
+  describe('offsetFromPosition', () => {
+    it('returns 0 for empty input', () => {
+      expect(offsetFromPosition('', 0, 0, 80)).toBe(0)
+    })
+
+    it('clamps negative row/col', () => {
+      expect(offsetFromPosition('hello', -1, -1, 80)).toBe(0)
+    })
+
+    it('returns end-of-line for col past the line width', () => {
+      expect(offsetFromPosition('abc', 0, 999, 80)).toBe(3)
+    })
+
+    it('maps CJK columns back to grapheme offsets', () => {
+      expect(offsetFromPosition('你好', 0, 0, 10)).toBe(0)
+      expect(offsetFromPosition('你好', 0, 2, 10)).toBe(1)
+    })
+
+    it('snaps to grapheme start when col lands inside a wide grapheme', () => {
+      expect(offsetFromPosition('你好', 0, 1, 10)).toBe(0)
+    })
+  })
+
+  describe('inputVisualHeight', () => {
+    it('returns 1 for empty input', () => {
+      expect(inputVisualHeight('', 80)).toBe(1)
+    })
+
+    it('returns 1 for single short line', () => {
+      expect(inputVisualHeight('hello', 80)).toBe(1)
+    })
+
+    it('counts \\n-separated logical lines', () => {
+      expect(inputVisualHeight('a\nb\nc', 80)).toBe(3)
+    })
+
+    it('counts wrapped visual lines for long input', () => {
+      const long = 'a'.repeat(200)
+      expect(inputVisualHeight(long, 50)).toBeGreaterThanOrEqual(4)
+    })
+
+    it('counts CJK width when computing wrap', () => {
+      const cjk = '你'.repeat(50)
+      expect(inputVisualHeight(cjk, 20)).toBeGreaterThanOrEqual(5)
+    })
+  })
+})


### PR DESCRIPTION
## What does this PR do?

- `cursorLayout`: empty input, negative cursor clamp, past-end clamp, cols<=0 fallback, CJK width=2, CJK overflow wrap, ZWJ emoji as single grapheme, multi-line \\n, trailing cursor at exact wrap column. - `offsetFromPosition`: empty input, negative clamp, col past line width, CJK col→offset mapping, mid-grapheme snap to start. - `inputVisualHeight`: empty/short returns 1, multi-line count, ASCII wrap count, CJK wrap count.

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- Standardizes the PR description to the same review format used in #29640.
- Preserves the original detailed description below so no context is lost.

## Why this shape

`inputMetrics.ts` is the foundation for visual-line cursor navigation (HOME/END/UP/DOWN handling shipped in #22197). The CJK and emoji-grapheme paths drive width math; covering them now prevents regressions when wrap rules evolve.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

- Related to #22197.

<details>
<summary>Original body</summary>

## Summary

- `cursorLayout`: empty input, negative cursor clamp, past-end clamp, cols<=0 fallback, CJK width=2, CJK overflow wrap, ZWJ emoji as single grapheme, multi-line \\n, trailing cursor at exact wrap column. - `offsetFromPosition`: empty input, negative clamp, col past line width, CJK col→offset mapping, mid-grapheme snap to start. - `inputVisualHeight`: empty/short returns 1, multi-line count, ASCII wrap count, CJK wrap count.

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Summary
Adds 20 vitest cases under `ui-tui/src/__tests__/inputMetricsEdgeCases.test.ts` covering branches in `ui-tui/src/lib/inputMetrics.ts` not exercised by existing suites:

- `cursorLayout`: empty input, negative cursor clamp, past-end clamp, cols<=0 fallback, CJK width=2, CJK overflow wrap, ZWJ emoji as single grapheme, multi-line \\n, trailing cursor at exact wrap column.
- `offsetFromPosition`: empty input, negative clamp, col past line width, CJK col→offset mapping, mid-grapheme snap to start.
- `inputVisualHeight`: empty/short returns 1, multi-line count, ASCII wrap count, CJK wrap count.

## Why
`inputMetrics.ts` is the foundation for visual-line cursor navigation (HOME/END/UP/DOWN handling shipped in #22197). The CJK and emoji-grapheme paths drive width math; covering them now prevents regressions when wrap rules evolve.

## Test plan
- [x] `npx vitest run src/__tests__/inputMetricsEdgeCases.test.ts` → 20 passed.
- [x] Full ui-tui suite: 668 passed (62 files).

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_