### PR TITLE
fix(telegram): download reply-to-message photo for agent vision

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2994,6 +2994,11 @@ class TelegramAdapter(BasePlatformAdapter):
 
         event = self._build_message_event(update.message, MessageType.TEXT, update_id=update.update_id)
         event.text = self._clean_bot_trigger_text(event.text)
+
+        # If this text message is replying to a message that contains a photo,
+        # download the replied-to photo so the agent can see what's being referenced.
+        await self._fetch_reply_to_photo(update.message, event)
+
         self._enqueue_text_event(event)
 
     async def _handle_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -3116,6 +3121,51 @@ class TelegramAdapter(BasePlatformAdapter):
         finally:
             if self._pending_text_batch_tasks.get(key) is current_task:
                 self._pending_text_batch_tasks.pop(key, None)
+
+    # ------------------------------------------------------------------
+    # Reply-to media fetching
+    # ------------------------------------------------------------------
+
+    async def _fetch_reply_to_photo(self, message: Message, event: MessageEvent) -> None:
+        """Download the photo from a replied-to message and attach it to the event.
+
+        When a user sends a text message as a reply to a message containing a
+        photo, the agent needs access to that image in order to reason about it.
+        This method fetches the replied-to photo (if any), caches it locally,
+        and attaches the path to ``event.media_urls`` / ``event.media_types`` so
+        the downstream image-routing logic in ``run.py`` picks it up.
+
+        If the replied-to message has no photo, this is a no-op.
+        """
+        reply_msg = getattr(message, "reply_to_message", None)
+        if not reply_msg or not getattr(reply_msg, "photo", None):
+            return
+
+        try:
+            # reply_msg.photo is a list of PhotoSize sorted by size; take the largest
+            photo = reply_msg.photo[-1]
+            file_obj = await photo.get_file()
+            image_bytes = await file_obj.download_as_bytearray()
+
+            ext = ".jpg"
+            if file_obj.file_path:
+                for candidate in [".png", ".webp", ".gif", ".jpeg", ".jpg"]:
+                    if file_obj.file_path.lower().endswith(candidate):
+                        ext = candidate
+                        break
+
+            cached_path = cache_image_from_bytes(bytes(image_bytes), ext=ext)
+            event.media_urls.append(cached_path)
+            event.media_types.append(f"image/{ext.lstrip('.')}")
+            logger.info("[Telegram] Cached reply-to photo at %s", cached_path)
+
+            # Ensure reply_to_text conveys that the replied message has an image,
+            # even when there's no caption.
+            if not event.reply_to_text:
+                event.reply_to_text = "[photo]"
+
+        except Exception as e:
+            logger.warning("[Telegram] Failed to cache reply-to photo: %s", e, exc_info=True)
 
     # ------------------------------------------------------------------
     # Photo batching

--- a/tests/gateway/test_telegram_reply_to_photo.py
+++ b/tests/gateway/test_telegram_reply_to_photo.py
@@ -1,0 +1,265 @@
+"""Tests for reply-to photo download in the Telegram adapter.
+
+When a user sends a text message as a reply to a message containing a photo,
+the adapter should download the replied-to photo, cache it locally, and
+attach it to the event's media_urls/media_types so the agent can see it.
+
+Regression test for: https://github.com/NousResearch/hermes-agent/issues/TBD
+"""
+import asyncio
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource
+
+
+def _make_message_with_photo_reply(has_caption: bool = False):
+    """Create a mock Telegram Message that is a text reply to a photo message."""
+    # The replied-to message (contains a photo)
+    reply_photo_size = MagicMock()
+    reply_photo_size.get_file = AsyncMock()
+
+    file_obj = MagicMock()
+    file_obj.file_path = "photos/file_123.jpg"
+    file_obj.download_as_bytearray = AsyncMock(
+        return_value=bytearray(b"\xff\xd8\xff\xe0" + b"\x00" * 100)  # JPEG magic bytes
+    )
+    reply_photo_size.get_file.return_value = file_obj
+
+    reply_msg = MagicMock()
+    reply_msg.photo = [MagicMock(), reply_photo_size]  # list sorted by size
+    reply_msg.text = None
+    reply_msg.caption = "Look at this!" if has_caption else None
+    reply_msg.message_id = 41
+
+    # The current message (text reply)
+    message = MagicMock()
+    message.reply_to_message = reply_msg
+    message.text = "What do you think about this?"
+    message.message_id = 42
+    message.chat = MagicMock()
+    message.chat.id = 123456
+    message.chat.type = "private"
+    message.chat.title = None
+    message.chat.full_name = "Test User"
+    message.from_user = MagicMock()
+    message.from_user.id = 789
+    message.from_user.full_name = "Test User"
+    message.message_thread_id = None
+    message.date = None
+
+    return message
+
+
+def _make_message_without_photo_reply():
+    """Create a mock Telegram Message that is a text reply to a text message."""
+    reply_msg = MagicMock()
+    reply_msg.photo = None
+    reply_msg.text = "Hello there"
+    reply_msg.caption = None
+    reply_msg.message_id = 41
+
+    message = MagicMock()
+    message.reply_to_message = reply_msg
+    message.text = "Hi!"
+    message.message_id = 42
+    message.chat = MagicMock()
+    message.chat.id = 123456
+    message.chat.type = "private"
+    message.chat.title = None
+    message.chat.full_name = "Test User"
+    message.from_user = MagicMock()
+    message.from_user.id = 789
+    message.from_user.full_name = "Test User"
+    message.message_thread_id = None
+    message.date = None
+
+    return message
+
+
+def _make_message_no_reply():
+    """Create a mock Telegram Message with no reply context."""
+    message = MagicMock()
+    message.reply_to_message = None
+    message.text = "Just a regular message"
+    message.message_id = 42
+    message.chat = MagicMock()
+    message.chat.id = 123456
+    message.chat.type = "private"
+    message.chat.title = None
+    message.chat.full_name = "Test User"
+    message.from_user = MagicMock()
+    message.from_user.id = 789
+    message.from_user.full_name = "Test User"
+    message.message_thread_id = None
+    message.date = None
+
+    return message
+
+
+@pytest.fixture
+def telegram_adapter():
+    """Create a minimal TelegramAdapter instance for testing."""
+    from gateway.config import Platform, PlatformConfig
+    from gateway.platforms.telegram import TelegramAdapter
+
+    config = PlatformConfig(enabled=True, token="fake:token")
+    adapter = object.__new__(TelegramAdapter)
+    adapter._platform = Platform.TELEGRAM
+    adapter.config = config
+    adapter._bot = MagicMock()
+    return adapter
+
+
+@pytest.mark.asyncio
+async def test_fetch_reply_to_photo_downloads_and_attaches(telegram_adapter):
+    """When replying to a photo message, the photo should be downloaded and
+    attached to the event's media_urls."""
+    message = _make_message_with_photo_reply(has_caption=False)
+    event = MessageEvent(
+        text="What do you think about this?",
+        source=SessionSource(
+            platform="telegram", chat_id="123456", chat_type="dm", user_id="789"
+        ),
+        reply_to_message_id="41",
+        reply_to_text=None,
+    )
+
+    with patch(
+        "gateway.platforms.telegram.cache_image_from_bytes",
+        return_value="/tmp/cache/reply_photo_abc.jpg",
+    ) as mock_cache:
+        await telegram_adapter._fetch_reply_to_photo(message, event)
+
+    # Photo should be cached and attached
+    assert event.media_urls == ["/tmp/cache/reply_photo_abc.jpg"]
+    assert event.media_types == ["image/jpg"]
+    mock_cache.assert_called_once()
+
+    # reply_to_text should be set to "[photo]" since there was no caption
+    assert event.reply_to_text == "[photo]"
+
+
+@pytest.mark.asyncio
+async def test_fetch_reply_to_photo_preserves_existing_reply_text(telegram_adapter):
+    """When the replied-to message has both a caption and a photo, the existing
+    reply_to_text (from the caption) should NOT be overwritten."""
+    message = _make_message_with_photo_reply(has_caption=True)
+    event = MessageEvent(
+        text="Nice!",
+        source=SessionSource(
+            platform="telegram", chat_id="123456", chat_type="dm", user_id="789"
+        ),
+        reply_to_message_id="41",
+        reply_to_text="Look at this!",  # Already set from caption
+    )
+
+    with patch(
+        "gateway.platforms.telegram.cache_image_from_bytes",
+        return_value="/tmp/cache/reply_photo_abc.jpg",
+    ):
+        await telegram_adapter._fetch_reply_to_photo(message, event)
+
+    # Photo should still be attached
+    assert event.media_urls == ["/tmp/cache/reply_photo_abc.jpg"]
+    # But reply_to_text should NOT be overwritten with "[photo]"
+    assert event.reply_to_text == "Look at this!"
+
+
+@pytest.mark.asyncio
+async def test_fetch_reply_to_photo_noop_when_no_photo(telegram_adapter):
+    """When replying to a text-only message, _fetch_reply_to_photo is a no-op."""
+    message = _make_message_without_photo_reply()
+    event = MessageEvent(
+        text="Hi!",
+        source=SessionSource(
+            platform="telegram", chat_id="123456", chat_type="dm", user_id="789"
+        ),
+        reply_to_message_id="41",
+        reply_to_text="Hello there",
+    )
+
+    await telegram_adapter._fetch_reply_to_photo(message, event)
+
+    # No media should be attached
+    assert event.media_urls == []
+    assert event.media_types == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_reply_to_photo_noop_when_no_reply(telegram_adapter):
+    """When the message is not a reply at all, _fetch_reply_to_photo is a no-op."""
+    message = _make_message_no_reply()
+    event = MessageEvent(
+        text="Just a regular message",
+        source=SessionSource(
+            platform="telegram", chat_id="123456", chat_type="dm", user_id="789"
+        ),
+    )
+
+    await telegram_adapter._fetch_reply_to_photo(message, event)
+
+    assert event.media_urls == []
+    assert event.media_types == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_reply_to_photo_handles_download_failure_gracefully(telegram_adapter):
+    """If the photo download fails, the error should be logged but not raised."""
+    message = _make_message_with_photo_reply()
+    # Make get_file raise an exception
+    message.reply_to_message.photo[-1].get_file = AsyncMock(
+        side_effect=Exception("Telegram API timeout")
+    )
+
+    event = MessageEvent(
+        text="What's this?",
+        source=SessionSource(
+            platform="telegram", chat_id="123456", chat_type="dm", user_id="789"
+        ),
+        reply_to_message_id="41",
+        reply_to_text=None,
+    )
+
+    # Should not raise
+    await telegram_adapter._fetch_reply_to_photo(message, event)
+
+    # No media attached due to failure
+    assert event.media_urls == []
+    assert event.media_types == []
+
+
+@pytest.mark.asyncio
+async def test_fetch_reply_to_photo_detects_png_extension(telegram_adapter):
+    """File extension detection should work for PNG screenshots."""
+    message = _make_message_with_photo_reply()
+    # Override file_path to be a PNG (common for iPhone screenshots)
+    file_obj = MagicMock()
+    file_obj.file_path = "photos/file_123.png"
+    file_obj.download_as_bytearray = AsyncMock(
+        return_value=bytearray(b"\x89PNG\r\n\x1a\n" + b"\x00" * 100)  # PNG magic bytes
+    )
+    message.reply_to_message.photo[-1].get_file = AsyncMock(return_value=file_obj)
+
+    event = MessageEvent(
+        text="What's in this screenshot?",
+        source=SessionSource(
+            platform="telegram", chat_id="123456", chat_type="dm", user_id="789"
+        ),
+        reply_to_message_id="41",
+        reply_to_text=None,
+    )
+
+    with patch(
+        "gateway.platforms.telegram.cache_image_from_bytes",
+        return_value="/tmp/cache/reply_screenshot.png",
+    ) as mock_cache:
+        await telegram_adapter._fetch_reply_to_photo(message, event)
+
+    assert event.media_urls == ["/tmp/cache/reply_screenshot.png"]
+    assert event.media_types == ["image/png"]
+    # Verify the correct extension was passed to cache_image_from_bytes
+    call_args = mock_cache.call_args
+    assert call_args[1].get("ext", call_args[0][1] if len(call_args[0]) > 1 else None) == ".png"


### PR DESCRIPTION
## Summary

When a user replies to a photo message with text (e.g., "What do you think about this?" as a reply to a screenshot), the agent could not see the referenced image. Only `reply_to_text`/caption was extracted — the photo itself was never downloaded or forwarded.

Fixes #22250

## Changes

### `gateway/platforms/telegram.py`

- **New method `_fetch_reply_to_photo()`** — async helper that:
  1. Checks if `message.reply_to_message` has a photo
  2. Downloads the largest `PhotoSize` variant via `get_file()`
  3. Caches locally via `cache_image_from_bytes()`
  4. Attaches path to `event.media_urls` / `event.media_types`
  5. Sets `reply_to_text = "[photo]"` when no caption exists (so the disambiguation pointer in `run.py` still fires)
  
- **Called from `_handle_text_message()`** — right after building the event, before enqueueing

### `tests/gateway/test_telegram_reply_to_photo.py`

6 regression tests covering:
- Photo download + attachment to event
- Caption preservation (existing `reply_to_text` not overwritten)
- No-op when replying to text-only message
- No-op when message is not a reply
- Graceful handling of download failures
- PNG extension detection (iPhone screenshots)

## How It Works

The fix reuses the existing image-routing pipeline in `run.py` — the replied-to photo flows through the same native/vision-analyze path as directly-sent photos. No changes needed to `run.py` or `base.py`.

## How to Test

1. Send a photo to a Telegram chat with the bot
2. Reply to that photo with a text message asking about it
3. The agent should now be able to see and discuss the photo

## Platforms Tested

- macOS (development) — unit tests pass
- Telegram gateway (real-world reproduction)