### PR TITLE
test(tui): cover content/fortunes dailyFortune determinism

### DIFF
--- a/ui-tui/src/__tests__/contentFortunes.test.ts
+++ b/ui-tui/src/__tests__/contentFortunes.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { dailyFortune, randomFortune } from '../content/fortunes.js'
+
+describe('dailyFortune', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-15T12:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('is deterministic for the same seed within the same day', () => {
+    expect(dailyFortune('alice')).toBe(dailyFortune('alice'))
+  })
+
+  it('produces different values for different seeds', () => {
+    const samples = new Set<string>()
+
+    for (const seed of ['a', 'b', 'c', 'd', 'e', 'f', 'g', 'h']) {
+      samples.add(dailyFortune(seed))
+    }
+
+    expect(samples.size).toBeGreaterThan(1)
+  })
+
+  it('falls back to "anon" when seed is null', () => {
+    expect(dailyFortune(null)).toBe(dailyFortune('anon'))
+  })
+
+  it('falls back to "anon" when seed is empty string', () => {
+    expect(dailyFortune('')).toBe(dailyFortune('anon'))
+  })
+
+  it('changes when the day changes', () => {
+    const day1 = dailyFortune('alice')
+
+    vi.setSystemTime(new Date('2026-06-15T12:00:00Z'))
+    const day2 = dailyFortune('alice')
+
+    expect(day1).not.toBe(day2)
+  })
+
+  it('output begins with either common or legendary glyph', () => {
+    const out = dailyFortune('alice')
+
+    expect(out.startsWith('🔮 ') || out.startsWith('🌟 ')).toBe(true)
+  })
+})
+
+describe('randomFortune', () => {
+  it('returns a valid fortune string', () => {
+    const out = randomFortune()
+
+    expect(typeof out).toBe('string')
+    expect(out.length).toBeGreaterThan(0)
+    expect(out.startsWith('🔮 ') || out.startsWith('🌟 ')).toBe(true)
+  })
+})


### PR DESCRIPTION
## What does this PR do?

test(tui): cover content/fortunes dailyFortune determinism

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- Standardizes the PR description to the same review format used in #29640.
- Preserves the original detailed description below so no context is lost.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

- Original body preserved below for full context.

<details>
<summary>Original body</summary>

## Summary

test(tui): cover content/fortunes dailyFortune determinism

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Summary
Add 7 vitest cases for the previously untested `dailyFortune` + `randomFortune` in `ui-tui/src/content/fortunes.ts`.

## Coverage
- `dailyFortune` deterministic for same seed within the same day
- different seeds produce variety
- falls back to \`anon\` when seed is null
- falls back to \`anon\` when seed is empty string
- value changes when the day changes
- output begins with common (🔮) or legendary (🌟) glyph
- `randomFortune` returns a valid fortune string

## Test plan
- [x] `npx vitest run src/__tests__/contentFortunes.test.ts` (7/7 passed)
- [x] `npx vitest run` (661/661 across 63 files)

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_