### PR TITLE
fix(skills): drop None entries from disabled-skill set normaliser

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -165,7 +165,11 @@ def _normalize_string_set(values) -> Set[str]:
         return set()
     if isinstance(values, str):
         values = [values]
-    return {str(v).strip() for v in values if str(v).strip()}
+    return {
+        str(v).strip()
+        for v in values
+        if v is not None and str(v).strip()
+    }
 
 
 # ── External skills directories ──────────────────────────────────────────

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -1,6 +1,6 @@
 """Tests for agent/skill_utils.py — extract_skill_conditions metadata handling."""
 
-from agent.skill_utils import extract_skill_conditions
+from agent.skill_utils import extract_skill_conditions, _normalize_string_set
 
 
 def test_metadata_as_dict_with_hermes():
@@ -56,3 +56,18 @@ def test_metadata_missing_entirely():
         "fallback_for_tools": [],
         "requires_tools": [],
     }
+
+
+def test_normalize_string_set_drops_none_entries():
+    """``None`` items in the iterable are filtered, not coerced to ``"None"``.
+
+    Regression: ``str(None)`` is ``"None"`` (truthy after .strip()), so the
+    naive ``{str(v).strip() for v in values if str(v).strip()}`` comprehension
+    produced the literal string ``"None"`` in the output set.  Disabled-skill
+    matching against that bogus name silently disabled nothing while making
+    the configured set look populated.
+    """
+    assert _normalize_string_set([None]) == set()
+    assert _normalize_string_set([None, "foo"]) == {"foo"}
+    assert _normalize_string_set([None, None, "bar"]) == {"bar"}
+    assert _normalize_string_set([None, "  ", "baz", ""]) == {"baz"}


### PR DESCRIPTION
## What does this PR do?

`agent/skill_utils._normalize_string_set` is fed values from YAML config keys like `skills.disabled` and `skills.platform_disabled.<platform>`. When a user writes a stray dash with no value, PyYAML parses that entry as `None`. The existing comprehension `{str(v).strip() for v in values if str(v).strip()}` coerces `None` to the literal string `"None"` (truthy after `.strip()`), so the disabled-skill set ends up populated with the bogus name `"None"` instead of filtering the bad entry out.

## Root cause

`agent/skill_utils._normalize_string_set` is fed values from YAML config keys
like `skills.disabled` and `skills.platform_disabled.<platform>`. When a user
writes a stray dash with no value, PyYAML parses that entry as `None`. The
existing comprehension `{str(v).strip() for v in values if str(v).strip()}`
coerces `None` to the literal string `"None"` (truthy after `.strip()`), so the
disabled-skill set ends up populated with the bogus name `"None"` instead of
filtering the bad entry out.

Net effect: the operator thinks they disabled something, but the matcher only
ever blocks a hypothetical skill literally named `None` — every real skill
remains active.

## Fix

Add an explicit `v is not None` guard before the `str(...).strip()` call so
`None` items are filtered, not coerced.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

N/A

<details>
<summary>Original body</summary>

## Summary

`agent/skill_utils._normalize_string_set` is fed values from YAML config keys like `skills.disabled` and `skills.platform_disabled.<platform>`. When a user writes a stray dash with no value, PyYAML parses that entry as `None`. The existing comprehension `{str(v).strip() for v in values if str(v).strip()}` coerces `None` to the literal string `"None"` (truthy after `.strip()`), so the disabled-skill set ends up populated with the bogus name `"None"` instead of filtering the bad entry out.

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Problem

`agent/skill_utils._normalize_string_set` is fed values from YAML config keys
like `skills.disabled` and `skills.platform_disabled.<platform>`. When a user
writes a stray dash with no value, PyYAML parses that entry as `None`. The
existing comprehension `{str(v).strip() for v in values if str(v).strip()}`
coerces `None` to the literal string `"None"` (truthy after `.strip()`), so the
disabled-skill set ends up populated with the bogus name `"None"` instead of
filtering the bad entry out.

Net effect: the operator thinks they disabled something, but the matcher only
ever blocks a hypothetical skill literally named `None` — every real skill
remains active.

## Root cause

`str(v).strip()` masks `None` because `str(None) == "None"`. Same trap as
`#22521` (cron `deliver`) and `#22525` (skill prerequisites).

## Fix

Add an explicit `v is not None` guard before the `str(...).strip()` call so
`None` items are filtered, not coerced.

## Tests

`tests/agent/test_skill_utils.py::test_normalize_string_set_drops_none_entries`
— covers `[None]`, `[None, "foo"]`, `[None, None, "bar"]`, and a mix with
whitespace + empty strings. Verified red without the fix and green with it.

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_