### PR TITLE
fix(docker): install Node 22 from NodeSource to match install.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,9 +12,19 @@ ENV PLAYWRIGHT_BROWSERS_PATH=/opt/hermes/.playwright
 # Install system dependencies in one layer, clear APT cache
 # tini reaps orphaned zombie processes (MCP stdio subprocesses, git, bun, etc.)
 # that would otherwise accumulate when hermes runs as PID 1. See #15012.
+#
+# Node 22 is installed from NodeSource so the image matches the Node version
+# pinned by scripts/install.sh (NODE_VERSION="22"). Debian 13's apt-shipped
+# nodejs is 20.x, and at least one transitive web/ dep (language-tags@2.1.0)
+# requires Node ≥22. npm only WARN-s on engine mismatch, so the install
+# completes but the resolver chain breaks silently and the Vite build fails
+# with a misleading "can't resolve clsx" error. (#21656)
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
-    build-essential curl nodejs npm python3 ripgrep ffmpeg gcc python3-dev libffi-dev procps git openssh-client docker-cli tini && \
+    build-essential curl python3 ripgrep ffmpeg gcc python3-dev libffi-dev \
+    procps git openssh-client docker-cli tini ca-certificates gnupg && \
+    curl -fsSL https://deb.nodesource.com/setup_22.x | bash - && \
+    apt-get install -y --no-install-recommends nodejs && \
     rm -rf /var/lib/apt/lists/*
 
 # Non-root user for runtime; UID can be overridden via HERMES_UID at runtime

--- a/tests/test_dockerfile_node_version.py
+++ b/tests/test_dockerfile_node_version.py
@@ -1,0 +1,76 @@
+"""Static guards: Dockerfile installs Node from NodeSource at the same major
+version pinned by scripts/install.sh.
+
+Background — issue #21656.  Debian 13's apt-shipped nodejs is 20.x.  Some
+transitive web/ deps (e.g. language-tags@2.1.0) require Node >= 22.  npm
+only WARNs on engine mismatch, so the install completes but the resolver
+chain breaks silently and the Vite build dies with a misleading
+"can't resolve clsx" error.  scripts/install.sh already pins
+NODE_VERSION="22"; the Dockerfile must match.
+
+These are pure text inspections — no `docker build`, no subprocess.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+DOCKERFILE = REPO_ROOT / "Dockerfile"
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def _installer_node_major() -> str:
+    """Extract the NODE_VERSION="<major>" pin from scripts/install.sh."""
+    text = INSTALL_SH.read_text(encoding="utf-8")
+    match = re.search(r'^NODE_VERSION="(\d+)"', text, re.MULTILINE)
+    assert match, "scripts/install.sh must declare NODE_VERSION=\"<major>\""
+    return match.group(1)
+
+
+def test_dockerfile_installs_node_from_nodesource_not_debian_apt() -> None:
+    """The Dockerfile must not rely on Debian apt's bundled nodejs/npm.
+
+    Debian 13 ships nodejs 20.x; we need >= 22 (see #21656).  A line that
+    apt-installs both `nodejs` and `npm` without a NodeSource setup script
+    is the regression we are guarding against.
+    """
+    text = DOCKERFILE.read_text(encoding="utf-8")
+    lower = text.lower()
+
+    assert "deb.nodesource.com/setup_" in lower, (
+        "Dockerfile must install Node from NodeSource (deb.nodesource.com/setup_<major>.x), "
+        "not from Debian's apt nodejs package, which is too old (#21656)."
+    )
+
+    for raw_line in text.splitlines():
+        line = raw_line.lower()
+        if "apt-get install" not in line:
+            continue
+        if "nodesource" in line:
+            continue
+        if " nodejs" in f" {line}" and " npm" in f" {line}":
+            raise AssertionError(
+                "Dockerfile installs both `nodejs` and `npm` from Debian apt "
+                f"(line: {raw_line!r}). This pulls Node 20.x on Debian 13 and "
+                "breaks the web/ build (#21656). Use NodeSource setup_<major>.x instead."
+            )
+
+
+def test_dockerfile_node_major_matches_installer() -> None:
+    """Dockerfile's NodeSource major must equal scripts/install.sh's NODE_VERSION.
+
+    Drift between the two is exactly the failure mode #21656 reported:
+    install.sh upgraded to 22, the Dockerfile kept shipping 20, and the
+    container build started failing in CI on PRs that touched web/ deps.
+    """
+    major = _installer_node_major()
+    text = DOCKERFILE.read_text(encoding="utf-8").lower()
+
+    expected = f"deb.nodesource.com/setup_{major}.x"
+    assert expected in text, (
+        f"scripts/install.sh pins NODE_VERSION=\"{major}\" but the Dockerfile "
+        f"does not contain {expected!r}. Bump the NodeSource setup script in "
+        "the Dockerfile to match (#21656)."
+    )


### PR DESCRIPTION
## What does this PR do?

Closes #21656.

## Root cause

Debian 13's apt-shipped `nodejs` package is 20.x. At least one transitive
`web/` dep (`language-tags@2.1.0`) requires Node >= 22. npm only WARNs on
engine mismatch, so the install completes but the resolver chain breaks
silently and the Vite build dies with a misleading `can't resolve clsx`
error.

`scripts/install.sh` already pins `NODE_VERSION="22"`. The Dockerfile
was still installing Node from apt, so the container build drifted from
the host installer.

## Fix

`Dockerfile` now installs Node from NodeSource's `setup_22.x` script
(adds `gnupg` + `ca-certificates` to the base apt layer for the GPG key
fetch). No other layer touched.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

Closes #21656.

<details>
<summary>Original body</summary>

## Summary

Closes #21656.

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

Closes #21656.

## Problem

Debian 13's apt-shipped `nodejs` package is 20.x. At least one transitive
`web/` dep (`language-tags@2.1.0`) requires Node >= 22. npm only WARNs on
engine mismatch, so the install completes but the resolver chain breaks
silently and the Vite build dies with a misleading `can't resolve clsx`
error.

`scripts/install.sh` already pins `NODE_VERSION="22"`. The Dockerfile
was still installing Node from apt, so the container build drifted from
the host installer.

## Fix

`Dockerfile` now installs Node from NodeSource's `setup_22.x` script
(adds `gnupg` + `ca-certificates` to the base apt layer for the GPG key
fetch). No other layer touched.

## Regression guards

`tests/test_dockerfile_node_version.py` adds two pure-text guards (no
`docker build`, no subprocess):

1. `test_dockerfile_installs_node_from_nodesource_not_debian_apt` — fails
   if any `apt-get install` line co-installs `nodejs` and `npm` without a
   NodeSource setup script in the same layer.
2. `test_dockerfile_node_major_matches_installer` — extracts
   `NODE_VERSION="<major>"` from `scripts/install.sh` and asserts the
   Dockerfile contains `deb.nodesource.com/setup_<major>.x`. If
   `install.sh` bumps in the future and the Dockerfile lags, CI fails
   instead of CI passing and the container build breaking on prod
   deploys.

## Verification

Stash-verified — both tests fail on baseline, pass with the fix:

```
$ git stash push Dockerfile
$ ./scripts/run_tests.sh tests/test_dockerfile_node_version.py -v
... 2 failed
$ git stash pop
$ ./scripts/run_tests.sh tests/test_dockerfile_node_version.py -v
... 2 passed in 1.45s
```

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

Closes #21656.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_