### PR TITLE
fix(discord): honor "*" wildcard in DISCORD_ALLOWED_USERS

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -2189,6 +2189,12 @@ class DiscordAdapter(BasePlatformAdapter):
         has_roles = bool(allowed_roles)
         if not has_users and not has_roles:
             return True
+        # Open-mode wildcard ("*" entry) means "any user" — same convention as
+        # SIGNAL_ALLOWED_USERS, DISCORD_ALLOWED_CHANNELS, and the `claw migrate`
+        # output for OpenClaw `allowFrom: ["*"]`. Without this, mixed lists
+        # like `<id>,*` silently reject everyone except <id> (#22334).
+        if has_users and "*" in allowed_users:
+            return True
         # Check user ID allowlist (works for both DMs and guild messages)
         if has_users and user_id in allowed_users:
             return True

--- a/tests/gateway/test_discord_allowed_users_wildcard.py
+++ b/tests/gateway/test_discord_allowed_users_wildcard.py
@@ -1,0 +1,59 @@
+"""Regression tests for #22334.
+
+OpenClaw stored Discord allowlists as ``allowFrom: ["<id>", "*"]`` where
+``"*"`` meant "any user".  ``hermes claw migrate`` preserves the literal
+list as ``DISCORD_ALLOWED_USERS=<id>,*``, but
+``DiscordAdapter._is_allowed_user`` did set-membership against the literal
+``"*"`` instead of treating it as an open-mode wildcard, silently rejecting
+every user except ``<id>`` after migration.
+
+The fix mirrors the convention already used by
+``DISCORD_ALLOWED_CHANNELS``, ``DISCORD_IGNORED_CHANNELS``, and
+``SIGNAL_ALLOWED_USERS``: ``"*"`` in the allowlist short-circuits to True
+for any user.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from gateway.platforms.discord import DiscordAdapter
+
+
+def _make_adapter(allowed_users=None, allowed_roles=None):
+    adapter = object.__new__(DiscordAdapter)
+    adapter._allowed_user_ids = set(allowed_users or [])
+    adapter._allowed_role_ids = set(allowed_roles or [])
+    adapter._client = MagicMock()
+    return adapter
+
+
+class TestDiscordAllowedUsersWildcard:
+    def test_wildcard_alone_allows_any_user(self):
+        adapter = _make_adapter(allowed_users={"*"})
+        assert adapter._is_allowed_user("42") is True
+        assert adapter._is_allowed_user("999999999999999999") is True
+
+    def test_wildcard_mixed_with_id_allows_other_users(self):
+        """The bug from #22334: ``{"<id>", "*"}`` must allow any user, not
+        only ``<id>``."""
+        adapter = _make_adapter(allowed_users={"123456789012345678", "*"})
+        assert adapter._is_allowed_user("42") is True
+        assert adapter._is_allowed_user("123456789012345678") is True
+
+    def test_wildcard_in_dm_allows_any_user(self):
+        """DMs (``is_dm=True``, no guild context) must also honor the user
+        wildcard — DMs have no role-fallback path."""
+        adapter = _make_adapter(allowed_users={"*"})
+        assert adapter._is_allowed_user("42", is_dm=True, guild=None) is True
+
+    def test_no_wildcard_keeps_strict_membership(self):
+        """No wildcard → must still reject non-listed users."""
+        adapter = _make_adapter(allowed_users={"123456789012345678"})
+        assert adapter._is_allowed_user("42") is False
+        assert adapter._is_allowed_user("123456789012345678") is True
+
+    def test_empty_allowlist_still_open(self):
+        """Empty allowlist preserves the existing 'no restriction' default;
+        the wildcard short-circuit must not regress that path."""
+        adapter = _make_adapter(allowed_users=set(), allowed_roles=set())
+        assert adapter._is_allowed_user("42") is True


### PR DESCRIPTION
## Problem

After `hermes claw migrate` from an OpenClaw config whose `allowFrom` list contained `"*"` (open mode), the migrator preserves the literal entry as `DISCORD_ALLOWED_USERS=<id>,*`. The gateway then silently rejects every user except `<id>` — no log line, no slash-command feedback — because `DiscordAdapter._is_allowed_user` does set-membership against the literal string `"*"` instead of treating it as the documented open-mode wildcard.

Direct repro:

```python
adapter._allowed_user_ids = {"123456789012345678", "*"}
adapter._is_allowed_user("42")
# Returns False on main; expected True.
```

Closes #22334.

## Root cause

`_is_allowed_user` predates the wildcard convention. Sister allowlists (`DISCORD_ALLOWED_CHANNELS`, `DISCORD_IGNORED_CHANNELS`, `SIGNAL_ALLOWED_USERS`) all already treat `"*"` as "any value matches" — see `"*" not in _free_channels` at `gateway/platforms/discord.py:782` and `"*" not in self.dm_allow_from` at `gateway/platforms/signal.py:1456`. The user allowlist was simply missed.

## Fix

Short-circuit `_is_allowed_user` to `True` when `"*"` is in the user allowlist, before the literal set-membership check. Purely permissive change: deployments without `"*"` in the env see no behavior change. The empty-allowlist 'no restriction' default at the top of the function is unaffected.

## Tests

`tests/gateway/test_discord_allowed_users_wildcard.py`:

- Wildcard alone allows any user (guild + DM)
- Wildcard mixed with an explicit ID allows non-listed users — the exact scenario from the issue's `claw migrate` output
- No-wildcard case still rejects non-listed users
- Empty allowlist still open by default

3/5 tests fail without the fix (the 'no wildcard' and 'empty allowlist' cases pass either way and verify the change did not regress the existing branches). All adjacent Discord auth tests (`test_discord_roles_dm_scope`, `test_discord_slash_auth`, `test_discord_allowed_channels`) remain green — 64 passed in the combined run.