### PR TITLE
test(time): cover invalid timezone fallback edge cases

### DIFF
--- a/tests/test_hermes_time_invalid_tz_fallback.py
+++ b/tests/test_hermes_time_invalid_tz_fallback.py
@@ -1,6 +1,5 @@
 """Edge-case tests for hermes_time fallback when timezone resolution fails."""
 import logging
-from pathlib import Path
 
 import pytest
 import yaml
@@ -10,9 +9,9 @@ import hermes_time
 
 @pytest.fixture(autouse=True)
 def _reset_cache(monkeypatch):
-    monkeypatch.setattr(hermes_time, "_cached_tz", None, raising=False)
-    monkeypatch.setattr(hermes_time, "_cached_tz_name", None, raising=False)
-    monkeypatch.setattr(hermes_time, "_cache_resolved", False, raising=False)
+    monkeypatch.setattr(hermes_time, "_cached_tz", None)
+    monkeypatch.setattr(hermes_time, "_cached_tz_name", None)
+    monkeypatch.setattr(hermes_time, "_cache_resolved", False)
 
 
 class TestInvalidTimezoneFallback:
@@ -27,20 +26,31 @@ class TestInvalidTimezoneFallback:
         assert "Invalid timezone" in caplog.text
         assert "Bogus/Zone" in caplog.text
 
-    def test_whitespace_only_env_uses_local(self, monkeypatch):
+    def test_whitespace_only_env_uses_local(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_TIMEZONE", "    ")
-        monkeypatch.setattr(hermes_time, "get_config_path", lambda: Path("/nonexistent/config.yaml"))
+        missing_config = tmp_path / "does_not_exist" / "config.yaml"
+        monkeypatch.setattr(hermes_time, "get_config_path", lambda: missing_config)
         result = hermes_time.now()
         assert result.tzinfo is not None
         assert hermes_time.get_timezone() is None
 
     def test_invalid_tz_caches_none(self, monkeypatch):
         monkeypatch.setenv("HERMES_TIMEZONE", "Not/Real/Zone")
+        calls = {"n": 0}
+        real_resolver = hermes_time._resolve_timezone_name
+
+        def counting_resolver():
+            calls["n"] += 1
+            return real_resolver()
+
+        monkeypatch.setattr(hermes_time, "_resolve_timezone_name", counting_resolver)
         first = hermes_time.get_timezone()
         second = hermes_time.get_timezone()
         assert first is None
         assert second is None
         assert hermes_time._cache_resolved is True
+        # Resolver must run only on the first call; second call must hit cache.
+        assert calls["n"] == 1
 
     def test_config_yaml_missing_timezone_key_uses_local(self, tmp_path, monkeypatch):
         config = tmp_path / "config.yaml"
@@ -63,3 +73,5 @@ class TestInvalidTimezoneFallback:
         monkeypatch.delenv("HERMES_TIMEZONE", raising=False)
         result = hermes_time.now()
         assert result.tzinfo is not None
+        # Confirm the corrupt-config path actually fell back to server-local.
+        assert hermes_time.get_timezone() is None

--- a/tests/test_hermes_time_invalid_tz_fallback.py
+++ b/tests/test_hermes_time_invalid_tz_fallback.py
@@ -1,0 +1,65 @@
+"""Edge-case tests for hermes_time fallback when timezone resolution fails."""
+import logging
+from pathlib import Path
+
+import pytest
+import yaml
+
+import hermes_time
+
+
+@pytest.fixture(autouse=True)
+def _reset_cache(monkeypatch):
+    monkeypatch.setattr(hermes_time, "_cached_tz", None, raising=False)
+    monkeypatch.setattr(hermes_time, "_cached_tz_name", None, raising=False)
+    monkeypatch.setattr(hermes_time, "_cache_resolved", False, raising=False)
+
+
+class TestInvalidTimezoneFallback:
+    def test_config_yaml_invalid_tz_falls_back_to_local(self, tmp_path, monkeypatch, caplog):
+        config = tmp_path / "config.yaml"
+        config.write_text(yaml.dump({"timezone": "Bogus/Zone"}))
+        monkeypatch.setattr(hermes_time, "get_config_path", lambda: config)
+        monkeypatch.delenv("HERMES_TIMEZONE", raising=False)
+        with caplog.at_level(logging.WARNING, logger="hermes_time"):
+            result = hermes_time.now()
+        assert result.tzinfo is not None
+        assert "Invalid timezone" in caplog.text
+        assert "Bogus/Zone" in caplog.text
+
+    def test_whitespace_only_env_uses_local(self, monkeypatch):
+        monkeypatch.setenv("HERMES_TIMEZONE", "    ")
+        monkeypatch.setattr(hermes_time, "get_config_path", lambda: Path("/nonexistent/config.yaml"))
+        result = hermes_time.now()
+        assert result.tzinfo is not None
+        assert hermes_time.get_timezone() is None
+
+    def test_invalid_tz_caches_none(self, monkeypatch):
+        monkeypatch.setenv("HERMES_TIMEZONE", "Not/Real/Zone")
+        first = hermes_time.get_timezone()
+        second = hermes_time.get_timezone()
+        assert first is None
+        assert second is None
+        assert hermes_time._cache_resolved is True
+
+    def test_config_yaml_missing_timezone_key_uses_local(self, tmp_path, monkeypatch):
+        config = tmp_path / "config.yaml"
+        config.write_text(yaml.dump({"other_setting": "value"}))
+        monkeypatch.setattr(hermes_time, "get_config_path", lambda: config)
+        monkeypatch.delenv("HERMES_TIMEZONE", raising=False)
+        assert hermes_time.get_timezone() is None
+
+    def test_config_yaml_non_string_tz_uses_local(self, tmp_path, monkeypatch):
+        config = tmp_path / "config.yaml"
+        config.write_text(yaml.dump({"timezone": 12345}))
+        monkeypatch.setattr(hermes_time, "get_config_path", lambda: config)
+        monkeypatch.delenv("HERMES_TIMEZONE", raising=False)
+        assert hermes_time.get_timezone() is None
+
+    def test_corrupt_config_yaml_uses_local(self, tmp_path, monkeypatch):
+        config = tmp_path / "config.yaml"
+        config.write_text("::not: valid\nyaml: [unclosed")
+        monkeypatch.setattr(hermes_time, "get_config_path", lambda: config)
+        monkeypatch.delenv("HERMES_TIMEZONE", raising=False)
+        result = hermes_time.now()
+        assert result.tzinfo is not None


### PR DESCRIPTION
## What does this PR do?

- add focused coverage around the target helper/path without broadening runtime behavior - keep the assertions tied to one contract or regression surface per test file - use the smallest validation set that proves the intended invariant

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- add focused coverage around the target helper/path without broadening runtime behavior
- keep the assertions tied to one contract or regression surface per test file
- use the smallest validation set that proves the intended invariant

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

N/A

<details>
<summary>Original body</summary>

## Summary

- add focused coverage around the target helper/path without broadening runtime behavior - keep the assertions tied to one contract or regression surface per test file - use the smallest validation set that proves the intended invariant

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Summary
Adds 6 pytest cases for `hermes_time` fallback paths not covered by existing `tests/test_timezone.py` (which only tests env-var invalid). Covers:
- Invalid `timezone` in `config.yaml` → warning + server-local
- Whitespace-only `HERMES_TIMEZONE` → server-local
- Cache invariant: invalid tz caches `None` (no re-resolution)
- Missing `timezone` key in config.yaml
- Non-string `timezone` value
- Corrupt `config.yaml` syntax → server-local

## Test plan
- [x] `pytest tests/test_hermes_time_invalid_tz_fallback.py -v` — 6 passed

## Solution Sketch

- add focused coverage around the target helper/path without broadening runtime behavior
- keep the assertions tied to one contract or regression surface per test file
- use the smallest validation set that proves the intended invariant

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_