### PR TITLE
fix(agent): notify context_compressor on commit_memory_session

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5067,12 +5067,24 @@ class AIAgent:
         Called when session_id rotates (e.g. /new, context compression);
         providers keep their state and continue running under the old
         session_id — they just flush pending extraction now."""
-        if not self._memory_manager:
-            return
-        try:
-            self._memory_manager.on_session_end(messages or [])
-        except Exception:
-            pass
+        if self._memory_manager:
+            try:
+                self._memory_manager.on_session_end(messages or [])
+            except Exception:
+                pass
+        # Also notify the context engine so plugin compressors (e.g. LCM)
+        # flush their final session state. Without this, messages that
+        # arrived after the last compress() call are lost on /new and on
+        # gateway session expiry, and the plugin's lifecycle store keeps
+        # the session marked as active forever (#22394).
+        if hasattr(self, "context_compressor") and self.context_compressor:
+            try:
+                self.context_compressor.on_session_end(
+                    self.session_id or "",
+                    messages or [],
+                )
+            except Exception:
+                pass
 
     def _sync_external_memory_for_turn(
         self,

--- a/tests/agent/test_commit_memory_session_compressor.py
+++ b/tests/agent/test_commit_memory_session_compressor.py
@@ -1,0 +1,87 @@
+"""Regression tests for AIAgent.commit_memory_session — must notify both the
+memory manager and the context compressor (#22394).
+
+Without the fix, plugin context engines like hermes-lcm miss the final
+session-end flush on /new and gateway session expiry, losing the messages
+that arrived after the last compress() call and leaving the LCM session
+marked as active forever.
+"""
+
+from types import MethodType
+from unittest.mock import MagicMock
+
+from run_agent import AIAgent
+
+
+def _make_stub_agent(*, memory_manager=None, context_compressor=None, session_id="sess-1"):
+    """Build a bare AIAgent stub with only the attributes the method needs."""
+    agent = AIAgent.__new__(AIAgent)
+    agent._memory_manager = memory_manager
+    agent.session_id = session_id
+    if context_compressor is not None:
+        agent.context_compressor = context_compressor
+    agent.commit_memory_session = MethodType(AIAgent.commit_memory_session, agent)
+    return agent
+
+
+class TestCommitMemorySessionFanOut:
+    def test_notifies_both_memory_manager_and_context_compressor(self):
+        """Both backends must be flushed on session rotation."""
+        mm = MagicMock()
+        cc = MagicMock()
+        msgs = [{"role": "user", "content": "hi"}]
+        agent = _make_stub_agent(memory_manager=mm, context_compressor=cc)
+
+        agent.commit_memory_session(msgs)
+
+        mm.on_session_end.assert_called_once_with(msgs)
+        cc.on_session_end.assert_called_once_with("sess-1", msgs)
+
+    def test_compressor_flushed_even_when_memory_manager_absent(self):
+        """A configured context engine must still get the flush even if
+        no external memory provider is wired up."""
+        cc = MagicMock()
+        msgs = [{"role": "assistant", "content": "bye"}]
+        agent = _make_stub_agent(memory_manager=None, context_compressor=cc)
+
+        agent.commit_memory_session(msgs)
+
+        cc.on_session_end.assert_called_once_with("sess-1", msgs)
+
+    def test_memory_manager_failure_does_not_block_compressor(self):
+        """A throwing provider must not prevent the compressor flush."""
+        mm = MagicMock()
+        mm.on_session_end.side_effect = RuntimeError("boom")
+        cc = MagicMock()
+        agent = _make_stub_agent(memory_manager=mm, context_compressor=cc)
+
+        agent.commit_memory_session([])
+
+        cc.on_session_end.assert_called_once_with("sess-1", [])
+
+    def test_compressor_failure_is_swallowed(self):
+        """A throwing compressor must not surface to the caller."""
+        mm = MagicMock()
+        cc = MagicMock()
+        cc.on_session_end.side_effect = RuntimeError("kaput")
+        agent = _make_stub_agent(memory_manager=mm, context_compressor=cc)
+
+        # Must not raise.
+        agent.commit_memory_session([])
+
+        mm.on_session_end.assert_called_once()
+
+    def test_no_op_when_neither_backend_present(self):
+        """Method must be safe to call on a minimal agent."""
+        agent = _make_stub_agent(memory_manager=None, context_compressor=None)
+        # Must not raise even when the attribute is missing entirely.
+        agent.commit_memory_session([])
+
+    def test_uses_empty_string_session_id_when_none(self):
+        """When session_id is None, compressor still receives an empty string."""
+        cc = MagicMock()
+        agent = _make_stub_agent(memory_manager=None, context_compressor=cc, session_id=None)
+
+        agent.commit_memory_session([{"role": "user", "content": "x"}])
+
+        cc.on_session_end.assert_called_once_with("", [{"role": "user", "content": "x"}])


### PR DESCRIPTION
## Summary

`AIAgent.commit_memory_session()` is invoked when the session_id rotates
without tearing providers down — CLI `/new`, gateway session expiry, and
in-flight context compression. It already calls
`_memory_manager.on_session_end()`, but never called
`context_compressor.on_session_end()`, so plugin context engines like
[hermes-lcm](https://github.com/) miss the final session-end flush:

- Messages that arrived after the last `compress()` call are never
  persisted to `lcm.db`.
- The LCM lifecycle store keeps the session marked **active** forever.

`shutdown_memory_provider()` already does both calls; `commit_memory_session`
was the asymmetric outlier.

## Fix

Mirror the `shutdown_memory_provider()` pattern: the compressor flush is
now invoked under the same `hasattr(...) and self.context_compressor`
guard, and each backend is checked independently so a missing
`_memory_manager` no longer skips the compressor.

```python
if self._memory_manager:
    try:
        self._memory_manager.on_session_end(messages or [])
    except Exception:
        pass
if hasattr(self, "context_compressor") and self.context_compressor:
    try:
        self.context_compressor.on_session_end(self.session_id or "", messages or [])
    except Exception:
        pass
```

## Tests

New regression tests in `tests/agent/test_commit_memory_session_compressor.py`:

- `test_notifies_both_memory_manager_and_context_compressor`
- `test_compressor_flushed_even_when_memory_manager_absent`
- `test_memory_manager_failure_does_not_block_compressor`
- `test_compressor_failure_is_swallowed`
- `test_no_op_when_neither_backend_present`
- `test_uses_empty_string_session_id_when_none`

Stash-verified: 4/6 fail without the fix (the two no-op cases pass either
way), all 6 pass with it.

## Test plan

- [x] New regression tests pass with fix; fail without it
- [x] Wider regression: `pytest tests/agent/test_memory_provider.py tests/run_agent/ tests/cli/test_cli_new_session.py tests/agent/test_commit_memory_session_compressor.py` → 1332 passed, 9 skipped
- [x] Full regression: `pytest` → 21240 passed; the 115 failures match the pre-existing flaky baseline on `origin/main` (test_discord_*, test_gateway_service, test_gateway_wsl, test_file_*, test_terminal_tool_requirements, test_tts_media_routing, test_setup_openclaw_migration, test_tencent_tokenhub_provider, test_list_picker_providers, test_model_switch_custom_providers, test_tui_gateway_server, test_web_server::test_pub_broadcasts) — none touched by this PR

Closes #22394