### PR TITLE
feat: add gateway plugin dispatch hooks

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -954,15 +954,12 @@ _PLAINTEXT_GATEWAY_RESTART_PATTERNS: tuple[re.Pattern[str], ...] = (
 
 
 def coerce_plaintext_gateway_command(event: "MessageEvent") -> None:
-    """Rewrite a tiny set of DM plaintext admin phrases into slash commands.
+    """Rewrite configured plaintext aliases into slash commands.
 
-    This keeps high-impact operational phrases like ``restart gateway`` out of
-    the LLM/tool path, where they can trigger a self-restart from inside the
-    currently running agent and leave the gateway stuck in ``draining`` while it
-    waits for that same agent to finish.
-
-    Scope is intentionally narrow: DM text messages only, exact restart-style
-    phrases only. Group chats keep natural-language semantics.
+    Core keeps its historical restart phrases for compatibility and also
+    consults plugin-registered aliases so private phrases can live outside the
+    upstream core. Restart phrases remain DM-only; plugin aliases are DM-only
+    by default but may opt into non-DM chats when registered.
     """
     try:
         if event is None or event.message_type != MessageType.TEXT:
@@ -971,12 +968,19 @@ def coerce_plaintext_gateway_command(event: "MessageEvent") -> None:
         if not text or text.startswith("/"):
             return
         source = getattr(event, "source", None)
-        if getattr(source, "chat_type", None) != "dm":
-            return
-        for pattern in _PLAINTEXT_GATEWAY_RESTART_PATTERNS:
-            if pattern.match(text):
-                event.text = "/restart"
-                return
+        is_dm = getattr(source, "chat_type", None) == "dm"
+        if is_dm:
+            for pattern in _PLAINTEXT_GATEWAY_RESTART_PATTERNS:
+                if pattern.match(text):
+                    event.text = "/restart"
+                    return
+        try:
+            from hermes_cli.plugins import resolve_plaintext_command_alias
+            command = resolve_plaintext_command_alias(text, is_dm=is_dm)
+        except Exception:
+            command = None
+        if command:
+            event.text = f"/{command}"
     except Exception:
         return
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5113,8 +5113,8 @@ class GatewayRunner:
         # without triggering the pairing flow.
         if not is_internal:
             try:
-                from hermes_cli.plugins import invoke_hook as _invoke_hook
-                _hook_results = _invoke_hook(
+                from hermes_cli.plugins import invoke_hook_async as _invoke_hook_async
+                _hook_results = await _invoke_hook_async(
                     "pre_gateway_dispatch",
                     event=event,
                     gateway=self,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5106,9 +5106,11 @@ class GatewayRunner:
         # Plugins receive the MessageEvent and may return a dict influencing flow:
         #   {"action": "skip",    "reason": ...}    -> drop (no reply, plugin handled)
         #   {"action": "rewrite", "text":  ...}     -> replace event.text, continue
+        #   {"action": "respond", "response": ...} -> return response, no agent dispatch
         #   {"action": "allow"}   /   None          -> normal dispatch
-        # Hook runs BEFORE auth so plugins can handle unauthorized senders
-        # (e.g. customer handover ingest) without triggering the pairing flow.
+        # Hook runs BEFORE auth so trusted plugins can intentionally handle
+        # unauthenticated messages (for example external handover ingest)
+        # without triggering the pairing flow.
         if not is_internal:
             try:
                 from hermes_cli.plugins import invoke_hook as _invoke_hook
@@ -5134,6 +5136,9 @@ class GatewayRunner:
                         source.chat_id or "unknown",
                     )
                     return None
+                if _action == "respond":
+                    _response = _result.get("response")
+                    return _response if isinstance(_response, str) else None
                 if _action == "rewrite":
                     _new_text = _result.get("text")
                     if isinstance(_new_text, str):

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -404,6 +404,14 @@ def _is_gateway_available(cmd: CommandDef, config_overrides: set[str] | None = N
     return False
 
 
+def is_gateway_command_available(name: str) -> bool:
+    """Return True when a built-in command name or alias is gateway-dispatchable."""
+    cmd = resolve_command(name)
+    if cmd is None:
+        return False
+    return _is_gateway_available(cmd)
+
+
 def _requires_argument(args_hint: str) -> bool:
     """Return True when selecting a command without text would be incomplete."""
     return args_hint.strip().startswith("<")

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -22,8 +22,8 @@ Each directory plugin must contain a ``plugin.yaml`` manifest **and** an
 Lifecycle hooks
 ---------------
 Plugins may register callbacks for any of the hooks in ``VALID_HOOKS``.
-The agent core calls ``invoke_hook(name, **kwargs)`` at the appropriate
-points.
+The agent core calls ``invoke_hook(name, **kwargs)`` or
+``await invoke_hook_async(name, **kwargs)`` at the appropriate points.
 
 Tool registration
 -----------------
@@ -1192,6 +1192,31 @@ class PluginManager:
                 )
         return results
 
+    async def invoke_hook_async(self, hook_name: str, **kwargs: Any) -> List[Any]:
+        """Call registered callbacks for *hook_name*, awaiting async callbacks.
+
+        This mirrors ``invoke_hook`` but lets async gateway paths run
+        subprocess/IO-heavy plugin hooks without blocking the event loop.
+        Synchronous callbacks remain supported.
+        """
+        callbacks = self._hooks.get(hook_name, [])
+        results: List[Any] = []
+        for cb in callbacks:
+            try:
+                ret = cb(**kwargs)
+                if inspect.isawaitable(ret):
+                    ret = await ret
+                if ret is not None:
+                    results.append(ret)
+            except Exception as exc:
+                logger.warning(
+                    "Async hook '%s' callback %s raised: %s",
+                    hook_name,
+                    getattr(cb, "__name__", repr(cb)),
+                    exc,
+                )
+        return results
+
     # -----------------------------------------------------------------------
     # Introspection
     # -----------------------------------------------------------------------
@@ -1270,6 +1295,11 @@ def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
     Returns a list of non-``None`` return values from plugin callbacks.
     """
     return get_plugin_manager().invoke_hook(hook_name, **kwargs)
+
+
+async def invoke_hook_async(hook_name: str, **kwargs: Any) -> List[Any]:
+    """Invoke a lifecycle hook and await async plugin callbacks."""
+    return await get_plugin_manager().invoke_hook_async(hook_name, **kwargs)
 
 
 

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -98,6 +98,7 @@ VALID_HOOKS: Set[str] = {
     # dispatch. Plugins may return a dict to influence flow:
     #   {"action": "skip",    "reason": "..."}  -> drop message (no reply)
     #   {"action": "rewrite", "text": "..."}    -> replace event.text, continue
+    #   {"action": "respond", "response": "..."}-> return response, no agent dispatch
     #   {"action": "allow"}  /  None             -> normal dispatch
     # Kwargs: event: MessageEvent, gateway: GatewayRunner, session_store.
     "pre_gateway_dispatch",
@@ -527,6 +528,73 @@ class PluginContext:
             name,
         )
 
+    # -- plaintext command aliases -----------------------------------------
+
+    def register_plaintext_command_alias(
+        self,
+        alias: str,
+        command: str = "",
+        *,
+        target_command: str = "",
+        first_token: bool = False,
+        dm_only: bool = True,
+        **_: Any,
+    ) -> None:
+        """Register a plaintext message alias for a slash command.
+
+        Gateway adapters may use these aliases to rewrite plaintext messages
+        into slash commands before normal dispatch. This is a trusted-plugin
+        extension point: aliases can route user text into existing command
+        handlers, so they are DM-only by default. ``first_token=True`` means
+        ``"alias rest"`` rewrites to ``"/command rest"``; otherwise the whole
+        message must exactly match the alias. Aliases are resolved by the
+        longest matching word branch, so a specific alias such as ``"foo bar"``
+        wins over a broader first-token alias such as ``"foo"``. The
+        ``target_command`` keyword is accepted for plugin compatibility with
+        manifest/stub terminology.
+        """
+        clean_alias = " ".join(str(alias or "").strip().split()).lower()
+        raw_command = target_command or command
+        clean_command = str(raw_command or "").strip().lstrip("/").replace("_", "-")
+        if not clean_alias or not clean_command or "/" in clean_command or " " in clean_command:
+            logger.warning(
+                "Plugin '%s' tried to register an invalid plaintext command alias.",
+                self.manifest.name,
+            )
+            return
+        command_registered = clean_command in self._manager._plugin_commands
+        if not command_registered:
+            try:
+                from hermes_cli.commands import is_gateway_command_available
+                command_registered = is_gateway_command_available(clean_command)
+            except Exception:
+                command_registered = False
+        if not command_registered:
+            logger.warning(
+                "Plugin '%s' tried to register plaintext alias '%s' for unknown or gateway-unavailable command '/%s'.",
+                self.manifest.name,
+                clean_alias,
+                clean_command,
+            )
+            return
+        if clean_alias in self._manager._plaintext_command_aliases:
+            logger.warning(
+                "Plugin '%s' tried to overwrite plaintext command alias '%s'; keeping existing target.",
+                self.manifest.name,
+                clean_alias,
+            )
+            return
+        self._manager._plaintext_command_aliases[clean_alias] = {
+            "command": clean_command,
+            "first_token": bool(first_token),
+            "dm_only": bool(dm_only),
+        }
+        logger.debug(
+            "Plugin %s registered plaintext command alias for /%s",
+            self.manifest.name,
+            clean_command,
+        )
+
     # -- hook registration --------------------------------------------------
 
     def register_hook(self, hook_name: str, callback: Callable) -> None:
@@ -609,6 +677,7 @@ class PluginManager:
         self._cli_commands: Dict[str, dict] = {}
         self._context_engine = None  # Set by a plugin via register_context_engine()
         self._plugin_commands: Dict[str, dict] = {}  # Slash commands registered by plugins
+        self._plaintext_command_aliases: Dict[str, dict] = {}
         self._discovered: bool = False
         self._cli_ref = None  # Set by CLI after plugin discovery
         # Plugin skill registry: qualified name → metadata dict.
@@ -633,6 +702,7 @@ class PluginManager:
             self._plugin_tool_names.clear()
             self._cli_commands.clear()
             self._plugin_commands.clear()
+            self._plaintext_command_aliases.clear()
             self._plugin_skills.clear()
             self._context_engine = None
         self._discovered = True
@@ -1319,6 +1389,55 @@ def get_plugin_commands() -> Dict[str, dict]:
     before any explicit discover_plugins() call.
     """
     return _ensure_plugins_discovered()._plugin_commands
+
+
+def get_plaintext_command_aliases() -> Dict[str, str]:
+    """Return plugin-registered plaintext aliases as alias → command."""
+    return {
+        alias: str(entry.get("command"))
+        for alias, entry in _ensure_plugins_discovered()._plaintext_command_aliases.items()
+        if isinstance(entry, dict) and entry.get("command")
+    }
+
+
+def resolve_plaintext_command_alias(text: str, *, is_dm: bool = True) -> Optional[str]:
+    """Resolve plaintext alias text to a slash command string without leading slash.
+
+    Matching is word-branch based: the resolver chooses the longest alias whose
+    words match the start of the message. Exact aliases match only the full
+    message, while ``first_token`` aliases also preserve trailing words as
+    command arguments. This lets plugins register both a broad branch like
+    ``"foo"`` and a more specific branch like ``"foo bar"`` deterministically.
+    """
+    stripped = str(text or "").strip()
+    words = stripped.split()
+    key_words = [word.lower() for word in words]
+    if not key_words:
+        return None
+
+    def _entry_allowed(entry: dict) -> bool:
+        return is_dm or not bool(entry.get("dm_only", True))
+
+    candidates: list[tuple[int, str, dict, str]] = []
+    aliases = _ensure_plugins_discovered()._plaintext_command_aliases
+    for alias, entry in aliases.items():
+        if not isinstance(entry, dict) or not entry.get("command") or not _entry_allowed(entry):
+            continue
+        alias_words = str(alias or "").split()
+        if not alias_words or key_words[: len(alias_words)] != alias_words:
+            continue
+        has_remainder = len(key_words) > len(alias_words)
+        if has_remainder and not entry.get("first_token"):
+            continue
+        remainder = " ".join(words[len(alias_words):])
+        candidates.append((len(alias_words), str(alias), entry, remainder))
+
+    if not candidates:
+        return None
+
+    _, _, entry, remainder = max(candidates, key=lambda item: (item[0], len(item[1])))
+    command = str(entry["command"])
+    return f"{command} {remainder}".strip()
 
 
 def get_plugin_toolsets() -> List[tuple]:

--- a/tests/gateway/test_plaintext_command_aliases.py
+++ b/tests/gateway/test_plaintext_command_aliases.py
@@ -1,0 +1,116 @@
+"""Tests for plugin-owned plaintext gateway command aliases."""
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, coerce_plaintext_gateway_command
+from gateway.session import SessionSource
+
+
+def _make_event(text: str, *, chat_type: str = "dm") -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_id="m1",
+        source=SessionSource(
+            platform=Platform.TELEGRAM,
+            user_id="u1",
+            chat_id="c1",
+            user_name="tester",
+            chat_type=chat_type,
+        ),
+    )
+
+
+def test_plugin_plaintext_alias_rewrites_dm(monkeypatch):
+    """Exact plugin aliases are rewritten to slash commands in DMs."""
+    monkeypatch.setattr(
+        "hermes_cli.plugins.resolve_plaintext_command_alias",
+        lambda text, *, is_dm=True: "mycmd" if text == "aliascmd" and is_dm else None,
+    )
+    event = _make_event("aliascmd")
+
+    coerce_plaintext_gateway_command(event)
+
+    assert event.text == "/mycmd"
+
+
+def test_plugin_plaintext_alias_rewrites_first_token_args(monkeypatch):
+    """First-token plugin aliases preserve the message remainder as command args."""
+    monkeypatch.setattr(
+        "hermes_cli.plugins.resolve_plaintext_command_alias",
+        lambda text, *, is_dm=True: "mycmd do it" if text == "aliascmd do it" and is_dm else None,
+    )
+    event = _make_event("aliascmd do it")
+
+    coerce_plaintext_gateway_command(event)
+
+    assert event.text == "/mycmd do it"
+
+
+def test_plugin_plaintext_alias_group_stays_plain_text_by_default(monkeypatch):
+    """Plugin plaintext aliases remain DM-scoped unless the plugin opts out."""
+    monkeypatch.setattr(
+        "hermes_cli.plugins.resolve_plaintext_command_alias",
+        lambda text, *, is_dm=True: "mycmd" if text == "aliascmd" and is_dm else None,
+    )
+    event = _make_event("aliascmd", chat_type="group")
+
+    coerce_plaintext_gateway_command(event)
+
+    assert event.text == "aliascmd"
+
+
+def test_plugin_plaintext_alias_group_can_be_allowed_by_plugin(monkeypatch):
+    """Plugins can opt an alias into non-DM chats through resolver metadata."""
+    monkeypatch.setattr(
+        "hermes_cli.plugins.resolve_plaintext_command_alias",
+        lambda text, *, is_dm=True: "mycmd" if text == "aliascmd" and not is_dm else None,
+    )
+    event = _make_event("aliascmd", chat_type="group")
+
+    coerce_plaintext_gateway_command(event)
+
+    assert event.text == "/mycmd"
+
+
+def test_plugin_plaintext_alias_exception_preserves_text(monkeypatch):
+    """Alias lookup failures never break message processing."""
+    def _raise(_text, *, is_dm=True):
+        raise RuntimeError("plugin failed")
+
+    monkeypatch.setattr("hermes_cli.plugins.resolve_plaintext_command_alias", _raise)
+    event = _make_event("aliascmd")
+
+    coerce_plaintext_gateway_command(event)
+
+    assert event.text == "aliascmd"
+
+
+def test_plugin_plaintext_alias_registration_to_gateway_rewrite(tmp_path, monkeypatch):
+    """Real plugin alias registration feeds the gateway plaintext rewrite path."""
+    plugin_dir = tmp_path / "plugins" / "alias-plugin"
+    plugin_dir.mkdir(parents=True)
+    (plugin_dir / "plugin.yaml").write_text(
+        "name: alias-plugin\nversion: 0.1.0\ndescription: alias test\n",
+        encoding="utf-8",
+    )
+    (plugin_dir / "__init__.py").write_text(
+        "def register(ctx):\n"
+        "    ctx.register_command('mycmd', lambda args: args)\n"
+        "    ctx.register_plaintext_command_alias(\n"
+        "        'aliascmd', target_command='mycmd', first_token=True, dm_only=False\n"
+        "    )\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "config.yaml").write_text(
+        "plugins:\n  enabled:\n    - alias-plugin\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    import hermes_cli.plugins as plugins_mod
+
+    monkeypatch.setattr(plugins_mod, "_plugin_manager", None)
+    event = _make_event("AliasCmd do it", chat_type="group")
+
+    coerce_plaintext_gateway_command(event)
+
+    assert event.text == "/mycmd do it"

--- a/tests/gateway/test_pre_gateway_dispatch.py
+++ b/tests/gateway/test_pre_gateway_dispatch.py
@@ -65,12 +65,12 @@ async def test_hook_skip_short_circuits_dispatch(monkeypatch):
     """A plugin returning {'action': 'skip'} drops the message before auth."""
     _clear_auth_env(monkeypatch)
 
-    def _fake_hook(name, **kwargs):
+    async def _fake_hook(name, **kwargs):
         if name == "pre_gateway_dispatch":
             return [{"action": "skip", "reason": "plugin-handled"}]
         return []
 
-    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", _fake_hook)
 
     runner, adapter = _make_runner(Platform.WHATSAPP)
 
@@ -86,12 +86,12 @@ async def test_hook_respond_short_circuits_dispatch_before_auth(monkeypatch):
     """A trusted plugin can respond before auth/pairing and agent dispatch."""
     _clear_auth_env(monkeypatch)
 
-    def _fake_hook(name, **kwargs):
+    async def _fake_hook(name, **kwargs):
         if name == "pre_gateway_dispatch":
             return [{"action": "respond", "response": "plugin response"}]
         return []
 
-    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", _fake_hook)
 
     runner, adapter = _make_runner(Platform.WHATSAPP)
 
@@ -110,7 +110,7 @@ async def test_hook_rewrite_replaces_event_text(monkeypatch):
 
     seen_text = {}
 
-    def _fake_hook(name, **kwargs):
+    async def _fake_hook(name, **kwargs):
         if name == "pre_gateway_dispatch":
             return [{"action": "rewrite", "text": "REWRITTEN"}]
         return []
@@ -119,7 +119,7 @@ async def test_hook_rewrite_replaces_event_text(monkeypatch):
         seen_text["value"] = event.text
         return "ok"
 
-    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", _fake_hook)
 
     runner, _adapter = _make_runner(Platform.WHATSAPP)
     runner._handle_message_with_agent = _capture  # noqa: SLF001
@@ -136,12 +136,12 @@ async def test_hook_allow_falls_through_to_auth(monkeypatch):
     # No allowed users set → auth fails → pairing flow triggers.
     monkeypatch.delenv("WHATSAPP_ALLOWED_USERS", raising=False)
 
-    def _fake_hook(name, **kwargs):
+    async def _fake_hook(name, **kwargs):
         if name == "pre_gateway_dispatch":
             return [{"action": "allow"}]
         return []
 
-    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", _fake_hook)
 
     runner, adapter = _make_runner(Platform.WHATSAPP)
     runner.pairing_store.generate_code.return_value = "12345"
@@ -159,10 +159,10 @@ async def test_hook_exception_does_not_break_dispatch(monkeypatch):
     _clear_auth_env(monkeypatch)
     monkeypatch.delenv("WHATSAPP_ALLOWED_USERS", raising=False)
 
-    def _fake_hook(name, **kwargs):
+    async def _fake_hook(name, **kwargs):
         raise RuntimeError("plugin blew up")
 
-    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", _fake_hook)
 
     runner, _adapter = _make_runner(Platform.WHATSAPP)
     runner.pairing_store.generate_code.return_value = None
@@ -180,14 +180,14 @@ async def test_internal_events_bypass_hook(monkeypatch):
 
     called = {"count": 0}
 
-    def _fake_hook(name, **kwargs):
+    async def _fake_hook(name, **kwargs):
         called["count"] += 1
         return [{"action": "skip"}]
 
     async def _capture(event, source, _quick_key, _run_generation):
         return "ok"
 
-    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook_async", _fake_hook)
 
     runner, _adapter = _make_runner(Platform.WHATSAPP)
     runner._handle_message_with_agent = _capture  # noqa: SLF001

--- a/tests/gateway/test_pre_gateway_dispatch.py
+++ b/tests/gateway/test_pre_gateway_dispatch.py
@@ -1,8 +1,8 @@
 """Tests for the pre_gateway_dispatch plugin hook.
 
-The hook allows plugins to intercept incoming messages before auth and
-agent dispatch. It runs in _handle_message and acts on returned action
-dicts: {"action": "skip"|"rewrite"|"allow"}.
+The hook allows trusted plugins to intercept incoming messages before auth and
+agent dispatch. It runs in _handle_message and acts on returned action dicts:
+{"action": "skip"|"rewrite"|"respond"|"allow"}.
 """
 
 from types import SimpleNamespace
@@ -77,6 +77,27 @@ async def test_hook_skip_short_circuits_dispatch(monkeypatch):
     result = await runner._handle_message(_make_event("hi"))
 
     assert result is None
+    adapter.send.assert_not_awaited()
+    runner.pairing_store.generate_code.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_hook_respond_short_circuits_dispatch_before_auth(monkeypatch):
+    """A trusted plugin can respond before auth/pairing and agent dispatch."""
+    _clear_auth_env(monkeypatch)
+
+    def _fake_hook(name, **kwargs):
+        if name == "pre_gateway_dispatch":
+            return [{"action": "respond", "response": "plugin response"}]
+        return []
+
+    monkeypatch.setattr("hermes_cli.plugins.invoke_hook", _fake_hook)
+
+    runner, adapter = _make_runner(Platform.WHATSAPP)
+
+    result = await runner._handle_message(_make_event("hi"))
+
+    assert result == "plugin response"
     adapter.send.assert_not_awaited()
     runner.pairing_store.generate_code.assert_not_called()
 

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -361,6 +361,31 @@ class TestPluginHooks:
         assert len(results) == 1
         assert results[0] == {"action": "skip", "reason": "test"}
 
+    @pytest.mark.asyncio
+    async def test_invoke_hook_async_awaits_async_and_sync_callbacks(self):
+        """invoke_hook_async() awaits async callbacks and preserves sync hooks."""
+        mgr = PluginManager()
+
+        async def async_hook(**kwargs):
+            return {"action": "respond", "response": kwargs["event"]}
+
+        def sync_hook(**kwargs):
+            return {"action": "allow"}
+
+        mgr._hooks["pre_gateway_dispatch"] = [async_hook, sync_hook]
+
+        results = await mgr.invoke_hook_async(
+            "pre_gateway_dispatch",
+            event="async-response",
+            gateway=object(),
+            session_store=object(),
+        )
+
+        assert results == [
+            {"action": "respond", "response": "async-response"},
+            {"action": "allow"},
+        ]
+
     def test_register_and_invoke_hook(self, tmp_path, monkeypatch):
         """Registered hooks are called on invoke_hook()."""
         plugins_dir = tmp_path / "hermes_test" / "plugins"

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -20,7 +20,9 @@ from hermes_cli.plugins import (
     get_plugin_manager,
     get_plugin_command_handler,
     get_plugin_commands,
+    get_plaintext_command_aliases,
     get_pre_tool_call_block_message,
+    resolve_plaintext_command_alias,
     resolve_plugin_command_result,
     discover_plugins,
     invoke_hook,
@@ -887,6 +889,91 @@ class TestPluginCommands:
         ctx.register_command("status-cmd", lambda a: a)
         assert mgr._plugin_commands["status-cmd"]["description"] == "Plugin command"
 
+    def test_register_plaintext_command_alias(self):
+        """Plugins can register exact plaintext aliases for slash commands."""
+        mgr = PluginManager()
+        manifest = PluginManifest(name="test-plugin", source="user")
+        ctx = PluginContext(manifest, mgr)
+
+        ctx.register_command("my-cmd", lambda a: a)
+        ctx.register_plaintext_command_alias("  AliasCmd  ", "/my_cmd")
+
+        assert mgr._plaintext_command_aliases == {
+            "aliascmd": {"command": "my-cmd", "first_token": False, "dm_only": True}
+        }
+
+    def test_register_plaintext_command_alias_accepts_target_keyword(self):
+        """Plugins can use target_command/first_token metadata like bundle stubs."""
+        mgr = PluginManager()
+        manifest = PluginManifest(name="test-plugin", source="user")
+        ctx = PluginContext(manifest, mgr)
+
+        ctx.register_command("mycmd", lambda a: a)
+        ctx.register_plaintext_command_alias(
+            "aliascmd", target_command="mycmd", first_token=True, dm_only=False
+        )
+
+        assert mgr._plaintext_command_aliases == {
+            "aliascmd": {"command": "mycmd", "first_token": True, "dm_only": False}
+        }
+
+    def test_register_plaintext_command_alias_rejects_invalid(self, caplog):
+        """Invalid plaintext aliases are ignored."""
+        mgr = PluginManager()
+        manifest = PluginManifest(name="test-plugin", source="user")
+        ctx = PluginContext(manifest, mgr)
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+            ctx.register_plaintext_command_alias("aliascmd", "bad/command")
+
+        assert mgr._plaintext_command_aliases == {}
+        assert "invalid plaintext command alias" in caplog.text
+
+    def test_register_plaintext_command_alias_rejects_unknown_target(self, caplog):
+        """Aliases cannot target commands that are not gateway dispatchable."""
+        mgr = PluginManager()
+        manifest = PluginManifest(name="test-plugin", source="user")
+        ctx = PluginContext(manifest, mgr)
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+            ctx.register_plaintext_command_alias("aliascmd", "missingcmd")
+            ctx.register_plaintext_command_alias("clear-screen", "clear")
+
+        assert mgr._plaintext_command_aliases == {}
+        assert "unknown or gateway-unavailable command '/missingcmd'" in caplog.text
+        assert "unknown or gateway-unavailable command '/clear'" in caplog.text
+
+    def test_register_plaintext_command_alias_accepts_gateway_command_target(self):
+        """Trusted plugins may alias gateway-dispatchable built-in commands."""
+        mgr = PluginManager()
+        manifest = PluginManifest(name="test-plugin", source="user")
+        ctx = PluginContext(manifest, mgr)
+
+        ctx.register_plaintext_command_alias("status please", "status")
+
+        assert mgr._plaintext_command_aliases == {
+            "status please": {"command": "status", "first_token": False, "dm_only": True}
+        }
+
+    def test_register_plaintext_command_alias_collision_keeps_first(self, caplog):
+        """Alias collisions warn and preserve the first registered target."""
+        mgr = PluginManager()
+        first_manifest = PluginManifest(name="first-plugin", source="user")
+        second_manifest = PluginManifest(name="second-plugin", source="user")
+        first_ctx = PluginContext(first_manifest, mgr)
+        second_ctx = PluginContext(second_manifest, mgr)
+        first_ctx.register_command("firstcmd", lambda a: a)
+        second_ctx.register_command("secondcmd", lambda a: a)
+        first_ctx.register_plaintext_command_alias("aliascmd", "firstcmd")
+
+        with caplog.at_level(logging.WARNING, logger="hermes_cli.plugins"):
+            second_ctx.register_plaintext_command_alias("aliascmd", "secondcmd")
+
+        assert mgr._plaintext_command_aliases == {
+            "aliascmd": {"command": "firstcmd", "first_token": False, "dm_only": True}
+        }
+        assert "keeping existing target" in caplog.text
+
     def test_get_plugin_command_handler_found(self):
         """get_plugin_command_handler() returns the handler for a registered command."""
         mgr = PluginManager()
@@ -919,6 +1006,89 @@ class TestPluginCommands:
             assert "cmd-a" in cmds
             assert "cmd-b" in cmds
             assert cmds["cmd-a"]["description"] == "A"
+
+    def test_get_plaintext_command_aliases_returns_copy(self):
+        """Plaintext alias lookup exposes plugin aliases without mutable internals."""
+        mgr = PluginManager()
+        manifest = PluginManifest(name="test-plugin", source="user")
+        ctx = PluginContext(manifest, mgr)
+        ctx.register_command("mycmd", lambda a: a)
+        ctx.register_plaintext_command_alias("aliascmd", "mycmd")
+
+        with patch("hermes_cli.plugins._plugin_manager", mgr):
+            aliases = get_plaintext_command_aliases()
+            aliases["aliascmd"] = "changed"
+
+        assert mgr._plaintext_command_aliases == {
+            "aliascmd": {"command": "mycmd", "first_token": False, "dm_only": True}
+        }
+
+    def test_resolve_plaintext_command_alias_preserves_first_token_args(self):
+        """First-token aliases preserve the remaining user text as command args."""
+        mgr = PluginManager()
+        manifest = PluginManifest(name="test-plugin", source="user")
+        ctx = PluginContext(manifest, mgr)
+        ctx.register_command("mycmd", lambda a: a)
+        ctx.register_plaintext_command_alias("aliascmd", target_command="mycmd", first_token=True)
+
+        with patch("hermes_cli.plugins._plugin_manager", mgr):
+            assert resolve_plaintext_command_alias("aliascmd do this") == "mycmd do this"
+            assert resolve_plaintext_command_alias("AliasCmd") == "mycmd"
+
+    def test_resolve_plaintext_command_alias_uses_longest_word_branch(self):
+        """Specific aliases branch below broader first-token aliases."""
+        mgr = PluginManager()
+        manifest = PluginManifest(name="test-plugin", source="user")
+        ctx = PluginContext(manifest, mgr)
+        ctx.register_command("rootcmd", lambda a: a)
+        ctx.register_command("childcmd", lambda a: a)
+        ctx.register_plaintext_command_alias("foo", target_command="rootcmd", first_token=True)
+        ctx.register_plaintext_command_alias("foo bar", target_command="childcmd", first_token=True)
+
+        with patch("hermes_cli.plugins._plugin_manager", mgr):
+            assert resolve_plaintext_command_alias("foo") == "rootcmd"
+            assert resolve_plaintext_command_alias("foo baz") == "rootcmd baz"
+            assert resolve_plaintext_command_alias("foo bar") == "childcmd"
+            assert resolve_plaintext_command_alias("foo bar baz") == "childcmd baz"
+
+    def test_resolve_plaintext_command_alias_exact_specific_branch(self):
+        """Exact multi-word aliases can specialize a first-token parent branch."""
+        mgr = PluginManager()
+        manifest = PluginManifest(name="test-plugin", source="user")
+        ctx = PluginContext(manifest, mgr)
+        ctx.register_command("rootcmd", lambda a: a)
+        ctx.register_command("exactcmd", lambda a: a)
+        ctx.register_plaintext_command_alias("foo", target_command="rootcmd", first_token=True)
+        ctx.register_plaintext_command_alias("foo bar", target_command="exactcmd")
+
+        with patch("hermes_cli.plugins._plugin_manager", mgr):
+            assert resolve_plaintext_command_alias("foo bar") == "exactcmd"
+            assert resolve_plaintext_command_alias("foo bar baz") == "rootcmd bar baz"
+
+    def test_resolve_plaintext_command_alias_honors_dm_only(self):
+        """DM-only aliases do not resolve for non-DM gateway contexts."""
+        mgr = PluginManager()
+        manifest = PluginManifest(name="test-plugin", source="user")
+        ctx = PluginContext(manifest, mgr)
+        ctx.register_command("mycmd", lambda a: a)
+        ctx.register_plaintext_command_alias("aliascmd", target_command="mycmd", first_token=True)
+
+        with patch("hermes_cli.plugins._plugin_manager", mgr):
+            assert resolve_plaintext_command_alias("aliascmd rest", is_dm=True) == "mycmd rest"
+            assert resolve_plaintext_command_alias("aliascmd rest", is_dm=False) is None
+
+    def test_resolve_plaintext_command_alias_can_opt_into_non_dm(self):
+        """Plugins can opt aliases into group/thread contexts explicitly."""
+        mgr = PluginManager()
+        manifest = PluginManifest(name="test-plugin", source="user")
+        ctx = PluginContext(manifest, mgr)
+        ctx.register_command("mycmd", lambda a: a)
+        ctx.register_plaintext_command_alias(
+            "aliascmd", target_command="mycmd", first_token=True, dm_only=False
+        )
+
+        with patch("hermes_cli.plugins._plugin_manager", mgr):
+            assert resolve_plaintext_command_alias("aliascmd rest", is_dm=False) == "mycmd rest"
 
     def test_get_plugin_command_handler_discovers_plugins_lazily(self, tmp_path, monkeypatch):
         """Handler lookup should work before any explicit discover_plugins() call."""


### PR DESCRIPTION
## Summary

Adds generic gateway/plugin dispatch extension points so trusted plugins can move private gateway behavior out of core without hardcoding platform-specific aliases or handlers.

- add `pre_gateway_dispatch` hook handling before auth/agent dispatch with explicit actions: `skip`, `rewrite`, `respond`, `allow`
- add plugin plaintext command alias registration/resolution for gateway adapters
- keep plaintext aliases DM-only by default, with explicit plugin opt-in for group/thread contexts
- resolve aliases by longest matching word branch, so broad aliases like `foo` can coexist with specific branches like `foo bar`
- validate alias targets against plugin commands or gateway-dispatchable built-in commands
- preserve existing slash commands and Korean restart plaintext aliases

## Verification

- `python -m pytest -q tests/hermes_cli/test_plugins.py tests/gateway/test_plaintext_command_aliases.py tests/gateway/test_pre_gateway_dispatch.py` → `86 passed`
- `python -m compileall -q gateway hermes_cli tests`
- `git diff --check origin/main...HEAD`
- plugin smoke with temp `HERMES_HOME` and `torrrr4885/hermes-hyde-plugins` symlink → `HHP_PR_BRANCH_PLUGIN_SMOKE_OK`
- diff secret scan → `DIFF_SECRET_SCAN_OK`

## Notes

This does not remove any existing gateway hardcoding by itself; it adds generic extension points needed to migrate private gateway behavior into plugins safely.