### PR TITLE
fix(gateway): preserve queued text messages in busy_input_mode=queue

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2759,7 +2759,14 @@ class BasePlatformAdapter(ABC):
 
             # Default behavior for non-photo follow-ups: interrupt the running agent
             logger.debug("[%s] New message while session %s is active — triggering interrupt", self.name, session_key)
-            self._pending_messages[session_key] = event
+            # Merge text follow-ups so simultaneous queued user messages
+            # don't clobber each other.  Falls back to overwrite for non-text.
+            if event.message_type == MessageType.TEXT:
+                merge_pending_message_event(
+                    self._pending_messages, session_key, event, merge_text=True
+                )
+            else:
+                self._pending_messages[session_key] = event
             # Signal the interrupt (the processing task checks this)
             self._active_sessions[session_key].set()
             return  # Don't process now - will be handled after current task finishes

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2388,7 +2388,9 @@ class GatewayRunner:
         adapter = self.adapters.get(event.source.platform)
         if not adapter:
             return
-        merge_pending_message_event(adapter._pending_messages, session_key, event)
+        merge_pending_message_event(
+            adapter._pending_messages, session_key, event, merge_text=True
+        )
 
     async def _handle_active_session_busy_message(self, event: MessageEvent, session_key: str) -> bool:
         # --- Authorization gate (#17775) ---
@@ -2470,8 +2472,14 @@ class GatewayRunner:
         # current run finishes (or is interrupted).  Skip this for a
         # successful steer — the text already landed inside the run and
         # must NOT also be replayed as a next-turn user message.
+        # ``merge_text=True`` matches the rapid-follow-up path in
+        # _handle_message (5620/5640) so two text messages queued during
+        # the same busy turn append instead of the later one clobbering
+        # the earlier — preserves user intent in queue mode.
         if not steered:
-            merge_pending_message_event(adapter._pending_messages, session_key, event)
+            merge_pending_message_event(
+                adapter._pending_messages, session_key, event, merge_text=True
+            )
 
         is_queue_mode = effective_mode == "queue"
         is_steer_mode = effective_mode == "steer"

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -552,3 +552,46 @@ class TestBusySessionOnboardingHint:
         assert "/busy interrupt" in content
         # Must NOT tell the user to /busy queue when they're already on queue.
         assert "/busy queue" not in content
+
+    @pytest.mark.asyncio
+    async def test_queue_mode_appends_text_messages(self, tmp_path, monkeypatch):
+        """Two queued text messages must append, not overwrite each other.
+
+        Regression: ``_handle_active_session_busy_message`` previously called
+        ``merge_pending_message_event`` without ``merge_text=True``, so the
+        second message in queue mode silently clobbered the first — losing
+        user intent.  See run.py site near the "Store the message so it's
+        processed as the next turn" comment.
+        """
+        import gateway.run as _gr
+
+        monkeypatch.setattr(_gr, "_hermes_home", tmp_path)
+        monkeypatch.setattr(_gr, "_load_gateway_config", lambda: {})
+
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "queue"
+        adapter = _make_adapter()
+
+        first = _make_event(text="search the web")
+        # Reuse the first event's source so both events route to the same
+        # adapter slot (the runner.adapters dict is keyed on source.platform,
+        # which is a MagicMock instance — different MagicMock per _make_event
+        # would land in separate adapter slots).
+        second = MessageEvent(
+            text="and tell me about KOOMPI OS",
+            message_type=MessageType.TEXT,
+            source=first.source,
+            message_id="msg2",
+        )
+        sk = build_session_key(first.source)
+
+        runner.adapters[first.source.platform] = adapter
+        runner._running_agents[sk] = MagicMock()
+
+        await runner._handle_active_session_busy_message(first, sk)
+        await runner._handle_active_session_busy_message(second, sk)
+
+        pending = adapter._pending_messages.get(sk)
+        assert pending is not None, "queued event should exist"
+        assert "search the web" in pending.text
+        assert "and tell me about KOOMPI OS" in pending.text


### PR DESCRIPTION
## Summary

Three call sites that queue a follow-up MessageEvent for a busy session pass it to `merge_pending_message_event` without `merge_text=True`. As a result, a second text message arriving during the same busy turn **overwrites** the first instead of being appended — silently dropping user intent in `busy_input_mode=queue`.

The rapid-follow-up paths already in `_handle_message` (`gateway/run.py:5620`, `5640`) correctly pass `merge_text=True`. This PR aligns three remaining sites:

- `gateway/run.py` `_handle_active_session_busy_message` — main busy handler.
- `gateway/run.py` `_queue_or_replace_pending_event` — drain-time queueing helper.
- `gateway/platforms/base.py` default text-follow-up path in `BasePlatformAdapter`.

After the fix, two text messages queued during the same busy turn append (joined with `\n`) instead of clobbering each other.

## Reproduction (without the fix)

1. `display.busy_input_mode: queue`
2. Send a long-running prompt to the gateway.
3. While it runs, send a second text follow-up.
4. Send a third text follow-up.
5. Observe: only the **third** message is processed in the next turn — messages 2 was silently dropped.

## Test plan

- [x] New regression test `test_queue_mode_appends_text_messages` in `tests/gateway/test_busy_session_ack.py` exercises `_handle_active_session_busy_message` twice and asserts the pending event contains both texts.
- [x] Existing 16 tests in `test_busy_session_ack.py` pass.
- [x] `test_pending_drain_race`, `test_pending_drain_no_recursion`, `test_telegram_text_batching`, `test_message_deduplicator` pass (21 tests).
- [x] Full `tests/gateway/` suite — 2245 pass; the one pre-existing `test_blocking_approval_approve_once` failure is unrelated (reproduces on clean `main`).

## Notes

- Photo-burst behaviour is unchanged — `merge_text` only applies when *both* existing and incoming events are `MessageType.TEXT`. The non-text branch in `BasePlatformAdapter` keeps the legacy overwrite to avoid changing the photo-merge path.
- No public API change; `merge_text` was already supported by `merge_pending_message_event`.