### PR TITLE
fix(gateway): auto-recover stale runtime lock after Windows sleep/wake

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15169,6 +15169,7 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
     # allow concurrent instances without tripping this guard.
     from gateway.status import (
         acquire_gateway_runtime_lock,
+        force_recover_stale_gateway_lock,
         get_running_pid,
         get_process_start_time,
         release_gateway_runtime_lock,
@@ -15409,10 +15410,24 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         )
         return False
     if not acquire_gateway_runtime_lock():
-        logger.error(
-            "Gateway runtime lock is already held by another instance. Exiting."
-        )
-        return False
+        recovered, reason = force_recover_stale_gateway_lock()
+        if recovered:
+            logger.warning(
+                "Stale gateway lock recovered (%s). Retrying lock acquisition.",
+                reason or "lock cleaned up",
+            )
+            # Retry once after recovery
+            if not acquire_gateway_runtime_lock():
+                logger.error(
+                    "Gateway runtime lock is already held by another instance. Exiting."
+                )
+                return False
+        else:
+            logger.error(
+                "Gateway runtime lock is already held by another instance: %s",
+                reason or "use --replace to override",
+            )
+            return False
     try:
         write_pid_file()
     except FileExistsError:
@@ -15457,16 +15472,34 @@ async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = 
         name="cron-ticker",
     )
     cron_thread.start()
-    
+
+    # Start a periodic heartbeat that updates the runtime status timestamp.
+    # This lets force_recover_stale_gateway_lock() (status.py) distinguish a
+    # frozen/zombie gateway from a healthy one — critical for sleep/wake
+    # recovery on Windows where the OS may keep the process alive but the
+    # connections are long-dead.
+    _heartbeat_stop = threading.Event()
+
+    def _run_heartbeat():
+        while not _heartbeat_stop.wait(timeout=120):
+            try:
+                from gateway.status import write_runtime_status
+                write_runtime_status()
+            except Exception:
+                pass
+
+    _heartbeat_thread = threading.Thread(
+        target=_run_heartbeat,
+        daemon=True,
+        name="gateway-heartbeat",
+    )
+    _heartbeat_thread.start()
+
     # Wait for shutdown
     await runner.wait_for_shutdown()
 
-    if runner.should_exit_with_failure:
-        if runner.exit_reason:
-            logger.error("Gateway exiting with failure: %s", runner.exit_reason)
-        return False
-    
-    # Stop cron ticker cleanly
+    # Stop heartbeat and cron ticker cleanly
+    _heartbeat_stop.set()
     cron_stop.set()
     cron_thread.join(timeout=5)
 

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -13,6 +13,7 @@ concurrently under distinct configurations).
 
 import hashlib
 import json
+import logging
 import os
 import signal
 import subprocess
@@ -24,9 +25,13 @@ from typing import Any, Optional
 from utils import atomic_json_write
 
 if sys.platform == "win32":
+    import ctypes
+    import ctypes.wintypes
     import msvcrt
 else:
     import fcntl
+
+_logger = logging.getLogger(__name__)
 
 _GATEWAY_KIND = "hermes-gateway"
 _RUNTIME_STATUS_FILE = "gateway_state.json"
@@ -138,6 +143,13 @@ def _read_process_cmdline(pid: int) -> Optional[str]:
 
 def _looks_like_gateway_process(pid: int) -> bool:
     """Return True when the live PID still looks like the Hermes gateway."""
+    if _IS_WINDOWS:
+        return _looks_like_gateway_process_windows(pid)
+    return _looks_like_gateway_process_posix(pid)
+
+
+def _looks_like_gateway_process_posix(pid: int) -> bool:
+    """POSIX: read /proc/<pid>/cmdline to identify gateway."""
     cmdline = _read_process_cmdline(pid)
     if not cmdline:
         return False
@@ -150,6 +162,49 @@ def _looks_like_gateway_process(pid: int) -> bool:
         "gateway/run.py",
     )
     return any(pattern in cmdline for pattern in patterns)
+
+
+def _looks_like_gateway_process_windows(pid: int) -> bool:
+    """Windows: use kernel32 to query process image path.
+
+    Falls back to a wmic subprocess call when the lightweight OpenProcess
+    route fails (e.g. insufficient permissions or the process has already
+    exited).
+    """
+    try:
+        kernel32 = ctypes.windll.kernel32
+        PROCESS_QUERY_LIMITED_INFORMATION = 0x1000
+
+        handle = kernel32.OpenProcess(PROCESS_QUERY_LIMITED_INFORMATION, False, pid)
+        if handle:
+            try:
+                size = ctypes.wintypes.DWORD(260)
+                buf = ctypes.create_unicode_buffer(260)
+                if kernel32.QueryFullProcessImageNameW(handle, 0, buf, ctypes.byref(size)):
+                    exe_path = buf.value.lower()
+                    return any(
+                        kw in exe_path for kw in ("python", "hermes")
+                    )
+            finally:
+                kernel32.CloseHandle(handle)
+    except Exception:
+        pass
+
+    # Fallback: use wmic for command line inspection
+    try:
+        result = subprocess.run(
+            ["wmic", "process", "where", f"ProcessId={pid}", "get", "CommandLine"],
+            capture_output=True, text=True, timeout=10,
+        )
+        if result.returncode == 0:
+            cmdline = result.stdout.lower()
+            return any(
+                kw in cmdline for kw in ("hermes", "gateway")
+            )
+    except Exception:
+        pass
+
+    return False
 
 
 def _record_looks_like_gateway(record: dict[str, Any]) -> bool:
@@ -329,6 +384,167 @@ def acquire_gateway_runtime_lock() -> bool:
     _write_gateway_lock_record(handle)
     _gateway_lock_handle = handle
     return True
+
+
+def force_recover_stale_gateway_lock(
+    lock_path: Optional[Path] = None,
+) -> tuple[bool, Optional[str]]:
+    """Attempt to recover a gateway runtime lock held by a dead or invalid process.
+
+    This is called when ``acquire_gateway_runtime_lock()`` fails at startup.
+    It heuristically determines whether the lock holder is still a viable
+    gateway process.  Common cases:
+
+    * **Sleep/wake on Windows**: the OS suspended the process, connections
+      timed out, and the process is in a broken state.  The runtime status
+      file will show the last heartbeat was long ago.
+    * **PID reuse**: the recorded PID belongs to an unrelated process that
+      happened to get the same PID.
+    * **Crash without lock release**: rare, but possible on edge-case kernel
+      bugs or when the process was killed via ``taskkill /F`` from another
+      session that bypassed normal cleanup.
+
+    Returns ``(True, None)`` when the lock was successfully recovered.
+    Returns ``(False, reason)`` when the lock holder appears valid.
+    """
+    resolved_lock_path = lock_path or _get_gateway_lock_path()
+    record = _read_gateway_lock_record(resolved_lock_path)
+    if record is None:
+        _logger.debug("force_recover: no lock record found")
+        return False, "no lock record to inspect"
+
+    pid = _pid_from_record(record)
+    if pid is None:
+        _logger.debug("force_recover: no valid PID in lock record")
+        return False, "no PID in lock record"
+
+    # ── Check 1: Is the PID still alive? ───────────────────────────
+    pid_alive = _pid_is_alive(pid)
+    if not pid_alive:
+        _logger.info(
+            "force_recover: PID %d is dead — removing stale lock file", pid
+        )
+        _hard_remove_lock_file(resolved_lock_path)
+        return True, None
+
+    # ── Check 2: If alive, does it still look like a gateway? ─────
+    if not (_looks_like_gateway_process(pid) or _record_looks_like_gateway(record)):
+        _logger.warning(
+            "force_recover: PID %d is alive but does not look like a gateway "
+            "— killing it and removing lock file",
+            pid,
+        )
+        _force_kill_pid(pid)
+        _hard_remove_lock_file(resolved_lock_path)
+        return True, None
+
+    # ── Check 3: Check runtime status for staleness ────────────────
+    _STALE_HEARTBEAT_SECONDS = 600  # 10 min without update = stale
+    status = read_runtime_status()
+    if status is not None:
+        status_pid = status.get("pid")
+        if status_pid == pid:
+            updated_at = status.get("updated_at") or ""
+            gateway_state = status.get("gateway_state") or ""
+            exit_reason = status.get("exit_reason")
+
+            # The state file says it's exiting/has exited
+            if gateway_state in ("stopping", "exited") or exit_reason:
+                _logger.info(
+                    "force_recover: PID %d state=%s exit_reason=%s — treating as stale",
+                    pid, gateway_state, exit_reason,
+                )
+                _force_kill_pid(pid)
+                _hard_remove_lock_file(resolved_lock_path)
+                return True, None
+
+            # Check for stale heartbeat (sleep/wake detection)
+            try:
+                last_update = datetime.fromisoformat(updated_at)
+                age = (datetime.now(timezone.utc) - last_update).total_seconds()
+                if age > _STALE_HEARTBEAT_SECONDS:
+                    _logger.warning(
+                        "force_recover: PID %d last heartbeat was %.0fs ago "
+                        "(> %ds) — likely sleep/wake or frozen process",
+                        pid, age, _STALE_HEARTBEAT_SECONDS,
+                    )
+                    _force_kill_pid(pid)
+                    _hard_remove_lock_file(resolved_lock_path)
+                    return True, None
+            except (TypeError, ValueError):
+                pass
+
+    # ── The lock holder looks legitimate ───────────────────────────
+    reason = (
+        f"PID {pid} is alive and appears to be a healthy Hermes gateway. "
+        f"To replace it, run: hermes gateway stop, or hermes gateway run --replace"
+    )
+    return False, reason
+
+
+def _pid_is_alive(pid: int) -> bool:
+    """Check whether a process with the given PID exists."""
+    try:
+        os.kill(pid, 0)
+        return True
+    except (ProcessLookupError, PermissionError, OSError):
+        pass
+
+    if not _IS_WINDOWS:
+        return False
+
+    # On Windows, os.kill(SIGTERM-like) can give permission errors even
+    # when the process exists.  Try a lightweight handle.
+    try:
+        kernel32 = ctypes.windll.kernel32
+        SYNCHRONIZE = 0x00100000
+        handle = kernel32.OpenProcess(SYNCHRONIZE, False, pid)
+        if handle:
+            kernel32.CloseHandle(handle)
+            return True
+    except Exception:
+        pass
+    return False
+
+
+def _hard_remove_lock_file(lock_path: Optional[Path] = None) -> None:
+    """Best-effort removal of the gateway lock file after recovery.
+
+    On Windows, byte-range locks are mandatory — the kernel must have
+    already released the lock before we can unlink the file.  If the
+    owning process is dead, the OS has already done this.
+    """
+    resolved = lock_path or _get_gateway_lock_path()
+    try:
+        resolved.unlink(missing_ok=True)
+    except OSError as exc:
+        _logger.debug("_hard_remove_lock_file: %s", exc)
+
+
+def _force_kill_pid(pid: int) -> None:
+    """Best-effort termination of a process by PID.
+
+    On Windows, attempts graceful taskkill first, then force-kill the
+    process tree.  On POSIX, sends SIGTERM then SIGKILL.
+    """
+    try:
+        if _IS_WINDOWS:
+            # Graceful first
+            try:
+                subprocess.run(
+                    ["taskkill", "/PID", str(pid)], capture_output=True, timeout=10,
+                )
+                # Force-kill if still alive
+                subprocess.run(
+                    ["taskkill", "/PID", str(pid), "/F", "/T"],
+                    capture_output=True, timeout=10,
+                )
+            except Exception:
+                pass
+        else:
+            os.kill(pid, signal.SIGTERM)
+    except Exception as exc:
+        _logger.debug("_force_kill_pid: %s", exc)
 
 
 def release_gateway_runtime_lock() -> None:
@@ -835,9 +1051,10 @@ def get_running_pid(
             if _record_looks_like_gateway(record):
                 return pid
             continue
-        except OSError:
+        except (OSError, SystemError):
             # Windows raises OSError with WinError 87 for an invalid pid
             # (process is definitely gone). Treat as "process doesn't exist".
+            # Some Windows Python builds also raise SystemError wrapping OSError.
             continue
 
         recorded_start = record.get("start_time")


### PR DESCRIPTION
When Windows enters sleep mode, the gateway process is suspended but its byte-range lock (gateway.lock) persists. After wake-up, the old process may be alive but its connections are dead. The lock is mandatory on Windows (msvcrt.LK_NBLCK), so a new instance cannot start — hitting "Gateway runtime lock is already held by another instance. Exiting."

Changes in gateway/status.py:
- Add Windows-compatible process detection via kernel32.OpenProcess
  + wmic fallback (the old code relied on /proc/pid/cmdline which does not exist on Windows)
- Add force_recover_stale_gateway_lock() with three-tier detection:
  1. PID lookup (process dead → lock is stale)
  2. Gateway process identity check (not a gateway → lock is stale)
  3. Heartbeat staleness (last heartbeat > 10 min → sleep/wake)
- When any tier flags staleness, force-kill the old process and clean up the lock file so the new instance can proceed

Changes in gateway/run.py:
- On lock acquisition failure, call force_recover_stale_gateway_lock() before giving up
- Add a periodic heartbeat thread (120 s) that updates the runtime status timestamp so the staleness detection is reliable

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

