### PR TITLE
fix(auxiliary): strip /v1 from Kimi base URL before Anthropic SDK wraps it

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -978,22 +978,37 @@ def _maybe_wrap_anthropic(
         )
         return client_obj
 
+    # The Anthropic SDK appends /v1/messages to base_url.  If the caller
+    # already rewrote the URL through _to_openai_base_url() (which adds /v1
+    # for Kimi Coding's /coding endpoint), the SDK would double it:
+    #   /coding/v1  →  /coding/v1/v1/messages  (404).
+    # Strip the trailing /v1 for endpoints the Anthropic SDK handles.
+    anthropic_base_url = base_url
+    if base_url and base_url.rstrip("/").endswith("/v1"):
+        from agent.anthropic_adapter import _is_kimi_coding_endpoint
+        if _is_kimi_coding_endpoint(base_url):
+            anthropic_base_url = base_url.rstrip("/")[:-3]  # strip "/v1"
+            logger.debug(
+                "Stripped /v1 from Kimi base URL for Anthropic SDK: %s → %s",
+                base_url, anthropic_base_url,
+            )
+
     try:
-        real_client = build_anthropic_client(api_key, base_url)
+        real_client = build_anthropic_client(api_key, anthropic_base_url)
     except Exception as exc:
         logger.warning(
             "Failed to build Anthropic client for %s (%s) — falling back to "
-            "OpenAI-wire client.", base_url, exc,
+            "OpenAI-wire client.", anthropic_base_url, exc,
         )
         return client_obj
 
     logger.debug(
         "Auxiliary transport: wrapping client in AnthropicAuxiliaryClient "
         "(model=%s, base_url=%s, api_mode=%s)",
-        model, base_url[:60] if base_url else "", api_mode or "auto-detected",
+        model, anthropic_base_url[:60] if anthropic_base_url else "", api_mode or "auto-detected",
     )
     return AnthropicAuxiliaryClient(
-        real_client, model, api_key, base_url, is_oauth=False,
+        real_client, model, api_key, anthropic_base_url, is_oauth=False,
     )
 
 


### PR DESCRIPTION
## What

When `_to_openai_base_url()` rewrites `api.kimi.com/coding` → `api.kimi.com/coding/v1` (for the OpenAI SDK), the same URL is later passed to `_maybe_wrap_anthropic()` which creates an Anthropic SDK client. The Anthropic SDK appends `/v1/messages` to `base_url`, producing the double path:

```
/api.kimi.com/coding/v1/v1/messages  →  404 Not Found
```

## Why

The Kimi Coding Plan endpoint (`api.kimi.com/coding`) speaks the Anthropic Messages wire format. When a user configures `auxiliary.vision.provider: kimi` with `auxiliary.vision.base_url: https://api.kimi.com/coding`, the auxiliary client:

1. Rewrites the URL through `_to_openai_base_url()` → `/coding/v1`
2. Creates an OpenAI client with this base URL
3. Detects the endpoint speaks Anthropic Messages via `_endpoint_speaks_anthropic_messages()`
4. Wraps in `AnthropicAuxiliaryClient` → calls `build_anthropic_client(api_key, base_url)`
5. Anthropic SDK appends `/v1/messages` → `/coding/v1/v1/messages` ✗

## How

Strip the trailing `/v1` from the base URL for Kimi Coding endpoints before handing it to the Anthropic SDK. The SDK will re-add `/v1/messages` correctly, producing `/coding/v1/messages`.

This only affects Kimi Coding endpoints (`api.kimi.com/coding*`) — other Anthropic-compatible endpoints (MiniMax `/anthropic`, native Anthropic) don't go through `_to_openai_base_url()` so they aren't affected.

## How to test

```python
# Before fix: 404 (double /v1)
# After fix: 200 OK
from tools.vision_tools import vision_analyze_tool
result = await vision_analyze_tool(
    image_url="path/to/image.jpg",
    user_prompt="Describe this image"
)
```

Verified locally with Kimi Coding Plan API key + `kimi-for-coding` model.

## Related

- Fixes #16254 (root cause: `custom = OpenAI` assumption forces provider to `custom`, losing named provider's API key)
- Related to #18990 / PR #18999 (remove from `_PROVIDERS_WITHOUT_VISION`)
- Related to #2125 (add kimi-coding as vision provider)