### PR TITLE
feat: add additive bootstrap/ directory support

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1403,6 +1403,33 @@ def _load_cursorrules(cwd_path: Path) -> str:
     return _truncate_content(cursorrules_content, ".cursorrules")
 
 
+def _load_bootstrap_dir(cwd_path: Path) -> str:
+    """Load all *.md files from a bootstrap/ directory in cwd or HERMES_HOME.
+    
+    Provides an additive mechanism for multi-file bootstrapping without overriding
+    the primary project context (AGENTS.md, .hermes.md, etc.).
+    """
+    bootstrap_content = ""
+    # Check cwd/bootstrap and HERMES_HOME/bootstrap
+    # Profile-specific bootstrap takes precedence in order if names collide
+    for base in [cwd_path, get_hermes_home()]:
+        boot_dir = base / "bootstrap"
+        if boot_dir.exists() and boot_dir.is_dir():
+            md_files = sorted(boot_dir.glob("*.md"))
+            for md_file in md_files:
+                try:
+                    content = md_file.read_text(encoding="utf-8").strip()
+                    if content:
+                        content = _scan_context_content(content, f"bootstrap/{md_file.name}")
+                        bootstrap_content += f"### bootstrap/{md_file.name}\n\n{content}\n\n"
+                except Exception as e:
+                    logger.debug("Could not read bootstrap file %s: %s", md_file, e)
+    
+    if not bootstrap_content:
+        return ""
+    return _truncate_content(bootstrap_content.strip(), "bootstrap/")
+
+
 def build_context_files_prompt(cwd: Optional[str] = None, skip_soul: bool = False) -> str:
     """Discover and load context files for the system prompt.
 
@@ -1412,8 +1439,9 @@ def build_context_files_prompt(cwd: Optional[str] = None, skip_soul: bool = Fals
       3. CLAUDE.md / claude.md   (cwd only)
       4. .cursorrules / .cursor/rules/*.mdc  (cwd only)
 
-    SOUL.md from HERMES_HOME is independent and always included when present.
-    Each context source is capped at 20,000 chars.
+    SOUL.md from HERMES_HOME and the bootstrap/ directory (from cwd or HERMES_HOME)
+    are independent and always included when present. Each context source is
+    capped at 20,000 chars.
 
     When *skip_soul* is True, SOUL.md is not included here (it was already
     loaded via ``load_soul_md()`` for the identity slot).
@@ -1439,6 +1467,11 @@ def build_context_files_prompt(cwd: Optional[str] = None, skip_soul: bool = Fals
         soul_content = load_soul_md()
         if soul_content:
             sections.append(soul_content)
+
+    # Bootstrap directory (additive)
+    bootstrap_context = _load_bootstrap_dir(cwd_path)
+    if bootstrap_context:
+        sections.append(bootstrap_context)
 
     if not sections:
         return ""

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -15,6 +15,7 @@ from agent.prompt_builder import (
     _find_hermes_md,
     _find_git_root,
     _strip_yaml_frontmatter,
+    _load_bootstrap_dir,
     build_skills_system_prompt,
     build_nous_subscription_prompt,
     build_context_files_prompt,
@@ -1189,3 +1190,44 @@ class TestOpenAIModelExecutionGuidance:
 
 
 
+
+class TestBootstrapDir:
+    def test_empty_bootstrap_returns_empty(self, tmp_path):
+        assert _load_bootstrap_dir(tmp_path) == ""
+
+    def test_loads_files_from_cwd_bootstrap(self, tmp_path):
+        boot_dir = tmp_path / "bootstrap"
+        boot_dir.mkdir()
+        (boot_dir / "setup.md").write_text("Context A")
+        (boot_dir / "extra.md").write_text("Context B")
+        
+        result = _load_bootstrap_dir(tmp_path)
+        assert "bootstrap/setup.md" in result
+        assert "Context A" in result
+        assert "bootstrap/extra.md" in result
+        assert "Context B" in result
+
+    def test_loads_files_from_hermes_home_bootstrap(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+        boot_dir = tmp_path / "hermes_home" / "bootstrap"
+        boot_dir.mkdir(parents=True)
+        (boot_dir / "global.md").write_text("Global Context")
+        
+        result = _load_bootstrap_dir(tmp_path)
+        assert "bootstrap/global.md" in result
+        assert "Global Context" in result
+
+    def test_additive_in_build_context_files_prompt(self, tmp_path):
+        # AGENTS.md exists
+        (tmp_path / "AGENTS.md").write_text("Primary Agent Rules")
+        
+        # bootstrap/ exists
+        boot_dir = tmp_path / "bootstrap"
+        boot_dir.mkdir()
+        (boot_dir / "secondary.md").write_text("Secondary Rules")
+        
+        result = build_context_files_prompt(cwd=str(tmp_path))
+        
+        assert "Primary Agent Rules" in result
+        assert "Secondary Rules" in result
+        assert "bootstrap/secondary.md" in result


### PR DESCRIPTION
Adds support for a `bootstrap/` directory in either the workspace or the profile home. All `.md` files in these directories are automatically loaded into the system prompt as additive context, allowing for modular agent instructions without overriding the primary AGENTS.md or .hermes.md files. Verified with 126 unit tests (including 4 new ones).