### PR TITLE
fix(metadata): bump hy3-preview static context length to 262144

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -210,8 +210,9 @@ DEFAULT_CONTEXT_LENGTHS = {
     "grok": 131072,             # catch-all (grok-beta, unknown grok-*)
     # Kimi
     "kimi": 262144,
-    # Tencent — Hy3 Preview (Hunyuan) with 256K context window
-    "hy3-preview": 256000,
+    # Tencent — Hy3 Preview (Hunyuan); OpenRouter live API reports 262144 (256
+    # KiB) since 2026-04-20, up from 256000 at launch (#22268).
+    "hy3-preview": 262144,
     # Nemotron — NVIDIA's open-weights series (128K context across all sizes)
     "nemotron": 131072,
     # Arcee

--- a/tests/hermes_cli/test_tencent_tokenhub_provider.py
+++ b/tests/hermes_cli/test_tencent_tokenhub_provider.py
@@ -309,7 +309,10 @@ class TestTencentTokenhubContextLength:
     def test_hy3_preview_context_length(self):
         from agent.model_metadata import get_model_context_length
         ctx = get_model_context_length("hy3-preview")
-        assert ctx == 256000
+        # OpenRouter's live API now reports 262144 (256 KiB) for hy3-preview;
+        # the metadata cache reaches the static fallback only when offline,
+        # so both the live and offline paths must agree (#22268).
+        assert ctx == 262144
 
 
 # =============================================================================


### PR DESCRIPTION
## Problem

`TestTencentTokenhubContextLength::test_hy3_preview_context_length` fails on `main`:

```
assert 262144 == 256000
```

Closes #22268.

## Root cause

OpenRouter's live API now reports `hy3-preview` with `context_length: 262144` (256 KiB), up from 256000 at launch. `get_model_context_length("hy3-preview")` consults the OpenRouter metadata cache before reaching the static fallback in `DEFAULT_CONTEXT_LENGTHS`, so it returns the live value (262144) and the test (which asserted the old static value) fails.

## Fix

Update both sides:

- `agent/model_metadata.py`: bump the static fallback to `262144` so the offline path agrees with the live API.
- `tests/hermes_cli/test_tencent_tokenhub_provider.py`: assert `262144` to match the value the resolver now returns.

## Tests

`TestTencentTokenhubContextLength` passes with the fix and fails without it (verified by stashing both edits and re-running the scoped test — reproduces `assert 262144 == 256000`). Full `tests/hermes_cli/test_tencent_tokenhub_provider.py` (61 tests) green.