### PR TITLE
fix(kanban): trigger recompute_ready after unlink_tasks

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1490,6 +1490,13 @@ def _would_cycle(conn: sqlite3.Connection, parent_id: str, child_id: str) -> boo
 
 
 def unlink_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> bool:
+    """Delete a parent→child dependency edge.
+
+    Removes the link and re-runs :func:`recompute_ready` so the child is
+    promoted immediately if the removed parent was the last blocker
+    (same pattern as :func:`complete_task` and :func:`unblock_task`).
+    """
+    removed = False
     with write_txn(conn):
         cur = conn.execute(
             "DELETE FROM task_links WHERE parent_id = ? AND child_id = ?",
@@ -1500,7 +1507,10 @@ def unlink_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> boo
                 conn, child_id, "unlinked",
                 {"parent": parent_id, "child": child_id},
             )
-        return cur.rowcount > 0
+            removed = True
+    if removed:
+        recompute_ready(conn)
+    return removed
 
 
 def parent_ids(conn: sqlite3.Connection, task_id: str) -> list[str]:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -914,3 +914,28 @@ def test_latest_summaries_batch_omits_tasks_without_summary(kanban_home):
         assert out == {t1: "alpha", t3: "charlie"}
         # Empty input → empty dict, no SQL syntax error from "IN ()".
         assert kb.latest_summaries(conn, []) == {}
+
+
+def test_unlink_promotes_when_blocker_removed(kanban_home):
+    """Unlinking the last blocking parent must trigger recompute_ready."""
+    with kb.connect() as conn:
+        # Done parent A
+        pa = kb.create_task(conn, title="A", assignee="worker")
+        kb.claim_task(conn, pa)
+        kb.complete_task(conn, pa, summary="done")
+
+        # Child B depends on A → A done → B starts ready
+        pb = kb.create_task(conn, title="B", assignee="worker", parents=[pa])
+        assert kb.get_task(conn, pb).status == "ready"
+
+        # Running parent C, link to B → demotes B to todo
+        pc = kb.create_task(conn, title="C", assignee="worker")
+        kb.claim_task(conn, pc)
+        kb.link_tasks(conn, pc, pb)
+        assert kb.get_task(conn, pb).status == "todo"
+
+        # Unlink C → only done parent A remains → B should be ready
+        assert kb.unlink_tasks(conn, pc, pb) is True
+        assert kb.get_task(conn, pb).status == "ready", (
+            "unlink must trigger recompute_ready so child promotes"
+        )


### PR DESCRIPTION
## What does this PR do?

`unlink_tasks` now calls `recompute_ready(conn)` after removing a parent→child dependency edge. Previously, unlinking the last blocking parent left the child stuck in `todo` — in CLI-only usage with no dispatcher tick to catch up, this meant indefinite stall.

## Related Issue

Fixes #22459

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `hermes_cli/kanban_db.py` — `unlink_tasks`: call `recompute_ready(conn)` outside the write txn after removing a link, same pattern as `complete_task` and `unblock_task`
- `tests/hermes_cli/test_kanban_db.py` — `test_unlink_promotes_when_blocker_removed`

## How to Test

1. `pytest tests/hermes_cli/test_kanban_db.py::test_unlink_promotes_when_blocker_removed -v`
2. Full suite: `pytest tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py -q` — 213 passed