### PR TITLE
fix(tests): skip pwd/fcntl-dependent suites on Windows via importorskip

### DIFF
--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1,12 +1,16 @@
 """Tests for gateway service management helpers."""
 
 import os
-import pwd
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+
+pwd = pytest.importorskip(
+    "pwd",
+    reason="pwd is a UNIX-only stdlib module; the user-systemd surface this file exercises is not available on Windows",
+)
 
 import hermes_cli.gateway as gateway_cli
 from gateway import status

--- a/tests/tools/test_file_sync_back.py
+++ b/tests/tools/test_file_sync_back.py
@@ -1,6 +1,5 @@
 """Tests for FileSyncManager.sync_back() — pull remote changes to host."""
 
-import fcntl
 import io
 import logging
 import os
@@ -11,6 +10,11 @@ from pathlib import Path
 from unittest.mock import MagicMock, call, patch
 
 import pytest
+
+fcntl = pytest.importorskip(
+    "fcntl",
+    reason="fcntl is a UNIX-only stdlib module; advisory file locking exercised here is not available on Windows",
+)
 
 from tools.environments.file_sync import (
     FileSyncManager,


### PR DESCRIPTION
## Summary

`tests/hermes_cli/test_gateway_service.py` and `tests/tools/test_file_sync_back.py` import the UNIX-only stdlib modules `pwd` and `fcntl` at module top level. On Windows these modules do not exist, so pytest collection raises `ModuleNotFoundError` and aborts the entire run before any test executes. This is exactly the failure reported in #22420.

Replacing the bare imports with `pytest.importorskip(...)` lets each suite skip cleanly on Windows with a clear platform reason while keeping POSIX behavior identical (`importorskip` returns the real module when present, so every existing reference such as `pwd.getpwnam`, `fcntl.flock`, `fcntl.LOCK_EX`, and `fcntl.LOCK_UN` continues to resolve).

Closes #22420.

## Changes

- `tests/hermes_cli/test_gateway_service.py`: drop top-level `import pwd`; bind `pwd = pytest.importorskip("pwd", reason=...)` after `import pytest`.
- `tests/tools/test_file_sync_back.py`: drop top-level `import fcntl`; bind `fcntl = pytest.importorskip("fcntl", reason=...)` after `import pytest`.

Two files, ten lines, no production-code changes.

## Why `importorskip` (over `pytest.mark.skipif`)

- Self-documents the platform requirement at the import site.
- Skips automatically on any platform that lacks the module (not just `sys.platform == "win32"`), e.g. some embedded distributions.
- This is the exact remediation suggested in the issue's "Option 1".

## Validation

Windows (Python 3.13), prior behavior:

~~~
tests\hermes_cli\test_gateway_service.py:4: in <module>
    import pwd
E   ModuleNotFoundError: No module named 'pwd'
~~~

After the patch:

~~~
$ python -m pytest tests/hermes_cli/test_gateway_service.py tests/tools/test_file_sync_back.py -rs
============================= test session starts =============================
platform win32 -- Python 3.13.7, pytest-9.0.3 ...
collected 0 items / 2 skipped

SKIPPED [1] tests/hermes_cli/test_gateway_service.py:10: pwd is a UNIX-only stdlib module; the user-systemd surface this file exercises is not available on Windows
SKIPPED [1] tests/tools/test_file_sync_back.py:14: fcntl is a UNIX-only stdlib module; advisory file locking exercised here is not available on Windows
============================= 2 skipped in 1.99s ==============================
~~~

POSIX behavior is unchanged: `importorskip` resolves to the real `pwd` / `fcntl` module, so all downstream references (`pwd.getpwnam("root")`, `fcntl.flock`, `fcntl.LOCK_EX`, `fcntl.LOCK_UN`) continue to work identically to the previous bare imports.

## Risk

Minimal. No production-code changes; only test-collection guards on two files that are themselves UNIX-only by design.