### PR TITLE
feat(api_server): include arguments+result in /v1/runs tool events

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -2728,6 +2728,12 @@ class APIServerAdapter(BasePlatformAdapter):
                     "timestamp": ts,
                     "tool": tool_name,
                     "preview": preview,
+                    # Full structured arguments — lets /v1/runs SSE consumers
+                    # render an expandable tool-call card without falling back
+                    # to the chat-completions Responses API. Empty dict if the
+                    # caller didn't supply args (matches existing semantics in
+                    # the chat-completions branch's _on_tool_start).
+                    "arguments": args or {},
                 })
             elif event_type == "tool.completed":
                 _push({
@@ -2737,6 +2743,9 @@ class APIServerAdapter(BasePlatformAdapter):
                     "tool": tool_name,
                     "duration": round(kwargs.get("duration", 0), 3),
                     "error": kwargs.get("is_error", False),
+                    # Pair with `arguments` on tool.started so the run-events
+                    # stream is self-sufficient for tool-card UIs.
+                    "result": kwargs.get("result"),
                 })
             elif event_type == "reasoning.available":
                 _push({

--- a/run_agent.py
+++ b/run_agent.py
@@ -10264,6 +10264,7 @@ class AIAgent:
                         self.tool_progress_callback(
                             "tool.completed", function_name, None, None,
                             duration=tool_duration, is_error=is_error,
+                            result=function_result,
                         )
                     except Exception as cb_err:
                         logging.debug(f"Tool progress callback error: {cb_err}")
@@ -10689,6 +10690,7 @@ class AIAgent:
                     self.tool_progress_callback(
                         "tool.completed", function_name, None, None,
                         duration=tool_duration, is_error=_is_error_result,
+                        result=function_result,
                     )
                 except Exception as cb_err:
                     logging.debug(f"Tool progress callback error: {cb_err}")


### PR DESCRIPTION
## What

Adds two existing runtime values into the structured run-event SSE stream emitted by `GET /v1/runs/{run_id}/events`:

- `tool.started` gains `arguments` (the dict already passed as `args` into the progress callback; defaults to `{}` when absent — mirrors `_on_tool_start` in the chat-completions branch).
- `tool.completed` gains `result` (the `function_result` string captured by `run_agent`; both call sites updated).

11 lines total. No new state, no new APIs.

## Why

The structured run-event stream currently sends tool lifecycle events with just the tool name, preview, duration, and a success bool. A client that wants to render an expandable tool-use card — showing the structured arguments the model passed plus the function output — has to fall back to the chat-completions Responses API stream just for that detail.

This is awkward when the rest of a UI is built around `/v1/runs` (e.g. for `approval.request` / `clarify.request` events keyed by `run_id`): you'd be juggling two SSE protocols across the same conversation. Surfacing the same data through `/v1/runs` keeps a `/v1/runs`-centric UI self-sufficient.

## Compatibility

Pure additive change. SSE consumers that don't know about `arguments` / `result` continue to ignore them; nothing existing changes shape.

## Test plan

- [x] `tool.started` SSE frame now contains `"arguments": {…}` when an Alkaka-qt-style client subscribes via `GET /v1/runs/{run_id}/events`
- [x] `tool.completed` SSE frame now contains `"result": "<function_result>"`
- [x] Chat-completions Responses path unchanged (separate code path, untouched)
- [x] No new dependencies; `args` and `function_result` were already available in the surrounding scope at both call sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)