### PR TITLE
fix(cron): do not seed HERMES_SESSION_* contextvars from cron origin (salvage of #22356)

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1204,10 +1204,31 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     # don't clobber each other's targets (os.environ is process-global).
     from gateway.session_context import set_session_vars, clear_session_vars, _VAR_MAP
 
+    # Cron execution is an internal scheduler context, not a live inbound
+    # gateway message. Do not seed HERMES_SESSION_* contextvars from the
+    # stored ``origin`` (which is delivery routing metadata, not a sender
+    # identity). Several tool consumers branch on these vars during job
+    # execution and would otherwise behave as if a real user from the
+    # origin chat was driving the agent:
+    #   - tools/terminal_tool.py: background-process notification routing
+    #     (notify_on_complete / watch_patterns) reads HERMES_SESSION_PLATFORM
+    #     and HERMES_SESSION_CHAT_ID to populate watcher_platform / chat_id,
+    #     which would route completion notifications to the origin chat
+    #     instead of via HERMES_CRON_AUTO_DELIVER_* below.
+    #   - tools/tts_tool.py: picks Opus vs MP3 based on
+    #     HERMES_SESSION_PLATFORM == "telegram".
+    #   - tools/skills_tool.py + agent/prompt_builder.py: per-platform
+    #     skill-disable lists and the system-prompt cache key both consume
+    #     HERMES_SESSION_PLATFORM.
+    #   - tools/send_message_tool.py: mirror source labelling and the
+    #     send_message gate read HERMES_SESSION_PLATFORM.
+    # Cron output delivery itself reads job["origin"] directly via
+    # _resolve_origin(job) and the HERMES_CRON_AUTO_DELIVER_* vars set
+    # below, so clearing HERMES_SESSION_* here does not affect delivery.
     _ctx_tokens = set_session_vars(
-        platform=origin["platform"] if origin else "",
-        chat_id=str(origin["chat_id"]) if origin else "",
-        chat_name=origin.get("chat_name", "") if origin else "",
+        platform="",
+        chat_id="",
+        chat_name="",
     )
     _cron_delivery_vars = (
         "HERMES_CRON_AUTO_DELIVER_PLATFORM",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -909,6 +909,7 @@ AUTHOR_MAP = {
     "promptsiren@gmail.com": "firefly",  # PR #18123 salvage of #16660 (ContextVars)
     "wtyopenclaw@gmail.com": "WuTianyi123",  # PR #20275 salvage of #13723 (feishu markdown)
     "zhicheng.han@mathematik.uni-goettingen.de": "hanzckernel",  # PR #20311 (api-server approval events)
+    "agentsmithlaor@gmail.com": "oferlaor",  # PR #22356 salvage (cron origin sender identity)
     # pander: empty email, salvaged via PR #19665 from #16126 by @ms-alan
 }
 


### PR DESCRIPTION
Salvage of #22356 by @oferlaor (Closes #22351). Cherry-picked onto current main with original authorship preserved (origin PR is 366 commits behind main).

## What changed

`cron/scheduler.py` was seeding `HERMES_SESSION_PLATFORM`, `HERMES_SESSION_CHAT_ID`, and `HERMES_SESSION_CHAT_NAME` from the cron job's stored `origin` immediately before constructing `AIAgent`. Those contextvars are designed to identify a *live inbound gateway sender*, not delivery routing metadata. This change replaces the seed with empty values:

```python
_ctx_tokens = set_session_vars(
    platform="",
    chat_id="",
    chat_name="",
)
```

Cron output delivery is unaffected — it reads `job["origin"]` directly via `_resolve_origin(job)` and the `HERMES_CRON_AUTO_DELIVER_*` contextvars, both of which are still set in the same block.

## Why this matters (tightened framing vs the original PR)

The original PR/issue framed this as access-control filtering stripping toolsets (`web_search`, `terminal`, `read_file`) from authorized cron jobs. We were not able to reproduce that on current main — there is no per-identity toolset filter between the contextvar-set and `AIAgent` construction; `enabled_toolsets` are passed straight through. We've left the structural fix in place though, because several tool consumers branch on `HERMES_SESSION_*` during job execution and were observably misbehaving as a result. The expanded comment in the diff lists them; the concrete ones:

- **`tools/terminal_tool.py`** (background-process notification routing) — when a cron job ran `terminal(background=True, notify_on_complete=True)`, `watcher_platform` / `watcher_chat_id` / `watcher_user_id` etc. were populated from the seeded WhatsApp/Telegram origin instead of from the cron's own `HERMES_CRON_AUTO_DELIVER_*` machinery, so completion notifications routed to the gateway origin chat. This is the most user-visible bug the change fixes.
- **`tools/tts_tool.py`** — `platform == "telegram"` decides Opus vs MP3. A cron with a non-telegram origin would silently pick the wrong format if the agent called TTS.
- **`tools/skills_tool.py` + `agent/prompt_builder.py`** — per-platform skill-disable lists and the system-prompt cache key both consume `HERMES_SESSION_PLATFORM`. Cron was slotting into the origin platform's cache instead of cron's own.
- **`tools/send_message_tool.py`** — mirror source labelling and the `_check_send_message` gate read `HERMES_SESSION_PLATFORM`.
- **`tools/cronjob_tools.py::_origin_from_env`** — falls back to the seeded vars; mostly defensive since the cronjob toolset is in `disabled_toolsets` for cron, but still wrong shape.

## Verification

E2E test against a fresh main worktree, simulating a cron job created from a WhatsApp group origin:

| Probe at AIAgent construction time | Before fix | After fix |
|---|---|---|
| `HERMES_SESSION_PLATFORM` | `"whatsapp"` | `""` ✅ |
| `HERMES_SESSION_CHAT_ID` | `"123-456-789@g.us"` | `""` ✅ |
| `HERMES_SESSION_CHAT_NAME` | `"Test Group"` | `""` ✅ |
| `HERMES_CRON_AUTO_DELIVER_PLATFORM` | `"whatsapp"` | `"whatsapp"` ✅ (delivery routing preserved) |
| `HERMES_CRON_AUTO_DELIVER_CHAT_ID` | `"123-456-789@g.us"` | `"123-456-789@g.us"` ✅ |
| `tools/cronjob_tools._origin_from_env()` | `{platform: whatsapp, chat_id: ...}` | `None` ✅ |
| `tools/tts_tool` `platform == "telegram"` check | `False` (correct here, depends on origin) | `False` ✅ |
| `enabled_toolsets` passed to `AIAgent` | `["web", "file", "terminal"]` | `["web", "file", "terminal"]` (unchanged — confirms no filtering happens regardless) |
| `kwargs["platform"]` to `AIAgent` | `"cron"` | `"cron"` ✅ |

Tests run from the worktree:

```
$ bash scripts/run_tests.sh tests/cron/ tests/tools/test_cronjob_tools.py
362 passed in 10.92s

$ bash scripts/run_tests.sh tests/tools/test_send_message_tool.py tests/tools/test_cron_approval_mode.py \
                            tests/agent/test_skill_commands.py tests/gateway/test_session_env.py tests/cron/
504 passed in 13.03s
```

No regressions in any consumer test path. `ruff check` clean.

## Files

- `cron/scheduler.py` — the patch (kept @oferlaor's original edit; expanded the comment to document the real consumer list rather than "access-control filtering" so future readers don't go looking for a per-identity toolset filter that doesn't exist).
- `scripts/release.py` — added `agentsmithlaor@gmail.com → oferlaor` to `AUTHOR_MAP` for the contributor audit.

## Original PR

Closes #22351. Original PR (#22356, 366 commits behind main) being closed with credit pointing here.
