### PR TITLE
fix(browser_tool): do not cache transient None cloud provider resolution

### DIFF
--- a/tests/tools/test_browser_cloud_provider_cache.py
+++ b/tests/tools/test_browser_cloud_provider_cache.py
@@ -1,0 +1,125 @@
+"""Tests for ``_get_cloud_provider()`` caching policy.
+
+Regression coverage for issue #22324: a transient ``None`` from the resolver
+must not be cached for the lifetime of the process. Cache only when:
+
+* The user explicitly opts in to ``cloud_provider: local``, OR
+* A provider is successfully resolved.
+
+All other ``None`` outcomes (no credentials yet, config read error, explicit
+provider instantiation failure) leave the cache unset so the next call retries.
+"""
+import logging
+from unittest.mock import Mock, patch
+
+import pytest
+
+import tools.browser_tool as browser_tool
+
+
+@pytest.fixture(autouse=True)
+def _reset_resolver_state(monkeypatch):
+    monkeypatch.setattr(browser_tool, "_cached_cloud_provider", None)
+    monkeypatch.setattr(browser_tool, "_cloud_provider_resolved", False)
+    yield
+
+
+class TestCloudProviderCachePolicy:
+    def test_explicit_local_caches_permanently(self, monkeypatch):
+        """`cloud_provider: local` is a positive choice and must stick."""
+        monkeypatch.setattr(
+            "hermes_cli.config.read_raw_config",
+            lambda: {"browser": {"cloud_provider": "local"}},
+        )
+
+        assert browser_tool._get_cloud_provider() is None
+        assert browser_tool._cloud_provider_resolved is True
+
+        # Even if config later changes, the cache stays.
+        monkeypatch.setattr(
+            "hermes_cli.config.read_raw_config",
+            lambda: {"browser": {"cloud_provider": "browser-use"}},
+        )
+        assert browser_tool._get_cloud_provider() is None
+
+    def test_successful_cloud_resolution_caches_permanently(self, monkeypatch):
+        """A real provider instance must be cached and reused."""
+        fake_provider = Mock(name="BrowserUseProvider-instance")
+        factory = Mock(return_value=fake_provider)
+        monkeypatch.setattr(
+            browser_tool, "_PROVIDER_REGISTRY", {"browser-use": factory}
+        )
+        monkeypatch.setattr(
+            "hermes_cli.config.read_raw_config",
+            lambda: {"browser": {"cloud_provider": "browser-use"}},
+        )
+
+        assert browser_tool._get_cloud_provider() is fake_provider
+        assert browser_tool._cloud_provider_resolved is True
+
+        # Subsequent calls hit the cache; factory not called again.
+        assert browser_tool._get_cloud_provider() is fake_provider
+        assert factory.call_count == 1
+
+    def test_no_credentials_yet_does_not_cache_none(self, monkeypatch):
+        """Auto-detect path with no creds: must NOT poison the cache."""
+        monkeypatch.setattr(
+            "hermes_cli.config.read_raw_config",
+            lambda: {"browser": {}},
+        )
+
+        bu_unconfigured = Mock()
+        bu_unconfigured.is_configured.return_value = False
+        bb_unconfigured = Mock()
+        bb_unconfigured.is_configured.return_value = False
+        monkeypatch.setattr(
+            browser_tool, "BrowserUseProvider", lambda: bu_unconfigured
+        )
+        monkeypatch.setattr(
+            browser_tool, "BrowserbaseProvider", lambda: bb_unconfigured
+        )
+
+        assert browser_tool._get_cloud_provider() is None
+        assert browser_tool._cloud_provider_resolved is False
+
+        # Credentials self-heal — next call must retry and pick up the provider.
+        healed = Mock(name="healed-provider")
+        healed.is_configured.return_value = True
+        monkeypatch.setattr(browser_tool, "BrowserUseProvider", lambda: healed)
+
+        assert browser_tool._get_cloud_provider() is healed
+        assert browser_tool._cloud_provider_resolved is True
+
+    def test_config_read_failure_does_not_cache_none(self, monkeypatch):
+        """A raised config read must not pin the resolver to local mode."""
+        def boom():
+            raise OSError("config file locked")
+
+        monkeypatch.setattr("hermes_cli.config.read_raw_config", boom)
+
+        assert browser_tool._get_cloud_provider() is None
+        assert browser_tool._cloud_provider_resolved is False
+
+    def test_explicit_provider_instantiation_failure_does_not_cache(
+        self, monkeypatch, caplog
+    ):
+        """If `_PROVIDER_REGISTRY[key]()` raises, log warning and don't cache."""
+        def exploding_factory():
+            raise RuntimeError("missing dependency")
+
+        monkeypatch.setattr(
+            browser_tool, "_PROVIDER_REGISTRY", {"browser-use": exploding_factory}
+        )
+        monkeypatch.setattr(
+            "hermes_cli.config.read_raw_config",
+            lambda: {"browser": {"cloud_provider": "browser-use"}},
+        )
+
+        with caplog.at_level(logging.WARNING, logger="tools.browser_tool"):
+            assert browser_tool._get_cloud_provider() is None
+
+        assert browser_tool._cloud_provider_resolved is False
+        assert any(
+            "browser-use" in r.message and r.levelno == logging.WARNING
+            for r in caplog.records
+        )

--- a/tests/tools/test_browser_cloud_provider_cache.py
+++ b/tests/tools/test_browser_cloud_provider_cache.py
@@ -10,7 +10,7 @@ All other ``None`` outcomes (no credentials yet, config read error, explicit
 provider instantiation failure) leave the cache unset so the next call retries.
 """
 import logging
-from unittest.mock import Mock, patch
+from unittest.mock import Mock
 
 import pytest
 

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -422,7 +422,7 @@ def _get_cloud_provider() -> Optional[CloudBrowserProvider]:
     if _cloud_provider_resolved:
         return _cached_cloud_provider
 
-    _cloud_provider_resolved = True
+    resolved: Optional[CloudBrowserProvider] = None
     try:
         from hermes_cli.config import read_raw_config
         cfg = read_raw_config()
@@ -434,23 +434,39 @@ def _get_cloud_provider() -> Optional[CloudBrowserProvider]:
             )
             if provider_key == "local":
                 _cached_cloud_provider = None
+                _cloud_provider_resolved = True
                 return None
         if provider_key and provider_key in _PROVIDER_REGISTRY:
-            _cached_cloud_provider = _PROVIDER_REGISTRY[provider_key]()
+            try:
+                resolved = _PROVIDER_REGISTRY[provider_key]()
+            except Exception:
+                logger.warning(
+                    "Failed to instantiate explicit cloud_provider %r; will retry on next call",
+                    provider_key,
+                    exc_info=True,
+                )
+                return None
     except Exception as e:
         logger.debug("Could not read cloud_provider from config: %s", e)
+        return None
 
-    if _cached_cloud_provider is None:
+    if resolved is None:
         # Prefer Browser Use (managed Nous gateway or direct API key),
         # fall back to Browserbase (direct credentials only).
         fallback_provider = BrowserUseProvider()
         if fallback_provider.is_configured():
-            _cached_cloud_provider = fallback_provider
+            resolved = fallback_provider
         else:
             fallback_provider = BrowserbaseProvider()
             if fallback_provider.is_configured():
-                _cached_cloud_provider = fallback_provider
+                resolved = fallback_provider
 
+    if resolved is None:
+        # Transient None — credentials may self-heal. Don't poison the cache.
+        return None
+
+    _cached_cloud_provider = resolved
+    _cloud_provider_resolved = True
     return _cached_cloud_provider
 
 

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -447,19 +447,24 @@ def _get_cloud_provider() -> Optional[CloudBrowserProvider]:
                 )
                 return None
     except Exception as e:
+        # Config file may be temporarily unreadable; still try auto-detect so
+        # env-based / managed-gateway credentials can resolve. Don't pin cache.
         logger.debug("Could not read cloud_provider from config: %s", e)
-        return None
 
     if resolved is None:
         # Prefer Browser Use (managed Nous gateway or direct API key),
         # fall back to Browserbase (direct credentials only).
-        fallback_provider = BrowserUseProvider()
-        if fallback_provider.is_configured():
-            resolved = fallback_provider
-        else:
-            fallback_provider = BrowserbaseProvider()
+        try:
+            fallback_provider = BrowserUseProvider()
             if fallback_provider.is_configured():
                 resolved = fallback_provider
+            else:
+                fallback_provider = BrowserbaseProvider()
+                if fallback_provider.is_configured():
+                    resolved = fallback_provider
+        except Exception:  # pragma: no cover - defensive: never poison cache
+            logger.debug("Cloud provider auto-detect failed", exc_info=True)
+            return None
 
     if resolved is None:
         # Transient None — credentials may self-heal. Don't poison the cache.


### PR DESCRIPTION
## Problem

`_get_cloud_provider()` in `tools/browser_tool.py` caches a transient `None` for the entire process lifetime. If credentials are briefly unavailable on the first browser call (managed Nous Portal access token mid-refresh, config read raises, explicit provider's `__init__` momentarily fails), the resolver pins the gateway to local mode forever, even after credentials self-heal seconds later.

This regresses #10883: that issue's PR added runtime fallback in `_get_session_info()`, but the resolver itself still poisons its own cache up front.

## Root cause

`_cloud_provider_resolved = True` was set **before** resolution. Every fall-through path returned `_cached_cloud_provider` (still `None`) and the flag was already sticky.

## Fix

Invert the bookkeeping. The cache flag is now set only when:

- The user explicitly chose `cloud_provider: local` (a positive opt-in), or
- A provider was successfully resolved (registry hit or auto-detect found credentials).

All transient `None` paths return without setting the flag, so the next call retries. Explicit-provider instantiation failures are now logged at `warning` level with `exc_info=True` so operators can see why their config didn't take effect.

## Tests

5 new cases in `tests/tools/test_browser_cloud_provider_cache.py`:

- `test_explicit_local_caches_permanently` — regression guard for the explicit case
- `test_successful_cloud_resolution_caches_permanently` — happy path
- `test_no_credentials_yet_does_not_cache_none` — primary regression guard for #22324
- `test_config_read_failure_does_not_cache_none`
- `test_explicit_provider_instantiation_failure_does_not_cache`

Stash-verify confirmed the 3 transient-`None` tests fail on `main` and pass with the fix. All 320 existing browser tests in `tests/tools/` still green.

Closes #22324