### PR TITLE
feat(feishu): add opt-in reaction shortcuts

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -126,7 +126,7 @@ except ImportError:
 FEISHU_WEBSOCKET_AVAILABLE = websockets is not None
 FEISHU_WEBHOOK_AVAILABLE = aiohttp is not None
 
-from gateway.config import Platform, PlatformConfig
+from gateway.config import Platform, PlatformConfig, _coerce_bool
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
@@ -235,6 +235,21 @@ _FEISHU_REPLY_FALLBACK_CODES = frozenset({230011, 231003})  # reply target withd
 # the success signal.
 _FEISHU_REACTION_IN_PROGRESS = "Typing"
 _FEISHU_REACTION_FAILURE = "CrossMark"
+_FEISHU_REACTION_SHORTCUTS: Dict[str, str] = {
+    "👀": "/status",
+    "Eyes": "/status",
+    "🔁": "/retry",
+    "Repeat": "/retry",
+    "CounterclockwiseArrowsButton": "/retry",
+    "🧹": "/new",
+    "Broom": "/new",
+    "✅": "/approve",
+    "CheckMarkButton": "/approve",
+    "WhiteCheckMark": "/approve",
+    "❌": "/deny",
+    "CrossMarkButton": "/deny",
+    "CrossMark": "/deny",
+}
 # Bound on the (message_id → reaction_id) handle cache. Happy-path entries
 # drain on completion; the cap is a safeguard against unbounded growth from
 # delete-failures, not a capacity plan.
@@ -262,6 +277,15 @@ FALLBACK_SHARE_CHAT_TEXT = "[Shared chat]"
 FALLBACK_INTERACTIVE_TEXT = "[Interactive message]"
 FALLBACK_IMAGE_TEXT = "[Image]"
 FALLBACK_ATTACHMENT_TEXT = "[Attachment]"
+
+
+def _reaction_shortcut_text(action: str, emoji_type: str) -> Optional[str]:
+    """Return a slash command for mapped inbound reactions on bot messages."""
+    if action != "added":
+        return None
+    return _FEISHU_REACTION_SHORTCUTS.get(str(emoji_type or ""))
+
+
 # ---------------------------------------------------------------------------
 # Post/card parsing helpers
 # ---------------------------------------------------------------------------
@@ -388,6 +412,7 @@ class FeishuAdapterSettings:
     ws_reconnect_interval: int = 120
     ws_ping_interval: Optional[int] = None
     ws_ping_timeout: Optional[int] = None
+    reaction_shortcuts_enabled: bool = False
     admins: frozenset[str] = frozenset()
     default_group_policy: str = ""
     group_rules: Dict[str, FeishuGroupRule] = field(default_factory=dict)
@@ -1503,6 +1528,7 @@ class FeishuAdapter(BasePlatformAdapter):
             ws_reconnect_interval=_coerce_required_int(extra.get("ws_reconnect_interval"), default=120, min_value=1),
             ws_ping_interval=_coerce_int(extra.get("ws_ping_interval"), default=None, min_value=1),
             ws_ping_timeout=_coerce_int(extra.get("ws_ping_timeout"), default=None, min_value=1),
+            reaction_shortcuts_enabled=_coerce_bool(extra.get("reaction_shortcuts_enabled"), default=False),
             admins=admins,
             default_group_policy=default_group_policy,
             group_rules=group_rules,
@@ -1540,6 +1566,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._ws_reconnect_interval = settings.ws_reconnect_interval
         self._ws_ping_interval = settings.ws_ping_interval
         self._ws_ping_timeout = settings.ws_ping_timeout
+        self._reaction_shortcuts_enabled = settings.reaction_shortcuts_enabled
         self._allow_bots = settings.allow_bots
         self._require_mention = settings.require_mention
 
@@ -2637,7 +2664,10 @@ class FeishuAdapter(BasePlatformAdapter):
         reaction_type_obj = getattr(event, "reaction_type", None)
         emoji_type = str(getattr(reaction_type_obj, "emoji_type", "") or "UNKNOWN")
         action = "added" if "created" in event_type else "removed"
-        synthetic_text = f"reaction:{action}:{emoji_type}"
+        shortcut_text = None
+        if self._reaction_shortcuts_enabled:
+            shortcut_text = _reaction_shortcut_text(action, emoji_type)
+        synthetic_text = shortcut_text or f"reaction:{action}:{emoji_type}"
 
         sender_profile = await self._resolve_sender_profile(user_id_obj)
         chat_info = await self.get_chat_info(chat_id)
@@ -2658,7 +2688,13 @@ class FeishuAdapter(BasePlatformAdapter):
             message_id=message_id,
             timestamp=datetime.now(),
         )
-        logger.info("[Feishu] Routing reaction %s:%s on bot message %s as synthetic event", action, emoji_type, message_id)
+        logger.info(
+            "[Feishu] Routing reaction %s:%s on bot message %s as synthetic event %r",
+            action,
+            emoji_type,
+            message_id,
+            synthetic_text,
+        )
         await self._handle_message_with_guards(synthetic_event)
 
     def _is_card_action_duplicate(self, token: str) -> bool:

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -700,7 +700,13 @@ class TestAdapterBehavior(unittest.TestCase):
             adapter._on_reaction_event("im.message.reaction.created_v1", data)
         run_threadsafe.assert_called_once()
 
-    def _build_reaction_adapter(self, *, msg_sender_id: str):
+    def _build_reaction_adapter(
+        self,
+        *,
+        msg_sender_id: str,
+        msg_sender_type: str = "app",
+        reaction_shortcuts_enabled: bool = False,
+    ):
         """Build a FeishuAdapter wired up to return a single GET-message result."""
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter
@@ -709,9 +715,10 @@ class TestAdapterBehavior(unittest.TestCase):
         adapter._app_id = "cli_self_app"
         adapter._bot_open_id = "ou_self_bot"
         adapter._bot_user_id = "u_self_bot"
+        adapter._reaction_shortcuts_enabled = reaction_shortcuts_enabled
 
         msg = SimpleNamespace(
-            sender=SimpleNamespace(sender_type="app", id=msg_sender_id, id_type="app_id"),
+            sender=SimpleNamespace(sender_type=msg_sender_type, id=msg_sender_id, id_type="app_id"),
             chat_id="oc_chat",
             chat_type="group",
         )
@@ -760,6 +767,122 @@ class TestAdapterBehavior(unittest.TestCase):
             adapter._handle_reaction_event("im.message.reaction.created_v1", data)
         )
         adapter._handle_message_with_guards.assert_awaited_once()
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_reaction_shortcuts_map_selected_emojis_when_enabled(self):
+        adapter = self._build_reaction_adapter(
+            msg_sender_id="cli_self_app",
+            reaction_shortcuts_enabled=True,
+        )
+        cases = {
+            "Eyes": "/status",
+            "Repeat": "/retry",
+            "Broom": "/new",
+            "CheckMarkButton": "/approve",
+            "CrossMarkButton": "/deny",
+        }
+
+        for emoji_type, expected_text in cases.items():
+            adapter._handle_message_with_guards.reset_mock()
+            data = SimpleNamespace(
+                event=SimpleNamespace(
+                    message_id="om_self_msg",
+                    user_id=SimpleNamespace(open_id="ou_human", user_id=None, union_id=None),
+                    reaction_type=SimpleNamespace(emoji_type=emoji_type),
+                )
+            )
+            asyncio.run(adapter._handle_reaction_event("im.message.reaction.created_v1", data))
+            routed_event = adapter._handle_message_with_guards.await_args.args[0]
+            self.assertEqual(routed_event.text, expected_text)
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_reaction_shortcuts_disabled_keeps_legacy_format_for_mapped_emoji(self):
+        adapter = self._build_reaction_adapter(
+            msg_sender_id="cli_self_app",
+            reaction_shortcuts_enabled=False,
+        )
+        data = SimpleNamespace(
+            event=SimpleNamespace(
+                message_id="om_self_msg",
+                user_id=SimpleNamespace(open_id="ou_human", user_id=None, union_id=None),
+                reaction_type=SimpleNamespace(emoji_type="Eyes"),
+            )
+        )
+        asyncio.run(adapter._handle_reaction_event("im.message.reaction.created_v1", data))
+        routed_event = adapter._handle_message_with_guards.await_args.args[0]
+        self.assertEqual(routed_event.text, "reaction:added:Eyes")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_reaction_shortcuts_removed_event_keeps_legacy_format(self):
+        adapter = self._build_reaction_adapter(
+            msg_sender_id="cli_self_app",
+            reaction_shortcuts_enabled=True,
+        )
+        data = SimpleNamespace(
+            event=SimpleNamespace(
+                message_id="om_self_msg",
+                user_id=SimpleNamespace(open_id="ou_human", user_id=None, union_id=None),
+                reaction_type=SimpleNamespace(emoji_type="Eyes"),
+            )
+        )
+        asyncio.run(adapter._handle_reaction_event("im.message.reaction.deleted_v1", data))
+        routed_event = adapter._handle_message_with_guards.await_args.args[0]
+        self.assertEqual(routed_event.text, "reaction:removed:Eyes")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_reaction_shortcuts_unmapped_emoji_keeps_legacy_format(self):
+        adapter = self._build_reaction_adapter(
+            msg_sender_id="cli_self_app",
+            reaction_shortcuts_enabled=True,
+        )
+        data = SimpleNamespace(
+            event=SimpleNamespace(
+                message_id="om_self_msg",
+                user_id=SimpleNamespace(open_id="ou_human", user_id=None, union_id=None),
+                reaction_type=SimpleNamespace(emoji_type="PartyPopper"),
+            )
+        )
+        asyncio.run(adapter._handle_reaction_event("im.message.reaction.created_v1", data))
+        routed_event = adapter._handle_message_with_guards.await_args.args[0]
+        self.assertEqual(routed_event.text, "reaction:added:PartyPopper")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_duplicate_created_reaction_replays_command_without_dedup(self):
+        adapter = self._build_reaction_adapter(
+            msg_sender_id="cli_self_app",
+            reaction_shortcuts_enabled=True,
+        )
+        data = SimpleNamespace(
+            event=SimpleNamespace(
+                message_id="om_self_msg",
+                user_id=SimpleNamespace(open_id="ou_human", user_id=None, union_id=None),
+                reaction_type=SimpleNamespace(emoji_type="Eyes"),
+            )
+        )
+        asyncio.run(adapter._handle_reaction_event("im.message.reaction.created_v1", data))
+        asyncio.run(adapter._handle_reaction_event("im.message.reaction.created_v1", data))
+        self.assertEqual(adapter._handle_message_with_guards.await_count, 2)
+        first_event = adapter._handle_message_with_guards.await_args_list[0].args[0]
+        second_event = adapter._handle_message_with_guards.await_args_list[1].args[0]
+        self.assertEqual(first_event.text, "/status")
+        self.assertEqual(second_event.text, "/status")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_reaction_on_user_message_is_not_routed(self):
+        adapter = self._build_reaction_adapter(
+            msg_sender_id="ou_user_message",
+            msg_sender_type="user",
+            reaction_shortcuts_enabled=True,
+        )
+        data = SimpleNamespace(
+            event=SimpleNamespace(
+                message_id="om_user_msg",
+                user_id=SimpleNamespace(open_id="ou_human", user_id=None, union_id=None),
+                reaction_type=SimpleNamespace(emoji_type="Eyes"),
+            )
+        )
+        asyncio.run(adapter._handle_reaction_event("im.message.reaction.created_v1", data))
+        adapter._handle_message_with_guards.assert_not_awaited()
 
     @patch.dict(os.environ, {"FEISHU_GROUP_POLICY": "open"}, clear=True)
     def test_group_message_requires_mentions_even_when_policy_open(self):


### PR DESCRIPTION
 ## Summary

  Adds opt-in Feishu reaction shortcuts that map selected inbound emoji reactions on this bot's own messages to lightweight gateway commands.

  This PR is intentionally scoped as an opt-in command mapping layer on top of the existing Feishu reaction observability flow. By default, reactions continue to use the legacy synthetic reaction format.

  When `reaction_shortcuts_enabled` is enabled for Feishu:

  - `👀` / `Eyes` -> `/status`
  - `🔁` / `Repeat` -> `/retry`
  - `🧹` / `Broom` -> `/new`
  - `✅` / `CheckMarkButton` -> `/approve`
  - `❌` / `CrossMarkButton` -> `/deny`

  By default this is off, so existing Feishu deployments keep the current behavior.

  ## What changed

  - Added a Feishu reaction shortcut map plus a small helper for translating selected `created` reaction events into slash commands
  - Added `reaction_shortcuts_enabled: false` as an opt-in Feishu adapter setting
  - Kept legacy fallback behavior for unmapped emoji, removed reactions, and disabled config
  - Added focused tests for enabled routing, disabled fallback, removed reactions, unmapped emoji, duplicate `created` events, and non-bot target messages

  ## Why

  This gives Feishu a lightweight native interaction surface for a few common gateway actions without changing behavior for existing deployments.

  ## Validation

  - Ran: `scripts/run_tests.sh tests/gateway/test_feishu.py`
  - Result: `204 passed`
