### PR TITLE
fix: keep insights model metadata in sync after /model switch

### DIFF
--- a/hermes_state.py
+++ b/hermes_state.py
@@ -518,11 +518,11 @@ class SessionDB:
         self,
         session_id: str,
         source: str,
-        model: str = None,
-        model_config: Dict[str, Any] = None,
-        system_prompt: str = None,
-        user_id: str = None,
-        parent_session_id: str = None,
+        model: Optional[str] = None,
+        model_config: Optional[Dict[str, Any]] = None,
+        system_prompt: Optional[str] = None,
+        user_id: Optional[str] = None,
+        parent_session_id: Optional[str] = None,
     ) -> None:
         """Shared INSERT OR IGNORE for session rows."""
         def _do(conn):
@@ -680,6 +680,50 @@ class SessionDB:
         )
         def _do(conn):
             conn.execute(sql, params)
+        self._execute_write(_do)
+
+    def set_session_runtime(
+        self,
+        session_id: str,
+        *,
+        model: Optional[str] = None,
+        billing_provider: Optional[str] = None,
+        billing_base_url: Optional[str] = None,
+    ) -> None:
+        """Explicitly overwrite runtime metadata for an existing session.
+
+        This is narrower than ``update_token_counts()``: use it only for
+        deliberate runtime changes such as an explicit ``/model`` switch
+        inside the current session, where ``COALESCE(model, ?)`` would keep
+        stale metadata forever and make ``/insights`` report the wrong model.
+        """
+        self._insert_session_row(session_id, "unknown", model=model)
+        params = (
+            model,
+            model,
+            billing_provider,
+            billing_provider,
+            billing_base_url,
+            billing_base_url,
+            session_id,
+        )
+
+        def _do(conn):
+            conn.execute(
+                """UPDATE sessions SET
+                   model = CASE WHEN ? IS NULL THEN model ELSE ? END,
+                   billing_provider = CASE
+                       WHEN ? IS NULL THEN billing_provider
+                       ELSE ?
+                   END,
+                   billing_base_url = CASE
+                       WHEN ? IS NULL THEN billing_base_url
+                       ELSE ?
+                   END
+                   WHERE id = ?""",
+                params,
+            )
+
         self._execute_write(_do)
 
     def ensure_session(
@@ -2671,4 +2715,3 @@ class SessionDB:
             result["error"] = str(exc)
 
         return result
-

--- a/run_agent.py
+++ b/run_agent.py
@@ -2674,6 +2674,27 @@ class AIAgent:
         self._fallback_chain = fallback_chain
         self._fallback_model = fallback_chain[0] if fallback_chain else None
 
+        # Keep /insights aligned with an explicit /model switch even when the
+        # session row was already stamped with the old runtime metadata.
+        session_db = getattr(self, "_session_db", None)
+        session_id = getattr(self, "session_id", None)
+        if session_db and session_id:
+            try:
+                session_db.set_session_runtime(
+                    session_id,
+                    model=self.model,
+                    billing_provider=self.provider,
+                    billing_base_url=self.base_url,
+                )
+            except Exception as exc:
+                logger.debug(
+                    "Failed to update session runtime metadata after model switch "
+                    "(session=%s, model=%s): %s",
+                    session_id,
+                    self.model,
+                    exc,
+                )
+
         logging.info(
             "Model switched in-place: %s (%s) -> %s (%s)",
             old_model, old_provider, new_model, new_provider,

--- a/tests/run_agent/test_switch_model_context.py
+++ b/tests/run_agent/test_switch_model_context.py
@@ -2,6 +2,8 @@
 
 from unittest.mock import MagicMock, patch
 
+from agent.insights import InsightsEngine
+from hermes_state import SessionDB
 from run_agent import AIAgent
 from agent.context_compressor import ContextCompressor
 
@@ -72,3 +74,42 @@ def test_switch_model_without_config_context_length():
         mock_ctx_len.assert_called_once()
         call_kwargs = mock_ctx_len.call_args.kwargs
         assert call_kwargs.get("config_context_length") is None
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=128_000)
+@patch("hermes_cli.timeouts.get_provider_request_timeout", return_value=None)
+def test_switch_model_updates_active_session_runtime_metadata(_mock_timeout, _mock_ctx_len, tmp_path):
+    """Explicit /model switches should overwrite stale session metadata for /insights."""
+    session_db = SessionDB(db_path=tmp_path / "state.db")
+    session_db.create_session(
+        session_id="sess-1",
+        source="telegram",
+        model="google/gemini-3.1-flash-lite-pre",
+    )
+    session_db.update_token_counts(
+        "sess-1",
+        input_tokens=1000,
+        output_tokens=500,
+        billing_provider="gmi",
+        billing_base_url="https://generativelanguage.googleapis.com/v1beta/openai/",
+    )
+
+    agent = _make_agent_with_compressor(config_context_length=None)
+    agent.session_id = "sess-1"
+    agent._session_db = session_db
+
+    agent.switch_model(
+        "glm-5.1",
+        "zai",
+        api_key="sk-zai",
+        base_url="https://api.z.ai/api/paas/v4",
+    )
+
+    row = session_db.get_session("sess-1")
+    assert row is not None
+    assert row["model"] == "glm-5.1"
+    assert row["billing_provider"] == "zai"
+    assert row["billing_base_url"] == "https://api.z.ai/api/paas/v4"
+
+    report = InsightsEngine(session_db).generate(days=30)
+    assert report["models"][0]["model"] == "glm-5.1"


### PR DESCRIPTION
## Summary
- overwrite persisted session runtime metadata when an active session explicitly switches models
- keep `/insights` aligned with the live provider/base URL instead of preserving stale first-write metadata forever
- add a regression test that reproduces the stale Gemini-vs-GLM provider report and asserts the corrected insights output

## Testing
- `./scripts/run_tests.sh tests/run_agent/test_switch_model_context.py tests/run_agent/test_switch_model_fallback_prune.py -q`
- `git diff --check`
- `uv sync --frozen --extra all`
- `uv run --frozen ruff check .`
- repo `lint-diff` semantics (`ruff` clean; `ty` advisory signal recorded in proof)
- clean `env -i` pytest attribution against latest `origin/main` (30 head failures, 27 reproduced on base, remaining 3 isolated and passed on retry/base)

Fixes #3988.
