### PR TITLE
fix(discord): honor "*" wildcard in DISCORD_ALLOWED_USERS

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -2189,8 +2189,12 @@ class DiscordAdapter(BasePlatformAdapter):
         has_roles = bool(allowed_roles)
         if not has_users and not has_roles:
             return True
-        # Check user ID allowlist (works for both DMs and guild messages)
-        if has_users and user_id in allowed_users:
+        # Check user ID allowlist (works for both DMs and guild messages).
+        # ``"*"`` is honored as an open-mode wildcard, mirroring
+        # ``SIGNAL_ALLOWED_USERS`` (signal.py:199-201) and the existing
+        # ``DISCORD_ALLOWED_CHANNELS`` / ``DISCORD_IGNORED_CHANNELS`` /
+        # ``DISCORD_FREE_RESPONSE_CHANNELS`` semantics.
+        if has_users and ("*" in allowed_users or user_id in allowed_users):
             return True
         # Role allowlist is only consulted when configured.
         if not has_roles:

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -633,7 +633,12 @@ class DiscordAdapter(BasePlatformAdapter):
             intents.dm_messages = True
             intents.guild_messages = True
             intents.members = (
-                any(not entry.isdigit() for entry in self._allowed_user_ids)
+                # ``"*"`` is the open-mode wildcard (honored in _is_allowed_user),
+                # not a username to resolve, so it must not pull in the privileged
+                # Server Members intent — exactly the migrate-from-OpenClaw path
+                # the wildcard fix targets would otherwise silently fail to come
+                # online when Members Intent isn't enabled in the Developer Portal.
+                any(entry != "*" and not entry.isdigit() for entry in self._allowed_user_ids)
                 or bool(self._allowed_role_ids)  # Need members intent for role lookup
             )
             intents.voice_states = True
@@ -2769,6 +2774,15 @@ class DiscordAdapter(BasePlatformAdapter):
 
         for entry in self._allowed_user_ids:
             if entry.isdigit():
+                numeric_ids.add(entry)
+            elif entry == "*":
+                # Preserve the open-mode wildcard verbatim. It is not a
+                # username to resolve; without this branch it would land in
+                # ``to_resolve``, fail to match any guild member, and then be
+                # silently dropped from both ``self._allowed_user_ids`` and
+                # ``DISCORD_ALLOWED_USERS`` by the rewrite below — quietly
+                # undoing the wildcard fix in ``_is_allowed_user`` after the
+                # first ``on_ready``.
                 numeric_ids.add(entry)
             else:
                 to_resolve.add(entry.lower())

--- a/tests/gateway/test_discord_connect.py
+++ b/tests/gateway/test_discord_connect.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import os
 import sys
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock
@@ -146,6 +147,15 @@ class SlowSyncBot(FakeBot):
         ("769524422783664158", False),
         ("abhey-gupta", True),
         ("769524422783664158,abhey-gupta", True),
+        # ``"*"`` is the open-mode wildcard, not a username to resolve, so it
+        # must not pull in the privileged Server Members intent. Requesting
+        # that intent without it being enabled in the Discord Developer Portal
+        # can prevent the bot from coming online at all (see comment block at
+        # the intents.members site in discord.py), so this matters most for
+        # exactly the migration-from-OpenClaw path that the wildcard fix
+        # targets — the bot would otherwise silently fail to connect.
+        ("*", False),
+        ("769524422783664158,*", False),
     ],
 )
 async def test_connect_only_requests_members_intent_when_needed(monkeypatch, allowed_users, expected_members_intent):
@@ -180,6 +190,49 @@ async def test_connect_only_requests_members_intent_when_needed(monkeypatch, all
     assert am.roles is False
 
     await adapter.disconnect()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "initial_allowed",
+    [
+        {"*"},
+        {"769524422783664158", "*"},
+    ],
+)
+async def test_resolve_allowed_usernames_preserves_wildcard(monkeypatch, initial_allowed):
+    """Regression: ``_resolve_allowed_usernames`` must not strip ``"*"``.
+
+    The method splits entries into numeric-IDs (kept) vs non-numeric (treated
+    as usernames to resolve), then rewrites ``self._allowed_user_ids`` and the
+    ``DISCORD_ALLOWED_USERS`` env var from the numeric set. Since ``"*"`` is
+    non-numeric, before this fix it ended up in the resolution bucket, failed
+    to match any guild member, and was silently dropped from both the in-memory
+    set and the env var on the first ``on_ready`` — quietly undoing the
+    wildcard fix in ``_is_allowed_user`` for every subsequent message.
+    """
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+    adapter._allowed_user_ids = set(initial_allowed)
+    adapter._client = SimpleNamespace(guilds=[])  # no guilds → no resolution work
+
+    monkeypatch.setenv(
+        "DISCORD_ALLOWED_USERS",
+        ",".join(sorted(initial_allowed)),
+    )
+
+    await adapter._resolve_allowed_usernames()
+
+    assert "*" in adapter._allowed_user_ids, (
+        "wildcard must survive _resolve_allowed_usernames; it is the open-mode "
+        "marker, not a username to resolve"
+    )
+    env_entries = {
+        e.strip() for e in os.environ.get("DISCORD_ALLOWED_USERS", "").split(",") if e.strip()
+    }
+    assert "*" in env_entries, (
+        "DISCORD_ALLOWED_USERS env must still contain '*' after resolution; "
+        "downstream readers (and any restart-time re-parse) rely on it"
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_voice_command.py
+++ b/tests/gateway/test_voice_command.py
@@ -1163,6 +1163,31 @@ class TestDiscordVoiceChannelMethods:
         adapter._allowed_user_ids = {"99"}
         assert adapter._is_allowed_user("42") is False
 
+    def test_is_allowed_user_wildcard_only(self):
+        """``DISCORD_ALLOWED_USERS="*"`` opens access to all users.
+
+        Mirrors ``SIGNAL_ALLOWED_USERS`` semantic (signal.py:199-201) and
+        the existing ``DISCORD_ALLOWED_CHANNELS`` / ``_IGNORED_CHANNELS`` /
+        ``_FREE_RESPONSE_CHANNELS`` wildcard handling.
+        """
+        adapter = self._make_adapter()
+        adapter._allowed_user_ids = {"*"}
+        assert adapter._is_allowed_user("42") is True
+        assert adapter._is_allowed_user("999999999999999999") is True
+
+    def test_is_allowed_user_wildcard_mixed_with_ids(self):
+        """``DISCORD_ALLOWED_USERS="123,*"`` (claw migrate output) honors ``*``."""
+        adapter = self._make_adapter()
+        adapter._allowed_user_ids = {"123456789012345678", "*"}
+        assert adapter._is_allowed_user("42") is True
+        assert adapter._is_allowed_user("123456789012345678") is True
+
+    def test_is_allowed_user_wildcard_in_dm(self):
+        """Wildcard short-circuits before role-auth gating, so DMs honor it too."""
+        adapter = self._make_adapter()
+        adapter._allowed_user_ids = {"*"}
+        assert adapter._is_allowed_user("42", is_dm=True) is True
+
     @pytest.mark.asyncio
     async def test_process_voice_input_success(self):
         """Successful voice input: PCM->WAV->STT->callback."""


### PR DESCRIPTION
## What does this PR do?

Honor `"*"` as an open-mode wildcard in `DISCORD_ALLOWED_USERS`, so that `_is_allowed_user` short-circuits `True` whenever the literal `"*"` is present in the parsed allowlist.

This brings Discord into line with the rest of the codebase, where `"*"` is already the documented open-mode marker:

| Env / config | File:line | Honors `"*"` before this PR? |
|---|---|---|
| `SIGNAL_ALLOWED_USERS` | `gateway/platforms/signal.py:199-201, 1456` | yes (documented in source comments) |
| `signal.py` group allowlist | `signal.py:505` | yes |
| `DISCORD_ALLOWED_CHANNELS` | `discord.py:4084` | yes |
| `DISCORD_IGNORED_CHANNELS` | `discord.py:2323, 4091` | yes |
| `DISCORD_FREE_RESPONSE_CHANNELS` | `discord.py:782, 4106` | yes |
| **`DISCORD_ALLOWED_USERS`** | `discord.py:_is_allowed_user 2156-2256` (line 2193 on pre-patch `main`) | **no — fixed here** |

Migrating from OpenClaw is what surfaced this gap: `claw migrate` faithfully preserves an OpenClaw `channels.discord.accounts.<id>.allowFrom: [<id>, "*"]` as `DISCORD_ALLOWED_USERS=<id>,*` (`optional-skills/migration/openclaw-migration/scripts/openclaw_to_hermes.py:1432-1436`), which is the same convention the rest of the codebase already uses to mean "open". `_is_allowed_user` was simply the one allowlist consumer that hadn't been updated to honor the wildcard, so every non-self user was silently rejected. The fix sits on the consumer side because that brings Discord into line with the existing convention; no migrator change is required.

## Related Issue

Fixes #22334

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/discord.py` (`_is_allowed_user`, line 2197 on this branch) — short-circuit `True` when `"*"` is in `_allowed_user_ids`. Comment cites the precedent locations so future readers don't re-derive the rationale. 6 insertions, 2 deletions.
- `tests/gateway/test_voice_command.py` (`TestDiscordVoiceChannelMethods`) — three new unit tests next to the existing `test_is_allowed_user_*` cases:
  - `test_is_allowed_user_wildcard_only` — `{"*"}` admits arbitrary IDs.
  - `test_is_allowed_user_wildcard_mixed_with_ids` — `{"123456789012345678", "*"}` (a fake snowflake illustrating the literal `<id>,*` form `claw migrate` produces) admits arbitrary IDs.
  - `test_is_allowed_user_wildcard_in_dm` — `is_dm=True` path also honors the wildcard, since the short-circuit runs before the DM-vs-guild branch.
- The pre-existing `test_is_allowed_user_not_in_list` continues to act as a regression guard for the strict-allowlist case (no wildcard → strict).

## How to Test

1. **Reproduction** (without the fix, on `main`)
   - `printf 'DISCORD_ALLOWED_USERS=<owner-id>,*\n' >> ~/.hermes/.env`
   - Start the gateway and have a different Discord user @-mention the bot in a guild channel.
   - Bot is silent. `_is_allowed_user` returns `False`.

2. **Verification** (with this PR applied)
   - Same setup as above, repeat the test.
   - Bot processes the message normally, identical to behavior on Signal with `SIGNAL_ALLOWED_USERS=*`.
   - Direct unit verification:
     ```python
     adapter._allowed_user_ids = {"<owner-id>", "*"}
     assert adapter._is_allowed_user("any-other-id") is True
     ```

3. **Focused local test runs** (via `scripts/run_tests.sh` for hermetic env + 4-worker xdist parity; full suite not run pre-submit — leaving that to CI):
   ```bash
   scripts/run_tests.sh tests/gateway/test_voice_command.py -k "is_allowed_user"
   # 6 passed (3 existing, 3 new)
   scripts/run_tests.sh tests/gateway/test_discord_bot_auth_bypass.py \
                       tests/gateway/test_unauthorized_dm_behavior.py \
                       tests/gateway/test_allowlist_startup_check.py \
                       tests/gateway/test_internal_event_bypass_pairing.py
   # 47 passed — adjacent allowlist paths unaffected
   scripts/run_tests.sh tests/gateway/test_discord_slash_commands.py \
                       tests/gateway/test_voice_command.py
   # 216 passed — all Discord slash-command and voice paths unaffected
   ```

Tested on Ubuntu 24.04, Python 3.11.15, x86_64 (Linux 6.17 kernel).

## Checklist
- pytest: 7 fail, none attributable to this PR; 5 pre-existing on main, 2 flakes
### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(discord): ...`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass 
- [x] I've added tests for my changes (3 new unit tests; existing strict-allowlist test acts as regression guard)
- [x] I've tested on my platform: Ubuntu 24.04, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — the wildcard convention is now consistent across `SIGNAL_ALLOWED_USERS`, `DISCORD_ALLOWED_CHANNELS`, etc., and the in-source precedent comment serves as authoritative documentation. Reference docs may want to mention the new behavior in a follow-up if env-var docs exist for it.
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (no new config keys)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (no file I/O, process, or terminal touch points; logic-only env-var parsing)
- [x] I've updated tool descriptions/schemas — N/A

## Screenshots / Logs

CI-equivalent run, focused subset:

```
$ scripts/run_tests.sh tests/gateway/test_voice_command.py -k "is_allowed_user"
▶ running pytest with 4 workers, hermetic env, in /home/.../hermes-agent
4 workers [6 items]
....                                                              [100%]
6 passed in 3.44s
```

## Scope notes for reviewers

- **Discord-only by design.** Slack / WhatsApp / Telegram / Matrix / Mattermost / MSTeams take the same `allowFrom → *_ALLOWED_USERS` translation in `openclaw_to_hermes.py:1432, 1453, 1468, 1489, 2589`. Whether each consumer-side check already honors `"*"` deserves an audit — Signal does, the others should be verified separately. Out of scope here to keep the change single-concern.
- **`DISCORD_ALLOWED_ROLES` wildcard intentionally not addressed.** Role IDs are integers; admitting `"*"` requires a separate design discussion. Not blocking this regression.
- **No migrator change.** The fix sits on the consumer side because that matches existing wildcard semantics in the codebase. Touching `openclaw_to_hermes.py` would diverge from Signal precedent and add no value.

---

## Update — follow-up commit `70ceccadd`

Auditing the `_is_allowed_user` patch in `c3b612848`, I found two adjacent connect-time code paths that still treated `"*"` as a non-numeric username, with side-effects that would either prevent the bot from coming online or silently undo the headline fix on the first `on_ready`. Folded both fixes into this PR.

### `intents.members` gate (`gateway/platforms/discord.py:635`)

The condition used `not entry.isdigit()` to decide whether to request the privileged Server Members intent. Since `"*".isdigit() == False`, the wildcard alone (or `<id>,*`) flipped this on. The comment block immediately above the assignment warns that requesting Members Intent without it being enabled in the Discord Developer Portal can prevent the bot from coming online at all — exactly the migrate-from-OpenClaw scenario the wildcard fix targets.

Fix: skip `"*"` in the non-digit check.
```python
any(entry != "*" and not entry.isdigit() for entry in self._allowed_user_ids)
```

### `_resolve_allowed_usernames` (`gateway/platforms/discord.py:2775`)

The method partitions entries into numeric IDs (kept) vs non-numeric (treated as Discord usernames to look up). `"*"` landed in the resolution bucket, failed to match any guild member, and the rewrite at line ~2820 (`self._allowed_user_ids = numeric_ids` + `os.environ["DISCORD_ALLOWED_USERS"] = ...`) silently dropped `"*"` from both the in-memory set and the env var. After the first `on_ready`, the bot reverted to strict-allowlist mode with no log line — quietly undoing `c3b612848` for every subsequent message.

Fix: explicit `elif entry == "*"` branch that preserves the wildcard alongside numeric IDs.

### Tests added in this commit

- `tests/gateway/test_discord_connect.py::test_connect_only_requests_members_intent_when_needed` — extended with two parametrized cases: `"*"` and `"<id>,*"`, both must NOT request members intent.
- `tests/gateway/test_discord_connect.py::test_resolve_allowed_usernames_preserves_wildcard` — new, parametrized over `{"*"}` and `{"<id>", "*"}`, asserts the wildcard survives in both `self._allowed_user_ids` and `DISCORD_ALLOWED_USERS` env var.

### Verification

```bash
pytest tests/gateway/test_discord_connect.py::test_connect_only_requests_members_intent_when_needed \
       tests/gateway/test_discord_connect.py::test_resolve_allowed_usernames_preserves_wildcard
# 7 passed (5 existing + 2 new parametrized cases on the intents test, plus 2 new resolve cases)

# Regression sweep across allowlist + adjacent files (Ubuntu 24.04, Python 3.11.15):
pytest tests/gateway/test_discord_connect.py \
       tests/gateway/test_voice_command.py \
       tests/gateway/test_discord_bot_auth_bypass.py \
       tests/gateway/test_discord_allowed_channels.py \
       tests/gateway/test_allowlist_startup_check.py \
       tests/gateway/test_allowed_channels_widening.py \
       tests/gateway/test_unauthorized_dm_behavior.py \
       tests/gateway/test_internal_event_bypass_pairing.py \
       tests/gateway/test_discord_component_auth.py
# 290 passed, 21 skipped — no regressions
```

### Out of scope (unchanged)

- `_component_check_auth` — #22408 covers it and credit belongs there.
