### PR TITLE
fix: always send tenant headers in OpenViking _headers() when account/user are set

### DIFF
--- a/plugins/memory/openviking/__init__.py
+++ b/plugins/memory/openviking/__init__.py
@@ -100,18 +100,19 @@ class _VikingClient:
             raise ImportError("httpx is required for OpenViking: pip install httpx")
 
     def _headers(self) -> dict:
-        # Only send tenant headers when the user actually configured them.
-        # Legacy installs had account/user defaulted to the literal string
-        # "default" — treat that as unset so authenticated remote servers
-        # that derive tenancy from the Bearer key aren't overridden by a
-        # bogus tenant value.
+        # Always send tenant headers when account/user are configured.
+        # OpenViking 0.3.x requires X-OpenViking-Account and X-OpenViking-User
+        # for ROOT API key requests to tenant-scoped APIs — omitting them
+        # causes INVALID_ARGUMENT errors even when account="default".
+        # User-level keys can omit them (server derives tenancy from the key),
+        # but ROOT keys must always include them explicitly.
         h = {
             "Content-Type": "application/json",
             "X-OpenViking-Agent": self._agent,
         }
-        if self._account and self._account != "default":
+        if self._account:
             h["X-OpenViking-Account"] = self._account
-        if self._user and self._user != "default":
+        if self._user:
             h["X-OpenViking-User"] = self._user
         if self._api_key:
             h["X-API-Key"] = self._api_key

--- a/tests/plugins/memory/test_openviking_provider.py
+++ b/tests/plugins/memory/test_openviking_provider.py
@@ -314,10 +314,11 @@ def test_viking_client_headers_include_bearer_when_api_key_set():
     assert headers["Authorization"] == "Bearer test-key"
 
 
-def test_viking_client_headers_omit_tenant_when_legacy_default():
-    # Existing installs have account/user set to the literal string "default".
-    # Those should NOT be sent as headers — the server would interpret that
-    # as a real tenant override and reject/misroute requests.
+def test_viking_client_headers_send_tenant_when_default():
+    # account/user set to the literal string "default". OpenViking 0.3.x
+    # requires X-OpenViking-Account and X-OpenViking-User for ROOT API key
+    # requests to tenant-scoped APIs — omitting them causes
+    # INVALID_ARGUMENT errors even when account="default".
     client = _VikingClient(
         "https://example.com",
         api_key="test-key",
@@ -326,13 +327,15 @@ def test_viking_client_headers_omit_tenant_when_legacy_default():
         agent="hermes",
     )
     headers = client._headers()
-    assert "X-OpenViking-Account" not in headers
-    assert "X-OpenViking-User" not in headers
+    assert headers["X-OpenViking-Account"] == "default"
+    assert headers["X-OpenViking-User"] == "default"
     assert headers["X-OpenViking-Agent"] == "hermes"
     assert headers["Authorization"] == "Bearer test-key"
 
 
-def test_viking_client_headers_omit_tenant_when_empty():
+def test_viking_client_headers_send_tenant_when_empty_falls_back_to_default():
+    # Empty account/user strings fall back to "default" via the constructor.
+    # Headers are sent even for the default value — ROOT API keys need them.
     client = _VikingClient(
         "https://example.com",
         api_key="",
@@ -341,8 +344,8 @@ def test_viking_client_headers_omit_tenant_when_empty():
         agent="hermes",
     )
     headers = client._headers()
-    assert "X-OpenViking-Account" not in headers
-    assert "X-OpenViking-User" not in headers
+    assert headers["X-OpenViking-Account"] == "default"
+    assert headers["X-OpenViking-User"] == "default"
     assert "Authorization" not in headers
     assert "X-API-Key" not in headers
 


### PR DESCRIPTION
## Salvage of #21775 (happy5318) — with test fixes

Original PR removed the `!= "default"` guard from `_headers()` so ROOT API keys can send tenant headers even when account/user are "default". OpenViking 0.3.x requires these headers for tenant-scoped APIs.

### Changes vs original

| Item | Status |
|------|--------|
| Production fix (remove `!= "default"` guard) | ✅ Cherry-picked as-is |
| `test_omit_tenant_when_legacy_default` → `test_headers_send_tenant_when_default` | ✅ Renamed, assertions flipped to `== "default"` |
| `test_omit_tenant_when_empty` → `test_headers_send_tenant_when_empty_falls_back_to_default` | ✅ Renamed, assertions flipped to `== "default"` |
| Author in AUTHOR_MAP | Already present ✅ |

### Test results

```
20 passed in tests/plugins/memory/test_openviking_provider.py
```

Based on #21775 by @happy5318 (NouseResearch/hermes-agent#21775)