### PR TITLE
chore(release): add leehack to AUTHOR_MAP for PR #22053 salvage

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -910,6 +910,7 @@ AUTHOR_MAP = {
     "wtyopenclaw@gmail.com": "WuTianyi123",  # PR #20275 salvage of #13723 (feishu markdown)
     "zhicheng.han@mathematik.uni-goettingen.de": "hanzckernel",  # PR #20311 (api-server approval events)
     "agentsmithlaor@gmail.com": "oferlaor",  # PR #22356 salvage (cron origin sender identity)
+    "jhin.lee@unity3d.com": "leehack",  # PR #22053 salvage (telegram DM topic reply fallback)
     # pander: empty email, salvaged via PR #19665 from #16126 by @ms-alan
 }
 


### PR DESCRIPTION
Adds `jhin.lee@unity3d.com` → `leehack` so `contributor_audit.py` strict mode passes when the salvage of #22053 (telegram DM topic reply fallback) lands on main.

Prerequisite for the upcoming salvage PR.