### PR TITLE
fix(terminal): Windows local backend compatibility

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -255,6 +255,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.10.12",
         "caniuse-lite": "^1.0.30001782",
@@ -1657,6 +1658,7 @@
       "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
       "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "playwright-core": "1.59.1"
       },
@@ -1675,6 +1677,7 @@
       "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
       "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },

--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -10,6 +10,7 @@ import codecs
 import json
 import logging
 import os
+import platform
 import select
 import shlex
 import subprocess
@@ -487,6 +488,30 @@ class BaseEnvironment(ABC):
         decoder = codecs.getincrementaldecoder("utf-8")(errors="replace")
 
         def _drain():
+            if platform.system() == "Windows":
+                # Windows: select.select() doesn't work on anonymous pipes
+                # (OSError WinError 10093).  Use blocking reads instead.
+                # The TextIOWrapper (text=True on Popen) already decodes UTF-8
+                # with errors="replace", so we read strings directly.
+                try:
+                    while True:
+                        try:
+                            chunk = proc.stdout.read(4096)
+                        except (ValueError, OSError):
+                            break
+                        if chunk:
+                            output_chunks.append(chunk)
+                        elif proc.poll() is not None:
+                            break  # process exited and pipe EOF'd
+                finally:
+                    try:
+                        tail = decoder.decode(b"", final=True)
+                        if tail:
+                            output_chunks.append(tail)
+                    except Exception:
+                        pass
+                return
+
             fd = proc.stdout.fileno()
             idle_after_exit = 0
             try:

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -2,6 +2,7 @@
 
 import os
 import platform
+import re
 import shutil
 import signal
 import subprocess
@@ -11,6 +12,34 @@ import time
 from tools.environments.base import BaseEnvironment, _pipe_stdin
 
 _IS_WINDOWS = platform.system() == "Windows"
+
+
+def _msys2_to_windows_path(path: str) -> str:
+    """Convert MSYS2/Cygwin/WSL unix paths to Windows paths.
+
+    On Windows with Git-Bash/MSYS2, bash's ``pwd -P`` emits Unix-style
+    paths (``/d/project``).  ``subprocess.Popen(..., cwd=...)`` requires
+    a native Windows path (``D:\\project``) or it raises
+    ``NotADirectoryError [WinError 267]``.
+    """
+    if not path or not _IS_WINDOWS:
+        return path
+    # Already a Windows path — nothing to do
+    if len(path) >= 2 and path[1] == ":":
+        return path
+    # /mnt/d/... → D:\...
+    mnt = re.match(r"^/mnt/([a-zA-Z])/(.*)", path)
+    if mnt:
+        return f"{mnt.group(1).upper()}:\\{mnt.group(2).replace('/', '\\')}"
+    # /d/... → D:\...
+    drive = re.match(r"^/([a-zA-Z])/(.*)", path)
+    if drive:
+        return f"{drive.group(1).upper()}:\\{drive.group(2).replace('/', '\\')}"
+    # Bare /... → prepend current drive
+    if path.startswith("/"):
+        cur_drive = os.getcwd()[:2]
+        return f"{cur_drive}\\{path[1:].replace('/', '\\')}"
+    return path
 
 
 # Hermes-internal env vars that should NOT leak into terminal subprocesses.
@@ -312,7 +341,8 @@ class LocalEnvironment(BaseEnvironment):
     def __init__(self, cwd: str = "", timeout: int = 60, env: dict = None):
         if cwd:
             cwd = os.path.expanduser(cwd)
-        super().__init__(cwd=cwd or os.getcwd(), timeout=timeout, env=env)
+        cwd = _msys2_to_windows_path(cwd or os.getcwd())
+        super().__init__(cwd=cwd, timeout=timeout, env=env)
         self.init_session()
 
     def get_temp_dir(self) -> str:
@@ -323,10 +353,15 @@ class LocalEnvironment(BaseEnvironment):
         Unix systems, and only fall back to tempfile.gettempdir() when it also
         resolves to a POSIX path.
 
-        Check the environment configured for this backend first so callers can
-        override the temp root explicitly (for example via terminal.env or a
-        custom TMPDIR), then fall back to the host process environment.
+        On Windows with MSYS2/Git-Bash, ``/tmp`` is mapped differently by bash
+        (to the Windows %TEMP% folder) than by Python (to ``<current_drive>:\\tmp``),
+        causing ``_cwd_file`` and ``_snapshot_path`` to be written by bash but
+        never found by Python.  We avoid this by returning the Windows temp dir
+        with forward slashes, which both bash and Python understand.
         """
+        if _IS_WINDOWS:
+            return tempfile.gettempdir().replace("\\", "/")
+
         for env_var in ("TMPDIR", "TMP", "TEMP"):
             candidate = self.env.get(env_var) or os.environ.get(env_var)
             if candidate and candidate.startswith("/"):
@@ -457,12 +492,16 @@ class LocalEnvironment(BaseEnvironment):
             with open(self._cwd_file) as f:
                 cwd_path = f.read().strip()
             if cwd_path:
-                self.cwd = cwd_path
+                self.cwd = _msys2_to_windows_path(cwd_path)
         except (OSError, FileNotFoundError):
             pass
 
         # Still strip the marker from output so it's not visible
         self._extract_cwd_from_output(result)
+
+        # _extract_cwd_from_output may have set a Unix path from the stdout
+        # marker; make sure we always store a Windows-native path.
+        self.cwd = _msys2_to_windows_path(self.cwd)
 
     def cleanup(self):
         """Clean up temp files."""


### PR DESCRIPTION
## Summary

This PR fixes critical compatibility issues preventing Hermes Agent from working on Windows with Git-Bash/MSYS2 environments.

## Problems Fixed

### 1. `select.select()` fails on Windows pipes (WinError 10093)
**File:** `tools/environments/base.py`

The `_drain()` function uses `select.select()` to non-blockingly read from subprocess stdout. On Windows, this fails with:
```
OSError: [WinError 10093] WSAStartup failed
```

**Fix:** On Windows, fall back to blocking `proc.stdout.read()` instead.

### 2. Unix paths break `subprocess.Popen` cwd (WinError 267)
**File:** `tools/environments/local.py`

MSYS2/Git-Bash's `pwd -P` returns Unix-style paths (`/d/project`), but `subprocess.Popen(..., cwd=...)` requires native Windows paths (`D:\project`), causing:
```
NotADirectoryError: [WinError 267] The directory name is invalid
```

**Fix:** Add `_msys2_to_windows_path()` converter to translate:
- `/d/...` → `D:\...`
- `/mnt/d/...` → `D:\...`
- `/tmp` → current drive temp

### 3. `/tmp` inconsistency between bash and Python
**File:** `tools/environments/local.py`

Bash maps `/tmp` to Windows `%TEMP%`, but Python resolves `/tmp` as `<current_drive>:\tmp`. This causes `_cwd_file` and `_snapshot_path` to be written by bash but read as non-existent by Python.

**Fix:** On Windows, return `tempfile.gettempdir()` with forward slashes instead of `/tmp`.

### 4. CWD marker extraction restores Unix paths
**File:** `tools/environments/local.py`

The `_extract_cwd_from_output()` method extracts cwd from stdout marker, which contains Unix paths from bash, overwriting the Windows path conversion done earlier.

**Fix:** Force Windows path conversion after `_extract_cwd_from_output()`.

## Testing

Tested on:
- Windows 11
- Git for Windows / MSYS2 environment
- Python 3.14

Before this fix:
- Terminal commands returned exit code 0 with empty output
- All commands failed with `WinError 267`

After this fix:
- Terminal commands work correctly
- File read/write tools function properly
- CWD persists correctly across commands

## Changes

- `tools/environments/base.py`: Add Windows-specific stdout reading
- `tools/environments/local.py`: Add path conversion and temp dir fixes

## Checklist

- [x] Tested on Windows 11 with Git-Bash/MSYS2
- [x] Backward compatible with Unix/Linux
- [x] No breaking changes to API

---

**Fixes:** Issues with Windows local terminal backend (select failure, path conversion, temp directory inconsistency)