### PR TITLE
fix(telegram): condense blank lines between consecutive list items

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2638,7 +2638,22 @@ class TelegramAdapter(BasePlatformAdapter):
             text,
         )
 
-        # 3) Convert markdown links – escape the display text; inside the URL
+        # 2.5) Condense blank lines between consecutive list items
+        #      LLM-generated bullet/ordered lists often have blank lines between
+        #      items (standard Markdown), but Telegram MarkdownV2 renders those
+        #      as visible empty rows. Removing the blank lines between consecutive
+        #      list items produces compact Telegram-native lists.
+        #      Code blocks are already in placeholders at this point and won't
+        #      be touched.
+        #      Handles: multiline items, multiple blank lines, checkboxes.
+        text = re.sub(
+            r'(^[ \t]*(?:[-*+•‣▪▫◦‒–—]|\d+[.)])\s+(?:(?!\n[ \t]*\n)[\s\S])*?)\n[ \t]*\n+(?=\s*(?:[-*+•‣▪▫◦‒–—]|\d+[.)])\s)',
+            r'\1\n',
+            text,
+            flags=re.MULTILINE,
+        )
+
+        # 3) Convert markdown links
         #    only ')' and '\' need escaping per the MarkdownV2 spec.
         def _convert_link(m):
             display = _escape_mdv2(m.group(1))


### PR DESCRIPTION
## Problem

LLM-generated bullet and ordered lists often include blank lines between items (standard Markdown). Telegram MarkdownV2 renders these blank lines as visible empty rows, creating unwanted vertical gaps:

```
- item 1

- item 2

- item 3
```

Renders in Telegram with blank rows between each item, which looks broken.

## Solution

Add a regex step (step 2.5) in `TelegramAdapter.format_message()` that removes blank lines between consecutive list items (both bullet `-`, `*`, `+` and numbered `1.`, `2.` patterns) before MarkdownV2 conversion runs.

Code block contents are already in placeholders at this point and are never touched.

## Testing

- The regex matches a list item line followed by a blank line followed by another list item line
- Only consecutive blank lines between list items are removed (not all blank lines)
- Single blank lines elsewhere are preserved
- Code blocks are fully protected by the existing placeholder system

## Checklist

- [x] Tests? — manually verified with sample messages containing lists
- [x] Does not break inline code or fenced blocks (placeholders protect them)