### PR TITLE
fix: map "openai" provider alias to "openai-codex"

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -147,6 +147,7 @@ _PROVIDER_ALIASES = {
     "gmicloud": "gmi",
     "minimax-china": "minimax-cn",
     "minimax_cn": "minimax-cn",
+    "openai": "openai-codex",
     "claude": "anthropic",
     "claude-code": "anthropic",
     "github": "copilot",


### PR DESCRIPTION
## Bug

When a session uses an OpenAI/GPT model (e.g. via model picker), the provider string is stored as `"openai"`. The `_PROVIDER_ALIASES` dict in `agent/auxiliary_client.py` has no mapping for `"openai"`, so `_normalize_aux_provider()` returns `"openai"` unchanged. Downstream, `resolve_provider_client()` finds no branch handling `"openai"` and returns `(None, None)`.

## Impact

- **Single-provider OpenAI setups**: compression fails entirely — `resolve_provider_client` returns `(None, None)`, the session grows unbounded, and eventually hits the token limit with no recovery.
- **Multi-provider setups**: silently falls back to the global provider for compression, often a cheaper/different model, degrading compression quality without any indication to the user.

## Fix

One-line addition to `_PROVIDER_ALIASES`:

```python
"openai": "openai-codex",
```

This maps `"openai"` to `"openai-codex"` the same way `"codex"` already does via the special-case in `_normalize_aux_provider()`.

## Testing

- 270 existing auxiliary-client tests pass with this change (0 failures)
- Verified `_normalize_aux_provider("openai")` returns `"openai-codex"` correctly