### PR TITLE
fix: keep disk cleanup out of git worktrees

### DIFF
--- a/plugins/disk-cleanup/disk_cleanup.py
+++ b/plugins/disk-cleanup/disk_cleanup.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 import json
 import logging
 import shutil
+import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
@@ -79,6 +80,27 @@ def is_safe_path(path: Path) -> bool:
     if len(parts) >= 3 and parts[1] == "tmp" and parts[2].startswith("hermes-"):
         return True
     return False
+
+
+def is_inside_git_worktree(path: Path) -> bool:
+    """Return True when *path* lives inside a Git working tree.
+
+    Auto-cleanup must not delete source files from repositories/worktrees,
+    even if an agent created a new file named ``test_*.py`` during a coding
+    task. Manual ``/disk-cleanup track`` still allows explicit cleanup.
+    """
+    anchor = path if path.is_dir() else path.parent
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--is-inside-work-tree"],
+            cwd=anchor,
+            capture_output=True,
+            text=True,
+            timeout=2,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    return result.returncode == 0 and result.stdout.strip().lower() == "true"
 
 
 # ---------------------------------------------------------------------------
@@ -467,6 +489,8 @@ def guess_category(path: Path) -> Optional[str]:
     Used by the ``post_tool_call`` hook to auto-track ephemeral files.
     """
     if not is_safe_path(path):
+        return None
+    if is_inside_git_worktree(path):
         return None
 
     # Skip the state dir itself, logs, memory files, sessions, config.

--- a/tests/plugins/test_disk_cleanup_plugin.py
+++ b/tests/plugins/test_disk_cleanup_plugin.py
@@ -14,6 +14,7 @@ Covers the bundled plugin at ``plugins/disk-cleanup/``:
 
 import importlib
 import json
+import subprocess
 import sys
 from pathlib import Path
 
@@ -139,6 +140,16 @@ class TestGuessCategory:
         dg = _load_lib()
         p = _isolate_env / "notes.md"
         p.write_text("x")
+        assert dg.guess_category(p) is None
+
+    def test_test_file_inside_git_worktree_returns_none(self, _isolate_env):
+        dg = _load_lib()
+        repo = _isolate_env / "worktrees" / "repo"
+        tests_dir = repo / "tests"
+        tests_dir.mkdir(parents=True)
+        subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+        p = tests_dir / "test_keep_me.py"
+        p.write_text("def test_keep_me():\n    assert True\n")
         assert dg.guess_category(p) is None
 
 


### PR DESCRIPTION
## Summary

The bundled `disk-cleanup` plugin can delete source files from Git repositories and worktrees. When `disk-cleanup` is enabled, the `post_tool_call` hook classifies files created by `write_file` / `patch` / `terminal` whose basenames match `test_*.py` or `*.test.py` as category "test". At `delegate_task` / subagent session end, the `on_session_end` hook runs `disk_cleanup.quick()`, which immediately deletes all tracked category "test" files — even when they are legitimate source files in a Git worktree.

This is reproducible and was caught during upstreamability verification when untracked test files disappeared from worktrees.

## Root cause

`guess_category()` had a single-scope filter: is the path under `HERMES_HOME` or `/tmp/hermes-*`? The path resolution was correct (the worktree IS under `HERMES_HOME`), but the category classification had no concept of "this is a source repository, not ephemeral detritus."

## Fix

Add `is_inside_git_worktree()` using `git rev-parse --is-inside-work-tree`. When the path lives inside a Git working tree, `guess_category()` returns `None` instead of `"test"`. This keeps auto-cleanup limited to truly ephemeral files while still allowing manual `/disk-cleanup track` for explicit cleanup.

## Verification

Red test on unpatched `origin/main`:
```
pytest tests/plugins/test_disk_cleanup_plugin.py::TestGuessCategory::test_test_file_inside_git_worktree_returns_none -q
  FAILED: assert 'test' is None
```

Green after fix:
```
pytest tests/plugins/test_disk_cleanup_plugin.py -q
  39 passed in 0.61s

pytest tests/plugins/test_disk_cleanup_plugin.py tests/hermes_cli/test_plugins.py tests/hermes_cli/test_plugin_cli_registration.py tests/hermes_cli/test_startup_plugin_gating.py -q
  146 passed in 1.41s
```

Static added-line scan: no findings.
`git diff --check` passed.

## Changed files

- `plugins/disk-cleanup/disk_cleanup.py`
- `tests/plugins/test_disk_cleanup_plugin.py`
