### PR TITLE
feat(slack): support SLACK_SLASH_PREFIX for namespaced commands

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -625,7 +625,10 @@ class SlackAdapter(BasePlatformAdapter):
             from hermes_cli.commands import slack_native_slashes
             import re as _re
 
+            _slash_prefix = os.getenv("SLACK_SLASH_PREFIX", "").rstrip("-")
             _slash_names = [name for name, _d, _h in slack_native_slashes()]
+            if _slash_prefix:
+                _slash_names = [_slash_prefix + "-" + n for n in _slash_names]
             if _slash_names:
                 _slash_pattern = _re.compile(
                     r"^/(?:" + "|".join(_re.escape(n) for n in _slash_names) + r")$"
@@ -2693,6 +2696,9 @@ class SlackAdapter(BasePlatformAdapter):
         message).
         """
         slash_name = (command.get("command") or "").lstrip("/").strip()
+        _prefix = os.getenv("SLACK_SLASH_PREFIX", "").rstrip("-")
+        if _prefix and slash_name.startswith(_prefix + "-"):
+            slash_name = slash_name[len(_prefix) + 1:]
         text = command.get("text", "").strip()
         user_id = command.get("user_id", "")
         channel_id = command.get("channel_id", "")


### PR DESCRIPTION
## Problem

When two Hermes bots share a Slack workspace, their native slash commands (`/hermes`, `/new`, `/model`, etc.) collide. Slack routes commands per-app, not per-socket, so both bots see every command.

## Solution

Add a `SLACK_SLASH_PREFIX` env var that lets operators namespace every slash command:

- Set `SLACK_SLASH_PREFIX=sable` in `.env`
- The Socket Mode regex matcher builds patterns like `/sable-hermes`, `/sable-new`
- `_handle_slash_command` strips the prefix before dispatch to the central command registry

Without the env var (default), behaviour is unchanged — no prefix, same regex pattern.

### Two touch points in `gateway/platforms/slack.py`

1. **Registration/pattern building** — when `SLACK_SLASH_PREFIX` is set, the regex pattern matches `/prefix-command` instead of bare `/command`
2. **Dispatch** — `_handle_slash_command` strips the prefix so the command name resolves correctly in the registry

Co-Authored-By: Mira <mira@hermes.local>