### PR TITLE
fix: support reverse proxy domains via HERMES_DASHBOARD_EXTRA_HOSTS env var

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -182,6 +182,13 @@ def _is_accepted_host(host_header: str, bound_host: str) -> bool:
     if bound_host in ("0.0.0.0", "::"):
         return True
 
+    # Extra hosts from environment (reverse proxy domains)
+    _extra_hosts = os.environ.get("HERMES_DASHBOARD_EXTRA_HOSTS", "")
+    if _extra_hosts:
+        extra = {h.strip().lower() for h in _extra_hosts.split(",") if h.strip()}
+        if host_only in extra:
+            return True
+
     # Loopback bind: accept the loopback names
     bound_lc = bound_host.lower()
     if bound_lc in _LOOPBACK_HOST_VALUES:


### PR DESCRIPTION
## Problem

When the dashboard is bound to `127.0.0.1` (default), the Host header validation middleware rejects requests from reverse proxy domains (e.g. `webui.bz9.me` via Cloudflare). This makes the dashboard unusable behind any reverse proxy without using `--insecure` (which binds to `0.0.0.0`).

The user sees a blank page because:
1. HTML loads (200 OK — the SPA fallback serves index.html for any path)
2. JS loads and React mounts
3. API calls fail with 400 (`Invalid Host header`)
4. React crashes with empty error

## Solution

Add `HERMES_DASHBOARD_EXTRA_HOSTS` environment variable support to `_is_accepted_host()`. When set (comma-separated list of hostnames), the specified domains are accepted alongside the loopback aliases.

### Usage

```bash
# CLI
HERMES_DASHBOARD_EXTRA_HOSTS=webui.bz9.me hermes dashboard

# systemd service
Environment=HERMES_DASHBOARD_EXTRA_HOSTS=webui.bz9.me,admin.example.com
```

### Why not --insecure?

`--insecure` binds to `0.0.0.0`, which exposes the dashboard to the entire network. The env var approach keeps the loopback bind while only adding specific trusted hostnames — much safer for users behind Cloudflare, Caddy, or Nginx reverse proxies.

## Changes

- `hermes_cli/web_server.py`: 7 lines added to `_is_accepted_host()` — reads `HERMES_DASHBOARD_EXTRA_HOSTS` env var and accepts matching hostnames.