### PR TITLE
fix(telegram): fail fast when user images cannot be accessed

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -3221,7 +3221,10 @@ class TelegramAdapter(BasePlatformAdapter):
                 # Save to local cache (for vision tool access)
                 cached_path = cache_image_from_bytes(bytes(image_bytes), ext=ext)
                 event.media_urls = [cached_path]
-                event.media_types = [f"image/{ext.lstrip('.')}" ]
+                # Normalize MIME: "image/jpg" → "image/jpeg" (standard MIME)
+                raw_ext = ext.lstrip('.')
+                mime_ext = "jpeg" if raw_ext == "jpg" else raw_ext
+                event.media_types = [f"image/{mime_ext}"]
                 logger.info("[Telegram] Cached user photo at %s", cached_path)
                 media_group_id = getattr(msg, "media_group_id", None)
                 if media_group_id:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -690,6 +690,10 @@ def _build_media_placeholder(event) -> str:
     dequeued, only .text is extracted.  If the event has no caption,
     the media would be silently lost.  This builds a placeholder that
     the vision enrichment pipeline will replace with a real description.
+
+    Returns a plain-text fallback so the agent never receives an empty
+    user message — empty input causes the agent to stall, retry, or
+    hallucinate for 30+ minutes (issue #22385).
     """
     parts = []
     media_urls = getattr(event, "media_urls", None) or []
@@ -702,7 +706,12 @@ def _build_media_placeholder(event) -> str:
             parts.append(f"[User sent audio: {url}]")
         else:
             parts.append(f"[User sent a file: {url}]")
-    return "\n".join(parts)
+    if parts:
+        return "\n".join(parts)
+    # Safeguard: if there's nothing to placehold (no media_urls at all),
+    # return a neutral fallback so the agent doesn't receive empty input.
+    return "[User sent a message with media that couldn't be accessed]"
+
 
 
 def _dequeue_pending_event(adapter, session_key: str) -> MessageEvent | None:
@@ -12171,6 +12180,7 @@ class GatewayRunner:
         )
 
         enriched_parts = []
+        all_failed = True
         for path in image_paths:
             try:
                 logger.debug("Auto-analyzing user image: %s", path)
@@ -12182,6 +12192,7 @@ class GatewayRunner:
                 if result.get("success"):
                     description = result.get("analysis", "")
                     description = sanitize_context(description)
+                    all_failed = False
                     enriched_parts.append(
                         f"[The user sent an image~ Here's what I can see:\n{description}]\n"
                         f"[If you need a closer look, use vision_analyze with "
@@ -12203,6 +12214,15 @@ class GatewayRunner:
 
         # Combine: vision descriptions first, then the user's original text
         if enriched_parts:
+            # If ALL images failed to analyze AND the user didn't
+            # provide a caption, give a clear fail-fast message
+            # so the agent doesn't keep retrying for 30+ minutes.
+            if all_failed and not user_text.strip():
+                return (
+                    "[The user sent an image but I'm unable to see it — "
+                    "the vision analysis is not available right now. "
+                    "Ask the user to describe what the image contains.]"
+                )
             prefix = "\n\n".join(enriched_parts)
             if user_text:
                 return f"{prefix}\n\n{user_text}"

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -910,6 +910,7 @@ AUTHOR_MAP = {
     "wtyopenclaw@gmail.com": "WuTianyi123",  # PR #20275 salvage of #13723 (feishu markdown)
     "zhicheng.han@mathematik.uni-goettingen.de": "hanzckernel",  # PR #20311 (api-server approval events)
     "agentsmithlaor@gmail.com": "oferlaor",  # PR #22356 salvage (cron origin sender identity)
+    "257965685+HiddenPuppy@users.noreply.github.com": "HiddenPuppy",  # PR #22413 (telegram image fail-fast)
     # pander: empty email, salvaged via PR #19665 from #16126 by @ms-alan
 }
 


### PR DESCRIPTION
## Summary

When a user sends an image via Telegram and the vision analysis pipeline fails (e.g. no Gemini key configured, transient API error), the agent previously received either an empty user message or a hint telling it to retry with `vision_analyze`. This caused the agent to spend 30+ minutes in futile retry loops (issue #22385).

## Root Cause

Two gaps conspired to create the loop:
1. If the Telegram gateway cached a photo successfully but the `_enrich_message_with_vision` pipeline subsequently failed for **all** images, the agent received the user's caption text (or an empty string if there was no caption), plus a hint telling it to try `vision_analyze` — which would fail again with the same reason, causing another retry.
2. If a pending/queued event had no `media_urls` at all, `_build_media_placeholder` returned an empty string, giving the agent nothing to work with.

## Changes

| File | Change |
|------|--------|
| `gateway/platforms/telegram.py` | Normalize MIME type `image/jpg` → `image/jpeg` to use standard MIME types |
| `gateway/run.py` — `_enrich_message_with_vision` | Track `all_failed` across all images. When ALL analyses fail AND the user provided no caption, return a clear fail-fast message (`[The user sent an image but I'm unable to see it...]`) instead of prompting the agent to retry |
| `gateway/run.py` — `_build_media_placeholder` | Return a neutral fallback string instead of empty string when there are no media URLs at all |

## Testing

- `pytest tests/gateway/` — 751 passed, 1 skipped, 1 pre-existing failure (unrelated DingTalk test)

Fixes #22385