### PR TITLE
fix(gateway): retry safe Telegram and IMAP timeouts

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -20,9 +20,11 @@ import email as email_lib
 import imaplib
 import logging
 import os
+import socket
 import re
 import smtplib
 import ssl
+import time
 import uuid
 from email.header import decode_header
 from email.mime.multipart import MIMEMultipart
@@ -44,6 +46,45 @@ from gateway.platforms.base import (
 from gateway.config import Platform, PlatformConfig
 
 logger = logging.getLogger(__name__)
+
+_DEFAULT_EMAIL_IMAP_TIMEOUT = 30
+_DEFAULT_EMAIL_IMAP_FETCH_ATTEMPTS = 3
+_DEFAULT_EMAIL_IMAP_RETRY_DELAY = 2.0
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float(os.getenv(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _is_transient_imap_error(error: Exception) -> bool:
+    if isinstance(error, (TimeoutError, socket.timeout, imaplib.IMAP4.abort)):
+        return True
+    lowered = str(error).lower()
+    return any(
+        marker in lowered
+        for marker in (
+            "timed out",
+            "timeout",
+            "temporarily unavailable",
+            "try again",
+            "connection reset",
+            "connection aborted",
+            "connection unexpectedly closed",
+            "socket error",
+        )
+    )
+
+
 # Automated sender patterns — emails from these are silently ignored
 _NOREPLY_PATTERNS = (
     "noreply", "no-reply", "no_reply", "donotreply", "do-not-reply",
@@ -255,6 +296,15 @@ class EmailAdapter(BasePlatformAdapter):
         self._smtp_host = os.getenv("EMAIL_SMTP_HOST", "")
         self._smtp_port = int(os.getenv("EMAIL_SMTP_PORT", "587"))
         self._poll_interval = int(os.getenv("EMAIL_POLL_INTERVAL", "15"))
+        self._imap_timeout = _env_int("EMAIL_IMAP_TIMEOUT", _DEFAULT_EMAIL_IMAP_TIMEOUT)
+        self._imap_fetch_attempts = max(
+            1,
+            _env_int("EMAIL_IMAP_FETCH_ATTEMPTS", _DEFAULT_EMAIL_IMAP_FETCH_ATTEMPTS),
+        )
+        self._imap_retry_delay = max(
+            0.0,
+            _env_float("EMAIL_IMAP_RETRY_DELAY", _DEFAULT_EMAIL_IMAP_RETRY_DELAY),
+        )
 
         # Skip attachments — configured via config.yaml:
         #   platforms:
@@ -297,7 +347,7 @@ class EmailAdapter(BasePlatformAdapter):
         """Connect to the IMAP server and start polling for new messages."""
         try:
             # Test IMAP connection
-            imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
+            imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=self._imap_timeout)
             imap.login(self._address, self._password)
             _send_imap_id(imap)
             # Mark all existing messages as seen so we only process new ones
@@ -363,69 +413,93 @@ class EmailAdapter(BasePlatformAdapter):
 
     def _fetch_new_messages(self) -> List[Dict[str, Any]]:
         """Fetch new (unseen) messages from IMAP. Runs in executor thread."""
-        results = []
-        try:
-            imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=30)
+        last_error: Exception | None = None
+        attempts_used = 0
+        for attempt in range(1, self._imap_fetch_attempts + 1):
+            attempts_used = attempt
             try:
-                imap.login(self._address, self._password)
-                _send_imap_id(imap)
-                imap.select("INBOX")
+                return self._fetch_new_messages_once()
+            except Exception as e:
+                last_error = e
+                if not _is_transient_imap_error(e) or attempt >= self._imap_fetch_attempts:
+                    break
+                wait = self._imap_retry_delay * attempt
+                logger.warning(
+                    "[Email] IMAP fetch transient error (attempt %d/%d), retrying in %.1fs: %s",
+                    attempt,
+                    self._imap_fetch_attempts,
+                    wait,
+                    e,
+                )
+                time.sleep(wait)
+        if last_error is not None:
+            logger.error("[Email] IMAP fetch error after %d attempt(s): %s", attempts_used, last_error)
+        return []
 
-                status, data = imap.uid("search", None, "UNSEEN")
-                if status != "OK" or not data or not data[0]:
-                    return results
+    def _fetch_new_messages_once(self) -> List[Dict[str, Any]]:
+        """Fetch new messages once; caller handles transient retries."""
+        results = []
+        imap = imaplib.IMAP4_SSL(self._imap_host, self._imap_port, timeout=self._imap_timeout)
+        try:
+            imap.login(self._address, self._password)
+            _send_imap_id(imap)
+            imap.select("INBOX")
 
-                for uid in data[0].split():
-                    if uid in self._seen_uids:
-                        continue
+            status, data = imap.uid("search", None, "UNSEEN")
+            if status != "OK" or not data or not data[0]:
+                return results
+
+            for uid in data[0].split():
+                if uid in self._seen_uids:
+                    continue
+
+                status, msg_data = imap.uid("fetch", uid, "(RFC822)")
+                if status != "OK":
+                    continue
+
+                raw_email = msg_data[0][1]
+                msg = email_lib.message_from_bytes(raw_email)
+
+                sender_raw = msg.get("From", "")
+                sender_addr = _extract_email_address(sender_raw)
+                sender_name = _decode_header_value(sender_raw)
+                # Remove email from name if present
+                if "<" in sender_name:
+                    sender_name = sender_name.split("<")[0].strip().strip('"')
+
+                subject = _decode_header_value(msg.get("Subject", "(no subject)"))
+                message_id = msg.get("Message-ID", "")
+                in_reply_to = msg.get("In-Reply-To", "")
+                # Skip automated/noreply senders before any processing
+                msg_headers = dict(msg.items())
+                if _is_automated_sender(sender_addr, msg_headers):
+                    logger.debug("[Email] Skipping automated sender: %s", sender_addr)
                     self._seen_uids.add(uid)
-                    # Trim periodically to prevent unbounded memory growth
-                    if len(self._seen_uids) > self._seen_uids_max:
-                        self._trim_seen_uids()
+                    continue
+                body = _extract_text_body(msg)
+                attachments = _extract_attachments(msg, skip_attachments=self._skip_attachments)
 
-                    status, msg_data = imap.uid("fetch", uid, "(RFC822)")
-                    if status != "OK":
-                        continue
+                self._seen_uids.add(uid)
+                # Trim periodically to prevent unbounded memory growth
+                if len(self._seen_uids) > self._seen_uids_max:
+                    self._trim_seen_uids()
 
-                    raw_email = msg_data[0][1]
-                    msg = email_lib.message_from_bytes(raw_email)
-
-                    sender_raw = msg.get("From", "")
-                    sender_addr = _extract_email_address(sender_raw)
-                    sender_name = _decode_header_value(sender_raw)
-                    # Remove email from name if present
-                    if "<" in sender_name:
-                        sender_name = sender_name.split("<")[0].strip().strip('"')
-
-                    subject = _decode_header_value(msg.get("Subject", "(no subject)"))
-                    message_id = msg.get("Message-ID", "")
-                    in_reply_to = msg.get("In-Reply-To", "")
-                    # Skip automated/noreply senders before any processing
-                    msg_headers = dict(msg.items())
-                    if _is_automated_sender(sender_addr, msg_headers):
-                        logger.debug("[Email] Skipping automated sender: %s", sender_addr)
-                        continue
-                    body = _extract_text_body(msg)
-                    attachments = _extract_attachments(msg, skip_attachments=self._skip_attachments)
-
-                    results.append({
-                        "uid": uid,
-                        "sender_addr": sender_addr,
-                        "sender_name": sender_name,
-                        "subject": subject,
-                        "message_id": message_id,
-                        "in_reply_to": in_reply_to,
-                        "body": body,
-                        "attachments": attachments,
-                        "date": msg.get("Date", ""),
-                    })
-            finally:
-                try:
-                    imap.logout()
-                except Exception:
-                    pass
-        except Exception as e:
-            logger.error("[Email] IMAP fetch error: %s", e)
+                results.append({
+                    "uid": uid,
+                    "sender_addr": sender_addr,
+                    "sender_name": sender_name,
+                    "subject": subject,
+                    "message_id": message_id,
+                    "in_reply_to": in_reply_to,
+                    "body": body,
+                    "attachments": attachments,
+                    "date": msg.get("Date", ""),
+                })
+        finally:
+            try:
+                imap.logout()
+            except Exception:
+                pass
         return results
 
     async def _dispatch_message(self, msg_data: Dict[str, Any]) -> None:

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -11,12 +11,16 @@ import asyncio
 import json
 import logging
 import os
+import random
 import tempfile
 import html as _html
 import re
 from typing import Dict, List, Optional, Any
 
 logger = logging.getLogger(__name__)
+
+_TELEGRAM_SEND_MAX_ATTEMPTS = 3
+_TELEGRAM_SEND_CONNECT_TIMEOUT_BACKOFF_BASE = 1.5
 
 try:
     from telegram import Update, Bot, Message, InlineKeyboardButton, InlineKeyboardMarkup
@@ -1427,7 +1431,7 @@ class TelegramAdapter(BasePlatformAdapter):
                 effective_thread_id = thread_kwargs.get("message_thread_id")
 
                 msg = None
-                for _send_attempt in range(3):
+                for _send_attempt in range(_TELEGRAM_SEND_MAX_ATTEMPTS):
                     try:
                         # Try Markdown first, fall back to plain text if it fails
                         try:
@@ -1501,10 +1505,23 @@ class TelegramAdapter(BasePlatformAdapter):
                             raise
                         # TimedOut is also a subclass of NetworkError but
                         # indicates the request may have reached the server —
-                        # retrying risks duplicate message delivery.
+                        # retrying risks duplicate message delivery unless the
+                        # wrapped cause proves no TCP connection was established.
                         if _TimedOut and isinstance(send_err, _TimedOut):
+                            if self._is_safe_to_retry_send_timeout(send_err) and _send_attempt < _TELEGRAM_SEND_MAX_ATTEMPTS - 1:
+                                wait = self._send_retry_delay(_send_attempt)
+                                logger.warning(
+                                    "[%s] Telegram send connect timeout (attempt %d/%d), retrying in %.1fs: %s",
+                                    self.name,
+                                    _send_attempt + 1,
+                                    _TELEGRAM_SEND_MAX_ATTEMPTS,
+                                    wait,
+                                    send_err,
+                                )
+                                await asyncio.sleep(wait)
+                                continue
                             raise
-                        if _send_attempt < 2:
+                        if _send_attempt < _TELEGRAM_SEND_MAX_ATTEMPTS - 1:
                             wait = 2 ** _send_attempt
                             logger.warning("[%s] Network error on send (attempt %d/3), retrying in %ds: %s",
                                            self.name, _send_attempt + 1, wait, send_err)
@@ -1542,6 +1559,33 @@ class TelegramAdapter(BasePlatformAdapter):
             err_str = str(e).lower()
             is_timeout = (_to and isinstance(e, _to)) or "timed out" in err_str
             return SendResult(success=False, error=str(e), retryable=not is_timeout)
+
+    @staticmethod
+    def _is_safe_to_retry_send_timeout(error: Exception) -> bool:
+        """Return True when Telegram send failed before a TCP connection existed.
+
+        PTB wraps httpx/httpcore exceptions in ``telegram.error.TimedOut``.
+        A read/write timeout on ``send_message`` is ambiguous because Telegram
+        may have received the request already; retrying can duplicate the reply.
+        A connect timeout is safe to retry because no connection was
+        established, which matches BasePlatformAdapter's retry semantics.
+        """
+        seen: set[int] = set()
+        current: BaseException | None = error
+        while current is not None and id(current) not in seen:
+            seen.add(id(current))
+            name = type(current).__name__.lower()
+            if "connecttimeout" in name:
+                return True
+            if "readtimeout" in name or "writetimeout" in name:
+                return False
+            current = getattr(current, "__cause__", None) or getattr(current, "__context__", None)
+        text = repr(error).lower()
+        return "connecttimeout" in text and "readtimeout" not in text and "writetimeout" not in text
+
+    @staticmethod
+    def _send_retry_delay(attempt: int) -> float:
+        return _TELEGRAM_SEND_CONNECT_TIMEOUT_BACKOFF_BASE * (2 ** attempt) + random.uniform(0, 0.5)
 
     async def edit_message(
         self,

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -13,6 +13,7 @@ Covers:
 """
 
 import os
+import socket
 import unittest
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
@@ -492,7 +493,7 @@ class TestDispatchMessage(unittest.TestCase):
                 del os.environ["EMAIL_ALLOWED_USERS"]
 
             adapter = self._make_adapter()
-            adapter._message_handler = MagicMock()
+            adapter._message_handler = AsyncMock(return_value=None)
 
             msg_data = {
                 "uid": b"101",
@@ -627,20 +628,35 @@ class TestSendMethods(unittest.TestCase):
         """send() should use SMTP to deliver email."""
         import asyncio
         adapter = self._make_adapter()
+        calls = {}
 
-        with patch("smtplib.SMTP") as mock_smtp:
-            mock_server = MagicMock()
-            mock_smtp.return_value = mock_server
+        class FakeSMTP:
+            def __init__(self, host, port, timeout=None):
+                calls["init"] = (host, port, timeout)
 
+            def starttls(self, context=None):
+                calls["starttls"] = context
+
+            def login(self, user, password):
+                calls["login"] = (user, password)
+
+            def send_message(self, msg):
+                calls["send_message"] = msg
+
+            def quit(self):
+                calls["quit"] = True
+
+        with patch("smtplib.SMTP", FakeSMTP):
             result = asyncio.run(
                 adapter.send("user@test.com", "Hello from Hermes!")
             )
 
-            self.assertTrue(result.success)
-            mock_server.starttls.assert_called_once()
-            mock_server.login.assert_called_once_with("hermes@test.com", "secret")
-            mock_server.send_message.assert_called_once()
-            mock_server.quit.assert_called_once()
+        self.assertTrue(result.success)
+        self.assertEqual(calls["init"], ("smtp.test.com", 587, 30))
+        self.assertIsNotNone(calls["starttls"])
+        self.assertEqual(calls["login"], ("hermes@test.com", "secret"))
+        self.assertEqual(calls["send_message"]["To"], "user@test.com")
+        self.assertTrue(calls["quit"])
 
     def test_send_failure_returns_error(self):
         """SMTP failure should return SendResult with error."""
@@ -870,6 +886,56 @@ class TestFetchNewMessages(unittest.TestCase):
             results = adapter._fetch_new_messages()
 
         self.assertEqual(results, [])
+
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "hermes@test.com",
+        "EMAIL_PASSWORD": "secret",
+        "EMAIL_IMAP_HOST": "imap.test.com",
+        "EMAIL_SMTP_HOST": "smtp.test.com",
+        "EMAIL_IMAP_FETCH_ATTEMPTS": "3",
+        "EMAIL_IMAP_RETRY_DELAY": "0",
+    }, clear=False)
+    def test_fetch_retries_transient_timeout(self):
+        """Transient IMAP timeouts should retry before giving up."""
+        adapter = self._make_adapter()
+
+        mock_imap = MagicMock()
+        mock_imap.uid.return_value = ("OK", [b""])
+
+        with patch("imaplib.IMAP4_SSL", side_effect=[socket.timeout("timed out"), mock_imap]) as mock_factory:
+            results = adapter._fetch_new_messages()
+
+        self.assertEqual(results, [])
+        self.assertEqual(mock_factory.call_count, 2)
+        mock_imap.logout.assert_called_once()
+
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "hermes@test.com",
+        "EMAIL_PASSWORD": "secret",
+        "EMAIL_IMAP_HOST": "imap.test.com",
+        "EMAIL_SMTP_HOST": "smtp.test.com",
+        "EMAIL_IMAP_FETCH_ATTEMPTS": "3",
+        "EMAIL_IMAP_RETRY_DELAY": "0",
+    }, clear=False)
+    def test_fetch_does_not_mark_uid_seen_until_fetch_succeeds(self):
+        """UIDs should not be marked seen when fetch times out mid-message."""
+        adapter = self._make_adapter()
+        mock_imap = MagicMock()
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"9"])
+            if command == "fetch":
+                raise socket.timeout("timed out")
+            return ("NO", [])
+
+        mock_imap.uid.side_effect = uid_handler
+
+        with patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+            results = adapter._fetch_new_messages()
+
+        self.assertEqual(results, [])
+        self.assertNotIn(b"9", adapter._seen_uids)
 
     def test_fetch_extracts_sender_name(self):
         """Sender name should be extracted from 'Name <addr>' format."""

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -983,8 +983,8 @@ async def test_send_retries_network_errors_normally():
 
 
 @pytest.mark.asyncio
-async def test_send_does_not_retry_timeout():
-    """TimedOut (subclass of NetworkError) should NOT be retried in send().
+async def test_send_does_not_retry_ambiguous_timeout():
+    """Read/write style TimedOut errors should NOT be retried in send().
 
     The request may have already been delivered to the user — retrying
     would send duplicate messages.
@@ -1006,8 +1006,36 @@ async def test_send_does_not_retry_timeout():
 
     assert result.success is False
     assert "Timed out" in result.error
-    # CRITICAL: only 1 attempt — no retry for TimedOut
+    # CRITICAL: only 1 attempt — no retry for ambiguous TimedOut
     assert attempt[0] == 1
+
+
+@pytest.mark.asyncio
+async def test_send_retries_safe_connect_timeout(monkeypatch):
+    """Connect timeout is safe to retry because no TCP connection existed."""
+    adapter = _make_adapter()
+    monkeypatch.setattr(adapter, "_send_retry_delay", lambda attempt: 0)
+
+    attempt = [0]
+
+    async def mock_send_message(**kwargs):
+        attempt[0] += 1
+        if attempt[0] < 3:
+            err = FakeTimedOut("Timed out")
+            err.__cause__ = type("ConnectTimeout", (TimeoutError,), {})("connect timed out")
+            raise err
+        return SimpleNamespace(message_id=201)
+
+    adapter._bot = SimpleNamespace(send_message=mock_send_message)
+
+    result = await adapter.send(
+        chat_id="123",
+        content="test message",
+    )
+
+    assert result.success is True
+    assert result.message_id == "201"
+    assert attempt[0] == 3
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- retry Telegram sends only for safe connect-timeout failures where the request never reached Telegram
- keep ambiguous Telegram read/write timeouts non-retryable to avoid duplicate replies
- add IMAP fetch retry handling and avoid marking email UIDs seen before a successful fetch

## Test Plan
- [x] `python -m pytest tests/gateway/test_telegram_thread_fallback.py tests/gateway/test_email.py tests/gateway/test_send_retry.py -q -o 'addopts='`
- [x] `python -m py_compile gateway/platforms/telegram.py gateway/platforms/email.py`
