### PR TITLE
fix: align doctor provider health checks

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -125,6 +125,16 @@ def _doctor_tool_availability_detail(toolset: str) -> str:
     return ""
 
 
+_DOCTOR_WARN_ONLY_MISSING_API_TOOLSETS = {"discord", "discord_admin", "rl", "homeassistant", "image_gen"}
+
+
+def _is_warn_only_missing_api_toolset(item: dict) -> bool:
+    """Return True for optional toolsets that should warn without failing doctor."""
+    toolset = (item.get("toolset") or "").strip().lower()
+    name = (item.get("name") or "").strip().lower()
+    return toolset in _DOCTOR_WARN_ONLY_MISSING_API_TOOLSETS or name in _DOCTOR_WARN_ONLY_MISSING_API_TOOLSETS
+
+
 def _apply_doctor_tool_availability_overrides(available: list[str], unavailable: list[dict]) -> tuple[list[str], list[dict]]:
     """Adjust runtime-gated tool availability for doctor diagnostics."""
     updated_available = list(available)
@@ -256,6 +266,27 @@ def _build_apikey_providers_list() -> list:
                 (v for v in _pp.env_vars if v.endswith("_BASE_URL") or v.endswith("_URL")),
                 None,
             )
+            if _base_var is None:
+                # ProviderProfile.env_vars is primarily for API keys.  Some
+                # bundled profiles (for example Xiaomi) keep the base-URL
+                # override in the auth/overlay registries instead.  Reuse that
+                # metadata so doctor validates the same endpoint Hermes will
+                # actually call at runtime, rather than incorrectly probing the
+                # provider's default URL and reporting a good regional key as
+                # invalid.
+                try:
+                    from hermes_cli.auth import PROVIDER_REGISTRY as _AUTH_PROVIDER_REGISTRY
+                    _auth_cfg = _AUTH_PROVIDER_REGISTRY.get(_pp.name)
+                    _base_var = getattr(_auth_cfg, "base_url_env_var", "") or None
+                except Exception:
+                    _base_var = None
+            if _base_var is None:
+                try:
+                    from hermes_cli.providers import get_provider as _get_provider_def
+                    _pdef = _get_provider_def(_pp.name)
+                    _base_var = getattr(_pdef, "base_url_env_var", "") or None
+                except Exception:
+                    _base_var = None
             if not _key_vars:
                 continue
             _models_url = (
@@ -1311,7 +1342,15 @@ def run_doctor(args):
         # Count disabled tools with API key requirements
         api_disabled = [u for u in unavailable if (u.get("missing_vars") or u.get("env_vars"))]
         if api_disabled:
-            issues.append("Run 'hermes setup' to configure missing API keys for full tool access")
+            # Only escalate to a top-level issue when core/default tools are blocked.
+            # Optional platform/integration tools (discord, rl, etc.) should warn in-place
+            # but not fail the overall doctor summary for users who don't use them.
+            _core_disabled = [
+                u for u in api_disabled
+                if not _is_warn_only_missing_api_toolset(u)
+            ]
+            if _core_disabled:
+                issues.append("Run 'hermes setup' to configure missing API keys for full tool access")
     except Exception as e:
         check_warn("Could not check tool availability", f"({e})")
     

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -167,6 +167,16 @@ class TestDoctorToolAvailabilityOverrides:
 
         assert doctor._doctor_tool_availability_detail("kanban") == "(runtime-gated; loaded only for dispatcher-spawned workers)"
 
+    def test_discord_admin_is_warn_only_missing_api_toolset(self):
+        entry = {"name": "discord_admin", "env_vars": ["DISCORD_BOT_TOKEN"]}
+
+        assert doctor._is_warn_only_missing_api_toolset(entry)
+
+    def test_non_optional_missing_api_toolset_is_not_warn_only(self):
+        entry = {"name": "web", "env_vars": ["EXA_API_KEY"]}
+
+        assert not doctor._is_warn_only_missing_api_toolset(entry)
+
 
 class TestHonchoDoctorConfigDetection:
     def test_reports_configured_when_enabled_with_api_key(self, monkeypatch):

--- a/tests/hermes_cli/test_xiaomi_provider.py
+++ b/tests/hermes_cli/test_xiaomi_provider.py
@@ -360,6 +360,17 @@ class TestXiaomiDoctor:
         from hermes_cli.doctor import _PROVIDER_ENV_HINTS
         assert "XIAOMI_API_KEY" in _PROVIDER_ENV_HINTS
 
+    def test_apikey_provider_list_uses_xiaomi_base_url_env(self):
+        """Doctor must probe XIAOMI_BASE_URL when set, not only the default endpoint."""
+        from hermes_cli import doctor
+
+        doctor._APIKEY_PROVIDERS_CACHE = None
+        entries = doctor._build_apikey_providers_list()
+        xiaomi_entries = [entry for entry in entries if entry[0] == "xiaomi"]
+
+        assert xiaomi_entries
+        assert xiaomi_entries[0][3] == "XIAOMI_BASE_URL"
+
 
 class TestXiaomiAgentInit:
     """Verify the agent can be constructed with xiaomi provider without errors."""


### PR DESCRIPTION
## Summary

- make `hermes doctor` resolve base URL override env vars from auth/provider metadata when dynamically adding API-key provider health checks
- keep optional integration credential warnings (for example `discord_admin`) out of the top-level missing-API-key summary issue
- add regression coverage for Xiaomi `XIAOMI_BASE_URL` detection and optional toolset warning classification

Closes #22223

## Test Plan

- `python -m pytest tests/hermes_cli/test_xiaomi_provider.py tests/hermes_cli/test_doctor.py -q -o 'addopts='`
- `npm audit --json`
- `python -m hermes_cli.main doctor` from the worktree (validates Xiaomi through the configured base URL; the worktree-only entry point warning is expected because this temp worktree is not installed as the active CLI)
