### PR TITLE
fix(runtime): classify delegation timeout telemetry

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -12,9 +12,11 @@ Run with:  python -m pytest tests/test_delegate.py -v
 import json
 import os
 import sys
+import tempfile
 import threading
 import time
 import unittest
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 from tools.delegate_tool import (
@@ -29,6 +31,7 @@ from tools.delegate_tool import (
     _build_child_agent,
     _build_child_progress_callback,
     _build_child_system_prompt,
+    _write_delegation_event,
     _strip_blocked_tools,
     _resolve_child_credential_pool,
     _resolve_delegation_credentials,
@@ -56,6 +59,72 @@ def _make_mock_parent(depth=0):
     parent.tool_progress_callback = None
     parent.thinking_callback = None
     return parent
+
+
+class TestDelegationRuntimeTelemetry(unittest.TestCase):
+    def _read_events(self, home, filename):
+        path = home / "logs" / filename
+        self.assertTrue(path.exists(), f"missing telemetry file: {path}")
+        return [json.loads(line) for line in path.read_text(encoding="utf-8").splitlines()]
+
+    def test_delegation_event_mirrors_runtime_telemetry(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            with patch.dict(os.environ, {"HERMES_HOME": str(home)}, clear=False):
+                _write_delegation_event(
+                    status="completed",
+                    provider="openrouter",
+                    model="test/model",
+                    session_id="parent-session",
+                    subagent_id="child-subagent",
+                    role="leaf",
+                    accepted=False,
+                    duration_seconds=1.23456,
+                    exit_reason="completed",
+                )
+
+            legacy_event = self._read_events(home, "delegation-events.jsonl")[-1]
+            self.assertEqual(legacy_event["status"], "completed")
+
+            runtime_event = self._read_events(home, "provider-failover-events.jsonl")[-1]
+            self.assertEqual(runtime_event["event_type"], "delegation.runtime")
+            self.assertEqual(runtime_event["status"], "completed")
+            self.assertEqual(runtime_event["provider"], "openrouter")
+            self.assertEqual(runtime_event["model"], "test/model")
+            self.assertEqual(runtime_event["role"], "leaf")
+            self.assertEqual(runtime_event["session_id"], "parent-session")
+            self.assertEqual(runtime_event["subagent_id"], "child-subagent")
+            self.assertEqual(runtime_event["latency_seconds"], 1.235)
+            self.assertEqual(runtime_event["failure_kind"], "none")
+            self.assertEqual(runtime_event["resolution"], "delegation_completed")
+            self.assertFalse(runtime_event["accepted"])
+
+    def test_failed_delegation_runtime_telemetry_redacts_error(self):
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            with patch.dict(os.environ, {"HERMES_HOME": str(home)}, clear=False):
+                _write_delegation_event(
+                    status="failed",
+                    provider="opencode-go",
+                    model="kimi-k2.6",
+                    session_id="parent-session",
+                    subagent_id="child-subagent",
+                    role="leaf",
+                    accepted=False,
+                    duration_seconds=2,
+                    exit_reason="error",
+                    error="provider failed with token=redactme123 and bearer redactedtoken456",
+                )
+
+            payload = json.dumps(self._read_events(home, "provider-failover-events.jsonl")[-1])
+            event = json.loads(payload)
+            self.assertEqual(event["event_type"], "delegation.runtime")
+            self.assertEqual(event["status"], "failed")
+            self.assertEqual(event["failure_kind"], "delegation_failed")
+            self.assertEqual(event["resolution"], "delegation_failed")
+            self.assertIn("[REDACTED]", event["error"])
+            self.assertNotIn("redactme123", payload)
+            self.assertNotIn("redactedtoken456", payload)
 
 
 class TestDelegateRequirements(unittest.TestCase):

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -25,6 +25,8 @@ from tools.delegate_tool import (
     DelegateEvent,
     _get_max_concurrent_children,
     _LEGACY_EVENT_MAP,
+    _delegation_runtime_failure_kind,
+    _delegation_runtime_resolution,
     MAX_DEPTH,
     check_delegate_requirements,
     delegate_task,
@@ -125,6 +127,59 @@ class TestDelegationRuntimeTelemetry(unittest.TestCase):
             self.assertIn("[REDACTED]", event["error"])
             self.assertNotIn("redactme123", payload)
             self.assertNotIn("redactedtoken456", payload)
+
+    def test_runtime_resolution_timeout_is_explicit_not_substring(self):
+        self.assertEqual(
+            _delegation_runtime_resolution("completed", "timeout"),
+            "delegation_timeout",
+        )
+        self.assertEqual(
+            _delegation_runtime_resolution("completed", "no timeout"),
+            "delegation_completed",
+        )
+        self.assertEqual(
+            _delegation_runtime_resolution("failed", "timed out"),
+            "delegation_timeout",
+        )
+        self.assertEqual(
+            _delegation_runtime_resolution("failed", None),
+            "delegation_failed",
+        )
+        self.assertEqual(
+            _delegation_runtime_resolution("", None),
+            "delegation_unknown",
+        )
+
+    def test_runtime_failure_kind_marks_terminal_failures(self):
+        self.assertEqual(_delegation_runtime_failure_kind("delegation_failed"), "delegation_failed")
+        self.assertEqual(_delegation_runtime_failure_kind("delegation_timeout"), "delegation_timeout")
+        self.assertEqual(_delegation_runtime_failure_kind("delegation_interrupted"), "delegation_interrupted")
+        self.assertEqual(_delegation_runtime_failure_kind("delegation_completed"), "none")
+
+    def test_runtime_event_failure_kind_matches_resolution(self):
+        cases = [
+            ("completed", "completed", "delegation_completed", "none"),
+            ("failed", "error", "delegation_failed", "delegation_failed"),
+            ("failed", "timeout", "delegation_timeout", "delegation_timeout"),
+            ("interrupted", "interrupted", "delegation_interrupted", "delegation_interrupted"),
+            ("queued", None, "delegation_queued", "none"),
+        ]
+        with tempfile.TemporaryDirectory() as tmp:
+            home = Path(tmp)
+            with patch.dict(os.environ, {"HERMES_HOME": str(home)}, clear=False):
+                for status, exit_reason, expected_resolution, expected_failure_kind in cases:
+                    with self.subTest(status=status, exit_reason=exit_reason):
+                        _write_delegation_event(
+                            status=status,
+                            provider="openrouter",
+                            model="test/model",
+                            accepted=False,
+                            duration_seconds=1,
+                            exit_reason=exit_reason,
+                        )
+                        event = self._read_events(home, "provider-failover-events.jsonl")[-1]
+                        self.assertEqual(event["resolution"], expected_resolution)
+                        self.assertEqual(event["failure_kind"], expected_failure_kind)
 
 
 class TestDelegateRequirements(unittest.TestCase):

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -535,15 +535,31 @@ def _redact_event_text(text: str) -> str:
 def _delegation_runtime_resolution(status: str, exit_reason: Optional[str]) -> str:
     normalized_status = str(status or "unknown").lower()
     normalized_exit = str(exit_reason or "").lower()
+    explicit_timeout = normalized_status in {"timeout", "timed_out"} or normalized_exit in {
+        "timeout",
+        "timed_out",
+        "timed out",
+    }
+    if explicit_timeout:
+        return "delegation_timeout"
     if normalized_status in {"completed", "success", "succeeded"}:
         return "delegation_completed"
     if normalized_status in {"failed", "error"} or normalized_exit == "error":
         return "delegation_failed"
-    if normalized_status in {"timeout", "timed_out"} or "timeout" in normalized_exit:
-        return "delegation_timeout"
     if normalized_status in {"interrupted", "cancelled", "canceled"}:
         return "delegation_interrupted"
     return f"delegation_{normalized_status}"
+
+
+_DELEGATION_RUNTIME_FAILURE_RESOLUTIONS = frozenset(
+    {"delegation_failed", "delegation_timeout", "delegation_interrupted"}
+)
+
+
+def _delegation_runtime_failure_kind(resolution: str) -> str:
+    if resolution in _DELEGATION_RUNTIME_FAILURE_RESOLUTIONS:
+        return resolution
+    return "none"
 
 
 def _write_delegation_runtime_event(
@@ -578,7 +594,7 @@ def _write_delegation_runtime_event(
             "status": status,
             "accepted": accepted,
             "role": role or "delegate",
-            "failure_kind": "delegation_failed" if resolution == "delegation_failed" else "none",
+            "failure_kind": _delegation_runtime_failure_kind(resolution),
             "resolution": resolution,
         }
         if session_id:

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -22,8 +22,10 @@ import logging
 
 logger = logging.getLogger(__name__)
 import os
+import re
 import threading
 import time
+from datetime import datetime, timezone
 from concurrent.futures import (
     ThreadPoolExecutor,
     TimeoutError as FuturesTimeoutError,
@@ -517,6 +519,149 @@ _HEARTBEAT_INTERVAL = 30  # seconds between parent activity heartbeats during de
 _HEARTBEAT_STALE_CYCLES_IDLE = 15  # 15 * 30s = 450s idle between turns → stale
 _HEARTBEAT_STALE_CYCLES_IN_TOOL = 40  # 40 * 30s = 1200s stuck on same tool → stale
 DEFAULT_TOOLSETS = ["terminal", "file", "web"]
+_DELEGATION_EVENT_LOCK = threading.Lock()
+
+
+def _redact_event_text(text: str) -> str:
+    value = str(text or "")
+    value = re.sub(r"(?i)(authorization\s*:\s*bearer\s+)[A-Za-z0-9._\-]+", r"\1[REDACTED]", value)
+    value = re.sub(r"(?i)(bearer\s+)[A-Za-z0-9._\-]+", r"\1[REDACTED]", value)
+    key_pattern = r"(?i)(api[_-]?key|token|password|secret|authorization)(\s*[=:]\s*)(?:\"[^\"]*\"|'[^']*'|[^\s,;}]+)"
+    value = re.sub(key_pattern, r"\1\2[REDACTED]", value)
+    value = re.sub(r"(?i)(\"(?:api[_-]?key|token|password|secret|authorization)\"\s*:\s*)(?:\"[^\"]*\"|[^\s,;}]+)", r"\1\"[REDACTED]\"", value)
+    return value
+
+
+def _delegation_runtime_resolution(status: str, exit_reason: Optional[str]) -> str:
+    normalized_status = str(status or "unknown").lower()
+    normalized_exit = str(exit_reason or "").lower()
+    if normalized_status in {"completed", "success", "succeeded"}:
+        return "delegation_completed"
+    if normalized_status in {"failed", "error"} or normalized_exit == "error":
+        return "delegation_failed"
+    if normalized_status in {"timeout", "timed_out"} or "timeout" in normalized_exit:
+        return "delegation_timeout"
+    if normalized_status in {"interrupted", "cancelled", "canceled"}:
+        return "delegation_interrupted"
+    return f"delegation_{normalized_status}"
+
+
+def _write_delegation_runtime_event(
+    *,
+    status: str,
+    engine: str,
+    provider: Optional[str],
+    model: Optional[str],
+    task_type: str,
+    session_id: Optional[str],
+    subagent_id: Optional[str],
+    role: Optional[str],
+    accepted: bool,
+    duration_seconds: Optional[float],
+    exit_reason: Optional[str],
+    error: Optional[str],
+) -> None:
+    """Append delegation lifecycle data to the Phase 5.75 runtime telemetry log."""
+    try:
+        from hermes_constants import get_hermes_home
+
+        logs_dir = get_hermes_home() / "logs"
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        resolution = _delegation_runtime_resolution(status, exit_reason)
+        event: Dict[str, Any] = {
+            "ts": datetime.now(timezone.utc).isoformat(timespec="milliseconds"),
+            "event_type": "delegation.runtime",
+            "engine": engine,
+            "provider": provider or "unknown",
+            "model": model or "unknown",
+            "task_type": task_type,
+            "status": status,
+            "accepted": accepted,
+            "role": role or "delegate",
+            "failure_kind": "delegation_failed" if resolution == "delegation_failed" else "none",
+            "resolution": resolution,
+        }
+        if session_id:
+            event["session_id"] = str(session_id)
+        if subagent_id:
+            event["subagent_id"] = str(subagent_id)
+        if duration_seconds is not None:
+            event["latency_seconds"] = round(float(duration_seconds), 3)
+            event["duration_seconds"] = round(float(duration_seconds), 3)
+        if exit_reason:
+            event["exit_reason"] = str(exit_reason)
+        if error:
+            event["error"] = _redact_event_text(str(error))[:500]
+        with _DELEGATION_EVENT_LOCK:
+            with (logs_dir / "provider-failover-events.jsonl").open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(event, sort_keys=True) + "\n")
+    except Exception as exc:
+        logger.debug("delegation runtime event log failed: %s", exc)
+
+
+def _write_delegation_event(
+    *,
+    status: str,
+    engine: str = "native_delegate_task",
+    provider: Optional[str] = None,
+    model: Optional[str] = None,
+    task_type: str = "delegate_task",
+    session_id: Optional[str] = None,
+    subagent_id: Optional[str] = None,
+    role: Optional[str] = None,
+    accepted: bool = False,
+    duration_seconds: Optional[float] = None,
+    exit_reason: Optional[str] = None,
+    error: Optional[str] = None,
+) -> None:
+    """Append a redacted unified delegation event for audit/telemetry."""
+    try:
+        from hermes_constants import get_hermes_home
+
+        logs_dir = get_hermes_home() / "logs"
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        # "accepted" is parent acceptance, not child success; delegation results
+        # remain unaccepted until the Hermes parent performs final review.
+        event: Dict[str, Any] = {
+            "ts": datetime.now(timezone.utc).isoformat(),
+            "engine": engine,
+            "provider": provider,
+            "model": model,
+            "task_type": task_type,
+            "status": status,
+            "accepted": accepted,
+        }
+        if session_id:
+            event["session_id"] = session_id
+        if subagent_id:
+            event["subagent_id"] = subagent_id
+        if role:
+            event["role"] = role
+        if duration_seconds is not None:
+            event["duration_seconds"] = duration_seconds
+        if exit_reason:
+            event["exit_reason"] = exit_reason
+        if error:
+            event["error"] = _redact_event_text(str(error))[:500]
+        with _DELEGATION_EVENT_LOCK:
+            with (logs_dir / "delegation-events.jsonl").open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(event, sort_keys=True) + "\n")
+    except Exception as exc:
+        logger.debug("delegation event log failed: %s", exc)
+    _write_delegation_runtime_event(
+        status=status,
+        engine=engine,
+        provider=provider,
+        model=model,
+        task_type=task_type,
+        session_id=session_id,
+        subagent_id=subagent_id,
+        role=role,
+        accepted=accepted,
+        duration_seconds=duration_seconds,
+        exit_reason=exit_reason,
+        error=error,
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds timeout-specific classification for delegated task telemetry.
- Keeps timeout metadata redacted while preserving useful provider/model/task context.
- Builds on the delegation telemetry mirroring work in the prerequisite stacked commit.

## Verification
- `python -m py_compile tools/delegate_tool.py tests/tools/test_delegate.py`
- `pytest tests/tools/test_delegate.py -q` — 125 passed, 5 subtests passed
- `git diff --check origin/main..HEAD`
- Public metadata/privacy scan completed; one dummy redaction-test fixture was classified as expected test data, not a live credential.

## Stacking note
This is intentionally opened as a draft stacked PR. The branch currently includes the prerequisite telemetry-mirroring commit because the upstream prerequisite PR has not landed yet. Once that lands, this branch should be rebased onto fresh `origin/main` so the final review only contains the timeout-classification slice.
