### PR TITLE
fix(run_agent): notify context engine on commit_memory_session (#22394)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5066,13 +5066,26 @@ class AIAgent:
         """Trigger end-of-session extraction without tearing providers down.
         Called when session_id rotates (e.g. /new, context compression);
         providers keep their state and continue running under the old
-        session_id — they just flush pending extraction now."""
+        session_id — they just flush pending extraction now.
+
+        Also notifies the context engine of the session end so plugin
+        engines like LCM can flush the final turns and finalize the
+        old session in their lifecycle store before the rotation
+        completes (#22394). Mirrors ``shutdown_memory_provider``."""
         if not self._memory_manager:
             return
         try:
             self._memory_manager.on_session_end(messages or [])
         except Exception:
             pass
+        if hasattr(self, "context_compressor") and self.context_compressor:
+            try:
+                self.context_compressor.on_session_end(
+                    self.session_id or "",
+                    messages or [],
+                )
+            except Exception:
+                pass
 
     def _sync_external_memory_for_turn(
         self,

--- a/tests/run_agent/test_commit_memory_session.py
+++ b/tests/run_agent/test_commit_memory_session.py
@@ -1,0 +1,114 @@
+"""Regression tests for AIAgent.commit_memory_session() (#22394).
+
+The function is called when the session_id rotates without tearing
+providers down (CLI ``/new``, gateway session expiry, in-process
+compression). Both the memory manager AND the context engine must
+receive ``on_session_end`` so plugin engines like LCM persist their
+final turns and finalize the rotating session.
+"""
+
+from run_agent import AIAgent
+
+
+class _Compressor:
+    def __init__(self):
+        self.session_end_calls = []
+
+    def on_session_end(self, session_id, messages):
+        self.session_end_calls.append((session_id, list(messages or [])))
+
+
+class _Manager:
+    def __init__(self):
+        self.session_end_calls = []
+
+    def on_session_end(self, messages):
+        self.session_end_calls.append(list(messages or []))
+
+
+def _agent(memory_manager=None, context_compressor=None, session_id="sess-1"):
+    a = AIAgent.__new__(AIAgent)
+    a._memory_manager = memory_manager
+    a.context_compressor = context_compressor
+    a.session_id = session_id
+    return a
+
+
+def test_commit_memory_session_notifies_context_compressor():
+    """Primary regression: with both manager and compressor configured,
+    ``commit_memory_session`` must fan out to both. Before the fix the
+    compressor never saw session-end on /new, gateway expiry, or
+    compression-driven rotation."""
+    mgr = _Manager()
+    comp = _Compressor()
+    agent = _agent(mgr, comp)
+    msgs = [{"role": "user", "content": "hi"}]
+
+    agent.commit_memory_session(msgs)
+
+    assert mgr.session_end_calls == [msgs]
+    assert comp.session_end_calls == [("sess-1", msgs)]
+
+
+def test_commit_memory_session_compressor_called_with_empty_when_no_messages():
+    mgr = _Manager()
+    comp = _Compressor()
+    agent = _agent(mgr, comp)
+
+    agent.commit_memory_session(None)
+
+    assert mgr.session_end_calls == [[]]
+    assert comp.session_end_calls == [("sess-1", [])]
+
+
+def test_commit_memory_session_uses_empty_session_id_when_unset():
+    """``self.session_id`` may be transiently None during early init or
+    test stubs — the compressor call must not raise on that."""
+    mgr = _Manager()
+    comp = _Compressor()
+    agent = _agent(mgr, comp, session_id=None)
+
+    agent.commit_memory_session([])
+
+    assert comp.session_end_calls == [("", [])]
+
+
+def test_commit_memory_session_swallows_compressor_exception():
+    """A misbehaving compressor must not break session rotation; the
+    memory manager call must still have happened."""
+
+    class _BadComp:
+        def on_session_end(self, session_id, messages):
+            raise RuntimeError("boom")
+
+    mgr = _Manager()
+    agent = _agent(mgr, _BadComp())
+
+    agent.commit_memory_session([{"role": "user", "content": "x"}])
+
+    assert mgr.session_end_calls == [[{"role": "user", "content": "x"}]]
+
+
+def test_commit_memory_session_no_compressor_attribute_is_no_op():
+    """An agent built without a compressor (older test stubs, plugin
+    engine never selected) must not raise."""
+    mgr = _Manager()
+    agent = AIAgent.__new__(AIAgent)
+    agent._memory_manager = mgr
+    agent.session_id = "sess-1"
+    # Deliberately no context_compressor attribute.
+
+    agent.commit_memory_session([])
+
+    assert mgr.session_end_calls == [[]]
+
+
+def test_commit_memory_session_compressor_set_to_none_is_no_op():
+    """Compressor explicitly None (no plugin engine selected) is a
+    common configuration; no compressor call must fire."""
+    mgr = _Manager()
+    agent = _agent(mgr, context_compressor=None)
+
+    agent.commit_memory_session([])
+
+    assert mgr.session_end_calls == [[]]


### PR DESCRIPTION
## Summary

`commit_memory_session` is the session-rotation entry point used by CLI `/new`, gateway session expiry (Telegram/Discord/Slack), and in-process compression. It called `self._memory_manager.on_session_end(...)` but never `self.context_compressor.on_session_end(...)`. As a result, plugin context engines like hermes-lcm silently lost the final turns and never finalized the rotating session in their lifecycle store.

The sibling `shutdown_memory_provider` already calls both. This PR restores parity by mirroring that pattern.

## The bug

`run_agent.py` `commit_memory_session` (before):

```python
def commit_memory_session(self, messages: list = None) -> None:
    if not self._memory_manager:
        return
    try:
        self._memory_manager.on_session_end(messages or [])
    except Exception:
        pass
    # context_compressor.on_session_end() is NOT called here
```

Compare with `shutdown_memory_provider` in the same file, which correctly notifies both:

```python
def shutdown_memory_provider(self, messages: list = None) -> None:
    if self._memory_manager:
        try:
            self._memory_manager.on_session_end(messages or [])
        ...
    if hasattr(self, "context_compressor") and self.context_compressor:
        try:
            self.context_compressor.on_session_end(self.session_id or "", messages or [])
        ...
```

Concrete impact (per the issue reporter, hermes-lcm v0.9.2):
- **CLI `/new`**: messages that arrived after the last `compress()` / preflight call are not persisted to `lcm.db`; the LCM session never gets `lifecycle.finalize_session()` and stays "active".
- **Gateway session expiry** (Telegram/Discord/Slack): same data loss — `_finalize_session()` calls `commit_memory_session()`.
- **In-process compression**: less severe because the new `on_session_start` fires immediately after, but the old session_id still ends without an `on_session_end` notification, breaking the engine's session lifecycle pairing.

## The fix

Add the missing `context_compressor.on_session_end(self.session_id or "", messages or [])` block after the memory-manager call, guarded the same way `shutdown_memory_provider` guards it (`hasattr` + truthiness + `try/except Exception`).

## Test plan

- [x] New focused regression suite `tests/run_agent/test_commit_memory_session.py` (6 tests):
  - primary: with both manager and compressor configured, both receive `on_session_end` with the same messages
  - compressor receives `(session_id, messages)` tuple shape
  - `messages=None` is normalized to `[]` for both
  - `session_id=None` is normalized to `""` for the compressor (mirrors `shutdown_memory_provider`)
  - exception in compressor `on_session_end` does not break session rotation; manager call still happens
  - no `context_compressor` attribute and `context_compressor=None` are both safe no-ops
- [x] Adjacent suites all green locally:
  - `tests/agent/test_memory_provider.py` (memory manager fan-out tests, including existing `TestCommitMemorySessionRouting`)
  - `tests/run_agent/test_compress_focus_plugin_fallback.py`, `test_compression_boundary.py`, `test_compression_persistence.py`
  - `tests/cli/test_cli_new_session.py`, `test_cli_shutdown_memory_messages.py`
  - `tests/gateway/test_shutdown_memory_provider_messages.py`, `test_compress_command.py`
  - 96 passed total, no regressions
- [x] Regression guard: with the production fix reverted (test branch only), the primary test fails with the expected `assert comp.session_end_calls == [(\"sess-1\", msgs)]` — `[] == [...]`. With the fix restored, all 6 pass.

Test command used:

```bash
uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest \
  tests/run_agent/test_commit_memory_session.py \
  tests/agent/test_memory_provider.py \
  tests/run_agent/test_compress_focus_plugin_fallback.py \
  tests/run_agent/test_compression_boundary.py \
  tests/run_agent/test_compression_persistence.py \
  tests/cli/test_cli_new_session.py \
  tests/cli/test_cli_shutdown_memory_messages.py \
  tests/gateway/test_shutdown_memory_provider_messages.py \
  tests/gateway/test_compress_command.py
```

## Related

Fixes #22394.

> Sibling code paths that may need the same fix: the `if not self._memory_manager: return` early-return is preserved here to keep the diff minimal and match the reporter's proposed patch. That means an agent configured with a context engine but no memory manager (an unusual but valid configuration) would still skip the compressor's session-end notification. Intentionally left out of this PR's scope — happy to widen by restructuring the guards independently (matching `shutdown_memory_provider`'s shape) if preferred.