### PR TITLE
fix(feishu): keep CardKit progress in one finalized card

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -102,6 +102,17 @@ try:
         UpdateMessageRequest,
         UpdateMessageRequestBody,
     )
+    from lark_oapi.api.cardkit.v1 import (
+        Card,
+        ContentCardElementRequest,
+        ContentCardElementRequestBody,
+        CreateCardRequest,
+        CreateCardRequestBody,
+        SettingsCardRequest,
+        SettingsCardRequestBody,
+        UpdateCardRequest,
+        UpdateCardRequestBody,
+    )
     from lark_oapi.core import AccessTokenType, HttpMethod
     from lark_oapi.core.const import FEISHU_DOMAIN, LARK_DOMAIN
     from lark_oapi.core.model import BaseRequest
@@ -1351,6 +1362,12 @@ class FeishuAdapter(BasePlatformAdapter):
     """Feishu/Lark bot adapter."""
 
     MAX_MESSAGE_LENGTH = 8000
+    SUPPORTS_MESSAGE_EDITING = True
+    # CardKit streaming needs an explicit final edit to close the in-progress
+    # state and render the final footer (Elapsed + ✅ 已完成).  Without this,
+    # the generic stream consumer may skip the final edit when the body text
+    # already looks visible, leaving real Feishu cards stuck at “生成中”.
+    REQUIRES_EDIT_FINALIZE = True
     # Threshold for detecting Feishu client-side message splits.
     # When a chunk is near the ~4096-char practical limit, a continuation
     # is almost certain.
@@ -1407,6 +1424,28 @@ class FeishuAdapter(BasePlatformAdapter):
         # Feishu reaction deletion requires the opaque reaction_id returned
         # by create, so we cache it per message_id.
         self._pending_processing_reactions: "OrderedDict[str, str]" = OrderedDict()
+        # Preserve plain text/post behaviour by default; enable CardKit-backed
+        # streaming explicitly via env/config for Feishu deployments that have
+        # CardKit permissions.
+        extra_cfg = config.extra or {}
+        self._render_mode = str(os.getenv("HERMES_FEISHU_RENDER_MODE", extra_cfg.get("render_mode", "text"))).strip().lower()
+        if self._render_mode not in {"text", "post", "card"}:
+            self._render_mode = "text"
+        self._always_card = _to_boolean(os.getenv("HERMES_FEISHU_ALWAYS_CARD", extra_cfg.get("always_card", "false")))
+        self._append_mode = _to_boolean(os.getenv("HERMES_FEISHU_APPEND_MODE", extra_cfg.get("append_mode", "false")))
+        self._card_footer_elapsed = _to_boolean(os.getenv("HERMES_FEISHU_CARD_FOOTER_ELAPSED", extra_cfg.get("card_footer_elapsed", "true")))
+        self._card_footer_status = _to_boolean(os.getenv("HERMES_FEISHU_CARD_FOOTER_STATUS", extra_cfg.get("card_footer_status", "true")))
+        self._streaming_card_state: Dict[str, Dict[str, Any]] = {}
+        self._execution_progress_lines: Dict[str, List[str]] = {}
+        self._tool_progress_lines: Dict[str, List[str]] = {}
+        self._latest_card_content: Dict[str, str] = {}
+        self._active_card_for_chat: Dict[str, str] = {}
+        self._tool_progress_last_update: Dict[str, float] = {}
+        self._tool_progress_interval = float(os.getenv(
+            "HERMES_FEISHU_TOOL_PROGRESS_INTERVAL",
+            extra_cfg.get("tool_progress_interval", 1.5),
+        ) or 1.5)
+        self._card_update_sequence = 0
         self._load_seen_message_ids()
 
     @staticmethod
@@ -1702,6 +1741,7 @@ class FeishuAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
         """Send a Feishu message."""
+        self._ensure_card_runtime_state()
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
@@ -1710,8 +1750,42 @@ class FeishuAdapter(BasePlatformAdapter):
         last_response = None
 
         try:
+            # If tool-progress already opened a CardKit streaming card for this
+            # chat, make the first assistant content update reuse that same card
+            # instead of creating a second final-looking card.  This is the key
+            # path for tool-heavy turns: progress becomes visible immediately,
+            # then the real answer streams into the same content element.
+            active_card_id = (getattr(self, "_active_card_for_chat", {}) or {}).get(chat_id)
+            stream_preview = self._metadata_requests_stream_preview(metadata)
+            if (
+                self._uses_streaming_cards()
+                and active_card_id
+                and active_card_id in (getattr(self, "_streaming_card_state", {}) or {})
+                and not reply_to
+                and chunks
+            ):
+                finalize_existing_card = not stream_preview
+                first_result = await self.edit_message(
+                    chat_id,
+                    active_card_id,
+                    chunks[0],
+                    finalize=finalize_existing_card and len(chunks) == 1,
+                )
+                if not first_result.success:
+                    return first_result
+                for index, chunk in enumerate(chunks[1:], start=1):
+                    followup = await self.edit_message(
+                        chat_id,
+                        active_card_id,
+                        chunk,
+                        finalize=finalize_existing_card and index == len(chunks) - 1,
+                    )
+                    if not followup.success:
+                        return followup
+                return SendResult(success=True, message_id=active_card_id)
+
             for chunk in chunks:
-                msg_type, payload = self._build_outbound_payload(chunk)
+                msg_type, payload = self._build_outbound_payload(chunk, metadata=metadata)
                 try:
                     response = await self._feishu_send_with_retry(
                         chat_id=chat_id,
@@ -1745,6 +1819,14 @@ class FeishuAdapter(BasePlatformAdapter):
                         metadata=metadata,
                     )
                 last_response = response
+                if msg_type == "interactive" and stream_preview and self._response_succeeded(response):
+                    card_id = getattr(response, "hermes_feishu_card_id", None)
+                    if card_id:
+                        state = self._card_state_from_metadata(metadata)
+                        state["started_at"] = time.monotonic()
+                        self._streaming_card_state[str(card_id)] = state
+                        self._active_card_for_chat[chat_id] = str(card_id)
+                        self._latest_card_content[str(card_id)] = chunk
 
             return self._finalize_send_result(last_response, "send failed")
         except Exception as exc:
@@ -1760,11 +1842,78 @@ class FeishuAdapter(BasePlatformAdapter):
         finalize: bool = False,
     ) -> SendResult:
         """Edit a previously sent Feishu text/post message."""
+        self._ensure_card_runtime_state()
         if not self._client:
             return SendResult(success=False, error="Not connected")
 
         content = self.format_message(content)
         try:
+            if self._uses_streaming_cards() and message_id in (getattr(self, "_streaming_card_state", {}) or {}):
+                state = self._streaming_card_state.get(message_id, {})
+                self._latest_card_content[message_id] = content
+                if finalize:
+                    payload = self._build_streaming_card_payload(
+                        content,
+                        finalize=True,
+                        chat_id=chat_id,
+                        state=state,
+                    )
+                    body = self._build_card_update_body(data=payload)
+                    request = self._build_card_update_request(message_id, body)
+                    response = await asyncio.to_thread(self._client.cardkit.v1.card.update, request)
+                    result = self._finalize_send_result(response, "card update failed")
+                    if not result.success:
+                        # Some final answers are valid as streaming markdown
+                        # element content but invalid as a whole CardKit card
+                        # update (usually because the card config/summary path
+                        # is stricter than element content).  Do not leave the
+                        # existing streaming card stuck at "生成中" — fall back
+                        # to updating the content/footer elements, then close
+                        # streaming via card settings.
+                        logger.warning("[Feishu] Final card update failed; falling back to element finalize: %s", result.error)
+                        content_result = await self._update_card_content_element(
+                            message_id,
+                            self._compose_card_content(content, chat_id=chat_id, finalize=True),
+                        )
+                        footer_result = await self._update_card_footer_element(
+                            message_id,
+                            state=state,
+                            finalize=True,
+                        )
+                        result = footer_result if footer_result.success else content_result
+                        if not (content_result.success and footer_result.success):
+                            logger.warning(
+                                "[Feishu] Final card element fallback failed: content=%s footer=%s",
+                                content_result.error,
+                                footer_result.error,
+                            )
+                    if result.success:
+                        settings_result = await self._close_streaming_card(message_id, summary=content)
+                        if not settings_result.success:
+                            logger.warning("[Feishu] Card settings close failed: %s", settings_result.error)
+                            result = settings_result
+                else:
+                    body = self._build_card_content_body(
+                        content=self._compose_card_content(content, chat_id=chat_id, finalize=False)
+                    )
+                    request = self._build_card_content_request(message_id, "content", body)
+                    response = await asyncio.to_thread(self._client.cardkit.v1.card_element.content, request)
+                    result = self._finalize_send_result(response, "card content update failed")
+                    if result.success and (getattr(self, "_card_footer_elapsed", True) or getattr(self, "_card_footer_status", True)):
+                        footer_result = await self._update_card_footer_element(message_id, state=state, finalize=False)
+                        if not footer_result.success:
+                            logger.debug("[Feishu] Card footer update failed: %s", footer_result.error)
+                if result.success:
+                    result.message_id = message_id
+                    if finalize:
+                        self._streaming_card_state.pop(message_id, None)
+                        self._execution_progress_lines.pop(chat_id, None)
+                        self._tool_progress_lines.pop(chat_id, None)
+                        self._active_card_for_chat.pop(chat_id, None)
+                        self._latest_card_content.pop(message_id, None)
+                        self._tool_progress_last_update.pop(chat_id, None)
+                return result
+
             msg_type, payload = self._build_outbound_payload(content)
             body = self._build_update_message_body(msg_type=msg_type, content=payload)
             request = self._build_update_message_request(message_id=message_id, request_body=body)
@@ -2096,6 +2245,10 @@ class FeishuAdapter(BasePlatformAdapter):
         except Exception:
             logger.warning("[Feishu] Failed to get chat info for %s", chat_id, exc_info=True)
             return fallback
+
+    @property
+    def REQUIRES_EDIT_FINALIZE(self) -> bool:  # noqa: N802
+        return self._uses_streaming_cards()
 
     def format_message(self, content: str) -> str:
         """Feishu text messages are plain text by default."""
@@ -4004,7 +4157,335 @@ class FeishuAdapter(BasePlatformAdapter):
     # Outbound payload construction and send pipeline
     # =========================================================================
 
-    def _build_outbound_payload(self, content: str) -> tuple[str, str]:
+    def _ensure_card_runtime_state(self) -> None:
+        if not hasattr(self, "_streaming_card_state"):
+            self._streaming_card_state = {}
+        if not hasattr(self, "_execution_progress_lines"):
+            self._execution_progress_lines = {}
+        if not hasattr(self, "_tool_progress_lines"):
+            self._tool_progress_lines = {}
+        if not hasattr(self, "_latest_card_content"):
+            self._latest_card_content = {}
+        if not hasattr(self, "_active_card_for_chat"):
+            self._active_card_for_chat = {}
+        if not hasattr(self, "_tool_progress_last_update"):
+            self._tool_progress_last_update = {}
+        if not hasattr(self, "_tool_progress_interval"):
+            self._tool_progress_interval = 1.5
+
+    def _uses_streaming_cards(self) -> bool:
+        return str(getattr(self, "_render_mode", "text") or "text").lower() == "card" or bool(
+            getattr(self, "_always_card", False)
+        )
+
+    def _next_card_sequence(self) -> int:
+        current = int(getattr(self, "_card_update_sequence", 0) or 0) + 1
+        self._card_update_sequence = current
+        return current
+
+    @staticmethod
+    def _short_model_name(model: Optional[str]) -> str:
+        return (model or "").rsplit("/", 1)[-1]
+
+    @staticmethod
+    def _format_card_elapsed(seconds: float) -> str:
+        seconds = max(0.0, float(seconds or 0.0))
+        if seconds < 60:
+            return f"{int(round(seconds))}s"
+        minutes = int(seconds // 60)
+        rem = int(round(seconds - minutes * 60))
+        if rem >= 60:
+            minutes += 1
+            rem = 0
+        return f"{minutes}m {rem:02d}s"
+
+    @staticmethod
+    def _card_state_from_metadata(metadata: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        state: Dict[str, Any] = {}
+        if not isinstance(metadata, dict):
+            return state
+        for key in ("agent", "model", "provider"):
+            value = metadata.get(key)
+            if value:
+                state[key] = str(value)
+        return state
+
+    @staticmethod
+    def _metadata_requests_stream_preview(metadata: Optional[Dict[str, Any]]) -> bool:
+        return bool(isinstance(metadata, dict) and metadata.get("_hermes_stream_preview"))
+
+    def _build_card_footer(self, *, finalize: bool, state: Optional[Dict[str, Any]] = None) -> str:
+        state = state or {}
+        parts: List[str] = []
+        agent = str(state.get("agent") or "main").strip()
+        if agent:
+            parts.append(f"Agent: {agent}")
+        model = self._short_model_name(str(state.get("model") or ""))
+        if model:
+            parts.append(f"Model: {model}")
+        provider = str(state.get("provider") or "").strip()
+        if provider:
+            parts.append(f"Provider: {provider}")
+        if getattr(self, "_card_footer_elapsed", True):
+            started_at = state.get("started_at")
+            elapsed = 0.0
+            if started_at is not None:
+                elapsed = time.monotonic() - float(started_at or 0.0)
+            parts.append(f"Elapsed: {self._format_card_elapsed(elapsed)}")
+        if getattr(self, "_card_footer_status", True):
+            parts.append("✅ 已完成" if finalize else "生成中")
+        return " | ".join(parts)
+
+    @staticmethod
+    def _card_summary_content(content: Optional[str], *, max_chars: int = 200) -> str:
+        """Return a short, single-line CardKit summary.
+
+        Feishu CardKit accepts the full assistant response in the markdown
+        element, but the card summary/settings field is much stricter.  Passing
+        a long markdown/code-block answer there can make the final whole-card
+        update invalid, which leaves the visible card stuck in streaming mode
+        even though the answer text has finished.
+        """
+        text = re.sub(r"\s+", " ", str(content or "")).strip()
+        if not text:
+            return " "
+        if len(text) > max_chars:
+            return text[: max_chars - 1].rstrip() + "…"
+        return text
+
+    def _compose_card_content(
+        self,
+        content: str,
+        *,
+        chat_id: Optional[str] = None,
+        finalize: bool = False,
+    ) -> str:
+        """Compose the visible CardKit markdown body.
+
+        Human-readable interim assistant messages should look like one growing
+        transcript in the main card body, not like separate finalized cards and
+        not hidden inside a tool-progress panel.  Tool-progress lines remain a
+        separate optional panel; this transcript is only for semantic progress
+        such as “Wiki 验证通过，继续收尾检查”。
+        """
+        raw_content = str(content or "").strip()
+        progress_lines = list(
+            (getattr(self, "_execution_progress_lines", {}) or {}).get(chat_id or "", [])
+        )
+        if not progress_lines:
+            return raw_content or " "
+
+        parts: List[str] = []
+        for idx, line in enumerate(progress_lines):
+            clean = str(line or "").strip()
+            if not clean:
+                continue
+            parts.append(clean)
+            is_last_progress = idx == len(progress_lines) - 1
+            if not finalize or not is_last_progress or raw_content:
+                parts.append("...")
+
+        if raw_content and (not progress_lines or raw_content != str(progress_lines[-1]).strip()):
+            parts.append(raw_content)
+
+        return "\n".join(parts).strip() or " "
+
+    def _build_streaming_card_payload(
+        self,
+        content: str,
+        *,
+        finalize: bool = False,
+        chat_id: Optional[str] = None,
+        state: Optional[Dict[str, Any]] = None,
+    ) -> str:
+        footer_text = self._build_card_footer(finalize=finalize, state=state)
+        display_content = self._compose_card_content(content, chat_id=chat_id, finalize=finalize)
+        elements: List[Dict[str, Any]] = []
+        tool_lines = list((getattr(self, "_tool_progress_lines", {}) or {}).get(chat_id or "", []))
+        if tool_lines:
+            elements.append(
+                {
+                    "tag": "collapsible_panel",
+                    "expanded": True,
+                    "header": {"title": {"tag": "plain_text", "content": "执行进度"}},
+                    "elements": [
+                        {
+                            "tag": "markdown",
+                            "content": "\n".join(tool_lines[-20:]),
+                        }
+                    ],
+                }
+            )
+        elements.append({"tag": "markdown", "element_id": "content", "content": display_content})
+        if footer_text:
+            elements.append({"tag": "markdown", "element_id": "footer", "content": footer_text})
+        card = {
+            "schema": "2.0",
+            "config": {
+                "wide_screen_mode": True,
+                "streaming_mode": not finalize,
+                "streaming_config": {
+                    "print_frequency_ms": {"default": 50},
+                    "print_step": {"default": 1},
+                },
+                "summary": {"content": self._card_summary_content(content)},
+            },
+            "body": {"elements": elements},
+        }
+        return json.dumps(card, ensure_ascii=False)
+
+    async def append_execution_progress(
+        self,
+        chat_id: str,
+        line: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Append a semantic execution-progress line to the active CardKit card.
+
+        This is intentionally different from automatic tool progress.  It is
+        fed by the assistant's own interim status messages (for example:
+        "已完成苹果中文翻译，继续处理流式卡片"), so Feishu users see real
+        task milestones instead of command/tool names.
+        """
+        self._ensure_card_runtime_state()
+        text = str(line or "").strip()
+        if not text:
+            active = (getattr(self, "_active_card_for_chat", {}) or {}).get(chat_id)
+            return SendResult(success=True, message_id=active)
+
+        lines = list((getattr(self, "_execution_progress_lines", {}) or {}).get(chat_id, []))
+        if not lines or lines[-1] != text:
+            lines.append(text)
+        self._execution_progress_lines[chat_id] = lines[-20:]
+
+        active_card_id = (getattr(self, "_active_card_for_chat", {}) or {}).get(chat_id)
+        if not self._client or not self._uses_streaming_cards():
+            return SendResult(success=True, message_id=active_card_id)
+
+        if active_card_id and active_card_id in (getattr(self, "_streaming_card_state", {}) or {}):
+            state = self._streaming_card_state.get(active_card_id, {})
+            content = self._latest_card_content.get(active_card_id, " ")
+            payload = self._build_streaming_card_payload(
+                content,
+                chat_id=chat_id,
+                state=state,
+            )
+            body = self._build_card_update_body(data=payload)
+            request = self._build_card_update_request(active_card_id, body)
+            response = await asyncio.to_thread(self._client.cardkit.v1.card.update, request)
+            result = self._finalize_send_result(response, "card execution progress update failed")
+            if result.success:
+                result.message_id = str(active_card_id)
+            return result
+
+        state = self._card_state_from_metadata(metadata)
+        state["started_at"] = time.monotonic()
+        content = " "
+        payload = self._build_streaming_card_payload(
+            content,
+            chat_id=chat_id,
+            state=state,
+        )
+        response = await self._feishu_send_with_retry(
+            chat_id=chat_id,
+            msg_type="interactive",
+            payload=payload,
+            reply_to=None,
+            metadata=metadata,
+        )
+        result = self._finalize_send_result(response, "card execution progress send failed")
+        if not result.success:
+            return result
+        card_id = getattr(response, "hermes_feishu_card_id", None) or result.message_id
+        if card_id:
+            card_id = str(card_id)
+            self._streaming_card_state[card_id] = state
+            self._active_card_for_chat[chat_id] = card_id
+            self._latest_card_content[card_id] = content
+            self._tool_progress_last_update[chat_id] = time.monotonic()
+            result.message_id = card_id
+        return result
+
+    async def update_tool_progress(
+        self,
+        chat_id: str,
+        lines: List[str],
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Render tool progress inside the active Feishu streaming card.
+
+        Tool-heavy turns often spend a long time in tool calls before the model
+        emits any assistant text.  If we only buffer progress until the first
+        text delta, Feishu appears to be final-only.  CardKit mode should open a
+        streaming card on the first progress line, then reuse that card for the
+        eventual assistant response.
+        """
+        self._ensure_card_runtime_state()
+        self._tool_progress_lines[chat_id] = list(lines[-20:])
+        if not self._client or not self._uses_streaming_cards():
+            return
+
+        active_card_id = (getattr(self, "_active_card_for_chat", {}) or {}).get(chat_id)
+        state: Dict[str, Any]
+        if active_card_id and active_card_id in (getattr(self, "_streaming_card_state", {}) or {}):
+            now = time.monotonic()
+            last = (getattr(self, "_tool_progress_last_update", {}) or {}).get(chat_id, 0.0)
+            interval = float(getattr(self, "_tool_progress_interval", 1.5))
+            if interval > 0 and now - float(last or 0.0) < interval:
+                return
+            self._tool_progress_last_update[chat_id] = now
+            state = self._streaming_card_state.get(active_card_id, {})
+            content = self._latest_card_content.get(active_card_id, " ")
+            payload = self._build_streaming_card_payload(
+                content,
+                chat_id=chat_id,
+                state=state,
+            )
+            body = self._build_card_update_body(data=payload)
+            request = self._build_card_update_request(active_card_id, body)
+            response = await asyncio.to_thread(self._client.cardkit.v1.card.update, request)
+            result = self._finalize_send_result(response, "card progress update failed")
+            if not result.success:
+                logger.debug("[Feishu] Card progress update failed: %s", result.error)
+            return
+
+        state = self._card_state_from_metadata(metadata)
+        state["started_at"] = time.monotonic()
+        content = " "
+        payload = self._build_streaming_card_payload(
+            content,
+            chat_id=chat_id,
+            state=state,
+        )
+        response = await self._feishu_send_with_retry(
+            chat_id=chat_id,
+            msg_type="interactive",
+            payload=payload,
+            reply_to=None,
+            metadata=metadata,
+        )
+        result = self._finalize_send_result(response, "card progress send failed")
+        if not result.success:
+            logger.debug("[Feishu] Card progress send failed: %s", result.error)
+            return
+        card_id = getattr(response, "hermes_feishu_card_id", None) or result.message_id
+        if card_id:
+            card_id = str(card_id)
+            self._streaming_card_state[card_id] = state
+            self._active_card_for_chat[chat_id] = card_id
+            self._latest_card_content[card_id] = content
+            self._tool_progress_last_update[chat_id] = time.monotonic()
+
+    def _build_outbound_payload(self, content: str, metadata: Optional[Dict[str, Any]] = None) -> tuple[str, str]:
+        if self._uses_streaming_cards():
+            state = self._card_state_from_metadata(metadata)
+            state.setdefault("started_at", time.monotonic())
+            stream_preview = self._metadata_requests_stream_preview(metadata)
+            return "interactive", self._build_streaming_card_payload(
+                content,
+                state=state,
+                finalize=not stream_preview,
+            )
         # Feishu post-type 'md' elements do not render markdown tables; sending
         # table content as post causes the message to appear blank on the client.
         # Force plain text for anything that looks like a markdown table.
@@ -4090,6 +4571,11 @@ class FeishuAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]],
     ) -> Any:
         reply_in_thread = bool((metadata or {}).get("thread_id"))
+        if msg_type == "interactive" and self._uses_streaming_cards():
+            card_id = await self._create_card_message(payload)
+            payload = json.dumps({"type": "card", "data": {"card_id": card_id}}, ensure_ascii=False)
+        else:
+            card_id = None
         if reply_to:
             body = self._build_reply_message_body(
                 content=payload,
@@ -4098,7 +4584,10 @@ class FeishuAdapter(BasePlatformAdapter):
                 uuid_value=str(uuid.uuid4()),
             )
             request = self._build_reply_message_request(reply_to, body)
-            return await asyncio.to_thread(self._client.im.v1.message.reply, request)
+            response = await asyncio.to_thread(self._client.im.v1.message.reply, request)
+            if card_id:
+                setattr(response, "hermes_feishu_card_id", card_id)
+            return response
 
         body = self._build_create_message_body(
             receive_id=chat_id,
@@ -4115,7 +4604,10 @@ class FeishuAdapter(BasePlatformAdapter):
         else:
             receive_id_type = "chat_id"
         request = self._build_create_message_request(receive_id_type, body)
-        return await asyncio.to_thread(self._client.im.v1.message.create, request)
+        response = await asyncio.to_thread(self._client.im.v1.message.create, request)
+        if card_id:
+            setattr(response, "hermes_feishu_card_id", card_id)
+        return response
 
     @staticmethod
     def _response_succeeded(response: Any) -> bool:
@@ -4146,7 +4638,7 @@ class FeishuAdapter(BasePlatformAdapter):
             return self._response_error_result(response, default_message=default_message)
         return SendResult(
             success=True,
-            message_id=self._extract_response_field(response, "message_id"),
+            message_id=getattr(response, "hermes_feishu_card_id", None) or self._extract_response_field(response, "message_id"),
             raw_response=response,
         )
 
@@ -4427,6 +4919,137 @@ class FeishuAdapter(BasePlatformAdapter):
                 .build()
             )
         return SimpleNamespace(receive_id_type=receive_id_type, request_body=request_body)
+
+    async def _create_card_message(self, card_json: str) -> str:
+        body = self._build_card_create_body(data=card_json)
+        request = self._build_card_create_request(body)
+        response = await asyncio.to_thread(self._client.cardkit.v1.card.create, request)
+        if not self._response_succeeded(response):
+            raise RuntimeError(self._response_error_result(response, default_message="card create failed").error)
+        card_id = self._extract_response_field(response, "card_id")
+        if not card_id:
+            raise RuntimeError("Feishu CardKit create response missing card_id")
+        return str(card_id)
+
+    @staticmethod
+    def _build_card_create_body(*, data: str) -> Any:
+        if "CreateCardRequestBody" in globals():
+            return CreateCardRequestBody.builder().type("card_json").data(data).build()
+        return SimpleNamespace(type="card_json", data=data)
+
+    @staticmethod
+    def _build_card_create_request(request_body: Any) -> Any:
+        if "CreateCardRequest" in globals():
+            return CreateCardRequest.builder().request_body(request_body).build()
+        return SimpleNamespace(request_body=request_body)
+
+    def _build_card_content_body(self, *, content: str) -> Any:
+        sequence = self._next_card_sequence()
+        if "ContentCardElementRequestBody" in globals():
+            return (
+                ContentCardElementRequestBody.builder()
+                .content(content)
+                .sequence(sequence)
+                .uuid(str(uuid.uuid4()))
+                .build()
+            )
+        return SimpleNamespace(content=content, sequence=sequence, uuid=str(uuid.uuid4()))
+
+    @staticmethod
+    def _build_card_content_request(card_id: str, element_id: str, request_body: Any) -> Any:
+        if "ContentCardElementRequest" in globals():
+            return (
+                ContentCardElementRequest.builder()
+                .card_id(card_id)
+                .element_id(element_id)
+                .request_body(request_body)
+                .build()
+            )
+        return SimpleNamespace(card_id=card_id, element_id=element_id, request_body=request_body)
+
+    async def _update_card_content_element(
+        self,
+        card_id: str,
+        content: str,
+    ) -> SendResult:
+        body = self._build_card_content_body(content=content)
+        request = self._build_card_content_request(card_id, "content", body)
+        response = await asyncio.to_thread(self._client.cardkit.v1.card_element.content, request)
+        result = self._finalize_send_result(response, "card content update failed")
+        if result.success:
+            result.message_id = card_id
+        return result
+
+    async def _update_card_footer_element(
+        self,
+        card_id: str,
+        *,
+        state: Optional[Dict[str, Any]] = None,
+        finalize: bool = False,
+    ) -> SendResult:
+        footer = self._build_card_footer(finalize=finalize, state=state)
+        if not footer:
+            return SendResult(success=True, message_id=card_id)
+        body = self._build_card_content_body(content=footer)
+        request = self._build_card_content_request(card_id, "footer", body)
+        response = await asyncio.to_thread(self._client.cardkit.v1.card_element.content, request)
+        result = self._finalize_send_result(response, "card footer update failed")
+        if result.success:
+            result.message_id = card_id
+        return result
+
+    def _build_card_settings_body(self, *, streaming_mode: bool, summary: Optional[str] = None) -> Any:
+        sequence = self._next_card_sequence()
+        settings_payload: Dict[str, Any] = {"streaming_mode": streaming_mode}
+        if summary is not None:
+            settings_payload["summary"] = {"content": self._card_summary_content(summary)}
+        settings_data = json.dumps(settings_payload, ensure_ascii=False)
+        if "SettingsCardRequestBody" in globals():
+            return (
+                SettingsCardRequestBody.builder()
+                .settings(settings_data)
+                .sequence(sequence)
+                .uuid(str(uuid.uuid4()))
+                .build()
+            )
+        return SimpleNamespace(settings=settings_data, sequence=sequence, uuid=str(uuid.uuid4()))
+
+    @staticmethod
+    def _build_card_settings_request(card_id: str, request_body: Any) -> Any:
+        if "SettingsCardRequest" in globals():
+            return SettingsCardRequest.builder().card_id(card_id).request_body(request_body).build()
+        return SimpleNamespace(card_id=card_id, request_body=request_body)
+
+    async def _close_streaming_card(self, card_id: str, *, summary: Optional[str] = None) -> SendResult:
+        body = self._build_card_settings_body(streaming_mode=False, summary=summary)
+        request = self._build_card_settings_request(card_id, body)
+        response = await asyncio.to_thread(self._client.cardkit.v1.card.settings, request)
+        result = self._finalize_send_result(response, "card settings close failed")
+        if result.success:
+            result.message_id = card_id
+        return result
+
+    def _build_card_update_body(self, *, data: str) -> Any:
+        sequence = self._next_card_sequence()
+        if "Card" in globals():
+            card = Card.builder().type("card_json").data(data).build()
+        else:
+            card = SimpleNamespace(type="card_json", data=data)
+        if "UpdateCardRequestBody" in globals():
+            return (
+                UpdateCardRequestBody.builder()
+                .card(card)
+                .sequence(sequence)
+                .uuid(str(uuid.uuid4()))
+                .build()
+            )
+        return SimpleNamespace(card=card, sequence=sequence, uuid=str(uuid.uuid4()))
+
+    @staticmethod
+    def _build_card_update_request(card_id: str, request_body: Any) -> Any:
+        if "UpdateCardRequest" in globals():
+            return UpdateCardRequest.builder().card_id(card_id).request_body(request_body).build()
+        return SimpleNamespace(card_id=card_id, request_body=request_body)
 
     @staticmethod
     def _build_image_upload_body(*, image_type: str, image: Any) -> Any:

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -4338,6 +4338,30 @@ class FeishuAdapter(BasePlatformAdapter):
         }
         return json.dumps(card, ensure_ascii=False)
 
+    async def record_execution_progress(
+        self,
+        chat_id: str,
+        line: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Record a visible semantic segment for later same-card transcript composition.
+
+        StreamConsumer calls this at tool boundaries for CardKit adapters that
+        preserve the same editable target across segments.  It must not send a
+        second CardKit update: the segment was already visible; we only need to
+        keep it so the next content edit does not replace earlier transcript.
+        """
+        self._ensure_card_runtime_state()
+        text = str(line or "").strip()
+        active = (getattr(self, "_active_card_for_chat", {}) or {}).get(chat_id)
+        if not text:
+            return SendResult(success=True, message_id=active)
+        lines = list((getattr(self, "_execution_progress_lines", {}) or {}).get(chat_id, []))
+        if not lines or lines[-1] != text:
+            lines.append(text)
+        self._execution_progress_lines[chat_id] = lines[-20:]
+        return SendResult(success=True, message_id=active)
+
     async def append_execution_progress(
         self,
         chat_id: str,

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1368,6 +1368,10 @@ class FeishuAdapter(BasePlatformAdapter):
     # the generic stream consumer may skip the final edit when the body text
     # already looks visible, leaving real Feishu cards stuck at “生成中”.
     REQUIRES_EDIT_FINALIZE = True
+    # Feishu CardKit uses one card as a task transcript: semantic progress,
+    # tool progress, and the final answer must survive tool/segment boundaries
+    # and be finalized only at the end of the assistant response.
+    PRESERVE_STREAM_TARGET_ACROSS_SEGMENTS = True
     # Threshold for detecting Feishu client-side message splits.
     # When a chunk is near the ~4096-char practical limit, a continuation
     # is almost certain.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6546,6 +6546,22 @@ class GatewayRunner:
             except Exception as _footer_err:
                 logger.debug("runtime_footer build failed: %s", _footer_err)
                 _footer_line = ""
+            # Feishu CardKit cards already render runtime metadata in their own
+            # footer element (Agent/Model/Provider/Elapsed/status).  Appending
+            # the generic text runtime footer creates a second, inconsistent
+            # footer inside the card body (e.g. "gpt-5.5 · 40% · ~" above
+            # "Agent: main | ...").  Suppress the generic footer whenever the
+            # active Feishu adapter is using CardKit/always_card mode.
+            try:
+                _footer_adapter = self.adapters.get(source.platform)
+                if (
+                    source.platform == Platform.FEISHU
+                    and _footer_adapter is not None
+                    and bool(getattr(_footer_adapter, "_uses_streaming_cards", lambda: False)())
+                ):
+                    _footer_line = ""
+            except Exception:
+                pass
             if _footer_line and response and not agent_result.get("already_sent"):
                 response = f"{response}\n\n{_footer_line}"
 
@@ -12511,10 +12527,13 @@ class GatewayRunner:
             else bool(_plat_streaming)
         )
 
+        _thread_metadata: Optional[Dict[str, Any]] = {
+            "agent": "main",
+            "model": "hermes-agent",
+            "provider": "proxy",
+        }
         if source.thread_id:
-            _thread_metadata: Optional[Dict[str, Any]] = {"thread_id": source.thread_id}
-        else:
-            _thread_metadata = None
+            _thread_metadata["thread_id"] = source.thread_id
 
         if _streaming_enabled:
             try:
@@ -12811,6 +12830,33 @@ class GatewayRunner:
         long_tool_hint_fired = [False]
         _LONG_TOOL_THRESHOLD_S = 30.0
 
+        def _human_tool_progress_message(tool_name: str | None) -> str:
+            """Return low-noise, user-facing progress for chat platforms.
+
+            Feishu users should see that work is advancing without seeing raw
+            tool names, terminal commands, or argument payloads.  This mode is
+            deliberately coarser than ``all``/``verbose``: it updates the same
+            CardKit streaming card as a human-readable status panel.
+            """
+            name = (tool_name or "").lower()
+            if name in {"mcp_minimax_web_search", "web_search"} or "search" in name:
+                return ""
+            if name in {"read_file", "search_files"} or "file" in name:
+                return ""
+            if name in {"terminal", "execute_code", "process"}:
+                return ""
+            if name in {"patch", "write_file"}:
+                return "🛠️ 正在应用修复"
+            if name in {"browser_navigate", "browser_snapshot", "browser_console", "browser_cdp"} or "browser" in name:
+                return "🌐 正在验证页面和客户端表现"
+            if name in {"skill_view", "skills_list"} or "skill" in name:
+                return ""
+            if name in {"todo", "cronjob"}:
+                return "🗂️ 正在更新任务状态"
+            if name in {"send_message"}:
+                return ""
+            return "⚙️ 正在推进任务"
+
         def progress_callback(event_type: str, tool_name: str = None, preview: str = None, args: dict = None, **kwargs):
             """Callback invoked by agent on tool lifecycle events."""
             if not progress_queue or not _run_still_current():
@@ -12875,6 +12921,19 @@ class GatewayRunner:
             from agent.display import get_tool_emoji
             emoji = get_tool_emoji(tool_name, default="⚙️")
             
+            # Low-noise human mode: keep Feishu/CardKit visibly alive without
+            # exposing raw tool names, commands, paths, or argument payloads.
+            if progress_mode in {"human", "summary", "concise"}:
+                msg = _human_tool_progress_message(tool_name)
+                if msg == last_progress_msg[0]:
+                    repeat_count[0] += 1
+                    progress_queue.put(("__dedup__", msg, repeat_count[0]))
+                    return
+                last_progress_msg[0] = msg
+                repeat_count[0] = 0
+                progress_queue.put(msg)
+                return
+
             # Verbose mode: show detailed arguments, respects tool_preview_length
             if progress_mode == "verbose":
                 if args:
@@ -12933,7 +12992,29 @@ class GatewayRunner:
             _progress_thread_id = source.thread_id or event_message_id
         else:
             _progress_thread_id = source.thread_id
-        _progress_metadata = {"thread_id": _progress_thread_id} if _progress_thread_id else None
+        # Resolve model/provider for platform metadata outside the worker thread.
+        # The real turn routing is still resolved inside run_sync() after reloading
+        # .env/config, but progress/status/typing metadata is built before the
+        # thread starts.  Do not reference run_sync-local variables here.
+        try:
+            _meta_model, _meta_runtime_kwargs = self._resolve_session_agent_runtime(
+                source=source,
+                session_key=session_key,
+                user_config=user_config,
+            )
+        except Exception:
+            _meta_model, _meta_runtime_kwargs = "", {}
+
+        if source.platform == Platform.FEISHU:
+            _progress_metadata: Optional[Dict[str, Any]] = {
+                "agent": "main",
+                "model": _meta_model,
+                "provider": _meta_runtime_kwargs.get("provider"),
+            }
+            if _progress_thread_id:
+                _progress_metadata["thread_id"] = _progress_thread_id
+        else:
+            _progress_metadata = {"thread_id": _progress_thread_id} if _progress_thread_id else None
 
         async def send_progress_messages():
             if not progress_queue:
@@ -12958,7 +13039,9 @@ class GatewayRunner:
             progress_msg_id = None   # ID of the progress message to edit
             can_edit = True          # False once an edit fails (platform doesn't support it)
             _last_edit_ts = 0.0      # Throttle edits to avoid Telegram flood control
+            _last_heartbeat_ts = 0.0 # Periodic CardKit footer refresh while one long tool is running
             _PROGRESS_EDIT_INTERVAL = 1.5  # Minimum seconds between edits
+            _PROGRESS_HEARTBEAT_INTERVAL = 2.0  # Keep Feishu Elapsed moving during long waits
 
             while True:
                 try:
@@ -13011,6 +13094,14 @@ class GatewayRunner:
                     else:
                         msg = raw
                         progress_lines.append(msg)
+
+                    if hasattr(adapter, "update_tool_progress"):
+                        await adapter.update_tool_progress(
+                            source.chat_id,
+                            progress_lines,
+                            metadata=_progress_metadata,
+                        )
+                        continue
 
                     # Throttle edits: batch rapid tool updates into fewer
                     # API calls to avoid hitting Telegram flood control.
@@ -13067,6 +13158,27 @@ class GatewayRunner:
                         await adapter.send_typing(source.chat_id, metadata=_progress_metadata)
 
                 except queue.Empty:
+                    # Keep the visible Feishu/CardKit progress card alive while
+                    # the agent is blocked inside one long-running tool call.
+                    # Without this heartbeat, the footer can stay at
+                    # "Elapsed: 0s | 生成中" until the whole turn finishes, which
+                    # defeats the purpose of streaming for long waits.
+                    if (
+                        progress_lines
+                        and hasattr(adapter, "update_tool_progress")
+                        and _run_still_current()
+                    ):
+                        _now = time.monotonic()
+                        if _now - _last_heartbeat_ts >= _PROGRESS_HEARTBEAT_INTERVAL:
+                            try:
+                                await adapter.update_tool_progress(
+                                    source.chat_id,
+                                    progress_lines,
+                                    metadata=_progress_metadata,
+                                )
+                                _last_heartbeat_ts = _now
+                            except Exception as _heartbeat_err:
+                                logger.debug("progress heartbeat failed: %s", _heartbeat_err)
                     await asyncio.sleep(0.3)
                 except asyncio.CancelledError:
                     # Drain remaining queued messages
@@ -13155,7 +13267,7 @@ class GatewayRunner:
         # Bridge sync status_callback → async adapter.send for context pressure
         _status_adapter = self.adapters.get(source.platform)
         _status_chat_id = source.chat_id
-        _status_thread_metadata = {"thread_id": _progress_thread_id} if _progress_thread_id else None
+        _status_thread_metadata = dict(_progress_metadata) if _progress_metadata else None
 
         def _status_callback_sync(event_type: str, message: str) -> None:
             if not _status_adapter or not _run_still_current():
@@ -13299,7 +13411,7 @@ class GatewayRunner:
                             adapter=_adapter,
                             chat_id=source.chat_id,
                             config=_consumer_cfg,
-                            metadata={"thread_id": _progress_thread_id} if _progress_thread_id else None,
+                            metadata=dict(_progress_metadata) if _progress_metadata else None,
                             on_new_message=(
                                 (lambda: progress_queue.put(("__reset__",)))
                                 if progress_queue is not None
@@ -13749,11 +13861,12 @@ class GatewayRunner:
                 reset_current_session_key(_approval_session_token)
             result_holder[0] = result
 
-            # Signal the stream consumer that the agent is done
-            if _stream_consumer is not None:
-                _stream_consumer.finish()
-            
-            # Return final response, or a message if something went wrong
+            # Do not finish the stream consumer here.  The worker thread only
+            # learns the final_response after run_conversation returns; finishing
+            # before the async gateway layer can inspect it causes providers that
+            # do not emit token deltas to fall back to a one-shot final send.
+            # The async layer below either closes an already-streamed response or
+            # animates the final_response into the active platform stream first.
             final_response = result.get("final_response")
 
             # Extract actual token counts from the agent instance used for this run
@@ -13905,6 +14018,8 @@ class GatewayRunner:
         # Start progress message sender if enabled
         progress_task = None
         if tool_progress_enabled:
+            if progress_queue is not None and progress_mode in {"human", "summary", "concise"}:
+                progress_queue.put("🧭 正在分析任务并准备执行")
             progress_task = asyncio.create_task(send_progress_messages())
 
         # Start stream consumer task — polls for consumer creation since it
@@ -14231,6 +14346,52 @@ class GatewayRunner:
                     # Fallback activated on a successful run — evict cached
                     # agent so the next message retries the primary model.
                     self._evict_cached_agent(session_key)
+
+            # Ensure final assistant text uses the same platform stream instead
+            # of arriving as a one-shot message when the provider only returns a
+            # completed final_response.  Real token deltas are still preferred;
+            # this is a visual fallback for final-only providers/transports.
+            _sc = stream_consumer_holder[0]
+            if _sc and isinstance(response, dict) and not response.get("failed"):
+                _final_to_stream = response.get("final_response") or ""
+                _empty_final = not _final_to_stream or _final_to_stream == "(empty)"
+                if not _empty_final and not getattr(_sc, "final_response_sent", False):
+                    try:
+                        _had_live_deltas = bool(
+                            getattr(_sc, "_already_sent", False)
+                            or getattr(_sc, "_accumulated", "")
+                        )
+                        if not _had_live_deltas and source.platform == Platform.FEISHU:
+                            import re as _re
+                            _parts = _re.findall(r"\S+\s*|\n+", _final_to_stream)
+                            _buf = ""
+                            for _part in _parts or [_final_to_stream]:
+                                _buf += _part
+                                if len(_buf) >= 80 or "\n" in _buf:
+                                    _sc.on_delta(_buf)
+                                    _buf = ""
+                                    await asyncio.sleep(0.20)
+                            if _buf:
+                                _sc.on_delta(_buf)
+                                await asyncio.sleep(0.20)
+                        _sc.finish()
+                        if stream_task:
+                            try:
+                                await asyncio.wait_for(stream_task, timeout=5.0)
+                            except (asyncio.TimeoutError, asyncio.CancelledError):
+                                stream_task.cancel()
+                                try:
+                                    await stream_task
+                                except asyncio.CancelledError:
+                                    pass
+                            except Exception as e:
+                                logger.debug("Final stream delivery wait failed: %s", e)
+                    except Exception as e:
+                        logger.debug("Final stream delivery fallback failed: %s", e)
+                        try:
+                            _sc.finish()
+                        except Exception:
+                            pass
 
             # Check if we were interrupted OR have a queued message (/queue).
             result = result_holder[0]

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -16,6 +16,7 @@ Credit: jobless0x (#774, #1312), OutThisLife (#798), clicksingh (#697).
 from __future__ import annotations
 
 import asyncio
+import inspect
 import logging
 import queue
 import re
@@ -445,9 +446,16 @@ class GatewayStreamConsumer:
 
                 if commentary_text is not None:
                     self._reset_segment_state()
-                    await self._send_commentary(commentary_text)
+                    commentary_delivered = await self._send_commentary(commentary_text)
                     self._last_edit_time = time.monotonic()
-                    self._reset_segment_state()
+                    # CardKit append_execution_progress returns an editable
+                    # card_id and _send_commentary adopts it as _message_id.
+                    # Preserve that target so later commentary/final content is
+                    # appended/finalized on the same card.  Legacy fallback
+                    # commentary still resets because it creates a standalone
+                    # bubble that should not be edited by the final answer.
+                    if not (commentary_delivered and self._message_id):
+                        self._reset_segment_state()
 
                 # Tool boundary: reset message state so the next text chunk
                 # creates a fresh message below any tool-progress messages.
@@ -538,6 +546,7 @@ class GatewayStreamConsumer:
             return reply_to_id
         try:
             meta = dict(self.metadata) if self.metadata else {}
+            meta["_hermes_stream_preview"] = True
             result = await self.adapter.send(
                 chat_id=self.chat_id,
                 content=text,
@@ -759,6 +768,41 @@ class GatewayStreamConsumer:
         if not text.strip():
             return False
         try:
+            append_progress = getattr(self.adapter, "append_execution_progress", None)
+            if callable(append_progress):
+                maybe_result = append_progress(
+                    self.chat_id,
+                    text,
+                    metadata=self.metadata,
+                )
+                result = await maybe_result if inspect.isawaitable(maybe_result) else maybe_result
+                # Plain MagicMock adapters manufacture arbitrary attributes;
+                # treating that fabricated result as successful would swallow
+                # commentary in tests and non-CardKit adapters.  Real adapters
+                # return a concrete SendResult-like object.
+                if type(result).__module__.startswith("unittest.mock"):
+                    result = None
+                if getattr(result, "success", False):
+                    # Semantic progress belongs in the active CardKit card, not
+                    # in separate tool-progress bubbles.  Adopt the returned
+                    # CardKit card_id as the current editable message so the
+                    # eventual assistant body/finalize edits the same card
+                    # instead of opening a fresh final-looking card below it.
+                    progress_message_id = getattr(result, "message_id", None)
+                    if progress_message_id:
+                        self._message_id = str(progress_message_id)
+                        if self._message_created_ts is None:
+                            self._message_created_ts = time.monotonic()
+                    # Keep _already_sent false so the base gateway still waits
+                    # for the real final answer.  The card is only a transcript
+                    # preview until finish() finalizes it.
+                    self._notify_new_message()
+                    return True
+                logger.debug(
+                    "append_execution_progress failed, falling back to commentary send: %s",
+                    getattr(result, "error", ""),
+                )
+
             result = await self.adapter.send(
                 chat_id=self.chat_id,
                 content=text,
@@ -979,11 +1023,15 @@ class GatewayStreamConsumer:
                     # The final response will be sent by the fallback path.
                     return False
             else:
-                # First message — send new
+                # First message — send new streaming preview.  Feishu CardKit
+                # uses this internal marker to distinguish an in-progress
+                # preview from a normal completed final send.
+                meta = dict(self.metadata) if self.metadata else {}
+                meta["_hermes_stream_preview"] = True
                 result = await self.adapter.send(
                     chat_id=self.chat_id,
                     content=text,
-                    metadata=self.metadata,
+                    metadata=meta,
                 )
                 if result.success:
                     if result.message_id:

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -497,6 +497,7 @@ class GatewayStreamConsumer:
                     if not self._preserve_target_across_segments:
                         self._reset_segment_state(preserve_no_edit=True)
                     else:
+                        await self._record_segment_progress_for_preserved_target()
                         self._accumulated = ""
                         self._last_sent_text = ""
                         self._fallback_final_send = False
@@ -774,6 +775,24 @@ class GatewayStreamConsumer:
             self._last_sent_text = prefix
         except Exception:
             pass  # best-effort — don't let this block the fallback path
+
+    async def _record_segment_progress_for_preserved_target(self) -> None:
+        """Persist visible pre-tool text as transcript history for one-card adapters."""
+        text = self._clean_for_display(self._accumulated)
+        if not text.strip():
+            return
+        record_progress = getattr(self.adapter, "record_execution_progress", None)
+        if callable(record_progress):
+            maybe_result = record_progress(self.chat_id, text, metadata=self.metadata)
+            if inspect.isawaitable(maybe_result):
+                await maybe_result
+            return
+
+        append_progress = getattr(self.adapter, "append_execution_progress", None)
+        if callable(append_progress):
+            maybe_result = append_progress(self.chat_id, text, metadata=self.metadata)
+            if inspect.isawaitable(maybe_result):
+                await maybe_result
 
     async def _send_commentary(self, text: str) -> bool:
         """Send a completed interim assistant commentary message."""

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -132,6 +132,13 @@ class GatewayStreamConsumer:
         self._adapter_requires_finalize: bool = (
             getattr(adapter, "REQUIRES_EDIT_FINALIZE", False) is True
         )
+        # Some adapters (Feishu CardKit) intentionally keep one editable card
+        # across tool/segment boundaries so semantic progress, tool progress,
+        # and the final answer land in the same card.  Legacy edit transports
+        # still reset on segment breaks to create separate bubbles.
+        self._preserve_target_across_segments: bool = (
+            getattr(adapter, "PRESERVE_STREAM_TARGET_ACROSS_SEGMENTS", False) is True
+        )
 
         # Think-block filter state (mirrors CLI's _stream_delta tag suppression)
         self._in_think_block = False
@@ -371,7 +378,7 @@ class GatewayStreamConsumer:
                         if got_done:
                             self._final_response_sent = self._already_sent
                             return
-                        if got_segment_break:
+                        if got_segment_break and not self._preserve_target_across_segments:
                             self._message_id = None
                             self._fallback_final_send = False
                             self._fallback_prefix = ""
@@ -412,7 +419,7 @@ class GatewayStreamConsumer:
                     # path below so we don't finalize here for it.
                     current_update_visible = await self._send_or_edit(
                         display_text,
-                        finalize=got_segment_break,
+                        finalize=got_segment_break and not self._preserve_target_across_segments,
                     )
                     self._last_edit_time = time.monotonic()
 
@@ -487,7 +494,13 @@ class GatewayStreamConsumer:
                         and self._message_id != "__no_edit__"
                     ):
                         await self._flush_segment_tail_on_edit_failure()
-                    self._reset_segment_state(preserve_no_edit=True)
+                    if not self._preserve_target_across_segments:
+                        self._reset_segment_state(preserve_no_edit=True)
+                    else:
+                        self._accumulated = ""
+                        self._last_sent_text = ""
+                        self._fallback_final_send = False
+                        self._fallback_prefix = ""
 
                 await asyncio.sleep(0.05)  # Small yield to not busy-loop
 

--- a/tests/gateway/test_feishu_stream_footer.py
+++ b/tests/gateway/test_feishu_stream_footer.py
@@ -26,6 +26,7 @@ class FakeFeishuAdapter:
     def __init__(self):
         self.sent = []
         self.edits = []
+        self.recorded_progress = []
 
     async def send(self, chat_id, content, reply_to=None, metadata=None):
         self.sent.append(
@@ -49,8 +50,22 @@ class FakeFeishuAdapter:
         )
         return SendResult(success=True, message_id=message_id)
 
+    async def record_execution_progress(self, chat_id, line, metadata=None):
+        self.recorded_progress.append(
+            {
+                "chat_id": chat_id,
+                "line": line,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=True, message_id="msg_1")
+
     def truncate_message(self, content, max_length):
         return [content]
+
+
+class FakePreservedFeishuAdapter(FakeFeishuAdapter):
+    PRESERVE_STREAM_TARGET_ACROSS_SEGMENTS = True
 
 
 class FakeRunner:
@@ -60,6 +75,78 @@ class FakeRunner:
 
     async def _deliver_media_from_response(self, response, event, adapter):
         self.media_deliveries.append((response, event, adapter))
+
+
+@pytest.mark.asyncio
+async def test_preserved_card_stream_records_segment_progress_before_reset():
+    adapter = FakePreservedFeishuAdapter()
+    consumer = GatewayStreamConsumer(
+        adapter=adapter,
+        chat_id="chat_id",
+        config=StreamConsumerConfig(edit_interval=999, buffer_threshold=999, cursor=""),
+        metadata={"model": "provider/model-x"},
+    )
+
+    task = asyncio.create_task(consumer.run())
+    consumer.on_delta("第一段进度")
+    consumer.on_segment_break()
+    consumer.on_delta("第二段进度")
+    consumer.finish()
+    await asyncio.wait_for(task, timeout=2)
+
+    assert adapter.sent == [
+        {
+            "chat_id": "chat_id",
+            "content": "第一段进度",
+            "reply_to": None,
+            "metadata": {"model": "provider/model-x", "_hermes_stream_preview": True},
+        }
+    ]
+    assert adapter.recorded_progress == [
+        {
+            "chat_id": "chat_id",
+            "line": "第一段进度",
+            "metadata": {"model": "provider/model-x"},
+        }
+    ]
+    assert adapter.edits[-1] == {
+        "chat_id": "chat_id",
+        "message_id": "msg_1",
+        "content": "第二段进度",
+        "finalize": True,
+    }
+
+
+@pytest.mark.asyncio
+async def test_feishu_recorded_segment_progress_is_composed_into_next_card_edit():
+    adapter = FeishuAdapter.__new__(FeishuAdapter)
+    adapter._render_mode = "card"
+    adapter._always_card = True
+    adapter._card_footer_elapsed = True
+    adapter._card_footer_status = True
+    adapter._streaming_card_state = {"card_123": {"started_at": 100.0}}
+    adapter._execution_progress_lines = {}
+    adapter._tool_progress_lines = {}
+    adapter._latest_card_content = {"card_123": "第一段进度"}
+    adapter._active_card_for_chat = {"chat_id": "card_123"}
+    adapter.format_message = lambda content: content
+    update_content = MagicMock(return_value=SimpleNamespace(success=lambda: True, data=SimpleNamespace()))
+    adapter._client = SimpleNamespace(
+        cardkit=SimpleNamespace(
+            v1=SimpleNamespace(
+                card_element=SimpleNamespace(content=update_content),
+            )
+        )
+    )
+
+    record_result = await adapter.record_execution_progress("chat_id", "第一段进度")
+    edit_result = await adapter.edit_message("chat_id", "card_123", "第二段进度")
+
+    assert record_result.success is True
+    assert edit_result.success is True
+    content_request = update_content.call_args_list[0].args[0]
+    assert content_request.element_id == "content"
+    assert content_request.request_body.content == "第一段进度\n...\n第二段进度"
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_feishu_stream_footer.py
+++ b/tests/gateway/test_feishu_stream_footer.py
@@ -1,0 +1,813 @@
+"""Feishu stream + footer regression tests."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import SendResult
+from gateway.platforms.feishu import FeishuAdapter
+from gateway.runtime_footer import build_footer_line
+from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+
+class FakeFeishuAdapter:
+    MAX_MESSAGE_LENGTH = 8000
+    SUPPORTS_MESSAGE_EDITING = True
+    _render_mode = "card"
+    _always_card = True
+
+    @property
+    def REQUIRES_EDIT_FINALIZE(self):
+        return self._render_mode == "card" or self._always_card
+
+    def __init__(self):
+        self.sent = []
+        self.edits = []
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        self.sent.append(
+            {
+                "chat_id": chat_id,
+                "content": content,
+                "reply_to": reply_to,
+                "metadata": metadata,
+            }
+        )
+        return SendResult(success=True, message_id="msg_1")
+
+    async def edit_message(self, chat_id, message_id, content, *, finalize=False):
+        self.edits.append(
+            {
+                "chat_id": chat_id,
+                "message_id": message_id,
+                "content": content,
+                "finalize": finalize,
+            }
+        )
+        return SendResult(success=True, message_id=message_id)
+
+    def truncate_message(self, content, max_length):
+        return [content]
+
+
+class FakeRunner:
+    def __init__(self, adapter):
+        self.adapters = {Platform.FEISHU: adapter}
+        self.media_deliveries = []
+
+    async def _deliver_media_from_response(self, response, event, adapter):
+        self.media_deliveries.append((response, event, adapter))
+
+
+@pytest.mark.asyncio
+async def test_feishu_text_mode_does_not_force_redundant_finalize_edit():
+    adapter = FeishuAdapter.__new__(FeishuAdapter)
+    adapter._render_mode = "text"
+    adapter._always_card = False
+
+    consumer = GatewayStreamConsumer(
+        adapter=adapter,
+        chat_id="chat_id",
+        config=StreamConsumerConfig(edit_interval=999, buffer_threshold=999, cursor=""),
+    )
+
+    assert consumer._adapter_requires_finalize is False
+
+
+@pytest.mark.asyncio
+async def test_feishu_card_mode_forces_finalize_edit_to_close_stream_card():
+    adapter = FakeFeishuAdapter()
+    consumer = GatewayStreamConsumer(
+        adapter=adapter,
+        chat_id="chat_id",
+        config=StreamConsumerConfig(edit_interval=999, buffer_threshold=999, cursor=""),
+    )
+
+    task = asyncio.create_task(consumer.run())
+    consumer.on_delta("流式正文")
+    consumer.finish()
+    await asyncio.wait_for(task, timeout=2)
+
+    assert consumer.final_response_sent is True
+    assert adapter.sent == [
+        {
+            "chat_id": "chat_id",
+            "content": "流式正文",
+            "reply_to": None,
+            "metadata": {"_hermes_stream_preview": True},
+        }
+    ]
+    assert adapter.edits[-1] == {
+        "chat_id": "chat_id",
+        "message_id": "msg_1",
+        "content": "流式正文",
+        "finalize": True,
+    }
+
+
+def test_feishu_card_payload_has_streaming_config_and_footer_elements():
+    adapter = FeishuAdapter.__new__(FeishuAdapter)
+    adapter._render_mode = "card"
+    adapter._always_card = True
+    adapter._card_footer_elapsed = True
+    adapter._card_footer_status = True
+
+    msg_type, payload = adapter._build_outbound_payload(
+        "测试 stream footer",
+        metadata={"_hermes_stream_preview": True},
+    )
+    card = __import__("json").loads(payload)
+
+    assert msg_type == "interactive"
+    assert card["schema"] == "2.0"
+    assert card["config"]["streaming_mode"] is True
+    assert card["config"]["streaming_config"]["print_frequency_ms"]["default"] == 50
+    assert card["body"]["elements"][0]["tag"] == "markdown"
+    assert card["body"]["elements"][0]["element_id"] == "content"
+    footer_text = card["body"]["elements"][1]["content"]
+    assert footer_text.startswith("Agent: main |")
+    assert "Elapsed: 0s" in footer_text
+    assert "生成中" in footer_text
+    assert "生成耗时实时更新" not in footer_text
+
+
+@pytest.mark.asyncio
+async def test_feishu_card_send_uses_cardkit_card_id_as_edit_target():
+    adapter = FeishuAdapter.__new__(FeishuAdapter)
+    adapter._render_mode = "card"
+    adapter._always_card = True
+    adapter._card_footer_elapsed = True
+    adapter._card_footer_status = True
+    adapter._streaming_card_state = {}
+    adapter._create_card_message = AsyncMock(return_value="card_123")
+    adapter._build_create_message_body = lambda **kwargs: SimpleNamespace(**kwargs)
+    adapter._build_create_message_request = lambda receive_id_type, request_body: SimpleNamespace(
+        receive_id_type=receive_id_type,
+        request_body=request_body,
+    )
+    create = MagicMock(return_value=SimpleNamespace(success=lambda: True, data=SimpleNamespace(message_id="om_message")))
+    adapter._client = SimpleNamespace(im=SimpleNamespace(v1=SimpleNamespace(message=SimpleNamespace(create=create))))
+
+    response = await adapter._send_raw_message(
+        chat_id="chat_id",
+        msg_type="interactive",
+        payload='{"schema":"2.0"}',
+        reply_to=None,
+        metadata=None,
+    )
+
+    adapter._create_card_message.assert_awaited_once_with('{"schema":"2.0"}')
+    request = create.call_args.args[0]
+    body = request.request_body
+    assert body.msg_type == "interactive"
+    assert body.content == '{"type": "card", "data": {"card_id": "card_123"}}'
+    assert response.hermes_feishu_card_id == "card_123"
+    result = adapter._finalize_send_result(response, "send failed")
+    assert result.message_id == "card_123"
+
+
+@pytest.mark.asyncio
+async def test_feishu_card_send_records_stream_start_time(monkeypatch):
+    adapter = FeishuAdapter.__new__(FeishuAdapter)
+    adapter._client = object()
+    adapter._render_mode = "card"
+    adapter._always_card = True
+    adapter._card_footer_elapsed = True
+    adapter._card_footer_status = True
+    adapter._streaming_card_state = {}
+    adapter.format_message = lambda content: content
+    adapter.truncate_message = lambda content, max_length: [content]
+    monkeypatch.setattr("gateway.platforms.feishu.time.monotonic", lambda: 123.45)
+    response = SimpleNamespace(success=lambda: True, hermes_feishu_card_id="card_123")
+    adapter._feishu_send_with_retry = AsyncMock(return_value=response)
+
+    result = await adapter.send("chat_id", "流式正文", metadata={"_hermes_stream_preview": True})
+
+    assert result.success is True
+    assert result.message_id == "card_123"
+    sent_payload = adapter._feishu_send_with_retry.await_args.kwargs["payload"]
+    sent_card = __import__("json").loads(sent_payload)
+    footer_text = sent_card["body"]["elements"][1]["content"]
+    assert footer_text.startswith("Agent: main |")
+    assert "Elapsed: 0s" in footer_text
+    assert "生成中" in footer_text
+    assert "生成耗时实时更新" not in footer_text
+    assert adapter._streaming_card_state == {"card_123": {"started_at": 123.45}}
+
+
+@pytest.mark.asyncio
+async def test_feishu_plain_final_card_send_is_completed_not_streaming(monkeypatch):
+    adapter = FeishuAdapter.__new__(FeishuAdapter)
+    adapter._client = object()
+    adapter._render_mode = "card"
+    adapter._always_card = True
+    adapter._card_footer_elapsed = True
+    adapter._card_footer_status = True
+    adapter._streaming_card_state = {}
+    adapter._active_card_for_chat = {}
+    adapter.format_message = lambda content: content
+    adapter.truncate_message = lambda content, max_length: [content]
+    monkeypatch.setattr("gateway.platforms.feishu.time.monotonic", lambda: 123.45)
+    response = SimpleNamespace(success=lambda: True, hermes_feishu_card_id="card_final_1")
+    adapter._feishu_send_with_retry = AsyncMock(return_value=response)
+
+    result = await adapter.send(
+        "chat_id",
+        "最终正文",
+        metadata={"model": "provider/model-x", "provider": "test"},
+    )
+
+    assert result.success is True
+    assert result.message_id == "card_final_1"
+    sent_payload = adapter._feishu_send_with_retry.await_args.kwargs["payload"]
+    sent_card = __import__("json").loads(sent_payload)
+    assert sent_card["config"]["streaming_mode"] is False
+    footer_text = sent_card["body"]["elements"][1]["content"]
+    assert "Model: model-x" in footer_text
+    assert "Provider: test" in footer_text
+    assert "Elapsed: 0s" in footer_text
+    assert "✅ 已完成" in footer_text
+    assert "生成中" not in footer_text
+    assert adapter._streaming_card_state == {}
+    assert adapter._active_card_for_chat == {}
+
+
+@pytest.mark.asyncio
+async def test_feishu_card_embeds_tool_progress_block_inline_in_same_card():
+    adapter = FeishuAdapter.__new__(FeishuAdapter)
+    adapter._render_mode = "card"
+    adapter._always_card = True
+    adapter._card_footer_elapsed = True
+    adapter._card_footer_status = True
+    adapter._streaming_card_state = {}
+    adapter._execution_progress_lines = {}
+    adapter._tool_progress_lines = {}
+    adapter._latest_card_content = {}
+    adapter._active_card_for_chat = {}
+    adapter._tool_progress_interval = 0
+    adapter.format_message = lambda content: content
+
+    update_content = MagicMock(
+        return_value=SimpleNamespace(success=lambda: True, data=SimpleNamespace())
+    )
+    update_card = MagicMock(
+        return_value=SimpleNamespace(success=lambda: True, data=SimpleNamespace())
+    )
+    settings_card = MagicMock(
+        return_value=SimpleNamespace(success=lambda: True, data=SimpleNamespace())
+    )
+    update_message = MagicMock()
+    adapter._client = SimpleNamespace(
+        cardkit=SimpleNamespace(
+            v1=SimpleNamespace(
+                card_element=SimpleNamespace(content=update_content),
+                card=SimpleNamespace(update=update_card, settings=settings_card),
+            )
+        ),
+        im=SimpleNamespace(v1=SimpleNamespace(message=SimpleNamespace(update=update_message))),
+    )
+
+    chat_id = "oc_chat_inline"
+    # First tool fires before any answer text exists. In CardKit mode this now
+    # opens the same streaming card immediately, instead of silently buffering
+    # until final text arrives.
+    msg_id = "card_inline_1"
+    adapter._feishu_send_with_retry = AsyncMock(
+        return_value=SimpleNamespace(success=lambda: True, hermes_feishu_card_id=msg_id)
+    )
+    await adapter.update_tool_progress(
+        chat_id,
+        ['💻 terminal: "first command"'],
+        metadata={"model": "provider/model-x", "provider": "test"},
+    )
+    update_content.assert_not_called()
+    update_card.assert_not_called()
+    update_message.assert_not_called()
+    assert adapter._active_card_for_chat[chat_id] == msg_id
+    assert msg_id in adapter._streaming_card_state
+    sent_payload = adapter._feishu_send_with_retry.await_args.kwargs["payload"]
+    assert "collapsible_panel" in sent_payload
+    assert "first command" in sent_payload
+    assert "Model: model-x" in sent_payload
+    assert "Provider: test" in sent_payload
+    adapter._latest_card_content[msg_id] = "正文开始了"
+
+    # First answer streaming chunk lands. The card already contains the progress
+    # panel, so streaming text updates only the content/footer elements.
+    await adapter.edit_message(chat_id, msg_id, "正文开始了")
+    update_card.assert_not_called()
+    update_message.assert_not_called()
+    assert update_content.call_args_list[0].args[0].element_id == "content"
+    assert update_content.call_args_list[0].args[0].request_body.content == "正文开始了"
+    assert update_content.call_args_list[1].args[0].element_id == "footer"
+
+    # Second tool fires: update_tool_progress edits the active CardKit card so
+    # long tool-heavy turns remain visibly alive before any final answer text.
+    update_card.reset_mock()
+    update_content.reset_mock()
+    await adapter.update_tool_progress(
+        chat_id,
+        ['💻 terminal: "first command"', '💻 terminal: "second command"'],
+    )
+    update_card.assert_called_once()
+    update_content.assert_not_called()
+    update_message.assert_not_called()
+    assert len(adapter._tool_progress_lines.get(chat_id, [])) == 2
+
+    # Next stream consumer edit updates the existing content/footer elements while
+    # the progress panel stays in the card.
+    update_card.reset_mock()
+    update_content.reset_mock()
+    await adapter.edit_message(chat_id, msg_id, "正文开始了更多")
+    assert update_content.call_args_list[0].args[0].element_id == "content"
+    assert update_content.call_args_list[0].args[0].request_body.content == "正文开始了更多"
+    assert update_content.call_args_list[1].args[0].element_id == "footer"
+    update_card.assert_not_called()
+
+    # Finalize the card: tool block clears so the next reply starts clean.
+    update_card.reset_mock()
+    await adapter.edit_message(chat_id, msg_id, "正文开始了。最终答复", finalize=True)
+    update_card.assert_called_once()
+    assert chat_id not in adapter._tool_progress_lines
+    assert chat_id not in adapter._active_card_for_chat
+
+
+@pytest.mark.asyncio
+async def test_feishu_send_reuses_progress_opened_card_for_first_answer_chunk():
+    adapter = FeishuAdapter.__new__(FeishuAdapter)
+    adapter._client = object()
+    adapter._render_mode = "card"
+    adapter._always_card = True
+    adapter._card_footer_elapsed = True
+    adapter._card_footer_status = True
+    adapter._streaming_card_state = {"card_progress_1": {"started_at": 100.0}}
+    adapter._tool_progress_lines = {"chat_id": ['💻 terminal: "scan"']}
+    adapter._latest_card_content = {"card_progress_1": " "}
+    adapter._active_card_for_chat = {"chat_id": "card_progress_1"}
+    adapter.format_message = lambda content: content
+    adapter.truncate_message = lambda content, max_length: [content]
+    adapter.edit_message = AsyncMock(return_value=SendResult(success=True, message_id="card_progress_1"))
+    adapter._feishu_send_with_retry = AsyncMock()
+
+    result = await adapter.send("chat_id", "最终答复开始", metadata={"model": "provider/model-x"})
+
+    assert result.success is True
+    assert result.message_id == "card_progress_1"
+    adapter.edit_message.assert_awaited_once_with(
+        "chat_id",
+        "card_progress_1",
+        "最终答复开始",
+        finalize=True,
+    )
+    adapter._feishu_send_with_retry.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_feishu_tool_progress_updates_are_throttled_after_initial_card(monkeypatch):
+    adapter = FeishuAdapter.__new__(FeishuAdapter)
+    adapter._render_mode = "card"
+    adapter._always_card = True
+    adapter._card_footer_elapsed = True
+    adapter._card_footer_status = True
+    adapter._tool_progress_interval = 1.5
+    adapter._streaming_card_state = {"card_progress_1": {"started_at": 100.0}}
+    adapter._tool_progress_lines = {}
+    adapter._latest_card_content = {"card_progress_1": " "}
+    adapter._active_card_for_chat = {"chat_id": "card_progress_1"}
+    adapter._tool_progress_last_update = {"chat_id": 10.0}
+    adapter._client = SimpleNamespace(
+        cardkit=SimpleNamespace(
+            v1=SimpleNamespace(
+                card=SimpleNamespace(update=MagicMock(return_value=SimpleNamespace(success=lambda: True)))
+            )
+        )
+    )
+    monkeypatch.setattr("gateway.platforms.feishu.time.monotonic", lambda: 10.5)
+
+    await adapter.update_tool_progress("chat_id", ["first", "second"])
+
+    adapter._client.cardkit.v1.card.update.assert_not_called()
+    assert adapter._tool_progress_lines["chat_id"] == ["first", "second"]
+
+
+@pytest.mark.asyncio
+async def test_feishu_edit_streaming_updates_card_content_element_not_whole_card():
+    adapter = FeishuAdapter.__new__(FeishuAdapter)
+    adapter._render_mode = "card"
+    adapter._always_card = True
+    adapter._card_footer_elapsed = True
+    adapter._card_footer_status = True
+    adapter._streaming_card_state = {"card_123": {"started_at": 100.0}}
+    adapter.format_message = lambda content: content
+    update_content = MagicMock(return_value=SimpleNamespace(success=lambda: True, data=SimpleNamespace()))
+    update_card = MagicMock()
+    update_message = MagicMock()
+    adapter._client = SimpleNamespace(
+        cardkit=SimpleNamespace(
+            v1=SimpleNamespace(
+                card_element=SimpleNamespace(content=update_content),
+                card=SimpleNamespace(update=update_card),
+            )
+        ),
+        im=SimpleNamespace(v1=SimpleNamespace(message=SimpleNamespace(update=update_message))),
+    )
+
+    result = await adapter.edit_message("chat_id", "card_123", "正在逐步输出", finalize=False)
+
+    assert result.success is True
+    assert result.message_id == "card_123"
+    update_message.assert_not_called()
+    update_card.assert_not_called()
+    update_content.assert_any_call(update_content.call_args_list[0].args[0])
+    content_request = update_content.call_args_list[0].args[0]
+    assert content_request.card_id == "card_123"
+    assert content_request.element_id == "content"
+    assert content_request.request_body.content == "正在逐步输出"
+    assert content_request.request_body.sequence == 1
+    footer_request = update_content.call_args_list[1].args[0]
+    assert footer_request.card_id == "card_123"
+    assert footer_request.element_id == "footer"
+    assert footer_request.request_body.sequence == 2
+    assert "card_123" in adapter._streaming_card_state
+
+
+@pytest.mark.asyncio
+async def test_feishu_card_create_uses_raw_card_json_data_not_nested_card():
+    adapter = FeishuAdapter.__new__(FeishuAdapter)
+    create = MagicMock(return_value=SimpleNamespace(success=lambda: True, data=SimpleNamespace(card_id="card_raw_1")))
+    adapter._client = SimpleNamespace(cardkit=SimpleNamespace(v1=SimpleNamespace(card=SimpleNamespace(create=create))))
+
+    card_id = await adapter._create_card_message('{"schema":"2.0"}')
+
+    assert card_id == "card_raw_1"
+    body = create.call_args.args[0].request_body
+    assert body.type == "card_json"
+    assert body.data == '{"schema":"2.0"}'
+    assert isinstance(body.data, str)
+
+
+@pytest.mark.asyncio
+async def test_feishu_edit_finalize_updates_cardkit_card_not_message_update(monkeypatch):
+    adapter = FeishuAdapter.__new__(FeishuAdapter)
+    adapter._render_mode = "card"
+    adapter._always_card = True
+    adapter._card_footer_elapsed = True
+    adapter._card_footer_status = True
+    adapter._streaming_card_state = {"card_123": {"started_at": 100.0, "model": "provider/model-x"}}
+    monkeypatch.setattr("gateway.platforms.feishu.time.monotonic", lambda: 103.24)
+    adapter.format_message = lambda content: content
+    adapter._build_card_update_request = lambda card_id, request_body: SimpleNamespace(
+        card_id=card_id,
+        request_body=request_body,
+    )
+    update_card = MagicMock(return_value=SimpleNamespace(success=lambda: True, data=SimpleNamespace()))
+    settings_card = MagicMock(return_value=SimpleNamespace(success=lambda: True, data=SimpleNamespace()))
+    update_message = MagicMock()
+    adapter._client = SimpleNamespace(
+        cardkit=SimpleNamespace(v1=SimpleNamespace(card=SimpleNamespace(update=update_card, settings=settings_card))),
+        im=SimpleNamespace(v1=SimpleNamespace(message=SimpleNamespace(update=update_message))),
+    )
+
+    result = await adapter.edit_message("chat_id", "card_123", "最终正文", finalize=True)
+
+    assert result.success is True
+    assert result.message_id == "card_123"
+    update_message.assert_not_called()
+    request = update_card.call_args.args[0]
+    assert request.card_id == "card_123"
+    assert request.request_body.sequence == 1
+    card = __import__("json").loads(request.request_body.card.data)
+    assert card["config"]["streaming_mode"] is False
+    assert card["config"]["summary"]["content"] == "最终正文"
+    footer_text = card["body"]["elements"][1]["content"]
+    assert "Agent: main" in footer_text
+    assert "Model: model-x" in footer_text
+    assert "Elapsed: 3s" in footer_text
+    assert "✅ 已完成" in footer_text
+    assert "生成耗时实时更新" not in footer_text
+    settings_card.assert_called_once()
+    settings_request = settings_card.call_args.args[0]
+    assert settings_request.card_id == "card_123"
+    assert isinstance(settings_request.request_body.settings, str)
+    settings_config = __import__("json").loads(settings_request.request_body.settings)
+    assert settings_config["streaming_mode"] is False
+    assert settings_config["summary"]["content"] == "最终正文"
+    assert "card_123" not in adapter._streaming_card_state
+
+
+@pytest.mark.asyncio
+async def test_feishu_finalize_uses_short_summary_for_long_markdown(monkeypatch):
+    adapter = FeishuAdapter.__new__(FeishuAdapter)
+    adapter._render_mode = "card"
+    adapter._always_card = True
+    adapter._card_footer_elapsed = True
+    adapter._card_footer_status = True
+    adapter._streaming_card_state = {"card_123": {"started_at": 100.0}}
+    monkeypatch.setattr("gateway.platforms.feishu.time.monotonic", lambda: 103.24)
+    adapter.format_message = lambda content: content
+    adapter._build_card_update_request = lambda card_id, request_body: SimpleNamespace(
+        card_id=card_id,
+        request_body=request_body,
+    )
+    long_markdown = "# 标题\n" + "很长的正文 " * 80 + "\n```python\nprint('x')\n```"
+    update_card = MagicMock(return_value=SimpleNamespace(success=lambda: True, data=SimpleNamespace()))
+    settings_card = MagicMock(return_value=SimpleNamespace(success=lambda: True, data=SimpleNamespace()))
+    adapter._client = SimpleNamespace(
+        cardkit=SimpleNamespace(v1=SimpleNamespace(card=SimpleNamespace(update=update_card, settings=settings_card))),
+        im=SimpleNamespace(v1=SimpleNamespace(message=SimpleNamespace(update=MagicMock()))),
+    )
+
+    result = await adapter.edit_message("chat_id", "card_123", long_markdown, finalize=True)
+
+    assert result.success is True
+    card = __import__("json").loads(update_card.call_args.args[0].request_body.card.data)
+    summary = card["config"]["summary"]["content"]
+    assert len(summary) <= 200
+    assert "\n" not in summary
+    settings_config = __import__("json").loads(settings_card.call_args.args[0].request_body.settings)
+    assert settings_config["summary"]["content"] == summary
+
+
+@pytest.mark.asyncio
+async def test_feishu_finalize_falls_back_to_element_updates_when_whole_card_update_fails(monkeypatch):
+    adapter = FeishuAdapter.__new__(FeishuAdapter)
+    adapter._render_mode = "card"
+    adapter._always_card = True
+    adapter._card_footer_elapsed = True
+    adapter._card_footer_status = True
+    adapter._streaming_card_state = {"card_123": {"started_at": 100.0}}
+    adapter._tool_progress_lines = {"chat_id": ["tool line"]}
+    adapter._active_card_for_chat = {"chat_id": "card_123"}
+    adapter._latest_card_content = {"card_123": "old"}
+    adapter._tool_progress_last_update = {"chat_id": 1.0}
+    monkeypatch.setattr("gateway.platforms.feishu.time.monotonic", lambda: 103.24)
+    adapter.format_message = lambda content: content
+    adapter._build_card_update_request = lambda card_id, request_body: SimpleNamespace(
+        card_id=card_id,
+        request_body=request_body,
+    )
+    update_card = MagicMock(return_value=SimpleNamespace(success=lambda: False, code=999, msg="invalid card"))
+    update_content = MagicMock(return_value=SimpleNamespace(success=lambda: True, data=SimpleNamespace()))
+    settings_card = MagicMock(return_value=SimpleNamespace(success=lambda: True, data=SimpleNamespace()))
+    adapter._client = SimpleNamespace(
+        cardkit=SimpleNamespace(
+            v1=SimpleNamespace(
+                card_element=SimpleNamespace(content=update_content),
+                card=SimpleNamespace(update=update_card, settings=settings_card),
+            )
+        ),
+        im=SimpleNamespace(v1=SimpleNamespace(message=SimpleNamespace(update=MagicMock()))),
+    )
+
+    result = await adapter.edit_message("chat_id", "card_123", "最终正文", finalize=True)
+
+    assert result.success is True
+    assert update_card.call_count == 1
+    assert update_content.call_count == 2
+    assert update_content.call_args_list[0].args[0].element_id == "content"
+    assert update_content.call_args_list[1].args[0].element_id == "footer"
+    assert "✅ 已完成" in update_content.call_args_list[1].args[0].request_body.content
+    settings_card.assert_called_once()
+    assert "card_123" not in adapter._streaming_card_state
+    assert "chat_id" not in adapter._active_card_for_chat
+
+
+@pytest.mark.asyncio
+async def test_feishu_append_mode_still_uses_element_updates_so_client_streams(monkeypatch):
+    adapter = FeishuAdapter.__new__(FeishuAdapter)
+    adapter._render_mode = "card"
+    adapter._always_card = True
+    adapter._append_mode = True
+    adapter._card_footer_elapsed = True
+    adapter._card_footer_status = True
+    adapter._streaming_card_state = {
+        "card_append_1": {
+            "started_at": 100.0,
+            "agent": "main",
+            "model": "MiniMax-M2.7-highspeed",
+            "provider": "minimax-cn",
+        }
+    }
+    monkeypatch.setattr("gateway.platforms.feishu.time.monotonic", lambda: 108.0)
+    adapter.format_message = lambda content: content
+    adapter._build_card_update_request = lambda card_id, request_body: SimpleNamespace(
+        card_id=card_id,
+        request_body=request_body,
+    )
+    update_content = MagicMock()
+    update_card = MagicMock(return_value=SimpleNamespace(success=lambda: True, data=SimpleNamespace()))
+    update_message = MagicMock()
+    adapter._client = SimpleNamespace(
+        cardkit=SimpleNamespace(
+            v1=SimpleNamespace(
+                card_element=SimpleNamespace(content=update_content),
+                card=SimpleNamespace(update=update_card),
+            )
+        ),
+        im=SimpleNamespace(v1=SimpleNamespace(message=SimpleNamespace(update=update_message))),
+    )
+
+    result = await adapter.edit_message("chat_id", "card_append_1", "1/2 旧进度\n2/2 新进度", finalize=False)
+
+    assert result.success is True
+    update_message.assert_not_called()
+    update_card.assert_not_called()
+    assert update_content.call_count == 2
+    content_request = update_content.call_args_list[0].args[0]
+    assert content_request.element_id == "content"
+    assert content_request.request_body.content == "1/2 旧进度\n2/2 新进度"
+    footer_request = update_content.call_args_list[1].args[0]
+    assert footer_request.element_id == "footer"
+    footer_text = footer_request.request_body.content
+    assert "Agent: main" in footer_text
+    assert "Model: MiniMax-M2.7-highspeed" in footer_text
+    assert "Provider: minimax-cn" in footer_text
+    assert "Elapsed: 8s" in footer_text
+    assert footer_text.endswith("生成中")
+
+
+def test_feishu_card_update_sequence_uses_small_incrementing_ints():
+    adapter = FeishuAdapter.__new__(FeishuAdapter)
+
+    first = adapter._build_card_update_body(data="{}")
+    second = adapter._build_card_update_body(data="{}")
+
+    assert first.sequence == 1
+    assert second.sequence == 2
+
+
+@pytest.mark.asyncio
+async def test_trailing_footer_uses_same_feishu_card_send_path_when_stream_already_sent():
+    footer = build_footer_line(
+        user_config={
+            "display": {
+                "platforms": {
+                    "feishu": {
+                        "runtime_footer": {
+                            "enabled": True,
+                            "fields": ["model", "context_pct", "cwd"],
+                        }
+                    }
+                }
+            }
+        },
+        platform_key="feishu",
+        model="provider/model-x",
+        context_tokens=50,
+        context_length=100,
+        cwd="/tmp/project",
+    )
+    adapter = AsyncMock()
+    adapter.send.return_value = SendResult(success=True, message_id="footer_msg")
+    runner = FakeRunner(adapter)
+    source = SimpleNamespace(platform=Platform.FEISHU, chat_id="chat_id")
+    event = SimpleNamespace(source=source)
+    agent_result = {"already_sent": True, "failed": False}
+
+    await runner._deliver_media_from_response("正文", event, adapter)
+    await adapter.send(source.chat_id, footer)
+
+    adapter.send.assert_awaited_once_with("chat_id", footer)
+    assert "model-x" in footer
+    assert "50%" in footer
+
+
+@pytest.mark.asyncio
+async def test_stream_commentary_appends_semantic_progress_instead_of_sending_bubble():
+    adapter = AsyncMock()
+    adapter.MAX_MESSAGE_LENGTH = 8000
+    adapter.SUPPORTS_MESSAGE_EDITING = True
+    adapter.REQUIRES_EDIT_FINALIZE = True
+    adapter.append_execution_progress.return_value = SendResult(success=True, message_id="card_progress")
+    adapter.send.return_value = SendResult(success=True, message_id="separate_msg")
+
+    consumer = GatewayStreamConsumer(
+        adapter=adapter,
+        chat_id="chat_id",
+        config=StreamConsumerConfig(edit_interval=999, buffer_threshold=999, cursor=""),
+        metadata={"model": "provider/model-x"},
+    )
+
+    ok = await consumer._send_commentary("已完成苹果中文翻译，继续处理流式卡片")
+
+    assert ok is True
+    adapter.append_execution_progress.assert_awaited_once_with(
+        "chat_id",
+        "已完成苹果中文翻译，继续处理流式卡片",
+        metadata={"model": "provider/model-x"},
+    )
+    adapter.send.assert_not_awaited()
+    assert consumer.already_sent is False
+    assert consumer._message_id == "card_progress"
+
+
+@pytest.mark.asyncio
+async def test_stream_commentary_preserves_card_for_later_final_edit():
+    adapter = AsyncMock()
+    adapter.MAX_MESSAGE_LENGTH = 8000
+    adapter.SUPPORTS_MESSAGE_EDITING = True
+    adapter.REQUIRES_EDIT_FINALIZE = True
+    adapter.append_execution_progress.return_value = SendResult(success=True, message_id="card_progress")
+    adapter.edit_message.return_value = SendResult(success=True, message_id="card_progress")
+    adapter.send.return_value = SendResult(success=True, message_id="separate_msg")
+
+    consumer = GatewayStreamConsumer(
+        adapter=adapter,
+        chat_id="chat_id",
+        config=StreamConsumerConfig(edit_interval=999, buffer_threshold=999, cursor=""),
+        metadata={"model": "provider/model-x"},
+    )
+
+    consumer.on_commentary("第一段人类可读进度")
+    consumer.on_commentary("第二段人类可读进度")
+    consumer.on_delta("最终答复")
+    consumer.finish()
+    await consumer.run()
+
+    assert adapter.append_execution_progress.await_count == 2
+    adapter.send.assert_not_awaited()
+    assert adapter.edit_message.await_count == 2
+    final_edit = adapter.edit_message.await_args
+    assert final_edit.kwargs == {
+        "chat_id": "chat_id",
+        "message_id": "card_progress",
+        "content": "最终答复",
+        "finalize": True,
+    }
+    assert all(call.kwargs["message_id"] == "card_progress" for call in adapter.edit_message.await_args_list)
+    assert consumer.final_response_sent is True
+
+
+@pytest.mark.asyncio
+async def test_feishu_append_execution_progress_uses_same_card_without_tool_noise():
+    adapter = FeishuAdapter.__new__(FeishuAdapter)
+    adapter._render_mode = "card"
+    adapter._always_card = True
+    adapter._card_footer_elapsed = True
+    adapter._card_footer_status = True
+    adapter._streaming_card_state = {}
+    adapter._execution_progress_lines = {}
+    adapter._tool_progress_lines = {}
+    adapter._latest_card_content = {}
+    adapter._active_card_for_chat = {}
+    adapter._tool_progress_interval = 0
+    adapter.format_message = lambda content: content
+    adapter.truncate_message = lambda content, max_length: [content]
+    adapter._client = SimpleNamespace(
+        cardkit=SimpleNamespace(
+            v1=SimpleNamespace(
+                card=SimpleNamespace(update=MagicMock(return_value=SimpleNamespace(success=lambda: True))),
+                card_element=SimpleNamespace(content=MagicMock(return_value=SimpleNamespace(success=lambda: True))),
+            )
+        ),
+        im=SimpleNamespace(v1=SimpleNamespace(message=SimpleNamespace(update=MagicMock()))),
+    )
+    adapter._feishu_send_with_retry = AsyncMock(
+        return_value=SimpleNamespace(success=lambda: True, hermes_feishu_card_id="card_semantic_1")
+    )
+
+    first = await adapter.append_execution_progress(
+        "chat_id",
+        "已完成苹果中文翻译，继续处理流式卡片",
+        metadata={"model": "provider/model-x", "provider": "test"},
+    )
+
+    assert first.success is True
+    assert first.message_id == "card_semantic_1"
+    payload = adapter._feishu_send_with_retry.await_args.kwargs["payload"]
+    assert "已完成苹果中文翻译" in payload
+    assert "terminal" not in payload
+    assert "collapsible_panel" not in payload
+    assert adapter._tool_progress_lines == {}
+    assert adapter._active_card_for_chat["chat_id"] == "card_semantic_1"
+
+    second = await adapter.append_execution_progress(
+        "chat_id",
+        "第二段人类可读进度",
+        metadata={"model": "provider/model-x", "provider": "test"},
+    )
+
+    assert second.success is True
+    update_request = adapter._client.cardkit.v1.card.update.call_args.args[0]
+    updated_card = __import__("json").loads(update_request.request_body.card.data)
+    content_element = next(
+        element for element in updated_card["body"]["elements"] if element.get("element_id") == "content"
+    )
+    assert content_element["content"] == "已完成苹果中文翻译，继续处理流式卡片\n...\n第二段人类可读进度\n..."
+    assert all(element.get("tag") != "collapsible_panel" for element in updated_card["body"]["elements"])
+    assert adapter._tool_progress_lines == {}
+
+    adapter.edit_message = AsyncMock(return_value=SendResult(success=True, message_id="card_semantic_1"))
+    result = await adapter.send("chat_id", "最终答复开始", metadata={"model": "provider/model-x"})
+
+    assert result.success is True
+    assert result.message_id == "card_semantic_1"
+    adapter.edit_message.assert_awaited_once_with(
+        "chat_id",
+        "card_semantic_1",
+        "最终答复开始",
+        finalize=True,
+    )

--- a/tests/gateway/test_feishu_stream_footer.py
+++ b/tests/gateway/test_feishu_stream_footer.py
@@ -742,6 +742,89 @@ async def test_stream_commentary_preserves_card_for_later_final_edit():
 
 
 @pytest.mark.asyncio
+async def test_stream_commentary_survives_segment_break_and_finalizes_same_card():
+    adapter = AsyncMock()
+    adapter.MAX_MESSAGE_LENGTH = 8000
+    adapter.SUPPORTS_MESSAGE_EDITING = True
+    adapter.REQUIRES_EDIT_FINALIZE = True
+    adapter.PRESERVE_STREAM_TARGET_ACROSS_SEGMENTS = True
+    adapter.append_execution_progress.return_value = SendResult(success=True, message_id="card_progress")
+    adapter.edit_message.return_value = SendResult(success=True, message_id="card_progress")
+    adapter.send.return_value = SendResult(success=True, message_id="separate_msg")
+
+    consumer = GatewayStreamConsumer(
+        adapter=adapter,
+        chat_id="chat_id",
+        config=StreamConsumerConfig(edit_interval=999, buffer_threshold=999, cursor=""),
+        metadata={"model": "provider/model-x"},
+    )
+
+    consumer.on_commentary("先汇报计划，随后执行工具")
+    consumer.on_delta(None)  # Tool/segment boundary must not orphan the CardKit progress card.
+    consumer.on_delta("最终答复")
+    consumer.finish()
+    await consumer.run()
+
+    adapter.append_execution_progress.assert_awaited_once_with(
+        "chat_id",
+        "先汇报计划，随后执行工具",
+        metadata={"model": "provider/model-x"},
+    )
+    adapter.send.assert_not_awaited()
+    assert adapter.edit_message.await_count == 2
+    assert all(call.kwargs["message_id"] == "card_progress" for call in adapter.edit_message.await_args_list)
+    assert adapter.edit_message.await_args_list[-1].kwargs == {
+        "chat_id": "chat_id",
+        "message_id": "card_progress",
+        "content": "最终答复",
+        "finalize": True,
+    }
+    assert consumer.final_response_sent is True
+
+
+@pytest.mark.asyncio
+async def test_stream_delta_segment_break_does_not_finalize_preserved_card_early():
+    adapter = AsyncMock()
+    adapter.MAX_MESSAGE_LENGTH = 8000
+    adapter.SUPPORTS_MESSAGE_EDITING = True
+    adapter.REQUIRES_EDIT_FINALIZE = True
+    adapter.PRESERVE_STREAM_TARGET_ACROSS_SEGMENTS = True
+    adapter.send.return_value = SendResult(success=True, message_id="card_stream")
+    adapter.edit_message.return_value = SendResult(success=True, message_id="card_stream")
+
+    consumer = GatewayStreamConsumer(
+        adapter=adapter,
+        chat_id="chat_id",
+        config=StreamConsumerConfig(edit_interval=999, buffer_threshold=999, cursor=""),
+        metadata={"model": "provider/model-x"},
+    )
+
+    consumer.on_delta("前半部分")
+    consumer.on_delta(None)  # Tool/segment boundary: keep card open.
+    consumer.on_delta("最终答复")
+    consumer.finish()
+    await consumer.run()
+
+    assert adapter.send.await_count == 1
+    assert adapter.send.await_args.kwargs["metadata"] == {
+        "model": "provider/model-x",
+        "_hermes_stream_preview": True,
+    }
+    assert adapter.edit_message.await_count == 2
+    first_edit = adapter.edit_message.await_args_list[0]
+    final_edit = adapter.edit_message.await_args_list[-1]
+    assert first_edit.kwargs["message_id"] == "card_stream"
+    assert first_edit.kwargs["finalize"] is False
+    assert final_edit.kwargs == {
+        "chat_id": "chat_id",
+        "message_id": "card_stream",
+        "content": "最终答复",
+        "finalize": True,
+    }
+    assert consumer.final_response_sent is True
+
+
+@pytest.mark.asyncio
 async def test_feishu_append_execution_progress_uses_same_card_without_tool_noise():
     adapter = FeishuAdapter.__new__(FeishuAdapter)
     adapter._render_mode = "card"


### PR DESCRIPTION
## Summary
- keep Feishu CardKit semantic progress in the same card body instead of opening separate cards
- distinguish stream preview sends from normal final sends via internal metadata so final cards close with completed footers
- route Feishu/CardKit tool progress through one active card and suppress duplicate generic runtime footers
- add regression coverage for CardKit create/update/finalize, semantic progress transcript, stream-preview vs final-send behavior

## Validation
- venv/bin/python -m pytest tests/gateway/test_feishu_stream_footer.py -q
- venv/bin/python -m py_compile gateway/platforms/feishu.py gateway/run.py gateway/stream_consumer.py gateway/runtime_footer.py
- venv/bin/python -m pytest tests/gateway/test_feishu.py tests/gateway/test_setup_feishu.py tests/gateway/test_feishu_stream_footer.py -q
