### PR TITLE
test(constants): cover get_hermes_dir new vs legacy fallback

### DIFF
--- a/tests/test_hermes_constants_get_hermes_dir.py
+++ b/tests/test_hermes_constants_get_hermes_dir.py
@@ -34,5 +34,5 @@ class TestGetHermesDir:
         first = get_hermes_dir("cache/x", "old")
         monkeypatch.setenv("HERMES_HOME", str(b))
         second = get_hermes_dir("cache/x", "old")
-        assert str(first).startswith(str(a))
-        assert str(second).startswith(str(b))
+        assert first == a / "cache" / "x"
+        assert second == b / "cache" / "x"

--- a/tests/test_hermes_constants_get_hermes_dir.py
+++ b/tests/test_hermes_constants_get_hermes_dir.py
@@ -1,0 +1,38 @@
+"""Tests for hermes_constants.get_hermes_dir() — new vs old layout fallback."""
+from hermes_constants import get_hermes_dir
+
+
+class TestGetHermesDir:
+    def test_returns_old_path_when_legacy_dir_exists(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        legacy = tmp_path / "image_cache"
+        legacy.mkdir()
+        assert get_hermes_dir("cache/images", "image_cache") == legacy
+
+    def test_returns_new_path_when_legacy_absent(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        assert get_hermes_dir("cache/images", "image_cache") == tmp_path / "cache" / "images"
+
+    def test_legacy_can_be_a_file_not_dir(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        legacy = tmp_path / "old_file"
+        legacy.write_text("x")
+        assert get_hermes_dir("new/path", "old_file") == legacy
+
+    def test_returns_new_when_legacy_does_not_exist(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        result = get_hermes_dir("new/sub", "missing_legacy")
+        assert result == tmp_path / "new" / "sub"
+        assert not result.exists()
+
+    def test_uses_current_hermes_home_each_call(self, tmp_path, monkeypatch):
+        a = tmp_path / "a"
+        b = tmp_path / "b"
+        a.mkdir()
+        b.mkdir()
+        monkeypatch.setenv("HERMES_HOME", str(a))
+        first = get_hermes_dir("cache/x", "old")
+        monkeypatch.setenv("HERMES_HOME", str(b))
+        second = get_hermes_dir("cache/x", "old")
+        assert str(first).startswith(str(a))
+        assert str(second).startswith(str(b))


### PR DESCRIPTION
## What does this PR do?

- add focused coverage around the target helper/path without broadening runtime behavior - keep the assertions tied to one contract or regression surface per test file - use the smallest validation set that proves the intended invariant

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- add focused coverage around the target helper/path without broadening runtime behavior
- keep the assertions tied to one contract or regression surface per test file
- use the smallest validation set that proves the intended invariant

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

N/A

<details>
<summary>Original body</summary>

## Summary

- add focused coverage around the target helper/path without broadening runtime behavior - keep the assertions tied to one contract or regression surface per test file - use the smallest validation set that proves the intended invariant

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Summary
Adds 5 pytest cases for `hermes_constants.get_hermes_dir(new_subpath, old_name)` covering: returns legacy dir when it exists, falls back to new layout when legacy missing, treats legacy file (not dir) as existing, returns non-existent new path, re-resolves on `HERMES_HOME` change.

## Test plan
- [x] `pytest tests/test_hermes_constants_get_hermes_dir.py -v` — 5 passed

## Solution Sketch

- add focused coverage around the target helper/path without broadening runtime behavior
- keep the assertions tied to one contract or regression surface per test file
- use the smallest validation set that proves the intended invariant

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_