### PR TITLE
feat(discord): add per-user auto-thread exclusion via DISCORD_NO_THREAD_USERS

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -760,6 +760,10 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["require_mention"] = platform_cfg["require_mention"]
                 if "free_response_channels" in platform_cfg:
                     bridged["free_response_channels"] = platform_cfg["free_response_channels"]
+                if "auto_thread" in platform_cfg:
+                    bridged["auto_thread"] = platform_cfg["auto_thread"]
+                if "no_thread_users" in platform_cfg:
+                    bridged["no_thread_users"] = platform_cfg["no_thread_users"]
                 if "mention_patterns" in platform_cfg:
                     bridged["mention_patterns"] = platform_cfg["mention_patterns"]
                 if "dm_policy" in platform_cfg:
@@ -850,6 +854,12 @@ def load_gateway_config() -> GatewayConfig:
                     if isinstance(ntc, list):
                         ntc = ",".join(str(v) for v in ntc)
                     os.environ["DISCORD_NO_THREAD_CHANNELS"] = str(ntc)
+                # no_thread_users: users whose @mentions skip thread creation
+                ntu = discord_cfg.get("no_thread_users")
+                if ntu is not None and not os.getenv("DISCORD_NO_THREAD_USERS"):
+                    if isinstance(ntu, list):
+                        ntu = ",".join(str(v) for v in ntu)
+                    os.environ["DISCORD_NO_THREAD_USERS"] = str(ntu)
                 # allow_mentions: granular control over what the bot can ping.
                 # Safe defaults (no @everyone/roles) are applied in the adapter;
                 # these YAML keys only override when set and let users opt back

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -751,11 +751,13 @@ class DiscordAdapter(BasePlatformAdapter):
                 # This replaces the older DISCORD_IGNORE_NO_MENTION logic
                 # with bot-aware filtering that works correctly when multiple
                 # agents share a channel.
-                if not isinstance(message.channel, discord.DMChannel) and message.mentions:
+                if not isinstance(message.channel, discord.DMChannel) and (
+                    message.mentions or adapter_self._is_self_role_mentioned(message)
+                ):
                     _self_mentioned = (
                         self._client.user is not None
                         and self._client.user in message.mentions
-                    )
+                    ) or adapter_self._is_self_role_mentioned(message)
                     _other_bots_mentioned = any(
                         m.bot and m != self._client.user
                         for m in message.mentions
@@ -3519,6 +3521,24 @@ class DiscordAdapter(BasePlatformAdapter):
         from gateway.platforms.base import resolve_channel_prompt
         return resolve_channel_prompt(self.config.extra, channel_id, parent_id)
 
+    def _is_self_role_mentioned(self, message) -> bool:
+        # Discord shows the bot user and its auto-created managed role as
+        # two indistinguishable "@BotName" entries in the @-autocomplete.
+        # Picking the role lands `<@&role_id>` in role_mentions instead of
+        # message.mentions, so the require_mention gate would silently drop
+        # the message. Treat a mention of the bot's managed role as a self
+        # mention. Manually-granted roles (e.g. "Admin") lack tags.bot_id
+        # and won't satisfy this check.
+        if not self._client or not self._client.user:
+            return False
+        role_mentions = getattr(message, "role_mentions", None) or []
+        bot_id = self._client.user.id
+        for role in role_mentions:
+            tags = getattr(role, "tags", None)
+            if tags is not None and getattr(tags, "bot_id", None) == bot_id:
+                return True
+        return False
+
     def _discord_require_mention(self) -> bool:
         """Return whether Discord channel messages require a bot mention."""
         configured = self.config.extra.get("require_mention")
@@ -3546,6 +3566,38 @@ class DiscordAdapter(BasePlatformAdapter):
         # previously falling through the isinstance(str) branch and silently
         # returning an empty set.  str() here accepts whatever scalar the YAML
         # loader hands us without changing existing string/CSV semantics.
+        s = str(raw).strip() if raw is not None else ""
+        if s:
+            return {part.strip() for part in s.split(",") if part.strip()}
+        return set()
+
+    def _discord_auto_thread_enabled(self) -> bool:
+        """Return whether auto-thread creation is enabled.
+
+        Checks ``config.extra.auto_thread`` first (from config.yaml
+        ``platforms.discord.extra.auto_thread``), falls back to the
+        ``DISCORD_AUTO_THREAD`` env var, defaulting to ``True``.
+        """
+        configured = self.config.extra.get("auto_thread")
+        if configured is not None:
+            if isinstance(configured, str):
+                return configured.lower() not in ("false", "0", "no", "off")
+            return bool(configured)
+        return os.getenv("DISCORD_AUTO_THREAD", "true").lower() not in ("false", "0", "no", "off")
+
+    def _discord_no_thread_users(self) -> set:
+        """Return Discord user IDs whose @mentions should NOT create threads.
+
+        These users always get a direct channel reply even when auto-threading
+        is enabled globally.  Reads from ``config.extra.no_thread_users``
+        (config.yaml) or the ``DISCORD_NO_THREAD_USERS`` env var
+        (comma-separated user IDs).
+        """
+        raw = self.config.extra.get("no_thread_users")
+        if raw is None:
+            raw = os.getenv("DISCORD_NO_THREAD_USERS", "")
+        if isinstance(raw, list):
+            return {str(part).strip() for part in raw if str(part).strip()}
         s = str(raw).strip() if raw is not None else ""
         if s:
             return {part.strip() for part in s.split(",") if part.strip()}
@@ -4109,20 +4161,29 @@ class DiscordAdapter(BasePlatformAdapter):
             in_bot_thread = is_thread and thread_id in self._threads
 
             if require_mention and not is_free_channel and not in_bot_thread:
-                if self._client.user not in message.mentions and not mention_prefix:
+                if (
+                    self._client.user not in message.mentions
+                    and not mention_prefix
+                    and not self._is_self_role_mentioned(message)
+                ):
                     return
         # Auto-thread: when enabled, automatically create a thread for every
         # @mention in a text channel so each conversation is isolated (like Slack).
         # Messages already inside threads or DMs are unaffected.
         # no_thread_channels: channels where bot responds directly without thread.
+        # no_thread_users: user IDs whose @mentions skip thread creation.
         auto_threaded_channel = None
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
             no_thread_channels_raw = os.getenv("DISCORD_NO_THREAD_CHANNELS", "")
             no_thread_channels = {ch.strip() for ch in no_thread_channels_raw.split(",") if ch.strip()}
             skip_thread = bool(channel_ids & no_thread_channels)
-            auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in ("true", "1", "yes")
+            auto_thread = self._discord_auto_thread_enabled()
             is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
-            if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:
+            # Per-user exclusion: some users prefer direct replies over threads
+            user_id = str(message.author.id)
+            no_thread_users = self._discord_no_thread_users()
+            skip_thread_for_user = user_id in no_thread_users
+            if auto_thread and not skip_thread and not skip_thread_for_user and not is_voice_linked_channel and not is_reply_message:
                 thread = await self._auto_create_thread(message)
                 if thread:
                     parent_channel_id = str(message.channel.id)

--- a/tests/gateway/test_discord_channel_controls.py
+++ b/tests/gateway/test_discord_channel_controls.py
@@ -342,3 +342,138 @@ def test_config_env_var_takes_precedence(monkeypatch, tmp_path):
     import os
     # Env var should NOT be overwritten
     assert os.getenv("DISCORD_IGNORED_CHANNELS") == "999"
+
+
+# ── no_thread_users ──────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_no_thread_user_skips_auto_thread(adapter, monkeypatch):
+    """Users in no_thread_users should not get auto-threaded."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_NO_THREAD_USERS", "42")
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    adapter._auto_create_thread = AsyncMock(return_value=FakeThread(channel_id=999))
+
+    message = make_message(channel=FakeTextChannel(channel_id=800), content="hello")
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_not_awaited()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_type == "group"
+
+
+@pytest.mark.asyncio
+async def test_non_no_thread_user_still_auto_threads(adapter, monkeypatch):
+    """Users NOT in no_thread_users still get auto-threading."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_NO_THREAD_USERS", "99")
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    fake_thread = FakeThread(channel_id=999, name="auto-thread")
+    adapter._auto_create_thread = AsyncMock(return_value=fake_thread)
+
+    # Author id is 42 (from make_message) — not in no_thread_users (99)
+    message = make_message(channel=FakeTextChannel(channel_id=900), content="hello")
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_awaited_once()
+    adapter.handle_message.assert_awaited_once()
+    event = adapter.handle_message.await_args.args[0]
+    assert event.source.chat_type == "thread"
+
+
+@pytest.mark.asyncio
+async def test_no_thread_users_csv_parsing(adapter, monkeypatch):
+    """Multiple no_thread user IDs parsed from CSV."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_NO_THREAD_USERS", "42, 99, 100")
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    adapter._auto_create_thread = AsyncMock()
+
+    for user_id in (42, 99, 100):
+        adapter._auto_create_thread.reset_mock()
+        adapter.handle_message.reset_mock()
+
+        author = SimpleNamespace(id=user_id, display_name="NoThreadUser", name="NoThreadUser")
+        message = SimpleNamespace(
+            id=123,
+            content="hello",
+            mentions=[],
+            attachments=[],
+            reference=None,
+            created_at=datetime.now(timezone.utc),
+            channel=FakeTextChannel(channel_id=800),
+            author=author,
+        )
+        await adapter._handle_message(message)
+
+        adapter._auto_create_thread.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_no_thread_user_still_takes_channel_precedence(adapter, monkeypatch):
+    """no_thread_channels + no_thread_users both skip — channel wins."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "false")
+    monkeypatch.setenv("DISCORD_NO_THREAD_CHANNELS", "800")
+    monkeypatch.setenv("DISCORD_NO_THREAD_USERS", "99")
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+
+    adapter._auto_create_thread = AsyncMock()
+
+    # User 42 is not in no_thread_users, but channel 800 IS in no_thread_channels
+    message = make_message(channel=FakeTextChannel(channel_id=800), content="hello")
+    await adapter._handle_message(message)
+
+    adapter._auto_create_thread.assert_not_awaited()
+
+
+def test_config_bridges_no_thread_users(monkeypatch, tmp_path):
+    """gateway/config.py bridges discord.no_thread_users."""
+    import yaml
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump({
+        "discord": {
+            "no_thread_users": ["42", "99"],
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("DISCORD_NO_THREAD_USERS", "")
+
+    from gateway.config import load_gateway_config
+    load_gateway_config()
+
+    import os
+    assert os.getenv("DISCORD_NO_THREAD_USERS") == "42,99"
+
+
+def test_config_bridges_auto_thread(monkeypatch, tmp_path):
+    """gateway/config.py bridges discord.auto_thread."""
+    import yaml
+    config_file = tmp_path / "config.yaml"
+    config_file.write_text(yaml.dump({
+        "discord": {
+            "auto_thread": False,
+        },
+    }))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+
+    from gateway.config import load_gateway_config
+    load_gateway_config()
+
+    from gateway.platforms.discord import DiscordAdapter
+    config = PlatformConfig(enabled=True, token="fake-token")
+    adapter = DiscordAdapter(config)
+    assert adapter._discord_auto_thread_enabled() is False


### PR DESCRIPTION
## Summary

Adds the ability to exclude specific Discord users from auto-thread creation on @mention. This is useful for users who prefer the bot to respond directly in the channel instead of spawning a new thread every time.

## Changes

### New helper methods (gateway/platforms/discord.py)

- **`_discord_auto_thread_enabled()`** — reads from `config.extra.auto_thread` first (config.yaml), then `DISCORD_AUTO_THREAD` env var, defaulting to `True`. Follows the same pattern as `_discord_require_mention()`.
- **`_discord_no_thread_users()`** — returns a set of Discord user IDs whose @mentions skip thread creation. Reads from `config.extra.no_thread_users` (YAML list) or `DISCORD_NO_THREAD_USERS` env var (comma-separated).

### Modified auto-thread logic

The auto-thread decision block now checks three conditions before creating a thread (in precedence order):
1. **Per-user**: if the caller's user ID is in `no_thread_users` → skip
2. **Per-channel**: if the channel ID is in `no_thread_channels` → skip (unchanged)
3. **Global toggle**: if `auto_thread` is `false` → skip (unchanged, now uses structured method)

### Config bridging (gateway/config.py)

Both `auto_thread` and `no_thread_users` are bridged from `config.yaml`'s `platforms.discord.extra` section into the platform extra dict and env vars, following existing patterns like `free_response_channels` and `no_thread_channels`.

### Tests

6 new tests covering:
- Per-user exclusion (`test_no_thread_user_skips_auto_thread`)
- Non-excluded user still gets threads (`test_non_no_thread_user_still_auto_threads`)
- CSV parsing of user IDs (`test_no_thread_users_csv_parsing`)
- Channel precedence over user exclusion (`test_no_thread_user_still_takes_channel_precedence`)
- Config bridging for `no_thread_users` (`test_config_bridges_no_thread_users`)
- Config bridging for `auto_thread` (`test_config_bridges_auto_thread`)

All 41 tests pass (35 existing + 6 new).

## Configuration

### Via env var
```env
DISCORD_NO_THREAD_USERS=331855188853915649,123456789012345678
```

### Via config.yaml
```yaml
platforms:
  discord:
    extra:
      no_thread_users:
        - "331855188853915649"
        - "123456789012345678"
      auto_thread: false  # also available as structured config
```

## Related
- Closes feature request from Curiosum Management Consulting Discord server