### PR TITLE
test(tui): cover memory.formatBytes byte-size formatter

### DIFF
--- a/ui-tui/src/__tests__/memoryFormatBytes.test.ts
+++ b/ui-tui/src/__tests__/memoryFormatBytes.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest'
+
+import { formatBytes } from '../lib/memory.js'
+
+describe('formatBytes', () => {
+  it('returns 0B for zero', () => {
+    expect(formatBytes(0)).toBe('0B')
+  })
+
+  it('returns 0B for negative', () => {
+    expect(formatBytes(-100)).toBe('0B')
+  })
+
+  it('returns 0B for NaN', () => {
+    expect(formatBytes(Number.NaN)).toBe('0B')
+  })
+
+  it('returns 0B for Infinity', () => {
+    expect(formatBytes(Number.POSITIVE_INFINITY)).toBe('0B')
+  })
+
+  it('formats small byte values with B unit', () => {
+    expect(formatBytes(1)).toMatch(/B$/)
+    expect(formatBytes(500)).toMatch(/B$/)
+  })
+
+  it('formats kilobyte-range values with KB unit', () => {
+    expect(formatBytes(2048)).toMatch(/KB$/)
+  })
+
+  it('formats megabyte-range values with MB unit', () => {
+    expect(formatBytes(2_000_000)).toMatch(/MB$/)
+  })
+
+  it('formats gigabyte-range values with GB unit', () => {
+    expect(formatBytes(5_000_000_000)).toMatch(/GB$/)
+  })
+
+  it('formats terabyte-range values with TB unit', () => {
+    expect(formatBytes(2_000_000_000_000)).toMatch(/TB$/)
+  })
+
+  it('caps unit at TB for petabyte-scale inputs', () => {
+    expect(formatBytes(1e18)).toMatch(/TB$/)
+  })
+
+  it('uses one decimal place for values below 100 in their unit', () => {
+    const out = formatBytes(2_500_000)
+    expect(out).toMatch(/^\d+\.\d[A-Z]+$/)
+  })
+
+  it('uses zero decimal places for values >= 100 in their unit', () => {
+    const out = formatBytes(150_000_000)
+    expect(out).toMatch(/^\d+[A-Z]+$/)
+    expect(out).not.toMatch(/\./)
+  })
+
+  it('produces a stable shape: digits then unit suffix', () => {
+    for (const n of [1, 999, 1024, 10_000, 1_000_000, 1_000_000_000]) {
+      expect(formatBytes(n)).toMatch(/^\d+(\.\d)?[A-Z]+$/)
+    }
+  })
+})

--- a/ui-tui/src/__tests__/memoryFormatBytes.test.ts
+++ b/ui-tui/src/__tests__/memoryFormatBytes.test.ts
@@ -20,8 +20,10 @@ describe('formatBytes', () => {
   })
 
   it('formats small byte values with B unit', () => {
-    expect(formatBytes(1)).toMatch(/B$/)
-    expect(formatBytes(500)).toMatch(/B$/)
+    // /B$/ alone would also match KB/MB/GB/TB; assert exact strings so a
+    // unit regression for small values fails this test.
+    expect(formatBytes(1)).toBe('1.0B')
+    expect(formatBytes(500)).toBe('500B')
   })
 
   it('formats kilobyte-range values with KB unit', () => {


### PR DESCRIPTION
## What does this PR do?

13 vitest cases pinning `formatBytes` in `ui-tui/src/lib/memory.ts`.

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- Standardizes the PR description to the same review format used in #29640.
- Preserves the original detailed description below so no context is lost.

## Why this shape

`formatBytes` is the byte-size pretty-printer used by heap-dump diagnostics, perfPane and the TUI banner. It had **zero** direct unit tests despite a non-trivial surface (zero / negative / NaN / Infinity guards, TB cap, decimal-places threshold). A future cleanup that drops the early-return or tweaks the threshold would pass CI green and silently break the renderer.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

- Original body preserved below for full context.

<details>
<summary>Original body</summary>

## Summary

13 vitest cases pinning `formatBytes` in `ui-tui/src/lib/memory.ts`.

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What

13 vitest cases pinning `formatBytes` in `ui-tui/src/lib/memory.ts`.

## Why

`formatBytes` is the byte-size pretty-printer used by heap-dump diagnostics, perfPane and the TUI banner. It had **zero** direct unit tests despite a non-trivial surface (zero / negative / NaN / Infinity guards, TB cap, decimal-places threshold). A future cleanup that drops the early-return or tweaks the threshold would pass CI green and silently break the renderer.

## Coverage

- 0B for zero / negative / NaN / +Infinity
- B / KB / MB / GB / TB at each scale
- TB cap for petabyte-scale inputs
- 1 decimal when value < 100 in its unit; 0 decimals when >= 100
- Output shape invariant: `digits[(.d)?]unit`

## Verification

```
$ npx vitest run src/__tests__/memoryFormatBytes.test.ts
 Test Files  1 passed (1)
      Tests  13 passed (13)

$ npx vitest run
 Test Files  63 passed (63)
      Tests  667 passed (667)
```

No production code changed.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_