### PR TITLE
fix(api_server): return 500 on failed/truncated runs instead of flattening to assistant content

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1085,8 +1085,28 @@ class APIServerAdapter(BasePlatformAdapter):
                 )
 
         final_response = result.get("final_response", "")
+        is_failed = result.get("failed", False)
+        is_partial = result.get("partial", False)
+        agent_error = result.get("error", "")
+
+        # When the agent loop failed or produced a partial/truncated result,
+        # do not flatten the error into normal assistant content — that makes
+        # it impossible for API clients to distinguish a real answer from an
+        # agent failure (issue #22496).
+        if is_failed or (is_partial and not final_response):
+            error_msg = agent_error or "Agent run failed without producing a response"
+            return web.json_response(
+                _openai_error(error_msg, err_type="server_error"),
+                status=500,
+                headers={"X-Hermes-Session-Id": session_id},
+            )
+
         if not final_response:
-            final_response = result.get("error", "(No response generated)")
+            final_response = agent_error or "(No response generated)"
+
+        # Reflect truncation/partial state in finish_reason so clients can
+        # detect incomplete responses without parsing content text.
+        finish_reason = "length" if is_partial else "stop"
 
         response_data = {
             "id": completion_id,
@@ -1100,7 +1120,7 @@ class APIServerAdapter(BasePlatformAdapter):
                         "role": "assistant",
                         "content": final_response,
                     },
-                    "finish_reason": "stop",
+                    "finish_reason": finish_reason,
                 }
             ],
             "usage": {


### PR DESCRIPTION
## Problem

When the agent loop fails or produces a truncated result, the API server mapped result[error] into normal assistant content, making it impossible for clients to distinguish a real answer from an agent failure.

## Fix

- failed=True → 500 server_error response
- partial=True with no final_response → 500 server_error
- partial=True with partial content → finish_reason=length instead of stop

Fixes #22496