### PR TITLE
fix(delegate): salvage #21933 JSON-string batch + diagnostic logging

### DIFF
--- a/model_tools.py
+++ b/model_tools.py
@@ -550,6 +550,16 @@ def coerce_tool_args(tool_name: str, args: Dict[str, Any]) -> Dict[str, Any]:
                     # nullable "null" → None).
                     args[key] = coerced
                     continue
+                # If the string looks like a JSON array but _coerce_value
+                # failed to parse it, warn clearly instead of silently wrapping.
+                if value.strip().startswith("["):
+                    logger.warning(
+                        "coerce_tool_args: %s.%s looks like a JSON array string "
+                        "but could not be parsed — model may have emitted a "
+                        "JSON-encoded string instead of a native array. "
+                        "Falling back to single-element list.",
+                        tool_name, key,
+                    )
                 args[key] = [value]
                 logger.info(
                     "coerce_tool_args: wrapped bare string in list for %s.%s",
@@ -637,7 +647,12 @@ def _coerce_json(value: str, expected_python_type: type):
     """
     try:
         parsed = json.loads(value)
-    except (ValueError, TypeError):
+    except (ValueError, TypeError) as exc:
+        logger.warning(
+            "coerce_tool_args: failed to parse string as JSON for expected type %s: %s",
+            expected_python_type.__name__,
+            exc,
+        )
         return value
     if isinstance(parsed, expected_python_type):
         logger.debug(
@@ -645,6 +660,11 @@ def _coerce_json(value: str, expected_python_type: type):
             expected_python_type.__name__,
         )
         return parsed
+    logger.warning(
+        "coerce_tool_args: JSON-parsed value is %s, expected %s — skipping coercion",
+        type(parsed).__name__,
+        expected_python_type.__name__,
+    )
     return value
 
 

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -168,6 +168,63 @@ class TestDelegateTask(unittest.TestCase):
         self.assertIn("total_duration_seconds", result)
 
     @patch("tools.delegate_tool._run_single_child")
+    def test_batch_mode_accepts_json_string_tasks(self, mock_run):
+        mock_run.side_effect = [
+            {
+                "task_index": 0,
+                "status": "completed",
+                "summary": "Result A",
+                "api_calls": 2,
+                "duration_seconds": 3.0,
+            },
+            {
+                "task_index": 1,
+                "status": "completed",
+                "summary": "Result B",
+                "api_calls": 4,
+                "duration_seconds": 6.0,
+            },
+        ]
+        parent = _make_mock_parent()
+        tasks = json.dumps(
+            [
+                {"goal": "Research topic A"},
+                {"goal": "Research topic B"},
+            ]
+        )
+
+        result = json.loads(delegate_task(tasks=tasks, parent_agent=parent))
+
+        self.assertIn("results", result)
+        self.assertEqual(len(result["results"]), 2)
+        self.assertEqual(result["results"][0]["summary"], "Result A")
+        self.assertEqual(result["results"][1]["summary"], "Result B")
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_batch_mode_rejects_non_object_tasks(self, mock_run):
+        parent = _make_mock_parent()
+
+        result = json.loads(
+            delegate_task(tasks=["not a task object"], parent_agent=parent)
+        )
+
+        self.assertIn("error", result)
+        self.assertIn("Task 0 must be an object", result["error"])
+        mock_run.assert_not_called()
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_batch_mode_rejects_malformed_json_string_tasks(self, mock_run):
+        parent = _make_mock_parent()
+
+        result = json.loads(
+            delegate_task(tasks='[{"goal": "bad}', parent_agent=parent)
+        )
+
+        self.assertIn("error", result)
+        self.assertIn("could not be parsed as JSON", result["error"])
+        mock_run.assert_not_called()
+
+    @patch("tools.delegate_tool._run_single_child")
     def test_batch_capped_at_3(self, mock_run):
         mock_run.return_value = {
             "task_index": 0, "status": "completed",

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1867,6 +1867,29 @@ def _run_single_child(
             logger.debug("Failed to close child agent after delegation")
 
 
+def _recover_tasks_from_json_string(
+    tasks: Any,
+) -> tuple[Optional[List[Dict[str, Any]]], Optional[str]]:
+    if not isinstance(tasks, str):
+        return None, None
+    raw = tasks.strip()
+    if not raw:
+        return None, "Provide either 'goal' (single task) or 'tasks' (batch)."
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        return None, (
+            "tasks must be a JSON array of task objects; received a string "
+            f"that could not be parsed as JSON ({exc.msg})."
+        )
+    if not isinstance(parsed, list):
+        return None, (
+            f"tasks must be a JSON array of task objects; parsed "
+            f"{type(parsed).__name__} instead."
+        )
+    return parsed, None
+
+
 def delegate_task(
     goal: Optional[str] = None,
     context: Optional[str] = None,
@@ -1951,6 +1974,12 @@ def delegate_task(
 
     # Normalize to task list
     max_children = _get_max_concurrent_children()
+    recovered_tasks, tasks_error = _recover_tasks_from_json_string(tasks)
+    if tasks_error:
+        return tool_error(tasks_error)
+    if recovered_tasks is not None:
+        tasks = recovered_tasks
+
     if tasks and isinstance(tasks, list):
         if len(tasks) > max_children:
             return tool_error(
@@ -1973,6 +2002,10 @@ def delegate_task(
 
     # Validate each task has a goal
     for i, task in enumerate(task_list):
+        if not isinstance(task, dict):
+            return tool_error(
+                f"Task {i} must be an object, got {type(task).__name__}."
+            )
         if not task.get("goal", "").strip():
             return tool_error(f"Task {i} is missing a 'goal'.")
 


### PR DESCRIPTION
## Summary

Salvage of #21966 (Bartok9) plus the model_tools.py diagnostic logging from #22092 (uzunkuyruk), addressing #21933 — `delegate_task` batch mode silently failing when open-weight models (Qwen, DeepSeek, GLM) emit the `tasks` array as a JSON-encoded string instead of a native array.

Also closes the duplicate PRs #21957, #21966, #22092.

## Why a salvage

Three PRs targeted #21933:

| PR | Author | Verdict |
|---|---|---|
| #21957 | liuhao1024 | Right idea, but mixed in unrelated WhatsApp `npm install` timeout changes and a `PATCH_SCHEMA` edit that incorrectly marks mode-specific params as `required` |
| #21966 | Bartok9 | Clean, focused, with tests. **Picked.** |
| #22092 | uzunkuyruk | Adds useful diagnostic logging in `model_tools.py`, but its `delegate_task` recovery path targets a wrapped-list form (`tasks=["[json]"]`) that never reaches `delegate_task` — the function is in `_AGENT_LOOP_TOOLS` and bypasses `coerce_tool_args` entirely (dispatched directly from `run_agent.py` via `_dispatch_delegate_task` with raw `function_args`). Logging changes salvaged; the `delegate_tool.py` recovery dropped. |

## What this PR does

**Commit 1 — `fix(delegate): accept JSON string batch tasks`** (Bartok9, cherry-picked from #21966)

Adds a `_recover_tasks_from_json_string()` helper at the top of `delegate_task()` that:

- accepts `tasks` arriving as a raw JSON-encoded string and parses it into a list (the actual production failure mode for #21933)
- returns a structured `tool_error` for malformed JSON, non-array JSON, or empty strings
- adds per-element type validation rejecting non-object list entries with a clear message

**Commit 2 — `fix(model_tools): log warnings for failed JSON-array coercion`** (uzunkuyruk, salvaged from #22092)

Adds `WARNING`-level logs in `_coerce_json` and `coerce_tool_args` so that when *any other* tool (the ones that DO go through `handle_function_call` → `coerce_tool_args`) gets a stringified array argument that fails to parse, it's no longer silent. The `delegate_task`-specific recovery from #22092 was dropped — the actual fix is the previous commit.

## Tests

3 new tests from #21966 (Bartok9):

- `test_batch_mode_accepts_json_string_tasks` — JSON-encoded array string runs the batch
- `test_batch_mode_rejects_non_object_tasks` — non-object list elements yield clear error
- `test_batch_mode_rejects_malformed_json_string_tasks` — malformed JSON yields clear error

All pass. Full `tests/tools/test_delegate.py` (123 tests) and `tests/run_agent/test_tool_arg_coercion.py` (61 tests) green locally on this branch.

## E2E verification

Confirmed the actual production failure mode, with both fixes applied:

```
Test 1: tasks = '[{"goal":"task1"},{"goal":"task2"}]'  (raw string, the bug)
  → batch executes 2 tasks ✓

Test 2: tasks = '[{"goal": "bad}'                       (malformed JSON)
  → "tasks must be a JSON array of task objects; received a string that
     could not be parsed as JSON (Unterminated string starting at)." ✓

Test 3: tasks = '{"goal": "x"}'                         (non-array JSON)
  → "tasks must be a JSON array of task objects; parsed dict instead." ✓

Test 4: tasks = [{"goal":"task1"},{"goal":"task2"}]     (native list, regression)
  → batch executes 2 tasks ✓

Test 5: tasks = ["not an object"]                       (bad list element)
  → "Task 0 must be an object, got str." ✓

Test 6: goal = "do something"                           (single-task mode)
  → reaches dispatch, tasks unaffected ✓

Test 7: model_tools._coerce_json('[{"bad json}', list)  (logging)
  → WARNING: "coerce_tool_args: failed to parse string as JSON for
     expected type list: Unterminated string starting at..." ✓
```

I also empirically verified that #22092's standalone `delegate_task` recovery does NOT fix the bug — running it alone, Test 1 still returns `"Provide either 'goal' (single task) or 'tasks' (batch)."` because `coerce_tool_args` never wraps the string into the form the PR's recovery expects.

## Credit

- **#21966 by @Bartok9** — picked as the salvage base; their commit is preserved with original authorship.
- **#22092 by @uzunkuyruk** — `model_tools.py` diagnostic logging cherry-picked with `Author:` preserved.
- **#21957 by @liuhao1024** — same intent at the `delegate_task` boundary; not picked due to scope creep, but the upstream issue diagnosis is valuable. Closing with credit.

## Closes

- Fixes #21933
- Closes #21957
- Closes #21966 (via merge of cherry-picked commit)
- Closes #22092 (via merge of cherry-picked logging commit)

## Notes for reviewer

This salvage depends on #22434 (`chore(release): add uzunkuyruk to AUTHOR_MAP`) being merged first, since contributor_audit.py requires the email→login mapping for `egitimviscara@gmail.com` before this branch can land cleanly.

Merge with `--rebase` to preserve per-commit authorship.
