### PR TITLE
fix(cronjob): drop None entries from deliver list before joining

### DIFF
--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -310,3 +310,18 @@ class TestUnifiedCronjobTool:
         assert updated["success"] is True
         stored = get_job(created["job_id"])
         assert stored["deliver"] == "telegram"
+
+    def test_normalize_deliver_drops_none_entries(self):
+        """List entries that are None must be dropped, not stringified to 'None'.
+
+        JSON-deserialized payloads from MCP/web clients can include nulls
+        (``[null, "telegram"]``).  Before the fix, ``str(None).strip()`` was
+        ``"None"`` (truthy) and produced a malformed ``"None,telegram"`` value
+        that the scheduler then tried to dispatch as a delivery platform.
+        """
+        from tools.cronjob_tools import _normalize_deliver_param
+
+        assert _normalize_deliver_param([None, "telegram"]) == "telegram"
+        assert _normalize_deliver_param(["telegram", None, "discord"]) == "telegram,discord"
+        assert _normalize_deliver_param([None, None]) is None
+        assert _normalize_deliver_param([None]) is None

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -174,7 +174,7 @@ def _normalize_deliver_param(value: Any) -> Optional[str]:
     if value is None:
         return None
     if isinstance(value, (list, tuple)):
-        parts = [str(p).strip() for p in value if str(p).strip()]
+        parts = [str(p).strip() for p in value if p is not None and str(p).strip()]
         return ",".join(parts) if parts else None
     text = str(value).strip()
     return text or None


### PR DESCRIPTION
## Problem

`_normalize_deliver_param([None, \"telegram\"])` returned `\"None,telegram\"` instead of `\"telegram\"`. JSON-deserialized payloads from MCP / web clients can include explicit nulls; `str(None).strip()` yielded the truthy string `\"None\"`, which the scheduler later tried to dispatch as a delivery platform.

## Root cause

The list comprehension stringified each element *before* testing truthiness, so `None` survived as the literal string `\"None\"`.

```python
parts = [str(p).strip() for p in value if str(p).strip()]
```

## Fix

Skip `None` entries before stringifying:

```python
parts = [str(p).strip() for p in value if p is not None and str(p).strip()]
```

## Tests

`test_normalize_deliver_drops_none_entries` covers:
- `[None, \"telegram\"]` → `\"telegram\"`
- `[\"telegram\", None, \"discord\"]` → `\"telegram,discord\"`
- `[None, None]` → `None`
- `[None]` → `None`

Stash-verify confirmed the new test flips red without the fix.