### PR TITLE
fix(acp): resolve custom providers when set_session_model receives provider:model prefix

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -594,6 +594,26 @@ class HermesACPAgent(acp.Agent):
             from hermes_cli.models import detect_provider_for_model, parse_model_input
 
             target_provider, new_model = parse_model_input(new_model, current_provider)
+
+            # parse_model_input only recognises built-in providers (openrouter,
+            # anthropic, etc.).  Custom providers declared under ``providers:``
+            # in config.yaml (e.g. BitFun) are invisible to it.  When the
+            # resolved model still contains a colon we check whether the
+            # left-hand side matches a user-declared custom provider.
+            if ":" in new_model:
+                colon = new_model.find(":")
+                candidate_prov = new_model[:colon].strip()
+                if candidate_prov:
+                    from hermes_cli.config import load_config
+
+                    providers = load_config().get("providers") or {}
+                    if isinstance(providers, dict):
+                        for key in providers:
+                            if key.lower() == candidate_prov.lower():
+                                target_provider = key
+                                new_model = new_model[colon + 1:].strip()
+                                break
+
             if target_provider == current_provider:
                 detected = detect_provider_for_model(new_model, current_provider)
                 if detected:


### PR DESCRIPTION
## Problem

ACP clients (Multica, Zed, etc.) call `set_session_model` with provider-prefixed model strings like `BitFun:deepseek-v4-pro`.  The `parse_model_input()` helper only recognises built-in providers (openrouter, anthropic, etc.) — custom providers declared under `providers:` in config.yaml are invisible to it.  The entire string becomes the model name, causing `AIAgent` construction to fail with:

```
RuntimeError: No LLM provider configured
```

## Fix

Add a fallback in `_resolve_model_selection` that detects unresolved `ProviderName:model-id` strings by checking `config.yaml`'s `providers` section for a matching key.  When found, the prefix is stripped and the correct provider is used.

## Test Plan

- [x] 60 existing ACP tests pass
- [x] Manual repro confirms `set_session_model('BitFun:deepseek-v4-pro')` succeeds
  - agent.base_url → `https://api.openbitfun.com/v1` ✅
  - agent.model → `deepseek-v4-pro` ✅
  - No RuntimeError ✅

## Related

This affects any ACP client that uses `providers:` entries rather than the legacy `custom_providers:` config keys.