### PR TITLE
fix(gateway): return OpenAI-style errors for failed agent runs in API server

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -440,6 +440,32 @@ def _openai_error(message: str, err_type: str = "invalid_request_error", param: 
     }
 
 
+def _flattened_agent_failure(result: Any) -> bool:
+    """True when the run finished with an error and no usable assistant text.
+
+    Without this guard, :func:`_handle_chat_completions` mapped ``result["error"]``
+    into normal assistant ``content``, so HTTP 200 responses looked like success
+    (GitHub #22496).
+    """
+    if not isinstance(result, dict):
+        return False
+    if result.get("completed", True):
+        return False
+    err = result.get("error")
+    if err is None or (isinstance(err, str) and not err.strip()):
+        return False
+    fr = result.get("final_response")
+    if fr is not None and str(fr).strip():
+        return False
+    return True
+
+
+def _json_agent_failure_envelope(result: dict) -> Dict[str, Any]:
+    msg = str(result.get("error") or "Agent run failed")
+    code = "output_truncation_failed" if result.get("partial") else "agent_run_failed"
+    return _openai_error(msg, err_type="server_error", code=code)
+
+
 if AIOHTTP_AVAILABLE:
     @web.middleware
     async def body_limit_middleware(request, handler):
@@ -1201,6 +1227,21 @@ class APIServerAdapter(BasePlatformAdapter):
                     status=500,
                 )
 
+        if _flattened_agent_failure(result):
+            response_headers = {
+                "X-Hermes-Session-Id": result.get("session_id", session_id),
+                "X-Hermes-Completed": "false",
+            }
+            if result.get("partial"):
+                response_headers["X-Hermes-Partial"] = "true"
+            if gateway_session_key:
+                response_headers["X-Hermes-Session-Key"] = gateway_session_key
+            return web.json_response(
+                _json_agent_failure_envelope(result),
+                status=500,
+                headers=response_headers,
+            )
+
         final_response = result.get("final_response", "")
         if not final_response:
             final_response = result.get("error", "(No response generated)")
@@ -1331,6 +1372,7 @@ class APIServerAdapter(BasePlatformAdapter):
 
             # Get usage from completed agent
             usage = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+            result: Any = None
             try:
                 result, agent_usage = await agent_task
                 usage = agent_usage or usage
@@ -1338,10 +1380,16 @@ class APIServerAdapter(BasePlatformAdapter):
                 logger.warning("Agent task %s failed, usage data lost: %s", completion_id, exc)
 
             # Finish chunk
+            finish_reason = "stop"
+            if isinstance(result, dict) and _flattened_agent_failure(result):
+                finish_reason = "error"
+                await response.write(
+                    f"data: {json.dumps(_json_agent_failure_envelope(result))}\n\n".encode()
+                )
             finish_chunk = {
                 "id": completion_id, "object": "chat.completion.chunk",
                 "created": created, "model": model,
-                "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                "choices": [{"index": 0, "delta": {}, "finish_reason": finish_reason}],
                 "usage": {
                     "prompt_tokens": usage.get("input_tokens", 0),
                     "completion_tokens": usage.get("output_tokens", 0),
@@ -2200,6 +2248,21 @@ class APIServerAdapter(BasePlatformAdapter):
                     _openai_error(f"Internal server error: {e}", err_type="server_error"),
                     status=500,
                 )
+
+        if _flattened_agent_failure(result):
+            response_headers = {
+                "X-Hermes-Session-Id": session_id,
+                "X-Hermes-Completed": "false",
+            }
+            if result.get("partial"):
+                response_headers["X-Hermes-Partial"] = "true"
+            if gateway_session_key:
+                response_headers["X-Hermes-Session-Key"] = gateway_session_key
+            return web.json_response(
+                _json_agent_failure_envelope(result),
+                status=500,
+                headers=response_headers,
+            )
 
         final_response = result.get("final_response", "")
         if not final_response:

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -29,6 +29,7 @@ from gateway.platforms.api_server import (
     _IdempotencyCache,
     _CORS_HEADERS,
     _derive_chat_session_id,
+    _flattened_agent_failure,
     check_api_server_requirements,
     cors_middleware,
     security_headers_middleware,
@@ -38,6 +39,37 @@ from gateway.platforms.api_server import (
 # ---------------------------------------------------------------------------
 # check_api_server_requirements
 # ---------------------------------------------------------------------------
+
+
+class TestFlattenedAgentFailure:
+    def test_partial_error_without_assistant_text(self):
+        assert _flattened_agent_failure(
+            {
+                "final_response": None,
+                "completed": False,
+                "partial": True,
+                "error": "Response truncated due to output length limit",
+            }
+        )
+
+    def test_false_when_assistant_text_present(self):
+        assert not _flattened_agent_failure(
+            {
+                "final_response": "partial body",
+                "completed": False,
+                "partial": True,
+                "error": "Response remained truncated after 3 continuation attempts",
+            }
+        )
+
+    def test_false_when_completed(self):
+        assert not _flattened_agent_failure(
+            {
+                "final_response": "",
+                "completed": True,
+                "error": "ignored",
+            }
+        )
 
 
 class TestCheckRequirements:
@@ -649,6 +681,73 @@ class TestChatCompletionsEndpoint:
             assert resp.status == 400
 
     @pytest.mark.asyncio
+    async def test_incomplete_run_with_error_returns_500_openai_envelope(self, adapter):
+        """Do not surface internal failure strings as HTTP-200 assistant content (issue #22496)."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+
+            async def _mock_run_agent(**kwargs):
+                return (
+                    {
+                        "final_response": None,
+                        "completed": False,
+                        "partial": True,
+                        "error": "Response truncated due to output length limit",
+                        "messages": [],
+                    },
+                    {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "x"}],
+                    },
+                )
+            assert resp.status == 500
+            data = await resp.json()
+            assert data["error"]["code"] == "output_truncation_failed"
+            assert "truncated" in data["error"]["message"].lower()
+            assert resp.headers.get("X-Hermes-Partial") == "true"
+            assert resp.headers.get("X-Hermes-Completed") == "false"
+
+    @pytest.mark.asyncio
+    async def test_stream_incomplete_run_emits_error_finish_reason(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+
+            async def _mock_run_agent(**kwargs):
+                cb = kwargs.get("stream_delta_callback")
+                if cb:
+                    cb(None)
+                return (
+                    {
+                        "final_response": None,
+                        "completed": False,
+                        "partial": True,
+                        "error": "Response truncated due to output length limit",
+                        "messages": [],
+                    },
+                    {"input_tokens": 1, "output_tokens": 0, "total_tokens": 1},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "x"}],
+                        "stream": True,
+                    },
+                )
+            assert resp.status == 200
+            body = await resp.text()
+            assert '"finish_reason": "error"' in body
+            assert "output_truncation_failed" in body
+
+    @pytest.mark.asyncio
     async def test_stream_true_returns_sse(self, adapter):
         """stream=true returns SSE format with the full response."""
         app = _create_app(adapter)
@@ -1226,6 +1325,27 @@ class TestResponsesEndpoint:
             assert resp.status == 400
             data = await resp.json()
             assert "input" in data["error"]["message"]
+
+    @pytest.mark.asyncio
+    async def test_incomplete_run_returns_500_openai_envelope(self, adapter):
+        mock_result = {
+            "final_response": None,
+            "completed": False,
+            "partial": True,
+            "error": "Response truncated due to output length limit",
+            "messages": [],
+        }
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (mock_result, {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={"model": "hermes-agent", "input": "hi"},
+                )
+            assert resp.status == 500
+            data = await resp.json()
+            assert data["error"]["code"] == "output_truncation_failed"
 
     @pytest.mark.asyncio
     async def test_invalid_json_returns_400(self, adapter):


### PR DESCRIPTION
## Summary

When the agent finishes with `completed=false`, an `error` string, and no usable `final_response` (e.g. output truncation after failed continuation), the OpenAI-compatible API previously put that error text into `choices[0].message.content` with HTTP 200, so clients treated it as a normal assistant reply.

This change returns a structured OpenAI error payload with HTTP 500 on non-streaming `/v1/chat/completions` and `/v1/responses`, and for streaming chat completions emits an error `data:` line plus `finish_reason: "error"`. Response headers `X-Hermes-Completed` / `X-Hermes-Partial` expose the run state for integrations that opt in.

Fixes NousResearch/hermes-agent#22496.

## Test plan

- [x] `pytest tests/gateway/test_api_server.py` (including new cases for non-stream, stream, responses, and `_flattened_agent_failure`)