### PR TITLE
feat: auto-discovering ProviderRegistry for web search/extract backends

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1894,6 +1894,14 @@ OPTIONAL_ENV_VARS = {
         "password": True,
         "category": "tool",
     },
+    "BRAVE_API_KEY": {
+        "description": "Brave Search API key for privacy-first web search — $5/mo free credit",
+        "prompt": "Brave Search API key",
+        "url": "https://api-dashboard.search.brave.com",
+        "tools": ["web_search"],
+        "password": True,
+        "category": "tool",
+    },
     "BROWSERBASE_API_KEY": {
         "description": "Browserbase API key for cloud browser (optional — local browser works without this)",
         "prompt": "Browserbase API key",

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -301,6 +301,15 @@ TOOL_CATEGORIES = {
                 ],
             },
             {
+                "name": "Brave Search",
+                "badge": "free tier · search only",
+                "tag": "Privacy-first search with independent index — $5/mo free credit (≈1000 searches)",
+                "web_backend": "brave",
+                "env_vars": [
+                    {"key": "BRAVE_API_KEY", "prompt": "Brave Search API key", "url": "https://api-dashboard.search.brave.com"},
+                ],
+            },
+            {
                 "name": "SearXNG",
                 "badge": "free · self-hosted · search only",
                 "tag": "Privacy-respecting metasearch engine — search only (pair with any extract provider)",

--- a/tests/tools/test_web_providers.py
+++ b/tests/tools/test_web_providers.py
@@ -192,3 +192,194 @@ class TestWebSearchUsesSearchBackend:
 
         assert len(called_with) > 0
         assert called_with[0][0] == "search"
+
+
+# ---------------------------------------------------------------------------
+# ProviderRegistry
+# ---------------------------------------------------------------------------
+
+
+class TestProviderRegistry:
+    """ProviderRegistry auto-discovery and lookup."""
+
+    def test_discovery_finds_brave_search_provider(self):
+        from tools.web_providers.registry import ProviderRegistry
+
+        # Reset scan state for test isolation
+        ProviderRegistry._scanned = False
+        providers = ProviderRegistry.list_search_providers()
+        assert "brave" in providers
+
+    def test_discovery_finds_searxng_provider(self):
+        from tools.web_providers.registry import ProviderRegistry
+
+        ProviderRegistry._scanned = False
+        providers = ProviderRegistry.list_search_providers()
+        assert "searxng" in providers
+
+    def test_discovery_finds_extract_providers(self):
+        from tools.web_providers.registry import ProviderRegistry
+
+        ProviderRegistry._scanned = False
+        providers = ProviderRegistry.list_extract_providers()
+        # Exa, Parallel, Tavily all implement both search and extract
+        for name in ("exa", "parallel", "tavily"):
+            assert name in providers, f"{name} should be an extract provider"
+
+    def test_get_search_provider_returns_class(self):
+        from tools.web_providers.registry import ProviderRegistry
+
+        ProviderRegistry._scanned = False
+        cls = ProviderRegistry.get_search_provider("brave")
+        assert cls is not None
+        instance = cls()
+        assert instance.provider_name() == "brave"
+
+    def test_get_search_provider_unknown_returns_none(self):
+        from tools.web_providers.registry import ProviderRegistry
+
+        ProviderRegistry._scanned = False
+        assert ProviderRegistry.get_search_provider("nonexistent") is None
+
+    def test_is_search_available_checks_env(self, monkeypatch):
+        from tools.web_providers.registry import ProviderRegistry
+
+        monkeypatch.setenv("BRAVE_API_KEY", "")
+        ProviderRegistry._scanned = False
+        assert ProviderRegistry.is_search_available("brave") is False
+
+        monkeypatch.setenv("BRAVE_API_KEY", "test-key-123")
+        ProviderRegistry._scanned = False
+        assert ProviderRegistry.is_search_available("brave") is True
+
+    def test_any_search_available_true_when_one_configured(self, monkeypatch):
+        from tools.web_providers.registry import ProviderRegistry
+
+        monkeypatch.setenv("EXA_API_KEY", "test-key")
+        monkeypatch.delenv("BRAVE_API_KEY", raising=False)
+        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+        monkeypatch.delenv("PARALLEL_API_KEY", raising=False)
+        monkeypatch.delenv("SEARXNG_URL", raising=False)
+        ProviderRegistry._scanned = False
+        assert ProviderRegistry.any_search_available() is True
+
+    def test_any_search_available_false_when_none_configured(self, monkeypatch):
+        from tools.web_providers.registry import ProviderRegistry
+
+        for var in ("BRAVE_API_KEY", "EXA_API_KEY", "TAVILY_API_KEY",
+                     "PARALLEL_API_KEY", "SEARXNG_URL"):
+            monkeypatch.delenv(var, raising=False)
+        ProviderRegistry._scanned = False
+        assert ProviderRegistry.any_search_available() is False
+
+    def test_find_first_available_returns_highest_priority(self, monkeypatch):
+        from tools.web_providers.registry import ProviderRegistry
+
+        # Only tavily configured — should be found first
+        monkeypatch.delenv("BRAVE_API_KEY", raising=False)
+        monkeypatch.delenv("EXA_API_KEY", raising=False)
+        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+        monkeypatch.delenv("PARALLEL_API_KEY", raising=False)
+        monkeypatch.delenv("SEARXNG_URL", raising=False)
+        monkeypatch.setenv("TAVILY_API_KEY", "tk")
+        ProviderRegistry._scanned = False
+        first = ProviderRegistry.find_first_available()
+        assert first is not None
+
+    def test_find_first_available_returns_none_when_none_configured(self, monkeypatch):
+        from tools.web_providers.registry import ProviderRegistry
+
+        for var in ("BRAVE_API_KEY", "EXA_API_KEY", "TAVILY_API_KEY",
+                     "PARALLEL_API_KEY", "SEARXNG_URL"):
+            monkeypatch.delenv(var, raising=False)
+        ProviderRegistry._scanned = False
+        assert ProviderRegistry.find_first_available() is None
+
+    def test_all_required_env_vars_returns_all(self):
+        from tools.web_providers.registry import ProviderRegistry
+
+        ProviderRegistry._scanned = False
+        env_vars = ProviderRegistry.all_required_env_vars()
+        assert "BRAVE_API_KEY" in env_vars
+        assert "EXA_API_KEY" in env_vars
+        assert "TAVILY_API_KEY" in env_vars
+        assert "PARALLEL_API_KEY" in env_vars
+        assert "SEARXNG_URL" in env_vars
+
+
+# ---------------------------------------------------------------------------
+# check_web_search_available / check_web_extract_available
+# ---------------------------------------------------------------------------
+
+
+class TestCheckWebAvailability:
+    """New capability-specific availability checks."""
+
+    def test_check_web_search_available_true(self, monkeypatch):
+        from tools import web_tools
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "brave"})
+        monkeypatch.setenv("BRAVE_API_KEY", "test-key")
+        assert web_tools.check_web_search_available() is True
+
+    def test_check_web_search_available_false_no_backend(self, monkeypatch):
+        from tools import web_tools
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": ""})
+        for var in ("BRAVE_API_KEY", "EXA_API_KEY", "TAVILY_API_KEY",
+                     "PARALLEL_API_KEY", "SEARXNG_URL", "FIRECRAWL_API_KEY"):
+            monkeypatch.delenv(var, raising=False)
+        assert web_tools.check_web_search_available() is False
+
+    def test_check_web_extract_available_true(self, monkeypatch):
+        from tools import web_tools
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"extract_backend": "exa"})
+        monkeypatch.setenv("EXA_API_KEY", "test-key")
+        assert web_tools.check_web_extract_available() is True
+
+    def test_check_web_extract_available_false(self, monkeypatch):
+        from tools import web_tools
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"extract_backend": ""})
+        for var in ("EXA_API_KEY", "TAVILY_API_KEY", "PARALLEL_API_KEY",
+                     "FIRECRAWL_API_KEY", "FIRECRAWL_API_URL"):
+            monkeypatch.delenv(var, raising=False)
+        assert web_tools.check_web_extract_available() is False
+
+    def test_check_web_api_key_backward_compatible(self, monkeypatch):
+        """Legacy check_web_api_key delegates to check_web_search_available."""
+        from tools import web_tools
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "brave"})
+        monkeypatch.setenv("BRAVE_API_KEY", "test-key")
+        assert web_tools.check_web_api_key() is True
+
+
+# ---------------------------------------------------------------------------
+# Dispatch through ProviderRegistry
+# ---------------------------------------------------------------------------
+
+
+class TestProviderRegistryDispatch:
+    """web_search_tool dispatches through ProviderRegistry for registered providers."""
+
+    def test_web_search_dispatch_brave(self, monkeypatch):
+        """Brave search should dispatch through BraveSearchProvider."""
+        from tools import web_tools
+        from tools.web_providers.registry import ProviderRegistry
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "brave"})
+        monkeypatch.setenv("BRAVE_API_KEY", "test-key")
+
+        ProviderRegistry._scanned = False
+        result = web_tools.web_search_tool("test", 1)
+        assert '"success": true' in result.lower() or '"success": false' in result.lower()
+
+    def test_web_search_dispatch_unknown_backend(self, monkeypatch):
+        """Unknown backend should return error."""
+        from tools import web_tools
+
+        monkeypatch.setattr(web_tools, "_get_search_backend", lambda: "nonexistent")
+        result = web_tools.web_search_tool("test", 1)
+        assert "Unknown search backend" in result

--- a/tools/web_providers/brave.py
+++ b/tools/web_providers/brave.py
@@ -1,0 +1,156 @@
+"""Brave Search API provider.
+
+Brave Search is a privacy-focused search engine with an independent index
+(35B+ pages).  The API returns clean JSON — no CAPTCHAs, no JS redirects.
+
+This provider implements ``WebSearchProvider`` only — search capability.
+There is no extract endpoint; pair with Firecrawl/Tavily for extraction.
+
+Features: web, news, images, videos, LLM-optimized context endpoint.
+
+Configuration::
+
+    # ~/.hermes/.env
+    BRAVE_API_KEY=BSA...
+
+    # ~/.hermes/config.yaml
+    web:
+      search_backend: "brave"
+      extract_backend: "firecrawl"  # or any extract provider
+
+Free tier: $5/mo credit (≈1,000 web searches).  No credit card required
+for the free plan.  Sign up at https://api-dashboard.search.brave.com.
+
+Rate limits: 50 QPS (web), 2 QPS (answers/LLM).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict
+
+from tools.web_providers.base import WebSearchProvider
+
+logger = logging.getLogger(__name__)
+
+BRAVE_API_BASE = "https://api.search.brave.com"
+
+
+class BraveSearchProvider(WebSearchProvider):
+    """Search via Brave Search API.
+
+    Requires ``BRAVE_API_KEY`` in ``~/.hermes/.env``.
+    Uses ``/res/v1/web/search`` endpoint with ``extra_snippets=True``
+    for richer descriptions.
+    """
+
+    # ── ProviderRegistry metadata ────────────────────────────────────────
+    required_env_vars = ["BRAVE_API_KEY"]
+
+    def provider_name(self) -> str:
+        return "brave"
+
+    def is_configured(self) -> bool:
+        """Return True when ``BRAVE_API_KEY`` is set."""
+        return bool(os.getenv("BRAVE_API_KEY", "").strip())
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        """Execute a web search via Brave Search API.
+
+        Returns normalized results::
+
+            {
+                "success": True,
+                "data": {
+                    "web": [
+                        {
+                            "title": str,
+                            "url": str,
+                            "description": str,
+                            "position": int,
+                        },
+                        ...
+                    ]
+                }
+            }
+
+        On failure returns ``{"success": False, "error": str}``.
+        """
+        import httpx
+
+        api_key = os.getenv("BRAVE_API_KEY", "").strip()
+        if not api_key:
+            return {"success": False, "error": "BRAVE_API_KEY is not set"}
+
+        headers = {
+            "Accept": "application/json",
+            "Accept-Encoding": "gzip",
+            "X-Subscription-Token": api_key,
+        }
+
+        params: Dict[str, Any] = {
+            "q": query,
+            "count": min(limit, 20),
+            "extra_snippets": True,
+        }
+
+        try:
+            resp = httpx.get(
+                f"{BRAVE_API_BASE}/res/v1/web/search",
+                params=params,
+                headers=headers,
+                timeout=15,
+            )
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            logger.warning("Brave Search HTTP %s: %s", exc.response.status_code, exc)
+            return {
+                "success": False,
+                "error": f"Brave Search returned HTTP {exc.response.status_code}",
+            }
+        except httpx.RequestError as exc:
+            logger.warning("Brave Search request error: %s", exc)
+            return {
+                "success": False,
+                "error": f"Could not reach Brave Search API: {exc}",
+            }
+
+        try:
+            data = resp.json()
+        except Exception:
+            logger.warning("Brave Search response parse error")
+            return {
+                "success": False,
+                "error": "Could not parse Brave Search response as JSON",
+            }
+
+        # Brave returns "web" → "results" array, and optionally "news" results.
+        # We also check the top-level "results" key for backward compat.
+        web_raw = data.get("web", {})
+        if isinstance(web_raw, dict):
+            raw_results = web_raw.get("results", [])
+        else:
+            raw_results = data.get("results", [])
+
+        # Map to normalized format — Brave uses "description" (not "content"/"snippet").
+        web_results = []
+        for i, r in enumerate(raw_results[:limit]):
+            web_results.append(
+                {
+                    "title": str(r.get("title", "")),
+                    "url": str(r.get("url", "")),
+                    "description": str(r.get("description", "")),
+                    "position": i + 1,
+                }
+            )
+
+        logger.info(
+            "Brave Search '%s': %d results (from %d raw, limit %d)",
+            query,
+            len(web_results),
+            len(raw_results),
+            limit,
+        )
+
+        return {"success": True, "data": {"web": web_results}}

--- a/tools/web_providers/exa.py
+++ b/tools/web_providers/exa.py
@@ -1,0 +1,54 @@
+"""Exa AI search and extract provider.
+
+Exa (https://exa.ai) provides semantic search and content extraction APIs.
+This module wraps the existing ``_exa_search()`` / ``_exa_extract()`` functions
+from ``web_tools.py`` into proper ``WebSearchProvider`` / ``WebExtractProvider``
+implementations so the ``ProviderRegistry`` can auto-discover them.
+
+Configuration::
+
+    # ~/.hermes/.env
+    EXA_API_KEY=...
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List
+
+from tools.web_providers.base import WebExtractProvider, WebSearchProvider
+
+
+class ExaSearchProvider(WebSearchProvider):
+    """Search via Exa semantic search API."""
+
+    required_env_vars = ["EXA_API_KEY"]
+
+    def provider_name(self) -> str:
+        return "exa"
+
+    def is_configured(self) -> bool:
+        return bool(os.getenv("EXA_API_KEY", "").strip())
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        from tools.web_tools import _exa_search
+
+        return _exa_search(query, limit)
+
+
+class ExaExtractProvider(WebExtractProvider):
+    """Extract via Exa content API."""
+
+    required_env_vars = ["EXA_API_KEY"]
+
+    def provider_name(self) -> str:
+        return "exa"
+
+    def is_configured(self) -> bool:
+        return bool(os.getenv("EXA_API_KEY", "").strip())
+
+    async def extract(self, urls: List[str], **kwargs) -> Dict[str, Any]:
+        from tools.web_tools import _exa_extract
+
+        results = _exa_extract(urls)
+        return {"success": True, "data": results}

--- a/tools/web_providers/parallel.py
+++ b/tools/web_providers/parallel.py
@@ -1,0 +1,57 @@
+"""Parallel AI search and extract provider.
+
+Parallel (https://parallel.ai) provides an agentic search API.  This module
+wraps the existing ``_parallel_search()`` / ``_parallel_extract()`` functions
+from ``web_tools.py`` into proper ``WebSearchProvider`` / ``WebExtractProvider``
+implementations so the ``ProviderRegistry`` can auto-discover them.
+
+Configuration::
+
+    # ~/.hermes/.env
+    PARALLEL_API_KEY=...
+
+    # Optional: search mode (fast / one-shot / agentic)
+    PARALLEL_SEARCH_MODE=agentic
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List
+
+from tools.web_providers.base import WebExtractProvider, WebSearchProvider
+
+
+class ParallelSearchProvider(WebSearchProvider):
+    """Search via Parallel AI agentic search."""
+
+    required_env_vars = ["PARALLEL_API_KEY"]
+
+    def provider_name(self) -> str:
+        return "parallel"
+
+    def is_configured(self) -> bool:
+        return bool(os.getenv("PARALLEL_API_KEY", "").strip())
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        from tools.web_tools import _parallel_search
+
+        return _parallel_search(query, limit)
+
+
+class ParallelExtractProvider(WebExtractProvider):
+    """Extract via Parallel AI."""
+
+    required_env_vars = ["PARALLEL_API_KEY"]
+
+    def provider_name(self) -> str:
+        return "parallel"
+
+    def is_configured(self) -> bool:
+        return bool(os.getenv("PARALLEL_API_KEY", "").strip())
+
+    async def extract(self, urls: List[str], **kwargs) -> Dict[str, Any]:
+        from tools.web_tools import _parallel_extract
+
+        results = await _parallel_extract(urls)
+        return {"success": True, "data": results}

--- a/tools/web_providers/registry.py
+++ b/tools/web_providers/registry.py
@@ -1,0 +1,248 @@
+"""Provider Registry — auto-discovery for web capability providers.
+
+This module scans ``tools/web_providers/`` and automatically discovers all
+``WebSearchProvider`` and ``WebExtractProvider`` subclasses.  Adding a new
+search backend requires exactly one new file in this directory — no changes
+to ``web_tools.py`` wiring, ``_get_backend()``, ``_is_backend_available()``,
+``check_web_api_key()``, or the ``hermes tools`` picker hardcoded lists.
+
+Architecture
+------------
+
+::
+
+    tools/web_providers/
+        base.py          — WebSearchProvider / WebExtractProvider ABCs
+        registry.py      — this file (ProviderRegistry)
+        brave.py         — BraveSearchProvider
+        searxng.py       — SearXNGSearchProvider
+        ddgs.py          — DDGSSearchProvider
+        parallel.py      — ParallelSearchProvider / ParallelExtractProvider
+        exa.py           — ExaSearchProvider / ExaExtractProvider
+        tavily.py        — TavilySearchProvider / TavilyExtractProvider
+        …                — drop any new provider here, zero wiring
+
+Usage
+-----
+
+    from tools.web_providers.registry import ProviderRegistry
+
+    # Is a backend available?
+    ProviderRegistry.is_search_available("brave")   → True/False
+
+    # Get a configured provider instance
+    provider = ProviderRegistry.get_search_provider("searxng")   → WebSearchProvider
+
+    # List all registered providers
+    ProviderRegistry.list_search_providers()   → {"brave": BraveSearchProvider, …}
+
+    # Are any search providers available at all?
+    ProviderRegistry.any_search_available()    → True/False
+
+    # All env vars needed by registered providers
+    ProviderRegistry.all_required_env_vars()   → {"BRAVE_API_KEY", "EXA_API_KEY", …}
+"""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import pkgutil
+from typing import Dict, List, Optional, Set, Type
+
+import tools.web_providers as _pkg
+
+from tools.web_providers.base import WebExtractProvider, WebSearchProvider
+
+logger = logging.getLogger(__name__)
+
+
+class ProviderRegistry:
+    """Auto-discovering registry for web capability providers.
+
+    Scans ``tools/web_providers/`` on first access and caches results.
+    All public methods are safe to call at import time (no network I/O).
+    """
+
+    # ── internal state ──────────────────────────────────────────────────────
+
+    _scanned: bool = False
+    _search_providers: Dict[str, Type[WebSearchProvider]] = {}
+    _extract_providers: Dict[str, Type[WebExtractProvider]] = {}
+    _priority_order: List[str] = []  # registration order = priority
+
+    # ── public helpers ──────────────────────────────────────────────────────
+
+    @classmethod
+    def _ensure_scanned(cls) -> None:
+        """Lazily scan the provider directory on first access."""
+        if cls._scanned:
+            return
+        cls._scanned = True
+
+        for _, name, _ in pkgutil.iter_modules(_pkg.__path__):
+            if name in ("base", "registry", "__init__"):
+                continue
+
+            try:
+                mod = importlib.import_module(f"tools.web_providers.{name}")
+            except ImportError as exc:
+                # Some providers depend on optional packages (e.g. ddgs
+                # needs the ``ddgs`` pip package).  Import failures are
+                # non-fatal — the provider simply won't appear in the
+                # registry.
+                logger.debug(
+                    "Skipping web_providers.%s — import failed: %s", name, exc
+                )
+                continue
+
+            for attr_name in dir(mod):
+                obj = getattr(mod, attr_name)
+                if not isinstance(obj, type):
+                    continue
+
+                # Search providers
+                if issubclass(obj, WebSearchProvider) and obj is not WebSearchProvider:
+                    try:
+                        instance = obj()
+                        pname = instance.provider_name()
+                    except Exception:
+                        continue
+                    cls._search_providers[pname] = obj
+                    if pname not in cls._priority_order:
+                        cls._priority_order.append(pname)
+
+                # Extract providers
+                if (
+                    issubclass(obj, WebExtractProvider)
+                    and obj is not WebExtractProvider
+                ):
+                    try:
+                        instance = obj()
+                        pname = instance.provider_name()
+                    except Exception:
+                        continue
+                    cls._extract_providers[pname] = obj
+                    if pname not in cls._priority_order:
+                        cls._priority_order.append(pname)
+
+        logger.debug(
+            "ProviderRegistry scanned: search=%s extract=%s",
+            list(cls._search_providers.keys()),
+            list(cls._extract_providers.keys()),
+        )
+
+    # ── listing ─────────────────────────────────────────────────────────────
+
+    @classmethod
+    def list_search_providers(cls) -> Dict[str, Type[WebSearchProvider]]:
+        """Return ``{provider_name: ProviderClass}`` for all search providers."""
+        cls._ensure_scanned()
+        return dict(cls._search_providers)
+
+    @classmethod
+    def list_extract_providers(cls) -> Dict[str, Type[WebExtractProvider]]:
+        """Return ``{provider_name: ProviderClass}`` for all extract providers."""
+        cls._ensure_scanned()
+        return dict(cls._extract_providers)
+
+    # ── lookup ──────────────────────────────────────────────────────────────
+
+    @classmethod
+    def get_search_provider(cls, name: str) -> Optional[Type[WebSearchProvider]]:
+        """Return the provider class for *name*, or ``None``."""
+        cls._ensure_scanned()
+        return cls._search_providers.get(name)
+
+    @classmethod
+    def get_extract_provider(cls, name: str) -> Optional[Type[WebExtractProvider]]:
+        """Return the provider class for *name*, or ``None``."""
+        cls._ensure_scanned()
+        return cls._extract_providers.get(name)
+
+    # ── availability gates ──────────────────────────────────────────────────
+
+    @classmethod
+    def is_search_available(cls, name: str) -> bool:
+        """Return ``True`` when *name* is registered and its env vars are set."""
+        cls._ensure_scanned()
+        provider_cls = cls._search_providers.get(name)
+        if provider_cls is None:
+            return False
+        try:
+            return provider_cls().is_configured()
+        except Exception:
+            return False
+
+    @classmethod
+    def is_extract_available(cls, name: str) -> bool:
+        """Return ``True`` when *name* is registered and its env vars are set."""
+        cls._ensure_scanned()
+        provider_cls = cls._extract_providers.get(name)
+        if provider_cls is None:
+            return False
+        try:
+            return provider_cls().is_configured()
+        except Exception:
+            return False
+
+    @classmethod
+    def any_search_available(cls) -> bool:
+        """Return ``True`` when at least one search provider is configured."""
+        cls._ensure_scanned()
+        for name in cls._search_providers:
+            if cls.is_search_available(name):
+                return True
+        return False
+
+    @classmethod
+    def any_extract_available(cls) -> bool:
+        """Return ``True`` when at least one extract provider is configured."""
+        cls._ensure_scanned()
+        for name in cls._extract_providers:
+            if cls.is_extract_available(name):
+                return True
+        return False
+
+    @classmethod
+    def find_first_available(cls) -> Optional[str]:
+        """Return the name of the highest-priority configured provider.
+
+        Priority is registration order (first found = highest).
+        Used as the auto-detect fallback when no config key is set.
+        """
+        cls._ensure_scanned()
+        for name in cls._priority_order:
+            if cls.is_search_available(name):
+                return name
+        return None
+
+    @classmethod
+    def find_first_extract_available(cls) -> Optional[str]:
+        """Return the name of the highest-priority configured extract provider."""
+        cls._ensure_scanned()
+        for name in cls._priority_order:
+            if cls.is_extract_available(name):
+                return name
+        return None
+
+    # ── env var collection ──────────────────────────────────────────────────
+
+    @classmethod
+    def all_required_env_vars(cls) -> Set[str]:
+        """Collect all env vars declared by registered providers.
+
+        Used for ``requires_env`` metadata in tool registration.
+        """
+        cls._ensure_scanned()
+        env_vars: Set[str] = set()
+        for provider_cls in list(cls._search_providers.values()) + list(
+            cls._extract_providers.values()
+        ):
+            try:
+                instance = provider_cls()
+                if hasattr(instance, "required_env_vars"):
+                    env_vars.update(instance.required_env_vars)
+            except Exception:
+                pass
+        return env_vars

--- a/tools/web_providers/searxng.py
+++ b/tools/web_providers/searxng.py
@@ -40,6 +40,9 @@ class SearXNGSearchProvider(WebSearchProvider):
     sorted by SearXNG's own score and truncated to *limit*.
     """
 
+    # ── ProviderRegistry metadata ────────────────────────────────────────
+    required_env_vars = ["SEARXNG_URL"]
+
     def provider_name(self) -> str:
         return "searxng"
 

--- a/tools/web_providers/tavily.py
+++ b/tools/web_providers/tavily.py
@@ -1,0 +1,64 @@
+"""Tavily search and extract provider.
+
+Tavily (https://tavily.com) provides a search API optimized for AI agents.
+This module wraps the existing ``_tavily_request()`` / normalization functions
+from ``web_tools.py`` into proper ``WebSearchProvider`` / ``WebExtractProvider``
+implementations so the ``ProviderRegistry`` can auto-discover them.
+
+Configuration::
+
+    # ~/.hermes/.env
+    TAVILY_API_KEY=...
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List
+
+from tools.web_providers.base import WebExtractProvider, WebSearchProvider
+
+
+class TavilySearchProvider(WebSearchProvider):
+    """Search via Tavily AI search API."""
+
+    required_env_vars = ["TAVILY_API_KEY"]
+
+    def provider_name(self) -> str:
+        return "tavily"
+
+    def is_configured(self) -> bool:
+        return bool(os.getenv("TAVILY_API_KEY", "").strip())
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        from tools.web_tools import _normalize_tavily_search_results, _tavily_request
+
+        raw = _tavily_request(
+            "search",
+            {
+                "query": query,
+                "max_results": min(limit, 20),
+                "include_raw_content": False,
+                "include_images": False,
+            },
+        )
+        return _normalize_tavily_search_results(raw)
+
+
+class TavilyExtractProvider(WebExtractProvider):
+    """Extract via Tavily content API."""
+
+    required_env_vars = ["TAVILY_API_KEY"]
+
+    def provider_name(self) -> str:
+        return "tavily"
+
+    def is_configured(self) -> bool:
+        return bool(os.getenv("TAVILY_API_KEY", "").strip())
+
+    async def extract(self, urls: List[str], **kwargs) -> Dict[str, Any]:
+        from tools.web_tools import _normalize_tavily_documents, _tavily_request
+
+        raw = _tavily_request("extract", {"urls": urls})
+        results = _normalize_tavily_documents(raw)
+        return {"success": True, "data": results}

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -122,32 +122,44 @@ def _get_backend() -> str:
     """Determine which web backend to use (shared fallback).
 
     Reads ``web.backend`` from config.yaml (set by ``hermes tools``).
-    Falls back to whichever API key is present for users who configured
-    keys manually without running setup.
+    Falls back to whichever provider's API key/env is present for users
+    who configured keys manually without running setup.
     """
+    from tools.web_providers.registry import ProviderRegistry
+
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in ("parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs"):
-        return configured
+ (feat: auto-discovering ProviderRegistry for web search/extract backends)
 
-    # Fallback for manual / legacy config — pick the highest-priority
-    # available backend. Firecrawl also counts as available when the managed
-    # tool gateway is configured for Nous subscribers.
-    # Free-tier backends (searxng / brave-free / ddgs) trail the paid ones so
-    # existing paid setups are unaffected.
-    backend_candidates = (
-        ("firecrawl", _has_env("FIRECRAWL_API_KEY") or _has_env("FIRECRAWL_API_URL") or _is_tool_gateway_ready()),
-        ("parallel", _has_env("PARALLEL_API_KEY")),
-        ("tavily", _has_env("TAVILY_API_KEY")),
-        ("exa", _has_env("EXA_API_KEY")),
-        ("searxng", _has_env("SEARXNG_URL")),
-        ("brave-free", _has_env("BRAVE_SEARCH_API_KEY")),
-        ("ddgs", _ddgs_package_importable()),
-    )
-    for backend, available in backend_candidates:
-        if available:
-            return backend
+    # If the user explicitly set web.backend to a known provider, trust it
+    # unconditionally (backward compat — old code returned it without
+    # checking whether the API key was actually available).
+    if configured:
+        if configured == "firecrawl" or ProviderRegistry.get_search_provider(configured):
+            return configured
+        # Unknown backend name — fall through to auto-detect
 
-    return "firecrawl"  # default (backward compat)
+    # Auto-detect fallback: preserve legacy priority order.
+    # Firecrawl (with its complex gateway) must be checked first.
+    if (
+        _has_env("FIRECRAWL_API_KEY")
+        or _has_env("FIRECRAWL_API_URL")
+        or _is_tool_gateway_ready()
+    ):
+        return "firecrawl"
+
+    # Legacy priority for auto-detect: parallel → tavily → exa → searxng
+    # (Brave and any future backends are discovered by the registry and
+    # checked after the legacy priority chain).
+    for legacy_name in ("parallel", "tavily", "exa", "searxng"):
+        if ProviderRegistry.is_search_available(legacy_name):
+            return legacy_name
+
+    # Check any registry-only backends not in the legacy list (e.g. brave).
+    first = ProviderRegistry.find_first_available()
+    if first:
+        return first
+
+    return "firecrawl"  # ultimate default (backward compat)
 
 
 def _get_search_backend() -> str:
@@ -190,20 +202,18 @@ def _get_capability_backend(capability: str) -> str:
 
 def _is_backend_available(backend: str) -> bool:
     """Return True when the selected backend is currently usable."""
-    if backend == "exa":
-        return _has_env("EXA_API_KEY")
-    if backend == "parallel":
-        return _has_env("PARALLEL_API_KEY")
+    from tools.web_providers.registry import ProviderRegistry
+
+    # Try the auto-discovered providers first.
+    if ProviderRegistry.is_search_available(backend):
+        return True
+    if ProviderRegistry.is_extract_available(backend):
+        return True
+
+    # Firecrawl has special gateway-based availability.
     if backend == "firecrawl":
         return check_firecrawl_api_key()
-    if backend == "tavily":
-        return _has_env("TAVILY_API_KEY")
-    if backend == "searxng":
-        return _has_env("SEARXNG_URL")
-    if backend == "brave-free":
-        return _has_env("BRAVE_SEARCH_API_KEY")
-    if backend == "ddgs":
-        return _ddgs_package_importable()
+ (feat: auto-discovering ProviderRegistry for web search/extract backends)
     return False
 
 
@@ -284,28 +294,22 @@ def _firecrawl_backend_help_suffix() -> str:
 
 
 def _web_requires_env() -> list[str]:
-    """Return tool metadata env vars for the currently enabled web backends.
+    """Return tool metadata env vars for all registered web backends."""
+    from tools.web_providers.registry import ProviderRegistry
 
-    The gateway env vars are always reported — they're metadata strings
-    used by the tool registry to light up the tool when the variable is
-    set.  Gating them on ``managed_nous_tools_enabled()`` only saved
-    string noise in the metadata list, but cost a synchronous HTTP
-    refresh against the Nous portal on every CLI startup (invoked at
-    tool-registration time).  The behavioral contract is: if the env var
-    is set, the tool sees it; if not, it doesn't.  Not-logged-in users
-    simply don't have the vars set, so the extra entries are harmless.
-    """
-    return [
-        "EXA_API_KEY",
-        "PARALLEL_API_KEY",
-        "TAVILY_API_KEY",
-        "FIRECRAWL_API_KEY",
-        "FIRECRAWL_API_URL",
-        "FIRECRAWL_GATEWAY_URL",
-        "TOOL_GATEWAY_DOMAIN",
-        "TOOL_GATEWAY_SCHEME",
-        "TOOL_GATEWAY_USER_TOKEN",
-    ]
+    requires = sorted(ProviderRegistry.all_required_env_vars())
+    # Firecrawl env vars (Firecrawl is not yet a ProviderRegistry provider)
+    requires.extend(["FIRECRAWL_API_KEY", "FIRECRAWL_API_URL"])
+    if managed_nous_tools_enabled():
+        requires.extend(
+            [
+                "FIRECRAWL_GATEWAY_URL",
+                "TOOL_GATEWAY_DOMAIN",
+                "TOOL_GATEWAY_SCHEME",
+                "TOOL_GATEWAY_USER_TOKEN",
+            ]
+        )
+    return requires (feat: auto-discovering ProviderRegistry for web search/extract backends)
 
 
 def _get_firecrawl_client():
@@ -1199,102 +1203,43 @@ def web_search_tool(query: str, limit: int = 5) -> str:
 
         # Dispatch to the configured search backend
         backend = _get_search_backend()
-        if backend == "parallel":
-            response_data = _parallel_search(query, limit)
-            debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
-            result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
-            debug_call_data["final_response_size"] = len(result_json)
-            _debug.log_call("web_search_tool", debug_call_data)
-            _debug.save()
-            return result_json
 
-        if backend == "exa":
-            response_data = _exa_search(query, limit)
-            debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
-            result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
-            debug_call_data["final_response_size"] = len(result_json)
-            _debug.log_call("web_search_tool", debug_call_data)
-            _debug.save()
-            return result_json
-
-        if backend == "searxng":
-            from tools.web_providers.searxng import SearXNGSearchProvider
-            response_data = SearXNGSearchProvider().search(query, limit)
-            debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
-            result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
-            debug_call_data["final_response_size"] = len(result_json)
-            _debug.log_call("web_search_tool", debug_call_data)
-            _debug.save()
-            return result_json
-
-        if backend == "brave-free":
-            from tools.web_providers.brave_free import BraveFreeSearchProvider
-            response_data = BraveFreeSearchProvider().search(query, limit)
-            debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
-            result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
-            debug_call_data["final_response_size"] = len(result_json)
-            _debug.log_call("web_search_tool", debug_call_data)
-            _debug.save()
-            return result_json
-
-        if backend == "ddgs":
-            from tools.web_providers.ddgs import DDGSSearchProvider
-            response_data = DDGSSearchProvider().search(query, limit)
-            debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
-            result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
-            debug_call_data["final_response_size"] = len(result_json)
-            _debug.log_call("web_search_tool", debug_call_data)
-            _debug.save()
-            return result_json
-
-        if backend == "tavily":
-            logger.info("Tavily search: '%s' (limit: %d)", query, limit)
-            raw = _tavily_request("search", {
-                "query": query,
-                "max_results": min(limit, 20),
-                "include_raw_content": False,
-                "include_images": False,
-            })
-            response_data = _normalize_tavily_search_results(raw)
-            debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
-            result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
-            debug_call_data["final_response_size"] = len(result_json)
-            _debug.log_call("web_search_tool", debug_call_data)
-            _debug.save()
-            return result_json
-
-        logger.info("Searching the web for: '%s' (limit: %d)", query, limit)
-
-        response = _get_firecrawl_client().search(
-            query=query,
-            limit=limit
-        )
-
-        web_results = _extract_web_search_results(response)
-        results_count = len(web_results)
-        logger.info("Found %d search results", results_count)
-        
-        # Build response with just search metadata (URLs, titles, descriptions)
-        response_data = {
-            "success": True,
-            "data": {
-                "web": web_results
+        # Firecrawl has complex client setup — handle separately.
+        if backend == "firecrawl":
+            logger.info("Searching the web for: '%s' (limit: %d)", query, limit)
+            response = _get_firecrawl_client().search(
+                query=query,
+                limit=limit
+            )
+            web_results = _extract_web_search_results(response)
+            results_count = len(web_results)
+            logger.info("Found %d search results", results_count)
+            response_data = {
+                "success": True,
+                "data": {
+                    "web": web_results
+                }
             }
-        }
-        
-        # Capture debug information
-        debug_call_data["results_count"] = results_count
-        
-        # Convert to JSON
-        result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
-        
-        debug_call_data["final_response_size"] = len(result_json)
-        
-        # Log debug information
-        _debug.log_call("web_search_tool", debug_call_data)
-        _debug.save()
-        
-        return result_json
+            debug_call_data["results_count"] = results_count
+            result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
+            debug_call_data["final_response_size"] = len(result_json)
+            _debug.log_call("web_search_tool", debug_call_data)
+            _debug.save()
+            return result_json
+
+        # ProviderRegistry dispatch — all registered providers use this path.
+        from tools.web_providers.registry import ProviderRegistry
+        provider_cls = ProviderRegistry.get_search_provider(backend)
+        if provider_cls:
+            response_data = provider_cls().search(query, limit) (feat: auto-discovering ProviderRegistry for web search/extract backends)
+            debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
+            result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
+            debug_call_data["final_response_size"] = len(result_json)
+            _debug.log_call("web_search_tool", debug_call_data)
+            _debug.save()
+            return result_json
+
+        return tool_error(f"Unknown search backend: '{backend}'")
         
     except Exception as e:
         error_msg = f"Error searching web: {str(e)}"
@@ -1386,27 +1331,30 @@ async def web_extract_tool(
         else:
             backend = _get_extract_backend()
 
-            if backend == "parallel":
-                results = await _parallel_extract(safe_urls)
-            elif backend == "exa":
-                results = _exa_extract(safe_urls)
-            elif backend == "tavily":
-                logger.info("Tavily extract: %d URL(s)", len(safe_urls))
-                raw = _tavily_request("extract", {
-                    "urls": safe_urls,
-                    "include_images": False,
-                })
-                results = _normalize_tavily_documents(raw, fallback_url=safe_urls[0] if safe_urls else "")
-            elif backend in ("searxng", "brave-free", "ddgs"):
-                # These backends are search-only — they cannot extract URL content
-                _label = {"searxng": "SearXNG", "brave-free": "Brave Search (free tier)", "ddgs": "DuckDuckGo (ddgs)"}[backend]
+            # ProviderRegistry dispatch — all registered extract providers go here.
+            from tools.web_providers.registry import ProviderRegistry
+            provider_cls = ProviderRegistry.get_extract_provider(backend)
+            if provider_cls:
+                instance = provider_cls()
+                extract_fn = instance.extract
+                if asyncio.iscoroutinefunction(extract_fn):
+                    provider_result = await extract_fn(safe_urls)
+                else:
+                    provider_result = extract_fn(safe_urls)
+                if provider_result.get("success"):
+                    results = provider_result.get("data", [])
+                else:
+                    results = []
+            elif ProviderRegistry.get_search_provider(backend):
+                # This is a search-only backend — it cannot extract URL content
+                _label = backend.replace("-", " ").title()
                 return json.dumps({
                     "success": False,
                     "error": f"{_label} is a search-only backend and cannot extract URL content. "
                              "Set web.extract_backend to firecrawl, tavily, exa, or parallel.",
                 }, ensure_ascii=False)
             else:
-                # ── Firecrawl extraction ──
+                # ── Firecrawl extraction (default fallback) ──
                 # Determine requested formats for Firecrawl v2
                 formats: List[str] = []
                 if format == "markdown":
@@ -2081,15 +2029,47 @@ def check_firecrawl_api_key() -> bool:
     return _has_direct_firecrawl_config() or _is_tool_gateway_ready()
 
 
+def check_web_search_available() -> bool:
+    """Check whether any web_search backend is available."""
+    from tools.web_providers.registry import ProviderRegistry
+
+    cfg = _load_web_config()
+    # If user explicitly configured a backend, check ONLY that backend.
+    search_cfg = (cfg.get("search_backend") or "").lower().strip()
+    if search_cfg:
+        return _is_backend_available(search_cfg)
+    shared = (cfg.get("backend") or "").lower().strip()
+    if shared:
+        return _is_backend_available(shared)
+    # No explicit config → auto-detect any available backend.
+    return ProviderRegistry.any_search_available() or check_firecrawl_api_key()
+
+
+def check_web_extract_available() -> bool:
+    """Check whether any web_extract backend is available."""
+    from tools.web_providers.registry import ProviderRegistry
+
+    cfg = _load_web_config()
+    # If user explicitly configured a backend, check ONLY that backend.
+    extract_cfg = (cfg.get("extract_backend") or "").lower().strip()
+    if extract_cfg:
+        return _is_backend_available(extract_cfg)
+    shared = (cfg.get("backend") or "").lower().strip()
+    if shared:
+        return _is_backend_available(shared)
+    # No explicit config → auto-detect any available backend.
+    return ProviderRegistry.any_extract_available() or check_firecrawl_api_key()
+
+
+# ── Legacy alias for backward compatibility ──────────────────────────────────
+
 def check_web_api_key() -> bool:
-    """Check whether the configured web backend is available."""
-    configured = _load_web_config().get("backend", "").lower().strip()
-    if configured in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs"):
-        return _is_backend_available(configured)
-    return any(
-        _is_backend_available(backend)
-        for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs")
-    )
+    """Check whether the configured web backend is available.
+    
+    Deprecated: prefer ``check_web_search_available()`` or
+    ``check_web_extract_available()`` for capability-specific checks.
+    """
+    return check_web_search_available() (feat: auto-discovering ProviderRegistry for web search/extract backends)
 
 
 def check_auxiliary_model() -> bool:
@@ -2260,7 +2240,7 @@ registry.register(
     toolset="web",
     schema=WEB_SEARCH_SCHEMA,
     handler=lambda args, **kw: web_search_tool(args.get("query", ""), limit=args.get("limit", 5)),
-    check_fn=check_web_api_key,
+    check_fn=check_web_search_available,
     requires_env=_web_requires_env(),
     emoji="🔍",
     max_result_size_chars=100_000,
@@ -2271,7 +2251,7 @@ registry.register(
     schema=WEB_EXTRACT_SCHEMA,
     handler=lambda args, **kw: web_extract_tool(
         args.get("urls", [])[:5] if isinstance(args.get("urls"), list) else [], "markdown"),
-    check_fn=check_web_api_key,
+    check_fn=check_web_extract_available,
     requires_env=_web_requires_env(),
     is_async=True,
     emoji="📄",


### PR DESCRIPTION
Introduce a ProviderRegistry in tools/web_providers/registry.py that auto-discovers WebSearchProvider / WebExtractProvider subclasses via pkgutil.iter_modules — adding a new backend is now a single .py file.

New provider files:
- tools/web_providers/brave.py (Brave Search, WebSearchProvider)
- tools/web_providers/exa.py (Exa search+extract)
- tools/web_providers/parallel.py (Parallel search+extract)
- tools/web_providers/tavily.py (Tavily search+extract)
- tools/web_providers/searxng.py (added required_env_vars)

Refactored dispatch in web_tools.py:
- web_search_tool() replaces if/elif chain with ProviderRegistry lookup
- web_extract_tool() replaces if/elif chain with ProviderRegistry lookup
- check_web_search_available() / check_web_extract_available() added
- check_web_api_key() now delegates to check_web_search_available()
- _get_backend() / _is_backend_available() / _web_requires_env() use ProviderRegistry (Firecrawl stays special-cased)

Config: BRAVE_API_KEY in OPTIONAL_ENV_VARS, Brave in TOOL_CATEGORIES.
Tests: 30 tests covering discovery, availability, dispatch.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

