### PR TITLE
fix(tests): scrub HERMES_CRON_SESSION in canonical test runner

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -63,6 +63,9 @@ while IFS='=' read -r name _; do
 done < <(env)
 
 # Unset HERMES_* behavioral vars too.
+# HERMES_CRON_SESSION is set by the scheduler when invoking jobs; if leaked
+# into pytest (e.g. running this script from a Hermes cron job) it flips
+# approval mode and makes interactive-callback tests fail.
 unset HERMES_YOLO_MODE HERMES_INTERACTIVE HERMES_QUIET HERMES_TOOL_PROGRESS \
       HERMES_TOOL_PROGRESS_MODE HERMES_MAX_ITERATIONS HERMES_SESSION_PLATFORM \
       HERMES_SESSION_CHAT_ID HERMES_SESSION_CHAT_NAME HERMES_SESSION_THREAD_ID \
@@ -70,7 +73,7 @@ unset HERMES_YOLO_MODE HERMES_INTERACTIVE HERMES_QUIET HERMES_TOOL_PROGRESS \
       HERMES_PLATFORM HERMES_INFERENCE_PROVIDER HERMES_MANAGED HERMES_DEV \
       HERMES_CONTAINER HERMES_EPHEMERAL_SYSTEM_PROMPT HERMES_TIMEZONE \
       HERMES_REDACT_SECRETS HERMES_BACKGROUND_NOTIFICATIONS HERMES_EXEC_ASK \
-      HERMES_HOME_MODE 2>/dev/null || true
+      HERMES_HOME_MODE HERMES_CRON_SESSION 2>/dev/null || true
 
 # Pin deterministic runtime.
 export TZ=UTC

--- a/tests/test_run_tests_env_scrub.py
+++ b/tests/test_run_tests_env_scrub.py
@@ -1,0 +1,24 @@
+"""Regression: `scripts/run_tests.sh` must scrub scheduler-injected
+HERMES_CRON_SESSION before running pytest.
+
+Without this, running the canonical test runner from a Hermes cron job
+leaks cron approval mode into the test process and flips approval
+callbacks to deny — making interactive-callback tests fail only under
+cron (#22400).
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RUN_TESTS = REPO_ROOT / "scripts" / "run_tests.sh"
+
+
+def test_run_tests_script_scrubs_hermes_cron_session():
+    body = RUN_TESTS.read_text(encoding="utf-8")
+
+    # Confined to the explicit `unset HERMES_*` block — string-search the
+    # variable name is enough and lets contributors reorder the list freely.
+    assert "HERMES_CRON_SESSION" in body, (
+        "scripts/run_tests.sh must unset HERMES_CRON_SESSION so cron "
+        "approval mode does not leak into pytest (#22400)"
+    )

--- a/tests/test_run_tests_env_scrub.py
+++ b/tests/test_run_tests_env_scrub.py
@@ -7,6 +7,7 @@ callbacks to deny — making interactive-callback tests fail only under
 cron (#22400).
 """
 
+import re
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -16,9 +17,19 @@ RUN_TESTS = REPO_ROOT / "scripts" / "run_tests.sh"
 def test_run_tests_script_scrubs_hermes_cron_session():
     body = RUN_TESTS.read_text(encoding="utf-8")
 
-    # Confined to the explicit `unset HERMES_*` block — string-search the
-    # variable name is enough and lets contributors reorder the list freely.
-    assert "HERMES_CRON_SESSION" in body, (
-        "scripts/run_tests.sh must unset HERMES_CRON_SESSION so cron "
-        "approval mode does not leak into pytest (#22400)"
+    # Extract the `unset HERMES_*` stanza (with bash line continuations) and
+    # assert the variable appears in that block — not just anywhere in the
+    # file, otherwise a comment mentioning it would silently pass.
+    match = re.search(
+        r"^unset\s+HERMES_[A-Za-z0-9_ \\\n\t]+",
+        body,
+        flags=re.MULTILINE,
+    )
+    assert match, "scripts/run_tests.sh must contain an `unset HERMES_*` stanza"
+
+    unset_block = match.group(0)
+    assert re.search(r"\bHERMES_CRON_SESSION\b", unset_block), (
+        "scripts/run_tests.sh must unset HERMES_CRON_SESSION (in the `unset` "
+        "block, not just in a comment) so cron approval mode does not leak "
+        "into pytest (#22400)"
     )


### PR DESCRIPTION
## Summary

`scripts/run_tests.sh` documents itself as fully hermetic but its `HERMES_*` unset list omitted `HERMES_CRON_SESSION`. When the script runs from a Hermes scheduled cron job, the variable leaks into the pytest process and `tools/approval.py` flips from the normal non-interactive auto-approve path to cron-deny — failing approval-callback tests only under cron.

## Repro (per the issue)

```bash
HERMES_CRON_SESSION=1 venv/bin/python -m pytest -o addopts= -n 0 \
  tests/acp/test_approval_isolation.py::TestAcpExecAskGate::test_interactive_env_var_routes_to_callback
# FAILED

env -u HERMES_CRON_SESSION venv/bin/python -m pytest -o addopts= -n 0 \
  tests/acp/test_approval_isolation.py::TestAcpExecAskGate::test_interactive_env_var_routes_to_callback
# 1 passed
```

## Fix

Add `HERMES_CRON_SESSION` to the existing `unset HERMES_*` block in `scripts/run_tests.sh`. Lock it in with `tests/test_run_tests_env_scrub.py` asserting the variable appears in the script body — stash-verified to fail without the fix.

Closes #22400