### PR TITLE
feat(plugins): show onboarding metadata after install

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -14,6 +14,7 @@ import importlib.metadata
 import json
 import logging
 import os
+import re
 import shutil
 import subprocess
 import sys
@@ -418,6 +419,134 @@ def _display_after_install(plugin_dir: Path, identifier: str) -> None:
         console.print()
 
 
+_ONBOARDING_PLACEHOLDER_RE = re.compile(r"\{(plugin_dir|plugin_name)\}")
+
+
+def _format_onboarding_command(command: str, plugin_dir: Path) -> str:
+    """Expand supported convenience placeholders in an onboarding command."""
+    replacements = {
+        "plugin_dir": str(plugin_dir),
+        "plugin_name": plugin_dir.name,
+    }
+    return _ONBOARDING_PLACEHOLDER_RE.sub(
+        lambda match: replacements[match.group(1)],
+        command,
+    )
+
+
+def _escape_onboarding_controls(value: str) -> str:
+    """Render terminal and Unicode format controls as visible escape sequences."""
+    import unicodedata
+
+    escaped: list[str] = []
+    for char in value:
+        if unicodedata.category(char) not in {"Cc", "Cf", "Cs"}:
+            escaped.append(char)
+            continue
+
+        codepoint = ord(char)
+        if codepoint <= 0xFF:
+            escaped.append(f"\\x{codepoint:02x}")
+        elif codepoint <= 0xFFFF:
+            escaped.append(f"\\u{codepoint:04x}")
+        else:
+            escaped.append(f"\\U{codepoint:08x}")
+    return "".join(escaped)
+
+
+def _normalize_onboarding_text(value: Any) -> str | None:
+    """Validate plugin text, escape controls, and discard plain whitespace."""
+    if not isinstance(value, str):
+        return None
+    normalized = _escape_onboarding_controls(value)
+    return normalized if normalized.strip() else None
+
+
+def _normalize_recommended_env(value: Any) -> list[tuple[str, str | None, str | None]]:
+    """Return well-formed, terminal-safe environment-variable metadata."""
+    if not isinstance(value, list):
+        return []
+
+    normalized: list[tuple[str, str | None, str | None]] = []
+    for item in value:
+        if isinstance(item, str):
+            name = _normalize_onboarding_text(item)
+            if name:
+                normalized.append((name, None, None))
+            continue
+        if not isinstance(item, dict):
+            continue
+
+        raw_name = item.get("name")
+        raw_description = item.get("description")
+        raw_url = item.get("url")
+        if not isinstance(raw_name, str):
+            continue
+        if raw_description is not None and not isinstance(raw_description, str):
+            continue
+        if raw_url is not None and not isinstance(raw_url, str):
+            continue
+
+        name = _normalize_onboarding_text(raw_name)
+        if not name:
+            continue
+        description = _normalize_onboarding_text(raw_description)
+        url = _normalize_onboarding_text(raw_url)
+        normalized.append((name, description, url))
+
+    return normalized
+
+
+def _display_onboarding(manifest: dict, plugin_dir: Path, console) -> None:
+    """Display manifest-declared onboarding steps without executing them."""
+    onboarding = manifest.get("onboarding") or {}
+    if not isinstance(onboarding, dict):
+        return
+
+    setup_command = _normalize_onboarding_text(onboarding.get("setup_command"))
+    status_command = _normalize_onboarding_text(onboarding.get("status_command"))
+    note = _normalize_onboarding_text(onboarding.get("note"))
+    recommended_env = _normalize_recommended_env(onboarding.get("recommended_env"))
+
+    if not any([setup_command, status_command, recommended_env, note]):
+        return
+
+    from rich.panel import Panel
+    from rich.text import Text
+
+    lines: list[str] = []
+    if note:
+        lines.extend([note, ""])
+    if setup_command:
+        lines.append("Next setup command:")
+        formatted_setup = _format_onboarding_command(setup_command, plugin_dir)
+        lines.append(f"  {_escape_onboarding_controls(formatted_setup)}")
+    if status_command:
+        if lines:
+            lines.append("")
+        lines.append("Check setup status:")
+        formatted_status = _format_onboarding_command(status_command, plugin_dir)
+        lines.append(f"  {_escape_onboarding_controls(formatted_status)}")
+    if recommended_env:
+        if lines:
+            lines.append("")
+        lines.append("Recommended environment variables:")
+        for name, description, url in recommended_env:
+            description_text = f" — {description}" if description else ""
+            url_text = f" ({url})" if url else ""
+            lines.append(f"  - {name}{description_text}{url_text}")
+
+    console.print(
+        Panel(
+            Text("\n".join(lines)),
+            title="Plugin onboarding",
+            border_style="cyan",
+            expand=False,
+        )
+    )
+    console.print()
+
+
 def _display_removed(name: str, plugins_dir: Path) -> None:
     """Show confirmation after removing a plugin."""
     from rich.console import Console
@@ -598,6 +727,7 @@ def cmd_install(
     _prompt_plugin_env_vars(installed_manifest, console)
 
     _display_after_install(target, identifier)
+    _display_onboarding(installed_manifest, target, console)
 
     should_enable = enable
     if should_enable is None:

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -391,11 +391,305 @@ class TestReadManifest:
         assert result == {}
 
 
+# ── plugin onboarding ─────────────────────────────────────────────────────────
+
+
+class TestPluginOnboarding:
+    def test_format_onboarding_command_expands_placeholders(self, tmp_path):
+        from hermes_cli import plugins_cmd
+
+        plugin_dir = tmp_path / "my-plugin"
+
+        assert plugins_cmd._format_onboarding_command(
+            "python {plugin_dir}/setup.py setup --name {plugin_name}",
+            plugin_dir,
+        ) == f"python {plugin_dir}/setup.py setup --name my-plugin"
+
+    def test_format_onboarding_command_does_not_reexpand_replacement_text(self, tmp_path):
+        from hermes_cli import plugins_cmd
+
+        plugin_dir = tmp_path / "{plugin_name}" / "actual-plugin"
+
+        assert plugins_cmd._format_onboarding_command(
+            "cd {plugin_dir} && echo {plugin_name}",
+            plugin_dir,
+        ) == f"cd {plugin_dir} && echo actual-plugin"
+
+    def test_display_onboarding_prints_declared_steps(self, tmp_path):
+        from rich.console import Console
+
+        from hermes_cli import plugins_cmd
+
+        plugin_dir = tmp_path / "web-search-plus"
+        manifest = {
+            "name": "web-search-plus",
+            "onboarding": {
+                "setup_command": "python {plugin_dir}/setup.py setup",
+                "status_command": "python {plugin_dir}/setup.py status",
+                "note": "At least one provider key is required.",
+                "recommended_env": [
+                    {
+                        "name": "TAVILY_API_KEY",
+                        "description": "Tavily search",
+                        "url": "https://tavily.com",
+                    },
+                    "BRAVE_API_KEY",
+                ],
+            },
+        }
+        console = Console(record=True, force_terminal=False, width=120)
+
+        plugins_cmd._display_onboarding(manifest, plugin_dir, console)
+
+        out = console.export_text()
+        assert "Plugin onboarding" in out
+        assert f"python {plugin_dir}/setup.py setup" in out
+        assert f"python {plugin_dir}/setup.py status" in out
+        assert "TAVILY_API_KEY" in out
+        assert "BRAVE_API_KEY" in out
+
+    def test_display_onboarding_ignores_scalar_recommended_env(self, tmp_path):
+        from rich.console import Console
+
+        from hermes_cli import plugins_cmd
+
+        console = Console(record=True, force_terminal=False)
+
+        plugins_cmd._display_onboarding(
+            {"onboarding": {"recommended_env": "FOO_API_KEY"}},
+            tmp_path / "plugin",
+            console,
+        )
+
+        assert console.export_text() == ""
+
+    def test_display_onboarding_renders_markup_like_values_literally(self, tmp_path):
+        from rich.console import Console
+
+        from hermes_cli import plugins_cmd
+
+        console = Console(record=True, force_terminal=False, width=160)
+        plugins_cmd._display_onboarding(
+            {
+                "onboarding": {
+                    "note": "[/]",
+                    "setup_command": "[link=https://evil.example]safe-command[/link]",
+                }
+            },
+            tmp_path / "plugin",
+            console,
+        )
+
+        out = console.export_text()
+        assert "[/]" in out
+        assert "[link=https://evil.example]safe-command[/link]" in out
+
+    def test_display_onboarding_filters_malformed_field_types(self, tmp_path):
+        from rich.console import Console
+
+        from hermes_cli import plugins_cmd
+
+        console = Console(record=True, force_terminal=False, width=160)
+        plugins_cmd._display_onboarding(
+            {
+                "onboarding": {
+                    "note": ["not text"],
+                    "setup_command": {"command": "not a string"},
+                    "status_command": 123,
+                    "recommended_env": [
+                        "PLAIN_API_KEY",
+                        {"name": 456},
+                        {"name": "BAD_DESCRIPTION", "description": ["not text"]},
+                        {"name": "BAD_URL", "url": 789},
+                        {
+                            "name": "VALID_API_KEY",
+                            "description": "Valid provider",
+                            "url": "https://example.com/keys",
+                        },
+                    ],
+                }
+            },
+            tmp_path / "plugin",
+            console,
+        )
+
+        out = console.export_text()
+        assert "PLAIN_API_KEY" in out
+        assert "VALID_API_KEY" in out
+        assert "BAD_DESCRIPTION" not in out
+        assert "BAD_URL" not in out
+        assert "456" not in out
+        assert "not a string" not in out
+        assert "123" not in out
+
+    def test_display_onboarding_skips_all_invalid_recommendations(self, tmp_path):
+        from rich.console import Console
+
+        from hermes_cli import plugins_cmd
+
+        console = Console(record=True, force_terminal=False)
+        plugins_cmd._display_onboarding(
+            {
+                "onboarding": {
+                    "recommended_env": [
+                        {"name": 123},
+                        {"description": "missing name"},
+                        ["not a mapping"],
+                    ]
+                }
+            },
+            tmp_path / "plugin",
+            console,
+        )
+
+        assert console.export_text() == ""
+
+    def test_display_onboarding_escapes_terminal_control_characters(self, tmp_path):
+        from rich.console import Console
+
+        from hermes_cli import plugins_cmd
+
+        console = Console(record=True, force_terminal=False, width=240)
+        plugins_cmd._display_onboarding(
+            {
+                "onboarding": {
+                    "note": "\x1b[2Jclear attempt",
+                    "setup_command": (
+                        "\x1b]8;;https://evil.example\x07linked command\x1b]8;;\x07"
+                    ),
+                    "recommended_env": [
+                        {
+                            "name": "SAFE\x9b2J_API_KEY",
+                            "description": "before\rafter",
+                        }
+                    ],
+                }
+            },
+            tmp_path / "plugin",
+            console,
+        )
+
+        out = console.export_text()
+        assert "\\x1b[2Jclear attempt" in out
+        assert "\\x1b]8;;https://evil.example\\x07linked command" in out
+        assert "SAFE\\x9b2J_API_KEY" in out
+        assert "before\\x0dafter" in out
+        assert "\x1b" not in out
+        assert "\x07" not in out
+        assert "\x9b" not in out
+        assert "\r" not in out
+
+    def test_display_onboarding_renders_lf_tab_only_metadata_as_visible_escapes(
+        self, tmp_path
+    ):
+        from rich.console import Console
+
+        from hermes_cli import plugins_cmd
+
+        console = Console(record=True, force_terminal=False)
+        plugins_cmd._display_onboarding(
+            {"onboarding": {"note": "\n\t"}},
+            tmp_path / "plugin",
+            console,
+        )
+
+        out = console.export_text()
+        assert "Plugin onboarding" in out
+        assert "\\x0a\\x09" in out
+
+    def test_display_onboarding_suppresses_plain_whitespace_only_metadata(self, tmp_path):
+        from rich.console import Console
+
+        from hermes_cli import plugins_cmd
+
+        console = Console(record=True, force_terminal=False)
+        plugins_cmd._display_onboarding(
+            {
+                "onboarding": {
+                    "note": "   ",
+                    "setup_command": " ",
+                    "status_command": "   ",
+                    "recommended_env": ["   ", {"name": "  "}],
+                }
+            },
+            tmp_path / "plugin",
+            console,
+        )
+
+        assert console.export_text() == ""
+
+    @patch("hermes_cli.plugins_cmd.subprocess.run")
+    def test_display_onboarding_never_executes_declared_commands(self, mock_run, tmp_path):
+        from rich.console import Console
+
+        from hermes_cli import plugins_cmd
+
+        console = Console(record=True, force_terminal=False)
+        plugins_cmd._display_onboarding(
+            {"onboarding": {"setup_command": "touch /tmp/must-not-run"}},
+            tmp_path / "plugin",
+            console,
+        )
+
+        mock_run.assert_not_called()
+
+
 # ── cmd_install tests ─────────────────────────────────────────────────────────
 
 
 class TestCmdInstall:
     """Test the install command."""
+
+    def test_install_forwards_installed_manifest_to_onboarding(self, tmp_path, monkeypatch):
+        from hermes_cli import plugins_cmd
+
+        target = tmp_path / "example-plugin"
+        target.mkdir()
+        (target / "plugin.yaml").write_text("name: example-plugin\n", encoding="utf-8")
+        manifest = {
+            "name": "example-plugin",
+            "onboarding": {"setup_command": "python {plugin_dir}/setup.py setup"},
+        }
+        display_events: list[str] = []
+        prompt_env = MagicMock()
+        display_after_install = MagicMock(
+            side_effect=lambda *_args: display_events.append("after-install")
+        )
+        display_onboarding = MagicMock(
+            side_effect=lambda *_args: display_events.append("onboarding")
+        )
+
+        monkeypatch.setattr(
+            plugins_cmd,
+            "_resolve_git_url",
+            lambda _identifier: ("https://github.com/owner/repo.git", None),
+        )
+        monkeypatch.setattr(
+            plugins_cmd,
+            "_install_plugin_core",
+            lambda _identifier, force=False: (target, manifest, "example-plugin"),
+        )
+        monkeypatch.setattr(plugins_cmd, "_prompt_plugin_env_vars", prompt_env)
+        monkeypatch.setattr(
+            plugins_cmd,
+            "_display_after_install",
+            display_after_install,
+        )
+        monkeypatch.setattr(
+            plugins_cmd,
+            "_display_onboarding",
+            display_onboarding,
+            raising=False,
+        )
+
+        plugins_cmd.cmd_install("owner/repo", enable=False)
+
+        display_onboarding.assert_called_once()
+        args = display_onboarding.call_args.args
+        assert args[0] is manifest
+        assert args[1] == target
+        assert args[2] is prompt_env.call_args.args[1]
+        assert display_events == ["after-install", "onboarding"]
 
     def test_install_requires_identifier(self):
         from hermes_cli.plugins_cmd import cmd_install

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -165,6 +165,29 @@ hermes plugins disable <name>     # remove from allow-list + add to disabled
 
 After `hermes plugins install owner/repo`, you're asked `Enable 'name' now? [y/N]` — defaults to no. Skip the prompt for scripted installs with `--enable` or `--no-enable`.
 
+### Manifest-declared onboarding
+
+A plugin can declare structured follow-up guidance in `plugin.yaml`. Hermes displays these fields after installation but **never executes plugin-provided commands automatically**:
+
+```yaml
+onboarding:
+  note: "Configure at least one provider before enabling this plugin."
+  setup_command: "python {plugin_dir}/setup.py setup"
+  status_command: "python {plugin_dir}/setup.py status"
+  recommended_env:
+    - PROVIDER_API_KEY
+    - name: OPTIONAL_API_KEY
+      description: "Enables the optional provider"
+      url: "https://example.com/keys"
+```
+
+`note`, `setup_command`, and `status_command` must be strings. `setup_command` and `status_command` support two display-only substitutions:
+
+- `{plugin_dir}` — the installed plugin directory
+- `{plugin_name}` — the installed directory name
+
+All onboarding values are rendered literally; Rich markup in plugin metadata is not interpreted, terminal or Unicode formatting controls are shown as visible escape sequences, and plain whitespace-only fields are ignored. `recommended_env` must be a YAML list. Entries can be variable-name strings or mappings with a string `name` plus optional string `description` and `url` fields. Malformed fields and entries are ignored. Unlike `requires_env`, these recommendations are informational: the installer does not prompt for or save them.
+
 ### What the allow-list does NOT gate
 
 Several categories of plugin bypass `plugins.enabled` — they're part of Hermes' built-in surface and would break basic functionality if gated off by default:


### PR DESCRIPTION
## Summary
- display structured `plugin.yaml` onboarding metadata after `hermes plugins install`
- support setup/status commands, notes, recommended environment variables, and `{plugin_dir}` / `{plugin_name}` placeholders
- keep install-time behavior safe: onboarding commands are displayed, never executed
- validate malformed onboarding fields and normalize `recommended_env` entries before rendering
- expand placeholders in one pass so replacement text cannot be reinterpreted
- sanitize each plugin-controlled field before composing trusted panel layout; surface terminal/Unicode controls as visible escape sequences
- ignore plain whitespace-only onboarding fields
- document the public onboarding manifest contract

## Why
Plugins can already declare richer setup information, but the installer only prompts for `requires_env` and then falls back to generic install text or `after-install.md`. This gives plugins a structured, manifest-driven way to tell users exactly what to run next without requiring plugin-specific installer logic.

## Tests
- `scripts/run_tests.sh tests/hermes_cli/test_plugins_cmd.py` → 111 passed
- broader `tests/hermes_cli/` slice → 8,612 passed; 3 root-environment failures reproduced unchanged on `main`
- `ruff check .`
- `python -m py_compile hermes_cli/plugins_cmd.py tests/hermes_cli/test_plugins_cmd.py`
- temporary Git-plugin install smoke verified Rich-like, ANSI, Unicode, LF, and TAB metadata renders literally with no raw control bytes while the declared setup command remains unexecuted
- `git diff --check`

## Risk
Low. The new path only renders normalized optional manifest metadata after a successful install. Existing install, environment prompting, and enable/disable behavior remain unchanged.
