### PR TITLE
test(constants): cover is_wsl env + /proc detection

### DIFF
--- a/tests/test_hermes_constants_is_wsl.py
+++ b/tests/test_hermes_constants_is_wsl.py
@@ -1,0 +1,42 @@
+"""Tests for hermes_constants.is_wsl() — WSL detection via /proc/version."""
+
+from unittest.mock import mock_open, patch
+
+import pytest
+
+import hermes_constants
+from hermes_constants import is_wsl
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache(monkeypatch):
+    monkeypatch.setattr(hermes_constants, "_wsl_detected", None, raising=False)
+
+
+class TestIsWsl:
+    def test_true_when_proc_version_contains_microsoft(self):
+        with patch("builtins.open", mock_open(read_data="Linux 5.10 microsoft-standard-WSL2")):
+            assert is_wsl() is True
+
+    def test_true_for_lowercase_microsoft_marker(self):
+        with patch("builtins.open", mock_open(read_data="microsoft hypervisor build")):
+            assert is_wsl() is True
+
+    def test_false_for_native_linux_proc_version(self):
+        with patch("builtins.open", mock_open(read_data="Linux 6.1 generic-amd64")):
+            assert is_wsl() is False
+
+    def test_false_when_proc_version_missing(self):
+        with patch("builtins.open", side_effect=FileNotFoundError):
+            assert is_wsl() is False
+
+    def test_false_when_proc_version_unreadable(self):
+        with patch("builtins.open", side_effect=PermissionError):
+            assert is_wsl() is False
+
+    def test_result_is_cached_after_first_call(self):
+        with patch("builtins.open", mock_open(read_data="microsoft")):
+            assert is_wsl() is True
+
+        with patch("builtins.open", side_effect=AssertionError("should not re-read /proc/version")):
+            assert is_wsl() is True

--- a/tests/test_hermes_constants_is_wsl.py
+++ b/tests/test_hermes_constants_is_wsl.py
@@ -9,8 +9,14 @@ from hermes_constants import is_wsl
 
 
 @pytest.fixture(autouse=True)
-def _reset_cache(monkeypatch):
-    monkeypatch.setattr(hermes_constants, "_wsl_detected", None, raising=False)
+def _reset_cache():
+    # Force-clear any cached value from previous tests/workers and clear again
+    # after each test so we don't restore a stale True/False into the module.
+    hermes_constants._wsl_detected = None
+    is_wsl.__globals__["_wsl_detected"] = None
+    yield
+    hermes_constants._wsl_detected = None
+    is_wsl.__globals__["_wsl_detected"] = None
 
 
 class TestIsWsl:


### PR DESCRIPTION
## What does this PR do?

- add focused coverage around the target helper/path without broadening runtime behavior - keep the assertions tied to one contract or regression surface per test file - use the smallest validation set that proves the intended invariant

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- add focused coverage around the target helper/path without broadening runtime behavior
- keep the assertions tied to one contract or regression surface per test file
- use the smallest validation set that proves the intended invariant

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

N/A

<details>
<summary>Original body</summary>

## Summary

- add focused coverage around the target helper/path without broadening runtime behavior - keep the assertions tied to one contract or regression surface per test file - use the smallest validation set that proves the intended invariant

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Summary
Add 6 pytest cases for the previously untested `is_wsl()` in `hermes_constants.py`.

## Coverage
- true when `/proc/version` contains `microsoft-standard-WSL2`
- true for lowercase `microsoft` marker
- false for native Linux `/proc/version`
- false when `/proc/version` is missing (`FileNotFoundError`)
- false when `/proc/version` is unreadable (`PermissionError`)
- result is cached after first call (no re-read)

## Test plan
- [x] `pytest tests/test_hermes_constants_is_wsl.py` (6/6 passed)
- [x] `pytest tests/test_hermes_constants*.py` (40/40 passed)

## Solution Sketch

- add focused coverage around the target helper/path without broadening runtime behavior
- keep the assertions tied to one contract or regression surface per test file
- use the smallest validation set that proves the intended invariant

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_