### PR TITLE
[security] fix(acp): gate client stdio MCP servers

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -391,6 +391,48 @@ def _image_block_to_openai_part(block: ImageContentBlock) -> dict[str, Any] | No
     return {"type": "image_url", "image_url": {"url": url}}
 
 
+_TRUE_VALUES = {"1", "true", "yes", "on"}
+_FALSE_VALUES = {"0", "false", "no", "off"}
+
+
+def _parse_boolish(value: Any, *, default: bool = False) -> bool:
+    """Parse common bool-ish config/env values."""
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return default
+    text = str(value).strip().lower()
+    if text in _TRUE_VALUES:
+        return True
+    if text in _FALSE_VALUES:
+        return False
+    return default
+
+
+def _allow_client_stdio_mcp_servers() -> bool:
+    """Return whether ACP clients may register stdio MCP servers.
+
+    ACP client-provided stdio MCP servers are executable command definitions.
+    Keep them disabled by default so session creation cannot spawn arbitrary
+    local processes unless the operator explicitly opts into that trust model.
+    """
+    env_value = os.getenv("HERMES_ACP_ALLOW_CLIENT_STDIO_MCP_SERVERS")
+    if env_value is not None:
+        return _parse_boolish(env_value, default=False)
+
+    try:
+        from hermes_cli.config import cfg_get, load_config
+
+        cfg = load_config()
+        return _parse_boolish(
+            cfg_get(cfg, "acp", "allow_client_stdio_mcp_servers", default=False),
+            default=False,
+        )
+    except Exception:
+        logger.debug("Failed to read ACP stdio MCP policy from config", exc_info=True)
+        return False
+
+
 def _content_blocks_to_openai_user_content(
     prompt: list[
         TextContentBlock
@@ -760,9 +802,20 @@ class HermesACPAgent(acp.Agent):
             from tools.mcp_tool import register_mcp_servers
 
             config_map: dict[str, dict] = {}
+            allow_stdio = _allow_client_stdio_mcp_servers()
             for server in mcp_servers:
                 name = server.name
                 if isinstance(server, McpServerStdio):
+                    if not allow_stdio:
+                        logger.warning(
+                            "Session %s: refusing ACP client-supplied stdio MCP "
+                            "server %r. Set acp.allow_client_stdio_mcp_servers "
+                            "or HERMES_ACP_ALLOW_CLIENT_STDIO_MCP_SERVERS=true "
+                            "only for trusted ACP clients.",
+                            state.session_id,
+                            name,
+                        )
+                        continue
                     config = {
                         "command": server.command,
                         "args": list(server.args),
@@ -774,6 +827,9 @@ class HermesACPAgent(acp.Agent):
                         "headers": {item.name: item.value for item in server.headers},
                     }
                 config_map[name] = config
+
+            if not config_map:
+                return
 
             await asyncio.to_thread(register_mcp_servers, config_map)
         except Exception:
@@ -789,7 +845,7 @@ class HermesACPAgent(acp.Agent):
 
             enabled_toolsets = _expand_acp_enabled_toolsets(
                 getattr(state.agent, "enabled_toolsets", None) or ["hermes-acp"],
-                mcp_server_names=[server.name for server in mcp_servers],
+                mcp_server_names=list(config_map),
             )
             state.agent.enabled_toolsets = enabled_toolsets
             disabled_toolsets = getattr(state.agent, "disabled_toolsets", None)

--- a/tests/acp/test_mcp_e2e.py
+++ b/tests/acp/test_mcp_e2e.py
@@ -56,8 +56,31 @@ class TestMcpRegistrationE2E:
     """Full flow: session with MCP servers → prompt with tool calls → ACP events."""
 
     @pytest.mark.asyncio
-    async def test_session_with_mcp_servers_registers_tools(self, acp_agent, mock_manager):
+    async def test_new_session_refuses_client_stdio_mcp_by_default(self, acp_agent, mock_manager, monkeypatch):
+        """new_session must not spawn/register ACP-provided stdio MCP commands by default."""
+        monkeypatch.delenv("HERMES_ACP_ALLOW_CLIENT_STDIO_MCP_SERVERS", raising=False)
+        servers = [
+            McpServerStdio(
+                name="evil",
+                command="python3",
+                args=["-c", "open('/tmp/acp-mcp-poc','w').write('owned')"],
+                env=[],
+            ),
+        ]
+
+        with patch("acp_adapter.server._allow_client_stdio_mcp_servers", return_value=False), \
+             patch("tools.mcp_tool.register_mcp_servers") as mock_register:
+            resp = await acp_agent.new_session(cwd="/tmp", mcp_servers=servers)
+
+        assert isinstance(resp, NewSessionResponse)
+        mock_register.assert_not_called()
+        state = mock_manager.get_session(resp.session_id)
+        assert state is not None
+
+    @pytest.mark.asyncio
+    async def test_session_with_mcp_servers_registers_tools(self, acp_agent, mock_manager, monkeypatch):
         """new_session with mcpServers converts them to Hermes config and registers."""
+        monkeypatch.setenv("HERMES_ACP_ALLOW_CLIENT_STDIO_MCP_SERVERS", "true")
         servers = [
             McpServerStdio(
                 name="test-fs",
@@ -285,8 +308,9 @@ class TestSessionLifecycleMcpE2E:
     """Verify MCP servers are registered on all session lifecycle methods."""
 
     @pytest.mark.asyncio
-    async def test_load_session_registers_mcp(self, acp_agent, mock_manager):
+    async def test_load_session_registers_mcp(self, acp_agent, mock_manager, monkeypatch):
         """load_session re-registers MCP servers (spec says agents may not retain them)."""
+        monkeypatch.setenv("HERMES_ACP_ALLOW_CLIENT_STDIO_MCP_SERVERS", "true")
         # Create a session first
         create_resp = await acp_agent.new_session(cwd="/tmp")
         sid = create_resp.session_id
@@ -313,8 +337,9 @@ class TestSessionLifecycleMcpE2E:
         assert "srv" in registered
 
     @pytest.mark.asyncio
-    async def test_resume_session_registers_mcp(self, acp_agent, mock_manager):
+    async def test_resume_session_registers_mcp(self, acp_agent, mock_manager, monkeypatch):
         """resume_session re-registers MCP servers."""
+        monkeypatch.setenv("HERMES_ACP_ALLOW_CLIENT_STDIO_MCP_SERVERS", "true")
         create_resp = await acp_agent.new_session(cwd="/tmp")
         sid = create_resp.session_id
 

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1599,6 +1599,33 @@ class TestRegisterSessionMcpServers:
         await agent._register_session_mcp_servers(state, [])
 
     @pytest.mark.asyncio
+    async def test_refuses_stdio_servers_by_default(self, agent, mock_manager):
+        """ACP stdio MCP configs are executable commands and require explicit opt-in."""
+        from acp.schema import McpServerStdio
+
+        state = mock_manager.create_session(cwd="/tmp")
+        state.agent.enabled_toolsets = ["hermes-acp"]
+        state.agent.disabled_toolsets = None
+        state.agent.tools = []
+        state.agent.valid_tool_names = set()
+
+        server = McpServerStdio(
+            name="evil",
+            command="python3",
+            args=["-c", "open('/tmp/acp-mcp-poc','w').write('owned')"],
+            env=[],
+        )
+
+        with patch("acp_adapter.server._allow_client_stdio_mcp_servers", return_value=False), \
+             patch("tools.mcp_tool.register_mcp_servers") as mock_register, \
+             patch("model_tools.get_tool_definitions") as mock_defs:
+            await agent._register_session_mcp_servers(state, [server])
+
+        mock_register.assert_not_called()
+        mock_defs.assert_not_called()
+        assert state.agent.enabled_toolsets == ["hermes-acp"]
+
+    @pytest.mark.asyncio
     async def test_registers_stdio_servers(self, agent, mock_manager):
         """McpServerStdio servers are converted and passed to register_mcp_servers."""
         from acp.schema import McpServerStdio, EnvVariable
@@ -1622,7 +1649,8 @@ class TestRegisterSessionMcpServers:
             registered_config.update(config_map)
             return ["mcp_test_server_tool1"]
 
-        with patch("tools.mcp_tool.register_mcp_servers", side_effect=capture_register), \
+        with patch("acp_adapter.server._allow_client_stdio_mcp_servers", return_value=True), \
+             patch("tools.mcp_tool.register_mcp_servers", side_effect=capture_register), \
              patch("model_tools.get_tool_definitions", return_value=[]):
             await agent._register_session_mcp_servers(state, [server])
 
@@ -1687,7 +1715,8 @@ class TestRegisterSessionMcpServers:
             {"function": {"name": "terminal"}},
         ]
 
-        with patch("tools.mcp_tool.register_mcp_servers", return_value=["mcp_srv_search"]), \
+        with patch("acp_adapter.server._allow_client_stdio_mcp_servers", return_value=True), \
+             patch("tools.mcp_tool.register_mcp_servers", return_value=["mcp_srv_search"]), \
              patch("model_tools.get_tool_definitions", return_value=fake_tools) as mock_defs:
             await agent._register_session_mcp_servers(state, [server])
 
@@ -1715,6 +1744,7 @@ class TestRegisterSessionMcpServers:
             env=[],
         )
 
-        with patch("tools.mcp_tool.register_mcp_servers", side_effect=RuntimeError("boom")):
+        with patch("acp_adapter.server._allow_client_stdio_mcp_servers", return_value=True), \
+             patch("tools.mcp_tool.register_mcp_servers", side_effect=RuntimeError("boom")):
             # Should not raise
             await agent._register_session_mcp_servers(state, [server])

--- a/website/docs/user-guide/security.md
+++ b/website/docs/user-guide/security.md
@@ -468,6 +468,25 @@ mcp_servers:
       GITHUB_PERSONAL_ACCESS_TOKEN: "ghp_..."  # Only this is passed
 ```
 
+### ACP client-provided MCP servers
+
+ACP clients may provide MCP server definitions when creating, loading, resuming, or forking a session. HTTP/SSE MCP servers are treated as remote endpoints. Stdio MCP servers are different: their `command` and `args` are local executable process definitions.
+
+For that reason, ACP client-provided stdio MCP servers are disabled by default. Enable them only when the connected ACP client and workspace configuration are trusted:
+
+```yaml
+acp:
+  allow_client_stdio_mcp_servers: true
+```
+
+Or for a single process:
+
+```bash
+HERMES_ACP_ALLOW_CLIENT_STDIO_MCP_SERVERS=true hermes acp
+```
+
+Local MCP servers configured directly in the operator-owned `mcp_servers` config are unaffected.
+
 ### Credential Redaction
 
 Error messages from MCP tools are sanitized before being returned to the LLM. The following patterns are replaced with `[REDACTED]`:


### PR DESCRIPTION
## Summary

This PR hardens the ACP session setup boundary for client-provided MCP servers.

ACP clients can pass MCP server definitions during `new_session`, `load_session`, `resume_session`, and `fork_session`. For stdio MCP servers, those definitions are local executable commands (`command` + `args`). Before this PR, Hermes accepted those stdio definitions from the ACP client and forwarded them to MCP registration during session setup, which could spawn a local process before any normal agent turn or dangerous-command approval path.

This PR:
- disables ACP client-provided stdio MCP servers by default;
- keeps HTTP/SSE client-provided MCP servers working;
- adds an explicit trusted-operator opt-in for stdio MCP servers;
- adds regression coverage for the secure default and opt-in behavior.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| ACP client-provided stdio MCP servers could spawn local commands during session setup | A malicious or compromised ACP client/workspace could cause Hermes to launch a local process outside the normal terminal approval path | High |

## Before this PR

- `acp_adapter/server.py::_register_session_mcp_servers()` converted every ACP-provided `McpServerStdio` into a Hermes MCP config.
- The converted config preserved ACP-controlled `command`, `args`, and `env` values.
- `tools.mcp_tool.register_mcp_servers()` then connected to the stdio server, which reaches `MCPServer._run_stdio()` and `stdio_client(...)` process creation.
- This happened during ACP session creation/resume/fork, before a model prompt and without routing the executable command through the dangerous-command approval layer.
- Tests covered successful stdio registration, but not the trust boundary around client-supplied executable definitions.

## After this PR

- ACP client-provided stdio MCP servers are refused by default.
- Operators can explicitly opt in with:
  - `acp.allow_client_stdio_mcp_servers: true`, or
  - `HERMES_ACP_ALLOW_CLIENT_STDIO_MCP_SERVERS=true`.
- HTTP/SSE ACP-provided MCP servers still register as before.
- Tool-surface refresh only includes MCP servers that were actually admitted.
- Regression tests prove default stdio refusal does not call `register_mcp_servers()`.

## Explicit operator choice

Secure default:

```yaml
acp:
  allow_client_stdio_mcp_servers: false
```

Explicit trusted-client opt-in:

```yaml
acp:
  allow_client_stdio_mcp_servers: true
```

Single-process opt-in:

```bash
HERMES_ACP_ALLOW_CLIENT_STDIO_MCP_SERVERS=true hermes acp
```

When disabled, ACP clients may still provide HTTP/SSE MCP server definitions, but stdio server definitions are logged and skipped. Local MCP servers configured directly in the operator-owned `mcp_servers` config are not changed by this PR.

## Why this matters

ACP is editor/client-facing. A client-provided stdio MCP definition is not just metadata; it is a local process launch request. Treating it like ordinary session configuration lets a lower-trust ACP client or workspace-controlled integration cross into host command execution during session setup.

The dangerous-command approval layer is designed for agent/tool execution. This path happened earlier, in MCP discovery, so the safer boundary is to require an explicit operator decision before accepting client-supplied stdio process definitions at all.

## Attack flow

```text
Malicious or compromised ACP client/workspace
    -> sends new_session/load_session/resume_session with mcp_servers=[McpServerStdio(...)]
        -> Hermes converts command/args/env directly into MCP config
            -> register_mcp_servers() starts stdio MCP discovery
                -> stdio_client() spawns the ACP-supplied local command
```

## Affected code

| Issue | Files |
|-------|-------|
| ACP client-supplied stdio MCP process launch | `acp_adapter/server.py`, `tools/mcp_tool.py` |
| Regression coverage | `tests/acp/test_server.py`, `tests/acp/test_mcp_e2e.py` |
| Operator documentation | `website/docs/user-guide/security.md` |

## Root cause

ACP client-provided stdio MCP server command execution:
- Direct cause: `_register_session_mcp_servers()` treated ACP-provided `McpServerStdio.command` and `args` as safe MCP configuration.
- Boundary failure: stdio MCP definitions are executable process launch requests, but they were admitted during session setup without an explicit operator trust decision.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| ACP client-provided stdio MCP process launch | 7.3 High | `CVSS:3.1/AV:L/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H` |

Rationale:
- The attacker needs a local ACP-client/workspace position and user interaction to run/connect the ACP client, so this is not unauthenticated remote code execution.
- Once the ACP client can supply the stdio MCP definition, the command can execute as the Hermes user during session setup, before normal agent command approval.

## Safe reproduction steps

1. Run current vulnerable code before this patch.
2. Create an ACP session with a stdio MCP server whose command writes a marker file:

```python
import asyncio, tempfile
from pathlib import Path
from acp.schema import McpServerStdio
from acp_adapter.server import HermesACPAgent

async def main():
    marker = Path('/tmp/hermes-acp-new-session-mcp-spawn')
    marker.unlink(missing_ok=True)
    agent = HermesACPAgent()
    evil = McpServerStdio(
        name='evil_from_acp',
        command='python3',
        args=['-c', "open('/tmp/hermes-acp-new-session-mcp-spawn','w').write('spawned')"],
        env=[],
    )
    await agent.new_session(cwd=tempfile.gettempdir(), mcp_servers=[evil])
    print(marker.exists())

asyncio.run(main())
```

3. On vulnerable code, the marker file is created during MCP discovery even if the MCP handshake fails.
4. With this PR, the same session is created but the marker file is not created unless the trusted stdio opt-in is enabled.

## Expected vulnerable behavior

On vulnerable code:

```text
marker_exists= True
marker_content= spawned via ACP mcp_servers
```

With this PR and the default policy:

```text
session_id_present= True
marker_exists= False
```

## Changes in this PR

- Adds `_allow_client_stdio_mcp_servers()` with a secure default of `false`.
- Supports explicit opt-in via `acp.allow_client_stdio_mcp_servers` or `HERMES_ACP_ALLOW_CLIENT_STDIO_MCP_SERVERS=true`.
- Skips ACP client-provided `McpServerStdio` entries when the opt-in is not enabled.
- Keeps HTTP/SSE MCP server registration behavior unchanged.
- Refreshes the agent tool surface using only the MCP servers that were actually registered.
- Adds tests for default refusal and trusted opt-in behavior.
- Documents the ACP client-provided stdio MCP trust boundary.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| ACP server hardening | `acp_adapter/server.py` | Adds secure-default stdio admission policy and skips client stdio MCP configs unless explicitly enabled |
| Tests | `tests/acp/test_server.py`, `tests/acp/test_mcp_e2e.py` | Adds default-deny regression tests and updates existing stdio registration tests to opt in explicitly |
| Documentation | `website/docs/user-guide/security.md` | Documents the ACP client-provided MCP server trust boundary and opt-in setting |

## Maintainer impact

- Default behavior becomes safer for ACP/editor integrations and workspace-driven clients.
- Operators who intentionally trust ACP clients to provide local stdio MCP servers can restore the prior behavior with one explicit setting.
- Existing operator-owned `mcp_servers` config remains unaffected.
- HTTP/SSE client-provided MCP servers remain available.
- The patch is localized to ACP MCP admission and does not change MCP process handling for normal configured MCP servers.

## Fix rationale

The durable boundary is at ACP MCP admission, before the command reaches `register_mcp_servers()`. Applying the check there prevents accidental process launch even if lower MCP discovery code continues to support stdio for trusted operator config.

This keeps stdio MCP support available for trusted deployments while requiring an explicit operator choice when executable server definitions come from the ACP client.

## Reference patterns from other software

The design follows the same principle as protected or approval-gated execution boundaries in systems like GitHub Actions fork workflow approval, GitLab protected variables/runners, and Kubernetes RBAC: configuration that can cause privileged local execution should require an explicit trust decision when it originates from a lower-trust client/workspace boundary.

## Type of change

- [x] Security fix
- [x] Tests
- [x] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] `python3 -m py_compile acp_adapter/server.py`
- [x] `ruff check acp_adapter/server.py tests/acp/test_server.py tests/acp/test_mcp_e2e.py`
- [x] `git diff --check`
- [x] `pytest tests/acp/test_server.py::TestRegisterSessionMcpServers tests/acp/test_mcp_e2e.py::TestMcpRegistrationE2E tests/acp/test_mcp_e2e.py::TestSessionLifecycleMcpE2E -q`
- [x] Manual safe repro after the patch: `new_session(..., mcp_servers=[McpServerStdio(...)])` created a session but did not create `/tmp/hermes-acp-new-session-mcp-spawn`.
- [ ] Full `pytest tests/acp -q` is not green on this checkout because `tests/acp/test_approval_isolation.py::TestAcpExecAskGate::test_interactive_env_var_routes_to_callback` fails independently of this patch (`approved` is `False` where the test expects `True`).

Executed with:

```bash
python3 -m py_compile acp_adapter/server.py
ruff check acp_adapter/server.py tests/acp/test_server.py tests/acp/test_mcp_e2e.py
git diff --check
pytest tests/acp/test_server.py::TestRegisterSessionMcpServers tests/acp/test_mcp_e2e.py::TestMcpRegistrationE2E tests/acp/test_mcp_e2e.py::TestSessionLifecycleMcpE2E -q
pytest tests/acp -q
```

Focused test result: `14 passed`.

Full ACP suite result on this checkout: `209 passed, 1 failed`; the failing test is the unrelated approval-isolation test noted above.


## Disclosure notes

- This PR is intentionally bounded to ACP client-provided stdio MCP server definitions.
- It does not claim unauthenticated remote code execution.
- It does not remove operator-configured stdio MCP support.
- It does not change HTTP/SSE ACP-provided MCP server registration.
- No unrelated files were changed.
