### PR TITLE
fix(async): replace get_event_loop() with get_running_loop() — salvage of #21930

### DIFF
--- a/environments/agent_loop.py
+++ b/environments/agent_loop.py
@@ -403,7 +403,7 @@ class HermesAgentLoop:
                                     # Run tool calls in a thread pool so backends that
                                     # use asyncio.run() internally (modal, docker, daytona) get
                                     # a clean event loop instead of deadlocking.
-                                    loop = asyncio.get_event_loop()
+                                    loop = asyncio.get_running_loop()
                                     # Capture current tool_name/args for the lambda
                                     _tn, _ta, _tid = tool_name, args, self.task_id
                                     tool_result = await loop.run_in_executor(

--- a/environments/benchmarks/terminalbench_2/terminalbench2_env.py
+++ b/environments/benchmarks/terminalbench_2/terminalbench2_env.py
@@ -575,7 +575,7 @@ class TerminalBench2EvalEnv(HermesAgentBaseEnv):
                 # other tasks, tqdm updates, and timeout timers).
                 ctx = ToolContext(task_id)
                 try:
-                    loop = asyncio.get_event_loop()
+                    loop = asyncio.get_running_loop()
                     reward = await loop.run_in_executor(
                         None,  # default thread pool
                         self._run_tests, eval_item, ctx, task_name,

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -533,7 +533,7 @@ async def get_status():
     remote_health_body: dict | None = None
 
     if not gateway_running and _GATEWAY_HEALTH_URL:
-        loop = asyncio.get_event_loop()
+        loop = asyncio.get_running_loop()
         alive, remote_health_body = await loop.run_in_executor(
             None, _probe_gateway_health
         )
@@ -1845,7 +1845,7 @@ async def _start_device_code_flow(provider_id: str) -> Dict[str, Any]:
                     client_id=client_id,
                     scope=scope,
                 )
-        device_data = await asyncio.get_event_loop().run_in_executor(None, _do_nous_device_request)
+        device_data = await asyncio.get_running_loop().run_in_executor(None, _do_nous_device_request)
         sid, sess = _new_oauth_session("nous", "device_code")
         sess["device_code"] = str(device_data["device_code"])
         sess["interval"] = int(device_data["interval"])
@@ -2134,7 +2134,7 @@ async def submit_oauth_code(provider_id: str, body: OAuthSubmitBody, request: Re
     """Submit the auth code for PKCE flows. Token-protected."""
     _require_token(request)
     if provider_id == "anthropic":
-        return await asyncio.get_event_loop().run_in_executor(
+        return await asyncio.get_running_loop().run_in_executor(
             None, _submit_anthropic_pkce, body.session_id, body.code,
         )
     raise HTTPException(status_code=400, detail=f"submit not supported for {provider_id}")

--- a/tools/browser_cdp_tool.py
+++ b/tools/browser_cdp_tool.py
@@ -132,9 +132,9 @@ async def _cdp_call(
                     }
                 )
             )
-            deadline = asyncio.get_event_loop().time() + timeout
+            deadline = asyncio.get_running_loop().time() + timeout
             while True:
-                remaining = deadline - asyncio.get_event_loop().time()
+                remaining = deadline - asyncio.get_running_loop().time()
                 if remaining <= 0:
                     raise TimeoutError(
                         f"Timed out attaching to target {target_id}"
@@ -166,9 +166,9 @@ async def _cdp_call(
             req["sessionId"] = session_id
         await ws.send(json.dumps(req))
 
-        deadline = asyncio.get_event_loop().time() + timeout
+        deadline = asyncio.get_running_loop().time() + timeout
         while True:
-            remaining = deadline - asyncio.get_event_loop().time()
+            remaining = deadline - asyncio.get_running_loop().time()
             if remaining <= 0:
                 raise TimeoutError(
                     f"Timed out waiting for response to {method}"


### PR DESCRIPTION
## Summary

Salvage of #21930 by @Zhekinmaksim — replaces 9 calls to deprecated `asyncio.get_event_loop()` with `asyncio.get_running_loop()` across 4 files, all unconditionally inside `async def` bodies. Follow-up to #21293 which fixed the same anti-pattern in `cli.py`.

## Why a salvage

#21930 was 109 commits behind `main`, and its diff against current `main` carried two unintended stale-branch reverts beyond the +9/-9 the author actually wrote:

1. Reverted the `encoding="utf-8"` addition on `_tail_lines` (`cbce5e93f` "codebase: add encoding='utf-8' to all bare open() calls (PLW1514)")
2. Reverted the entire Windows PTY bridge guard (`9de893e3b` "feat(windows): close native-Windows install gaps") — both the try/except around `pty_bridge` import and the runtime `_PTY_BRIDGE_AVAILABLE` check that gives Windows users a clean error instead of an `ImportError`

Force-merging #21930 as-is would have silently undone both fixes. This salvage applies only the 9 intended swaps onto fresh `main`, preserving @Zhekinmaksim's authorship via `--author`.

## Sites

| File | Sites | Function |
|---|---|---|
| `tools/browser_cdp_tool.py` | 4 | `_cdp_call()` deadline + remaining computations inside `async with websockets.connect` |
| `hermes_cli/web_server.py` | 3 | `get_status`, `_start_device_code_flow`, `submit_oauth_code` — async FastAPI endpoints offloading blocking work to `run_in_executor` |
| `environments/agent_loop.py` | 1 | `HermesAgentLoop.run()` — tool dispatch inside async rollout loop |
| `environments/benchmarks/terminalbench_2/terminalbench2_env.py` | 1 | `rollout_and_score_eval()` — test verification thread offload |

I verified all 9 sites are unconditionally inside `async def` bodies, so a running loop is guaranteed and no `try/except RuntimeError` fallback is needed (unlike the cli.py case in #21293, which ran from a background thread). Inside a coroutine, both functions return the same loop — semantics are identical.

## Verification

```
$ git diff origin/main..HEAD --stat
 environments/agent_loop.py                                    | 2 +-
 environments/benchmarks/terminalbench_2/terminalbench2_env.py | 2 +-
 hermes_cli/web_server.py                                      | 6 +++---
 tools/browser_cdp_tool.py                                     | 8 ++++----
 4 files changed, 9 insertions(+), 9 deletions(-)
```

Pure +9/-9, no stale reverts.

- `python3 -m py_compile` — clean on all 4 files
- `ruff check` — clean
- `tests/tools/test_browser_cdp_tool.py` + `tests/hermes_cli/test_web_server.py` — 156/156 pass via `scripts/run_tests.sh`
- `rg "asyncio.get_event_loop\(\)"` in non-test/non-docs code — zero remaining occurrences (matches PR #21930's claim)

## Credit

Original work by **@Zhekinmaksim** in #21930. Their commit is preserved here with original authorship via `git -c user.email=zhekinmaksim@gmail.com -c user.name=Zhekinmaksim`. Closing #21930 with credit and explaining the salvage rationale on merge.

## Notes for reviewer

Depends on #22449 (`chore(release): add Zhekinmaksim to AUTHOR_MAP`) being merged first.

Merge with `--rebase` to preserve @Zhekinmaksim's authorship in the commit history.

Closes #21930
