### PR TITLE
fix: materialize Vertex AI env for Hindsight daemon

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -424,6 +424,34 @@ def _build_embedded_profile_env(config: dict[str, Any], *, llm_api_key: str | No
     if current_base_url:
         env_values["HINDSIGHT_API_LLM_BASE_URL"] = str(current_base_url)
 
+    # Vertex AI needs provider-specific settings in the standalone embedded
+    # daemon env. Without these, the daemon starts with only provider/model and
+    # fails before serving memory calls.
+    if str(daemon_provider).lower() == "vertexai":
+        vertex_project_id = (
+            config.get("vertexai_project_id")
+            or config.get("llm_vertexai_project_id")
+            or config.get("vertexai_project")
+            or os.environ.get("HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID", "")
+        )
+        vertex_region = (
+            config.get("vertexai_region")
+            or config.get("llm_vertexai_region")
+            or os.environ.get("HINDSIGHT_API_LLM_VERTEXAI_REGION", "")
+        )
+        vertex_service_account_key = (
+            config.get("vertexai_service_account_key")
+            or config.get("llm_vertexai_service_account_key")
+            or config.get("vertexai_credentials")
+            or os.environ.get("HINDSIGHT_API_LLM_VERTEXAI_SERVICE_ACCOUNT_KEY", "")
+        )
+        if vertex_project_id:
+            env_values["HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID"] = str(vertex_project_id)
+        if vertex_region:
+            env_values["HINDSIGHT_API_LLM_VERTEXAI_REGION"] = str(vertex_region)
+        if vertex_service_account_key:
+            env_values["HINDSIGHT_API_LLM_VERTEXAI_SERVICE_ACCOUNT_KEY"] = str(vertex_service_account_key)
+
     idle_timeout = (
         config.get("idle_timeout")
         if config.get("idle_timeout") is not None

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -40,6 +40,9 @@ def _clean_env(monkeypatch):
         "HINDSIGHT_IDLE_TIMEOUT", "HINDSIGHT_LLM_API_KEY",
         "HINDSIGHT_RETAIN_TAGS", "HINDSIGHT_RETAIN_SOURCE",
         "HINDSIGHT_RETAIN_USER_PREFIX", "HINDSIGHT_RETAIN_ASSISTANT_PREFIX",
+        "HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID",
+        "HINDSIGHT_API_LLM_VERTEXAI_REGION",
+        "HINDSIGHT_API_LLM_VERTEXAI_SERVICE_ACCOUNT_KEY",
     ):
         monkeypatch.delenv(key, raising=False)
 
@@ -253,6 +256,51 @@ class TestConfig:
         assert cfg["apiKey"] == "env-key"
         assert cfg["banks"]["hermes"]["bankId"] == "env-bank"
         assert cfg["banks"]["hermes"]["budget"] == "high"
+
+    def test_embedded_profile_env_includes_vertexai_values_from_config(self):
+        env = _build_embedded_profile_env({
+            "llm_provider": "vertexai",
+            "llm_model": "gemini-2.5-flash",
+            "vertexai_project_id": "config-project",
+            "vertexai_region": "us-central1",
+            "vertexai_service_account_key": "/secure/vertex-sa.json",
+        })
+
+        assert env["HINDSIGHT_API_LLM_PROVIDER"] == "vertexai"
+        assert env["HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID"] == "config-project"
+        assert env["HINDSIGHT_API_LLM_VERTEXAI_REGION"] == "us-central1"
+        assert env["HINDSIGHT_API_LLM_VERTEXAI_SERVICE_ACCOUNT_KEY"] == "/secure/vertex-sa.json"
+
+    def test_embedded_profile_env_includes_vertexai_values_from_env(self, monkeypatch):
+        monkeypatch.setenv("HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID", "env-project")
+        monkeypatch.setenv("HINDSIGHT_API_LLM_VERTEXAI_REGION", "asia-southeast1")
+        monkeypatch.setenv("HINDSIGHT_API_LLM_VERTEXAI_SERVICE_ACCOUNT_KEY", "/env/vertex-sa.json")
+
+        env = _build_embedded_profile_env({
+            "llm_provider": "vertexai",
+            "llm_model": "gemini-2.5-flash",
+        })
+
+        assert env["HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID"] == "env-project"
+        assert env["HINDSIGHT_API_LLM_VERTEXAI_REGION"] == "asia-southeast1"
+        assert env["HINDSIGHT_API_LLM_VERTEXAI_SERVICE_ACCOUNT_KEY"] == "/env/vertex-sa.json"
+
+    def test_embedded_profile_env_omits_vertexai_values_for_non_vertex_providers(self, monkeypatch):
+        monkeypatch.setenv("HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID", "env-project")
+        monkeypatch.setenv("HINDSIGHT_API_LLM_VERTEXAI_REGION", "asia-southeast1")
+        monkeypatch.setenv("HINDSIGHT_API_LLM_VERTEXAI_SERVICE_ACCOUNT_KEY", "/env/vertex-sa.json")
+
+        env = _build_embedded_profile_env({
+            "llm_provider": "openai",
+            "llm_model": "gpt-4o-mini",
+            "vertexai_project_id": "config-project",
+            "vertexai_region": "us-central1",
+            "vertexai_service_account_key": "/secure/vertex-sa.json",
+        })
+
+        assert "HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID" not in env
+        assert "HINDSIGHT_API_LLM_VERTEXAI_REGION" not in env
+        assert "HINDSIGHT_API_LLM_VERTEXAI_SERVICE_ACCOUNT_KEY" not in env
 
     def test_embedded_profile_env_includes_idle_timeout_from_config(self):
         env = _build_embedded_profile_env({


### PR DESCRIPTION
## Summary
- materialize Vertex AI project, region, and service-account-key values into the Hindsight embedded daemon profile env when `llm_provider` resolves to `vertexai`
- supports config values first, then `HINDSIGHT_API_LLM_VERTEXAI_*` env fallback
- keeps Vertex AI-specific env keys out of non-Vertex provider daemon envs

## Root cause
`_build_embedded_profile_env` only wrote generic provider/model/API-key/base-url values. For Vertex AI, the standalone embedded daemon also needs project ID, region, and service account key, so it could start without required provider config and fail with `HINDSIGHT_API_LLM_VERTEXAI_PROJECT_ID is required for Vertex AI provider`.

## Test plan
- `python -m pytest tests/plugins/memory/test_hindsight_provider.py::TestConfig::test_embedded_profile_env_includes_vertexai_values_from_config tests/plugins/memory/test_hindsight_provider.py::TestConfig::test_embedded_profile_env_includes_vertexai_values_from_env tests/plugins/memory/test_hindsight_provider.py::TestConfig::test_embedded_profile_env_omits_vertexai_values_for_non_vertex_providers -q -o 'addopts='`
- `python -m pytest tests/plugins/memory/test_hindsight_provider.py -q -o 'addopts='`
- `python -m pytest tests/plugins/memory -q -o 'addopts='`

## Remaining risk
This fixes env materialization for the embedded daemon. Existing long-running daemon processes may still need restart/recreation before they pick up a newly written profile env.
