### PR TITLE
test(skills): cover get_all_skills_dirs local-first ordering

### DIFF
--- a/tests/test_skill_utils_get_all_skills_dirs_ordering.py
+++ b/tests/test_skill_utils_get_all_skills_dirs_ordering.py
@@ -1,0 +1,58 @@
+"""Tests for agent.skill_utils.get_all_skills_dirs — local-first ordering invariant."""
+from pathlib import Path
+
+from agent import skill_utils
+
+
+class TestGetAllSkillsDirsOrdering:
+    def test_local_skills_dir_is_first(self, tmp_path, monkeypatch):
+        local = tmp_path / "local"
+        ext_a = tmp_path / "ext_a"
+        ext_b = tmp_path / "ext_b"
+        for d in (local, ext_a, ext_b):
+            d.mkdir()
+        monkeypatch.setattr(skill_utils, "get_skills_dir", lambda: local)
+        monkeypatch.setattr(skill_utils, "get_external_skills_dirs", lambda: [ext_a, ext_b])
+        result = skill_utils.get_all_skills_dirs()
+        assert result[0] == local
+        assert result[1:] == [ext_a, ext_b]
+
+    def test_only_local_when_no_externals(self, tmp_path, monkeypatch):
+        local = tmp_path / "local"
+        local.mkdir()
+        monkeypatch.setattr(skill_utils, "get_skills_dir", lambda: local)
+        monkeypatch.setattr(skill_utils, "get_external_skills_dirs", lambda: [])
+        assert skill_utils.get_all_skills_dirs() == [local]
+
+    def test_local_included_even_when_missing_on_disk(self, tmp_path, monkeypatch):
+        local = tmp_path / "does_not_exist"
+        monkeypatch.setattr(skill_utils, "get_skills_dir", lambda: local)
+        monkeypatch.setattr(skill_utils, "get_external_skills_dirs", lambda: [])
+        result = skill_utils.get_all_skills_dirs()
+        assert result == [local]
+        assert not local.exists()
+
+    def test_preserves_external_dir_order(self, tmp_path, monkeypatch):
+        local = tmp_path / "local"
+        local.mkdir()
+        externals = [tmp_path / f"ext_{i}" for i in range(5)]
+        for d in externals:
+            d.mkdir()
+        monkeypatch.setattr(skill_utils, "get_skills_dir", lambda: local)
+        monkeypatch.setattr(skill_utils, "get_external_skills_dirs", lambda: list(externals))
+        result = skill_utils.get_all_skills_dirs()
+        assert result == [local, *externals]
+
+    def test_returns_list_type(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(skill_utils, "get_skills_dir", lambda: tmp_path)
+        monkeypatch.setattr(skill_utils, "get_external_skills_dirs", lambda: [])
+        assert isinstance(skill_utils.get_all_skills_dirs(), list)
+
+    def test_each_entry_is_path_instance(self, tmp_path, monkeypatch):
+        local = tmp_path / "local"
+        ext = tmp_path / "ext"
+        local.mkdir(); ext.mkdir()
+        monkeypatch.setattr(skill_utils, "get_skills_dir", lambda: local)
+        monkeypatch.setattr(skill_utils, "get_external_skills_dirs", lambda: [ext])
+        result = skill_utils.get_all_skills_dirs()
+        assert all(isinstance(p, Path) for p in result)


### PR DESCRIPTION
## What does this PR do?

- add focused coverage around the target helper/path without broadening runtime behavior - keep the assertions tied to one contract or regression surface per test file - use the smallest validation set that proves the intended invariant

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- add focused coverage around the target helper/path without broadening runtime behavior
- keep the assertions tied to one contract or regression surface per test file
- use the smallest validation set that proves the intended invariant

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

N/A

<details>
<summary>Original body</summary>

## Summary

- add focused coverage around the target helper/path without broadening runtime behavior - keep the assertions tied to one contract or regression surface per test file - use the smallest validation set that proves the intended invariant

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Summary
Adds 6 pytest cases for `agent.skill_utils.get_all_skills_dirs()` covering: local skills dir first, only-local when no externals, local included even when missing on disk, preserves external dir order, return type is list, each entry is a `Path`.

## Test plan
- [x] `pytest tests/test_skill_utils_get_all_skills_dirs_ordering.py -v` — 6 passed

## Solution Sketch

- add focused coverage around the target helper/path without broadening runtime behavior
- keep the assertions tied to one contract or regression surface per test file
- use the smallest validation set that proves the intended invariant

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_