### PR TITLE
fix(gateway): adopt unit's HERMES_HOME for --system CLI ops

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -635,6 +635,66 @@ def _probe_systemd_service_running(system: bool = False) -> tuple[bool, bool]:
     return selected_system, result.stdout.strip() == "active"
 
 
+def _read_systemd_unit_environment(system: bool = False) -> dict[str, str]:
+    """Parse the gateway unit's ``Environment=`` directives.
+
+    ``systemctl show -p Environment`` returns a single line of
+    space-separated ``KEY=VALUE`` pairs; values are not quoted in the output
+    even when the unit file quoted them. We split on whitespace and ``=``.
+    """
+    selected_system = _select_systemd_scope(system)
+    try:
+        result = _run_systemctl(
+            [
+                "show",
+                get_service_name(),
+                "--no-pager",
+                "--property",
+                "Environment",
+            ],
+            system=selected_system,
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (RuntimeError, subprocess.TimeoutExpired, OSError):
+        return {}
+    if result.returncode != 0:
+        return {}
+    parsed: dict[str, str] = {}
+    for line in result.stdout.splitlines():
+        if not line.startswith("Environment="):
+            continue
+        body = line[len("Environment="):].strip()
+        for token in body.split():
+            if "=" not in token:
+                continue
+            key, value = token.split("=", 1)
+            parsed[key] = value
+    return parsed
+
+
+def _sync_hermes_home_from_systemd_unit(system: bool) -> None:
+    """When acting on a system-scope unit, adopt its ``HERMES_HOME``.
+
+    Under ``sudo``, ``HERMES_HOME`` is stripped and ``HOME=/root``, so
+    :func:`get_hermes_home` falls back to ``/root/.hermes`` — the wrong
+    profile. The unit file pins ``HERMES_HOME`` for the actual gateway
+    process, so we mirror that into our own environment to make
+    ``read_runtime_status`` / ``get_running_pid`` read the correct files.
+    """
+    if not system:
+        return
+    env = _read_systemd_unit_environment(system=True)
+    unit_home = env.get("HERMES_HOME", "").strip()
+    if not unit_home:
+        return
+    current = os.environ.get("HERMES_HOME", "").strip()
+    if current == unit_home:
+        return
+    os.environ["HERMES_HOME"] = unit_home
+
+
 def _read_systemd_unit_properties(
     system: bool = False,
     properties: tuple[str, ...] = (
@@ -2380,6 +2440,7 @@ def systemd_stop(system: bool = False):
     if system:
         _require_root_for_system_service("stop")
     _require_service_installed("stop", system=system)
+    _sync_hermes_home_from_systemd_unit(system=system)
     try:
         from gateway.status import get_running_pid, write_planned_stop_marker
         pid = get_running_pid(cleanup_stale=False)
@@ -2408,6 +2469,7 @@ def systemd_restart(system: bool = False):
         _preflight_user_systemd()
     _require_service_installed("restart", system=system)
     refresh_systemd_unit_if_needed(system=system)
+    _sync_hermes_home_from_systemd_unit(system=system)
     from gateway.status import get_running_pid
 
     pid = get_running_pid() or _systemd_main_pid(system=system)
@@ -2502,6 +2564,8 @@ def systemd_status(deep: bool = False, system: bool = False, full: bool = False)
         print("✗ Gateway service is not installed")
         print(f"  Run: {'sudo ' if system else ''}hermes gateway install{scope_flag}")
         return
+
+    _sync_hermes_home_from_systemd_unit(system=system)
 
     if has_conflicting_systemd_units():
         print_systemd_scope_conflict_warning()


### PR DESCRIPTION
> **Authorship & review disclaimer**
>
> This patch was authored by Claude (Opus) under the guidance of @mbac. @mbac is not proficient in coding and cannot personally attest to the quality or safety of this code. Reviewers, please review carefully.

## What does this PR do?

Fixes the bug reported in #22035: `sudo hermes gateway restart [--system]` always reports "did not become active within 60s" (twice, ~245s total) even though the gateway restarts successfully.

Root cause: under `sudo`, `HERMES_HOME` is stripped and `HOME=/root`, so `get_hermes_home()` falls back to `/root/.hermes`. The wait loop in `_wait_for_systemd_service_restart` reads `gateway_state.json` from the wrong path, never observes `gateway_state == "running"`, and hits the 60s timeout. The forced fallback then SIGTERMs the in-progress new instance.

The installed unit already pins `Environment="HERMES_HOME=…"`, so we recover the correct path from the unit definition (`systemctl show -p Environment`) and mirror it into `os.environ` before any status read. This implements **Option 1** from the issue's "Proposed Fix" section.

## Related Issue

Fixes #22035

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

All in `hermes_cli/gateway.py`:

- New `_read_systemd_unit_environment(system)` helper — parses the unit's `Environment=` line via `systemctl show`.
- New `_sync_hermes_home_from_systemd_unit(system)` helper — when `system=True`, mirrors the unit's `HERMES_HOME` into `os.environ` if missing or different. No-op for user-scope units (they already inherit the user's env).
- Call site added at the start of `systemd_restart` (after `_require_service_installed`), `systemd_status` (after the unit-existence check), and `systemd_stop` (before the `get_running_pid` / `write_planned_stop_marker` block). These are the `--system` entrypoints that subsequently read PID or runtime-status files derived from `HERMES_HOME`.

## How to Test

Reproduction (from #22035):

1. `sudo hermes gateway install --system --run-as-user $USER`
2. `sudo hermes gateway start --system`
3. Wait until `~/.hermes/gateway_state.json` shows `"gateway_state":"running"`.
4. `sudo hermes gateway restart --system`

Before this patch: ~245s, two `did not become active within 60s` warnings, forced fallback SIGTERMs the new instance.

After this patch (verified on Ubuntu against this PR's branch on a system service running as a non-root user):

```
$ sudo hermes gateway restart
⏳ System service restarting gracefully (PID 654313)...
⏳ System service process started (PID 685819); waiting for gateway runtime...
✓ System service restarted (PID 685819)
```

A direct probe confirms the env sync produces the correct path resolution under sudo:

```python
# Before sync: hermes_home = /root/.hermes; read_runtime_status() = None
# After sync:  hermes_home = /home/<user>/.hermes; gateway_state = "running"
```

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(gateway): …`)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass — **not run by the author; reviewers please verify**
- [ ] I've added tests for my changes — **no new tests added; the fix is small and the failure mode requires a privileged systemd-level setup that's awkward to fixture. Happy to add a unit test for `_read_systemd_unit_environment` parsing if reviewers want one.**
- [x] I've tested on my platform: Ubuntu 24.04 (system-scope service, non-root run-as user)

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (no user-visible config/docs change)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (the bug and fix are systemd-specific; helpers are guarded by `system=True` and only run when an existing systemd code path executes; macOS/Windows paths unaffected)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A