### PR TITLE
fix(agent): hydrate _turns_since_memory from history in gateway mode

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -11125,8 +11125,26 @@ class AIAgent:
             and self._memory_nudge_interval > 0
             and self._turns_since_memory == 0
         ):
+            # Locate the most recent memory tool invocation; runtime resets
+            # _turns_since_memory to 0 whenever it runs, so on hydration we
+            # count user turns from that point. Falls back to total user
+            # turns when no prior memory tool call exists.
+            last_memory_idx = -1
+            for idx, msg in enumerate(conversation_history):
+                if (
+                    isinstance(msg, dict)
+                    and msg.get("role") == "tool"
+                    and msg.get("name") == "memory"
+                ):
+                    last_memory_idx = idx
+            if last_memory_idx >= 0:
+                relevant = conversation_history[last_memory_idx + 1 :]
+            else:
+                relevant = conversation_history
             prior_user_turns = sum(
-                1 for msg in conversation_history if msg.get("role") == "user"
+                1
+                for msg in relevant
+                if isinstance(msg, dict) and msg.get("role") == "user"
             )
             self._turns_since_memory = prior_user_turns % self._memory_nudge_interval
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -11112,7 +11112,24 @@ class AIAgent:
         # recover the todo state from the most recent todo tool response in history)
         if conversation_history and not self._todo_store.has_items():
             self._hydrate_todo_store(conversation_history)
-        
+
+        # Hydrate memory nudge counter from conversation history. The gateway
+        # builds a fresh AIAgent per inbound message while the persisted
+        # session history keeps growing; without this, _turns_since_memory
+        # restarts at 0 every turn and memory.nudge_interval may never fire.
+        # Only run on the first turn of this agent instance so manual resets
+        # mid-session (e.g. after the memory tool ran) are not undone.
+        if (
+            conversation_history
+            and self._user_turn_count == 0
+            and self._memory_nudge_interval > 0
+            and self._turns_since_memory == 0
+        ):
+            prior_user_turns = sum(
+                1 for msg in conversation_history if msg.get("role") == "user"
+            )
+            self._turns_since_memory = prior_user_turns % self._memory_nudge_interval
+
         # Prefill messages (few-shot priming) are injected at API-call time only,
         # never stored in the messages list. This keeps them ephemeral: they won't
         # be saved to session DB, session logs, or batch trajectories, but they're

--- a/tests/run_agent/test_memory_nudge_counter_hydrate.py
+++ b/tests/run_agent/test_memory_nudge_counter_hydrate.py
@@ -25,8 +25,22 @@ def _hydrate(agent, conversation_history):
         and agent._memory_nudge_interval > 0
         and agent._turns_since_memory == 0
     ):
+        last_memory_idx = -1
+        for idx, msg in enumerate(conversation_history):
+            if (
+                isinstance(msg, dict)
+                and msg.get("role") == "tool"
+                and msg.get("name") == "memory"
+            ):
+                last_memory_idx = idx
+        if last_memory_idx >= 0:
+            relevant = conversation_history[last_memory_idx + 1 :]
+        else:
+            relevant = conversation_history
         prior_user_turns = sum(
-            1 for msg in conversation_history if msg.get("role") == "user"
+            1
+            for msg in relevant
+            if isinstance(msg, dict) and msg.get("role") == "user"
         )
         agent._turns_since_memory = (
             prior_user_turns % agent._memory_nudge_interval
@@ -106,6 +120,33 @@ def test_messages_without_role_field_are_ignored():
     history = _hist(3) + [{"content": "no role"}, {"role": "tool", "content": "x"}]
     _hydrate(agent, history)
     assert agent._turns_since_memory == 3
+
+
+def test_hydration_counts_user_turns_since_last_memory_tool():
+    """When the memory tool ran mid-history, runtime resets the counter to 0;
+    hydration must mirror that by only counting user turns AFTER that tool call."""
+    agent = _make_agent(interval=10)
+    history = (
+        _hist(8)
+        + [{"role": "tool", "name": "memory", "content": "saved"}]
+        + [{"role": "user", "content": "u_after_1"}, {"role": "assistant", "content": "a"}]
+        + [{"role": "user", "content": "u_after_2"}]
+    )
+    _hydrate(agent, history)
+    assert agent._turns_since_memory == 2
+
+
+def test_hydration_uses_most_recent_memory_tool_call():
+    agent = _make_agent(interval=10)
+    history = (
+        [{"role": "user", "content": "u0"}]
+        + [{"role": "tool", "name": "memory", "content": "first"}]
+        + [{"role": "user", "content": "u1"}, {"role": "user", "content": "u2"}]
+        + [{"role": "tool", "name": "memory", "content": "second"}]
+        + [{"role": "user", "content": "u3"}]
+    )
+    _hydrate(agent, history)
+    assert agent._turns_since_memory == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/run_agent/test_memory_nudge_counter_hydrate.py
+++ b/tests/run_agent/test_memory_nudge_counter_hydrate.py
@@ -1,0 +1,132 @@
+"""Regression: gateway creates a fresh AIAgent per inbound message but the
+persisted conversation_history keeps growing. Without hydration the
+``_turns_since_memory`` counter restarts at 0 every turn and
+``memory.nudge_interval`` may never trigger (issue #22357).
+
+Rather than instantiating a real AIAgent (heavy: loads providers, plugins,
+config), we replicate the exact hydration block from
+``AIAgent.run_conversation`` and assert its behavior, plus a source-level
+guard so future refactors don't drop the block.
+"""
+
+from __future__ import annotations
+
+import inspect
+from types import SimpleNamespace
+
+import pytest
+
+
+def _hydrate(agent, conversation_history):
+    """Mirror of the hydration block in run_agent.py."""
+    if (
+        conversation_history
+        and agent._user_turn_count == 0
+        and agent._memory_nudge_interval > 0
+        and agent._turns_since_memory == 0
+    ):
+        prior_user_turns = sum(
+            1 for msg in conversation_history if msg.get("role") == "user"
+        )
+        agent._turns_since_memory = (
+            prior_user_turns % agent._memory_nudge_interval
+        )
+
+
+def _make_agent(interval=10, turns_since_memory=0, user_turn_count=0):
+    return SimpleNamespace(
+        _memory_nudge_interval=interval,
+        _turns_since_memory=turns_since_memory,
+        _user_turn_count=user_turn_count,
+    )
+
+
+def _hist(user_turns, assistant_turns=None):
+    if assistant_turns is None:
+        assistant_turns = user_turns
+    out = []
+    for i in range(max(user_turns, assistant_turns)):
+        if i < user_turns:
+            out.append({"role": "user", "content": f"u{i}"})
+        if i < assistant_turns:
+            out.append({"role": "assistant", "content": f"a{i}"})
+    return out
+
+
+def test_hydrates_from_prior_history_so_next_turn_can_trigger():
+    agent = _make_agent(interval=10)
+    _hydrate(agent, _hist(9))
+    assert agent._turns_since_memory == 9
+
+
+def test_hydrate_then_increment_reaches_interval_on_first_new_turn():
+    agent = _make_agent(interval=10)
+    _hydrate(agent, _hist(9))
+    agent._turns_since_memory += 1
+    assert agent._turns_since_memory == 10
+
+
+def test_modulo_keeps_counter_bounded_for_long_histories():
+    agent = _make_agent(interval=10)
+    _hydrate(agent, _hist(127))
+    assert agent._turns_since_memory == 7
+
+
+def test_no_hydration_when_history_empty():
+    agent = _make_agent(interval=10)
+    _hydrate(agent, None)
+    assert agent._turns_since_memory == 0
+    _hydrate(agent, [])
+    assert agent._turns_since_memory == 0
+
+
+def test_no_hydration_when_interval_disabled():
+    agent = _make_agent(interval=0)
+    _hydrate(agent, _hist(50))
+    assert agent._turns_since_memory == 0
+
+
+def test_no_hydration_after_first_turn_consumed():
+    agent = _make_agent(interval=10, user_turn_count=3)
+    _hydrate(agent, _hist(50))
+    assert agent._turns_since_memory == 0
+
+
+def test_no_hydration_when_counter_already_advanced():
+    """Manual reset by the memory tool sets _turns_since_memory to 0
+    mid-session; the _user_turn_count guard ensures hydration is one-shot
+    so a non-zero counter is not clobbered on a re-entered first turn."""
+    agent = _make_agent(interval=10, turns_since_memory=4, user_turn_count=0)
+    _hydrate(agent, _hist(50))
+    assert agent._turns_since_memory == 4
+
+
+def test_messages_without_role_field_are_ignored():
+    agent = _make_agent(interval=10)
+    history = _hist(3) + [{"content": "no role"}, {"role": "tool", "content": "x"}]
+    _hydrate(agent, history)
+    assert agent._turns_since_memory == 3
+
+
+@pytest.mark.parametrize(
+    "interval,prior_turns,expected",
+    [
+        (5, 4, 4),
+        (5, 5, 0),
+        (5, 6, 1),
+        (1, 100, 0),
+        (3, 7, 1),
+    ],
+)
+def test_hydration_modulo_table(interval, prior_turns, expected):
+    agent = _make_agent(interval=interval)
+    _hydrate(agent, _hist(prior_turns))
+    assert agent._turns_since_memory == expected
+
+
+def test_source_level_guard_for_hydration_block():
+    """Future refactor must not silently drop the hydration block."""
+    import run_agent
+
+    src = inspect.getsource(run_agent.AIAgent.run_conversation)
+    assert "_turns_since_memory = prior_user_turns % self._memory_nudge_interval" in src


### PR DESCRIPTION
## What does this PR do?

Closes #22357

## Root cause

The gateway builds a fresh `AIAgent` per inbound message while the persisted `conversation_history` keeps growing. `_turns_since_memory` is initialized to `0` in `AIAgent.__init__`, so it restarts at zero on every gateway turn and `memory.nudge_interval` may never be reached. The periodic self-improvement / memory review effectively stops firing in long-running messaging-platform sessions, and durable user corrections are not proactively saved.

## Fix

On the first `run_conversation` call of an `AIAgent` instance (guarded by `_user_turn_count == 0`), if `conversation_history` is non-empty and `_memory_nudge_interval > 0`, hydrate the counter to `prior_user_turns % _memory_nudge_interval`. The subsequent `+= 1` advances toward the threshold on schedule, so the next appropriate turn triggers the review.

The `_user_turn_count == 0` guard makes the hydration one-shot, so a manual reset by the `memory` tool mid-session is not clobbered if `run_conversation` is somehow re-entered.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

Closes #22357

<details>
<summary>Original body</summary>

## Summary

Closes #22357

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

Closes #22357

## Problem
The gateway builds a fresh `AIAgent` per inbound message while the persisted `conversation_history` keeps growing. `_turns_since_memory` is initialized to `0` in `AIAgent.__init__`, so it restarts at zero on every gateway turn and `memory.nudge_interval` may never be reached. The periodic self-improvement / memory review effectively stops firing in long-running messaging-platform sessions, and durable user corrections are not proactively saved.

## Root cause
`run_conversation` never reconciles `_turns_since_memory` with `conversation_history`. CLI mode reuses the same `AIAgent` across turns so the counter accumulates correctly there; the gateway's per-message agent loses the count.

## Fix
On the first `run_conversation` call of an `AIAgent` instance (guarded by `_user_turn_count == 0`), if `conversation_history` is non-empty and `_memory_nudge_interval > 0`, hydrate the counter to `prior_user_turns % _memory_nudge_interval`. The subsequent `+= 1` advances toward the threshold on schedule, so the next appropriate turn triggers the review.

The `_user_turn_count == 0` guard makes the hydration one-shot, so a manual reset by the `memory` tool mid-session is not clobbered if `run_conversation` is somehow re-entered.

## Tests
`tests/run_agent/test_memory_nudge_counter_hydrate.py` — 14 cases:
- modulo arithmetic for fresh hydration
- increment-then-fire reaches interval on first new turn
- empty / `None` history → no hydration
- disabled interval (`0`) → no hydration
- post-first-turn (`_user_turn_count > 0`) → no-op
- already-advanced counter → no-op
- messages without `role` field → ignored
- parametrised `(interval, prior_turns) → expected` table
- source-level guard: refactor must not silently drop the hydration line

The 4 pre-existing failures observed in full regression (`test_discord_*`, `test_anthropic_adapter::test_reads_valid_credentials`) reproduce on `origin/main` without this change and are unrelated (env-leak / xdist test ordering).

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

Closes #22357

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_