### PR TITLE
feat(agent): eager fallback on stream-stall timeouts (#22277)

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -424,6 +424,15 @@ DEFAULT_CONFIG = {
         # on flaky primaries; raise it if you prefer to tolerate longer
         # provider hiccups on a single provider.
         "api_max_retries": 3,
+        # Eager-fallback on stream-stall / call timeouts (#22277).  When
+        # true AND `fallback_providers` is configured, a classified
+        # FailoverReason.timeout (typically a stale-detector-killed hung
+        # stream) immediately activates the next fallback provider instead
+        # of retrying the same broken primary.  Default false to preserve
+        # historical behavior; flip to true if you've seen multi-minute
+        # silent hangs against a degraded primary while a healthy fallback
+        # was sitting idle.
+        "eager_fallback_on_timeout": False,
         "service_tier": "",
         # Tool-use enforcement: injects system prompt guidance that tells the
         # model to actually call tools instead of describing intended actions.

--- a/run_agent.py
+++ b/run_agent.py
@@ -1747,6 +1747,23 @@ class AIAgent:
         self._fallback_activated = getattr(self, "_fallback_activated", False)
         # Legacy attribute kept for backward compat (tests, external callers)
         self._fallback_model = self._fallback_chain[0] if self._fallback_chain else None
+
+        # Eager fallback on stream-stall / connection timeouts (#22277).
+        # Default off to preserve historical behavior; users with paid
+        # primaries + OAuth-backed fallbacks (e.g. Anthropic + openai-codex)
+        # opt in via `agent.eager_fallback_on_timeout: true` so a degraded
+        # primary doesn't cause 15+ min silent hangs from retry-loop pile-up.
+        try:
+            from hermes_cli.config import load_config as _load_eft_config
+            _eft_cfg = _load_eft_config() or {}
+            _eft_agent = _eft_cfg.get("agent", {}) or {}
+            self._eager_fallback_on_timeout = bool(
+                _eft_agent.get("eager_fallback_on_timeout", False)
+            )
+        except Exception:
+            self._eager_fallback_on_timeout = False
+
+
         if self._fallback_chain and not self.quiet_mode:
             if len(self._fallback_chain) == 1:
                 fb = self._fallback_chain[0]
@@ -13057,6 +13074,31 @@ class AIAgent:
                                 compression_attempts = 0
                                 primary_recovery_attempted = False
                                 continue
+
+                    # Eager fallback for stream-stall / connection timeouts
+                    # (issue #22277).  When the stale detector kills a hung
+                    # stream, the error classifies as FailoverReason.timeout
+                    # and the loop normally retries the same broken primary
+                    # — burning the full retry budget (3+ stale kills × 5min
+                    # each = 15+ min silent hang).  When the user has
+                    # configured a fallback chain AND opted in via
+                    # `agent.eager_fallback_on_timeout`, switch to fallback
+                    # after the first stale kill instead of compounding.
+                    is_timeout_eager = (
+                        classified.reason == FailoverReason.timeout
+                        and self._eager_fallback_on_timeout
+                        and self._fallback_index < len(self._fallback_chain)
+                    )
+                    if is_timeout_eager:
+                        self._emit_status(
+                            "⚠️ Provider stalled (stream/call timeout) — "
+                            "switching to fallback provider..."
+                        )
+                        if self._try_activate_fallback(reason=classified.reason):
+                            retry_count = 0
+                            compression_attempts = 0
+                            primary_recovery_attempted = False
+                            continue
 
                     # ── Nous Portal: record rate limit & skip retries ─────
                     # When Nous returns a 429 that is a genuine account-

--- a/tests/run_agent/test_eager_fallback_on_timeout.py
+++ b/tests/run_agent/test_eager_fallback_on_timeout.py
@@ -1,0 +1,96 @@
+"""Tests for eager fallback on stream-stall / call timeouts (issue #22277).
+
+When a primary provider's stream stalls and the stale detector kills the
+connection, the error classifies as ``FailoverReason.timeout``.  Without
+this feature, the retry loop hammers the same broken primary repeatedly,
+producing 15+ min silent hangs.  With ``agent.eager_fallback_on_timeout``
+enabled, the next fallback provider activates after the first stale kill.
+"""
+
+from unittest.mock import MagicMock, patch
+
+from agent.error_classifier import FailoverReason
+from run_agent import AIAgent
+
+
+def _make_agent(fallback_model=None, eager_on_timeout=None):
+    config_overlay = {}
+    if eager_on_timeout is not None:
+        config_overlay = {"agent": {"eager_fallback_on_timeout": eager_on_timeout}}
+
+    def _fake_load_config(*_args, **_kwargs):
+        return config_overlay
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("hermes_cli.config.load_config", side_effect=_fake_load_config),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            fallback_model=fallback_model,
+        )
+        agent.client = MagicMock()
+        return agent
+
+
+# ── Config wiring ─────────────────────────────────────────────────────────
+
+
+class TestEagerFallbackConfigDefaults:
+    def test_default_is_false_when_unset(self):
+        agent = _make_agent()
+        assert agent._eager_fallback_on_timeout is False
+
+    def test_explicit_false(self):
+        agent = _make_agent(eager_on_timeout=False)
+        assert agent._eager_fallback_on_timeout is False
+
+    def test_explicit_true(self):
+        agent = _make_agent(eager_on_timeout=True)
+        assert agent._eager_fallback_on_timeout is True
+
+    def test_truthy_int_coerced_to_bool(self):
+        agent = _make_agent(eager_on_timeout=1)
+        assert agent._eager_fallback_on_timeout is True
+
+
+# ── Trigger gating logic (unit-level) ─────────────────────────────────────
+#
+# We don't drive the full retry loop end-to-end (it's a 700-line block of
+# inline state); instead we assert the gate predicate that the loop checks.
+
+
+class TestEagerFallbackOnTimeoutGate:
+    def _gate(self, classified_reason, eager_flag, fb_index, fb_chain_len):
+        return (
+            classified_reason == FailoverReason.timeout
+            and eager_flag
+            and fb_index < fb_chain_len
+        )
+
+    def test_fires_when_all_conditions_met(self):
+        assert self._gate(FailoverReason.timeout, True, 0, 1) is True
+
+    def test_does_not_fire_when_flag_off(self):
+        assert self._gate(FailoverReason.timeout, False, 0, 1) is False
+
+    def test_does_not_fire_when_no_chain(self):
+        assert self._gate(FailoverReason.timeout, True, 0, 0) is False
+
+    def test_does_not_fire_when_chain_exhausted(self):
+        assert self._gate(FailoverReason.timeout, True, 1, 1) is False
+
+    def test_does_not_fire_for_non_timeout_reason(self):
+        for reason in (
+            FailoverReason.unknown,
+            FailoverReason.server_error,
+            FailoverReason.format_error,
+            FailoverReason.thinking_signature,
+        ):
+            assert self._gate(reason, True, 0, 1) is False, reason


### PR DESCRIPTION
## Summary

Fixes #22277. Adds `agent.eager_fallback_on_timeout` config flag (default `false`). When `true` AND `fallback_providers` is configured, a classified `FailoverReason.timeout` immediately activates the next fallback provider instead of retrying the same broken primary.

## The bug

`run_agent.py:13035-13059` already implements eager fallback for rate-limit and billing errors. But timeouts (typically a stale-detector-killed hung stream) classify as `FailoverReason.timeout` with `retryable=True`, and the retry loop just re-hits the same broken provider. With ~5 min stale-kill threshold × N retries, this compounds into the 15+ min silent hang documented in the issue.

The configured fallback chain sits idle the entire time.

## Fix

Mirror the existing rate-limit eager-fallback block, gated behind a new opt-in flag:

```python
is_timeout_eager = (
    classified.reason == FailoverReason.timeout
    and self._eager_fallback_on_timeout
    and self._fallback_index < len(self._fallback_chain)
)
if is_timeout_eager:
    self._emit_status("⚠️ Provider stalled (stream/call timeout) — switching to fallback provider...")
    if self._try_activate_fallback(reason=classified.reason):
        retry_count = 0
        compression_attempts = 0
        primary_recovery_attempted = False
        continue
```

Default `false` to preserve historical behavior; users with paid primaries + OAuth-backed fallbacks (the motivating case: Anthropic + `openai-codex`) opt in.

Config loaded via `hermes_cli.config.load_config()` rather than the cached `cli.CLI_CONFIG` to avoid the staleness issue addressed by #18947.

## Files

- `run_agent.py` — `_eager_fallback_on_timeout` instance flag + new eager-fallback block
- `hermes_cli/config.py` — `agent.eager_fallback_on_timeout: False` schema entry with doc comment
- `tests/run_agent/test_eager_fallback_on_timeout.py` — 9 new tests

## Tests

`pytest tests/run_agent/test_eager_fallback_on_timeout.py` — 9 passed:

- `TestEagerFallbackConfigDefaults` — default false, explicit false/true, truthy-int coercion
- `TestEagerFallbackOnTimeoutGate` — gate predicate fires iff `reason==timeout AND flag AND chain has room`; does not fire for `unknown`/`server_error`/`format_error`/`thinking_signature`

Existing fallback suite still green:

`pytest tests/run_agent/test_provider_fallback.py tests/run_agent/test_fallback_model.py` — 47 passed.

## Notes

- The full retry-loop path is a 700-line inline block that's hard to drive end-to-end in unit tests; the gate predicate is asserted directly. Happy to add an integration test if reviewers want one.
- I did NOT change behavior on `FailoverReason.connection` (clean socket drops). Those still go through the normal retry-with-backoff path. Could be a follow-up.
- Symmetric to #21444's territory but the inverse direction: that issue is about Codex-as-primary stalling; this is about any-provider-as-primary stalling while a fallback exists.

Fixes #22277
