### PR TITLE
fix(browser): use querySelectorAll instead of document.images

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -2788,7 +2788,7 @@ def browser_get_images(task_id: Optional[str] = None) -> str:
 
     # Use eval to run JavaScript that extracts images
     js_code = """JSON.stringify(
-        [...document.images].map(img => ({
+        [...document.querySelectorAll('img')].map(img => ({
             src: img.src,
             alt: img.alt || '',
             width: img.naturalWidth,


### PR DESCRIPTION
## Summary

Fixes #22012

document.images is unreliable on SPA and JavaScript-heavy pages, causing `SyntaxError: Unexpected end of input`.

## Root Cause

The eval bridge sends `[...document.images].map(...)` but document.images behaves inconsistently across page types on modern sites.

## Fix

Changed to `document.querySelectorAll('img')` which returns a static NodeList and works consistently.

## Changes

- `tools/browser_tool.py`: 1 line changed (+1 -1)

## Testing

- Verified on SPA page: images returned correctly ✅
- Verified on static page: no regression ✅