### PR TITLE
feat(cli): add safe context composition report

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Hermes has two entry points: start the terminal UI with `hermes`, or run the gat
 | Change model | `/model [provider:model]` | `/model [provider:model]` |
 | Set a personality | `/personality [name]` | `/personality [name]` |
 | Retry or undo the last turn | `/retry`, `/undo` | `/retry`, `/undo` |
-| Compress context / check usage | `/compress`, `/usage`, `/insights [--days N]` | `/compress`, `/usage`, `/insights [days]` |
+| Compress context / inspect usage | `/compress`, `/context`, `/usage`, `/insights [--days N]` | `/compress`, `/usage`, `/insights [days]` |
 | Browse skills | `/skills` or `/<skill-name>` | `/<skill-name>` |
 | Interrupt current work | `Ctrl+C` or send a new message | `/stop` or send a new message |
 | Platform-specific status | `/platforms` | `/status`, `/sethome` |

--- a/agent/context_observability.py
+++ b/agent/context_observability.py
@@ -1,0 +1,249 @@
+"""Read-only context composition observability utilities.
+
+This module intentionally reports sizes and labels, not raw prompt content.
+It is safe to use from CLI/Gateway/WebUI surfaces without dumping secrets.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+import json
+from typing import Any, Iterable, Mapping, Sequence
+
+
+@dataclass(frozen=True)
+class ContextSection:
+    """One high-level bucket in a provider request."""
+
+    name: str
+    estimated_tokens: int
+    item_count: int = 0
+    cacheability: str = "unknown"
+    notes: list[str] = field(default_factory=list)
+
+    @property
+    def share(self) -> float:
+        """Placeholder kept for callers that prefer section-local access.
+
+        The true share depends on the full report total; use
+        ``ContextBreakdown.section_shares`` for exact percentages.
+        """
+        return 0.0
+
+
+@dataclass(frozen=True)
+class CacheSummary:
+    """Provider cache eligibility/configuration summary."""
+
+    supported: bool = False
+    configured: bool = False
+    stable_estimated_tokens: int = 0
+    volatile_estimated_tokens: int = 0
+    status: str = "unknown"
+
+
+@dataclass(frozen=True)
+class ContextBreakdown:
+    """Safe, structured summary of the active request context."""
+
+    model: str = "unknown"
+    provider: str = "unknown"
+    context_window: int = 0
+    total_estimated_tokens: int = 0
+    sections: list[ContextSection] = field(default_factory=list)
+    cache: CacheSummary = field(default_factory=CacheSummary)
+    warnings: list[str] = field(default_factory=list)
+    suggestions: list[str] = field(default_factory=list)
+    estimator: str = "rough_chars_div_4"
+    message_count: int = 0
+    tool_count: int = 0
+    enabled_toolsets: list[str] = field(default_factory=list)
+
+    def section_shares(self) -> dict[str, float]:
+        if not self.total_estimated_tokens:
+            return {section.name: 0.0 for section in self.sections}
+        return {
+            section.name: section.estimated_tokens / self.total_estimated_tokens
+            for section in self.sections
+        }
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+def _rough_tokens(value: Any) -> int:
+    """Estimate tokens without provider-specific tokenizer dependencies."""
+    if value is None or value == "":
+        return 0
+    if isinstance(value, str):
+        text = value
+    else:
+        try:
+            text = json.dumps(value, ensure_ascii=False, sort_keys=True, default=str)
+        except TypeError:
+            text = str(value)
+    return (len(text) + 3) // 4
+
+
+def _message_role(message: Mapping[str, Any]) -> str:
+    return str(message.get("role") or "unknown")
+
+
+def _split_messages(messages: Sequence[Mapping[str, Any]]) -> tuple[list[Mapping[str, Any]], list[Mapping[str, Any]], list[Mapping[str, Any]]]:
+    system_messages: list[Mapping[str, Any]] = []
+    tool_results: list[Mapping[str, Any]] = []
+    conversation_messages: list[Mapping[str, Any]] = []
+    for message in messages:
+        role = _message_role(message)
+        if role == "system":
+            system_messages.append(message)
+        elif role == "tool":
+            tool_results.append(message)
+        else:
+            conversation_messages.append(message)
+    return system_messages, conversation_messages, tool_results
+
+
+def _provider_cache_summary(
+    provider: str,
+    *,
+    sections: Sequence[ContextSection],
+    openrouter_cache_enabled: bool | None,
+) -> CacheSummary:
+    provider_key = (provider or "").lower()
+    supported = provider_key in {"openrouter", "openrouter.ai"}
+    configured = bool(openrouter_cache_enabled) if supported else False
+    stable = sum(section.estimated_tokens for section in sections if section.cacheability == "stable")
+    volatile = sum(section.estimated_tokens for section in sections if section.cacheability == "volatile")
+    if supported and configured:
+        status = "configured"
+    elif supported:
+        status = "supported_not_configured"
+    else:
+        status = "unknown"
+    return CacheSummary(
+        supported=supported,
+        configured=configured,
+        stable_estimated_tokens=stable,
+        volatile_estimated_tokens=volatile,
+        status=status,
+    )
+
+
+def _nonzero_section(name: str, value: Any, *, item_count: int, cacheability: str, notes: Iterable[str] = ()) -> ContextSection | None:
+    tokens = _rough_tokens(value)
+    if tokens <= 0 and item_count <= 0:
+        return None
+    return ContextSection(
+        name=name,
+        estimated_tokens=tokens,
+        item_count=item_count,
+        cacheability=cacheability,
+        notes=list(notes),
+    )
+
+
+def build_context_breakdown(
+    messages: Sequence[Mapping[str, Any]] | None,
+    *,
+    tools: Sequence[Mapping[str, Any]] | None = None,
+    system_prompt: str = "",
+    model: str = "unknown",
+    provider: str = "unknown",
+    context_window: int = 0,
+    enabled_toolsets: Sequence[str] | None = None,
+    openrouter_cache_enabled: bool | None = None,
+) -> ContextBreakdown:
+    """Build a safe breakdown of request context buckets.
+
+    The function deliberately avoids returning prompt text, message content,
+    tool descriptions, environment values, or any other raw payload data.
+    """
+    messages = list(messages or [])
+    tools = list(tools or [])
+    system_messages, conversation_messages, tool_results = _split_messages(messages)
+
+    sections: list[ContextSection] = []
+    for section in (
+        _nonzero_section("system_prompt", system_prompt, item_count=1 if system_prompt else 0, cacheability="stable"),
+        _nonzero_section("system_messages", system_messages, item_count=len(system_messages), cacheability="stable"),
+        _nonzero_section("conversation_messages", conversation_messages, item_count=len(conversation_messages), cacheability="volatile"),
+        _nonzero_section("tool_results", tool_results, item_count=len(tool_results), cacheability="volatile"),
+        _nonzero_section("tool_schemas", tools, item_count=len(tools), cacheability="stable"),
+    ):
+        if section is not None:
+            sections.append(section)
+
+    total = sum(section.estimated_tokens for section in sections)
+    cache = _provider_cache_summary(
+        provider,
+        sections=sections,
+        openrouter_cache_enabled=openrouter_cache_enabled,
+    )
+
+    shares = {section.name: (section.estimated_tokens / total if total else 0.0) for section in sections}
+    warnings: list[str] = []
+    suggestions: list[str] = []
+    tool_share = shares.get("tool_schemas", 0.0)
+    if tool_share >= 0.30 and tools:
+        warnings.append("Tool schemas dominate the estimated request context.")
+        suggestions.append("Use narrower toolsets or route heavy MCP/native tools only when needed.")
+    if context_window and total >= int(context_window * 0.50):
+        warnings.append("Estimated request is over half the model context window.")
+        suggestions.append("Compress, branch, or move raw data to files and reference paths/manifests only.")
+    if cache.supported and not cache.configured:
+        suggestions.append("OpenRouter cache appears supported but not configured for this request path.")
+
+    return ContextBreakdown(
+        model=model or "unknown",
+        provider=provider or "unknown",
+        context_window=int(context_window or 0),
+        total_estimated_tokens=total,
+        sections=sections,
+        cache=cache,
+        warnings=warnings,
+        suggestions=suggestions,
+        message_count=len(messages),
+        tool_count=len(tools),
+        enabled_toolsets=[str(toolset) for toolset in (enabled_toolsets or [])],
+    )
+
+
+def format_context_breakdown(report: ContextBreakdown) -> str:
+    """Format a breakdown as a compact, content-free text report."""
+    shares = report.section_shares()
+    lines = [
+        "  🧮 Context Composition",
+        f"  {'─' * 40}",
+        f"  Model:                  {report.model}",
+        f"  Provider:               {report.provider}",
+    ]
+    for section in report.sections:
+        share = shares.get(section.name, 0.0) * 100.0
+        label = "item" if section.item_count == 1 else "items"
+        lines.append(
+            f"  {section.name + ':':<24} {section.estimated_tokens:>10,} tokens "
+            f"({share:>4.1f}%, {section.item_count} {label}, {section.cacheability})"
+        )
+    lines.append(f"  Estimated request:      {report.total_estimated_tokens:>10,} tokens")
+    if report.context_window:
+        pct = min(100.0, report.total_estimated_tokens / report.context_window * 100.0)
+        lines.append(f"  Context window:         {report.context_window:>10,} tokens ({pct:.1f}% estimated)")
+    else:
+        lines.append(f"  Context window:         {'unknown':>10}")
+    lines.append(
+        "  Cache:                  "
+        f"{report.cache.status} "
+        f"(stable ~{report.cache.stable_estimated_tokens:,}, volatile ~{report.cache.volatile_estimated_tokens:,})"
+    )
+    if report.enabled_toolsets:
+        lines.append(f"  Enabled toolsets:       {', '.join(report.enabled_toolsets)}")
+    lines.append(f"  Loaded tools:           {report.tool_count:>10,}")
+    if report.warnings:
+        lines.append("  Warnings:")
+        lines.extend(f"    - {warning}" for warning in report.warnings)
+    if report.suggestions:
+        lines.append("  Suggestions:")
+        lines.extend(f"    - {suggestion}" for suggestion in report.suggestions)
+    lines.append("  Note: rough estimate; provider tokenizers and cache accounting differ.")
+    return "\n".join(lines)

--- a/cli.py
+++ b/cli.py
@@ -6922,6 +6922,8 @@ class HermesCLI:
             self._manual_compress(cmd_original)
         elif canonical == "usage":
             self._show_usage()
+        elif canonical == "context":
+            self._show_context_report()
         elif canonical == "insights":
             self._show_insights(cmd_original)
         elif canonical == "copy":
@@ -8100,6 +8102,46 @@ class HermesCLI:
 
         args = SimpleNamespace(lines=200, expire=7, local=False)
         run_debug_share(args)
+
+    def _show_context_report(self):
+        """Show a rough pre-flight breakdown of the active request context."""
+        if not self.agent:
+            print("(._.) No active agent -- send a message first.")
+            return
+
+        from agent.context_observability import build_context_breakdown, format_context_breakdown
+
+        agent = self.agent
+        messages = getattr(self, "conversation_history", []) or []
+        tools = getattr(agent, "tools", None) or []
+        system_prompt = (
+            getattr(agent, "_cached_system_prompt", None)
+            or getattr(agent, "system_prompt", "")
+            or ""
+        )
+        compressor = getattr(agent, "context_compressor", None)
+        ctx_len = getattr(compressor, "context_length", 0) or 0
+        enabled_toolsets = getattr(agent, "enabled_toolsets", None) or getattr(self, "enabled_toolsets", None) or []
+        model = getattr(agent, "model", getattr(self, "model", "unknown"))
+        provider = getattr(agent, "provider", getattr(self, "provider", "unknown"))
+        openrouter_cache_enabled = None
+        try:
+            cfg = globals().get("CLI_CONFIG", {}) or {}
+            openrouter_cache_enabled = bool((cfg.get("openrouter") or {}).get("response_cache"))
+        except Exception:
+            openrouter_cache_enabled = None
+
+        report = build_context_breakdown(
+            messages,
+            tools=tools,
+            system_prompt=system_prompt,
+            model=model,
+            provider=provider,
+            context_window=ctx_len,
+            enabled_toolsets=enabled_toolsets,
+            openrouter_cache_enabled=openrouter_cache_enabled,
+        )
+        print(format_context_breakdown(report))
 
     def _show_usage(self):
         """Show rate limits (if available) and session token usage."""

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -187,6 +187,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("restart", "Gracefully restart the gateway after draining active runs", "Session",
                gateway_only=True),
     CommandDef("usage", "Show token usage and rate limits for the current session", "Info"),
+    CommandDef("context", "Show estimated prompt/context composition for the current session", "Info",
+               cli_only=True),
     CommandDef("insights", "Show usage insights and analytics", "Info",
                args_hint="[days]"),
     CommandDef("platforms", "Show gateway/messaging platform status", "Info",

--- a/tests/agent/test_context_observability.py
+++ b/tests/agent/test_context_observability.py
@@ -1,0 +1,79 @@
+"""Tests for agent/context_observability.py."""
+
+from agent.context_observability import build_context_breakdown, format_context_breakdown
+
+
+def test_breakdown_separates_system_messages_and_tool_schemas():
+    messages = [
+        {"role": "system", "content": "You are Hermes."},
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"},
+        {"role": "tool", "tool_name": "read_file", "content": "large tool result"},
+    ]
+    tools = [
+        {"type": "function", "function": {"name": "read_file", "description": "Read files"}},
+        {"type": "function", "function": {"name": "web_search", "description": "Search web"}},
+    ]
+
+    report = build_context_breakdown(
+        messages,
+        tools=tools,
+        system_prompt="Injected system prefix",
+        model="openai/gpt-5.5",
+        provider="openrouter",
+        context_window=100_000,
+        enabled_toolsets=["file", "web"],
+    )
+
+    section_names = [section.name for section in report.sections]
+    assert section_names == [
+        "system_prompt",
+        "system_messages",
+        "conversation_messages",
+        "tool_results",
+        "tool_schemas",
+    ]
+    assert report.total_estimated_tokens == sum(section.estimated_tokens for section in report.sections)
+    assert report.tool_count == 2
+    assert report.enabled_toolsets == ["file", "web"]
+    assert report.cache.supported is True
+    assert report.cache.configured is False
+    assert report.sections[-1].cacheability == "stable"
+    assert report.sections[-2].cacheability == "volatile"
+
+
+def test_breakdown_warns_when_tool_schemas_dominate():
+    messages = [{"role": "user", "content": "tiny"}]
+    tools = [
+        {
+            "type": "function",
+            "function": {
+                "name": f"tool_{idx}",
+                "description": "x" * 400,
+                "parameters": {"type": "object", "properties": {"value": {"type": "string"}}},
+            },
+        }
+        for idx in range(5)
+    ]
+
+    report = build_context_breakdown(messages, tools=tools)
+
+    assert any("Tool schemas dominate" in warning for warning in report.warnings)
+    assert any("narrower toolsets" in suggestion for suggestion in report.suggestions)
+
+
+def test_format_context_breakdown_outputs_safe_summary_without_raw_content():
+    messages = [
+        {"role": "system", "content": "secret system prompt with sk-test-should-not-print"},
+        {"role": "user", "content": "my password is hunter2"},
+    ]
+    report = build_context_breakdown(messages, tools=[], context_window=1000)
+
+    output = format_context_breakdown(report)
+
+    assert "Context Composition" in output
+    assert "system_messages" in output
+    assert "conversation_messages" in output
+    assert "sk-test-should-not-print" not in output
+    assert "hunter2" not in output
+    assert "Estimated request" in output

--- a/tests/cli/test_context_command.py
+++ b/tests/cli/test_context_command.py
@@ -1,0 +1,91 @@
+"""Tests for the CLI /context command."""
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from cli import HermesCLI
+from hermes_cli.commands import resolve_command
+
+
+def _make_cli():
+    cli_obj = HermesCLI.__new__(HermesCLI)
+    cli_obj.model = "openai/gpt-5.5"
+    cli_obj.provider = "openai"
+    cli_obj.base_url = ""
+    cli_obj.console = MagicMock()
+    cli_obj.agent = None
+    cli_obj.session_start = datetime(2026, 5, 7, 13, 0)
+    cli_obj.conversation_history = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi"},
+    ]
+    return cli_obj
+
+
+def _attach_agent(cli_obj):
+    cli_obj.agent = SimpleNamespace(
+        model=cli_obj.model,
+        provider=cli_obj.provider,
+        base_url=cli_obj.base_url,
+        tools=[
+            {"type": "function", "function": {"name": "search", "description": "web search"}},
+            {"type": "function", "function": {"name": "read_file", "description": "read files"}},
+        ],
+        _cached_system_prompt="system prompt text",
+        system_prompt="fallback system prompt",
+        enabled_toolsets=["web", "file"],
+        context_compressor=SimpleNamespace(
+            last_prompt_tokens=1234,
+            context_length=200000,
+            compression_count=2,
+            threshold_percent=0.5,
+        ),
+    )
+    return cli_obj
+
+
+def test_context_command_is_available_in_cli_registry():
+    cmd = resolve_command("context")
+    assert cmd is not None
+    assert cmd.gateway_only is False
+    assert cmd.cli_only is True
+    assert cmd.category == "Info"
+
+
+def test_process_command_context_dispatches_to_reporter():
+    cli_obj = _make_cli()
+
+    with patch.object(cli_obj, "_show_context_report", create=True) as mock_context:
+        assert cli_obj.process_command("/context") is True
+
+    mock_context.assert_called_once_with()
+
+
+def test_show_context_report_breaks_down_request_buckets(capsys):
+    cli_obj = _attach_agent(_make_cli())
+
+    with patch("agent.model_metadata.estimate_messages_tokens_rough", return_value=50), \
+         patch("agent.model_metadata.estimate_request_tokens_rough", return_value=200):
+        cli_obj._show_context_report()
+
+    output = capsys.readouterr().out
+    assert "Context Composition" in output
+    assert "Provider:" in output
+    assert "system_prompt:" in output
+    assert "conversation_messages:" in output
+    assert "tool_schemas:" in output
+    assert "Estimated request:" in output
+    assert "Context window:" in output
+    assert "Cache:" in output
+    assert "Loaded tools:" in output
+    assert "2" in output
+    assert "web, file" in output
+
+
+def test_show_context_report_handles_missing_agent(capsys):
+    cli_obj = _make_cli()
+
+    cli_obj._show_context_report()
+
+    output = capsys.readouterr().out
+    assert "No active agent" in output

--- a/website/docs/reference/slash-commands.md
+++ b/website/docs/reference/slash-commands.md
@@ -81,6 +81,7 @@ Type `/` in the CLI to open the autocomplete menu. Built-in commands are case-in
 |---------|-------------|
 | `/help` | Show this help message |
 | `/usage` | Show token usage, cost breakdown, session duration, and — when available from the active provider — an **Account limits** section with remaining quota / credits / plan usage pulled live from the provider's API. |
+| `/context` | Show rough prompt/context composition for the active CLI session: system prompt, messages, tool schemas, estimated request size, context window, and compression threshold. |
 | `/insights` | Show usage insights and analytics (last 30 days) |
 | `/platforms` (alias: `/gateway`) | Show gateway/messaging platform status |
 | `/paste` | Attach a clipboard image |


### PR DESCRIPTION
## Summary
- add a safe `/context` CLI report for rough request composition
- break down estimated context by system prompt/messages/tool results/tool schemas without printing raw prompt or message content
- surface rough cacheability, tool-schema share warnings, and enabled toolset counts
- add unit coverage for the read-only context observability helper and CLI command wiring

## Problem
When a Hermes session becomes expensive or approaches compression, users currently have little visibility into whether the request is dominated by conversation history, tool schemas, tool results, or system/context material. Debugging that from raw prompts would be unsafe because it can expose private messages, environment details, and secrets.

## Approach
The report is deliberately content-free: it returns labels, counts, rough token estimates, cacheability categories, and suggestions. It does not include prompt text, message bodies, tool descriptions, env values, or tool outputs.

## Test plan
- `python -m pytest tests/agent/test_context_observability.py tests/cli/test_context_command.py -q -o 'addopts='`
- `git diff --check`
