### PR TITLE
fix(tui): pop inputBuf on backspace when composer is empty

### DIFF
--- a/ui-tui/src/__tests__/useInputHandlers.test.ts
+++ b/ui-tui/src/__tests__/useInputHandlers.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { applyVoiceRecordResponse } from '../app/useInputHandlers.js'
+import { applyVoiceRecordResponse, popInputBufOnEmptyBackspace } from '../app/useInputHandlers.js'
 
 describe('applyVoiceRecordResponse', () => {
   it('reverts optimistic REC state when the gateway reports voice busy', () => {
@@ -33,5 +33,51 @@ describe('applyVoiceRecordResponse', () => {
 
     expect(setRecording).toHaveBeenCalledWith(false)
     expect(setProcessing).toHaveBeenCalledWith(false)
+  })
+})
+
+describe('popInputBufOnEmptyBackspace', () => {
+  it('returns null when the input is non-empty (textInput owns its own backspace)', () => {
+    expect(popInputBufOnEmptyBackspace('hello', ['line1'])).toBeNull()
+  })
+
+  it('returns null when the input is empty but the buffer is empty too', () => {
+    expect(popInputBufOnEmptyBackspace('', [])).toBeNull()
+  })
+
+  it('restores the last buffered line into the input and pops it from the buffer', () => {
+    expect(popInputBufOnEmptyBackspace('', ['77', '88'])).toEqual({
+      input: '88',
+      inputBuf: ['77']
+    })
+  })
+
+  it('handles a single-line buffer by emptying the buffer and restoring that line', () => {
+    expect(popInputBufOnEmptyBackspace('', ['only line'])).toEqual({
+      input: 'only line',
+      inputBuf: []
+    })
+  })
+
+  it('preserves earlier buffered lines when popping the most recent one', () => {
+    expect(popInputBufOnEmptyBackspace('', ['a', 'b', 'c'])).toEqual({
+      input: 'c',
+      inputBuf: ['a', 'b']
+    })
+  })
+
+  it('preserves an empty-string buffered line as the restored value', () => {
+    expect(popInputBufOnEmptyBackspace('', ['first', ''])).toEqual({
+      input: '',
+      inputBuf: ['first']
+    })
+  })
+
+  it('does not mutate the input buffer array', () => {
+    const buf = ['a', 'b']
+
+    popInputBufOnEmptyBackspace('', buf)
+
+    expect(buf).toEqual(['a', 'b'])
   })
 })

--- a/ui-tui/src/app/useInputHandlers.ts
+++ b/ui-tui/src/app/useInputHandlers.ts
@@ -23,6 +23,26 @@ import { getUiState } from './uiStore.js'
 
 const isCtrl = (key: { ctrl: boolean }, ch: string, target: string) => key.ctrl && ch.toLowerCase() === target
 
+/**
+ * When the composer input is empty and the user presses Backspace, restore the
+ * last buffered continuation line (`\` + Enter aggregator in useSubmission)
+ * back into the input so it can be edited or deleted. Returns null when no
+ * action is needed.
+ */
+export function popInputBufOnEmptyBackspace(
+  input: string,
+  inputBuf: readonly string[]
+): { input: string; inputBuf: string[] } | null {
+  if (input !== '' || inputBuf.length === 0) {
+    return null
+  }
+
+  return {
+    input: inputBuf[inputBuf.length - 1] ?? '',
+    inputBuf: inputBuf.slice(0, -1)
+  }
+}
+
 export function applyVoiceRecordResponse(
   response: null | VoiceRecordResponse,
   starting: boolean,
@@ -372,6 +392,17 @@ export function useInputHandlers(ctx: InputHandlerContext): InputHandlerResult {
 
     if (key.escape && terminal.hasSelection) {
       return clearSelection()
+    }
+
+    if (key.backspace) {
+      const popped = popInputBufOnEmptyBackspace(cState.input, cState.inputBuf)
+
+      if (popped) {
+        cActions.setInputBuf(popped.inputBuf)
+        cActions.setInput(popped.input)
+
+        return
+      }
     }
 
     if (key.upArrow && !cState.inputBuf.length) {


### PR DESCRIPTION
## What does this PR do?

Sub-issue of #22034 (specifically #18394 — "TUI backspace cannot delete newline characters in composer input").

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- Standardizes the PR description to the same review format used in #29640.
- Preserves the original detailed description below so no context is lost.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

- Related to #22034. - Related to #18394.

<details>
<summary>Original body</summary>

## Summary

Sub-issue of #22034 (specifically #18394 — "TUI backspace cannot delete newline characters in composer input").

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Summary

Sub-issue of #22034 (specifically #18394 — "TUI backspace cannot delete newline characters in composer input").

The composer aggregates multi-line input via `\` + Enter by pushing each typed line into a `inputBuf` array and clearing the active input ([`useSubmission.ts:402-406`](https://github.com/NousResearch/hermes-agent/blob/main/ui-tui/src/app/useSubmission.ts#L402-L406)). Those buffered lines live **outside** the textInput's value, so the textInput's internal Backspace handler can never reach them — Backspace from an empty input was a no-op, leaving accumulated lines stranded until submission.

This PR adds a global Backspace handler in `useInputHandlers` that, when the input is empty and the buffer is non-empty, pops the last buffered line back into the input as the new editable value. Normal Backspace (input non-empty) still belongs to textInput.

The pop logic is extracted as a pure helper `popInputBufOnEmptyBackspace` so it is unit-tested in isolation without rebuilding the full Ink hook surface.

## Test plan

- [x] 7 new unit tests in `useInputHandlers.test.ts` (10/10 in file pass) — empty buffer, single-line buffer, multi-line buffer, empty-string buffered line, non-mutation guarantee, no-op when input is non-empty
- [x] Full ui-tui regression: `npx vitest run` → **655/655 pass**

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_