### PR TITLE
feat(gateway/feishu): normalize location messages so they reach the agent

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -869,8 +869,36 @@ def normalize_feishu_message(
         return _normalize_share_chat_message(payload)
     if normalized_type in {"interactive", "card"}:
         return _normalize_interactive_message(normalized_type, payload)
+    if normalized_type == "location":
+        return _normalize_location_message(payload)
 
     return FeishuNormalizedMessage(raw_type=normalized_type, text_content="")
+
+
+def _normalize_location_message(payload: Dict[str, Any]) -> FeishuNormalizedMessage:
+    """Render Feishu location messages as text so they flow through the text pipeline.
+
+    Feishu sends location messages with a payload of {"name", "longitude", "latitude"}.
+    Without this normalizer the message_type "location" falls through to the empty
+    fallback and is silently dropped by _process_inbound_message.
+    """
+    name = str(payload.get("name", "") or "").strip()
+    longitude = str(payload.get("longitude", "") or "").strip()
+    latitude = str(payload.get("latitude", "") or "").strip()
+
+    parts: List[str] = []
+    if name:
+        parts.append(name)
+    if latitude and longitude:
+        parts.append(f"({latitude},{longitude})")
+    text_content = "📍 " + " ".join(parts) if parts else "📍 (location)"
+
+    return FeishuNormalizedMessage(
+        raw_type="location",
+        text_content=text_content,
+        relation_kind="location",
+        metadata={"name": name, "longitude": longitude, "latitude": latitude},
+    )
 
 
 def _load_feishu_payload(raw_content: str) -> Dict[str, Any]:

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -158,6 +158,58 @@ class TestFeishuMessageNormalization(unittest.TestCase):
             "Build Failed\nService: payments-api\nBranch: main\nView Logs\nRetry\nActions: View Logs, Retry",
         )
 
+    def test_normalize_location_renders_name_and_coordinates(self):
+        from gateway.platforms.feishu import normalize_feishu_message
+
+        normalized = normalize_feishu_message(
+            message_type="location",
+            raw_content=json.dumps(
+                {
+                    "name": "Apple Park, Cupertino",
+                    "longitude": "-122.0090",
+                    "latitude": "37.3349",
+                }
+            ),
+        )
+
+        self.assertEqual(normalized.raw_type, "location")
+        self.assertEqual(normalized.relation_kind, "location")
+        self.assertEqual(
+            normalized.text_content,
+            "📍 Apple Park, Cupertino (37.3349,-122.0090)",
+        )
+        self.assertEqual(normalized.metadata["name"], "Apple Park, Cupertino")
+        self.assertEqual(normalized.metadata["latitude"], "37.3349")
+        self.assertEqual(normalized.metadata["longitude"], "-122.0090")
+
+    def test_normalize_location_handles_missing_name(self):
+        from gateway.platforms.feishu import normalize_feishu_message
+
+        normalized = normalize_feishu_message(
+            message_type="location",
+            raw_content=json.dumps(
+                {
+                    "longitude": "-122.0090",
+                    "latitude": "37.3349",
+                }
+            ),
+        )
+
+        self.assertEqual(normalized.relation_kind, "location")
+        self.assertEqual(normalized.text_content, "📍 (37.3349,-122.0090)")
+        self.assertEqual(normalized.metadata["name"], "")
+
+    def test_normalize_location_falls_back_when_payload_empty(self):
+        from gateway.platforms.feishu import normalize_feishu_message
+
+        normalized = normalize_feishu_message(
+            message_type="location",
+            raw_content=json.dumps({}),
+        )
+
+        self.assertEqual(normalized.relation_kind, "location")
+        self.assertEqual(normalized.text_content, "📍 (location)")
+
 
 class TestFeishuAdapterMessaging(unittest.TestCase):
     @patch.dict(os.environ, {


### PR DESCRIPTION
## Problem

Feishu users can share locations via `+ → Location` in chat. The platform delivers these as events with `message_type="location"` and a content payload of `{"name", "longitude", "latitude"}`. Hermes' Feishu adapter has never handled this type — `normalize_feishu_message` falls through to the empty-content fallback, then `_process_inbound_message` matches the `(MessageType.TEXT, no text, no media)` guard and silently drops the message with `logger.debug("Ignoring unsupported or empty message type")`. From a user's perspective the bot simply does not respond.

## Root cause

Walking the existing branches in `normalize_feishu_message`:

- `text`, `post`, `image`, `file/audio/media`, `merge_forward`, `share_chat`, `interactive/card` all have explicit handlers.
- `location` does not, despite being a documented Feishu message type ([docs](https://open.feishu.cn/document/server-docs/im-v1/message-content-description/message_content?lang=zh-CN)).

So the adapter receives the event, but normalization produces an empty `text_content`, and the inbound pipeline treats that as "nothing to do."

## Fix

Add `_normalize_location_message` that:

1. Renders the payload as a short text line (`📍 <name> (<lat>,<lng>)`) so it flows through the existing text pipeline. Downstream agents can read this just like a text message saying "I'm at X."
2. Preserves the structured fields (`name`, `longitude`, `latitude`) on `metadata` for any consumer that wants the raw coordinates.
3. Sets `relation_kind="location"` so callers that care about the source type can distinguish it.

Falls back to a generic `📍 (location)` placeholder when the payload is missing all fields, so the message still surfaces rather than being dropped.

## Verification

**Manual end-to-end test**: Sent a location card from the Feishu app to a personal Hermes deployment running this branch. The agent receives the message as `📍 <place> (<lat>,<lng>)`, replies normally, and the location ends up in session memory.

**Unit tests** (added in `tests/gateway/test_feishu.py`, all 6 tests in `TestFeishuMessageNormalization` pass):

- `test_normalize_location_renders_name_and_coordinates` — full payload
- `test_normalize_location_handles_missing_name` — coordinates only
- `test_normalize_location_falls_back_when_payload_empty` — empty payload

```
tests/gateway/test_feishu.py::TestFeishuMessageNormalization — 6 passed in 4.24s
```

## Notes

- No changes to public APIs.
- No changes to other platforms or to the abstract `MessageType.LOCATION` enum, which remains available for any platform that wants to surface location as a first-class type rather than as text.
