### PR TITLE
test(tui): cover content/verbs TOOL_VERBS surface

### DIFF
--- a/ui-tui/src/__tests__/contentVerbs.test.ts
+++ b/ui-tui/src/__tests__/contentVerbs.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest'
+
+import { TOOL_VERBS, VERBS } from '../content/verbs.js'
+
+describe('TOOL_VERBS', () => {
+  it('exposes a verb for every known tool name used in the TUI', () => {
+    const required = [
+      'browser',
+      'clarify',
+      'create_file',
+      'delegate_task',
+      'delete_file',
+      'execute_code',
+      'image_generate',
+      'list_files',
+      'memory',
+      'patch',
+      'read_file',
+      'run_command',
+      'search_code',
+      'search_files',
+      'terminal',
+      'web_extract',
+      'web_search',
+      'write_file'
+    ]
+
+    for (const tool of required) {
+      expect(TOOL_VERBS[tool], `expected verb for ${tool}`).toBeTypeOf('string')
+    }
+  })
+
+  it('all verbs are non-empty lowercase strings', () => {
+    for (const [tool, verb] of Object.entries(TOOL_VERBS)) {
+      expect(verb.length, `${tool} verb`).toBeGreaterThan(0)
+      expect(verb, `${tool} verb`).toBe(verb.toLowerCase())
+    }
+  })
+
+  it('most verbs end in "ing" gerund form', () => {
+    const ingCount = Object.values(TOOL_VERBS).filter(v => v.endsWith('ing')).length
+
+    expect(ingCount).toBeGreaterThanOrEqual(Object.keys(TOOL_VERBS).length - 2)
+  })
+})
+
+describe('VERBS thinking pool', () => {
+  it('has at least 10 entries', () => {
+    expect(VERBS.length).toBeGreaterThanOrEqual(10)
+  })
+
+  it('all entries are unique', () => {
+    expect(new Set(VERBS).size).toBe(VERBS.length)
+  })
+
+  it('all entries are non-empty lowercase strings', () => {
+    for (const v of VERBS) {
+      expect(v.length).toBeGreaterThan(0)
+      expect(v).toBe(v.toLowerCase())
+    }
+  })
+
+  it('all entries are gerund (ing) form', () => {
+    for (const v of VERBS) {
+      expect(v).toMatch(/ing$/)
+    }
+  })
+})


### PR DESCRIPTION
## What does this PR do?

**VERBS** - has at least 10 entries - all entries unique - all entries non-empty lowercase - all entries are gerund form

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- add focused coverage around the target helper/path without broadening runtime behavior
- keep the assertions tied to one contract or regression surface per test file
- use the smallest validation set that proves the intended invariant

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

N/A

<details>
<summary>Original body</summary>

## Summary

**VERBS** - has at least 10 entries - all entries unique - all entries non-empty lowercase - all entries are gerund form

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Summary
Add 7 vitest cases for the previously untested `TOOL_VERBS` + `VERBS` exports in `ui-tui/src/content/verbs.ts`.

## Coverage
**TOOL_VERBS**
- exposes a verb for every known tool name used in the TUI
- all verbs are non-empty lowercase strings
- most verbs end in \`ing\` gerund form

**VERBS**
- has at least 10 entries
- all entries unique
- all entries non-empty lowercase
- all entries are gerund form

## Test plan
- [x] `npx vitest run src/__tests__/contentVerbs.test.ts` (7/7 passed)
- [x] `npx vitest run` (661/661 across 63 files)

## Solution Sketch

- add focused coverage around the target helper/path without broadening runtime behavior
- keep the assertions tied to one contract or regression surface per test file
- use the smallest validation set that proves the intended invariant

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_