### PR TITLE
fix(gemini): translate video_url content blocks to inlineData parts

### DIFF
--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -209,6 +209,24 @@ def _extract_multimodal_parts(content: Any) -> List[Dict[str, Any]]:
                     }
                 }
             )
+        elif ptype == "video_url":
+            url = ((item.get("video_url") or {}).get("url") or "")
+            if not isinstance(url, str) or not url.startswith("data:"):
+                continue
+            try:
+                header, encoded = url.split(",", 1)
+                mime = header.split(":", 1)[1].split(";", 1)[0]
+                raw = base64.b64decode(encoded)
+            except Exception:
+                continue
+            parts.append(
+                {
+                    "inlineData": {
+                        "mimeType": mime,
+                        "data": base64.b64encode(raw).decode("ascii"),
+                    }
+                }
+            )
     return parts
 
 

--- a/tests/agent/test_gemini_native_video_url.py
+++ b/tests/agent/test_gemini_native_video_url.py
@@ -1,0 +1,74 @@
+"""Regression tests for `_extract_multimodal_parts` video_url handling (#21920).
+
+Without the fix, the Gemini native adapter silently drops `video_url` content
+blocks emitted by `tools/vision_tools.video_analyze`, so the model never sees
+the video the user asked it to analyze.
+"""
+
+import base64
+
+from agent.gemini_native_adapter import _extract_multimodal_parts
+
+
+def _video_data_url(mime: str = "video/mp4", payload: bytes = b"\x00\x00\x00\x18ftypmp4") -> str:
+    encoded = base64.b64encode(payload).decode("ascii")
+    return f"data:{mime};base64,{encoded}"
+
+
+class TestExtractMultimodalPartsVideoUrl:
+    def test_video_url_data_uri_becomes_inline_data_part(self):
+        url = _video_data_url()
+        content = [{"type": "video_url", "video_url": {"url": url}}]
+
+        parts = _extract_multimodal_parts(content)
+
+        assert len(parts) == 1
+        assert "inlineData" in parts[0]
+        assert parts[0]["inlineData"]["mimeType"] == "video/mp4"
+        assert parts[0]["inlineData"]["data"] == base64.b64encode(b"\x00\x00\x00\x18ftypmp4").decode("ascii")
+
+    def test_video_url_preserves_non_default_mime(self):
+        url = _video_data_url(mime="video/webm", payload=b"webmpayload")
+        content = [{"type": "video_url", "video_url": {"url": url}}]
+
+        parts = _extract_multimodal_parts(content)
+
+        assert parts[0]["inlineData"]["mimeType"] == "video/webm"
+
+    def test_video_url_alongside_text_keeps_both_parts_in_order(self):
+        url = _video_data_url()
+        content = [
+            {"type": "text", "text": "describe this video"},
+            {"type": "video_url", "video_url": {"url": url}},
+        ]
+
+        parts = _extract_multimodal_parts(content)
+
+        assert len(parts) == 2
+        assert parts[0] == {"text": "describe this video"}
+        assert "inlineData" in parts[1]
+
+    def test_non_data_uri_video_url_is_skipped(self):
+        content = [
+            {"type": "video_url", "video_url": {"url": "https://example.com/v.mp4"}},
+        ]
+
+        parts = _extract_multimodal_parts(content)
+
+        assert parts == []
+
+    def test_malformed_base64_video_url_is_skipped_without_raising(self):
+        content = [
+            {"type": "video_url", "video_url": {"url": "data:video/mp4;base64,not!!base64"}},
+        ]
+
+        parts = _extract_multimodal_parts(content)
+
+        assert parts == []
+
+    def test_missing_video_url_key_is_skipped(self):
+        content = [{"type": "video_url"}]
+
+        parts = _extract_multimodal_parts(content)
+
+        assert parts == []


### PR DESCRIPTION
## What does this PR do?

`_extract_multimodal_parts` in `agent/gemini_native_adapter.py` only handled `text` and `image_url` content parts. When `tools/vision_tools.video_analyze` ran with Gemini as the vision provider, it emitted

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

Mirror the existing `image_url` branch: parse the data URL, extract the mime type, base64-decode the payload, and emit a Gemini `inlineData` part. Same defensive guards as `image_url` (skip non-data URIs and malformed base64 instead of raising).

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

Closes #21920

<details>
<summary>Original body</summary>

## Summary

`_extract_multimodal_parts` in `agent/gemini_native_adapter.py` only handled `text` and `image_url` content parts. When `tools/vision_tools.video_analyze` ran with Gemini as the vision provider, it emitted

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Summary

`_extract_multimodal_parts` in `agent/gemini_native_adapter.py` only handled `text` and `image_url` content parts. When `tools/vision_tools.video_analyze` ran with Gemini as the vision provider, it emitted

```json
{"type": "video_url", "video_url": {"url": "data:video/mp4;base64,..."}}
```

the adapter silently dropped the part, and the model received only the surrounding text — making it impossible for Gemini to actually analyze the video.

## Fix

Mirror the existing `image_url` branch: parse the data URL, extract the mime type, base64-decode the payload, and emit a Gemini `inlineData` part. Same defensive guards as `image_url` (skip non-data URIs and malformed base64 instead of raising).

## Tests

New regression suite `tests/agent/test_gemini_native_video_url.py` (6 tests) covers:

- `video_url` data URI → `inlineData` part with correct mime + payload
- non-default mime preserved (`video/webm`)
- ordering preserved when `video_url` is mixed with `text`
- non-data URIs skipped
- malformed base64 skipped without raising
- missing `video_url` key skipped

Stash-verified: 3/6 fail without the adapter fix; 6/6 pass with it. Wider `tests/agent/` regression: no new failures introduced.

Closes #21920

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

Closes #21920

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_