### PR TITLE
fix(gateway): scope quiet-mode tool schema cache by sender identity

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -261,6 +261,72 @@ _LEGACY_TOOLSET_MAP = {
 _tool_defs_cache: Dict[tuple, List[Dict[str, Any]]] = {}
 
 
+def _gateway_identity_fingerprint() -> tuple:
+    """Return the active gateway identity for access-control/cache scoping."""
+    try:
+        from gateway.session_context import get_session_env
+
+        platform = (get_session_env("HERMES_SESSION_PLATFORM", "") or "").strip().lower()
+        chat_id = (get_session_env("HERMES_SESSION_CHAT_ID", "") or "").strip()
+        user_id = (get_session_env("HERMES_SESSION_USER_ID", "") or "").strip()
+        chat_name = (get_session_env("HERMES_SESSION_CHAT_NAME", "") or "").strip()
+        user_name = (get_session_env("HERMES_SESSION_USER_NAME", "") or "").strip()
+    except Exception:
+        return ("", "", "", "", "")
+    return (platform, chat_id, user_id, chat_name, user_name)
+
+
+def _identity_allowed(values: Any, platform: str, identities: tuple[str, ...]) -> bool:
+    if not platform or not isinstance(values, dict):
+        return False
+    allowed = {str(v).strip() for v in values.get(platform, []) if str(v).strip()}
+    return any(identity in allowed for identity in identities if identity)
+
+
+def _load_access_control_config() -> Dict[str, Any]:
+    try:
+        from hermes_cli.config import load_config
+
+        return (load_config().get("skills", {}).get("access_control", {}) or {})
+    except Exception:
+        return {}
+
+
+def _is_toolset_allowed_for_identity(toolset_name: str) -> bool:
+    """Return whether the current gateway identity may use a restricted toolset."""
+    platform, chat_id, user_id, chat_name, user_name = _gateway_identity_fingerprint()
+    if not platform:
+        return True
+    identities = tuple(x for x in (user_id, chat_id, user_name, chat_name) if x)
+    ac = _load_access_control_config()
+
+    by_name = ac.get("toolset_allowed_identities_by_name", {}) or {}
+    if _identity_allowed(by_name.get(toolset_name), platform, identities):
+        allowed = True
+    elif _identity_allowed(ac.get("toolset_allowed_identities"), platform, identities):
+        allowed = True
+    elif _identity_allowed(ac.get("allowed_identities"), platform, identities):
+        allowed = True
+    else:
+        allowed = False
+
+    blocked_by_name = ac.get("toolset_blocked_identities_by_name", {}) or {}
+    if _identity_allowed(blocked_by_name.get(toolset_name), platform, identities):
+        return False
+    return allowed
+
+
+def _filter_restricted_toolsets_for_identity(tools_to_include: set) -> set:
+    ac = _load_access_control_config()
+    restricted = set(ac.get("restricted_toolsets") or [])
+    if not restricted:
+        return tools_to_include
+    for toolset_name in restricted:
+        if not _is_toolset_allowed_for_identity(str(toolset_name)):
+            tools_to_include.difference_update(resolve_toolset(str(toolset_name)))
+    return tools_to_include
+
+
 def _clear_tool_defs_cache() -> None:
     """Drop memoized get_tool_definitions() results. Called when dynamic
     schema dependencies change (e.g. discord capability cache reset,
@@ -307,6 +373,7 @@ def get_tool_definitions(
             frozenset(disabled_toolsets) if disabled_toolsets else None,
             registry._generation,
             cfg_fp,
+            _gateway_identity_fingerprint(),
         )
         cached = _tool_defs_cache.get(cache_key)
         if cached is not None:
@@ -381,6 +448,11 @@ def _compute_tool_definitions(
             else:
                 if not quiet_mode:
                     print(f"⚠️  Unknown toolset: {toolset_name}")
+
+    # Apply local gateway access-control after the requested toolsets are
+    # resolved. Restricted toolsets stay available in local CLI/cron-internal
+    # contexts, but are stripped for unauthorized gateway identities.
+    tools_to_include = _filter_restricted_toolsets_for_identity(tools_to_include)
 
     # Plugin-registered tools are now resolved through the normal toolset
     # path — validate_toolset() / resolve_toolset() / get_all_toolsets()

--- a/tests/test_get_tool_definitions_cache_isolation.py
+++ b/tests/test_get_tool_definitions_cache_isolation.py
@@ -88,7 +88,67 @@ class TestQuietModeCacheIsolation:
         )
 
     def test_non_quiet_mode_does_not_use_cache(self):
-        """Sanity: quiet_mode=False (TUI path) skips the cache entirely \u2014
+        """Sanity: quiet_mode=False (TUI path) skips the cache entirely —
         explains why the bug only hit Gateway."""
         model_tools.get_tool_definitions(quiet_mode=False)
         assert len(model_tools._tool_defs_cache) == 0
+
+
+class TestGatewayAccessControlCacheIsolation:
+    def _patch_access_config(self, monkeypatch):
+        import hermes_cli.config as config_mod
+
+        cfg = {
+            "skills": {
+                "access_control": {
+                    "restricted_toolsets": ["terminal"],
+                    "allowed_identities": {"whatsapp": ["owner@lid"]},
+                }
+            }
+        }
+        monkeypatch.setattr(config_mod, "load_config", lambda *a, **k: cfg)
+
+    def _tool_names(self):
+        tools = model_tools.get_tool_definitions(
+            enabled_toolsets=["terminal"],
+            quiet_mode=True,
+        )
+        return {t["function"]["name"] for t in tools}
+
+    def test_restricted_toolset_hidden_for_unauthorized_gateway_identity(self, monkeypatch):
+        from gateway.session_context import clear_session_vars, set_session_vars
+
+        self._patch_access_config(monkeypatch)
+        tokens = set_session_vars(platform="whatsapp", chat_id="stranger@lid", user_id="stranger@lid")
+        try:
+            names = self._tool_names()
+            assert "terminal" not in names
+        finally:
+            clear_session_vars(tokens)
+
+    def test_restricted_toolset_visible_for_authorized_gateway_identity(self, monkeypatch):
+        from gateway.session_context import clear_session_vars, set_session_vars
+
+        self._patch_access_config(monkeypatch)
+        tokens = set_session_vars(platform="whatsapp", chat_id="owner@lid", user_id="owner@lid")
+        try:
+            names = self._tool_names()
+            assert "terminal" in names
+        finally:
+            clear_session_vars(tokens)
+
+    def test_quiet_mode_cache_is_scoped_by_gateway_identity(self, monkeypatch):
+        from gateway.session_context import clear_session_vars, set_session_vars
+
+        self._patch_access_config(monkeypatch)
+        first = set_session_vars(platform="whatsapp", chat_id="owner@lid", user_id="owner@lid")
+        try:
+            assert "terminal" in self._tool_names()
+        finally:
+            clear_session_vars(first)
+
+        second = set_session_vars(platform="whatsapp", chat_id="stranger@lid", user_id="stranger@lid")
+        try:
+            assert "terminal" not in self._tool_names()
+        finally:
+            clear_session_vars(second)


### PR DESCRIPTION
Title: fix(gateway): scope quiet-mode tool schema cache by sender identity

## Summary
- add sender/access-control-aware filtering for restricted toolsets in `get_tool_definitions`
- include a gateway identity fingerprint in the quiet-mode cache key
- add regression coverage for unauthorized vs authorized gateway identities and cache isolation

## Why
Gateway tool availability can depend on the active messaging sender. Without identity-scoped caching, a long-lived gateway process can reuse an authorized sender's cached restricted tools for an unauthorized sender.

## Tests
- `python -m pytest tests/test_get_tool_definitions_cache_isolation.py -q -o 'addopts='`


Closes #22349
