### PR TITLE
fix(install): set world-readable uv python dirs for root FHS layout

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -245,10 +245,18 @@ resolve_install_layout() {
         fi
         INSTALL_DIR="/usr/local/lib/hermes-agent"
         ROOT_FHS_LAYOUT=true
+        # Place uv-managed Python under /usr/local/share so the venv interpreter
+        # is world-readable.  Default uv paths land in /root/.local/share/uv,
+        # which non-root users can't traverse — leaving the shared
+        # /usr/local/bin/hermes wrapper unable to exec the bad-interpreter venv
+        # python.  See #21457.
+        export UV_PYTHON_INSTALL_DIR="${UV_PYTHON_INSTALL_DIR:-/usr/local/share/uv/python}"
+        export UV_PYTHON_BIN_DIR="${UV_PYTHON_BIN_DIR:-/usr/local/share/uv/bin}"
         log_info "Root install on Linux — using FHS layout"
         log_info "  Code:    $INSTALL_DIR"
         log_info "  Command: /usr/local/bin/hermes"
         log_info "  Data:    $HERMES_HOME (unchanged)"
+        log_info "  uv Python: $UV_PYTHON_INSTALL_DIR (world-readable)"
         return 0
     fi
 

--- a/tests/test_install_sh_root_fhs_uv_python_path.py
+++ b/tests/test_install_sh_root_fhs_uv_python_path.py
@@ -1,0 +1,35 @@
+"""Regression test for install.sh root-mode uv Python install path.
+
+When installing as root with the FHS layout (INSTALL_DIR=/usr/local/lib/...),
+``uv python install`` must place the managed Python under a world-readable
+location, otherwise the venv interpreter ends up at ``/root/.local/share/uv/...``
+and the shared ``/usr/local/bin/hermes`` wrapper fails for non-root users with
+"bad interpreter: Permission denied".  See #21457.
+"""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+
+
+def test_root_fhs_layout_exports_world_readable_uv_python_dirs() -> None:
+    text = INSTALL_SH.read_text()
+
+    assert 'export UV_PYTHON_INSTALL_DIR="${UV_PYTHON_INSTALL_DIR:-/usr/local/share/uv/python}"' in text
+    assert 'export UV_PYTHON_BIN_DIR="${UV_PYTHON_BIN_DIR:-/usr/local/share/uv/bin}"' in text
+
+
+def test_root_fhs_uv_python_export_is_inside_root_branch() -> None:
+    """The export must live in the root-FHS branch of resolve_install_layout,
+    above its `return 0`, so non-root and Termux installs are unaffected."""
+    text = INSTALL_SH.read_text()
+
+    marker = 'ROOT_FHS_LAYOUT=true'
+    assert marker in text
+    after_marker = text.split(marker, 1)[1]
+    return_idx = after_marker.find('return 0')
+    export_idx = after_marker.find('UV_PYTHON_INSTALL_DIR')
+    assert export_idx != -1
+    assert export_idx < return_idx


### PR DESCRIPTION
## What does this PR do?

Closes #21457

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

Closes #21457

<details>
<summary>Original body</summary>

## Summary

Closes #21457

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Summary
- Root install on Linux with the FHS layout (`/usr/local/lib/hermes-agent`) lets `uv python install` place the managed Python under `/root/.local/share/uv/python/`, which non-root users cannot traverse.
- The shared `/usr/local/bin/hermes` wrapper then fails for non-root users with `bad interpreter: Permission denied` when execing the venv python.
- Export `UV_PYTHON_INSTALL_DIR` and `UV_PYTHON_BIN_DIR` to `/usr/local/share/uv/` (with `${VAR:-default}` so caller overrides win) inside the root-FHS branch of `resolve_install_layout` — Python lands somewhere world-readable and the shared wrapper works for any user.

Closes #21457

## Test plan
- [x] New `tests/test_install_sh_root_fhs_uv_python_path.py` asserts the exports exist and live inside the root-FHS branch.
- [x] Stash-verified: tests fail without the install.sh edit, pass with it.
- [x] Existing `tests/test_install_sh_*.py` regression suite stays green (12 passed).

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

Closes #21457

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_