### PR TITLE
fix(mcp): drop broken approval tools from MCP surface

### DIFF
--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -5,12 +5,16 @@ Starts a stdio MCP server that lets any MCP client (Claude Code, Cursor, Codex,
 etc.) list conversations, read message history, send messages, poll for live
 events, and manage approval requests across all connected platforms.
 
-Matches OpenClaw's 9-tool MCP channel bridge surface:
+Matches OpenClaw's messaging MCP bridge surface for conversation and event
+access:
   conversations_list, conversation_get, messages_read, attachments_fetch,
-  events_poll, events_wait, messages_send, permissions_list_open,
-  permissions_respond
+  events_poll, events_wait, messages_send
 
 Plus: channels_list (Hermes-specific extra)
+
+Approval-response tools are intentionally not exposed here yet. Hermes'
+gateway approval state is process-local today, and this MCP bridge does not
+have a truthful IPC path for listing or resolving those approvals.
 
 Usage:
     hermes mcp serve
@@ -817,44 +821,6 @@ def create_mcp_server(event_bridge: Optional[EventBridge] = None) -> "FastMCP":
                         })
 
         return json.dumps({"count": len(channels), "channels": channels}, indent=2)
-
-    # -- permissions_list_open ---------------------------------------------
-
-    @mcp.tool()
-    def permissions_list_open() -> str:
-        """List pending approval requests observed during this bridge session.
-
-        Returns exec and plugin approval requests that the bridge has seen
-        since it started. Approvals are live-session only — older approvals
-        from before the bridge connected are not included.
-        """
-        approvals = bridge.list_pending_approvals()
-        return json.dumps({
-            "count": len(approvals),
-            "approvals": approvals,
-        }, indent=2)
-
-    # -- permissions_respond -----------------------------------------------
-
-    @mcp.tool()
-    def permissions_respond(
-        id: str,
-        decision: str,
-    ) -> str:
-        """Respond to a pending approval request.
-
-        Args:
-            id: The approval ID from permissions_list_open
-            decision: One of "allow-once", "allow-always", or "deny"
-        """
-        if decision not in ("allow-once", "allow-always", "deny"):
-            return json.dumps({
-                "error": f"Invalid decision: {decision}. "
-                         f"Must be allow-once, allow-always, or deny"
-            })
-
-        result = bridge.respond_to_approval(id, decision)
-        return json.dumps(result, indent=2)
 
     return mcp
 

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -869,59 +869,8 @@ class TestE2EChannelsList:
         assert result["channels"][0]["target"] == "discord:789"
 
 
-class TestE2EPermissions:
-    def test_list_empty(self, mcp_server_e2e, _event_loop):
-        server, _ = mcp_server_e2e
-        result = _run_tool(server, "permissions_list_open")
-        assert result["count"] == 0
-        assert result["approvals"] == []
-
-    def test_list_with_approvals(self, mcp_server_e2e, _event_loop):
-        server, bridge = mcp_server_e2e
-        bridge._pending_approvals["a1"] = {
-            "id": "a1", "kind": "exec",
-            "description": "sudo rm -rf /",
-            "session_key": "test",
-            "created_at": "2026-03-29T12:00:00",
-        }
-        result = _run_tool(server, "permissions_list_open")
-        assert result["count"] == 1
-        assert result["approvals"][0]["id"] == "a1"
-
-    def test_respond_allow(self, mcp_server_e2e, _event_loop):
-        server, bridge = mcp_server_e2e
-        bridge._pending_approvals["a1"] = {"id": "a1", "kind": "exec"}
-        result = _run_tool(server, "permissions_respond",
-                          {"id": "a1", "decision": "allow-once"})
-        assert result["resolved"] is True
-        assert result["decision"] == "allow-once"
-        # Should be gone now
-        check = _run_tool(server, "permissions_list_open")
-        assert check["count"] == 0
-
-    def test_respond_deny(self, mcp_server_e2e, _event_loop):
-        server, bridge = mcp_server_e2e
-        bridge._pending_approvals["a2"] = {"id": "a2", "kind": "plugin"}
-        result = _run_tool(server, "permissions_respond",
-                          {"id": "a2", "decision": "deny"})
-        assert result["resolved"] is True
-
-    def test_respond_invalid_decision(self, mcp_server_e2e, _event_loop):
-        server, bridge = mcp_server_e2e
-        bridge._pending_approvals["a3"] = {"id": "a3", "kind": "exec"}
-        result = _run_tool(server, "permissions_respond",
-                          {"id": "a3", "decision": "maybe"})
-        assert "error" in result
-
-    def test_respond_nonexistent(self, mcp_server_e2e, _event_loop):
-        server, _ = mcp_server_e2e
-        result = _run_tool(server, "permissions_respond",
-                          {"id": "nope", "decision": "deny"})
-        assert "error" in result
-
-
 # ---------------------------------------------------------------------------
-# 4. TOOL LISTING — verify all 10 tools are registered
+# 4. TOOL LISTING — verify the exposed MCP tools match the truthful surface
 # ---------------------------------------------------------------------------
 
 class TestToolRegistration:
@@ -934,7 +883,6 @@ class TestToolRegistration:
             "conversations_list", "conversation_get", "messages_read",
             "attachments_fetch", "events_poll", "events_wait",
             "messages_send", "channels_list",
-            "permissions_list_open", "permissions_respond",
         }
         assert expected == tool_names, f"Missing: {expected - tool_names}, Extra: {tool_names - expected}"
 


### PR DESCRIPTION
## Summary
- stop exposing `permissions_list_open` and `permissions_respond` from `hermes mcp serve`
- document that Hermes does not yet have truthful gateway approval IPC for the MCP bridge
- update MCP surface tests to assert the exposed tool list matches reality

Fixes #22001

## Testing
- `.venv/bin/pytest -q tests/test_mcp_serve.py`
- `uv run --frozen ruff check .`
- clean `env -i` repo collect-only smoke
