### PR TITLE
test(tui): cover externalCli launchHermesCommand spawn shape

### DIFF
--- a/ui-tui/src/__tests__/externalCli.test.ts
+++ b/ui-tui/src/__tests__/externalCli.test.ts
@@ -1,0 +1,142 @@
+import { EventEmitter } from 'node:events'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const spawnSpy = vi.fn()
+
+vi.mock('node:child_process', () => ({
+  spawn: (...args: unknown[]) => spawnSpy(...args)
+}))
+
+const { launchHermesCommand } = await import('../lib/externalCli.js')
+
+class FakeChild extends EventEmitter {}
+
+describe('launchHermesCommand', () => {
+  let originalBin: string | undefined
+
+  beforeEach(() => {
+    originalBin = process.env.HERMES_BIN
+    delete process.env.HERMES_BIN
+    spawnSpy.mockReset()
+  })
+
+  afterEach(() => {
+    if (originalBin === undefined) {
+      delete process.env.HERMES_BIN
+    } else {
+      process.env.HERMES_BIN = originalBin
+    }
+  })
+
+  it('spawns the default hermes binary with stdio inherit', async () => {
+    const child = new FakeChild()
+
+    spawnSpy.mockReturnValue(child)
+
+    const promise = launchHermesCommand(['setup'])
+
+    child.emit('exit', 0)
+
+    await promise
+
+    expect(spawnSpy).toHaveBeenCalledWith('hermes', ['setup'], { stdio: 'inherit' })
+  })
+
+  it('honors HERMES_BIN env override', async () => {
+    process.env.HERMES_BIN = '/opt/hermes/bin/hermes'
+
+    const child = new FakeChild()
+
+    spawnSpy.mockReturnValue(child)
+
+    const promise = launchHermesCommand([])
+
+    child.emit('exit', 0)
+
+    await promise
+
+    expect(spawnSpy.mock.calls[0]?.[0]).toBe('/opt/hermes/bin/hermes')
+  })
+
+  it('trims whitespace from HERMES_BIN', async () => {
+    process.env.HERMES_BIN = '  /usr/local/bin/hermes  '
+
+    const child = new FakeChild()
+
+    spawnSpy.mockReturnValue(child)
+
+    const promise = launchHermesCommand([])
+
+    child.emit('exit', 0)
+
+    await promise
+
+    expect(spawnSpy.mock.calls[0]?.[0]).toBe('/usr/local/bin/hermes')
+  })
+
+  it('falls back to default when HERMES_BIN is empty/whitespace', async () => {
+    process.env.HERMES_BIN = '   '
+
+    const child = new FakeChild()
+
+    spawnSpy.mockReturnValue(child)
+
+    const promise = launchHermesCommand([])
+
+    child.emit('exit', 0)
+
+    await promise
+
+    expect(spawnSpy.mock.calls[0]?.[0]).toBe('hermes')
+  })
+
+  it('resolves with exit code 0 on clean exit', async () => {
+    const child = new FakeChild()
+
+    spawnSpy.mockReturnValue(child)
+
+    const promise = launchHermesCommand([])
+
+    child.emit('exit', 0)
+
+    await expect(promise).resolves.toEqual({ code: 0 })
+  })
+
+  it('resolves with non-zero exit code', async () => {
+    const child = new FakeChild()
+
+    spawnSpy.mockReturnValue(child)
+
+    const promise = launchHermesCommand([])
+
+    child.emit('exit', 2)
+
+    await expect(promise).resolves.toEqual({ code: 2 })
+  })
+
+  it('resolves with {code: null, error} on spawn error event', async () => {
+    const child = new FakeChild()
+
+    spawnSpy.mockReturnValue(child)
+
+    const promise = launchHermesCommand([])
+
+    child.emit('error', new Error('ENOENT'))
+
+    await expect(promise).resolves.toEqual({ code: null, error: 'ENOENT' })
+  })
+
+  it('passes args through unchanged', async () => {
+    const child = new FakeChild()
+
+    spawnSpy.mockReturnValue(child)
+
+    const promise = launchHermesCommand(['setup', '--force', '--verbose'])
+
+    child.emit('exit', 0)
+
+    await promise
+
+    expect(spawnSpy.mock.calls[0]?.[1]).toEqual(['setup', '--force', '--verbose'])
+  })
+})


### PR DESCRIPTION
## What does this PR do?

test(tui): cover externalCli launchHermesCommand spawn shape

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- Standardizes the PR description to the same review format used in #29640.
- Preserves the original detailed description below so no context is lost.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

- Original body preserved below for full context.

<details>
<summary>Original body</summary>

## Summary

test(tui): cover externalCli launchHermesCommand spawn shape

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Summary
Add 8 vitest cases for the previously untested `launchHermesCommand` helper in `ui-tui/src/lib/externalCli.ts`.

## Coverage
- spawns default `hermes` binary with `stdio: 'inherit'`
- honors `HERMES_BIN` env override
- trims whitespace from `HERMES_BIN`
- falls back to default when `HERMES_BIN` is empty/whitespace-only
- resolves with `{ code: 0 }` on clean exit
- resolves with non-zero exit code
- resolves with `{ code: null, error }` on spawn error event
- passes args through unchanged

## Test plan
- [x] `npx vitest run src/__tests__/externalCli.test.ts` (8/8 passed)
- [x] `npx vitest run` (662/662 passed across 63 files)

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_