### PR TITLE
test(tui): cover CircularBuffer push/tail/drain/clear behaviors

### DIFF
--- a/ui-tui/src/__tests__/circularBuffer.test.ts
+++ b/ui-tui/src/__tests__/circularBuffer.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from 'vitest'
+
+import { CircularBuffer } from '../lib/circularBuffer.js'
+
+describe('CircularBuffer', () => {
+  describe('constructor', () => {
+    it('rejects zero capacity', () => {
+      expect(() => new CircularBuffer<number>(0)).toThrow(RangeError)
+    })
+
+    it('rejects negative capacity', () => {
+      expect(() => new CircularBuffer<number>(-1)).toThrow(RangeError)
+    })
+
+    it('rejects fractional capacity', () => {
+      expect(() => new CircularBuffer<number>(1.5)).toThrow(RangeError)
+    })
+
+    it('rejects NaN capacity', () => {
+      expect(() => new CircularBuffer<number>(Number.NaN)).toThrow(RangeError)
+    })
+
+    it('accepts capacity of one', () => {
+      const buf = new CircularBuffer<number>(1)
+      buf.push(7)
+      expect(buf.tail()).toEqual([7])
+    })
+  })
+
+  describe('push + tail', () => {
+    it('returns nothing when empty', () => {
+      const buf = new CircularBuffer<string>(4)
+      expect(buf.tail()).toEqual([])
+    })
+
+    it('preserves insertion order while under capacity', () => {
+      const buf = new CircularBuffer<number>(4)
+      buf.push(1)
+      buf.push(2)
+      buf.push(3)
+      expect(buf.tail()).toEqual([1, 2, 3])
+    })
+
+    it('drops the oldest items once capacity is exceeded', () => {
+      const buf = new CircularBuffer<number>(3)
+      buf.push(1)
+      buf.push(2)
+      buf.push(3)
+      buf.push(4)
+      buf.push(5)
+      expect(buf.tail()).toEqual([3, 4, 5])
+    })
+
+    it('handles many wraps without losing order', () => {
+      const buf = new CircularBuffer<number>(3)
+      for (let i = 1; i <= 10; i++) {
+        buf.push(i)
+      }
+      expect(buf.tail()).toEqual([8, 9, 10])
+    })
+  })
+
+  describe('tail(n)', () => {
+    it('returns the last n items when buffer is full', () => {
+      const buf = new CircularBuffer<number>(5)
+      for (let i = 1; i <= 5; i++) {
+        buf.push(i)
+      }
+      expect(buf.tail(2)).toEqual([4, 5])
+    })
+
+    it('clamps n above the current length', () => {
+      const buf = new CircularBuffer<number>(5)
+      buf.push(1)
+      buf.push(2)
+      expect(buf.tail(10)).toEqual([1, 2])
+    })
+
+    it('returns an empty array for n = 0', () => {
+      const buf = new CircularBuffer<number>(5)
+      buf.push(1)
+      expect(buf.tail(0)).toEqual([])
+    })
+
+    it('treats negative n as zero', () => {
+      const buf = new CircularBuffer<number>(5)
+      buf.push(1)
+      buf.push(2)
+      expect(buf.tail(-3)).toEqual([])
+    })
+
+    it('returns last n after wrap-around', () => {
+      const buf = new CircularBuffer<number>(3)
+      for (let i = 1; i <= 6; i++) {
+        buf.push(i)
+      }
+      expect(buf.tail(2)).toEqual([5, 6])
+    })
+  })
+
+  describe('drain', () => {
+    it('returns all items and empties the buffer', () => {
+      const buf = new CircularBuffer<number>(3)
+      buf.push(1)
+      buf.push(2)
+      buf.push(3)
+      expect(buf.drain()).toEqual([1, 2, 3])
+      expect(buf.tail()).toEqual([])
+    })
+
+    it('returns empty array when draining empty buffer', () => {
+      const buf = new CircularBuffer<number>(3)
+      expect(buf.drain()).toEqual([])
+    })
+
+    it('returns post-wrap snapshot, not raw underlying array', () => {
+      const buf = new CircularBuffer<number>(3)
+      for (let i = 1; i <= 5; i++) {
+        buf.push(i)
+      }
+      expect(buf.drain()).toEqual([3, 4, 5])
+    })
+  })
+
+  describe('clear', () => {
+    it('resets length and head so subsequent pushes start fresh', () => {
+      const buf = new CircularBuffer<number>(3)
+      buf.push(1)
+      buf.push(2)
+      buf.clear()
+      expect(buf.tail()).toEqual([])
+      buf.push(9)
+      expect(buf.tail()).toEqual([9])
+    })
+  })
+
+  describe('returned arrays', () => {
+    it('does not share storage between callers — mutating result is safe', () => {
+      const buf = new CircularBuffer<number>(3)
+      buf.push(1)
+      buf.push(2)
+      const a = buf.tail()
+      a[0] = 999
+      expect(buf.tail()).toEqual([1, 2])
+    })
+  })
+})


### PR DESCRIPTION
## What does this PR do?

Adds direct unit coverage for `ui-tui/src/lib/circularBuffer.ts` — a tiny FIFO ring buffer used by `gatewayClient` to hold the last N gateway log lines and events.

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- Standardizes the PR description to the same review format used in #29640.
- Preserves the original detailed description below so no context is lost.

## Why this shape

`CircularBuffer<T>` had **zero** direct unit tests. The only coverage was incidental, through `gatewayClient` integration paths, which exercise just a thin slice of the surface (push + drain after wrap). A regression in any of the corner cases below would slip through CI today.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

- Original body preserved below for full context.

<details>
<summary>Original body</summary>

## Summary

Adds direct unit coverage for `ui-tui/src/lib/circularBuffer.ts` — a tiny FIFO ring buffer used by `gatewayClient` to hold the last N gateway log lines and events.

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What

Adds direct unit coverage for `ui-tui/src/lib/circularBuffer.ts` — a tiny FIFO ring buffer used by `gatewayClient` to hold the last N gateway log lines and events.

## Why

`CircularBuffer<T>` had **zero** direct unit tests. The only coverage was incidental, through `gatewayClient` integration paths, which exercise just a thin slice of the surface (push + drain after wrap). A regression in any of the corner cases below would slip through CI today.

## Coverage added (19 cases)

| Area | Cases |
|---|---|
| Constructor validation | zero / negative / fractional / NaN capacity all throw `RangeError`; capacity = 1 works |
| push + tail under capacity | empty returns `[]`; insertion order preserved |
| push past capacity | oldest dropped; FIFO maintained after one wrap and after many wraps |
| `tail(n)` variants | full buffer + n; n above length is clamped; n = 0; negative n treated as 0; n after wrap |
| `drain` | returns full snapshot then empties; drain on empty buffer; drain after wrap returns post-wrap window |
| `clear` | resets head + length so subsequent pushes start fresh |
| Returned arrays | `tail()` returns fresh array — mutating it does not corrupt internal state |

## Verification

```
$ npx vitest run src/__tests__/circularBuffer.test.ts
 Test Files  1 passed (1)
      Tests  19 passed (19)
```

Full ui-tui suite:

```
$ npx vitest run
 Test Files  63 passed (63)
      Tests  673 passed (673)
```

## Out of scope

No production code is touched.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_