### PR TITLE
chore(release): add uzunkuyruk to AUTHOR_MAP

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -64,6 +64,7 @@ AUTHOR_MAP = {
     "ytchen0719@gmail.com": "liquidchen",
     "am@studio1.tailb672fe.ts.net": "subtract0",
     "axmaiqiu@gmail.com": "qWaitCrypto",
+    "egitimviscara@gmail.com": "uzunkuyruk",
     "159539633+MottledShadow@users.noreply.github.com": "MottledShadow",
     "aludwin+gh@gmail.com": "adamludwin",
     "ngusev@astralinux.ru": "NikolayGusev-astra",


### PR DESCRIPTION
Maps `egitimviscara@gmail.com` → GitHub login `uzunkuyruk` so `scripts/release.py` `contributor_audit.py` recognizes their authored commits.

Needed before merging the #21933 salvage PR (which contains a commit attributed to `uzunkuyruk`).