### PR TITLE
fix(status): never print raw API keys in --all output

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -165,12 +165,14 @@ def show_status(args):
             continue
         value = _resolve_env(env_ref)
         has_key = bool(value)
-        display = redact_key(value) if not show_all else value
+        # Even `hermes status --all` must not print raw secrets. The flag expands
+        # component coverage, not credential disclosure.
+        display = redact_key(value)
         print(f"  {name:<12}  {check_mark(has_key)} {display}")
 
     from hermes_cli.auth import get_anthropic_key
     anthropic_value = get_anthropic_key()
-    anthropic_display = redact_key(anthropic_value) if not show_all else anthropic_value
+    anthropic_display = redact_key(anthropic_value)
     print(f"  {'Anthropic':<12}  {check_mark(bool(anthropic_value))} {anthropic_display}")
 
     # =========================================================================

--- a/tests/hermes_cli/test_status_model_provider.py
+++ b/tests/hermes_cli/test_status_model_provider.py
@@ -124,6 +124,31 @@ def test_show_status_hides_nous_subscription_section_when_feature_flag_is_off(mo
     assert "Nous Tool Gateway" not in out
 
 
+def test_show_status_all_redacts_api_keys(monkeypatch, capsys, tmp_path):
+    from hermes_cli import status as status_mod
+
+    raw_key = "sk-or-v1-abcdefghijklmnopqrstuvwxyz1234567890"
+
+    def _get_env_value(name: str):
+        if name == "OPENROUTER_API_KEY":
+            return raw_key
+        return ""
+
+    _patch_common_status_deps(monkeypatch, status_mod, tmp_path)
+    monkeypatch.setattr(status_mod, "get_env_value", _get_env_value, raising=False)
+    monkeypatch.setattr(status_mod, "load_config", lambda: {}, raising=False)
+    monkeypatch.setattr(status_mod, "resolve_requested_provider", lambda requested=None: "openrouter", raising=False)
+    monkeypatch.setattr(status_mod, "resolve_provider", lambda requested=None, **kwargs: "openrouter", raising=False)
+    monkeypatch.setattr(status_mod, "provider_label", lambda provider: "OpenRouter", raising=False)
+
+    status_mod.show_status(SimpleNamespace(all=True, deep=False))
+
+    out = capsys.readouterr().out
+    assert raw_key not in out
+    assert "OpenRouter" in out
+    assert "sk-o...7890" in out
+
+
 def test_show_status_reports_empty_lmstudio_listing_as_reachable(monkeypatch, capsys, tmp_path):
     from hermes_cli import status as status_mod
 


### PR DESCRIPTION
## Summary
- ensure `hermes status --all` still redacts provider API keys
- keep `--all` scoped to expanded status coverage rather than credential disclosure
- add a regression test for OpenRouter key output redaction

## Problem
`hermes status` normally masks configured provider credentials, but the `--all` path could print raw API key values. That makes a diagnostic command unsafe to paste into issue reports or support chats.

## Test plan
- `python -m pytest tests/hermes_cli/test_status_model_provider.py -q -o 'addopts='`
- `git diff --check`
