### PR TITLE
test(tui): cover content/charms LONG_RUN_CHARMS invariants

### DIFF
--- a/ui-tui/src/__tests__/contentCharms.test.ts
+++ b/ui-tui/src/__tests__/contentCharms.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+
+import { LONG_RUN_CHARMS } from '../content/charms.js'
+
+describe('LONG_RUN_CHARMS', () => {
+  it('exposes a non-empty array of charm strings', () => {
+    expect(Array.isArray(LONG_RUN_CHARMS)).toBe(true)
+    expect(LONG_RUN_CHARMS.length).toBeGreaterThan(0)
+  })
+
+  it('every entry is a non-empty string', () => {
+    for (const charm of LONG_RUN_CHARMS) {
+      expect(typeof charm).toBe('string')
+      expect(charm.length).toBeGreaterThan(0)
+    }
+  })
+
+  it('all charms are unique (no duplicates)', () => {
+    expect(new Set(LONG_RUN_CHARMS).size).toBe(LONG_RUN_CHARMS.length)
+  })
+
+  it('every entry ends with the ellipsis "…" character', () => {
+    for (const charm of LONG_RUN_CHARMS) {
+      expect(charm.endsWith('…')).toBe(true)
+    }
+  })
+
+  it('no entry contains literal newlines (single-line surface only)', () => {
+    for (const charm of LONG_RUN_CHARMS) {
+      expect(charm.includes('\n')).toBe(false)
+    }
+  })
+
+  it('every entry stays under 60 chars (suffix appended at runtime fits status row)', () => {
+    for (const charm of LONG_RUN_CHARMS) {
+      expect(charm.length).toBeLessThan(60)
+    }
+  })
+})


### PR DESCRIPTION
## What does this PR do?

Adds 6 unit tests for ui-tui/src/content/charms.ts (previously untested). Locks structural invariants of the LONG_RUN_CHARMS array used by useLongRunToolCharms when long-running tool calls need a status row charm:

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- add focused coverage around the target helper/path without broadening runtime behavior
- keep the assertions tied to one contract or regression surface per test file
- use the smallest validation set that proves the intended invariant

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

N/A

<details>
<summary>Original body</summary>

## Summary

Adds 6 unit tests for ui-tui/src/content/charms.ts (previously untested). Locks structural invariants of the LONG_RUN_CHARMS array used by useLongRunToolCharms when long-running tool calls need a status row charm:

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Summary

Adds 6 unit tests for ui-tui/src/content/charms.ts (previously untested). Locks structural invariants of the LONG_RUN_CHARMS array used by useLongRunToolCharms when long-running tool calls need a status row charm:

- non-empty array of strings
- every entry is a non-empty string
- no duplicate entries
- every entry ends with the ellipsis '…' character (consistent typography)
- no entry contains literal newlines (single-line surface)
- every entry stays under 60 chars (fits the status row with the runtime suffix)

## Test plan
- [x] bun run test (ui-tui) → 63 files / 660 tests pass (+6 new)

## Solution Sketch

- add focused coverage around the target helper/path without broadening runtime behavior
- keep the assertions tied to one contract or regression surface per test file
- use the smallest validation set that proves the intended invariant

## Related Issue

N/A

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_