### PR TITLE
fix(browser): don't cache None cloud provider on transient startup race (#22324)

### DIFF
--- a/tests/tools/test_browser_cloud_provider_cache.py
+++ b/tests/tools/test_browser_cloud_provider_cache.py
@@ -1,0 +1,177 @@
+"""Tests for ``_get_cloud_provider`` cache-only-on-success semantics.
+
+A transient credential gap at process startup (e.g. a managed Nous Portal
+access token mid-refresh, or a config-read raising) must not pin the
+process to local mode for its entire lifetime. Subsequent calls should
+re-resolve and pick up the cloud provider once credentials are available.
+
+Conversely, an explicit ``cloud_provider: local`` choice and a successful
+cloud-provider resolution should both cache permanently.
+"""
+import pytest
+
+import tools.browser_tool as browser_tool
+
+
+def _reset_resolver(monkeypatch):
+    """Clear the resolver cache so each test starts fresh."""
+    monkeypatch.setattr(browser_tool, "_cached_cloud_provider", None)
+    monkeypatch.setattr(browser_tool, "_cloud_provider_resolved", False)
+
+
+class TestCloudProviderCacheSemantics:
+    """Cache-only-on-success: None results re-resolve on next call."""
+
+    def test_explicit_local_caches_permanently(self, monkeypatch):
+        """``cloud_provider: local`` must be cached so we don't re-read every call."""
+        _reset_resolver(monkeypatch)
+
+        calls = {"n": 0}
+
+        def fake_read():
+            calls["n"] += 1
+            return {"browser": {"cloud_provider": "local"}}
+
+        monkeypatch.setattr(
+            "hermes_cli.config.read_raw_config", fake_read,
+        )
+
+        assert browser_tool._get_cloud_provider() is None
+        assert browser_tool._get_cloud_provider() is None
+        assert browser_tool._get_cloud_provider() is None
+        # Resolved on first call, cached after.
+        assert calls["n"] == 1
+        assert browser_tool._cloud_provider_resolved is True
+
+    def test_successful_cloud_resolution_caches_permanently(self, monkeypatch):
+        """A successful provider lookup pins the cache."""
+        _reset_resolver(monkeypatch)
+
+        calls = {"n": 0}
+
+        class FakeProvider:
+            def is_configured(self):
+                return True
+
+        monkeypatch.setitem(browser_tool._PROVIDER_REGISTRY, "fake", FakeProvider)
+
+        def fake_read():
+            calls["n"] += 1
+            return {"browser": {"cloud_provider": "fake"}}
+
+        monkeypatch.setattr(
+            "hermes_cli.config.read_raw_config", fake_read,
+        )
+
+        first = browser_tool._get_cloud_provider()
+        second = browser_tool._get_cloud_provider()
+        assert isinstance(first, FakeProvider)
+        # Same cached instance — no re-instantiation.
+        assert first is second
+        assert calls["n"] == 1
+        assert browser_tool._cloud_provider_resolved is True
+
+    def test_no_credentials_yet_does_not_cache_none(self, monkeypatch):
+        """Auto-detect with no creds returns None but does NOT pin the cache.
+
+        This is the primary regression test for the startup-race bug: a
+        transient credential gap must not pin the process to local mode
+        forever.
+        """
+        _reset_resolver(monkeypatch)
+
+        # No explicit cloud_provider; both auto-detect candidates unconfigured
+        # at first, then Browser Use becomes available.
+        bu_state = {"configured": False}
+
+        class FakeBrowserUseUnconfigured:
+            def is_configured(self):
+                return bu_state["configured"]
+
+        class FakeBrowserbaseUnconfigured:
+            def is_configured(self):
+                return False
+
+        monkeypatch.setattr(
+            browser_tool, "BrowserUseProvider", FakeBrowserUseUnconfigured,
+        )
+        monkeypatch.setattr(
+            browser_tool, "BrowserbaseProvider", FakeBrowserbaseUnconfigured,
+        )
+        monkeypatch.setattr(
+            "hermes_cli.config.read_raw_config",
+            lambda: {"browser": {}},
+        )
+
+        # First call: no creds yet → None, not cached.
+        assert browser_tool._get_cloud_provider() is None
+        assert browser_tool._cloud_provider_resolved is False
+
+        # Token refresh / creds now available.
+        bu_state["configured"] = True
+        result = browser_tool._get_cloud_provider()
+        assert isinstance(result, FakeBrowserUseUnconfigured)
+        assert browser_tool._cloud_provider_resolved is True
+
+    def test_config_read_failure_does_not_cache_none(self, monkeypatch):
+        """A raising config read must not pin local mode for the rest of life."""
+        _reset_resolver(monkeypatch)
+
+        attempts = {"n": 0}
+
+        def flaky_read():
+            attempts["n"] += 1
+            if attempts["n"] == 1:
+                raise OSError("config not yet readable")
+            return {"browser": {"cloud_provider": "local"}}
+
+        monkeypatch.setattr(
+            "hermes_cli.config.read_raw_config", flaky_read,
+        )
+
+        # First call: config read raises → None returned, NOT cached.
+        assert browser_tool._get_cloud_provider() is None
+        assert browser_tool._cloud_provider_resolved is False
+        assert attempts["n"] == 1
+
+        # Second call: config now readable, explicit local — caches.
+        assert browser_tool._get_cloud_provider() is None
+        assert browser_tool._cloud_provider_resolved is True
+        assert attempts["n"] == 2
+
+    def test_explicit_provider_instantiation_failure_does_not_cache(
+        self, monkeypatch, caplog,
+    ):
+        """If an explicit provider's __init__ raises, retry on next call."""
+        import logging
+        _reset_resolver(monkeypatch)
+
+        attempts = {"n": 0}
+
+        class FlakyProvider:
+            def __init__(self):
+                attempts["n"] += 1
+                if attempts["n"] == 1:
+                    raise RuntimeError("transient init failure")
+
+            def is_configured(self):
+                return True
+
+        monkeypatch.setitem(browser_tool._PROVIDER_REGISTRY, "flaky", FlakyProvider)
+        monkeypatch.setattr(
+            "hermes_cli.config.read_raw_config",
+            lambda: {"browser": {"cloud_provider": "flaky"}},
+        )
+
+        with caplog.at_level(logging.WARNING, logger=browser_tool.logger.name):
+            assert browser_tool._get_cloud_provider() is None
+        assert browser_tool._cloud_provider_resolved is False
+        assert any(
+            "Failed to instantiate explicit cloud_provider" in r.message
+            for r in caplog.records
+        )
+
+        # Second call succeeds and caches.
+        result = browser_tool._get_cloud_provider()
+        assert isinstance(result, FlakyProvider)
+        assert browser_tool._cloud_provider_resolved is True

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -413,16 +413,25 @@ _browser_engine_resolved = False
 def _get_cloud_provider() -> Optional[CloudBrowserProvider]:
     """Return the configured cloud browser provider, or None for local mode.
 
-    Reads ``config["browser"]["cloud_provider"]`` once and caches the result
-    for the process lifetime. An explicit ``local`` provider disables cloud
-    fallback. If unset, fall back to Browserbase when direct or managed
-    Browserbase credentials are available.
+    Reads ``config["browser"]["cloud_provider"]`` and caches the result for
+    the process lifetime. An explicit ``local`` provider disables cloud
+    routing and is cached permanently. If unset, fall back to Browser Use
+    (managed or direct) then Browserbase when credentials are available.
+
+    Cache-only-on-success semantics: a ``None`` result is NEVER cached
+    (except for the explicit ``local`` case) so a transient credential gap
+    at process startup — for example a Nous Portal access token that
+    hasn't refreshed yet, or a config-read exception that was silently
+    logged at debug level — does not pin the process to local mode for
+    its entire lifetime. Subsequent calls re-resolve and pick up cloud
+    provider once credentials become available.
     """
     global _cached_cloud_provider, _cloud_provider_resolved
     if _cloud_provider_resolved:
         return _cached_cloud_provider
 
-    _cloud_provider_resolved = True
+    explicit_local = False
+    resolved_provider: Optional[CloudBrowserProvider] = None
     try:
         from hermes_cli.config import read_raw_config
         cfg = read_raw_config()
@@ -433,25 +442,54 @@ def _get_cloud_provider() -> Optional[CloudBrowserProvider]:
                 browser_cfg.get("cloud_provider")
             )
             if provider_key == "local":
+                explicit_local = True
+        if not explicit_local and provider_key and provider_key in _PROVIDER_REGISTRY:
+            try:
+                resolved_provider = _PROVIDER_REGISTRY[provider_key]()
+            except Exception as inst_exc:
+                # Surface instantiation failures at warning level (not debug)
+                # so operators can see why an explicit cloud_provider didn't
+                # take effect. Do NOT cache the None result — retry on next call.
+                logger.warning(
+                    "Failed to instantiate explicit cloud_provider %r: %s; "
+                    "will retry on next browser call",
+                    provider_key, inst_exc, exc_info=True,
+                )
                 _cached_cloud_provider = None
                 return None
-        if provider_key and provider_key in _PROVIDER_REGISTRY:
-            _cached_cloud_provider = _PROVIDER_REGISTRY[provider_key]()
     except Exception as e:
+        # Config-read failure: don't cache, retry on next call.
         logger.debug("Could not read cloud_provider from config: %s", e)
+        _cached_cloud_provider = None
+        return None
 
-    if _cached_cloud_provider is None:
+    if explicit_local:
+        # Explicit user choice — cache permanently.
+        _cached_cloud_provider = None
+        _cloud_provider_resolved = True
+        return None
+
+    if resolved_provider is None:
+        # No explicit provider configured — try the auto-detect chain.
         # Prefer Browser Use (managed Nous gateway or direct API key),
         # fall back to Browserbase (direct credentials only).
         fallback_provider = BrowserUseProvider()
         if fallback_provider.is_configured():
-            _cached_cloud_provider = fallback_provider
+            resolved_provider = fallback_provider
         else:
             fallback_provider = BrowserbaseProvider()
             if fallback_provider.is_configured():
-                _cached_cloud_provider = fallback_provider
+                resolved_provider = fallback_provider
 
-    return _cached_cloud_provider
+    _cached_cloud_provider = resolved_provider
+    if resolved_provider is not None:
+        # Only mark resolved when we actually picked a provider. A None
+        # result means no credentials were available *yet* — re-check on
+        # the next call so transient startup races (e.g. a Nous Portal
+        # token mid-refresh) self-heal instead of pinning to local for
+        # the rest of the process lifetime.
+        _cloud_provider_resolved = True
+    return resolved_provider
 
 
 from hermes_constants import is_termux as _is_termux_environment


### PR DESCRIPTION
## Summary

Fixes #22324. `_get_cloud_provider()` cached its first result for the life of the process — including transient-`None` outcomes from a credential gap at startup. After this fix, a `None` result is only cached when the user explicitly opts into `cloud_provider: local`. Transient gaps (Nous Portal token mid-refresh, config-read raising, provider `__init__` momentarily failing) re-resolve on the next browser call and the process self-heals.

## The bug

`tools/browser_tool.py:425` set `_cloud_provider_resolved = True` *before* trying to resolve, so any path that left `_cached_cloud_provider` at `None` (silent debug-logged config-read exception, auto-detect finding nothing yet, explicit provider's `__init__` raising) pinned the process to local mode for the rest of its lifetime.

The repro I hit: managed Nous Portal Browser-Use gateway, with the access token expiring shortly after gateway start. First `browser_navigate` call lands while the token is mid-refresh; `BrowserUseProvider.is_configured()` returns False; cache poisoned; every subsequent call returns `features: {"local": true}` with the `Running WITHOUT residential proxies` stealth warning, even though the token rotated 30 seconds later and `hermes status` correctly reports `Browser automation ✓ active via Nous subscription`.

## Fix

Cache-only-on-success semantics. The flag now flips only when:

1. We actually picked a provider (`resolved_provider is not None`), or
2. The user explicitly opted into `cloud_provider: local`.

Three other behavior tweaks bundled in:

- Config-read failures and explicit-provider instantiation failures now return `None` *without* caching, so they retry on the next call.
- Explicit-provider instantiation failures now surface at `warning` level with `exc_info=True` instead of being swallowed at `debug`. Operators who set `browser.cloud_provider: browser-use` deserve to see why it didn't take effect.
- The docstring spells out the cache-only-on-success contract so a future maintainer doesn't reintroduce the eager-flag pattern.

The hot path for the dominant case (process running with a healthy explicit cloud_provider) is unchanged: first call resolves and caches, subsequent calls short-circuit on `_cloud_provider_resolved`.

## Tests

5 new tests in `tests/tools/test_browser_cloud_provider_cache.py`:

- `test_explicit_local_caches_permanently` — `cloud_provider: local` is cached so we don't re-read config every call (regression guard for the explicit case)
- `test_successful_cloud_resolution_caches_permanently` — happy path still caches the picked provider instance (regression guard)
- `test_no_credentials_yet_does_not_cache_none` — **primary regression guard for #22324**: provider becomes configured between calls, second call must pick it up
- `test_config_read_failure_does_not_cache_none` — flaky `read_raw_config` self-heals
- `test_explicit_provider_instantiation_failure_does_not_cache` — flaky provider `__init__` self-heals + warning surfaced

```
$ pytest tests/tools/test_browser_cloud_provider_cache.py -x -q
5 passed in 1.67s

$ pytest tests/tools/test_browser_cloud_fallback.py tests/tools/test_browser_ssrf_local.py \
        tests/tools/test_browser_hybrid_routing.py tests/tools/test_browser_cdp_override.py \
        tests/tools/test_browser_lightpanda.py tests/tools/test_browser_homebrew_paths.py \
        tests/tools/test_managed_browserbase_and_modal.py tests/tools/test_browser_chromium_check.py \
        -x -q
138 passed in 1.95s
```

## Notes

- Backward compatible. Explicit `cloud_provider: local` users still get the same single-resolution behavior. Explicit cloud-provider users hit the same hot path. Only previously-undefined behavior (cached transient None) is changed.
- Companion to #10883's PR, which added runtime `create_session()` fallback in `_get_session_info()`. That fix handled the case where the resolver returns a provider that then fails at session creation. This fix handles the case where the resolver returns `None` due to a transient credential gap.
- No schema, config, or public API changes.
