### PR TITLE
fix: honor Xiaomi doctor base URL override

### DIFF
--- a/plugins/model-providers/xiaomi/__init__.py
+++ b/plugins/model-providers/xiaomi/__init__.py
@@ -6,7 +6,7 @@ from providers.base import ProviderProfile
 xiaomi = ProviderProfile(
     name="xiaomi",
     aliases=("mimo", "xiaomi-mimo"),
-    env_vars=("XIAOMI_API_KEY",),
+    env_vars=("XIAOMI_API_KEY", "XIAOMI_BASE_URL"),
     base_url="https://api.xiaomimimo.com/v1",
 )
 

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -765,6 +765,64 @@ def test_run_doctor_opencode_go_skips_invalid_models_probe(monkeypatch, tmp_path
     assert not any("opencode" in url.lower() and "models" in url.lower() for url, _, _ in calls)
 
 
+def test_run_doctor_xiaomi_honors_base_url_override(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+    (home / ".env").write_text(
+        "XIAOMI_API_KEY=sk-test\n"
+        "XIAOMI_BASE_URL=https://token-plan-sgp.xiaomimimo.com/v1\n",
+        encoding="utf-8",
+    )
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    monkeypatch.setattr(doctor_mod, "_APIKEY_PROVIDERS_CACHE", None)
+    monkeypatch.setenv("XIAOMI_API_KEY", "sk-test")
+    monkeypatch.setenv("XIAOMI_BASE_URL", "https://token-plan-sgp.xiaomimimo.com/v1")
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+    except ImportError:
+        pass
+
+    calls = []
+
+    def fake_get(url, headers=None, timeout=None):
+        calls.append((url, headers, timeout))
+        return types.SimpleNamespace(status_code=200)
+
+    import httpx
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    assert "xiaomi" in out.lower()
+    assert (
+        "https://token-plan-sgp.xiaomimimo.com/v1/models",
+        {"Authorization": "Bearer sk-test", "User-Agent": doctor_mod._HERMES_USER_AGENT},
+        10,
+    ) in calls
+    assert not any(
+        url == "https://api.xiaomimimo.com/v1/models"
+        for url, _, _ in calls
+    )
+
+
 class TestGitHubTokenCheck:
     """Tests for GitHub token / gh auth detection in doctor."""
 


### PR DESCRIPTION
## Why

`hermes doctor` should validate the same Xiaomi endpoint the user configured with `XIAOMI_BASE_URL`, including regional token-plan endpoints. Before this, the Xiaomi provider profile only exposed `XIAOMI_API_KEY`, so the profile-derived doctor health check fell back to `https://api.xiaomimimo.com/v1/models` and could report misleading results for users on an override endpoint.

Fixes #22237.

## Validation

- `uv run --extra dev pytest tests/hermes_cli/test_doctor.py::test_run_doctor_xiaomi_honors_base_url_override -q` (failed before the fix, passes after)
- `uv run --extra dev pytest tests/hermes_cli/test_doctor.py::test_run_doctor_xiaomi_honors_base_url_override tests/hermes_cli/test_xiaomi_provider.py -q`
- `uv run --extra dev pytest tests/hermes_cli/test_doctor.py -q`
- `uv run ruff check plugins/model-providers/xiaomi/__init__.py tests/hermes_cli/test_doctor.py`