### PR TITLE
test(tui): cover fpsStore trackFrame state

### DIFF
--- a/ui-tui/src/__tests__/fpsStore.test.ts
+++ b/ui-tui/src/__tests__/fpsStore.test.ts
@@ -1,0 +1,104 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../config/env.js', () => ({ SHOW_FPS: true }))
+
+describe('fpsStore trackFrame', () => {
+  let nowSpy: ReturnType<typeof vi.spyOn>
+  let now = 0
+
+  beforeEach(async () => {
+    vi.resetModules()
+    now = 1_000
+    nowSpy = vi.spyOn(performance, 'now').mockImplementation(() => now)
+  })
+
+  afterEach(() => {
+    nowSpy.mockRestore()
+  })
+
+  it('is defined when SHOW_FPS env is enabled', async () => {
+    const mod = await import('../lib/fpsStore.js')
+
+    expect(mod.trackFrame).toBeTypeOf('function')
+  })
+
+  it('does not update fps state on a single frame (needs >=2 samples)', async () => {
+    const { $fpsState, trackFrame } = await import('../lib/fpsStore.js')
+    const before = $fpsState.get()
+
+    trackFrame!(5)
+
+    expect($fpsState.get()).toEqual(before)
+  })
+
+  it('computes fps after two frames', async () => {
+    const { $fpsState, trackFrame } = await import('../lib/fpsStore.js')
+
+    trackFrame!(10)
+    now += 1000
+    trackFrame!(10)
+
+    const state = $fpsState.get()
+
+    expect(state.fps).toBe(1)
+    expect(state.totalFrames).toBe(2)
+  })
+
+  it('rounds lastDurationMs to two decimal places', async () => {
+    const { $fpsState, trackFrame } = await import('../lib/fpsStore.js')
+
+    trackFrame!(0)
+    now += 1000
+    trackFrame!(7.12345)
+
+    expect($fpsState.get().lastDurationMs).toBe(7.12)
+  })
+
+  it('rounds fps to one decimal place', async () => {
+    const { $fpsState, trackFrame } = await import('../lib/fpsStore.js')
+
+    trackFrame!(0)
+    now += 333
+    trackFrame!(0)
+
+    expect($fpsState.get().fps).toBe(3)
+  })
+
+  it('caps the sliding window at 30 timestamps', async () => {
+    const { $fpsState, trackFrame } = await import('../lib/fpsStore.js')
+
+    for (let i = 0; i < 60; i++) {
+      trackFrame!(0)
+      now += 100
+    }
+
+    const state = $fpsState.get()
+
+    expect(state.totalFrames).toBe(60)
+    expect(state.fps).toBe(10)
+  })
+
+  it('totalFrames keeps incrementing past the window cap', async () => {
+    const { $fpsState, trackFrame } = await import('../lib/fpsStore.js')
+
+    for (let i = 0; i < 100; i++) {
+      trackFrame!(0)
+      now += 10
+    }
+
+    expect($fpsState.get().totalFrames).toBe(100)
+  })
+})
+
+describe('fpsStore trackFrame disabled', () => {
+  it('is undefined when SHOW_FPS is false', async () => {
+    vi.resetModules()
+    vi.doMock('../config/env.js', () => ({ SHOW_FPS: false }))
+
+    const mod = await import('../lib/fpsStore.js')
+
+    expect(mod.trackFrame).toBeUndefined()
+
+    vi.doUnmock('../config/env.js')
+  })
+})


### PR DESCRIPTION
## What does this PR do?

test(tui): cover fpsStore trackFrame state

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- Standardizes the PR description to the same review format used in #29640.
- Preserves the original detailed description below so no context is lost.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

- Original body preserved below for full context.

<details>
<summary>Original body</summary>

## Summary

test(tui): cover fpsStore trackFrame state

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Summary
Add 8 vitest cases for the previously untested `trackFrame` / `\$fpsState` in `ui-tui/src/lib/fpsStore.ts`.

## Coverage
- `trackFrame` is a function when `SHOW_FPS=true`
- single frame does not update fps state (needs >=2 samples)
- two frames compute fps
- `lastDurationMs` rounded to two decimal places
- `fps` rounded to one decimal place
- 30-frame sliding window cap
- `totalFrames` keeps incrementing past the cap
- `trackFrame` is undefined when `SHOW_FPS=false`

## Test plan
- [x] `npx vitest run src/__tests__/fpsStore.test.ts` (8/8 passed)
- [x] `npx vitest run` (662/662 across 63 files)

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_