### PR TITLE
fix(scripts): unset HERMES_CRON_SESSION and use uv for pytest-split install

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -44,7 +44,13 @@ PYTHON="$VENV/bin/python"
 # ── Ensure pytest-split is installed (required for shard-equivalent runs) ──
 if ! "$PYTHON" -c "import pytest_split" 2>/dev/null; then
   echo "→ installing pytest-split into $VENV"
-  "$PYTHON" -m pip install --quiet "pytest-split>=0.9,<1"
+  # Try uv first (works in uv-managed venvs that lack pip), fall back to pip.
+  if command -v uv >/dev/null 2>&1; then
+    uv pip install --quiet --python "$PYTHON" "pytest-split>=0.9,<1" 2>/dev/null \
+      || "$PYTHON" -m pip install --quiet "pytest-split>=0.9,<1"
+  else
+    "$PYTHON" -m pip install --quiet "pytest-split>=0.9,<1"
+  fi
 fi
 
 # ── Hermetic environment ────────────────────────────────────────────────────
@@ -70,7 +76,7 @@ unset HERMES_YOLO_MODE HERMES_INTERACTIVE HERMES_QUIET HERMES_TOOL_PROGRESS \
       HERMES_PLATFORM HERMES_INFERENCE_PROVIDER HERMES_MANAGED HERMES_DEV \
       HERMES_CONTAINER HERMES_EPHEMERAL_SYSTEM_PROMPT HERMES_TIMEZONE \
       HERMES_REDACT_SECRETS HERMES_BACKGROUND_NOTIFICATIONS HERMES_EXEC_ASK \
-      HERMES_HOME_MODE 2>/dev/null || true
+      HERMES_HOME_MODE HERMES_CRON_SESSION 2>/dev/null || true
 
 # Pin deterministic runtime.
 export TZ=UTC

--- a/tests/test_run_tests_wrapper.py
+++ b/tests/test_run_tests_wrapper.py
@@ -1,0 +1,120 @@
+"""Regression tests for scripts/run_tests.sh env-scrubbing logic.
+
+Covers:
+  - #22400: HERMES_CRON_SESSION must be unset so cron-invoked test runs
+    don't leak into pytest approval behavior.
+  - #22401: pytest-split installation must fall back to ``uv pip install``
+    when pip is unavailable (uv-managed venvs).
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RUN_TESTS = REPO_ROOT / "scripts" / "run_tests.sh"
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _extract_unset_block(script: str) -> str:
+    """Return the ``unset HERMES_* …`` continuation line (may span lines)."""
+    lines = script.splitlines()
+    collecting = False
+    buf: list[str] = []
+    for line in lines:
+        if line.startswith("unset HERMES_"):
+            collecting = True
+        if collecting:
+            buf.append(line)
+            if "2>/dev/null" in line:
+                break
+    return "\n".join(buf)
+
+
+def _extract_pytest_split_block(script: str) -> str:
+    """Return the pytest-split installation block."""
+    lines = script.splitlines()
+    collecting = False
+    buf: list[str] = []
+    for line in lines:
+        if "pytest-split" in line and "install" in line.lower():
+            collecting = True
+        if collecting:
+            buf.append(line)
+            if line.strip() == "fi" and len(buf) > 2:
+                break
+    return "\n".join(buf)
+
+
+# ── tests ────────────────────────────────────────────────────────────────────
+
+
+class TestEnvScrub:
+    """The env-scrub section must unset every HERMES_* behavioral var."""
+
+    SCRIPT_TEXT: str = RUN_TESTS.read_text()
+
+    def test_hermes_cron_session_in_unset_list(self):
+        """#22400 — HERMES_CRON_SESSION must appear in the unset block."""
+        block = _extract_unset_block(self.SCRIPT_TEXT)
+        assert "HERMES_CRON_SESSION" in block, (
+            "HERMES_CRON_SESSION is missing from the unset block in "
+            "scripts/run_tests.sh — cron-invoked test runs will leak "
+            "HERMES_CRON_SESSION=1 into pytest, changing approval behavior."
+        )
+
+    def test_hermes_cron_session_not_in_env_after_scrub(self):
+        """#22400 — Running the script with HERMES_CRON_SESSION=1 must drop it.
+
+        We simulate the env-scrub section in a subshell and verify the var
+        is absent afterward.  This avoids actually running pytest.
+        """
+        snippet = textwrap.dedent("""\
+            set -euo pipefail
+            # Reproduce the unset block from run_tests.sh
+            unset HERMES_YOLO_MODE HERMES_INTERACTIVE HERMES_QUIET HERMES_TOOL_PROGRESS \\
+                  HERMES_TOOL_PROGRESS_MODE HERMES_MAX_ITERATIONS HERMES_SESSION_PLATFORM \\
+                  HERMES_SESSION_CHAT_ID HERMES_SESSION_CHAT_NAME HERMES_SESSION_THREAD_ID \\
+                  HERMES_SESSION_SOURCE HERMES_SESSION_KEY HERMES_GATEWAY_SESSION \\
+                  HERMES_PLATFORM HERMES_INFERENCE_PROVIDER HERMES_MANAGED HERMES_DEV \\
+                  HERMES_CONTAINER HERMES_EPHEMERAL_SYSTEM_PROMPT HERMES_TIMEZONE \\
+                  HERMES_REDACT_SECRETS HERMES_BACKGROUND_NOTIFICATIONS HERMES_EXEC_ASK \\
+                  HERMES_HOME_MODE HERMES_CRON_SESSION 2>/dev/null || true
+            echo "CRON_SESSION=${HERMES_CRON_SESSION:-<UNSET>}"
+        """)
+        result = subprocess.run(
+            ["bash", "-c", snippet],
+            capture_output=True, text=True,
+            env={**os.environ, "HERMES_CRON_SESSION": "1"},
+        )
+        assert result.returncode == 0, result.stderr
+        assert "CRON_SESSION=<UNSET>" in result.stdout, (
+            f"HERMES_CRON_SESSION leaked through the unset block: {result.stdout}"
+        )
+
+
+class TestPytestSplitInstall:
+    """The pytest-split install block must try uv before pip."""
+
+    SCRIPT_TEXT: str = RUN_TESTS.read_text()
+
+    def test_uv_fallback_present(self):
+        """#22401 — The install block must attempt ``uv pip install`` first."""
+        block = _extract_pytest_split_block(self.SCRIPT_TEXT)
+        assert "uv pip install" in block, (
+            "scripts/run_tests.sh does not try 'uv pip install' — "
+            "uv-managed venvs without pip will fail to install pytest-split."
+        )
+
+    def test_pip_fallback_present(self):
+        """The install block must still fall back to ``python -m pip``."""
+        block = _extract_pytest_split_block(self.SCRIPT_TEXT)
+        assert "pip install" in block, (
+            "scripts/run_tests.sh dropped the pip fallback — "
+            "systems without uv will fail to install pytest-split."
+        )


### PR DESCRIPTION
## What does this PR do?

Two fixes in `scripts/run_tests.sh`:

1. **Add `HERMES_CRON_SESSION` to the env-scrub unset block** so cron-invoked test runs do not leak `HERMES_CRON_SESSION=1` into pytest, which changes approval behavior from the normal non-interactive auto-approve path to cron-deny behavior.

2. **Try `uv pip install` before `python -m pip`** when `pytest-split` is missing, so `uv`-managed venvs without `pip` can still run the canonical test runner without failing at the install step.


### Root Cause

**#22400**: The env-scrub section in `run_tests.sh` explicitly unsets `HERMES_*` behavioral vars, but `HERMES_CRON_SESSION` was omitted. When the test runner is invoked from a scheduled Hermes cron job, this variable leaks into pytest and changes approval behavior, causing otherwise-passing approval tests to fail.

**#22401**: `pytest-split` is not declared in `pyproject.toml` dev dependencies. The script tries to auto-install it via `python -m pip`, but `uv`-managed venvs created without pip have no `pip` module, causing the script to exit before running any tests.

## Related Issue

Fixes #22400

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A