### PR TITLE
fix: soften maintenance restart notifications

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -293,6 +293,74 @@ def _restart_notification_pending() -> bool:
     return (_hermes_home / ".restart_notify.json").exists()
 
 
+def _maintenance_restart_notice_path() -> Path:
+    return _hermes_home / ".maintenance_restart.json"
+
+
+def _load_maintenance_restart_notice() -> dict[str, Any] | None:
+    # Best-effort marker written by safe-update for calmer maintenance wording.
+    path = _maintenance_restart_notice_path()
+    try:
+        if not path.exists():
+            return None
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            return None
+        created_at = float(data.get("created_at", 0) or 0)
+        if created_at and time.time() - created_at > 60 * 60:
+            try:
+                path.unlink()
+            except Exception:
+                pass
+            return None
+        if data.get("kind") != "safe-update":
+            return None
+        return data
+    except Exception as exc:
+        logger.debug("Failed to load maintenance restart notice: %s", exc)
+        return None
+
+
+def _clear_maintenance_restart_notice() -> None:
+    try:
+        _maintenance_restart_notice_path().unlink(missing_ok=True)
+    except Exception as exc:
+        logger.debug("Failed to clear maintenance restart notice: %s", exc)
+
+
+def _format_maintenance_restart_message(notice: dict[str, Any], *, complete: bool) -> str:
+    raw_commits = notice.get("commits_pending")
+    try:
+        commits = int(raw_commits) if raw_commits is not None else None
+    except (TypeError, ValueError):
+        commits = None
+
+    if complete:
+        lines = [
+            "✅ Hermes maintenance complete — gateway is back.",
+            "",
+            "Result: update applied; gateway restarted",
+        ]
+    else:
+        lines = [
+            "🛠 Hermes maintenance restart — gateway will be back shortly.",
+            "",
+            "Status: updating",
+        ]
+
+    if commits is not None:
+        noun = "commit" if commits == 1 else "commits"
+        status = "applied" if complete else "pending"
+        lines.append(f"Change: {commits} {noun} {status}")
+
+    head = notice.get("head")
+    target = notice.get("target")
+    if head and target and head != target:
+        lines.append(f"Version: {head} → {target}")
+
+    return "\n".join(lines)
+
+
 # Mark this process as a gateway so cli.py's module-level load_cli_config()
 # knows not to clobber TERMINAL_CWD if lazily imported.
 os.environ["_HERMES_GATEWAY"] = "1"
@@ -2589,14 +2657,18 @@ class GatewayRunner:
         """
         active = self._snapshot_running_agents()
 
-        action = "restarting" if self._restart_requested else "shutting down"
-        hint = (
-            "Your current task will be interrupted. "
-            "Send any message after restart and I'll try to resume where you left off."
-            if self._restart_requested
-            else "Your current task will be interrupted."
-        )
-        msg = f"⚠️ Gateway {action} — {hint}"
+        maintenance_notice = _load_maintenance_restart_notice()
+        if maintenance_notice:
+            msg = _format_maintenance_restart_message(maintenance_notice, complete=False)
+        else:
+            action = "restarting" if self._restart_requested else "shutting down"
+            hint = (
+                "Your current task will be interrupted. "
+                "Send any message after restart and I'll try to resume where you left off."
+                if self._restart_requested
+                else "Your current task will be interrupted."
+            )
+            msg = f"⚠️ Gateway {action} — {hint}"
 
         notified: set[tuple[str, str, Optional[str]]] = set()
         for session_key in active:
@@ -12010,7 +12082,12 @@ class GatewayRunner:
         """
         delivered: set[tuple[str, str, Optional[str]]] = set()
         skipped = skip_targets or set()
-        message = "♻️ Gateway online — Hermes is back and ready."
+        maintenance_notice = _load_maintenance_restart_notice()
+        message = (
+            _format_maintenance_restart_message(maintenance_notice, complete=True)
+            if maintenance_notice
+            else "♻️ Gateway online — Hermes is back and ready."
+        )
 
         for platform, adapter in self.adapters.items():
             home = self.config.get_home_channel(platform)
@@ -12050,6 +12127,8 @@ class GatewayRunner:
                     platform.value,
                     home.chat_id,
                 )
+                if maintenance_notice:
+                    _clear_maintenance_restart_notice()
             except Exception as exc:
                 logger.warning(
                     "Home-channel startup notification failed for %s:%s: %s",

--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -210,6 +210,27 @@ async def test_shutdown_notification_says_restarting_when_restart_requested():
 
 
 @pytest.mark.asyncio
+async def test_shutdown_notification_uses_maintenance_notice(tmp_path, monkeypatch):
+    """Safe-update restarts use calm maintenance wording instead of interruption wording."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    (tmp_path / ".maintenance_restart.json").write_text(
+        '{"kind":"safe-update","created_at":9999999999,"commits_pending":3,"head":"abc1234","target":"def5678"}',
+        encoding="utf-8",
+    )
+    runner, adapter = make_restart_runner()
+    runner._running_agents["agent:main:telegram:dm:999"] = MagicMock()
+
+    await runner._notify_active_sessions_of_shutdown()
+
+    assert len(adapter.sent) == 1
+    assert "Hermes maintenance restart" in adapter.sent[0]
+    assert "gateway will be back shortly" in adapter.sent[0]
+    assert "3 commits pending" in adapter.sent[0]
+    assert "abc1234 → def5678" in adapter.sent[0]
+    assert "interrupted" not in adapter.sent[0]
+
+
+@pytest.mark.asyncio
 async def test_shutdown_notification_deduplicates_per_chat():
     """Multiple sessions in the same chat only get one notification."""
     runner, adapter = make_restart_runner()

--- a/tests/gateway/test_restart_notification.py
+++ b/tests/gateway/test_restart_notification.py
@@ -274,6 +274,36 @@ async def test_send_home_channel_startup_notification_preserves_thread_metadata(
 
 
 @pytest.mark.asyncio
+async def test_send_home_channel_startup_notification_uses_and_clears_maintenance_notice(tmp_path, monkeypatch):
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    notice_path = tmp_path / ".maintenance_restart.json"
+    notice_path.write_text(
+        '{"kind":"safe-update","created_at":9999999999,"commits_pending":5,"head":"1111111","target":"2222222"}',
+        encoding="utf-8",
+    )
+
+    runner, adapter = make_restart_runner()
+    runner.config.platforms[Platform.TELEGRAM].home_channel = HomeChannel(
+        platform=Platform.TELEGRAM,
+        chat_id="home-42",
+        name="Ops Home",
+    )
+    adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="home"))
+
+    delivered = await runner._send_home_channel_startup_notifications()
+
+    assert delivered == {("telegram", "home-42", None)}
+    adapter.send.assert_called_once_with(
+        "home-42",
+        "✅ Hermes maintenance complete — gateway is back.\n\n"
+        "Result: update applied; gateway restarted\n"
+        "Change: 5 commits applied\n"
+        "Version: 1111111 → 2222222",
+    )
+    assert not notice_path.exists()
+
+
+@pytest.mark.asyncio
 async def test_send_home_channel_startup_notification_skips_restart_target(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## Summary
- add a safe-update maintenance marker so scheduled restarts use calmer wording
- show pending/applied commit counts and version transition in restart messages
- clear the marker after the gateway returns online

## Test Plan
- venv/bin/python -m py_compile gateway/run.py
- venv/bin/python -m pytest tests/gateway/test_restart_drain.py tests/gateway/test_restart_notification.py -q -o addopts=

_🤖 Drafted by Hermes Agent_