### PR TITLE
fix(kanban): route unblock_task through parent-dependency gate

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2465,7 +2465,7 @@ def block_task(
 
 
 def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
-    """Transition ``blocked -> ready``.
+    """Transition ``blocked -> ready`` (or ``todo`` when parents not yet done).
 
     Defensively closes any stale ``current_run_id`` pointer before flipping
     status. In the common path (``block_task`` closed the run already) this
@@ -2473,6 +2473,12 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
     the leaked run is closed as ``reclaimed`` inside the same txn so the
     runs invariant (``current_run_id IS NULL`` ⇔ run row in terminal
     state) holds for the rest of this function's lifetime.
+
+    Lands the task in ``ready`` only when every parent (if any) is ``done``;
+    otherwise lands in ``todo`` so ``recompute_ready`` re-evaluates the
+    dependency gate on the next dispatcher tick. Without this check
+    ``unblock_task`` was the only path that could promote a task to
+    ``ready`` while parents were still open (#22375).
     """
     now = int(time.time())
     with write_txn(conn):
@@ -2492,10 +2498,17 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
                 """,
                 (now, int(stale["current_run_id"])),
             )
-        cur = conn.execute(
-            "UPDATE tasks SET status = 'ready', current_run_id = NULL "
-            "WHERE id = ? AND status = 'blocked'",
+        parents = conn.execute(
+            "SELECT t.status FROM tasks t "
+            "JOIN task_links l ON l.parent_id = t.id "
+            "WHERE l.child_id = ?",
             (task_id,),
+        ).fetchall()
+        next_status = "ready" if all(p["status"] == "done" for p in parents) else "todo"
+        cur = conn.execute(
+            "UPDATE tasks SET status = ?, current_run_id = NULL "
+            "WHERE id = ? AND status = 'blocked'",
+            (next_status, task_id),
         )
         if cur.rowcount != 1:
             return False

--- a/tests/hermes_cli/test_kanban_unblock_parent_gate.py
+++ b/tests/hermes_cli/test_kanban_unblock_parent_gate.py
@@ -1,0 +1,110 @@
+"""Regression tests for #22375.
+
+``unblock_task`` was the only path that could land a task in ``ready``
+without consulting the parent-dependency gate that ``recompute_ready``
+enforces.  Steps to reproduce from the bug report:
+
+1. Create parent task A.
+2. Create child task B with ``parents=[A]``; B starts as ``todo``.
+3. Force B into ``blocked`` (skipping the normal ``ready -> running ->
+   blocked`` path).
+4. ``unblock_task(B)`` jumped B to ``ready`` even though A is still
+   ``todo``, and the dispatcher could claim B before A was done.
+
+The fix routes ``unblock_task`` through the same parent-status check
+used by ``recompute_ready``: land in ``ready`` only when every parent is
+``done``, otherwise land in ``todo`` so the next dispatcher tick re-runs
+the gate.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _force_blocked(conn, task_id: str) -> None:
+    """Drop a task into ``blocked`` directly.
+
+    Mirrors the bug-report scenario where a child task ends up ``blocked``
+    while its parent is still ``todo`` — the legitimate API path requires
+    ``ready -> running -> blocked``, which itself implies the parent gate
+    was already cleared, so we bypass it for the regression case.
+    """
+    with kb.write_txn(conn):
+        conn.execute(
+            "UPDATE tasks SET status = 'blocked' WHERE id = ?",
+            (task_id,),
+        )
+
+
+class TestUnblockParentGate:
+    def test_unblock_with_open_parent_lands_in_todo(self, kanban_home):
+        """Bug from #22375: child must NOT jump to ready while parent is open."""
+        with kb.connect() as conn:
+            parent = kb.create_task(conn, title="parent")
+            child = kb.create_task(conn, title="child", parents=[parent])
+            assert kb.get_task(conn, parent).status == "ready"
+            assert kb.get_task(conn, child).status == "todo"
+
+            _force_blocked(conn, child)
+            assert kb.get_task(conn, child).status == "blocked"
+
+            assert kb.unblock_task(conn, child) is True
+            assert kb.get_task(conn, child).status == "todo"
+
+    def test_unblock_with_done_parent_lands_in_ready(self, kanban_home):
+        """All parents done → unblock promotes straight to ready."""
+        with kb.connect() as conn:
+            parent = kb.create_task(conn, title="parent", assignee="a")
+            child = kb.create_task(conn, title="child", parents=[parent])
+            kb.claim_task(conn, parent)
+            kb.complete_task(conn, parent, result="ok")
+            kb.recompute_ready(conn)
+            assert kb.get_task(conn, child).status == "ready"
+
+            _force_blocked(conn, child)
+            assert kb.unblock_task(conn, child) is True
+            assert kb.get_task(conn, child).status == "ready"
+
+    def test_unblock_with_no_parents_lands_in_ready(self, kanban_home):
+        """No-parents case keeps the original behaviour."""
+        with kb.connect() as conn:
+            t = kb.create_task(conn, title="solo", assignee="a")
+            kb.claim_task(conn, t)
+            assert kb.block_task(conn, t, reason="need input")
+            assert kb.unblock_task(conn, t) is True
+            assert kb.get_task(conn, t).status == "ready"
+
+    def test_unblock_with_partially_done_parents_lands_in_todo(self, kanban_home):
+        """Some parents done, others still open → todo (not ready)."""
+        with kb.connect() as conn:
+            p1 = kb.create_task(conn, title="p1", assignee="a")
+            p2 = kb.create_task(conn, title="p2", assignee="b")
+            child = kb.create_task(conn, title="c", parents=[p1, p2])
+            kb.claim_task(conn, p1)
+            kb.complete_task(conn, p1, result="ok")
+            assert kb.get_task(conn, child).status == "todo"
+
+            _force_blocked(conn, child)
+            assert kb.unblock_task(conn, child) is True
+            assert kb.get_task(conn, child).status == "todo"
+
+    def test_unblock_returns_false_when_not_blocked(self, kanban_home):
+        """Original contract preserved: False when row isn't in blocked."""
+        with kb.connect() as conn:
+            t = kb.create_task(conn, title="x")
+            assert kb.unblock_task(conn, t) is False
+            assert kb.get_task(conn, t).status == "ready"


### PR DESCRIPTION
## Summary

Closes #22375.

`unblock_task` jumped `blocked -> ready` unconditionally, bypassing the parent-status check that `recompute_ready` enforces. A child task could land in `ready` while its parent was still `todo`/`ready`, and the dispatcher could then claim and start the child before the parent ever ran. This was the only path in the DB layer that could promote a task to `ready` without consulting the dependency gate.

## Fix

Re-evaluate the gate inside the same `write_txn`: query parent statuses (same `JOIN task_links` query `recompute_ready` uses) and land in `ready` only when every parent is `done`, otherwise land in `todo`. The next dispatcher tick re-runs `recompute_ready` and promotes the row when it is actually unblocked by dependencies.

The no-parents case is preserved by construction — `all([])` is True, so a parent-free task still goes straight to `ready` (the existing `test_block_then_unblock` continues to pass unchanged).

## Test plan

- New `tests/hermes_cli/test_kanban_unblock_parent_gate.py` covers:
  - open parent → `todo`
  - all parents done → `ready`
  - partial parents done → `todo`
  - no parents → `ready`
  - `unblock_task` still returns `False` when row isn't in `blocked`
- Stash-verified: with the fix removed, the two parent-gate tests fail with `assert 'ready' == 'todo'`. With the fix, all 5 pass.
- Wider kanban suite (`test_kanban_db.py`, `test_kanban_specify*.py`, `test_kanban_core_functionality.py`, `test_kanban_tools.py`, `test_kanban_dashboard_plugin.py`): 350 passed, 1 skipped.
- Full `pytest -q`: 110 pre-existing failures (file_read_guards, file_staleness, file_state_registry, gateway_wsl, gateway_service, model_switch_custom_providers, terminal_tool_requirements, tui_gateway_server) — confirmed pre-existing by stashing the fix and re-running the same files (identical 8/8 failures in `test_file_read_guards.py` and `test_gateway_wsl.py`). None touch `kanban_db.py` or are in the dependency graph of this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)