### PR TITLE
fix(gateway): send typing indicator before agent starts processing

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6899,6 +6899,18 @@ class GatewayRunner:
             }
             await self.hooks.emit("agent:start", hook_ctx)
 
+            # Send typing indicator so the user sees "..." while agent works
+            try:
+                _typing_adapter = self.adapters.get(source.platform)
+                if _typing_adapter and hasattr(_typing_adapter, "send_typing"):
+                    logger.info("Sending typing indicator for %s on %s", source.chat_id, source.platform)
+                    await _typing_adapter.send_typing(source.chat_id)
+                    logger.info("Typing indicator sent successfully for %s", source.chat_id)
+                else:
+                    logger.debug("No send_typing support for platform %s", source.platform)
+            except Exception as e:
+                logger.warning("Failed to send typing indicator: %s", e)
+
             # Run the agent
             agent_result = await self._run_agent(
                 message=message_text,


### PR DESCRIPTION
## Problem
The main agent flow in `_process_inbound_message` calls `stop_typing()` after the agent finishes, but never calls `send_typing()` beforehand. This means the user never sees a "typing..." indicator while the agent is working.

The proxy path (`_run_agent_via_proxy`) already does this correctly — the main path was simply missing the call.

## Fix
Add `send_typing()` before `_run_agent()` in the main gateway message processing loop, paired with the existing `stop_typing()` after completion.

This works for all platforms that support typing indicators (Discord, Telegram, Slack, etc.) since the check uses `hasattr`.

## Changes
- `gateway/run.py`: Added `send_typing()` call before `_run_agent()` with proper error handling and logging