### PR TITLE
chore(gitignore): ignore CocoIndex code cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,5 @@ mini-swe-agent/
 result
 website/static/api/skills-index.json
 models-dev-upstream/
+# CocoIndex Code (ccc)
+/.cocoindex_code/


### PR DESCRIPTION
## Summary
- Ignore the local CocoIndex Code cache directory `/.cocoindex_code/`.

## Verification
- `git diff --check origin/main..HEAD`
- Outgoing diff reviewed: only `.gitignore` changes
- Secret/privacy scan: no hits

## Notes
- Clean branch created from current `origin/main` and contains only this `.gitignore` change.
