### PR TITLE
fix(tui): emoji width edge case in cursorLayout

### DIFF
--- a/ui-tui/src/__tests__/cursorLayoutEmoji.test.ts
+++ b/ui-tui/src/__tests__/cursorLayoutEmoji.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import { cursorLayout } from '../lib/inputMetrics.js'
+
+describe('cursorLayout — grapheme boundary snapping', () => {
+  it('snaps mid-surrogate cursor in single emoji back to grapheme start', () => {
+    expect(cursorLayout('👍', 1, 80)).toEqual({ column: 0, line: 0 })
+  })
+
+  it('reports full width at end of single emoji', () => {
+    expect(cursorLayout('👍', 2, 80)).toEqual({ column: 2, line: 0 })
+  })
+
+  it('snaps mid-flag (regional indicator pair) cursor back to flag start', () => {
+    expect(cursorLayout('🇧🇷', 2, 80)).toEqual({ column: 0, line: 0 })
+  })
+
+  it('reports full width at end of regional flag', () => {
+    expect(cursorLayout('🇧🇷', 4, 80)).toEqual({ column: 2, line: 0 })
+  })
+
+  it('positions cursor before emoji embedded in ascii', () => {
+    expect(cursorLayout('a👍b', 1, 80)).toEqual({ column: 1, line: 0 })
+  })
+
+  it('snaps mid-surrogate cursor inside embedded emoji back to emoji start', () => {
+    expect(cursorLayout('a👍b', 2, 80)).toEqual({ column: 1, line: 0 })
+  })
+
+  it('positions cursor at end of embedded emoji', () => {
+    expect(cursorLayout('a👍b', 3, 80)).toEqual({ column: 3, line: 0 })
+  })
+
+  it('handles ZWJ family sequences as a single grapheme', () => {
+    const family = '👨‍👩‍👧'
+    expect(cursorLayout(family, 1, 80)).toEqual({ column: 0, line: 0 })
+    expect(cursorLayout(family, family.length, 80)).toEqual({
+      column: 2,
+      line: 0
+    })
+  })
+
+  it('preserves ascii cursor positions unchanged', () => {
+    expect(cursorLayout('hello', 0, 80)).toEqual({ column: 0, line: 0 })
+    expect(cursorLayout('hello', 3, 80)).toEqual({ column: 3, line: 0 })
+    expect(cursorLayout('hello', 5, 80)).toEqual({ column: 5, line: 0 })
+  })
+
+  it('clamps negative cursor to start', () => {
+    expect(cursorLayout('👍', -5, 80)).toEqual({ column: 0, line: 0 })
+  })
+
+  it('clamps overflow cursor to end of value', () => {
+    expect(cursorLayout('👍', 99, 80)).toEqual({ column: 2, line: 0 })
+  })
+})

--- a/ui-tui/src/lib/inputMetrics.ts
+++ b/ui-tui/src/lib/inputMetrics.ts
@@ -105,12 +105,33 @@ function widthBetween(value: string, start: number, end: number) {
   return width
 }
 
+function snapToGrapheme(value: string, pos: number): number {
+  if (pos <= 0 || pos >= value.length) {
+    return pos
+  }
+
+  let snapped = 0
+
+  for (const { index, segment } of seg().segment(value)) {
+    const end = index + segment.length
+
+    if (end > pos) {
+      return snapped
+    }
+
+    snapped = end
+  }
+
+  return snapped
+}
+
 /**
  * Mirrors the word-wrap behavior used by the composer TextInput.
  * Returns the zero-based visual line and column of the cursor cell.
  */
 export function cursorLayout(value: string, cursor: number, cols: number) {
-  const pos = Math.max(0, Math.min(cursor, value.length))
+  const rawPos = Math.max(0, Math.min(cursor, value.length))
+  const pos = snapToGrapheme(value, rawPos)
   const w = Math.max(1, cols)
   const lines = visualLines(value, w)
   let lineIndex = 0


### PR DESCRIPTION
## What does this PR do?

`cursorLayout` in `ui-tui/src/lib/inputMetrics.ts` reports the wrong column when the cursor index lands inside a multi-UTF16-unit grapheme.

## Root cause

`cursorLayout` in `ui-tui/src/lib/inputMetrics.ts` reports the wrong column when the cursor index lands inside a multi-UTF16-unit grapheme.

Reproduced with:

| value | cursor | actual | expected |
|---|---|---|---|
| `'👍'` | `1` | `{column: 1, line: 0}` | `{column: 0, line: 0}` |
| `'🇧🇷'` | `2` | `{column: 1, line: 0}` | `{column: 0, line: 0}` |
| `'a👍b'` | `2` | `{column: 2, line: 0}` | `{column: 1, line: 0}` |

Root cause: `widthBetween(value, line.start, Math.min(pos, line.end))` slices the string at the raw cursor offset. When `pos` is mid-surrogate, `Intl.Segmenter` treats the surviving half-surrogate as one segment, and `Math.max(1, stringWidth(segment))` clamps its width to `1`,…

## Fix

Add an internal `snapToGrapheme(value, pos)` step that walks `Intl.Segmenter` boundaries and snaps `pos` back to the nearest grapheme stop `≤ pos` before measuring. ASCII paths are unaffected (`pos <= 0 || pos >= length` early exits).

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

- Original body preserved below for full context.

<details>
<summary>Original body</summary>

## Summary

`cursorLayout` in `ui-tui/src/lib/inputMetrics.ts` reports the wrong column when the cursor index lands inside a multi-UTF16-unit grapheme.

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Problem

`cursorLayout` in `ui-tui/src/lib/inputMetrics.ts` reports the wrong column when the cursor index lands inside a multi-UTF16-unit grapheme.

Reproduced with:

| value | cursor | actual | expected |
|---|---|---|---|
| `'👍'` | `1` | `{column: 1, line: 0}` | `{column: 0, line: 0}` |
| `'🇧🇷'` | `2` | `{column: 1, line: 0}` | `{column: 0, line: 0}` |
| `'a👍b'` | `2` | `{column: 2, line: 0}` | `{column: 1, line: 0}` |

Root cause: `widthBetween(value, line.start, Math.min(pos, line.end))` slices the string at the raw cursor offset. When `pos` is mid-surrogate, `Intl.Segmenter` treats the surviving half-surrogate as one segment, and `Math.max(1, stringWidth(segment))` clamps its width to `1`, pushing the visual cursor one cell past the grapheme it actually sits inside.

## Fix

Add an internal `snapToGrapheme(value, pos)` step that walks `Intl.Segmenter` boundaries and snaps `pos` back to the nearest grapheme stop `≤ pos` before measuring. ASCII paths are unaffected (`pos <= 0 || pos >= length` early exits).

## Tests

`ui-tui/src/__tests__/cursorLayoutEmoji.test.ts` — 11 cases covering:
- Single emoji surrogate pair (`👍`)
- Regional indicator flag (`🇧🇷`)
- ZWJ family sequence (`👨‍👩‍👧`)
- Emoji embedded between ASCII (`a👍b`)
- ASCII no-op verification
- Negative / overflow clamping

## Verification

- `vitest run` — **659/659 pass** (all 62 files)
- New emoji test file — **11/11 pass**
- No public signature changes; no other call sites affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_