### PR TITLE
test(tui): clipboard.ts coverage gap

### DIFF
--- a/ui-tui/src/__tests__/clipboardCoverageGap.test.ts
+++ b/ui-tui/src/__tests__/clipboardCoverageGap.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import { isUsableClipboardText, readClipboardText, writeClipboardText } from '../lib/clipboard.js'
+
+const NUL = '\u0000'
+const SOH = '\u0001'
+const STX = '\u0002'
+const ETX = '\u0003'
+const EOT = '\u0004'
+const REPLACEMENT = '\ufffd'
+
+describe('isUsableClipboardText — gap coverage', () => {
+  it('rejects null input', () => {
+    expect(isUsableClipboardText(null)).toBe(false)
+  })
+
+  it('rejects strings containing a NUL byte even when surrounding text is printable', () => {
+    expect(isUsableClipboardText(`hello${NUL}world`)).toBe(false)
+  })
+
+  it('treats newline, carriage-return, and tab as non-suspicious whitespace controls', () => {
+    expect(isUsableClipboardText('line1\nline2\r\nline3\ttabbed')).toBe(true)
+  })
+
+  it('accepts the absolute floor of 2 stray control chars in short text', () => {
+    expect(isUsableClipboardText(`hi${SOH}${STX}`)).toBe(true)
+  })
+
+  it('rejects short text once stray control chars exceed the absolute floor of 2', () => {
+    expect(isUsableClipboardText(`hi${SOH}${STX}${ETX}`)).toBe(false)
+  })
+
+  it('scales tolerance to 2% of length on long text', () => {
+    const longClean = 'a'.repeat(200)
+    expect(isUsableClipboardText(longClean + `${SOH}${STX}${ETX}${EOT}`)).toBe(true)
+  })
+
+  it('rejects long text that breaches the 2% suspicious-char ceiling', () => {
+    const longClean = 'a'.repeat(100)
+    expect(isUsableClipboardText(longClean + SOH.repeat(10))).toBe(false)
+  })
+
+  it('counts U+FFFD replacement chars as suspicious', () => {
+    expect(isUsableClipboardText(`a${REPLACEMENT}${REPLACEMENT}${REPLACEMENT}`)).toBe(false)
+  })
+})
+
+describe('readClipboardText — gap coverage', () => {
+  it('falls back from powershell.exe to xclip on WSL when powershell.exe rejects', async () => {
+    const run = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('powershell.exe missing'))
+      .mockResolvedValueOnce({ stdout: 'from xclip after wsl miss\n' })
+
+    await expect(
+      readClipboardText('linux', run, { WSL_INTEROP: '/tmp/sock' } as NodeJS.ProcessEnv)
+    ).resolves.toBe('from xclip after wsl miss\n')
+    expect(run).toHaveBeenNthCalledWith(
+      1,
+      'powershell.exe',
+      expect.arrayContaining(['Get-Clipboard -Raw']),
+      expect.anything()
+    )
+    expect(run).toHaveBeenNthCalledWith(2, 'xclip', ['-selection', 'clipboard', '-out'], expect.anything())
+  })
+
+  it('returns null when the backend resolves with non-string stdout', async () => {
+    const run = vi.fn().mockResolvedValue({ stdout: undefined as unknown as string })
+
+    await expect(readClipboardText('darwin', run)).resolves.toBeNull()
+  })
+
+  it('on bare Linux without Wayland or WSL goes straight to xclip (no wl-paste attempt)', async () => {
+    const run = vi.fn().mockResolvedValue({ stdout: 'plain x11\n' })
+
+    await expect(readClipboardText('linux', run, {} as NodeJS.ProcessEnv)).resolves.toBe('plain x11\n')
+    expect(run).toHaveBeenCalledTimes(1)
+    expect(run).toHaveBeenCalledWith('xclip', ['-selection', 'clipboard', '-out'], expect.anything())
+  })
+})
+
+describe('writeClipboardText — gap coverage', () => {
+  function makeChild(stdinEnd: ReturnType<typeof vi.fn>, exitCode: number) {
+    const child = {
+      once: vi.fn((event: string, cb: (code?: number) => void) => {
+        if (event === 'close') {
+          cb(exitCode)
+        }
+
+        return child
+      }),
+      stdin: { end: stdinEnd }
+    }
+
+    return child
+  }
+
+  it('forwards an empty string to the backend without short-circuiting', async () => {
+    const stdin = vi.fn()
+    const start = vi.fn().mockReturnValue(makeChild(stdin, 0))
+
+    await expect(writeClipboardText('', 'darwin', start as never)).resolves.toBe(true)
+    expect(start).toHaveBeenCalledWith('pbcopy', [], expect.anything())
+    expect(stdin).toHaveBeenCalledWith('')
+  })
+
+  it('returns false on bare Linux when both xclip and xsel exit non-zero', async () => {
+    const stdin = vi.fn()
+    const start = vi.fn().mockReturnValue(makeChild(stdin, 1))
+
+    await expect(writeClipboardText('hello', 'linux', start as never, {})).resolves.toBe(false)
+    expect(start).toHaveBeenNthCalledWith(1, 'xclip', ['-selection', 'clipboard', '-in'], expect.anything())
+    expect(start).toHaveBeenNthCalledWith(2, 'xsel', ['--clipboard', '--input'], expect.anything())
+  })
+})


### PR DESCRIPTION
## What does this PR do?

`ui-tui/src/lib/clipboard.ts` had several uncovered branches in `clipboard.test.ts`:

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- Standardizes the PR description to the same review format used in #29640.
- Preserves the original detailed description below so no context is lost.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

- Original body preserved below for full context.

<details>
<summary>Original body</summary>

## Summary

`ui-tui/src/lib/clipboard.ts` had several uncovered branches in `clipboard.test.ts`:

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Summary

`ui-tui/src/lib/clipboard.ts` had several uncovered branches in `clipboard.test.ts`:

- `isUsableClipboardText`: null input, NUL-byte rejection mid-text, whitespace-control allowance (`\n\r\t`), absolute floor of 2 stray controls in short text, the 2% scaling threshold for long text, and U+FFFD replacement-char counting.
- `readClipboardText`: WSL `powershell.exe` failure → `xclip` fallback, non-string `stdout` returning `null`, bare-Linux skipping `wl-paste` straight to `xclip`.
- `writeClipboardText`: empty-string forwarded to backend (no short-circuit), bare-Linux failing both `xclip` and `xsel`.

Adds **13 tests** in a new file `clipboardCoverageGap.test.ts` — no production code change, only fills gaps.

## Test plan

- [x] `npx vitest run src/__tests__/clipboardCoverageGap.test.ts` → 13/13 pass
- [x] Full `ui-tui` regression: `npx vitest run` → **661/661 pass**

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_