### PR TITLE
[security] fix(gateway): harden callbacks, CDP, and health diagnostics

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -924,8 +924,14 @@ class APIServerAdapter(BasePlatformAdapter):
 
         Returns gateway state, connected platforms, PID, and uptime so the
         dashboard can display full status without needing a shared PID file or
-        /proc access.  No authentication required.
+        /proc access. When the API server is configured with an API key, this
+        detailed diagnostic endpoint requires the same authentication as other
+        state-bearing API routes.
         """
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
         from gateway.status import read_runtime_status
 
         runtime = read_runtime_status() or {}

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2912,6 +2912,16 @@ class TelegramAdapter(BasePlatformAdapter):
         if data.startswith(("mp:", "mm:", "mb", "mx", "mg:")):
             chat_id = str(query.message.chat_id) if query.message else None
             if chat_id:
+                caller_id = str(getattr(query.from_user, "id", ""))
+                if not self._is_callback_user_authorized(
+                    caller_id,
+                    chat_id=chat_id,
+                    chat_type=query_chat_type,
+                    thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                    user_name=query_user_name,
+                ):
+                    await query.answer(text="⛔ You are not authorized to change models.")
+                    return
                 await self._handle_model_picker_callback(query, data, chat_id)
             return
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -518,13 +518,31 @@ class TestHealthDetailedEndpoint:
                 assert data["platforms"] == {}
 
     @pytest.mark.asyncio
-    async def test_health_detailed_does_not_require_auth(self, auth_adapter):
-        """Health detailed endpoint should be accessible without auth, like /health."""
+    async def test_health_detailed_requires_auth_when_api_key_configured(self, auth_adapter):
+        """Detailed runtime diagnostics require auth when API auth is configured."""
         app = _create_app(auth_adapter)
-        with patch("gateway.status.read_runtime_status", return_value=None):
+        runtime_status = {
+            "gateway_state": "running",
+            "platforms": {
+                "telegram": {
+                    "state": "error",
+                    "error_message": "sensitive diagnostic text",
+                }
+            },
+            "active_agents": 1,
+        }
+        with patch("gateway.status.read_runtime_status", return_value=runtime_status):
             async with TestClient(TestServer(app)) as cli:
-                resp = await cli.get("/health/detailed")
-                assert resp.status == 200
+                unauth = await cli.get("/health/detailed")
+                assert unauth.status == 401
+
+                auth = await cli.get(
+                    "/health/detailed",
+                    headers={"Authorization": "Bearer sk-secret"},
+                )
+                assert auth.status == 200
+                data = await auth.json()
+                assert data["platforms"]["telegram"]["error_message"] == "sensitive diagnostic text"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -452,14 +452,17 @@ class TestTelegramApprovalCallback:
 
     @pytest.mark.asyncio
     async def test_model_picker_callback_not_affected(self):
-        """Ensure model picker callbacks still route correctly."""
+        """Ensure authorized model picker callbacks still route correctly."""
         adapter = _make_adapter()
 
         query = AsyncMock()
         query.data = "mp:some_provider"
         query.message = MagicMock()
         query.message.chat_id = 12345
+        query.message.chat.type = "private"
         query.from_user = MagicMock()
+        query.from_user.id = 111
+        query.from_user.first_name = "Alice"
 
         update = MagicMock()
         update.callback_query = query
@@ -468,10 +471,72 @@ class TestTelegramApprovalCallback:
         # Model picker callback should be handled (not crash)
         # We just verify it doesn't try to resolve an approval
         with patch("tools.approval.resolve_gateway_approval") as mock_resolve:
-            with patch.object(adapter, "_handle_model_picker_callback", new_callable=AsyncMock):
-                await adapter._handle_callback_query(update, context)
+            with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "111"}):
+                with patch.object(adapter, "_handle_model_picker_callback", new_callable=AsyncMock) as mock_picker:
+                    await adapter._handle_callback_query(update, context)
 
         mock_resolve.assert_not_called()
+        mock_picker.assert_awaited_once_with(query, "mp:some_provider", "12345")
+
+    @pytest.mark.asyncio
+    async def test_model_picker_callback_rejects_unauthorized_user(self):
+        """Model picker buttons should honor TELEGRAM_ALLOWED_USERS."""
+        adapter = _make_adapter()
+
+        query = AsyncMock()
+        query.data = "mm:0"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.message.chat.type = "supergroup"
+        query.message.message_thread_id = 99
+        query.from_user = MagicMock()
+        query.from_user.id = 222
+        query.from_user.first_name = "Mallory"
+        query.answer = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": "111"}):
+            with patch.object(adapter, "_handle_model_picker_callback", new_callable=AsyncMock) as mock_picker:
+                await adapter._handle_callback_query(update, context)
+
+        mock_picker.assert_not_called()
+        query.answer.assert_called_once()
+        assert "not authorized" in query.answer.call_args[1]["text"].lower()
+
+    @pytest.mark.asyncio
+    async def test_model_picker_callback_rejects_user_blocked_by_global_allowlist(self):
+        adapter = _make_adapter()
+        runner = _AuthRunner(authorized=False)
+        adapter._message_handler = runner._handle_message
+
+        query = AsyncMock()
+        query.data = "mg:1"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.message.chat.type = "private"
+        query.from_user = MagicMock()
+        query.from_user.id = 222
+        query.from_user.first_name = "Mallory"
+        query.answer = AsyncMock()
+
+        update = MagicMock()
+        update.callback_query = query
+        context = MagicMock()
+
+        with patch.dict(os.environ, {"TELEGRAM_ALLOWED_USERS": ""}):
+            with patch.object(adapter, "_handle_model_picker_callback", new_callable=AsyncMock) as mock_picker:
+                await adapter._handle_callback_query(update, context)
+
+        mock_picker.assert_not_called()
+        query.answer.assert_called_once()
+        assert "not authorized" in query.answer.call_args[1]["text"].lower()
+        assert runner.last_source is not None
+        assert runner.last_source.platform == Platform.TELEGRAM
+        assert runner.last_source.user_id == "222"
+        assert runner.last_source.chat_id == "12345"
 
     @pytest.mark.asyncio
     async def test_update_prompt_callback_not_affected(self, tmp_path):

--- a/tests/tools/test_browser_cdp_override.py
+++ b/tests/tools/test_browser_cdp_override.py
@@ -12,7 +12,8 @@ class TestResolveCdpOverride:
     def test_keeps_full_devtools_websocket_url(self):
         from tools.browser_tool import _resolve_cdp_override
 
-        assert _resolve_cdp_override(WS_URL) == WS_URL
+        with patch("tools.browser_tool._is_safe_cdp_endpoint", return_value=True):
+            assert _resolve_cdp_override(WS_URL) == WS_URL
 
     def test_resolves_http_discovery_endpoint_to_websocket(self):
         from tools.browser_tool import _resolve_cdp_override
@@ -21,11 +22,12 @@ class TestResolveCdpOverride:
         response.raise_for_status.return_value = None
         response.json.return_value = {"webSocketDebuggerUrl": WS_URL}
 
-        with patch("tools.browser_tool.requests.get", return_value=response) as mock_get:
+        with patch("tools.browser_tool._is_safe_cdp_endpoint", return_value=True), \
+             patch("tools.browser_tool.requests.get", return_value=response) as mock_get:
             resolved = _resolve_cdp_override(HTTP_URL)
 
         assert resolved == WS_URL
-        mock_get.assert_called_once_with(VERSION_URL, timeout=10)
+        mock_get.assert_called_once_with(VERSION_URL, timeout=10, allow_redirects=False)
 
     def test_resolves_bare_ws_hostport_to_discovery_websocket(self):
         from tools.browser_tool import _resolve_cdp_override
@@ -34,16 +36,18 @@ class TestResolveCdpOverride:
         response.raise_for_status.return_value = None
         response.json.return_value = {"webSocketDebuggerUrl": WS_URL}
 
-        with patch("tools.browser_tool.requests.get", return_value=response) as mock_get:
+        with patch("tools.browser_tool._is_safe_cdp_endpoint", return_value=True), \
+             patch("tools.browser_tool.requests.get", return_value=response) as mock_get:
             resolved = _resolve_cdp_override(f"ws://{HOST}:{PORT}")
 
         assert resolved == WS_URL
-        mock_get.assert_called_once_with(VERSION_URL, timeout=10)
+        mock_get.assert_called_once_with(VERSION_URL, timeout=10, allow_redirects=False)
 
     def test_falls_back_to_raw_url_when_discovery_fails(self):
         from tools.browser_tool import _resolve_cdp_override
 
-        with patch("tools.browser_tool.requests.get", side_effect=RuntimeError("boom")):
+        with patch("tools.browser_tool._is_safe_cdp_endpoint", return_value=True), \
+             patch("tools.browser_tool.requests.get", side_effect=RuntimeError("boom")):
             assert _resolve_cdp_override(HTTP_URL) == HTTP_URL
 
     def test_normalizes_provider_returned_http_cdp_url_when_creating_session(self, monkeypatch):
@@ -68,7 +72,8 @@ class TestResolveCdpOverride:
         monkeypatch.setattr(browser_tool, "_get_cdp_override", lambda: "")
         monkeypatch.setattr(browser_tool, "_get_cloud_provider", lambda: provider)
 
-        with patch("tools.browser_tool.requests.get", return_value=response) as mock_get:
+        with patch("tools.browser_tool._is_safe_cdp_endpoint", return_value=True), \
+             patch("tools.browser_tool.requests.get", return_value=response) as mock_get:
             session_info = browser_tool._get_session_info("task-browser-use")
 
         assert session_info["cdp_url"] == WS_URL
@@ -76,6 +81,7 @@ class TestResolveCdpOverride:
         mock_get.assert_called_once_with(
             "https://cdp.browser-use.example/session/json/version",
             timeout=10,
+            allow_redirects=False,
         )
 
 
@@ -95,11 +101,12 @@ class TestGetCdpOverride:
         response.raise_for_status.return_value = None
         response.json.return_value = {"webSocketDebuggerUrl": WS_URL}
 
-        with patch("tools.browser_tool.requests.get", return_value=response) as mock_get:
+        with patch("tools.browser_tool._is_safe_cdp_endpoint", return_value=True), \
+             patch("tools.browser_tool.requests.get", return_value=response) as mock_get:
             resolved = browser_tool._get_cdp_override()
 
         assert resolved == WS_URL
-        mock_get.assert_called_once_with(VERSION_URL, timeout=10)
+        mock_get.assert_called_once_with(VERSION_URL, timeout=10, allow_redirects=False)
 
     def test_uses_config_browser_cdp_url_when_env_missing(self, monkeypatch):
         import tools.browser_tool as browser_tool
@@ -111,8 +118,45 @@ class TestGetCdpOverride:
         response.json.return_value = {"webSocketDebuggerUrl": WS_URL}
 
         with patch("hermes_cli.config.read_raw_config", return_value={"browser": {"cdp_url": HTTP_URL}}), \
+             patch("tools.browser_tool._is_safe_cdp_endpoint", return_value=True), \
              patch("tools.browser_tool.requests.get", return_value=response) as mock_get:
             resolved = browser_tool._get_cdp_override()
 
         assert resolved == WS_URL
-        mock_get.assert_called_once_with(VERSION_URL, timeout=10)
+        mock_get.assert_called_once_with(VERSION_URL, timeout=10, allow_redirects=False)
+
+    def test_blocks_unsafe_http_discovery_endpoint_without_request(self):
+        from tools.browser_tool import _resolve_cdp_override
+
+        with patch("tools.browser_tool._is_safe_cdp_endpoint", return_value=False), \
+             patch("tools.browser_tool.requests.get") as mock_get:
+            assert _resolve_cdp_override("http://169.254.169.254:9222") == ""
+
+        mock_get.assert_not_called()
+
+    def test_blocks_unsafe_websocket_endpoint(self):
+        from tools.browser_tool import _resolve_cdp_override
+
+        unsafe_ws = "ws://169.254.169.254:9222/devtools/browser/secret"
+        with patch("tools.browser_tool._is_safe_cdp_endpoint", return_value=False):
+            assert _resolve_cdp_override(unsafe_ws) == ""
+
+    def test_blocks_unsafe_non_devtools_websocket_endpoint(self):
+        from tools.browser_tool import _resolve_cdp_override
+
+        unsafe_ws = "ws://169.254.169.254:9222/custom/path"
+        with patch("tools.browser_tool._is_safe_cdp_endpoint", return_value=False):
+            assert _resolve_cdp_override(unsafe_ws) == ""
+
+    def test_blocks_unsafe_returned_websocket(self):
+        from tools.browser_tool import _resolve_cdp_override
+
+        response = Mock()
+        response.raise_for_status.return_value = None
+        response.json.return_value = {
+            "webSocketDebuggerUrl": "ws://169.254.169.254:9222/devtools/browser/secret"
+        }
+
+        with patch("tools.browser_tool._is_safe_cdp_endpoint", side_effect=[True, False]), \
+             patch("tools.browser_tool.requests.get", return_value=response):
+            assert _resolve_cdp_override(HTTP_URL) == ""

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -54,6 +54,7 @@ import functools
 import json
 import logging
 import os
+import ipaddress
 import re
 import signal
 import subprocess
@@ -65,6 +66,7 @@ import time
 import requests
 from typing import Dict, Any, Optional, List, Tuple
 from pathlib import Path
+from urllib.parse import urlparse
 from agent.auxiliary_client import call_llm
 from hermes_constants import get_hermes_home
 from utils import is_truthy_value
@@ -232,6 +234,41 @@ def _get_extraction_model() -> Optional[str]:
     return os.getenv("AUXILIARY_WEB_EXTRACT_MODEL", "").strip() or None
 
 
+def _is_loopback_host(hostname: str) -> bool:
+    """Return True for localhost / loopback CDP endpoints."""
+    host = (hostname or "").strip().lower().rstrip(".")
+    if host == "localhost":
+        return True
+    try:
+        return ipaddress.ip_address(host).is_loopback
+    except ValueError:
+        return False
+
+
+def _is_safe_cdp_endpoint(url: str) -> bool:
+    """Return whether Hermes may probe/connect to a CDP endpoint.
+
+    Local Chromium normally exposes CDP on loopback, so loopback endpoints are
+    allowed. Other targets must pass the ordinary URL SSRF guard. The
+    always-blocked metadata/link-local floor is enforced for every endpoint,
+    including when private URLs are globally allowed.
+    """
+    try:
+        parsed = urlparse(url)
+        if (parsed.scheme or "").lower() not in {"http", "https", "ws", "wss"}:
+            return False
+        if not parsed.hostname:
+            return False
+        if _is_always_blocked_url(url):
+            return False
+        if _is_loopback_host(parsed.hostname):
+            return True
+        return _is_safe_url(url)
+    except Exception as exc:
+        logger.warning("Blocked CDP endpoint due to safety-check error for %s: %s", url, exc)
+        return False
+
+
 def _resolve_cdp_override(cdp_url: str) -> str:
     """Normalize a user-supplied CDP endpoint into a concrete connectable URL.
 
@@ -250,6 +287,9 @@ def _resolve_cdp_override(cdp_url: str) -> str:
 
     lowered = raw.lower()
     if "/devtools/browser/" in lowered:
+        if not _is_safe_cdp_endpoint(raw):
+            logger.warning("Blocked unsafe CDP websocket endpoint: %s", raw)
+            return ""
         return raw
 
     discovery_url = raw
@@ -257,6 +297,9 @@ def _resolve_cdp_override(cdp_url: str) -> str:
         if raw.count(":") == 2 and raw.rstrip("/").rsplit(":", 1)[-1].isdigit() and "/" not in raw.split(":", 2)[-1]:
             discovery_url = ("http://" if lowered.startswith("ws://") else "https://") + raw.split("://", 1)[1]
         else:
+            if not _is_safe_cdp_endpoint(raw):
+                logger.warning("Blocked unsafe CDP websocket endpoint: %s", raw)
+                return ""
             return raw
 
     if discovery_url.lower().endswith("/json/version"):
@@ -264,8 +307,12 @@ def _resolve_cdp_override(cdp_url: str) -> str:
     else:
         version_url = discovery_url.rstrip("/") + "/json/version"
 
+    if not _is_safe_cdp_endpoint(version_url):
+        logger.warning("Blocked unsafe CDP discovery endpoint: %s", version_url)
+        return ""
+
     try:
-        response = requests.get(version_url, timeout=10)
+        response = requests.get(version_url, timeout=10, allow_redirects=False)
         response.raise_for_status()
         payload = response.json()
     except Exception as exc:
@@ -274,6 +321,9 @@ def _resolve_cdp_override(cdp_url: str) -> str:
 
     ws_url = str(payload.get("webSocketDebuggerUrl") or "").strip()
     if ws_url:
+        if not _is_safe_cdp_endpoint(ws_url):
+            logger.warning("Blocked unsafe CDP websocket returned by %s: %s", version_url, ws_url)
+            return ""
         logger.info("Resolved CDP endpoint %s -> %s", raw, ws_url)
         return ws_url
 


### PR DESCRIPTION
## Summary

This PR hardens three small security boundaries in Hermes gateway/tool surfaces:

- Telegram model-picker inline callbacks now reuse the same callback authorization path as approval-style callbacks.
- Explicit Chrome DevTools Protocol (CDP) override endpoints are validated before Hermes connects to them or performs discovery.
- `/health/detailed` now requires API authentication when the API server is configured with an API key.

The changes are intentionally narrow and covered by focused regression tests.

## Security issues covered

| Issue | Surface | Impact | Fix |
| --- | --- | --- | --- |
| Unauthorized Telegram model picker callbacks | `gateway/platforms/telegram.py` | A denied Telegram user who can press an inline model picker button could change a chat/session model setting | Check callback user authorization before dispatching model-picker callbacks |
| Unsafe explicit CDP override endpoints | `tools/browser_tool.py` | A malicious or unsafe CDP override URL could make Hermes connect to non-public hosts or perform discovery against internal targets | Validate explicit WebSocket/discovery endpoints with URL safety checks and disable redirects |
| Unauthenticated detailed API health diagnostics | `gateway/platforms/api_server.py` | Detailed runtime/platform status could be read without auth even when the API server has an API key configured | Require the configured API key for `/health/detailed`, while preserving unauthenticated `/health` liveness |

## Before this PR

- Telegram approval, slash-confirm, and prompt-update callbacks used gateway callback authorization, but model picker callbacks (`mp:`, `mm:`, `mb`, `mx`, `mg:`) only checked that picker state existed for the chat.
- `_resolve_cdp_override()` preserved full `ws://.../devtools/browser/...` endpoints directly and performed `/json/version` discovery without first rejecting unsafe endpoint hosts.
- `/health/detailed` explicitly skipped authentication and returned gateway runtime state, platform status, active agent count, exit reason, timestamp, and PID.

## After this PR

- Model picker callbacks call `_is_callback_user_authorized()` with chat/thread/user context before mutating picker state.
- Explicit CDP WebSocket and discovery endpoints are blocked unless they pass the existing safe URL/IP checks; discovery requests also disable redirects.
- `/health/detailed` uses `_check_auth()` whenever an API key is configured, matching other state-bearing API routes.

## Why this matters

These surfaces sit at trust boundaries that are easy to overlook because they are convenience/control-plane paths rather than primary chat message handling:

- Inline Telegram buttons can be clicked by users other than the user who opened the panel, especially in group contexts.
- CDP endpoints are powerful browser-control channels; connecting to an attacker-controlled or internal endpoint can expose browser automation capabilities or internal network metadata.
- Detailed health diagnostics are useful for operators, but they can contain platform error messages and runtime state that should not be disclosed to unauthenticated callers when an API key is configured.

## How this differs from related issue/PR

- Telegram approval callbacks were already hardened in #18180. That PR explicitly called out model picker callbacks as a separate follow-up concern. This PR addresses that separate callback family rather than approval/confirm/update-prompt callbacks.
- CDP trust semantics are related to the broader discussion in #8084. This PR does not attempt to redesign all browser trust semantics; it only blocks unsafe explicit override endpoints before direct use/discovery and preserves local/allowed behavior covered by tests.
- `/health/detailed` is distinct from the dashboard host/plugin-auth family and from basic `/health` liveness checks. This PR keeps `/health` unauthenticated and only protects the detailed diagnostic endpoint when an API key exists.

## Attack flow

1. Telegram model picker callback:
   1. An authorized user opens a model picker panel in a chat.
   2. A denied user presses one of the inline model picker buttons.
   3. Vulnerable code dispatches the callback based on chat picker state without checking the callback user.

2. Explicit CDP override endpoint:
   1. A CDP override is supplied via config/environment/provider output.
   2. Vulnerable code accepts a full `ws://.../devtools/browser/...` URL directly, or performs HTTP discovery against a supplied endpoint.
   3. Hermes attempts to connect to or query an unsafe host.

3. Detailed API health diagnostics:
   1. The API server is configured with an API key.
   2. An unauthenticated caller requests `/health/detailed`.
   3. Vulnerable code returns runtime/platform diagnostics without checking the key.

## Affected code

- `gateway/platforms/telegram.py` — Telegram callback dispatch for model picker actions.
- `tools/browser_tool.py` — CDP override URL normalization/discovery.
- `gateway/platforms/api_server.py` — detailed health endpoint.
- Focused regression tests under:
  - `tests/gateway/test_telegram_approval_buttons.py`
  - `tests/tools/test_browser_cdp_override.py`
  - `tests/gateway/test_api_server.py`

## Root cause

- Model picker callbacks were outside the callback authorization coverage added for approval-style callbacks.
- CDP override handling trusted explicit endpoints before applying URL/IP safety policy.
- `/health/detailed` treated a diagnostic endpoint as equivalent to a minimal liveness probe even when API auth was configured.

## CVSS assessment

- Telegram model picker callback authorization: CVSS v3.1 4.3 — `CVSS:3.1/AV:N/AC:L/PR:L/UI:R/S:U/C:N/I:L/A:N`. A denied Telegram user with access to an inline button can alter model selection/state.
- Unsafe explicit CDP override endpoint: CVSS v3.1 6.5 — `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N`. A malicious unsafe endpoint can drive Hermes to connect/query internal browser-control or metadata surfaces when override input is accepted from a lower-trust source.
- Unauthenticated detailed health diagnostics: CVSS v3.1 5.3 — `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:L/I:N/A:N`. Detailed platform/runtime diagnostics are disclosed without auth despite API-key configuration.

## Safe reproduction steps

Run the focused regression tests on vulnerable code before applying the patch:

```bash
python -m pytest tests/tools/test_browser_cdp_override.py tests/gateway/test_telegram_approval_buttons.py tests/gateway/test_api_server.py -q
```

The added/updated tests exercise:

- Unauthorized Telegram model-picker callback users are rejected and the picker handler is not called.
- Unsafe CDP WebSocket/discovery endpoints are rejected before connection/discovery.
- `/health/detailed` returns `401` without the configured API key and `200` with the key.

## Expected vulnerable behavior

On vulnerable code:

- Telegram model picker callbacks route to `_handle_model_picker_callback()` without checking the callback user.
- Unsafe CDP override URLs are accepted or queried during discovery.
- `/health/detailed` returns `200` without `Authorization` even when `platforms.api_server.key` is configured.

## Changes in this PR

- Added an authorization check before model picker callback dispatch.
- Added CDP endpoint safety validation for full WebSocket endpoints and discovery endpoints.
- Disabled redirects for CDP `/json/version` discovery requests.
- Required API key authentication for `/health/detailed` when API auth is configured.
- Added focused regression tests for all three behaviors.

## Files changed

| Category | Files | What changed |
| --- | --- | --- |
| Telegram gateway | `gateway/platforms/telegram.py`, `tests/gateway/test_telegram_approval_buttons.py` | Model picker callbacks now honor callback authorization |
| Browser tool | `tools/browser_tool.py`, `tests/tools/test_browser_cdp_override.py` | CDP override endpoints are validated before use/discovery |
| API server | `gateway/platforms/api_server.py`, `tests/gateway/test_api_server.py` | Detailed health diagnostics require auth when an API key exists |

## Maintainer impact

- Basic `/health` remains unauthenticated for liveness probes.
- Existing safe/local CDP override behavior remains covered by tests.
- Authorized Telegram model picker use still works.
- The stricter `/health/detailed` behavior only affects deployments that configured an API key and were relying on unauthenticated detailed diagnostics.

## Fix rationale

The patch enforces the security boundary at the point where each action crosses from low-trust input into control-plane behavior:

- callback user identity before model mutation,
- endpoint safety before browser-control connection/discovery,
- API key authentication before detailed runtime disclosure.

This keeps the changes focused and avoids broad rewrites of unrelated gateway/tool behavior.

## Type of change

- [x] Security hardening
- [x] Bug fix
- [x] Tests
- [ ] Documentation-only change

## Test plan

Commands run:

```bash
python -m pytest tests/tools/test_browser_cdp_override.py tests/gateway/test_telegram_approval_buttons.py tests/gateway/test_api_server.py -q
python -m ruff check gateway/platforms/api_server.py gateway/platforms/telegram.py tools/browser_tool.py tests/gateway/test_api_server.py tests/gateway/test_telegram_approval_buttons.py tests/tools/test_browser_cdp_override.py
python -m py_compile gateway/platforms/api_server.py gateway/platforms/telegram.py tools/browser_tool.py
```

Results:

- `166 passed, 89 warnings`
- `ruff`: `All checks passed!`
- `py_compile`: passed

## Disclosure notes

This PR is intentionally bounded to three concrete, locally reproduced hardening fixes. It does not claim to redesign the entire Telegram callback model, CDP trust model, or API server observability model. Related public prior art is noted above where applicable so maintainers can review the differences quickly.
