### PR TITLE
fix(anthropic): defend normalize_response against content=None

### DIFF
--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -95,7 +95,14 @@ class AnthropicTransport(ProviderTransport):
         reasoning_details = []
         tool_calls = []
 
-        for block in response.content:
+        # Some Anthropic-compatible endpoints (e.g. Kimi For Coding) return
+        # HTTP 200 with `content: null` for cache-only hits or trailing-assistant
+        # turns. Iterate over `(content or [])` so the normalizer hands a
+        # NormalizedResponse to validate_response, which already classifies
+        # non-list content as malformed and routes to the empty-response path.
+        # Without this, TypeError: 'NoneType' object is not iterable burns the
+        # per-call retry budget. (NousResearch/hermes-agent#21820)
+        for block in (response.content or []):
             if block.type == "text":
                 text_parts.append(block.text)
             elif block.type == "thinking":

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1474,6 +1474,21 @@ class TestNormalizeResponse:
         assert nr.content is None
         assert len(nr.tool_calls) == 1
 
+    def test_null_content_does_not_raise(self):
+        # Regression: some Anthropic-compatible endpoints (Kimi For Coding,
+        # third-party gateways) return HTTP 200 with `content: null` for
+        # cache-only hits or trailing-assistant message arrays. Previously,
+        # `for block in response.content` raised TypeError and burned the
+        # per-call retry budget before validate_response could classify the
+        # response as malformed. (NousResearch/hermes-agent#21820)
+        nr = get_transport("anthropic_messages").normalize_response(
+            self._make_response(None, "end_turn")
+        )
+        assert nr.content is None
+        assert nr.tool_calls is None
+        assert nr.reasoning is None
+        assert nr.finish_reason == "stop"
+
 
 # ---------------------------------------------------------------------------
 # Role alternation


### PR DESCRIPTION
## Summary

Some Anthropic-compatible endpoints return HTTP 200 with `content: null` instead of a (possibly empty) list of blocks. **Kimi For Coding** (`api.kimi.com/coding/v1/messages`) has been observed in the wild returning

```json
{"content": null, "stop_reason": "end_turn", "output_tokens": 1, ...}
```

for some prompt shapes — large cache-only hits, or message arrays whose last entry is an `assistant` turn. The shape is non-spec but the server returns 200, so the failure surfaces inside the SDK's response object rather than as an HTTP error.

`AnthropicTransport.normalize_response` previously did

```python
for block in response.content:
```

which raises `TypeError: 'NoneType' object is not iterable` on those responses. The downstream `validate_response` already correctly classifies non-list `content` as malformed and routes through the agent's normal empty-response / fallback path — but it never gets to see the response, because the TypeError fires first and burns the per-call retry budget.

## Fix

Iterate `(response.content or [])`, matching the contract `validate_response` already expects. When `content` is `None` the normalizer returns `NormalizedResponse(content=None, tool_calls=None, reasoning=None, finish_reason="stop", ...)`, which the validator then rejects so the empty-response path takes over.

```diff
-        for block in response.content:
+        for block in (response.content or []):
```

## Affected paths

The fix is provider-agnostic — it covers any Anthropic-compatible endpoint that returns non-spec `content: null`:
- `kimi-coding` / `kimi-coding-cn` (`api.kimi.com/coding`)
- Any third-party `/anthropic`-suffixed gateway that mirrors the quirk
- Local proxies / self-hosted Anthropic-compatible servers

## Test plan

- [x] New regression `TestNormalizeResponse::test_null_content_does_not_raise` — without fix raises `TypeError: 'NoneType' object is not iterable`; with fix returns a `NormalizedResponse` with `content=None`, `tool_calls=None`, `reasoning=None`, `finish_reason="stop"`. Stash-verified.
- [x] All 7 existing `TestNormalizeResponse` cases still pass (`test_text_response`, `test_tool_use_response`, `test_thinking_response`, `test_thinking_response_preserves_signature`, `test_stop_reason_mapping`, `test_stop_reason_refusal_and_context_exceeded`, `test_no_text_content`).
- [x] No behavior change for spec-compliant responses (empty `[]` and populated lists already iterate fine; `None or []` short-circuits to `[]`).

Closes #21820