### PR TITLE
fix(scripts): make run_tests.sh pytest-split bootstrap uv-aware

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
 modal = ["modal>=1.0.0,<2"]
 daytona = ["daytona>=0.148.0,<1"]
 vercel = ["vercel>=0.5.7,<0.6.0"]
-dev = ["debugpy>=1.8.0,<2", "pytest>=9.0.2,<10", "pytest-asyncio>=1.3.0,<2", "pytest-xdist>=3.0,<4", "mcp>=1.2.0,<2", "ty>=0.0.1a29,<0.0.22", "ruff"]
+dev = ["debugpy>=1.8.0,<2", "pytest>=9.0.2,<10", "pytest-asyncio>=1.3.0,<2", "pytest-xdist>=3.0,<4", "pytest-split>=0.9,<1", "mcp>=1.2.0,<2", "ty>=0.0.1a29,<0.0.22", "ruff"]
 messaging = ["python-telegram-bot[webhooks]>=22.6,<23", "discord.py[voice]>=2.7.1,<3", "aiohttp>=3.13.3,<4", "slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4", "qrcode>=7.0,<8"]
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
 slack = ["slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4"]

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -42,9 +42,20 @@ fi
 PYTHON="$VENV/bin/python"
 
 # ── Ensure pytest-split is installed (required for shard-equivalent runs) ──
+# Declared in pyproject.toml's [project.optional-dependencies].dev — usually
+# already there. Bootstrap path covers older venvs and supports uv-created
+# venvs without pip (#22401).
 if ! "$PYTHON" -c "import pytest_split" 2>/dev/null; then
   echo "→ installing pytest-split into $VENV"
-  "$PYTHON" -m pip install --quiet "pytest-split>=0.9,<1"
+  if "$PYTHON" -m pip --version >/dev/null 2>&1; then
+    "$PYTHON" -m pip install --quiet "pytest-split>=0.9,<1"
+  elif command -v uv >/dev/null 2>&1; then
+    VIRTUAL_ENV="$VENV" uv pip install --quiet "pytest-split>=0.9,<1"
+  else
+    echo "error: cannot install pytest-split — venv has no pip and 'uv' is not on PATH" >&2
+    echo "       install it manually:  uv pip install --python '$PYTHON' 'pytest-split>=0.9,<1'" >&2
+    exit 1
+  fi
 fi
 
 # ── Hermetic environment ────────────────────────────────────────────────────

--- a/tests/test_run_tests_pytest_split_bootstrap.py
+++ b/tests/test_run_tests_pytest_split_bootstrap.py
@@ -1,0 +1,88 @@
+"""Regression for #22401: scripts/run_tests.sh must work in uv-created venvs
+without pip.
+
+The script self-installs ``pytest-split`` when it's missing. The original
+implementation called ``"$PYTHON" -m pip install`` unconditionally — which
+fails in a uv-managed venv where pip is not present, exiting before any
+test runs.
+
+These are static guards on the script text (no subprocess required): the
+bootstrap block must declare the dependency in pyproject's ``dev`` extra
+*and* fall back from pip → uv when pip is missing rather than aborting.
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RUN_TESTS_SH = REPO_ROOT / "scripts" / "run_tests.sh"
+PYPROJECT = REPO_ROOT / "pyproject.toml"
+
+
+@pytest.fixture(scope="module")
+def script_text() -> str:
+    return RUN_TESTS_SH.read_text()
+
+
+@pytest.fixture(scope="module")
+def pyproject_text() -> str:
+    return PYPROJECT.read_text()
+
+
+def test_pytest_split_declared_in_dev_extra(pyproject_text: str) -> None:
+    """The dev extra must list pytest-split so a fresh `uv sync --extra dev`
+    or `pip install -e '.[dev]'` brings it in without an ad-hoc bootstrap.
+    """
+    dev_line = next(
+        (
+            line
+            for line in pyproject_text.splitlines()
+            if line.lstrip().startswith("dev =")
+        ),
+        None,
+    )
+    assert dev_line is not None, "could not find dev = [...] in pyproject.toml"
+    assert "pytest-split" in dev_line, (
+        f"dev extra must declare pytest-split (#22401); got: {dev_line}"
+    )
+
+
+def _bootstrap_block(script_text: str) -> str:
+    block_match = re.search(
+        r"if\s+!\s+\"\$PYTHON\"\s+-c\s+\"import pytest_split\".*?\nfi\n",
+        script_text,
+        flags=re.DOTALL,
+    )
+    assert block_match, "could not locate pytest_split bootstrap block"
+    return block_match.group(0)
+
+
+def test_bootstrap_falls_back_to_uv_when_pip_missing(script_text: str) -> None:
+    """In a uv-created venv without pip, calling ``python -m pip install``
+    crashes with ``No module named pip`` and the script aborts before any
+    test runs. The bootstrap must probe pip first and fall back to ``uv pip
+    install`` when pip isn't available.
+    """
+    block = _bootstrap_block(script_text)
+
+    assert '"$PYTHON" -m pip --version' in block, (
+        "bootstrap must probe `pip --version` before invoking `pip install`"
+    )
+
+    assert "uv pip install" in block, (
+        "bootstrap must fall back to `uv pip install` when pip is missing"
+    )
+
+
+def test_bootstrap_emits_actionable_error_when_neither_available(
+    script_text: str,
+) -> None:
+    """If neither pip nor uv is available, the script must exit non-zero
+    with a clear message rather than running pytest with the missing dep.
+    """
+    block = _bootstrap_block(script_text)
+    assert "exit 1" in block, (
+        "bootstrap must exit non-zero when pytest-split cannot be installed"
+    )


### PR DESCRIPTION
Closes #22401.

## Problem
`scripts/run_tests.sh` requires `pytest-split`, but `pytest-split` was not declared as a dev dependency. When the dev venv is uv-created without pip (the default for `uv venv`), the bootstrap path crashes with `No module named pip` and the script exits before any test runs.

```
→ installing pytest-split into /home/seedrop/.hermes/hermes-agent/venv
/home/seedrop/.hermes/hermes-agent/venv/bin/python: No module named pip
```

## Fix
Two-pronged so the runner works in every supported dev environment:

1. **`pyproject.toml`** — declare `pytest-split>=0.9,<1` in the `dev` extra so `uv sync --extra dev` / `pip install -e '.[dev]'` brings it in. The ad-hoc bootstrap then rarely runs.
2. **`scripts/run_tests.sh`** — bootstrap probes `pip --version` first, falls back to `uv pip install` when pip is absent, and only exits non-zero (with an actionable error) when neither is available. No silent abort, no running pytest with the missing plugin.

## Tests
`tests/test_run_tests_pytest_split_bootstrap.py` — three static guards:
- dev extra declares `pytest-split`
- bootstrap probes pip and falls back to `uv pip install`
- bootstrap emits actionable error and exits non-zero when neither is available

Stash-verified to fail without the fix (3 failures on baseline) and pass with the fix (3 passed in 1.47s).