### PR TITLE
fix(tests): pin UTF-8 encoding in test_auxiliary_config_bridge — salvage of #21473

### DIFF
--- a/tests/agent/test_auxiliary_config_bridge.py
+++ b/tests/agent/test_auxiliary_config_bridge.py
@@ -200,7 +200,11 @@ class TestGatewayBridgeCodeParity:
     def test_gateway_has_auxiliary_bridge(self):
         """The gateway config bridge must include auxiliary.* bridging."""
         gateway_path = Path(__file__).parent.parent.parent / "gateway" / "run.py"
-        content = gateway_path.read_text()
+        # Pin encoding to UTF-8: source files in this repo are UTF-8, but
+        # Path.read_text() defaults to the system locale — which is cp1252
+        # on most Western Windows installs and crashes as soon as the file
+        # contains any non-ASCII byte (e.g. an em-dash in a comment).
+        content = gateway_path.read_text(encoding="utf-8")
         # Check for key patterns that indicate the bridge is present
         assert "AUXILIARY_VISION_PROVIDER" in content
         assert "AUXILIARY_VISION_MODEL" in content
@@ -214,7 +218,9 @@ class TestGatewayBridgeCodeParity:
     def test_gateway_no_compression_env_bridge(self):
         """Gateway should NOT bridge compression config to env vars (config-only)."""
         gateway_path = Path(__file__).parent.parent.parent / "gateway" / "run.py"
-        content = gateway_path.read_text()
+        # See note in test_gateway_has_auxiliary_bridge — pin UTF-8 so the
+        # test runs on Windows where the default locale is cp1252.
+        content = gateway_path.read_text(encoding="utf-8")
         assert "CONTEXT_COMPRESSION_PROVIDER" not in content
         assert "CONTEXT_COMPRESSION_MODEL" not in content
 
@@ -289,7 +295,9 @@ class TestCLIDefaultsHaveAuxiliaryKeys:
         # So auxiliary config from config.yaml gets merged even though
         # cli.py's defaults dict doesn't define it.
         import cli as _cli_mod
-        source = Path(_cli_mod.__file__).read_text()
+        # See note in test_gateway_has_auxiliary_bridge — pin UTF-8 so the
+        # test runs on Windows where the default locale is cp1252.
+        source = Path(_cli_mod.__file__).read_text(encoding="utf-8")
         assert "auxiliary_config = defaults.get(\"auxiliary\"" in source
         assert "AUXILIARY_VISION_PROVIDER" in source
         assert "AUXILIARY_VISION_MODEL" in source


### PR DESCRIPTION
## Summary

Salvage of #21473 by @KvnGz — pins `encoding="utf-8"` on 3 `Path.read_text()` calls in `tests/agent/test_auxiliary_config_bridge.py` that read in-tree source files (`gateway/run.py`, `cli.py`). On Western Windows installs the default locale is cp1252, so any non-ASCII byte in those source files (em-dash in a comment, etc.) crashes the read with `UnicodeDecodeError: 'charmap' codec can't decode byte ...`. Linux CI doesn't catch this; Windows contributors hit it on every test run.

Matches the existing precedent in `hermes_cli/doctor.py:363`.

## Why a salvage

#21473 was 161 commits behind main. Although the diff applies cleanly with no stale-branch reverts (the PR is small and surgical), I ran the salvage path so the commit lands against fresh main rather than 161 commits stale, and so I could rerun the suite end-to-end. @KvnGz's commit is preserved with original authorship via plain `git cherry-pick` (no `--author` rewrite needed).

## Verification

```
$ git diff origin/main..HEAD --stat
 tests/agent/test_auxiliary_config_bridge.py | 14 +++++++++++---
 1 file changed, 11 insertions(+), 3 deletions(-)
```

- `scripts/run_tests.sh tests/agent/test_auxiliary_config_bridge.py` — 19/19 pass on the salvage branch
- `git diff` shows pure additions of `encoding="utf-8"` and explanatory comments, no other edits
- Diff verified clean against current main (`git diff origin/main..pr-21473 | git apply --check` returned 0)

## Sibling-area note

I also audited every other `.read_text()` in `tests/` while reviewing — there are ~30 more without `encoding=`, but they all read test-controlled JSON / state files that won't contain non-ASCII bytes. The 3 calls in this PR are the only ones reading repo source files (which DO contain em-dashes). Author's scope is correctly minimal.

## Credit

Original work by **@KvnGz** in #21473. Their commit is preserved here with original authorship (`obafemiferanmi1999@gmail.com`, mapped to KvnGz via #22458).

## Notes for reviewer

Depends on #22458 (`chore(release): add KvnGz to AUTHOR_MAP`) being merged first.

Merge with `--rebase` to preserve @KvnGz's authorship in the commit history.

Closes #21473
