### PR TITLE
chore(release): add Zhekinmaksim to AUTHOR_MAP

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -65,6 +65,7 @@ AUTHOR_MAP = {
     "am@studio1.tailb672fe.ts.net": "subtract0",
     "axmaiqiu@gmail.com": "qWaitCrypto",
     "egitimviscara@gmail.com": "uzunkuyruk",
+    "zhekinmaksim@gmail.com": "Zhekinmaksim",
     "159539633+MottledShadow@users.noreply.github.com": "MottledShadow",
     "aludwin+gh@gmail.com": "adamludwin",
     "ngusev@astralinux.ru": "NikolayGusev-astra",


### PR DESCRIPTION
Maps `zhekinmaksim@gmail.com` → GitHub login `Zhekinmaksim` so `scripts/release.py` `contributor_audit.py` recognizes their authored commit.

Needed before merging the #21930 salvage PR.