### PR TITLE
fix: skip memory consolidation after interrupt

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5042,12 +5042,19 @@ class AIAgent:
         manager, and on_session_end() on the context engine.
         NOT called per-turn — only at CLI exit, /reset, gateway
         session expiry, etc.
+
+        When the agent has already been interrupted (SIGTERM, Ctrl+C,
+        /stop), skip memory-manager on_session_end() so cleanup does not
+        start local-LLM consolidation work while native inference threads
+        may still be unwinding. Resource shutdown still runs.
         """
+        was_interrupted = getattr(self, "_interrupt_requested", False)
         if self._memory_manager:
-            try:
-                self._memory_manager.on_session_end(messages or [])
-            except Exception:
-                pass
+            if not was_interrupted:
+                try:
+                    self._memory_manager.on_session_end(messages or [])
+                except Exception:
+                    pass
             try:
                 self._memory_manager.shutdown_all()
             except Exception:

--- a/tests/run_agent/test_sigterm_llama_race_guardrail.py
+++ b/tests/run_agent/test_sigterm_llama_race_guardrail.py
@@ -1,0 +1,44 @@
+"""Regression tests for interrupted memory-provider shutdown.
+
+When SIGTERM/Ctrl+C fires, the Python signal handler calls agent.interrupt(),
+sets _interrupt_requested=True, then unwinds the main thread. The cleanup path
+(_run_cleanup -> shutdown_memory_provider) must not call memory
+``on_session_end()`` because Mnemosyne may enter local llama.cpp inference during
+that hook. Native ggml worker threads cannot be interrupted from Python, so
+starting consolidation during signal cleanup can race native tensor-buffer
+lifetime. Resource cleanup still needs to call ``shutdown_all()``.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from run_agent import AIAgent
+
+
+def _agent_with_memory_manager(*, interrupted: bool) -> tuple[AIAgent, MagicMock]:
+    agent = object.__new__(AIAgent)
+    memory_manager = MagicMock()
+    agent._memory_manager = memory_manager
+    agent._interrupt_requested = interrupted
+    agent.context_compressor = None
+    agent.session_id = "test-session"
+    return agent, memory_manager
+
+
+def test_shutdown_memory_provider_skips_on_session_end_when_interrupted():
+    agent, memory_manager = _agent_with_memory_manager(interrupted=True)
+
+    agent.shutdown_memory_provider([{"role": "user", "content": "hello"}])
+
+    memory_manager.on_session_end.assert_not_called()
+    memory_manager.shutdown_all.assert_called_once_with()
+
+
+def test_shutdown_memory_provider_runs_on_session_end_when_not_interrupted():
+    messages = [{"role": "user", "content": "hello"}]
+    agent, memory_manager = _agent_with_memory_manager(interrupted=False)
+
+    agent.shutdown_memory_provider(messages)
+
+    memory_manager.on_session_end.assert_called_once_with(messages)
+    memory_manager.shutdown_all.assert_called_once_with()


### PR DESCRIPTION
## Summary
- Skip memory-manager `on_session_end()` during interrupted agent shutdown.
- Still call `shutdown_all()` so memory providers release resources.
- Add a production-path regression test that exercises `AIAgent.shutdown_memory_provider()` directly for both interrupted and normal shutdown.

## Rationale
During SIGTERM/Ctrl+C cleanup, `on_session_end()` may trigger local memory consolidation work. For local LLM-backed providers, starting consolidation while native inference threads are unwinding can create a shutdown race. The interrupted path should avoid starting new consolidation work while preserving resource cleanup.

## Test Plan
- `/home/steve/.hermes/hermes-agent/venv/bin/python -m pytest tests/run_agent/test_sigterm_llama_race_guardrail.py -q -o 'addopts='`
- `git diff --check`
