### PR TITLE
[codex] Extract TurnRunner characterization seam

### DIFF
--- a/docs/plans/2026-05-09-turnrunner-characterization.md
+++ b/docs/plans/2026-05-09-turnrunner-characterization.md
@@ -1,0 +1,51 @@
+# TurnRunner Characterization Seam
+
+## Current seam
+
+`run_agent.TurnRunner` is the smallest runtime interface currently implicit in
+`AIAgent`: one foreground user turn enters through `run_conversation(...)` and
+returns the existing result mapping. The seam deliberately does not include
+agent construction, provider configuration, persistence ownership,
+interrupt/steer control, or transport-specific streaming. Those concerns still
+belong to the delivery surfaces until their behavior is characterized.
+
+The characterized one-turn path is:
+
+1. Copy prior `conversation_history`.
+2. Append the current user message.
+3. Call the configured model until a final assistant response is available.
+4. Append the assistant response to the returned `messages`.
+5. Return the existing result dict, including `final_response`, `messages`,
+   `api_calls`, `completed`, `interrupted`, and token/cost fields.
+
+## Future adapters
+
+CLI adapter:
+Wrap the prompt loop in `cli.py` and submit each accepted user input to a
+`TurnRunner`. The CLI should keep owning keyboard input, slash commands,
+display, local cwd, and session lifecycle. `AIAgent.chat(...)` remains a
+convenience wrapper over the same one-turn seam.
+
+Gateway adapter:
+Wrap platform events in `gateway/run.py` into `user_message`,
+`conversation_history`, `task_id`, and optional `persist_user_message` before
+calling a `TurnRunner`. Platform delivery, batching, auth, thread/session
+routing, and progress callbacks stay in the gateway layer.
+
+TUI adapter:
+Map JSON-RPC `prompt.submit` requests in `tui_gateway/server.py` onto the
+`TurnRunner` call. The TUI gateway should continue owning session records,
+JSON-RPC event emission, approval prompts, resize/display state, and
+stream/progress callback translation.
+
+ACP adapter:
+Map ACP session prompts in `acp_adapter/session.py` and `acp_adapter/server.py`
+onto the `TurnRunner` call. ACP protocol state, editor-facing permissions,
+request cancellation, and event formatting remain in the ACP layer.
+
+## Stop line
+
+Do not make delivery surfaces depend on this protocol until each adapter path
+has its own characterization tests. If the next slice requires changing CLI,
+gateway, TUI, and ACP in one patch, stop and split the extraction into smaller
+adapter-specific work.

--- a/run_agent.py
+++ b/run_agent.py
@@ -51,7 +51,7 @@ import threading
 from types import SimpleNamespace
 import urllib.request
 import uuid
-from typing import List, Dict, Any, Optional
+from typing import List, Dict, Any, Optional, Protocol, runtime_checkable
 from urllib.parse import urlparse, parse_qs, urlunparse
 # NOTE: `from openai import OpenAI` is deliberately NOT at module top — the
 # SDK pulls ~240 ms of imports. We expose `OpenAI` as a thin proxy object
@@ -1023,6 +1023,23 @@ def _qwen_portal_headers() -> dict:
         "X-DashScope-UserAgent": _ua,
         "X-DashScope-AuthType": "qwen-oauth",
     }
+
+
+@runtime_checkable
+class TurnRunner(Protocol):
+    """Minimal one-turn runtime seam shared by delivery adapters."""
+
+    def run_conversation(
+        self,
+        user_message: str,
+        system_message: str = None,
+        conversation_history: List[Dict[str, Any]] = None,
+        task_id: str = None,
+        stream_callback: Optional[callable] = None,
+        persist_user_message: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Run one foreground user turn and return the existing result mapping."""
+        ...
 
 
 class AIAgent:

--- a/tests/run_agent/test_turn_runner_characterization.py
+++ b/tests/run_agent/test_turn_runner_characterization.py
@@ -1,0 +1,101 @@
+"""Characterization tests for the minimal TurnRunner runtime seam."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from run_agent import AIAgent, TurnRunner
+
+
+def _tool_defs(*names: str) -> list[dict]:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+def _mock_response(content: str) -> SimpleNamespace:
+    message = SimpleNamespace(content=content, tool_calls=None)
+    choice = SimpleNamespace(message=message, finish_reason="stop")
+    return SimpleNamespace(choices=[choice], model="test/model", usage=None)
+
+
+def _make_agent() -> AIAgent:
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_tool_defs("web_search")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+    ):
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://openrouter.ai/api/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            max_iterations=3,
+        )
+
+    agent.client = MagicMock()
+    agent._cached_system_prompt = "You are helpful."
+    agent._use_prompt_caching = False
+    agent.tool_delay = 0
+    agent.compression_enabled = False
+    agent.save_trajectories = False
+    return agent
+
+
+def _run_one_turn(
+    runner: TurnRunner,
+    user_message: str,
+    conversation_history: list[dict] | None = None,
+) -> dict:
+    return runner.run_conversation(
+        user_message,
+        conversation_history=conversation_history,
+        task_id="sym-273-turn",
+    )
+
+
+def test_aiagent_satisfies_turn_runner_protocol() -> None:
+    assert isinstance(_make_agent(), TurnRunner)
+
+
+def test_turn_runner_stop_turn_preserves_result_shape_and_history() -> None:
+    agent = _make_agent()
+    agent.client.chat.completions.create.return_value = _mock_response("Final answer")
+    history = [
+        {"role": "user", "content": "prior question"},
+        {"role": "assistant", "content": "prior answer"},
+    ]
+
+    with (
+        patch("hermes_cli.plugins.invoke_hook", return_value=[]),
+        patch.object(agent, "_ensure_db_session"),
+        patch.object(agent, "_persist_session"),
+        patch.object(agent, "_save_trajectory"),
+        patch.object(agent, "_cleanup_task_resources"),
+    ):
+        result = _run_one_turn(agent, "hello", conversation_history=history)
+
+    assert history == [
+        {"role": "user", "content": "prior question"},
+        {"role": "assistant", "content": "prior answer"},
+    ]
+    assert result["final_response"] == "Final answer"
+    assert result["api_calls"] == 1
+    assert result["completed"] is True
+    assert result["interrupted"] is False
+    assert result["partial"] is False
+    assert result["messages"][:2] == history
+    assert result["messages"][-2] == {"role": "user", "content": "hello"}
+    assistant_message = result["messages"][-1]
+    assert assistant_message["role"] == "assistant"
+    assert assistant_message["content"] == "Final answer"
+    assert assistant_message["reasoning"] is None
+    assert assistant_message["finish_reason"] == "stop"


### PR DESCRIPTION
## Summary

- Add a minimal `run_agent.TurnRunner` protocol for the existing one-turn `run_conversation(...)` seam.
- Add focused characterization coverage for the stop-with-final-response path through that seam.
- Document future CLI, gateway, TUI, and ACP adapter boundaries without wiring delivery surfaces yet.

## Validation

- `python3 -m pytest -q tests/run_agent/test_turn_runner_characterization.py` - passed, 2 tests.
- `python3 -m pytest -q` - blocked in this environment after installing `pytest-xdist`; collection stops on `tests/acp/test_entry.py` with `ModuleNotFoundError: No module named 'acp'`.\n\n## Notes\n\nThis slice intentionally does not refactor CLI, gateway, TUI, or ACP call sites. The seam is characterization-only until each delivery adapter has its own tests.