### PR TITLE
fix(xai-image): send literal 1k/2k resolution to API

### DIFF
--- a/plugins/image_gen/xai/__init__.py
+++ b/plugins/image_gen/xai/__init__.py
@@ -177,7 +177,8 @@ class XAIImageGenProvider(ImageGenProvider):
         aspect = resolve_aspect_ratio(aspect_ratio)
         xai_ar = _XAI_ASPECT_RATIOS.get(aspect, "1:1")
         resolution = _resolve_resolution()
-        xai_res = _XAI_RESOLUTIONS.get(resolution, "1024")
+        # API expects the literal "1k" / "2k" strings, not the numeric mapping
+        xai_res = resolution if resolution in _XAI_RESOLUTIONS else DEFAULT_RESOLUTION
 
         payload: Dict[str, Any] = {
             "model": API_MODEL,


### PR DESCRIPTION
The xAI grok-imagine-image endpoint expects the strings "1k" or "2k" for the resolution parameter. The provider was incorrectly mapping them to numeric strings ("1024"/"2048").

This caused image generation to fail when using the xAI provider (especially noticeable via Telegram).

Fix verified with live generation after the change.