### PR TITLE
fix(send_message): make Discord/Slack adapter imports optional in shared dispatcher

### DIFF
--- a/tests/tools/test_send_message_optional_adapter_imports.py
+++ b/tests/tools/test_send_message_optional_adapter_imports.py
@@ -1,0 +1,109 @@
+"""#22153: missing optional deps for one platform must not abort sending
+to an unrelated platform.
+
+The shared dispatcher `_send_to_platform` historically imported
+`gateway.platforms.discord` and `gateway.platforms.slack` unconditionally
+at function entry, so a missing optional dependency for either of those
+platforms would raise ImportError before the QQ branch could run.
+"""
+
+import asyncio
+import sys
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture
+def force_missing_discord_slack(monkeypatch):
+    """Make `from gateway.platforms.{discord,slack} import ...` raise ImportError.
+
+    Setting a module entry to None is the documented Python trick that turns
+    a subsequent `from x import y` into ImportError, simulating a missing
+    optional dependency without uninstalling anything.
+    """
+    monkeypatch.setitem(sys.modules, "gateway.platforms.discord", None)
+    monkeypatch.setitem(sys.modules, "gateway.platforms.slack", None)
+
+
+def test_send_to_platform_qq_survives_missing_discord_and_slack(force_missing_discord_slack):
+    from gateway.config import Platform
+    from tools.send_message_tool import _send_to_platform
+
+    pconfig = SimpleNamespace(token="secret", extra={"app_id": "1001"})
+
+    async def _fake_qqbot(_pconfig, _chat_id, _message):
+        return {
+            "success": True,
+            "platform": "qqbot",
+            "chat_id": _chat_id,
+            "message_id": "m-1",
+        }
+
+    with patch("tools.send_message_tool._send_qqbot", side_effect=_fake_qqbot):
+        result = asyncio.run(
+            _send_to_platform(
+                platform=Platform.QQBOT,
+                pconfig=pconfig,
+                chat_id="user42",
+                message="hello",
+            )
+        )
+
+    assert result == {
+        "success": True,
+        "platform": "qqbot",
+        "chat_id": "user42",
+        "message_id": "m-1",
+    }
+
+
+def test_send_to_platform_signal_survives_missing_discord_and_slack(force_missing_discord_slack):
+    """Signal text path also goes through the dispatcher loop."""
+    from gateway.config import Platform
+    from tools.send_message_tool import _send_to_platform
+
+    pconfig = SimpleNamespace(token="", extra={"signal_url": "http://localhost:8080"})
+
+    async def _fake_signal(_extra, _chat_id, _msg, **_kw):
+        return {"success": True, "platform": "signal", "chat_id": _chat_id, "message_id": "ts-1"}
+
+    with patch("tools.send_message_tool._send_signal", side_effect=_fake_signal):
+        result = asyncio.run(
+            _send_to_platform(
+                platform=Platform.SIGNAL,
+                pconfig=pconfig,
+                chat_id="+15551234567",
+                message="hi",
+            )
+        )
+
+    assert result["success"] is True
+    assert result["platform"] == "signal"
+
+
+def test_send_to_platform_slack_chunk_limit_falls_back_when_slack_unavailable(force_missing_discord_slack):
+    """When the Slack adapter import fails, the dispatcher must still know a
+    safe MAX_MESSAGE_LENGTH for SLACK (used purely for chunking) instead of
+    crashing on `SlackAdapter.MAX_MESSAGE_LENGTH`."""
+    from gateway.config import Platform
+    from tools.send_message_tool import _send_to_platform
+
+    pconfig = SimpleNamespace(token="xoxb-fake", extra={})
+
+    async def _fake_slack(_token, _chat_id, _msg, **_kw):
+        return {"success": True, "platform": "slack", "chat_id": _chat_id, "message_id": "S1"}
+
+    with patch("tools.send_message_tool._send_slack", side_effect=_fake_slack):
+        result = asyncio.run(
+            _send_to_platform(
+                platform=Platform.SLACK,
+                pconfig=pconfig,
+                chat_id="C123",
+                message="hello slack",
+            )
+        )
+
+    assert isinstance(result, dict)
+    assert result.get("success") is True

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -453,8 +453,20 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     """
     from gateway.config import Platform
     from gateway.platforms.base import BasePlatformAdapter, utf16_len
-    from gateway.platforms.discord import DiscordAdapter
-    from gateway.platforms.slack import SlackAdapter
+
+    # All adapter imports are optional: a missing optional dependency for one
+    # platform must not abort sending to an unrelated platform (#22153).
+    try:
+        from gateway.platforms.discord import DiscordAdapter
+        _discord_available = True
+    except ImportError:
+        _discord_available = False
+
+    try:
+        from gateway.platforms.slack import SlackAdapter
+        _slack_available = True
+    except ImportError:
+        _slack_available = False
 
     # Telegram adapter import is optional (requires python-telegram-bot)
     try:
@@ -472,18 +484,20 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
 
     media_files = media_files or []
 
-    if platform == Platform.SLACK and message:
+    if platform == Platform.SLACK and message and _slack_available:
         try:
             slack_adapter = SlackAdapter.__new__(SlackAdapter)
             message = slack_adapter.format_message(message)
         except Exception:
             logger.debug("Failed to apply Slack mrkdwn formatting in _send_to_platform", exc_info=True)
 
-    # Platform message length limits (from adapter class attributes)
+    # Platform message length limits (from adapter class attributes).
+    # Defaults match each adapter's MAX_MESSAGE_LENGTH so an unrelated
+    # missing adapter does not skew chunking for the requested platform.
     _MAX_LENGTHS = {
         Platform.TELEGRAM: TelegramAdapter.MAX_MESSAGE_LENGTH if _telegram_available else 4096,
-        Platform.DISCORD: DiscordAdapter.MAX_MESSAGE_LENGTH,
-        Platform.SLACK: SlackAdapter.MAX_MESSAGE_LENGTH,
+        Platform.DISCORD: DiscordAdapter.MAX_MESSAGE_LENGTH if _discord_available else 2000,
+        Platform.SLACK: SlackAdapter.MAX_MESSAGE_LENGTH if _slack_available else 39000,
     }
     if _feishu_available:
         _MAX_LENGTHS[Platform.FEISHU] = FeishuAdapter.MAX_MESSAGE_LENGTH


### PR DESCRIPTION
## What does this PR do?

Closes #22153.

## Root cause

`tools/send_message_tool.py::_send_to_platform` imported
`gateway.platforms.discord` and `gateway.platforms.slack` unconditionally at function entry:

```python
from gateway.platforms.discord import DiscordAdapter
from gateway.platforms.slack import SlackAdapter
```

Telegram and Feishu adapter imports right below were already guarded with try/except for exactly this reason (their optional deps may be absent), but Discord and Slack were not. So when Hermes ran outside the main venv — or with `discord.py` / `slack-sdk` not installed — sending to QQ (or any other platform) failed because the dispatcher raised `ImportError` before reaching the platform-specific branch.

## Fix

Wrap both imports in try/except guarded by `_discord_available` / `_slack_available` flags. The Slack pre-format step is skipped when the Slack adapter is unavailable, and the chunking length table falls back to each adapter's documented `MAX_MESSAGE_LENGTH` (2000 for Discord, 39000 for Slack) so chunking still works for the requested platform when an unrelated adapter is missing.

Tiny, mirrors the existing Telegram/Feishu pattern — no API changes.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

Closes #22153.

<details>
<summary>Original body</summary>

## Summary

Closes #22153.

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

Closes #22153.

## Root cause

`tools/send_message_tool.py::_send_to_platform` imported
`gateway.platforms.discord` and `gateway.platforms.slack` unconditionally at function entry:

```python
from gateway.platforms.discord import DiscordAdapter
from gateway.platforms.slack import SlackAdapter
```

Telegram and Feishu adapter imports right below were already guarded with try/except for exactly this reason (their optional deps may be absent), but Discord and Slack were not. So when Hermes ran outside the main venv — or with `discord.py` / `slack-sdk` not installed — sending to QQ (or any other platform) failed because the dispatcher raised `ImportError` before reaching the platform-specific branch.

## Fix

Wrap both imports in try/except guarded by `_discord_available` / `_slack_available` flags. The Slack pre-format step is skipped when the Slack adapter is unavailable, and the chunking length table falls back to each adapter's documented `MAX_MESSAGE_LENGTH` (2000 for Discord, 39000 for Slack) so chunking still works for the requested platform when an unrelated adapter is missing.

Tiny, mirrors the existing Telegram/Feishu pattern — no API changes.

## Tests

Adds `tests/tools/test_send_message_optional_adapter_imports.py` with three regression tests covering the QQ, Signal, and Slack send paths under simulated ImportError for `gateway.platforms.{discord,slack}` (via `monkeypatch.setitem(sys.modules, ..., None)`).

Stash-verified the fix is required: all 3 tests fail without it with
`ModuleNotFoundError: import of gateway.platforms.discord halted; None in sys.modules`. With the fix applied, all 3 pass.

## Regression

Full `pytest -q`: 21230 passed, 86 skipped. Diff against `origin/main` baseline: +3 new tests pass; the only extra failure (`test_reset_failed_also_runs_before_retry_restart` in `tests/hermes_cli/test_update_gateway_restart.py`) passes when run in isolation — flaky under xdist, unrelated to this change. The 114 pre-existing failures (`test_file_read_guards`, `test_file_staleness`, `test_file_state_registry`, `test_gateway_wsl`, `test_gateway_service`, `test_discord_*`, `test_anthropic_adapter`, etc.) reproduce on `origin/main` without this branch and are out of scope.

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

Closes #22153.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_