### PR TITLE
fix gateway: clear slash confirm state during session boundary cleanup

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12804,6 +12804,20 @@ class GatewayRunner:
             update_prompt_pending.pop(session_key, None)
 
         try:
+            from tools import slash_confirm as _slash_confirm_mod
+        except Exception:
+            _slash_confirm_mod = None
+        if _slash_confirm_mod is not None:
+            try:
+                _slash_confirm_mod.clear(session_key)
+            except Exception as e:
+                logger.debug(
+                    "Failed to clear slash-confirm state for session boundary %s: %s",
+                    session_key,
+                    e,
+                )
+
+        try:
             from tools.approval import clear_session as _clear_approval_session
         except Exception:
             return

--- a/tests/gateway/test_session_boundary_security_state.py
+++ b/tests/gateway/test_session_boundary_security_state.py
@@ -9,6 +9,7 @@ from gateway.config import Platform
 from gateway.platforms.base import MessageEvent
 from gateway.session import SessionEntry, SessionSource, build_session_key
 from tools import approval as approval_mod
+from tools import slash_confirm as slash_confirm_mod
 from tools.approval import (
     _ApprovalEntry,
     approve_session,
@@ -26,6 +27,7 @@ def _clear_approval_state():
     approval_mod._session_yolo.clear()
     approval_mod._permanent_approved.clear()
     approval_mod._pending.clear()
+    slash_confirm_mod._pending.clear()
     yield
     approval_mod._gateway_queues.clear()
     approval_mod._gateway_notify_cbs.clear()
@@ -33,6 +35,7 @@ def _clear_approval_state():
     approval_mod._session_yolo.clear()
     approval_mod._permanent_approved.clear()
     approval_mod._pending.clear()
+    slash_confirm_mod._pending.clear()
 
 
 def _make_source() -> SessionSource:
@@ -249,6 +252,15 @@ def test_clear_session_boundary_security_state_is_scoped():
         "[USER INITIATED SKILLS RELOAD: other]"
     )
 
+    async def _target_handler(choice):
+        return f"target:{choice}"
+
+    async def _other_handler(choice):
+        return f"other:{choice}"
+
+    slash_confirm_mod.register(session_key, "confirm-target", "reload-mcp", _target_handler)
+    slash_confirm_mod.register(other_key, "confirm-other", "reload-mcp", _other_handler)
+
     runner._clear_session_boundary_security_state(session_key)
 
     # Target session cleared
@@ -257,18 +269,21 @@ def test_clear_session_boundary_security_state_is_scoped():
     assert session_key not in runner._pending_approvals
     assert session_key not in runner._update_prompt_pending
     assert session_key not in runner._pending_skills_reload_notes
+    assert slash_confirm_mod.get_pending(session_key) is None
     # Other session untouched
     assert is_approved(other_key, "recursive delete") is True
     assert is_session_yolo_enabled(other_key) is True
     assert other_key in runner._pending_approvals
     assert other_key in runner._update_prompt_pending
     assert other_key in runner._pending_skills_reload_notes
+    assert slash_confirm_mod.get_pending(other_key) is not None
 
     # Empty session_key is a no-op
     runner._clear_session_boundary_security_state("")
     assert is_approved(other_key, "recursive delete") is True
     assert other_key in runner._update_prompt_pending
     assert other_key in runner._pending_skills_reload_notes
+    assert slash_confirm_mod.get_pending(other_key) is not None
 
 
 def test_clear_session_boundary_security_state_wakes_blocked_approvals():


### PR DESCRIPTION
## Summary

Clear pending slash-confirm state when the gateway crosses a session boundary.

This fixes a state-leak where a pending `/reload-mcp` confirmation could survive `/new`, `/resume`, or `/branch` and still be resolved afterward in the reused session key.

## Problem

`GatewayRunner._clear_session_boundary_security_state()` already clears approval, YOLO, pending update-prompt, and skills-reload state, but it did not clear module-level pending state in `tools.slash_confirm`.

That meant an old slash-confirm prompt could outlive a conversation boundary and trigger side effects in the wrong session context.

## Changes

- Clear `tools.slash_confirm` pending state inside session-boundary cleanup
- Extend the session-boundary regression test to cover slash-confirm isolation
- Verify the target session is cleared while other sessions remain untouched

## Testing



- `scripts/run_tests.sh tests/gateway/test_session_boundary_security_state.py`

- `5 passed in 6.25s`
