### PR TITLE
test(constants): cover get_env_path resolution

### DIFF
--- a/tests/test_hermes_constants_get_env_path.py
+++ b/tests/test_hermes_constants_get_env_path.py
@@ -14,8 +14,7 @@ class TestGetEnvPath:
         monkeypatch.setattr(Path, "home", lambda: tmp_path)
         monkeypatch.setenv("HOME", str(tmp_path))
         result = get_env_path()
-        assert result.name == ".env"
-        assert result.parent.name == ".hermes"
+        assert result == tmp_path / ".hermes" / ".env"
 
     def test_filename_is_always_dotenv(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))

--- a/tests/test_hermes_constants_get_env_path.py
+++ b/tests/test_hermes_constants_get_env_path.py
@@ -1,0 +1,36 @@
+"""Tests for hermes_constants.get_env_path() — .env under HERMES_HOME."""
+from pathlib import Path
+
+from hermes_constants import get_env_path
+
+
+class TestGetEnvPath:
+    def test_returns_dotenv_under_hermes_home(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        assert get_env_path() == tmp_path / ".env"
+
+    def test_uses_default_home_when_env_unset(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        result = get_env_path()
+        assert result.name == ".env"
+        assert result.parent.name == ".hermes"
+
+    def test_filename_is_always_dotenv(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        assert get_env_path().name == ".env"
+
+    def test_returns_a_path_object(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        assert isinstance(get_env_path(), Path)
+
+    def test_changes_when_hermes_home_changes(self, tmp_path, monkeypatch):
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        monkeypatch.setenv("HERMES_HOME", str(a))
+        first = get_env_path()
+        monkeypatch.setenv("HERMES_HOME", str(b))
+        second = get_env_path()
+        assert first.parent == a
+        assert second.parent == b


### PR DESCRIPTION
## What does this PR do?

- add focused coverage around the target helper/path without broadening runtime behavior - keep the assertions tied to one contract or regression surface per test file - use the smallest validation set that proves the intended invariant

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- add focused coverage around the target helper/path without broadening runtime behavior
- keep the assertions tied to one contract or regression surface per test file
- use the smallest validation set that proves the intended invariant

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

N/A

<details>
<summary>Original body</summary>

## Summary

- add focused coverage around the target helper/path without broadening runtime behavior - keep the assertions tied to one contract or regression surface per test file - use the smallest validation set that proves the intended invariant

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Summary
Adds 5 pytest cases for `hermes_constants.get_env_path()` covering path resolution under `HERMES_HOME`, default home fallback, filename invariance, return type, and env-driven re-resolution.

## Test plan
- [x] `pytest tests/test_hermes_constants_get_env_path.py -v` — 5 passed

## Solution Sketch

- add focused coverage around the target helper/path without broadening runtime behavior
- keep the assertions tied to one contract or regression surface per test file
- use the smallest validation set that proves the intended invariant

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_