### PR TITLE
fix(auxiliary): prefer named custom provider default_model over main model (#22317)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2045,6 +2045,13 @@ def _resolve_auto(main_runtime: Optional[Dict[str, Any]] = None) -> Tuple[Option
     # on aggregators (OpenRouter, Nous) who previously got routed to a
     # cheap provider-side default.  Explicit per-task overrides set via
     # config.yaml (auxiliary.<task>.provider) still win over this.
+    #
+    # For named custom providers (defined in providers: dict or
+    # custom_providers: list), prefer the provider's own default_model
+    # over the main chat model.  Auxiliary tasks (compression, session
+    # search, title generation, …) don't need the user's heavyweight
+    # main model — the provider's lighter default_model is the right
+    # choice.  See hermes-agent#22317.
     main_provider = runtime_provider or _read_main_provider()
     main_model = runtime_model or _read_main_model()
     if (main_provider and main_model
@@ -2056,17 +2063,28 @@ def _resolve_auto(main_runtime: Optional[Dict[str, Any]] = None) -> Tuple[Option
             resolved_provider = "custom"
             explicit_base_url = runtime_base_url
             explicit_api_key = runtime_api_key or None
+        # For named custom providers, prefer the provider's default_model
+        # over the main chat model for auxiliary tasks.
+        aux_model = main_model
+        if not explicit_base_url:
+            try:
+                from hermes_cli.runtime_provider import _get_named_custom_provider
+                _ncp = _get_named_custom_provider(resolved_provider)
+                if _ncp and _ncp.get("model"):
+                    aux_model = _ncp["model"]
+            except (ImportError, Exception):
+                pass
         client, resolved = resolve_provider_client(
             resolved_provider,
-            main_model,
+            aux_model,
             explicit_base_url=explicit_base_url,
             explicit_api_key=explicit_api_key,
             api_mode=runtime_api_mode or None,
         )
         if client is not None:
             logger.info("Auxiliary auto-detect: using main provider %s (%s)",
-                        main_provider, resolved or main_model)
-            return client, resolved or main_model
+                        main_provider, resolved or aux_model)
+            return client, resolved or aux_model
 
     # ── Step 2: aggregator / fallback chain ──────────────────────────────
     tried = []

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -141,14 +141,15 @@ class TestResolveProviderClientNamedCustom:
         _write_config(tmp_path, {
             "model": {"default": "main-model"},
             "custom_providers": [
-                {"name": "beans", "base_url": "http://beans.local/v1", "api_key": "k"},
+                {"name": "beans", "base_url": "http://beans.local/v1", "api_key": "k",
+                 "default_model": "provider-default"},
             ],
         })
         from agent.auxiliary_client import resolve_provider_client
         client, model = resolve_provider_client("beans")
         assert client is not None
-        # Should use _read_main_model() fallback
-        assert model == "main-model"
+        # Named custom provider: default_model should be used, not _read_main_model()
+        assert model == "provider-default"
 
     def test_named_custom_no_api_key_uses_fallback(self, tmp_path):
         _write_config(tmp_path, {
@@ -492,3 +493,52 @@ class TestCustomProviderAliasCollision:
         assert isinstance(client, OpenAI)
         assert "override.example.com" in str(client.base_url)
         assert client.api_key == "override-key"
+
+
+class TestResolveAutoPrefersProviderDefaultModel:
+    """_resolve_auto should prefer named custom provider's default_model
+    over the main chat model for auxiliary tasks (#22317)."""
+
+    def test_auto_uses_provider_default_model(self, tmp_path):
+        """Named custom provider with default_model: aux tasks should use it."""
+        _write_config(tmp_path, {
+            "model": {"default": "big-expensive-model", "provider": "my-llm"},
+            "providers": {
+                "my-llm": {
+                    "api": "http://localhost:11434/v1",
+                    "default_model": "small-aux-model",
+                },
+            },
+        })
+        from agent.auxiliary_client import _resolve_auto
+        client, model = _resolve_auto()
+        assert client is not None
+        assert model == "small-aux-model", (
+            f"Expected provider's default_model 'small-aux-model', got '{model}'"
+        )
+
+    def test_auto_falls_back_to_main_model_when_no_default(self, tmp_path):
+        """Named custom provider without default_model: should use main model."""
+        _write_config(tmp_path, {
+            "model": {"default": "big-model", "provider": "my-llm"},
+            "providers": {
+                "my-llm": {
+                    "api": "http://localhost:11434/v1",
+                },
+            },
+        })
+        from agent.auxiliary_client import _resolve_auto
+        client, model = _resolve_auto()
+        assert client is not None
+        assert model == "big-model"
+
+    def test_auto_standard_provider_uses_main_model(self, tmp_path, monkeypatch):
+        """Standard provider (not named custom): should use main model."""
+        _write_config(tmp_path, {
+            "model": {"default": "anthropic/claude-sonnet-4", "provider": "openrouter"},
+        })
+        monkeypatch.setenv("OPENROUTER_API_KEY", "test-key")
+        from agent.auxiliary_client import _resolve_auto
+        client, model = _resolve_auto()
+        assert client is not None
+        assert model == "anthropic/claude-sonnet-4"


### PR DESCRIPTION
## What does this PR do?

Fixes #22317 — auxiliary auto-detect ignores named custom providers'
`default_model` and routes all unconfigured tasks to the main chat model.

## Root cause

`_resolve_auto()` Step 1 reads `main_model` from config and passes it
directly to `resolve_provider_client()`.  In the named custom provider
branch, the model selection priority is:

```python
model                                    # ← passed param (main_model) — always wins
or custom_entry.get("model")             # ← provider's default_model — never reached
or _read_main_model()
or "gpt-4o-mini"
```

So the provider's `default_model` is shadowed by the main model.

## Fix

In `_resolve_auto()`, before calling `resolve_provider_client()`, check
if the provider is a named custom provider with a `default_model`.  If
so, use it instead of `main_model`.

## Config example

```yaml
model:
  default: glm-5.1:cloud          # expensive main model
  provider: ollama-launch
providers:
  ollama-launch:
    api: http://127.0.0.1:11434/v1
    default_model: kimi-k2.6:cloud  # lighter default
```

Before: `session_search` → `glm-5.1:cloud` (main model)
After: `session_search` → `kimi-k2.6:cloud` (provider default)

## Testing

- Updated `test_named_custom_provider_default_model` to reflect new behavior
- Added 3 new tests in `TestResolveAutoPrefersProviderDefaultModel`:
  - `test_auto_uses_provider_default_model` — provider has default_model → uses it
  - `test_auto_falls_back_to_main_model_when_no_default` — no default_model → falls back
  - `test_auto_standard_provider_uses_main_model` — standard provider → unchanged
- Full suite: 185 auxiliary tests pass, 0 regressions

Fixes #22317