### PR TITLE
fix(gateway): treat home_channel: null as absent in PlatformConfig.from_dict

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -301,8 +301,9 @@ class PlatformConfig:
     @classmethod
     def from_dict(cls, data: Dict[str, Any]) -> "PlatformConfig":
         home_channel = None
-        if "home_channel" in data:
-            home_channel = HomeChannel.from_dict(data["home_channel"])
+        raw_home_channel = data.get("home_channel")
+        if raw_home_channel:
+            home_channel = HomeChannel.from_dict(raw_home_channel)
 
         return cls(
             enabled=_coerce_bool(data.get("enabled"), False),

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -70,6 +70,17 @@ class TestPlatformConfigRoundtrip:
         restored = PlatformConfig.from_dict({"gateway_restart_notification": "false"})
         assert restored.gateway_restart_notification is False
 
+    def test_from_dict_treats_explicit_null_home_channel_as_absent(self):
+        # YAML `home_channel: null` used to crash in HomeChannel.from_dict
+        # because the key was present so we tried to subscript None. (#13708)
+        restored = PlatformConfig.from_dict({"enabled": True, "home_channel": None})
+        assert restored.enabled is True
+        assert restored.home_channel is None
+
+    def test_from_dict_treats_empty_home_channel_dict_as_absent(self):
+        restored = PlatformConfig.from_dict({"enabled": True, "home_channel": {}})
+        assert restored.home_channel is None
+
 
 class TestGetConnectedPlatforms:
     def test_returns_enabled_with_token(self):


### PR DESCRIPTION
## Problem

`PlatformConfig.from_dict()` checked only whether `home_channel` was a key in the platform dict, then passed the value straight into `HomeChannel.from_dict()`. YAML `home_channel: null` — a common way to clear an inherited optional section — crashed with `TypeError: 'NoneType' object is not subscriptable`, breaking `load_gateway_config()` for otherwise valid configs.

```python
PlatformConfig.from_dict({"enabled": True, "home_channel": None})
# TypeError: 'NoneType' object is not subscriptable
```

## Root cause

Presence-only check ignored explicit `None` values:

```python
if "home_channel" in data:
    home_channel = HomeChannel.from_dict(data["home_channel"])
```

## Fix

Read with `.get()` and only descend when the value is truthy. Empty dict is also treated as absent for consistency with the previous absence-equivalence semantics.

## Tests

`TestPlatformConfigRoundtrip` gains:
- `test_from_dict_treats_explicit_null_home_channel_as_absent`
- `test_from_dict_treats_empty_home_channel_dict_as_absent`

Stash-verify confirmed `test_from_dict_treats_explicit_null_home_channel_as_absent` flips red without the fix (with the original `TypeError` from `HomeChannel.from_dict`).

Closes #13708