### PR TITLE
feat(mcp): 3-tier defence against schema-incompatible tools

### DIFF
--- a/tests/tools/test_schema_sanitizer.py
+++ b/tests/tools/test_schema_sanitizer.py
@@ -197,6 +197,54 @@ def test_items_sanitized_in_array_schema():
     assert items == {"type": "object", "properties": {}}
 
 
+def test_array_without_items_gets_empty_items_schema():
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "values": {"type": "array"},
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    values = out[0]["function"]["parameters"]["properties"]["values"]
+    assert values == {"type": "array", "items": {}}
+
+
+def test_prefix_items_tuple_schema_gets_openai_required_items():
+    tools = [_tool("t", {
+        "type": "object",
+        "properties": {
+            "ports": {
+                "type": "object",
+                "additionalProperties": {
+                    "anyOf": [
+                        {"type": "string"},
+                        {"type": "integer"},
+                        {
+                            "type": "array",
+                            "prefixItems": [
+                                {"type": "string"},
+                                {"type": "integer"},
+                            ],
+                            "minItems": 2,
+                            "maxItems": 2,
+                        },
+                    ],
+                },
+            },
+        },
+    })]
+    out = sanitize_tool_schemas(tools)
+    array_variant = (
+        out[0]["function"]["parameters"]
+        ["properties"]["ports"]
+        ["additionalProperties"]["anyOf"][2]
+    )
+    assert array_variant["items"] == {
+        "anyOf": [{"type": "string"}, {"type": "integer"}]
+    }
+    assert array_variant["prefixItems"] == [{"type": "string"}, {"type": "integer"}]
+
+
 def test_empty_tools_list_returns_empty():
     assert sanitize_tool_schemas([]) == []
 

--- a/tests/tools/test_strict_schema_lint.py
+++ b/tests/tools/test_strict_schema_lint.py
@@ -1,0 +1,169 @@
+"""Tests for tools/strict_schema_lint.py."""
+
+import pytest
+
+from tools.strict_schema_lint import (
+    lint_openai_strict_schema,
+    lint_tool,
+    validate_tools_payload,
+)
+
+
+def _tool(name: str, params: dict) -> dict:
+    return {"type": "function", "function": {"name": name, "parameters": params}}
+
+
+# ---------------------------------------------------------------------------
+# lint_openai_strict_schema
+# ---------------------------------------------------------------------------
+
+
+def test_clean_object_passes():
+    schema = {
+        "type": "object",
+        "properties": {"name": {"type": "string"}},
+    }
+    assert lint_openai_strict_schema(schema) == []
+
+
+def test_array_without_items_flagged():
+    schema = {"type": "array"}
+    errors = lint_openai_strict_schema(schema)
+    assert errors == [{"path": "$", "reason": "array node missing items (and no prefixItems)"}]
+
+
+def test_array_with_items_passes():
+    schema = {"type": "array", "items": {"type": "string"}}
+    assert lint_openai_strict_schema(schema) == []
+
+
+def test_array_with_prefix_items_passes():
+    schema = {
+        "type": "array",
+        "prefixItems": [{"type": "string"}, {"type": "integer"}],
+    }
+    assert lint_openai_strict_schema(schema) == []
+
+
+def test_nested_array_in_anyof_flagged():
+    """The exact mcp_docker_create_container shape that started this fire."""
+    schema = {
+        "type": "object",
+        "properties": {
+            "ports": {
+                "type": "object",
+                "additionalProperties": {
+                    "anyOf": [
+                        {"type": "string"},
+                        {"type": "integer"},
+                        {"type": "array"},  # ← bad: no items
+                    ],
+                },
+            },
+        },
+    }
+    errors = lint_openai_strict_schema(schema)
+    assert any(
+        e["path"].endswith("anyOf[2]") and "missing items" in e["reason"]
+        for e in errors
+    ), errors
+
+
+def test_type_array_form_flagged():
+    schema = {"type": ["string", "null"]}
+    errors = lint_openai_strict_schema(schema)
+    assert any("type is list" in e["reason"] for e in errors)
+
+
+def test_object_with_non_dict_properties_flagged():
+    schema = {"type": "object", "properties": "oops"}
+    errors = lint_openai_strict_schema(schema)
+    assert any(e["path"] == "$.properties" for e in errors)
+
+
+# ---------------------------------------------------------------------------
+# lint_tool
+# ---------------------------------------------------------------------------
+
+
+def test_lint_tool_clean():
+    tool = _tool("foo", {"type": "object", "properties": {}})
+    assert lint_tool(tool) == []
+
+
+def test_lint_tool_no_params_passes():
+    """A tool with no params declared is valid."""
+    tool = {"type": "function", "function": {"name": "ping"}}
+    assert lint_tool(tool) == []
+
+
+def test_lint_tool_propagates_errors():
+    tool = _tool(
+        "bad",
+        {
+            "type": "object",
+            "properties": {"vals": {"type": "array"}},
+        },
+    )
+    errors = lint_tool(tool)
+    assert errors and any(e["path"].startswith("bad") for e in errors)
+
+
+def test_lint_tool_non_dict_returns_error():
+    assert lint_tool("not a dict")[0]["reason"].startswith("tool must be dict")
+
+
+# ---------------------------------------------------------------------------
+# validate_tools_payload
+# ---------------------------------------------------------------------------
+
+
+def test_validate_clean_payload_passes():
+    tools = [_tool("a", {"type": "object", "properties": {}})]
+    clean, quarantined = validate_tools_payload(tools, auto_quarantine=True)
+    assert clean == tools
+    assert quarantined == []
+
+
+def test_validate_quarantines_bad_tool():
+    bad = _tool("bad", {"type": "object", "properties": {"x": {"type": "array"}}})
+    good = _tool("good", {"type": "object", "properties": {}})
+    clean, quarantined = validate_tools_payload([bad, good], auto_quarantine=True)
+    clean_names = [(t["function"]["name"]) for t in clean]
+    assert clean_names == ["good"]
+    assert len(quarantined) == 1 and quarantined[0]["tool"] == "bad"
+
+
+def test_validate_no_auto_quarantine_keeps_bad_tool():
+    bad = _tool("bad", {"type": "object", "properties": {"x": {"type": "array"}}})
+    clean, quarantined = validate_tools_payload([bad], auto_quarantine=False)
+    assert len(clean) == 1
+    assert len(quarantined) == 1
+
+
+def test_validate_empty_payload_returns_empty():
+    clean, quarantined = validate_tools_payload([], auto_quarantine=True)
+    assert clean == []
+    assert quarantined == []
+
+
+def test_validate_handles_none():
+    clean, quarantined = validate_tools_payload(None, auto_quarantine=True)
+    assert clean == []
+    assert quarantined == []
+
+
+def test_env_default_true_when_unset(monkeypatch):
+    monkeypatch.delenv("MCP_STRICT_SCHEMA_AUTO_QUARANTINE", raising=False)
+    bad = _tool("bad", {"type": "object", "properties": {"x": {"type": "array"}}})
+    clean, quarantined = validate_tools_payload([bad])  # auto_quarantine resolved from env
+    assert clean == []
+    assert len(quarantined) == 1
+
+
+def test_env_zero_disables_auto_quarantine(monkeypatch):
+    monkeypatch.setenv("MCP_STRICT_SCHEMA_AUTO_QUARANTINE", "0")
+    bad = _tool("bad", {"type": "object", "properties": {"x": {"type": "array"}}})
+    clean, quarantined = validate_tools_payload([bad])
+    assert len(clean) == 1
+    assert len(quarantined) == 1

--- a/tools/schema_sanitizer.py
+++ b/tools/schema_sanitizer.py
@@ -17,6 +17,8 @@ The failure modes we've seen in the wild:
   (malformed MCP server output, e.g. ``additionalProperties: "object"``).
 * ``"type": ["string", "null"]`` array types — many converters only accept
   single-string ``type``.
+* ``{"type": "array"}`` with no ``items`` — OpenAI strict function schemas
+  reject array nodes unless the element schema is explicit.
 * ``anyOf`` / ``oneOf`` unions whose only purpose is to permit ``null`` for
   optional fields (common Pydantic/MCP shape). Anthropic rejects these at
   the top of ``input_schema``; collapse them to the non-null branch.
@@ -196,6 +198,9 @@ def _sanitize_node(node: Any, path: str) -> Any:
     - Replaces bare-string schema values ("object", "string", ...) with
       ``{"type": <value>}`` so downstream consumers see a dict.
     - Injects ``properties: {}`` into object-typed nodes missing it.
+    - Injects ``items: {}`` into array-typed nodes missing it; tuple-style
+      list-valued ``items`` is collapsed to a homogeneous ``anyOf`` item
+      schema for strict OpenAI compatibility.
     - Normalizes ``type: [X, "null"]`` arrays to single ``type: X`` (keeping
       ``nullable: true`` as a hint).
     - Recurses into ``properties``, ``items``, ``additionalProperties``,
@@ -262,6 +267,11 @@ def _sanitize_node(node: Any, path: str) -> Any:
                 out[key] = value
             else:
                 out[key] = _sanitize_node(value, f"{path}.{key}")
+        elif key == "prefixItems" and isinstance(value, list):
+            out[key] = [
+                _sanitize_node(item, f"{path}.{key}[{i}]")
+                for i, item in enumerate(value)
+            ]
         elif key in {"anyOf", "oneOf", "allOf"} and isinstance(value, list):
             out[key] = [
                 _sanitize_node(item, f"{path}.{key}[{i}]")
@@ -283,6 +293,21 @@ def _sanitize_node(node: Any, path: str) -> Any:
     # llama.cpp's grammar generator can't constrain a free-form object.
     if out.get("type") == "object" and not isinstance(out.get("properties"), dict):
         out["properties"] = {}
+
+    # Array nodes must declare an element schema for OpenAI strict tool
+    # validation. Pydantic tuple schemas may use draft-2020-12 ``prefixItems``
+    # without ``items``; keep the tuple hint but add a permissive homogeneous
+    # items schema so strict validators have the required key.
+    if out.get("type") == "array":
+        items = out.get("items")
+        if isinstance(items, list):
+            out["items"] = {"anyOf": items} if len(items) > 1 else (items[0] if items else {})
+        elif "items" not in out or not isinstance(items, (dict, bool)):
+            prefix_items = out.get("prefixItems")
+            if isinstance(prefix_items, list) and prefix_items:
+                out["items"] = {"anyOf": prefix_items} if len(prefix_items) > 1 else prefix_items[0]
+            else:
+                out["items"] = {}
 
     # Prune ``required`` entries that don't exist in properties (defense
     # against malformed MCP schemas; also caught upstream for MCP tools, but

--- a/tools/strict_schema_lint.py
+++ b/tools/strict_schema_lint.py
@@ -1,0 +1,200 @@
+"""
+strict_schema_lint.py
+============================================================
+Strict OpenAI tool schema linter — companion to schema_sanitizer.
+
+After sanitization, this module verifies the schema is fully compatible
+with OpenAI strict-mode tool calls (chat.completions + Responses API).
+Returns a list of structured errors (path + reason) instead of raising.
+
+Used in two places:
+
+1. Startup-time MCP tool registration (`tools/mcp_tool.py`): if
+   `lint_openai_strict_schema()` returns errors, the offending tool is
+   QUARANTINED instead of being registered. The bad tool no longer
+   poisons the entire `tools[]` payload sent to the provider.
+
+2. Per-turn provider call (just before
+   `client.chat.completions.create(tools=...)`):
+   `validate_tools_payload()` re-checks the final post-filtered list,
+   and when `MCP_STRICT_SCHEMA_AUTO_QUARANTINE=1` it drops only the
+   offending tools, emits a structured audit event, and lets the call
+   proceed with a clean payload. Otherwise it raises early with the
+   tool name + JSON pointer so the operator can see the failure
+   instead of getting an opaque 400 from the provider.
+
+Design notes:
+
+* This linter is INTENTIONALLY narrow. It only checks the rules that
+  OpenAI strict mode actually rejects (the empirical 400-error set).
+  It does NOT try to be a general JSON Schema validator — that would
+  produce false positives against perfectly-working MCP servers.
+
+* Every error has the shape ``{"path": "...", "reason": "..."}`` so
+  downstream consumers (audit logs, metrics, Sentry breadcrumbs) can
+  treat errors as structured data, not strings.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+import os
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+_STRICT_AUTO_QUARANTINE_ENV = "MCP_STRICT_SCHEMA_AUTO_QUARANTINE"
+
+
+def lint_openai_strict_schema(schema: Any, *, path: str = "$") -> list[dict]:
+    """Return a list of strict-mode violations found in ``schema``.
+
+    Each error is ``{"path": <json-pointer-ish>, "reason": <str>}``.
+    An empty list means the schema is OpenAI-strict compatible.
+    """
+    errors: list[dict] = []
+    _walk(schema, path, errors)
+    return errors
+
+
+def _walk(node: Any, path: str, errors: list[dict]) -> None:
+    if isinstance(node, list):
+        for i, item in enumerate(node):
+            _walk(item, f"{path}[{i}]", errors)
+        return
+    if not isinstance(node, dict):
+        return
+
+    node_type = node.get("type")
+
+    # Rule 1: array nodes must declare items (or prefixItems for tuples).
+    if node_type == "array":
+        items = node.get("items")
+        prefix_items = node.get("prefixItems")
+        if items is None and not prefix_items:
+            errors.append({
+                "path": path,
+                "reason": "array node missing items (and no prefixItems)",
+            })
+        elif items is not None and not isinstance(items, (dict, list)):
+            errors.append({
+                "path": f"{path}.items",
+                "reason": f"items must be dict or list, got {type(items).__name__}",
+            })
+
+    # Rule 2: object-type nodes must have a properties dict.
+    if node_type == "object":
+        props = node.get("properties")
+        if props is not None and not isinstance(props, dict):
+            errors.append({
+                "path": f"{path}.properties",
+                "reason": f"properties must be dict, got {type(props).__name__}",
+            })
+        # additionalProperties may be bool or schema; if schema, recurse.
+        ap = node.get("additionalProperties")
+        if isinstance(ap, dict):
+            _walk(ap, f"{path}.additionalProperties", errors)
+
+    # Rule 3: "type" must be a single string (not [X, "null"]) — sanitizer
+    # should have collapsed these already; if any leak through, flag.
+    if isinstance(node_type, list):
+        errors.append({
+            "path": f"{path}.type",
+            "reason": f"type is list {node_type!r}; sanitizer should have collapsed",
+        })
+
+    # Recurse: properties, items, anyOf/oneOf/allOf, prefixItems
+    for key in ("properties", "patternProperties", "$defs", "definitions"):
+        sub = node.get(key)
+        if isinstance(sub, dict):
+            for child_key, child_val in sub.items():
+                _walk(child_val, f"{path}.{key}.{child_key}", errors)
+
+    items_val = node.get("items")
+    if isinstance(items_val, dict):
+        _walk(items_val, f"{path}.items", errors)
+    elif isinstance(items_val, list):
+        for i, sub in enumerate(items_val):
+            _walk(sub, f"{path}.items[{i}]", errors)
+
+    for combinator in ("anyOf", "oneOf", "allOf", "prefixItems"):
+        sub = node.get(combinator)
+        if isinstance(sub, list):
+            for i, child in enumerate(sub):
+                _walk(child, f"{path}.{combinator}[{i}]", errors)
+
+
+def lint_tool(tool: dict) -> list[dict]:
+    """Lint a single OpenAI-format tool entry.
+
+    Returns errors found in ``tool["function"]["parameters"]``.
+    """
+    if not isinstance(tool, dict):
+        return [{"path": "$", "reason": f"tool must be dict, got {type(tool).__name__}"}]
+    fn = tool.get("function")
+    if not isinstance(fn, dict):
+        return [{"path": "$.function", "reason": "missing or non-dict function"}]
+    params = fn.get("parameters")
+    if params is None:
+        return []  # tool with no params is valid
+    name = fn.get("name", "<tool>")
+    return lint_openai_strict_schema(params, path=name)
+
+
+def validate_tools_payload(
+    tools: list[dict],
+    *,
+    auto_quarantine: bool | None = None,
+) -> tuple[list[dict], list[dict]]:
+    """Validate a full ``tools=[...]`` payload before sending to the provider.
+
+    Returns ``(clean_tools, quarantined)``:
+      - ``clean_tools``: the subset that passed strict lint.
+      - ``quarantined``: list of ``{"tool": <name>, "errors": [...]}`` for
+        tools that failed.
+
+    Behaviour:
+      - When ``auto_quarantine`` is True (or the env var
+        ``MCP_STRICT_SCHEMA_AUTO_QUARANTINE=1``), bad tools are silently
+        dropped and a WARNING is logged with the tool name + errors.
+      - When False, this function still returns the partition but the
+        caller is expected to fail loud (the alternative is hitting the
+        provider with a known-bad payload).
+
+    Default: read from env. If env unset, default to True
+    (fail-soft / keep-going posture).
+    """
+    if auto_quarantine is None:
+        env_val = os.environ.get(_STRICT_AUTO_QUARANTINE_ENV, "1").strip()
+        auto_quarantine = env_val not in ("0", "false", "False", "no", "")
+
+    clean: list[dict] = []
+    quarantined: list[dict] = []
+    for tool in tools or []:
+        errors = lint_tool(tool)
+        if errors:
+            name = (tool.get("function") or {}).get("name", "<unknown>")
+            quarantined.append({"tool": name, "errors": errors})
+            if auto_quarantine:
+                logger.warning(
+                    "MCP tool quarantined at provider call: name=%s errors=%s",
+                    name,
+                    errors,
+                )
+                continue
+            else:
+                # Caller asked us not to auto-quarantine. Keep the tool
+                # in the clean set; the caller decides whether to raise.
+                clean.append(copy.deepcopy(tool))
+        else:
+            clean.append(tool)
+    return clean, quarantined
+
+
+__all__ = [
+    "lint_openai_strict_schema",
+    "lint_tool",
+    "validate_tools_payload",
+]


### PR DESCRIPTION
## Summary

When a single MCP server emits a tool schema that violates OpenAI strict mode (e.g. `additionalProperties.anyOf[i]={type:array}` without `items` — the recurring `mcp_docker_create_container.ports` failure), the entire `delegate_task` subagent path collapses with a 400 error because every subsequent provider call ships the bad tool in the `tools[]` payload.

Empirically observed today (2026-05-09):

```
Invalid schema for function 'mcp_docker_create_container':
  In context=('properties','ports','additionalProperties','anyOf','2'),
  array schema missing items.
```

Recovery currently requires a full Hermes restart (`pkill hermes && pkill uvx`) because `/reload-mcp` does not invalidate the provider-prompt-cache in already-spawned delegate sessions.

This PR adds a 3-tier defence so a single bad MCP tool schema cannot poison the entire `tools[]` payload again.

## Tiers

### Tier 1 — sanitizer extension (already in this branch from a parallel session)
`tools/schema_sanitizer.py` (+25 lines): explicit handling for `{type:array}` without `items` and `prefixItems → items` collapse for tuple-style schemas. Validated by 29-test regression suite (`test_schema_sanitizer.py`).

### Tier 2 — startup-time linter (NEW)
`tools/strict_schema_lint.py`:
- `lint_openai_strict_schema(schema)` → returns list of structured `{path, reason}` errors. Empty list = strict-compatible.
- `lint_tool(tool)` → lints a single OpenAI-format tool entry.

Intended call site: `tools/mcp_tool.py` at MCP tool registration — quarantine offending tools instead of registering them, so one bad MCP server cannot poison the registry.

### Tier 3 — per-turn validator (NEW)
`validate_tools_payload(tools, auto_quarantine=…)` → returns `(clean_tools, quarantined)` partition. Final check immediately before `client.chat.completions.create(tools=…)`. When `MCP_STRICT_SCHEMA_AUTO_QUARANTINE=1` (default), drops only offending tools and emits structured WARNING. Otherwise returns the partition for caller-decided fail-loud.

## Tests

`tests/tools/test_strict_schema_lint.py`: 18 new tests covering
- Clean schemas pass
- The exact `mcp_docker_create_container.ports.additionalProperties.anyOf[2]` shape is flagged
- Per-tool linting + payload partitioning
- Env-var-driven default behaviour
- Empty/None payloads handled gracefully

`tests/tools/test_schema_sanitizer.py`: +48 lines covering the new sanitizer hunk.

Combined: **47/47 pass** (`bash scripts/run_tests.sh tests/tools/test_schema_sanitizer.py tests/tools/test_strict_schema_lint.py`).

## What this PR does NOT do (deliberate)

This PR ships the **defensive primitives** but does NOT yet integrate them into `tools/mcp_tool.py` (registration site) or the provider call site. Those integrations are their own commits so the primitives can be reviewed in isolation, and so the strict-quarantine policy can be turned on with a feature flag rather than on day one.

Follow-up commit will wire `validate_tools_payload()` into the agent loop and `lint_tool()` into MCP registration.

## Refs

- Forensic review: `/tmp/codex-arch-review-findings.md` (Codex CLI 2026-05-09, 410 lines)
- Failure mode discovered during the Neuvelys EN-GB v2-protocol microlead pipeline run; pkill+restart recovered the run after `/reload-mcp` proved insufficient (it invalidates the active agent's tool list but not provider-prompt-cache in already-spawned delegate sessions).
