### PR TITLE
fix(auth): handle MiniMax OAuth epoch-ms expiries

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -4757,20 +4757,30 @@ def _minimax_request_user_code(
     return payload
 
 
+def _minimax_parse_expired_in(value: Any) -> tuple[float, int]:
+    """Parse MiniMax/OpenClaw ``expired_in`` as epoch-ms or TTL seconds.
+
+    Some flows return ``expired_in`` as a unix-ms timestamp, while others return
+    a TTL in seconds.  Return both the absolute expiry time (epoch seconds) and
+    a normalized positive TTL in seconds for storage.
+    """
+    raw = int(value)
+    now_s = time.time()
+    if raw > int(now_s * 1000) // 2:
+        expires_at_s = raw / 1000.0
+        ttl_s = max(1, int(expires_at_s - now_s))
+    else:
+        ttl_s = max(1, raw)
+        expires_at_s = now_s + ttl_s
+    return expires_at_s, ttl_s
+
+
 def _minimax_poll_token(
     client: httpx.Client, *, portal_base_url: str, client_id: str,
     user_code: str, code_verifier: str, expired_in: int, interval_ms: Optional[int],
 ) -> Dict[str, Any]:
-    # OpenClaw treats expired_in as a unix-ms timestamp (Date.now() < expireTimeMs).
-    # Defensive parsing: if it's small enough to be a duration, treat as seconds.
     import time as _time
-    now_ms = int(_time.time() * 1000)
-    if expired_in > now_ms // 2:
-        # Looks like a unix-ms timestamp.
-        deadline = expired_in / 1000.0
-    else:
-        # Treat as duration in seconds from now.
-        deadline = _time.time() + max(1, expired_in)
+    deadline, _ = _minimax_parse_expired_in(expired_in)
     interval = max(2.0, (interval_ms or 2000) / 1000.0)
 
     while _time.time() < deadline:
@@ -4884,8 +4894,7 @@ def _minimax_oauth_login(
         )
 
     now = datetime.now(timezone.utc)
-    expires_in_s = int(token_data["expired_in"])
-    expires_at = now.timestamp() + expires_in_s
+    expires_at, expires_in_s = _minimax_parse_expired_in(token_data["expired_in"])
 
     auth_state = {
         "provider": "minimax-oauth",
@@ -4960,14 +4969,13 @@ def _refresh_minimax_oauth_state(
             relogin_required=True,
         )
     now_dt = datetime.now(timezone.utc)
-    expires_in_s = int(payload["expired_in"])
+    expires_at, expires_in_s = _minimax_parse_expired_in(payload["expired_in"])
     new_state = dict(state)
     new_state.update({
         "access_token": payload["access_token"],
         "refresh_token": payload.get("refresh_token", state["refresh_token"]),
         "obtained_at": now_dt.isoformat(),
-        "expires_at": datetime.fromtimestamp(now_dt.timestamp() + expires_in_s,
-                                             tz=timezone.utc).isoformat(),
+        "expires_at": datetime.fromtimestamp(expires_at, tz=timezone.utc).isoformat(),
         "expires_in": expires_in_s,
     })
     _minimax_save_auth_state(new_state)

--- a/tests/test_minimax_oauth.py
+++ b/tests/test_minimax_oauth.py
@@ -30,6 +30,7 @@ from hermes_cli.auth import (
     MINIMAX_OAUTH_CN_INFERENCE,
     MINIMAX_OAUTH_REFRESH_SKEW_SECONDS,
     _minimax_pkce_pair,
+    _minimax_oauth_login,
     _minimax_request_user_code,
     _minimax_poll_token,
     _refresh_minimax_oauth_state,
@@ -362,6 +363,38 @@ def test_refresh_updates_access_token():
     assert result["expires_in"] == 7200
 
 
+def test_minimax_oauth_login_accepts_epoch_ms_expired_in():
+    future_expiry_ms = int((time.time() + 7200) * 1000)
+
+    with patch("hermes_cli.auth._minimax_pkce_pair", return_value=("verifier", "challenge", "state")), \
+         patch("hermes_cli.auth._minimax_request_user_code", return_value={
+             "verification_uri": "https://minimax.io/verify",
+             "user_code": "ABC-123",
+             "expired_in": future_expiry_ms,
+         }), \
+         patch("hermes_cli.auth._minimax_poll_token", return_value={
+             "status": "success",
+             "access_token": "access-abc",
+             "refresh_token": "refresh-xyz",
+             "expired_in": future_expiry_ms,
+             "token_type": "Bearer",
+         }), \
+         patch("hermes_cli.auth._minimax_save_auth_state"), \
+         patch("hermes_cli.auth.webbrowser.open", return_value=False), \
+         patch("hermes_cli.auth._is_remote_session", return_value=True), \
+         patch("httpx.Client") as mock_client_class:
+        mock_client_instance = MagicMock()
+        mock_client_instance.__enter__ = MagicMock(return_value=mock_client_instance)
+        mock_client_instance.__exit__ = MagicMock(return_value=False)
+        mock_client_class.return_value = mock_client_instance
+
+        result = _minimax_oauth_login(open_browser=False)
+
+    expires_at_ts = datetime.fromisoformat(result["expires_at"]).timestamp()
+    assert expires_at_ts == pytest.approx(future_expiry_ms / 1000.0, abs=2)
+    assert 7190 <= result["expires_in"] <= 7200
+
+
 # ---------------------------------------------------------------------------
 # 10. test_refresh_reuse_triggers_relogin_required
 # ---------------------------------------------------------------------------
@@ -394,6 +427,40 @@ def test_refresh_reuse_triggers_relogin_required():
 
     assert exc_info.value.code == "refresh_failed"
     assert exc_info.value.relogin_required is True
+
+
+def test_refresh_accepts_epoch_ms_expired_in():
+    future_expiry_ms = int((time.time() + 7200) * 1000)
+    state = {
+        "access_token": "old-access",
+        "refresh_token": "my-refresh",
+        "portal_base_url": MINIMAX_OAUTH_GLOBAL_BASE,
+        "client_id": MINIMAX_OAUTH_CLIENT_ID,
+        "inference_base_url": MINIMAX_OAUTH_GLOBAL_INFERENCE,
+        "expires_at": _future_iso(MINIMAX_OAUTH_REFRESH_SKEW_SECONDS - 1),
+    }
+    new_token_body = {
+        "status": "success",
+        "access_token": "new-access",
+        "refresh_token": "new-refresh",
+        "expired_in": future_expiry_ms,
+    }
+
+    mock_resp = _make_httpx_response(200, new_token_body)
+
+    with patch("httpx.Client") as mock_client_class:
+        mock_client_instance = MagicMock()
+        mock_client_instance.__enter__ = MagicMock(return_value=mock_client_instance)
+        mock_client_instance.__exit__ = MagicMock(return_value=False)
+        mock_client_instance.post.return_value = mock_resp
+        mock_client_class.return_value = mock_client_instance
+
+        with patch("hermes_cli.auth._minimax_save_auth_state"):
+            result = _refresh_minimax_oauth_state(state)
+
+    expires_at_ts = datetime.fromisoformat(result["expires_at"]).timestamp()
+    assert expires_at_ts == pytest.approx(future_expiry_ms / 1000.0, abs=2)
+    assert 7190 <= result["expires_in"] <= 7200
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fix MiniMax OAuth flows that persist `expired_in` as if it were always a TTL in seconds. MiniMax can return a unix-ms expiry timestamp instead, which made Hermes compute impossible dates like year 58381 and fail immediately after browser approval.

## Changes

- add `_minimax_parse_expired_in()` to normalize MiniMax/OpenClaw `expired_in` values from either unix-ms epoch or TTL seconds
- reuse that parser in `_minimax_poll_token()`, `_minimax_oauth_login()`, and `_refresh_minimax_oauth_state()`
- add regression coverage for login and refresh when `expired_in` is an epoch-ms timestamp

Fixes #21779.

## Verification

- `uv sync --frozen --extra all`
- `git diff --check`
- `./scripts/run_tests.sh tests/test_minimax_oauth.py -q`
- `uv run --frozen ruff check .`
- repo `lint-diff` semantics on `hermes_cli/auth.py` and `tests/test_minimax_oauth.py`
- clean `env -i` repo smoke: `pytest tests/ --collect-only -q --ignore=tests/integration --ignore=tests/e2e -n auto`
