### PR TITLE
fix(webui): add platform hint for MEDIA rendering

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -564,6 +564,18 @@ PLATFORM_HINTS = {
         "code fences). Treat this like a conversation, not a document. Keep responses "
         "brief and natural."
     ),
+    "webui": (
+        "You are in the Hermes WebUI, a browser-based chat interface. "
+        "Full Markdown rendering is supported — headings, bold, italic, code "
+        "blocks, tables, math (LaTeX), and Mermaid diagrams all render natively. "
+        "To display local or remote media/files inline, include "
+        "MEDIA:/absolute/path/to/file or MEDIA:https://... in your response. "
+        "Local file paths must be absolute. Images, audio (with playback speed "
+        "controls), video, PDFs, HTML, CSV, diffs/patches, and Excalidraw files "
+        "render as rich previews. Do not use Markdown image syntax like "
+        "![alt](/path) for local files; local paths are not served that way. "
+        "Use MEDIA:/path instead."
+    ),
 }
 
 # ---------------------------------------------------------------------------

--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -574,7 +574,7 @@ PLATFORM_HINTS = {
         "controls), video, PDFs, HTML, CSV, diffs/patches, and Excalidraw files "
         "render as rich previews. Do not use Markdown image syntax like "
         "![alt](/path) for local files; local paths are not served that way. "
-        "Use MEDIA:/path instead."
+        "Use MEDIA:/absolute/path instead."
     ),
 }
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -789,6 +789,7 @@ class TestPromptBuilderConstants:
         assert "cron" in PLATFORM_HINTS
         assert "cli" in PLATFORM_HINTS
         assert "api_server" in PLATFORM_HINTS
+        assert "webui" in PLATFORM_HINTS
 
     def test_cli_hint_does_not_suggest_media_tags(self):
         # Regression: MEDIA:/path tags are intercepted only by messaging
@@ -825,6 +826,13 @@ class TestPromptBuilderConstants:
         assert "Feishu" in hint
         assert "MEDIA:" in hint
         assert "Markdown" in hint
+
+    def test_platform_hints_webui(self):
+        hint = PLATFORM_HINTS["webui"]
+        assert "WebUI" in hint
+        assert "MEDIA:" in hint
+        assert "Markdown" in hint
+        assert "absolute" in hint
 
 
 # =========================================================================


### PR DESCRIPTION
Salvage of #21891 by @qWaitCrypto onto current `main`.

## What this does

Adds a `"webui"` entry to `PLATFORM_HINTS` in `agent/prompt_builder.py` so external clients that instantiate `AIAgent(platform="webui")` (e.g. `nesquena/hermes-webui`) get explicit guidance about the WebUI's rendering surface:

- Standard Markdown renders (headings, bold, italic, code blocks, tables, LaTeX math, Mermaid).
- Local files: `MEDIA:/absolute/path/to/file` (images, audio, video, PDF, HTML, CSV, diffs, Excalidraw all get rich previews).
- Remote files: `MEDIA:https://...`.
- Don't use `![alt](/path)` Markdown image syntax for local files — it doesn't render.

Without the hint, `platform_key="webui"` falls through `PLATFORM_HINTS` → plugin registry → nothing, and the agent gets no platform context.

## Why salvage

PR #21891 was the first and more thorough of two open PRs targeting #21883 (the other being #22049). #21891 included tests, mentioned LaTeX/Mermaid, and was opened ~6 hours earlier. Cherry-picked both of @qWaitCrypto's commits (`6e23da4` adding the hint + tests, `f82a0ac` clarifying absolute-path wording) onto current `main`. Authorship preserved.

## Tests

- Adds `test_platform_hints_webui` covering the new key.
- Updates `test_platform_hints_known_platforms` to include `"webui"` in the canonical-keys list.
- Full `tests/agent/test_prompt_builder.py` suite: 121 passed, 1 skipped.
- E2E verified: `PLATFORM_HINTS["webui"]` resolves correctly in the `run_agent.py:5454` resolver path.

Closes #21883. Closes #21891. Closes #22049 (duplicate).

Use `--rebase` merge to preserve @qWaitCrypto's authorship.
