### PR TITLE
fix(install): preserve pip entry point when re-running on symlinked install

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1109,6 +1109,13 @@ setup_path() {
     # We intentionally clear PYTHONPATH/PYTHONHOME here so inherited env vars
     # can't make this launcher import modules from another checkout.
     mkdir -p "$command_link_dir"
+    # Remove any prior entry first: on systems that installed an older layout
+    # ($command_link_dir/hermes was a symlink to venv/bin/hermes), `cat >`
+    # follows the symlink and overwrites the pip-generated entry point with
+    # the shim body, producing a self-execing wrapper that hangs on every
+    # invocation. Deleting first ensures the shim is a regular file in
+    # $command_link_dir and the venv entry point survives. (#21454, #21513)
+    rm -f "$command_link_dir/hermes"
     cat > "$command_link_dir/hermes" <<EOF
 #!/usr/bin/env bash
 unset PYTHONPATH

--- a/tests/test_install_sh_symlink_stomp.py
+++ b/tests/test_install_sh_symlink_stomp.py
@@ -1,0 +1,91 @@
+"""Regression tests for install.sh shim creation overwriting a prior symlink.
+
+When users re-run scripts/install.sh on a system installed with an older layout,
+$command_link_dir/hermes used to be a symlink pointing at venv/bin/hermes (the
+pip-generated entry point). The shim writer used `cat > "$command_link_dir/hermes"`
+which follows the symlink and rewrites the venv entry point with the shim body,
+producing an `exec "$HERMES_BIN"` that calls itself. Result: `hermes` hangs on
+every invocation. (#21454, #21513)
+
+The fix is to `rm -f` the destination before the heredoc so the shim is created
+as a regular file in $command_link_dir, leaving venv/bin/hermes intact.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+import textwrap
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def test_shim_writer_removes_existing_path_before_heredoc() -> None:
+    """Static guard: `rm -f` must precede the `cat >` heredoc for the shim."""
+    text = INSTALL_SH.read_text()
+    heredoc_marker = 'cat > "$command_link_dir/hermes" <<EOF'
+    idx = text.index(heredoc_marker)
+    preamble = text[:idx]
+    last_rm = preamble.rfind('rm -f "$command_link_dir/hermes"')
+    assert last_rm != -1, "missing `rm -f` before shim heredoc"
+    last_mkdir = preamble.rfind('mkdir -p "$command_link_dir"')
+    assert last_mkdir < last_rm < idx, "rm must sit between mkdir and heredoc"
+
+
+@pytest.mark.skipif(os.name == "nt", reason="POSIX symlink semantics")
+def test_shim_write_does_not_stomp_symlinked_venv_entrypoint(tmp_path: Path) -> None:
+    """Behavioural reproducer: drive the real shim-write block from install.sh.
+
+    Pre-create the symlink-to-venv layout that legacy installs left behind, run
+    the shim creation block, and assert the venv entry point survives untouched.
+    """
+    venv_bin = tmp_path / "venv" / "bin"
+    venv_bin.mkdir(parents=True)
+    venv_entry = venv_bin / "hermes"
+    pip_body = "#!/usr/bin/env python3\n# pip-generated entry point\nprint('venv-hermes')\n"
+    venv_entry.write_text(pip_body)
+    venv_entry.chmod(0o755)
+
+    command_link_dir = tmp_path / "bin"
+    command_link_dir.mkdir()
+    legacy_link = command_link_dir / "hermes"
+    legacy_link.symlink_to(venv_entry)
+    assert legacy_link.is_symlink()
+
+    text = INSTALL_SH.read_text()
+    heredoc_start = text.index('cat > "$command_link_dir/hermes" <<EOF')
+    heredoc_end = text.index('EOF\n    chmod +x "$command_link_dir/hermes"', heredoc_start)
+    block_start = text.rfind('mkdir -p "$command_link_dir"', 0, heredoc_start)
+    block_end = heredoc_end + len('EOF\n    chmod +x "$command_link_dir/hermes"')
+    block = text[block_start:block_end]
+
+    script = textwrap.dedent(
+        f"""\
+        #!/usr/bin/env bash
+        set -euo pipefail
+        command_link_dir={command_link_dir!s}
+        HERMES_BIN={venv_entry!s}
+        {block}
+        """
+    )
+    runner = tmp_path / "run.sh"
+    runner.write_text(script)
+    runner.chmod(0o755)
+
+    subprocess.run(["bash", str(runner)], check=True)
+
+    assert venv_entry.read_text() == pip_body, "venv entry point was overwritten through symlink"
+    shim = command_link_dir / "hermes"
+    assert shim.exists()
+    assert not shim.is_symlink()
+    shim_body = shim.read_text()
+    assert "unset PYTHONPATH" in shim_body
+    assert "unset PYTHONHOME" in shim_body
+    assert f'exec "{venv_entry}"' in shim_body
+    assert os.stat(shim).st_mode & stat.S_IXUSR

--- a/tests/test_install_sh_symlink_stomp.py
+++ b/tests/test_install_sh_symlink_stomp.py
@@ -14,6 +14,7 @@ as a regular file in $command_link_dir, leaving venv/bin/hermes intact.
 from __future__ import annotations
 
 import os
+import shlex
 import stat
 import subprocess
 import textwrap
@@ -69,8 +70,8 @@ def test_shim_write_does_not_stomp_symlinked_venv_entrypoint(tmp_path: Path) -> 
         f"""\
         #!/usr/bin/env bash
         set -euo pipefail
-        command_link_dir={command_link_dir!s}
-        HERMES_BIN={venv_entry!s}
+        command_link_dir={shlex.quote(str(command_link_dir))}
+        HERMES_BIN={shlex.quote(str(venv_entry))}
         {block}
         """
     )


### PR DESCRIPTION
## Summary

Re-running `scripts/install.sh` on a system installed under an older layout destroys the pip-generated `venv/bin/hermes` entry point and replaces it with a self-recursing bash shim, so `hermes` hangs on every invocation.

### Cause

`setup_path()` writes the launcher with `cat > "$command_link_dir/hermes"`. On a prior install `$command_link_dir/hermes` is a symlink pointing at `venv/bin/hermes`. The redirect follows the symlink and overwrites the pip entry point with the shim body. `$HERMES_BIN` then resolves to the same path — `exec` calls itself.

### Fix

`rm -f` the destination before the heredoc so the shim is created as a regular file in `$command_link_dir`, leaving the venv entry point intact. No restructuring of `setup_path()` — smallest change that captures the diagnosis.

## Changes

- `scripts/install.sh` — added `rm -f "$command_link_dir/hermes"` before the `cat >` heredoc.
- `tests/test_install_sh_symlink_stomp.py` — new file:
  - static guard that the `rm` precedes the heredoc (and follows the `mkdir`).
  - behavioural reproducer that pre-creates the symlinked legacy layout, drives the real shim-write block extracted from `install.sh`, and asserts `venv/bin/hermes` survives.

## Test plan

- [x] `./scripts/run_tests.sh tests/test_install_sh_symlink_stomp.py -v` — both tests pass with fix.
- [x] Stash-verify: `git stash push scripts/install.sh` → both tests fail (static guard misses `rm`; behavioural test sees pip body replaced by shim). `git stash pop` restores fix and tests pass again.
- [x] `bash -n scripts/install.sh` clean.

Closes #21513
Refs #21454

🤖 Generated with [Claude Code](https://claude.com/claude-code)