### PR TITLE
fix(deps): declare pytest-split in dev extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
 modal = ["modal>=1.0.0,<2"]
 daytona = ["daytona>=0.148.0,<1"]
 vercel = ["vercel>=0.5.7,<0.6.0"]
-dev = ["debugpy>=1.8.0,<2", "pytest>=9.0.2,<10", "pytest-asyncio>=1.3.0,<2", "pytest-xdist>=3.0,<4", "mcp>=1.2.0,<2", "ty>=0.0.1a29,<0.0.22", "ruff"]
+dev = ["debugpy>=1.8.0,<2", "pytest>=9.0.2,<10", "pytest-asyncio>=1.3.0,<2", "pytest-xdist>=3.0,<4", "pytest-split>=0.9,<1", "mcp>=1.2.0,<2", "ty>=0.0.1a29,<0.0.22", "ruff"]
 messaging = ["python-telegram-bot[webhooks]>=22.6,<23", "discord.py[voice]>=2.7.1,<3", "aiohttp>=3.13.3,<4", "slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4", "qrcode>=7.0,<8"]
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
 slack = ["slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4"]

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -41,10 +41,15 @@ fi
 
 PYTHON="$VENV/bin/python"
 
-# ── Ensure pytest-split is installed (required for shard-equivalent runs) ──
+# ── pytest-split (declared in ``[project.optional-dependencies].dev``) ──
+# uv-managed venvs often ship without ``pip``; do not try to bootstrap here.
 if ! "$PYTHON" -c "import pytest_split" 2>/dev/null; then
-  echo "→ installing pytest-split into $VENV"
-  "$PYTHON" -m pip install --quiet "pytest-split>=0.9,<1"
+  echo "error: pytest-split is not installed in $VENV" >&2
+  echo "  Install dev dependencies (includes pytest-split), for example:" >&2
+  echo "    uv sync --extra dev" >&2
+  echo "    # or: uv pip install 'pytest-split>=0.9,<1'" >&2
+  echo "    # or: python -m pip install 'pytest-split>=0.9,<1'  (when pip exists)" >&2
+  exit 1
 fi
 
 # ── Hermetic environment ────────────────────────────────────────────────────


### PR DESCRIPTION
### Summary

`scripts/run_tests.sh` effectively requires `pytest-split`, but it was not part of the declared dev dependency set. On uv-created virtualenvs that ship without `pip`, the runner's ad-hoc `python -m pip install` bootstrap failed before pytest started (see issue #22401).

### Changes

- Add `pytest-split>=0.9,<1` to `[project.optional-dependencies].dev` in `pyproject.toml` so `uv sync --extra dev` (and similar) installs it with the rest of the test stack.
- Update `scripts/run_tests.sh`: if `pytest_split` is missing, exit with actionable hints (`uv sync --extra dev`, `uv pip install …`, optional `pip` when present) instead of assuming `pip` exists.

### Verification

After `uv sync --extra dev`, `import pytest_split` succeeds and `scripts/run_tests.sh` proceeds past the import check.

Fixes NousResearch/hermes-agent#22401