### PR TITLE
fix(send_message): map Telegram General topic id to None for forum groups

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -742,6 +742,64 @@ class TestSendTelegramHtmlDetection:
         sleep_mock.assert_awaited_once()
 
 
+class TestSendTelegramThreadIdMapping:
+    """General-topic mapping in _send_telegram (issue #22267).
+
+    Telegram forum supergroups address the General topic as
+    ``message_thread_id="1"`` on incoming updates, but the Bot API rejects
+    sends with ``message_thread_id=1`` ("Message thread not found"). The
+    gateway adapter's ``_message_thread_id_for_send`` helper maps "1" to
+    ``None`` for that reason; the standalone ``_send_telegram`` helper used
+    by the ``send_message`` tool needs the same mapping.
+    """
+
+    def _make_bot(self):
+        bot = MagicMock()
+        bot.send_message = AsyncMock(return_value=SimpleNamespace(message_id=1))
+        return bot
+
+    def test_general_topic_thread_id_omitted(self, monkeypatch):
+        """thread_id="1" must be dropped before calling the Bot API."""
+        bot = self._make_bot()
+        _install_telegram_mock(monkeypatch, bot)
+
+        asyncio.run(_send_telegram("tok", "-1001234567890", "hello", thread_id="1"))
+
+        bot.send_message.assert_awaited_once()
+        kwargs = bot.send_message.await_args.kwargs
+        assert "message_thread_id" not in kwargs
+
+    def test_non_general_topic_thread_id_preserved(self, monkeypatch):
+        """Real forum-topic thread ids (>1) still pass through as ints."""
+        bot = self._make_bot()
+        _install_telegram_mock(monkeypatch, bot)
+
+        asyncio.run(_send_telegram("tok", "-1001234567890", "hello", thread_id="17585"))
+
+        kwargs = bot.send_message.await_args.kwargs
+        assert kwargs["message_thread_id"] == 17585
+
+    def test_no_thread_id_no_kwarg(self, monkeypatch):
+        """With no thread_id, message_thread_id must not appear in kwargs."""
+        bot = self._make_bot()
+        _install_telegram_mock(monkeypatch, bot)
+
+        asyncio.run(_send_telegram("tok", "-1001234567890", "hello"))
+
+        kwargs = bot.send_message.await_args.kwargs
+        assert "message_thread_id" not in kwargs
+
+    def test_general_topic_thread_id_int_input_also_dropped(self, monkeypatch):
+        """thread_id passed as the int 1 (not str) must still be dropped."""
+        bot = self._make_bot()
+        _install_telegram_mock(monkeypatch, bot)
+
+        asyncio.run(_send_telegram("tok", "-1001234567890", "hello", thread_id=1))
+
+        kwargs = bot.send_message.await_args.kwargs
+        assert "message_thread_id" not in kwargs
+
+
 # ---------------------------------------------------------------------------
 # Tests for Discord thread_id support
 # ---------------------------------------------------------------------------

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -710,7 +710,27 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
         media_files = media_files or []
         thread_kwargs = {}
         if thread_id is not None:
-            thread_kwargs["message_thread_id"] = int(thread_id)
+            # Reuse the gateway adapter's General-topic mapping: in Telegram
+            # forum supergroups, the General topic is addressed as
+            # message_thread_id="1" on incoming updates, but Bot API
+            # sendMessage rejects message_thread_id=1 with "Message thread
+            # not found". The adapter's helper maps "1" to None for that
+            # reason; the send_message tool needs the same mapping or a
+            # send to a forum group's General topic always errors out
+            # (see issue #22267).
+            try:
+                from gateway.platforms.telegram import TelegramAdapter
+                effective_thread_id = TelegramAdapter._message_thread_id_for_send(
+                    str(thread_id)
+                )
+            except Exception:
+                # Fallback: explicit mapping in case the adapter import
+                # fails (e.g. python-telegram-bot missing in this venv).
+                effective_thread_id = (
+                    None if str(thread_id) == "1" else int(thread_id)
+                )
+            if effective_thread_id is not None:
+                thread_kwargs["message_thread_id"] = effective_thread_id
         if disable_link_previews:
             thread_kwargs["disable_web_page_preview"] = True
 


### PR DESCRIPTION
## Summary

Fixes #22267 — `send_message` tool fails on Topics-enabled Telegram groups with "Message thread not found" when targeting the General topic.

## Root cause

Telegram forum supergroups address the General topic as `message_thread_id="1"` on incoming updates, but the Bot API rejects sends with `message_thread_id=1` (`"Bad Request: Message thread not found"`). The gateway adapter has had a `_message_thread_id_for_send` helper that maps `"1"` to `None` for this reason, but the standalone `_send_telegram` helper in `tools/send_message_tool.py` (used by the agent-facing `send_message` tool) never got the same mapping.

So any `send_message` call to a forum group's General topic — i.e. target shape `telegram:<chat_id>:1` — failed with the error from the issue.

## Fix

Reuse the gateway adapter's `_message_thread_id_for_send` classmethod from inside `_send_telegram`. Since the adapter is also imported a few lines above for `format_message`, a fresh import here is essentially free. Includes an explicit fallback that does the same `"1" → None` mapping inline, in case the adapter import fails (e.g. python-telegram-bot missing in this venv during a stripped-down install).

## Verification

```text
$ scripts/run_tests.sh tests/tools/test_send_message_tool.py
99 passed in 3.98s
```

Includes 4 new regression tests in `TestSendTelegramThreadIdMapping`:

- `test_general_topic_thread_id_omitted` — `thread_id="1"` → no `message_thread_id` kwarg
- `test_non_general_topic_thread_id_preserved` — real topic ids (e.g. 17585) still pass through
- `test_no_thread_id_no_kwarg` — no thread_id stays absent
- `test_general_topic_thread_id_int_input_also_dropped` — `thread_id=1` (int) handled too

E2E test in an isolated env confirms both the primary path (via adapter helper) and the fallback path (explicit `"1"` check when adapter import fails) work correctly:

```text
thread_id="1" (General): message_thread_id absent ✓
thread_id="17585": message_thread_id=17585 ✓
no thread_id: message_thread_id absent ✓
```

Lint diff: 0 new ruff issues.

## Closes / supersedes

- Fixes #22267 — Telegram Send Failed: "Message thread not found" when sending to Topics-enabled groups

## Related (already fixed, closing with credit)

The same General-topic mapping was incidentally fixed for the gateway adapter's `send_model_picker` path by #22410 (salvage of #22053). These five PRs were all targeting the same `_message_thread_id_for_send` mapping in `send_model_picker` and are now redundant; will close with credit pointing here:

- #12873 by @ztexydt-cqh
- #18612 by @chiyema
- #19961 by @baenregod
- #21542 by @echo-mydevbot
- #22383 by @Matthieu-C

This PR completes the fix for the parallel code path (the `send_message` tool's standalone `_send_telegram` helper), which #22410 didn't touch.
