### PR TITLE
fix(aux-client): propagate default_headers through auxiliary transport

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -517,6 +517,7 @@ def build_anthropic_client(
     timeout: float = None,
     *,
     drop_context_1m_beta: bool = False,
+    default_headers: dict = None,
 ):
     """Create an Anthropic client, auto-detecting setup-tokens vs API keys.
 
@@ -609,6 +610,13 @@ def build_anthropic_client(
         kwargs["api_key"] = api_key
         if common_betas:
             kwargs["default_headers"] = {"anthropic-beta": ",".join(common_betas)}
+
+    # Caller-supplied headers (e.g. gateway auth like Ocp-Apim-Subscription-Key)
+    # win over our defaults so users can override anthropic-beta, user-agent, etc.
+    if isinstance(default_headers, dict) and default_headers:
+        merged = dict(kwargs.get("default_headers") or {})
+        merged.update({k: v for k, v in default_headers.items() if v is not None})
+        kwargs["default_headers"] = merged
 
     return _anthropic_sdk.Anthropic(**kwargs)
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1061,6 +1061,8 @@ def _maybe_wrap_anthropic(
     api_key: str,
     base_url: str,
     api_mode: Optional[str] = None,
+    *,
+    default_headers: Optional[Dict[str, str]] = None,
 ) -> Any:
     """Rewrap a plain OpenAI client in ``AnthropicAuxiliaryClient`` when
     the endpoint actually speaks Anthropic Messages.
@@ -1119,7 +1121,10 @@ def _maybe_wrap_anthropic(
         return client_obj
 
     try:
-        real_client = build_anthropic_client(api_key, base_url)
+        real_client = build_anthropic_client(
+            api_key, base_url,
+            default_headers=default_headers if default_headers else None,
+        )
     except Exception as exc:
         logger.warning(
             "Failed to build Anthropic client for %s (%s) — falling back to "
@@ -1743,11 +1748,17 @@ _AUTO_PROVIDER_LABELS = {
 _MAIN_RUNTIME_FIELDS = ("provider", "model", "base_url", "api_key", "api_mode")
 
 
-def _normalize_main_runtime(main_runtime: Optional[Dict[str, Any]]) -> Dict[str, str]:
-    """Return a sanitized copy of a live main-runtime override."""
+def _normalize_main_runtime(main_runtime: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Return a sanitized copy of a live main-runtime override.
+
+    String fields (provider/model/base_url/api_key/api_mode) are stripped and
+    lowercased where appropriate.  ``default_headers`` (dict) is preserved so
+    transports that need extra HTTP headers (e.g. AMD LLM Gateway's
+    ``Ocp-Apim-Subscription-Key``) can forward them to the underlying SDK.
+    """
     if not isinstance(main_runtime, dict):
         return {}
-    normalized: Dict[str, str] = {}
+    normalized: Dict[str, Any] = {}
     for field in _MAIN_RUNTIME_FIELDS:
         value = main_runtime.get(field)
         if isinstance(value, str) and value.strip():
@@ -1755,6 +1766,12 @@ def _normalize_main_runtime(main_runtime: Optional[Dict[str, Any]]) -> Dict[str,
     provider = normalized.get("provider")
     if provider:
         normalized["provider"] = provider.lower()
+    headers = main_runtime.get("default_headers")
+    if isinstance(headers, dict) and headers:
+        normalized["default_headers"] = {
+            k: v for k, v in headers.items()
+            if isinstance(k, str) and v is not None
+        }
     return normalized
 
 
@@ -2302,6 +2319,7 @@ def _resolve_auto(main_runtime: Optional[Dict[str, Any]] = None) -> Tuple[Option
             explicit_base_url=explicit_base_url,
             explicit_api_key=explicit_api_key,
             api_mode=runtime_api_mode or None,
+            main_runtime=runtime,
         )
         if client is not None:
             logger.info("Auxiliary auto-detect: using main provider %s (%s)",
@@ -2484,7 +2502,9 @@ def resolve_provider_client(
         return False
 
     def _wrap_if_needed(client_obj, final_model_str: str, base_url_str: str = "",
-                        api_key_str: str = ""):
+                        api_key_str: str = "",
+                        *,
+                        default_headers: Optional[Dict[str, str]] = None):
         """Wrap a plain OpenAI client in the correct transport adapter.
 
         Handles two cases:
@@ -2496,6 +2516,9 @@ def resolve_provider_client(
           suffix, ``api.kimi.com/coding``, or ``api.anthropic.com``).
 
         Clients that are already specialized wrappers pass through unchanged.
+        ``default_headers`` (when provided) is forwarded to ``build_anthropic_client``
+        so gateway auth headers like ``Ocp-Apim-Subscription-Key`` propagate to
+        the wrapped Anthropic SDK transport.
         """
         if _needs_codex_wrap(client_obj, base_url_str, final_model_str):
             logger.debug(
@@ -2508,6 +2531,7 @@ def resolve_provider_client(
         # chat.completions.create() is translated to /v1/messages.
         return _maybe_wrap_anthropic(
             client_obj, final_model_str, api_key_str, base_url_str, api_mode,
+            default_headers=default_headers,
         )
 
     # ── Auto: try all providers in priority order ────────────────────
@@ -2615,6 +2639,17 @@ def resolve_provider_client(
             _clean_base, _dq = _extract_url_query_params(custom_base)
             if _dq:
                 extra["default_query"] = _dq
+            # Extract caller-supplied headers from main_runtime so gateway
+            # auth (e.g. Ocp-Apim-Subscription-Key) propagates to the
+            # auxiliary transport.
+            _runtime_headers: Optional[Dict[str, str]] = None
+            if isinstance(main_runtime, dict):
+                _rh = main_runtime.get("default_headers")
+                if isinstance(_rh, dict) and _rh:
+                    _runtime_headers = {
+                        k: v for k, v in _rh.items()
+                        if isinstance(k, str) and v is not None
+                    }
             if base_url_host_matches(custom_base, "api.kimi.com"):
                 extra["default_headers"] = {"User-Agent": "claude-code/0.1.0"}
             elif base_url_host_matches(custom_base, "api.githubcopilot.com"):
@@ -2632,8 +2667,15 @@ def resolve_provider_client(
                         extra["default_headers"] = dict(_ph_custom.default_headers)
                 except Exception:
                     pass
+            if _runtime_headers:
+                merged = dict(extra.get("default_headers") or {})
+                merged.update(_runtime_headers)
+                extra["default_headers"] = merged
             client = OpenAI(api_key=custom_key, base_url=_clean_base, **extra)
-            client = _wrap_if_needed(client, final_model, custom_base, custom_key)
+            client = _wrap_if_needed(
+                client, final_model, custom_base, custom_key,
+                default_headers=extra.get("default_headers"),
+            )
             return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode
                     else (client, final_model))
         # Try custom first, then API-key providers (Codex excluded here:
@@ -3272,7 +3314,18 @@ def _client_cache_key(
     is_vision: bool = False,
 ) -> tuple:
     runtime = _normalize_main_runtime(main_runtime)
-    runtime_key = tuple(runtime.get(field, "") for field in _MAIN_RUNTIME_FIELDS) if provider == "auto" else ()
+    if provider == "auto":
+        parts = [runtime.get(field, "") for field in _MAIN_RUNTIME_FIELDS]
+        _hdrs = runtime.get("default_headers")
+        if isinstance(_hdrs, dict) and _hdrs:
+            # Freeze the dict to a sorted tuple so the cache key stays
+            # hashable and deterministic across insertion-order variation.
+            parts.append(tuple(sorted(_hdrs.items())))
+        else:
+            parts.append(())
+        runtime_key = tuple(parts)
+    else:
+        runtime_key = ()
     pool_hint = _pool_cache_hint(provider, main_runtime=main_runtime)
     return (provider, async_mode, base_url or "", api_key or "", api_mode or "", runtime_key, is_vision, pool_hint)
 

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -381,6 +381,7 @@ class ContextCompressor(ContextEngine):
         api_key: str = "",
         provider: str = "",
         api_mode: str = "",
+        default_headers: Optional[Dict[str, str]] = None,
     ) -> None:
         """Update model info after a model switch or fallback activation."""
         self.model = model
@@ -388,6 +389,11 @@ class ContextCompressor(ContextEngine):
         self.api_key = api_key
         self.provider = provider
         self.api_mode = api_mode
+        self.default_headers = (
+            dict(default_headers)
+            if isinstance(default_headers, dict) and default_headers
+            else None
+        )
         self.context_length = context_length
         self.threshold_tokens = max(
             int(context_length * self.threshold_percent),
@@ -415,12 +421,18 @@ class ContextCompressor(ContextEngine):
         config_context_length: int | None = None,
         provider: str = "",
         api_mode: str = "",
+        default_headers: Optional[Dict[str, str]] = None,
     ):
         self.model = model
         self.base_url = base_url
         self.api_key = api_key
         self.provider = provider
         self.api_mode = api_mode
+        self.default_headers = (
+            dict(default_headers)
+            if isinstance(default_headers, dict) and default_headers
+            else None
+        )
         self.threshold_percent = threshold_percent
         self.protect_first_n = protect_first_n
         self.protect_last_n = protect_last_n
@@ -941,6 +953,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                     "base_url": self.base_url,
                     "api_key": self.api_key,
                     "api_mode": self.api_mode,
+                    "default_headers": getattr(self, "default_headers", None),
                 },
                 "messages": [{"role": "user", "content": prompt}],
                 "max_tokens": int(summary_budget * 1.3),

--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -195,12 +195,17 @@ class ContextEngine(ABC):
         base_url: str = "",
         api_key: str = "",
         provider: str = "",
+        **kwargs,
     ) -> None:
         """Called when the user switches models or on fallback activation.
 
         Default updates context_length and recalculates threshold_tokens
         from threshold_percent. Override if your engine needs more
         (e.g. recalculate DAG budgets, switch summary models).
+
+        Accepts ``**kwargs`` so callers can pass forward-compatible fields
+        (``api_mode``, ``default_headers``, …) that not every engine cares
+        about.
         """
         self.context_length = context_length
         self.threshold_tokens = int(context_length * self.threshold_percent)

--- a/cli.py
+++ b/cli.py
@@ -10108,6 +10108,11 @@ class HermesCLI:
                     _title_failure_cb = getattr(
                         self.agent, "_emit_auxiliary_failure", None
                     ) if self.agent else None
+                    _agent_ck = getattr(self.agent, "_client_kwargs", None) if self.agent else None
+                    _agent_hdrs = (
+                        _agent_ck.get("default_headers")
+                        if isinstance(_agent_ck, dict) else None
+                    )
                     maybe_auto_title(
                         self._session_db,
                         self.session_id,
@@ -10121,6 +10126,11 @@ class HermesCLI:
                             "base_url": self.base_url,
                             "api_key": self.api_key,
                             "api_mode": self.api_mode,
+                            "default_headers": (
+                                dict(_agent_hdrs)
+                                if isinstance(_agent_hdrs, dict) and _agent_hdrs
+                                else None
+                            ),
                         },
                     )
                 except Exception:

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14845,6 +14845,11 @@ class GatewayRunner:
                     _title_failure_cb = getattr(
                         agent, "_emit_auxiliary_failure", None
                     )
+                    _agent_ck = getattr(agent, "_client_kwargs", None) if agent else None
+                    _agent_hdrs = (
+                        _agent_ck.get("default_headers")
+                        if isinstance(_agent_ck, dict) else None
+                    )
                     maybe_auto_title_kwargs = {
                         "failure_callback": _title_failure_cb,
                         "main_runtime": {
@@ -14853,6 +14858,11 @@ class GatewayRunner:
                             "base_url": getattr(agent, "base_url", None),
                             "api_key": getattr(agent, "api_key", None),
                             "api_mode": getattr(agent, "api_mode", None),
+                            "default_headers": (
+                                dict(_agent_hdrs)
+                                if isinstance(_agent_hdrs, dict) and _agent_hdrs
+                                else None
+                            ),
                         } if agent else None,
                     }
                     if self._is_telegram_topic_lane(source):

--- a/run_agent.py
+++ b/run_agent.py
@@ -2228,6 +2228,7 @@ class AIAgent:
                 base_url=self.base_url,
                 api_key=getattr(self, "api_key", ""),
                 provider=self.provider,
+                default_headers=(getattr(self, "_client_kwargs", {}) or {}).get("default_headers"),
             )
             if not self.quiet_mode:
                 logger.info("Using context engine: %s", _selected_engine.name)
@@ -2245,6 +2246,7 @@ class AIAgent:
                 config_context_length=_config_context_length,
                 provider=self.provider,
                 api_mode=self.api_mode,
+                default_headers=(getattr(self, "_client_kwargs", {}) or {}).get("default_headers"),
             )
         self.compression_enabled = compression_enabled
 
@@ -2515,6 +2517,7 @@ class AIAgent:
                         api_key=getattr(self, "api_key", ""),
                         provider=self.provider,
                         api_mode=self.api_mode,
+                        default_headers=(getattr(self, "_client_kwargs", {}) or {}).get("default_headers"),
                     )
         except Exception as err:
             logger.debug("LM Studio preload skipped: %s", err)
@@ -2651,6 +2654,7 @@ class AIAgent:
                 api_key=getattr(self, "api_key", ""),
                 provider=self.provider,
                 api_mode=self.api_mode,
+                default_headers=(getattr(self, "_client_kwargs", {}) or {}).get("default_headers"),
             )
 
         # ── Invalidate cached system prompt so it rebuilds next turn ──
@@ -2834,14 +2838,17 @@ class AIAgent:
             detail = detail[:217].rstrip() + "..."
         self._emit_warning(f"⚠ Auxiliary {task} failed: {detail}")
 
-    def _current_main_runtime(self) -> Dict[str, str]:
+    def _current_main_runtime(self) -> Dict[str, Any]:
         """Return the live main runtime for session-scoped auxiliary routing."""
+        _ck = getattr(self, "_client_kwargs", None) or {}
+        _hdrs = _ck.get("default_headers") if isinstance(_ck, dict) else None
         return {
             "model": getattr(self, "model", "") or "",
             "provider": getattr(self, "provider", "") or "",
             "base_url": getattr(self, "base_url", "") or "",
             "api_key": getattr(self, "api_key", "") or "",
             "api_mode": getattr(self, "api_mode", "") or "",
+            "default_headers": dict(_hdrs) if isinstance(_hdrs, dict) and _hdrs else None,
         }
 
     def _check_compression_model_feasibility(self) -> None:
@@ -8262,6 +8269,7 @@ class AIAgent:
                     base_url=self.base_url,
                     api_key=getattr(self, "api_key", ""),
                     provider=self.provider,
+                    default_headers=(getattr(self, "_client_kwargs", {}) or {}).get("default_headers"),
                 )
 
             self._emit_status(
@@ -8341,6 +8349,7 @@ class AIAgent:
                 base_url=rt["compressor_base_url"],
                 api_key=rt["compressor_api_key"],
                 provider=rt["compressor_provider"],
+                default_headers=(getattr(self, "_client_kwargs", {}) or {}).get("default_headers"),
             )
 
             # ── Reset fallback chain for the new turn ──
@@ -13124,6 +13133,7 @@ class AIAgent:
                                 base_url=self.base_url,
                                 api_key=getattr(self, "api_key", ""),
                                 provider=self.provider,
+                                default_headers=(getattr(self, "_client_kwargs", {}) or {}).get("default_headers"),
                             )
                             # Context probing flags — only set on built-in
                             # compressor (plugin engines manage their own).
@@ -13400,6 +13410,7 @@ class AIAgent:
                                 base_url=self.base_url,
                                 api_key=getattr(self, "api_key", ""),
                                 provider=self.provider,
+                                default_headers=(getattr(self, "_client_kwargs", {}) or {}).get("default_headers"),
                             )
                             # Context probing flags — only set on built-in
                             # compressor (plugin engines manage their own).

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -244,6 +244,7 @@ class TestNonStringContent:
             "base_url": "https://chatgpt.com/backend-api/codex",
             "api_key": "codex-token",
             "api_mode": "codex_responses",
+            "default_headers": None,
         }
 
 

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -156,6 +156,7 @@ def test_feasibility_check_passes_live_main_runtime():
             "base_url": "https://chatgpt.com/backend-api/codex",
             "api_key": "codex-token",
             "api_mode": "codex_responses",
+            "default_headers": None,
         },
     )
 


### PR DESCRIPTION
## Summary

Custom HTTP headers configured on the main runtime (set via `custom_headers:` under a `custom_providers:` entry in `config.yaml`) were not reaching the auxiliary client. As a result, gateways that authenticate **via client-level headers** — e.g. Third-party Gateway's `Ocp-Apim-Subscription-Key`, Azure APIM-style proxies, internal corporate gateways — would `401` on every auxiliary call (compression, summarization, title generation, vision, web extract, session search, MCP, curator) even when the main agent path worked.

This plumbs `default_headers` end-to-end through the auxiliary resolution chain:

```
agent._client_kwargs["default_headers"]
  → _current_main_runtime() / ad-hoc main_runtime= dicts (cli.py, gateway/run.py)
  → call_llm(main_runtime=…)
  → resolve_provider_client / _resolve_auto
  → _wrap_if_needed → _maybe_wrap_anthropic
  → build_anthropic_client(default_headers=…)
```

### Behavior

- Caller-supplied headers are **merged on top of** provider-derived defaults so `anthropic-beta`, `user-agent`, `x-app`, etc. remain set unless explicitly overridden.
- `_client_cache_key` freezes the headers dict to a sorted tuple so runtime variants don't collide on cache lookups while still keeping the key hashable.
- The base `ContextEngine.update_model` gains `**kwargs` so plugin engines tolerate forward-compatible fields without raising `TypeError`.

### Files touched

| File | Change |
|---|---|
| `agent/anthropic_adapter.py` | `build_anthropic_client` now accepts `default_headers=` and merges it over the resolved kwargs |
| `agent/auxiliary_client.py` | `_normalize_main_runtime` preserves dict-typed `default_headers`; `_resolve_auto` forwards `runtime` to `resolve_provider_client`; the `custom + explicit_base_url` branch merges runtime headers; `_wrap_if_needed` / `_maybe_wrap_anthropic` thread them through; `_client_cache_key` freezes the dict |
| `agent/context_compressor.py` | `__init__` and `update_model` accept `default_headers`; `compress()` includes it in `main_runtime` |
| `agent/context_engine.py` | base `update_model` accepts `**kwargs` for forward compat |
| `run_agent.py` | `_current_main_runtime` reads `default_headers` from `_client_kwargs`; 7 ContextCompressor `__init__` / `update_model` callsites forward it |
| `cli.py` | title-gen `main_runtime` includes `default_headers` |
| `gateway/run.py` | title-gen `main_runtime` includes `default_headers` |
| `tests/agent/test_context_compressor.py` | strict-equality fixture updated for new field |
| `tests/run_agent/test_compression_feasibility.py` | strict-equality fixture updated for new field |

### Repro / context

The setup that triggers this is a `custom_providers:` entry that talks Anthropic Messages and authenticates via `custom_headers`:

```yaml
custom_providers:
  custom-gateway:
    api_mode: anthropic_messages
    base_url: https://custom-url.com:port/Anthropic
    custom_headers:
      x-api-key: somekey
      Ocp-Apim-Subscription-Key: <subscription-key>
      Host: custom-url.com
```

Pre-fix: `Auxiliary title generation failed: HTTP 401: Access denied due to missing subscription key.` (and identical 401s from compression / summarization).
Post-fix: header rides through to `build_anthropic_client(default_headers=…)` and the auxiliary call succeeds end-to-end.

## Test plan

- [x] `pytest tests/agent/ tests/run_agent/` — 3810 passed
- [x] `pytest tests/agent/test_context_compressor.py tests/agent/test_auxiliary_client.py tests/agent/test_anthropic_adapter.py` — 357 passed
- [x] `pytest tests/hermes_cli/` (excl. pre-existing tencent_tokenhub flake) — 3985 passed
- [x] Live verification against a thid-party gateway (e.g Azure): title generation and compression both confirmed working with `Ocp-Apim-Subscription-Key`
- [x] AST-parse all 9 modified files