### PR TITLE
test(tui): cover protocol/interpolation regex + helper

### DIFF
--- a/ui-tui/src/__tests__/protocolInterpolation.test.ts
+++ b/ui-tui/src/__tests__/protocolInterpolation.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+
+import { INTERPOLATION_RE, hasInterpolation } from '../protocol/interpolation.js'
+
+const matchAll = (s: string) => s.match(new RegExp(INTERPOLATION_RE.source, INTERPOLATION_RE.flags)) ?? []
+
+describe('INTERPOLATION_RE', () => {
+  it('matches {!name}', () => {
+    expect(matchAll('hello {!name}')).toEqual(['{!name}'])
+  })
+
+  it('matches multiple tokens', () => {
+    expect(matchAll('{!a} mid {!b}')).toEqual(['{!a}', '{!b}'])
+  })
+
+  it('is non-greedy across adjacent tokens', () => {
+    expect(matchAll('{!a}{!b}')).toEqual(['{!a}', '{!b}'])
+  })
+
+  it('captures inner identifier', () => {
+    const re = new RegExp(INTERPOLATION_RE.source, INTERPOLATION_RE.flags)
+    const m = re.exec('value: {!user_name}')
+
+    expect(m?.[1]).toBe('user_name')
+  })
+
+  it('does not match without bang', () => {
+    expect(matchAll('{name}')).toEqual([])
+  })
+
+  it('does not match empty body', () => {
+    expect(matchAll('{!}')).toEqual([])
+  })
+
+  it('exposes the global flag', () => {
+    expect(INTERPOLATION_RE.global).toBe(true)
+  })
+})
+
+describe('hasInterpolation', () => {
+  it('returns true when at least one token is present', () => {
+    expect(hasInterpolation('hi {!name}')).toBe(true)
+  })
+
+  it('returns false for plain text', () => {
+    expect(hasInterpolation('plain text')).toBe(false)
+  })
+
+  it('returns false for {!} alone', () => {
+    expect(hasInterpolation('value {!}')).toBe(false)
+  })
+
+  it('returns false for {name} without bang', () => {
+    expect(hasInterpolation('hi {name}')).toBe(false)
+  })
+
+  it('returns true when token is wedged between text', () => {
+    expect(hasInterpolation('a{!x}b')).toBe(true)
+  })
+})


### PR DESCRIPTION
## What does this PR do?

**hasInterpolation** - true when token present - false on plain text - false on `{!}` alone - false on `{name}` (no bang) - true when token wedged between text

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- Standardizes the PR description to the same review format used in #29640.
- Preserves the original detailed description below so no context is lost.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

- Original body preserved below for full context.

<details>
<summary>Original body</summary>

## Summary

**hasInterpolation** - true when token present - false on plain text - false on `{!}` alone - false on `{name}` (no bang) - true when token wedged between text

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Summary
Add 12 vitest cases for the previously untested `INTERPOLATION_RE` and `hasInterpolation` in `ui-tui/src/protocol/interpolation.ts`.

## Coverage
**INTERPOLATION_RE**
- matches `{!name}`
- matches multiple tokens
- non-greedy across adjacent tokens
- captures inner identifier
- rejects `{name}` (no bang)
- rejects `{!}` (empty body)
- exposes the global flag

**hasInterpolation**
- true when token present
- false on plain text
- false on `{!}` alone
- false on `{name}` (no bang)
- true when token wedged between text

## Test plan
- [x] `npx vitest run src/__tests__/protocolInterpolation.test.ts` (12/12 passed)
- [x] `npx vitest run` (666/666 across 63 files)

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_