### PR TITLE
fix(metadata): update hy3-preview context length to 262144

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -210,8 +210,8 @@ DEFAULT_CONTEXT_LENGTHS = {
     "grok": 131072,             # catch-all (grok-beta, unknown grok-*)
     # Kimi
     "kimi": 262144,
-    # Tencent — Hy3 Preview (Hunyuan) with 256K context window
-    "hy3-preview": 256000,
+    # Tencent — Hy3 Preview (Hunyuan) with 256K context window (262144 tokens)
+    "hy3-preview": 262144,
     # Nemotron — NVIDIA's open-weights series (128K context across all sizes)
     "nemotron": 131072,
     # Arcee

--- a/tests/hermes_cli/test_tencent_tokenhub_provider.py
+++ b/tests/hermes_cli/test_tencent_tokenhub_provider.py
@@ -309,7 +309,7 @@ class TestTencentTokenhubContextLength:
     def test_hy3_preview_context_length(self):
         from agent.model_metadata import get_model_context_length
         ctx = get_model_context_length("hy3-preview")
-        assert ctx == 256000
+        assert ctx == 262144
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Fixes the failing test `TestTencentTokenhubContextLength::test_hy3_preview_context_length` by updating the stale context length value for `hy3-preview`.

Fixes #22268

## Changes

**`agent/model_metadata.py`**
- Update `DEFAULT_CONTEXT_LENGTHS["hy3-preview"]` from 256000 → 262144
- Update comment to reflect the token count

**`tests/hermes_cli/test_tencent_tokenhub_provider.py`**
- Update assertion: `assert ctx == 262144`

## Why

OpenRouter's live API now reports `hy3-preview` with `context_length: 262144` (the model provider updated it after the initial 256000 launch value). Since `get_model_context_length("hy3-preview")` hits the OpenRouter metadata cache (step 6 in resolution) before the static fallback table (step 8), the function already returns 262144 in practice — the static table and test assertion were just stale.

## How to Test

```bash
pytest tests/hermes_cli/test_tencent_tokenhub_provider.py::TestTencentTokenhubContextLength::test_hy3_preview_context_length -v
```

## Platforms Tested

- macOS (local, pytest)