### PR TITLE
fix(discord): honor "*" wildcard in DISCORD_ALLOWED_USERS across auth paths

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -2189,8 +2189,9 @@ class DiscordAdapter(BasePlatformAdapter):
         has_roles = bool(allowed_roles)
         if not has_users and not has_roles:
             return True
-        # Check user ID allowlist (works for both DMs and guild messages)
-        if has_users and user_id in allowed_users:
+        # Check user ID allowlist (works for both DMs and guild messages).
+        # ``*`` means "allow any user" for parity with channel allowlist semantics.
+        if has_users and ("*" in allowed_users or user_id in allowed_users):
             return True
         # Role allowlist is only consulted when configured.
         if not has_roles:
@@ -4455,6 +4456,8 @@ def _component_check_auth(
         return False
 
     if has_users:
+        if "*" in user_set:
+            return True
         try:
             uid = str(user.id)
         except AttributeError:

--- a/tests/gateway/test_discord_component_auth.py
+++ b/tests/gateway/test_discord_component_auth.py
@@ -69,6 +69,11 @@ def test_component_check_user_in_user_allowlist_passes():
     assert _component_check_auth(interaction, {"11111"}, set()) is True
 
 
+def test_component_check_user_wildcard_passes():
+    interaction = _interaction(99999)
+    assert _component_check_auth(interaction, {"*"}, set()) is True
+
+
 def test_component_check_user_not_in_user_allowlist_rejected():
     interaction = _interaction(99999)
     assert _component_check_auth(interaction, {"11111"}, set()) is False

--- a/tests/gateway/test_discord_slash_auth.py
+++ b/tests/gateway/test_discord_slash_auth.py
@@ -207,6 +207,14 @@ async def test_allowed_user_passes(adapter):
 
 
 @pytest.mark.asyncio
+async def test_allowed_user_wildcard_passes(adapter):
+    adapter._allowed_user_ids = {"*"}
+    interaction = _make_interaction("999999999")
+    assert await adapter._check_slash_authorization(interaction, "/background hi") is True
+    interaction.response.send_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_disallowed_user_rejected_with_ephemeral(adapter, caplog):
     adapter._allowed_user_ids = {"100200300"}
     interaction = _make_interaction("999999999")


### PR DESCRIPTION
## Summary
- Add wildcard support for `DISCORD_ALLOWED_USERS` so `*` authorizes any user ID.
- Apply the behavior consistently across message/slash auth (`_is_allowed_user`) and Discord component auth (`_component_check_auth`).
- Keep existing role-based checks and fallback behavior unchanged.

## Why
Issue #22395 reports that wildcard user allowlist entries were not honored consistently, causing authorization behavior to differ across Discord interaction surfaces.

## Changes
- Update `gateway/platforms/discord.py`:
  - `_is_allowed_user`: treat `*` in `_allowed_user_ids` as allow-any.
  - `_component_check_auth`: treat `*` in `allowed_user_ids` as allow-any.
- Add regression tests:
  - `tests/gateway/test_discord_slash_auth.py::test_allowed_user_wildcard_passes`
  - `tests/gateway/test_discord_component_auth.py::test_component_check_user_wildcard_passes`

## Test Plan
- `python -m pytest tests/gateway/test_discord_component_auth.py tests/gateway/test_discord_slash_auth.py -q -n 4`
- Result: `53 passed`