### PR TITLE
test(tui): cover gracefulExit signal handler ordering

### DIFF
--- a/ui-tui/src/__tests__/gracefulExit.test.ts
+++ b/ui-tui/src/__tests__/gracefulExit.test.ts
@@ -1,0 +1,153 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+type Handler = (...args: unknown[]) => void
+
+describe('setupGracefulExit', () => {
+  let handlers: Map<string, Handler[]>
+  let onSpy: ReturnType<typeof vi.spyOn>
+  let exitSpy: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.resetModules()
+    vi.useFakeTimers()
+    handlers = new Map()
+    onSpy = vi.spyOn(process, 'on').mockImplementation((event: string, h: Handler) => {
+      const list = handlers.get(event) ?? []
+
+      list.push(h)
+      handlers.set(event, list)
+
+      return process
+    }) as never
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((_code?: number) => undefined) as never) as never
+  })
+
+  afterEach(() => {
+    onSpy.mockRestore()
+    exitSpy.mockRestore()
+    vi.useRealTimers()
+  })
+
+  const fire = (event: string, ...args: unknown[]) => {
+    for (const h of handlers.get(event) ?? []) {
+      h(...args)
+    }
+  }
+
+  it('registers handlers for SIGINT, SIGTERM, SIGHUP, uncaughtException, unhandledRejection', async () => {
+    const { setupGracefulExit } = await import('../lib/gracefulExit.js')
+
+    setupGracefulExit()
+
+    expect(handlers.has('SIGINT')).toBe(true)
+    expect(handlers.has('SIGTERM')).toBe(true)
+    expect(handlers.has('SIGHUP')).toBe(true)
+    expect(handlers.has('uncaughtException')).toBe(true)
+    expect(handlers.has('unhandledRejection')).toBe(true)
+  })
+
+  it('SIGINT exits with code 130 and calls onSignal', async () => {
+    const { setupGracefulExit } = await import('../lib/gracefulExit.js')
+    const onSignal = vi.fn()
+
+    setupGracefulExit({ onSignal })
+    fire('SIGINT')
+
+    expect(onSignal).toHaveBeenCalledWith('SIGINT')
+
+    await vi.runAllTimersAsync()
+    expect(exitSpy).toHaveBeenCalledWith(130)
+  })
+
+  it('SIGTERM exits with code 143', async () => {
+    const { setupGracefulExit } = await import('../lib/gracefulExit.js')
+
+    setupGracefulExit()
+    fire('SIGTERM')
+    await vi.runAllTimersAsync()
+
+    expect(exitSpy).toHaveBeenCalledWith(143)
+  })
+
+  it('SIGHUP exits with code 129', async () => {
+    const { setupGracefulExit } = await import('../lib/gracefulExit.js')
+
+    setupGracefulExit()
+    fire('SIGHUP')
+    await vi.runAllTimersAsync()
+
+    expect(exitSpy).toHaveBeenCalledWith(129)
+  })
+
+  it('runs all cleanup functions before exit', async () => {
+    const { setupGracefulExit } = await import('../lib/gracefulExit.js')
+    const a = vi.fn(async () => {})
+    const b = vi.fn(() => {})
+
+    setupGracefulExit({ cleanups: [a, b] })
+    fire('SIGINT')
+    await vi.runAllTimersAsync()
+
+    expect(a).toHaveBeenCalledTimes(1)
+    expect(b).toHaveBeenCalledTimes(1)
+  })
+
+  it('still exits when a cleanup rejects', async () => {
+    const { setupGracefulExit } = await import('../lib/gracefulExit.js')
+    const failing = vi.fn(async () => {
+      throw new Error('boom')
+    })
+
+    setupGracefulExit({ cleanups: [failing] })
+    fire('SIGINT')
+    await vi.runAllTimersAsync()
+
+    expect(failing).toHaveBeenCalled()
+    expect(exitSpy).toHaveBeenCalledWith(130)
+  })
+
+  it('failsafe timer fires process.exit after failsafeMs', async () => {
+    const { setupGracefulExit } = await import('../lib/gracefulExit.js')
+
+    setupGracefulExit({ cleanups: [], failsafeMs: 1000 })
+    fire('SIGTERM')
+
+    vi.advanceTimersByTime(1000)
+    expect(exitSpy).toHaveBeenCalledWith(143)
+  })
+
+  it('second signal during shutdown is a no-op', async () => {
+    const { setupGracefulExit } = await import('../lib/gracefulExit.js')
+    const onSignal = vi.fn()
+
+    setupGracefulExit({ onSignal })
+    fire('SIGINT')
+    fire('SIGTERM')
+
+    expect(onSignal).toHaveBeenCalledTimes(1)
+    expect(onSignal).toHaveBeenCalledWith('SIGINT')
+  })
+
+  it('routes uncaughtException + unhandledRejection to onError', async () => {
+    const { setupGracefulExit } = await import('../lib/gracefulExit.js')
+    const onError = vi.fn()
+
+    setupGracefulExit({ onError })
+    fire('uncaughtException', new Error('uncaught'))
+    fire('unhandledRejection', 'rejection-reason')
+
+    expect(onError).toHaveBeenNthCalledWith(1, 'uncaughtException', expect.any(Error))
+    expect(onError).toHaveBeenNthCalledWith(2, 'unhandledRejection', 'rejection-reason')
+  })
+
+  it('second setupGracefulExit call within the same module instance is a no-op', async () => {
+    const { setupGracefulExit } = await import('../lib/gracefulExit.js')
+
+    setupGracefulExit()
+    onSpy.mockClear()
+
+    setupGracefulExit()
+
+    expect(onSpy).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## What does this PR do?

test(tui): cover gracefulExit signal handler ordering

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- Standardizes the PR description to the same review format used in #29640.
- Preserves the original detailed description below so no context is lost.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

- Original body preserved below for full context.

<details>
<summary>Original body</summary>

## Summary

test(tui): cover gracefulExit signal handler ordering

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Summary
Add 10 vitest cases for the previously untested `setupGracefulExit` in `ui-tui/src/lib/gracefulExit.ts`.

## Coverage
- registers handlers for SIGINT / SIGTERM / SIGHUP / uncaughtException / unhandledRejection
- SIGINT exits with code 130 and calls `onSignal`
- SIGTERM exits with code 143
- SIGHUP exits with code 129
- runs all cleanup callbacks before exit
- still exits when a cleanup rejects
- failsafe timer fires `process.exit` after `failsafeMs`
- second signal during shutdown is a no-op
- routes `uncaughtException` + `unhandledRejection` to `onError`
- second `setupGracefulExit` call within the same module instance is a no-op

## Test plan
- [x] `npx vitest run src/__tests__/gracefulExit.test.ts` (10/10 passed)
- [x] `npx vitest run` (664/664 across 63 files)

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_