### PR TITLE
fix(tests): add Windows skip guards for UNIX-only pwd/fcntl imports

### DIFF
--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1,12 +1,16 @@
 """Tests for gateway service management helpers."""
 
 import os
-import pwd
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+
+# `pwd` is a UNIX-only stdlib module. Skip the whole file on platforms
+# (e.g. Windows) where it's unavailable so pytest collection doesn't
+# hard-fail before any test runs (#22420).
+pwd = pytest.importorskip("pwd")
 
 import hermes_cli.gateway as gateway_cli
 from gateway import status

--- a/tests/test_windows_skip_guards.py
+++ b/tests/test_windows_skip_guards.py
@@ -1,0 +1,40 @@
+"""Regression: tests importing UNIX-only stdlib modules must use
+``pytest.importorskip`` so collection on Windows doesn't hard-fail
+before any test runs (#22420).
+"""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _read(path: Path) -> str:
+    return path.read_text(encoding="utf-8")
+
+
+def _top_level_imports(body: str) -> list[str]:
+    """Return only the unindented import lines (module-level)."""
+    return [
+        line for line in body.splitlines()
+        if line.startswith("import ") or line.startswith("from ")
+    ]
+
+
+def test_gateway_service_uses_importorskip_for_pwd():
+    body = _read(REPO_ROOT / "tests" / "hermes_cli" / "test_gateway_service.py")
+    top = _top_level_imports(body)
+    assert "import pwd" not in top, (
+        "test_gateway_service.py must not `import pwd` at module top — "
+        "use `pwd = pytest.importorskip('pwd')` so Windows can skip the file."
+    )
+    assert 'pytest.importorskip("pwd")' in body
+
+
+def test_file_sync_back_uses_importorskip_for_fcntl():
+    body = _read(REPO_ROOT / "tests" / "tools" / "test_file_sync_back.py")
+    top = _top_level_imports(body)
+    assert "import fcntl" not in top, (
+        "test_file_sync_back.py must not `import fcntl` at module top — "
+        "use `fcntl = pytest.importorskip('fcntl')` so Windows can skip the file."
+    )
+    assert 'pytest.importorskip("fcntl")' in body

--- a/tests/test_windows_skip_guards.py
+++ b/tests/test_windows_skip_guards.py
@@ -3,6 +3,7 @@
 before any test runs (#22420).
 """
 
+import ast
 from pathlib import Path
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -12,19 +13,28 @@ def _read(path: Path) -> str:
     return path.read_text(encoding="utf-8")
 
 
-def _top_level_imports(body: str) -> list[str]:
-    """Return only the unindented import lines (module-level)."""
-    return [
-        line for line in body.splitlines()
-        if line.startswith("import ") or line.startswith("from ")
-    ]
+def _module_level_imports(body: str) -> set[str]:
+    """Return module names imported at module scope.
+
+    Uses ``ast`` so aliases (``import pwd as _pwd``), inline comments
+    (``import pwd  # noqa``) and trailing whitespace are all detected.
+    """
+    tree = ast.parse(body)
+    names: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                names.add(alias.name.split(".", 1)[0])
+        elif isinstance(node, ast.ImportFrom) and node.module:
+            names.add(node.module.split(".", 1)[0])
+    return names
 
 
 def test_gateway_service_uses_importorskip_for_pwd():
     body = _read(REPO_ROOT / "tests" / "hermes_cli" / "test_gateway_service.py")
-    top = _top_level_imports(body)
-    assert "import pwd" not in top, (
-        "test_gateway_service.py must not `import pwd` at module top — "
+    top = _module_level_imports(body)
+    assert "pwd" not in top, (
+        "test_gateway_service.py must not import `pwd` at module top — "
         "use `pwd = pytest.importorskip('pwd')` so Windows can skip the file."
     )
     assert 'pytest.importorskip("pwd")' in body
@@ -32,9 +42,9 @@ def test_gateway_service_uses_importorskip_for_pwd():
 
 def test_file_sync_back_uses_importorskip_for_fcntl():
     body = _read(REPO_ROOT / "tests" / "tools" / "test_file_sync_back.py")
-    top = _top_level_imports(body)
-    assert "import fcntl" not in top, (
-        "test_file_sync_back.py must not `import fcntl` at module top — "
+    top = _module_level_imports(body)
+    assert "fcntl" not in top, (
+        "test_file_sync_back.py must not import `fcntl` at module top — "
         "use `fcntl = pytest.importorskip('fcntl')` so Windows can skip the file."
     )
     assert 'pytest.importorskip("fcntl")' in body

--- a/tests/tools/test_file_sync_back.py
+++ b/tests/tools/test_file_sync_back.py
@@ -1,6 +1,5 @@
 """Tests for FileSyncManager.sync_back() — pull remote changes to host."""
 
-import fcntl
 import io
 import logging
 import os
@@ -11,6 +10,11 @@ from pathlib import Path
 from unittest.mock import MagicMock, call, patch
 
 import pytest
+
+# `fcntl` is a UNIX-only stdlib module. Skip the whole file on platforms
+# (e.g. Windows) where it's unavailable so pytest collection doesn't
+# hard-fail before any test runs (#22420).
+fcntl = pytest.importorskip("fcntl")
 
 from tools.environments.file_sync import (
     FileSyncManager,


### PR DESCRIPTION
## Summary

Closes #22420.

`tests/hermes_cli/test_gateway_service.py:4` does `import pwd` and
`tests/tools/test_file_sync_back.py:3` does `import fcntl` at module
top. Both are UNIX-only stdlib modules — on Windows, pytest
collection hard-fails with `ModuleNotFoundError` before any test in
those files runs, blocking the whole suite from completing in a
Windows CI/local environment.

## Fix

Replace the bare imports with `pytest.importorskip(...)` so the
affected files cleanly skip on platforms that don't ship the module:

```python
# tests/hermes_cli/test_gateway_service.py
pwd = pytest.importorskip("pwd")

# tests/tools/test_file_sync_back.py
fcntl = pytest.importorskip("fcntl")
```

On Linux/macOS the binding `pwd` / `fcntl` resolves to the same
module object, so existing tests are unchanged.

`importorskip` is preferred over a manual `pytest.skip()` +
try/except because it self-documents the platform requirement at the
import site and works for any platform that lacks the module — not
just Windows.

## Regression

`tests/test_windows_skip_guards.py` asserts that neither file has a
top-level `import pwd` / `import fcntl` and that both call
`pytest.importorskip(...)`. Stash-verified: tests fail without the
fix, pass with it.

## Test plan

- [x] `pytest tests/test_windows_skip_guards.py` → 2 passed
- [x] `pytest tests/hermes_cli/test_gateway_service.py tests/tools/test_file_sync_back.py` on macOS → unchanged from main (pre-existing D-Bus failures only — confirmed via stash)
- [ ] Cannot test Windows locally; relies on CI Windows runner if present