### PR TITLE
fix: repair checkpoint store refs scaffolding

### DIFF
--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -3,6 +3,7 @@
 import json
 import logging
 import os
+import shutil
 import subprocess
 import time
 import pytest
@@ -130,6 +131,23 @@ class TestStoreInit:
         assert _init_store(store, str(work_dir)) is None
         assert _init_store(store, str(work_dir)) is None
 
+    def test_init_repairs_missing_refs_scaffolding(self, work_dir, checkpoint_base, monkeypatch):
+        """A store with HEAD/config/objects but no refs/ must self-heal."""
+        monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base)
+        store = _store_path(checkpoint_base)
+        assert _init_store(store, str(work_dir)) is None
+        shutil.rmtree(store / "refs")
+
+        assert _init_store(store, str(work_dir)) is None
+
+        assert (store / "refs" / "heads").is_dir()
+        assert (store / "refs" / "tags").is_dir()
+        assert (store / "refs" / "hermes").is_dir()
+        dir_hash = _project_hash(str(work_dir))
+        index_file = store / "indexes" / dir_hash
+        ok, _, err = _run_git(["status", "--short"], store, str(work_dir), index_file=index_file)
+        assert ok, err
+
     def test_bc_init_shadow_repo_shim(self, work_dir, checkpoint_base, monkeypatch):
         """Backward-compatible helper still works for old callers/tests."""
         monkeypatch.setattr("tools.checkpoint_manager.CHECKPOINT_BASE", checkpoint_base)
@@ -201,6 +219,21 @@ class TestTakeCheckpoint:
         mgr.ensure_checkpoint(str(work_dir), "initial")
         mgr.new_turn()
         assert mgr.ensure_checkpoint(str(work_dir), "no changes") is False
+
+    def test_checkpoint_write_after_refs_scaffolding_repair(self, mgr, work_dir, checkpoint_base):
+        """Repair path must support the original write operation, not just status."""
+        assert mgr.ensure_checkpoint(str(work_dir), "initial") is True
+        store = _store_path(checkpoint_base)
+        ok, _, err = _run_git(["pack-refs", "--all"], store, str(work_dir))
+        assert ok, err
+        shutil.rmtree(store / "refs")
+
+        mgr.new_turn()
+        (work_dir / "main.py").write_text("print('after repair')\n")
+
+        assert mgr.ensure_checkpoint(str(work_dir), "after repair") is True
+        listed = mgr.list_checkpoints(str(work_dir))
+        assert [item["reason"] for item in listed] == ["after repair", "initial"]
 
     def test_skip_root_dir(self, mgr):
         assert mgr.ensure_checkpoint("/", "root") is False

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -384,6 +384,22 @@ def _migrate_legacy_store(base: Path) -> Optional[Path]:
     return legacy_root
 
 
+def _ensure_store_scaffolding(store: Path) -> None:
+    """Ensure required bare-repo subdirectories exist.
+
+    Git treats a bare repository with a missing ``refs/`` directory as not a
+    repository at all.  Older/pruned checkpoint stores can keep HEAD, config,
+    and objects while losing refs/, which makes every later ``git add`` fail
+    with ``fatal: not a git repository``.  Recreating the empty scaffolding is
+    safe and preserves packed refs and objects.
+    """
+    (store / "refs" / "heads").mkdir(parents=True, exist_ok=True)
+    (store / "refs" / "tags").mkdir(parents=True, exist_ok=True)
+    (store / _REFS_PREFIX).mkdir(parents=True, exist_ok=True)
+    (store / _INDEXES_DIRNAME).mkdir(parents=True, exist_ok=True)
+    (store / _PROJECTS_DIRNAME).mkdir(parents=True, exist_ok=True)
+
+
 def _init_store(store: Path, working_dir: str) -> Optional[str]:
     """Initialise the shared shadow store if needed.  Returns error or None.
 
@@ -402,11 +418,11 @@ def _init_store(store: Path, working_dir: str) -> Optional[str]:
         _migrate_legacy_store(base)
 
     if (store / "HEAD").exists():
+        _ensure_store_scaffolding(store)
         return None
 
     store.mkdir(parents=True, exist_ok=True)
-    (store / _INDEXES_DIRNAME).mkdir(exist_ok=True)
-    (store / _PROJECTS_DIRNAME).mkdir(exist_ok=True)
+    _ensure_store_scaffolding(store)
 
     # ``git init --bare`` rejects GIT_WORK_TREE, so we can't use _run_git
     # here (which always sets GIT_DIR + GIT_WORK_TREE).  Use a raw


### PR DESCRIPTION
## Summary
- Repair existing checkpoint stores whose bare-repo scaffolding lost `refs/` subdirectories.
- Create `refs/heads`, `refs/tags`, `refs/hermes`, `indexes`, and `projects` idempotently during checkpoint store initialization.
- Add regression coverage proving both direct repair and writing a new checkpoint after repair while packed historical refs remain listable.

## Why
A bare checkpoint store can still have `HEAD`, `config`, and `objects/` while missing `refs/`. Git then reports the store as not a repository during later checkpoint writes, e.g. `fatal: not a git repository: '<hermes-home>/checkpoints/store'`. Recreating empty scaffolding is safe and preserves packed refs and objects.

## Verification
- `python3 /home/steve/.hermes/skills/software-development/requesting-code-review/scripts/static_added_line_scan.py --base origin/main` → `{ "findings": [] }`
- `git diff --check HEAD~1..HEAD` → passed
- `/home/steve/.hermes/hermes-agent/venv/bin/python -m pytest tests/tools/test_checkpoint_manager.py -q -o 'addopts='` → `75 passed`
- Independent pre-push review verdict: passed; no security concerns or logic errors found.

## Scope
Changed files only:
- `tools/checkpoint_manager.py`
- `tests/tools/test_checkpoint_manager.py`

This PR intentionally does not address local legacy checkpoint archive cleanup.
