### PR TITLE
fix(tui): right-click copies selection, only pastes when no selection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,4 @@ mini-swe-agent/
 result
 website/static/api/skills-index.json
 models-dev-upstream/
+.claude/scheduled_tasks.lock

--- a/ui-tui/src/__tests__/textInputRightClick.test.ts
+++ b/ui-tui/src/__tests__/textInputRightClick.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+
+import { decideRightClickAction } from '../components/textInput.js'
+
+describe('decideRightClickAction', () => {
+  it('returns paste when there is no selection', () => {
+    expect(decideRightClickAction('hello world', null)).toEqual({ action: 'paste' })
+  })
+
+  it('returns paste for a collapsed (empty) range', () => {
+    expect(decideRightClickAction('hello world', { end: 5, start: 5 })).toEqual({
+      action: 'paste'
+    })
+  })
+
+  it('copies the slice when range covers non-empty text', () => {
+    expect(decideRightClickAction('hello world', { end: 5, start: 0 })).toEqual({
+      action: 'copy',
+      text: 'hello'
+    })
+  })
+
+  it('copies a middle slice', () => {
+    expect(decideRightClickAction('hello world', { end: 11, start: 6 })).toEqual({
+      action: 'copy',
+      text: 'world'
+    })
+  })
+
+  it('falls back to paste when range is inverted (end < start)', () => {
+    expect(decideRightClickAction('hello', { end: 1, start: 4 })).toEqual({ action: 'paste' })
+  })
+
+  it('falls back to paste when slice is empty (out-of-range indices)', () => {
+    expect(decideRightClickAction('', { end: 5, start: 0 })).toEqual({ action: 'paste' })
+  })
+
+  it('handles unicode (emoji, CJK) in the slice', () => {
+    const value = 'hi 你好 🎉'
+    expect(decideRightClickAction(value, { end: 5, start: 3 })).toEqual({
+      action: 'copy',
+      text: '你好'
+    })
+  })
+
+  it('preserves leading/trailing whitespace in the copied slice', () => {
+    expect(decideRightClickAction('  spaced  ', { end: 10, start: 0 })).toEqual({
+      action: 'copy',
+      text: '  spaced  '
+    })
+  })
+})

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -970,10 +970,15 @@ export function TextInput({
           return
         }
 
-        // Right-click → route through the same path as Alt+V so the composer
-        // clipboard RPC (text or image) handles it.
+        // Right-click → copy active selection if any, otherwise paste.
         if (e.button === 2) {
           e.stopImmediatePropagation?.()
+          const decision = decideRightClickAction(vRef.current, selRange())
+          if (decision.action === 'copy') {
+            void writeClipboardText(decision.text)
+
+            return
+          }
           emitPaste({ cursor: curRef.current, hotkey: true, text: '', value: vRef.current })
 
           return
@@ -1043,6 +1048,31 @@ interface TextInputProps {
   placeholder?: string
   value: string
   voiceRecordKey?: ParsedVoiceRecordKey
+}
+
+export type RightClickDecision =
+  | { action: 'copy'; text: string }
+  | { action: 'paste' }
+
+/**
+ * Decide what right-click should do on the composer:
+ *   - non-empty selection → copy that text to the clipboard
+ *   - no selection (or empty/collapsed range) → fall through to paste
+ *
+ * Mirrors terminal-native behavior (xterm, iTerm, gnome-terminal) where
+ * right-click pastes only when there is nothing selected to copy.
+ */
+export function decideRightClickAction(
+  value: string,
+  range: { end: number; start: number } | null
+): RightClickDecision {
+  if (range && range.end > range.start) {
+    const text = value.slice(range.start, range.end)
+    if (text) {
+      return { action: 'copy', text }
+    }
+  }
+  return { action: 'paste' }
 }
 
 export const shouldPassThroughToGlobalHandler = (


### PR DESCRIPTION
## Summary

Sub-issue 5 of #22034.

Right-click on the composer always pasted from the clipboard, even when the user had highlighted text — diverging from terminal-native behavior (xterm, iTerm, gnome-terminal) where right-click copies an active selection and only pastes when there is nothing selected to copy.

## Changes

- Extract a small pure helper `decideRightClickAction(value, range)` that returns either `{ action: 'copy', text }` (non-empty selection) or `{ action: 'paste' }` (no/empty/inverted range).
- Route the existing `onMouseDown` right-click branch in `textInput.tsx` through it. On `'copy'`, call the existing `writeClipboardText` (already imported); on `'paste'`, fall through to the existing `emitPaste` flow — no behavior change for users without an active selection.

## Test plan

- New `ui-tui/src/__tests__/textInputRightClick.test.ts` (8 cases): null range, collapsed range, normal slice, mid-string slice, inverted range, empty value, unicode (CJK + emoji), whitespace preservation.
- Full vitest suite: 656 passed (62 files).