### PR TITLE
fix(browser): resolve SyntaxError in browser_get_images eval on CDP bridges

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -3044,14 +3044,16 @@ def browser_get_images(task_id: Optional[str] = None) -> str:
     effective_task_id = _last_session_key(task_id or "default")
 
     # Use eval to run JavaScript that extracts images
-    js_code = """JSON.stringify(
-        [...document.images].map(img => ({
-            src: img.src,
-            alt: img.alt || '',
-            width: img.naturalWidth,
-            height: img.naturalHeight
-        })).filter(img => img.src && !img.src.startsWith('data:'))
-    )"""
+    js_code = """(() => {
+        return JSON.stringify(
+            [...document.images].map(img => ({
+                src: img.src,
+                alt: img.alt || '',
+                width: img.naturalWidth,
+                height: img.naturalHeight
+            })).filter(img => img.src && !img.src.startsWith('data:'))
+        );
+    })()"""
 
     result = _run_browser_command(effective_task_id, "eval", [js_code])
 


### PR DESCRIPTION
## Summary

Fixes a `SyntaxError: Unexpected end of input` raised by `browser_get_images` on real content pages. The CDP eval bridge cannot parse a bare multi-line `JSON.stringify(...)` expression as a complete JavaScript statement — wrapping it as an IIFE (`(() => { return JSON.stringify(...) })()`) makes it unambiguous regardless of how the bridge constructs its `new Function()` call.

## Root cause

The `browser_get_images` function at `tools/browser_tool.py:2790` passed a raw multi-line `JSON.stringify(...)` string to `_run_browser_command(task_id, "eval", [...])`. When the bridge resolves this via `new Function(code)` without an explicit `return`, the trailing `)` on its own line is interpreted as an incomplete expression, producing `SyntaxError: Unexpected end of input`.

The same expression wrapped in an IIFE via `browser_console` succeeds, confirming the fix is at the call site's expression shape.

## Fix

Wrap the `JSON.stringify(...)` call in an IIFE so it is a complete, self-contained statement body:

```javascript
(() => {
    return JSON.stringify(
        [...document.images].map(img => ({ ... })).filter(...)
    );
})()
```

This is the minimal, non-invasive fix that works for all CDP eval bridge implementations.

## Verification

- `python3 -m py_compile tools/browser_tool.py` — pass
- `ruff check tools/browser_tool.py` — pass
- The fix does not change any logic, return type, or call signature; it only adjusts how the JS expression is wrapped for the eval bridge.

Closes #22012
