### PR TITLE
fix(cli): skip dedicated-check providers in apikey loop

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -1262,7 +1262,14 @@ def run_doctor(args):
     if _APIKEY_PROVIDERS_CACHE is None:
         _APIKEY_PROVIDERS_CACHE = _build_apikey_providers_list()
     _apikey_providers = _APIKEY_PROVIDERS_CACHE
+    # Providers with dedicated health-check sections above — skip to avoid
+    # duplicate checks with wrong auth headers (e.g. anthropic needs x-api-key,
+    # not the generic Bearer token the loop uses).
+    _DEDICATED_CHECKS = {"anthropic", "openrouter"}
     for _pname, _env_vars, _default_url, _base_env, _supports_health_check in _apikey_providers:
+        # Skip providers that have dedicated health-check sections above
+        if _pname.lower() in _DEDICATED_CHECKS:
+            continue
         _key = ""
         for _ev in _env_vars:
             _key = os.getenv(_ev, "")


### PR DESCRIPTION
Fixes #22346: `hermes doctor` runs duplicate health checks for providers that already have dedicated check sections (Anthropic, OpenRouter).

## Root Cause
The generic `_apikey_providers` loop at line 1265 uses `Authorization: Bearer` header, which fails for Anthropic's required `x-api-key` header. Since Anthropic already has a dedicated check section (lines 1203-1256), the generic loop creates a duplicate check with wrong auth.

## Fix
Add `_DEDICATED_CHECKS` set with provider names that have dedicated health-check sections. Skip these providers in the `_apikey_providers` loop to avoid duplicate checks with wrong auth headers.

## Testing
- `hermes doctor` now shows single Anthropic API check (✓) instead of duplicate (✓ + ⚠ HTTP 404)