### PR TITLE
fix(cronjob): drop None entries from list-form deliver parameter

### DIFF
--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -310,3 +310,18 @@ class TestUnifiedCronjobTool:
         assert updated["success"] is True
         stored = get_job(created["job_id"])
         assert stored["deliver"] == "telegram"
+
+    def test_normalize_deliver_drops_none_entries(self):
+        """List entries that are None must be dropped, not stringified to 'None'.
+
+        JSON-deserialized payloads from MCP/web clients can include nulls
+        (``[null, "telegram"]``).  Before the fix, ``str(None).strip()`` was
+        ``"None"`` (truthy) and produced a malformed ``"None,telegram"`` value
+        that the scheduler then tried to dispatch as a delivery platform.
+        """
+        from tools.cronjob_tools import _normalize_deliver_param
+
+        assert _normalize_deliver_param([None, "telegram"]) == "telegram"
+        assert _normalize_deliver_param(["telegram", None, "discord"]) == "telegram,discord"
+        assert _normalize_deliver_param([None, None]) is None
+        assert _normalize_deliver_param([None]) is None

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -174,7 +174,7 @@ def _normalize_deliver_param(value: Any) -> Optional[str]:
     if value is None:
         return None
     if isinstance(value, (list, tuple)):
-        parts = [str(p).strip() for p in value if str(p).strip()]
+        parts = [str(p).strip() for p in value if p is not None and str(p).strip()]
         return ",".join(parts) if parts else None
     text = str(value).strip()
     return text or None


### PR DESCRIPTION
## What does this PR do?

When a caller (MCP client, JSON payload, etc.) supplies `deliver=[None, "telegram"]` or `deliver=[None]` to the unified `cronjob` create/update tool, the value stored on the job record becomes the malformed string `"None,telegram"` (or `"None"`). The cron scheduler then splits that on commas and tries to dispatch a delivery to a platform literally named `"None"`, which silently fails or spams logs.

## Root cause

When a caller (MCP client, JSON payload, etc.) supplies `deliver=[None, "telegram"]` or `deliver=[None]` to the unified `cronjob` create/update tool, the value stored on the job record becomes the malformed string `"None,telegram"` (or `"None"`). The cron scheduler then splits that on commas and tries to dispatch a delivery to a platform literally named `"None"`, which silently fails or spams logs.

## Fix

Add an explicit `p is not None` guard before the truthiness check. `None` entries are now dropped, an all-`None` list collapses to `None` (treated as "not supplied"), and lists like `["telegram", None, "discord"]` cleanly become `"telegram,discord"`.

```diff
-        parts = [str(p).strip() for p in value if str(p).strip()]
+        parts = [str(p).strip() for p in value if p is not None and str(p).strip()]
```

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

N/A

<details>
<summary>Original body</summary>

## Summary

When a caller (MCP client, JSON payload, etc.) supplies `deliver=[None, "telegram"]` or `deliver=[None]` to the unified `cronjob` create/update tool, the value stored on the job record becomes the malformed string `"None,telegram"` (or `"None"`). The cron scheduler then splits that on commas and tries to dispatch a delivery to a platform literally named `"None"`, which silently fails or spams logs.

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Problem

When a caller (MCP client, JSON payload, etc.) supplies `deliver=[None, "telegram"]` or `deliver=[None]` to the unified `cronjob` create/update tool, the value stored on the job record becomes the malformed string `"None,telegram"` (or `"None"`). The cron scheduler then splits that on commas and tries to dispatch a delivery to a platform literally named `"None"`, which silently fails or spams logs.

## Root cause

`tools.cronjob_tools._normalize_deliver_param` filtered list entries with `if str(p).strip()` — but `str(None) == "None"` is truthy, so `None` survived the filter and was joined into the canonical string.

## Fix

Add an explicit `p is not None` guard before the truthiness check. `None` entries are now dropped, an all-`None` list collapses to `None` (treated as "not supplied"), and lists like `["telegram", None, "discord"]` cleanly become `"telegram,discord"`.

```diff
-        parts = [str(p).strip() for p in value if str(p).strip()]
+        parts = [str(p).strip() for p in value if p is not None and str(p).strip()]
```

## Tests

`tests/tools/test_cronjob_tools.py::TestUnifiedCronjobTool::test_normalize_deliver_drops_none_entries` exercises the four relevant shapes (`[None, str]`, `[str, None, str]`, `[None, None]`, `[None]`) and was confirmed to fail on `main` before the one-line fix:

```
AssertionError: assert 'None,telegram' == 'telegram'
```

Local regression on the impacted suite (`tests/tools/test_cronjob_tools.py`) is green: 30 passed.

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_