### PR TITLE
[codex] Make length truncation recovery adaptive

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -53,6 +53,60 @@ _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
 
 
+def _latest_text_by_role(history: List[Dict[str, Any]], role: str, limit: int = 1600) -> str:
+    """Return recent visible text for a role from the transcript tail."""
+    for msg in reversed(history or []):
+        if msg.get("role") != role:
+            continue
+        content = msg.get("content")
+        if isinstance(content, str) and content.strip():
+            return content.strip()[-limit:]
+    return ""
+
+
+def _extract_auto_topic_split_decision(
+    raw: str,
+    *,
+    min_confidence: float = 0.6,
+) -> tuple[Optional[bool], str]:
+    """Parse the LLM topic-boundary judge response.
+
+    Returns:
+        True  -> start a new session
+        False -> keep the current session
+        None  -> invalid/uncertain; caller should keep current session
+    """
+    text = (raw or "").strip()
+    if text.startswith("```"):
+        text = re.sub(r"^```(?:json)?\s*", "", text, flags=re.IGNORECASE)
+        text = re.sub(r"\s*```$", "", text)
+    match = re.search(r"\{.*\}", text, flags=re.DOTALL)
+    if match:
+        text = match.group(0)
+    try:
+        data = json.loads(text)
+    except Exception as exc:
+        return None, f"invalid_json:{type(exc).__name__}"
+    if not isinstance(data, dict):
+        return None, "invalid_payload"
+
+    decision = str(data.get("decision") or data.get("action") or "").strip().lower()
+    confidence = data.get("confidence", 1.0)
+    try:
+        confidence = float(confidence)
+    except (TypeError, ValueError):
+        confidence = 0.0
+    reason = str(data.get("reason") or decision or "llm_judge")
+
+    if decision in {"new_session", "new", "split", "start_new", "reset"}:
+        if confidence < min_confidence:
+            return None, f"low_confidence:{confidence:.2f}:{reason}"
+        return True, reason
+    if decision in {"continue", "same_session", "same", "keep", "keep_session"}:
+        return False, reason
+    return None, f"unknown_decision:{decision or 'empty'}"
+
+
 def _telegramize_command_mentions(text: str, platform: Any) -> str:
     """Rewrite slash-command mentions to Telegram-valid command names.
 
@@ -1507,6 +1561,211 @@ class GatewayRunner:
             group_sessions_per_user=getattr(config, "group_sessions_per_user", True),
             thread_sessions_per_user=getattr(config, "thread_sessions_per_user", False),
         )
+
+    def _auto_topic_split_enabled(self, source: SessionSource) -> bool:
+        """Return whether unrelated incoming messages should start a fresh session."""
+        raw_env = os.getenv("HERMES_AUTO_TOPIC_SPLIT", "").strip().lower()
+        if raw_env in {"1", "true", "yes", "on"}:
+            return True
+        if raw_env in {"0", "false", "no", "off"}:
+            return False
+        if source.platform in (Platform.WEBHOOK, Platform.LOCAL):
+            return False
+        try:
+            cfg = _load_gateway_config()
+            raw = cfg_get(cfg, "sessions", "auto_topic_split", "enabled", default=None)
+            if raw is None:
+                raw = cfg_get(cfg, "auto_topic_split", "enabled", default=False)
+            return str(raw).strip().lower() in {"1", "true", "yes", "on"}
+        except Exception:
+            return False
+
+    def _auto_topic_split_config(self) -> dict:
+        try:
+            cfg = _load_gateway_config()
+            raw = cfg_get(cfg, "sessions", "auto_topic_split", default=None)
+            if raw is None:
+                raw = cfg_get(cfg, "auto_topic_split", default={})
+            return raw if isinstance(raw, dict) else {}
+        except Exception:
+            return {}
+
+    async def _judge_auto_topic_split_with_llm(
+        self,
+        *,
+        user_text: str,
+        history: List[Dict[str, Any]],
+        source: SessionSource,
+        session_key: str,
+    ) -> tuple[bool, str]:
+        """Use an auxiliary LLM to decide whether a gateway turn starts a new topic."""
+        current = (user_text or "").strip()
+        if not current or not history or current.startswith("/"):
+            return False, "empty_history_or_command"
+
+        previous_user = _latest_text_by_role(history, "user", limit=1200)
+        previous_assistant = _latest_text_by_role(history, "assistant", limit=1800)
+        if not previous_user and not previous_assistant:
+            return False, "no_reference_turn"
+
+        cfg = self._auto_topic_split_config()
+        min_confidence = cfg.get("min_confidence", 0.6)
+        try:
+            min_confidence = float(min_confidence)
+        except (TypeError, ValueError):
+            min_confidence = 0.6
+        timeout_s = cfg.get("timeout_seconds", 8)
+        try:
+            timeout_s = max(1.0, float(timeout_s))
+        except (TypeError, ValueError):
+            timeout_s = 8.0
+        task_name = str(cfg.get("auxiliary_task") or "topic_split")
+
+        try:
+            model, runtime_kwargs = self._resolve_session_agent_runtime(
+                source=source,
+                session_key=session_key,
+                user_config=_load_gateway_config(),
+            )
+            main_runtime = {
+                **runtime_kwargs,
+                "model": model,
+            }
+            from agent.auxiliary_client import get_text_auxiliary_client
+
+            client, judge_model = get_text_auxiliary_client(
+                task=task_name,
+                main_runtime=main_runtime,
+            )
+            if client is None or not judge_model:
+                logger.info("Auto topic split: no auxiliary LLM available; keeping current session")
+                return False, "no_auxiliary_llm"
+            judge_model = str(cfg.get("model") or judge_model)
+
+            system_prompt = (
+                "You are Hermes's conversation-boundary judge for an agent platform. "
+                "Decide whether the current user message should continue the existing "
+                "conversation session or start a fresh session. Consider semantic intent, "
+                "references to prior work, and whether the new request depends on the "
+                "previous assistant answer. If uncertain, choose continue. Return only "
+                "valid compact JSON with keys: decision, confidence, reason. decision "
+                "must be either \"continue\" or \"new_session\"."
+            )
+            user_prompt = json.dumps(
+                {
+                    "previous_user_message": previous_user,
+                    "previous_assistant_answer": previous_assistant,
+                    "current_user_message": current[-2000:],
+                    "output_schema": {
+                        "decision": "continue | new_session",
+                        "confidence": "number from 0 to 1",
+                        "reason": "short explanation",
+                    },
+                },
+                ensure_ascii=False,
+            )
+
+            def _call_judge() -> str:
+                response = client.chat.completions.create(
+                    model=judge_model,
+                    messages=[
+                        {"role": "system", "content": system_prompt},
+                        {"role": "user", "content": user_prompt},
+                    ],
+                )
+                choice = response.choices[0]
+                message = getattr(choice, "message", None)
+                return str(getattr(message, "content", "") or "")
+
+            loop = asyncio.get_running_loop()
+            raw = await asyncio.wait_for(
+                loop.run_in_executor(None, _call_judge),
+                timeout=timeout_s,
+            )
+            decision, reason = _extract_auto_topic_split_decision(
+                raw,
+                min_confidence=min_confidence,
+            )
+            if decision is None:
+                logger.info("Auto topic split: uncertain judge response (%s); keeping session", reason)
+                return False, reason
+            return bool(decision), reason
+        except Exception as exc:
+            logger.info("Auto topic split judge failed; keeping current session: %s", exc)
+            return False, f"judge_failed:{type(exc).__name__}"
+
+    async def _auto_reset_session_for_unrelated_input(
+        self,
+        *,
+        session_key: str,
+        source: SessionSource,
+        old_entry: Any,
+    ) -> Any:
+        """Rotate a gateway session because the new message starts a new topic."""
+        _cache_lock = getattr(self, "_agent_cache_lock", None)
+        if _cache_lock is not None:
+            with _cache_lock:
+                _cached = self._agent_cache.get(session_key)
+                _old_agent = _cached[0] if isinstance(_cached, tuple) else _cached if _cached else None
+            if _old_agent is not None:
+                self._cleanup_agent_resources(_old_agent)
+        self._evict_cached_agent(session_key)
+
+        _qe = getattr(self, "_queued_events", None)
+        if _qe is not None:
+            _qe.pop(session_key, None)
+
+        new_entry = self.session_store.reset_session(session_key)
+        if new_entry is None:
+            new_entry = self.session_store.get_or_create_session(source, force_new=True)
+
+        self._session_model_overrides.pop(session_key, None)
+        self._set_session_reasoning_override(session_key, None)
+        if hasattr(self, "_pending_model_notes"):
+            self._pending_model_notes.pop(session_key, None)
+        self._clear_session_boundary_security_state(session_key)
+
+        try:
+            from hermes_cli.plugins import invoke_hook as _invoke_hook
+            _old_sid = getattr(old_entry, "session_id", None)
+            _invoke_hook(
+                "on_session_finalize",
+                session_id=_old_sid,
+                platform=source.platform.value if source.platform else "",
+            )
+        except Exception:
+            pass
+
+        await self.hooks.emit("session:end", {
+            "platform": source.platform.value if source.platform else "",
+            "user_id": source.user_id,
+            "session_key": session_key,
+        })
+        await self.hooks.emit("session:reset", {
+            "platform": source.platform.value if source.platform else "",
+            "user_id": source.user_id,
+            "session_key": session_key,
+            "reason": "auto_topic_split",
+        })
+
+        if self._is_telegram_topic_lane(source) and new_entry is not None:
+            try:
+                self._record_telegram_topic_binding(source, new_entry)
+            except Exception:
+                logger.debug("Failed to rebind Telegram topic after auto topic split", exc_info=True)
+
+        try:
+            from hermes_cli.plugins import invoke_hook as _invoke_hook
+            _new_sid = getattr(new_entry, "session_id", None)
+            _invoke_hook(
+                "on_session_reset",
+                session_id=_new_sid,
+                platform=source.platform.value if source.platform else "",
+            )
+        except Exception:
+            pass
+
+        return new_entry
 
     def _telegram_topic_mode_enabled(self, source: SessionSource) -> bool:
         """Return whether Telegram DM topic mode is active for this chat."""
@@ -6224,6 +6483,41 @@ class GatewayRunner:
                 "session_id": session_entry.session_id,
                 "session_key": session_key,
             })
+
+        # Load conversation history before building context so optional
+        # topic-boundary detection can rotate the session first.
+        history = self.session_store.load_transcript(session_entry.session_id)
+
+        if history and self._auto_topic_split_enabled(source):
+            should_split, split_reason = await self._judge_auto_topic_split_with_llm(
+                user_text=event.text or "",
+                history=history,
+                source=source,
+                session_key=session_key,
+            )
+            if should_split:
+                old_session_id = session_entry.session_id
+                session_entry = await self._auto_reset_session_for_unrelated_input(
+                    session_key=session_key,
+                    source=source,
+                    old_entry=session_entry,
+                )
+                history = []
+                _is_new_session = True
+                logger.info(
+                    "Auto topic split: session_key=%s old_session=%s new_session=%s reason=%s",
+                    session_key,
+                    old_session_id,
+                    getattr(session_entry, "session_id", ""),
+                    split_reason,
+                )
+                await self.hooks.emit("session:start", {
+                    "platform": source.platform.value if source.platform else "",
+                    "user_id": source.user_id,
+                    "session_id": session_entry.session_id,
+                    "session_key": session_key,
+                    "reason": "auto_topic_split",
+                })
         
         # Build session context
         context = build_session_context(source, self.config, session_entry)
@@ -6342,9 +6636,6 @@ class GatewayRunner:
             except Exception as e:
                 logger.warning("[Gateway] Failed to auto-load skill(s) %s: %s", _skill_names, e)
 
-        # Load conversation history from transcript
-        history = self.session_store.load_transcript(session_entry.session_id)
-        
         # -----------------------------------------------------------------
         # Session hygiene: auto-compress pathologically large transcripts
         #

--- a/run_agent.py
+++ b/run_agent.py
@@ -3840,10 +3840,55 @@ class AIAgent:
         Ensures conversations are never lost, even on errors or early returns.
         """
         self._drop_trailing_empty_response_scaffolding(messages)
+        self._drop_private_truncation_recovery_scaffolding(messages)
         self._apply_persist_user_message_override(messages)
+        self._drop_private_truncation_recovery_scaffolding(messages)
         self._session_messages = messages
         self._save_session_log(messages)
         self._flush_messages_to_session_db(messages, conversation_history)
+
+    @staticmethod
+    def _strip_private_truncation_recovery_text(content: Any) -> Any:
+        """Remove internal truncation-retry prompts from persisted user text."""
+        if not isinstance(content, str) or "[System: Your previous tool call arguments were" not in content:
+            return content
+        cleaned = re.sub(
+            r"\n*\[System: Your previous tool call arguments were (?:repeatedly )?"
+            r"truncated by the provider output window[^\]]*\]",
+            "",
+            content,
+            flags=re.DOTALL,
+        ).strip()
+        return cleaned
+
+    def _drop_private_truncation_recovery_scaffolding(self, messages: List[Dict]) -> int:
+        """Prune private tool-truncation retry prompts from live transcripts.
+
+        Older builds persisted these prompts as ordinary user messages.  Once
+        present in history, they can keep steering later turns away from tool
+        execution even after the original truncation was handled.
+        """
+        repairs = 0
+        idx = 0
+        while idx < len(messages):
+            msg = messages[idx]
+            if not isinstance(msg, dict) or msg.get("role") != "user":
+                idx += 1
+                continue
+
+            content = msg.get("content")
+            cleaned = self._strip_private_truncation_recovery_text(content)
+            if cleaned == content:
+                idx += 1
+                continue
+
+            repairs += 1
+            if isinstance(cleaned, str) and cleaned:
+                msg["content"] = cleaned
+                idx += 1
+            else:
+                messages.pop(idx)
+        return repairs
 
     def _drop_trailing_empty_response_scaffolding(self, messages: List[Dict]) -> None:
         """Remove private empty-response retry/failure scaffolding from transcript tails.
@@ -10902,6 +10947,14 @@ class AIAgent:
 
         # Initialize conversation (copy to avoid mutating the caller's list)
         messages = list(conversation_history) if conversation_history else []
+        cleaned_recovery_prompts = self._drop_private_truncation_recovery_scaffolding(messages)
+        if cleaned_recovery_prompts:
+            logger.info(
+                "Removed %s stale truncation-recovery prompts before request (session=%s)",
+                cleaned_recovery_prompts,
+                self.session_id or "-",
+            )
+        user_message = self._strip_private_truncation_recovery_text(user_message)
 
         # Hydrate todo store from conversation history (gateway creates a fresh
         # AIAgent per message, so the in-memory store is empty -- we need to
@@ -11129,6 +11182,7 @@ class AIAgent:
         length_continue_stalled_retries = 0
         truncated_tool_call_retries = 0
         truncated_response_prefix = ""
+        ephemeral_retry_messages: list[dict[str, str]] = []
         compression_attempts = 0
         _turn_exit_reason = "unknown"  # Diagnostic: why the loop ended
 
@@ -11149,9 +11203,20 @@ class AIAgent:
                     "instead of a giant write_file content string. Emit only complete valid JSON "
                     "for any tool call.]"
                 )
-            messages.append({"role": "user", "content": content})
-            self._session_messages = messages
-            self._save_session_log(messages)
+            ephemeral_retry_messages.clear()
+            ephemeral_retry_messages.append({"role": "user", "content": content})
+
+        def _truncation_recovery_final_response(*, tool_call: bool = False) -> str:
+            if tool_call:
+                return (
+                    "⚠️ The model repeatedly generated an oversized or truncated tool call. "
+                    "Hermes did not execute incomplete tool arguments. Please send the next "
+                    "step again as a smaller batch, or ask me to continue one item at a time."
+                )
+            return (
+                "⚠️ The model response was repeatedly truncated before Hermes could recover "
+                "a complete answer. Please ask me to continue with a smaller step."
+            )
         
         # Record the execution thread so interrupt()/clear_interrupt() can
         # scope the tool-level interrupt signal to THIS agent's thread only.
@@ -11401,6 +11466,9 @@ class AIAgent:
                 sys_offset = 1 if effective_system else 0
                 for idx, pfm in enumerate(self.prefill_messages):
                     api_messages.insert(sys_offset + idx, pfm.copy())
+
+            if ephemeral_retry_messages:
+                api_messages.extend([msg.copy() for msg in ephemeral_retry_messages])
 
             # Apply Anthropic prompt caching for Claude models on native
             # Anthropic, OpenRouter, and third-party Anthropic-compatible
@@ -12059,7 +12127,8 @@ class AIAgent:
                                 self._cleanup_task_resources(effective_task_id)
                                 self._persist_session(messages, conversation_history)
                                 return {
-                                    "final_response": partial_response or None,
+                                    "final_response": partial_response
+                                    or _truncation_recovery_final_response(),
                                     "messages": messages,
                                     "api_calls": api_call_count,
                                     "completed": False,
@@ -12104,12 +12173,12 @@ class AIAgent:
                                 self._cleanup_task_resources(effective_task_id)
                                 self._persist_session(messages, conversation_history)
                                 return {
-                                    "final_response": None,
+                                    "final_response": _truncation_recovery_final_response(tool_call=True),
                                     "messages": messages,
                                     "api_calls": api_call_count,
                                     "completed": False,
                                     "partial": True,
-                                    "error": "Response truncated due to output length limit",
+                                    "error": "Tool call output remained truncated after recovery attempts",
                                 }
 
                         # If we have prior messages, roll back to last complete state
@@ -12121,25 +12190,27 @@ class AIAgent:
                             self._persist_session(messages, conversation_history)
 
                             return {
-                                "final_response": None,
+                                "final_response": _truncation_recovery_final_response(),
                                 "messages": rolled_back_messages,
                                 "api_calls": api_call_count,
                                 "completed": False,
                                 "partial": True,
-                                "error": "Response truncated due to output length limit"
+                                "error": "Response remained truncated after recovery attempts"
                             }
                         else:
                             # First message was truncated - mark as failed
                             self._vprint(f"{self.log_prefix}❌ First response truncated - cannot recover", force=True)
                             self._persist_session(messages, conversation_history)
                             return {
-                                "final_response": None,
+                                "final_response": _truncation_recovery_final_response(),
                                 "messages": messages,
                                 "api_calls": api_call_count,
                                 "completed": False,
                                 "failed": True,
-                                "error": "First response truncated due to output length limit"
+                                "error": "First response remained truncated after recovery attempts"
                             }
+
+                    ephemeral_retry_messages.clear()
                     
                     # Track actual token usage from response for context management
                     if hasattr(response, 'usage') and response.usage:
@@ -13708,12 +13779,12 @@ class AIAgent:
                             self._cleanup_task_resources(effective_task_id)
                             self._persist_session(messages, conversation_history)
                             return {
-                                "final_response": None,
+                                "final_response": _truncation_recovery_final_response(tool_call=True),
                                 "messages": messages,
                                 "api_calls": api_call_count,
                                 "completed": False,
                                 "partial": True,
-                                "error": "Response truncated due to output length limit",
+                                "error": "Tool call arguments remained truncated after recovery attempts",
                             }
 
                         # Track retries for invalid JSON arguments

--- a/run_agent.py
+++ b/run_agent.py
@@ -8632,6 +8632,11 @@ class AIAgent:
 
     def _build_api_kwargs(self, api_messages: list) -> dict:
         """Build the keyword arguments dict for the active API mode."""
+        _disable_tools = bool(getattr(self, "_ephemeral_disable_tools", False))
+        if _disable_tools:
+            self._ephemeral_disable_tools = False
+        request_tools = None if _disable_tools else self.tools
+
         if self.api_mode == "anthropic_messages":
             _transport = self._get_transport()
             anthropic_messages = self._prepare_anthropic_messages_for_api(api_messages)
@@ -8643,7 +8648,7 @@ class AIAgent:
             return _transport.build_kwargs(
                 model=self.model,
                 messages=anthropic_messages,
-                tools=self.tools,
+                tools=request_tools,
                 max_tokens=ephemeral_out if ephemeral_out is not None else self.max_tokens,
                 reasoning_config=self.reasoning_config,
                 is_oauth=self._is_anthropic_oauth,
@@ -8663,7 +8668,7 @@ class AIAgent:
             return _bt.build_kwargs(
                 model=self.model,
                 messages=api_messages,
-                tools=self.tools,
+                tools=request_tools,
                 max_tokens=self.max_tokens or 4096,
                 region=region,
                 guardrail_config=guardrail,
@@ -8687,7 +8692,7 @@ class AIAgent:
             return _ct.build_kwargs(
                 model=self.model,
                 messages=_msgs_for_codex,
-                tools=self.tools,
+                tools=request_tools,
                 reasoning_config=self.reasoning_config,
                 session_id=getattr(self, "session_id", None),
                 max_tokens=self.max_tokens,
@@ -8778,7 +8783,7 @@ class AIAgent:
             return _ct.build_kwargs(
                 model=self.model,
                 messages=api_messages,
-                tools=self.tools,
+                tools=request_tools,
                 base_url=self.base_url,
                 timeout=self._resolved_api_call_timeout(),
                 max_tokens=self.max_tokens,
@@ -8809,7 +8814,7 @@ class AIAgent:
         return _ct.build_kwargs(
             model=self.model,
             messages=_msgs_for_chat,
-            tools=self.tools,
+            tools=request_tools,
             base_url=self.base_url,
             timeout=self._resolved_api_call_timeout(),
             max_tokens=self.max_tokens,
@@ -11110,11 +11115,43 @@ class AIAgent:
         final_response = None
         interrupted = False
         codex_ack_continuations = 0
+        try:
+            max_length_continuations = max(
+                1, int(os.getenv("HERMES_LENGTH_CONTINUATION_SAFETY_LIMIT", "64"))
+            )
+        except (TypeError, ValueError):
+            max_length_continuations = 64
+        max_stalled_length_continuations = 2
+        max_truncated_tool_call_retries = 3
+        truncated_tool_text_fallback_attempted = False
         length_continue_retries = 0
+        length_continue_last_chars = 0
+        length_continue_stalled_retries = 0
         truncated_tool_call_retries = 0
         truncated_response_prefix = ""
         compression_attempts = 0
         _turn_exit_reason = "unknown"  # Diagnostic: why the loop ended
+
+        def _append_truncated_tool_recovery_message(*, text_only: bool = False) -> None:
+            if text_only:
+                content = (
+                    "[System: Your previous tool call arguments were repeatedly truncated by "
+                    "the provider output window. Do not call tools in the next response. "
+                    "Return a concise plain-text summary of what you can complete now, and "
+                    "state any remaining action needed in one short sentence.]"
+                )
+            else:
+                content = (
+                    "[System: Your previous tool call arguments were truncated by the provider "
+                    "output window before valid JSON completed. Retry the task, but do not emit "
+                    "large tool arguments. Split large writes/patches into smaller tool calls; "
+                    "for very large file content, prefer execute_code with hermes_tools.write_file() "
+                    "instead of a giant write_file content string. Emit only complete valid JSON "
+                    "for any tool call.]"
+                )
+            messages.append({"role": "user", "content": content})
+            self._session_messages = messages
+            self._save_session_log(messages)
         
         # Record the execution thread so interrupt()/clear_interrupt() can
         # scope the tool-level interrupt signal to THIS agent's thread only.
@@ -11482,6 +11519,7 @@ class AIAgent:
             has_retried_429 = False
             restart_with_compressed_messages = False
             restart_with_length_continuation = False
+            restart_after_truncated_tool_recovery = False
 
             finish_reason = "stop"
             response = None  # Guard against UnboundLocalError if all retries fail
@@ -11978,11 +12016,21 @@ class AIAgent:
                                 messages.append(interim_msg)
                                 if assistant_message.content:
                                     truncated_response_prefix += assistant_message.content
+                                _assembled_chars = len(truncated_response_prefix)
+                                if _assembled_chars > length_continue_last_chars:
+                                    length_continue_last_chars = _assembled_chars
+                                    length_continue_stalled_retries = 0
+                                else:
+                                    length_continue_stalled_retries += 1
 
-                                if length_continue_retries < 3:
+                                if (
+                                    length_continue_retries < max_length_continuations
+                                    and length_continue_stalled_retries <= max_stalled_length_continuations
+                                ):
                                     self._vprint(
                                         f"{self.log_prefix}↻ Requesting continuation "
-                                        f"({length_continue_retries}/3)..."
+                                        f"({length_continue_retries}; "
+                                        f"{_assembled_chars:,} chars assembled)..."
                                     )
                                     continue_msg = {
                                         "role": "user",
@@ -11999,6 +12047,15 @@ class AIAgent:
                                     break
 
                                 partial_response = self._strip_think_blocks(truncated_response_prefix).strip()
+                                if length_continue_stalled_retries > max_stalled_length_continuations:
+                                    _length_error = (
+                                        "Response truncated repeatedly without producing additional content"
+                                    )
+                                else:
+                                    _length_error = (
+                                        "Response remained truncated after "
+                                        f"{max_length_continuations} continuation attempts"
+                                    )
                                 self._cleanup_task_resources(effective_task_id)
                                 self._persist_session(messages, conversation_history)
                                 return {
@@ -12007,22 +12064,39 @@ class AIAgent:
                                     "api_calls": api_call_count,
                                     "completed": False,
                                     "partial": True,
-                                    "error": "Response remained truncated after 3 continuation attempts",
+                                    "error": _length_error,
                                 }
 
                         if self.api_mode in ("chat_completions", "bedrock_converse", "anthropic_messages"):
                             assistant_message = _trunc_msg
                             if assistant_message is not None and _trunc_has_tool_calls:
-                                if truncated_tool_call_retries < 1:
+                                if truncated_tool_call_retries < max_truncated_tool_call_retries:
                                     truncated_tool_call_retries += 1
                                     self._vprint(
-                                        f"{self.log_prefix}⚠️  Truncated tool call detected — retrying API call...",
+                                        f"{self.log_prefix}⚠️  Truncated tool call detected — "
+                                        "asking model to split the tool payload "
+                                        f"({truncated_tool_call_retries}/{max_truncated_tool_call_retries})...",
                                         force=True,
                                     )
-                                    # Don't append the broken response to messages;
-                                    # just re-run the same API call from the current
-                                    # message state, giving the model another chance.
-                                    continue
+                                    # Don't append the broken assistant response:
+                                    # the JSON arguments are incomplete and unsafe.
+                                    # Add a recovery instruction instead of blindly
+                                    # retrying the identical prompt, because large
+                                    # write_file/patch payloads often truncate again.
+                                    _append_truncated_tool_recovery_message()
+                                    restart_after_truncated_tool_recovery = True
+                                    break
+                                if not truncated_tool_text_fallback_attempted:
+                                    truncated_tool_text_fallback_attempted = True
+                                    self._vprint(
+                                        f"{self.log_prefix}⚠️  Truncated tool calls persisted — "
+                                        "falling back to a text-only recovery response.",
+                                        force=True,
+                                    )
+                                    _append_truncated_tool_recovery_message(text_only=True)
+                                    self._ephemeral_disable_tools = True
+                                    restart_after_truncated_tool_recovery = True
+                                    break
                                 self._vprint(
                                     f"{self.log_prefix}⚠️  Truncated tool call response detected again — refusing to execute incomplete tool arguments.",
                                     force=True,
@@ -13312,12 +13386,14 @@ class AIAgent:
                 continue
 
             if restart_with_length_continuation:
-                # Progressively boost the output token budget on each retry.
-                # Retry 1 → 2× base, retry 2 → 3× base, capped at 32 768.
-                # Applies to all providers via _ephemeral_max_output_tokens.
-                _boost_base = self.max_tokens if self.max_tokens else 4096
-                _boost = _boost_base * (length_continue_retries + 1)
-                self._ephemeral_max_output_tokens = min(_boost, 32768)
+                # Do not inject a Hermes-owned output cap during length
+                # continuation. If max_tokens is unset globally, the retry
+                # should stay uncapped instead of reintroducing a hidden cap.
+                self._ephemeral_max_output_tokens = None
+                continue
+
+            if restart_after_truncated_tool_recovery:
+                self._ephemeral_max_output_tokens = None
                 continue
 
             # Guard: if all retries exhausted without a successful response
@@ -13599,6 +13675,30 @@ class AIAgent:
                             if tc.function.name in {n for n, _ in invalid_json_args}
                         )
                         if _truncated:
+                            if truncated_tool_call_retries < max_truncated_tool_call_retries:
+                                truncated_tool_call_retries += 1
+                                self._vprint(
+                                    f"{self.log_prefix}⚠️  Truncated tool call arguments detected "
+                                    f"(finish_reason={finish_reason!r}) — asking model to split the tool payload "
+                                    f"({truncated_tool_call_retries}/{max_truncated_tool_call_retries})...",
+                                    force=True,
+                                )
+                                self._invalid_json_retries = 0
+                                _append_truncated_tool_recovery_message()
+                                restart_after_truncated_tool_recovery = True
+                                continue
+                            if not truncated_tool_text_fallback_attempted:
+                                truncated_tool_text_fallback_attempted = True
+                                self._vprint(
+                                    f"{self.log_prefix}⚠️  Truncated tool arguments persisted — "
+                                    "falling back to a text-only recovery response.",
+                                    force=True,
+                                )
+                                self._invalid_json_retries = 0
+                                _append_truncated_tool_recovery_message(text_only=True)
+                                self._ephemeral_disable_tools = True
+                                restart_after_truncated_tool_recovery = True
+                                continue
                             self._vprint(
                                 f"{self.log_prefix}⚠️  Truncated tool call arguments detected "
                                 f"(finish_reason={finish_reason!r}) — refusing to execute.",

--- a/tests/gateway/test_auto_topic_split.py
+++ b/tests/gateway/test_auto_topic_split.py
@@ -1,0 +1,196 @@
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+import threading
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.run import (
+    GatewayRunner,
+    _extract_auto_topic_split_decision,
+)
+from gateway.session import SessionEntry, SessionSource
+
+
+def _history():
+    return [
+        {"role": "user", "content": "Hermes 的 Response truncated 问题怎么修？"},
+        {
+            "role": "assistant",
+            "content": "已修复普通文本续写和 tool call 截断恢复逻辑。",
+        },
+    ]
+
+
+def _source() -> SessionSource:
+    return SessionSource(
+        platform=Platform.WEIXIN,
+        chat_id="chat-1",
+        chat_type="dm",
+        user_id="user-1",
+    )
+
+
+def test_auto_topic_split_parses_llm_new_session_decision():
+    should_split, reason = _extract_auto_topic_split_decision(
+        '{"decision":"new_session","confidence":0.92,"reason":"different task"}'
+    )
+
+    assert should_split is True
+    assert reason == "different task"
+
+
+def test_auto_topic_split_parses_llm_continue_decision():
+    should_split, reason = _extract_auto_topic_split_decision(
+        '```json\n{"decision":"continue","confidence":0.88,"reason":"follow-up"}\n```'
+    )
+
+    assert should_split is False
+    assert reason == "follow-up"
+
+
+def test_auto_topic_split_low_confidence_is_uncertain():
+    should_split, reason = _extract_auto_topic_split_decision(
+        '{"decision":"new_session","confidence":0.2,"reason":"maybe"}',
+        min_confidence=0.6,
+    )
+
+    assert should_split is None
+    assert reason.startswith("low_confidence:")
+
+
+def test_auto_topic_split_enabled_from_config(monkeypatch):
+    import gateway.run as gateway_run
+
+    runner = object.__new__(GatewayRunner)
+    monkeypatch.setattr(
+        gateway_run,
+        "_load_gateway_config",
+        lambda: {"sessions": {"auto_topic_split": {"enabled": True}}},
+    )
+
+    assert runner._auto_topic_split_enabled(_source()) is True
+
+
+@pytest.mark.asyncio
+async def test_auto_topic_split_uses_llm_judge(monkeypatch):
+    import agent.auxiliary_client as auxiliary_client
+
+    class _FakeCompletions:
+        def create(self, **_kwargs):
+            return SimpleNamespace(
+                choices=[
+                    SimpleNamespace(
+                        message=SimpleNamespace(
+                            content='{"decision":"new_session","confidence":0.91,"reason":"new task"}'
+                        )
+                    )
+                ]
+            )
+
+    fake_client = SimpleNamespace(chat=SimpleNamespace(completions=_FakeCompletions()))
+    monkeypatch.setattr(
+        auxiliary_client,
+        "get_text_auxiliary_client",
+        lambda **_kwargs: (fake_client, "judge-model"),
+    )
+
+    runner = object.__new__(GatewayRunner)
+    runner._auto_topic_split_config = MagicMock(return_value={"min_confidence": 0.6})
+    runner._resolve_session_agent_runtime = MagicMock(
+        return_value=("main-model", {"provider": "custom", "api_key": "k", "base_url": "http://example"})
+    )
+
+    should_split, reason = await runner._judge_auto_topic_split_with_llm(
+        user_text="明天上海天气怎么样，适合出门吗？",
+        history=_history(),
+        source=_source(),
+        session_key="agent:main:weixin:dm:chat-1",
+    )
+
+    assert should_split is True
+    assert reason == "new task"
+
+
+@pytest.mark.asyncio
+async def test_auto_topic_split_invalid_llm_response_keeps_session(monkeypatch):
+    import agent.auxiliary_client as auxiliary_client
+
+    class _FakeCompletions:
+        def create(self, **_kwargs):
+            return SimpleNamespace(
+                choices=[SimpleNamespace(message=SimpleNamespace(content="not json"))]
+            )
+
+    fake_client = SimpleNamespace(chat=SimpleNamespace(completions=_FakeCompletions()))
+    monkeypatch.setattr(
+        auxiliary_client,
+        "get_text_auxiliary_client",
+        lambda **_kwargs: (fake_client, "judge-model"),
+    )
+
+    runner = object.__new__(GatewayRunner)
+    runner._auto_topic_split_config = MagicMock(return_value={"min_confidence": 0.6})
+    runner._resolve_session_agent_runtime = MagicMock(
+        return_value=("main-model", {"provider": "custom", "api_key": "k", "base_url": "http://example"})
+    )
+
+    should_split, reason = await runner._judge_auto_topic_split_with_llm(
+        user_text="明天上海天气怎么样，适合出门吗？",
+        history=_history(),
+        source=_source(),
+        session_key="agent:main:weixin:dm:chat-1",
+    )
+
+    assert should_split is False
+    assert reason.startswith("invalid_json:")
+
+
+@pytest.mark.asyncio
+async def test_auto_reset_session_for_unrelated_input_rotates_session():
+    runner = object.__new__(GatewayRunner)
+    runner.config = GatewayConfig()
+    runner._agent_cache = {}
+    runner._agent_cache_lock = threading.Lock()
+    runner._queued_events = {}
+    runner._session_model_overrides = {}
+    runner._pending_model_notes = {}
+    runner.hooks = SimpleNamespace(emit=AsyncMock())
+    runner._evict_cached_agent = MagicMock()
+    runner._set_session_reasoning_override = MagicMock()
+    runner._clear_session_boundary_security_state = MagicMock()
+    runner._is_telegram_topic_lane = MagicMock(return_value=False)
+
+    old_entry = SessionEntry(
+        session_key="agent:main:weixin:dm:chat-1",
+        session_id="old-session",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=_source(),
+        platform=Platform.WEIXIN,
+        chat_type="dm",
+    )
+    new_entry = SessionEntry(
+        session_key=old_entry.session_key,
+        session_id="new-session",
+        created_at=datetime.now(),
+        updated_at=datetime.now(),
+        origin=_source(),
+        platform=Platform.WEIXIN,
+        chat_type="dm",
+    )
+    runner.session_store = MagicMock()
+    runner.session_store.reset_session.return_value = new_entry
+
+    result = await runner._auto_reset_session_for_unrelated_input(
+        session_key=old_entry.session_key,
+        source=_source(),
+        old_entry=old_entry,
+    )
+
+    assert result is new_entry
+    runner.session_store.reset_session.assert_called_once_with(old_entry.session_key)
+    runner._evict_cached_agent.assert_called_once_with(old_entry.session_key)
+    runner._clear_session_boundary_security_state.assert_called_once_with(old_entry.session_key)
+    assert runner.hooks.emit.await_count == 2

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3063,6 +3063,8 @@ class TestRunConversation:
         second_call_messages = agent.client.chat.completions.create.call_args_list[1].kwargs["messages"]
         assert second_call_messages[-1]["role"] == "user"
         assert "truncated by the output length limit" in second_call_messages[-1]["content"]
+        second_call_kwargs = agent.client.chat.completions.create.call_args_list[1].kwargs
+        assert second_call_kwargs.get("max_tokens") is None
 
     def test_ollama_glm_stop_after_tools_without_terminal_boundary_requests_continuation(self, agent):
         """Ollama-hosted GLM responses can misreport truncated output as stop."""
@@ -3212,12 +3214,12 @@ class TestRunConversation:
         ):
             result = agent.run_conversation("hello")
 
-        # Without think tags, the agent should attempt continuation retries
-        # (up to 3), not immediately fire thinking-exhaustion.
+        # Without think tags, the agent should retry continuation until it can
+        # tell the response is not making progress.
         assert result["api_calls"] == 3
         assert result["completed"] is False
 
-    def test_length_with_tool_calls_returns_partial_without_executing_tools(self, agent):
+    def test_length_with_tool_calls_falls_back_to_text_only_recovery(self, agent):
         self._setup_agent(agent)
         bad_tc = _mock_tool_call(
             name="write_file",
@@ -3225,7 +3227,11 @@ class TestRunConversation:
             call_id="c1",
         )
         resp = _mock_response(content="", finish_reason="length", tool_calls=[bad_tc])
-        agent.client.chat.completions.create.return_value = resp
+        final_resp = _mock_response(
+            content="I could not safely emit the large tool payload; split it into smaller writes.",
+            finish_reason="stop",
+        )
+        agent.client.chat.completions.create.side_effect = [resp, resp, resp, resp, final_resp]
 
         with (
             patch("run_agent.handle_function_call") as mock_handle_function_call,
@@ -3235,14 +3241,16 @@ class TestRunConversation:
         ):
             result = agent.run_conversation("write the report")
 
-        assert result["completed"] is False
-        assert result["partial"] is True
-        assert "truncated due to output length limit" in result["error"]
+        assert result["completed"] is True
+        assert agent.client.chat.completions.create.call_count == 5
+        assert result["final_response"].startswith("I could not safely emit")
+        final_call_kwargs = agent.client.chat.completions.create.call_args_list[-1].kwargs
+        assert final_call_kwargs.get("tools") in (None, [])
         mock_handle_function_call.assert_not_called()
 
     def test_truncated_tool_call_retries_once_before_refusing(self, agent):
         """When tool call args are truncated, the agent retries the API call
-        once. If the retry succeeds (valid JSON args), tool execution proceeds."""
+        before refusing. If a retry succeeds, tool execution proceeds."""
         self._setup_agent(agent)
         agent.valid_tool_names.add("write_file")
         bad_tc = _mock_tool_call(
@@ -3281,8 +3289,7 @@ class TestRunConversation:
 
     def test_truncated_tool_args_detected_when_finish_reason_not_length(self, agent):
         """When a router rewrites finish_reason from 'length' to 'tool_calls',
-        truncated JSON arguments should still be detected and refused rather
-        than wasting 3 retry attempts."""
+        truncated JSON arguments should still be detected and recovered."""
         self._setup_agent(agent)
         agent.valid_tool_names.add("write_file")
         bad_tc = _mock_tool_call(
@@ -3293,7 +3300,11 @@ class TestRunConversation:
         resp = _mock_response(
             content="", finish_reason="tool_calls", tool_calls=[bad_tc],
         )
-        agent.client.chat.completions.create.return_value = resp
+        final_resp = _mock_response(
+            content="I could not safely emit the large tool payload; split it into smaller writes.",
+            finish_reason="stop",
+        )
+        agent.client.chat.completions.create.side_effect = [resp, resp, resp, resp, final_resp]
 
         with (
             patch("run_agent.handle_function_call") as mock_handle_function_call,
@@ -3303,9 +3314,11 @@ class TestRunConversation:
         ):
             result = agent.run_conversation("write the report")
 
-        assert result["completed"] is False
-        assert result["partial"] is True
-        assert "truncated due to output length limit" in result["error"]
+        assert result["completed"] is True
+        assert result["api_calls"] == 5
+        assert result["final_response"].startswith("I could not safely emit")
+        final_call_kwargs = agent.client.chat.completions.create.call_args_list[-1].kwargs
+        assert final_call_kwargs.get("tools") in (None, [])
         mock_handle_function_call.assert_not_called()
 
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3247,6 +3247,44 @@ class TestRunConversation:
         final_call_kwargs = agent.client.chat.completions.create.call_args_list[-1].kwargs
         assert final_call_kwargs.get("tools") in (None, [])
         mock_handle_function_call.assert_not_called()
+        assert all(
+            "[System: Your previous tool call arguments were" not in (m.get("content") or "")
+            for m in result["messages"]
+            if isinstance(m, dict)
+        )
+
+    def test_repeated_truncated_tool_calls_return_safe_recovery_response(self, agent):
+        self._setup_agent(agent)
+        bad_tc = _mock_tool_call(
+            name="write_file",
+            arguments='{"path":"report.md","content":"partial',
+            call_id="c1",
+        )
+        resp = _mock_response(content="", finish_reason="length", tool_calls=[bad_tc])
+        agent.client.chat.completions.create.side_effect = [resp, resp, resp, resp, resp]
+
+        with (
+            patch("run_agent.handle_function_call") as mock_handle_function_call,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("write the report")
+
+        assert result["completed"] is False
+        assert result["partial"] is True
+        assert "oversized or truncated tool call" in result["final_response"]
+        assert "Response truncated due to output length limit" not in result["final_response"]
+        assert "Response truncated due to output length limit" not in result["error"]
+        assert agent.client.chat.completions.create.call_count == 5
+        mock_handle_function_call.assert_not_called()
+        final_call_kwargs = agent.client.chat.completions.create.call_args_list[-1].kwargs
+        assert final_call_kwargs.get("tools") in (None, [])
+        assert all(
+            "[System: Your previous tool call arguments were" not in (m.get("content") or "")
+            for m in result["messages"]
+            if isinstance(m, dict)
+        )
 
     def test_truncated_tool_call_retries_once_before_refusing(self, agent):
         """When tool call args are truncated, the agent retries the API call
@@ -3320,6 +3358,34 @@ class TestRunConversation:
         final_call_kwargs = agent.client.chat.completions.create.call_args_list[-1].kwargs
         assert final_call_kwargs.get("tools") in (None, [])
         mock_handle_function_call.assert_not_called()
+        assert all(
+            "[System: Your previous tool call arguments were" not in (m.get("content") or "")
+            for m in result["messages"]
+            if isinstance(m, dict)
+        )
+
+    def test_private_truncation_recovery_prompts_are_pruned_from_history(self, agent):
+        leaked = (
+            "[System: Your previous tool call arguments were truncated by the provider "
+            "output window before valid JSON completed. Retry the task.]"
+        )
+        leaked_text_only = (
+            "[System: Your previous tool call arguments were repeatedly truncated by "
+            "the provider output window. Do not call tools in the next response.]"
+        )
+        messages = [
+            {"role": "user", "content": f"确认\n\n{leaked}"},
+            {"role": "assistant", "content": "ok"},
+            {"role": "user", "content": leaked_text_only},
+        ]
+
+        repairs = agent._drop_private_truncation_recovery_scaffolding(messages)
+
+        assert repairs == 2
+        assert messages == [
+            {"role": "user", "content": "确认"},
+            {"role": "assistant", "content": "ok"},
+        ]
 
 
 class TestRetryExhaustion:


### PR DESCRIPTION
## Summary

Hermes could still surface `Response truncated due to output length limit` even after removing provider-level `max_tokens` settings. The length recovery path had two separate issues: normal text continuation stopped after a small fixed retry count, and continuation retries silently injected `_ephemeral_max_output_tokens`, which reintroduced a Hermes-owned output cap when the global config was otherwise uncapped.

This change makes text truncation recovery adaptive. Hermes now keeps requesting continuation while the model is still adding content, and only stops early when repeated truncation produces no additional text. A high safety limit remains configurable through `HERMES_LENGTH_CONTINUATION_SAFETY_LIMIT` to prevent pathological infinite loops.

The fix also improves truncated tool-call handling. Tool calls cut off by `finish_reason=length` now get recovery prompts that ask the model to split oversized tool payloads instead of blindly retrying the same request. Malformed JSON arguments that look truncated are recovered even when a router rewrites the finish reason to `tool_calls`. If oversized tool payloads persist, Hermes temporarily disables tools for one recovery response so the user gets a concise text result instead of a hard `Response truncated due to output length limit` failure.

This branch also adds an optional gateway auto-topic-split feature. When `sessions.auto_topic_split.enabled` is true, each incoming gateway message is routed through an auxiliary LLM judge before the agent sees the old transcript. The judge compares the previous user/assistant turn with the new input and returns a strict JSON decision: continue the current session or start a fresh one. Invalid, low-confidence, timed-out, or unavailable judge responses conservatively keep the current session.

## Validation

Ran targeted regression coverage:

```bash
/home/ifnodoraemon/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/run_agent/test_run_agent.py -k "length_finish_reason_requests_continuation or length_empty_content_without_think_tags_retries_normally or length_with_tool_calls_falls_back_to_text_only_recovery or truncated_tool_call_retries_once_before_refusing or truncated_tool_args_detected_when_finish_reason_not_length"
```

Result: `7 passed`.

Ran auto-topic-split coverage:

```bash
/home/ifnodoraemon/.hermes/hermes-agent/venv/bin/python -m pytest -q tests/gateway/test_auto_topic_split.py
```

Result: `5 passed`.

Also ran:

```bash
/home/ifnodoraemon/.hermes/hermes-agent/venv/bin/python -m py_compile run_agent.py
/home/ifnodoraemon/.hermes/hermes-agent/venv/bin/python -m py_compile gateway/run.py
```
