### PR TITLE
test: isolate Kanban env pins in hermetic fixture

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -158,6 +158,32 @@ def _looks_like_credential(name: str) -> bool:
     return any(name.endswith(suf) for suf in _CREDENTIAL_SUFFIXES)
 
 
+# Kanban env pins are legitimate production/operator controls: the CLI uses
+# them for board selection, the dispatcher injects them into worker processes,
+# and the gateway honours the dispatcher toggle. They still must be scrubbed
+# from pytest's ambient process env because tests that need Kanban context set
+# it explicitly and default-board tests rely on no ambient board/path pin.
+#
+# Scope this set to HERMES_KANBAN_* variables. The dispatcher also injects
+# HERMES_PROFILE for worker author attribution, but that is a broader profile
+# selector rather than a Kanban-specific pin and is intentionally out of this
+# narrow regression fix.
+_HERMES_KANBAN_BEHAVIORAL_VARS = frozenset({
+    # Board and path resolution pins.
+    "HERMES_KANBAN_BOARD",
+    "HERMES_KANBAN_DB",
+    "HERMES_KANBAN_HOME",
+    "HERMES_KANBAN_WORKSPACES_ROOT",
+    # Dispatcher-spawned worker runtime pins.
+    "HERMES_KANBAN_TASK",
+    "HERMES_KANBAN_WORKSPACE",
+    "HERMES_KANBAN_RUN_ID",
+    "HERMES_KANBAN_CLAIM_LOCK",
+    # Gateway dispatcher escape hatch.
+    "HERMES_KANBAN_DISPATCH_IN_GATEWAY",
+})
+
+
 # HERMES_* vars that change test behavior by being set. Unset all of these
 # unconditionally — individual tests that need them set do so explicitly.
 _HERMES_BEHAVIORAL_VARS = frozenset({
@@ -188,6 +214,7 @@ _HERMES_BEHAVIORAL_VARS = frozenset({
     "HERMES_BACKGROUND_NOTIFICATIONS",
     "HERMES_EXEC_ASK",
     "HERMES_HOME_MODE",
+    *_HERMES_KANBAN_BEHAVIORAL_VARS,
     "TERMINAL_CWD",
     "TERMINAL_ENV",
     "TERMINAL_VERCEL_RUNTIME",

--- a/tests/test_hermetic_environment.py
+++ b/tests/test_hermetic_environment.py
@@ -1,0 +1,33 @@
+"""Regression coverage for process-level pytest environment isolation."""
+
+from __future__ import annotations
+
+import os
+
+import tests.conftest as hermes_conftest
+
+
+def test_kanban_env_pins_do_not_leak_from_pytest_process_env():
+    """Ambient Kanban pins must not be visible inside test bodies.
+
+    Hermes sessions and dispatcher workers legitimately export these variables,
+    so local developer shells can carry them into `pytest`. The global hermetic
+    fixture owns clearing them; individual Kanban tests opt back in with
+    `monkeypatch.setenv(...)` when a variable is part of the behavior under test.
+    """
+
+    leaked = {
+        name: os.environ[name]
+        for name in sorted(hermes_conftest._HERMES_KANBAN_BEHAVIORAL_VARS)
+        if name in os.environ
+    }
+
+    assert leaked == {}
+
+
+def test_tests_can_still_set_kanban_env_pins_explicitly(monkeypatch):
+    """The hermetic fixture clears ambient state, not test-local setup."""
+
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "explicit-test-board")
+
+    assert os.environ["HERMES_KANBAN_BOARD"] == "explicit-test-board"


### PR DESCRIPTION
## Summary

Ambient Kanban operator/dispatcher environment variables (`HERMES_KANBAN_BOARD`, `HERMES_KANBAN_TASK`, `HERMES_KANBAN_RUN_ID`, `HERMES_KANBAN_CLAIM_LOCK`, `HERMES_KANBAN_WORKSPACE`, etc.) legitimately affect production Kanban board/path/runtime resolution. However, the test harness did not clear these globally, so a local Hermes session with `HERMES_KANBAN_BOARD=meta-hermes` (or any Kanban worker runtime pins) caused upstream-style tests to fail by resolving to unexpected boards/paths/run contexts.

This is not a production-code bug — production Kanban behavior is correct and documented. The fix is purely test-harness isolation.

## Root cause

Two concrete failure modes:

1. **Default-board path tests** — with ambient `HERMES_KANBAN_BOARD=meta-hermes`, `tests/hermes_cli/test_kanban_db.py::TestSharedBoardPaths::test_default_install_anchors_at_home_dot_hermes` failed because `kanban_db_path()` resolved to `<temp>/.hermes/kanban/boards/meta-hermes/kanban.db` instead of `<temp>/.hermes/kanban.db`.

2. **Worker-runtime lifecycle tests** — with ambient `HERMES_KANBAN_TASK`, `HERMES_KANBAN_RUN_ID`, `HERMES_KANBAN_CLAIM_LOCK`, and `HERMES_KANBAN_WORKSPACE` set, `tests/tools/test_kanban_tools.py` produced 9 failures because worker tool handlers bound to a stale ambient run/claim context instead of the per-test task/run.

## Fix

Factor a `_HERMES_KANBAN_BEHAVIORAL_VARS` set in `tests/conftest.py`, splice it into the existing `_HERMES_BEHAVIORAL_VARS` cleared by the hermetic fixture, and add a small `tests/test_hermetic_environment.py` regression proving ambient Kanban pins are absent inside test bodies while explicit `monkeypatch.setenv(...)` still works.

Kanban pins covered (9 total):
- `HERMES_KANBAN_BOARD`
- `HERMES_KANBAN_DB`
- `HERMES_KANBAN_HOME`
- `HERMES_KANBAN_WORKSPACES_ROOT`
- `HERMES_KANBAN_TASK`
- `HERMES_KANBAN_WORKSPACE`
- `HERMES_KANBAN_RUN_ID`
- `HERMES_KANBAN_CLAIM_LOCK`
- `HERMES_KANBAN_DISPATCH_IN_GATEWAY`

`HERMES_PROFILE` is intentionally excluded — it is a broader profile selector, not a Kanban pin, and the dispatcher also injects it for worker author attribution.

## Verification — Red (on unpatched `origin/main`)

Board-focused hostile env:
```
env HERMES_KANBAN_BOARD=meta-hermes pytest tests/hermes_cli/test_kanban_db.py::TestSharedBoardPaths::test_default_install_anchors_at_home_dot_hermes -q --tb=short
  FAILED: path resolved under kanban/boards/meta-hermes/kanban.db
```

Worker-runtime hostile env:
```
env HERMES_KANBAN_TASK=t_ambient HERMES_KANBAN_RUN_ID=999 HERMES_KANBAN_CLAIM_LOCK=ambient-lock HERMES_KANBAN_WORKSPACE=/tmp/ambient-worker \
  pytest tests/tools/test_kanban_tools.py -q --tb=short
  9 failed, 30 passed
```

## Verification — Green (with this patch)

Board-focused hostile env: `1 passed`

Worker-runtime hostile env: `39 passed`

New hermetic fixture regression under full hostile Kanban env: `2 passed`

Combined hostile env across hermetic regression + Kanban DB/boards/core/tooling/doctor/pin-board tests: `341 passed, 1 warning`

Static added-line scan: `{"findings": []}`

Independent pre-commit review passed: no security concerns, no logic errors.

`git diff --check` / staged diff check passed.

## Changed files

- `tests/conftest.py`
- `tests/test_hermetic_environment.py` (new)
