### PR TITLE
fix(weixin): remove _LIVE_ADAPTERS session reuse to avoid aiohttp timeout error

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -2094,35 +2094,11 @@ async def send_weixin_direct(
     token_store.restore(account_id)
     context_token = token_store.get(account_id, chat_id)
 
-    live_adapter = _LIVE_ADAPTERS.get(resolved_token)
-    send_session = getattr(live_adapter, '_send_session', None)
-    if (live_adapter is not None and send_session is not None
-            and not send_session.closed
-            and send_session._loop is asyncio.get_running_loop()):
-        last_result: Optional[SendResult] = None
-        cleaned = live_adapter.format_message(message)
-        if cleaned:
-            last_result = await live_adapter.send(chat_id, cleaned)
-            if not last_result.success:
-                return {"error": f"Weixin send failed: {last_result.error}"}
-
-        for media_path, _is_voice in media_files or []:
-            ext = Path(media_path).suffix.lower()
-            if ext in {".jpg", ".jpeg", ".png", ".gif", ".webp", ".bmp"}:
-                last_result = await live_adapter.send_image_file(chat_id, media_path)
-            else:
-                last_result = await live_adapter.send_document(chat_id, media_path)
-            if not last_result.success:
-                return {"error": f"Weixin media send failed: {last_result.error}"}
-
-        return {
-            "success": True,
-            "platform": "weixin",
-            "chat_id": chat_id,
-            "message_id": last_result.message_id if last_result else None,
-            "context_token_used": bool(context_token),
-        }
-
+    # FIX: Always create fresh session — do NOT reuse _LIVE_ADAPTERS.
+    # aiohttp 3.13.5's asyncio.timeout() context guard fails when a session
+    # created in __init__ (with trust_env=True) is reused from a
+    # ThreadPoolExecutor context via _run_async (loop.is_running()=True).
+    # The reuse optimization is removed; a fresh session per send is reliable.
     async with aiohttp.ClientSession(trust_env=True, connector=_make_ssl_connector()) as session:
         adapter = WeixinAdapter(
             PlatformConfig(


### PR DESCRIPTION
## Problem

In aiohttp 3.13.5,  context manager fails when a session created with  is reused from a  context via  (where ).

The  optimization that reuses an existing adapter+session across calls causes intermittent errors:


## Fix

Always create a fresh  per  call instead of reusing . This is slightly less efficient but eliminates the non-deterministic timeout failures.

## Changes

- : remove  session reuse logic in , always create fresh session