### PR TITLE
fix: add youtube-transcript-api dependency for youtube-content skill (#22243)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,8 @@ dependencies = [
   # (which is a silent killer on Windows — see CONTRIBUTING.md) and
   # `os.killpg` (which doesn't exist on Windows).
   "psutil>=5.9.0,<8",
+  # Skills
+  "youtube-transcript-api>=1.2.0,<2",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
## Description

Fix #22243 — The `youtube-content` skill imports `youtube-transcript-api` at runtime but it is not declared in `pyproject.toml`. Fresh installs fail with `ModuleNotFoundError: No module named 'youtube_transcript_api'` on first invocation of the skill.

## Changes

- Add `youtube-transcript-api>=1.2.0,<2` to core dependencies in `pyproject.toml`

## Testing

- [x] `uv sync` now installs `youtube-transcript-api` automatically
- [x] `youtube-content` skill no longer raises `ModuleNotFoundError`