### PR TITLE
fix(voice): honor PULSE_SERVER/PIPEWIRE_REMOTE inside Docker (#21203)

### DIFF
--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -232,7 +232,7 @@ class TestDetectAudioEnvironment:
 
         assert result["available"] is True
         assert result["warnings"] == []
-        assert any("Docker" in n for n in result.get("notices", []))
+        assert any("container" in n.lower() for n in result.get("notices", []))
 
     def test_docker_with_pipewire_remote_allows_voice(self, monkeypatch):
         """Docker with PIPEWIRE_REMOTE set should NOT block voice mode (#21203)."""
@@ -250,7 +250,7 @@ class TestDetectAudioEnvironment:
 
         assert result["available"] is True
         assert result["warnings"] == []
-        assert any("Docker" in n for n in result.get("notices", []))
+        assert any("container" in n.lower() for n in result.get("notices", []))
 
     def test_docker_without_audio_forwarding_blocks_voice(self, monkeypatch):
         """Docker without PULSE_SERVER/PIPEWIRE_REMOTE keeps blocking voice mode."""
@@ -267,7 +267,7 @@ class TestDetectAudioEnvironment:
         result = detect_audio_environment()
 
         assert result["available"] is False
-        assert any("Docker" in w for w in result["warnings"])
+        assert any("container" in w.lower() for w in result["warnings"])
         assert any("PULSE_SERVER" in w or "PIPEWIRE_REMOTE" in w for w in result["warnings"])
 
     def test_termux_api_microphone_allows_voice_without_sounddevice(self, monkeypatch):

--- a/tests/tools/test_voice_mode.py
+++ b/tests/tools/test_voice_mode.py
@@ -216,6 +216,60 @@ class TestDetectAudioEnvironment:
         assert any("Termux:API Android app is not installed" in w for w in result["warnings"])
 
 
+    def test_docker_with_pulse_server_allows_voice(self, monkeypatch):
+        """Docker with PULSE_SERVER set should NOT block voice mode (#21203)."""
+        monkeypatch.delenv("SSH_CLIENT", raising=False)
+        monkeypatch.delenv("SSH_TTY", raising=False)
+        monkeypatch.delenv("SSH_CONNECTION", raising=False)
+        monkeypatch.setenv("PULSE_SERVER", "unix:/run/user/1000/pulse/native")
+        monkeypatch.delenv("PIPEWIRE_REMOTE", raising=False)
+        monkeypatch.setattr("hermes_constants.is_container", lambda: True)
+        monkeypatch.setattr("tools.voice_mode._import_audio",
+                            lambda: (MagicMock(), MagicMock()))
+
+        from tools.voice_mode import detect_audio_environment
+        result = detect_audio_environment()
+
+        assert result["available"] is True
+        assert result["warnings"] == []
+        assert any("Docker" in n for n in result.get("notices", []))
+
+    def test_docker_with_pipewire_remote_allows_voice(self, monkeypatch):
+        """Docker with PIPEWIRE_REMOTE set should NOT block voice mode (#21203)."""
+        monkeypatch.delenv("SSH_CLIENT", raising=False)
+        monkeypatch.delenv("SSH_TTY", raising=False)
+        monkeypatch.delenv("SSH_CONNECTION", raising=False)
+        monkeypatch.delenv("PULSE_SERVER", raising=False)
+        monkeypatch.setenv("PIPEWIRE_REMOTE", "/run/user/1000/pipewire-0")
+        monkeypatch.setattr("hermes_constants.is_container", lambda: True)
+        monkeypatch.setattr("tools.voice_mode._import_audio",
+                            lambda: (MagicMock(), MagicMock()))
+
+        from tools.voice_mode import detect_audio_environment
+        result = detect_audio_environment()
+
+        assert result["available"] is True
+        assert result["warnings"] == []
+        assert any("Docker" in n for n in result.get("notices", []))
+
+    def test_docker_without_audio_forwarding_blocks_voice(self, monkeypatch):
+        """Docker without PULSE_SERVER/PIPEWIRE_REMOTE keeps blocking voice mode."""
+        monkeypatch.delenv("SSH_CLIENT", raising=False)
+        monkeypatch.delenv("SSH_TTY", raising=False)
+        monkeypatch.delenv("SSH_CONNECTION", raising=False)
+        monkeypatch.delenv("PULSE_SERVER", raising=False)
+        monkeypatch.delenv("PIPEWIRE_REMOTE", raising=False)
+        monkeypatch.setattr("hermes_constants.is_container", lambda: True)
+        monkeypatch.setattr("tools.voice_mode._import_audio",
+                            lambda: (MagicMock(), MagicMock()))
+
+        from tools.voice_mode import detect_audio_environment
+        result = detect_audio_environment()
+
+        assert result["available"] is False
+        assert any("Docker" in w for w in result["warnings"])
+        assert any("PULSE_SERVER" in w or "PIPEWIRE_REMOTE" in w for w in result["warnings"])
+
     def test_termux_api_microphone_allows_voice_without_sounddevice(self, monkeypatch):
         monkeypatch.setenv("TERMUX_VERSION", "0.118.3")
         monkeypatch.setenv("PREFIX", "/data/data/com.termux/files/usr")

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -102,10 +102,22 @@ def detect_audio_environment() -> dict:
     if any(os.environ.get(v) for v in ('SSH_CLIENT', 'SSH_TTY', 'SSH_CONNECTION')):
         warnings.append("Running over SSH -- no audio devices available")
 
-    # Docker/Podman container detection
+    # Docker/Podman container detection — honor host audio forwarding.
+    # When the user mounts a PulseAudio/PipeWire socket into the container
+    # and points PULSE_SERVER / PIPEWIRE_REMOTE at it, audio works fine
+    # (issue #21203).  Only block when no forwarding is configured.
     from hermes_constants import is_container
     if is_container():
-        warnings.append("Running inside Docker container -- no audio devices")
+        if os.environ.get('PULSE_SERVER') or os.environ.get('PIPEWIRE_REMOTE'):
+            notices.append("Running inside Docker container with host audio forwarding")
+        else:
+            warnings.append(
+                "Running inside Docker container -- no audio devices.\n"
+                "  Forward host audio with one of:\n"
+                "    PulseAudio:  -v /run/user/1000/pulse/native:/run/user/1000/pulse/native \\\n"
+                "                 -e PULSE_SERVER=unix:/run/user/1000/pulse/native\n"
+                "    PipeWire:    -e PIPEWIRE_REMOTE=/run/user/1000/pipewire-0"
+            )
 
     # WSL detection — PulseAudio bridge makes audio work in WSL.
     # Only block if PULSE_SERVER is not configured.

--- a/tools/voice_mode.py
+++ b/tools/voice_mode.py
@@ -109,14 +109,15 @@ def detect_audio_environment() -> dict:
     from hermes_constants import is_container
     if is_container():
         if os.environ.get('PULSE_SERVER') or os.environ.get('PIPEWIRE_REMOTE'):
-            notices.append("Running inside Docker container with host audio forwarding")
+            notices.append("Running inside container (Docker/Podman/LXC) with host audio forwarding")
         else:
             warnings.append(
-                "Running inside Docker container -- no audio devices.\n"
-                "  Forward host audio with one of:\n"
-                "    PulseAudio:  -v /run/user/1000/pulse/native:/run/user/1000/pulse/native \\\n"
-                "                 -e PULSE_SERVER=unix:/run/user/1000/pulse/native\n"
-                "    PipeWire:    -e PIPEWIRE_REMOTE=/run/user/1000/pipewire-0"
+                "Running inside container (Docker/Podman/LXC) -- no audio devices.\n"
+                "  Forward host audio with one of (substitute $XDG_RUNTIME_DIR for your runtime dir,\n"
+                "  typically /run/user/$UID):\n"
+                "    PulseAudio:  -v $XDG_RUNTIME_DIR/pulse/native:$XDG_RUNTIME_DIR/pulse/native \\\n"
+                "                 -e PULSE_SERVER=unix:$XDG_RUNTIME_DIR/pulse/native\n"
+                "    PipeWire:    -e PIPEWIRE_REMOTE=$XDG_RUNTIME_DIR/pipewire-0"
             )
 
     # WSL detection — PulseAudio bridge makes audio work in WSL.


### PR DESCRIPTION
## What does this PR do?

`detect_audio_environment()` unconditionally added a hard warning when running inside a Docker/Podman container, blocking `/voice on` even when the host PulseAudio/PipeWire socket was correctly mounted and `sounddevice` could enumerate devices (issue #21203).

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

Mirror the existing WSL/PulseAudio handling at `tools/voice_mode.py:110-125`:

- If `is_container()` **and** `PULSE_SERVER` or `PIPEWIRE_REMOTE` is set → downgrade to an informational `notices` entry (does not block voice).
- If `is_container()` **and** neither is set → keep the hard block, but extend the message with the exact `-v` / `-e` flags users need.

No public surface changes. `detect_audio_environment()` still returns `{available, warnings, notices}`.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

Closes #21203

<details>
<summary>Original body</summary>

## Summary

`detect_audio_environment()` unconditionally added a hard warning when running inside a Docker/Podman container, blocking `/voice on` even when the host PulseAudio/PipeWire socket was correctly mounted and `sounddevice` could enumerate devices (issue #21203).

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Summary

`detect_audio_environment()` unconditionally added a hard warning when running inside a Docker/Podman container, blocking `/voice on` even when the host PulseAudio/PipeWire socket was correctly mounted and `sounddevice` could enumerate devices (issue #21203).

## Fix

Mirror the existing WSL/PulseAudio handling at `tools/voice_mode.py:110-125`:

- If `is_container()` **and** `PULSE_SERVER` or `PIPEWIRE_REMOTE` is set → downgrade to an informational `notices` entry (does not block voice).
- If `is_container()` **and** neither is set → keep the hard block, but extend the message with the exact `-v` / `-e` flags users need.

No public surface changes. `detect_audio_environment()` still returns `{available, warnings, notices}`.

## Test plan

- [x] 3 new regression tests in `tests/tools/test_voice_mode.py::TestDetectAudioEnvironment`:
  - `test_docker_with_pulse_server_allows_voice`
  - `test_docker_with_pipewire_remote_allows_voice`
  - `test_docker_without_audio_forwarding_blocks_voice`
- [x] Stash-verified: all 3 fail on `origin/main`, pass with the fix.
- [x] Full file `tests/tools/test_voice_mode.py`: 63/63 pass.

Closes #21203

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

Closes #21203

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_