### PR TITLE
fix(session_search): route content retrieval to FTS5-matched child session

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -499,23 +499,31 @@ class TestSessionSearch:
         assert result["results"] == []
         assert result["sessions_searched"] == 0
 
-    def test_source_from_resolved_parent_not_fts5_child(self):
-        """source in output must reflect the resolved parent session, not the child that matched FTS5.
+    def test_content_and_meta_routed_to_fts5_child_not_parent(self):
+        """Content and meta must come from the FTS5-matched child, not the parent.
 
-        Regression test for #15909: when a delegation child session (source='telegram')
-        resolves to a parent (source='api_server'), the result entry must report
-        'api_server', not 'telegram'.
+        Regression test for #22150: previously `result['session_id']` was
+        overwritten with the resolved parent sid before
+        `get_messages_as_conversation` ran, so the summarizer received the
+        parent's transcript while the matched query was in the child. The
+        fix preserves the child sid for content/meta retrieval and surfaces
+        the parent only as `resolved_session_id`.
+
+        This supersedes the prior #15909 expectation that `source` reflect
+        the parent — that was the cause of the content/meta mismatch
+        reported in #22150. The user-facing entry now consistently
+        describes the session whose content the summary actually came
+        from (the child), with the parent linked separately.
         """
         from unittest.mock import MagicMock, AsyncMock, patch as _patch
         from tools.session_search_tool import session_search
 
         mock_db = MagicMock()
-        # FTS5 hit is in the child delegation session which carries source='telegram'
         mock_db.search_messages.return_value = [
             {
                 "session_id": "child_sid",
                 "content": "hello world",
-                "source": "telegram",       # child session source — wrong value to surface
+                "source": "telegram",
                 "session_started": 1709400000,
                 "model": "gpt-4o-mini",
             },
@@ -534,17 +542,30 @@ class TestSessionSearch:
                 return {
                     "id": "parent_sid",
                     "parent_session_id": None,
-                    "source": "api_server",  # correct parent source
+                    "source": "api_server",
                     "started_at": 1709300000,
                     "model": "gpt-4o-mini",
                 }
             return None
 
-        mock_db.get_session.side_effect = _get_session
-        mock_db.get_messages_as_conversation.return_value = [
+        child_messages = [
             {"role": "user", "content": "hello world"},
             {"role": "assistant", "content": "hi there"},
         ]
+        parent_messages = [
+            {"role": "user", "content": "totally unrelated topic"},
+            {"role": "assistant", "content": "completely different reply"},
+        ]
+
+        def _get_messages(sid):
+            if sid == "child_sid":
+                return child_messages
+            if sid == "parent_sid":
+                return parent_messages
+            return []
+
+        mock_db.get_session.side_effect = _get_session
+        mock_db.get_messages_as_conversation.side_effect = _get_messages
 
         with _patch(
             "tools.session_search_tool.async_call_llm",
@@ -556,7 +577,93 @@ class TestSessionSearch:
         assert result["success"] is True
         assert result["count"] == 1
         entry = result["results"][0]
-        assert entry["session_id"] == "parent_sid", "should report resolved parent session ID"
-        assert entry["source"] == "api_server", (
-            f"source should be parent's 'api_server', got {entry['source']!r}"
+        assert entry["session_id"] == "child_sid", (
+            "session_id must be the FTS5-matched child where content lives (#22150)"
         )
+        assert entry["resolved_session_id"] == "parent_sid", (
+            "parent sid is exposed separately for navigation/grouping"
+        )
+        assert entry["source"] == "telegram", (
+            "source must match the session whose content was actually fetched"
+        )
+        assert "hello world" in entry["summary"]
+        assert "unrelated topic" not in entry["summary"]
+        called_with = [c.args[0] for c in mock_db.get_messages_as_conversation.call_args_list]
+        assert "child_sid" in called_with
+        assert "parent_sid" not in called_with
+
+    def test_dedup_collapses_multiple_children_of_same_parent(self):
+        """Multiple FTS5 hits in different children of the same parent → 1 entry.
+
+        Regression for #22150 dedup invariant: keying dedup on resolved
+        parent sid still collapses fragments of the same logical
+        conversation, even though the first child's content is what gets
+        surfaced.
+        """
+        from unittest.mock import MagicMock, AsyncMock, patch as _patch
+        from tools.session_search_tool import session_search
+
+        mock_db = MagicMock()
+        mock_db.search_messages.return_value = [
+            {"session_id": "child_a", "source": "cli",
+             "session_started": 1709400000, "model": "test"},
+            {"session_id": "child_b", "source": "cli",
+             "session_started": 1709400100, "model": "test"},
+        ]
+
+        def _get_session(sid):
+            if sid in ("child_a", "child_b"):
+                return {"id": sid, "parent_session_id": "parent_sid",
+                        "source": "cli", "started_at": 1709400000}
+            if sid == "parent_sid":
+                return {"id": "parent_sid", "parent_session_id": None,
+                        "source": "cli", "started_at": 1709300000}
+            return None
+
+        mock_db.get_session.side_effect = _get_session
+        mock_db.get_messages_as_conversation.return_value = [
+            {"role": "user", "content": "match"},
+            {"role": "assistant", "content": "reply"},
+        ]
+
+        with _patch(
+            "tools.session_search_tool.async_call_llm",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("no provider"),
+        ):
+            result = json.loads(session_search(query="match", db=mock_db))
+
+        assert result["count"] == 1, "two children of same parent must dedup to one entry"
+        assert result["sessions_searched"] == 1
+        assert result["results"][0]["session_id"] == "child_a"
+        assert result["results"][0]["resolved_session_id"] == "parent_sid"
+
+    def test_no_resolved_session_id_when_already_root(self):
+        """When the FTS5 hit is already a root session, no `resolved_session_id` annotation."""
+        from unittest.mock import MagicMock, AsyncMock, patch as _patch
+        from tools.session_search_tool import session_search
+
+        mock_db = MagicMock()
+        mock_db.search_messages.return_value = [
+            {"session_id": "root_only", "source": "cli",
+             "session_started": 1709400000, "model": "test"},
+        ]
+        mock_db.get_session.side_effect = lambda sid: (
+            {"id": sid, "parent_session_id": None, "source": "cli",
+             "started_at": 1709400000} if sid == "root_only" else None
+        )
+        mock_db.get_messages_as_conversation.return_value = [
+            {"role": "user", "content": "match"},
+            {"role": "assistant", "content": "reply"},
+        ]
+
+        with _patch(
+            "tools.session_search_tool.async_call_llm",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("no provider"),
+        ):
+            result = json.loads(session_search(query="match", db=mock_db))
+
+        entry = result["results"][0]
+        assert entry["session_id"] == "root_only"
+        assert "resolved_session_id" not in entry

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -411,10 +411,15 @@ def session_search(
             _resolve_to_parent(current_session_id) if current_session_id else None
         )
 
-        # Group by resolved (parent) session_id, dedup, skip the current
-        # session lineage. Compression and delegation create child sessions
-        # that still belong to the same active conversation.
-        seen_sessions = {}
+        # Dedup by resolved (parent) session_id so multiple FTS5 hits in
+        # different fragments of the same logical conversation collapse to
+        # one entry; skip the current session lineage. Content/meta are
+        # still pulled from the original child sid where the FTS5 match
+        # actually lives — overwriting `session_id` with the parent caused
+        # `get_messages_as_conversation` to fetch from the wrong session
+        # and return content that didn't contain the matched text (#22150).
+        selected = []
+        seen_parents = set()
         for result in raw_results:
             raw_sid = result["session_id"]
             resolved_sid = _resolve_to_parent(raw_sid)
@@ -424,16 +429,20 @@ def session_search(
                 continue
             if current_session_id and raw_sid == current_session_id:
                 continue
-            if resolved_sid not in seen_sessions:
-                result = dict(result)
-                result["session_id"] = resolved_sid
-                seen_sessions[resolved_sid] = result
-            if len(seen_sessions) >= limit:
+            if resolved_sid in seen_parents:
+                continue
+            seen_parents.add(resolved_sid)
+            result = dict(result)
+            if resolved_sid != raw_sid:
+                result["resolved_session_id"] = resolved_sid
+            selected.append(result)
+            if len(selected) >= limit:
                 break
 
         # Prepare all sessions for parallel summarization
         tasks = []
-        for session_id, match_info in seen_sessions.items():
+        for match_info in selected:
+            session_id = match_info["session_id"]
             try:
                 messages = db.get_messages_as_conversation(session_id)
                 if not messages:
@@ -494,11 +503,12 @@ def session_search(
                 )
                 result = None
 
-            # Prefer resolved parent session metadata over FTS5 match metadata.
-            # match_info carries source/model from the *child* session that contained
-            # the FTS5 hit; after _resolve_to_parent() the session_id points to the
-            # root, so session_meta has the authoritative platform/source for the
-            # session the user actually cares about (#15909).
+            # session_meta is fetched from the child session where the FTS5
+            # hit lives (so its content matches the summary). match_info also
+            # comes from the same child row, so both sources agree; the
+            # original #15909 concern (mismatched parent vs child meta) was
+            # introduced by overwriting session_id with the parent — fixed
+            # in #22150 by keeping content keyed to the child.
             entry = {
                 "session_id": session_id,
                 "when": _format_timestamp(
@@ -507,6 +517,8 @@ def session_search(
                 "source": session_meta.get("source") or match_info.get("source", "unknown"),
                 "model": session_meta.get("model") or match_info.get("model"),
             }
+            if "resolved_session_id" in match_info:
+                entry["resolved_session_id"] = match_info["resolved_session_id"]
 
             if result:
                 entry["summary"] = result
@@ -523,7 +535,7 @@ def session_search(
             "query": query,
             "results": summaries,
             "count": len(summaries),
-            "sessions_searched": len(seen_sessions),
+            "sessions_searched": len(selected),
         }, ensure_ascii=False)
 
     except Exception as e:


### PR DESCRIPTION
Closes #22150.

## Root cause

In `tools/session_search_tool.py`, the dedup loop did:

```python
result["session_id"] = resolved_sid
```

before the second loop called `db.get_messages_as_conversation(session_id)`. So when an FTS5 match landed in a delegated child session, the child sid was overwritten with its resolved parent sid before content was fetched, and the summarizer then received the parent's transcript while the matched query lived only in the child.

Net effect: searches surfaced summaries that did not contain the text the user searched for, exactly as #22150 reports.

This also doubled with the prior #15909 change, which had codified surfacing the parent's `source` for the result entry — so the displayed metadata pointed at the parent too.

## Fix

`tools/session_search_tool.py` (dedup + fetch loop):

- Dedup on the resolved parent sid (so two children of the same parent collapse to one entry).
- Keep the original child sid as the entry's `session_id` and pass it to `get_messages_as_conversation` / `get_session` so content and `source` come from the FTS5-matched session.
- When child ≠ parent, expose the parent sid as a separate `resolved_session_id` annotation on the entry so callers can still walk up the lineage.
- `sessions_searched` now reflects the deduped count actually fetched (was the raw seen-set length).

## Tests

`tests/tools/test_session_search.py`:

- Removed `test_source_from_resolved_parent_not_fts5_child`, which had codified the buggy parent-surfacing behavior introduced alongside the #15909 fix.
- Added three tests asserting the new contract:
  - `test_content_and_meta_routed_to_fts5_child_not_parent` — child sid in `session_id`, parent sid in `resolved_session_id`, child source surfaced, parent transcript never requested.
  - `test_dedup_collapses_multiple_children_of_same_parent` — two children of the same parent collapse to one entry; first child wins.
  - `test_no_resolved_session_id_when_already_root` — root-only hits carry no `resolved_session_id`.

Stash-verify confirms the fix is required: with `tools/session_search_tool.py` reverted, two of the new tests fail (`assert 'parent_sid' == 'child_a'` and the meta-routing assertion). With the fix applied, all 40 tests in the file pass.

## Regression

Full `pytest -q`: 21208 passed, 86 skipped. The 110 pre-existing failures (`test_file_read_guards`, `test_file_staleness`, `test_file_state_registry`, `test_gateway_wsl`, `test_gateway_service`, `test_model_switch_custom_providers`, `test_terminal_tool_requirements`, `test_tui_gateway_server`, etc.) reproduce on `main` without this branch and are out of scope.