### PR TITLE
fix(session_search): retrieve content from FTS5 child, not resolved parent

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -560,3 +560,85 @@ class TestSessionSearch:
         assert entry["source"] == "api_server", (
             f"source should be parent's 'api_server', got {entry['source']!r}"
         )
+
+    def test_content_retrieved_from_fts5_child_not_resolved_parent(self):
+        """Regression for #22150: when FTS5 hits a child, content must come from the child.
+
+        Delegation/compression stores the matched conversation in the child session.
+        The resolved parent often does NOT contain the matched text. Calling
+        ``get_messages_as_conversation()`` with the parent SID returned the wrong
+        content. The fix preserves the original child SID for content retrieval
+        while still surfacing the resolved parent in the output ``session_id``
+        (per #15909).
+        """
+        from unittest.mock import MagicMock, AsyncMock, patch as _patch
+        from tools.session_search_tool import session_search
+
+        mock_db = MagicMock()
+        mock_db.search_messages.return_value = [
+            {
+                "session_id": "child_sid",
+                "content": "headless-chatgpt run",
+                "source": "cli",
+                "session_started": 1709400000,
+                "model": "test",
+            },
+        ]
+
+        def _get_session(session_id):
+            if session_id == "child_sid":
+                return {
+                    "id": "child_sid",
+                    "parent_session_id": "parent_sid",
+                    "source": "cli",
+                    "started_at": 1709400000,
+                    "model": "test",
+                }
+            if session_id == "parent_sid":
+                return {
+                    "id": "parent_sid",
+                    "parent_session_id": None,
+                    "source": "cli",
+                    "started_at": 1709300000,
+                    "model": "test",
+                }
+            return None
+
+        mock_db.get_session.side_effect = _get_session
+
+        # Different content per session — child has the FTS5 hit, parent doesn't.
+        def _conversation_for(session_id):
+            if session_id == "child_sid":
+                return [
+                    {"role": "user", "content": "run headless-chatgpt"},
+                    {"role": "assistant", "content": "headless-chatgpt running"},
+                ]
+            return [
+                {"role": "user", "content": "unrelated parent topic"},
+                {"role": "assistant", "content": "no match here"},
+            ]
+
+        mock_db.get_messages_as_conversation.side_effect = _conversation_for
+
+        with _patch(
+            "tools.session_search_tool.async_call_llm",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("no provider"),
+        ):
+            result = json.loads(session_search(query="headless-chatgpt", db=mock_db))
+
+        assert result["success"] is True
+        assert result["count"] == 1
+        # Output still surfaces the resolved parent (preserves #15909 contract).
+        assert result["results"][0]["session_id"] == "parent_sid"
+        # But content retrieval used the child SID — this is the #22150 fix.
+        called_sids = [
+            call.args[0] if call.args else call.kwargs.get("session_id")
+            for call in mock_db.get_messages_as_conversation.call_args_list
+        ]
+        assert "child_sid" in called_sids, (
+            f"content must be retrieved from FTS5 child sid; got calls {called_sids!r}"
+        )
+        assert "parent_sid" not in called_sids, (
+            f"must NOT retrieve content from resolved parent sid; got calls {called_sids!r}"
+        )

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -416,6 +416,10 @@ def session_search(
         # session lineage. Compression and delegation create child sessions
         # that still belong to the same active conversation.
         seen_sessions = {}
+        # Map resolved parent sid → original FTS5 child sid for content lookup.
+        # The resolved parent may not contain the matched text — delegation/
+        # compression stores the actual conversation in the child (#22150).
+        content_source_sid = {}
         for result in raw_results:
             raw_sid = result["session_id"]
             resolved_sid = _resolve_to_parent(raw_sid)
@@ -429,6 +433,7 @@ def session_search(
                 result = dict(result)
                 result["session_id"] = resolved_sid
                 seen_sessions[resolved_sid] = result
+                content_source_sid[resolved_sid] = raw_sid
             if len(seen_sessions) >= limit:
                 break
 
@@ -436,7 +441,10 @@ def session_search(
         tasks = []
         for session_id, match_info in seen_sessions.items():
             try:
-                messages = db.get_messages_as_conversation(session_id)
+                # Fetch content from the FTS5-matched child, not the resolved
+                # parent — the parent may not contain the matched text (#22150).
+                content_sid = content_source_sid.get(session_id, session_id)
+                messages = db.get_messages_as_conversation(content_sid)
                 if not messages:
                     continue
                 session_meta = db.get_session(session_id) or {}


### PR DESCRIPTION
## Problem

`session_search()` returned content unrelated to the query when the FTS5 hit was in a delegation/compression child session. Searching for "headless-chatgpt" matched a 156-message child correctly, but the returned conversation came from the resolved 42-message parent — which never contained the term.

## Root cause

In `tools/session_search_tool.py`, `seen_sessions[resolved_sid] = result` overwrote `result["session_id"]` with the parent SID. The downstream loop then iterated `seen_sessions.items()` and called `get_messages_as_conversation(session_id)` with that parent SID, throwing away the original FTS5 child SID where the matched text actually lives.

## Fix

Track the original child SID alongside the resolved-parent grouping:

```python
content_source_sid = {}
...
if resolved_sid not in seen_sessions:
    result = dict(result)
    result["session_id"] = resolved_sid
    seen_sessions[resolved_sid] = result
    content_source_sid[resolved_sid] = raw_sid
...
content_sid = content_source_sid.get(session_id, session_id)
messages = db.get_messages_as_conversation(content_sid)
```

The output `session_id` field still surfaces the resolved parent — the #15909 contract for source/metadata display is unchanged.

## Tests

New regression in `tests/tools/test_session_search.py::test_content_retrieved_from_fts5_child_not_resolved_parent`: mocks distinct conversations per SID and asserts `get_messages_as_conversation` is called with the child SID, not the parent. Stash-verify confirmed the test fails on `main` (`['parent_sid']`) and passes with the fix (`['child_sid']`). All 39 `test_session_search.py` tests green.

Closes #22150