### PR TITLE
fix(gateway): recognize Atomic desktop-gateway in --replace detection

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -164,20 +164,30 @@ def _read_process_cmdline(pid: int) -> Optional[str]:
     return None
 
 
+# Recognised gateway-process command-line fragments. ``desktop-gateway``
+# covers the Atomic Hermes desktop app's bundled runner
+# (``/Applications/Atomic Hermes.app/Contents/Resources/python-server/desktop-gateway.py``),
+# which shares HERMES_HOME with the CLI. Without it, a CLI ``gateway run
+# --replace`` does not recognise the desktop runner as a gateway, skips the
+# replacement path, and then collides with the desktop runner's still-held
+# scoped lock (e.g. ``Discord bot token already in use``). See #22418.
+_GATEWAY_CMDLINE_PATTERNS = (
+    "hermes_cli.main gateway",
+    "hermes_cli/main.py gateway",
+    "hermes gateway",
+    "hermes-gateway",
+    "gateway/run.py",
+    "desktop-gateway",
+)
+
+
 def _looks_like_gateway_process(pid: int) -> bool:
     """Return True when the live PID still looks like the Hermes gateway."""
     cmdline = _read_process_cmdline(pid)
     if not cmdline:
         return False
 
-    patterns = (
-        "hermes_cli.main gateway",
-        "hermes_cli/main.py gateway",
-        "hermes gateway",
-        "hermes-gateway",
-        "gateway/run.py",
-    )
-    return any(pattern in cmdline for pattern in patterns)
+    return any(pattern in cmdline for pattern in _GATEWAY_CMDLINE_PATTERNS)
 
 
 def _record_looks_like_gateway(record: dict[str, Any]) -> bool:
@@ -191,13 +201,7 @@ def _record_looks_like_gateway(record: dict[str, Any]) -> bool:
 
     # Normalize Windows backslashes so patterns match cross-platform.
     cmdline = " ".join(str(part) for part in argv).replace("\\", "/")
-    patterns = (
-        "hermes_cli.main gateway",
-        "hermes_cli/main.py gateway",
-        "hermes gateway",
-        "gateway/run.py",
-    )
-    return any(pattern in cmdline for pattern in patterns)
+    return any(pattern in cmdline for pattern in _GATEWAY_CMDLINE_PATTERNS)
 
 
 def _build_pid_record() -> dict:

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -208,6 +208,68 @@ class TestGatewayPidState:
         assert not pid_path.exists()
         assert not lock_path.exists()
 
+    def test_get_running_pid_accepts_atomic_desktop_gateway_cmdline(self, tmp_path, monkeypatch):
+        """Atomic Hermes' bundled desktop-gateway.py shares HERMES_HOME with the CLI.
+
+        Regression for #22418: ``gateway run --replace`` must recognise it as
+        a gateway so the replace path runs (kill PID, release scoped locks);
+        otherwise the CLI proceeds without replacing, then trips the still-
+        held Discord token lock and the platform stays down.
+        """
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pid_path = tmp_path / "gateway.pid"
+        pid_path.write_text(json.dumps({
+            "pid": os.getpid(),
+            "kind": "hermes-gateway",
+            "argv": [
+                "/Applications/Atomic Hermes.app/Contents/Resources/python-server/python",
+                "/Applications/Atomic Hermes.app/Contents/Resources/python-server/desktop-gateway.py",
+            ],
+            "start_time": 123,
+        }))
+
+        monkeypatch.setattr(status.os, "kill", lambda pid, sig: None)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
+        monkeypatch.setattr(
+            status,
+            "_read_process_cmdline",
+            lambda pid: (
+                "/Applications/Atomic Hermes.app/Contents/Resources/python-server/python "
+                "/Applications/Atomic Hermes.app/Contents/Resources/python-server/desktop-gateway.py"
+            ),
+        )
+
+        assert status.acquire_gateway_runtime_lock() is True
+        try:
+            assert status.get_running_pid() == os.getpid()
+        finally:
+            status.release_gateway_runtime_lock()
+
+    def test_get_running_pid_accepts_desktop_gateway_metadata_when_cmdline_unavailable(
+        self, tmp_path, monkeypatch,
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        pid_path = tmp_path / "gateway.pid"
+        pid_path.write_text(json.dumps({
+            "pid": os.getpid(),
+            "kind": "hermes-gateway",
+            "argv": [
+                "/Applications/Atomic Hermes.app/Contents/Resources/python-server/python",
+                "/Applications/Atomic Hermes.app/Contents/Resources/python-server/desktop-gateway.py",
+            ],
+            "start_time": 123,
+        }))
+
+        monkeypatch.setattr(status.os, "kill", lambda pid, sig: None)
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 123)
+        monkeypatch.setattr(status, "_read_process_cmdline", lambda pid: None)
+
+        assert status.acquire_gateway_runtime_lock() is True
+        try:
+            assert status.get_running_pid() == os.getpid()
+        finally:
+            status.release_gateway_runtime_lock()
+
     def test_get_running_pid_falls_back_to_live_lock_record(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
         pid_path = tmp_path / "gateway.pid"


### PR DESCRIPTION
On macOS, `hermes gateway run --replace` failed when Atomic Hermes' bundled `desktop-gateway.py` was already running, leaving Discord down with `Discord bot token already in use (PID <desktop-gateway-pid>)` until the user manually killed the desktop runner.

## What changed and why
- `gateway/status.py`: Atomic Hermes ships a bundled gateway runner at `/Applications/Atomic Hermes.app/Contents/Resources/python-server/desktop-gateway.py` and symlinks HERMES_HOME to `~/.hermes`, so it writes the same `gateway.pid`/`gateway.lock` and the same scoped locks the CLI uses. But `_looks_like_gateway_process` / `_record_looks_like_gateway` only matched CLI-launched cmdlines (`hermes_cli.main gateway`, `hermes-gateway`, `gateway/run.py`, …), so `get_running_pid()` rejected the desktop runner as foreign. `start_gateway(replace=True)` therefore saw `existing_pid = None`, skipped the SIGTERM + `release_all_scoped_locks(owner_pid=…)` handoff, and the new CLI gateway then collided with the desktop runner's still-held `discord-bot-token-*.lock` in `_acquire_platform_lock`. Adding `desktop-gateway` to the recognised cmdline-pattern tuple routes the takeover through the documented `--replace` path. Patterns are now defined once as a module-level constant so the two recognition helpers stay in sync.
- `tests/gateway/test_status.py`: regression tests covering both branches — `_looks_like_gateway_process` (cmdline-driven) and `_record_looks_like_gateway` (PID-record-driven, used when `_read_process_cmdline` returns `None`).

## How to test
- `pytest tests/gateway/test_status.py -q --timeout=60` (44 passed locally, including the two new tests).
- `pytest tests/gateway/ -q --timeout=60` (2021 passed; the 2 failures are pre-existing on this branch's base and unrelated to this change — see PR summary).
- Manual repro on macOS: launch Atomic Hermes (desktop-gateway connects Discord), then `~/.local/bin/hermes gateway run --replace` from a terminal. With this fix the CLI logs `Replacing existing gateway instance (PID …)`, the desktop runner exits, and the CLI's Discord adapter connects without `discord-bot-token_lock`.

## What platforms tested on
- macOS on darwin-arm64 (local, unit tests)

Fixes #22418

<!-- autocontrib:worker-id=issue-new-632d9555 kind=pr-open -->