### PR TITLE
fix(cli): surface clear error on Python <3.11 instead of TypeError on import

### DIFF
--- a/hermes_cli/__init__.py
+++ b/hermes_cli/__init__.py
@@ -17,6 +17,34 @@ import sys
 __version__ = "0.13.0"
 __release_date__ = "2026.5.7"
 
+_MIN_PYTHON = (3, 11)
+
+
+def _assert_python_version(current=None, min_version=_MIN_PYTHON, exit_fn=sys.exit):
+    """Fail fast with a friendly message on unsupported Python versions.
+
+    The package uses 3.10+ syntax (`X | None`) that raises an opaque
+    TypeError on import under older interpreters. Surface a clear error.
+    """
+    info = current if current is not None else sys.version_info
+    if tuple(info[:2]) < min_version:
+        running = ".".join(str(p) for p in info[:3])
+        required = ".".join(str(p) for p in min_version)
+        sys.stderr.write(
+            "hermes-agent requires Python "
+            + required
+            + "+ (found "
+            + running
+            + ").\nInstall Python "
+            + required
+            + " or newer and re-run.\n"
+        )
+        return exit_fn(1)
+    return None
+
+
+_assert_python_version()
+
 
 def _ensure_utf8():
     """Force UTF-8 stdout/stderr on Windows to prevent UnicodeEncodeError.

--- a/tests/hermes_cli/test_python_version.py
+++ b/tests/hermes_cli/test_python_version.py
@@ -1,0 +1,89 @@
+"""Tests for the Python version guard in hermes_cli.__init__."""
+
+from __future__ import annotations
+
+import pytest
+
+import hermes_cli
+
+
+def test_passes_on_current_interpreter():
+    calls = []
+
+    result = hermes_cli._assert_python_version(exit_fn=lambda code: calls.append(code))
+
+    assert result is None
+    assert calls == []
+
+
+def test_passes_on_explicit_minimum():
+    calls = []
+    result = hermes_cli._assert_python_version(
+        current=hermes_cli._MIN_PYTHON + (0,),
+        exit_fn=lambda code: calls.append(code),
+    )
+    assert result is None
+    assert calls == []
+
+
+def test_passes_on_above_minimum():
+    calls = []
+    major, minor = hermes_cli._MIN_PYTHON
+    result = hermes_cli._assert_python_version(
+        current=(major, minor + 1, 0),
+        exit_fn=lambda code: calls.append(code),
+    )
+    assert result is None
+    assert calls == []
+
+
+def test_exits_on_python_3_9(capsys):
+    calls = []
+    hermes_cli._assert_python_version(
+        current=(3, 9, 18),
+        exit_fn=lambda code: calls.append(code),
+    )
+
+    captured = capsys.readouterr()
+    assert calls == [1]
+    assert "requires Python 3.11+" in captured.err
+    assert "found 3.9.18" in captured.err
+
+
+def test_exits_on_python_3_10(capsys):
+    calls = []
+    hermes_cli._assert_python_version(
+        current=(3, 10, 12),
+        exit_fn=lambda code: calls.append(code),
+    )
+
+    captured = capsys.readouterr()
+    assert calls == [1]
+    assert "found 3.10.12" in captured.err
+
+
+def test_message_uses_configured_minimum(capsys):
+    calls = []
+    hermes_cli._assert_python_version(
+        current=(3, 8, 0),
+        min_version=(3, 12),
+        exit_fn=lambda code: calls.append(code),
+    )
+
+    captured = capsys.readouterr()
+    assert calls == [1]
+    assert "requires Python 3.12+" in captured.err
+    assert "found 3.8.0" in captured.err
+
+
+@pytest.mark.parametrize(
+    "current",
+    [(2, 7, 18), (3, 0, 0), (3, 5, 9), (3, 9, 0)],
+)
+def test_exits_on_assorted_legacy_versions(current):
+    calls = []
+    hermes_cli._assert_python_version(
+        current=current,
+        exit_fn=lambda code: calls.append(code),
+    )
+    assert calls == [1]


### PR DESCRIPTION
## What does this PR do?

Closes #21798

## Root cause

Running `hermes` under Python 3.9/3.10 crashes with an opaque
`TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'`
during package import, because `hermes_cli/main.py` uses 3.10+ type-hint
syntax (`X | None`).

## Fix

Add a small `_assert_python_version` guard at the top of the package
init (before any other `hermes_cli` import path can fire). On versions
below `_MIN_PYTHON = (3, 11)` (the project's declared minimum) it writes
a clear stderr message and exits 1:

```
hermes-agent requires Python 3.11+ (found 3.9.18).
Install Python 3.11 or newer and re-run.
```

The guard takes optional `current` / `min_version` / `exit_fn`
parameters so it can be unit-tested without spawning a subprocess or
needing a real interpreter mismatch.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

Closes #21798

<details>
<summary>Original body</summary>

## Summary

Closes #21798

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

Closes #21798

## Problem
Running `hermes` under Python 3.9/3.10 crashes with an opaque
`TypeError: unsupported operand type(s) for |: 'type' and 'NoneType'`
during package import, because `hermes_cli/main.py` uses 3.10+ type-hint
syntax (`X | None`).

## Root cause
`hermes_cli/__init__.py` performs no Python-version check before the
package's heavy imports run. The first 3.10+ syntax encountered explodes
with a low-level TypeError that gives users no signal that their
interpreter is too old. `pyproject.toml` already declares
`requires-python = ">=3.11"` but nothing enforces it at runtime.

## Fix
Add a small `_assert_python_version` guard at the top of the package
init (before any other `hermes_cli` import path can fire). On versions
below `_MIN_PYTHON = (3, 11)` (the project's declared minimum) it writes
a clear stderr message and exits 1:

```
hermes-agent requires Python 3.11+ (found 3.9.18).
Install Python 3.11 or newer and re-run.
```

The guard takes optional `current` / `min_version` / `exit_fn`
parameters so it can be unit-tested without spawning a subprocess or
needing a real interpreter mismatch.

## Tests
`tests/hermes_cli/test_python_version.py` — 10 cases covering:
- passes on current interpreter
- passes at exact minimum and above
- exits 1 with clear "requires Python 3.11+" stderr on 3.9 and 3.10
- honors a configurable `min_version`
- exits on assorted legacy versions (2.7, 3.0, 3.5, 3.9)

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

Closes #21798

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_