### PR TITLE
fix(agent): clear stale config context_length on model switch

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2526,6 +2526,11 @@ class AIAgent:
         old_model = self.model
         old_provider = self.provider
 
+        # Clear the per-config context_length override so the new model's
+        # actual context window is resolved via get_model_context_length()
+        # instead of inheriting the stale value from the previous model.
+        self._config_context_length = None
+
         # ── Swap core runtime fields ──
         self.model = new_model
         self.provider = new_provider
@@ -8093,6 +8098,11 @@ class AIAgent:
                 fb_api_mode = "bedrock_converse"
 
             old_model = self.model
+
+            # Clear the per-config context_length override so the fallback
+            # model's actual context window is resolved instead of inheriting
+            # the stale value from the previous model.  See #22387.
+            self._config_context_length = None
             self.model = fb_model
             self.provider = fb_provider
             self.base_url = fb_base_url


### PR DESCRIPTION
## Problem

When switching models (via `/model` or fallback), `AIAgent._config_context_length` is never cleared, so the new model inherits the previous model's context window instead of auto-detecting the correct one via `get_model_context_length()`.

## Root Cause

`AIAgent._config_context_length` is set once during `__init__` from `model.context_length` in config.yaml. This value is never cleared in either:

1. **`switch_model()`** — the `/model` command handler
2. **`_try_activate_fallback()`** — the failover path on primary model failure

Since `get_model_context_length()` checks this value at resolution step 0 and returns it immediately, the new/fallback model inherits the old override instead of going through the full resolution chain (custom_providers per-model, endpoint metadata, models.dev, etc.).

## Fix

Clear `self._config_context_length = None` in both code paths, before the runtime field swap. This allows `get_model_context_length()` to skip the stale step-0 override and properly resolve the context window for the newly selected model through the standard chain (step 0b: `custom_providers` per-model, then endpoint probe, models.dev, etc.).

## Testing

1. Configure `model.context_length: 1048576` in config.yaml for model A (1M context)
2. Start Hermes with model A — verify 1M context window
3. Switch to model B (e.g. 200K context) via `/model` — **before fix**: still shows 1M; **after fix**: correctly shows 200K
4. Switch back to model A — correctly shows 1M again
5. Trigger a fallback (e.g. rate-limit the primary model) — **before fix**: fallback model inherits primary's context window; **after fix**: fallback model resolves its own context window

Closes #21509