### PR TITLE
fix(process-registry): guard checkpoint recovery against malformed JSON shapes

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -664,6 +664,35 @@ class TestCheckpoint:
             data = json.loads(checkpoint.read_text())
             assert data == []
 
+    def test_recover_handles_non_list_checkpoint(self, registry, tmp_path):
+        """Checkpoint shaped as a JSON object/null must not crash recovery."""
+        checkpoint = tmp_path / "procs.json"
+
+        for payload in ('null', '{}', '{"session_id": "x", "pid": 1}', '"oops"', '42'):
+            checkpoint.write_text(payload)
+            with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):
+                assert registry.recover_from_checkpoint() == 0
+
+    def test_recover_skips_non_dict_entries(self, registry, tmp_path):
+        """A list with garbage entries must not abort recovery of the good ones."""
+        checkpoint = tmp_path / "procs.json"
+        checkpoint.write_text(json.dumps([
+            None,
+            "garbage",
+            42,
+            {
+                "session_id": "proc_live",
+                "command": "sleep 999",
+                "pid": os.getpid(),
+                "task_id": "t1",
+                "session_key": "sk1",
+            },
+        ]))
+        with patch("tools.process_registry.CHECKPOINT_PATH", checkpoint):
+            recovered = registry.recover_from_checkpoint()
+            assert recovered == 1
+            assert registry.get("proc_live") is not None
+
     def test_detached_recovered_process_eventually_exits(self, registry, tmp_path):
         proc = _spawn_python_sleep(0.4)
         checkpoint = tmp_path / "procs.json"

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -1297,8 +1297,18 @@ class ProcessRegistry:
         except Exception:
             return 0
 
+        if not isinstance(entries, list):
+            logger.warning(
+                "Checkpoint file %s is not a JSON list (got %s); skipping recovery",
+                CHECKPOINT_PATH,
+                type(entries).__name__,
+            )
+            return 0
+
         recovered = 0
         for entry in entries:
+            if not isinstance(entry, dict):
+                continue
             pid = entry.get("pid")
             if not pid:
                 continue


### PR DESCRIPTION
## What does this PR do?

`ProcessRegistry.recover_from_checkpoint` parses `CHECKPOINT_PATH` and then iterates with `for entry in entries: entry.get(...)`. The surrounding `try/except` only wraps `json.loads`, so any successfully-parsed but unexpectedly-shaped payload (a JSON object, a `null`, a scalar, or a list that contains non-dict items) raises mid-loop:

## Root cause

`ProcessRegistry.recover_from_checkpoint` parses `CHECKPOINT_PATH` and then
iterates with `for entry in entries: entry.get(...)`. The surrounding
`try/except` only wraps `json.loads`, so any successfully-parsed but
unexpectedly-shaped payload (a JSON object, a `null`, a scalar, or a list
that contains non-dict items) raises mid-loop:

```
TypeError: 'NoneType' object is not iterable
AttributeError: 'str' object has no attribute 'get'
```

The gateway start-up handler (`gateway/run.py:3286`) swallows the exception
and logs a warning, so a single corrupt or partially-truncated checkpoint
silently aborts recovery of every other live process listed in the file.

## Fix

After parsing, return early when the top-level value is not a list (with a
warning log so the operator notices), and skip non-dict entries inside the
loop. Survivors recover normally.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

N/A

<details>
<summary>Original body</summary>

## Summary

`ProcessRegistry.recover_from_checkpoint` parses `CHECKPOINT_PATH` and then iterates with `for entry in entries: entry.get(...)`. The surrounding `try/except` only wraps `json.loads`, so any successfully-parsed but unexpectedly-shaped payload (a JSON object, a `null`, a scalar, or a list that contains non-dict items) raises mid-loop:

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Problem

`ProcessRegistry.recover_from_checkpoint` parses `CHECKPOINT_PATH` and then
iterates with `for entry in entries: entry.get(...)`. The surrounding
`try/except` only wraps `json.loads`, so any successfully-parsed but
unexpectedly-shaped payload (a JSON object, a `null`, a scalar, or a list
that contains non-dict items) raises mid-loop:

```
TypeError: 'NoneType' object is not iterable
AttributeError: 'str' object has no attribute 'get'
```

The gateway start-up handler (`gateway/run.py:3286`) swallows the exception
and logs a warning, so a single corrupt or partially-truncated checkpoint
silently aborts recovery of every other live process listed in the file.

## Root cause

Missing shape guard between `json.loads` and the `for entry in entries`
loop. The code assumes `list[dict]`, but JSON parsing only guarantees
"some valid JSON value".

## Fix

After parsing, return early when the top-level value is not a list (with a
warning log so the operator notices), and skip non-dict entries inside the
loop. Survivors recover normally.

## Tests

- `TestCheckpoint::test_recover_handles_non_list_checkpoint` covers `null`,
  `{}`, an arbitrary object, a JSON string, and a scalar number.
- `TestCheckpoint::test_recover_skips_non_dict_entries` covers a list
  containing `None`, a string, an int, and one valid dict — the valid entry
  must still be recovered.

Both tests are red on `main` and green with the fix; full
`tests/tools/test_process_registry.py` (49 tests) plus related suites
(`test_notify_on_complete`, `test_watch_patterns`,
`test_windows_native_support`, `test_terminal_tool` — 171 tests total)
green.

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_