### PR TITLE
fix(osv-check): treat trailing '@' in npm token as no version

### DIFF
--- a/tests/tools/test_osv_check.py
+++ b/tests/tools/test_osv_check.py
@@ -50,6 +50,14 @@ class TestParseNpmPackage:
     def test_latest_ignored(self):
         assert _parse_npm_package("react@latest") == ("react", None)
 
+    def test_trailing_at_no_version(self):
+        """Trailing '@' with no version is treated as no version specified.
+
+        Regression: prior behaviour returned ``('react', '')`` which then
+        propagated an empty string into the OSV query payload.
+        """
+        assert _parse_npm_package("react@") == ("react", None)
+
 
 class TestParsePypiPackage:
     def test_simple(self):

--- a/tools/osv_check.py
+++ b/tools/osv_check.py
@@ -114,7 +114,8 @@ def _parse_npm_package(token: str) -> Tuple[Optional[str], Optional[str]]:
     if "@" in token:
         parts = token.rsplit("@", 1)
         name = parts[0]
-        version = parts[1] if len(parts) > 1 and parts[1] != "latest" else None
+        raw_version = parts[1] if len(parts) > 1 else ""
+        version = raw_version if raw_version and raw_version != "latest" else None
         return name, version
     return token, None
 


### PR DESCRIPTION
## What does this PR do?

For an npm token like `react@` (trailing `@` with no version), `_parse_npm_package` returned `("react", "")` instead of `("react", None)`.

## Root cause

For an npm token like `react@` (trailing `@` with no version),
`_parse_npm_package` returned `("react", "")` instead of `("react", None)`.

The empty string is falsy, so the downstream `_query_osv` happens to skip
the `version` field — but the parser's return contract is
`Optional[str]`, and any call site that distinguishes "unpinned" via
`is None` would mis-classify the package.

## Fix

Treat any falsy version (empty string) the same as `"latest"` — return
`None`. Surgical change inside the unscoped branch only; the scoped
branch (regex-based) and the PyPI parser are unaffected.

```python
raw_version = parts[1] if len(parts) > 1 else ""
version = raw_version if raw_version and raw_version != "latest" else None
```

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

N/A

<details>
<summary>Original body</summary>

## Summary

For an npm token like `react@` (trailing `@` with no version), `_parse_npm_package` returned `("react", "")` instead of `("react", None)`.

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Problem

For an npm token like `react@` (trailing `@` with no version),
`_parse_npm_package` returned `("react", "")` instead of `("react", None)`.

The empty string is falsy, so the downstream `_query_osv` happens to skip
the `version` field — but the parser's return contract is
`Optional[str]`, and any call site that distinguishes "unpinned" via
`is None` would mis-classify the package.

## Root cause

`tools/osv_check.py:117`

```python
version = parts[1] if len(parts) > 1 and parts[1] != "latest" else None
```

Only the literal token `"latest"` was filtered; an empty version string
was returned verbatim.

## Fix

Treat any falsy version (empty string) the same as `"latest"` — return
`None`. Surgical change inside the unscoped branch only; the scoped
branch (regex-based) and the PyPI parser are unaffected.

```python
raw_version = parts[1] if len(parts) > 1 else ""
version = raw_version if raw_version and raw_version != "latest" else None
```

## Tests

Added `TestParseNpmPackage::test_trailing_at_no_version` covering the
`"react@"` case. Stash-verified the test is red without the fix.

Full `tests/tools/test_osv_check.py` suite passes (25/25).

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_