### PR TITLE
fix(kanban): disambiguate worker comment authors

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4024,7 +4024,7 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
             )
         for c in shown_c:
             ts = time.strftime("%Y-%m-%d %H:%M", time.localtime(c.created_at))
-            lines.append(f"**{c.author}** ({ts}):")
+            lines.append(f"comment from worker @{c.author} at {ts}:")
             lines.append(_cap(c.body, _CTX_MAX_COMMENT_BYTES))
             lines.append("")
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -384,6 +384,16 @@ def test_worker_context_includes_parent_results_and_comments(kanban_home):
     assert "child" in ctx
 
 
+def test_worker_context_disambiguates_comment_author(kanban_home):
+    with kb.connect() as conn:
+        t = kb.create_task(conn, title="x")
+        kb.add_comment(conn, t, "hermes-system", "COMMENT_MARKER")
+        ctx = kb.build_worker_context(conn, t)
+    assert "comment from worker @hermes-system at " in ctx
+    assert "**hermes-system**" not in ctx
+    assert "COMMENT_MARKER" in ctx
+
+
 # ---------------------------------------------------------------------------
 # Dispatcher
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- render kanban worker-context comment authors as explicit worker provenance instead of Markdown bold text
- add a regression test for misleading profile names such as `hermes-system`

## Why
This closes the remaining defense-in-depth surface from #22452: an operator-controlled profile name should not render like an authoritative Markdown speaker label directly above comment body text in the next worker prompt.

## Test
- `python3 -m py_compile upstream/hermes_cli/kanban_db.py upstream/tests/hermes_cli/test_kanban_db.py`
- `PYTHONPATH=/Users/a1234/Documents/Codex/2026-05-09/hermes-agent-pr/test_stubs:/Users/a1234/Documents/Codex/2026-05-09/hermes-agent-pr/upstream uv run --with pytest --python 3.14 python -m pytest upstream/tests/hermes_cli/test_kanban_db.py::test_worker_context_disambiguates_comment_author -q`

Closes #22452
