### PR TITLE
fix(doctor): skip duplicate anthropic Bearer-auth check

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -245,6 +245,11 @@ def _build_apikey_providers_list() -> list:
     }
     for _label, _canonical in _name_to_canonical.items():
         _known_canonical.add(_canonical)
+    # Providers with their own dedicated check earlier in run_doctor() that
+    # use non-Bearer auth (e.g. Anthropic's x-api-key + anthropic-version).
+    # Without this, the generic Bearer-auth loop re-checks the same key with
+    # the wrong header and reports a bogus HTTP 4xx for the same provider.
+    _known_canonical.add("anthropic")
     try:
         from providers import list_providers
         from providers.base import ProviderProfile as _PP

--- a/tests/hermes_cli/test_doctor_anthropic_dedup.py
+++ b/tests/hermes_cli/test_doctor_anthropic_dedup.py
@@ -1,0 +1,42 @@
+"""Regression: anthropic ProviderProfile must not duplicate the dedicated
+Anthropic doctor check via the generic Bearer-auth loop (issue #22346).
+"""
+
+from __future__ import annotations
+
+import hermes_cli.doctor as doctor
+
+
+def test_anthropic_excluded_from_generic_apikey_loop(monkeypatch):
+    monkeypatch.setattr(doctor, "_APIKEY_PROVIDERS_CACHE", None, raising=False)
+
+    providers = doctor._build_apikey_providers_list()
+
+    labels = {entry[0].lower() for entry in providers}
+    # Tuple shape: (display_label, env_vars, models_url, base_env, supports_models_endpoint)
+    # An "anthropic"-shaped entry would mean the generic loop will re-check
+    # Anthropic with Bearer auth and produce a 404 duplicate.
+    assert "anthropic" not in labels
+    assert all("anthropic" not in label for label in labels)
+
+
+def test_known_static_providers_still_present(monkeypatch):
+    monkeypatch.setattr(doctor, "_APIKEY_PROVIDERS_CACHE", None, raising=False)
+    providers = doctor._build_apikey_providers_list()
+
+    labels = {entry[0] for entry in providers}
+    for required in ("Z.AI / GLM", "DeepSeek", "Hugging Face", "MiniMax"):
+        assert required in labels, f"missing {required} from apikey providers"
+
+
+def test_dedup_set_includes_anthropic_canonical():
+    """Source-level guard: 'anthropic' must remain in the canonical skip set
+    so future ProviderProfile reorderings still skip it.
+    """
+    import inspect
+
+    src = inspect.getsource(doctor._build_apikey_providers_list)
+    assert (
+        '_known_canonical.add("anthropic")' in src
+        or "_known_canonical.add('anthropic')" in src
+    )


### PR DESCRIPTION
Closes #22346

## Problem
`hermes doctor` prints two Anthropic-related lines: the dedicated `Anthropic API` check passes, but a second lowercase `anthropic` check fails with HTTP 404.

```
Checking Anthropic API...  ✓ Anthropic API
Checking anthropic API...  ⚠ anthropic            (HTTP 404)
```

## Root cause
`_build_apikey_providers_list()` (in `hermes_cli/doctor.py`) adds every `ProviderProfile` with `auth_type="api_key"` to the generic Bearer-auth health-check loop, but the Anthropic profile is already covered by a dedicated check earlier in `run_doctor()` that uses Anthropic's required `x-api-key` + `anthropic-version` headers.

The generic loop sends `Authorization: Bearer <key>` against `https://api.anthropic.com/v1/models`, which Anthropic rejects with 404.

## Fix
Add `"anthropic"` to `_known_canonical` so the generic loop skips the ProviderProfile when assembling the apikey provider list. The dedicated check remains the sole source of truth for Anthropic connectivity, and no other dedicated-check provider is currently affected.

## Tests
`tests/hermes_cli/test_doctor_anthropic_dedup.py` — 3 cases:
- generic apikey list does not contain an "anthropic"-shaped entry
- unrelated static providers (Z.AI, DeepSeek, HF, MiniMax) still present
- source-level guard so future ProviderProfile reorderings still skip