### PR TITLE
fix(gateway): exit cleanly under systemd when duplicate instance detected

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15476,6 +15476,22 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
                 f"   or 'hermes gateway stop' to kill it first.\n"
                 f"   Or use 'hermes gateway run --replace' to auto-replace.\n"
             )
+            # Under systemd, returning False (exit 1) makes Restart=always
+            # immediately respawn — and if the original instance is still
+            # alive (typical during the restart race after systemctl restart
+            # without --replace, or with a stale unit file installed before
+            # --replace was added), every spawn detects the same duplicate
+            # and exits 1, producing an infinite restart-flap loop that
+            # eventually trips StartLimitBurst (#21915).  Treat the
+            # duplicate as a clean exit (0) when systemd is the parent so
+            # the service stays in 'active (exited)' instead of flapping.
+            # The CLI path (no INVOCATION_ID) still exits non-zero so the
+            # user's shell sees the error.
+            if os.environ.get("INVOCATION_ID"):
+                logger.info(
+                    "Running under systemd; exiting cleanly to avoid restart flap."
+                )
+                return True
             return False
 
     # Sync bundled skills on gateway start (fast -- skips unchanged)

--- a/tests/gateway/test_start_gateway_systemd_duplicate_clean_exit.py
+++ b/tests/gateway/test_start_gateway_systemd_duplicate_clean_exit.py
@@ -1,0 +1,102 @@
+"""Regression tests for #21915.
+
+When the duplicate-instance guard fires under systemd (Restart=always), the
+gateway must NOT exit with a non-zero status — that triggers an immediate
+respawn that detects the same duplicate and exits non-zero again, producing
+a flap loop that eventually trips StartLimitBurst and leaves the unit in
+``failed`` state.
+
+The fix: when the parent is systemd (``INVOCATION_ID`` env var is set), the
+duplicate-detected branch returns True (clean exit 0) so the unit settles in
+``active (exited)``.  When invoked from a user shell (no ``INVOCATION_ID``),
+behavior is unchanged — return False so the shell sees a non-zero exit code
+and the user knows the start was rejected.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from gateway.config import GatewayConfig
+
+
+@pytest.mark.asyncio
+async def test_duplicate_under_systemd_returns_true_for_clean_exit(
+    monkeypatch, tmp_path
+):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("INVOCATION_ID", "deadbeef-cafe-1234-5678-aabbccddeeff")
+
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: 42)
+    monkeypatch.setattr("gateway.run.os.getpid", lambda: 100)
+
+    from gateway.run import start_gateway
+
+    ok = await start_gateway(config=GatewayConfig(), replace=False, verbosity=None)
+
+    assert ok is True
+
+
+@pytest.mark.asyncio
+async def test_duplicate_outside_systemd_returns_false(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.delenv("INVOCATION_ID", raising=False)
+
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: 42)
+    monkeypatch.setattr("gateway.run.os.getpid", lambda: 100)
+
+    from gateway.run import start_gateway
+
+    ok = await start_gateway(config=GatewayConfig(), replace=False, verbosity=None)
+
+    assert ok is False
+
+
+@pytest.mark.asyncio
+async def test_duplicate_under_systemd_logs_clean_exit_reason(
+    monkeypatch, tmp_path, caplog
+):
+    """The clean-exit path emits an INFO log explaining why we returned 0,
+    so an operator inspecting ``journalctl`` can see the unit-flap-prevention
+    behavior rather than just an unexplained ``active (exited)``.
+    """
+    import logging
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("INVOCATION_ID", "deadbeef-cafe-1234-5678-aabbccddeeff")
+
+    monkeypatch.setattr("gateway.status.get_running_pid", lambda: 42)
+    monkeypatch.setattr("gateway.run.os.getpid", lambda: 100)
+
+    from gateway.run import start_gateway
+
+    with caplog.at_level(logging.INFO, logger="gateway.run"):
+        ok = await start_gateway(
+            config=GatewayConfig(), replace=False, verbosity=None
+        )
+
+    assert ok is True
+    assert any(
+        "systemd" in rec.getMessage().lower()
+        and "exiting cleanly" in rec.getMessage().lower()
+        for rec in caplog.records
+    ), f"expected clean-exit log, got: {[r.getMessage() for r in caplog.records]}"
+
+
+def test_source_guards_invocation_id_check_in_duplicate_branch():
+    """Source-level guard: regardless of refactor, the duplicate-detected
+    branch must consult ``INVOCATION_ID`` and return True under systemd —
+    otherwise #21915 silently regresses.
+    """
+    src = Path(__file__).resolve().parents[2] / "gateway" / "run.py"
+    text = src.read_text(encoding="utf-8")
+
+    assert "INVOCATION_ID" in text, (
+        "gateway/run.py no longer references INVOCATION_ID — the systemd "
+        "clean-exit guard for #21915 has likely been removed."
+    )
+    assert "#21915" in text, (
+        "gateway/run.py no longer references #21915 — the comment anchoring "
+        "the systemd clean-exit guard has been dropped."
+    )


### PR DESCRIPTION
## What does this PR do?

When the gateway is managed by systemd (`Restart=always`) and a previous instance is still alive during a restart race — typical when restarting without `--replace`, or when the installed unit file pre-dates the `--replace` flag — every spawn detects the duplicate, prints "Gateway already running", and exits 1. `Restart=always` then immediately respawns, the new spawn detects the same duplicate, exits 1 again, and the unit flap-loops until `StartLimitBurst` trips and the unit is left in `failed` state.

## Root cause

When the gateway is managed by systemd (`Restart=always`) and a previous instance is still alive during a restart race — typical when restarting without `--replace`, or when the installed unit file pre-dates the `--replace` flag — every spawn detects the duplicate, prints "Gateway already running", and exits 1. `Restart=always` then immediately respawns, the new spawn detects the same duplicate, exits 1 again, and the unit flap-loops until `StartLimitBurst` trips and the unit is left in `failed` state.

Closes #21915.

## Fix

When `INVOCATION_ID` is set in the environment (systemd unconditionally sets this for service-managed processes), return `True` from the duplicate branch so the unit settles in `active (exited)` instead of flapping. When invoked from a user shell (no `INVOCATION_ID`), behavior is unchanged — return `False` so the user's shell sees a non-zero exit code and knows the start was rejected. An `INFO` log explains the clean-exit decision so `journalctl -u hermes-gateway` shows why the unit exited 0 rather than ran continuously.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

Closes #21915.

<details>
<summary>Original body</summary>

## Summary

When the gateway is managed by systemd (`Restart=always`) and a previous instance is still alive during a restart race — typical when restarting without `--replace`, or when the installed unit file pre-dates the `--replace` flag — every spawn detects the duplicate, prints "Gateway already running", and exits 1. `Restart=always` then immediately respawns, the new spawn detects the same duplicate, exits 1 again, and the unit flap-loops until `StartLimitBurst` trips and the unit is left in `failed` state.

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Problem

When the gateway is managed by systemd (`Restart=always`) and a previous instance is still alive during a restart race — typical when restarting without `--replace`, or when the installed unit file pre-dates the `--replace` flag — every spawn detects the duplicate, prints "Gateway already running", and exits 1. `Restart=always` then immediately respawns, the new spawn detects the same duplicate, exits 1 again, and the unit flap-loops until `StartLimitBurst` trips and the unit is left in `failed` state.

Closes #21915.

## Root cause

`start_gateway()`'s duplicate-instance branch returned `False` unconditionally, propagating to a non-zero exit code. systemd interprets non-zero as a failure and respawns under `Restart=always`, which is the right behavior for a transient adapter crash but wrong for a deterministic duplicate-instance check that will keep failing the same way until the original instance exits on its own.

## Fix

When `INVOCATION_ID` is set in the environment (systemd unconditionally sets this for service-managed processes), return `True` from the duplicate branch so the unit settles in `active (exited)` instead of flapping. When invoked from a user shell (no `INVOCATION_ID`), behavior is unchanged — return `False` so the user's shell sees a non-zero exit code and knows the start was rejected. An `INFO` log explains the clean-exit decision so `journalctl -u hermes-gateway` shows why the unit exited 0 rather than ran continuously.

## Tests

`tests/gateway/test_start_gateway_systemd_duplicate_clean_exit.py` covers:

- Duplicate detected with `INVOCATION_ID` set → returns `True`
- Duplicate detected without `INVOCATION_ID` → returns `False` (preserves CLI shell behavior)
- Clean-exit log message present in the systemd path
- Source-level guard asserting `INVOCATION_ID` and `#21915` references remain in `gateway/run.py`

All four tests fail without the fix (3/4 — the shell-mode test passes either way because pre-fix behavior already returned `False`, and the test asserts that).

Full regression: 21205 passed. The 112 failures observed are pre-existing on `main` (verified by stashing the fix and re-running the same files — identical failures appear), unrelated to this change. Affected pre-existing files include `tests/tools/test_file_read_guards.py`, `tests/hermes_cli/test_gateway_wsl.py`, `tests/hermes_cli/test_model_switch_custom_providers.py`, `tests/hermes_cli/test_setup_openclaw_migration.py`, `tests/gateway/test_discord_allowed_mentions.py`.

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

Closes #21915.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_