### PR TITLE
feat(vision): make pre-analysis prompt configurable via auxiliary.vision.user_prompt

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3414,6 +3414,35 @@ def _get_task_extra_body(task: str) -> Dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# Vision pre-analysis prompt
+# ---------------------------------------------------------------------------
+
+DEFAULT_VISION_USER_PROMPT = (
+    "Describe everything visible in this image in thorough detail. "
+    "Include any text, code, UI, data, objects, people, layout, colors, "
+    "and any other notable visual information."
+)
+
+
+def _get_vision_user_prompt() -> str:
+    """Return the user_prompt for vision pre-analysis.
+
+    Reads ``auxiliary.vision.user_prompt`` from config.yaml. When empty or unset,
+    returns ``DEFAULT_VISION_USER_PROMPT`` so behavior is unchanged for users
+    who haven't customized it.
+
+    Centralized here so all four pre-analysis call sites
+    (``gateway/run.py``, ``run_agent.py``, ``cli.py``, ``tui_gateway/server.py``)
+    share one source of truth and one default string.
+    """
+    cfg = _get_auxiliary_task_config("vision")
+    raw = cfg.get("user_prompt")
+    if isinstance(raw, str) and raw.strip():
+        return raw
+    return DEFAULT_VISION_USER_PROMPT
+
+
+# ---------------------------------------------------------------------------
 # Anthropic-compatible endpoint detection + image block conversion
 # ---------------------------------------------------------------------------
 

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -414,6 +414,12 @@ prompt_caching:
 #     timeout: 30            # LLM API call timeout (seconds)
 #     download_timeout: 30   # Image HTTP download timeout (seconds)
 #                            # Increase for slow connections or self-hosted image servers
+#     user_prompt: ""        # Optional. Override the default vision pre-analysis prompt.
+#                            # Empty / unset → use the built-in English default
+#                            # ("Describe everything visible..."). Set this when running a
+#                            # custom auxiliary vision model (Qwen-VL, MiMo-VL, etc.) that
+#                            # benefits from a tuned / structured prompt — e.g. one that
+#                            # asks for explicit confidence levels to reduce hallucination.
 #
 #   # Web page scraping / summarization + browser page text extraction
 #   web_extract:

--- a/cli.py
+++ b/cli.py
@@ -4788,12 +4788,9 @@ class HermesCLI:
         """
         import asyncio as _asyncio
         from tools.vision_tools import vision_analyze_tool
+        from agent.auxiliary_client import _get_vision_user_prompt
 
-        analysis_prompt = (
-            "Describe everything visible in this image in thorough detail. "
-            "Include any text, code, data, objects, people, layout, colors, "
-            "and any other notable visual information."
-        )
+        analysis_prompt = _get_vision_user_prompt()
 
         enriched_parts = []
         for img_path in images:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12224,12 +12224,9 @@ class GatewayRunner:
         """
         from tools.vision_tools import vision_analyze_tool
         from agent.memory_manager import sanitize_context
+        from agent.auxiliary_client import _get_vision_user_prompt
 
-        analysis_prompt = (
-            "Describe everything visible in this image in thorough detail. "
-            "Include any text, code, data, objects, people, layout, colors, "
-            "and any other notable visual information."
-        )
+        analysis_prompt = _get_vision_user_prompt()
 
         enriched_parts = []
         for path in image_paths:

--- a/run_agent.py
+++ b/run_agent.py
@@ -8403,11 +8403,8 @@ class AIAgent:
             "assistant": "assistant",
             "tool": "tool result",
         }.get(role, "user")
-        analysis_prompt = (
-            "Describe everything visible in this image in thorough detail. "
-            "Include any text, code, UI, data, objects, people, layout, colors, "
-            "and any other notable visual information."
-        )
+        from agent.auxiliary_client import _get_vision_user_prompt
+        analysis_prompt = _get_vision_user_prompt()
 
         vision_source = str(image_url or "")
         cleanup_path: Optional[Path] = None

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2164,3 +2164,82 @@ class TestAnthropicExplicitApiKey:
         assert mock_build.call_args.args[0] == "explicit-fallback-key", (
             "resolve_provider_client must forward explicit_api_key to _try_anthropic()"
         )
+
+
+# ---------------------------------------------------------------------------
+# _get_vision_user_prompt — config-driven override of vision pre-analysis prompt
+# ---------------------------------------------------------------------------
+
+
+class TestGetVisionUserPrompt:
+    """Behaviour of agent.auxiliary_client._get_vision_user_prompt()."""
+
+    def test_returns_default_when_config_missing(self):
+        from agent.auxiliary_client import (
+            _get_vision_user_prompt,
+            DEFAULT_VISION_USER_PROMPT,
+        )
+        with patch("agent.auxiliary_client._get_auxiliary_task_config", return_value={}):
+            assert _get_vision_user_prompt() == DEFAULT_VISION_USER_PROMPT
+
+    def test_returns_default_when_user_prompt_unset(self):
+        from agent.auxiliary_client import (
+            _get_vision_user_prompt,
+            DEFAULT_VISION_USER_PROMPT,
+        )
+        cfg = {"provider": "openai", "model": "gpt-4.1-mini"}
+        with patch("agent.auxiliary_client._get_auxiliary_task_config", return_value=cfg):
+            assert _get_vision_user_prompt() == DEFAULT_VISION_USER_PROMPT
+
+    def test_returns_default_when_user_prompt_empty_string(self):
+        from agent.auxiliary_client import (
+            _get_vision_user_prompt,
+            DEFAULT_VISION_USER_PROMPT,
+        )
+        with patch(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            return_value={"user_prompt": ""},
+        ):
+            assert _get_vision_user_prompt() == DEFAULT_VISION_USER_PROMPT
+
+    def test_returns_default_when_user_prompt_whitespace_only(self):
+        from agent.auxiliary_client import (
+            _get_vision_user_prompt,
+            DEFAULT_VISION_USER_PROMPT,
+        )
+        with patch(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            return_value={"user_prompt": "   \n\t  "},
+        ):
+            assert _get_vision_user_prompt() == DEFAULT_VISION_USER_PROMPT
+
+    def test_returns_custom_when_user_prompt_set(self):
+        from agent.auxiliary_client import _get_vision_user_prompt
+        custom = "Describe this image strictly in JSON with keys: type, ocr, summary."
+        with patch(
+            "agent.auxiliary_client._get_auxiliary_task_config",
+            return_value={"user_prompt": custom},
+        ):
+            assert _get_vision_user_prompt() == custom
+
+    def test_returns_default_when_user_prompt_non_string(self):
+        from agent.auxiliary_client import (
+            _get_vision_user_prompt,
+            DEFAULT_VISION_USER_PROMPT,
+        )
+        # malformed config: list / dict / int — should not crash, fall back to default
+        for bad in [["a", "b"], {"nested": "yes"}, 42, True]:
+            with patch(
+                "agent.auxiliary_client._get_auxiliary_task_config",
+                return_value={"user_prompt": bad},
+            ):
+                assert _get_vision_user_prompt() == DEFAULT_VISION_USER_PROMPT, (
+                    f"non-string user_prompt={bad!r} should fall back to default"
+                )
+
+    def test_default_includes_canonical_keywords(self):
+        """The default string must remain compatible with all 4 call sites' expectations."""
+        from agent.auxiliary_client import DEFAULT_VISION_USER_PROMPT
+        # canonical keywords from the run_agent.py variant (most informative)
+        for kw in ("text", "code", "UI", "data", "objects", "people", "layout", "colors"):
+            assert kw in DEFAULT_VISION_USER_PROMPT, f"default missing '{kw}'"

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1981,12 +1981,9 @@ def _enrich_with_attached_images(user_text: str, image_paths: list[str]) -> str:
     """Pre-analyze attached images via vision and prepend descriptions to user text."""
     import asyncio, json as _json
     from tools.vision_tools import vision_analyze_tool
+    from agent.auxiliary_client import _get_vision_user_prompt
 
-    prompt = (
-        "Describe everything visible in this image in thorough detail. "
-        "Include any text, code, data, objects, people, layout, colors, "
-        "and any other notable visual information."
-    )
+    prompt = _get_vision_user_prompt()
 
     parts: list[str] = []
     for path in image_paths:


### PR DESCRIPTION
## What does this PR do?

The vision pre-analysis prompt was hardcoded in four places
(`gateway/run.py`, `run_agent.py`, `cli.py`, `tui_gateway/server.py`),
with `run_agent.py` carrying a slightly different `code, UI, data...`
wording vs the other three's `code, data...` (noted by @konsisumer in
the issue thread).

Consolidate the four sites through a new helper
`agent.auxiliary_client._get_vision_user_prompt()`, and add an optional
`auxiliary.vision.user_prompt` config key. Empty/unset preserves current
behavior; non-empty overrides verbatim.

Motivation: users running custom auxiliary vision models (Qwen-VL,
MiMo-VL, etc.) typically benefit from a structured, confidence-tagged
prompt to reduce hallucination, but currently the only way is to fork
and patch four files.

## Related Issue

Fixes #21816

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ♻️ Refactor (no behavior change for existing users — empty/unset config = unchanged)

## Changes Made

- `agent/auxiliary_client.py`: add `DEFAULT_VISION_USER_PROMPT` constant
  and `_get_vision_user_prompt()` helper. The default uses the
  `run_agent.py` "with UI" wording (strict superset of the other three
  — chose this so consolidation doesn't lose information).
- `gateway/run.py`, `run_agent.py`, `cli.py`, `tui_gateway/server.py`:
  replace the four inline prompt strings with `_get_vision_user_prompt()`.
- `tests/agent/test_auxiliary_client.py`: 7 unit tests for the helper —
  default fallback (missing/unset/empty/whitespace/non-string config),
  custom prompt pass-through, canonical-keyword regression guard.
- `cli-config.yaml.example`: document the new `auxiliary.vision.user_prompt`
  config key.

## How to Test

1. Set `auxiliary.vision.user_prompt: "your custom prompt"` in
   `~/.hermes/config.yaml`.
2. Send a message containing an image to a non-vision main model (so the
   gateway auto-analyzes via the auxiliary vision provider).
3. Verify the auxiliary vision call uses the custom prompt instead of
   the default English one.

Hand-tested on macOS with `dashscope` provider + `qwen3.6-plus` aux
vision, using a longer Chinese structured prompt with explicit
confidence-level guidance. Output came back with the requested section
headers and \"看起来像 / 应为 / 可能是 / 无法确定\" hedging language as
designed.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs (none for this issue)
- [x] My PR contains only changes related to this fix/feature
- [x] I've run \`pytest tests/agent/test_auxiliary_client.py -q\` and all
      tests pass except one pre-existing failure
      (\`test_custom_endpoint_uses_codex_wrapper_when_runtime_requests_responses_api\`)
      that fails on pristine \`origin/main\` too — unrelated to this PR.
- [x] I've added tests for my changes
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] \`cli-config.yaml.example\` updated with the new key
- [ ] N/A — README / \`docs/\` / docstrings unchanged
- [ ] N/A — no architecture / workflow changes
- [x] Cross-platform: pure config read, no platform-specific code paths
- [ ] N/A — no tool description / schema change