### PR TITLE
fix(install): detect non-Python venv/bin/hermes and regenerate via pip

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1100,6 +1100,41 @@ setup_path() {
         return 0
     fi
 
+    # Defensive guard against the recursive-wrapper hang (#21802): a correct
+    # pip-generated venv/bin/hermes is a Python script with a python shebang.
+    # If it is instead a bash wrapper that execs back into venv/bin/hermes
+    # (left over from a botched install or a clobbered venv), the launcher
+    # we are about to write would call into an infinite exec loop and `hermes`
+    # would hang silently.  Detect that shape and regenerate via pip.
+    if [ "$USE_VENV" = true ]; then
+        first_line="$(head -n 1 "$HERMES_BIN" 2>/dev/null || true)"
+        case "$first_line" in
+            '#!'*python*) : ;;
+            *)
+                log_warn "venv entry point at $HERMES_BIN is not a Python script"
+                log_info "Regenerating with pip to avoid recursive-exec hang (#21802)..."
+                if (cd "$INSTALL_DIR" && ./venv/bin/python -m pip install \
+                        --force-reinstall --no-deps -e . >/dev/null 2>&1); then
+                    first_line="$(head -n 1 "$HERMES_BIN" 2>/dev/null || true)"
+                    case "$first_line" in
+                        '#!'*python*)
+                            log_success "venv entry point regenerated"
+                            ;;
+                        *)
+                            log_warn "venv entry point still not a Python script"
+                            log_info "Manual fix: cd $INSTALL_DIR && uv pip install -e '.[all]'"
+                            return 0
+                            ;;
+                    esac
+                else
+                    log_warn "Could not regenerate venv entry point"
+                    log_info "Manual fix: cd $INSTALL_DIR && uv pip install -e '.[all]'"
+                    return 0
+                fi
+                ;;
+        esac
+    fi
+
     local command_link_dir
     local command_link_display_dir
     command_link_dir="$(get_command_link_dir)"

--- a/tests/test_install_sh_recursive_wrapper_guard.py
+++ b/tests/test_install_sh_recursive_wrapper_guard.py
@@ -1,0 +1,86 @@
+"""Regression: install.sh must detect a non-Python venv/bin/hermes.
+
+Issue hermes-agent#21802: when the venv entry point is itself a bash
+wrapper (left over from a botched install, a clobbered venv, or an
+older installer), the launcher written to ``~/.local/bin/hermes``
+execs back into ``venv/bin/hermes`` which execs back into itself —
+``hermes`` hangs silently with no output.
+
+The fix adds a defensive check inside ``setup_path()`` that inspects
+the shebang of ``$HERMES_BIN``, and regenerates the entry point via
+``pip install --force-reinstall --no-deps -e .`` when the shebang is
+not a Python interpreter.  These tests assert the guard is present in
+``scripts/install.sh`` so it cannot be silently dropped during future
+refactors.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+@pytest.fixture(scope="module")
+def install_sh_text() -> str:
+    return INSTALL_SH.read_text()
+
+
+def test_install_sh_inspects_hermes_bin_shebang(install_sh_text: str) -> None:
+    # The guard reads the first line of $HERMES_BIN to look at its shebang.
+    assert 'head -n 1 "$HERMES_BIN"' in install_sh_text
+
+
+def test_install_sh_accepts_python_shebang_only(install_sh_text: str) -> None:
+    # The case branch must require a python interpreter in the shebang;
+    # any other shape (bash, sh, missing) triggers the regeneration path.
+    assert "'#!'*python*" in install_sh_text
+
+
+def test_install_sh_regenerates_via_force_reinstall(install_sh_text: str) -> None:
+    # Regeneration must use --force-reinstall so a clobbered console
+    # script is overwritten, and --no-deps so we don't rebuild the
+    # whole dependency tree just to fix the entry point.
+    assert "--force-reinstall" in install_sh_text
+    assert "--no-deps" in install_sh_text
+
+
+def test_install_sh_references_issue_in_guard_comment(install_sh_text: str) -> None:
+    # Future maintainers must be able to trace the guard back to the
+    # original bug report so they don't remove it as "unused" code.
+    assert "#21802" in install_sh_text
+
+
+def test_install_sh_falls_back_to_manual_instruction_on_failure(
+    install_sh_text: str,
+) -> None:
+    # When automatic regeneration fails the user must see the exact
+    # command to run by hand — not a silent skip.
+    assert "Manual fix: cd $INSTALL_DIR && uv pip install -e '.[all]'" in install_sh_text
+
+
+def test_install_sh_guard_runs_before_launcher_is_written(install_sh_text: str) -> None:
+    # The guard would be useless if the launcher (which would exec into
+    # the broken wrapper) were written first.  Order must be: detect →
+    # regenerate → write launcher.
+    guard_marker = "Defensive guard against the recursive-wrapper hang"
+    launcher_marker = 'cat > "$command_link_dir/hermes" <<EOF'
+    guard_pos = install_sh_text.find(guard_marker)
+    launcher_pos = install_sh_text.find(launcher_marker)
+    assert guard_pos != -1, "guard marker missing"
+    assert launcher_pos != -1, "launcher marker missing"
+    assert guard_pos < launcher_pos, "guard must run before launcher write"
+
+
+def test_install_sh_guard_skipped_when_not_using_venv(install_sh_text: str) -> None:
+    # Non-venv paths (system install) don't have a $INSTALL_DIR/venv at
+    # all, so the regeneration command would be nonsensical.  The guard
+    # must be conditional on USE_VENV.
+    guard_idx = install_sh_text.find("Defensive guard against the recursive-wrapper hang")
+    assert guard_idx != -1
+    window = install_sh_text[guard_idx : guard_idx + 1500]
+    assert '[ "$USE_VENV" = true ]' in window


### PR DESCRIPTION
## Problem

After running the curl|bash installer (or after any condition that clobbers the pip-generated console script), `venv/bin/hermes` can end up as a bash wrapper that execs back into itself. The installer then writes `~/.local/bin/hermes` as a launcher that execs `\$HERMES_BIN`, which execs `venv/bin/hermes`, which execs itself — `hermes` hangs silently with no output, no error, no CPU activity. The reporter describes the exact shape in #21802.

## Root cause

`scripts/install.sh::setup_path` validates only that `\$HERMES_BIN` exists and is executable. It never inspects the file's shape, so a clobbered console script with a bash shebang slips through and the launcher we write on top of it perpetuates the recursion.

## Fix

After the existing `[ ! -x \"\$HERMES_BIN\" ]` check, inspect the first line of `\$HERMES_BIN`. A correct pip-generated entry point starts with a python shebang (`#!.../python...`). Anything else triggers a `pip install --force-reinstall --no-deps -e .` to regenerate the console script in place; if regeneration also fails, surface the exact manual fix instead of silently writing the broken launcher.

The guard is conditional on `USE_VENV=true` because the system-install path has no venv to reinstall into.

## Tests

`tests/test_install_sh_recursive_wrapper_guard.py` asserts the guard's shape:

- inspects `\$HERMES_BIN`'s shebang
- accepts a python shebang only
- regenerates with `--force-reinstall --no-deps`
- references the issue number so future maintainers can trace it
- falls back to a manual instruction on failure
- runs before the launcher write
- is gated on `USE_VENV`

Pre-existing install.sh tests (pythonpath sanitization, setup wizard tty probe, termux network prereqs) still pass. Bash syntax validated with `bash -n`.

Closes #21802