### PR TITLE
fix(scripts): support uv venv for pytest-split + unset HERMES_CRON_SESSION

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -42,10 +42,12 @@ fi
 PYTHON="$VENV/bin/python"
 
 # ── Ensure pytest-split is installed (required for shard-equivalent runs) ──
+# Use uv pip if available (for uv-created venvs without pip), fall back to pip.
 if ! "$PYTHON" -c "import pytest_split" 2>/dev/null; then
   echo "→ installing pytest-split into $VENV"
   if command -v uv >/dev/null 2>&1; then
-    uv pip install --python "$PYTHON" --quiet "pytest-split>=0.9,<1"
+    uv pip install --python "$PYTHON" --quiet "pytest-split>=0.9,<1" || \
+    uv pip install --quiet "pytest-split>=0.9,<1"
   elif "$PYTHON" -m pip --version >/dev/null 2>&1; then
     "$PYTHON" -m pip install --quiet "pytest-split>=0.9,<1"
   else
@@ -79,7 +81,7 @@ unset HERMES_YOLO_MODE HERMES_INTERACTIVE HERMES_QUIET HERMES_TOOL_PROGRESS \
       HERMES_PLATFORM HERMES_INFERENCE_PROVIDER HERMES_MANAGED HERMES_DEV \
       HERMES_CONTAINER HERMES_EPHEMERAL_SYSTEM_PROMPT HERMES_TIMEZONE \
       HERMES_REDACT_SECRETS HERMES_BACKGROUND_NOTIFICATIONS HERMES_EXEC_ASK \
-      HERMES_HOME_MODE 2>/dev/null || true
+      HERMES_HOME_MODE HERMES_CRON_SESSION 2>/dev/null || true
 
 # Pin deterministic runtime.
 export TZ=UTC


### PR DESCRIPTION
## Summary

Fixes two test runner issues:

1. **Fix #22401**: `scripts/run_tests.sh` now supports `uv pip install` when `uv` is available, falling back to `pip` for uv-created venvs that lack the pip module
2. **Fix #22400**: Added `HERMES_CRON_SESSION` to the hermetic environment unset list to prevent cron environment leaking into pytest approval tests

## Changes

- `scripts/run_tests.sh`: 
  - Add `uv pip` fallback for pytest-split installation
  - Add `HERMES_CRON_SESSION` to unset list