### PR TITLE
feat(feishu): default to threaded replies in group chats

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -81,8 +81,14 @@ def _reply_anchor_for_event(event) -> str | None:
         return getattr(event, "message_id", None) or getattr(event, "reply_to_message_id", None)
     if platform == "telegram" and thread_id:
         return None
-    if platform == "feishu" and thread_id and getattr(event, "reply_to_message_id", None):
-        return getattr(event, "reply_to_message_id", None)
+    # NOTE: do NOT special-case Feishu to return event.reply_to_message_id when
+    # the user quoted another message. Anchoring on the quoted message makes
+    # bot replies appear visually attached to the *quoted* message (e.g. an
+    # unrelated meego link) instead of the user's own @-mention message, which
+    # is wrong when the user is asking the bot to act on their own request.
+    # event.message_id (the user's own message) is always in the same topic if
+    # the user is in one, so reply_in_thread=true still keeps the bot inside
+    # the topic.
     return getattr(event, "message_id", None)
 
 

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -4316,30 +4316,39 @@ class FeishuAdapter(BasePlatformAdapter):
             # reply path.
             effective_reply_to = metadata.get("reply_to_message_id")
         reply_in_thread = bool((metadata or {}).get("thread_id"))
-        # In group chats, default to threaded replies so the bot's response
-        # forms a topic instead of flooding the main feed. Opt out via
-        # `feishu.reply_in_thread: false` in config. Only applies when we
-        # have a parent message to reply to — Feishu's API can't create a
-        # topic from a top-level send. DMs (chat_type=dm) are unaffected.
+        # Group-chat anchor fallback. Two distinct cases handled together:
+        #   (a) reply_in_thread is False (no metadata.thread_id) AND no
+        #       reply_to: classic auto-thread — pick a cached user message id
+        #       so the bot's reply starts/joins a topic instead of flooding
+        #       the main feed.
+        #   (b) reply_in_thread is True (metadata carries a thread_id) but no
+        #       reply_to / metadata.reply_to_message_id: the caller wants the
+        #       send inside an existing topic but didn't supply an anchor.
+        #       Without one we'd fall through to a top-level send (Feishu's
+        #       reply API is the *only* way to land in a topic), so the
+        #       thread_id silently no-ops. _deliver_media_from_response is
+        #       the canonical example: it builds metadata={thread_id} only.
+        # In both cases we need an anchor message that lives in (or will
+        # anchor) the right topic. The most recent inbound user message in
+        # this chat is exactly that — the user's own message is in their
+        # topic, and replying to it with reply_in_thread=true joins (case b)
+        # or starts (case a) the topic.
         if (
-            not reply_in_thread
+            not effective_reply_to
             and bool(self.config.extra.get("reply_in_thread", True))
         ):
             chat_mode = await self._get_chat_mode(chat_id)
             # Per Feishu docs, chat_mode is the canonical chat-classification
             # field: "p2p" (DM), "group" (regular group), "topic" (topic
-            # group). Auto-threading only makes sense for "group" — DMs don't
-            # need it and topic groups already enforce a topic structure.
+            # group). The fallback is only safe for "group" — DMs don't need
+            # threading, and topic groups have their own enforcement.
             if chat_mode == "group":
-                # Implicit anchor: when the gateway didn't pass an explicit
-                # reply_to (e.g. tool-progress / status / approval paths in
-                # fresh group chats where source.thread_id is empty), fall
-                # back to the most recent inbound user message in this chat.
-                # Without this, those sends bypass the auto-thread branch and
-                # flood the main feed alongside the threaded final reply.
-                if not effective_reply_to:
-                    effective_reply_to = self._last_user_message_id.get(chat_id)
-                if effective_reply_to:
+                anchor = self._last_user_message_id.get(chat_id)
+                if anchor:
+                    effective_reply_to = anchor
+                    # Always ensure reply_in_thread=true when we supply an
+                    # implicit anchor — covers case (a) and is a no-op for
+                    # case (b) (already True).
                     reply_in_thread = True
         if effective_reply_to:
             body = self._build_reply_message_body(

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -239,6 +239,7 @@ _FEISHU_REACTION_FAILURE = "CrossMark"
 # drain on completion; the cap is a safeguard against unbounded growth from
 # delete-failures, not a capacity plan.
 _FEISHU_PROCESSING_REACTION_CACHE_SIZE = 1024
+_FEISHU_LAST_USER_MESSAGE_CACHE_SIZE = 2048
 
 # QR onboarding constants
 _ONBOARD_ACCOUNTS_URLS = {
@@ -1396,6 +1397,12 @@ class FeishuAdapter(BasePlatformAdapter):
         # auto-thread routing. Populated lazily via chats.get; separate from
         # _chat_info_cache because that one stores the wrong field as "type".
         self._chat_mode_cache: Dict[str, str] = {}
+        # Per-chat record of the most recent inbound user message id. Used as
+        # an implicit reply anchor by the group-chat auto-thread logic so
+        # interim sends (status callbacks, tool-progress, approval cards) that
+        # don't carry an explicit reply_to still get pulled into the topic
+        # rooted at the user's triggering message.
+        self._last_user_message_id: "OrderedDict[str, str]" = OrderedDict()
         self._message_text_cache: Dict[str, Optional[str]] = {}
         self._app_lock_identity: Optional[str] = None
         self._text_batch_state = FeishuBatchState()
@@ -2962,6 +2969,18 @@ class FeishuAdapter(BasePlatformAdapter):
         )
 
         chat_id = getattr(message, "chat_id", "") or ""
+        # Remember the most recent inbound user message id per chat. Used as
+        # an implicit reply anchor for group-chat auto-thread routing so
+        # interim sends without an explicit reply_to (status callbacks,
+        # tool-progress, approval cards) still land in the same topic as the
+        # user's triggering message. Skip bot-originated messages so the bot
+        # never anchors topics to its own posts.
+        if chat_id and message_id and not is_bot:
+            cache = self._last_user_message_id
+            cache[chat_id] = message_id
+            cache.move_to_end(chat_id)
+            while len(cache) > _FEISHU_LAST_USER_MESSAGE_CACHE_SIZE:
+                cache.popitem(last=False)
         chat_info = await self.get_chat_info(chat_id)
         sender_profile = await self._resolve_sender_profile(sender_id, is_bot=is_bot)
         source = self.build_source(
@@ -4288,7 +4307,13 @@ class FeishuAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]],
     ) -> Any:
         effective_reply_to = reply_to
-        if not effective_reply_to and metadata and metadata.get("thread_id"):
+        if not effective_reply_to and metadata and metadata.get("reply_to_message_id"):
+            # Carry the anchoring message id from metadata when no explicit
+            # reply_to was passed. Originally only fired when thread_id was
+            # also set (preserving thread membership for status callbacks);
+            # broadened so the group-chat auto-thread branch below can also
+            # anchor interim/status sends that don't go through the main
+            # reply path.
             effective_reply_to = metadata.get("reply_to_message_id")
         reply_in_thread = bool((metadata or {}).get("thread_id"))
         # In group chats, default to threaded replies so the bot's response
@@ -4298,7 +4323,6 @@ class FeishuAdapter(BasePlatformAdapter):
         # topic from a top-level send. DMs (chat_type=dm) are unaffected.
         if (
             not reply_in_thread
-            and effective_reply_to
             and bool(self.config.extra.get("reply_in_thread", True))
         ):
             chat_mode = await self._get_chat_mode(chat_id)
@@ -4307,7 +4331,16 @@ class FeishuAdapter(BasePlatformAdapter):
             # group). Auto-threading only makes sense for "group" — DMs don't
             # need it and topic groups already enforce a topic structure.
             if chat_mode == "group":
-                reply_in_thread = True
+                # Implicit anchor: when the gateway didn't pass an explicit
+                # reply_to (e.g. tool-progress / status / approval paths in
+                # fresh group chats where source.thread_id is empty), fall
+                # back to the most recent inbound user message in this chat.
+                # Without this, those sends bypass the auto-thread branch and
+                # flood the main feed alongside the threaded final reply.
+                if not effective_reply_to:
+                    effective_reply_to = self._last_user_message_id.get(chat_id)
+                if effective_reply_to:
+                    reply_in_thread = True
         if effective_reply_to:
             body = self._build_reply_message_body(
                 content=payload,

--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -1392,6 +1392,10 @@ class FeishuAdapter(BasePlatformAdapter):
         self._sent_message_ids_to_chat: Dict[str, str] = {}  # message_id → chat_id (for reaction routing)
         self._sent_message_id_order: List[str] = []  # LRU order for _sent_message_ids_to_chat
         self._chat_info_cache: Dict[str, Dict[str, Any]] = {}
+        # Per-chat cache of chat_mode ("p2p" / "group" / "topic") used for
+        # auto-thread routing. Populated lazily via chats.get; separate from
+        # _chat_info_cache because that one stores the wrong field as "type".
+        self._chat_mode_cache: Dict[str, str] = {}
         self._message_text_cache: Dict[str, Optional[str]] = {}
         self._app_lock_identity: Optional[str] = None
         self._text_batch_state = FeishuBatchState()
@@ -4250,6 +4254,30 @@ class FeishuAdapter(BasePlatformAdapter):
             logger.error("[Feishu] Failed to send file %s: %s", file_path, exc, exc_info=True)
             return SendResult(success=False, error=str(exc))
 
+    async def _get_chat_mode(self, chat_id: str) -> str:
+        """Return Feishu chat_mode ("p2p" / "group" / "topic" / "").
+
+        Cached per-chat. Used by auto-thread routing in group sends.
+        Returns "" on lookup failure so callers can fall back safely.
+        """
+        cached = self._chat_mode_cache.get(chat_id)
+        if cached is not None:
+            return cached
+        if not self._client:
+            return ""
+        try:
+            request = self._build_get_chat_request(chat_id)
+            response = await asyncio.to_thread(self._client.im.v1.chat.get, request)
+            if not response or getattr(response, "success", lambda: False)() is False:
+                return ""
+            data = getattr(response, "data", None)
+            mode = str(getattr(data, "chat_mode", "") or "").strip().lower()
+            self._chat_mode_cache[chat_id] = mode
+            return mode
+        except Exception:
+            logger.warning("[Feishu] Failed to get chat_mode for %s", chat_id, exc_info=True)
+            return ""
+
     async def _send_raw_message(
         self,
         *,
@@ -4263,6 +4291,23 @@ class FeishuAdapter(BasePlatformAdapter):
         if not effective_reply_to and metadata and metadata.get("thread_id"):
             effective_reply_to = metadata.get("reply_to_message_id")
         reply_in_thread = bool((metadata or {}).get("thread_id"))
+        # In group chats, default to threaded replies so the bot's response
+        # forms a topic instead of flooding the main feed. Opt out via
+        # `feishu.reply_in_thread: false` in config. Only applies when we
+        # have a parent message to reply to — Feishu's API can't create a
+        # topic from a top-level send. DMs (chat_type=dm) are unaffected.
+        if (
+            not reply_in_thread
+            and effective_reply_to
+            and bool(self.config.extra.get("reply_in_thread", True))
+        ):
+            chat_mode = await self._get_chat_mode(chat_id)
+            # Per Feishu docs, chat_mode is the canonical chat-classification
+            # field: "p2p" (DM), "group" (regular group), "topic" (topic
+            # group). Auto-threading only makes sense for "group" — DMs don't
+            # need it and topic groups already enforce a topic structure.
+            if chat_mode == "group":
+                reply_in_thread = True
         if effective_reply_to:
             body = self._build_reply_message_body(
                 content=payload,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13885,11 +13885,15 @@ class GatewayRunner:
         # Bridge sync status_callback → async adapter.send for context pressure
         _status_adapter = self.adapters.get(source.platform)
         _status_chat_id = source.chat_id
-        if source.platform == Platform.FEISHU and source.thread_id and event_message_id:
+        if source.platform == Platform.FEISHU and event_message_id:
             # Feishu topics only keep messages inside the topic when they are
             # sent via the reply API with reply_in_thread=true. Status/interim,
             # approval, and stream-consumer paths usually only receive metadata,
             # so carry the triggering message id as a Feishu-specific fallback.
+            # Done unconditionally for Feishu (not gated on source.thread_id) so
+            # the FeishuAdapter's group-chat auto-thread logic can also anchor
+            # interim sends in fresh group conversations that haven't started
+            # a topic yet.
             _status_thread_metadata: Optional[Dict[str, Any]] = {
                 "thread_id": _progress_thread_id,
                 "reply_to_message_id": event_message_id,


### PR DESCRIPTION
In Feishu group chats the bot currently posts every response into the main message stream, which floods the chat. Default to in-thread replies for regular group chats so each conversation collapses into its own topic.

Behavior:
- Group chats (chat_mode="group"): replies are auto-threaded.
- Direct messages (chat_mode="p2p"): unchanged.
- Topic groups (chat_mode="topic"): unchanged — already topic-scoped.
- Replies that already carry a thread_id: unchanged.
- Sends without a parent message_id: unchanged (Feishu's API can't create a topic from a top-level send).

Opt out via:

    feishu:
      reply_in_thread: false

The reply_in_thread key is already bridged to platform.extra by gateway/config.py for parity with Slack.

Implementation notes:
- Adds a small _get_chat_mode helper that calls im.v1.chat.get and caches the chat_mode field per-chat in a dedicated dict.
- Doesn't reuse _chat_info_cache["type"] because _map_chat_type maps the wrong API field (chat_type — group visibility, "private"/"public") as the chat-mode classifier and silently falls back to "dm" for groups. That pre-existing inconsistency is intentionally left alone in this patch and should be fixed separately.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

