### PR TITLE
fix(skill_commands): preserve cache when scan fails

### DIFF
--- a/agent/skill_commands.py
+++ b/agent/skill_commands.py
@@ -245,8 +245,11 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
         Dict mapping "/skill-name" to {name, description, skill_md_path, skill_dir}.
     """
     global _skill_commands, _skill_commands_platform
-    _skill_commands_platform = _resolve_skill_commands_platform()
-    _skill_commands = {}
+    next_platform = _resolve_skill_commands_platform()
+    # Build into a local mapping. Only commit to module state on success
+    # so that an import or scan failure does not silently wipe a previously
+    # populated cache (#18659).
+    new_commands: Dict[str, Dict[str, Any]] = {}
     try:
         from tools.skills_tool import SKILLS_DIR, _parse_frontmatter, skill_matches_platform, _get_disabled_skill_names
         from agent.skill_utils import get_external_skills_dirs, iter_skill_index_files
@@ -291,7 +294,7 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                     cmd_name = _SKILL_MULTI_HYPHEN.sub('-', cmd_name).strip('-')
                     if not cmd_name:
                         continue
-                    _skill_commands[f"/{cmd_name}"] = {
+                    new_commands[f"/{cmd_name}"] = {
                         "name": name,
                         "description": description or f"Invoke the {name} skill",
                         "skill_md_path": str(skill_md),
@@ -300,7 +303,12 @@ def scan_skill_commands() -> Dict[str, Dict[str, Any]]:
                 except Exception:
                     continue
     except Exception:
-        pass
+        # Top-level scan failed (e.g. ImportError from skills_tool /
+        # skill_utils). Preserve the existing cache rather than wiping it.
+        return _skill_commands
+
+    _skill_commands = new_commands
+    _skill_commands_platform = next_platform
     return _skill_commands
 
 

--- a/tests/agent/test_skill_commands.py
+++ b/tests/agent/test_skill_commands.py
@@ -766,3 +766,51 @@ class TestInlineShellExpansion:
         # The command's intended stdout never made it through — only the
         # timeout marker (which echoes the command text) survives.
         assert "DYN_MARKER" not in msg.replace("sleep 5 && printf DYN_MARKER", "")
+
+
+class TestScanPreservesCacheOnFailure:
+    """Regression for #18659.
+
+    ``scan_skill_commands`` previously cleared ``_skill_commands`` before
+    its outer ``try`` block. Any exception during the scan silently wiped
+    a previously populated mapping. The fix builds into a local dict and
+    only commits to module state on success.
+    """
+
+    def test_scan_failure_keeps_previous_cache(self, tmp_path):
+        import agent.skill_commands as mod
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "kept-skill")
+            commands = scan_skill_commands()
+
+        assert "/kept-skill" in commands
+        snapshot_before = dict(commands)
+
+        def _boom(*args, **kwargs):
+            raise ImportError("simulated skills_tool failure")
+
+        with patch(
+            "tools.skills_tool._get_disabled_skill_names", side_effect=_boom
+        ):
+            result = mod.scan_skill_commands()
+
+        # Cache must be preserved, not wiped.
+        assert result == snapshot_before
+        assert mod._skill_commands == snapshot_before
+
+    def test_successful_scan_replaces_cache(self, tmp_path):
+        import agent.skill_commands as mod
+
+        with patch("tools.skills_tool.SKILLS_DIR", tmp_path):
+            _make_skill(tmp_path, "first-skill")
+            scan_skill_commands()
+            assert "/first-skill" in mod._skill_commands
+
+            (tmp_path / "first-skill" / "SKILL.md").unlink()
+            (tmp_path / "first-skill").rmdir()
+            _make_skill(tmp_path, "second-skill")
+            result = scan_skill_commands()
+
+        assert "/first-skill" not in result
+        assert "/second-skill" in result


### PR DESCRIPTION
## Problem

`scan_skill_commands()` clears `_skill_commands` and `_skill_lower_to_canonical` at the start of the function. If a later import or scan step raises, the function returns the wiped dicts and leaves module state empty — every previously cached skill command is silently lost until the next successful rescan.

## Root cause

In-place clear of module-level dicts before the work that could fail.

## Fix

Build a local `new_commands` dict and only commit to module state once the full scan succeeds. On exception, return the existing `_skill_commands` (cache preserved).

## Tests

`TestScanPreservesCacheOnFailure`:
- `test_scan_failure_keeps_previous_cache` — patches a downstream import to raise mid-scan, asserts the previously populated cache is preserved.
- `test_successful_scan_replaces_cache` — confirms a successful rescan still replaces the cache normally.

Stash-verify confirmed the new test flips red without the fix.

Closes #18659