### PR TITLE
[security] fix(gateway): harden Yuanbao URL downloads

### DIFF
--- a/gateway/platforms/yuanbao_media.py
+++ b/gateway/platforms/yuanbao_media.py
@@ -29,6 +29,9 @@ from typing import Optional, Any
 
 import httpx
 
+from gateway.platforms.base import _ssrf_redirect_guard, safe_url_for_log
+from tools import url_safety
+
 logger = logging.getLogger(__name__)
 
 # ============ 常量 ============
@@ -217,8 +220,17 @@ async def download_url(
         ValueError:  内容超过大小限制
         httpx.HTTPError: 网络/HTTP 错误
     """
+    if not url_safety.is_safe_url(url):
+        raise ValueError(
+            f"Blocked unsafe URL (SSRF protection): {safe_url_for_log(url)}"
+        )
+
     max_bytes = max_size_mb * 1024 * 1024
-    async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+    async with httpx.AsyncClient(
+        timeout=30.0,
+        follow_redirects=True,
+        event_hooks={"response": [_ssrf_redirect_guard]},
+    ) as client:
         # 先 HEAD 检查大小
         try:
             head = await client.head(url)

--- a/tests/test_yuanbao_media_security.py
+++ b/tests/test_yuanbao_media_security.py
@@ -1,0 +1,57 @@
+import pytest
+
+from gateway.platforms import yuanbao_media
+
+
+@pytest.mark.asyncio
+async def test_download_url_rejects_unsafe_url_before_http(monkeypatch):
+    monkeypatch.setattr(yuanbao_media.url_safety, "is_safe_url", lambda url: False)
+    client_cls = MockAsyncClientFactory()
+    monkeypatch.setattr(yuanbao_media.httpx, "AsyncClient", client_cls)
+
+    with pytest.raises(ValueError, match="Blocked unsafe URL"):
+        await yuanbao_media.download_url("http://127.0.0.1:8000/private.png")
+
+    assert client_cls.calls == []
+
+
+@pytest.mark.asyncio
+async def test_download_url_installs_redirect_ssrf_guard(monkeypatch):
+    monkeypatch.setattr(yuanbao_media.url_safety, "is_safe_url", lambda url: True)
+    client_cls = MockAsyncClientFactory(enter_exception=StopAfterClientCreated)
+    monkeypatch.setattr(yuanbao_media.httpx, "AsyncClient", client_cls)
+
+    with pytest.raises(StopAfterClientCreated):
+        await yuanbao_media.download_url("https://example.com/image.png")
+
+    assert len(client_cls.calls) == 1
+    kwargs = client_cls.calls[0]
+    assert kwargs["follow_redirects"] is True
+    assert kwargs["event_hooks"] == {"response": [yuanbao_media._ssrf_redirect_guard]}
+
+
+class StopAfterClientCreated(Exception):
+    pass
+
+
+class MockAsyncClientFactory:
+    def __init__(self, enter_exception=None):
+        self.calls = []
+        self.enter_exception = enter_exception
+
+    def __call__(self, **kwargs):
+        self.calls.append(kwargs)
+        return MockAsyncClient(self.enter_exception)
+
+
+class MockAsyncClient:
+    def __init__(self, enter_exception=None):
+        self.enter_exception = enter_exception
+
+    async def __aenter__(self):
+        if self.enter_exception:
+            raise self.enter_exception()
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False


### PR DESCRIPTION
## Summary

This PR hardens the Yuanbao media URL downloader so user-supplied HTTP(S) media URLs are checked with Hermes' existing SSRF protections before any network request is created, and so redirects are re-checked during the HTTPX redirect chain.

The change is intentionally narrow:

- validate the original URL with `tools.url_safety.is_safe_url()` before `HEAD` or `GET`
- attach the shared `_ssrf_redirect_guard` response hook while following redirects
- add focused regression coverage that proves unsafe URLs are rejected before HTTP client creation and that the redirect guard is installed

## Security issues covered

- Issue: Yuanbao media URL download SSRF guard bypass
- Impact: a user-controlled Yuanbao media URL could be fetched by the gateway without the SSRF admission checks already used by other platform download paths
- Fix: enforce initial URL validation and redirect-time validation in `gateway/platforms/yuanbao_media.py`

## Before this PR

- `download_url()` accepted a caller-provided URL and immediately created an `httpx.AsyncClient` with `follow_redirects=True`.
- No initial `url_safety.is_safe_url()` check was applied before the `HEAD` or streamed `GET` request.
- Redirect targets were followed by HTTPX without the shared response hook that blocks unsafe redirect destinations.

## After this PR

- Unsafe URLs are rejected before any HTTP client is created.
- Redirect-following remains enabled for normal Yuanbao media use, but each redirect response is passed through the existing SSRF redirect guard.
- Regression tests cover both the pre-network rejection path and the redirect hook wiring.

## Why this matters

Yuanbao media sending can cause the gateway host to fetch a URL selected by a message/tool caller. Without the same SSRF boundary used elsewhere in Hermes, a malicious or compromised caller could try to make the gateway connect to loopback, private-network, metadata, or other host-local services. Redirects are especially important because an apparently public URL can later redirect to an internal address.

## Attack flow

1. A caller supplies a Yuanbao media URL for delivery.
2. The Yuanbao media helper calls `download_url()`.
3. Vulnerable code creates an HTTPX client and issues `HEAD` / `GET` requests to the supplied URL.
4. With redirects enabled and no SSRF guard, the gateway can be steered toward an internal or otherwise blocked destination.

## Affected code

- `gateway/platforms/yuanbao_media.py`
  - `download_url()` URL admission and redirect behavior

## Root cause

- The Yuanbao media downloader implemented its own HTTP fetch path instead of reusing the SSRF validation pattern already present in shared platform code.
- Redirects were enabled without a response hook that validates redirect destinations.

## CVSS assessment

- CVSS v3.1: 6.5 Medium
- Vector: `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:U/C:H/I:N/A:N`
- Rationale: exploitation requires access to a Hermes message/tool path that can request Yuanbao media delivery, but the vulnerable fetch is network-reachable from the gateway host and may expose sensitive local/internal HTTP responses depending on deployment topology.

## Safe reproduction steps

On vulnerable code, inspect `gateway/platforms/yuanbao_media.py` and observe that `download_url()` creates an HTTPX client with `follow_redirects=True` before any `url_safety.is_safe_url()` check and without the shared `_ssrf_redirect_guard` response hook.

This PR adds safe unit coverage instead of connecting to real internal services:

```bash
python3 -m pytest tests/test_yuanbao_media_security.py -q
```

The tests monkeypatch the URL safety checker and HTTP client so they verify the vulnerable boundary without performing real network requests.

## Expected vulnerable behavior

- An unsafe URL is not rejected before HTTP client creation.
- Redirect-following is configured without the shared SSRF response hook.

## Changes in this PR

- Import the shared SSRF redirect guard and safe URL log helper from `gateway.platforms.base`.
- Import the existing URL safety checker from `tools.url_safety`.
- Reject unsafe Yuanbao media URLs before creating an HTTP client.
- Install `_ssrf_redirect_guard` as an HTTPX response hook while preserving redirect-following behavior.
- Add focused async regression tests for both security boundaries.

## Files changed

- `gateway/platforms/yuanbao_media.py`
  - Adds initial URL validation and redirect-time SSRF guard wiring.
- `tests/test_yuanbao_media_security.py`
  - Adds regression tests for unsafe URL rejection and redirect guard installation.

## Maintainer impact

- Normal public HTTP(S) Yuanbao media URLs continue to work.
- URLs that Hermes' shared SSRF policy already considers unsafe are blocked consistently with other guarded download paths.
- No Yuanbao COS upload behavior is changed.

## Fix rationale

The gateway should enforce the same SSRF policy at both relevant boundaries: before the first outbound request and during redirect traversal. Validating only the initial URL would still leave redirect-to-internal bypasses; relying only on redirect hooks would still create unnecessary HTTP client/request activity for obviously unsafe inputs. This patch applies both checks with the existing shared helpers.

## Type of change

- [x] Security hardening
- [x] Bug fix
- [x] Regression tests
- [ ] Documentation-only change

## Test plan

Run locally:

```bash
python3 -m pytest tests/test_yuanbao_media_security.py -q
python3 -m ruff check gateway/platforms/yuanbao_media.py tests/test_yuanbao_media_security.py
git diff --check
```

Results:

- `2 passed`
- `All checks passed!`
- `git diff --check` passed

Note: `ruff format --check gateway/platforms/yuanbao_media.py ...` reports pre-existing formatting churn across the legacy Yuanbao media file, so I avoided whole-file formatting changes and kept this PR's diff focused on the security boundary.

## Disclosure notes

This PR is bounded to the Yuanbao media URL download path. It does not claim to audit every URL-fetching surface in Hermes, nor does it change the global SSRF policy itself.