### PR TITLE
test(tui): cover lib/text helpers edge cases

### DIFF
--- a/ui-tui/src/__tests__/textHelpersEdgeCases.test.ts
+++ b/ui-tui/src/__tests__/textHelpersEdgeCases.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  cleanThinkingText,
+  flat,
+  formatToolCall,
+  hasAnsi,
+  isPasteBackedText,
+  isTransientTrailLine,
+  parseToolTrailResultLine,
+  splitToolDuration,
+  stripAnsi,
+  stripTrailingPasteNewlines,
+  toolTrailLabel
+} from '../lib/text.js'
+
+const ESC = String.fromCharCode(27)
+
+describe('hasAnsi', () => {
+  it('detects CSI sequences', () => {
+    expect(hasAnsi(`${ESC}[31mred${ESC}[0m`)).toBe(true)
+  })
+
+  it('detects OSC sequences', () => {
+    expect(hasAnsi(`${ESC}]0;title${ESC}\\`)).toBe(true)
+  })
+
+  it('returns false for plain text', () => {
+    expect(hasAnsi('plain text without escapes')).toBe(false)
+  })
+
+  it('returns false for empty string', () => {
+    expect(hasAnsi('')).toBe(false)
+  })
+})
+
+describe('stripAnsi', () => {
+  it('removes CSI color sequences', () => {
+    expect(stripAnsi(`${ESC}[31mred${ESC}[0m`)).toBe('red')
+  })
+
+  it('leaves text without escapes untouched', () => {
+    expect(stripAnsi('hello world')).toBe('hello world')
+  })
+})
+
+describe('stripTrailingPasteNewlines', () => {
+  it('removes trailing newlines from non-empty text', () => {
+    expect(stripTrailingPasteNewlines('hello\n\n\n')).toBe('hello')
+  })
+
+  it('preserves intermediate newlines', () => {
+    expect(stripTrailingPasteNewlines('a\nb\n')).toBe('a\nb')
+  })
+
+  it('returns text unchanged when only newlines (whitespace fallback)', () => {
+    expect(stripTrailingPasteNewlines('\n\n\n')).toBe('\n\n\n')
+  })
+
+  it('returns text unchanged when no trailing newline', () => {
+    expect(stripTrailingPasteNewlines('hello')).toBe('hello')
+  })
+})
+
+describe('toolTrailLabel', () => {
+  it('title-cases snake_case', () => {
+    expect(toolTrailLabel('read_file')).toBe('Read File')
+  })
+
+  it('handles single word', () => {
+    expect(toolTrailLabel('bash')).toBe('Bash')
+  })
+
+  it('drops empty parts from leading underscore', () => {
+    expect(toolTrailLabel('_get_status')).toBe('Get Status')
+  })
+
+  it('falls back to original for empty input', () => {
+    expect(toolTrailLabel('')).toBe('')
+  })
+})
+
+describe('formatToolCall', () => {
+  it('appends compact preview in quotes when context present', () => {
+    expect(formatToolCall('read_file', 'src/app.ts')).toBe('Read File("src/app.ts")')
+  })
+
+  it('returns label only when context empty', () => {
+    expect(formatToolCall('bash')).toBe('Bash')
+  })
+
+  it('truncates long context to 64 chars', () => {
+    const ctx = 'a'.repeat(100)
+    const out = formatToolCall('write', ctx)
+    expect(out.startsWith('Write("')).toBe(true)
+    expect(out.endsWith('…")')).toBe(true)
+  })
+
+  it('collapses whitespace in context', () => {
+    expect(formatToolCall('grep', '  foo\n  bar  ')).toBe('Grep("foo bar")')
+  })
+})
+
+describe('parseToolTrailResultLine', () => {
+  it('parses success mark with detail via " :: "', () => {
+    expect(parseToolTrailResultLine('Read("a") :: 12 lines ✓')).toEqual({
+      call: 'Read("a")',
+      detail: '12 lines',
+      mark: '✓'
+    })
+  })
+
+  it('parses error mark', () => {
+    expect(parseToolTrailResultLine('Bash("x") :: failed ✗')).toEqual({
+      call: 'Bash("x")',
+      detail: 'failed',
+      mark: '✗'
+    })
+  })
+
+  it('falls back to legacy ": " separator', () => {
+    expect(parseToolTrailResultLine('Read: ok ✓')).toEqual({ call: 'Read', detail: 'ok', mark: '✓' })
+  })
+
+  it('returns body as call when no separator', () => {
+    expect(parseToolTrailResultLine('Bash ✓')).toEqual({ call: 'Bash', detail: '', mark: '✓' })
+  })
+
+  it('returns null when not a result line', () => {
+    expect(parseToolTrailResultLine('drafting answer')).toBeNull()
+  })
+})
+
+describe('splitToolDuration', () => {
+  it('extracts trailing duration', () => {
+    expect(splitToolDuration('Read("x") (1.5s)')).toEqual({ label: 'Read("x")', duration: ' (1.5s)' })
+  })
+
+  it('handles integer seconds', () => {
+    expect(splitToolDuration('Bash (12s)')).toEqual({ label: 'Bash', duration: ' (12s)' })
+  })
+
+  it('returns empty duration when none present', () => {
+    expect(splitToolDuration('Read("x")')).toEqual({ label: 'Read("x")', duration: '' })
+  })
+})
+
+describe('isTransientTrailLine', () => {
+  it('matches drafting prefix', () => {
+    expect(isTransientTrailLine('drafting reply…')).toBe(true)
+  })
+
+  it('matches exact "analyzing tool output…"', () => {
+    expect(isTransientTrailLine('analyzing tool output…')).toBe(true)
+  })
+
+  it('rejects unrelated lines', () => {
+    expect(isTransientTrailLine('Bash ✓')).toBe(false)
+  })
+})
+
+describe('isPasteBackedText', () => {
+  it('detects [[paste:N]] token', () => {
+    expect(isPasteBackedText('hello [[paste:42]] world')).toBe(true)
+  })
+
+  it('detects "[paste #N attached]" form', () => {
+    expect(isPasteBackedText('see [paste #1 attached]')).toBe(true)
+  })
+
+  it('detects "[paste #N excerpt]" form', () => {
+    expect(isPasteBackedText('see [paste #2 excerpt: foo]')).toBe(true)
+  })
+
+  it('returns false when no paste markers', () => {
+    expect(isPasteBackedText('plain text without paste tokens')).toBe(false)
+  })
+})
+
+describe('flat', () => {
+  it('flattens record values into one array', () => {
+    expect(flat({ a: ['x', 'y'], b: ['z'] })).toEqual(['x', 'y', 'z'])
+  })
+
+  it('returns empty array for empty record', () => {
+    expect(flat({})).toEqual([])
+  })
+
+  it('preserves order of insertion across keys', () => {
+    expect(flat({ first: ['1'], second: ['2', '3'] })).toEqual(['1', '2', '3'])
+  })
+})
+
+describe('cleanThinkingText', () => {
+  it('returns trimmed input when no status verbs to strip', () => {
+    expect(cleanThinkingText('Reasoning about edge case.')).toBe('Reasoning about edge case.')
+  })
+
+  it('drops blank lines between content', () => {
+    expect(cleanThinkingText('a\n\n\n\nb')).toBe('a\nb')
+  })
+
+  it('inserts blank line before bold markers', () => {
+    expect(cleanThinkingText('intro **bold**')).toBe('intro \n\n**bold**')
+  })
+
+  it('returns empty string when input is whitespace only', () => {
+    expect(cleanThinkingText('   \n\n   ')).toBe('')
+  })
+})


### PR DESCRIPTION
## What does this PR do?

Adds 40 unit tests covering 10 ui-tui/src/lib/text.ts helpers that had no direct coverage: hasAnsi, stripAnsi, stripTrailingPasteNewlines, toolTrailLabel, formatToolCall, parseToolTrailResultLine, splitToolDuration, isTransientTrailLine, isPasteBackedText, flat, cleanThinkingText.

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- add focused coverage around the target helper/path without broadening runtime behavior
- keep the assertions tied to one contract or regression surface per test file
- use the smallest validation set that proves the intended invariant

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

N/A

<details>
<summary>Original body</summary>

## Summary

Adds 40 unit tests covering 10 ui-tui/src/lib/text.ts helpers that had no direct coverage: hasAnsi, stripAnsi, stripTrailingPasteNewlines, toolTrailLabel, formatToolCall, parseToolTrailResultLine, splitToolDuration, isTransientTrailLine, isPasteBackedText, flat, cleanThinkingText.

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Summary

Adds 40 unit tests covering 10 ui-tui/src/lib/text.ts helpers that had no direct coverage: hasAnsi, stripAnsi, stripTrailingPasteNewlines, toolTrailLabel, formatToolCall, parseToolTrailResultLine, splitToolDuration, isTransientTrailLine, isPasteBackedText, flat, cleanThinkingText.

Coverage focuses on edge cases: empty input, ANSI CSI vs OSC, snake_case/leading-underscore handling, 64-char compactPreview truncation, legacy ': ' separator fallback in parseToolTrailResultLine, all three paste-token formats, blank-line filtering and bold-marker spacing in cleanThinkingText.

## Test plan
- [x] bun run test (ui-tui) → 63 files / 694 tests pass (+40 new)

## Solution Sketch

- add focused coverage around the target helper/path without broadening runtime behavior
- keep the assertions tied to one contract or regression surface per test file
- use the smallest validation set that proves the intended invariant

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_