### PR TITLE
fix(approval): respect tirith_fail_open=false on scanner ImportError

### DIFF
--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -965,3 +965,99 @@ class TestFailClosedUnderPromptToolkit:
             assert result == "once"
         finally:
             ptc.get_app_or_none = orig
+
+
+class TestTirithImportFailOpenRespected:
+    """Regression for #20733.
+
+    When ``tools.tirith_security`` cannot be imported, the previous code
+    silently allowed every command. ``security.tirith_fail_open: false``
+    must be honoured even when the scanner package is missing.
+    """
+
+    def test_setting_helper_env_override_false(self, monkeypatch):
+        from tools.approval import _tirith_fail_open_setting
+
+        monkeypatch.setenv("TIRITH_FAIL_OPEN", "false")
+        assert _tirith_fail_open_setting() is False
+
+    def test_setting_helper_env_override_true(self, monkeypatch):
+        from tools.approval import _tirith_fail_open_setting
+
+        monkeypatch.setenv("TIRITH_FAIL_OPEN", "true")
+        assert _tirith_fail_open_setting() is True
+
+    def test_setting_helper_reads_config_when_env_absent(self, monkeypatch):
+        from tools.approval import _tirith_fail_open_setting
+
+        monkeypatch.delenv("TIRITH_FAIL_OPEN", raising=False)
+        with mock_patch(
+            "hermes_cli.config.load_config",
+            return_value={"security": {"tirith_fail_open": False}},
+        ):
+            assert _tirith_fail_open_setting() is False
+
+    def test_setting_helper_defaults_true_when_load_fails(self, monkeypatch):
+        from tools.approval import _tirith_fail_open_setting
+
+        monkeypatch.delenv("TIRITH_FAIL_OPEN", raising=False)
+        with mock_patch(
+            "hermes_cli.config.load_config",
+            side_effect=RuntimeError("boom"),
+        ):
+            assert _tirith_fail_open_setting() is True
+
+    def test_import_error_with_fail_open_false_blocks(self, monkeypatch):
+        """ImportError on tirith_security + fail_open=False must block."""
+        import sys
+
+        from tools.approval import check_all_command_guards
+
+        monkeypatch.setitem(sys.modules, "tools.tirith_security", None)
+        monkeypatch.setenv("TIRITH_FAIL_OPEN", "false")
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+
+        captured = {}
+
+        def fake_callback(command, description, **kwargs):
+            captured["description"] = description
+            return "deny"
+
+        with mock_patch(
+            "tools.approval._get_approval_mode", return_value="ask"
+        ):
+            result = check_all_command_guards(
+                "echo hello",
+                env_type="local",
+                approval_callback=fake_callback,
+            )
+
+        assert result["approved"] is False
+        assert "fail-closed" in (captured.get("description") or "").lower()
+
+    def test_import_error_with_fail_open_true_allows(self, monkeypatch):
+        """Default fail_open=True still allows when scanner missing."""
+        import sys
+
+        from tools.approval import check_all_command_guards
+
+        monkeypatch.setitem(sys.modules, "tools.tirith_security", None)
+        monkeypatch.setenv("TIRITH_FAIL_OPEN", "true")
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+        monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
+
+        with mock_patch(
+            "tools.approval._get_approval_mode", return_value="ask"
+        ):
+            result = check_all_command_guards(
+                "echo hello",
+                env_type="local",
+                approval_callback=lambda *a, **kw: "deny",
+            )
+
+        assert result["approved"] is True

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -94,6 +94,26 @@ def _get_session_platform() -> str:
         return os.getenv("HERMES_SESSION_PLATFORM", "") or ""
 
 
+def _tirith_fail_open_setting() -> bool:
+    """Return the effective tirith_fail_open value without importing tirith.
+
+    Used when ``tools.tirith_security`` itself is not importable so we can
+    still honour ``security.tirith_fail_open: false`` and refuse to silently
+    allow commands. Env var ``TIRITH_FAIL_OPEN`` wins over config; default
+    matches ``_load_security_config`` (True).
+    """
+    env_val = os.getenv("TIRITH_FAIL_OPEN")
+    if env_val is not None and env_val != "":
+        return is_truthy_value(env_val)
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config().get("security", {}) or {}
+        return bool(cfg.get("tirith_fail_open", True))
+    except Exception:
+        return True
+
+
 def _is_gateway_approval_context() -> bool:
     """True when this call is inside a gateway/API session.
 
@@ -1010,7 +1030,19 @@ def check_all_command_guards(command: str, env_type: str,
         from tools.tirith_security import check_command_security
         tirith_result = check_command_security(command)
     except ImportError:
-        pass  # tirith module not installed — allow
+        # Module not installed. Respect tirith_fail_open: when False, block
+        # rather than silently allowing — otherwise the setting is bypassed
+        # whenever the scanner package is missing.
+        if not _tirith_fail_open_setting():
+            logger.warning(
+                "tirith module unavailable and tirith_fail_open=false; "
+                "blocking command"
+            )
+            tirith_result = {
+                "action": "block",
+                "findings": [],
+                "summary": "tirith scanner unavailable (fail-closed)",
+            }
 
     # Dangerous command check (detection only, no approval)
     is_dangerous, pattern_key, description = detect_dangerous_command(command)


### PR DESCRIPTION
## Problem
`check_all_command_guards` in `tools/approval.py` swallowed every `ImportError` from `tools.tirith_security` with `pass`, allowing the command. Operators who set `security.tirith_fail_open: false` still got fail-open behaviour whenever the scanner package was unavailable. Closes #20733.

## Root cause
The `except ImportError: pass` branch predates the `tirith_fail_open` config knob. Only the in-process scan (`check_command_security`) consulted the setting; if the module itself didn't import, the setting was bypassed entirely.

## Fix
- Add `_tirith_fail_open_setting()` helper that resolves the effective value independently of `tools.tirith_security`:
  1. env var `TIRITH_FAIL_OPEN`
  2. `security.tirith_fail_open` in config
  3. default `True` (matches existing default).
- On `ImportError`, when fail-open is False, populate `tirith_result` with `action="block"` and summary `"tirith scanner unavailable (fail-closed)"` so the command flows through the normal approval pipeline.
- When fail-open is True, behaviour is unchanged.

## Tests
`tests/tools/test_approval.py::TestTirithImportFailOpenRespected`:
- env override returns False/True
- helper reads config when env unset
- helper defaults to True when `load_config` raises
- ImportError + fail-open=false → blocked
- ImportError + fail-open=true → allowed

Stash-verified: removing the fix flips `test_import_error_with_fail_open_false_blocks` from green to red.

Adjacent suites still pass (`tests/tools/test_approval.py`, `test_command_guards.py`, `test_yolo_mode.py`, `test_cron_approval_mode.py`, `test_hardline_blocklist.py`, `test_tirith_security.py`, `test_approval_plugin_hooks.py` — 360 passed).