### PR TITLE
fix(gateway): use GUI-domain launchd status checks

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -108,22 +108,11 @@ def _get_service_pids() -> set:
     # --- launchd (macOS) ---
     if is_macos():
         try:
-            label = get_launchd_label()
-            result = subprocess.run(
-                ["launchctl", "list", label],
-                capture_output=True, text=True, timeout=5,
-            )
+            result = _launchd_print_service(timeout=5)
             if result.returncode == 0:
-                # Output: "PID\tStatus\tLabel" header, then one data line
-                for line in result.stdout.strip().splitlines():
-                    parts = line.split()
-                    if len(parts) >= 3 and parts[2] == label:
-                        try:
-                            pid = int(parts[0])
-                            if pid > 0:
-                                pids.add(pid)
-                        except ValueError:
-                            pass
+                pid = _launchd_pid_from_print(result.stdout)
+                if pid is not None:
+                    pids.add(pid)
         except (FileNotFoundError, subprocess.TimeoutExpired):
             pass
 
@@ -870,15 +859,10 @@ def _probe_launchd_service_running() -> bool:
     if not get_launchd_plist_path().exists():
         return False
     try:
-        result = subprocess.run(
-            ["launchctl", "list", get_launchd_label()],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
+        result = _launchd_print_service(timeout=10)
     except subprocess.TimeoutExpired:
         return False
-    return result.returncode == 0
+    return result.returncode == 0 and _launchd_print_indicates_running(result.stdout)
 
 
 def get_gateway_runtime_snapshot(system: bool = False) -> GatewayRuntimeSnapshot:
@@ -2606,6 +2590,50 @@ def _launchd_domain() -> str:
     return f"gui/{os.getuid()}"  # windows-footgun: ok — POSIX launchd (macOS) helper, never invoked on Windows
 
 
+def _launchd_service_target() -> str:
+    return f"{_launchd_domain()}/{get_launchd_label()}"
+
+
+def _launchd_print_service(timeout: float = 10) -> subprocess.CompletedProcess[str]:
+    """Return launchd's domain-scoped view of the gateway LaunchAgent.
+
+    `launchctl list <label>` queries the caller's bootstrap domain, which may
+    not be the GUI domain where LaunchAgents are bootstrapped. Use the explicit
+    target that install/start/restart already use.
+    """
+    return subprocess.run(
+        ["launchctl", "print", _launchd_service_target()],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _launchd_pid_from_print(output: str) -> int | None:
+    raw_pid = _launchd_field_from_print(output, "pid")
+    if raw_pid is None:
+        return None
+    try:
+        pid = int(raw_pid)
+    except ValueError:
+        return None
+    return pid if pid > 0 else None
+
+
+def _launchd_field_from_print(output: str, field: str) -> str | None:
+    for line in output.splitlines():
+        key, sep, value = line.strip().partition("=")
+        if sep and key.strip() == field:
+            return value.strip()
+    return None
+
+
+def _launchd_print_indicates_running(output: str) -> bool:
+    if _launchd_pid_from_print(output) is not None:
+        return True
+    return any(line.strip() == "state = running" for line in output.splitlines())
+
+
 def generate_launchd_plist() -> str:
     python_path = get_python_path()
     working_dir = str(PROJECT_ROOT)
@@ -2888,14 +2916,8 @@ def launchd_restart():
 
 def launchd_status(deep: bool = False):
     plist_path = get_launchd_plist_path()
-    label = get_launchd_label()
     try:
-        result = subprocess.run(
-            ["launchctl", "list", label],
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
+        result = _launchd_print_service(timeout=10)
         loaded = result.returncode == 0
         loaded_output = result.stdout
     except subprocess.TimeoutExpired:
@@ -2911,7 +2933,16 @@ def launchd_status(deep: bool = False):
 
     if loaded:
         print("✓ Gateway service is loaded")
-        print(loaded_output)
+        pid = _launchd_pid_from_print(loaded_output)
+        state = _launchd_field_from_print(loaded_output, "state")
+        if _launchd_print_indicates_running(loaded_output):
+            print("✓ Gateway service is running")
+        else:
+            print("⚠ Gateway service is loaded but not running")
+        if state:
+            print(f"  State: {state}")
+        if pid is not None:
+            print(f"  PID: {pid}")
     else:
         print("✗ Gateway service is not loaded")
         print("  Service definition exists locally but launchd has not loaded it.")
@@ -4024,14 +4055,7 @@ def _is_service_running() -> bool:
 
         return False
     elif is_macos() and get_launchd_plist_path().exists():
-        try:
-            result = subprocess.run(
-                ["launchctl", "list", get_launchd_label()],
-                capture_output=True, text=True, timeout=10,
-            )
-            return result.returncode == 0
-        except subprocess.TimeoutExpired:
-            return False
+        return _probe_launchd_service_running()
     elif is_windows():
         from hermes_cli import gateway_windows
         if gateway_windows.is_installed():

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7946,23 +7946,17 @@ def _cmd_update_impl(args, gateway_mode: bool):
                         launchd_restart,
                         get_launchd_label,
                         get_launchd_plist_path,
+                        _probe_launchd_service_running,
                     )
 
                     plist_path = get_launchd_plist_path()
-                    if plist_path.exists():
-                        check = subprocess.run(
-                            ["launchctl", "list", get_launchd_label()],
-                            capture_output=True,
-                            text=True,
-                            timeout=5,
-                        )
-                        if check.returncode == 0:
-                            try:
-                                launchd_restart()
-                                restarted_services.append(get_launchd_label())
-                            except subprocess.CalledProcessError as e:
-                                stderr = (getattr(e, "stderr", "") or "").strip()
-                                print(f"  ⚠ Gateway restart failed: {stderr}")
+                    if plist_path.exists() and _probe_launchd_service_running():
+                        try:
+                            launchd_restart()
+                            restarted_services.append(get_launchd_label())
+                        except subprocess.CalledProcessError as e:
+                            stderr = (getattr(e, "stderr", "") or "").strip()
+                            print(f"  ⚠ Gateway restart failed: {stderr}")
                 except (FileNotFoundError, subprocess.TimeoutExpired, ImportError):
                     pass
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -610,11 +610,13 @@ class TestLaunchdServiceRecovery:
         plist_path.write_text("<plist>old content</plist>", encoding="utf-8")
 
         monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
-        monkeypatch.setattr(
-            gateway_cli.subprocess,
-            "run",
-            lambda *args, **kwargs: SimpleNamespace(returncode=113, stdout="", stderr="Could not find service"),
-        )
+        calls = []
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=113, stdout="", stderr="Could not find service")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
 
         gateway_cli.launchd_status()
 
@@ -622,6 +624,57 @@ class TestLaunchdServiceRecovery:
         assert str(plist_path) in output
         assert "stale" in output.lower()
         assert "not loaded" in output.lower()
+        assert calls == [["launchctl", "print", gateway_cli._launchd_service_target()]]
+
+    def test_launchd_status_uses_gui_domain_print_when_loaded(self, tmp_path, monkeypatch, capsys):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        launchd_output = "\n".join(
+            [
+                "gui/502/ai.hermes.gateway = {",
+                "\tstate = running",
+                "\tpid = 67890",
+                "}",
+            ]
+        )
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(returncode=0, stdout=launchd_output, stderr="")
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        gateway_cli.launchd_status()
+
+        output = capsys.readouterr().out
+        assert "Gateway service is loaded" in output
+        assert "Gateway service is running" in output
+        assert "State: running" in output
+        assert "PID: 67890" in output
+        assert calls[-1] == ["launchctl", "print", gateway_cli._launchd_service_target()]
+
+    def test_probe_launchd_service_running_requires_running_print_state(self, tmp_path, monkeypatch):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text("<plist/>", encoding="utf-8")
+        calls = []
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+
+        def fake_run(cmd, **kwargs):
+            calls.append(cmd)
+            return SimpleNamespace(
+                returncode=0,
+                stdout="gui/502/ai.hermes.gateway = {\n\tstate = waiting\n}",
+                stderr="",
+            )
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        assert gateway_cli._probe_launchd_service_running() is False
+        assert calls == [["launchctl", "print", gateway_cli._launchd_service_target()]]
 
 
 class TestGatewayServiceDetection:

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -102,10 +102,15 @@ def _make_run_side_effect(
                 return subprocess.CompletedProcess(cmd, system_restart_rc, stdout="", stderr=stderr)
             return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
 
-        # launchctl list ai.hermes.gateway
-        if "launchctl" in joined and "list" in joined:
+        # launchctl print gui/<uid>/ai.hermes.gateway
+        if "launchctl" in joined and "print" in joined:
             if launchctl_loaded:
-                return subprocess.CompletedProcess(cmd, 0, stdout="PID\tStatus\tLabel\n123\t0\tai.hermes.gateway\n", stderr="")
+                return subprocess.CompletedProcess(
+                    cmd,
+                    0,
+                    stdout="gui/501/ai.hermes.gateway = {\n\tstate = running\n\tpid = 123\n}\n",
+                    stderr="",
+                )
             return subprocess.CompletedProcess(cmd, 113, stdout="", stderr="Could not find service")
 
         return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
@@ -1016,12 +1021,15 @@ class TestGetServicePids:
         monkeypatch.setattr(gateway_cli, "is_macos", lambda: True)
         monkeypatch.setattr(gateway_cli, "get_launchd_label", lambda: "ai.hermes.gateway")
 
+        calls = []
+
         def fake_run(cmd, **kwargs):
+            calls.append(cmd)
             joined = " ".join(str(c) for c in cmd)
-            if "launchctl" in joined and "list" in joined:
+            if "launchctl" in joined and "print" in joined:
                 return subprocess.CompletedProcess(
                     cmd, 0,
-                    stdout="PID\tStatus\tLabel\n67890\t0\tai.hermes.gateway\n",
+                    stdout="gui/501/ai.hermes.gateway = {\n\tstate = running\n\tpid = 67890\n}\n",
                     stderr="",
                 )
             return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
@@ -1030,6 +1038,7 @@ class TestGetServicePids:
 
         pids = gateway_cli._get_service_pids()
         assert 67890 in pids
+        assert calls == [["launchctl", "print", gateway_cli._launchd_service_target()]]
 
     def test_returns_empty_when_no_services(self, monkeypatch):
         monkeypatch.setattr(gateway_cli, "is_linux", lambda: False)


### PR DESCRIPTION
## What does this PR do?

Fixes macOS launchd gateway false negatives by querying the explicit GUI-domain LaunchAgent target instead of relying on `launchctl list <label>`.

On macOS, `launchctl list <label>` can report a service as missing from the caller's bootstrap domain even when the LaunchAgent is loaded and running under `gui/<uid>`. Hermes already bootstraps, kickstarts, and boots out the gateway using that explicit GUI-domain target, so status/update checks should use the same launchd authority.

This is a narrow current-`main` alternative to related open work:

- #9707 covers broader macOS launchd observability.
- #9708 covers the update-path launchd gate as a stacked draft.
- #6435 is a much broader launchd status/plist comparison PR.

## Related Issue

No issue filed. Related PRs: #9707, #9708, #6435.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/gateway.py`
  - Adds a shared `launchctl print gui/<uid>/<label>` helper for macOS LaunchAgent inspection.
  - Uses that helper for launchd service PID discovery, running-state detection, and `hermes gateway status`.
  - Keeps `gateway status` concise by printing state and PID instead of dumping full launchd output.
- `hermes_cli/main.py`
  - Reuses the shared launchd running check before restarting a macOS gateway during `hermes update`.
- `tests/hermes_cli/test_gateway_service.py`
  - Adds coverage for loaded/running launchd status and non-running loaded jobs.
- `tests/hermes_cli/test_update_gateway_restart.py`
  - Updates macOS launchd mocks to use `launchctl print` output and verifies PID parsing.

## How to Test

1. Install/start a macOS profile gateway so the job is loaded under `gui/<uid>/<label>`.
2. Run `hermes --profile personal gateway status`.
3. Confirm it reports the LaunchAgent as loaded/running with a state and PID.

Commands run locally:

```bash
scripts/run_tests.sh tests/hermes_cli/test_gateway_service.py::TestLaunchdServiceRecovery tests/hermes_cli/test_update_gateway_restart.py::TestGetServicePids -q
venv/bin/python scripts/check-windows-footguns.py
hermes --profile personal gateway status
```

Results:

- `16 passed in 1.10s`
- `✓ No Windows footguns found (4 file(s) scanned).`
- macOS 15 local runtime reported `Gateway service is loaded`, `Gateway service is running`, `State: running`, and `PID: 87687`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
  - Related overlapping PRs reviewed: #9707, #9708, #6435.
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
  - Not run locally. Ran the focused CI-parity wrapper command listed above.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] N/A - no documentation changes required for this focused bug fix
