### PR TITLE
test(constants): cover apply_ipv4_preference idempotency

### DIFF
--- a/tests/test_hermes_constants_apply_ipv4_preference.py
+++ b/tests/test_hermes_constants_apply_ipv4_preference.py
@@ -1,0 +1,76 @@
+"""Tests for hermes_constants.apply_ipv4_preference() — socket.getaddrinfo monkeypatch."""
+import socket
+
+import pytest
+
+from hermes_constants import apply_ipv4_preference
+
+
+@pytest.fixture(autouse=True)
+def _restore_getaddrinfo():
+    original = socket.getaddrinfo
+    yield
+    socket.getaddrinfo = original
+
+
+class TestApplyIpv4Preference:
+    def test_noop_when_force_false(self):
+        original = socket.getaddrinfo
+        apply_ipv4_preference(force=False)
+        assert socket.getaddrinfo is original
+
+    def test_default_is_force_false(self):
+        original = socket.getaddrinfo
+        apply_ipv4_preference()
+        assert socket.getaddrinfo is original
+
+    def test_patches_when_force_true(self):
+        original = socket.getaddrinfo
+        apply_ipv4_preference(force=True)
+        assert socket.getaddrinfo is not original
+        assert getattr(socket.getaddrinfo, "_hermes_ipv4_patched", False) is True
+
+    def test_idempotent_double_apply(self):
+        apply_ipv4_preference(force=True)
+        first = socket.getaddrinfo
+        apply_ipv4_preference(force=True)
+        assert socket.getaddrinfo is first
+
+    def test_passes_through_explicit_family(self, monkeypatch):
+        calls = []
+
+        def fake_resolver(host, port, family=0, type=0, proto=0, flags=0):
+            calls.append(family)
+            return [(family, 0, 0, "", (host, port))]
+
+        monkeypatch.setattr(socket, "getaddrinfo", fake_resolver)
+        apply_ipv4_preference(force=True)
+        socket.getaddrinfo("example.com", 80, socket.AF_INET6)
+        assert calls == [socket.AF_INET6]
+
+    def test_unspec_request_forces_ipv4(self, monkeypatch):
+        calls = []
+
+        def fake_resolver(host, port, family=0, type=0, proto=0, flags=0):
+            calls.append(family)
+            return [(family, 0, 0, "", (host, port))]
+
+        monkeypatch.setattr(socket, "getaddrinfo", fake_resolver)
+        apply_ipv4_preference(force=True)
+        socket.getaddrinfo("example.com", 80)
+        assert calls == [socket.AF_INET]
+
+    def test_falls_back_to_original_on_gaierror(self, monkeypatch):
+        calls = []
+
+        def fake_resolver(host, port, family=0, type=0, proto=0, flags=0):
+            calls.append(family)
+            if family == socket.AF_INET:
+                raise socket.gaierror("no A record")
+            return [(family, 0, 0, "", (host, port))]
+
+        monkeypatch.setattr(socket, "getaddrinfo", fake_resolver)
+        apply_ipv4_preference(force=True)
+        result = socket.getaddrinfo("ipv6-only.example", 80)
+        assert calls == [socket.AF_INET, 0]
+        assert result


### PR DESCRIPTION
## What does this PR do?

Autouse fixture restores `socket.getaddrinfo` after each test.

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- add focused coverage around the target helper/path without broadening runtime behavior
- keep the assertions tied to one contract or regression surface per test file
- use the smallest validation set that proves the intended invariant

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

N/A

<details>
<summary>Original body</summary>

## Summary

Autouse fixture restores `socket.getaddrinfo` after each test.

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Summary
Adds 7 pytest cases for `hermes_constants.apply_ipv4_preference()` covering: noop when `force=False`, default-arg is `force=False`, monkeypatches `socket.getaddrinfo` when `force=True`, idempotent double-apply (same patched fn), passes through explicit family, forces `AF_INET` for `AF_UNSPEC`, falls back to original resolver on `gaierror` for IPv6-only hosts.

Autouse fixture restores `socket.getaddrinfo` after each test.

## Test plan
- [x] `pytest tests/test_hermes_constants_apply_ipv4_preference.py -v` — 7 passed

## Solution Sketch

- add focused coverage around the target helper/path without broadening runtime behavior
- keep the assertions tied to one contract or regression surface per test file
- use the smallest validation set that proves the intended invariant

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_