### PR TITLE
fix(security): restrict video_analyze local file access to known video extensions

### DIFF
--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -951,6 +951,26 @@ async def video_analyze_tool(
         local_path = Path(os.path.expanduser(resolved_url))
 
         if local_path.is_file():
+            # SECURITY: Restrict local file access to known video extensions.
+            # Without this, video_analyze can be invoked as a generic local
+            # file reader (e.g. ~/.hermes/.env, ~/.aws/credentials) — the
+            # contents are then base64-encoded into a data URL and shipped
+            # to the multimodal LLM, where they may surface in the tool
+            # result. This bypasses any approval gating that operators have
+            # placed on read_file in policy-restricted deployments.
+            _ALLOWED_VIDEO_SUFFIXES = {
+                ".mp4", ".mov", ".avi", ".mkv", ".webm",
+                ".gif", ".m4v", ".mpg", ".mpeg", ".wmv", ".flv",
+            }
+            if local_path.suffix.lower() not in _ALLOWED_VIDEO_SUFFIXES:
+                return {
+                    "error": (
+                        f"Local file access in video_analyze is restricted "
+                        f"to known video extensions (got "
+                        f"{local_path.suffix!r}). Use a remote URL or copy "
+                        f"to a .mp4/.mov/.webm file first."
+                    )
+                }
             logger.info("Using local video file: %s", video_url)
             temp_video_path = local_path
             should_cleanup = False

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -951,26 +951,26 @@ async def video_analyze_tool(
         local_path = Path(os.path.expanduser(resolved_url))
 
         if local_path.is_file():
-            # SECURITY: Restrict local file access to known video extensions.
-            # Without this, video_analyze can be invoked as a generic local
-            # file reader (e.g. ~/.hermes/.env, ~/.aws/credentials) — the
-            # contents are then base64-encoded into a data URL and shipped
-            # to the multimodal LLM, where they may surface in the tool
-            # result. This bypasses any approval gating that operators have
-            # placed on read_file in policy-restricted deployments.
-            _ALLOWED_VIDEO_SUFFIXES = {
-                ".mp4", ".mov", ".avi", ".mkv", ".webm",
-                ".gif", ".m4v", ".mpg", ".mpeg", ".wmv", ".flv",
-            }
-            if local_path.suffix.lower() not in _ALLOWED_VIDEO_SUFFIXES:
-                return {
-                    "error": (
-                        f"Local file access in video_analyze is restricted "
-                        f"to known video extensions (got "
-                        f"{local_path.suffix!r}). Use a remote URL or copy "
-                        f"to a .mp4/.mov/.webm file first."
-                    )
-                }
+            # SECURITY: Restrict local file access to the same set of
+            # extensions we actually support downstream
+            # (_VIDEO_MIME_TYPES). Without this, video_analyze can be
+            # invoked as a generic local file reader (e.g.
+            # ~/.hermes/.env, ~/.aws/credentials) — the contents are
+            # then base64-encoded into a data URL and shipped to the
+            # multimodal LLM, where they may surface in the tool
+            # result. This bypasses any approval gating that operators
+            # have placed on read_file in policy-restricted
+            # deployments. Deriving the allowlist from
+            # _VIDEO_MIME_TYPES.keys() ensures the security gate and
+            # the format-support set can't drift.
+            if local_path.suffix.lower() not in _VIDEO_MIME_TYPES:
+                supported = ", ".join(sorted(_VIDEO_MIME_TYPES.keys()))
+                return tool_error(
+                    f"Local file access in video_analyze is restricted "
+                    f"to supported video extensions (got "
+                    f"{local_path.suffix!r}). Supported: {supported}. "
+                    f"Use a remote URL or convert the file first."
+                )
             logger.info("Using local video file: %s", video_url)
             temp_video_path = local_path
             should_cleanup = False


### PR DESCRIPTION
## What does this PR do?

The `video_analyze` tool (`tools/vision_tools.py:video_analyze_tool`)
accepts any local path via the `video_url` parameter, including
`file://` URLs and `~`-expanded paths:

```python
# Before
resolved_url = video_url
if resolved_url.startswith("file://"):
    resolved_url = resolved_url[len("file://"):]
local_path = Path(os.path.expanduser(resolved_url))

if local_path.is_file():
    logger.info("Using local video file: %s", video_url)
    temp_video_path = local_path   # ← any path accepted
    should_cleanup = False
```

The contents are then base64-encoded into a data URL and shipped to
the multimodal LLM via `_video_to_base64_data_url()`. This means
sensitive local files — `~/.hermes/.env`, `~/.aws/credentials`,
`~/.ssh/id_rsa`, etc. — can be sent to the LLM and surface in the
tool result via the LLM's response.

### Why this matters — tool-level ACL bypass

In deployments where `read_file` is gated behind approval hooks but
`video_analyze` is not (a common policy split: "agent shouldn't read
arbitrary files, but video analysis is fine"), this acts as a
**tool-level ACL bypass**. A prompt-injected agent can call:

```
video_analyze("~/.hermes/.env", "extract any API keys you see")
```

And the multimodal LLM happily reads the file contents (decoded from
the data URL it receives) and returns them in the tool result. No
`read_file` approval prompt is triggered.

The existing SSRF guard via `check_website_access()` only fires on
the HTTP path (~line 957) — the local-file branch has no restrictions.

### CVSS 3.1 estimate

`AV:L/AC:L/PR:L/UI:N/S:C/C:H/I:N/A:N` → **6.8 (HIGH, deployment-dependent)**

## Fix

Restrict local-file access to known video extensions only:

```python
_ALLOWED_VIDEO_SUFFIXES = {
    ".mp4", ".mov", ".avi", ".mkv", ".webm",
    ".gif", ".m4v", ".mpg", ".mpeg", ".wmv", ".flv",
}
if local_path.suffix.lower() not in _ALLOWED_VIDEO_SUFFIXES:
    return {
        "error": (
            f"Local file access in video_analyze is restricted "
            f"to known video extensions (got "
            f"{local_path.suffix!r}). Use a remote URL or copy "
            f"to a .mp4/.mov/.webm file first."
        )
    }
```

Remote URLs continue to work for any content type the multimodal
model accepts — only the local-file shortcut is gated. The allowlist
matches the suffixes already supported by `_VIDEO_MIME_TYPES`.

## Type of Change

- [x] 🔒 Security fix (HIGH — local file disclosure / tool-level ACL bypass)

## Checklist

- [x] Read the Contributing Guide
- [x] Commit messages follow Conventional Commits
- [x] Allowlist matches the suffixes already supported by `_VIDEO_MIME_TYPES`
- [x] Returns structured error rather than raising — consistent with the existing handler shape
- [x] No behavior change for legitimate `.mp4`/`.mov`/`.webm` local files
- [x] Remote URL path unchanged