### PR TITLE
fix(qqbot): enable WS-level heartbeat to detect half-open connections

### DIFF
--- a/gateway/platforms/qqbot/adapter.py
+++ b/gateway/platforms/qqbot/adapter.py
@@ -440,6 +440,11 @@ class QQAdapter(BasePlatformAdapter):
             or os.getenv("ALL_PROXY")
             or os.getenv("all_proxy")
         )
+        # heartbeat= enables aiohttp WS-level Ping/Pong keepalive so
+        # half-open TCP connections (NAT/firewall state expiry) raise an
+        # error in _read_events() instead of hanging on receive() forever.
+        # The op 1 heartbeat in _heartbeat_loop() is QQ-app-level and does
+        # not detect dead transports on its own. See #21633.
         self._ws = await self._session.ws_connect(
             gateway_url,
             headers={
@@ -447,6 +452,7 @@ class QQAdapter(BasePlatformAdapter):
             },
             timeout=CONNECT_TIMEOUT_SECONDS,
             proxy=ws_proxy,
+            heartbeat=30.0,
         )
         logger.info("[%s] WebSocket connected to %s", self._log_tag, gateway_url)
 

--- a/tests/gateway/test_qqbot.py
+++ b/tests/gateway/test_qqbot.py
@@ -235,6 +235,49 @@ class TestQQWebSocketProxy:
         assert seen_session_kwargs.get("trust_env") is True
         assert seen_ws_kwargs.get("proxy") == "http://127.0.0.1:7897"
 
+    @pytest.mark.asyncio
+    async def test_open_ws_passes_heartbeat_for_keepalive(self, monkeypatch):
+        """Regression for #21633: aiohttp ws_connect must receive a
+        heartbeat= so half-open TCP connections don't hang receive()
+        forever.  Without this the QQ bot dies silently when NAT/firewall
+        state expires."""
+        from gateway.platforms.qqbot import QQAdapter
+
+        for key in (
+            "WSS_PROXY", "wss_proxy", "HTTPS_PROXY", "https_proxy",
+            "ALL_PROXY", "all_proxy",
+        ):
+            monkeypatch.delenv(key, raising=False)
+
+        adapter = QQAdapter(_make_config(app_id="a", client_secret="b"))
+
+        seen_ws_kwargs: dict = {}
+
+        class FakeSession:
+            def __init__(self, **kwargs):
+                self.closed = False
+
+            async def close(self):
+                self.closed = True
+
+            async def ws_connect(self, *args, **kwargs):
+                seen_ws_kwargs.update(kwargs)
+                return mock.AsyncMock(closed=False)
+
+        with mock.patch(
+            "gateway.platforms.qqbot.adapter.aiohttp.ClientSession",
+            side_effect=FakeSession,
+        ):
+            await adapter._open_ws("wss://api.sgroup.qq.com/websocket")
+
+        heartbeat = seen_ws_kwargs.get("heartbeat")
+        assert heartbeat is not None, (
+            "ws_connect() must be called with heartbeat= so aiohttp emits "
+            "WS-level Ping/Pong to detect dead connections (#21633)."
+        )
+        assert isinstance(heartbeat, (int, float))
+        assert 0 < heartbeat <= 60.0
+
 # ---------------------------------------------------------------------------
 # _strip_at_mention
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

The QQ Bot WebSocket adapter dies silently after some minutes of operation:
\`self._ws.receive()\` in \`_read_events()\` hangs indefinitely on a half-open TCP
connection (NAT/firewall state expiry, etc.) — no error logs, no reconnection,
gateway process still running but the bot is offline. Manual restart required.

## Root cause

\`gateway/platforms/qqbot/adapter.py::_open_ws\` calls
\`aiohttp.ClientSession.ws_connect()\` without the \`heartbeat=\` parameter.
Without it, aiohttp does **not** emit WebSocket-level Ping frames, so a dead
transport never raises in \`receive()\`.

The op-1 application heartbeat in \`_heartbeat_loop()\` is QQ-protocol level
and is not sufficient on its own — the heartbeats just queue into the void
when the underlying socket is half-open.

## Fix

Pass \`heartbeat=30.0\` to \`ws_connect()\`. aiohttp will emit Ping frames and
raise when no Pong is received within the same window, which surfaces the
dead transport to the existing reconnect loop in \`_listen_loop()\`.

## Test

\`tests/gateway/test_qqbot.py::TestQQWebSocketProxy::test_open_ws_passes_heartbeat_for_keepalive\`
asserts \`heartbeat=\` is passed and is a sane positive number. Stash-verified
to fail without the fix.

Full \`tests/gateway/test_qqbot.py\` suite: 145 passed.

Closes #21633