### PR TITLE
fix(test): use i18n t() for restart drain assertion

### DIFF
--- a/tests/gateway/test_restart_drain.py
+++ b/tests/gateway/test_restart_drain.py
@@ -7,6 +7,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 
 import gateway.run as gateway_run
+from agent.i18n import t
 from gateway.platforms.base import MessageEvent, MessageType
 from gateway.restart import DEFAULT_GATEWAY_RESTART_DRAIN_TIMEOUT
 from gateway.session import SessionEntry, build_session_key
@@ -32,7 +33,7 @@ async def test_restart_command_while_busy_requests_drain_without_interrupt(monke
 
     result = await runner._handle_message(event)
 
-    assert result == "⏳ Draining 1 active agent(s) before restart..."
+    assert result == t("gateway.draining", count=1)
     running_agent.interrupt.assert_not_called()
     runner.request_restart.assert_called_once_with(detached=True, via_service=False)
 


### PR DESCRIPTION
## Summary

Fixes the failing test `test_restart_command_while_busy_requests_drain_without_interrupt` which broke after the i18n migration of gateway response strings.

Fixes #22266

## Changes

**`tests/gateway/test_restart_drain.py`**

- Import `t` from `agent.i18n`
- Replace hardcoded string assertion with `t("gateway.draining", count=1)`

## Why

After `gateway/run.py` migrated from hardcoded strings to `t("gateway.draining", count=count)`, the test kept asserting against the old literal string. In xdist workers where the locale catalog may not resolve, `t()` returns the raw key, causing a mismatch either way.

Using `t()` in the assertion makes the test validate the actual return value regardless of locale resolution.

## How to Test

```bash
pytest tests/gateway/test_restart_drain.py::test_restart_command_while_busy_requests_drain_without_interrupt -v
```

## Platforms Tested

- macOS (local, pytest)