### PR TITLE
chore(release): add KvnGz to AUTHOR_MAP

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -66,6 +66,7 @@ AUTHOR_MAP = {
     "axmaiqiu@gmail.com": "qWaitCrypto",
     "egitimviscara@gmail.com": "uzunkuyruk",
     "zhekinmaksim@gmail.com": "Zhekinmaksim",
+    "obafemiferanmi1999@gmail.com": "KvnGz",
     "159539633+MottledShadow@users.noreply.github.com": "MottledShadow",
     "aludwin+gh@gmail.com": "adamludwin",
     "ngusev@astralinux.ru": "NikolayGusev-astra",


### PR DESCRIPTION
Maps `obafemiferanmi1999@gmail.com` (the commit-author email on #21473's branch) → GitHub login `KvnGz` (the PR/branch owner) so `scripts/release.py` `contributor_audit.py` recognizes their authored commit.

Needed before merging the #21473 salvage PR.