### PR TITLE
test(skills): cover get_external_skills_dirs input validation branches

### DIFF
--- a/tests/agent/test_external_skills_dirs_validation.py
+++ b/tests/agent/test_external_skills_dirs_validation.py
@@ -1,0 +1,181 @@
+"""Branch coverage for ``get_external_skills_dirs`` input validation.
+
+The mtime-cache happy paths are covered in ``test_external_skills_dirs_cache``.
+This module pins the input-validation and entry-normalization branches that
+guard malformed config.yaml and exotic ``external_dirs`` entries:
+
+- YAML root is not a mapping
+- ``skills:`` is not a mapping
+- ``external_dirs`` is a single string (coerced to a one-item list)
+- ``external_dirs`` is a non-list / non-string scalar (rejected)
+- entries with ``~`` and ``${VAR}`` expansion
+- relative entries resolve under ``HERMES_HOME``, not the cwd
+- entries pointing to the local ``~/.hermes/skills/`` are silently dropped
+- duplicates collapse to a single result
+- entries pointing at non-existent paths are silently skipped
+- empty / whitespace-only entries are skipped
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from agent.skill_utils import (
+    _external_dirs_cache_clear,
+    get_external_skills_dirs,
+)
+
+
+@pytest.fixture
+def isolated_hermes_home(tmp_path, monkeypatch):
+    """Empty isolated ``~/.hermes/`` with no config — caller writes config.yaml."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    (home / "skills").mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    _external_dirs_cache_clear()
+    yield home, tmp_path
+    _external_dirs_cache_clear()
+
+
+def _write_config(home: Path, body: str) -> Path:
+    config = home / "config.yaml"
+    config.write_text(body, encoding="utf-8")
+    return config
+
+
+def test_yaml_root_not_mapping_returns_empty(isolated_hermes_home):
+    home, _ = isolated_hermes_home
+    _write_config(home, "- item1\n- item2\n")  # YAML list at root, not a mapping
+
+    assert get_external_skills_dirs() == []
+
+
+def test_skills_section_not_mapping_returns_empty(isolated_hermes_home):
+    home, _ = isolated_hermes_home
+    _write_config(home, "skills: just_a_string\n")
+
+    assert get_external_skills_dirs() == []
+
+
+def test_external_dirs_as_single_string_is_coerced_to_list(isolated_hermes_home):
+    home, root = isolated_hermes_home
+    target = root / "string_external"
+    target.mkdir()
+
+    _write_config(home, f"skills:\n  external_dirs: {target}\n")
+
+    assert get_external_skills_dirs() == [target.resolve()]
+
+
+def test_external_dirs_as_invalid_type_returns_empty(isolated_hermes_home):
+    home, _ = isolated_hermes_home
+    _write_config(home, "skills:\n  external_dirs:\n    nested: dict\n")
+
+    assert get_external_skills_dirs() == []
+
+
+def test_environment_variable_in_entry_is_expanded(isolated_hermes_home, monkeypatch):
+    home, root = isolated_hermes_home
+    target = root / "env_expanded"
+    target.mkdir()
+    monkeypatch.setenv("EXT_SKILLS", str(target))
+
+    _write_config(home, "skills:\n  external_dirs:\n    - ${EXT_SKILLS}\n")
+
+    assert get_external_skills_dirs() == [target.resolve()]
+
+
+def test_tilde_in_entry_is_expanded(isolated_hermes_home):
+    home, root = isolated_hermes_home
+    # Path.home() is patched to tmp_path by the fixture.
+    target = root / "tilde_target"
+    target.mkdir()
+
+    _write_config(home, "skills:\n  external_dirs:\n    - ~/tilde_target\n")
+
+    assert get_external_skills_dirs() == [target.resolve()]
+
+
+def test_relative_entry_is_resolved_against_hermes_home(isolated_hermes_home):
+    home, _ = isolated_hermes_home
+    relative_target = home / "subdir_skills"
+    relative_target.mkdir()
+
+    _write_config(home, "skills:\n  external_dirs:\n    - subdir_skills\n")
+
+    assert get_external_skills_dirs() == [relative_target.resolve()]
+
+
+def test_local_skills_dir_is_silently_dropped(isolated_hermes_home):
+    home, root = isolated_hermes_home
+    local_skills = home / "skills"
+    extra = root / "extra_skills"
+    extra.mkdir()
+
+    _write_config(
+        home,
+        "skills:\n"
+        "  external_dirs:\n"
+        f"    - {local_skills}\n"
+        f"    - {extra}\n",
+    )
+
+    result = get_external_skills_dirs()
+    assert local_skills.resolve() not in result
+    assert extra.resolve() in result
+
+
+def test_duplicate_entries_collapse(isolated_hermes_home):
+    home, root = isolated_hermes_home
+    target = root / "dup_skills"
+    target.mkdir()
+
+    _write_config(
+        home,
+        "skills:\n"
+        "  external_dirs:\n"
+        f"    - {target}\n"
+        f"    - {target}\n"
+        f"    - {target}\n",
+    )
+
+    assert get_external_skills_dirs() == [target.resolve()]
+
+
+def test_nonexistent_entries_are_skipped(isolated_hermes_home):
+    home, root = isolated_hermes_home
+    real = root / "real_skills"
+    real.mkdir()
+    fake = root / "does_not_exist"
+
+    _write_config(
+        home,
+        "skills:\n"
+        "  external_dirs:\n"
+        f"    - {fake}\n"
+        f"    - {real}\n",
+    )
+
+    assert get_external_skills_dirs() == [real.resolve()]
+
+
+def test_empty_and_whitespace_entries_are_skipped(isolated_hermes_home):
+    home, root = isolated_hermes_home
+    target = root / "kept_skills"
+    target.mkdir()
+
+    _write_config(
+        home,
+        "skills:\n"
+        "  external_dirs:\n"
+        "    - ''\n"
+        "    - '   '\n"
+        f"    - {target}\n",
+    )
+
+    assert get_external_skills_dirs() == [target.resolve()]

--- a/tests/agent/test_external_skills_dirs_validation.py
+++ b/tests/agent/test_external_skills_dirs_validation.py
@@ -92,7 +92,8 @@ def test_environment_variable_in_entry_is_expanded(isolated_hermes_home, monkeyp
 
 def test_tilde_in_entry_is_expanded(isolated_hermes_home):
     home, root = isolated_hermes_home
-    # Path.home() is patched to tmp_path by the fixture.
+    # The fixture sets HOME=tmp_path; get_external_skills_dirs() expands `~`
+    # via os.path.expanduser(), which on POSIX consults the HOME env var.
     target = root / "tilde_target"
     target.mkdir()
 


### PR DESCRIPTION
## What does this PR do?

Adds 11 pytest cases pinning the input-validation and entry-normalization branches of `agent.skill_utils.get_external_skills_dirs` that the existing mtime-cache happy-path suite (`test_external_skills_dirs_cache.py`) leaves uncovered.

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- Standardizes the PR description to the same review format used in #29640.
- Preserves the original detailed description below so no context is lost.

## Why this shape

`get_external_skills_dirs` is on the cold-start hot path (called once per skill during banner / tool-registry scans) and silently swallows malformed `config.yaml` shapes — a YAML root that isn't a mapping, a `skills:` value that isn't a mapping, an `external_dirs` that isn't a list, etc. Today none of those defensive branches have a regression test, so a future cleanup that drops the wrong `isinstance` check would pass CI green and break user configs at runtime.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

- Original body preserved below for full context.

<details>
<summary>Original body</summary>

## Summary

Adds 11 pytest cases pinning the input-validation and entry-normalization branches of `agent.skill_utils.get_external_skills_dirs` that the existing mtime-cache happy-path suite (`test_external_skills_dirs_cache.py`) leaves uncovered.

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What

Adds 11 pytest cases pinning the input-validation and entry-normalization branches of `agent.skill_utils.get_external_skills_dirs` that the existing mtime-cache happy-path suite (`test_external_skills_dirs_cache.py`) leaves uncovered.

## Why

`get_external_skills_dirs` is on the cold-start hot path (called once per skill during banner / tool-registry scans) and silently swallows malformed `config.yaml` shapes — a YAML root that isn't a mapping, a `skills:` value that isn't a mapping, an `external_dirs` that isn't a list, etc. Today none of those defensive branches have a regression test, so a future cleanup that drops the wrong `isinstance` check would pass CI green and break user configs at runtime.

## Coverage added

| Branch in `skill_utils.py` | Test |
|---|---|
| `not isinstance(parsed, dict)` | `test_yaml_root_not_mapping_returns_empty` |
| `not isinstance(skills_cfg, dict)` | `test_skills_section_not_mapping_returns_empty` |
| `isinstance(raw_dirs, str)` coercion | `test_external_dirs_as_single_string_is_coerced_to_list` |
| `not isinstance(raw_dirs, list)` | `test_external_dirs_as_invalid_type_returns_empty` |
| `os.path.expandvars` | `test_environment_variable_in_entry_is_expanded` |
| `os.path.expanduser` | `test_tilde_in_entry_is_expanded` |
| `not p.is_absolute()` resolves under `HERMES_HOME` | `test_relative_entry_is_resolved_against_hermes_home` |
| `p == local_skills` drop | `test_local_skills_dir_is_silently_dropped` |
| `p in seen` dedup | `test_duplicate_entries_collapse` |
| `p.is_dir()` skip | `test_nonexistent_entries_are_skipped` |
| `if not entry: continue` | `test_empty_and_whitespace_entries_are_skipped` |

## Test design

A single `isolated_hermes_home` fixture spins up a throwaway `~/.hermes/` under `tmp_path`, monkeypatches `HERMES_HOME`, `HOME`, and `Path.home`, and clears `_external_dirs_cache_clear()` before and after each case so no test leaks into another. Every test writes its own `config.yaml` body — there is no shared YAML fixture to mis-edit later.

## Verification

```
pytest tests/agent/test_external_skills_dirs_validation.py -v
============================== 11 passed in 1.95s ==============================
```

Full repo suite (`pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e -n auto`) was also run; the new file adds 11 passes and no regressions. The 37 unrelated failures observed in the run reproduce on the parent commit `78b0008f4` without this patch (mostly env-dependent: anthropic-adapter OAuth, systemd-on-macOS, file-state registry).

## Out of scope

No production code is touched — this PR is pure test coverage.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_