### PR TITLE
完成 Hermes A-F 升级回归修复

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1461,10 +1461,16 @@ def _cprint(text: str):
     """
     _record_output_history(text)
 
+    def _safe_pt_print(value: str) -> None:
+        try:
+            _pt_print(_PT_ANSI(value))
+        except Exception:
+            print(value)
+
     try:
         from prompt_toolkit.application import get_app_or_none, run_in_terminal
     except Exception:
-        _pt_print(_PT_ANSI(text))
+        _safe_pt_print(text)
         return
 
     app = None
@@ -1477,7 +1483,7 @@ def _cprint(text: str):
     # direct prompt_toolkit print is safe and matches existing behavior
     # (spinner frames, streamed tokens, tool activity prefixes, …).
     if app is None or not getattr(app, "_is_running", False):
-        _pt_print(_PT_ANSI(text))
+        _safe_pt_print(text)
         return
 
     try:
@@ -1485,7 +1491,7 @@ def _cprint(text: str):
     except Exception:
         loop = None
     if loop is None:
-        _pt_print(_PT_ANSI(text))
+        _safe_pt_print(text)
         return
 
     import asyncio as _asyncio
@@ -1501,7 +1507,7 @@ def _cprint(text: str):
         current_loop = None
     # Same thread as the app's loop → safe to print directly.
     if current_loop is loop and loop.is_running():
-        _pt_print(_PT_ANSI(text))
+        _safe_pt_print(text)
         return
 
     # Cross-thread emission: ask the app's event loop to schedule a
@@ -1510,10 +1516,10 @@ def _cprint(text: str):
     # fails we fall back to a direct print so the line isn't lost.
     def _schedule():
         try:
-            run_in_terminal(lambda: _pt_print(_PT_ANSI(text)))
+            run_in_terminal(lambda: _safe_pt_print(text))
         except Exception:
             try:
-                _pt_print(_PT_ANSI(text))
+                _safe_pt_print(text)
             except Exception:
                 pass
 
@@ -1521,7 +1527,7 @@ def _cprint(text: str):
         loop.call_soon_threadsafe(_schedule)
     except Exception:
         try:
-            _pt_print(_PT_ANSI(text))
+            _safe_pt_print(text)
         except Exception:
             pass
 
@@ -1549,8 +1555,10 @@ def _termux_example_image_path(filename: str = "cat.png") -> str:
     ]
     for root in candidates:
         if os.path.isdir(root):
+            if root.startswith("/"):
+                return f"{root.rstrip('/')}/Pictures/{filename}"
             return os.path.join(root, "Pictures", filename)
-    return os.path.join("~/storage/shared", "Pictures", filename)
+    return f"~/storage/shared/Pictures/{filename}"
 
 
 def _split_path_input(raw: str) -> tuple[str, str]:
@@ -1621,9 +1629,17 @@ def _resolve_attachment_path(raw_path: str) -> Path | None:
                 expanded = unquote(parsed.path or "")
                 if parsed.netloc and os.name == "nt":
                     expanded = f"//{parsed.netloc}{expanded}"
+                elif os.name == "nt" and len(expanded) >= 4 and expanded[0] == "/" and expanded[2] == ":":
+                    expanded = expanded[1:]
         except Exception:
             expanded = token
-    expanded = os.path.expandvars(os.path.expanduser(expanded))
+    expanded = os.path.expandvars(expanded)
+    if expanded == "~" or expanded.startswith("~/") or expanded.startswith("~\\"):
+        home = os.environ.get("HOME") or os.path.expanduser("~")
+        rest = expanded[2:] if len(expanded) > 1 else ""
+        expanded = os.path.join(home, rest) if rest else home
+    else:
+        expanded = os.path.expanduser(expanded)
     if os.name != "nt":
         normalized = expanded.replace("\\", "/")
         if len(normalized) >= 3 and normalized[1] == ":" and normalized[2] == "/" and normalized[0].isalpha():
@@ -7045,7 +7061,7 @@ class HermesCLI:
                             if output:
                                 self._console_print(_rich_text_from_ansi(output))
                             else:
-                                self._console_print("[dim]Command returned no output[/]")
+                                self._output_console().print("Command returned no output")
                         except subprocess.TimeoutExpired:
                             self._console_print("[bold red]Quick command timed out (30s)[/]")
                         except Exception as e:

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -46,6 +46,16 @@ OUTPUT_DIR = CRON_DIR / "output"
 ONESHOT_GRACE_SECONDS = 120
 
 
+def _expand_user_path(path: str) -> Path:
+    """Expand leading ~ while honoring HOME overrides on Windows tests."""
+    if path == "~" or path.startswith("~/") or path.startswith("~\\"):
+        home = os.environ.get("HOME") or os.environ.get("USERPROFILE")
+        if home:
+            suffix = path[1:].lstrip("/\\")
+            return Path(home) / suffix if suffix else Path(home)
+    return Path(path).expanduser()
+
+
 def _normalize_skill_list(skill: Optional[str] = None, skills: Optional[Any] = None) -> List[str]:
     """Normalize legacy/single-skill and multi-skill inputs into a unique ordered list."""
     if skills is None:
@@ -465,7 +475,7 @@ def _normalize_workdir(workdir: Optional[str]) -> Optional[str]:
     raw = str(workdir).strip()
     if not raw:
         return None
-    expanded = Path(raw).expanduser()
+    expanded = _expand_user_path(raw)
     if not expanded.is_absolute():
         raise ValueError(
             f"Cron workdir must be an absolute path (got {raw!r}). "

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -660,6 +660,53 @@ _DEFAULT_SCRIPT_TIMEOUT = 120  # seconds
 _SCRIPT_TIMEOUT = _DEFAULT_SCRIPT_TIMEOUT
 
 
+def _is_windows_wsl_bash(path: str | None) -> bool:
+    """Return True for Windows bash launchers that require a working WSL distro."""
+    if os.name != "nt" or not path:
+        return False
+    normalized = str(path).replace("/", "\\").lower()
+    return (
+        normalized.endswith("\\system32\\bash.exe")
+        or normalized.endswith("\\windowsapps\\bash.exe")
+    )
+
+
+def _resolve_bash_executable() -> str | None:
+    """Resolve a usable bash executable for cron shell scripts."""
+    candidates: list[str] = []
+    found = shutil.which("bash")
+    if found:
+        candidates.append(found)
+
+    if os.name == "nt":
+        git = shutil.which("git")
+        if git:
+            git_root = Path(git).resolve().parent.parent
+            candidates.extend([
+                str(git_root / "bin" / "bash.exe"),
+                str(git_root / "usr" / "bin" / "bash.exe"),
+            ])
+        candidates.extend([
+            r"C:\Program Files\Git\bin\bash.exe",
+            r"C:\Program Files\Git\usr\bin\bash.exe",
+            r"C:\Program Files (x86)\Git\bin\bash.exe",
+            r"C:\Program Files (x86)\Git\usr\bin\bash.exe",
+        ])
+    else:
+        candidates.append("/bin/bash")
+
+    seen: set[str] = set()
+    for candidate in candidates:
+        if not candidate or candidate in seen:
+            continue
+        seen.add(candidate)
+        if _is_windows_wsl_bash(candidate):
+            continue
+        if os.path.isfile(candidate):
+            return candidate
+    return None
+
+
 def _get_script_timeout() -> int:
     """Resolve cron pre-run script timeout from module/env/config with a safe default."""
     if _SCRIPT_TIMEOUT != _DEFAULT_SCRIPT_TIMEOUT:
@@ -756,13 +803,10 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
     suffix = path.suffix.lower()
     if suffix in (".sh", ".bash"):
         # Resolve bash dynamically so Windows (Git Bash) and Linux/macOS
-        # all work.  On native Windows without Git for Windows installed
-        # shutil.which returns None — fall back to a clear error rather
-        # than a FileNotFoundError with a confusing "[WinError 2]"
-        # traceback.
-        _bash = shutil.which("bash") or (
-            "/bin/bash" if os.path.isfile("/bin/bash") else None
-        )
+        # all work.  Native Windows often exposes C:\Windows\System32\bash.exe
+        # or the WindowsApps shim, both of which require a working WSL distro;
+        # prefer Git Bash when available.
+        _bash = _resolve_bash_executable()
         if _bash is None:
             return False, (
                 f"Cannot run .sh/.bash script {path.name!r}: bash not found on PATH. "
@@ -778,6 +822,8 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
             argv,
             capture_output=True,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             timeout=script_timeout,
             cwd=str(path.parent),
         )

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5914,16 +5914,32 @@ class GatewayRunner:
                 if qcmd.get("type") == "exec":
                     exec_cmd = qcmd.get("command", "")
                     if exec_cmd:
+                        proc = None
+                        communicate_task = None
                         try:
                             proc = await asyncio.create_subprocess_shell(
                                 exec_cmd,
                                 stdout=asyncio.subprocess.PIPE,
                                 stderr=asyncio.subprocess.PIPE,
                             )
-                            stdout, stderr = await asyncio.wait_for(proc.communicate(), timeout=30)
+                            communicate_task = asyncio.create_task(proc.communicate())
+                            stdout, stderr = await asyncio.wait_for(communicate_task, timeout=30)
                             output = (stdout or stderr).decode().strip()
                             return output if output else "Command returned no output."
                         except asyncio.TimeoutError:
+                            if communicate_task is not None and not communicate_task.done():
+                                communicate_task.cancel()
+                            if proc is not None and proc.returncode is None:
+                                proc.kill()
+                                try:
+                                    await proc.wait()
+                                except Exception:
+                                    logger.debug("Timed-out quick command cleanup failed", exc_info=True)
+                            if communicate_task is not None:
+                                try:
+                                    await communicate_task
+                                except (asyncio.CancelledError, Exception):
+                                    pass
                             return "Quick command timed out (30s)."
                         except Exception as e:
                             return f"Quick command error: {e}"

--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -36,7 +36,10 @@ _RST = "\033[0m"
 
 def cprint(text: str):
     """Print ANSI-colored text through prompt_toolkit's renderer."""
-    _pt_print(_PT_ANSI(text))
+    try:
+        _pt_print(_PT_ANSI(text))
+    except Exception:
+        print(text)
 
 
 # =========================================================================

--- a/hermes_cli/browser_connect.py
+++ b/hermes_cli/browser_connect.py
@@ -76,6 +76,12 @@ def get_chrome_debug_candidates(system: str) -> list[str]:
     for name in _LINUX_BIN_NAMES:
         add(shutil.which(name))
     add_install_paths(("/mnt/c/Program Files", "/mnt/c/Program Files (x86)"))
+    # WSL mounts Windows drives with forward-slash paths even when tests run on
+    # native Windows.  os.path.join() would introduce backslashes there, so keep
+    # these candidates POSIX-shaped.
+    for base in ("/mnt/c/Program Files", "/mnt/c/Program Files (x86)"):
+        for parts in _WINDOWS_INSTALL_PARTS:
+            add("/".join((base.rstrip("/"), *parts)))
     return candidates
 
 

--- a/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
+++ b/optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py
@@ -817,14 +817,17 @@ class Migrator:
         **details: Any,
     ) -> None:
         sensitive = bool(details.pop("sensitive", False))
+        normalized_details: Dict[str, Any] = {}
+        for key, value in details.items():
+            normalized_details[key] = self._report_path(value) if key.endswith(("path", "from", "backup", "file")) else value
         self.items.append(
             ItemResult(
                 kind=kind,
-                source=str(source) if source else None,
-                destination=str(destination) if destination else None,
+                source=self._report_path(source),
+                destination=self._report_path(destination),
                 status=status,
                 reason=reason,
-                details=details,
+                details=normalized_details,
                 sensitive=sensitive,
             )
         )
@@ -835,6 +838,16 @@ class Migrator:
             dest_str = str(destination)
             if dest_str.endswith("config.yaml") or dest_str.endswith("config.yml"):
                 self._config_apply_blocked = True
+
+    @staticmethod
+    def _report_path(value: Any) -> Any:
+        if value is None:
+            return None
+        if isinstance(value, Path):
+            return value.as_posix()
+        if isinstance(value, str):
+            return value.replace("\\", "/")
+        return value
 
     def source_candidate(self, *relative_paths: str) -> Optional[Path]:
         for rel in relative_paths:

--- a/plugins/disk-cleanup/__init__.py
+++ b/plugins/disk-cleanup/__init__.py
@@ -42,7 +42,9 @@ _lock = threading.Lock()
 
 # Tool-call result shapes we can parse
 _WRITE_FILE_PATH_KEY = "path"
-_TERMINAL_PATH_REGEX = re.compile(r"(?:^|\s)(/[^\s'\"`]+|\~/[^\s'\"`]+)")
+_TERMINAL_PATH_REGEX = re.compile(
+    r"(?:^|\s)([A-Za-z]:[\\/][^\s'\"`]+|/[^\s'\"`]+|\~/[^\s'\"`]+)"
+)
 
 
 # ---------------------------------------------------------------------------
@@ -110,7 +112,7 @@ def _extract_paths_from_terminal(args: Dict[str, Any], result: str) -> Set[str]:
         # Tokenise the command — catches `touch /tmp/hermes-x/test_foo.py`
         try:
             for tok in shlex.split(cmd, posix=True):
-                if tok.startswith(("/", "~")):
+                if tok.startswith(("/", "~")) or re.match(r"^[A-Za-z]:[\\/]", tok):
                     paths.add(tok)
         except ValueError:
             pass

--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -299,8 +299,6 @@ def _load_config() -> dict:
       2. ~/.hindsight/config.json             (legacy, shared)
       3. Environment variables
     """
-    from pathlib import Path
-
     # Profile-scoped path (preferred)
     profile_path = get_hermes_home() / "hindsight" / "config.json"
     if profile_path.exists():
@@ -310,7 +308,7 @@ def _load_config() -> dict:
             pass
 
     # Legacy shared path (backward compat)
-    legacy_path = Path.home() / ".hindsight" / "config.json"
+    legacy_path = _user_home() / ".hindsight" / "config.json"
     if legacy_path.exists():
         try:
             return json.loads(legacy_path.read_text(encoding="utf-8"))
@@ -334,6 +332,14 @@ def _load_config() -> dict:
             }
         },
     }
+
+
+def _user_home():
+    """Return the user home, honoring HOME overrides on Windows tests."""
+    from pathlib import Path
+
+    home = os.environ.get("HOME") or os.environ.get("USERPROFILE")
+    return Path(home) if home else Path.home()
 
 
 def _normalize_retain_tags(value: Any) -> List[str]:
@@ -437,9 +443,7 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
 
 
 def _embedded_profile_env_path(config: dict[str, Any]):
-    from pathlib import Path
-
-    return Path.home() / ".hindsight" / "profiles" / f"{_embedded_profile_name(config)}.env"
+    return _user_home() / ".hindsight" / "profiles" / f"{_embedded_profile_name(config)}.env"
 
 
 def _materialize_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | None = None):

--- a/skills/productivity/google-workspace/scripts/_hermes_home.py
+++ b/skills/productivity/google-workspace/scripts/_hermes_home.py
@@ -37,6 +37,6 @@ except (ModuleNotFoundError, ImportError):
         Mirrors ``hermes_constants.display_hermes_home()``."""
         home = get_hermes_home()
         try:
-            return "~/" + str(home.relative_to(Path.home()))
+            return "~/" + home.relative_to(Path.home()).as_posix()
         except ValueError:
-            return str(home)
+            return home.as_posix()

--- a/tests/acp/test_events.py
+++ b/tests/acp/test_events.py
@@ -17,6 +17,21 @@ from acp_adapter.events import (
 )
 
 
+def _close_scheduled_coroutine(mock_rcts):
+    """Close the coroutine captured by the mocked scheduler."""
+    coro = mock_rcts.call_args[0][0]
+    if hasattr(coro, "close"):
+        coro.close()
+    return coro
+
+
+def _close_all_scheduled_coroutines(mock_rcts) -> None:
+    for call in mock_rcts.call_args_list:
+        coro = call.args[0]
+        if hasattr(coro, "close"):
+            coro.close()
+
+
 @pytest.fixture()
 def mock_conn():
     """Mock ACP Client connection."""
@@ -60,7 +75,7 @@ class TestToolProgressCallback:
 
         # Should have called run_coroutine_threadsafe
         mock_rcts.assert_called_once()
-        coro = mock_rcts.call_args[0][0]
+        coro = _close_scheduled_coroutine(mock_rcts)
         # The coroutine should be conn.session_update
         assert mock_conn.session_update.called or coro is not None
 
@@ -80,6 +95,7 @@ class TestToolProgressCallback:
             cb("tool.started", "read_file", "Reading /etc/hosts", '{"path": "/etc/hosts"}')
 
         assert "read_file" in tool_call_ids
+        _close_scheduled_coroutine(mock_rcts)
 
     def test_handles_non_dict_args(self, mock_conn, event_loop_fixture):
         """If args is not a dict, it should be wrapped."""
@@ -97,6 +113,7 @@ class TestToolProgressCallback:
             cb("tool.started", "terminal", "$ echo hi", None)
 
         assert "terminal" in tool_call_ids
+        _close_scheduled_coroutine(mock_rcts)
 
     def test_duplicate_same_name_tool_calls_use_fifo_ids(self, mock_conn, event_loop_fixture):
         """Multiple same-name tool calls should be tracked independently in order."""
@@ -121,6 +138,7 @@ class TestToolProgressCallback:
 
             step_cb(2, [{"name": "terminal", "result": "ok-2"}])
             assert "terminal" not in tool_call_ids
+        _close_all_scheduled_coroutines(mock_rcts)
 
 
 # ---------------------------------------------------------------------------
@@ -143,6 +161,7 @@ class TestThinkingCallback:
             cb("Analyzing the code...")
 
         mock_rcts.assert_called_once()
+        _close_scheduled_coroutine(mock_rcts)
 
     def test_ignores_empty_text(self, mock_conn, event_loop_fixture):
         """Empty text should not emit any update."""
@@ -179,6 +198,7 @@ class TestStepCallback:
         # Tool should have been removed from tracking
         assert "terminal" not in tool_call_ids
         mock_rcts.assert_called_once()
+        _close_scheduled_coroutine(mock_rcts)
 
     def test_ignores_untracked_tools(self, mock_conn, event_loop_fixture):
         """Tools not in tool_call_ids should be silently ignored."""
@@ -208,6 +228,7 @@ class TestStepCallback:
 
         assert "read_file" not in tool_call_ids
         mock_rcts.assert_called_once()
+        _close_scheduled_coroutine(mock_rcts)
 
     def test_result_passed_to_build_tool_complete(self, mock_conn, event_loop_fixture):
         """Tool result from prev_tools dict is forwarded to build_tool_complete."""
@@ -230,6 +251,7 @@ class TestStepCallback:
         mock_btc.assert_called_once_with(
             "tc-xyz789", "terminal", result='{"output": "hello"}', function_args=None, snapshot=None
         )
+        _close_scheduled_coroutine(mock_rcts)
 
     def test_none_result_passed_through(self, mock_conn, event_loop_fixture):
         """When result is None (e.g. first iteration), None is passed through."""
@@ -249,6 +271,7 @@ class TestStepCallback:
             cb(1, [{"name": "web_search", "result": None}])
 
         mock_btc.assert_called_once_with("tc-aaa", "web_search", result=None, function_args=None, snapshot=None)
+        _close_scheduled_coroutine(mock_rcts)
 
     def test_step_callback_passes_arguments_and_snapshot(self, mock_conn, event_loop_fixture):
         from collections import deque
@@ -274,6 +297,7 @@ class TestStepCallback:
             function_args={"path": "diff-test.txt"},
             snapshot="snap",
         )
+        _close_scheduled_coroutine(mock_rcts)
 
     def test_tool_progress_captures_snapshot_metadata(self, mock_conn, event_loop_fixture):
         tool_call_ids = {}
@@ -314,6 +338,7 @@ class TestMessageCallback:
             cb("Here is your answer.")
 
         mock_rcts.assert_called_once()
+        _close_scheduled_coroutine(mock_rcts)
 
     def test_ignores_empty_message(self, mock_conn, event_loop_fixture):
         """Empty text should not emit any update."""

--- a/tests/acp/test_ping_suppression.py
+++ b/tests/acp/test_ping_suppression.py
@@ -12,6 +12,8 @@ import asyncio
 import json
 import logging
 import os
+import sys
+import textwrap
 from io import StringIO
 
 import pytest
@@ -126,6 +128,91 @@ async def test_bare_ping_request_produces_proper_response_and_no_stderr_noise(
     when the filter is installed on the handler.
     """
     import acp
+
+    if sys.platform == "win32":
+        script = textwrap.dedent(
+            """
+            import asyncio
+            import logging
+            import sys
+
+            import acp
+
+            from acp_adapter.entry import _BenignProbeMethodFilter
+
+
+            class _FakeAgent:
+                async def initialize(self, **kwargs):
+                    from acp.schema import AgentCapabilities, InitializeResponse
+                    return InitializeResponse(protocol_version=1, agent_capabilities=AgentCapabilities())
+
+                async def new_session(self, cwd, mcp_servers=None, **kwargs):
+                    from acp.schema import NewSessionResponse
+                    return NewSessionResponse(session_id="test")
+
+                async def prompt(self, session_id, prompt, **kwargs):
+                    from acp.schema import PromptResponse
+                    return PromptResponse(stop_reason="end_turn")
+
+                async def cancel(self, session_id, **kwargs):
+                    pass
+
+                async def authenticate(self, **kwargs):
+                    pass
+
+                def on_connect(self, conn):
+                    pass
+
+
+            handler = logging.StreamHandler(sys.stderr)
+            handler.addFilter(_BenignProbeMethodFilter())
+            root = logging.getLogger()
+            root.handlers.clear()
+            root.addHandler(handler)
+            root.setLevel(logging.INFO)
+
+            asyncio.run(acp.run_agent(_FakeAgent(), use_unstable_protocol=True))
+            """
+        )
+        request = {"jsonrpc": "2.0", "id": 1, "method": "ping", "params": {}}
+        proc = await asyncio.create_subprocess_exec(
+            sys.executable,
+            "-c",
+            script,
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        assert proc.stdin is not None
+        assert proc.stdout is not None
+        assert proc.stderr is not None
+        proc.stdin.write((json.dumps(request) + "\n").encode())
+        await proc.stdin.drain()
+        try:
+            response_line = await asyncio.wait_for(proc.stdout.readline(), timeout=5.0)
+        finally:
+            proc.stdin.close()
+            try:
+                await proc.stdin.wait_closed()
+            except (BrokenPipeError, ConnectionResetError):
+                pass
+
+        stderr_bytes = await proc.stderr.read()
+        try:
+            await asyncio.wait_for(proc.wait(), timeout=5.0)
+        except asyncio.TimeoutError:
+            proc.kill()
+            await proc.wait()
+
+        stderr = stderr_bytes.decode(errors="replace")
+        assert response_line, (
+            f"ACP subprocess produced no stdout; rc={proc.returncode}\nstderr:\n{stderr}"
+        )
+        response = json.loads(response_line.decode())
+        assert response["error"]["code"] == -32601, response
+        assert response["error"]["data"] == {"method": "ping"}, response
+        assert "Background task failed" not in stderr, stderr
+        return
 
     # Attach the filter to a fresh stream handler that mirrors entry._setup_logging.
     stream = StringIO()

--- a/tests/cli/test_quick_commands.py
+++ b/tests/cli/test_quick_commands.py
@@ -1,5 +1,6 @@
 """Tests for user-defined quick commands that bypass the agent loop."""
 import subprocess
+import sys
 from unittest.mock import MagicMock, patch, AsyncMock
 from rich.text import Text
 import pytest
@@ -60,7 +61,7 @@ class TestCLIQuickCommands:
         cli.console.print.assert_called_once()
 
     def test_exec_command_no_output_shows_fallback(self):
-        cli = self._make_cli({"empty": {"type": "exec", "command": "true"}})
+        cli = self._make_cli({"empty": {"type": "exec", "command": f'"{sys.executable}" -c ""'}})
         cli.process_command("/empty")
         cli.console.print.assert_called_once()
         args = cli.console.print.call_args[0][0]

--- a/tests/cron/test_file_permissions.py
+++ b/tests/cron/test_file_permissions.py
@@ -3,10 +3,18 @@
 import json
 import os
 import stat
+import sys
 import tempfile
 import unittest
 from pathlib import Path
 from unittest.mock import patch
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform == "win32",
+    reason="POSIX chmod mode bits are not reliable on Windows",
+)
 
 
 class TestCronFilePermissions(unittest.TestCase):


### PR DESCRIPTION
## 概要
- 完成 Hermes A-F 升级计划相关修复
- 加固 Windows 路径、终端、进程、skills、execute_code、vision 等稳定性路径
- 清理 ACP / CLI 相关 Windows 异步测试警告

## 验证
- python -m pytest tests\\acp -q -W error::RuntimeWarning -W error::DeprecationWarning -> 139 passed
- python -m pytest tests\\acp tests\\cli tests\\cron tests\\environments tests\\honcho_plugin tests\\plugins tests\\skills -q -> 1149 passed, 1 skipped, 2 warnings

## 说明
- 上游 main 当前比本地基线领先 929 个提交；本 PR 从 fork 分支提交，未直接推上游 main。
- 剩余 2 个 warning 是 Windows 并行测试里的异步子进程清理噪音，未造成测试失败。