### PR TITLE
test(constants): cover is_termux env detection

### DIFF
--- a/tests/test_hermes_constants_is_termux.py
+++ b/tests/test_hermes_constants_is_termux.py
@@ -1,0 +1,41 @@
+"""Tests for hermes_constants.is_termux() — Termux/Android env detection."""
+
+from hermes_constants import is_termux
+
+
+class TestIsTermux:
+    def test_returns_false_on_clean_env(self, monkeypatch):
+        monkeypatch.delenv("TERMUX_VERSION", raising=False)
+        monkeypatch.setenv("PREFIX", "/usr")
+
+        assert is_termux() is False
+
+    def test_returns_true_when_termux_version_set(self, monkeypatch):
+        monkeypatch.setenv("TERMUX_VERSION", "0.118.0")
+        monkeypatch.setenv("PREFIX", "/usr")
+
+        assert is_termux() is True
+
+    def test_returns_true_for_termux_prefix_path(self, monkeypatch):
+        monkeypatch.delenv("TERMUX_VERSION", raising=False)
+        monkeypatch.setenv("PREFIX", "/data/data/com.termux/files/usr")
+
+        assert is_termux() is True
+
+    def test_returns_false_for_unrelated_prefix(self, monkeypatch):
+        monkeypatch.delenv("TERMUX_VERSION", raising=False)
+        monkeypatch.setenv("PREFIX", "/opt/homebrew")
+
+        assert is_termux() is False
+
+    def test_returns_false_when_prefix_unset(self, monkeypatch):
+        monkeypatch.delenv("TERMUX_VERSION", raising=False)
+        monkeypatch.delenv("PREFIX", raising=False)
+
+        assert is_termux() is False
+
+    def test_termux_version_takes_precedence_over_unrelated_prefix(self, monkeypatch):
+        monkeypatch.setenv("TERMUX_VERSION", "0.118.0")
+        monkeypatch.setenv("PREFIX", "/usr/local")
+
+        assert is_termux() is True


### PR DESCRIPTION
## What does this PR do?

- add focused coverage around the target helper/path without broadening runtime behavior - keep the assertions tied to one contract or regression surface per test file - use the smallest validation set that proves the intended invariant

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- add focused coverage around the target helper/path without broadening runtime behavior
- keep the assertions tied to one contract or regression surface per test file
- use the smallest validation set that proves the intended invariant

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

N/A

<details>
<summary>Original body</summary>

## Summary

- add focused coverage around the target helper/path without broadening runtime behavior - keep the assertions tied to one contract or regression surface per test file - use the smallest validation set that proves the intended invariant

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Summary
Add 6 pytest cases for the previously untested `is_termux()` in `hermes_constants.py`.

## Coverage
- false on clean env
- true when `TERMUX_VERSION` env is set
- true for Termux-specific `PREFIX` path (`com.termux/files/usr`)
- false for unrelated `PREFIX`
- false when both `TERMUX_VERSION` and `PREFIX` are unset
- `TERMUX_VERSION` takes precedence over unrelated `PREFIX`

## Test plan
- [x] `pytest tests/test_hermes_constants_is_termux.py` (6/6 passed)
- [x] `pytest tests/test_hermes_constants*.py` (40/40 passed)

## Solution Sketch

- add focused coverage around the target helper/path without broadening runtime behavior
- keep the assertions tied to one contract or regression surface per test file
- use the smallest validation set that proves the intended invariant

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_