### PR TITLE
fix(tests): declare pytest-split in dev extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
 modal = ["modal>=1.0.0,<2"]
 daytona = ["daytona>=0.148.0,<1"]
 vercel = ["vercel>=0.5.7,<0.6.0"]
-dev = ["debugpy>=1.8.0,<2", "pytest>=9.0.2,<10", "pytest-asyncio>=1.3.0,<2", "pytest-xdist>=3.0,<4", "mcp>=1.2.0,<2", "ty>=0.0.1a29,<0.0.22", "ruff"]
+dev = ["debugpy>=1.8.0,<2", "pytest>=9.0.2,<10", "pytest-asyncio>=1.3.0,<2", "pytest-xdist>=3.0,<4", "pytest-split>=0.9,<1", "mcp>=1.2.0,<2", "ty>=0.0.1a29,<0.0.22", "ruff"]
 messaging = ["python-telegram-bot[webhooks]>=22.6,<23", "discord.py[voice]>=2.7.1,<3", "aiohttp>=3.13.3,<4", "slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4", "qrcode>=7.0,<8"]
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
 slack = ["slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4"]


### PR DESCRIPTION
## Summary

Fixes #22440

scripts/run_tests.sh requires pytest-split for local shard testing but the dependency was undeclared. In uv-managed venvs, the self-bootstrap fails because uv doesn't install pip by default.

## Root Cause

pytest-split was listed in the script's inline pip install fallback but not in pyproject.toml's dev extras. When run in a uv-created venv, pip is unavailable and the script exits before pytest starts.

## Fix

Added pytest-split>=0.9,<1 to [project.optional-dependencies].dev in pyproject.toml.

## Changes

- pyproject.toml: 1 line changed (+1 -1)

## Testing

- uv venv + uv pip install -e ".[dev]": pytest-split installed ✅
- scripts/run_tests.sh in uv-managed venv: no more pip error ✅