### PR TITLE
fix(gateway): platform_registry.get() instead of is_registered() in Platform._missing_()

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -141,7 +141,7 @@ class Platform(Enum):
         # the enum was defined).
         try:
             from gateway.platform_registry import platform_registry
-            if platform_registry.is_registered(value):
+            if platform_registry.get(value) is not None:
                 pseudo = object.__new__(cls)
                 pseudo._value_ = value
                 pseudo._name_ = value.upper().replace("-", "_").replace(" ", "_")
@@ -158,18 +158,25 @@ class Platform(Enum):
         """Return names of bundled platform plugins under ``plugins/platforms/``."""
         names: set = set()
         try:
-            platforms_dir = Path(__file__).parent.parent / "plugins" / "platforms"
-            if platforms_dir.is_dir():
-                for child in platforms_dir.iterdir():
-                    if (
-                        child.is_dir()
-                        and (child / "__init__.py").exists()
-                        and (
-                            (child / "plugin.yaml").exists()
-                            or (child / "plugin.yml").exists()
-                        )
-                    ):
-                        names.add(child.name.lower())
+            # Scan both the bundled plugins/ dir and the user's plugins/ dir
+            bases = [Path(__file__).parent.parent / "plugins" / "platforms"]
+            herimes_home = Path(os.environ.get("HERMES_HOME") or str(Path.home() / ".hermes"))
+            user_plugins = herimes_home / "plugins" / "platforms"
+            if user_plugins.is_dir():
+                bases.append(user_plugins)
+
+            for platforms_dir in bases:
+                if platforms_dir.is_dir():
+                    for child in platforms_dir.iterdir():
+                        if (
+                            child.is_dir()
+                            and (child / "__init__.py").exists()
+                            and (
+                                (child / "plugin.yaml").exists()
+                                or (child / "plugin.yml").exists()
+                            )
+                        ):
+                            names.add(child.name.lower())
         except Exception:
             pass
         return names


### PR DESCRIPTION
## What does this PR do?

Fixes two bugs in `gateway/config.py`:

1. `Platform._missing_()` (line 144): Calls `platform_registry.is_registered(value)` but that method does not exist on `PlatformRegistry`. Changed to `platform_registry.get(value) is not None` which correctly returns the adapter or None.

2. `Platform._scan_bundled_plugin_platforms()` (lines 161-177): Only scanned `plugins/platforms/` inside the repo. Added `HERMES_HOME/plugins/platforms/` (i.e. `~/.hermes/plugins/platforms/`) so user-installed platform plugins are detected by the Platform enum.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `gateway/config.py`: `_missing_()` — `is_registered` → `get() is not None`
- `gateway/config.py`: `_scan_bundled_plugin_platforms()` — scan both bundled and `~/.hermes/plugins/platforms/`

## How to Test

1. Place a platform plugin in `~/.hermes/plugins/platforms/<name>/` with `__init__.py` and `plugin.yaml`
2. Start hermes-agent — the Platform enum should detect the plugin
3. Verify no `AttributeError` for `is_registered` in logs

## Checklist

- [x] I have read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I have searched for existing PRs to avoid duplicates
- [x] My PR contains only the two changes (no unrelated commits)