### PR TITLE
[codex] Add Hermes Workspace dashboard plugin

### DIFF
--- a/plugins/hermes-workspace/README.md
+++ b/plugins/hermes-workspace/README.md
@@ -1,0 +1,28 @@
+# Hermes Workspace Dashboard Plugin
+
+Hermes Workspace adds a local orchestration cockpit to the dashboard:
+
+- profile and agent roster visibility
+- dashboard and runtime plugin inventory
+- memory and context provider status
+- Kanban board counters and recent tasks
+- quick Kanban task creation
+- multi-agent blueprint launchers
+- debug shortcuts for dashboard, gateway, logs, sessions, and Workspace V2
+- prompt shortcuts injected into the embedded chat tab
+
+## Local Roster Configuration
+
+The plugin avoids shipping personal agent lists in the repository. To customize
+the cockpit locally, create `~/.hermes/workspace_agents.json`:
+
+```json
+{
+  "catalog_label": "Personal Agents",
+  "active_profiles": ["pilot", "ops", "docs"],
+  "catalog_agents": ["orchestrator", "research", "self_review"]
+}
+```
+
+If the file is absent, the plugin derives installed profiles from Hermes and
+uses a generic built-in profile hint list.

--- a/plugins/hermes-workspace/dashboard/dist/index.js
+++ b/plugins/hermes-workspace/dashboard/dist/index.js
@@ -1,0 +1,556 @@
+(function () {
+  "use strict";
+
+  const SDK = window.__HERMES_PLUGIN_SDK__;
+  if (!SDK) return;
+
+  const React = SDK.React;
+  const hooks = SDK.hooks;
+  const components = SDK.components;
+  const Button = components.Button;
+  const Badge = components.Badge;
+
+  const h = React.createElement;
+
+  const WORKSPACE_API = "/api/plugins/hermes-workspace";
+  const PROMPTS = [
+    {
+      label: "Orchestrer",
+      text: "Agis comme orchestrateur Hermes. Decoupe mon objectif en taches Kanban, assigne les bons profils, precise ready/done, risques, dependances et commandes de verification.",
+    },
+    {
+      label: "Debug",
+      text: "Diagnostique Hermes dashboard/chat/Kanban/gateway. Donne les hypotheses, commandes locales, endpoints a tester, logs a lire et corrections minimales.",
+    },
+    {
+      label: "Plugins",
+      text: "Propose les plugins Hermes utiles pour enrichir ce workspace: memoire, observabilite, providers, outils, UX dashboard, securite locale et automatisation.",
+    },
+    {
+      label: "Workers",
+      text: "Cree une strategie multi-agent: pilot orchestre, ops debug, docs documente, research cartographie, cyber audite, growth/business monetise.",
+    },
+  ];
+
+  function number(value) {
+    return Number.isFinite(Number(value)) ? Number(value) : 0;
+  }
+
+  function countBy(list, predicate) {
+    return (list || []).filter(predicate).length;
+  }
+
+  function statusText(data) {
+    const gateway = data && data.gateway && data.gateway.state;
+    if (gateway && gateway.state) return gateway.state;
+    if (gateway && gateway.platforms) return "running";
+    return "unknown";
+  }
+
+  function nav(path) {
+    window.location.href = path;
+  }
+
+  function copy(text, setMessage) {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(text).then(function () {
+        setMessage("Prompt copie");
+        setTimeout(function () { setMessage(""); }, 1800);
+      }).catch(function () {
+        setMessage(text);
+      });
+      return;
+    }
+    setMessage(text);
+  }
+
+  function useSummary() {
+    const useState = hooks.useState;
+    const useEffect = hooks.useEffect;
+    const useCallback = hooks.useCallback;
+    const state = useState({ loading: true, error: "", data: null });
+    const current = state[0];
+    const setCurrent = state[1];
+
+    const refresh = useCallback(function () {
+      setCurrent(function (prev) {
+        return { loading: true, error: "", data: prev.data };
+      });
+      SDK.fetchJSON(WORKSPACE_API + "/summary")
+        .then(function (data) {
+          setCurrent({ loading: false, error: "", data: data });
+        })
+        .catch(function (err) {
+          setCurrent({ loading: false, error: String(err && err.message ? err.message : err), data: null });
+        });
+    }, []);
+
+    useEffect(function () {
+      refresh();
+      const timer = setInterval(refresh, 15000);
+      return function () { clearInterval(timer); };
+    }, [refresh]);
+
+    return { summary: current, refresh: refresh };
+  }
+
+  function Kpi(props) {
+    return h("div", { className: "hw-kpi" },
+      h("span", { className: "hw-muted hw-small" }, props.label),
+      h("strong", null, props.value),
+      h("span", { className: "hw-muted hw-small" }, props.detail || "")
+    );
+  }
+
+  function Pill(props) {
+    return h("span", { className: "hw-pill", "data-state": props.state || "" },
+      props.children
+    );
+  }
+
+  function WorkspaceHero(props) {
+    const data = props.data;
+    const profiles = data.profiles || [];
+    const activeProfiles = data.active_profiles || [];
+    const catalogLabel = data.catalog_label || "Personal Agents";
+    const dashboardPlugins = (data.plugins && data.plugins.dashboard) || [];
+    const agentPlugins = (data.plugins && data.plugins.agent) || [];
+    const boards = (data.kanban && data.kanban.boards) || [];
+    const activeBoard = data.kanban && data.kanban.active_board;
+    const currentBoard = boards.find(function (b) { return b.slug === activeBoard; }) || {};
+    const installedActive = countBy(activeProfiles, function (p) { return p.installed; });
+    const enabledAgentPlugins = countBy(agentPlugins, function (p) { return p.status === "enabled"; });
+
+    return h("section", { className: "hw-hero" },
+      h("div", { className: "hw-grid" },
+        h("div", null,
+          h("h1", { className: "hw-title" }, "Hermes Workspace"),
+          h("p", { className: "hw-muted" },
+            "Cockpit local pour piloter profils, plugins, memoire, debug, Kanban et workers Hermes."
+          )
+        ),
+        h("div", { className: "hw-pills" },
+          h(Pill, { state: statusText(data) === "running" ? "ok" : "warn" }, "Gateway: " + statusText(data)),
+          h(Pill, { state: "ok" }, "Board: " + (activeBoard || "default")),
+          h(Pill, null, "Memoire: " + ((data.memory && data.memory.provider) || "default")),
+          h(Pill, null, "Workspace V2: " + (data.workspace_v2 && data.workspace_v2.exists ? "present" : "absent"))
+        ),
+        h("div", { className: "hw-actions" },
+          h(Button, { onClick: function () { nav("/kanban"); } }, "Ouvrir Kanban"),
+          h(Button, { onClick: function () { nav("/chat"); } }, "Ouvrir Chat"),
+          h(Button, { onClick: function () { nav("/plugins"); } }, "Plugins"),
+          h(Button, { onClick: props.refresh }, "Rafraichir")
+        )
+      ),
+      h("div", { className: "hw-grid hw-grid-2" },
+        h(Kpi, { label: "Profils actifs", value: installedActive + "/" + activeProfiles.length, detail: profiles.length + " profils installes" }),
+        h(Kpi, { label: catalogLabel, value: (data.catalog_agents || []).length, detail: "catalogue local" }),
+        h(Kpi, { label: "Plugins dashboard", value: dashboardPlugins.length, detail: "dont Workspace et Kanban" }),
+        h(Kpi, { label: "Plugins agents", value: enabledAgentPlugins + "/" + agentPlugins.length, detail: "actifs / visibles" }),
+        h(Kpi, { label: "Skills profils", value: data.skills ? data.skills.total_profile_skills : 0, detail: "SKILL.md installes" }),
+        h(Kpi, { label: "Taches board", value: currentBoard.total || 0, detail: activeBoard || "default" })
+      )
+    );
+  }
+
+  function AgentMatrix(props) {
+    const data = props.data;
+    const profiles = data.profiles || [];
+    const activeNames = new Set((data.active_profiles || []).map(function (p) { return p.name; }));
+
+    return h("section", { className: "hw-section" },
+      h("div", { className: "hw-section-head" },
+        h("div", null,
+          h("h2", null, "Agents / profils"),
+          h("span", { className: "hw-muted hw-small" }, "Etat des profils Hermes et mapping du catalogue local.")
+        ),
+        h("div", { className: "hw-actions" },
+          h(Button, { onClick: function () { nav("/profiles"); } }, "Profils"),
+          h(Button, { onClick: function () { nav("/skills"); } }, "Skills")
+        )
+      ),
+      h("div", { className: "hw-grid hw-grid-3" },
+        h("div", null,
+          h("h3", null, "Hermes actifs"),
+          h("div", { className: "hw-pills" },
+            (data.active_profiles || []).map(function (agent) {
+              return h(Pill, { key: agent.name, state: agent.installed ? "ok" : "warn" }, agent.name);
+            })
+          )
+        ),
+        h("div", null,
+          h("h3", null, data.catalog_label || "Personal Agents"),
+          h("div", { className: "hw-pills" },
+            (data.catalog_agents || []).map(function (agent) {
+              return h(Pill, { key: agent.name, state: agent.installed_profile ? "ok" : "" }, agent.name);
+            })
+          )
+        ),
+        h("div", null,
+          h("h3", null, "Profils installes"),
+          profiles.map(function (profile) {
+            return h("div", { className: "hw-row", key: profile.name },
+              h("div", { className: "hw-row-main" },
+                h("strong", null, profile.name),
+                h("span", { className: "hw-muted hw-small" },
+                  (profile.provider || "provider ?") + " / " + (profile.model || "model ?")
+                )
+              ),
+              h("div", { className: "hw-pills" },
+                h(Pill, { state: activeNames.has(profile.name) ? "ok" : "" }, profile.skill_count + " skills"),
+                profile.gateway_running ? h(Pill, { state: "ok" }, "gateway") : null
+              )
+            );
+          })
+        )
+      )
+    );
+  }
+
+  function PluginsPanel(props) {
+    const data = props.data;
+    const dashboard = (data.plugins && data.plugins.dashboard) || [];
+    const agent = (data.plugins && data.plugins.agent) || [];
+    const providers = (data.plugins && data.plugins.providers) || {};
+
+    return h("section", { className: "hw-section" },
+      h("div", { className: "hw-section-head" },
+        h("div", null,
+          h("h2", null, "Plugins / providers"),
+          h("span", { className: "hw-muted hw-small" }, "Inventaire runtime, dashboard, memoire et contexte.")
+        ),
+        h(Button, { onClick: function () { nav("/plugins"); } }, "Manager plugins")
+      ),
+      h("div", { className: "hw-grid hw-grid-2" },
+        h("div", null,
+          h("h3", null, "Dashboard"),
+          dashboard.map(function (p) {
+            return h("div", { className: "hw-row", key: p.name },
+              h("div", { className: "hw-row-main" },
+                h("strong", null, p.label || p.name),
+                h("span", { className: "hw-muted hw-small" }, p.description || p.name)
+              ),
+              h(Pill, { state: p.has_api ? "ok" : "" }, p.has_api ? "api" : "ui")
+            );
+          })
+        ),
+        h("div", null,
+          h("h3", null, "Agent plugins"),
+          h("div", { className: "hw-pills" },
+            h(Pill, null, "memory: " + (providers.memory_provider || "default")),
+            h(Pill, null, "context: " + (providers.context_engine || "default"))
+          ),
+          agent.slice(0, 18).map(function (p) {
+            return h("div", { className: "hw-row", key: p.name },
+              h("div", { className: "hw-row-main" },
+                h("strong", null, p.name),
+                h("span", { className: "hw-muted hw-small" }, p.description || p.source)
+              ),
+              h(Pill, { state: p.status === "enabled" ? "ok" : p.status === "disabled" ? "warn" : "" }, p.status)
+            );
+          })
+        )
+      )
+    );
+  }
+
+  function WorkflowLaunchers(props) {
+    const useState = hooks.useState;
+    const data = props.data;
+    const state = useState("");
+    const message = state[0];
+    const setMessage = state[1];
+    const busyState = useState("");
+    const busy = busyState[0];
+    const setBusy = busyState[1];
+
+    function launch(key) {
+      setBusy(key);
+      setMessage("");
+      SDK.fetchJSON(WORKSPACE_API + "/blueprints/" + encodeURIComponent(key) + "/launch", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ workspace: "workspace_v2", priority: 9, triage: true }),
+      }).then(function (result) {
+        const ids = (result.created || []).map(function (x) { return x.task_id; }).join(", ");
+        setMessage("Pack cree: " + ids);
+        props.refresh();
+      }).catch(function (err) {
+        setMessage("Erreur: " + String(err && err.message ? err.message : err));
+      }).finally(function () {
+        setBusy("");
+      });
+    }
+
+    return h("section", { className: "hw-section" },
+      h("div", { className: "hw-section-head" },
+        h("div", null,
+          h("h2", null, "Launchers Kanban"),
+          h("span", { className: "hw-muted hw-small" }, "Packs de taches pre-assignees aux workers specialises.")
+        ),
+        h("div", { className: "hw-actions" },
+          h(Button, { onClick: function () { nav("/kanban"); } }, "Voir board"),
+          message ? h("span", { className: "hw-muted hw-small" }, message) : null
+        )
+      ),
+      h("div", { className: "hw-grid hw-grid-4" },
+        (data.blueprints || []).map(function (bp) {
+          return h("div", { className: "hw-blueprint", key: bp.key },
+            h("div", null,
+              h("h3", null, bp.label),
+              h("p", { className: "hw-muted hw-small" }, bp.description),
+              h("div", { className: "hw-pills" },
+                h(Pill, null, "lead: " + bp.profile),
+                h(Pill, null, (bp.tasks || []).length + " tasks")
+              )
+            ),
+            h(Button, { disabled: busy === bp.key, onClick: function () { launch(bp.key); } },
+              busy === bp.key ? "Creation..." : "Creer pack"
+            )
+          );
+        })
+      )
+    );
+  }
+
+  function QuickTaskPanel(props) {
+    const useState = hooks.useState;
+    const data = props.data;
+    const profiles = data.active_profiles || [];
+    const formState = useState({
+      title: "",
+      assignee: "pilot",
+      priority: 7,
+      workspace: "workspace_v2",
+      triage: true,
+      body: "",
+      skills: "",
+    });
+    const form = formState[0];
+    const setForm = formState[1];
+    const msgState = useState("");
+    const msg = msgState[0];
+    const setMsg = msgState[1];
+
+    function setField(key, value) {
+      setForm(function (prev) {
+        const next = {};
+        Object.keys(prev).forEach(function (k) { next[k] = prev[k]; });
+        next[key] = value;
+        return next;
+      });
+    }
+
+    function submit() {
+      if (!form.title.trim()) {
+        setMsg("Titre requis.");
+        return;
+      }
+      setMsg("Creation...");
+      SDK.fetchJSON(WORKSPACE_API + "/tasks", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          title: form.title,
+          body: form.body,
+          assignee: form.assignee,
+          priority: number(form.priority),
+          workspace: form.workspace,
+          triage: Boolean(form.triage),
+          skills: form.skills.split(",").map(function (s) { return s.trim(); }).filter(Boolean),
+        }),
+      }).then(function (result) {
+        setMsg("Tache creee: " + result.task_id);
+        setField("title", "");
+        setField("body", "");
+        props.refresh();
+      }).catch(function (err) {
+        setMsg("Erreur: " + String(err && err.message ? err.message : err));
+      });
+    }
+
+    return h("section", { className: "hw-section" },
+      h("div", { className: "hw-section-head" },
+        h("div", null,
+          h("h2", null, "Creation rapide"),
+          h("span", { className: "hw-muted hw-small" }, "Ajoute une tache au board actif sans quitter le cockpit.")
+        ),
+        msg ? h("span", { className: "hw-muted hw-small" }, msg) : null
+      ),
+      h("div", { className: "hw-form" },
+        h("div", { className: "hw-field" },
+          h("label", null, "Titre"),
+          h("input", {
+            value: form.title,
+            onChange: function (event) { setField("title", event.target.value); },
+            placeholder: "Ex: Ajouter vue memoire Workspace",
+          })
+        ),
+        h("div", { className: "hw-field" },
+          h("label", null, "Assignee"),
+          h("select", {
+            value: form.assignee,
+            onChange: function (event) { setField("assignee", event.target.value); },
+          },
+            profiles.map(function (p) {
+              return h("option", { key: p.name, value: p.name }, p.name);
+            })
+          )
+        ),
+        h("div", { className: "hw-field" },
+          h("label", null, "Priorite"),
+          h("input", {
+            type: "number",
+            value: form.priority,
+            onChange: function (event) { setField("priority", event.target.value); },
+          })
+        ),
+        h(Button, { onClick: submit }, "Creer")
+      ),
+      h("div", { className: "hw-grid hw-grid-2", style: { marginTop: "10px" } },
+        h("div", { className: "hw-field" },
+          h("label", null, "Workspace"),
+          h("select", {
+            value: form.workspace,
+            onChange: function (event) { setField("workspace", event.target.value); },
+          },
+            Object.keys(data.workspaces || {}).map(function (key) {
+              const item = data.workspaces[key];
+              return h("option", { key: key, value: key }, item.label || key);
+            })
+          )
+        ),
+        h("div", { className: "hw-field" },
+          h("label", null, "Skills forces, separes par virgule"),
+          h("input", {
+            value: form.skills,
+            onChange: function (event) { setField("skills", event.target.value); },
+            placeholder: "kanban-worker, code-security",
+          })
+        ),
+        h("div", { className: "hw-field" },
+          h("label", null, "Body"),
+          h("textarea", {
+            value: form.body,
+            onChange: function (event) { setField("body", event.target.value); },
+            placeholder: "Contexte, definition of done, contraintes, liens.",
+          })
+        ),
+        h("div", { className: "hw-field" },
+          h("label", null, "Mode"),
+          h("label", { className: "hw-pill", style: { justifyContent: "flex-start" } },
+            h("input", {
+              type: "checkbox",
+              checked: Boolean(form.triage),
+              onChange: function (event) { setField("triage", event.target.checked); },
+            }),
+            "Triage avant execution"
+          )
+        )
+      )
+    );
+  }
+
+  function DebugPanel(props) {
+    const data = props.data;
+    const tasks = (data.kanban && data.kanban.recent_tasks) || [];
+    const runtime = data.runtime || {};
+    const workspace = data.workspace_v2 || {};
+
+    return h("section", { className: "hw-section" },
+      h("div", { className: "hw-section-head" },
+        h("div", null,
+          h("h2", null, "Debug / chemins"),
+          h("span", { className: "hw-muted hw-small" }, "Raccourcis de verification locale.")
+        ),
+        h("div", { className: "hw-actions" },
+          h(Button, { onClick: function () { nav("/logs"); } }, "Logs"),
+          h(Button, { onClick: function () { nav("/sessions"); } }, "Sessions")
+        )
+      ),
+      h("div", { className: "hw-grid hw-grid-3" },
+        h("div", null,
+          h("h3", null, "Runtime"),
+          h("div", { className: "hw-code hw-muted" }, runtime.path || ""),
+          h("div", { className: "hw-code" }, runtime.status || "")
+        ),
+        h("div", null,
+          h("h3", null, "Workspace V2"),
+          h("div", { className: "hw-code hw-muted" }, workspace.path || ""),
+          h("div", { className: "hw-code" }, workspace.status || "")
+        ),
+        h("div", null,
+          h("h3", null, "Taches recentes"),
+          tasks.length === 0 ? h("span", { className: "hw-muted hw-small" }, "Aucune tache sur le board actif.") :
+            tasks.map(function (task) {
+              return h("div", { className: "hw-row", key: task.id },
+                h("div", { className: "hw-row-main" },
+                  h("strong", null, task.title),
+                  h("span", { className: "hw-muted hw-small" }, task.id + " / " + task.assignee)
+                ),
+                h(Pill, null, task.status)
+              );
+            })
+        )
+      )
+    );
+  }
+
+  function WorkspacePage() {
+    const state = useSummary();
+    const summary = state.summary;
+
+    if (summary.loading && !summary.data) {
+      return h("div", { className: "hw-root" }, h("div", { className: "hw-section" }, "Chargement Workspace..."));
+    }
+    if (summary.error && !summary.data) {
+      return h("div", { className: "hw-root" }, h("div", { className: "hw-section" }, "Erreur Workspace: " + summary.error));
+    }
+
+    const data = summary.data;
+    return h("div", { className: "hw-root" },
+      h(WorkspaceHero, { data: data, refresh: state.refresh }),
+      h(QuickTaskPanel, { data: data, refresh: state.refresh }),
+      h(WorkflowLaunchers, { data: data, refresh: state.refresh }),
+      h(AgentMatrix, { data: data }),
+      h(PluginsPanel, { data: data }),
+      h(DebugPanel, { data: data })
+    );
+  }
+
+  function ChatTopSlot() {
+    const useState = hooks.useState;
+    const msgState = useState("");
+    const msg = msgState[0];
+    const setMsg = msgState[1];
+    return h("div", { className: "hw-chat-top" },
+      h("div", null,
+        h("strong", null, "Workspace prompts"),
+        h("span", { className: "hw-muted hw-small", style: { display: "block" } },
+          "Copie un prompt puis colle-le dans le TUI."
+        )
+      ),
+      h("div", { className: "hw-actions" },
+        PROMPTS.map(function (prompt) {
+          return h(Button, { key: prompt.label, onClick: function () { copy(prompt.text, setMsg); } }, prompt.label);
+        }),
+        h(Button, { onClick: function () { nav("/workspace"); } }, "Cockpit")
+      ),
+      msg ? h("span", { className: "hw-muted hw-small" }, msg) : null
+    );
+  }
+
+  function HeaderBannerSlot() {
+    return h("div", { className: "hw-banner" },
+      h("span", { className: "hw-small" }, "Hermes Workspace actif: agents, plugins, Kanban et debug centralises."),
+      h("div", { className: "hw-actions" },
+        h("button", { className: "hw-pill", onClick: function () { nav("/workspace"); } }, "Workspace"),
+        h("button", { className: "hw-pill", onClick: function () { nav("/kanban"); } }, "Kanban")
+      )
+    );
+  }
+
+  window.__HERMES_PLUGINS__.register("hermes-workspace", WorkspacePage);
+  window.__HERMES_PLUGINS__.registerSlot("hermes-workspace", "chat:top", ChatTopSlot);
+  window.__HERMES_PLUGINS__.registerSlot("hermes-workspace", "header-banner", HeaderBannerSlot);
+})();

--- a/plugins/hermes-workspace/dashboard/dist/style.css
+++ b/plugins/hermes-workspace/dashboard/dist/style.css
@@ -1,0 +1,246 @@
+.hw-root {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  min-width: 0;
+  text-transform: none;
+}
+
+.hw-hero,
+.hw-section,
+.hw-chat-top,
+.hw-banner {
+  border: 1px solid rgba(63, 211, 255, 0.28);
+  background: linear-gradient(180deg, rgba(7, 16, 38, 0.92), rgba(5, 9, 26, 0.86));
+  box-shadow: inset 0 0 0 1px rgba(255, 206, 58, 0.08), 0 18px 48px -32px rgba(63, 211, 255, 0.65);
+}
+
+.hw-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(280px, 0.8fr);
+  gap: 16px;
+  padding: 16px;
+}
+
+.hw-title {
+  margin: 0;
+  font-size: 1.35rem;
+  line-height: 1.1;
+  letter-spacing: 0;
+}
+
+.hw-muted {
+  color: rgb(160, 184, 202);
+}
+
+.hw-grid {
+  display: grid;
+  gap: 12px;
+}
+
+.hw-grid-4 {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.hw-grid-3 {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+}
+
+.hw-grid-2 {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.hw-kpi {
+  border: 1px solid rgba(216, 240, 255, 0.16);
+  background: rgba(255, 255, 255, 0.035);
+  padding: 12px;
+  min-height: 92px;
+}
+
+.hw-kpi strong {
+  display: block;
+  font-size: 1.55rem;
+  line-height: 1.1;
+}
+
+.hw-section {
+  padding: 14px;
+}
+
+.hw-section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.hw-section h2,
+.hw-section h3 {
+  margin: 0;
+  letter-spacing: 0;
+}
+
+.hw-pills {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.hw-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  border: 1px solid rgba(216, 240, 255, 0.18);
+  background: rgba(255, 255, 255, 0.04);
+  color: rgb(216, 240, 255);
+  min-height: 28px;
+  padding: 4px 8px;
+  font-size: 0.75rem;
+}
+
+.hw-pill[data-state="ok"] {
+  border-color: rgba(74, 222, 128, 0.4);
+  color: rgb(134, 239, 172);
+}
+
+.hw-pill[data-state="warn"] {
+  border-color: rgba(255, 206, 58, 0.45);
+  color: rgb(255, 224, 138);
+}
+
+.hw-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  border-top: 1px solid rgba(216, 240, 255, 0.1);
+  padding: 9px 0;
+}
+
+.hw-row:first-child {
+  border-top: 0;
+}
+
+.hw-row-main {
+  min-width: 0;
+}
+
+.hw-row-main strong,
+.hw-row-main span {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.hw-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.hw-form {
+  display: grid;
+  grid-template-columns: minmax(220px, 1fr) minmax(140px, 180px) minmax(96px, 120px) auto;
+  gap: 8px;
+  align-items: end;
+}
+
+.hw-field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  min-width: 0;
+}
+
+.hw-field label {
+  color: rgb(160, 184, 202);
+  font-size: 0.72rem;
+}
+
+.hw-field input,
+.hw-field select,
+.hw-field textarea {
+  min-height: 36px;
+  border: 1px solid rgba(216, 240, 255, 0.18);
+  background: rgba(0, 0, 0, 0.18);
+  color: rgb(248, 252, 255);
+  padding: 8px;
+  outline: none;
+}
+
+.hw-field textarea {
+  min-height: 78px;
+  resize: vertical;
+}
+
+.hw-blueprint {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 12px;
+  border: 1px solid rgba(216, 240, 255, 0.15);
+  background: rgba(255, 255, 255, 0.035);
+  padding: 12px;
+  min-height: 170px;
+}
+
+.hw-code {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.72rem;
+  word-break: break-all;
+}
+
+.hw-chat-top {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 10px;
+}
+
+.hw-banner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  padding: 7px 12px;
+  color: rgb(216, 240, 255);
+  text-transform: none;
+}
+
+.hw-small {
+  font-size: 0.78rem;
+}
+
+@media (max-width: 1100px) {
+  .hw-grid-4 {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .hw-hero,
+  .hw-grid-3,
+  .hw-grid-2 {
+    grid-template-columns: 1fr;
+  }
+
+  .hw-form {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 640px) {
+  .hw-form,
+  .hw-grid-4 {
+    grid-template-columns: 1fr;
+  }
+
+  .hw-section-head,
+  .hw-chat-top,
+  .hw-banner {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+}

--- a/plugins/hermes-workspace/dashboard/manifest.json
+++ b/plugins/hermes-workspace/dashboard/manifest.json
@@ -1,0 +1,15 @@
+{
+  "name": "hermes-workspace",
+  "label": "Workspace",
+  "description": "Hermes orchestration cockpit: agents, profiles, plugins, memory, Kanban launchers and debug shortcuts.",
+  "icon": "Activity",
+  "version": "1.0.0",
+  "tab": {
+    "path": "/workspace",
+    "position": "after:kanban"
+  },
+  "slots": ["chat:top", "header-banner"],
+  "entry": "dist/index.js",
+  "css": "dist/style.css",
+  "api": "plugin_api.py"
+}

--- a/plugins/hermes-workspace/dashboard/plugin_api.py
+++ b/plugins/hermes-workspace/dashboard/plugin_api.py
@@ -1,0 +1,494 @@
+"""Hermes Workspace dashboard plugin API.
+
+Mounted at /api/plugins/hermes-workspace/.
+This is a local dashboard helper: it reads non-secret runtime metadata,
+summarises profiles/plugins/Kanban, and can create supervised Kanban tasks.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import time
+from dataclasses import asdict
+from pathlib import Path
+from typing import Any, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel, Field
+
+from hermes_constants import get_hermes_home
+from hermes_cli import kanban_db
+from hermes_cli.config import cfg_get, load_config
+from hermes_cli.profiles import list_profiles, normalize_profile_name
+
+router = APIRouter()
+
+DEFAULT_ACTIVE_PROFILE_HINTS = [
+    "business",
+    "cyber",
+    "docs",
+    "finance",
+    "freelance",
+    "growth",
+    "jobsearch",
+    "legal",
+    "location",
+    "meeting",
+    "ops",
+    "personal",
+    "pilot",
+    "pricing",
+    "privacy",
+    "research",
+    "trading",
+    "veille",
+]
+
+WORKSPACE_PATHS = {
+    "scratch": {"label": "Scratch", "kind": "scratch", "path": None},
+    "hermes_runtime": {
+        "label": "Hermes runtime",
+        "kind": "dir",
+        "path": str(get_hermes_home() / "hermes-agent"),
+    },
+    "workspace_v2": {
+        "label": "Hermes Workspace V2",
+        "kind": "dir",
+        "path": str(Path.home() / "Documents" / "hermes-agent-workspace-v2"),
+    },
+}
+
+
+def _string_list(value: Any) -> list[str]:
+    if not isinstance(value, list):
+        return []
+    return [str(item).strip() for item in value if str(item).strip()]
+
+
+def _load_workspace_catalog(installed_profile_names: set[str]) -> dict[str, Any]:
+    """Load optional local roster metadata without hardcoding private data.
+
+    Users can create ``~/.hermes/workspace_agents.json`` with:
+    {
+      "active_profiles": ["ops", "pilot"],
+      "catalog_label": "Personal Agents",
+      "catalog_agents": ["orchestrator", "research"]
+    }
+    """
+    default_active = [name for name in DEFAULT_ACTIVE_PROFILE_HINTS if name in installed_profile_names]
+    if not default_active:
+        default_active = sorted(name for name in installed_profile_names if name != "default")
+
+    catalog = {
+        "active_profiles": default_active,
+        "catalog_label": "Personal Agents",
+        "catalog_agents": [],
+    }
+    path = get_hermes_home() / "workspace_agents.json"
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return catalog
+    if not isinstance(raw, dict):
+        return catalog
+
+    active_profiles = _string_list(raw.get("active_profiles"))
+    catalog_agents = _string_list(raw.get("catalog_agents"))
+    catalog_label = str(raw.get("catalog_label") or "").strip()
+
+    if active_profiles:
+        catalog["active_profiles"] = active_profiles
+    if catalog_agents:
+        catalog["catalog_agents"] = catalog_agents
+    if catalog_label:
+        catalog["catalog_label"] = catalog_label
+    return catalog
+
+
+class QuickTask(BaseModel):
+    title: str = Field(..., min_length=1, max_length=240)
+    body: Optional[str] = None
+    assignee: Optional[str] = None
+    priority: int = Field(default=5, ge=-100, le=100)
+    triage: bool = False
+    workspace: str = "scratch"
+    skills: list[str] = Field(default_factory=list)
+
+
+class BlueprintLaunch(BaseModel):
+    workspace: str = "workspace_v2"
+    priority: int = Field(default=8, ge=-100, le=100)
+    triage: bool = False
+
+
+def _safe_count_dir(path: Path, pattern: str) -> int:
+    try:
+        if not path.is_dir():
+            return 0
+        return sum(1 for _ in path.rglob(pattern))
+    except Exception:
+        return 0
+
+
+def _workspace_ref(key: str) -> tuple[str, Optional[str], str]:
+    ref = WORKSPACE_PATHS.get(key) or WORKSPACE_PATHS["scratch"]
+    kind = ref["kind"]
+    path = ref["path"]
+    if kind == "dir" and path and not Path(path).exists():
+        return "scratch", None, "scratch"
+    return kind, path, key
+
+
+def _task_dict(task: kanban_db.Task) -> dict[str, Any]:
+    data = asdict(task)
+    for key in ("body", "result", "claim_lock", "last_failure_error"):
+        value = data.get(key)
+        if isinstance(value, str) and len(value) > 220:
+            data[key] = value[:220] + "..."
+    return data
+
+
+def _board_counts(board: str) -> dict[str, int]:
+    try:
+        kanban_db.init_db(board=board)
+        with kanban_db.connect(board=board) as conn:
+            rows = conn.execute(
+                "SELECT status, COUNT(*) AS n FROM tasks GROUP BY status"
+            ).fetchall()
+        return {str(r["status"]): int(r["n"]) for r in rows}
+    except Exception:
+        return {}
+
+
+def _recent_tasks(board: str, limit: int = 8) -> list[dict[str, Any]]:
+    try:
+        kanban_db.init_db(board=board)
+        with kanban_db.connect(board=board) as conn:
+            tasks = kanban_db.list_tasks(conn, include_archived=False, limit=limit)
+        return [_task_dict(t) for t in tasks]
+    except Exception:
+        return []
+
+
+def _discover_dashboard_plugins() -> list[dict[str, Any]]:
+    try:
+        from hermes_cli import web_server
+
+        plugins = web_server._get_dashboard_plugins(force_rescan=True)
+        return [
+            {k: v for k, v in p.items() if not k.startswith("_")}
+            for p in plugins
+        ]
+    except Exception:
+        return []
+
+
+def _discover_agent_plugins() -> dict[str, Any]:
+    try:
+        from hermes_cli.plugins_cmd import (
+            _discover_all_plugins,
+            _get_current_context_engine,
+            _get_current_memory_provider,
+            _get_disabled_set,
+            _get_enabled_set,
+        )
+    except Exception:
+        return {
+            "plugins": [],
+            "providers": {"memory_provider": "", "context_engine": ""},
+        }
+
+    try:
+        enabled = _get_enabled_set()
+        disabled = _get_disabled_set()
+    except Exception:
+        enabled = set()
+        disabled = set()
+
+    rows: list[dict[str, Any]] = []
+    for name, version, description, source, path in _discover_all_plugins():
+        if name in disabled:
+            status = "disabled"
+        elif name in enabled:
+            status = "enabled"
+        else:
+            status = "inactive"
+        rows.append(
+            {
+                "name": name,
+                "version": version,
+                "description": description,
+                "source": source,
+                "status": status,
+                "path": str(path),
+            }
+        )
+
+    try:
+        memory_provider = _get_current_memory_provider() or ""
+    except Exception:
+        memory_provider = ""
+    try:
+        context_engine = _get_current_context_engine() or ""
+    except Exception:
+        context_engine = ""
+
+    return {
+        "plugins": rows,
+        "providers": {
+            "memory_provider": memory_provider,
+            "context_engine": context_engine,
+        },
+    }
+
+
+def _git_summary(path: Path) -> dict[str, Any]:
+    if not (path / ".git").exists():
+        return {"exists": path.exists(), "path": str(path)}
+    try:
+        status = subprocess.run(
+            ["git", "status", "--short", "--branch"],
+            cwd=str(path),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        ).stdout.strip()
+        head = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            cwd=str(path),
+            check=False,
+            capture_output=True,
+            text=True,
+            timeout=5,
+        ).stdout.strip()
+    except Exception as exc:
+        return {"exists": path.exists(), "path": str(path), "error": str(exc)}
+    return {"exists": True, "path": str(path), "status": status, "head": head}
+
+
+def _profile_row(profile) -> dict[str, Any]:
+    return {
+        "name": profile.name,
+        "path": str(profile.path),
+        "is_default": bool(profile.is_default),
+        "gateway_running": bool(profile.gateway_running),
+        "model": profile.model or "",
+        "provider": profile.provider or "",
+        "has_env": bool(profile.has_env),
+        "skill_count": int(profile.skill_count or 0),
+        "alias": str(profile.alias_path) if profile.alias_path else "",
+        "distribution": profile.distribution_name or "",
+    }
+
+
+def _blueprints() -> list[dict[str, Any]]:
+    return [
+        {
+            "key": "workspace-v2-full",
+            "label": "Workspace V2 full build",
+            "profile": "pilot",
+            "description": "Decoupe GUI, agents, memory, skills, debug and multi-agent flow.",
+            "tasks": [
+                ["pilot", "Orchestrer Workspace V2", "Decouper l'interface en vues agents, memoire, skills, debug et kanban."],
+                ["ops", "Brancher debug runtime", "Verifier gateway, logs, dashboard, services launchd et workflow de restart."],
+                ["docs", "Documenter l'utilisation Workspace V2", "Produire un guide court: dashboard, Kanban, Electron, agents et commandes."],
+                ["research", "Cartographier plugins et providers", "Lister plugins utiles, providers memoire/contexte et opportunites d'extension."],
+                ["cyber", "Revue securite locale", "Verifier exposition API plugin, donnees sensibles, hosts, logs et secrets."],
+            ],
+        },
+        {
+            "key": "kanban-orchestration",
+            "label": "Kanban multi-agent",
+            "profile": "pilot",
+            "description": "Installe une boucle orchestrateur + workers specialises sur le board actif.",
+            "tasks": [
+                ["pilot", "Design workflow orchestrateur", "Definir colonnes, criteres ready/done, dependances et conventions de handoff."],
+                ["ops", "Verifier dispatcher Kanban", "Controler gateway, DB board actif, reclaim/reassign, logs et diagnostics."],
+                ["docs", "Guide worker Kanban", "Documenter create/list/watch/show/log/reassign/specify avec exemples."],
+                ["research", "Backlog plugins agentiques", "Identifier les plugins/outils a brancher par profil."],
+            ],
+        },
+        {
+            "key": "personal-agent-grid",
+            "label": "Personal agent grid",
+            "profile": "personal",
+            "description": "Aligns catalogued personal agents, active profiles and supervised usage.",
+            "tasks": [
+                ["personal", "Map personal agent catalogue", "Relier les agents catalogues aux profils Hermes actifs et aux dossiers locaux."],
+                ["growth", "Agent business opportunities", "Transformer les agents business/cyber/growth en workflows monetisables."],
+                ["privacy", "Personal data guardrails", "Definir ce qui reste local, ce qui ne doit jamais etre pousse, et les validations."],
+                ["ops", "Operations routines", "Preparer commandes de run, logs, scorecards, cron et reprise d'erreur."],
+            ],
+        },
+        {
+            "key": "debug-sweep",
+            "label": "Debug sweep",
+            "profile": "ops",
+            "description": "Passe rapide pour incidents dashboard, chat, plugins, gateway, Kanban.",
+            "tasks": [
+                ["ops", "Audit dashboard/chat", "Verifier /chat, /workspace, /kanban, plugins charges, console et endpoints API."],
+                ["cyber", "Audit exposition locale", "Verifier localhost, routes plugins, secrets non exposes et logs."],
+                ["docs", "Runbook debug", "Ecrire les commandes de restart, status, logs, curl et diagnostics."],
+            ],
+        },
+    ]
+
+
+@router.get("/summary")
+async def summary():
+    config = load_config()
+    hermes_home = get_hermes_home()
+    active_board = kanban_db.get_current_board() or kanban_db.DEFAULT_BOARD
+
+    try:
+        boards = kanban_db.list_boards(include_archived=False)
+    except Exception:
+        boards = []
+
+    board_rows = []
+    for board in boards:
+        slug = board.get("slug") or kanban_db.DEFAULT_BOARD
+        counts = _board_counts(slug)
+        board_rows.append({**board, "counts": counts, "total": sum(counts.values())})
+
+    profiles = [_profile_row(p) for p in list_profiles()]
+    profile_names = {p["name"] for p in profiles}
+    roster = _load_workspace_catalog(profile_names)
+    active_profiles = [
+        {"name": name, "installed": name in profile_names}
+        for name in roster["active_profiles"]
+    ]
+    catalog_agents = [
+        {
+            "name": name,
+            "profile_match": name if name in profile_names else "",
+            "installed_profile": name in profile_names,
+        }
+        for name in roster["catalog_agents"]
+    ]
+
+    dashboard_plugins = _discover_dashboard_plugins()
+    agent_plugins = _discover_agent_plugins()
+
+    workspace_v2 = Path(WORKSPACE_PATHS["workspace_v2"]["path"] or "")
+    runtime_repo = Path(WORKSPACE_PATHS["hermes_runtime"]["path"] or "")
+
+    gateway_state_path = hermes_home / "gateway_state.json"
+    gateway_state = {}
+    try:
+        gateway_state = json.loads(gateway_state_path.read_text(encoding="utf-8"))
+    except Exception:
+        gateway_state = {}
+
+    memory_provider = cfg_get(config, "memory", "provider", default="") or agent_plugins["providers"].get("memory_provider", "")
+    context_engine = cfg_get(config, "context_engine", "provider", default="") or agent_plugins["providers"].get("context_engine", "")
+
+    return {
+        "generated_at": int(time.time()),
+        "hermes_home": str(hermes_home),
+        "runtime": _git_summary(runtime_repo),
+        "workspace_v2": _git_summary(workspace_v2),
+        "memory": {
+            "provider": memory_provider,
+            "context_engine": context_engine,
+            "default_memory_files": {
+                "memory_md": (hermes_home / "memories" / "MEMORY.md").exists(),
+                "user_md": (hermes_home / "memories" / "USER.md").exists(),
+            },
+        },
+        "gateway": {
+            "pid_file": str(hermes_home / "gateway.pid"),
+            "state": gateway_state,
+        },
+        "profiles": profiles,
+        "active_profiles": active_profiles,
+        "catalog_label": roster["catalog_label"],
+        "catalog_agents": catalog_agents,
+        "skills": {
+            "total_profile_skills": sum(p["skill_count"] for p in profiles),
+            "runtime_skills": _safe_count_dir(runtime_repo / "skills", "SKILL.md"),
+        },
+        "plugins": {
+            "dashboard": dashboard_plugins,
+            "agent": agent_plugins["plugins"],
+            "providers": agent_plugins["providers"],
+        },
+        "kanban": {
+            "active_board": active_board,
+            "boards": board_rows,
+            "recent_tasks": _recent_tasks(active_board),
+        },
+        "workspaces": WORKSPACE_PATHS,
+        "blueprints": _blueprints(),
+    }
+
+
+@router.get("/blueprints")
+async def blueprints():
+    return {"blueprints": _blueprints()}
+
+
+@router.post("/tasks")
+async def create_task(body: QuickTask):
+    kind, path, workspace_key = _workspace_ref(body.workspace)
+    assignee = normalize_profile_name(body.assignee) if body.assignee else None
+    try:
+        kanban_db.init_db()
+        with kanban_db.connect() as conn:
+            task_id = kanban_db.create_task(
+                conn,
+                title=body.title,
+                body=body.body,
+                assignee=assignee,
+                created_by="dashboard:hermes-workspace",
+                workspace_kind=kind,
+                workspace_path=path,
+                priority=body.priority,
+                triage=body.triage,
+                skills=body.skills or None,
+            )
+            task = kanban_db.get_task(conn, task_id)
+    except (ValueError, sqlite3.Error) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    return {"ok": True, "task_id": task_id, "workspace": workspace_key, "task": _task_dict(task) if task else None}
+
+
+@router.post("/blueprints/{key}/launch")
+async def launch_blueprint(key: str, body: BlueprintLaunch):
+    blueprint = next((bp for bp in _blueprints() if bp["key"] == key), None)
+    if not blueprint:
+        raise HTTPException(status_code=404, detail="Unknown blueprint.")
+
+    kind, path, workspace_key = _workspace_ref(body.workspace)
+    created: list[dict[str, Any]] = []
+    try:
+        kanban_db.init_db()
+        with kanban_db.connect() as conn:
+            for index, (assignee, title, task_body) in enumerate(blueprint["tasks"]):
+                task_id = kanban_db.create_task(
+                    conn,
+                    title=title,
+                    body=f"{task_body}\n\nBlueprint: {blueprint['label']}",
+                    assignee=assignee,
+                    created_by="dashboard:hermes-workspace",
+                    workspace_kind=kind,
+                    workspace_path=path,
+                    priority=body.priority - index,
+                    triage=body.triage,
+                    skills=["kanban-worker"],
+                    idempotency_key=f"hermes-workspace:{key}:{workspace_key}:{assignee}:{title}",
+                )
+                task = kanban_db.get_task(conn, task_id)
+                created.append({"task_id": task_id, "task": _task_dict(task) if task else None})
+    except (ValueError, sqlite3.Error) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    return {
+        "ok": True,
+        "blueprint": blueprint,
+        "workspace": workspace_key,
+        "created": created,
+    }


### PR DESCRIPTION
## Summary

Adds a bundled `hermes-workspace` dashboard plugin that turns the Hermes dashboard into a local orchestration cockpit.

The plugin surfaces:
- profile and local agent roster visibility
- dashboard and runtime plugin inventory
- memory/context provider status
- Kanban board counters and recent tasks
- quick Kanban task creation
- multi-agent blueprint launchers
- debug shortcuts for dashboard, gateway, logs, sessions, and Workspace V2
- prompt shortcuts injected into the embedded chat tab

## Privacy / Local Configuration

The plugin does not ship personal agent rosters. Users can opt in locally with `~/.hermes/workspace_agents.json` to customize active profiles and catalogued agents.

## Validation

- `python -m py_compile plugins/hermes-workspace/dashboard/plugin_api.py`
- `node --check plugins/hermes-workspace/dashboard/dist/index.js`
- Verified local dashboard plugin discovery at `/api/dashboard/plugins`
- Verified Workspace API at `/api/plugins/hermes-workspace/summary`
- Verified `/workspace` and `/chat` plugin slot rendering in the dashboard
