### PR TITLE
fix(gemini): coalesce parallel tool responses into single user turn

### DIFF
--- a/agent/gemini_cloudcode_adapter.py
+++ b/agent/gemini_cloudcode_adapter.py
@@ -137,6 +137,8 @@ def _build_gemini_contents(
     system_text_parts: List[str] = []
     contents: List[Dict[str, Any]] = []
 
+    pending_tool_parts: List[Dict[str, Any]] = []
+
     for msg in messages:
         if not isinstance(msg, dict):
             continue
@@ -146,13 +148,15 @@ def _build_gemini_contents(
             system_text_parts.append(_coerce_content_to_text(msg.get("content")))
             continue
 
-        # Tool result message — emit a user-role turn with functionResponse
+        # Buffer tool/function results; flush as a single user turn later
         if role == "tool" or role == "function":
-            contents.append({
-                "role": "user",
-                "parts": [_translate_tool_result_to_gemini(msg)],
-            })
+            pending_tool_parts.append(_translate_tool_result_to_gemini(msg))
             continue
+
+        # Flush buffered tool results as a single user turn
+        if pending_tool_parts:
+            contents.append({"role": "user", "parts": pending_tool_parts})
+            pending_tool_parts = []
 
         gemini_role = _ROLE_MAP_OPENAI_TO_GEMINI.get(role, "user")
         parts: List[Dict[str, Any]] = []
@@ -173,6 +177,10 @@ def _build_gemini_contents(
             continue
 
         contents.append({"role": gemini_role, "parts": parts})
+
+    # Flush any remaining tool results after the loop
+    if pending_tool_parts:
+        contents.append({"role": "user", "parts": pending_tool_parts})
 
     system_instruction: Optional[Dict[str, Any]] = None
     joined_system = "\n".join(p for p in system_text_parts if p).strip()

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -278,6 +278,8 @@ def _build_gemini_contents(messages: List[Dict[str, Any]]) -> tuple[List[Dict[st
     contents: List[Dict[str, Any]] = []
     tool_name_by_call_id: Dict[str, str] = {}
 
+    pending_tool_parts: List[Dict[str, Any]] = []
+
     for msg in messages:
         if not isinstance(msg, dict):
             continue
@@ -287,19 +289,20 @@ def _build_gemini_contents(messages: List[Dict[str, Any]]) -> tuple[List[Dict[st
             system_text_parts.append(_coerce_content_to_text(msg.get("content")))
             continue
 
+        # Buffer tool/function results; flush as a single user turn later
         if role in {"tool", "function"}:
-            contents.append(
-                {
-                    "role": "user",
-                    "parts": [
-                        _translate_tool_result_to_gemini(
-                            msg,
-                            tool_name_by_call_id=tool_name_by_call_id,
-                        )
-                    ],
-                }
+            pending_tool_parts.append(
+                _translate_tool_result_to_gemini(
+                    msg,
+                    tool_name_by_call_id=tool_name_by_call_id,
+                )
             )
             continue
+
+        # Flush buffered tool results as a single user turn
+        if pending_tool_parts:
+            contents.append({"role": "user", "parts": pending_tool_parts})
+            pending_tool_parts = []
 
         gemini_role = "model" if role == "assistant" else "user"
         parts: List[Dict[str, Any]] = []
@@ -319,6 +322,10 @@ def _build_gemini_contents(messages: List[Dict[str, Any]]) -> tuple[List[Dict[st
 
         if parts:
             contents.append({"role": gemini_role, "parts": parts})
+
+    # Flush any remaining tool results after the loop
+    if pending_tool_parts:
+        contents.append({"role": "user", "parts": pending_tool_parts})
 
     system_instruction = None
     joined_system = "\n".join(part for part in system_text_parts if part).strip()

--- a/tests/agent/test_gemini_cloudcode.py
+++ b/tests/agent/test_gemini_cloudcode.py
@@ -1196,3 +1196,91 @@ class TestRunGeminiOauthLoginPure:
         assert result["email"] == "u@e.com"
         assert result["project_id"] == "p"
         assert isinstance(result["expires_at_ms"], int)
+
+
+class TestParallelToolResponseCoalescing:
+    """Regression test: consecutive tool-role messages must be bundled into a
+    single Gemini user turn with all functionResponse parts, not emitted as
+    separate user turns (which causes HTTP 400 INVALID_ARGUMENT).
+    """
+
+    def test_parallel_tool_results_coalesced_into_single_user_turn(self):
+        from agent.gemini_cloudcode_adapter import build_gemini_request
+
+        messages = [
+            {"role": "user", "content": "Check these three files"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_a",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": '{"path": "a.txt"}'},
+                    },
+                    {
+                        "id": "call_b",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": '{"path": "b.txt"}'},
+                    },
+                    {
+                        "id": "call_c",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": '{"path": "c.txt"}'},
+                    },
+                ],
+            },
+            {
+                "role": "tool",
+                "name": "read_file",
+                "tool_call_id": "call_a",
+                "content": "content of a",
+            },
+            {
+                "role": "tool",
+                "name": "read_file",
+                "tool_call_id": "call_b",
+                "content": "content of b",
+            },
+            {
+                "role": "tool",
+                "name": "read_file",
+                "tool_call_id": "call_c",
+                "content": "content of c",
+            },
+            {"role": "user", "content": "Now summarize them"},
+        ]
+
+        req = build_gemini_request(messages=messages)
+        contents = req["contents"]
+
+        # Expected structure:
+        # [0] user turn (initial "Check these three files")
+        # [1] model turn with 3 functionCall parts
+        # [2] user turn with 3 functionResponse parts (coalesced!)
+        # [3] user turn ("Now summarize them")
+
+        # Verify model turn has 3 functionCall parts
+        model_turn = contents[1]
+        assert model_turn["role"] == "model"
+        fc_parts = [p for p in model_turn["parts"] if "functionCall" in p]
+        assert len(fc_parts) == 3
+
+        # Verify exactly ONE user turn for all 3 tool results
+        tool_response_turn = contents[2]
+        assert tool_response_turn["role"] == "user"
+        fr_parts = [p for p in tool_response_turn["parts"] if "functionResponse" in p]
+        assert len(fr_parts) == 3, (
+            f"Expected 3 functionResponse parts in a single turn, got {len(fr_parts)}"
+        )
+
+        # Verify the next turn is the user follow-up, not another tool result
+        assert contents[3]["role"] == "user"
+        assert contents[3]["parts"] == [{"text": "Now summarize them"}]
+
+        # Most important: there should be exactly 4 turns total, NOT 6
+        # (6 would mean each tool result got its own user turn)
+        assert len(contents) == 4, (
+            f"Expected 4 content turns, got {len(contents)} — "
+            "tool results were not coalesced"
+        )

--- a/tests/agent/test_gemini_native_adapter.py
+++ b/tests/agent/test_gemini_native_adapter.py
@@ -326,3 +326,92 @@ def test_stream_event_translation_keeps_identical_calls_in_distinct_parts():
     assert tool_chunks[0].choices[0].delta.tool_calls[0].index == 0
     assert tool_chunks[1].choices[0].delta.tool_calls[0].index == 1
     assert tool_chunks[0].choices[0].delta.tool_calls[0].id != tool_chunks[1].choices[0].delta.tool_calls[0].id
+
+
+class TestParallelToolResponseCoalescing:
+    """Regression test: consecutive tool-role messages must be bundled into a
+    single Gemini user turn with all functionResponse parts, not emitted as
+    separate user turns (which causes HTTP 400 INVALID_ARGUMENT).
+    """
+
+    def test_parallel_tool_results_coalesced_into_single_user_turn(self):
+        from agent.gemini_native_adapter import build_gemini_request
+
+        messages = [
+            {"role": "user", "content": "Check these three files"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_a",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": '{"path": "a.txt"}'},
+                    },
+                    {
+                        "id": "call_b",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": '{"path": "b.txt"}'},
+                    },
+                    {
+                        "id": "call_c",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": '{"path": "c.txt"}'},
+                    },
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_a",
+                "content": "content of a",
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_b",
+                "content": "content of b",
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_c",
+                "content": "content of c",
+            },
+            {"role": "user", "content": "Now summarize them"},
+        ]
+
+        req = build_gemini_request(messages=messages)
+        contents = req["contents"]
+
+        # Expected structure:
+        # [0] user turn (initial "Check these three files")
+        # [1] model turn with 3 functionCall parts
+        # [2] user turn with 3 functionResponse parts (coalesced!)
+        # [3] user turn ("Now summarize them")
+
+        # Verify model turn has 3 functionCall parts
+        model_turn = contents[1]
+        assert model_turn["role"] == "model"
+        fc_parts = [p for p in model_turn["parts"] if "functionCall" in p]
+        assert len(fc_parts) == 3
+
+        # Verify exactly ONE user turn for all 3 tool results
+        tool_response_turn = contents[2]
+        assert tool_response_turn["role"] == "user"
+        fr_parts = [p for p in tool_response_turn["parts"] if "functionResponse" in p]
+        assert len(fr_parts) == 3, (
+            f"Expected 3 functionResponse parts in a single turn, got {len(fr_parts)}"
+        )
+
+        # Verify the function names are resolved from tool_name_by_call_id
+        names = [p["functionResponse"]["name"] for p in fr_parts]
+        assert names == ["read_file", "read_file", "read_file"]
+
+        # Verify the next turn is the user follow-up, not another tool result
+        assert contents[3]["role"] == "user"
+        assert contents[3]["parts"] == [{"text": "Now summarize them"}]
+
+        # Most important: there should be exactly 4 turns total, NOT 6
+        # (6 would mean each tool result got its own user turn)
+        assert len(contents) == 4, (
+            f"Expected 4 content turns, got {len(contents)} — "
+            "tool results were not coalesced"
+        )


### PR DESCRIPTION
## What

Coalesce consecutive `tool`/`function`-role messages into a single `user`-role turn with all `functionResponse` parts bundled together in `_build_gemini_contents()` for both the native and CloudCode Gemini adapters.

## Why

When a non-Gemini primary model (e.g. GLM-5.1, Claude, GPT-4o) makes **parallel tool calls** (multiple `tool_calls` in a single assistant turn) and the session falls back to a Gemini provider, the API returns:

```
HTTP 400 (INVALID_ARGUMENT): Please ensure that the number of function response parts is equal to the number of function call parts of the function call turn.
```

Both adapters emitted each `tool`-role message as a **separate** `user`-role turn:

```json
[
  {"role": "model", "parts": [{"functionCall": {...}}, {"functionCall": {...}}]},
  {"role": "user",  "parts": [{"functionResponse": {...}}]},
  {"role": "user",  "parts": [{"functionResponse": {...}}]}
]
```

Gemini requires all `functionResponse` parts for a given `model` turn to be in **one** `user` turn:

```json
[
  {"role": "model", "parts": [{"functionCall": {...}}, {"functionCall": {...}}]},
  {"role": "user",  "parts": [{"functionResponse": {...}}, {"functionResponse": {...}}]}
]
```

This only manifests on fallback because when Gemini is the primary model, it typically returns single tool calls per turn (1:1 = no mismatch).

## How

- Buffer consecutive `tool`/`function`-role messages in `pending_tool_parts`
- Flush as a single `user` turn when a non-tool message arrives
- Flush remaining buffer after the loop

## Testing

- Added `TestParallelToolResponseCoalescing` to both `test_gemini_cloudcode.py` and `test_gemini_native_adapter.py`
- Tests verify 3 parallel tool results produce exactly 1 user turn (not 3) with all 3 `functionResponse` parts
- All 98 existing Gemini adapter tests pass (0 regressions)

## Files Changed

- `agent/gemini_cloudcode_adapter.py` — buffer + flush in `_build_gemini_contents()`
- `agent/gemini_native_adapter.py` — same fix
- `tests/agent/test_gemini_cloudcode.py` — coalescing test
- `tests/agent/test_gemini_native_adapter.py` — coalescing test