### PR TITLE
fix(copilot): add gpt-5.5, gpt-5.2, claude-opus-4.5/4.6/4.7 to curated /model picker

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -208,22 +208,34 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "copilot-acp",
     ],
     "copilot": [
+        # OpenAI / Azure OpenAI (newest first)
+        "gpt-5.5",
         "gpt-5.4",
         "gpt-5.4-mini",
-        "gpt-5-mini",
         "gpt-5.3-codex",
+        "gpt-5.2",
         "gpt-5.2-codex",
+        "gpt-5-mini",
         "gpt-4.1",
         "gpt-4o",
         "gpt-4o-mini",
+        # Anthropic (newest first; opus-4.7 reasoning variants are gated to internal accounts)
+        "claude-opus-4.7",
+        "claude-opus-4.7-high",
+        "claude-opus-4.7-xhigh",
+        "claude-opus-4.7-1m-internal",
+        "claude-opus-4.6",
+        "claude-opus-4.5",
         "claude-sonnet-4.6",
-        "claude-sonnet-4",
         "claude-sonnet-4.5",
+        "claude-sonnet-4",
         "claude-haiku-4.5",
+        # Google
         "gemini-3.1-pro-preview",
         "gemini-3-pro-preview",
         "gemini-3-flash-preview",
         "gemini-2.5-pro",
+        # xAI
         "grok-code-fast-1",
     ],
     "gemini": [

--- a/tests/hermes_cli/test_copilot_in_model_list.py
+++ b/tests/hermes_cli/test_copilot_in_model_list.py
@@ -16,13 +16,17 @@ def test_copilot_picker_keeps_curated_copilot_models_when_live_catalog_unavailab
     copilot = next((p for p in providers if p["slug"] == "copilot"), None)
 
     assert copilot is not None
+    assert "gpt-5.5" in copilot["models"]
     assert "gpt-5.4" in copilot["models"]
+    assert "gpt-5.2" in copilot["models"]
+    assert "claude-opus-4.7" in copilot["models"]
+    assert "claude-opus-4.6" in copilot["models"]
+    assert "claude-opus-4.5" in copilot["models"]
     assert "claude-sonnet-4.6" in copilot["models"]
     assert "claude-sonnet-4" in copilot["models"]
     assert "claude-sonnet-4.5" in copilot["models"]
     assert "claude-haiku-4.5" in copilot["models"]
     assert "gemini-3.1-pro-preview" in copilot["models"]
-    assert "claude-opus-4.6" not in copilot["models"]
 
 
 @patch.dict(os.environ, {"GH_TOKEN": "test-key"}, clear=False)

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -227,13 +227,14 @@ class TestProviderModelIds:
              patch("hermes_cli.models._fetch_github_models", return_value=None):
             ids = provider_model_ids("copilot")
 
+        assert "gpt-5.5" in ids
         assert "gpt-5.4" in ids
+        assert "claude-opus-4.7" in ids
         assert "claude-sonnet-4.6" in ids
         assert "claude-sonnet-4" in ids
         assert "claude-sonnet-4.5" in ids
         assert "claude-haiku-4.5" in ids
         assert "gemini-3.1-pro-preview" in ids
-        assert "claude-opus-4.6" not in ids
 
     def test_copilot_acp_falls_back_to_copilot_defaults(self):
         with patch("hermes_cli.models._resolve_copilot_catalog_api_key", return_value="gh-token"), \
@@ -245,7 +246,6 @@ class TestProviderModelIds:
         assert "claude-sonnet-4" in ids
         assert "gemini-3.1-pro-preview" in ids
         assert "copilot-acp" not in ids
-        assert "claude-opus-4.6" not in ids
 
 
 # -- fetch_api_models --------------------------------------------------------


### PR DESCRIPTION
## Problem

The hardcoded curated Copilot model list in `hermes_cli/models.py` (`COPILOT_MODELS["copilot"]`) is missing several models the live GitHub Copilot `/models` API exposes today.

Users authenticating with **classic PATs (`ghp_*`)** — which the Copilot catalog API rejects — fall back to this curated list (the live-fetch in `_fetch_github_models` returns `None` for those tokens). For these users the missing models are unselectable from `/model`.

## Missing models added

- `gpt-5.5`
- `gpt-5.2`
- `claude-opus-4.7` + `claude-opus-4.7-high` / `-xhigh` / `-1m-internal`
- `claude-opus-4.6`
- `claude-opus-4.5`

Verified against `https://api.githubcopilot.com/models` (May 2026).

## Tests

Updated the two pinned regression tests that explicitly asserted the old contents:
- `tests/hermes_cli/test_copilot_in_model_list.py`
- `tests/hermes_cli/test_model_validation.py` (`TestProviderModelIds`)

```
162 passed in 3.01s
```

## Reporter

Reported by an end-user (classic-PAT setup) whose `/model` picker shows the curated fallback. Live-catalog flow remains the source of truth for OAuth (`gho_*`) and fine-grained PAT users — no change there.