### PR TITLE
test(skills): cover get_external_skills_dirs cache mtime invalidation

### DIFF
--- a/tests/test_skill_utils_external_cache.py
+++ b/tests/test_skill_utils_external_cache.py
@@ -1,5 +1,6 @@
 """Tests for agent.skill_utils.get_external_skills_dirs cache mtime invalidation."""
 import os
+from pathlib import Path
 
 import pytest
 import yaml
@@ -15,7 +16,10 @@ def cleared_cache():
 
 
 def _write_config(path, dirs):
-    path.write_text(yaml.dump({"skills": {"external_dirs": [str(d) for d in dirs]}}))
+    path.write_text(
+        yaml.dump({"skills": {"external_dirs": [str(d) for d in dirs]}}),
+        encoding="utf-8",
+    )
 
 
 class TestExternalDirsCache:
@@ -30,7 +34,15 @@ class TestExternalDirsCache:
         _write_config(config, [ext])
         monkeypatch.setattr(skill_utils, "get_config_path", lambda: config)
         monkeypatch.setattr(skill_utils, "get_skills_dir", lambda: tmp_path / "local")
+
+        # Prime the cache.
         first = skill_utils.get_external_skills_dirs()
+
+        # If the second call hits the cache, yaml_load must NOT be invoked again.
+        def _explode(_content):
+            raise AssertionError("yaml_load should not be called on cache hit")
+
+        monkeypatch.setattr(skill_utils, "yaml_load", _explode)
         second = skill_utils.get_external_skills_dirs()
         assert first == [ext]
         assert second == [ext]
@@ -43,9 +55,10 @@ class TestExternalDirsCache:
         monkeypatch.setattr(skill_utils, "get_config_path", lambda: config)
         monkeypatch.setattr(skill_utils, "get_skills_dir", lambda: tmp_path / "local")
         first = skill_utils.get_external_skills_dirs()
-        first.append("poisoned")
+        poison = Path("/tmp/poisoned")
+        first.append(poison)
         second = skill_utils.get_external_skills_dirs()
-        assert "poisoned" not in second
+        assert poison not in second
         assert second == [ext]
 
     def test_cache_invalidates_when_mtime_changes(self, tmp_path, monkeypatch, cleared_cache):

--- a/tests/test_skill_utils_external_cache.py
+++ b/tests/test_skill_utils_external_cache.py
@@ -1,0 +1,98 @@
+"""Tests for agent.skill_utils.get_external_skills_dirs cache mtime invalidation."""
+import os
+
+import pytest
+import yaml
+
+from agent import skill_utils
+
+
+@pytest.fixture
+def cleared_cache():
+    skill_utils._external_dirs_cache_clear()
+    yield
+    skill_utils._external_dirs_cache_clear()
+
+
+def _write_config(path, dirs):
+    path.write_text(yaml.dump({"skills": {"external_dirs": [str(d) for d in dirs]}}))
+
+
+class TestExternalDirsCache:
+    def test_returns_empty_when_config_missing(self, tmp_path, monkeypatch, cleared_cache):
+        monkeypatch.setattr(skill_utils, "get_config_path", lambda: tmp_path / "missing.yaml")
+        assert skill_utils.get_external_skills_dirs() == []
+
+    def test_caches_first_call_result(self, tmp_path, monkeypatch, cleared_cache):
+        config = tmp_path / "config.yaml"
+        ext = tmp_path / "ext"
+        ext.mkdir()
+        _write_config(config, [ext])
+        monkeypatch.setattr(skill_utils, "get_config_path", lambda: config)
+        monkeypatch.setattr(skill_utils, "get_skills_dir", lambda: tmp_path / "local")
+        first = skill_utils.get_external_skills_dirs()
+        second = skill_utils.get_external_skills_dirs()
+        assert first == [ext]
+        assert second == [ext]
+
+    def test_returns_copy_so_mutation_does_not_poison_cache(self, tmp_path, monkeypatch, cleared_cache):
+        config = tmp_path / "config.yaml"
+        ext = tmp_path / "ext"
+        ext.mkdir()
+        _write_config(config, [ext])
+        monkeypatch.setattr(skill_utils, "get_config_path", lambda: config)
+        monkeypatch.setattr(skill_utils, "get_skills_dir", lambda: tmp_path / "local")
+        first = skill_utils.get_external_skills_dirs()
+        first.append("poisoned")
+        second = skill_utils.get_external_skills_dirs()
+        assert "poisoned" not in second
+        assert second == [ext]
+
+    def test_cache_invalidates_when_mtime_changes(self, tmp_path, monkeypatch, cleared_cache):
+        config = tmp_path / "config.yaml"
+        ext_a = tmp_path / "ext_a"
+        ext_b = tmp_path / "ext_b"
+        ext_a.mkdir()
+        ext_b.mkdir()
+        monkeypatch.setattr(skill_utils, "get_config_path", lambda: config)
+        monkeypatch.setattr(skill_utils, "get_skills_dir", lambda: tmp_path / "local")
+
+        _write_config(config, [ext_a])
+        first = skill_utils.get_external_skills_dirs()
+
+        _write_config(config, [ext_b])
+        os.utime(config, (config.stat().st_atime + 10, config.stat().st_mtime + 10))
+        second = skill_utils.get_external_skills_dirs()
+
+        assert first == [ext_a]
+        assert second == [ext_b]
+
+    def test_cache_clear_forces_reread(self, tmp_path, monkeypatch, cleared_cache):
+        config = tmp_path / "config.yaml"
+        ext = tmp_path / "ext"
+        ext.mkdir()
+        _write_config(config, [ext])
+        monkeypatch.setattr(skill_utils, "get_config_path", lambda: config)
+        monkeypatch.setattr(skill_utils, "get_skills_dir", lambda: tmp_path / "local")
+        skill_utils.get_external_skills_dirs()
+        assert skill_utils._EXTERNAL_DIRS_CACHE
+        skill_utils._external_dirs_cache_clear()
+        assert not skill_utils._EXTERNAL_DIRS_CACHE
+
+    def test_corrupt_yaml_returns_empty(self, tmp_path, monkeypatch, cleared_cache):
+        config = tmp_path / "config.yaml"
+        config.write_text("::not:valid\n[unclosed")
+        monkeypatch.setattr(skill_utils, "get_config_path", lambda: config)
+        assert skill_utils.get_external_skills_dirs() == []
+
+    def test_skips_nonexistent_dirs(self, tmp_path, monkeypatch, cleared_cache):
+        config = tmp_path / "config.yaml"
+        good = tmp_path / "good"
+        good.mkdir()
+        bad = tmp_path / "ghost"
+        _write_config(config, [good, bad])
+        monkeypatch.setattr(skill_utils, "get_config_path", lambda: config)
+        monkeypatch.setattr(skill_utils, "get_skills_dir", lambda: tmp_path / "local")
+        result = skill_utils.get_external_skills_dirs()
+        assert good in result
+        assert bad not in result


### PR DESCRIPTION
## What does this PR do?

Adds 7 unit tests for `agent.skill_utils.get_external_skills_dirs` cache behavior — fills a gap where existing tests in `tests/agent/test_external_skills.py` cover function output but not cache hit/miss/invalidation semantics.

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- add focused coverage around the target helper/path without broadening runtime behavior
- keep the assertions tied to one contract or regression surface per test file
- use the smallest validation set that proves the intended invariant

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

N/A

<details>
<summary>Original body</summary>

## Summary

Adds 7 unit tests for `agent.skill_utils.get_external_skills_dirs` cache behavior — fills a gap where existing tests in `tests/agent/test_external_skills.py` cover function output but not cache hit/miss/invalidation semantics.

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Summary

Adds 7 unit tests for `agent.skill_utils.get_external_skills_dirs` cache behavior — fills a gap where existing tests in `tests/agent/test_external_skills.py` cover function output but not cache hit/miss/invalidation semantics.

Coverage:
- Returns empty when config.yaml missing
- Caches first call result (subsequent calls return same)
- Returns copy so external mutation does not poison cache
- Cache invalidates when config.yaml mtime changes (re-reads disk)
- `_external_dirs_cache_clear()` test hook empties `_EXTERNAL_DIRS_CACHE`
- Corrupt yaml returns empty list
- Skips dirs that don't exist on disk

## Test plan
- [x] `pytest tests/test_skill_utils_external_cache.py -v` → 7/7 pass
- [x] Full pytest regression: no new failures introduced (110 pre-existing failures unchanged across other suites)

## Solution Sketch

- add focused coverage around the target helper/path without broadening runtime behavior
- keep the assertions tied to one contract or regression surface per test file
- use the smallest validation set that proves the intended invariant

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_