### PR TITLE
test(tui): cover /exit and /q alias parity with /quit

### DIFF
--- a/ui-tui/src/__tests__/createSlashHandler.test.ts
+++ b/ui-tui/src/__tests__/createSlashHandler.test.ts
@@ -34,6 +34,38 @@ describe('createSlashHandler', () => {
     expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
   })
 
+  it('exits locally for /exit alias', () => {
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)('/exit')).toBe(true)
+    expect(ctx.session.die).toHaveBeenCalledTimes(1)
+    expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
+    expect(ctx.gateway.rpc).not.toHaveBeenCalled()
+  })
+
+  it('exits locally for /q short alias', () => {
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)('/q')).toBe(true)
+    expect(ctx.session.die).toHaveBeenCalledTimes(1)
+    expect(ctx.gateway.gw.request).not.toHaveBeenCalled()
+    expect(ctx.gateway.rpc).not.toHaveBeenCalled()
+  })
+
+  it('quit aliases ignore trailing args without crashing', () => {
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)('/exit now')).toBe(true)
+    expect(ctx.session.die).toHaveBeenCalledTimes(1)
+  })
+
+  it('treats /exit as case-insensitive', () => {
+    const ctx = buildCtx()
+
+    expect(createSlashHandler(ctx)('/EXIT')).toBe(true)
+    expect(ctx.session.die).toHaveBeenCalledTimes(1)
+  })
+
   it('routes /status to live session.status instead of slash worker', async () => {
     patchUiState({ sid: 'sid-abc' })
     const rpc = vi.fn(() => Promise.resolve({ output: 'Hermes TUI Status' }))


### PR DESCRIPTION
## What does this PR do?

`createSlashHandler.test.ts` asserts `/quit` calls `session.die()` locally without a gateway round-trip, but the registered aliases (`exit`, `q`) declared in `ui-tui/src/app/slash/commands/core.ts` had **no regression coverage**:

## Root cause

`createSlashHandler.test.ts` asserts `/quit` calls `session.die()` locally without a gateway round-trip, but the registered aliases (`exit`, `q`) declared in `ui-tui/src/app/slash/commands/core.ts` had **no regression coverage**:

\`\`\`ts
{
  aliases: ['exit', 'q'],
  help: 'exit hermes',
  name: 'quit',
  run: (_arg, ctx) => ctx.session.die()
}
\`\`\`

If a future change to \`slash/registry.ts\` (alias map flattening) or \`createSlashHandler.ts\` (lowercasing/lookup) silently breaks alias dispatch, the suite would still pass.

## Fix

- Standardizes the PR description to the same review format used in #29640.
- Preserves the original detailed description below so no context is lost.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

- Original body preserved below for full context.

<details>
<summary>Original body</summary>

## Summary

`createSlashHandler.test.ts` asserts `/quit` calls `session.die()` locally without a gateway round-trip, but the registered aliases (`exit`, `q`) declared in `ui-tui/src/app/slash/commands/core.ts` had **no regression coverage**:

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Problem

`createSlashHandler.test.ts` asserts `/quit` calls `session.die()` locally without a gateway round-trip, but the registered aliases (`exit`, `q`) declared in `ui-tui/src/app/slash/commands/core.ts` had **no regression coverage**:

\`\`\`ts
{
  aliases: ['exit', 'q'],
  help: 'exit hermes',
  name: 'quit',
  run: (_arg, ctx) => ctx.session.die()
}
\`\`\`

If a future change to \`slash/registry.ts\` (alias map flattening) or \`createSlashHandler.ts\` (lowercasing/lookup) silently breaks alias dispatch, the suite would still pass.

## Tests added

`ui-tui/src/__tests__/createSlashHandler.test.ts` — 4 new cases mirroring the existing `/quit` test:

1. `/exit` → `session.die()` called once, no `gw.request`/`rpc`
2. `/q` → `session.die()` called once, no `gw.request`/`rpc`
3. `/exit now` (alias + trailing arg) → still triggers `die()` without crashing
4. `/EXIT` (uppercase) → resolves through the case-insensitive `byName` lookup

## Verification

- New cases — **5/5 pass** in `createSlashHandler.test.ts` (56 total in file)
- Full vitest regression — **652/652 pass** across 61 files
- Pure test addition; no production code touched

## Why this matters

Aliases are part of the documented user contract (`/exit` and `/q` are published as the natural quit commands in `helpHint.tsx`). Locking the contract in tests prevents silent regressions when the slash registry is refactored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_