### PR TITLE
feat(gateway): stream Telegram edits safely — salvage of #22264

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -500,6 +500,7 @@ group_sessions_per_user: true
 # Stream tokens to messaging platforms in real-time. The bot sends a message
 # on first token, then progressively edits it as more tokens arrive.
 # Disabled by default — enable to try the streaming UX on Telegram/Discord/Slack.
+# For Telegram, partial edits are sent as plain text and only the final edit uses MarkdownV2.
 streaming:
   enabled: false
   # transport: edit           # "edit" = progressive editMessageText

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1515,6 +1515,14 @@ class TelegramAdapter(BasePlatformAdapter):
         if not self._bot:
             return SendResult(success=False, error="Not connected")
         try:
+            if not finalize:
+                await self._bot.edit_message_text(
+                    chat_id=int(chat_id),
+                    message_id=int(message_id),
+                    text=content,
+                )
+                return SendResult(success=True, message_id=message_id)
+
             formatted = self.format_message(content)
             try:
                 await self._bot.edit_message_text(

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -170,6 +170,8 @@ AUTHOR_MAP = {
     "momowind@gmail.com": "momowind",
     "clockwork-codex@users.noreply.github.com": "misery-hl",
     "207811921+misery-hl@users.noreply.github.com": "misery-hl",
+    "20nik.nosov21@gmail.com": "nik1t7n",
+    "90299797+nik1t7n@users.noreply.github.com": "nik1t7n",
     "suncokret@protonmail.com": "suncokret12",
     "mio.imoto.ai@gmail.com": "mioimotoai-lgtm",
     "aamirjawaid@microsoft.com": "heyitsaamir",

--- a/tests/gateway/test_telegram_format.py
+++ b/tests/gateway/test_telegram_format.py
@@ -716,3 +716,44 @@ async def test_send_escapes_chunk_indicator_for_markdownv2(adapter):
     assert len(sent_texts) > 1
     assert re.search(r" \\\([0-9]+/[0-9]+\\\)$", sent_texts[0])
     assert re.search(r" \\\([0-9]+/[0-9]+\\\)$", sent_texts[-1])
+
+
+# =========================================================================
+# edit_message — streaming Markdown safety
+# =========================================================================
+
+
+class TestEditMessageStreamingSafety:
+    @pytest.mark.asyncio
+    async def test_non_final_edit_uses_plain_text_without_markdown(self):
+        adapter = TelegramAdapter(PlatformConfig(enabled=True, token="fake-token"))
+        adapter._bot = MagicMock()
+        adapter._bot.edit_message_text = AsyncMock()
+
+        result = await adapter.edit_message("123", "456", "partial **bold", finalize=False)
+
+        assert result.success is True
+        adapter._bot.edit_message_text.assert_awaited_once_with(
+            chat_id=123,
+            message_id=456,
+            text="partial **bold",
+        )
+
+    @pytest.mark.asyncio
+    async def test_final_edit_uses_markdownv2_with_plain_fallback(self):
+        adapter = TelegramAdapter(PlatformConfig(enabled=True, token="fake-token"))
+        adapter._bot = MagicMock()
+        adapter._bot.edit_message_text = AsyncMock(side_effect=[Exception("bad markdown"), None])
+
+        result = await adapter.edit_message("123", "456", "final **bold**", finalize=True)
+
+        assert result.success is True
+        first_call = adapter._bot.edit_message_text.await_args_list[0].kwargs
+        second_call = adapter._bot.edit_message_text.await_args_list[1].kwargs
+        assert "parse_mode" in first_call
+        assert first_call["text"] == "final *bold*"
+        assert second_call == {
+            "chat_id": 123,
+            "message_id": 456,
+            "text": "final **bold**",
+        }


### PR DESCRIPTION
## Summary

Salvage of #22264 by @nik1t7n — cherry-picked onto current `main` with authorship preserved, plus AUTHOR_MAP entry.

## What this PR does

Makes non-final Telegram streaming edits (`edit_message`) send content as plain text instead of going through `format_message()` + MarkdownV2. During token-by-token streaming, partial markdown (e.g., `**bold` without closing `**`) frequently triggers Telegram's MarkdownV2 parser rejection. The old code would catch the rejection, then retry as plain text — doubling API calls per intermediate edit with zero benefit.

The fix: intermediate edits (`finalize=False`) bypass `format_message()` and `parse_mode=MarkdownV2`, sending content directly as plain text. Final edits (`finalize=True`) still go through the full MarkdownV2 + fallback-to-plain path, preserving rich formatting for the completed message.

## How this was verified

- `finalize=False` IS passed by the streaming consumer (`stream_consumer.py:926-930`) — the PR code path is actively exercised, not dead code.
- `format_message()` does only MarkdownV2 conversion + character escaping — no sanitization, truncation, or routing logic is skipped.
- The plain-text path is inside the same outer `try/except` as the old path, so `message_too_long`, flood control, and generic errors are handled identically.
- Side-effect: `send_progress_messages` in `gateway/run.py:13472` and `_try_strip_cursor`/`_send_fallback_final` in `stream_consumer.py` also take the plain-text path — all correct since they send status lines / cursor-stripped already-rendered text.

## Diff

- **nik1t7n's commit** (cherry-picked, authorship preserved): `gateway/platforms/telegram.py` +8, `tests/gateway/test_telegram_format.py` +41, `cli-config.yaml.example` +1
- **Our AUTHOR_MAP commit**: adds `20nik.nosov21@gmail.com` and `90299797+nik1t7n@users.noreply.github.com` → `nik1t7n`

## Test plan

- `bash scripts/run_tests.sh tests/gateway/test_telegram_format.py` → 90 passed
- Full telegram regression: 12 test files, 301 passed, 0 failed
- Ruff diff vs origin/main: All checks passed

## Closes

Closes #22264.

---

Credit to @nik1t7n (Nikita Nosov) for the fix.
