### PR TITLE
fix(context-refs): handle null data field in _default_url_fetcher

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -319,10 +319,11 @@ async def _default_url_fetcher(url: str) -> str:
 
     raw = await web_extract_tool([url], format="markdown", use_llm_processing=True)
     payload = json.loads(raw)
-    docs = payload.get("data", {}).get("documents", [])
+    data = payload.get("data") or {}
+    docs = data.get("documents") or []
     if not docs:
         return ""
-    doc = docs[0]
+    doc = docs[0] or {}
     return str(doc.get("content") or doc.get("raw_content") or "").strip()
 
 

--- a/tests/agent/test_context_references.py
+++ b/tests/agent/test_context_references.py
@@ -334,3 +334,60 @@ async def test_blocks_sensitive_home_and_hermes_paths(tmp_path: Path, monkeypatc
     assert "API_KEY=super-secret" not in result.message
     assert "PRIVATE-KEY" not in result.message
     assert any("sensitive credential" in warning for warning in result.warnings)
+
+
+@pytest.mark.asyncio
+async def test_default_url_fetcher_handles_null_data():
+    """web_extract_tool may return {"data": null} on extract failure;
+    _default_url_fetcher must not crash with AttributeError."""
+    import json as _json
+    import sys
+    import types
+    from agent.context_references import _default_url_fetcher
+
+    fake_module = types.ModuleType("tools.web_tools")
+
+    async def _fake_extract(*_args, **_kwargs):
+        return _json.dumps({"data": None})
+
+    fake_module.web_extract_tool = _fake_extract
+
+    saved = sys.modules.get("tools.web_tools")
+    sys.modules["tools.web_tools"] = fake_module
+    try:
+        result = await _default_url_fetcher("https://example.com/x")
+    finally:
+        if saved is not None:
+            sys.modules["tools.web_tools"] = saved
+        else:
+            sys.modules.pop("tools.web_tools", None)
+
+    assert result == ""
+
+
+@pytest.mark.asyncio
+async def test_default_url_fetcher_handles_null_documents():
+    """`{"data": {"documents": null}}` should also not crash."""
+    import json as _json
+    import sys
+    import types
+    from agent.context_references import _default_url_fetcher
+
+    fake_module = types.ModuleType("tools.web_tools")
+
+    async def _fake_extract(*_args, **_kwargs):
+        return _json.dumps({"data": {"documents": None}})
+
+    fake_module.web_extract_tool = _fake_extract
+
+    saved = sys.modules.get("tools.web_tools")
+    sys.modules["tools.web_tools"] = fake_module
+    try:
+        result = await _default_url_fetcher("https://example.com/x")
+    finally:
+        if saved is not None:
+            sys.modules["tools.web_tools"] = saved
+        else:
+            sys.modules.pop("tools.web_tools", None)
+
+    assert result == ""


### PR DESCRIPTION
## Problem

`_default_url_fetcher` in `agent/context_references.py` crashes with `AttributeError` when `web_extract_tool` returns `{"data": null}` or `{"data": {"documents": null}}` on extract failure.

```
AttributeError: 'NoneType' object has no attribute 'get'
agent/context_references.py:322: in _default_url_fetcher
    docs = payload.get("data", {}).get("documents", [])
```

## Root cause

`payload.get("data", {})` returns `None` (not `{}`) when the key exists with a null value — Python dict `.get` only uses the default when the key is **absent**. The chained `.get("documents", [])` then crashes. Same hazard if `documents` is explicitly null, or if `docs[0]` is null.

## Fix

Use `or {}` / `or []` fallbacks to coerce `None` into empty containers before chained access. Also guard `docs[0]` against `None`.

```python
data = payload.get("data") or {}
docs = data.get("documents") or []
if not docs:
    return ""
doc = docs[0] or {}
return str(doc.get("content") or doc.get("raw_content") or "").strip()
```

## Tests

Added in `tests/agent/test_context_references.py`:

- `test_default_url_fetcher_handles_null_data` — confirms `{"data": null}` no longer crashes. **Verified via stash-verify**: failed without fix with `AttributeError` on the original line; passes with fix.
- `test_default_url_fetcher_handles_null_documents` — confirms `{"data": {"documents": null}}` returns empty string.

Full file regression: `16 passed in 29.12s`.