### PR TITLE
fix(session_search): use original session ID for content retrieval

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -556,7 +556,79 @@ class TestSessionSearch:
         assert result["success"] is True
         assert result["count"] == 1
         entry = result["results"][0]
-        assert entry["session_id"] == "parent_sid", "should report resolved parent session ID"
+        # session_id reports the original child where FTS5 actually matched —
+        # callers need to reopen the transcript that contains the text (#22150).
+        assert entry["session_id"] == "child_sid", "should report original child session ID"
+        # Parent lineage is still surfaced for navigation via resolved_session_id.
+        assert entry["resolved_session_id"] == "parent_sid", (
+            "should expose resolved parent session ID separately"
+        )
+        # Metadata still comes from the parent (#15909).
         assert entry["source"] == "api_server", (
             f"source should be parent's 'api_server', got {entry['source']!r}"
         )
+
+    def test_content_fetched_from_child_not_parent(self):
+        """Content retrieval must use the child sid where FTS5 actually matched.
+
+        Regression for #22150: previously _resolve_to_parent overwrote
+        result['session_id'] with the parent sid, then
+        get_messages_as_conversation(parent_sid) returned content the parent
+        never had. Fix: keep child sid for content; expose parent separately.
+        """
+        from unittest.mock import MagicMock, AsyncMock, patch as _patch
+        from tools.session_search_tool import session_search
+
+        mock_db = MagicMock()
+        mock_db.search_messages.return_value = [
+            {
+                "session_id": "child_sid",
+                "content": "headless-chatgpt",
+                "source": "cli",
+                "session_started": 1709400000,
+                "model": "gpt-4o-mini",
+            },
+        ]
+
+        def _get_session(session_id):
+            if session_id == "child_sid":
+                return {"id": "child_sid", "parent_session_id": "parent_sid"}
+            if session_id == "parent_sid":
+                return {"id": "parent_sid", "parent_session_id": None,
+                        "source": "cli", "started_at": 1709300000}
+            return None
+
+        mock_db.get_session.side_effect = _get_session
+
+        # Child has the matching content; parent has nothing.
+        def _get_messages(sid):
+            if sid == "child_sid":
+                return [
+                    {"role": "user", "content": "tell me about headless-chatgpt"},
+                    {"role": "assistant", "content": "ok"},
+                ]
+            if sid == "parent_sid":
+                return []  # parent has no content matching the query
+            return []
+
+        mock_db.get_messages_as_conversation.side_effect = _get_messages
+
+        with _patch(
+            "tools.session_search_tool.async_call_llm",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("no provider"),
+        ):
+            result = json.loads(session_search(query="headless-chatgpt", db=mock_db))
+
+        assert result["success"] is True
+        assert result["count"] == 1, (
+            "should produce a result by fetching from the child, not the empty parent"
+        )
+        # Confirm get_messages_as_conversation was actually called with the child sid.
+        called_sids = [c.args[0] for c in mock_db.get_messages_as_conversation.call_args_list]
+        assert "child_sid" in called_sids, (
+            f"content should be fetched from child_sid; called with {called_sids!r}"
+        )
+        entry = result["results"][0]
+        assert entry["session_id"] == "child_sid"
+        assert entry["resolved_session_id"] == "parent_sid"

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -426,22 +426,31 @@ def session_search(
                 continue
             if resolved_sid not in seen_sessions:
                 result = dict(result)
-                result["session_id"] = resolved_sid
+                # Preserve the original child session_id for content retrieval —
+                # FTS5 matched in the child, not necessarily in the parent (#22150).
+                # Track the resolved parent separately for dedup + metadata lookup.
+                if resolved_sid != raw_sid:
+                    result["resolved_session_id"] = resolved_sid
                 seen_sessions[resolved_sid] = result
             if len(seen_sessions) >= limit:
                 break
 
         # Prepare all sessions for parallel summarization
         tasks = []
-        for session_id, match_info in seen_sessions.items():
+        for resolved_sid, match_info in seen_sessions.items():
+            # Fetch content from the original session that produced the FTS5 hit,
+            # not the parent — children can carry text the parent never had.
+            content_sid = match_info.get("session_id", resolved_sid)
             try:
-                messages = db.get_messages_as_conversation(session_id)
+                messages = db.get_messages_as_conversation(content_sid)
                 if not messages:
                     continue
-                session_meta = db.get_session(session_id) or {}
+                # Metadata (started_at, source, model) lives on the parent for
+                # delegation chains; keep that lookup on resolved_sid.
+                session_meta = db.get_session(resolved_sid) or {}
                 conversation_text = _format_conversation(messages)
                 conversation_text = _truncate_around_matches(conversation_text, query)
-                tasks.append((session_id, match_info, conversation_text, session_meta))
+                tasks.append((resolved_sid, match_info, conversation_text, session_meta))
             except Exception as e:
                 logging.warning(
                     "Failed to prepare session %s: %s",
@@ -486,27 +495,31 @@ def session_search(
             }, ensure_ascii=False)
 
         summaries = []
-        for (session_id, match_info, conversation_text, session_meta), result in zip(tasks, results):
+        for (resolved_sid, match_info, conversation_text, session_meta), result in zip(tasks, results):
             if isinstance(result, Exception):
                 logging.warning(
                     "Failed to summarize session %s: %s",
-                    session_id, result, exc_info=True,
+                    resolved_sid, result, exc_info=True,
                 )
                 result = None
 
             # Prefer resolved parent session metadata over FTS5 match metadata.
             # match_info carries source/model from the *child* session that contained
-            # the FTS5 hit; after _resolve_to_parent() the session_id points to the
-            # root, so session_meta has the authoritative platform/source for the
-            # session the user actually cares about (#15909).
+            # the FTS5 hit; session_meta has the authoritative platform/source for
+            # the lineage root (#15909). session_id points back at the child where
+            # the text actually lives so callers can reopen the right transcript
+            # (#22150).
+            content_sid = match_info.get("session_id", resolved_sid)
             entry = {
-                "session_id": session_id,
+                "session_id": content_sid,
                 "when": _format_timestamp(
                     session_meta.get("started_at") or match_info.get("session_started")
                 ),
                 "source": session_meta.get("source") or match_info.get("source", "unknown"),
                 "model": session_meta.get("model") or match_info.get("model"),
             }
+            if resolved_sid != content_sid:
+                entry["resolved_session_id"] = resolved_sid
 
             if result:
                 entry["summary"] = result


### PR DESCRIPTION
## Bug
When `session_search` matched a delegation child via FTS5, the code overwrote `result['session_id']` with the resolved parent before calling `db.get_messages_as_conversation(...)`. The parent never had the matching text, so the search returned the wrong content (or empty).

## Fix
- Preserve the original child sid as `session_id`. It's what the user needs to reopen the transcript that actually contains the match.
- Expose the resolved parent through a new `resolved_session_id` field, only when it differs.
- Metadata (`source`, `model`, `started_at`) still comes from the parent (`#15909` semantics preserved).
- Content fetch (`get_messages_as_conversation`) now uses the child sid stored on `match_info`.

## Test plan
- [x] Updated `test_source_from_resolved_parent_not_fts5_child` to reflect the corrected contract (`session_id == child_sid`, new `resolved_session_id == parent_sid`, source still from parent).
- [x] New regression `test_content_fetched_from_child_not_parent` asserts `get_messages_as_conversation` is called with the child sid and that the result is non-empty.
- [x] `pytest tests/tools/test_session_search.py -q` → 39 passed.

Closes #22150