### PR TITLE
fix(skills): drop None entries and strip whitespace in prerequisite normalisation

### DIFF
--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -160,6 +160,25 @@ class TestRequiredEnvironmentVariablesNormalization:
             }
         ]
 
+    def test_normalize_prerequisite_values_drops_none_and_strips(self):
+        """``None`` entries and surrounding whitespace must not survive normalisation.
+
+        YAML parsers commonly produce ``None`` for empty list items
+        (``env_vars: [FOO, , BAR]``) and editors leave incidental
+        whitespace.  Before the fix, ``str(None) == "None"`` (truthy) was
+        kept verbatim and ``str(item)`` was not stripped, so the agent
+        ended up trying to satisfy a prerequisite literally named
+        ``"None"`` or ``"  TENOR_API_KEY "``.
+        """
+        from tools.skills_tool import _normalize_prerequisite_values
+
+        assert _normalize_prerequisite_values([None, "FOO"]) == ["FOO"]
+        assert _normalize_prerequisite_values(["FOO", None, "BAR"]) == ["FOO", "BAR"]
+        assert _normalize_prerequisite_values([None]) == []
+        assert _normalize_prerequisite_values(["  FOO  "]) == ["FOO"]
+        assert _normalize_prerequisite_values(None) == []
+        assert _normalize_prerequisite_values("BAR") == ["BAR"]
+
     def test_empty_env_file_value_is_treated_as_missing(self, monkeypatch):
         monkeypatch.setenv("FILLED_KEY", "value")
         monkeypatch.setenv("EMPTY_HOST_KEY", "")

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -163,7 +163,7 @@ def _normalize_prerequisite_values(value: Any) -> List[str]:
         return []
     if isinstance(value, str):
         value = [value]
-    return [str(item) for item in value if str(item).strip()]
+    return [str(item).strip() for item in value if item is not None and str(item).strip()]
 
 
 def _collect_prerequisite_values(


### PR DESCRIPTION
## What does this PR do?

\`tools.skills_tool._normalize_prerequisite_values\` is the single boundary helper that flattens a skill's \`prerequisites.env_vars\` and \`prerequisites.commands\` frontmatter into a list of identifier strings. YAML parsers commonly produce \`None\` for empty list items (\`env_vars: [FOO, , BAR]\`) and editors leave incidental whitespace. The current implementation passed both through:

## Root cause

\`tools.skills_tool._normalize_prerequisite_values\` is the single boundary helper that flattens a skill's \`prerequisites.env_vars\` and \`prerequisites.commands\` frontmatter into a list of identifier strings. YAML parsers commonly produce \`None\` for empty list items (\`env_vars: [FOO, , BAR]\`) and editors leave incidental whitespace. The current implementation passed both through:

* \`None\` survived the truthiness filter because \`str(None) == "None"\` is truthy, so the agent then tried to satisfy a prerequisite literally named \`"None"\`.
* \`str(item)\` was not stripped, so leading/trailing whitespace ended up in the canonical identifier (\`"  TENOR_API_KEY "\`), breaking env-var…

## Fix

\`\`\`diff
-    return [str(item) for item in value if str(item).strip()]
+    return [str(item).strip() for item in value if item is not None and str(item).strip()]
\`\`\`

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

N/A

<details>
<summary>Original body</summary>

## Summary

\`tools.skills_tool._normalize_prerequisite_values\` is the single boundary helper that flattens a skill's \`prerequisites.env_vars\` and \`prerequisites.commands\` frontmatter into a list of identifier strings. YAML parsers commonly produce \`None\` for empty list items (\`env_vars: [FOO, , BAR]\`) and editors leave incidental whitespace. The current implementation passed both through:

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Problem

\`tools.skills_tool._normalize_prerequisite_values\` is the single boundary helper that flattens a skill's \`prerequisites.env_vars\` and \`prerequisites.commands\` frontmatter into a list of identifier strings. YAML parsers commonly produce \`None\` for empty list items (\`env_vars: [FOO, , BAR]\`) and editors leave incidental whitespace. The current implementation passed both through:

* \`None\` survived the truthiness filter because \`str(None) == "None"\` is truthy, so the agent then tried to satisfy a prerequisite literally named \`"None"\`.
* \`str(item)\` was not stripped, so leading/trailing whitespace ended up in the canonical identifier (\`"  TENOR_API_KEY "\`), breaking env-var lookups and command discovery.

## Root cause

\`\`\`python
return [str(item) for item in value if str(item).strip()]
\`\`\`

\`None\` is truthy under \`str()\`, and the value placed into the list is unstripped.

## Fix

\`\`\`diff
-    return [str(item) for item in value if str(item).strip()]
+    return [str(item).strip() for item in value if item is not None and str(item).strip()]
\`\`\`

## Tests

\`tests/tools/test_skills_tool.py::TestRequiredEnvironmentVariablesNormalization::test_normalize_prerequisite_values_drops_none_and_strips\` covers \`[None, str]\`, \`[str, None, str]\`, \`[None]\`, whitespace padding, \`None\` input, and bare-string input. Confirmed to fail on main before the fix:

\`\`\`
AssertionError: assert ['None', 'FOO'] == ['FOO']
\`\`\`

Local regression on the impacted suites is green: 159 passed across \`test_skills_tool\`, \`test_skill_improvements\`, \`test_skill_size_limits\`, \`test_skills_guard\`.

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_