### PR TITLE
fix: document local Microsoft Teams gateway install

### DIFF
--- a/plugins/platforms/teams/adapter.py
+++ b/plugins/platforms/teams/adapter.py
@@ -6,7 +6,7 @@ Runs an aiohttp webhook server to receive messages from Teams.
 Proactive messaging (send, typing) uses the SDK's App.send() method.
 
 Requires:
-    pip install microsoft-teams-apps aiohttp
+    pip install "microsoft-teams-apps>=2.0.0,<3" "aiohttp>=3.13.3,<4"
     TEAMS_CLIENT_ID, TEAMS_CLIENT_SECRET, and TEAMS_TENANT_ID env vars
 
 Configuration in config.yaml:
@@ -912,7 +912,11 @@ def interactive_setup() -> None:
         if not prompt_yes_no("Reconfigure Teams?", False):
             return
 
-    print_info("You'll need the Teams CLI. If you haven't already:")
+    print_info("Teams support is not bundled in Hermes core installs.")
+    print_info('Install the Python deps in your Hermes venv first:')
+    print_info('  pip install "microsoft-teams-apps>=2.0.0,<3" "aiohttp>=3.13.3,<4"')
+    print()
+    print_info("You'll also need the Teams CLI. If you haven't already:")
     print_info("  npm install -g @microsoft/teams.cli@preview")
     print_info("  teams login")
     print()
@@ -975,7 +979,7 @@ def register(ctx) -> None:
         validate_config=validate_config,
         is_connected=is_connected,
         required_env=["TEAMS_CLIENT_ID", "TEAMS_CLIENT_SECRET", "TEAMS_TENANT_ID"],
-        install_hint="pip install microsoft-teams-apps aiohttp",
+        install_hint='pip install "microsoft-teams-apps>=2.0.0,<3" "aiohttp>=3.13.3,<4"',
         setup_fn=interactive_setup,
         # Env-driven auto-configuration — seeds PlatformConfig.extra with
         # client_id/secret/tenant + port + home_channel so env-only setups

--- a/tests/gateway/test_teams.py
+++ b/tests/gateway/test_teams.py
@@ -330,6 +330,13 @@ class TestTeamsPluginRegistration:
         kwargs = ctx.register_platform.call_args[1]
         assert kwargs.get("platform_hint")
 
+    def test_register_install_hint_mentions_local_dependencies(self):
+        ctx = MagicMock()
+        register(ctx)
+        kwargs = ctx.register_platform.call_args[1]
+        assert "microsoft-teams-apps>=2.0.0,<3" in kwargs["install_hint"]
+        assert "aiohttp>=3.13.3,<4" in kwargs["install_hint"]
+
 
 # ---------------------------------------------------------------------------
 # Tests: Interactive setup (import fix regression — #18325 / #19173)
@@ -358,6 +365,25 @@ class TestTeamsInteractiveSetup:
         env_text = (hermes_home / ".env").read_text(encoding="utf-8")
         assert "TEAMS_CLIENT_ID=client-id" in env_text
         assert "TEAMS_TENANT_ID=tenant-id" in env_text
+
+    def test_interactive_setup_prints_local_install_hint(self, tmp_path, monkeypatch):
+        hermes_home = tmp_path / "hermes"
+        monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+        import hermes_cli.cli_output as cli_output_mod
+
+        answers = iter(["client-id", "client-secret", "tenant-id", "aad-1"])
+        info_lines = []
+        monkeypatch.setattr(cli_output_mod, "prompt", lambda *_a, **_kw: next(answers))
+        monkeypatch.setattr(cli_output_mod, "prompt_yes_no", lambda *_a, **_kw: True)
+        monkeypatch.setattr(cli_output_mod, "print_info", lambda msg="", *_a, **_kw: info_lines.append(msg))
+        monkeypatch.setattr(cli_output_mod, "print_success", lambda *_a, **_kw: None)
+        monkeypatch.setattr(cli_output_mod, "print_warning", lambda *_a, **_kw: None)
+
+        _teams_mod.interactive_setup()
+
+        assert any("not bundled in Hermes core installs" in line for line in info_lines)
+        assert any("microsoft-teams-apps>=2.0.0,<3" in line for line in info_lines)
 
 class TestTeamsConnect:
     @pytest.mark.anyio

--- a/website/docs/user-guide/messaging/teams.md
+++ b/website/docs/user-guide/messaging/teams.md
@@ -91,13 +91,39 @@ TEAMS_ALLOWED_USERS=<your-aad-object-id>
 
 ---
 
-## Step 5: Start the Gateway
+## Step 5: Install the Teams Python Dependencies
+
+Hermes does not bundle the Teams SDK in the default install. If you are running Hermes from a local checkout or virtualenv instead of the Nous Docker image, install the Teams dependencies into that same environment first:
+
+```bash
+python3 -m pip install "microsoft-teams-apps>=2.0.0,<3" "aiohttp>=3.13.3,<4"
+```
+
+If you are using the published Docker gateway image, you can skip this step because the image already includes the required packages.
+
+---
+
+## Step 6: Start the Gateway
+
+If you run Hermes locally without Docker:
+
+```bash
+hermes gateway
+```
+
+Then confirm the webhook server came up:
+
+```bash
+curl http://localhost:3978/health   # should return: ok
+```
+
+If you run the gateway with Docker:
 
 ```bash
 HERMES_UID=$(id -u) HERMES_GID=$(id -g) docker compose up -d gateway
 ```
 
-This starts the gateway. The default webhook port is `3978` (override with `TEAMS_PORT`). Check that it's running:
+The default webhook port is `3978` (override with `TEAMS_PORT`). Check that it's running:
 
 ```bash
 curl http://localhost:3978/health   # should return: ok
@@ -111,7 +137,7 @@ Look for:
 
 ---
 
-## Step 6: Install the App in Teams
+## Step 7: Install the App in Teams
 
 ```bash
 teams app get <teamsAppId> --install-link


### PR DESCRIPTION
## Summary
- document the non-Docker local install path for the Teams gateway docs
- clarify in Teams setup/install hints that `microsoft-teams-apps` is not bundled in core Hermes installs
- add regression coverage for the local install hint exposed by the Teams plugin registration/setup flow

## Verification
- `uv sync --frozen --extra all`
- `.venv/bin/python -m ensurepip`
- `.venv/bin/python -m pip install 'pytest-split>=0.9,<1'`
- `git diff --check`
- `./scripts/run_tests.sh tests/gateway/test_teams.py -q`
- `uv run --frozen ruff check .`
- `uv run --frozen ruff check plugins/platforms/teams/adapter.py tests/gateway/test_teams.py --output-format json`
- `uv run --frozen ty check plugins/platforms/teams/adapter.py tests/gateway/test_teams.py --output-format gitlab --exit-zero`
- `env -i ... "$WORKTREE/.venv/bin/python" -m pytest tests/ --collect-only -q --ignore=tests/integration --ignore=tests/e2e -n auto`

Fixes #22015.
