### PR TITLE
fix(test-runner): avoid pip bootstrap in uv venvs and scrub HERMES_CRON_SESSION

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -41,12 +41,6 @@ fi
 
 PYTHON="$VENV/bin/python"
 
-# ── Ensure pytest-split is installed (required for shard-equivalent runs) ──
-if ! "$PYTHON" -c "import pytest_split" 2>/dev/null; then
-  echo "→ installing pytest-split into $VENV"
-  "$PYTHON" -m pip install --quiet "pytest-split>=0.9,<1"
-fi
-
 # ── Hermetic environment ────────────────────────────────────────────────────
 # Mirror what CI does in .github/workflows/tests.yml + what conftest.py does.
 # Unset every credential-shaped var currently in the environment.
@@ -70,7 +64,7 @@ unset HERMES_YOLO_MODE HERMES_INTERACTIVE HERMES_QUIET HERMES_TOOL_PROGRESS \
       HERMES_PLATFORM HERMES_INFERENCE_PROVIDER HERMES_MANAGED HERMES_DEV \
       HERMES_CONTAINER HERMES_EPHEMERAL_SYSTEM_PROMPT HERMES_TIMEZONE \
       HERMES_REDACT_SECRETS HERMES_BACKGROUND_NOTIFICATIONS HERMES_EXEC_ASK \
-      HERMES_HOME_MODE 2>/dev/null || true
+      HERMES_HOME_MODE HERMES_CRON_SESSION 2>/dev/null || true
 
 # Pin deterministic runtime.
 export TZ=UTC


### PR DESCRIPTION
## Summary
- Remove the `pytest-split` auto-install fallback from `scripts/run_tests.sh` so the canonical runner no longer assumes `pip` exists in uv-created virtualenvs.
- Add `HERMES_CRON_SESSION` to the hermetic `unset HERMES_*` block to prevent cron-mode leakage into pytest behavior.
- Keep the wrapper behavior focused and deterministic while preserving existing worker/test selection logic.

## Why
Running the canonical wrapper should not fail in valid uv-managed environments that intentionally do not ship `pip`, and test runs launched from cron contexts should not inherit cron-only behavior flags.

## Test Plan
- [x] Verify diff scope is limited to `scripts/run_tests.sh`.
- [ ] Run `scripts/run_tests.sh -n 0 tests/acp/test_approval_isolation.py::TestAcpExecAskGate::test_interactive_env_var_routes_to_callback -q` in an environment with an available project venv.
- [ ] Run representative local CI-parity subset with `scripts/run_tests.sh` to confirm no regression in wrapper invocation.