### PR TITLE
test(tui): cover memoryMonitor level transitions

### DIFF
--- a/ui-tui/src/__tests__/memoryMonitor.test.ts
+++ b/ui-tui/src/__tests__/memoryMonitor.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const performHeapDumpSpy = vi.fn(async () => ({ success: true }))
+const evictInkCachesSpy = vi.fn()
+
+vi.mock('../lib/memory.js', () => ({
+  performHeapDump: (...args: unknown[]) => performHeapDumpSpy(...args)
+}))
+
+vi.mock('@hermes/ink', () => ({
+  evictInkCaches: (...args: unknown[]) => evictInkCachesSpy(...args)
+}))
+
+const { startMemoryMonitor } = await import('../lib/memoryMonitor.js')
+
+const GB = 1024 ** 3
+
+const flush = async () => {
+  for (let i = 0; i < 5; i++) {
+    await Promise.resolve()
+  }
+}
+
+describe('startMemoryMonitor level transitions', () => {
+  let memUsage: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    performHeapDumpSpy.mockClear()
+    evictInkCachesSpy.mockClear()
+    memUsage = vi.spyOn(process, 'memoryUsage') as never
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    memUsage.mockRestore()
+  })
+
+  const setHeap = (heapUsed: number) => {
+    ;(memUsage as unknown as { mockReturnValue: (v: unknown) => void }).mockReturnValue({
+      arrayBuffers: 0,
+      external: 0,
+      heapTotal: heapUsed,
+      heapUsed,
+      rss: heapUsed
+    })
+  }
+
+  it('does not fire callbacks while heap stays in normal range', async () => {
+    setHeap(0.5 * GB)
+    const onHigh = vi.fn()
+    const onCritical = vi.fn()
+
+    const stop = startMemoryMonitor({ intervalMs: 100, onCritical, onHigh })
+
+    await vi.advanceTimersByTimeAsync(100)
+    await flush()
+
+    expect(onHigh).not.toHaveBeenCalled()
+    expect(onCritical).not.toHaveBeenCalled()
+    expect(performHeapDumpSpy).not.toHaveBeenCalled()
+    stop()
+  })
+
+  it('fires onHigh once when heap crosses high threshold', async () => {
+    setHeap(1.6 * GB)
+    const onHigh = vi.fn()
+
+    const stop = startMemoryMonitor({ intervalMs: 100, onHigh })
+
+    await vi.advanceTimersByTimeAsync(100)
+    await flush()
+    await vi.advanceTimersByTimeAsync(100)
+    await flush()
+
+    expect(onHigh).toHaveBeenCalledTimes(1)
+    expect(performHeapDumpSpy).toHaveBeenCalledWith('auto-high')
+    stop()
+  })
+
+  it('fires onCritical with auto-critical trigger when heap crosses critical threshold', async () => {
+    setHeap(3 * GB)
+    const onCritical = vi.fn()
+
+    const stop = startMemoryMonitor({ intervalMs: 100, onCritical })
+
+    await vi.advanceTimersByTimeAsync(100)
+    await flush()
+
+    expect(onCritical).toHaveBeenCalledTimes(1)
+    expect(performHeapDumpSpy).toHaveBeenCalledWith('auto-critical')
+    stop()
+  })
+
+  it('passes "all" to evictInkCaches on critical', async () => {
+    setHeap(3 * GB)
+
+    const stop = startMemoryMonitor({ intervalMs: 100, onCritical: vi.fn() })
+
+    await vi.advanceTimersByTimeAsync(100)
+    await flush()
+
+    expect(evictInkCachesSpy).toHaveBeenCalledWith('all')
+    stop()
+  })
+
+  it('snapshot passed to callback carries level + heapUsed + rss', async () => {
+    setHeap(2 * GB)
+    const onHigh = vi.fn()
+
+    const stop = startMemoryMonitor({ intervalMs: 100, onHigh })
+
+    await vi.advanceTimersByTimeAsync(100)
+    await flush()
+
+    const [snap] = onHigh.mock.calls[0] ?? []
+
+    expect(snap).toMatchObject({ heapUsed: 2 * GB, level: 'high', rss: 2 * GB })
+    stop()
+  })
+
+  it('clears dedup state when level returns to normal then refires on next high', async () => {
+    setHeap(1.6 * GB)
+    const onHigh = vi.fn()
+
+    const stop = startMemoryMonitor({ intervalMs: 100, onHigh })
+
+    await vi.advanceTimersByTimeAsync(100)
+    await flush()
+    expect(onHigh).toHaveBeenCalledTimes(1)
+
+    setHeap(0.5 * GB)
+    await vi.advanceTimersByTimeAsync(100)
+    await flush()
+
+    setHeap(1.6 * GB)
+    await vi.advanceTimersByTimeAsync(100)
+    await flush()
+
+    expect(onHigh).toHaveBeenCalledTimes(2)
+    stop()
+  })
+
+  it('respects custom thresholds', async () => {
+    setHeap(50)
+    const onHigh = vi.fn()
+
+    const stop = startMemoryMonitor({ highBytes: 10, criticalBytes: 100, intervalMs: 100, onHigh })
+
+    await vi.advanceTimersByTimeAsync(100)
+    await flush()
+
+    expect(onHigh).toHaveBeenCalledTimes(1)
+    stop()
+  })
+
+  it('returns a stop function that cancels the interval', async () => {
+    setHeap(3 * GB)
+    const onCritical = vi.fn()
+
+    const stop = startMemoryMonitor({ intervalMs: 100, onCritical })
+
+    stop()
+
+    await vi.advanceTimersByTimeAsync(500)
+    await flush()
+
+    expect(onCritical).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## What does this PR do?

test(tui): cover memoryMonitor level transitions

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- Standardizes the PR description to the same review format used in #29640.
- Preserves the original detailed description below so no context is lost.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

- Original body preserved below for full context.

<details>
<summary>Original body</summary>

## Summary

test(tui): cover memoryMonitor level transitions

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Summary
Add 8 vitest cases for the previously untested `startMemoryMonitor` in `ui-tui/src/lib/memoryMonitor.ts`.

## Coverage
- no callbacks fire while heap stays in normal range
- `onHigh` fires exactly once when heap crosses high threshold (dedup)
- `onCritical` fires with `auto-critical` heap dump trigger
- `evictInkCaches` receives `'all'` on critical level
- snapshot passed to callbacks carries `{ level, heapUsed, rss }`
- dedup state clears when level returns to normal, refires on next high
- custom `highBytes`/`criticalBytes` thresholds respected
- returned stop function cancels the interval

## Test plan
- [x] `npx vitest run src/__tests__/memoryMonitor.test.ts` (8/8 passed)
- [x] `npx vitest run` (662/662 across 63 files)

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_