### PR TITLE
fix(skills): hide restricted skills from unauthorized gateway senders

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -248,7 +248,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
     _skill_commands_platform = _resolve_skill_commands_platform()
     _skill_commands = {}
     try:
-        from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, _get_disabled_skill_names
+        from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, _get_disabled_skill_names, _is_skill_access_restricted
         from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
         disabled = _get_disabled_skill_names()
         seen_names: set = set()
@@ -272,8 +272,10 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     name = frontmatter.get('name', skill_md.parent.name)
                     if name in seen_names:
                         continue
-                    # Respect user's disabled skills config
+                    # Respect user's disabled skills config and local sender access-control
                     if name in disabled:
+                        continue
+                    if _is_skill_access_restricted(name):
                         continue
                     description = frontmatter.get('description', '')
                     if not description:

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -524,6 +524,49 @@ def _get_session_platform() -> str:
         return ""
 
 
+def _gateway_identity_fingerprint() -> tuple[str, str, str, str, str]:
+    """Return active gateway identity for local restricted-skill filtering."""
+    try:
+        from gateway.session_context import get_session_env
+
+        platform = (get_session_env("HERMES_SESSION_PLATFORM", "") or "").strip().lower()
+        chat_id = (get_session_env("HERMES_SESSION_CHAT_ID", "") or "").strip()
+        user_id = (get_session_env("HERMES_SESSION_USER_ID", "") or "").strip()
+        chat_name = (get_session_env("HERMES_SESSION_CHAT_NAME", "") or "").strip()
+        user_name = (get_session_env("HERMES_SESSION_USER_NAME", "") or "").strip()
+    except Exception:
+        return ("", "", "", "", "")
+    return (platform, chat_id, user_id, chat_name, user_name)
+
+
+def _identity_allowed(values: Any, platform: str, identities: tuple[str, ...]) -> bool:
+    if not platform or not isinstance(values, dict):
+        return False
+    allowed = {str(v).strip() for v in values.get(platform, []) if str(v).strip()}
+    return any(identity in allowed for identity in identities if identity)
+
+
+def _is_skill_access_restricted(name: str) -> bool:
+    try:
+        from hermes_cli.config import load_config
+
+        ac = load_config().get("skills", {}).get("access_control", {}) or {}
+    except Exception:
+        return False
+    if name not in set(ac.get("restricted_skills") or []):
+        return False
+    platform, chat_id, user_id, chat_name, user_name = _gateway_identity_fingerprint()
+    if not platform:
+        return False
+    identities = tuple(x for x in (user_id, chat_id, user_name, chat_name) if x)
+    skill_allowed = ac.get("skill_allowed_identities", {}) or {}
+    if _identity_allowed(skill_allowed, platform, identities):
+        return False
+    if _identity_allowed(ac.get("allowed_identities"), platform, identities):
+        return False
+    return True
+
+
 def _is_skill_disabled(name: str, platform: str = None) -> bool:
     """Check if a skill is disabled in config.
 
@@ -589,6 +632,8 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
                 if name in seen_names:
                     continue
                 if name in disabled:
+                    continue
+                if _is_skill_access_restricted(name):
                     continue
 
                 description = frontmatter.get("description", "")
@@ -1069,8 +1114,16 @@ def skill_view(
                 ensure_ascii=False,
             )
 
-        # Check if the skill is disabled by the user
+        # Check if the skill is disabled/restricted for the active identity
         resolved_name = parsed_frontmatter.get("name", skill_md.parent.name)
+        if _is_skill_access_restricted(resolved_name):
+            return json.dumps(
+                {
+                    "success": False,
+                    "error": f"Skill '{resolved_name}' is restricted for this sender.",
+                },
+                ensure_ascii=False,
+            )
         if _is_skill_disabled(resolved_name):
             return json.dumps(
                 {


### PR DESCRIPTION
Title: fix(skills): hide restricted skills from unauthorized gateway senders

## Summary
- add sender-aware restricted-skill checks for live gateway contexts
- filter `skills_list` and reject direct `skill_view` for unauthorized senders
- filter slash/preload skill command discovery through the same check

## Why
Owner-only skills may expose sensitive operational workflows. Unauthorized gateway users should not be able to discover or load them.

## Tests
- `python -m pytest tests/agent/test_skill_commands.py tests/tools/test_skills_tool.py -q -o 'addopts='`


Closes #22350
