### PR TITLE
test(constants): cover display_hermes_home formatter

### DIFF
--- a/tests/test_hermes_constants_display_hermes_home.py
+++ b/tests/test_hermes_constants_display_hermes_home.py
@@ -1,0 +1,46 @@
+"""Tests for hermes_constants.display_hermes_home() — user-facing path string."""
+from pathlib import Path
+
+from hermes_constants import display_hermes_home
+
+
+class TestDisplayHermesHome:
+    def test_uses_tilde_shorthand_for_default(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.delenv("HERMES_HOME", raising=False)
+        result = display_hermes_home()
+        assert result.startswith("~/")
+        assert ".hermes" in result
+
+    def test_uses_tilde_for_path_under_home(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "custom-hermes"))
+        assert display_hermes_home() == "~/custom-hermes"
+
+    def test_returns_absolute_when_outside_home(self, tmp_path, monkeypatch):
+        outside = tmp_path / "elsewhere" / "hermes"
+        outside.mkdir(parents=True)
+        home = tmp_path / "user-home"
+        home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: home)
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setenv("HERMES_HOME", str(outside))
+        result = display_hermes_home()
+        assert result == str(outside)
+        assert "~" not in result
+
+    def test_returns_string_type(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        assert isinstance(display_hermes_home(), str)
+
+    def test_profile_path_under_home_uses_tilde(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HOME", str(tmp_path))
+        profile = tmp_path / ".hermes" / "profiles" / "coder"
+        monkeypatch.setenv("HERMES_HOME", str(profile))
+        result = display_hermes_home()
+        assert result.startswith("~/.hermes/profiles/")
+        assert result.endswith("coder")


### PR DESCRIPTION
## What does this PR do?

- add focused coverage around the target helper/path without broadening runtime behavior - keep the assertions tied to one contract or regression surface per test file - use the smallest validation set that proves the intended invariant

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- add focused coverage around the target helper/path without broadening runtime behavior
- keep the assertions tied to one contract or regression surface per test file
- use the smallest validation set that proves the intended invariant

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

N/A

<details>
<summary>Original body</summary>

## Summary

- add focused coverage around the target helper/path without broadening runtime behavior - keep the assertions tied to one contract or regression surface per test file - use the smallest validation set that proves the intended invariant

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Summary
Adds 5 pytest cases for `hermes_constants.display_hermes_home()` covering: tilde shorthand for default `~/.hermes`, tilde for arbitrary paths under HOME, absolute path when HERMES_HOME is outside HOME, return type, profile-path tilde shorthand.

## Test plan
- [x] `pytest tests/test_hermes_constants_display_hermes_home.py -v` — 5 passed

## Solution Sketch

- add focused coverage around the target helper/path without broadening runtime behavior
- keep the assertions tied to one contract or regression surface per test file
- use the smallest validation set that proves the intended invariant

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_