### PR TITLE
Fix stale update cache invalidation for custom HERMES_HOME

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6422,14 +6422,26 @@ def _invalidate_update_cache():
 
     default_home = get_default_hermes_root()
     homes.append(default_home)
+    env_home = os.environ.get("HERMES_HOME", "").strip()
+    if env_home:
+        env_path = Path(env_home).expanduser()
+        try:
+            env_path.resolve().relative_to(default_home.resolve())
+        except ValueError:
+            homes.append(env_path)
     # Named profiles under <root>/profiles/
     profiles_root = default_home / "profiles"
     if profiles_root.is_dir():
         for entry in profiles_root.iterdir():
             if entry.is_dir():
                 homes.append(entry)
+    seen = set()
     for home in homes:
         try:
+            resolved = home.resolve()
+            if resolved in seen:
+                continue
+            seen.add(resolved)
             cache_file = home / ".update_check"
             if cache_file.exists():
                 cache_file.unlink()

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -151,3 +151,23 @@ def test_invalidate_update_cache_no_profiles_dir(tmp_path):
         _invalidate_update_cache()
 
     assert not (default_home / ".update_check").exists()
+
+
+def test_invalidate_update_cache_clears_external_hermes_home(tmp_path):
+    """Clear the active external HERMES_HOME cache in addition to the default tree."""
+    from hermes_cli.main import _invalidate_update_cache
+
+    default_home = tmp_path / ".hermes"
+    default_home.mkdir()
+    (default_home / ".update_check").write_text('{"ts":1,"behind":5}')
+
+    external_home = tmp_path / "custom-home"
+    external_home.mkdir()
+    (external_home / ".update_check").write_text('{"ts":1,"behind":7}')
+
+    with patch("hermes_constants.get_default_hermes_root", return_value=default_home), \
+         patch.dict(os.environ, {"HERMES_HOME": str(external_home)}):
+        _invalidate_update_cache()
+
+    assert not (default_home / ".update_check").exists()
+    assert not (external_home / ".update_check").exists()


### PR DESCRIPTION
## Summary
- invalidate the active external HERMES_HOME update cache when it sits outside the default .hermes tree
- dedupe cache home paths before unlinking .update_check files
- add a regression test covering an external custom HERMES_HOME

Fixes #21526