### PR TITLE
fix(kanban): defensive migration for duplicate max_retries column

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1035,7 +1035,11 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         # config, then ``DEFAULT_FAILURE_LIMIT``. Existing rows get NULL,
         # which is the correct default (they keep the global behaviour
         # they were getting before the column existed).
-        conn.execute("ALTER TABLE tasks ADD COLUMN max_retries INTEGER")
+        try:
+            conn.execute("ALTER TABLE tasks ADD COLUMN max_retries INTEGER")
+        except sqlite3.OperationalError as exc:
+            if "duplicate column name" not in str(exc):
+                raise
 
     # task_events gained a run_id column; back-fill it as NULL for
     # historical events (they predate runs and can't be attributed).


### PR DESCRIPTION
The `_migrate_add_optional_columns` guard reads `PRAGMA table_info(tasks)` once at function entry. After `executescript(SCHEMA_SQL)` creates the `max_retries` column for new DBs, legacy DBs that already have the column (from a prior upgrade or manual schema drift) can hit:

```
sqlite3.OperationalError: duplicate column name: max_retries
```

This wraps the `ALTER TABLE` in a defensive try/except that only swallows the duplicate-column error, preserving normal failure behaviour for all other `OperationalError` conditions.