### PR TITLE
feat(feishu): best-effort normalize unsupported outbound videos to mp4

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -56,6 +56,9 @@ import logging
 import mimetypes
 import os
 import re
+import shutil
+import subprocess
+import tempfile
 import threading
 import time
 import uuid
@@ -199,6 +202,7 @@ _DEFAULT_DEDUP_CACHE_SIZE = 2048
 _DEFAULT_WEBHOOK_HOST = "127.0.0.1"
 _DEFAULT_WEBHOOK_PORT = 8765
 _DEFAULT_WEBHOOK_PATH = "/feishu/webhook"
+_FEISHU_VIDEO_TRANSCODE_TIMEOUT_SECONDS = 120
 # ---------------------------------------------------------------------------
 # TTL, rate-limit and webhook security constants
 # ---------------------------------------------------------------------------
@@ -388,6 +392,7 @@ class FeishuAdapterSettings:
     ws_reconnect_interval: int = 120
     ws_ping_interval: Optional[int] = None
     ws_ping_timeout: Optional[int] = None
+    video_transcode_timeout_seconds: int = _FEISHU_VIDEO_TRANSCODE_TIMEOUT_SECONDS
     admins: frozenset[str] = frozenset()
     default_group_policy: str = ""
     group_rules: Dict[str, FeishuGroupRule] = field(default_factory=dict)
@@ -1503,6 +1508,15 @@ class FeishuAdapter(BasePlatformAdapter):
             ws_reconnect_interval=_coerce_required_int(extra.get("ws_reconnect_interval"), default=120, min_value=1),
             ws_ping_interval=_coerce_int(extra.get("ws_ping_interval"), default=None, min_value=1),
             ws_ping_timeout=_coerce_int(extra.get("ws_ping_timeout"), default=None, min_value=1),
+            video_transcode_timeout_seconds=_coerce_required_int(
+                extra.get("video_transcode_timeout_seconds")
+                or os.getenv(
+                    "HERMES_FEISHU_VIDEO_TRANSCODE_TIMEOUT_SECONDS",
+                    str(_FEISHU_VIDEO_TRANSCODE_TIMEOUT_SECONDS),
+                ),
+                default=_FEISHU_VIDEO_TRANSCODE_TIMEOUT_SECONDS,
+                min_value=1,
+            ),
             admins=admins,
             default_group_policy=default_group_policy,
             group_rules=group_rules,
@@ -1540,6 +1554,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._ws_reconnect_interval = settings.ws_reconnect_interval
         self._ws_ping_interval = settings.ws_ping_interval
         self._ws_ping_timeout = settings.ws_ping_timeout
+        self._video_transcode_timeout_seconds = settings.video_transcode_timeout_seconds
         self._allow_bots = settings.allow_bots
         self._require_mention = settings.require_mention
 
@@ -2017,14 +2032,40 @@ class FeishuAdapter(BasePlatformAdapter):
         **kwargs,
     ) -> SendResult:
         """Send a video file to Feishu."""
-        return await self._send_uploaded_file_message(
-            chat_id=chat_id,
-            file_path=video_path,
-            reply_to=reply_to,
-            metadata=metadata,
-            caption=caption,
-            outbound_message_type="media",
-        )
+        resolved_path = video_path
+        resolved_name: Optional[str] = None
+        temporary_mp4_path: Optional[str] = None
+        if Path(video_path).suffix.lower() not in _FEISHU_MEDIA_UPLOAD_EXTENSIONS:
+            normalized = await asyncio.to_thread(
+                self._normalize_outbound_video_to_mp4,
+                video_path,
+            )
+            if normalized is not None:
+                temporary_mp4_path, resolved_name = normalized
+                resolved_path = temporary_mp4_path
+
+        try:
+            return await self._send_uploaded_file_message(
+                chat_id=chat_id,
+                file_path=resolved_path,
+                file_name=resolved_name,
+                reply_to=reply_to,
+                metadata=metadata,
+                caption=caption,
+                outbound_message_type="media",
+            )
+        finally:
+            if temporary_mp4_path:
+                try:
+                    os.unlink(temporary_mp4_path)
+                except FileNotFoundError:
+                    pass
+                except OSError:
+                    logger.debug(
+                        "[Feishu] Failed to clean up temporary transcoded video %s",
+                        temporary_mp4_path,
+                        exc_info=True,
+                    )
 
     async def send_image_file(
         self,
@@ -4289,6 +4330,76 @@ class FeishuAdapter(BasePlatformAdapter):
             receive_id_type = "chat_id"
         request = self._build_create_message_request(receive_id_type, body)
         return await asyncio.to_thread(self._client.im.v1.message.create, request)
+
+    def _normalize_outbound_video_to_mp4(self, video_path: str) -> Optional[tuple[str, str]]:
+        """Best-effort normalize unsupported outbound videos to MP4 for native Feishu media send."""
+        ffmpeg_path = shutil.which("ffmpeg")
+        if not ffmpeg_path:
+            return None
+
+        stem = Path(video_path).stem or "video"
+        fd, temp_mp4_path = tempfile.mkstemp(prefix="feishu-video-", suffix=".mp4")
+        os.close(fd)
+
+        command = [
+            ffmpeg_path,
+            "-y",
+            "-i",
+            video_path,
+            "-movflags",
+            "+faststart",
+            "-pix_fmt",
+            "yuv420p",
+            "-c:v",
+            "libx264",
+            "-c:a",
+            "aac",
+            temp_mp4_path,
+        ]
+        try:
+            result = subprocess.run(
+                command,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+                timeout=self._video_transcode_timeout_seconds,
+                check=False,
+            )
+        except subprocess.TimeoutExpired:
+            logger.warning(
+                "[Feishu] Timed out transcoding %s to mp4 after %ss; falling back to file send",
+                video_path,
+                self._video_transcode_timeout_seconds,
+            )
+            try:
+                os.unlink(temp_mp4_path)
+            except OSError:
+                pass
+            return None
+        except OSError:
+            logger.warning(
+                "[Feishu] Failed to invoke ffmpeg for %s; falling back to file send",
+                video_path,
+                exc_info=True,
+            )
+            try:
+                os.unlink(temp_mp4_path)
+            except OSError:
+                pass
+            return None
+
+        if result.returncode != 0 or not os.path.exists(temp_mp4_path) or os.path.getsize(temp_mp4_path) <= 0:
+            logger.warning(
+                "[Feishu] ffmpeg could not normalize %s to mp4 (returncode=%s); falling back to file send",
+                video_path,
+                result.returncode,
+            )
+            try:
+                os.unlink(temp_mp4_path)
+            except OSError:
+                pass
+            return None
+
+        return temp_mp4_path, f"{stem}.mp4"
 
     @staticmethod
     def _response_succeeded(response: Any) -> bool:

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -502,6 +502,17 @@ class TestAdapterModule(unittest.TestCase):
         self.assertIsNone(settings.ws_ping_interval)
         self.assertIsNone(settings.ws_ping_timeout)
 
+    def test_load_settings_accepts_custom_video_transcode_timeout(self):
+        from gateway.platforms.feishu import FeishuAdapter
+
+        settings = FeishuAdapter._load_settings(
+            {
+                "video_transcode_timeout_seconds": 45,
+            }
+        )
+
+        self.assertEqual(settings.video_transcode_timeout_seconds, 45)
+
     def test_runtime_ws_overrides_reapply_after_sdk_configure(self):
         import sys
         from types import ModuleType
@@ -2408,6 +2419,354 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertEqual(captured["upload_request"].request_body.file_type, "mp4")
         self.assertEqual(captured["message_request"].request_body.msg_type, "media")
         self.assertEqual(captured["message_request"].request_body.content, '{"file_key": "file_video_123"}')
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_video_normalizes_unsupported_format_to_mp4_when_ffmpeg_available(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _FileAPI:
+            def create(self, request):
+                captured["upload_request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(file_key="file_video_123"),
+                )
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["message_request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_video_msg"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    file=_FileAPI(),
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        def _fake_ffmpeg_run(cmd, stdout=None, stderr=None, timeout=None, check=None):
+            Path(cmd[-1]).write_bytes(b"\x00\x00\x00\x18ftypmp42")
+            return SimpleNamespace(returncode=0)
+
+        with tempfile.NamedTemporaryFile("wb", suffix=".webm", delete=False) as tmp:
+            tmp.write(b"webm")
+            video_path = tmp.name
+
+        try:
+            with (
+                patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct),
+                patch("gateway.platforms.feishu.shutil.which", return_value="/usr/bin/ffmpeg"),
+                patch("gateway.platforms.feishu.subprocess.run", side_effect=_fake_ffmpeg_run) as run_mock,
+            ):
+                result = asyncio.run(adapter.send_video(chat_id="oc_chat", video_path=video_path))
+        finally:
+            os.unlink(video_path)
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["upload_request"].request_body.file_type, "mp4")
+        self.assertTrue(captured["upload_request"].request_body.file_name.endswith(".mp4"))
+        self.assertEqual(captured["message_request"].request_body.msg_type, "media")
+        run_mock.assert_called_once()
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_video_falls_back_to_file_when_ffmpeg_transcode_fails(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _FileAPI:
+            def create(self, request):
+                captured["upload_request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(file_key="file_video_fallback"),
+                )
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["message_request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_video_file"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    file=_FileAPI(),
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with tempfile.NamedTemporaryFile("wb", suffix=".webm", delete=False) as tmp:
+            tmp.write(b"webm")
+            video_path = tmp.name
+
+        try:
+            with (
+                patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct),
+                patch("gateway.platforms.feishu.shutil.which", return_value="/usr/bin/ffmpeg"),
+                patch(
+                    "gateway.platforms.feishu.subprocess.run",
+                    return_value=SimpleNamespace(returncode=1),
+                ),
+            ):
+                result = asyncio.run(adapter.send_video(chat_id="oc_chat", video_path=video_path))
+        finally:
+            os.unlink(video_path)
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["upload_request"].request_body.file_type, "stream")
+        self.assertEqual(captured["message_request"].request_body.msg_type, "file")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_video_falls_back_to_file_when_ffmpeg_outputs_zero_byte_mp4(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _FileAPI:
+            def create(self, request):
+                captured["upload_request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(file_key="file_video_fallback"),
+                )
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["message_request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_video_file"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    file=_FileAPI(),
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        def _fake_ffmpeg_run(_cmd, stdout=None, stderr=None, timeout=None, check=None):
+            return SimpleNamespace(returncode=0)
+
+        with tempfile.NamedTemporaryFile("wb", suffix=".webm", delete=False) as tmp:
+            tmp.write(b"webm")
+            video_path = tmp.name
+
+        try:
+            with (
+                patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct),
+                patch("gateway.platforms.feishu.shutil.which", return_value="/usr/bin/ffmpeg"),
+                patch("gateway.platforms.feishu.subprocess.run", side_effect=_fake_ffmpeg_run),
+            ):
+                result = asyncio.run(adapter.send_video(chat_id="oc_chat", video_path=video_path))
+        finally:
+            os.unlink(video_path)
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["upload_request"].request_body.file_type, "stream")
+        self.assertEqual(captured["message_request"].request_body.msg_type, "file")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_video_falls_back_to_file_when_ffmpeg_is_unavailable(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _FileAPI:
+            def create(self, request):
+                captured["upload_request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(file_key="file_video_fallback"),
+                )
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["message_request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_video_file"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    file=_FileAPI(),
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with tempfile.NamedTemporaryFile("wb", suffix=".3gp", delete=False) as tmp:
+            tmp.write(b"3gp")
+            video_path = tmp.name
+
+        try:
+            with (
+                patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct),
+                patch("gateway.platforms.feishu.shutil.which", return_value=None),
+                patch("gateway.platforms.feishu.subprocess.run") as run_mock,
+            ):
+                result = asyncio.run(adapter.send_video(chat_id="oc_chat", video_path=video_path))
+        finally:
+            os.unlink(video_path)
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["upload_request"].request_body.file_type, "stream")
+        self.assertEqual(captured["message_request"].request_body.msg_type, "file")
+        run_mock.assert_not_called()
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_video_supported_mp4_bypasses_normalization(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _FileAPI:
+            def create(self, request):
+                captured["upload_request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(file_key="file_video_123"),
+                )
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["message_request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_video_msg"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    file=_FileAPI(),
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with tempfile.NamedTemporaryFile("wb", suffix=".mp4", delete=False) as tmp:
+            tmp.write(b"\x00\x00\x00\x18ftypmp42")
+            video_path = tmp.name
+
+        try:
+            with (
+                patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct),
+                patch("gateway.platforms.feishu.shutil.which") as which_mock,
+                patch("gateway.platforms.feishu.subprocess.run") as run_mock,
+            ):
+                result = asyncio.run(adapter.send_video(chat_id="oc_chat", video_path=video_path))
+        finally:
+            os.unlink(video_path)
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["upload_request"].request_body.file_type, "mp4")
+        self.assertEqual(captured["message_request"].request_body.msg_type, "media")
+        which_mock.assert_not_called()
+        run_mock.assert_not_called()
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_send_video_fallback_preserves_caption_and_thread_metadata(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _FileAPI:
+            def create(self, request):
+                captured["upload_request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(file_key="file_video_fallback"),
+                )
+
+        class _MessageAPI:
+            def reply(self, request):
+                captured["reply_request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_video_reply"),
+                )
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(
+                v1=SimpleNamespace(
+                    file=_FileAPI(),
+                    message=_MessageAPI(),
+                )
+            )
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with tempfile.NamedTemporaryFile("wb", suffix=".mkv", delete=False) as tmp:
+            tmp.write(b"mkv")
+            video_path = tmp.name
+
+        try:
+            with (
+                patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct),
+                patch("gateway.platforms.feishu.shutil.which", return_value=None),
+            ):
+                result = asyncio.run(
+                    adapter.send_video(
+                        chat_id="oc_chat",
+                        video_path=video_path,
+                        caption="clip caption",
+                        reply_to="om_parent",
+                        metadata={"thread_id": "omt-thread"},
+                    )
+                )
+        finally:
+            os.unlink(video_path)
+
+        self.assertTrue(result.success)
+        self.assertEqual(captured["upload_request"].request_body.file_type, "stream")
+        self.assertEqual(captured["reply_request"].request_body.msg_type, "post")
+        self.assertTrue(captured["reply_request"].request_body.reply_in_thread)
+        self.assertIn("clip caption", captured["reply_request"].request_body.content)
 
     @patch.dict(os.environ, {}, clear=True)
     def test_send_voice_uploads_opus_and_sends_audio_message(self):


### PR DESCRIPTION
  ## Summary

  Adds best-effort outbound video normalization for Feishu so unsupported video formats can still be delivered as native media when `ffmpeg` is available.

  For unsupported outbound formats such as `.mkv`, `.webm`, and `.3gp`:

  - if `ffmpeg` is available, Hermes attempts to transcode the file to `.mp4`
  - if transcoding succeeds, the normalized file is sent through Feishu's native media path
  - if `ffmpeg` is unavailable, transcoding times out, the output is invalid, or the transcode fails, Hermes silently falls back to the existing file/document delivery path

  This does not change Feishu's native media extension set. Supported native upload types remain `.mp4`, `.mov`, `.avi`, and `.m4v`.

  ## What changed

  - Added a best-effort MP4 normalization step in the Feishu outbound `send_video` path
  - Kept `ffmpeg` optional via `shutil.which("ffmpeg")`
  - Added temp-file cleanup for transcoded outputs
  - Added a configurable transcode timeout via:
    - `feishu.video_transcode_timeout_seconds`
    - `HERMES_FEISHU_VIDEO_TRANSCODE_TIMEOUT_SECONDS`
  - Preserved caption, reply, and thread metadata on the fallback path

  ## Fallback behavior

  If normalization cannot be completed, Hermes does not fail the send and does not surface a user-visible error. It falls back to the existing file/document path instead.

  Fallback is used when:

  - `ffmpeg` is not installed
  - `ffmpeg` returns a non-zero exit code
  - transcoding exceeds the configured timeout
  - the output file is missing or zero-byte

  ## Validation

  Ran:

  - `scripts/run_tests.sh tests/gateway/test_feishu.py`

  Result:

  - `205 passed`

  ## Test coverage

  Added tests for:

  - unsupported format + `ffmpeg` available -> transcode -> native media send
  - unsupported format + transcode failure -> file fallback
  - unsupported format + zero-byte transcode output -> file fallback
  - unsupported format + no `ffmpeg` -> file fallback
  - supported `.mp4` -> direct native media send without normalization
  - fallback path preserving caption/thread metadata
  - custom video transcode timeout loading
