### PR TITLE
fix(api-server): preserve truncation/failure semantics in chat completions (#22496)

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1206,9 +1206,39 @@ class APIServerAdapter(BasePlatformAdapter):
                     status=500,
                 )
 
-        final_response = result.get("final_response", "")
-        if not final_response:
-            final_response = result.get("error", "(No response generated)")
+        final_response = result.get("final_response", "") or ""
+        result_completed = result.get("completed", True)
+        result_partial = bool(result.get("partial"))
+        result_failed = bool(result.get("failed"))
+        result_error = result.get("error")
+
+        # An agent run that failed without producing any partial assistant
+        # output should not be flattened into a "successful" assistant
+        # message — clients can't distinguish that from a real answer.
+        # Surface as a structured OpenAI error so HTTP status carries the
+        # signal (#22496).
+        if result_failed and not final_response:
+            err_msg = str(result_error) if result_error else "Agent run failed without a final response"
+            err_headers = {
+                "X-Hermes-Session-Id": result.get("session_id", session_id),
+            }
+            if gateway_session_key:
+                err_headers["X-Hermes-Session-Key"] = gateway_session_key
+            return web.json_response(
+                _openai_error(err_msg, err_type="server_error", code="agent_failed"),
+                status=500,
+                headers=err_headers,
+            )
+
+        # Truncation / non-completed runs: keep the OpenAI shape but mark
+        # finish_reason=length and surface metadata via headers. Never
+        # overwrite the assistant content with an internal error string.
+        if result_partial or not result_completed:
+            finish_reason = "length"
+            content = final_response
+        else:
+            finish_reason = "stop"
+            content = final_response if final_response else "(No response generated)"
 
         response_data = {
             "id": completion_id,
@@ -1220,9 +1250,9 @@ class APIServerAdapter(BasePlatformAdapter):
                     "index": 0,
                     "message": {
                         "role": "assistant",
-                        "content": final_response,
+                        "content": content,
                     },
-                    "finish_reason": "stop",
+                    "finish_reason": finish_reason,
                 }
             ],
             "usage": {
@@ -1237,6 +1267,12 @@ class APIServerAdapter(BasePlatformAdapter):
         }
         if gateway_session_key:
             response_headers["X-Hermes-Session-Key"] = gateway_session_key
+        if not result_completed:
+            response_headers["X-Hermes-Completed"] = "false"
+        if result_partial:
+            response_headers["X-Hermes-Partial"] = "true"
+        if result_error and (result_partial or not result_completed):
+            response_headers["X-Hermes-Error"] = str(result_error)[:500]
         return web.json_response(response_data, headers=response_headers)
 
     async def _write_sse_chat_completion(

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1180,6 +1180,73 @@ class TestChatCompletionsEndpoint:
 
         assert session_ids[0] != session_ids[1]
 
+    @pytest.mark.asyncio
+    async def test_truncated_partial_run_uses_length_finish_reason(self, adapter):
+        """Truncated partial responses must NOT be flattened into a normal
+        successful assistant message — finish_reason must be ``length`` and
+        the internal error string must NOT replace assistant content (#22496).
+        """
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**_kwargs):
+                return (
+                    {
+                        "final_response": "Partial answer so far",
+                        "messages": [],
+                        "api_calls": 1,
+                        "completed": False,
+                        "partial": True,
+                        "error": "Response remained truncated after 3 continuation attempts",
+                    },
+                    {"input_tokens": 5, "output_tokens": 5, "total_tokens": 10},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={"model": "test", "messages": [{"role": "user", "content": "hi"}]},
+                )
+                assert resp.status == 200
+                data = await resp.json()
+                choice = data["choices"][0]
+                assert choice["finish_reason"] == "length"
+                assert choice["message"]["content"] == "Partial answer so far"
+                assert "truncated" not in choice["message"]["content"].lower()
+                assert resp.headers.get("X-Hermes-Completed") == "false"
+                assert resp.headers.get("X-Hermes-Partial") == "true"
+                assert "truncated" in (resp.headers.get("X-Hermes-Error") or "").lower()
+
+    @pytest.mark.asyncio
+    async def test_failed_run_without_response_returns_500(self, adapter):
+        """A failed agent run with no partial output must surface as a 500
+        error, not a successful chat completion containing the error text
+        (#22496)."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**_kwargs):
+                return (
+                    {
+                        "final_response": None,
+                        "messages": [],
+                        "api_calls": 1,
+                        "completed": False,
+                        "failed": True,
+                        "error": "Operation interrupted: API error",
+                    },
+                    {"input_tokens": 5, "output_tokens": 0, "total_tokens": 5},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={"model": "test", "messages": [{"role": "user", "content": "hi"}]},
+                )
+                assert resp.status == 500
+                data = await resp.json()
+                assert "error" in data
+                assert data["error"]["code"] == "agent_failed"
+                assert "interrupted" in data["error"]["message"].lower()
+
 
 # ---------------------------------------------------------------------------
 # _derive_chat_session_id unit tests


### PR DESCRIPTION
## Problem
The non-streaming `/v1/chat/completions` handler in `gateway/platforms/api_server.py` flattened every agent run into a successful chat completion with `finish_reason="stop"`, even when the run failed or was truncated. Internal error strings could leak into `choices[0].message.content`, and OpenAI clients had no way to detect truncation or failure (no `length` finish reason, no error envelope).

## Root cause
`_handle_chat_completions` only inspected `result["final_response"]` and built the OpenAI envelope unconditionally, ignoring `result["completed"]`, `result["partial"]`, `result["failed"]`, and `result["error"]`.

## Fix
Branch on the agent result:
- `failed` with no `final_response` → HTTP 500 with OpenAI error envelope (`code="agent_failed"`).
- `partial=true` or `completed=false` → return content but with `finish_reason="length"`.
- success → unchanged (`finish_reason="stop"`).

Surface metadata via response headers: `X-Hermes-Completed`, `X-Hermes-Partial`, `X-Hermes-Error`.

## Tests
Added in `tests/gateway/test_api_server.py`:
- `test_truncated_partial_run_uses_length_finish_reason` — asserts `finish_reason="length"`, content is the partial text (not the error string), and headers reflect the truncation.
- `test_failed_run_without_response_returns_500` — asserts HTTP 500 with `error.code="agent_failed"`.

Both confirmed via stash-verify (fail pre-fix, pass post-fix). Full module: 140 passed.

Fixes #22496