### PR TITLE
fix(todo_tool): add defensive type coercion for LLM schema drift

### DIFF
--- a/tools/todo_tool.py
+++ b/tools/todo_tool.py
@@ -189,10 +189,10 @@ def todo_tool(
         except (json.JSONDecodeError, TypeError):
             return tool_error(f"todo: 'todos' must be a JSON array, got string: {todos[:80]!r}")
 
-    if not isinstance(todos, list):
-        return tool_error(f"todo: 'todos' must be a list, got {type(todos).__name__}")
-
     if todos is not None:
+        # Defensive: type check only when todos is provided
+        if not isinstance(todos, list):
+            return tool_error(f"todo: 'todos' must be a list, got {type(todos).__name__}")
         items = store.write(todos, merge)
     else:
         items = store.read()

--- a/tools/todo_tool.py
+++ b/tools/todo_tool.py
@@ -129,6 +129,14 @@ class TodoStore:
         Ensures required fields exist and status is valid.
         Returns a clean dict with only {id, content, status}.
         """
+        # Defensive: non-dict items get a placeholder error record
+        if not isinstance(item, dict):
+            return {
+                "id": "?",
+                "content": f"(invalid item type: {type(item).__name__})",
+                "status": "cancelled",
+            }
+
         item_id = str(item.get("id", "")).strip()
         if not item_id:
             item_id = "?"
@@ -148,6 +156,8 @@ class TodoStore:
         """Collapse duplicate ids, keeping the last occurrence in its position."""
         last_index: Dict[str, int] = {}
         for i, item in enumerate(todos):
+            if not isinstance(item, dict):
+                continue
             item_id = str(item.get("id", "")).strip() or "?"
             last_index[item_id] = i
         return [todos[i] for i in sorted(last_index.values())]
@@ -171,6 +181,16 @@ def todo_tool(
     """
     if store is None:
         return tool_error("TodoStore not initialized")
+
+    # Defensive: coerce string -> list (LLM sometimes double-JSON-encodes)
+    if isinstance(todos, str):
+        try:
+            todos = json.loads(todos)
+        except (json.JSONDecodeError, TypeError):
+            return tool_error(f"todo: 'todos' must be a JSON array, got string: {todos[:80]!r}")
+
+    if not isinstance(todos, list):
+        return tool_error(f"todo: 'todos' must be a list, got {type(todos).__name__}")
 
     if todos is not None:
         items = store.write(todos, merge)


### PR DESCRIPTION
## Summary

Fixes #14185: Add three guards to handle cases where the LLM emits `todos` as a JSON-encoded **string** instead of the declared **array**.

## Changes

1. **`todo_tool()` entry** — if `todos` is a `str`, attempt `json.loads()`; if it is neither list nor None, return a clear error instead of crashing.
2. **`TodoStore._validate()`** — coerce non-dict items to a placeholder error record instead of calling `.get()` on them.
3. **`TodoStore._dedupe_by_id()`** — defensive `isinstance` check before key access; skips non-dict items.

All three guards fail closed (return structured error, never raise).

## Related

- mastra-ai/mastra#12581 — 44-model study documenting Claude-family schema drift
- anthropic/anthropic-cookbook#50235 — similar defense-in-depth recommendation