### PR TITLE
fix: scope doctor API key issues to enabled toolsets

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -134,6 +134,46 @@ def _doctor_tool_availability_detail(toolset: str) -> str:
     return ""
 
 
+def _doctor_enabled_registry_toolsets_from_config() -> set[str] | None:
+    """Return registry toolsets enabled by Hermes config, or None if unknown.
+
+    ``check_tool_availability()`` reports every registered toolset globally, but
+    doctor should only turn missing API keys into actionable issues for toolsets
+    the user has enabled for at least one platform.  Optional platform-specific
+    tools like Discord can remain installed but intentionally unconfigured.
+    """
+    try:
+        from hermes_cli.config import load_config
+        from hermes_cli.tools_config import _get_platform_tools
+
+        cfg = load_config()
+        platform_toolsets = cfg.get("platform_toolsets")
+        platforms = {"cli"}
+        if isinstance(platform_toolsets, dict):
+            platforms.update(str(platform) for platform in platform_toolsets.keys())
+
+        enabled: set[str] = set()
+        for platform in platforms:
+            enabled.update(_get_platform_tools(cfg, platform))
+        return enabled
+    except Exception:
+        return None
+
+
+def _doctor_should_count_tool_api_issue(item: dict) -> bool:
+    """Whether an unavailable env-gated toolset should become a doctor issue."""
+    env_vars = item.get("missing_vars") or item.get("env_vars") or []
+    if not env_vars:
+        return False
+
+    enabled_toolsets = _doctor_enabled_registry_toolsets_from_config()
+    if enabled_toolsets is None:
+        # Fail open for unusual/test configs: preserve historical behaviour when
+        # we cannot tell which toolsets the user intentionally enabled.
+        return True
+    return str(item.get("name") or "") in enabled_toolsets
+
+
 def _apply_doctor_tool_availability_overrides(available: list[str], unavailable: list[dict]) -> tuple[list[str], list[dict]]:
     """Adjust runtime-gated tool availability for doctor diagnostics."""
     updated_available = list(available)
@@ -1395,10 +1435,13 @@ def run_doctor(args):
             else:
                 check_warn(item["name"], "(system dependency not met)")
 
-        # Count disabled tools with API key requirements
-        api_disabled = [u for u in unavailable if (u.get("missing_vars") or u.get("env_vars"))]
+        # Count disabled tools with API key requirements only when the toolset is
+        # enabled for at least one configured platform.  Optional installed
+        # integrations (for example Discord admin tools without a Discord bot)
+        # should remain warnings, not force a global setup issue.
+        api_disabled = [u for u in unavailable if _doctor_should_count_tool_api_issue(u)]
         if api_disabled:
-            issues.append("Run 'hermes setup' to configure missing API keys for full tool access")
+            issues.append("Run 'hermes setup' to configure missing API keys for enabled tool access")
     except Exception as e:
         check_warn("Could not check tool availability", f"({e})")
     

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -167,6 +167,39 @@ class TestDoctorToolAvailabilityOverrides:
 
         assert doctor._doctor_tool_availability_detail("kanban") == "(runtime-gated; loaded only for dispatcher-spawned workers)"
 
+    def test_default_config_does_not_treat_discord_as_enabled(self, monkeypatch):
+        import hermes_cli.config as config_mod
+
+        monkeypatch.setattr(config_mod, "load_config", lambda: {})
+
+        enabled = doctor._doctor_enabled_registry_toolsets_from_config()
+
+        assert enabled is not None
+        assert "web" in enabled
+        assert "discord" not in enabled
+        assert "discord_admin" not in enabled
+
+    def test_does_not_count_unenabled_optional_tool_api_issue(self, monkeypatch):
+        monkeypatch.setattr(doctor, "_doctor_enabled_registry_toolsets_from_config", lambda: {"web", "terminal"})
+
+        assert not doctor._doctor_should_count_tool_api_issue(
+            {"name": "discord", "env_vars": ["DISCORD_BOT_TOKEN"], "tools": ["discord"]}
+        )
+
+    def test_counts_enabled_platform_tool_api_issue(self, monkeypatch):
+        monkeypatch.setattr(doctor, "_doctor_enabled_registry_toolsets_from_config", lambda: {"hermes-discord", "discord", "discord_admin"})
+
+        assert doctor._doctor_should_count_tool_api_issue(
+            {"name": "discord", "env_vars": ["DISCORD_BOT_TOKEN"], "tools": ["discord"]}
+        )
+
+    def test_no_api_issue_for_system_dependency_failure(self, monkeypatch):
+        monkeypatch.setattr(doctor, "_doctor_enabled_registry_toolsets_from_config", lambda: {"browser"})
+
+        assert not doctor._doctor_should_count_tool_api_issue(
+            {"name": "browser", "env_vars": [], "tools": ["browser_navigate"]}
+        )
+
 
 class TestHonchoDoctorConfigDetection:
     def test_reports_configured_when_enabled_with_api_key(self, monkeypatch):


### PR DESCRIPTION
## Summary
- Scope `hermes doctor` API-key setup issues to toolsets enabled for at least one configured platform.
- Keep optional installed-but-disabled integrations, such as Discord tools without a Discord bot, as warnings instead of global setup failures.
- Reuse the existing `hermes_cli.tools_config._get_platform_tools()` resolver so doctor follows the same toolset semantics as the tools UI.

## Test Plan
- `/home/steve/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_doctor.py -q -o 'addopts='`
- `git diff --check`
