### PR TITLE
test(tui): cover history append/load roundtrip + 1000-line cap

### DIFF
--- a/ui-tui/src/__tests__/historyRoundtrip.test.ts
+++ b/ui-tui/src/__tests__/historyRoundtrip.test.ts
@@ -1,0 +1,99 @@
+import { mkdtempSync, readFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+let tmp: string
+let originalHome: string | undefined
+
+async function loadFreshModule() {
+  vi.resetModules()
+  return import('../lib/history.js')
+}
+
+beforeEach(() => {
+  originalHome = process.env.HERMES_HOME
+  tmp = mkdtempSync(join(tmpdir(), 'hermes-history-'))
+  process.env.HERMES_HOME = tmp
+})
+
+afterEach(() => {
+  if (originalHome === undefined) {
+    delete process.env.HERMES_HOME
+  } else {
+    process.env.HERMES_HOME = originalHome
+  }
+})
+
+describe('history.load', () => {
+  it('returns an empty list when no history file exists yet', async () => {
+    const { load } = await loadFreshModule()
+    expect(load()).toEqual([])
+  })
+
+  it('caches subsequent calls (returns the same array reference)', async () => {
+    const { load } = await loadFreshModule()
+    expect(load()).toBe(load())
+  })
+
+  it('round-trips single-line entries through append+load', async () => {
+    const { append, load } = await loadFreshModule()
+    append('first')
+    append('second')
+    expect(load()).toEqual(['first', 'second'])
+  })
+
+  it('preserves multi-line entries with embedded newlines', async () => {
+    const { append, load } = await loadFreshModule()
+    append('line a\nline b\nline c')
+    expect(load()).toEqual(['line a\nline b\nline c'])
+  })
+})
+
+describe('history.append', () => {
+  it('skips empty / whitespace-only input', async () => {
+    const { append, load } = await loadFreshModule()
+    append('')
+    append('   ')
+    append('\t\n')
+    expect(load()).toEqual([])
+  })
+
+  it('deduplicates consecutive duplicates', async () => {
+    const { append, load } = await loadFreshModule()
+    append('foo')
+    append('foo')
+    append('foo')
+    append('bar')
+    append('foo')
+    expect(load()).toEqual(['foo', 'bar', 'foo'])
+  })
+
+  it('trims surrounding whitespace before storing', async () => {
+    const { append, load } = await loadFreshModule()
+    append('  trimmed  ')
+    expect(load()).toEqual(['trimmed'])
+  })
+
+  it('encodes each line with a leading + so multi-line entries survive on disk', async () => {
+    const { append } = await loadFreshModule()
+    append('a\nb')
+    const file = readFileSync(join(tmp, '.hermes_history'), 'utf8')
+    expect(file).toContain('+a')
+    expect(file).toContain('+b')
+  })
+})
+
+describe('history.MAX cap', () => {
+  it('stays within the 1000-entry cap when appending many distinct lines', async () => {
+    const { append, load } = await loadFreshModule()
+    for (let i = 0; i < 1100; i++) {
+      append(`entry-${i}`)
+    }
+    const items = load()
+    expect(items.length).toBe(1000)
+    expect(items[0]).toBe('entry-100')
+    expect(items.at(-1)).toBe('entry-1099')
+  })
+})


### PR DESCRIPTION
## What does this PR do?

9 vitest cases pinning `load` + `append` in `ui-tui/src/lib/history.ts`.

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- Standardizes the PR description to the same review format used in #29640.
- Preserves the original detailed description below so no context is lost.

## Why this shape

`lib/history.ts` is the persistent input-history file backing the TUI's UP/DOWN recall, written to `$HERMES_HOME/.hermes_history`. It had zero direct unit tests despite owning several invariants users depend on:

- consecutive duplicates collapse so UP doesn't cycle the same line
- multi-line entries (composer `\` + Enter) survive on disk via `+line / +line / +line` encoding
- whitespace-only input is silently dropped
- file caps at `MAX = 1000` entries so it never grows unbounded

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

- Original body preserved below for full context.

<details>
<summary>Original body</summary>

## Summary

9 vitest cases pinning `load` + `append` in `ui-tui/src/lib/history.ts`.

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What

9 vitest cases pinning `load` + `append` in `ui-tui/src/lib/history.ts`.

## Why

`lib/history.ts` is the persistent input-history file backing the TUI's UP/DOWN recall, written to `$HERMES_HOME/.hermes_history`. It had zero direct unit tests despite owning several invariants users depend on:

- consecutive duplicates collapse so UP doesn't cycle the same line
- multi-line entries (composer `\` + Enter) survive on disk via `+line / +line / +line` encoding
- whitespace-only input is silently dropped
- file caps at `MAX = 1000` entries so it never grows unbounded

## Coverage

| Area | Cases |
|---|---|
| load | empty file, cache identity, single-line roundtrip, multi-line roundtrip |
| append | skip empty/whitespace, dedup consecutive, trim surrounding whitespace, +line encoding on disk |
| MAX cap | 1100 distinct lines collapse to 1000, oldest dropped, newest preserved |

Each test uses `vi.resetModules()` + a fresh `tmpdir` mounted at `HERMES_HOME` so the module-level cache and `dir` constant re-read between cases.

## Verification

```
$ npx vitest run src/__tests__/historyRoundtrip.test.ts
 Test Files  1 passed (1)
      Tests  9 passed (9)

$ npx vitest run
 Test Files  63 passed (63)
      Tests  663 passed (663)
```

No production code touched.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_