### PR TITLE
fix(qqbot): cap Resume retries and fall back to Identify on stale session

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -103,6 +103,7 @@ from gateway.platforms.qqbot.constants import (
     RATE_LIMIT_DELAY,
     QUICK_DISCONNECT_THRESHOLD,
     MAX_QUICK_DISCONNECT_COUNT,
+    MAX_RESUME_ATTEMPTS,
     MAX_MESSAGE_LENGTH,
     DEDUP_WINDOW_SECONDS,
     DEDUP_MAX_SIZE,
@@ -205,6 +206,12 @@ class QQAdapter(BasePlatformAdapter):
         self._heartbeat_interval: float = 30.0  # seconds, updated by Hello
         self._session_id: Optional[str] = None
         self._last_seq: Optional[int] = None
+        # Consecutive Resume attempts that have not yet been confirmed by a
+        # READY/RESUMED dispatch.  Used to break the "stale session resume
+        # loop" where the server accepts Resume but immediately closes the
+        # WebSocket — without this counter the adapter retries Resume with
+        # the same expired session_id forever (see hermes-agent#22179).
+        self._resume_attempts: int = 0
         self._chat_type_map: Dict[str, str] = {}  # chat_id → "c2c"|"group"|"guild"|"dm"
 
         # Request/response correlation
@@ -771,9 +778,29 @@ class QQAdapter(BasePlatformAdapter):
             )
             # Authenticate: send Resume if we have a session, else Identify.
             # Use _create_task which is safe when no event loop is running (tests).
-            if self._session_id and self._last_seq is not None:
+            #
+            # Resume loop guard (hermes-agent#22179): if the previous Resume
+            # attempts never produced a RESUMED/READY dispatch (server accepted
+            # Resume then immediately closed the WebSocket), discard the stale
+            # session_id and fall back to a fresh Identify — otherwise the
+            # adapter would loop forever sending the same expired session_id.
+            if (
+                self._session_id
+                and self._last_seq is not None
+                and self._resume_attempts < MAX_RESUME_ATTEMPTS
+            ):
+                self._resume_attempts += 1
                 self._create_task(self._send_resume())
             else:
+                if self._resume_attempts >= MAX_RESUME_ATTEMPTS:
+                    logger.warning(
+                        "[%s] Resume failed %d times — discarding stale session_id and re-identifying",
+                        self._log_tag,
+                        self._resume_attempts,
+                    )
+                    self._session_id = None
+                    self._last_seq = None
+                    self._resume_attempts = 0
                 self._create_task(self._send_identify())
             return
 
@@ -783,6 +810,7 @@ class QQAdapter(BasePlatformAdapter):
                 self._handle_ready(d)
             elif t == "RESUMED":
                 logger.info("[%s] Session resumed", self._log_tag)
+                self._resume_attempts = 0
             elif t in (
                     "C2C_MESSAGE_CREATE",
                     "GROUP_AT_MESSAGE_CREATE",
@@ -808,6 +836,8 @@ class QQAdapter(BasePlatformAdapter):
         if isinstance(d, dict):
             self._session_id = d.get("session_id")
             logger.info("[%s] Ready, session_id=%s", self._log_tag, self._session_id)
+        # Fresh Identify succeeded — clear the resume failure counter.
+        self._resume_attempts = 0
 
     # ------------------------------------------------------------------
     # JSON helpers

--- a/gateway/platforms/qqbot/constants.py
+++ b/gateway/platforms/qqbot/constants.py
@@ -44,6 +44,13 @@ RATE_LIMIT_DELAY = 60  # seconds
 QUICK_DISCONNECT_THRESHOLD = 5.0  # seconds
 MAX_QUICK_DISCONNECT_COUNT = 3
 
+# After this many consecutive Resume attempts that never produced a
+# RESUMED/READY dispatch, the adapter discards its stale session_id and
+# falls back to a fresh Identify handshake.  Without the cap, an expired
+# session causes an infinite Resume loop because the QQ server accepts
+# Resume then immediately closes the WebSocket (hermes-agent#22179).
+MAX_RESUME_ATTEMPTS = 3
+
 ONBOARD_POLL_INTERVAL = 2.0  # seconds between poll_bind_result calls
 ONBOARD_API_TIMEOUT = 10.0
 

--- a/tests/gateway/test_qqbot_resume_loop_fallback.py
+++ b/tests/gateway/test_qqbot_resume_loop_fallback.py
@@ -1,0 +1,130 @@
+"""Regression: stale session_id must not cause an infinite Resume loop.
+
+Issue hermes-agent#22179: when the QQ server expires a session, accepting
+a Resume but immediately closing the WebSocket, the adapter previously
+kept retrying Resume with the same expired session_id forever. The fix
+caps Resume attempts at MAX_RESUME_ATTEMPTS and then discards the stale
+session, falling back to a fresh Identify.
+
+Tests drive ``_dispatch_payload`` synchronously with op-10 Hello frames
+(where the Resume vs Identify decision is made) and inspect adapter
+state. ``_create_task`` no-ops when no event loop is running, so we don't
+need to actually fire the network calls — we just verify the bookkeeping.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _make_config(**extra):
+    return PlatformConfig(enabled=True, extra=extra)
+
+
+def _make_adapter():
+    from gateway.platforms.qqbot import QQAdapter
+
+    return QQAdapter(_make_config(app_id="a", client_secret="b"))
+
+
+def _hello(adapter):
+    adapter._dispatch_payload({"op": 10, "d": {"heartbeat_interval": 30000}})
+
+
+class TestResumeLoopFallback:
+    def test_initial_attempt_counter_is_zero(self):
+        adapter = _make_adapter()
+        assert adapter._resume_attempts == 0
+
+    def test_resume_increments_attempt_counter(self):
+        adapter = _make_adapter()
+        adapter._session_id = "stale"
+        adapter._last_seq = 42
+        _hello(adapter)
+        assert adapter._resume_attempts == 1
+        # Session not yet discarded — under the threshold.
+        assert adapter._session_id == "stale"
+        assert adapter._last_seq == 42
+
+    def test_resume_loop_capped_then_falls_back_to_identify(self):
+        from gateway.platforms.qqbot.constants import MAX_RESUME_ATTEMPTS
+
+        adapter = _make_adapter()
+        adapter._session_id = "stale"
+        adapter._last_seq = 42
+        # Drive Hello until the cap is reached: each Hello increments the
+        # counter and re-tries Resume.  The (cap+1)-th Hello must trip the
+        # guard and discard the stale session.
+        for _ in range(MAX_RESUME_ATTEMPTS):
+            _hello(adapter)
+        assert adapter._resume_attempts == MAX_RESUME_ATTEMPTS
+        assert adapter._session_id == "stale"
+
+        _hello(adapter)
+        assert adapter._session_id is None
+        assert adapter._last_seq is None
+        assert adapter._resume_attempts == 0
+
+    def test_resumed_dispatch_resets_counter(self):
+        adapter = _make_adapter()
+        adapter._session_id = "live"
+        adapter._last_seq = 7
+        _hello(adapter)
+        _hello(adapter)
+        assert adapter._resume_attempts == 2
+
+        adapter._dispatch_payload(
+            {"op": 0, "t": "RESUMED", "s": 8, "d": {}}
+        )
+        assert adapter._resume_attempts == 0
+        # Session must remain intact — RESUMED is the success signal.
+        assert adapter._session_id == "live"
+
+    def test_ready_dispatch_resets_counter(self):
+        adapter = _make_adapter()
+        adapter._session_id = "stale"
+        adapter._last_seq = 1
+        _hello(adapter)
+        _hello(adapter)
+        assert adapter._resume_attempts == 2
+
+        adapter._dispatch_payload(
+            {"op": 0, "t": "READY", "s": 1, "d": {"session_id": "fresh"}}
+        )
+        assert adapter._resume_attempts == 0
+        assert adapter._session_id == "fresh"
+
+    def test_no_session_picks_identify_without_consuming_attempts(self):
+        adapter = _make_adapter()
+        # No session_id / last_seq → Identify path, counter untouched.
+        _hello(adapter)
+        assert adapter._resume_attempts == 0
+
+    def test_after_fallback_subsequent_resume_starts_fresh(self):
+        from gateway.platforms.qqbot.constants import MAX_RESUME_ATTEMPTS
+
+        adapter = _make_adapter()
+        adapter._session_id = "stale"
+        adapter._last_seq = 42
+        for _ in range(MAX_RESUME_ATTEMPTS + 1):
+            _hello(adapter)
+        # Identify success arrives.
+        adapter._dispatch_payload(
+            {"op": 0, "t": "READY", "s": 1, "d": {"session_id": "new"}}
+        )
+        # New disconnect happens; Resume should now be tried again with
+        # the fresh session, starting from zero attempts.
+        adapter._last_seq = 1
+        _hello(adapter)
+        assert adapter._resume_attempts == 1
+        assert adapter._session_id == "new"
+
+
+def test_max_resume_attempts_constant_exists_and_is_positive():
+    """Source-level guard: future refactors must keep the cap configurable."""
+    from gateway.platforms.qqbot.constants import MAX_RESUME_ATTEMPTS
+
+    assert isinstance(MAX_RESUME_ATTEMPTS, int)
+    assert MAX_RESUME_ATTEMPTS >= 1


### PR DESCRIPTION
## What does this PR do?

When the QQ gateway accepts a Resume frame but immediately closes the WebSocket (the typical signal that the `session_id` has expired server-side), the adapter previously kept reconnecting and retrying Resume forever with the same expired `session_id`. The bot stays effectively offline until the process is restarted.

## Root cause

When the QQ gateway accepts a Resume frame but immediately closes the WebSocket (the typical signal that the `session_id` has expired server-side), the adapter previously kept reconnecting and retrying Resume forever with the same expired `session_id`. The bot stays effectively offline until the process is restarted.

## Fix

Track `_resume_attempts` on the adapter. Each op-10 Hello that picks Resume increments it; after `MAX_RESUME_ATTEMPTS = 3` consecutive unconfirmed attempts, discard `_session_id`/`_last_seq` and fall back to a fresh Identify. The counter resets on RESUMED dispatch and on successful READY (handled in `_handle_ready`), so a healthy reconnect cycle is unaffected.

The cap is exposed as `MAX_RESUME_ATTEMPTS` in `gateway/platforms/qqbot/constants.py` so future tuning is a one-line change.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

Closes #22179

<details>
<summary>Original body</summary>

## Summary

When the QQ gateway accepts a Resume frame but immediately closes the WebSocket (the typical signal that the `session_id` has expired server-side), the adapter previously kept reconnecting and retrying Resume forever with the same expired `session_id`. The bot stays effectively offline until the process is restarted.

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Problem

When the QQ gateway accepts a Resume frame but immediately closes the WebSocket (the typical signal that the `session_id` has expired server-side), the adapter previously kept reconnecting and retrying Resume forever with the same expired `session_id`. The bot stays effectively offline until the process is restarted.

## Root cause

`gateway/platforms/qqbot/adapter.py` op-10 Hello handler picks Resume whenever `_session_id` and `_last_seq` are non-None, with no notion of how many consecutive Resume attempts have *not* been confirmed by a RESUMED/READY dispatch. A server that accepts Resume then closes the socket leaves both fields populated, so every reconnect picks Resume again.

## Fix

Track `_resume_attempts` on the adapter. Each op-10 Hello that picks Resume increments it; after `MAX_RESUME_ATTEMPTS = 3` consecutive unconfirmed attempts, discard `_session_id`/`_last_seq` and fall back to a fresh Identify. The counter resets on RESUMED dispatch and on successful READY (handled in `_handle_ready`), so a healthy reconnect cycle is unaffected.

The cap is exposed as `MAX_RESUME_ATTEMPTS` in `gateway/platforms/qqbot/constants.py` so future tuning is a one-line change.

## Tests

`tests/gateway/test_qqbot_resume_loop_fallback.py` drives op-10 Hello through `_dispatch_payload` and asserts:

- counter starts at 0
- Resume increments the counter without discarding the session
- (cap+1)-th Hello discards `_session_id`/`_last_seq`
- RESUMED and READY both reset the counter
- absence of `_session_id` keeps the counter at 0 (Identify path)
- after fallback, a fresh session restarts the cycle from 0
- a source-level guard keeps `MAX_RESUME_ATTEMPTS` configurable

Verified failing on `main` (8/8) and passing on this branch (8/8). Full `tests/gateway/` suite still green (5050 passed). Pre-existing unrelated failures elsewhere in the suite (`tests/tools/test_file_read_guards`, `tests/hermes_cli/test_gateway_wsl`, etc.) reproduce on `main` without this change and are out of scope.

Closes #22179

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

Closes #22179

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_