### PR TITLE
test(tui): cover protocol/paste regex

### DIFF
--- a/ui-tui/src/__tests__/protocolPaste.test.ts
+++ b/ui-tui/src/__tests__/protocolPaste.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+
+import { PASTE_SNIPPET_RE } from '../protocol/paste.js'
+
+const matchAll = (s: string) => s.match(new RegExp(PASTE_SNIPPET_RE.source, PASTE_SNIPPET_RE.flags)) ?? []
+
+describe('PASTE_SNIPPET_RE', () => {
+  it('matches a basic [[label]] token', () => {
+    expect(matchAll('hello [[file.txt]] world')).toEqual(['[[file.txt]]'])
+  })
+
+  it('matches multiple tokens on the same line', () => {
+    expect(matchAll('[[a]] mid [[b]] tail [[c]]')).toEqual(['[[a]]', '[[b]]', '[[c]]'])
+  })
+
+  it('is non-greedy across adjacent tokens', () => {
+    expect(matchAll('[[a]][[b]]')).toEqual(['[[a]]', '[[b]]'])
+  })
+
+  it('matches empty token [[]]', () => {
+    expect(matchAll('x [[]] y')).toEqual(['[[]]'])
+  })
+
+  it('does not span newlines', () => {
+    expect(matchAll('[[broken\nlabel]]')).toEqual([])
+  })
+
+  it('returns empty array when no token present', () => {
+    expect(matchAll('plain text without snippets')).toEqual([])
+  })
+
+  it('matches across multiple lines independently', () => {
+    expect(matchAll('line1 [[a]]\nline2 [[b]]')).toEqual(['[[a]]', '[[b]]'])
+  })
+
+  it('exposes the global flag', () => {
+    expect(PASTE_SNIPPET_RE.global).toBe(true)
+  })
+
+  it('allows internal characters except newline', () => {
+    expect(matchAll('[[file with spaces & symbols! @1]]')).toEqual(['[[file with spaces & symbols! @1]]'])
+  })
+
+  it('replace() round-trip strips all tokens', () => {
+    const out = '[[a]] keep [[b]]'.replace(new RegExp(PASTE_SNIPPET_RE.source, PASTE_SNIPPET_RE.flags), '')
+
+    expect(out).toBe(' keep ')
+  })
+})


### PR DESCRIPTION
## What does this PR do?

test(tui): cover protocol/paste regex

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- Standardizes the PR description to the same review format used in #29640.
- Preserves the original detailed description below so no context is lost.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

- Original body preserved below for full context.

<details>
<summary>Original body</summary>

## Summary

test(tui): cover protocol/paste regex

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Summary
Add 10 vitest cases for the previously untested `PASTE_SNIPPET_RE` in `ui-tui/src/protocol/paste.ts` — used by `useSubmission.ts:35` to expand paste tokens.

## Coverage
- basic `[[label]]` token
- multiple tokens on the same line
- non-greedy across adjacent tokens
- empty `[[]]` token
- does not span newlines
- empty array when no token present
- multi-line independent matches
- global flag exposed
- internal characters except newline allowed
- `replace()` round-trip strips all tokens

## Test plan
- [x] `npx vitest run src/__tests__/protocolPaste.test.ts` (10/10 passed)
- [x] `npx vitest run` (664/664 across 63 files)

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_