### PR TITLE
fix: correct gemini doctor api-key probe

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -201,6 +201,25 @@ def _check_gateway_service_linger(issues: list[str]) -> None:
 _APIKEY_PROVIDERS_CACHE: list | None = None
 
 
+def _use_google_ai_studio_apikey_header(
+    env_vars: tuple[str, ...],
+    default_url: str | None,
+    base_url: str,
+) -> bool:
+    """Return True when doctor should authenticate with x-goog-api-key.
+
+    Google AI Studio API keys are not accepted via Authorization: Bearer on
+    generativelanguage.googleapis.com. Doctor's generic OpenAI-compatible probe
+    would otherwise misreport valid Gemini keys as invalid.
+    """
+    env_var_set = set(env_vars)
+    if {"GOOGLE_API_KEY", "GEMINI_API_KEY"} & env_var_set:
+        return True
+
+    candidate_urls = [u for u in (base_url, default_url) if u]
+    return any(base_url_host_matches(url, "generativelanguage.googleapis.com") for url in candidate_urls)
+
+
 def _build_apikey_providers_list() -> list:
     """Build the API-key provider health-check list once and cache it.
 
@@ -1291,10 +1310,11 @@ def run_doctor(args):
                 if base_url_host_matches(_base, "api.kimi.com") and _base.rstrip("/").endswith("/coding"):
                     _base = _base.rstrip("/") + "/v1"
                 _url = (_base.rstrip("/") + "/models") if _base else _default_url
-                _headers = {
-                    "Authorization": f"Bearer {_key}",
-                    "User-Agent": _HERMES_USER_AGENT,
-                }
+                _headers = {"User-Agent": _HERMES_USER_AGENT}
+                if _use_google_ai_studio_apikey_header(_env_vars, _default_url, _base):
+                    _headers["x-goog-api-key"] = _key
+                else:
+                    _headers["Authorization"] = f"Bearer {_key}"
                 if base_url_host_matches(_base, "api.kimi.com"):
                     _headers["User-Agent"] = "claude-code/0.1.0"
                 _resp = httpx.get(

--- a/tests/hermes_cli/test_doctor.py
+++ b/tests/hermes_cli/test_doctor.py
@@ -711,6 +711,55 @@ def test_run_doctor_dashscope_retries_china_endpoint_after_intl_unauthorized(mon
     )
 
 
+def test_run_doctor_gemini_uses_x_goog_api_key_header(monkeypatch, tmp_path):
+    home = tmp_path / ".hermes"
+    home.mkdir(parents=True, exist_ok=True)
+    (home / "config.yaml").write_text("memory: {}\n", encoding="utf-8")
+    (home / ".env").write_text("GOOGLE_API_KEY=AIza-test\n", encoding="utf-8")
+    project = tmp_path / "project"
+    project.mkdir(exist_ok=True)
+
+    monkeypatch.setattr(doctor_mod, "HERMES_HOME", home)
+    monkeypatch.setattr(doctor_mod, "PROJECT_ROOT", project)
+    monkeypatch.setattr(doctor_mod, "_DHH", str(home))
+    monkeypatch.setenv("GOOGLE_API_KEY", "AIza-test")
+
+    fake_model_tools = types.SimpleNamespace(
+        check_tool_availability=lambda *a, **kw: ([], []),
+        TOOLSET_REQUIREMENTS={},
+    )
+    monkeypatch.setitem(sys.modules, "model_tools", fake_model_tools)
+
+    try:
+        from hermes_cli import auth as _auth_mod
+        monkeypatch.setattr(_auth_mod, "get_nous_auth_status", lambda: {})
+        monkeypatch.setattr(_auth_mod, "get_codex_auth_status", lambda: {})
+    except ImportError:
+        pass
+
+    calls = []
+
+    def fake_get(url, headers=None, timeout=None):
+        calls.append((url, headers, timeout))
+        return types.SimpleNamespace(status_code=200)
+
+    import httpx
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        doctor_mod.run_doctor(Namespace(fix=False))
+    out = buf.getvalue()
+
+    gemini_calls = [call for call in calls if call[0] == "https://generativelanguage.googleapis.com/v1beta/models"]
+    assert gemini_calls
+    _, headers, timeout = gemini_calls[0]
+    assert headers["x-goog-api-key"] == "AIza-test"
+    assert "Authorization" not in headers
+    assert timeout == 10
+    assert "invalid API key" not in out
+
+
 @pytest.mark.parametrize("base_url", [None, "https://opencode.ai/zen/go/v1"])
 def test_run_doctor_opencode_go_skips_invalid_models_probe(monkeypatch, tmp_path, base_url):
     home = tmp_path / ".hermes"


### PR DESCRIPTION
## Summary
- use `x-goog-api-key` instead of `Authorization: Bearer` when doctor probes Google AI Studio Gemini endpoints
- keep the generic bearer-token probe for other API-key providers
- add a regression test covering the Gemini health check path

## Why
Google AI Studio API keys are rejected when sent as `Authorization: Bearer ...` to `generativelanguage.googleapis.com`, which made `hermes doctor` report valid Gemini keys as invalid even though real Hermes requests worked.

## Test Plan
- [x] `python -m pytest tests/hermes_cli/test_doctor.py -o 'addopts=' -q`\n- [x] `hermes doctor` shows `✓ gemini` with a valid `GOOGLE_API_KEY`\n- [x] `hermes chat --provider gemini --model gemini-2.5-flash -q 'Reply with exactly: HERMES_GEMINI_OK_AFTER_PATCH'`\n