### PR TITLE
fix(tests): add Windows skip guards for UNIX-only pwd/fcntl imports

### DIFF
--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1,7 +1,7 @@
 """Tests for gateway service management helpers."""
 
 import os
-import pwd
+pwd = __import__("pytest").importorskip("pwd")
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace

--- a/tests/tools/test_file_sync_back.py
+++ b/tests/tools/test_file_sync_back.py
@@ -1,6 +1,6 @@
 """Tests for FileSyncManager.sync_back() — pull remote changes to host."""
 
-import fcntl
+fcntl = __import__("pytest").importorskip("fcntl")
 import io
 import logging
 import os


### PR DESCRIPTION
## Summary

Fixes #22447

tests/hermes_cli/test_gateway_service.py and tests/tools/test_file_sync_back.py use bare imports of UNIX-only stdlib modules (pwd, fcntl), causing pytest collection to hard-fail on Windows.

## Root Cause

Module-level imports of pwd and fcntl are executed during pytest collection. On Windows, these modules don't exist, causing ModuleNotFoundError before any test runs.

## Fix

Replaced bare imports with pytest.importorskip calls so the affected files cleanly skip on unsupported platforms.

## Changes

- tests/hermes_cli/test_gateway_service.py: 1 line changed (+1 -1)
- tests/tools/test_file_sync_back.py: 1 line changed (+1 -1)

## Testing

- Linux/macOS: imports resolve normally ✅
- Windows: tests gracefully skip ✅