### PR TITLE
test(tui): cover content/setup default chunks

### DIFF
--- a/ui-tui/src/__tests__/contentSetup.test.ts
+++ b/ui-tui/src/__tests__/contentSetup.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildSetupRequiredSections, SETUP_REQUIRED_TITLE } from '../content/setup.js'
+
+describe('SETUP_REQUIRED_TITLE', () => {
+  it('exposes the panel title constant', () => {
+    expect(SETUP_REQUIRED_TITLE).toBe('Setup Required')
+  })
+})
+
+describe('buildSetupRequiredSections', () => {
+  it('returns two sections: intro text + actions table', () => {
+    const sections = buildSetupRequiredSections()
+    expect(sections).toHaveLength(2)
+  })
+
+  it('first section is the intro mentioning model provider', () => {
+    const [intro] = buildSetupRequiredSections()
+    expect(intro.text).toMatch(/model provider/i)
+    expect(intro.rows).toBeUndefined()
+  })
+
+  it('second section is the actions table with title "Actions"', () => {
+    const [, actions] = buildSetupRequiredSections()
+    expect(actions.title).toBe('Actions')
+    expect(actions.rows).toBeDefined()
+  })
+
+  it('actions table includes /model, /setup and Ctrl+C entries', () => {
+    const [, actions] = buildSetupRequiredSections()
+    const keys = (actions.rows ?? []).map(row => row[0])
+    expect(keys).toEqual(['/model', '/setup', 'Ctrl+C'])
+  })
+
+  it('every action row has a label and a description', () => {
+    const [, actions] = buildSetupRequiredSections()
+    for (const row of actions.rows ?? []) {
+      expect(row).toHaveLength(2)
+      expect(row[0]).toBeTruthy()
+      expect(row[1]).toBeTruthy()
+    }
+  })
+
+  it('returns a fresh array on each call (no shared mutable state)', () => {
+    const a = buildSetupRequiredSections()
+    const b = buildSetupRequiredSections()
+    expect(a).not.toBe(b)
+    expect(a).toEqual(b)
+  })
+})


### PR DESCRIPTION
## What does this PR do?

Adds 7 unit tests for ui-tui/src/content/setup.ts (previously untested):

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- add focused coverage around the target helper/path without broadening runtime behavior
- keep the assertions tied to one contract or regression surface per test file
- use the smallest validation set that proves the intended invariant

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

N/A

<details>
<summary>Original body</summary>

## Summary

Adds 7 unit tests for ui-tui/src/content/setup.ts (previously untested):

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Summary

Adds 7 unit tests for ui-tui/src/content/setup.ts (previously untested):

- SETUP_REQUIRED_TITLE constant value
- buildSetupRequiredSections returns 2 sections (intro + actions)
- intro section text mentions model provider
- second section is the actions table titled 'Actions'
- actions rows include /model, /setup, Ctrl+C in order
- every action row is [label, description] pair
- builder returns a fresh array on each call (not a shared singleton)

## Test plan
- [x] bun run test (ui-tui) → 63 files / 661 tests pass (+7 new)

## Solution Sketch

- add focused coverage around the target helper/path without broadening runtime behavior
- keep the assertions tied to one contract or regression surface per test file
- use the smallest validation set that proves the intended invariant

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_