### PR TITLE
fix(tests): declare pytest-split in dev extra; make run_tests.sh uv-aware

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
 modal = ["modal>=1.0.0,<2"]
 daytona = ["daytona>=0.148.0,<1"]
 vercel = ["vercel>=0.5.7,<0.6.0"]
-dev = ["debugpy>=1.8.0,<2", "pytest>=9.0.2,<10", "pytest-asyncio>=1.3.0,<2", "pytest-xdist>=3.0,<4", "mcp>=1.2.0,<2", "ty>=0.0.1a29,<0.0.22", "ruff"]
+dev = ["debugpy>=1.8.0,<2", "pytest>=9.0.2,<10", "pytest-asyncio>=1.3.0,<2", "pytest-xdist>=3.0,<4", "pytest-split>=0.9,<1", "mcp>=1.2.0,<2", "ty>=0.0.1a29,<0.0.22", "ruff"]
 messaging = ["python-telegram-bot[webhooks]>=22.6,<23", "discord.py[voice]>=2.7.1,<3", "aiohttp>=3.13.3,<4", "slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4", "qrcode>=7.0,<8"]
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
 slack = ["slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4"]

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -42,9 +42,24 @@ fi
 PYTHON="$VENV/bin/python"
 
 # ── Ensure pytest-split is installed (required for shard-equivalent runs) ──
+# Listed in pyproject.toml's dev extra, but venvs created before that change
+# (or by `uv venv` without pip) may still be missing it. Try pip first, fall
+# back to `uv pip install --python "$PYTHON"` so uv-managed venvs without pip
+# still bootstrap cleanly. If neither works, surface a clear setup hint
+# instead of silently exiting.
 if ! "$PYTHON" -c "import pytest_split" 2>/dev/null; then
   echo "→ installing pytest-split into $VENV"
-  "$PYTHON" -m pip install --quiet "pytest-split>=0.9,<1"
+  if "$PYTHON" -m pip --version >/dev/null 2>&1; then
+    "$PYTHON" -m pip install --quiet "pytest-split>=0.9,<1"
+  elif command -v uv >/dev/null 2>&1; then
+    uv pip install --quiet --python "$PYTHON" "pytest-split>=0.9,<1"
+  else
+    echo "error: pytest-split is not installed and neither pip nor uv is available." >&2
+    echo "       Re-create the venv with the dev extra, e.g.:" >&2
+    echo "         uv pip install -e \".[dev]\" --python \"$PYTHON\"" >&2
+    echo "       or install pip into the venv first." >&2
+    exit 1
+  fi
 fi
 
 # ── Hermetic environment ────────────────────────────────────────────────────

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -55,9 +55,10 @@ if ! "$PYTHON" -c "import pytest_split" 2>/dev/null; then
     uv pip install --quiet --python "$PYTHON" "pytest-split>=0.9,<1"
   else
     echo "error: pytest-split is not installed and neither pip nor uv is available." >&2
-    echo "       Re-create the venv with the dev extra, e.g.:" >&2
-    echo "         uv pip install -e \".[dev]\" --python \"$PYTHON\"" >&2
-    echo "       or install pip into the venv first." >&2
+    echo "       Bootstrap pip into the venv first, then install the dev extra:" >&2
+    echo "         \"$PYTHON\" -m ensurepip --upgrade" >&2
+    echo "         \"$PYTHON\" -m pip install -e \".[dev]\"" >&2
+    echo "       Or install uv (https://docs.astral.sh/uv/) and re-run." >&2
     exit 1
   fi
 fi

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -20,3 +20,16 @@ def test_manifest_includes_bundled_skills():
 
     assert "graft skills" in manifest
     assert "graft optional-skills" in manifest
+
+
+def test_dev_extra_declares_pytest_split():
+    """`scripts/run_tests.sh` requires pytest_split. Declare it in the dev
+    extra so a fresh `pip install -e .[dev]` (or `uv sync --extra dev`)
+    provisions everything the canonical test runner needs, instead of
+    forcing the script to self-bootstrap into the venv (#22401)."""
+    data = tomllib.loads((REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+    dev_extra = data["project"]["optional-dependencies"]["dev"]
+
+    assert any(dep.startswith("pytest-split") for dep in dev_extra), (
+        f"pytest-split missing from dev extra: {dev_extra}"
+    )


### PR DESCRIPTION
## What does this PR do?

`scripts/run_tests.sh` requires `pytest_split` for shard-equivalent local runs, but `pytest-split` was not declared in `[project.optional-dependencies].dev`. The script tried to self-bootstrap with `python -m pip install pytest-split`, which fails immediately in `uv venv`-created venvs because uv doesn't install pip by default — the canonical test runner exits before pytest can start with:

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

1. **Declare the dependency**: add `pytest-split>=0.9,<1` to the `dev` extra in `pyproject.toml`. A fresh `pip install -e \".[dev]\"` or `uv sync --extra dev` now provisions everything the canonical test runner needs.
2. **Make bootstrap uv-aware**: in `scripts/run_tests.sh`, try `python -m pip` first, fall back to `uv pip install --python \"\$PYTHON\"` when pip is unavailable, and exit with a clear setup hint if neither is present (instead of the cryptic `No module named pip`).

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

Closes #22401

<details>
<summary>Original body</summary>

## Summary

`scripts/run_tests.sh` requires `pytest_split` for shard-equivalent local runs, but `pytest-split` was not declared in `[project.optional-dependencies].dev`. The script tried to self-bootstrap with `python -m pip install pytest-split`, which fails immediately in `uv venv`-created venvs because uv doesn't install pip by default — the canonical test runner exits before pytest can start with:

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Summary

`scripts/run_tests.sh` requires `pytest_split` for shard-equivalent local runs, but `pytest-split` was not declared in `[project.optional-dependencies].dev`. The script tried to self-bootstrap with `python -m pip install pytest-split`, which fails immediately in `uv venv`-created venvs because uv doesn't install pip by default — the canonical test runner exits before pytest can start with:

```
→ installing pytest-split into <venv>
<venv>/bin/python: No module named pip
```

## Fix

1. **Declare the dependency**: add `pytest-split>=0.9,<1` to the `dev` extra in `pyproject.toml`. A fresh `pip install -e \".[dev]\"` or `uv sync --extra dev` now provisions everything the canonical test runner needs.
2. **Make bootstrap uv-aware**: in `scripts/run_tests.sh`, try `python -m pip` first, fall back to `uv pip install --python \"\$PYTHON\"` when pip is unavailable, and exit with a clear setup hint if neither is present (instead of the cryptic `No module named pip`).

## Tests

Adds `test_dev_extra_declares_pytest_split` in `tests/test_packaging_metadata.py` to lock the declaration in place. Stash-verified — the new assertion fails on `origin/main` without the `pyproject.toml` change.

`bash -n scripts/run_tests.sh` syntax-clean.

Closes #22401

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

Closes #22401

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_