### PR TITLE
Integrate Hermes v0.13 retrofit lanes

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2054,11 +2054,16 @@ def build_anthropic_kwargs(
             base_url,
             drop_context_1m_beta=drop_context_1m_beta,
         ))
+        if (
+            _is_bedrock_model_id(model)
+            and not drop_context_1m_beta
+            and _CONTEXT_1M_BETA not in betas
+        ):
+            betas.append(_CONTEXT_1M_BETA)
         if is_oauth:
             betas.extend(_OAUTH_ONLY_BETAS)
         betas.append(_FAST_MODE_BETA)
         kwargs["extra_headers"] = {"anthropic-beta": ",".join(betas)}
 
     return kwargs
-
 

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3778,6 +3778,8 @@ def call_llm(
         ):
             kwargs.pop("max_tokens", None)
             kwargs.pop("max_completion_tokens", None)
+            if not _is_zai_param_error:
+                kwargs["max_completion_tokens"] = max_tokens
             try:
                 return _validate_llm_response(
                     client.chat.completions.create(**kwargs), task)
@@ -4094,6 +4096,8 @@ async def async_call_llm(
         ):
             kwargs.pop("max_tokens", None)
             kwargs.pop("max_completion_tokens", None)
+            if not _is_zai_param_error:
+                kwargs["max_completion_tokens"] = max_tokens
             try:
                 return _validate_llm_response(
                     await client.chat.completions.create(**kwargs), task)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -865,8 +865,10 @@ def _build_job_prompt(job: dict, prerun_script: Optional[tuple] = None) -> str:
                     f"{prompt}"
                 )
             else:
-                # Script produced no output — nothing to report, skip AI call.
-                return None
+                prompt = (
+                    "[Script ran successfully but produced no output.]\n\n"
+                    f"{prompt}"
+                )
         else:
             prompt = (
                 "## Script Error\n"

--- a/docs/plans/2026-05-09-hermes-v013-integrated-final.md
+++ b/docs/plans/2026-05-09-hermes-v013-integrated-final.md
@@ -1,0 +1,128 @@
+# Hermes v0.13 Integrated Final Plan
+
+## Objective
+
+Merge the two concurrent retrofit threads onto the live v0.13 baseline without
+letting overlapping intent create duplicated routing, task, or learning logic.
+
+The integrated baseline is:
+
+- Base: `v2026.5.7` / `498bfc7bc`
+- Integration branch: `codex/hermes-integrated-final-v013`
+- Worktree: `/home/wutj/.hermes/hermes-agent/.worktrees/hermes-integrated-final-v013`
+- Live source reference: `/home/wutj/.hermes/hermes-agent-v013-20260509`
+
+## Thread Consolidation
+
+### Kept from the live v0.13 thread
+
+The live v0.13 work already provides the main self-improvement loop and should
+remain the semantic authority for learning-related behavior:
+
+- `tools/learning_absorption_tool.py`
+- capability/context injection in `run_agent.py`
+- scheduler and MCP/tool-surface cleanup
+- tests covering learning absorption, missing MCP dependencies, and tools config
+
+These changes were migrated into the integration branch as the base behavior.
+
+### Ported from the older retrofit thread
+
+Only the low-conflict, user-visible capabilities were ported:
+
+- Natural dispatch: short follow-up messages can route to background execution
+  when recent context shows an actionable technical task.
+- Delegate auth repair: placeholder Codex keys are rejected unless a compatible
+  parent runtime key can be safely reused.
+- OpenAI-compatible image lane: image generation can use an OpenAI-style image
+  endpoint before falling back to FAL.
+- Cron ticker heartbeat: the gateway writes a fresh cron heartbeat so the
+  external health guard does not misclassify a healthy gateway as stale.
+- Long cron tick heartbeat: legitimate long-running cron ticks refresh
+  `tick_running` while they are still making progress, so the external health
+  guard does not repeatedly restart a live gateway during normal cron work.
+
+### Deferred from the older retrofit thread
+
+The old durable task queue and worker-routing patch was not merged directly.
+It was structurally useful, but it targeted an older runtime shape and conflicts
+with v0.13 primitives such as background jobs, kanban state, and the live
+teacher/learning loop.
+
+Future work should adapt that intent as a small bridge into the v0.13
+background/kanban surfaces, not as a parallel task queue.
+
+Final audit result:
+
+- Do not port `agent/task_queue.py`, `agent/worker_routing.py`, or
+  `gateway/task_queue_bridge.py` into the v0.13 branch as a second scheduler.
+- v0.13 Kanban is the durable task surface: it already provides SQLite-backed
+  task state, claim locking, stale recovery, dispatcher control, and notifier
+  delivery.
+- `/background` remains an immediate separate-session execution path. Routing it
+  directly through Kanban would create duplicate-execution risk because the two
+  paths have different task ids, lifecycle state, retry behavior, and reply
+  delivery.
+- If background visibility is later needed, add metadata-only observability
+  around `/background`; do not transfer execution ownership to Kanban without a
+  single shared idempotency and state-transition model.
+
+## Safety Rules
+
+- Media generation stays in the foreground path unless explicitly commanded
+  otherwise.
+- Bare continuations such as "continue" route to background work only when
+  recent context contains technical execution intent.
+- Discussion, review, and analysis prompts stay conversational unless they
+  include clear work verbs.
+- Delegate children must not launch with placeholder provider keys.
+- OpenAI image support is additive and falls back to the existing FAL lane.
+
+## Verification
+
+Targeted integration suite:
+
+```text
+388 passed in 12.07s
+```
+
+Covered areas:
+
+- natural dispatch config and gateway routing
+- OpenAI image generation lane and FAL fallback compatibility
+- delegate credential resolution and provider integration
+- learning absorption tool
+- learning capability context injection
+- missing MCP dependency handling
+- tools config exposure
+- gateway runtime status and cron heartbeat freshness
+- systemd status comparison without transient PATH drift
+- full gateway service management helper coverage
+- long cron tick heartbeat regression
+
+Additional background/Kanban audit suite:
+
+```text
+328 passed in 147.58s
+```
+
+Covered areas:
+
+- `/background` command creation, cleanup, and response delivery
+- natural foreground/background admission control
+- Kanban database claim and dispatch semantics
+- Kanban CLI behavior and gateway dispatcher configuration
+- Kanban worker tool visibility
+
+Cron heartbeat regression suite:
+
+```text
+44 passed in 4.32s
+372 passed in 184.12s
+```
+
+Covered areas:
+
+- runtime status heartbeat persistence
+- long cron tick `tick_running` refresh behavior
+- combined background, natural dispatch, status, and Kanban regression surface

--- a/gateway/config.py
+++ b/gateway/config.py
@@ -419,6 +419,9 @@ class GatewayConfig:
 
     # User-defined quick commands (slash commands that bypass the agent loop)
     quick_commands: Dict[str, Any] = field(default_factory=dict)
+
+    # Natural-language admission control for Telegram foreground/background routing.
+    natural_dispatch: Dict[str, Any] = field(default_factory=lambda: {"enabled": True})
     
     # Storage paths
     sessions_dir: Path = field(default_factory=lambda: get_hermes_home() / "sessions")
@@ -531,6 +534,7 @@ class GatewayConfig:
             },
             "reset_triggers": self.reset_triggers,
             "quick_commands": self.quick_commands,
+            "natural_dispatch": self.natural_dispatch,
             "sessions_dir": str(self.sessions_dir),
             "always_log_local": self.always_log_local,
             "stt_enabled": self.stt_enabled,
@@ -575,6 +579,10 @@ class GatewayConfig:
         if not isinstance(quick_commands, dict):
             quick_commands = {}
 
+        natural_dispatch = data.get("natural_dispatch", {"enabled": True})
+        if not isinstance(natural_dispatch, dict):
+            natural_dispatch = {"enabled": True}
+
         stt_enabled = data.get("stt_enabled")
         if stt_enabled is None:
             stt_enabled = data.get("stt", {}).get("enabled") if isinstance(data.get("stt"), dict) else None
@@ -600,6 +608,7 @@ class GatewayConfig:
             reset_by_platform=reset_by_platform,
             reset_triggers=data.get("reset_triggers", ["/new", "/reset"]),
             quick_commands=quick_commands,
+            natural_dispatch=natural_dispatch,
             sessions_dir=sessions_dir,
             always_log_local=_coerce_bool(data.get("always_log_local"), True),
             stt_enabled=_coerce_bool(stt_enabled, True),
@@ -683,6 +692,17 @@ def load_gateway_config() -> GatewayConfig:
                         "Ignoring invalid quick_commands in config.yaml "
                         "(expected mapping, got %s)",
                         type(qc).__name__,
+                    )
+
+            natural_dispatch = yaml_cfg.get("natural_dispatch")
+            if natural_dispatch is not None:
+                if isinstance(natural_dispatch, dict):
+                    gw_data["natural_dispatch"] = natural_dispatch
+                else:
+                    logger.warning(
+                        "Ignoring invalid natural_dispatch in config.yaml "
+                        "(expected mapping, got %s)",
+                        type(natural_dispatch).__name__,
                     )
 
             stt_cfg = yaml_cfg.get("stt")

--- a/gateway/natural_dispatch.py
+++ b/gateway/natural_dispatch.py
@@ -1,0 +1,184 @@
+"""Natural foreground/background admission control for gateway messages."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class NaturalDispatchDecision:
+    should_background: bool
+    reason: str = ""
+
+
+def _config_enabled(config: Any) -> bool:
+    if isinstance(config, dict):
+        natural = config.get("natural_dispatch") or {}
+    else:
+        natural = getattr(config, "natural_dispatch", {}) or {}
+    if not isinstance(natural, dict):
+        return False
+    return bool(natural.get("enabled", False))
+
+
+def natural_dispatch_enabled(config: Any) -> bool:
+    return _config_enabled(config)
+
+
+def _norm(message: str) -> str:
+    return re.sub(r"\s+", " ", str(message or "").strip().lower())
+
+
+_FOREGROUND_DISCUSSION_MARKERS = (
+    "继续讨论", "讨论方案", "我有个想法", "我有一个想法", "你觉得",
+    "怎么推进", "如何推进", "下一步方向", "先分析", "不要执行",
+    "是否合理", "合不合理", "后台数据怎么同步", "怎么同步",
+    "方案是否", "只分析", "不用执行",
+)
+
+_FOREGROUND_OVERRIDE_MARKERS = ("后台帮", "后台执行", "后台跑", "放到后台", "转后台")
+
+_BACKGROUND_MARKERS = (
+    "后台帮", "后台执行", "后台跑", "放到后台", "转后台", "background",
+    "继续优化", "继续检查", "继续补完", "继续实现", "继续修复", "继续改",
+    "实现", "修复", "bug", "代码", "改代码", "测试", "跑测试",
+    "运行测试", "pytest", "smoke test", "smoke", "维护", "repair",
+    "部署", "构建", "编译",
+)
+
+_MULTI_STEP_TOKENS = ("检查", "修改", "测试", "验证", "运行", "实现", "修复", "生成", "补完", "优化")
+
+_BARE_CONTINUATION_MESSAGES = {"继续", "继续吧", "继续一下", "continue", "go on"}
+
+_EXECUTION_ACCEPTANCE_RE = re.compile(
+    r"(?:"
+    r"^同意$|"
+    r"同意[，,。 ]*(?:按|执行|开始|做|推进)|"
+    r"按(?:推荐|这个|上述|刚才)?方案(?:执行|来|推进|做)|"
+    r"按(?:你的|你刚才的)?建议(?:做|执行|推进)|"
+    r"(?:开始|继续|就这样|照这个|照此)(?:执行|做|推进)|"
+    r"执行吧|"
+    r"^(?:go ahead|proceed|please proceed|approved|do it)$"
+    r")"
+)
+_EXECUTION_REJECTION_MARKERS = ("不同意", "先别", "别执行", "不要执行", "不执行", "暂时不要")
+
+_TECHNICAL_CONTEXT_MARKERS = (
+    "gateway", "telegram", "foreground", "background", "natural_dispatch",
+    "systemd", "service", "worker", "pytest", "root cause", "debug",
+    "代码", "测试", "验证", "修复", "排查", "实现", "优化", "编译", ".py",
+)
+
+_TECHNICAL_ACTION_CONTEXT_MARKERS = (
+    "next step", "run ", "pytest", "test", "verify", "debug", "fix",
+    "root cause", "检查", "测试", "验证", "修复", "排查", "实现", "优化", "运行",
+)
+
+_MEDIA_NOUN_RE = re.compile(
+    r"(?:短视频|视频|动图|动画|图片|图像|海报图?|封面图?|插画|配图|出图|画图|logo|gif|mp4|image|video|photo|poster|thumbnail|animation)"
+)
+_MEDIA_REQUEST_RE = (
+    re.compile(
+        r"(?:生成|制作|做|画|设计|出|渲染|剪|剪辑|合成)(?:.{0,30})(?:短视频|视频|动图|动画|图片|图像|海报图?|封面图?|插画|配图|出图|画图|logo|gif|mp4)"
+    ),
+    re.compile(
+        r"(?:帮我|请|给我|来|搞|弄)(?:.{0,30})(?:短视频|视频|动图|动画|图片|图像|海报图?|封面图?|插画|配图|出图|画图|logo|gif|mp4)"
+    ),
+    re.compile(r"(?:generate|create|make|draw|render)(?:.{0,50})(?:image|video|photo|poster|thumbnail|animation|gif|mp4)"),
+)
+_BARE_MEDIA_REQUEST_RE = re.compile(
+    r"^(?:出图|发图|给我图|图呢|我的图呢|来张图|来一张图|生成图|生成图片|画图|draw image|make image)(?:[啊呀吧嘛吗呢？?！!。\s]*)$"
+)
+_MEDIA_CAPABILITY_QUESTION_RE = re.compile(
+    r"(?:能不能|可不可以|是否(?:能|可以)?|能|可以|会|支持)(?:.{0,20})(?:生成|制作|做|画|设计|出图|画图)(?:.{0,20})(?:短视频|视频|动图|动画|图片|图像|海报图?|封面图?|插画|配图|图|logo|gif|mp4)(?:了)?[吗么?？]?$"
+)
+_FOREGROUND_WORK_QUESTION_RE = re.compile(
+    r"(?:怎么|如何|为什么|为何|哪里|哪儿|什么原因|should|how should|why|what caused|what is causing)"
+    r"(?:.{0,40})"
+    r"(?:修复|实现|测试|验证|部署|构建|编译|优化|fix|implement|test|verify|deploy|build|compile|optimize)"
+)
+
+
+def _is_media_capability_question(text: str) -> bool:
+    return bool(_MEDIA_CAPABILITY_QUESTION_RE.search(text))
+
+
+def _is_media_generation_request(text: str) -> bool:
+    if _BARE_MEDIA_REQUEST_RE.search(text):
+        return True
+    if not _MEDIA_NOUN_RE.search(text):
+        return False
+    return any(pattern.search(text) for pattern in _MEDIA_REQUEST_RE)
+
+
+def is_bare_continuation_message(message: str) -> bool:
+    """Return true for short standalone continuation requests only."""
+    return _norm(message).rstrip(".。!！?？") in _BARE_CONTINUATION_MESSAGES
+
+
+def is_execution_acceptance_message(message: str) -> bool:
+    """Return true when a short reply appears to approve executing the prior plan."""
+    text = _norm(message).rstrip(".。!！")
+    if not text or any(marker in text for marker in _EXECUTION_REJECTION_MARKERS):
+        return False
+    if text.endswith(("?", "？")) or re.search(r"(?:吗|么|嘛)$", text):
+        return False
+    return bool(_EXECUTION_ACCEPTANCE_RE.search(text))
+
+
+def _has_technical_execution_context(context: Iterable[str] | None) -> bool:
+    if not context:
+        return False
+    text = _norm(" ".join(str(item or "") for item in context))
+    if not text:
+        return False
+    has_technical_marker = any(marker in text for marker in _TECHNICAL_CONTEXT_MARKERS)
+    has_action_marker = any(marker in text for marker in _TECHNICAL_ACTION_CONTEXT_MARKERS)
+    return has_technical_marker and has_action_marker
+
+
+def classify_natural_dispatch(
+    message: str,
+    config: Any | None = None,
+    *,
+    context: Iterable[str] | None = None,
+) -> NaturalDispatchDecision:
+    if not _config_enabled(config):
+        return NaturalDispatchDecision(False, "disabled")
+    text = _norm(message)
+    if not text:
+        return NaturalDispatchDecision(False, "empty")
+
+    if any(marker in text for marker in _FOREGROUND_DISCUSSION_MARKERS):
+        if not any(marker in text for marker in _FOREGROUND_OVERRIDE_MARKERS):
+            return NaturalDispatchDecision(False, "discussion")
+
+    if _is_media_capability_question(text):
+        return NaturalDispatchDecision(False, "media_capability_question")
+
+    if _is_media_generation_request(text):
+        return NaturalDispatchDecision(False, "media_generation")
+
+    if _FOREGROUND_WORK_QUESTION_RE.search(text):
+        return NaturalDispatchDecision(False, "work_question")
+
+    if is_execution_acceptance_message(text):
+        if _has_technical_execution_context(context):
+            return NaturalDispatchDecision(True, "accepted_execution_context")
+        return NaturalDispatchDecision(False, "execution_acceptance_without_context")
+
+    for marker in _BACKGROUND_MARKERS:
+        if marker in text:
+            return NaturalDispatchDecision(True, marker)
+
+    hits = sum(1 for token in _MULTI_STEP_TOKENS if token in text)
+    if hits >= 3 or (hits >= 2 and ("并" in text or "、" in text or "然后" in text)):
+        return NaturalDispatchDecision(True, "multi_step")
+
+    if is_bare_continuation_message(text) and _has_technical_execution_context(context):
+        return NaturalDispatchDecision(True, "continuation_context")
+
+    return NaturalDispatchDecision(False, "lightweight")

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -5104,6 +5104,93 @@ class GatewayRunner:
 
         await adapter.send(source.chat_id, content, metadata=metadata)
 
+    def _load_natural_dispatch_context(self, source: SessionSource, limit: int = 6) -> list[str]:
+        """Load a small recent transcript window for bare continuation admission."""
+        store = getattr(self, "session_store", None)
+        if not store:
+            return []
+        try:
+            session_entry = store.get_or_create_session(source)
+            history = store.load_transcript(session_entry.session_id)
+        except Exception:
+            logger.debug("Natural dispatch context load failed", exc_info=True)
+            return []
+
+        context: list[str] = []
+        for item in (history or [])[-limit:]:
+            content = item.get("content") if isinstance(item, dict) else getattr(item, "content", None)
+            if isinstance(content, list):
+                parts = []
+                for part in content:
+                    if isinstance(part, dict):
+                        part_text = part.get("text") or part.get("content")
+                        if part_text:
+                            parts.append(str(part_text))
+                    elif part:
+                        parts.append(str(part))
+                content = " ".join(parts)
+            if content:
+                text = str(content).strip()
+                if text:
+                    context.append(text[:600])
+        return context
+
+    def _build_natural_dispatch_continuation_prompt(self, original_text: str, context: list[str]) -> str:
+        recent = [item.strip().replace("\n", " ") for item in context if item and item.strip()]
+        excerpt = "\n".join(f"- {item[:400]}" for item in recent[-4:])
+        if not excerpt:
+            excerpt = "- No recent transcript excerpt was available."
+        return (
+            "Continue the active Telegram workstream from the recent transcript. "
+            f"The user sent: {(original_text or '').strip() or 'continue'}.\n\n"
+            f"Recent context:\n{excerpt}"
+        )
+
+    async def _maybe_handle_natural_dispatch(self, event: MessageEvent, source: SessionSource) -> Optional[str]:
+        """Route complex Telegram natural-language work to /background before agent execution."""
+        try:
+            if source.platform != Platform.TELEGRAM:
+                return None
+            if event.message_type != MessageType.TEXT or event.get_command():
+                return None
+            from gateway.natural_dispatch import (
+                classify_natural_dispatch,
+                is_bare_continuation_message,
+                is_execution_acceptance_message,
+            )
+
+            needs_context = (
+                is_bare_continuation_message(event.text or "")
+                or is_execution_acceptance_message(event.text or "")
+            )
+            context = self._load_natural_dispatch_context(source) if needs_context else []
+            decision = classify_natural_dispatch(
+                event.text or "",
+                getattr(self, "config", None),
+                context=context,
+            )
+            if not decision.should_background:
+                return None
+
+            prompt = (event.text or "").strip()
+            if decision.reason in {"continuation_context", "accepted_execution_context"}:
+                prompt = self._build_natural_dispatch_continuation_prompt(event.text or "", context)
+
+            bg_event = MessageEvent(
+                text=f"/background {prompt}",
+                message_type=MessageType.TEXT,
+                source=source,
+                raw_message=getattr(event, "raw_message", None),
+                message_id=getattr(event, "message_id", None),
+                reply_to_message_id=getattr(event, "reply_to_message_id", None),
+                reply_to_text=getattr(event, "reply_to_text", None),
+                channel_prompt=getattr(event, "channel_prompt", None),
+            )
+            return await self._handle_background_command(bg_event)
+        except Exception:
+            logger.debug("Natural dispatch admission failed; falling back to foreground", exc_info=True)
+            return None
+
     async def _handle_message(self, event: MessageEvent) -> Optional[str]:
         """
         Handle an incoming message from any platform.
@@ -6027,6 +6114,11 @@ class GatewayRunner:
         # Pending exec approvals are handled by /approve and /deny commands above.
         # No bare text matching — "yes" in normal conversation must not trigger
         # execution of a dangerous command.
+
+        if not command:
+            _natural_dispatch_response = await self._maybe_handle_natural_dispatch(event, source)
+            if _natural_dispatch_response is not None:
+                return _natural_dispatch_response
 
         if self._is_telegram_topic_root_lobby(source):
             # Debounce the lobby reminder so a user who forgets about
@@ -15341,6 +15433,7 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
     """
     from cron.scheduler import tick as cron_tick
     from gateway.platforms.base import cleanup_image_cache, cleanup_document_cache
+    from gateway.status import write_runtime_heartbeat
     from hermes_cli.debug import _sweep_expired_pastes
 
     IMAGE_CACHE_EVERY = 60   # ticks — once per hour at default 60s interval
@@ -15351,10 +15444,45 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
     logger.info("Cron ticker started (interval=%ds)", interval)
     tick_count = 0
     while not stop_event.is_set():
+        stale_after_seconds = _cron_ticker_stale_after_seconds(interval)
         try:
-            cron_tick(verbose=False, adapters=adapters, loop=loop)
+            write_runtime_heartbeat(
+                "cron_ticker",
+                phase="tick_started",
+                interval_seconds=interval,
+                stale_after_seconds=stale_after_seconds,
+            )
+        except Exception as e:
+            logger.debug("Cron ticker heartbeat start update error: %s", e)
+        try:
+            _run_cron_tick_with_heartbeat(
+                cron_tick,
+                adapters=adapters,
+                loop=loop,
+                interval=interval,
+                heartbeat_writer=write_runtime_heartbeat,
+            )
         except Exception as e:
             logger.debug("Cron tick error: %s", e)
+            try:
+                write_runtime_heartbeat(
+                    "cron_ticker",
+                    phase="tick_error",
+                    interval_seconds=interval,
+                    stale_after_seconds=stale_after_seconds,
+                )
+            except Exception as heartbeat_error:
+                logger.debug("Cron ticker heartbeat error update error: %s", heartbeat_error)
+        else:
+            try:
+                write_runtime_heartbeat(
+                    "cron_ticker",
+                    phase="tick_ok",
+                    interval_seconds=interval,
+                    stale_after_seconds=stale_after_seconds,
+                )
+            except Exception as e:
+                logger.debug("Cron ticker heartbeat ok update error: %s", e)
 
         tick_count += 1
 
@@ -15415,6 +15543,91 @@ def _start_cron_ticker(stop_event: threading.Event, adapters=None, loop=None, in
 
         stop_event.wait(timeout=interval)
     logger.info("Cron ticker stopped")
+
+
+def _cron_ticker_stale_after_seconds(interval: int) -> int:
+    """Return health-guard staleness threshold for cron loop heartbeats."""
+    return max(int(interval) * 4, int(interval) + 180)
+
+
+def _cron_ticker_running_heartbeat_max_seconds(interval: int) -> float:
+    """Bound how long a single cron tick may self-report as still running."""
+    raw = os.getenv("HERMES_CRON_TICK_HEARTBEAT_MAX_SECONDS", "").strip()
+    if raw:
+        try:
+            configured = float(raw)
+            if configured > 0:
+                return configured
+        except (TypeError, ValueError):
+            logger.warning(
+                "Invalid HERMES_CRON_TICK_HEARTBEAT_MAX_SECONDS=%r; using default",
+                raw,
+            )
+
+    raw_cron_timeout = os.getenv("HERMES_CRON_TIMEOUT", "").strip()
+    try:
+        cron_timeout = float(raw_cron_timeout) if raw_cron_timeout else 600.0
+        if cron_timeout <= 0:
+            cron_timeout = 600.0
+    except (TypeError, ValueError):
+        cron_timeout = 600.0
+
+    return max(900.0, cron_timeout + float(interval) + 120.0)
+
+
+def _run_cron_tick_with_heartbeat(
+    cron_tick,
+    *,
+    adapters,
+    loop,
+    interval: int,
+    heartbeat_writer,
+    heartbeat_period_seconds: Optional[float] = None,
+):
+    """Run one cron tick while refreshing heartbeats during legitimate long work."""
+    import concurrent.futures
+
+    stale_after_seconds = _cron_ticker_stale_after_seconds(interval)
+    max_running_seconds = _cron_ticker_running_heartbeat_max_seconds(interval)
+    heartbeat_period = (
+        float(heartbeat_period_seconds)
+        if heartbeat_period_seconds is not None
+        else min(30.0, max(5.0, float(interval) / 2.0))
+    )
+    started = time.monotonic()
+    warned_overdue = False
+
+    with concurrent.futures.ThreadPoolExecutor(
+        max_workers=1,
+        thread_name_prefix="hermes-cron-tick",
+    ) as pool:
+        future = pool.submit(cron_tick, verbose=False, adapters=adapters, loop=loop)
+        while True:
+            try:
+                return future.result(timeout=heartbeat_period)
+            except concurrent.futures.TimeoutError:
+                elapsed = time.monotonic() - started
+                if elapsed <= max_running_seconds:
+                    try:
+                        heartbeat_writer(
+                            "cron_ticker",
+                            phase="tick_running",
+                            interval_seconds=interval,
+                            stale_after_seconds=stale_after_seconds,
+                        )
+                    except Exception as e:
+                        logger.debug("Cron ticker running heartbeat update error: %s", e)
+                    continue
+
+                if not warned_overdue:
+                    warned_overdue = True
+                    logger.warning(
+                        "Cron tick exceeded %.0fs heartbeat window; suppressing "
+                        "running heartbeats so the external health guard can recover "
+                        "if the tick is wedged.",
+                        max_running_seconds,
+                    )
+                return future.result()
 
 
 async def start_gateway(config: Optional[GatewayConfig] = None, replace: bool = False, verbosity: Optional[int] = 0) -> bool:

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -511,6 +511,43 @@ def write_runtime_status(
     _write_json_file(path, payload)
 
 
+def write_runtime_heartbeat(
+    name: str,
+    *,
+    phase: str,
+    interval_seconds: Optional[int] = None,
+    stale_after_seconds: Optional[int] = None,
+) -> None:
+    """Persist a lightweight heartbeat for a gateway background loop."""
+    heartbeat_name = str(name or "").strip()
+    if not heartbeat_name:
+        raise ValueError("heartbeat name is required")
+
+    path = _get_runtime_status_path()
+    payload = _read_json_file(path) or _build_runtime_status_record()
+    payload.setdefault("platforms", {})
+    payload.setdefault("kind", _GATEWAY_KIND)
+    payload["pid"] = os.getpid()
+    payload["start_time"] = _get_process_start_time(os.getpid())
+    payload["updated_at"] = _utc_now_iso()
+
+    heartbeats = payload.get("heartbeats")
+    if not isinstance(heartbeats, dict):
+        heartbeats = {}
+
+    entry: dict[str, Any] = {
+        "updated_at": _utc_now_iso(),
+        "phase": str(phase),
+    }
+    if interval_seconds is not None:
+        entry["interval_seconds"] = int(interval_seconds)
+    if stale_after_seconds is not None:
+        entry["stale_after_seconds"] = int(stale_after_seconds)
+    heartbeats[heartbeat_name] = entry
+    payload["heartbeats"] = heartbeats
+    _write_json_file(path, payload)
+
+
 def read_runtime_status() -> Optional[dict[str, Any]]:
     """Read the persisted gateway runtime health/status information."""
     return _read_json_file(_get_runtime_status_path())

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -398,6 +398,9 @@ DEFAULT_CONFIG = {
     "fallback_providers": [],
     "credential_pool_strategies": {},
     "toolsets": ["hermes-cli"],
+    "natural_dispatch": {
+        "enabled": True,
+    },
     "agent": {
         "max_turns": 90,
         # Inactivity timeout for gateway agent execution (seconds).

--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -6,6 +6,7 @@ Handles: hermes gateway [run|start|stop|restart|status|install|uninstall|setup]
 
 import asyncio
 import os
+import re
 import shutil
 import signal
 import subprocess
@@ -2108,7 +2109,13 @@ WantedBy=default.target
 """
 
 def _normalize_service_definition(text: str) -> str:
-    return "\n".join(line.rstrip() for line in text.strip().splitlines())
+    normalized = "\n".join(line.rstrip() for line in text.strip().splitlines())
+    return re.sub(
+        r'^Environment="PATH=.*"$',
+        'Environment="PATH=__HERMES_PATH__"',
+        normalized,
+        flags=re.M,
+    )
 
 
 def _normalize_launchd_plist_for_comparison(text: str) -> str:

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -2599,6 +2599,9 @@ def _print_tools_list(enabled_toolsets: set, mcp_servers: dict, platform: str = 
         print()
         print("MCP servers:")
         for srv_name, srv_cfg in mcp_servers.items():
+            if not _parse_enabled_flag(srv_cfg.get("enabled", True), default=True):
+                _print_info(f"{srv_name}  {color('disabled', Colors.RED)}")
+                continue
             tools_cfg = srv_cfg.get("tools") or {}
             exclude = tools_cfg.get("exclude") or []
             include = tools_cfg.get("include") or []

--- a/run_agent.py
+++ b/run_agent.py
@@ -10023,7 +10023,11 @@ class AIAgent:
             if block_message is not None:
                 block_result = json.dumps({"error": block_message}, ensure_ascii=False)
             else:
-                guardrail_decision = self._tool_guardrails.before_call(function_name, function_args)
+                guardrails = getattr(self, "_tool_guardrails", None)
+                if guardrails is None:
+                    guardrails = ToolCallGuardrailController()
+                    self._tool_guardrails = guardrails
+                guardrail_decision = guardrails.before_call(function_name, function_args)
                 if not guardrail_decision.allows_execution:
                     block_result = self._guardrail_block_result(guardrail_decision)
                     blocked_by_guardrail = True

--- a/run_agent.py
+++ b/run_agent.py
@@ -11316,6 +11316,16 @@ class AIAgent:
         except Exception as exc:
             logger.warning("pre_llm_call hook failed: %s", exc)
 
+        _learning_capability_context = ""
+        if "learning_absorption" in self.valid_tool_names:
+            try:
+                from tools.learning_absorption_tool import build_capability_invocation_context
+
+                _query = original_user_message if isinstance(original_user_message, str) else ""
+                _learning_capability_context = build_capability_invocation_context(_query) or ""
+            except Exception as exc:
+                logger.debug("learning capability context build failed: %s", exc)
+
         # Main conversation loop
         api_call_count = 0
         final_response = None
@@ -11527,6 +11537,8 @@ class AIAgent:
                             _injections.append(_fenced)
                     if _plugin_user_context:
                         _injections.append(_plugin_user_context)
+                    if _learning_capability_context:
+                        _injections.append(_learning_capability_context)
                     if _injections:
                         _base = api_msg.get("content", "")
                         if isinstance(_base, str):
@@ -14575,6 +14587,18 @@ class AIAgent:
                         break  # First non-empty string wins
             except Exception as exc:
                 logger.warning("transform_llm_output hook failed: %s", exc)
+
+        # Learning self-review: the response has already been finalized for
+        # the user. This only records obvious speech-policy mismatches and
+        # must never mutate the reply.
+        if final_response and not interrupted and "learning_absorption" in self.valid_tool_names:
+            try:
+                if isinstance(original_user_message, str):
+                    from tools.learning_absorption_tool import evaluate_speech_response
+
+                    evaluate_speech_response(original_user_message, final_response)
+            except Exception as exc:
+                logger.debug("learning speech self-review failed: %s", exc)
 
         # Plugin hook: post_llm_call
         # Fired once per turn after the tool-calling loop completes.

--- a/tests/acp/test_approval_isolation.py
+++ b/tests/acp/test_approval_isolation.py
@@ -213,6 +213,7 @@ class TestAcpExecAskGate:
         monkeypatch.delenv("HERMES_GATEWAY_SESSION", raising=False)
         monkeypatch.delenv("HERMES_EXEC_ASK", raising=False)
         monkeypatch.delenv("HERMES_YOLO_MODE", raising=False)
+        monkeypatch.delenv("HERMES_CRON_SESSION", raising=False)
 
         from tools.approval import check_all_command_guards
 

--- a/tests/agent/test_bedrock_1m_context.py
+++ b/tests/agent/test_bedrock_1m_context.py
@@ -15,7 +15,27 @@ from unittest.mock import MagicMock, patch
 class TestBedrockContext1MBeta:
     """``context-1m-2025-08-07`` must reach Bedrock Claude requests."""
 
+    def test_common_betas_excludes_1m_for_native_safety(self):
+        from agent.anthropic_adapter import _COMMON_BETAS, _CONTEXT_1M_BETA
 
+        assert _CONTEXT_1M_BETA == "context-1m-2025-08-07"
+        assert _CONTEXT_1M_BETA not in _COMMON_BETAS
+
+    def test_common_betas_for_native_anthropic_exclude_1m(self):
+        """Native Anthropic endpoints do not get 1M unless explicitly gated."""
+        from agent.anthropic_adapter import (
+            _common_betas_for_base_url,
+            _CONTEXT_1M_BETA,
+        )
+
+        assert _CONTEXT_1M_BETA not in _common_betas_for_base_url(None)
+        assert _CONTEXT_1M_BETA not in _common_betas_for_base_url("")
+        assert _CONTEXT_1M_BETA not in _common_betas_for_base_url(
+            "https://api.anthropic.com"
+        )
+        assert _CONTEXT_1M_BETA in _common_betas_for_base_url(
+            "https://example.openai.azure.com/anthropic"
+        )
 
     def test_common_betas_strips_1m_for_minimax(self):
         """MiniMax bearer-auth endpoints host their own models — strip 1M beta."""
@@ -62,3 +82,27 @@ class TestBedrockContext1MBeta:
         assert "interleaved-thinking-2025-05-14" in beta_header
         assert "fine-grained-tool-streaming-2025-05-14" in beta_header
 
+    def test_build_anthropic_kwargs_includes_1m_for_bedrock_fastmode(self):
+        """Fast-mode requests (per-request extra_headers) still include 1M beta.
+
+        Per-request extra_headers override client-level default_headers, so
+        the fast-mode path must re-include everything in _COMMON_BETAS.
+        """
+        from agent.anthropic_adapter import build_anthropic_kwargs
+
+        kwargs = build_anthropic_kwargs(
+            model="anthropic.claude-opus-4-6",
+            messages=[{"role": "user", "content": "hi"}],
+            tools=None,
+            max_tokens=1024,
+            reasoning_config=None,
+            is_oauth=False,
+            # Empty base_url mirrors AnthropicBedrock (no HTTP base URL)
+            base_url=None,
+            fast_mode=True,
+        )
+        beta_header = kwargs.get("extra_headers", {}).get("anthropic-beta", "")
+        assert "context-1m-2025-08-07" in beta_header, (
+            "fast-mode extra_headers must carry the 1M beta or it overrides "
+            "client-level default_headers and Bedrock drops back to 200K"
+        )

--- a/tests/agent/test_credential_pool.py
+++ b/tests/agent/test_credential_pool.py
@@ -782,6 +782,7 @@ def test_thread_safety_concurrent_select(tmp_path, monkeypatch):
     from agent.credential_pool import load_pool
 
     pool = load_pool("openrouter")
+    monkeypatch.setattr(pool, "_persist", lambda: None)
     results = []
     errors = []
 

--- a/tests/agent/test_model_metadata_local_ctx.py
+++ b/tests/agent/test_model_metadata_local_ctx.py
@@ -4,12 +4,8 @@ get_model_context_length.
 All tests use synthetic inputs — no filesystem or live server required.
 """
 
-import sys
-import os
 import json
 from unittest.mock import MagicMock, patch
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import pytest
 

--- a/tests/agent/test_model_metadata_ssl.py
+++ b/tests/agent/test_model_metadata_ssl.py
@@ -9,11 +9,7 @@ No filesystem or network I/O required — we use tmp_path to create real
 CA bundle stand-in files and monkeypatch env vars.
 """
 
-import os
-import sys
 from pathlib import Path
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 import pytest
 

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -6,8 +6,6 @@ import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
-
 
 def _make_cli(env_overrides=None, config_overrides=None, **kwargs):
     """Create a HermesCLI instance with minimal mocking."""

--- a/tests/cli/test_cli_user_message_preview.py
+++ b/tests/cli/test_cli_user_message_preview.py
@@ -1,9 +1,6 @@
 import importlib
-import os
 import sys
 from unittest.mock import MagicMock, patch
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 
 _cli_mod = None

--- a/tests/cli/test_resume_display.py
+++ b/tests/cli/test_resume_display.py
@@ -5,15 +5,11 @@ Verifies that resuming a session shows a compact recap of the previous
 conversation with correct formatting, truncation, and config behavior.
 """
 
-import os
-import sys
 from io import StringIO
 from unittest.mock import MagicMock, patch
 
 import pytest
 import cli as cli_mod
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 
 def _make_cli(config_overrides=None, env_overrides=None, **kwargs):

--- a/tests/cli/test_tool_progress_scrollback.py
+++ b/tests/cli/test_tool_progress_scrollback.py
@@ -5,12 +5,9 @@ persistent lines to scrollback on tool.completed, restoring the stacked
 tool history that was lost when the TUI switched to a single-line spinner.
 """
 
-import os
-import sys
 import importlib
+import sys
 from unittest.mock import MagicMock, patch
-
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 # Module-level reference to the cli module (set by _make_cli on first call)
 _cli_mod = None

--- a/tests/cron/test_scheduler_mcp_init.py
+++ b/tests/cron/test_scheduler_mcp_init.py
@@ -20,8 +20,105 @@ from unittest.mock import patch, MagicMock
 import pytest
 
 
+def _fake_runtime_provider(**_kwargs):
+    return {
+        "provider": "openai",
+        "api_key": "test-api-key",
+        "base_url": "https://api.openai.com/v1",
+        "api_mode": None,
+    }
 
 
+def test_run_job_calls_discover_mcp_tools_before_agent_construction():
+    """The LLM-path branch of run_job must call discover_mcp_tools() before
+    the AIAgent construction, so MCP tools are in the registry by the time
+    the agent asks for its tool schema."""
+    from cron import scheduler
+
+    job = {
+        "id": "mcp-cron-test",
+        "name": "mcp-cron-test",
+        "prompt": "test",
+    }
+
+    call_order = []
+
+    def fake_discover():
+        call_order.append("discover_mcp_tools")
+        return ["mcp_server1_tool"]
+
+    # AIAgent is a class; replace with a recording stub
+    class _FakeAgent:
+        def __init__(self, *args, **kwargs):
+            call_order.append("AIAgent.__init__")
+            self._kwargs = kwargs
+            self._interrupt_requested = False
+            self.quiet_mode = True
+
+        def run_conversation(self, *args, **kwargs):
+            return {
+                "final_response": "ok",
+                "messages": [],
+            }
+
+    with patch("tools.mcp_tool.discover_mcp_tools", side_effect=fake_discover), \
+         patch("run_agent.AIAgent", _FakeAgent), \
+         patch("hermes_cli.runtime_provider.resolve_runtime_provider", side_effect=_fake_runtime_provider), \
+         patch("cron.scheduler._resolve_cron_enabled_toolsets", return_value=None):
+        scheduler.run_job(job)
+
+    # Discovery must be called, and must be called BEFORE agent construction.
+    assert "discover_mcp_tools" in call_order, (
+        "run_job did not call discover_mcp_tools — MCP tools unavailable in cron"
+    )
+    d_idx = call_order.index("discover_mcp_tools")
+    a_idx = call_order.index("AIAgent.__init__")
+    assert d_idx < a_idx, (
+        f"discover_mcp_tools was called AFTER AIAgent construction "
+        f"(indices discover={d_idx}, agent={a_idx}); MCP tools missed the "
+        f"registry window. Full order: {call_order}"
+    )
+
+
+def test_run_job_tolerates_discover_mcp_tools_failure():
+    """A broken MCP server must not kill an otherwise working cron job.
+    discover_mcp_tools() raising should be caught and logged, and the agent
+    should still run."""
+    from cron import scheduler
+
+    job = {
+        "id": "mcp-cron-fail",
+        "name": "mcp-cron-fail",
+        "prompt": "test",
+    }
+
+    agent_was_constructed = []
+
+    class _FakeAgent:
+        def __init__(self, *args, **kwargs):
+            agent_was_constructed.append(True)
+            self._interrupt_requested = False
+            self.quiet_mode = True
+
+        def run_conversation(self, *args, **kwargs):
+            return {"final_response": "ok", "messages": []}
+
+    def fake_discover_that_raises():
+        raise RuntimeError("MCP server unreachable")
+
+    with patch(
+        "tools.mcp_tool.discover_mcp_tools",
+        side_effect=fake_discover_that_raises,
+    ), patch("run_agent.AIAgent", _FakeAgent), \
+         patch("hermes_cli.runtime_provider.resolve_runtime_provider", side_effect=_fake_runtime_provider), \
+         patch("cron.scheduler._resolve_cron_enabled_toolsets", return_value=None):
+        # Should NOT raise
+        success, doc, final_response, error = scheduler.run_job(job)
+
+    assert agent_was_constructed, (
+        "AIAgent was not constructed after discover_mcp_tools raised — "
+        "MCP failure incorrectly killed the cron job"
+    )
 
 
 def test_no_agent_cron_job_does_not_initialize_mcp():

--- a/tests/gateway/test_cron_ticker_heartbeat.py
+++ b/tests/gateway/test_cron_ticker_heartbeat.py
@@ -1,0 +1,30 @@
+"""Regression tests for cron ticker runtime heartbeats."""
+
+import time
+
+
+def test_long_cron_tick_refreshes_running_heartbeat(monkeypatch):
+    """A legitimate long cron tick must not look stale to the health guard."""
+    from gateway.run import _run_cron_tick_with_heartbeat
+
+    monkeypatch.setenv("HERMES_CRON_TICK_HEARTBEAT_MAX_SECONDS", "5")
+    phases: list[str] = []
+
+    def fake_tick(**_kwargs):
+        time.sleep(0.08)
+        return 3
+
+    def fake_heartbeat(_name, *, phase, **_kwargs):
+        phases.append(phase)
+
+    result = _run_cron_tick_with_heartbeat(
+        fake_tick,
+        adapters=None,
+        loop=None,
+        interval=60,
+        heartbeat_writer=fake_heartbeat,
+        heartbeat_period_seconds=0.01,
+    )
+
+    assert result == 3
+    assert "tick_running" in phases

--- a/tests/gateway/test_natural_dispatch.py
+++ b/tests/gateway/test_natural_dispatch.py
@@ -1,0 +1,265 @@
+"""Tests for Telegram natural foreground/background admission control."""
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import asyncio
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.session import SessionSource
+from hermes_cli.config import DEFAULT_CONFIG
+
+
+def _source(platform=Platform.TELEGRAM):
+    return SessionSource(
+        platform=platform,
+        user_id="12345",
+        chat_id="67890",
+        user_name="tester",
+        chat_type="dm",
+    )
+
+
+def _event(text: str, platform=Platform.TELEGRAM):
+    return MessageEvent(text=text, message_type=MessageType.TEXT, source=_source(platform))
+
+
+def _runner():
+    from gateway.run import GatewayRunner
+
+    runner = object.__new__(GatewayRunner)
+    runner.config = {"natural_dispatch": {"enabled": True}}
+    runner.adapters = {}
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._pending_messages = {}
+    runner._update_prompt_pending = {}
+    runner._topic_routing = {"enabled": False}
+    runner._draining = False
+    runner.session_store = None
+    runner._is_user_authorized = lambda _source: True
+    runner._handle_background_command = AsyncMock(return_value="Background task started: natural dispatch")
+    runner._handle_message_with_agent = AsyncMock(return_value="foreground response")
+    return runner
+
+
+class _TranscriptSessionStore:
+    def __init__(self, history):
+        self.history = history
+
+    def _generate_session_key(self, _source):
+        return "telegram:dm:12345"
+
+    def get_or_create_session(self, _source):
+        return SimpleNamespace(session_id="session-current", session_key="telegram:dm:12345")
+
+    def load_transcript(self, session_id):
+        assert session_id == "session-current"
+        return list(self.history)
+
+
+def test_default_config_defines_natural_dispatch_enabled_flag():
+    assert isinstance(DEFAULT_CONFIG["natural_dispatch"]["enabled"], bool)
+    assert DEFAULT_CONFIG["natural_dispatch"]["enabled"] is True
+
+
+def test_gateway_config_object_enables_natural_dispatch_from_dict():
+    from gateway.natural_dispatch import classify_natural_dispatch
+
+    config = GatewayConfig.from_dict({"natural_dispatch": {"enabled": True}})
+    decision = classify_natural_dispatch("继续优化这个实现", config)
+
+    assert decision.should_background is True
+
+
+def test_load_gateway_config_maps_natural_dispatch_from_config_yaml(tmp_path, monkeypatch):
+    from gateway.config import load_gateway_config
+    from gateway.natural_dispatch import classify_natural_dispatch
+
+    (tmp_path / "config.yaml").write_text("natural_dispatch:\n  enabled: true\n", encoding="utf-8")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    config = load_gateway_config()
+    decision = classify_natural_dispatch("继续优化这个实现", config)
+
+    assert config.natural_dispatch["enabled"] is True
+    assert decision.should_background is True
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "后台帮我跑完整测试",
+        "继续优化这个实现",
+        "请修复这个 bug 并运行测试",
+        "实现 admission control 并验证",
+        "跑一次 smoke test 并检查结果",
+        "分步骤检查、修改、测试并给我结论",
+    ],
+)
+def test_complex_messages_route_to_background(message):
+    from gateway.natural_dispatch import classify_natural_dispatch
+
+    decision = classify_natural_dispatch(message, {"natural_dispatch": {"enabled": True}})
+
+    assert decision.should_background is True
+    assert decision.reason
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "生成视频：猫在火星上散步",
+        "生成一个机器人短视频",
+        "制作 10 秒产品介绍视频",
+        "生成图片：赛博朋克猫",
+        "帮我做一张产品海报图",
+        "draw an image of a robot assistant",
+        "出图啊",
+        "图呢？",
+        "给我图",
+    ],
+)
+def test_media_generation_stays_foreground_for_native_attachment_path(message):
+    from gateway.natural_dispatch import classify_natural_dispatch
+
+    decision = classify_natural_dispatch(message, {"natural_dispatch": {"enabled": True}})
+
+    assert decision.should_background is False
+    assert decision.reason == "media_generation"
+
+
+def test_bare_continuation_routes_to_background_only_with_technical_context():
+    from gateway.natural_dispatch import classify_natural_dispatch
+
+    config = {"natural_dispatch": {"enabled": True}}
+
+    without_context = classify_natural_dispatch("继续", config)
+    casual_context = classify_natural_dispatch(
+        "继续",
+        config,
+        context=["我们刚才在聊晚饭和旅行安排。"],
+    )
+    with_context = classify_natural_dispatch(
+        "继续",
+        config,
+        context=[
+            "Root cause: Telegram gateway stability foreground guard needs debugging.",
+            "Next step: run pytest and verify gateway/natural_dispatch.py.",
+        ],
+    )
+
+    assert without_context.should_background is False
+    assert casual_context.should_background is False
+    assert with_context.should_background is True
+    assert with_context.reason == "continuation_context"
+
+
+def test_execution_acceptance_routes_to_background_only_with_technical_context():
+    from gateway.natural_dispatch import classify_natural_dispatch
+
+    config = {"natural_dispatch": {"enabled": True}}
+    message = "同意，按推荐方案执行"
+
+    without_context = classify_natural_dispatch(message, config)
+    casual_context = classify_natural_dispatch(
+        message,
+        config,
+        context=["我们刚才在聊明天去哪家餐厅。"],
+    )
+    with_context = classify_natural_dispatch(
+        message,
+        config,
+        context=[
+            "方案：先补 gateway natural dispatch 测试，再改路由。",
+            "Next step: implement the smallest code change and run pytest.",
+        ],
+    )
+
+    assert without_context.should_background is False
+    assert casual_context.should_background is False
+    assert with_context.should_background is True
+    assert with_context.reason == "accepted_execution_context"
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "这个方案可以执行吗？",
+        "how should we proceed",
+        "should we proceed",
+        "can we proceed",
+    ],
+)
+def test_execution_acceptance_question_stays_foreground_even_with_technical_context(message):
+    from gateway.natural_dispatch import classify_natural_dispatch
+
+    decision = classify_natural_dispatch(
+        message,
+        {"natural_dispatch": {"enabled": True}},
+        context=[
+            "方案：补路由测试并修改 gateway natural_dispatch。",
+            "Next step: implement and run pytest.",
+        ],
+    )
+
+    assert decision.should_background is False
+
+
+@pytest.mark.parametrize(
+    "message",
+    [
+        "我们继续讨论方案",
+        "你先分析方案，不要执行",
+        "检查一下这个方案是否合理",
+        "我有个想法，想让 Hermes 帮我做 AI 老师兼助手，你觉得怎么推进？",
+        "后台数据怎么同步",
+        "现在能生成视频了吗",
+        "你先分析怎么生成图片，不要执行",
+        "这个 bug 应该怎么修复？",
+        "how should we fix this bug?",
+    ],
+)
+def test_lightweight_discussion_stays_foreground(message):
+    from gateway.natural_dispatch import classify_natural_dispatch
+
+    decision = classify_natural_dispatch(message, {"natural_dispatch": {"enabled": True}})
+
+    assert decision.should_background is False
+
+
+def test_gateway_handler_routes_bare_continuation_with_technical_transcript_to_background():
+    runner = _runner()
+    runner.session_store = _TranscriptSessionStore(
+        [
+            {"role": "user", "content": "检查 Telegram gateway stability 的 foreground guard"},
+            {"role": "assistant", "content": "Root cause found; next step is pytest verification."},
+        ]
+    )
+    event = _event("继续")
+
+    result = asyncio.run(runner._handle_message(event))
+
+    assert "Background task started" in result
+    runner._handle_background_command.assert_awaited_once()
+    background_event = runner._handle_background_command.await_args.args[0]
+    assert background_event.text.startswith("/background ")
+    assert "Continue the active Telegram workstream" in background_event.get_command_args()
+    assert "pytest verification" in background_event.get_command_args()
+    runner._handle_message_with_agent.assert_not_awaited()
+
+
+def test_gateway_handler_starts_background_and_returns_immediately_for_complex_message():
+    runner = _runner()
+    event = _event("继续优化这个实现并运行测试")
+
+    result = asyncio.run(runner._handle_message(event))
+
+    assert "Background task started" in result
+    runner._handle_background_command.assert_awaited_once()
+    background_event = runner._handle_background_command.await_args.args[0]
+    assert background_event.text.startswith("/background ")
+    assert "继续优化这个实现" in background_event.get_command_args()
+    runner._handle_message_with_agent.assert_not_awaited()

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -334,6 +334,41 @@ class TestGatewayRuntimeStatus:
         assert payload["platforms"]["discord"]["error_code"] is None
         assert payload["platforms"]["discord"]["error_message"] is None
 
+    def test_write_runtime_heartbeat_overwrites_stale_cron_ticker(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        state_path = tmp_path / "gateway_state.json"
+        state_path.write_text(json.dumps({
+            "pid": 99999,
+            "start_time": 1000.0,
+            "kind": "hermes-gateway",
+            "gateway_state": "running",
+            "platforms": {"telegram": {"state": "connected"}},
+            "heartbeats": {
+                "cron_ticker": {
+                    "updated_at": "2025-01-01T00:00:00+00:00",
+                    "interval_seconds": 60,
+                    "stale_after_seconds": 180,
+                    "phase": "tick_started",
+                }
+            },
+            "updated_at": "2025-01-01T00:00:00+00:00",
+        }))
+
+        status.write_runtime_heartbeat(
+            "cron_ticker",
+            phase="tick_ok",
+            interval_seconds=60,
+            stale_after_seconds=240,
+        )
+
+        payload = status.read_runtime_status()
+        heartbeat = payload["heartbeats"]["cron_ticker"]
+        assert payload["pid"] == os.getpid()
+        assert payload["platforms"]["telegram"]["state"] == "connected"
+        assert heartbeat["phase"] == "tick_ok"
+        assert heartbeat["stale_after_seconds"] == 240
+        assert heartbeat["updated_at"] != "2025-01-01T00:00:00+00:00"
+
 
 class TestTerminatePid:
     def test_force_uses_taskkill_on_windows(self, monkeypatch):

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -37,6 +37,14 @@ class TestUserSystemdPrivateSocketPreflight:
 
 
 class TestSystemdServiceRefresh:
+    def test_systemd_definition_normalization_ignores_path_env_drift(self):
+        installed = '[Service]\nEnvironment="PATH=/usr/bin:/bin"\nWorkingDirectory=/repo\n'
+        expected = '[Service]\nEnvironment="PATH=/usr/local/bin:/usr/bin:/bin"\nWorkingDirectory=/repo\n'
+
+        assert gateway_cli._normalize_service_definition(installed) == (
+            gateway_cli._normalize_service_definition(expected)
+        )
+
     def test_systemd_install_repairs_outdated_unit_without_force(self, tmp_path, monkeypatch):
         unit_path = tmp_path / "hermes-gateway.service"
         unit_path.write_text("old unit\n", encoding="utf-8")

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -11,6 +11,7 @@ from hermes_cli.tools_config import (
     _reconfigure_provider,
     _get_platform_tools,
     _platform_toolset_summary,
+    _print_tools_list,
     _reconfigure_tool,
     _save_platform_tools,
     _toolset_has_keys,
@@ -198,6 +199,16 @@ def test_get_platform_tools_includes_enabled_mcp_servers_by_default():
     assert "exa" in enabled
     assert "web-search-prime" in enabled
     assert "disabled-server" not in enabled
+
+
+def test_print_tools_list_marks_disabled_mcp_servers(capsys):
+    _print_tools_list(set(), {"obsidian": {"command": "npx", "enabled": False}}, "cli")
+
+    output = capsys.readouterr().out
+
+    assert "obsidian" in output
+    assert "disabled" in output
+    assert "all tools enabled" not in output
 
 
 def test_get_platform_tools_keeps_enabled_mcp_servers_with_explicit_builtin_selection():

--- a/tests/run_agent/test_compression_persistence.py
+++ b/tests/run_agent/test_compression_persistence.py
@@ -63,6 +63,7 @@ class TestFlushAfterCompression:
             db = SessionDB(db_path=db_path)
 
             agent = self._make_agent(db)
+            agent._last_flushed_db_idx = 0
 
             # Simulate the original long history (200 messages)
             original_history = [
@@ -72,7 +73,8 @@ class TestFlushAfterCompression:
             ]
 
             # First, flush original messages to the original session
-            agent._flush_messages_to_session_db(original_history, [])
+            db.create_session(session_id="original-session", source="test")
+            db.replace_messages("original-session", original_history)
             original_rows = db.get_messages("original-session")
             assert len(original_rows) == 200
 

--- a/tests/run_agent/test_concurrent_interrupt.py
+++ b/tests/run_agent/test_concurrent_interrupt.py
@@ -81,6 +81,7 @@ def _make_agent(monkeypatch):
     # tool batch. Stub it as a no-op — this test exercises interrupt
     # fanout, not steer injection.
     stub._apply_pending_steer_to_tool_results = lambda *a, **kw: None
+    stub._append_guardrail_observation = lambda _name, _args, result, **_kw: result
     stub._invoke_tool = MagicMock(side_effect=lambda *a, **kw: '{"ok": true}')
     return stub
 
@@ -97,6 +98,45 @@ class _FakeAssistantMsg:
         self.tool_calls = tool_calls
 
 
+def test_concurrent_interrupt_cancels_pending(monkeypatch):
+    """When _interrupt_requested is set during concurrent execution,
+    the wait loop should exit early and cancelled tools get interrupt messages."""
+    agent = _make_agent(monkeypatch)
+
+    # Create a tool that blocks until interrupted
+    barrier = threading.Event()
+
+    original_invoke = agent._invoke_tool
+
+    def slow_tool(name, args, task_id, call_id=None, **_kwargs):
+        if name == "slow_one":
+            # Block until the test sets the interrupt
+            barrier.wait(timeout=10)
+            return '{"slow": true}'
+        return '{"fast": true}'
+
+    agent._invoke_tool = MagicMock(side_effect=slow_tool)
+
+    tc1 = _FakeToolCall("fast_one", call_id="tc_fast")
+    tc2 = _FakeToolCall("slow_one", call_id="tc_slow")
+    msg = _FakeAssistantMsg([tc1, tc2])
+    messages = []
+
+    def _set_interrupt_after_delay():
+        time.sleep(0.3)
+        agent._interrupt_requested = True
+        barrier.set()  # unblock the slow tool
+
+    t = threading.Thread(target=_set_interrupt_after_delay)
+    t.start()
+
+    agent._execute_tool_calls_concurrent(msg, messages, "test_task")
+    t.join()
+
+    # Both tools should have results in messages
+    assert len(messages) == 2
+    # The interrupt was detected
+    assert agent._interrupt_requested is True
 
 
 def test_concurrent_preflight_interrupt_skips_all(monkeypatch):
@@ -119,6 +159,85 @@ def test_concurrent_preflight_interrupt_skips_all(monkeypatch):
     agent._invoke_tool.assert_not_called()
 
 
+def test_running_concurrent_worker_sees_is_interrupted(monkeypatch):
+    """Regression guard for the "interrupt-doesn't-reach-hung-tool" class of
+    bug Physikal reported in April 2026.
+
+    Before this fix, `AIAgent.interrupt()` called `_set_interrupt(True,
+    _execution_thread_id)` — which only flagged the agent's *main* thread.
+    Tools running inside `_execute_tool_calls_concurrent` execute on
+    ThreadPoolExecutor worker threads whose tids are NOT the agent's, so
+    `is_interrupted()` (which checks the *current* thread's tid) returned
+    False inside those tools no matter how many times the gateway called
+    `.interrupt()`.  Hung ssh / long curl / big make-build tools would run
+    to their own timeout.
+
+    This test runs a fake tool in the concurrent path that polls
+    `is_interrupted()` like a real terminal command does, then calls
+    `agent.interrupt()` from another thread, and asserts the poll sees True
+    within one second.
+    """
+    from tools.interrupt import is_interrupted
+
+    agent = _make_agent(monkeypatch)
+
+    # Counter plus observation hooks so we can prove the worker saw the flip.
+    observed = {"saw_true": False, "poll_count": 0, "worker_tid": None}
+    worker_started = threading.Event()
+
+    def polling_tool(name, args, task_id, call_id=None, messages=None, **_kwargs):
+        observed["worker_tid"] = threading.current_thread().ident
+        worker_started.set()
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            observed["poll_count"] += 1
+            if is_interrupted():
+                observed["saw_true"] = True
+                return '{"interrupted": true}'
+            time.sleep(0.05)
+        return '{"timed_out": true}'
+
+    agent._invoke_tool = MagicMock(side_effect=polling_tool)
+
+    tc1 = _FakeToolCall("hung_fake_tool_1", call_id="tc1")
+    tc2 = _FakeToolCall("hung_fake_tool_2", call_id="tc2")
+    msg = _FakeAssistantMsg([tc1, tc2])
+    messages = []
+
+    def _interrupt_after_start():
+        # Wait until at least one worker is running so its tid is tracked.
+        worker_started.wait(timeout=2.0)
+        time.sleep(0.2)  # let the other worker enter too
+        agent.interrupt("stop requested by test")
+
+    t = threading.Thread(target=_interrupt_after_start)
+    t.start()
+    start = time.monotonic()
+    agent._execute_tool_calls_concurrent(msg, messages, "test_task")
+    elapsed = time.monotonic() - start
+    t.join(timeout=2.0)
+
+    # The worker must have actually polled is_interrupted — otherwise the
+    # test isn't exercising what it claims to.
+    assert observed["poll_count"] > 0, (
+        "polling_tool never ran — test scaffold issue"
+    )
+    # The worker must see the interrupt within ~1 s of agent.interrupt()
+    # being called.  Before the fix this loop ran until its 5 s own-timeout.
+    assert observed["saw_true"], (
+        f"is_interrupted() never returned True inside the concurrent worker "
+        f"after agent.interrupt() — interrupt-propagation hole regressed. "
+        f"worker_tid={observed['worker_tid']!r} poll_count={observed['poll_count']}"
+    )
+    assert elapsed < 3.0, (
+        f"concurrent execution took {elapsed:.2f}s after interrupt — the fan-out "
+        f"to worker tids didn't shortcut the tool's poll loop as expected"
+    )
+    # Also verify cleanup: no stale worker tids should remain after all
+    # tools finished.
+    assert agent._tool_worker_threads == set(), (
+        f"worker tids leaked after run: {agent._tool_worker_threads}"
+    )
 
 
 def test_clear_interrupt_clears_worker_tids(monkeypatch):
@@ -143,4 +262,3 @@ def test_clear_interrupt_clears_worker_tids(monkeypatch):
         "clear_interrupt() did not clear the interrupt bit for a tracked "
         "worker tid — stale interrupt can leak into the next turn"
     )
-

--- a/tests/run_agent/test_learning_capabilities_context.py
+++ b/tests/run_agent/test_learning_capabilities_context.py
@@ -1,0 +1,163 @@
+import json
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+def _make_tool_defs(*names: str) -> list:
+    return [
+        {
+            "type": "function",
+            "function": {
+                "name": name,
+                "description": f"{name} tool",
+                "parameters": {"type": "object", "properties": {}},
+            },
+        }
+        for name in names
+    ]
+
+
+def _mock_response(content="Done"):
+    msg = SimpleNamespace(
+        content=content,
+        tool_calls=None,
+        reasoning_content=None,
+        reasoning=None,
+    )
+    choice = SimpleNamespace(message=msg, finish_reason="stop")
+    resp = SimpleNamespace(choices=[choice], model="test/model")
+    resp.usage = None
+    return resp
+
+
+def test_learning_capabilities_context_is_api_only_and_not_persisted(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.learning_absorption_tool import learning_absorption
+
+    registered = json.loads(
+        learning_absorption(
+            action="register",
+            candidate={
+                "finding": "Use evaluator-gated agent loops before changing default routing.",
+                "source_url": "https://platform.openai.com/docs/guides/evals",
+                "source_type": "official",
+                "verification_level": "official",
+                "impact": "medium",
+                "risk": "low",
+                "reusable_workflow": True,
+                "applies_to": ["agent orchestration"],
+            },
+        )
+    )
+    config = {
+        "memory": {"memory_enabled": False, "user_profile_enabled": False},
+        "skills": {"external_dirs": []},
+        "compression": {"enabled": False},
+    }
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("learning_absorption")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("hermes_cli.config.load_config", return_value=config),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://example.test/v1",
+            provider="custom",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.client = MagicMock()
+        agent.client.chat.completions.create.return_value = _mock_response()
+        agent._cached_system_prompt = "You are helpful."
+        agent._use_prompt_caching = False
+        agent.compression_enabled = False
+        agent.save_trajectories = False
+
+        with (
+            patch.object(agent, "_persist_session") as mock_persist_session,
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("Plan the next agent orchestration upgrade", task_id="learning-task")
+
+    api_messages = agent.client.chat.completions.create.call_args.kwargs["messages"]
+    api_user_messages = [msg for msg in api_messages if msg.get("role") == "user"]
+    assert registered["capability"]["id"] in api_user_messages[-1]["content"]
+    assert "<hermes-learning-capabilities>" in api_user_messages[-1]["content"]
+
+    assert result["messages"][0]["content"] == "Plan the next agent orchestration upgrade"
+    assert "hermes-learning-capabilities" not in result["messages"][0]["content"]
+    persisted_messages = mock_persist_session.call_args.args[0]
+    assert persisted_messages[0]["content"] == "Plan the next agent orchestration upgrade"
+
+
+def test_agent_records_speech_self_review_feedback_after_final_response(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.learning_absorption_tool import learning_absorption
+
+    learning_absorption(
+        action="register",
+        candidate={
+            "finding": "Use evaluator-gated agent loops before changing default routing.",
+            "source_url": "https://platform.openai.com/docs/guides/evals",
+            "source_type": "official",
+            "verification_level": "official",
+            "impact": "medium",
+            "risk": "low",
+            "reusable_workflow": True,
+            "applies_to": ["agent orchestration"],
+        },
+    )
+    config = {
+        "memory": {"memory_enabled": False, "user_profile_enabled": False},
+        "skills": {"external_dirs": []},
+        "compression": {"enabled": False},
+    }
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=_make_tool_defs("learning_absorption")),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("hermes_cli.config.load_config", return_value=config),
+    ):
+        from run_agent import AIAgent
+
+        agent = AIAgent(
+            api_key="test-key-1234567890",
+            base_url="https://example.test/v1",
+            provider="custom",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.client = MagicMock()
+        agent.client.chat.completions.create.return_value = _mock_response(
+            "我会参考这些已沉淀的 AI 使用经验：\n"
+            "这对当前问题的用法：先解释关键取舍，再自己执行、验证并沉淀结果。"
+        )
+        agent._cached_system_prompt = "You are helpful."
+        agent._use_prompt_caching = False
+        agent.compression_enabled = False
+        agent.save_trajectories = False
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            agent.run_conversation("直接修复 agent orchestration 的 bug，不要解释", task_id="learning-task")
+
+    summary = json.loads(learning_absorption(action="speech_feedback_summary"))
+
+    assert summary["summary"]["outcome_counts"]["too_much"] == 1
+    event = summary["summary"]["recent_events"][0]
+    assert event["source"] == "auto_self_review"
+    assert event["actual_mode"] == "teach"
+    assert event["expected_mode"] == "execute_quietly"

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -824,7 +824,50 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertIsNone(creds["base_url"])
         self.assertIsNone(creds["api_key"])
 
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_provider_resolves_full_credentials(self, mock_resolve):
+        """When delegation.provider is set, full credentials are resolved."""
+        mock_resolve.return_value = {
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "sk-or-test-key",
+            "api_mode": "chat_completions",
+        }
+        parent = _make_mock_parent(depth=0)
+        cfg = {"model": "google/gemini-3-flash-preview", "provider": "openrouter"}
+        creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertEqual(creds["model"], "google/gemini-3-flash-preview")
+        self.assertEqual(creds["provider"], "openrouter")
+        self.assertEqual(creds["base_url"], "https://openrouter.ai/api/v1")
+        self.assertEqual(creds["api_key"], "sk-or-test-key")
+        self.assertEqual(creds["api_mode"], "chat_completions")
+        mock_resolve.assert_called_once_with(
+            requested="openrouter",
+            target_model="google/gemini-3-flash-preview",
+        )
 
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_provider_resolution_uses_runtime_model_when_config_model_missing(self, mock_resolve):
+        """Named providers should propagate their runtime default model to children."""
+        mock_resolve.return_value = {
+            "provider": "custom",
+            "base_url": "https://my-server.example/v1",
+            "api_key": "sk-test-key",
+            "api_mode": "chat_completions",
+            "model": "server-default-model",
+        }
+        parent = _make_mock_parent(depth=0)
+        cfg = {"provider": "custom:my-server", "model": ""}
+
+        creds = _resolve_delegation_credentials(cfg, parent)
+
+        self.assertEqual(creds["model"], "server-default-model")
+        self.assertEqual(creds["provider"], "custom")
+        self.assertEqual(creds["base_url"], "https://my-server.example/v1")
+        mock_resolve.assert_called_once_with(
+            requested="custom:my-server",
+            target_model=None,
+        )
 
     def test_direct_endpoint_uses_configured_base_url_and_api_key(self):
         parent = _make_mock_parent(depth=0)
@@ -873,6 +916,25 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         self.assertIsNone(creds["api_key"])
         self.assertEqual(creds["provider"], "custom")
 
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_nous_provider_resolves_nous_credentials(self, mock_resolve):
+        """Nous provider resolves Nous Portal base_url and api_key."""
+        mock_resolve.return_value = {
+            "provider": "nous",
+            "base_url": "https://inference-api.nousresearch.com/v1",
+            "api_key": "nous-agent-key-xyz",
+            "api_mode": "chat_completions",
+        }
+        parent = _make_mock_parent(depth=0)
+        cfg = {"model": "hermes-3-llama-3.1-8b", "provider": "nous"}
+        creds = _resolve_delegation_credentials(cfg, parent)
+        self.assertEqual(creds["provider"], "nous")
+        self.assertEqual(creds["base_url"], "https://inference-api.nousresearch.com/v1")
+        self.assertEqual(creds["api_key"], "nous-agent-key-xyz")
+        mock_resolve.assert_called_once_with(
+            requested="nous",
+            target_model="hermes-3-llama-3.1-8b",
+        )
 
     @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
     def test_provider_resolution_failure_raises_valueerror(self, mock_resolve):
@@ -899,6 +961,46 @@ class TestDelegationCredentialResolution(unittest.TestCase):
         with self.assertRaises(ValueError) as ctx:
             _resolve_delegation_credentials(cfg, parent)
         self.assertIn("no API key", str(ctx.exception))
+
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_codex_named_provider_placeholder_key_reuses_matching_parent_key(self, mock_resolve):
+        """Codex-style named custom providers must not pass placeholder auth to children."""
+        mock_resolve.return_value = {
+            "provider": "custom",
+            "base_url": "http://127.0.0.1:8317/v1",
+            "api_key": "no-key-required",
+            "api_mode": "codex_responses",
+        }
+        parent = _make_mock_parent(depth=0)
+        parent.base_url = "http://127.0.0.1:8317/v1"
+        parent.api_key = "parent-auth-key"
+        parent.api_mode = "codex_responses"
+        cfg = {"model": "gpt-5.5", "provider": "gpt-mainline-codex-local"}
+
+        creds = _resolve_delegation_credentials(cfg, parent)
+
+        self.assertEqual(creds["api_key"], "parent-auth-key")
+        self.assertEqual(creds["api_mode"], "codex_responses")
+
+    @patch("hermes_cli.runtime_provider.resolve_runtime_provider")
+    def test_codex_named_provider_placeholder_key_raises_when_parent_cannot_supply_key(self, mock_resolve):
+        mock_resolve.return_value = {
+            "provider": "custom",
+            "base_url": "http://127.0.0.1:8317/v1",
+            "api_key": "no-key-required",
+            "api_mode": "codex_responses",
+        }
+        parent = _make_mock_parent(depth=0)
+        parent.base_url = "https://openrouter.ai/api/v1"
+        parent.api_key = "parent-auth-key"
+        parent.api_mode = "chat_completions"
+        cfg = {"model": "gpt-5.5", "provider": "gpt-mainline-codex-local"}
+
+        with self.assertRaises(ValueError) as ctx:
+            _resolve_delegation_credentials(cfg, parent)
+
+        self.assertIn("no usable API key", str(ctx.exception))
+        self.assertIn("gpt-mainline-codex-local", str(ctx.exception))
 
     def test_missing_config_keys_inherit_parent(self):
         """When config dict has no model/provider keys at all, inherits parent."""

--- a/tests/tools/test_learning_absorption_tool.py
+++ b/tests/tools/test_learning_absorption_tool.py
@@ -1,0 +1,1066 @@
+"""Tests for the AI learning absorption decision tool."""
+
+import json
+from datetime import datetime, timedelta, timezone
+
+
+def test_fetch_feed_retries_transient_urlopen_failure(monkeypatch):
+    from tools import learning_absorption_tool as tool
+
+    calls = []
+
+    class Headers:
+        def get_content_charset(self):
+            return "utf-8"
+
+    class Response:
+        headers = Headers()
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, traceback):
+            return False
+
+        def read(self, limit):
+            assert limit == 1_000_000
+            return b"<rss>ok</rss>"
+
+    def fake_urlopen(request, timeout):
+        calls.append((request, timeout))
+        if len(calls) == 1:
+            raise TimeoutError("transient handshake timeout")
+        return Response()
+
+    monkeypatch.setattr(tool.urllib.request, "urlopen", fake_urlopen)
+
+    assert tool._fetch_feed("https://example.com/feed.xml", timeout=3, attempts=2, retry_delay=0) == "<rss>ok</rss>"
+    assert len(calls) == 2
+
+
+def test_unverified_routing_change_goes_to_verification_backlog(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.learning_absorption_tool import learning_absorption
+
+    result = json.loads(
+        learning_absorption(
+            action="decide",
+            candidate={
+                "finding": "Route all execution approvals to a new background worker by default.",
+                "source_url": "https://example.com/community-post",
+                "source_type": "community",
+                "verification_level": "source_checked",
+                "impact": "high",
+                "risk": "high",
+                "affects_routing": True,
+            },
+        )
+    )
+
+    assert result["success"] is True
+    decision = result["decision"]
+    assert decision["promotion_target"] == "verification_backlog"
+    assert decision["can_apply_by_default"] is False
+    assert "local smoke" in " ".join(decision["required_evidence"]).lower()
+
+
+def test_verified_reusable_workflow_promotes_to_playbook(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.learning_absorption_tool import learning_absorption
+
+    result = json.loads(
+        learning_absorption(
+            action="decide",
+            candidate={
+                "finding": "Use evaluator-gated agent loops before changing default routing.",
+                "source_url": "https://platform.openai.com/docs/guides/evals",
+                "source_type": "official",
+                "verification_level": "official",
+                "impact": "medium",
+                "risk": "low",
+                "reusable_workflow": True,
+                "applies_to": ["agent orchestration", "workflow design"],
+            },
+        )
+    )
+
+    assert result["success"] is True
+    decision = result["decision"]
+    assert decision["promotion_target"] == "playbook"
+    assert decision["can_apply_by_default"] is True
+    assert decision["registry_status"] == "active"
+
+
+def test_front_channel_allows_major_new_technique(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.learning_absorption_tool import learning_absorption
+
+    result = json.loads(
+        learning_absorption(
+            action="decide",
+            candidate={
+                "finding": "A new official agent evaluation pattern changes how Hermes should score worker reliability.",
+                "source_url": "https://platform.openai.com/docs/guides/evals",
+                "source_type": "official",
+                "verification_level": "official",
+                "impact": "high",
+                "risk": "low",
+                "front_channel_reason": "major_new_technique",
+            },
+        )
+    )
+
+    assert result["decision"]["front_channel"]["allow"] is True
+    assert result["decision"]["front_channel"]["reason"] == "major_new_technique"
+
+
+def test_front_channel_allows_current_project_relevance(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.learning_absorption_tool import learning_absorption
+
+    result = json.loads(
+        learning_absorption(
+            action="decide",
+            candidate={
+                "finding": "Hermes v0.13 changed cron delivery semantics used by this retrofit.",
+                "source_url": "https://github.com/NousResearch/hermes-agent/releases",
+                "source_type": "official",
+                "verification_level": "official",
+                "impact": "medium",
+                "risk": "low",
+                "front_channel_reason": "current_project_relevance",
+            },
+        )
+    )
+
+    assert result["decision"]["front_channel"]["allow"] is True
+    assert result["decision"]["front_channel"]["reason"] == "current_project_relevance"
+
+
+def test_front_channel_allows_execution_blocker(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.learning_absorption_tool import learning_absorption
+
+    result = json.loads(
+        learning_absorption(
+            action="decide",
+            candidate={
+                "finding": "The configured provider is failing and blocks the live scout proof.",
+                "source_url": "local://hermes/runtime",
+                "source_type": "local",
+                "verification_level": "local_smoke",
+                "impact": "high",
+                "risk": "medium",
+                "front_channel_reason": "execution_blocker",
+            },
+        )
+    )
+
+    assert result["decision"]["front_channel"]["allow"] is True
+    assert result["decision"]["front_channel"]["reason"] == "execution_blocker"
+
+
+def test_front_channel_allows_direction_decision(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.learning_absorption_tool import learning_absorption
+
+    result = json.loads(
+        learning_absorption(
+            action="decide",
+            candidate={
+                "finding": "The next Hermes upgrade must choose between routing defaults and a playbook-only rollout.",
+                "source_url": "local://hermes/plan",
+                "source_type": "local",
+                "verification_level": "applied",
+                "impact": "high",
+                "risk": "medium",
+                "front_channel_reason": "direction_decision",
+            },
+        )
+    )
+
+    assert result["decision"]["front_channel"]["allow"] is True
+    assert result["decision"]["front_channel"]["reason"] == "direction_decision"
+
+
+def test_front_channel_blocks_low_value_learning_by_default(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.learning_absorption_tool import learning_absorption
+
+    result = json.loads(
+        learning_absorption(
+            action="decide",
+            candidate={
+                "finding": "A generic AI newsletter repeated common prompt tips.",
+                "source_url": "https://example.com/newsletter",
+                "source_type": "community",
+                "verification_level": "source_checked",
+                "impact": "low",
+                "risk": "low",
+            },
+        )
+    )
+
+    front_channel = result["decision"]["front_channel"]
+    assert front_channel["allow"] is False
+    assert front_channel["reason"] == "local_only"
+    assert "[SILENT]" in front_channel["default_response"]
+
+
+def test_register_persists_capability_idempotently(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.learning_absorption_tool import learning_absorption
+
+    candidate = {
+        "finding": "Use evaluator-gated agent loops before changing default routing.",
+        "source_url": "https://platform.openai.com/docs/guides/evals",
+        "source_type": "official",
+        "verification_level": "official",
+        "impact": "medium",
+        "risk": "low",
+        "reusable_workflow": True,
+        "applies_to": ["agent orchestration"],
+    }
+
+    first = json.loads(learning_absorption(action="register", candidate=candidate))
+    second = json.loads(learning_absorption(action="register", candidate=candidate))
+
+    assert first["success"] is True
+    assert second["success"] is True
+    assert first["capability"]["id"] == second["capability"]["id"]
+
+    registry_path = tmp_path / "learning" / "capabilities.json"
+    payload = json.loads(registry_path.read_text(encoding="utf-8"))
+    assert len(payload["capabilities"]) == 1
+    assert payload["capabilities"][0]["promotion_target"] == "playbook"
+    assert payload["capabilities"][0]["status"] == "active"
+
+
+def test_select_returns_relevant_active_capabilities_only(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.learning_absorption_tool import learning_absorption
+
+    active = {
+        "finding": "Use evaluator-gated agent loops before changing default routing.",
+        "source_url": "https://platform.openai.com/docs/guides/evals",
+        "source_type": "official",
+        "verification_level": "official",
+        "impact": "medium",
+        "risk": "low",
+        "reusable_workflow": True,
+        "applies_to": ["agent orchestration", "routing"],
+    }
+    pending = {
+        "finding": "Route every request through an unverified worker mesh.",
+        "source_url": "https://example.com/community",
+        "source_type": "community",
+        "verification_level": "unverified",
+        "impact": "high",
+        "risk": "high",
+        "affects_routing": True,
+        "applies_to": ["agent orchestration", "routing"],
+    }
+    learning_absorption(action="register", candidate=active)
+    learning_absorption(action="register", candidate=pending)
+
+    result = json.loads(
+        learning_absorption(
+            action="select",
+            query="How should Hermes handle agent orchestration and routing?",
+        )
+    )
+
+    assert result["success"] is True
+    assert [item["finding"] for item in result["capabilities"]] == [active["finding"]]
+
+
+def test_record_use_updates_capability_usage_log(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.learning_absorption_tool import learning_absorption
+
+    registered = json.loads(
+        learning_absorption(
+            action="register",
+            candidate={
+                "finding": "Use evaluator-gated agent loops before changing default routing.",
+                "source_url": "https://platform.openai.com/docs/guides/evals",
+                "source_type": "official",
+                "verification_level": "official",
+                "impact": "medium",
+                "risk": "low",
+                "reusable_workflow": True,
+                "applies_to": ["agent orchestration"],
+            },
+        )
+    )
+
+    result = json.loads(
+        learning_absorption(
+            action="record_use",
+            capability_id=registered["capability"]["id"],
+            usage={
+                "task": "Discuss Hermes orchestration upgrade",
+                "outcome": "used_in_plan",
+            },
+        )
+    )
+
+    assert result["success"] is True
+    assert result["capability"]["use_count"] == 1
+    assert result["capability"]["usage_log"][0]["outcome"] == "used_in_plan"
+
+
+def test_build_capability_invocation_context_is_bounded_and_actionable(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.learning_absorption_tool import (
+        build_capability_invocation_context,
+        learning_absorption,
+    )
+
+    registered = json.loads(
+        learning_absorption(
+            action="register",
+            candidate={
+                "finding": "Use evaluator-gated agent loops before changing default routing.",
+                "source_url": "https://platform.openai.com/docs/guides/evals",
+                "source_type": "official",
+                "verification_level": "official",
+                "impact": "medium",
+                "risk": "low",
+                "reusable_workflow": True,
+                "applies_to": ["agent orchestration"],
+            },
+        )
+    )
+
+    context = build_capability_invocation_context("agent orchestration upgrade")
+
+    assert "<hermes-learning-capabilities>" in context
+    assert registered["capability"]["id"] in context
+    assert "Apply these active capabilities when they fit this turn" in context
+
+
+def test_teacher_brief_explains_relevant_capabilities_in_chinese(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.learning_absorption_tool import LEARNING_ABSORPTION_SCHEMA, learning_absorption
+
+    registered = json.loads(
+        learning_absorption(
+            action="register",
+            candidate={
+                "finding": "Use evaluator-gated agent loops before changing default routing.",
+                "source_url": "https://platform.openai.com/docs/guides/evals",
+                "source_type": "official",
+                "verification_level": "official",
+                "impact": "medium",
+                "risk": "low",
+                "reusable_workflow": True,
+                "applies_to": ["agent orchestration", "AI product usage"],
+            },
+        )
+    )
+
+    result = json.loads(
+        learning_absorption(
+            action="teacher_brief",
+            query="教我怎么规划 AI agent 工作流的下一步",
+        )
+    )
+
+    assert result["success"] is True
+    assert "teacher_brief" in LEARNING_ABSORPTION_SCHEMA["parameters"]["properties"]["action"]["enum"]
+    assert result["should_speak"] is True
+    assert result["speech_policy"]["mode"] == "teach"
+    assert registered["capability"]["id"] in result["brief"]
+    assert "我会参考" in result["brief"]
+    assert "下一步" in result["brief"]
+
+
+def test_teacher_brief_stays_quiet_for_direct_execution_requests(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.learning_absorption_tool import learning_absorption
+
+    learning_absorption(
+        action="register",
+        candidate={
+            "finding": "Use evaluator-gated agent loops before changing default routing.",
+            "source_url": "https://platform.openai.com/docs/guides/evals",
+            "source_type": "official",
+            "verification_level": "official",
+            "impact": "medium",
+            "risk": "low",
+            "reusable_workflow": True,
+            "applies_to": ["agent orchestration", "AI product usage"],
+        },
+    )
+
+    result = json.loads(
+        learning_absorption(
+            action="teacher_brief",
+            query="直接修复 agent orchestration 的 bug，不要解释，完成后报告结果",
+        )
+    )
+
+    assert result["success"] is True
+    assert result["should_speak"] is False
+    assert result["speech_policy"]["mode"] == "execute_quietly"
+    assert result["brief"] == ""
+    assert result["capabilities"]
+
+
+def test_teacher_brief_speaks_for_direction_discussions(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.learning_absorption_tool import learning_absorption
+
+    learning_absorption(
+        action="register",
+        candidate={
+            "finding": "Use evaluator-gated agent loops before changing default routing.",
+            "source_url": "https://platform.openai.com/docs/guides/evals",
+            "source_type": "official",
+            "verification_level": "official",
+            "impact": "medium",
+            "risk": "low",
+            "reusable_workflow": True,
+            "applies_to": ["agent orchestration", "AI product usage"],
+        },
+    )
+
+    result = json.loads(
+        learning_absorption(
+            action="teacher_brief",
+            query="我们讨论一下 Hermes agent orchestration 下一步方向和取舍",
+        )
+    )
+
+    assert result["success"] is True
+    assert result["should_speak"] is True
+    assert result["speech_policy"]["mode"] == "direction"
+    assert "确认方向" in result["brief"]
+
+
+def test_teacher_brief_speaks_for_user_brief_capabilities_even_without_teaching_words(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.learning_absorption_tool import learning_absorption
+
+    learning_absorption(
+        action="register",
+        candidate={
+            "finding": "New official agent runtime changes how workspace agents coordinate tasks.",
+            "source_url": "https://openai.com/index/workspace-agents",
+            "source_type": "official",
+            "verification_level": "official",
+            "impact": "high",
+            "risk": "low",
+            "applies_to": ["workspace agents"],
+        },
+    )
+
+    result = json.loads(
+        learning_absorption(
+            action="teacher_brief",
+            query="workspace agents 这件事对 Hermes 有影响吗",
+        )
+    )
+
+    assert result["success"] is True
+    assert result["should_speak"] is True
+    assert result["speech_policy"]["mode"] == "decision"
+    assert "需要你关注" in result["brief"]
+
+
+def test_learning_context_includes_teacher_guidance_for_ai_usage_discussions(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.learning_absorption_tool import (
+        build_capability_invocation_context,
+        learning_absorption,
+    )
+
+    learning_absorption(
+        action="register",
+        candidate={
+            "finding": "Use evaluator-gated agent loops before changing default routing.",
+            "source_url": "https://platform.openai.com/docs/guides/evals",
+            "source_type": "official",
+            "verification_level": "official",
+            "impact": "medium",
+            "risk": "low",
+            "reusable_workflow": True,
+            "applies_to": ["agent orchestration", "AI product usage"],
+        },
+    )
+
+    context = build_capability_invocation_context("我想学习怎么更好使用 AI agent")
+
+    assert "teacher_mode" in context
+    assert "用中文简短解释" in context
+
+
+def test_learning_context_suppresses_teacher_mode_for_direct_execution(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.learning_absorption_tool import (
+        build_capability_invocation_context,
+        learning_absorption,
+    )
+
+    learning_absorption(
+        action="register",
+        candidate={
+            "finding": "Use evaluator-gated agent loops before changing default routing.",
+            "source_url": "https://platform.openai.com/docs/guides/evals",
+            "source_type": "official",
+            "verification_level": "official",
+            "impact": "medium",
+            "risk": "low",
+            "reusable_workflow": True,
+            "applies_to": ["agent orchestration", "AI product usage"],
+        },
+    )
+
+    context = build_capability_invocation_context("直接修复 agent orchestration 的 bug，不要解释")
+
+    assert "teacher_mode" not in context
+    assert "execute_quietly" in context
+
+
+def test_record_speech_feedback_persists_event_and_returns_summary(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.learning_absorption_tool import LEARNING_ABSORPTION_SCHEMA, learning_absorption
+
+    result = json.loads(
+        learning_absorption(
+            action="record_speech_feedback",
+            usage={
+                "query": "直接修复 agent orchestration 的 bug，不要解释",
+                "actual_mode": "teach",
+                "expected_mode": "execute_quietly",
+                "outcome": "too_much",
+                "note": "Hermes 讲解太多，应该直接做完后报告结果。",
+                "capability_ids": ["cap-1"],
+            },
+        )
+    )
+
+    assert result["success"] is True
+    assert "record_speech_feedback" in LEARNING_ABSORPTION_SCHEMA["parameters"]["properties"]["action"]["enum"]
+    assert result["event"]["outcome"] == "too_much"
+    assert result["event"]["actual_mode"] == "teach"
+    assert result["event"]["expected_mode"] == "execute_quietly"
+    assert result["summary"]["outcome_counts"]["too_much"] == 1
+    assert any("少解释" in item for item in result["summary"]["recommendations"])
+
+    summary = json.loads(learning_absorption(action="speech_feedback_summary"))
+
+    assert summary["success"] is True
+    assert summary["summary"]["total_events"] == 1
+    assert summary["summary"]["recent_events"][0]["capability_ids"] == ["cap-1"]
+
+
+def test_learning_context_includes_recent_speech_feedback_guidance(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.learning_absorption_tool import (
+        build_capability_invocation_context,
+        learning_absorption,
+    )
+
+    learning_absorption(
+        action="register",
+        candidate={
+            "finding": "Use evaluator-gated agent loops before changing default routing.",
+            "source_url": "https://platform.openai.com/docs/guides/evals",
+            "source_type": "official",
+            "verification_level": "official",
+            "impact": "medium",
+            "risk": "low",
+            "reusable_workflow": True,
+            "applies_to": ["agent orchestration", "AI product usage"],
+        },
+    )
+    learning_absorption(
+        action="record_speech_feedback",
+        usage={
+            "query": "直接修复 agent orchestration 的 bug，不要解释",
+            "actual_mode": "teach",
+            "expected_mode": "execute_quietly",
+            "outcome": "too_much",
+        },
+    )
+
+    context = build_capability_invocation_context("agent orchestration upgrade")
+
+    assert "<speech-feedback>" in context
+    assert "少解释" in context
+    assert "current user intent wins" in context
+
+
+def test_natural_speech_feedback_attributes_to_latest_teacher_brief(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.learning_absorption_tool import learning_absorption
+
+    registered = json.loads(
+        learning_absorption(
+            action="register",
+            candidate={
+                "finding": "Use evaluator-gated agent loops before changing default routing.",
+                "source_url": "https://platform.openai.com/docs/guides/evals",
+                "source_type": "official",
+                "verification_level": "official",
+                "impact": "medium",
+                "risk": "low",
+                "reusable_workflow": True,
+                "applies_to": ["agent orchestration", "AI product usage"],
+            },
+        )
+    )
+    brief = json.loads(
+        learning_absorption(
+            action="teacher_brief",
+            query="教我怎么规划 AI agent 工作流的下一步",
+        )
+    )
+
+    result = json.loads(
+        learning_absorption(
+            action="record_speech_feedback",
+            usage={"feedback_text": "你刚才讲太多了，应该直接做完后报告结果。"},
+        )
+    )
+
+    assert brief["speech_policy"]["mode"] == "teach"
+    assert result["success"] is True
+    assert result["event"]["outcome"] == "too_much"
+    assert result["event"]["actual_mode"] == "teach"
+    assert result["event"]["expected_mode"] == "execute_quietly"
+    assert result["event"]["query"] == "教我怎么规划 AI agent 工作流的下一步"
+    assert result["event"]["capability_ids"] == [registered["capability"]["id"]]
+    assert result["event"]["attribution"]["source"] == "latest_speech_policy_trace"
+    assert result["event"]["attribution"]["trace_id"] == brief["speech_trace"]["trace_id"]
+
+
+def test_natural_risk_feedback_attributes_to_latest_context_policy(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.learning_absorption_tool import (
+        build_capability_invocation_context,
+        learning_absorption,
+    )
+
+    registered = json.loads(
+        learning_absorption(
+            action="register",
+            candidate={
+                "finding": "Use evaluator-gated agent loops before changing default routing.",
+                "source_url": "https://platform.openai.com/docs/guides/evals",
+                "source_type": "official",
+                "verification_level": "official",
+                "impact": "medium",
+                "risk": "low",
+                "reusable_workflow": True,
+                "applies_to": ["agent orchestration"],
+            },
+        )
+    )
+
+    context = build_capability_invocation_context("直接改默认 agent orchestration 路由")
+    result = json.loads(
+        learning_absorption(
+            action="record_speech_feedback",
+            usage={"feedback_text": "这里应该先提醒我风险，再继续执行。"},
+        )
+    )
+
+    assert "execute_quietly" in context
+    assert result["event"]["outcome"] == "missed_decision"
+    assert result["event"]["actual_mode"] == "execute_quietly"
+    assert result["event"]["expected_mode"] == "decision"
+    assert result["event"]["query"] == "直接改默认 agent orchestration 路由"
+    assert result["event"]["capability_ids"] == [registered["capability"]["id"]]
+    assert result["event"]["attribution"]["trace_source"] == "invocation_context"
+
+
+def test_evaluate_speech_response_records_auto_feedback_when_direct_execution_overexplains(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.learning_absorption_tool import learning_absorption
+
+    registered = json.loads(
+        learning_absorption(
+            action="register",
+            candidate={
+                "finding": "Use evaluator-gated agent loops before changing default routing.",
+                "source_url": "https://platform.openai.com/docs/guides/evals",
+                "source_type": "official",
+                "verification_level": "official",
+                "impact": "medium",
+                "risk": "low",
+                "reusable_workflow": True,
+                "applies_to": ["agent orchestration"],
+            },
+        )
+    )
+
+    result = json.loads(
+        learning_absorption(
+            action="evaluate_speech_response",
+            query="直接修复 agent orchestration 的 bug，不要解释",
+            response=(
+                "我会参考这些已沉淀的 AI 使用经验：\n"
+                "这对当前问题的用法：先解释关键取舍，再自己执行、验证并沉淀结果。"
+            ),
+        )
+    )
+
+    assert result["success"] is True
+    assert result["feedback_recorded"] is True
+    assert result["speech_policy"]["mode"] == "execute_quietly"
+    assert result["event"]["source"] == "auto_self_review"
+    assert result["event"]["outcome"] == "too_much"
+    assert result["event"]["actual_mode"] == "teach"
+    assert result["event"]["expected_mode"] == "execute_quietly"
+    assert result["event"]["capability_ids"] == [registered["capability"]["id"]]
+    assert result["summary"]["outcome_counts"]["too_much"] == 1
+
+
+def test_evaluate_speech_response_records_missed_decision_for_high_attention_capability(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.learning_absorption_tool import learning_absorption
+
+    registered = json.loads(
+        learning_absorption(
+            action="register",
+            candidate={
+                "finding": "New default routing behavior can affect Hermes agent execution.",
+                "source_url": "https://platform.openai.com/docs/guides/agents",
+                "source_type": "official",
+                "verification_level": "official",
+                "impact": "high",
+                "risk": "low",
+                "reusable_workflow": False,
+                "applies_to": ["workspace agents"],
+            },
+        )
+    )
+
+    result = json.loads(
+        learning_absorption(
+            action="evaluate_speech_response",
+            query="workspace agents 对 Hermes 有影响吗",
+            response="我已经直接改好了。",
+        )
+    )
+
+    assert result["success"] is True
+    assert result["feedback_recorded"] is True
+    assert result["speech_policy"]["mode"] == "decision"
+    assert result["event"]["source"] == "auto_self_review"
+    assert result["event"]["outcome"] == "missed_decision"
+    assert result["event"]["actual_mode"] == "execute_quietly"
+    assert result["event"]["expected_mode"] == "decision"
+    assert result["event"]["capability_ids"] == [registered["capability"]["id"]]
+    assert result["summary"]["outcome_counts"]["missed_decision"] == 1
+
+
+def test_evaluate_speech_response_suppresses_recent_duplicate_auto_feedback(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.learning_absorption_tool import learning_absorption
+
+    learning_absorption(
+        action="register",
+        candidate={
+            "finding": "Use evaluator-gated agent loops before changing default routing.",
+            "source_url": "https://platform.openai.com/docs/guides/evals",
+            "source_type": "official",
+            "verification_level": "official",
+            "impact": "medium",
+            "risk": "low",
+            "reusable_workflow": True,
+            "applies_to": ["agent orchestration"],
+        },
+    )
+
+    first = json.loads(
+        learning_absorption(
+            action="evaluate_speech_response",
+            query="直接修复 agent orchestration 的 bug，不要解释",
+            response=(
+                "我会参考这些已沉淀的 AI 使用经验：\n"
+                "这对当前问题的用法：先解释关键取舍，再自己执行、验证并沉淀结果。"
+            ),
+        )
+    )
+    second = json.loads(
+        learning_absorption(
+            action="evaluate_speech_response",
+            query="直接修复 agent orchestration 的 bug，不要解释",
+            response=(
+                "我会参考这些已沉淀的 AI 使用经验：\n"
+                "这对当前问题的用法：先解释关键取舍，再自己执行、验证并沉淀结果。"
+            ),
+        )
+    )
+
+    assert first["feedback_recorded"] is True
+    assert second["feedback_recorded"] is False
+    assert second["reason"] == "duplicate_recent_auto_self_review"
+    assert second["summary"]["outcome_counts"]["too_much"] == 1
+
+
+def test_evaluate_speech_response_records_again_after_duplicate_cooldown(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools import learning_absorption_tool as tool
+
+    base_time = datetime(2026, 5, 9, 8, 0, tzinfo=timezone.utc)
+    monkeypatch.setattr(tool, "_hermes_now", lambda: base_time)
+
+    tool.learning_absorption(
+        action="register",
+        candidate={
+            "finding": "Use evaluator-gated agent loops before changing default routing.",
+            "source_url": "https://platform.openai.com/docs/guides/evals",
+            "source_type": "official",
+            "verification_level": "official",
+            "impact": "medium",
+            "risk": "low",
+            "reusable_workflow": True,
+            "applies_to": ["agent orchestration"],
+        },
+    )
+
+    response = (
+        "我会参考这些已沉淀的 AI 使用经验：\n"
+        "这对当前问题的用法：先解释关键取舍，再自己执行、验证并沉淀结果。"
+    )
+    first = json.loads(
+        tool.learning_absorption(
+            action="evaluate_speech_response",
+            query="直接修复 agent orchestration 的 bug，不要解释",
+            response=response,
+        )
+    )
+    monkeypatch.setattr(tool, "_hermes_now", lambda: base_time + timedelta(minutes=11))
+    second = json.loads(
+        tool.learning_absorption(
+            action="evaluate_speech_response",
+            query="直接修复 agent orchestration 的 bug，不要解释",
+            response=response,
+        )
+    )
+
+    assert first["feedback_recorded"] is True
+    assert second["feedback_recorded"] is True
+    assert second["summary"]["outcome_counts"]["too_much"] == 2
+
+
+def test_learning_report_summarizes_recent_capabilities_and_speech_feedback(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.learning_absorption_tool import learning_absorption
+
+    playbook = json.loads(
+        learning_absorption(
+            action="register",
+            candidate={
+                "finding": "Use evaluator-gated agent loops before changing default routing.",
+                "source_url": "https://platform.openai.com/docs/guides/evals",
+                "source_type": "official",
+                "verification_level": "official",
+                "impact": "medium",
+                "risk": "low",
+                "reusable_workflow": True,
+                "applies_to": ["agent orchestration"],
+            },
+        )
+    )
+    user_brief = json.loads(
+        learning_absorption(
+            action="register",
+            candidate={
+                "finding": "New agent routing defaults can affect Hermes execution policy.",
+                "source_url": "https://platform.openai.com/docs/guides/agents",
+                "source_type": "official",
+                "verification_level": "official",
+                "impact": "high",
+                "risk": "low",
+                "reusable_workflow": False,
+                "applies_to": ["workspace agents"],
+            },
+        )
+    )
+    learning_absorption(
+        action="record_speech_feedback",
+        usage={
+            "query": "直接修复 agent orchestration 的 bug，不要解释",
+            "actual_mode": "teach",
+            "expected_mode": "execute_quietly",
+            "outcome": "too_much",
+        },
+    )
+
+    result = json.loads(learning_absorption(action="learning_report", limit=5))
+
+    assert result["success"] is True
+    assert result["report"]["capability_count"] == 2
+    assert result["report"]["recent_capabilities"][0]["id"] == user_brief["capability"]["id"]
+    assert result["report"]["high_attention_capabilities"][0]["id"] == user_brief["capability"]["id"]
+    assert result["report"]["speech_feedback"]["outcome_counts"]["too_much"] == 1
+    assert "少解释" in result["report"]["front_channel_summary"]
+    assert playbook["capability"]["id"] in result["report"]["front_channel_summary"]
+
+
+def test_learning_report_is_silent_without_learning_or_feedback(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.learning_absorption_tool import learning_absorption
+
+    result = json.loads(learning_absorption(action="learning_report"))
+
+    assert result["success"] is True
+    assert result["report"]["capability_count"] == 0
+    assert result["report"]["front_channel_summary"] == "[SILENT]"
+
+
+def test_tool_is_available_in_core_toolsets():
+    import model_tools  # noqa: F401 - triggers tool discovery
+    from tools.registry import registry
+    from toolsets import resolve_toolset
+
+    assert "learning_absorption" in registry.get_all_tool_names()
+    assert "learning_absorption" in resolve_toolset("memory")
+    assert "learning_absorption" in resolve_toolset("hermes-telegram")
+    assert "learning_absorption" in resolve_toolset("hermes-api-server")
+    assert "learning_absorption" in resolve_toolset("hermes-acp")
+
+
+def test_radar_run_registers_new_ai_usage_findings(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.learning_absorption_tool import run_learning_radar
+
+    sources = [
+        {
+            "name": "OpenAI News",
+            "url": "https://example.com/openai.xml",
+            "source_type": "official",
+        }
+    ]
+    feed_xml = """<?xml version="1.0"?>
+    <rss><channel>
+      <item>
+        <title>New agent guide for tool use and evals</title>
+        <link>https://example.com/agents</link>
+        <description>How to combine tool use, evals, and prompts in AI assistants.</description>
+        <pubDate>Sat, 09 May 2026 10:00:00 GMT</pubDate>
+      </item>
+      <item>
+        <title>Unrelated office update</title>
+        <link>https://example.com/office</link>
+        <description>Campus news.</description>
+      </item>
+    </channel></rss>
+    """
+
+    def fake_fetch(url):
+        assert url == "https://example.com/openai.xml"
+        return feed_xml
+
+    result = run_learning_radar(sources=sources, fetcher=fake_fetch, register=True)
+
+    assert result["success"] is True
+    assert result["new_item_count"] == 1
+    assert result["registered_count"] == 1
+    assert result["registered"][0]["status"] == "active"
+    assert "agent guide" in result["registered"][0]["finding"].lower()
+
+    registry_path = tmp_path / "learning" / "capabilities.json"
+    payload = json.loads(registry_path.read_text(encoding="utf-8"))
+    assert len(payload["capabilities"]) == 1
+
+    second = run_learning_radar(sources=sources, fetcher=fake_fetch, register=True)
+    assert second["new_item_count"] == 0
+    assert second["registered_count"] == 0
+
+
+def test_radar_dry_run_does_not_mark_items_seen(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    from tools.learning_absorption_tool import run_learning_radar
+
+    sources = [
+        {
+            "name": "OpenAI News",
+            "url": "https://example.com/openai.xml",
+            "source_type": "official",
+        }
+    ]
+    feed_xml = """<?xml version="1.0"?>
+    <rss><channel>
+      <item>
+        <title>New agent guide for tool use and evals</title>
+        <link>https://example.com/agents</link>
+        <description>How to combine tool use, evals, and prompts in AI assistants.</description>
+        <pubDate>Sat, 09 May 2026 10:00:00 GMT</pubDate>
+      </item>
+    </channel></rss>
+    """
+
+    dry_run = run_learning_radar(sources=sources, fetcher=lambda _url: feed_xml, register=False)
+    assert dry_run["success"] is True
+    assert dry_run["new_item_count"] == 1
+    assert dry_run["registered_count"] == 0
+    assert not (tmp_path / "learning" / "radar_seen.json").exists()
+
+    real_run = run_learning_radar(sources=sources, fetcher=lambda _url: feed_xml, register=True)
+    assert real_run["new_item_count"] == 1
+    assert real_run["registered_count"] == 1
+
+
+def test_learning_radar_prompt_runs_report_after_source_scan():
+    from tools.learning_absorption_tool import _RADAR_JOB_PROMPT
+
+    assert "action=radar_run" in _RADAR_JOB_PROMPT
+    assert "action=learning_report" in _RADAR_JOB_PROMPT
+    assert "front_channel_summary" in _RADAR_JOB_PROMPT
+    assert "[SILENT]" in _RADAR_JOB_PROMPT
+
+
+def test_radar_install_is_not_exposed_to_agents(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+    import cron.jobs as jobs_mod
+    from tools.learning_absorption_tool import LEARNING_ABSORPTION_SCHEMA, learning_absorption
+
+    monkeypatch.setattr(jobs_mod, "HERMES_DIR", tmp_path)
+    monkeypatch.setattr(jobs_mod, "CRON_DIR", tmp_path / "cron")
+    monkeypatch.setattr(jobs_mod, "JOBS_FILE", tmp_path / "cron" / "jobs.json")
+    monkeypatch.setattr(jobs_mod, "OUTPUT_DIR", tmp_path / "cron" / "output")
+
+    actions = LEARNING_ABSORPTION_SCHEMA["parameters"]["properties"]["action"]["enum"]
+    result = json.loads(learning_absorption(action="radar_install", schedule="every 12h"))
+
+    assert "radar_install" not in actions
+    assert result["success"] is False
+    assert "disabled" in result["error"].lower()
+    assert jobs_mod.list_jobs(include_disabled=True) == []

--- a/tests/tools/test_mcp_missing_dependency.py
+++ b/tests/tools/test_mcp_missing_dependency.py
@@ -1,0 +1,15 @@
+import asyncio
+import sys
+
+import pytest
+
+
+def test_stdio_server_reports_missing_mcp_sdk(monkeypatch):
+    import tools.mcp_tool as mcp_mod
+
+    monkeypatch.setattr(mcp_mod, "_MCP_AVAILABLE", False)
+    monkeypatch.delattr(mcp_mod, "StdioServerParameters", raising=False)
+    server = mcp_mod.MCPServerTask("obsidian")
+
+    with pytest.raises(ImportError, match="MCP SDK is not installed"):
+        asyncio.run(server._run_stdio({"command": sys.executable, "args": []}))

--- a/tests/tools/test_openai_image_lane.py
+++ b/tests/tools/test_openai_image_lane.py
@@ -1,0 +1,131 @@
+import base64
+import json
+from pathlib import Path
+
+
+PNG_BYTES = b"\x89PNG\r\n\x1a\n" + b"\x00" * 32
+
+
+def _set_openai_image_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("IMAGE_OPENAI_BASE_URL", "http://image-sidecar.test/v1")
+    monkeypatch.setenv("IMAGE_OPENAI_API_KEY", "test-image-key")
+    monkeypatch.setenv("IMAGE_OPENAI_MODEL", "gpt-image-2")
+    monkeypatch.setenv("IMAGE_OPENAI_TIMEOUT", "30")
+    monkeypatch.delenv("FAL_KEY", raising=False)
+
+
+class _FakeImageResponse:
+    def __init__(self, payload, *, status_code=200, content=b"", content_type="image/png"):
+        self._payload = payload
+        self.status_code = status_code
+        self.content = content
+        self.headers = {"content-type": content_type}
+
+    def raise_for_status(self):
+        return None
+
+    def json(self):
+        return self._payload
+
+
+class _FakeImageClient:
+    instances = []
+
+    def __init__(self, *args, **kwargs):
+        self.posts = []
+        self.gets = []
+        _FakeImageClient.instances.append(self)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        return False
+
+    def post(self, url, headers=None, json=None):
+        self.posts.append({"url": url, "headers": headers or {}, "json": json or {}})
+        b64 = base64.b64encode(PNG_BYTES).decode("ascii")
+        return _FakeImageResponse({"data": [{"b64_json": b64}]})
+
+    def get(self, url, headers=None):
+        self.gets.append({"url": url, "headers": headers or {}})
+        return _FakeImageResponse({}, content=PNG_BYTES)
+
+
+def test_openai_image_env_makes_image_tool_available(monkeypatch, tmp_path):
+    _set_openai_image_env(monkeypatch, tmp_path)
+
+    from tools import image_generation_tool as image_tool
+
+    assert image_tool.check_image_generation_requirements() is True
+
+
+def test_openai_image_generation_writes_file_and_returns_media(monkeypatch, tmp_path):
+    _set_openai_image_env(monkeypatch, tmp_path)
+    _FakeImageClient.instances.clear()
+    monkeypatch.setattr("httpx.Client", _FakeImageClient)
+
+    from tools import image_generation_tool as image_tool
+
+    result = json.loads(image_tool.image_generate_tool("a simple blue dot on white background", aspect_ratio="square"))
+
+    assert result["success"] is True
+    assert result["model"] == "gpt-image-2"
+    assert result["file_path"].startswith(str(tmp_path / "generated-images"))
+    assert result["media"] == f"MEDIA:{result['file_path']}"
+    image_path = Path(result["file_path"])
+    assert image_path.exists()
+    assert image_path.read_bytes() == PNG_BYTES
+
+    client = _FakeImageClient.instances[0]
+    assert client.posts[0]["url"] == "http://image-sidecar.test/v1/images/generations"
+    assert client.posts[0]["headers"]["Authorization"] == "Bearer test-image-key"
+    assert client.posts[0]["json"]["model"] == "gpt-image-2"
+    assert client.posts[0]["json"]["prompt"] == "a simple blue dot on white background"
+    assert client.posts[0]["json"]["size"] == "1024x1024"
+
+
+def test_openai_image_generation_falls_back_to_backup(monkeypatch, tmp_path):
+    _set_openai_image_env(monkeypatch, tmp_path)
+    monkeypatch.setenv("IMAGE_OPENAI_BASE_URL", "http://primary-image.test/v1")
+    monkeypatch.setenv("IMAGE_OPENAI_API_KEY", "primary-image-key")
+    monkeypatch.setenv("IMAGE_OPENAI_BACKUP_BASE_URL", "http://backup-image.test/v1")
+    monkeypatch.setenv("IMAGE_OPENAI_BACKUP_API_KEY", "backup-image-key")
+    monkeypatch.setenv("IMAGE_OPENAI_BACKUP_MODEL", "gpt-image-2")
+    _FakeImageClient.instances.clear()
+
+    class _FallbackImageClient(_FakeImageClient):
+        def post(self, url, headers=None, json=None):
+            self.posts.append({"url": url, "headers": headers or {}, "json": json or {}})
+            if "primary-image.test" in url:
+                raise RuntimeError("primary image endpoint down")
+            b64 = base64.b64encode(PNG_BYTES).decode("ascii")
+            return _FakeImageResponse({"data": [{"b64_json": b64}]})
+
+    monkeypatch.setattr("httpx.Client", _FallbackImageClient)
+
+    from tools import image_generation_tool as image_tool
+
+    result = json.loads(image_tool.image_generate_tool("a simple blue dot on white background", aspect_ratio="square"))
+
+    assert result["success"] is True
+    assert result["backend_role"] == "backup"
+    assert result["model"] == "gpt-image-2"
+    assert Path(result["file_path"]).exists()
+
+    attempts = [post for client in _FakeImageClient.instances for post in client.posts]
+    assert attempts[0]["url"] == "http://primary-image.test/v1/images/generations"
+    assert attempts[1]["url"] == "http://backup-image.test/v1/images/generations"
+    assert attempts[1]["headers"]["Authorization"] == "Bearer backup-image-key"
+
+
+def test_image_generate_tool_is_exposed_when_openai_image_lane_is_configured(monkeypatch, tmp_path):
+    _set_openai_image_env(monkeypatch, tmp_path)
+
+    from model_tools import get_tool_definitions
+
+    tools = get_tool_definitions(enabled_toolsets=["image_gen"], quiet_mode=True)
+    names = [tool.get("function", tool).get("name") for tool in tools]
+
+    assert "image_generate" in names

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -306,6 +306,7 @@ class TestBuiltinDiscovery:
             "tools.homeassistant_tool",
             "tools.image_generation_tool",
             "tools.kanban_tools",
+            "tools.learning_absorption_tool",
             "tools.memory_tool",
             "tools.mixture_of_agents_tool",
             "tools.process_registry",

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -130,6 +130,87 @@ MAX_DEPTH = 1  # flat by default: parent (0) -> child (1); grandchild rejected u
 # stays as the default fallback and is still the symbol tests import.
 _MIN_SPAWN_DEPTH = 1
 _MAX_SPAWN_DEPTH_CAP = 3
+PLACEHOLDER_API_KEYS = frozenset({"", "no-key-required"})
+
+
+def _canonical_base_url(base_url: Any) -> str:
+    return str(base_url or "").strip().rstrip("/")
+
+
+def _is_local_adapter_url(base_url: str) -> bool:
+    lowered = str(base_url or "").lower()
+    return (
+        lowered.startswith("http://127.0.0.1:")
+        or lowered.startswith("http://localhost:")
+        or lowered.startswith("http://[::1]:")
+    )
+
+
+def _is_placeholder_api_key(api_key: Any) -> bool:
+    return str(api_key or "").strip().lower() in PLACEHOLDER_API_KEYS
+
+
+def _extract_parent_api_key(parent_agent) -> str:
+    parent_api_key = str(getattr(parent_agent, "api_key", None) or "").strip()
+    if (not parent_api_key) and hasattr(parent_agent, "_client_kwargs"):
+        parent_api_key = str(parent_agent._client_kwargs.get("api_key") or "").strip()
+    return parent_api_key
+
+
+def _delegation_requires_real_api_key(creds: Dict[str, Any], configured_provider: Optional[str] = None) -> bool:
+    api_mode = str(creds.get("api_mode") or "").strip().lower()
+    provider = str(configured_provider or creds.get("provider") or "").strip().lower()
+    base_url = str(creds.get("base_url") or "").strip().lower()
+    return (
+        api_mode == "codex_responses"
+        or "codex" in provider
+        or "chatgpt.com/backend-api/codex" in base_url
+    )
+
+
+def _parent_runtime_matches_credentials(creds: Dict[str, Any], parent_agent) -> bool:
+    if parent_agent is None:
+        return False
+    target_base_url = _canonical_base_url(creds.get("base_url"))
+    parent_base_url = _canonical_base_url(getattr(parent_agent, "base_url", None))
+    if not target_base_url or not parent_base_url or target_base_url != parent_base_url:
+        return False
+
+    target_api_mode = str(creds.get("api_mode") or "").strip()
+    parent_api_mode = str(getattr(parent_agent, "api_mode", "") or "").strip()
+    if target_api_mode and parent_api_mode and target_api_mode != parent_api_mode:
+        return False
+    return True
+
+
+def _resolve_usable_delegation_api_key(
+    creds: Dict[str, Any],
+    configured_provider: Optional[str],
+    parent_agent,
+) -> str:
+    api_key = str(creds.get("api_key") or "").strip()
+    if not _is_placeholder_api_key(api_key):
+        return api_key
+
+    if _delegation_requires_real_api_key(creds, configured_provider):
+        parent_api_key = _extract_parent_api_key(parent_agent)
+        if (
+            parent_api_key
+            and not _is_placeholder_api_key(parent_api_key)
+            and _parent_runtime_matches_credentials(creds, parent_agent)
+        ):
+            return parent_api_key
+        provider_label = configured_provider or creds.get("provider") or "delegation"
+        raise ValueError(
+            f"Delegation provider '{provider_label}' resolved but has no usable API key. "
+            "Set delegation.api_key, fix the named provider credentials, or disable child_api_keys if the endpoint cannot mint child keys."
+        )
+
+    provider = str(creds.get("provider") or "").strip().lower()
+    base_url = str(creds.get("base_url") or "").strip()
+    if provider == "custom" or _is_local_adapter_url(base_url):
+        return api_key or "no-key-required"
+    return ""
 
 
 # ---------------------------------------------------------------------------
@@ -972,9 +1053,7 @@ def _build_child_agent(
         child_depth=child_depth,
     )
     # Extract parent's API key so subagents inherit auth (e.g. Nous Portal).
-    parent_api_key = getattr(parent_agent, "api_key", None)
-    if (not parent_api_key) and hasattr(parent_agent, "_client_kwargs"):
-        parent_api_key = parent_agent._client_kwargs.get("api_key")
+    parent_api_key = _extract_parent_api_key(parent_agent)
 
     # Resolve the child's effective model early so it can ride on every event.
     effective_model_for_cb = model or getattr(parent_agent, "model", None)
@@ -1969,6 +2048,13 @@ def delegate_task(
     # children inherit from the parent.
     try:
         creds = _resolve_delegation_credentials(cfg, parent_agent)
+        creds = dict(creds)
+        if creds.get("provider") or creds.get("base_url") or creds.get("api_mode") or creds.get("api_key"):
+            creds["api_key"] = _resolve_usable_delegation_api_key(
+                creds,
+                str(cfg.get("provider") or "").strip() or None,
+                parent_agent,
+            )
     except ValueError as exc:
         return tool_error(str(exc))
 
@@ -2399,22 +2485,26 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
             f"Available providers: openrouter, nous, zai, kimi-coding, minimax."
         ) from exc
 
-    api_key = runtime.get("api_key", "")
-    if not api_key:
-        raise ValueError(
-            f"Delegation provider '{configured_provider}' resolved but has no API key. "
-            f"Set the appropriate environment variable or run 'hermes auth'."
-        )
-
-    return {
+    creds = {
         "model": configured_model or runtime.get("model") or None,
         "provider": runtime.get("provider"),
         "base_url": runtime.get("base_url"),
-        "api_key": api_key,
+        "api_key": runtime.get("api_key", ""),
         "api_mode": runtime.get("api_mode"),
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
     }
+    creds["api_key"] = _resolve_usable_delegation_api_key(
+        creds,
+        configured_provider,
+        parent_agent,
+    )
+    if not creds["api_key"] and creds.get("provider") != "custom":
+        raise ValueError(
+            f"Delegation provider '{configured_provider}' resolved but has no API key. "
+            f"Set the appropriate environment variable or run 'hermes auth'."
+        )
+    return creds
 
 
 def _load_config() -> dict:

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -20,19 +20,25 @@ Pricing shown in UI strings is as-of the initial commit; we accept drift and
 update when it's noticed.
 """
 
+import base64
 import json
 import logging
 import os
 import datetime
 import threading
 import uuid
+from pathlib import Path
 from typing import Any, Dict, Optional, Union
 from urllib.parse import urlencode
 
-import fal_client
+try:
+    import fal_client
+except ImportError:  # pragma: no cover - exercised through availability checks
+    fal_client = None
 
 from tools.debug_helpers import DebugSession
 from tools.managed_tool_gateway import resolve_managed_tool_gateway
+from hermes_cli.config import get_hermes_home
 from tools.tool_backend_helpers import (
     fal_key_is_configured,
     managed_nous_tools_enabled,
@@ -294,6 +300,12 @@ DEFAULT_MODEL = "fal-ai/flux-2/klein/9b"
 
 DEFAULT_ASPECT_RATIO = "landscape"
 VALID_ASPECT_RATIOS = ("landscape", "square", "portrait")
+OPENAI_IMAGE_DEFAULT_MODEL = "gpt-image-2"
+OPENAI_IMAGE_SIZE_MAP = {
+    "landscape": "1536x1024",
+    "square": "1024x1024",
+    "portrait": "1024x1536",
+}
 
 
 # ---------------------------------------------------------------------------
@@ -314,6 +326,174 @@ _debug = DebugSession("image_tools", env_var="IMAGE_TOOLS_DEBUG")
 _managed_fal_client = None
 _managed_fal_client_config = None
 _managed_fal_client_lock = threading.Lock()
+
+
+# ---------------------------------------------------------------------------
+# OpenAI-compatible Images API lane
+# ---------------------------------------------------------------------------
+def _coerce_openai_image_timeout(value: Any) -> float:
+    try:
+        timeout = float(value)
+    except (TypeError, ValueError):
+        return 60.0
+    return max(timeout, 1.0)
+
+
+def _resolve_openai_image_config(*, backup: bool = False) -> Optional[Dict[str, Any]]:
+    prefix = "IMAGE_OPENAI_BACKUP_" if backup else "IMAGE_OPENAI_"
+    base_url = os.getenv(f"{prefix}BASE_URL", "").strip()
+    api_key = os.getenv(f"{prefix}API_KEY", "").strip()
+    if not base_url or not api_key:
+        return None
+    model = os.getenv(f"{prefix}MODEL", "").strip() or OPENAI_IMAGE_DEFAULT_MODEL
+    timeout = _coerce_openai_image_timeout(os.getenv(f"{prefix}TIMEOUT") or os.getenv("IMAGE_OPENAI_TIMEOUT"))
+    return {
+        "base_url": base_url.rstrip("/"),
+        "api_key": api_key,
+        "model": model,
+        "timeout": timeout,
+        "role": "backup" if backup else "primary",
+    }
+
+
+def _resolve_openai_image_configs() -> list[Dict[str, Any]]:
+    configs: list[Dict[str, Any]] = []
+    primary = _resolve_openai_image_config()
+    backup = _resolve_openai_image_config(backup=True)
+    if primary:
+        configs.append(primary)
+    if backup:
+        configs.append(backup)
+    return configs
+
+
+def _generated_images_dir() -> Path:
+    path = get_hermes_home() / "generated-images"
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def _image_extension(content_type: str | None, output_format: str | None = None) -> str:
+    fmt = str(output_format or "").strip().lower()
+    if fmt in {"jpg", "jpeg"}:
+        return ".jpg"
+    if fmt in {"webp", "png"}:
+        return f".{fmt}"
+    content = str(content_type or "").lower()
+    if "jpeg" in content or "jpg" in content:
+        return ".jpg"
+    if "webp" in content:
+        return ".webp"
+    return ".png"
+
+
+def _write_generated_image(data: bytes, *, output_format: str | None = None, content_type: str | None = None) -> str:
+    ext = _image_extension(content_type, output_format)
+    path = _generated_images_dir() / f"image_{datetime.datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}{ext}"
+    path.write_bytes(data)
+    return str(path)
+
+
+def _decode_b64_image(value: str) -> bytes:
+    return base64.b64decode(str(value or "").encode("ascii"))
+
+
+def _extract_first_openai_image(data: Dict[str, Any]) -> Dict[str, Any]:
+    items = data.get("data")
+    if not isinstance(items, list) or not items:
+        raise ValueError("OpenAI-compatible image endpoint returned no image data")
+    first = items[0]
+    if not isinstance(first, dict):
+        raise ValueError("OpenAI-compatible image endpoint returned invalid image data")
+    return first
+
+
+def _post_openai_image_request(
+    config: Dict[str, Any],
+    prompt: str,
+    *,
+    aspect_ratio: str,
+    output_format: str,
+) -> Dict[str, Any]:
+    import httpx
+
+    url = f"{config['base_url']}/images/generations"
+    payload: Dict[str, Any] = {
+        "model": config["model"],
+        "prompt": prompt,
+        "size": OPENAI_IMAGE_SIZE_MAP.get(aspect_ratio, OPENAI_IMAGE_SIZE_MAP[DEFAULT_ASPECT_RATIO]),
+    }
+    if output_format:
+        payload["output_format"] = output_format
+    headers = {"Authorization": f"Bearer {config['api_key']}"}
+
+    with httpx.Client(timeout=config["timeout"]) as client:
+        try:
+            response = client.post(url, headers=headers, json=payload)
+            response.raise_for_status()
+        except Exception as exc:
+            status = _extract_http_status(exc)
+            if status != 400 or "size" not in payload:
+                raise
+            fallback_payload = dict(payload)
+            fallback_payload.pop("size", None)
+            response = client.post(url, headers=headers, json=fallback_payload)
+            response.raise_for_status()
+
+        image_item = _extract_first_openai_image(response.json())
+        if image_item.get("b64_json"):
+            image_bytes = _decode_b64_image(image_item["b64_json"])
+            content_type = f"image/{output_format or 'png'}"
+        elif image_item.get("url"):
+            download = client.get(str(image_item["url"]), headers=headers)
+            download.raise_for_status()
+            image_bytes = download.content
+            content_type = download.headers.get("content-type")
+        else:
+            raise ValueError("OpenAI-compatible image endpoint returned neither b64_json nor url")
+
+    file_path = _write_generated_image(
+        image_bytes,
+        output_format=output_format,
+        content_type=content_type,
+    )
+    return {
+        "success": True,
+        "image": file_path,
+        "media": f"MEDIA:{file_path}",
+        "file_path": file_path,
+        "model": config["model"],
+        "backend": "openai-compatible",
+        "backend_role": config["role"],
+    }
+
+
+def _generate_openai_image(
+    prompt: str,
+    *,
+    aspect_ratio: str,
+    output_format: str,
+) -> Dict[str, Any]:
+    configs = _resolve_openai_image_configs()
+    if not configs:
+        raise ValueError("IMAGE_OPENAI_BASE_URL and IMAGE_OPENAI_API_KEY are required")
+    last_error: BaseException | None = None
+    for config in configs:
+        try:
+            return _post_openai_image_request(
+                config,
+                prompt,
+                aspect_ratio=aspect_ratio,
+                output_format=output_format,
+            )
+        except Exception as exc:
+            last_error = exc
+            logger.warning(
+                "OpenAI-compatible image backend '%s' failed: %s",
+                config.get("role"),
+                exc,
+            )
+    raise RuntimeError(f"All OpenAI-compatible image backends failed: {last_error}") from last_error
 
 
 # ---------------------------------------------------------------------------
@@ -338,6 +518,8 @@ class _ManagedFalSyncClient:
     """Small per-instance wrapper around fal_client.SyncClient for managed queue hosts."""
 
     def __init__(self, *, key: str, queue_run_origin: str):
+        if fal_client is None:
+            raise RuntimeError("fal_client is required for managed FAL gateway mode")
         sync_client_class = getattr(fal_client, "SyncClient", None)
         if sync_client_class is None:
             raise RuntimeError("fal_client.SyncClient is required for managed FAL gateway mode")
@@ -438,6 +620,8 @@ def _submit_fal_request(model: str, arguments: Dict[str, Any]):
     request_headers = {"x-idempotency-key": str(uuid.uuid4())}
     managed_gateway = _resolve_managed_fal_gateway()
     if managed_gateway is None:
+        if fal_client is None:
+            raise RuntimeError("fal_client is required for FAL image generation")
         return fal_client.submit(model, arguments=arguments, headers=request_headers)
 
     managed_client = _get_managed_fal_client(managed_gateway)
@@ -659,12 +843,6 @@ def image_generate_tool(
         if not prompt or not isinstance(prompt, str) or len(prompt.strip()) == 0:
             raise ValueError("Prompt is required and must be a non-empty string")
 
-        if not (fal_key_is_configured() or _resolve_managed_fal_gateway()):
-            message = "FAL_KEY environment variable not set"
-            if managed_nous_tools_enabled():
-                message += " and managed FAL gateway is unavailable"
-            raise ValueError(message)
-
         aspect_lc = (aspect_ratio or DEFAULT_ASPECT_RATIO).lower().strip()
         if aspect_lc not in VALID_ASPECT_RATIOS:
             logger.warning(
@@ -672,6 +850,27 @@ def image_generate_tool(
                 aspect_ratio, DEFAULT_ASPECT_RATIO,
             )
             aspect_lc = DEFAULT_ASPECT_RATIO
+
+        if _resolve_openai_image_configs():
+            response_data = _generate_openai_image(
+                prompt.strip(),
+                aspect_ratio=aspect_lc,
+                output_format=(output_format or "png"),
+            )
+            generation_time = (datetime.datetime.now() - start_time).total_seconds()
+            debug_call_data["model"] = response_data.get("model", model_id)
+            debug_call_data["success"] = True
+            debug_call_data["images_generated"] = 1
+            debug_call_data["generation_time"] = generation_time
+            _debug.log_call("image_generate_tool", debug_call_data)
+            _debug.save()
+            return json.dumps(response_data, indent=2, ensure_ascii=False)
+
+        if not (fal_key_is_configured() or _resolve_managed_fal_gateway()):
+            message = "FAL_KEY environment variable not set"
+            if managed_nous_tools_enabled():
+                message += " and managed FAL gateway is unavailable"
+            raise ValueError(message)
 
         overrides: Dict[str, Any] = {}
         if num_inference_steps is not None:
@@ -787,9 +986,10 @@ def check_image_generation_requirements() -> bool:
     providers is resolved per-call by ``image_gen.provider``.
     """
     try:
-        if check_fal_api_key():
-            fal_client  # noqa: F401 — SDK presence check
+        if _resolve_openai_image_configs():
             return True
+        if check_fal_api_key():
+            return fal_client is not None
     except ImportError:
         pass
 

--- a/tools/learning_absorption_tool.py
+++ b/tools/learning_absorption_tool.py
@@ -1,0 +1,1928 @@
+#!/usr/bin/env python3
+"""AI learning absorption tool for candidate cards and capability registry."""
+
+from __future__ import annotations
+
+import hashlib
+import html
+import json
+import os
+import re
+import tempfile
+import time
+import urllib.error
+import urllib.request
+import xml.etree.ElementTree as ET
+from datetime import datetime
+from html.parser import HTMLParser
+from pathlib import Path
+from typing import Any, Callable, Dict, List
+from urllib.parse import urljoin
+
+from hermes_constants import get_hermes_home
+from hermes_time import now as _hermes_now
+
+
+LEARNING_DIR_NAME = "learning"
+CAPABILITIES_FILE_NAME = "capabilities.json"
+RADAR_SOURCES_FILE_NAME = "radar_sources.json"
+RADAR_SEEN_FILE_NAME = "radar_seen.json"
+RADAR_RUNS_FILE_NAME = "radar_runs.jsonl"
+SPEECH_FEEDBACK_FILE_NAME = "speech_feedback.jsonl"
+SPEECH_POLICY_TRACE_FILE_NAME = "speech_policy_trace.jsonl"
+
+_ACTIVE_VERIFICATION_LEVELS = {
+    "official",
+    "local_smoke",
+    "local_test",
+    "applied",
+    "user_validated",
+}
+_HIGH_CONFIDENCE_VERIFICATION_LEVELS = {
+    "local_smoke",
+    "local_test",
+    "applied",
+    "user_validated",
+}
+_HIGH_CHANGE_FLAGS = (
+    "affects_routing",
+    "affects_code",
+    "affects_execution",
+    "affects_default_behavior",
+    "requires_new_dependency",
+)
+_FRONT_CHANNEL_REASONS = {
+    "major_new_technique",
+    "current_project_relevance",
+    "execution_blocker",
+    "direction_decision",
+}
+_WORD_RE = re.compile(r"[a-zA-Z0-9_]{3,}|[\u4e00-\u9fff]{2,}")
+_MAX_CONTEXT_FINDING_CHARS = 260
+_MAX_USAGE_LOG_ENTRIES = 20
+_MAX_SPEECH_FEEDBACK_ENTRIES = 50
+_MAX_SPEECH_POLICY_TRACE_ENTRIES = 50
+_MAX_SPEECH_FEEDBACK_QUERY_CHARS = 240
+_MAX_SPEECH_FEEDBACK_NOTE_CHARS = 240
+_MAX_RADAR_SUMMARY_CHARS = 420
+_MAX_TEACHER_BRIEF_FINDING_CHARS = 190
+_AUTO_SELF_REVIEW_DUPLICATE_COOLDOWN_SECONDS = 10 * 60
+_RADAR_JOB_NAME = "Hermes AI learning radar"
+_RADAR_JOB_PROMPT = (
+    "Run learning_absorption with action=radar_run, register=true, max_items=8. "
+    "Then run learning_absorption with action=learning_report, limit=8. "
+    "Use the report.front_channel_summary as the final reply when it is not [SILENT]. "
+    "The summary should cover newly registered findings when they affect AI product usage, "
+    "agent workflows, prompt/tool practices, evaluations, model routing, Hermes operation, "
+    "or recent speech_feedback recommendations. "
+    "For any non-silent finding, include front_channel_reason only when it is a major_new_technique, "
+    "current_project_relevance, execution_blocker, or direction_decision. "
+    "If report.front_channel_summary is [SILENT], reply exactly [SILENT]. Do not change code or configuration."
+)
+_DEFAULT_RADAR_SOURCES = [
+    {
+        "name": "OpenAI News",
+        "url": "https://openai.com/news/rss.xml",
+        "source_type": "official",
+        "applies_to": ["OpenAI", "ChatGPT", "Codex", "agents", "AI product usage"],
+    },
+    {
+        "name": "Anthropic News",
+        "url": "https://www.anthropic.com/news",
+        "source_type": "official",
+        "format": "html",
+        "item_path_contains": "/news/",
+        "applies_to": ["Claude", "agents", "AI product usage"],
+    },
+    {
+        "name": "Google AI Blog",
+        "url": "https://blog.google/technology/ai/rss/",
+        "source_type": "official",
+        "applies_to": ["Gemini", "AI product usage", "model capabilities"],
+    },
+    {
+        "name": "Microsoft AI Blog",
+        "url": "https://blogs.microsoft.com/ai/feed/",
+        "source_type": "official",
+        "applies_to": ["Copilot", "AI product usage", "workflows"],
+    },
+]
+_RADAR_KEYWORDS = {
+    "agent": 5,
+    "agents": 5,
+    "assistant": 4,
+    "assistants": 4,
+    "tool": 4,
+    "tools": 4,
+    "tool use": 8,
+    "eval": 5,
+    "evals": 5,
+    "evaluation": 4,
+    "prompt": 4,
+    "prompts": 4,
+    "workflow": 4,
+    "workflows": 4,
+    "automation": 4,
+    "mcp": 4,
+    "api": 3,
+    "model": 3,
+    "models": 3,
+    "reasoning": 3,
+    "memory": 3,
+    "browser": 3,
+    "codex": 5,
+    "chatgpt": 5,
+    "claude": 4,
+    "gemini": 4,
+    "copilot": 4,
+    "guide": 4,
+    "cookbook": 4,
+    "best practice": 5,
+    "release": 2,
+}
+_TEACHER_QUERY_MARKERS = (
+    "ai",
+    "agent",
+    "agents",
+    "assistant",
+    "chatgpt",
+    "claude",
+    "gemini",
+    "copilot",
+    "codex",
+    "prompt",
+    "tool",
+    "workflow",
+    "模型",
+    "助手",
+    "老师",
+    "学习",
+    "技巧",
+    "用法",
+    "怎么",
+    "如何",
+    "为什么",
+    "方案",
+    "下一步",
+    "工作流",
+    "工具",
+    "提示词",
+)
+_QUIET_EXECUTION_MARKERS = (
+    "直接",
+    "执行",
+    "修复",
+    "实现",
+    "改完",
+    "完成后",
+    "跑测试",
+    "部署",
+    "不要解释",
+    "无需解释",
+    "别解释",
+    "少说",
+    "安静",
+    "只做",
+    "直接做",
+    "fix",
+    "repair",
+    "implement",
+    "run tests",
+    "no explanation",
+    "quiet",
+)
+_DIRECTION_DISCUSSION_MARKERS = (
+    "讨论",
+    "方向",
+    "取舍",
+    "方案",
+    "规划",
+    "下一步",
+    "要不要",
+    "是否",
+    "选择",
+    "路线",
+    "tradeoff",
+    "plan",
+    "strategy",
+    "direction",
+)
+_TEACHING_INTENT_MARKERS = (
+    "教我",
+    "学习",
+    "解释",
+    "为什么",
+    "怎么",
+    "如何",
+    "原理",
+    "技巧",
+    "用法",
+    "帮我理解",
+    "teach",
+    "learn",
+    "explain",
+    "why",
+    "how",
+)
+_SPEECH_FEEDBACK_OUTCOMES = {
+    "right",
+    "too_much",
+    "too_little",
+    "wrong_mode",
+    "missed_decision",
+    "unclear",
+}
+_SPEECH_TOO_MUCH_MARKERS = (
+    "讲太多",
+    "说太多",
+    "太多了",
+    "啰嗦",
+    "不用解释",
+    "不要解释",
+    "应该直接",
+    "直接做",
+    "直接执行",
+    "too much",
+    "verbose",
+)
+_SPEECH_TOO_LITTLE_MARKERS = (
+    "没讲清楚",
+    "没有讲清楚",
+    "应该解释",
+    "多解释",
+    "讲一下",
+    "解释一下",
+    "too little",
+    "explain more",
+)
+_SPEECH_MISSED_DECISION_MARKERS = (
+    "提醒我风险",
+    "提醒风险",
+    "先提醒",
+    "应该提醒",
+    "没提醒",
+    "没有提醒",
+    "影响方向",
+    "影响默认",
+    "risk first",
+    "warn me",
+)
+_RESPONSE_TEACHING_MARKERS = (
+    "我会参考这些已沉淀",
+    "已沉淀的 ai 使用经验",
+    "这对当前问题的用法",
+    "关键取舍",
+    "先解释",
+    "解释",
+    "为什么",
+    "原理",
+    "技巧",
+    "用法",
+    "teach",
+    "explain",
+)
+_RESPONSE_DECISION_MARKERS = (
+    "风险",
+    "影响",
+    "取舍",
+    "选择",
+    "路线",
+    "默认",
+    "路由",
+    "验证",
+    "可选",
+    "回滚",
+    "阻塞",
+    "先提醒",
+    "decision",
+    "risk",
+    "tradeoff",
+)
+_RESPONSE_ACTION_MARKERS = (
+    "已",
+    "完成",
+    "改好",
+    "修复",
+    "实现",
+    "部署",
+    "测试",
+    "验证",
+    "done",
+    "fixed",
+    "implemented",
+)
+
+
+def _learning_dir() -> Path:
+    return get_hermes_home() / LEARNING_DIR_NAME
+
+
+def _capabilities_path() -> Path:
+    return _learning_dir() / CAPABILITIES_FILE_NAME
+
+
+def _radar_sources_path() -> Path:
+    return _learning_dir() / RADAR_SOURCES_FILE_NAME
+
+
+def _radar_seen_path() -> Path:
+    return _learning_dir() / RADAR_SEEN_FILE_NAME
+
+
+def _radar_runs_path() -> Path:
+    return _learning_dir() / RADAR_RUNS_FILE_NAME
+
+
+def _speech_feedback_path() -> Path:
+    return _learning_dir() / SPEECH_FEEDBACK_FILE_NAME
+
+
+def _speech_policy_trace_path() -> Path:
+    return _learning_dir() / SPEECH_POLICY_TRACE_FILE_NAME
+
+
+def _norm(value: Any) -> str:
+    return str(value or "").strip().lower().replace("-", "_").replace(" ", "_")
+
+
+def _as_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    return str(value).strip().lower() in {"1", "true", "yes", "y", "on"}
+
+
+def _as_list(value: Any) -> List[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value] if value.strip() else []
+    if isinstance(value, (list, tuple, set)):
+        return [str(item).strip() for item in value if str(item).strip()]
+    return [str(value).strip()] if str(value).strip() else []
+
+
+def _positive_int(value: Any, *, default: int) -> int:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        parsed = default
+    return max(1, parsed)
+
+
+def _clip(value: Any, limit: int) -> str:
+    text = str(value or "").strip()
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 1)].rstrip() + "…"
+
+
+def _plain_text(value: Any) -> str:
+    text = html.unescape(str(value or ""))
+    text = re.sub(r"<[^>]+>", " ", text)
+    text = re.sub(r"\s+", " ", text)
+    return text.strip()
+
+
+def _tokens(value: Any) -> set[str]:
+    text = str(value or "").lower()
+    return {match.group(0) for match in _WORD_RE.finditer(text)}
+
+
+def _candidate_id(candidate: Dict[str, Any]) -> str:
+    seed = json.dumps(
+        {
+            "finding": str(candidate.get("finding") or "").strip(),
+            "source_url": str(candidate.get("source_url") or "").strip(),
+        },
+        sort_keys=True,
+        ensure_ascii=False,
+    )
+    return hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16]
+
+
+def _candidate_card(candidate: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "id": _candidate_id(candidate),
+        "finding": str(candidate.get("finding") or "").strip(),
+        "source_url": str(candidate.get("source_url") or "").strip(),
+        "source_type": _norm(candidate.get("source_type")) or "unknown",
+        "verification_level": _norm(candidate.get("verification_level")) or "unverified",
+        "impact": _norm(candidate.get("impact")) or "medium",
+        "risk": _norm(candidate.get("risk")) or "medium",
+        "applies_to": _as_list(candidate.get("applies_to")),
+        "reusable_workflow": _as_bool(candidate.get("reusable_workflow")),
+        "affects_routing": _as_bool(candidate.get("affects_routing")),
+        "affects_code": _as_bool(candidate.get("affects_code")),
+        "affects_execution": _as_bool(candidate.get("affects_execution")),
+        "affects_default_behavior": _as_bool(candidate.get("affects_default_behavior")),
+        "requires_new_dependency": _as_bool(candidate.get("requires_new_dependency")),
+        "front_channel_reason": _norm(candidate.get("front_channel_reason")),
+        "notes": str(candidate.get("notes") or "").strip(),
+    }
+
+
+def _required_evidence(card: Dict[str, Any]) -> List[str]:
+    evidence = []
+    if card["source_type"] != "official" and card["verification_level"] not in _ACTIVE_VERIFICATION_LEVELS:
+        evidence.append("official source confirmation or second independent source")
+    if any(card.get(flag) for flag in _HIGH_CHANGE_FLAGS) or card["risk"] == "high":
+        evidence.append("local smoke test on the real Hermes path")
+        evidence.append("rollback or disable path documented")
+    if not evidence:
+        evidence.append("short rationale and usage example")
+    return evidence
+
+
+def _can_apply_by_default(card: Dict[str, Any]) -> bool:
+    high_change = any(card.get(flag) for flag in _HIGH_CHANGE_FLAGS)
+    if high_change or card["risk"] == "high":
+        return card["verification_level"] in _HIGH_CONFIDENCE_VERIFICATION_LEVELS
+    if card["risk"] == "medium" and card["verification_level"] not in _ACTIVE_VERIFICATION_LEVELS:
+        return False
+    return card["verification_level"] in _ACTIVE_VERIFICATION_LEVELS or card["source_type"] == "official"
+
+
+def _front_channel_gate(card: Dict[str, Any]) -> Dict[str, Any]:
+    reason = card.get("front_channel_reason") or ""
+    if reason in _FRONT_CHANNEL_REASONS:
+        return {
+            "allow": True,
+            "reason": reason,
+            "default_response": "brief_user",
+            "policy": "Only deliver major techniques, current-project relevance, execution blockers, or direction decisions.",
+        }
+    return {
+        "allow": False,
+        "reason": "local_only",
+        "default_response": "[SILENT]",
+        "policy": "Keep ordinary source notes, generic news, and weak candidates local.",
+    }
+
+
+def decide_learning_absorption(candidate: Dict[str, Any]) -> Dict[str, Any]:
+    """Return the absorption decision for one learning candidate."""
+    if not isinstance(candidate, dict):
+        raise ValueError("candidate must be an object")
+    card = _candidate_card(candidate)
+    if not card["finding"]:
+        raise ValueError("candidate.finding is required")
+
+    can_apply = _can_apply_by_default(card)
+    high_change = any(card.get(flag) for flag in _HIGH_CHANGE_FLAGS)
+
+    if not can_apply and (high_change or card["risk"] == "high"):
+        promotion_target = "verification_backlog"
+    elif card["reusable_workflow"]:
+        promotion_target = "playbook"
+    elif high_change:
+        promotion_target = "routing_default"
+    elif card["impact"] == "high":
+        promotion_target = "user_brief"
+    elif card["source_type"] == "official":
+        promotion_target = "knowledge_base"
+    else:
+        promotion_target = "source_note"
+
+    registry_status = "active" if can_apply else "pending_verification"
+    if promotion_target == "source_note":
+        registry_status = "recorded"
+
+    return {
+        "candidate_card": card,
+        "decision": {
+            "promotion_target": promotion_target,
+            "can_apply_by_default": can_apply,
+            "registry_status": registry_status,
+            "required_evidence": _required_evidence(card),
+            "next_action": _next_action(promotion_target, registry_status),
+            "front_channel": _front_channel_gate(card),
+        },
+    }
+
+
+def _next_action(promotion_target: str, registry_status: str) -> str:
+    if promotion_target == "verification_backlog":
+        return "Verify locally before changing default Hermes behavior."
+    if promotion_target == "playbook":
+        return "Register as an active reusable workflow and reference it in relevant discussions."
+    if promotion_target == "routing_default":
+        return "Register only after route-specific smoke tests pass."
+    if promotion_target == "user_brief":
+        return "Summarize to the user when it affects current direction."
+    if promotion_target == "knowledge_base":
+        return "Store as durable reference material."
+    if registry_status == "pending_verification":
+        return "Keep in backlog until evidence improves."
+    return "Record for later retrieval."
+
+
+def _load_registry() -> Dict[str, Any]:
+    path = _capabilities_path()
+    if not path.exists():
+        return {"capabilities": [], "updated_at": None}
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            data = json.load(handle)
+    except (OSError, json.JSONDecodeError):
+        return {"capabilities": [], "updated_at": None}
+    capabilities = data.get("capabilities")
+    if not isinstance(capabilities, list):
+        capabilities = []
+    return {"capabilities": capabilities, "updated_at": data.get("updated_at")}
+
+
+def _atomic_write_json(path: Path, payload: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp", prefix=f".{path.name}_")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=False, indent=2)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, path)
+        try:
+            os.chmod(path, 0o600)
+        except OSError:
+            pass
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _load_radar_sources() -> List[Dict[str, Any]]:
+    path = _radar_sources_path()
+    if not path.exists():
+        return [dict(source) for source in _DEFAULT_RADAR_SOURCES]
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return [dict(source) for source in _DEFAULT_RADAR_SOURCES]
+    sources = data.get("sources") if isinstance(data, dict) else data
+    if not isinstance(sources, list):
+        return [dict(source) for source in _DEFAULT_RADAR_SOURCES]
+    return [dict(source) for source in sources if isinstance(source, dict) and str(source.get("url") or "").strip()]
+
+
+def _load_seen_items() -> Dict[str, Dict[str, Any]]:
+    path = _radar_seen_path()
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return {}
+    seen = data.get("seen") if isinstance(data, dict) else data
+    if isinstance(seen, dict):
+        return {str(key): value for key, value in seen.items() if isinstance(value, dict)}
+    if isinstance(seen, list):
+        return {
+            str(item.get("id")): item
+            for item in seen
+            if isinstance(item, dict) and str(item.get("id") or "").strip()
+        }
+    return {}
+
+
+def _save_seen_items(seen: Dict[str, Dict[str, Any]]) -> None:
+    payload = {
+        "seen": seen,
+        "updated_at": _hermes_now().isoformat(),
+    }
+    _atomic_write_json(_radar_seen_path(), payload)
+
+
+def _append_radar_run(record: Dict[str, Any]) -> None:
+    path = _radar_runs_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def _active_default_capability(capability: Dict[str, Any]) -> bool:
+    return _norm(capability.get("status")) == "active" and _as_bool(capability.get("can_apply_by_default"))
+
+
+def _capability_score(capability: Dict[str, Any], query: str) -> int:
+    query_text = str(query or "").strip().lower()
+    if not query_text:
+        return 1
+
+    score = 0
+    query_tokens = _tokens(query_text)
+    finding_tokens = _tokens(capability.get("finding"))
+    score += len(query_tokens.intersection(finding_tokens)) * 2
+
+    for applies_to in _as_list(capability.get("applies_to")):
+        phrase = applies_to.lower()
+        if phrase and phrase in query_text:
+            score += 10
+        score += len(query_tokens.intersection(_tokens(phrase))) * 3
+
+    if str(capability.get("promotion_target") or "") == "playbook":
+        score += 1
+    return score
+
+
+def select_applicable_capabilities(query: str, *, limit: int = 3) -> List[Dict[str, Any]]:
+    """Return active, default-safe capabilities relevant to a user turn."""
+
+    safe_limit = _positive_int(limit, default=3)
+    selected: list[tuple[int, Dict[str, Any]]] = []
+    for capability in _load_registry().get("capabilities", []):
+        if not isinstance(capability, dict) or not _active_default_capability(capability):
+            continue
+        score = _capability_score(capability, query)
+        if query and score <= 0:
+            continue
+        item = dict(capability)
+        item["score"] = score
+        selected.append((score, item))
+
+    selected.sort(
+        key=lambda pair: (
+            pair[0],
+            str(pair[1].get("last_used_at") or ""),
+            str(pair[1].get("updated_at") or ""),
+        ),
+        reverse=True,
+    )
+    return [item for _, item in selected[:safe_limit]]
+
+
+def build_capability_invocation_context(query: str, *, limit: int = 3) -> str:
+    """Build an API-only context block for active learning capabilities."""
+
+    capabilities = select_applicable_capabilities(query, limit=limit)
+    if not capabilities:
+        return ""
+    speech_policy = decide_teacher_speech_policy(query, capabilities)
+    if not _looks_like_speech_feedback(query):
+        _record_speech_policy_trace(query, speech_policy, capabilities, source="invocation_context")
+
+    lines = [
+        "<hermes-learning-capabilities>",
+        "[System note: Apply these active capabilities when they fit this turn. "
+        "Do not force irrelevant capabilities. If one materially shapes the answer "
+        "or execution path, call learning_absorption action=record_use after use.]",
+    ]
+    for capability in capabilities:
+        applies_to = ", ".join(_as_list(capability.get("applies_to"))) or "general"
+        lines.append(
+            "- "
+            f"id={capability.get('id')} "
+            f"target={capability.get('promotion_target')} "
+            f"verification={capability.get('verification_level')} "
+            f"applies_to={applies_to}\n"
+            f"  finding: {_clip(capability.get('finding'), _MAX_CONTEXT_FINDING_CHARS)}"
+        )
+        next_action = str(capability.get("next_action") or "").strip()
+        if next_action:
+            lines.append(f"  use: {_clip(next_action, 180)}")
+    if speech_policy["should_speak"]:
+        lines.append(
+            f"[teacher_mode: mode={speech_policy['mode']} reason={speech_policy['reason']}. "
+            "用中文简短解释哪些已沉淀经验适用于当前问题，再给出下一步建议；不要长篇授课。]"
+        )
+    elif speech_policy["mode"] == "execute_quietly":
+        lines.append(
+            "[speech_policy: mode=execute_quietly. The user asked for direct execution; "
+            "use relevant learned capabilities silently and report only result, blocker, and verification.]"
+        )
+    lines.extend(_speech_feedback_context_lines())
+    lines.append("</hermes-learning-capabilities>")
+    return "\n".join(lines)
+
+
+def _query_wants_teacher_mode(query: str) -> bool:
+    text = str(query or "").lower()
+    return any(marker in text for marker in _TEACHER_QUERY_MARKERS)
+
+
+def _contains_marker(text: str, markers: tuple[str, ...]) -> bool:
+    return any(marker in text for marker in markers)
+
+
+def _needs_user_attention(capabilities: List[Dict[str, Any]]) -> bool:
+    for capability in capabilities:
+        target = _norm(capability.get("promotion_target"))
+        if target in {"user_brief", "routing_default", "verification_backlog"}:
+            return True
+    return False
+
+
+def decide_teacher_speech_policy(query: str, capabilities: List[Dict[str, Any]] | None = None) -> Dict[str, Any]:
+    """Decide whether Hermes should teach, discuss direction, or stay quiet."""
+
+    selected = capabilities if capabilities is not None else select_applicable_capabilities(query)
+    text = str(query or "").lower()
+    explicit_quiet = _contains_marker(text, _QUIET_EXECUTION_MARKERS)
+    explicit_teaching = _contains_marker(text, _TEACHING_INTENT_MARKERS)
+    needs_attention = _needs_user_attention(selected)
+
+    if not selected:
+        return {
+            "mode": "silent",
+            "should_speak": False,
+            "reason": "no_relevant_capability",
+        }
+    if explicit_quiet and not needs_attention:
+        return {
+            "mode": "execute_quietly",
+            "should_speak": False,
+            "reason": "direct_execution_request",
+        }
+    if needs_attention:
+        return {
+            "mode": "decision",
+            "should_speak": True,
+            "reason": "learned_capability_may_affect_user_direction",
+        }
+    if explicit_teaching:
+        return {
+            "mode": "teach",
+            "should_speak": True,
+            "reason": "learning_or_ai_usage_request",
+        }
+    if _contains_marker(text, _DIRECTION_DISCUSSION_MARKERS):
+        return {
+            "mode": "direction",
+            "should_speak": True,
+            "reason": "direction_discussion",
+        }
+    return {
+        "mode": "execute_quietly",
+        "should_speak": False,
+        "reason": "task_can_use_capability_without_front_channel_teaching",
+    }
+
+
+def _teacher_target_label(capability: Dict[str, Any]) -> str:
+    target = _norm(capability.get("promotion_target"))
+    if target == "playbook":
+        return "可复用做法"
+    if target == "user_brief":
+        return "需要主动说明的变化"
+    if target == "knowledge_base":
+        return "背景知识"
+    if target == "routing_default":
+        return "执行策略候选"
+    return "参考经验"
+
+
+def _recent_capabilities(limit: int) -> List[Dict[str, Any]]:
+    safe_limit = _positive_int(limit, default=5)
+    capabilities = [
+        dict(item)
+        for item in _load_registry().get("capabilities", [])
+        if isinstance(item, dict)
+    ]
+    capabilities.sort(
+        key=lambda item: str(item.get("updated_at") or item.get("created_at") or ""),
+        reverse=True,
+    )
+    return capabilities[:safe_limit]
+
+
+def _high_attention_capabilities(capabilities: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    return [
+        item
+        for item in capabilities
+        if _norm(item.get("promotion_target")) in {"user_brief", "routing_default", "verification_backlog"}
+    ]
+
+
+def build_learning_report(*, limit: int = 5) -> Dict[str, Any]:
+    """Build a concise report of recently absorbed AI-use knowledge."""
+
+    registry = _load_registry()
+    safe_limit = _positive_int(limit, default=5)
+    recent = _recent_capabilities(safe_limit)
+    high_attention = _high_attention_capabilities(recent)
+    speech_feedback = summarize_speech_feedback(limit=20)
+
+    lines: List[str] = []
+    if recent:
+        lines.append("最近学习沉淀：")
+        for capability in recent:
+            label = _teacher_target_label(capability)
+            finding = _clip(capability.get("finding"), 140)
+            lines.append(f"- {capability.get('id')} [{label}] {finding}")
+    if high_attention:
+        lines.append("需要主动提醒你的发现：")
+        for capability in high_attention:
+            finding = _clip(capability.get("finding"), 120)
+            lines.append(f"- {capability.get('id')}：{finding}")
+    if speech_feedback.get("problem_events"):
+        lines.append("表达方式调整：")
+        for recommendation in speech_feedback.get("recommendations", [])[:3]:
+            lines.append(f"- {recommendation}")
+
+    return {
+        "generated_at": _hermes_now().isoformat(),
+        "capability_count": len(registry.get("capabilities", [])),
+        "recent_capabilities": recent,
+        "high_attention_capabilities": high_attention,
+        "speech_feedback": speech_feedback,
+        "front_channel_summary": "\n".join(lines) if lines else "[SILENT]",
+    }
+
+
+def build_teacher_brief(query: str, *, limit: int = 3) -> Dict[str, Any]:
+    """Build a concise Chinese teaching brief from relevant learned capabilities."""
+
+    capabilities = select_applicable_capabilities(query, limit=limit)
+    speech_policy = decide_teacher_speech_policy(query, capabilities)
+    speech_trace = _record_speech_policy_trace(query, speech_policy, capabilities, source="teacher_brief")
+    if not speech_policy["should_speak"]:
+        return {
+            "should_speak": False,
+            "brief": "",
+            "speech_policy": speech_policy,
+            "speech_trace": speech_trace,
+            "capabilities": capabilities,
+        }
+
+    if speech_policy["mode"] == "decision":
+        heading = "这条已沉淀经验可能影响当前方向，需要你关注："
+        use_line = "这对当前问题的用法：先说明它会影响什么，再决定是否调整方案；涉及默认行为、路由或代码时先验证。"
+        next_line = "下一步：我会先把影响和可选路线讲清楚，再继续执行。"
+    elif speech_policy["mode"] == "direction":
+        heading = "我会用这些已沉淀经验来帮助确认方向："
+        use_line = "这对当前问题的用法：把经验转成可比较的路线、风险和验证方式。"
+        next_line = "下一步：我会先和你确认方向与取舍，方向清楚后再自己执行、验证并沉淀结果。"
+    else:
+        heading = "我会参考这些已沉淀的 AI 使用经验："
+        use_line = "这对当前问题的用法：先把相关技巧转成可执行方案；如果会影响默认行为、路由或代码，再先验证后落地。"
+        next_line = "下一步：我会先解释关键取舍，再自己执行、验证并把结果沉淀回学习库。"
+
+    lines = [heading]
+    for index, capability in enumerate(capabilities, 1):
+        label = _teacher_target_label(capability)
+        finding = _clip(capability.get("finding"), _MAX_TEACHER_BRIEF_FINDING_CHARS)
+        lines.append(f"{index}. [{label}] id={capability.get('id')}：{finding}")
+
+    lines.extend([use_line, next_line])
+    return {
+        "should_speak": True,
+        "brief": "\n".join(lines),
+        "speech_policy": speech_policy,
+        "speech_trace": speech_trace,
+        "capabilities": capabilities,
+    }
+
+
+def _load_speech_feedback_events(*, limit: int = _MAX_SPEECH_FEEDBACK_ENTRIES) -> List[Dict[str, Any]]:
+    path = _speech_feedback_path()
+    if not path.exists():
+        return []
+    events: List[Dict[str, Any]] = []
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(event, dict):
+                    events.append(event)
+    except OSError:
+        return []
+    safe_limit = _positive_int(limit, default=_MAX_SPEECH_FEEDBACK_ENTRIES)
+    return events[-safe_limit:]
+
+
+def _append_speech_feedback_event(event: Dict[str, Any]) -> None:
+    path = _speech_feedback_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        json.dump(event, handle, ensure_ascii=False)
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
+
+
+def _append_jsonl(path: Path, event: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        json.dump(event, handle, ensure_ascii=False)
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+    try:
+        os.chmod(path, 0o600)
+    except OSError:
+        pass
+
+
+def _load_jsonl(path: Path, *, limit: int) -> List[Dict[str, Any]]:
+    if not path.exists():
+        return []
+    events: List[Dict[str, Any]] = []
+    try:
+        with path.open("r", encoding="utf-8") as handle:
+            for line in handle:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    event = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if isinstance(event, dict):
+                    events.append(event)
+    except OSError:
+        return []
+    safe_limit = _positive_int(limit, default=50)
+    return events[-safe_limit:]
+
+
+def _speech_trace_id(event: Dict[str, Any]) -> str:
+    seed = json.dumps(event, ensure_ascii=False, sort_keys=True)
+    return hashlib.sha256(seed.encode("utf-8")).hexdigest()[:16]
+
+
+def _record_speech_policy_trace(
+    query: str,
+    speech_policy: Dict[str, Any],
+    capabilities: List[Dict[str, Any]],
+    *,
+    source: str,
+) -> Dict[str, Any]:
+    event = {
+        "recorded_at": _hermes_now().isoformat(),
+        "source": source,
+        "query": _clip(query, _MAX_SPEECH_FEEDBACK_QUERY_CHARS),
+        "speech_policy": {
+            "mode": _norm(speech_policy.get("mode")) or "unknown",
+            "should_speak": bool(speech_policy.get("should_speak")),
+            "reason": _norm(speech_policy.get("reason")) or "unknown",
+        },
+        "capability_ids": [str(item.get("id")) for item in capabilities if item.get("id")],
+        "capability_targets": [
+            _norm(item.get("promotion_target")) or "unknown"
+            for item in capabilities
+            if item.get("promotion_target")
+        ],
+    }
+    event["trace_id"] = _speech_trace_id(event)
+    _append_jsonl(_speech_policy_trace_path(), event)
+    return event
+
+
+def _latest_speech_policy_trace() -> Dict[str, Any] | None:
+    traces = _load_jsonl(_speech_policy_trace_path(), limit=_MAX_SPEECH_POLICY_TRACE_ENTRIES)
+    return traces[-1] if traces else None
+
+
+def _looks_like_speech_feedback(value: Any) -> bool:
+    text = str(value or "").lower()
+    return any(
+        marker in text
+        for marker in (
+            *_SPEECH_TOO_MUCH_MARKERS,
+            *_SPEECH_TOO_LITTLE_MARKERS,
+            *_SPEECH_MISSED_DECISION_MARKERS,
+            "刚才",
+            "上次",
+            "你应该",
+        )
+    )
+
+
+def _infer_speech_feedback_from_text(text: str) -> Dict[str, str]:
+    lowered = text.lower()
+    if _contains_marker(lowered, _SPEECH_MISSED_DECISION_MARKERS) or (
+        "风险" in lowered and ("提醒" in lowered or "先" in lowered or "应该" in lowered)
+    ):
+        return {"outcome": "missed_decision", "expected_mode": "decision"}
+    if _contains_marker(lowered, _SPEECH_TOO_MUCH_MARKERS):
+        return {"outcome": "too_much", "expected_mode": "execute_quietly"}
+    if _contains_marker(lowered, _SPEECH_TOO_LITTLE_MARKERS):
+        return {"outcome": "too_little", "expected_mode": "teach"}
+    if "方向" in lowered and ("应该" in lowered or "不是" in lowered):
+        return {"outcome": "wrong_mode", "expected_mode": "direction"}
+    return {}
+
+
+def summarize_speech_feedback(*, limit: int = _MAX_SPEECH_FEEDBACK_ENTRIES) -> Dict[str, Any]:
+    events = _load_speech_feedback_events(limit=limit)
+    outcome_counts: Dict[str, int] = {}
+    mode_pairs: Dict[str, int] = {}
+    problem_events = 0
+    for event in events:
+        outcome = _norm(event.get("outcome")) or "unclear"
+        outcome_counts[outcome] = outcome_counts.get(outcome, 0) + 1
+        if outcome != "right":
+            problem_events += 1
+        actual = _norm(event.get("actual_mode")) or "unknown"
+        expected = _norm(event.get("expected_mode")) or "unknown"
+        pair = f"{actual}->{expected}"
+        mode_pairs[pair] = mode_pairs.get(pair, 0) + 1
+
+    recommendations: List[str] = []
+    if outcome_counts.get("too_much", 0) > 0:
+        recommendations.append("少解释：直接执行类请求优先静默使用经验，只报告结果、阻塞和验证。")
+    if outcome_counts.get("too_little", 0) > 0:
+        recommendations.append("该讲时要讲：用户询问学习、理解、方向或取舍时，先简短说明相关经验。")
+    if outcome_counts.get("wrong_mode", 0) > 0:
+        recommendations.append("复查模式：对照 actual_mode 与 expected_mode，避免把方向讨论当成教学或把执行请求当成讲解。")
+    if outcome_counts.get("missed_decision", 0) > 0:
+        recommendations.append("不要漏掉决策提醒：影响默认行为、路由或高风险执行时，先提示影响和可选路线。")
+    if not recommendations and events:
+        recommendations.append("继续沿用当前 speech_policy；只在用户反馈出现偏差时调整。")
+
+    return {
+        "total_events": len(events),
+        "problem_events": problem_events,
+        "outcome_counts": outcome_counts,
+        "mode_pairs": mode_pairs,
+        "recommendations": recommendations,
+        "recent_events": events[-5:],
+    }
+
+
+def _response_looks_like_teaching(response: str) -> bool:
+    text = str(response or "").lower()
+    plain = _plain_text(text)
+    return _contains_marker(text, _RESPONSE_TEACHING_MARKERS) or (
+        len(plain) >= 260 and _contains_marker(text, _TEACHING_INTENT_MARKERS)
+    )
+
+
+def _response_has_decision_context(response: str) -> bool:
+    text = str(response or "").lower()
+    return _contains_marker(text, _RESPONSE_DECISION_MARKERS)
+
+
+def _response_is_too_thin_for_teaching(response: str) -> bool:
+    text = str(response or "").lower()
+    plain = _plain_text(text)
+    if len(plain) >= 70:
+        return False
+    return not (
+        _contains_marker(text, _RESPONSE_TEACHING_MARKERS)
+        or _contains_marker(text, _RESPONSE_DECISION_MARKERS)
+        or _contains_marker(text, _TEACHING_INTENT_MARKERS)
+    )
+
+
+def _parse_recorded_at(value: Any) -> datetime | None:
+    text = str(value or "").strip()
+    if not text:
+        return None
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+
+
+def _events_have_same_capabilities(left: Dict[str, Any], right: Dict[str, Any]) -> bool:
+    return sorted(_as_list(left.get("capability_ids"))) == sorted(_as_list(right.get("capability_ids")))
+
+
+def _queries_are_similar(left: Any, right: Any) -> bool:
+    left_text = re.sub(r"\s+", " ", str(left or "").strip().lower())
+    right_text = re.sub(r"\s+", " ", str(right or "").strip().lower())
+    if not left_text or not right_text:
+        return False
+    if left_text == right_text:
+        return True
+
+    left_tokens = _tokens(left_text)
+    right_tokens = _tokens(right_text)
+    if not left_tokens or not right_tokens:
+        return False
+    overlap = len(left_tokens.intersection(right_tokens))
+    return overlap / max(1, min(len(left_tokens), len(right_tokens))) >= 0.75
+
+
+def _find_recent_auto_self_review_duplicate(candidate: Dict[str, Any]) -> Dict[str, Any] | None:
+    now = _hermes_now()
+    for event in reversed(_load_speech_feedback_events(limit=20)):
+        if event.get("source") != "auto_self_review":
+            continue
+        if _norm(event.get("outcome")) != _norm(candidate.get("outcome")):
+            continue
+        if _norm(event.get("actual_mode")) != _norm(candidate.get("actual_mode")):
+            continue
+        if _norm(event.get("expected_mode")) != _norm(candidate.get("expected_mode")):
+            continue
+        if not _events_have_same_capabilities(event, candidate):
+            continue
+        if not _queries_are_similar(event.get("query"), candidate.get("query")):
+            continue
+
+        recorded_at = _parse_recorded_at(event.get("recorded_at"))
+        if recorded_at is None:
+            continue
+        if recorded_at.tzinfo is None and now.tzinfo is not None:
+            recorded_at = recorded_at.replace(tzinfo=now.tzinfo)
+        age_seconds = (now - recorded_at).total_seconds()
+        if age_seconds < 0:
+            age_seconds = 0
+        if age_seconds <= _AUTO_SELF_REVIEW_DUPLICATE_COOLDOWN_SECONDS:
+            return event
+    return None
+
+
+def evaluate_speech_response(query: str, response: str, *, limit: int = 3) -> Dict[str, Any]:
+    """Evaluate Hermes's final response against the learned speech policy."""
+
+    capabilities = select_applicable_capabilities(query, limit=limit)
+    speech_policy = decide_teacher_speech_policy(query, capabilities)
+    mode = _norm(speech_policy.get("mode")) or "unknown"
+    result: Dict[str, Any] = {
+        "feedback_recorded": False,
+        "reason": "aligned_or_unclear",
+        "speech_policy": speech_policy,
+        "capabilities": capabilities,
+    }
+    if not capabilities:
+        result["reason"] = "no_relevant_capability"
+        return result
+
+    actual_mode = ""
+    expected_mode = ""
+    outcome = ""
+    note = ""
+    response_text = str(response or "")
+    if mode == "execute_quietly" and _response_looks_like_teaching(response_text):
+        actual_mode = "teach"
+        expected_mode = "execute_quietly"
+        outcome = "too_much"
+        note = "auto_self_review: direct execution response over-explained learned capabilities."
+    elif mode == "decision" and not _response_has_decision_context(response_text):
+        actual_mode = "execute_quietly" if _contains_marker(response_text.lower(), _RESPONSE_ACTION_MARKERS) else "unknown"
+        expected_mode = "decision"
+        outcome = "missed_decision"
+        note = "auto_self_review: response missed a decision or risk reminder for a high-attention capability."
+    elif mode == "teach" and _response_is_too_thin_for_teaching(response_text):
+        actual_mode = "execute_quietly"
+        expected_mode = "teach"
+        outcome = "too_little"
+        note = "auto_self_review: teaching response was too thin for the user's learning intent."
+
+    if not outcome:
+        return result
+
+    feedback_usage = {
+        "source": "auto_self_review",
+        "query": query,
+        "actual_mode": actual_mode,
+        "expected_mode": expected_mode,
+        "outcome": outcome,
+        "note": note,
+        "capability_ids": [item.get("id") for item in capabilities if item.get("id")],
+        "should_speak": speech_policy.get("should_speak"),
+    }
+    duplicate = _find_recent_auto_self_review_duplicate(feedback_usage)
+    if duplicate:
+        result.update(
+            {
+                "feedback_recorded": False,
+                "reason": "duplicate_recent_auto_self_review",
+                "duplicate_event": duplicate,
+                "summary": summarize_speech_feedback(),
+            }
+        )
+        return result
+
+    feedback = _record_speech_feedback(feedback_usage)
+    result.update(
+        {
+            "feedback_recorded": True,
+            "reason": outcome,
+            "event": feedback["event"],
+            "summary": feedback["summary"],
+        }
+    )
+    return result
+
+
+def _record_speech_feedback(usage: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    usage = usage if isinstance(usage, dict) else {}
+    latest_trace = _latest_speech_policy_trace()
+    feedback_text = _clip(
+        usage.get("feedback_text") or usage.get("feedback") or usage.get("note"),
+        _MAX_SPEECH_FEEDBACK_NOTE_CHARS,
+    )
+    inferred = _infer_speech_feedback_from_text(feedback_text)
+    feedback_value = _norm(usage.get("feedback"))
+    outcome = _norm(usage.get("outcome")) or (
+        feedback_value if feedback_value in _SPEECH_FEEDBACK_OUTCOMES else ""
+    ) or inferred.get("outcome") or "unclear"
+    if outcome not in _SPEECH_FEEDBACK_OUTCOMES:
+        outcome = "unclear"
+    latest_policy = latest_trace.get("speech_policy", {}) if latest_trace else {}
+    actual_mode = _norm(usage.get("actual_mode") or usage.get("mode")) or _norm(latest_policy.get("mode")) or "unknown"
+    expected_mode = _norm(usage.get("expected_mode")) or inferred.get("expected_mode") or "unknown"
+    if outcome == "unclear" and actual_mode != "unknown" and expected_mode != "unknown":
+        outcome = "right" if actual_mode == expected_mode else "wrong_mode"
+    query = _clip(
+        usage.get("query") or usage.get("task") or (latest_trace or {}).get("query"),
+        _MAX_SPEECH_FEEDBACK_QUERY_CHARS,
+    )
+    event = {
+        "recorded_at": _hermes_now().isoformat(),
+        "query": query,
+        "actual_mode": actual_mode,
+        "expected_mode": expected_mode,
+        "outcome": outcome,
+    }
+    source = _clip(usage.get("source"), 80)
+    if source:
+        event["source"] = source
+    if feedback_text:
+        event["feedback_text"] = feedback_text
+    note = _clip(usage.get("note"), _MAX_SPEECH_FEEDBACK_NOTE_CHARS)
+    if note:
+        event["note"] = note
+    capability_ids = _as_list(
+        usage.get("capability_ids")
+        or usage.get("capability_id")
+        or ((latest_trace or {}).get("capability_ids") if latest_trace else None)
+    )
+    if capability_ids:
+        event["capability_ids"] = capability_ids[:8]
+    if "should_speak" in usage:
+        event["should_speak"] = _as_bool(usage.get("should_speak"))
+    elif latest_policy:
+        event["should_speak"] = bool(latest_policy.get("should_speak"))
+    if latest_trace:
+        event["attribution"] = {
+            "source": "latest_speech_policy_trace",
+            "trace_id": latest_trace.get("trace_id"),
+            "trace_source": latest_trace.get("source"),
+            "trace_recorded_at": latest_trace.get("recorded_at"),
+            "confidence": "medium" if feedback_text else "low",
+        }
+
+    _append_speech_feedback_event(event)
+    return {"event": event, "summary": summarize_speech_feedback()}
+
+
+def _speech_feedback_context_lines() -> List[str]:
+    summary = summarize_speech_feedback(limit=20)
+    if not summary["total_events"] or not summary["problem_events"]:
+        return []
+    lines = [
+        "<speech-feedback>",
+        "[System note: Recent user feedback about Hermes speech policy. Apply as soft guidance; current user intent wins.]",
+        f"- recent_events={summary['total_events']} problem_events={summary['problem_events']}",
+    ]
+    for recommendation in summary["recommendations"][:3]:
+        lines.append(f"- {recommendation}")
+    lines.append("</speech-feedback>")
+    return lines
+
+
+def _save_registry(payload: Dict[str, Any]) -> None:
+    path = _capabilities_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload["updated_at"] = _hermes_now().isoformat()
+    fd, tmp_path = tempfile.mkstemp(dir=str(path.parent), suffix=".tmp", prefix=".capabilities_")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, ensure_ascii=False, indent=2)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, path)
+        try:
+            os.chmod(path, 0o600)
+        except OSError:
+            pass
+    except BaseException:
+        try:
+            os.unlink(tmp_path)
+        except OSError:
+            pass
+        raise
+
+
+def _register_candidate(candidate: Dict[str, Any]) -> Dict[str, Any]:
+    result = decide_learning_absorption(candidate)
+    card = result["candidate_card"]
+    decision = result["decision"]
+    now = _hermes_now().isoformat()
+    capability = {
+        "id": card["id"],
+        "finding": card["finding"],
+        "source_url": card["source_url"],
+        "source_type": card["source_type"],
+        "verification_level": card["verification_level"],
+        "promotion_target": decision["promotion_target"],
+        "status": decision["registry_status"],
+        "can_apply_by_default": decision["can_apply_by_default"],
+        "applies_to": card["applies_to"],
+        "required_evidence": decision["required_evidence"],
+        "next_action": decision["next_action"],
+        "updated_at": now,
+    }
+
+    registry_payload = _load_registry()
+    capabilities = registry_payload["capabilities"]
+    for index, existing in enumerate(capabilities):
+        if existing.get("id") == capability["id"]:
+            capability["created_at"] = existing.get("created_at") or now
+            capabilities[index] = {**existing, **capability}
+            _save_registry(registry_payload)
+            return capability
+
+    capability["created_at"] = now
+    capabilities.append(capability)
+    _save_registry(registry_payload)
+    return capability
+
+
+def _record_capability_use(capability_id: str, usage: Dict[str, Any] | None = None) -> Dict[str, Any]:
+    capability_id = str(capability_id or "").strip()
+    if not capability_id:
+        raise ValueError("capability_id is required")
+
+    usage = usage if isinstance(usage, dict) else {}
+    registry_payload = _load_registry()
+    capabilities = registry_payload["capabilities"]
+    now = _hermes_now().isoformat()
+    entry = {
+        "used_at": now,
+        "task": _clip(usage.get("task"), 240),
+        "outcome": _clip(usage.get("outcome") or "used", 120),
+    }
+    evidence = _as_list(usage.get("evidence"))
+    if evidence:
+        entry["evidence"] = evidence[:5]
+
+    for index, existing in enumerate(capabilities):
+        if not isinstance(existing, dict) or existing.get("id") != capability_id:
+            continue
+        updated = dict(existing)
+        try:
+            use_count = int(updated.get("use_count") or 0)
+        except (TypeError, ValueError):
+            use_count = 0
+        usage_log = updated.get("usage_log")
+        if not isinstance(usage_log, list):
+            usage_log = []
+        updated["use_count"] = use_count + 1
+        updated["last_used_at"] = now
+        updated["usage_log"] = (usage_log + [entry])[-_MAX_USAGE_LOG_ENTRIES:]
+        updated["updated_at"] = now
+        capabilities[index] = updated
+        _save_registry(registry_payload)
+        return updated
+
+    raise ValueError(f"capability not found: {capability_id}")
+
+
+def _fetch_feed(url: str, timeout: int = 20, attempts: int = 3, retry_delay: float = 0.5) -> str:
+    last_error: BaseException | None = None
+    safe_attempts = max(1, attempts)
+    for attempt in range(safe_attempts):
+        request = urllib.request.Request(
+            url,
+            headers={
+                "User-Agent": "HermesLearningRadar/1.0 (+https://hermes-agent.local)",
+                "Accept": "application/rss+xml, application/atom+xml, application/xml, text/xml, */*",
+                "Connection": "close",
+            },
+        )
+        try:
+            with urllib.request.urlopen(request, timeout=timeout) as response:
+                raw = response.read(1_000_000)
+                charset = response.headers.get_content_charset() or "utf-8"
+            return raw.decode(charset, errors="replace")
+        except (urllib.error.URLError, TimeoutError, OSError) as exc:
+            last_error = exc
+            if attempt + 1 >= safe_attempts:
+                raise
+            if retry_delay > 0:
+                time.sleep(retry_delay)
+    if last_error is not None:
+        raise last_error
+    raise RuntimeError("feed fetch failed without an error")
+
+
+class _LinkCollector(HTMLParser):
+    def __init__(self) -> None:
+        super().__init__()
+        self.links: List[Dict[str, str]] = []
+        self._href: str | None = None
+        self._text_parts: List[str] = []
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        if tag.lower() != "a":
+            return
+        attrs_dict = {name.lower(): value for name, value in attrs}
+        href = str(attrs_dict.get("href") or "").strip()
+        if href:
+            self._href = href
+            self._text_parts = []
+
+    def handle_data(self, data: str) -> None:
+        if self._href:
+            self._text_parts.append(data)
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag.lower() != "a" or not self._href:
+            return
+        text = _plain_text(" ".join(self._text_parts))
+        if text:
+            self.links.append({"href": self._href, "text": text})
+        self._href = None
+        self._text_parts = []
+
+
+def _parse_html_items(source: Dict[str, Any], html_text: str) -> List[Dict[str, Any]]:
+    collector = _LinkCollector()
+    collector.feed(html_text)
+    base_url = str(source.get("url") or "")
+    path_filter = str(source.get("item_path_contains") or "").strip()
+    seen_links: set[str] = set()
+    items: List[Dict[str, Any]] = []
+    for link in collector.links:
+        href = urljoin(base_url, link["href"])
+        if path_filter and path_filter not in href:
+            continue
+        if href in seen_links:
+            continue
+        seen_links.add(href)
+        title = _plain_text(link["text"])
+        if len(title) < 8:
+            continue
+        item_id = hashlib.sha256(
+            json.dumps(
+                {
+                    "source": source.get("url"),
+                    "link": href,
+                    "title": title,
+                },
+                sort_keys=True,
+                ensure_ascii=False,
+            ).encode("utf-8")
+        ).hexdigest()[:16]
+        items.append(
+            {
+                "id": item_id,
+                "source_name": str(source.get("name") or source.get("url") or "source"),
+                "source_url": base_url,
+                "source_type": _norm(source.get("source_type")) or "unknown",
+                "source_applies_to": _as_list(source.get("applies_to")),
+                "title": title,
+                "link": href,
+                "summary": title,
+                "published_at": "",
+            }
+        )
+    return items
+
+
+def _local_name(tag: str) -> str:
+    return tag.rsplit("}", 1)[-1] if "}" in tag else tag
+
+
+def _child_text(node: ET.Element, *names: str) -> str:
+    wanted = set(names)
+    for child in list(node):
+        if _local_name(child.tag) in wanted:
+            return _plain_text("".join(child.itertext()))
+    return ""
+
+
+def _entry_link(node: ET.Element) -> str:
+    direct = _child_text(node, "link")
+    if direct:
+        return direct
+    for child in list(node):
+        if _local_name(child.tag) == "link":
+            href = str(child.attrib.get("href") or "").strip()
+            if href:
+                return href
+    return ""
+
+
+def _parse_feed_items(source: Dict[str, Any], feed_text: str) -> List[Dict[str, Any]]:
+    if _norm(source.get("format")) == "html":
+        return _parse_html_items(source, feed_text)
+    try:
+        root = ET.fromstring(feed_text)
+    except ET.ParseError as exc:
+        if "<html" in feed_text[:2000].lower():
+            return _parse_html_items(source, feed_text)
+        raise ValueError(f"invalid feed XML: {exc}") from exc
+
+    nodes = [
+        node
+        for node in root.iter()
+        if _local_name(node.tag) in {"item", "entry"}
+    ]
+    items: List[Dict[str, Any]] = []
+    for node in nodes:
+        title = _child_text(node, "title")
+        link = _entry_link(node)
+        summary = _child_text(node, "description", "summary", "content")
+        published = _child_text(node, "pubDate", "published", "updated")
+        if not title and not link:
+            continue
+        item_id = hashlib.sha256(
+            json.dumps(
+                {
+                    "source": source.get("url"),
+                    "link": link,
+                    "title": title,
+                },
+                sort_keys=True,
+                ensure_ascii=False,
+            ).encode("utf-8")
+        ).hexdigest()[:16]
+        items.append(
+            {
+                "id": item_id,
+                "source_name": str(source.get("name") or source.get("url") or "source"),
+                "source_url": str(source.get("url") or ""),
+                "source_type": _norm(source.get("source_type")) or "unknown",
+                "source_applies_to": _as_list(source.get("applies_to")),
+                "title": title,
+                "link": link,
+                "summary": summary,
+                "published_at": published,
+            }
+        )
+    return items
+
+
+def _radar_score(item: Dict[str, Any]) -> int:
+    text = f"{item.get('title', '')} {item.get('summary', '')}".lower()
+    score = 0
+    for keyword, weight in _RADAR_KEYWORDS.items():
+        if keyword in text:
+            score += weight
+    if _norm(item.get("source_type")) == "official":
+        score += 2
+    return score
+
+
+def _radar_applies_to(item: Dict[str, Any]) -> List[str]:
+    text = f"{item.get('title', '')} {item.get('summary', '')}".lower()
+    applies = _as_list(item.get("source_applies_to"))
+    mappings = [
+        ("agent", "agent workflows"),
+        ("tool", "tool use"),
+        ("eval", "evaluation"),
+        ("prompt", "prompting"),
+        ("model", "model capabilities"),
+        ("api", "API usage"),
+        ("codex", "Codex"),
+        ("chatgpt", "ChatGPT"),
+        ("claude", "Claude"),
+        ("gemini", "Gemini"),
+        ("copilot", "Copilot"),
+        ("mcp", "MCP"),
+    ]
+    for needle, label in mappings:
+        if needle in text and label not in applies:
+            applies.append(label)
+    return applies[:8] or ["AI product usage"]
+
+
+def _radar_reusable_workflow(item: Dict[str, Any]) -> bool:
+    text = f"{item.get('title', '')} {item.get('summary', '')}".lower()
+    return any(
+        marker in text
+        for marker in (
+            "guide",
+            "cookbook",
+            "best practice",
+            "prompt",
+            "eval",
+            "tool use",
+            "workflow",
+            "agent",
+        )
+    )
+
+
+def _radar_candidate(item: Dict[str, Any]) -> Dict[str, Any]:
+    score = _radar_score(item)
+    summary = _clip(_plain_text(item.get("summary")), _MAX_RADAR_SUMMARY_CHARS)
+    title = _plain_text(item.get("title"))
+    finding = f"{item.get('source_name')}: {title}"
+    if summary:
+        finding = f"{finding}. {summary}"
+    return {
+        "finding": finding,
+        "source_url": item.get("link") or item.get("source_url"),
+        "source_type": item.get("source_type") or "unknown",
+        "verification_level": "official" if _norm(item.get("source_type")) == "official" else "source_checked",
+        "impact": "high" if score >= 12 else "medium",
+        "risk": "low",
+        "reusable_workflow": _radar_reusable_workflow(item),
+        "applies_to": _radar_applies_to(item),
+        "notes": f"learning_radar score={score}; published_at={item.get('published_at') or 'unknown'}",
+    }
+
+
+def run_learning_radar(
+    *,
+    sources: List[Dict[str, Any]] | None = None,
+    fetcher: Callable[[str], str] | None = None,
+    register: bool = True,
+    max_items: int = 8,
+) -> Dict[str, Any]:
+    """Fetch AI-product sources, filter new useful items, and register candidates."""
+
+    radar_sources = sources if sources is not None else _load_radar_sources()
+    fetch = fetcher or _fetch_feed
+    seen = _load_seen_items()
+    now = _hermes_now().isoformat()
+    max_new_items = _positive_int(max_items, default=8)
+    errors: List[Dict[str, str]] = []
+    candidates: List[Dict[str, Any]] = []
+
+    for source in radar_sources:
+        url = str(source.get("url") or "").strip()
+        if not url:
+            continue
+        try:
+            feed_text = fetch(url)
+            items = _parse_feed_items(source, feed_text)
+        except Exception as exc:
+            errors.append({"source": url, "error": str(exc)})
+            continue
+
+        for item in items:
+            if item["id"] in seen:
+                continue
+            score = _radar_score(item)
+            if score < 6:
+                continue
+            candidate = _radar_candidate(item)
+            candidates.append(
+                {
+                    "item": item,
+                    "score": score,
+                    "candidate": candidate,
+                }
+            )
+
+    candidates.sort(key=lambda entry: entry["score"], reverse=True)
+    candidates = candidates[:max_new_items]
+
+    registered: List[Dict[str, Any]] = []
+    for entry in candidates:
+        if register:
+            registered.append(_register_candidate(entry["candidate"]))
+            item = entry["item"]
+            seen[item["id"]] = {
+                "id": item["id"],
+                "seen_at": now,
+                "title": item.get("title"),
+                "link": item.get("link"),
+                "source_name": item.get("source_name"),
+            }
+
+    if register and candidates:
+        _save_seen_items(seen)
+
+    result = {
+        "success": True,
+        "source_count": len(radar_sources),
+        "new_item_count": len(candidates),
+        "registered_count": len(registered),
+        "candidates": [entry["candidate"] for entry in candidates],
+        "registered": registered,
+        "errors": errors,
+        "ran_at": now,
+    }
+    _append_radar_run(
+        {
+            "ran_at": now,
+            "source_count": result["source_count"],
+            "new_item_count": result["new_item_count"],
+            "registered_count": result["registered_count"],
+            "error_count": len(errors),
+        }
+    )
+    return result
+
+
+def ensure_learning_radar_cron(schedule: str = "every 12h") -> Dict[str, Any]:
+    """Create or update the single recurring cron job that runs the radar."""
+
+    from cron.jobs import create_job, list_jobs, parse_schedule, update_job
+
+    existing = next((job for job in list_jobs(include_disabled=True) if job.get("name") == _RADAR_JOB_NAME), None)
+    if existing:
+        parsed = parse_schedule(schedule)
+        job = update_job(
+            existing["id"],
+            {
+                "prompt": _RADAR_JOB_PROMPT,
+                "schedule": parsed,
+                "schedule_display": parsed.get("display", schedule),
+                "deliver": "local",
+                "lane": "cron_scout",
+                "skills": [],
+                "enabled": True,
+                "state": "scheduled",
+                "paused_at": None,
+                "paused_reason": None,
+            },
+        )
+        return {"success": True, "created": False, "job": job}
+
+    job = create_job(
+        prompt=_RADAR_JOB_PROMPT,
+        schedule=schedule,
+        name=_RADAR_JOB_NAME,
+        repeat=None,
+        deliver="local",
+    )
+    job = update_job(job["id"], {"lane": "cron_scout", "skills": []}) or job
+    return {"success": True, "created": True, "job": job}
+
+
+def learning_absorption(
+    action: str,
+    candidate: Dict[str, Any] | None = None,
+    query: str | None = None,
+    response: str | None = None,
+    capability_id: str | None = None,
+    usage: Dict[str, Any] | None = None,
+    limit: int | None = None,
+    sources: List[Dict[str, Any]] | None = None,
+    register: bool | None = None,
+    schedule: str | None = None,
+) -> str:
+    """Tool dispatcher for learning absorption decisions and registry updates."""
+    normalized = _norm(action)
+    try:
+        if normalized == "decide":
+            result = decide_learning_absorption(candidate or {})
+            return json.dumps({"success": True, **result}, ensure_ascii=False)
+        if normalized == "register":
+            capability = _register_candidate(candidate or {})
+            return json.dumps({"success": True, "capability": capability}, ensure_ascii=False)
+        if normalized == "select":
+            capabilities = select_applicable_capabilities(query or "", limit=_positive_int(limit, default=3))
+            return json.dumps({"success": True, "capabilities": capabilities}, ensure_ascii=False)
+        if normalized == "record_use":
+            capability = _record_capability_use(capability_id or "", usage)
+            return json.dumps({"success": True, "capability": capability}, ensure_ascii=False)
+        if normalized == "teacher_brief":
+            result = build_teacher_brief(query or "", limit=_positive_int(limit, default=3))
+            return json.dumps({"success": True, **result}, ensure_ascii=False)
+        if normalized == "record_speech_feedback":
+            result = _record_speech_feedback(usage)
+            return json.dumps({"success": True, **result}, ensure_ascii=False)
+        if normalized == "speech_feedback_summary":
+            result = summarize_speech_feedback(limit=_positive_int(limit, default=_MAX_SPEECH_FEEDBACK_ENTRIES))
+            return json.dumps({"success": True, "summary": result}, ensure_ascii=False)
+        if normalized == "learning_report":
+            result = build_learning_report(limit=_positive_int(limit, default=5))
+            return json.dumps({"success": True, "report": result}, ensure_ascii=False)
+        if normalized == "evaluate_speech_response":
+            result = evaluate_speech_response(
+                query or "",
+                response or "",
+                limit=_positive_int(limit, default=3),
+            )
+            return json.dumps({"success": True, **result}, ensure_ascii=False)
+        if normalized == "radar_run":
+            result = run_learning_radar(
+                sources=sources,
+                register=True if register is None else _as_bool(register),
+                max_items=_positive_int(limit, default=8),
+            )
+            return json.dumps(result, ensure_ascii=False)
+        if normalized == "radar_install":
+            return tool_error(
+                "radar_install is disabled from the agent tool surface; create recurring jobs explicitly through reviewed cron configuration.",
+                success=False,
+            )
+        if normalized == "radar_sources":
+            return json.dumps({"success": True, "sources": _load_radar_sources()}, ensure_ascii=False)
+        if normalized == "list":
+            payload = _load_registry()
+            return json.dumps({"success": True, **payload}, ensure_ascii=False)
+        return tool_error(
+            "Unknown action. Use: decide, register, select, record_use, teacher_brief, record_speech_feedback, speech_feedback_summary, learning_report, evaluate_speech_response, radar_run, radar_sources, list",
+            success=False,
+        )
+    except ValueError as exc:
+        return tool_error(str(exc), success=False)
+
+
+LEARNING_ABSORPTION_SCHEMA = {
+    "name": "learning_absorption",
+    "description": (
+        "Evaluate AI-product, agent-workflow, prompt, MCP, evaluation, or routing discoveries "
+        "before turning them into durable Hermes behavior. Use this after research/scout work "
+        "to create a candidate card, decide whether the finding should become a source note, "
+        "knowledge-base item, playbook, routing default, skill candidate, user brief, or "
+        "verification backlog item, and optionally register the resulting capability."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {
+                "type": "string",
+                "enum": [
+                    "decide",
+                    "register",
+                    "select",
+                    "record_use",
+                    "teacher_brief",
+                    "record_speech_feedback",
+                    "speech_feedback_summary",
+                    "learning_report",
+                    "evaluate_speech_response",
+                    "radar_run",
+                    "radar_sources",
+                    "list",
+                ],
+                "description": "decide returns an absorption decision; register persists it; select returns relevant active capabilities; record_use records that a capability shaped a turn; teacher_brief returns a concise Chinese explanation of relevant learned capabilities; record_speech_feedback stores user feedback about whether Hermes spoke too much, too little, or in the wrong mode; speech_feedback_summary summarizes that feedback; learning_report summarizes recent learned capabilities and speech feedback for user-facing updates; evaluate_speech_response checks a final response against the learned speech policy and records obvious mismatches; radar_run fetches AI learning sources and registers new findings; radar_sources lists configured sources; list reads the registry.",
+            },
+            "candidate": {
+                "type": "object",
+                "description": "Learning candidate card fields such as finding, source_url, source_type, verification_level, impact, risk, reusable_workflow, affects_routing, affects_code, applies_to, front_channel_reason, and notes. front_channel_reason may be major_new_technique, current_project_relevance, execution_blocker, or direction_decision; omit it for local-only learning.",
+                "additionalProperties": True,
+            },
+            "query": {
+                "type": "string",
+                "description": "User turn or task summary used by action=select, action=teacher_brief, or action=evaluate_speech_response to choose relevant active capabilities.",
+            },
+            "response": {
+                "type": "string",
+                "description": "Final assistant response text used by action=evaluate_speech_response.",
+            },
+            "capability_id": {
+                "type": "string",
+                "description": "Capability id used by action=record_use.",
+            },
+            "usage": {
+                "type": "object",
+                "description": "Usage evidence for action=record_use, such as task, outcome, and evidence. For action=record_speech_feedback, include query, actual_mode, expected_mode, outcome, note, and capability_ids when available.",
+                "additionalProperties": True,
+            },
+            "limit": {
+                "type": "integer",
+                "description": "Maximum number of selected capabilities for action=select, recent capabilities for action=learning_report, or maximum new items for action=radar_run.",
+                "minimum": 1,
+                "maximum": 10,
+            },
+            "sources": {
+                "type": "array",
+                "description": "Optional source override for action=radar_run; normally omitted so ~/.hermes/learning/radar_sources.json or built-in defaults are used.",
+                "items": {"type": "object", "additionalProperties": True},
+            },
+            "register": {
+                "type": "boolean",
+                "description": "For action=radar_run, whether to persist absorbed capabilities. Defaults to true.",
+            },
+            "schedule": {
+                "type": "string",
+                "description": "For action=radar_install, the cron schedule such as 'every 12h'.",
+            },
+        },
+        "required": ["action"],
+    },
+}
+
+
+def check_learning_absorption_requirements() -> bool:
+    return True
+
+
+from tools.registry import registry, tool_error
+
+registry.register(
+    name="learning_absorption",
+    toolset="memory",
+    schema=LEARNING_ABSORPTION_SCHEMA,
+    handler=lambda args, **kw: learning_absorption(
+        action=args.get("action", ""),
+        candidate=args.get("candidate"),
+        query=args.get("query"),
+        response=args.get("response"),
+        capability_id=args.get("capability_id"),
+        usage=args.get("usage"),
+        limit=args.get("limit"),
+        sources=args.get("sources"),
+        register=args.get("register"),
+        schedule=args.get("schedule"),
+    ),
+    check_fn=check_learning_absorption_requirements,
+    emoji="🧩",
+)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -249,6 +249,11 @@ _MCP_MESSAGE_HANDLER_SUPPORTED = _check_message_handler_support()
 if _MCP_AVAILABLE and not _MCP_MESSAGE_HANDLER_SUPPORTED:
     logger.debug("MCP SDK does not support message_handler -- dynamic tool discovery disabled")
 
+_MISSING_MCP_SDK_MESSAGE = (
+    "MCP SDK is not installed; install the optional 'mcp' package "
+    "or disable/remove MCP servers."
+)
+
 # ---------------------------------------------------------------------------
 # Constants
 # ---------------------------------------------------------------------------
@@ -1179,6 +1184,9 @@ class MCPServerTask:
 
     async def _run_stdio(self, config: dict):
         """Run the server using stdio transport."""
+        if not _MCP_AVAILABLE:
+            raise ImportError(_MISSING_MCP_SDK_MESSAGE)
+
         command = config.get("command")
         args = config.get("args", [])
         user_env = config.get("env")
@@ -1260,6 +1268,9 @@ class MCPServerTask:
 
     async def _run_http(self, config: dict):
         """Run the server using HTTP/StreamableHTTP transport."""
+        if not _MCP_AVAILABLE:
+            raise ImportError(_MISSING_MCP_SDK_MESSAGE)
+
         if not _MCP_HTTP_AVAILABLE:
             raise ImportError(
                 f"MCP server '{self.name}' requires HTTP transport but "

--- a/toolsets.py
+++ b/toolsets.py
@@ -47,7 +47,7 @@ _HERMES_CORE_TOOLS = [
     # Text-to-speech
     "text_to_speech",
     # Planning & memory
-    "todo", "memory",
+    "todo", "memory", "learning_absorption",
     # Session history search
     "session_search",
     # Clarifying questions
@@ -187,8 +187,8 @@ TOOLSETS = {
     },
     
     "memory": {
-        "description": "Persistent memory across sessions (personal notes + user profile)",
-        "tools": ["memory"],
+        "description": "Persistent memory, user profile, and learning absorption across sessions",
+        "tools": ["memory", "learning_absorption"],
         "includes": []
     },
     
@@ -325,7 +325,7 @@ TOOLSETS = {
             "browser_type", "browser_scroll", "browser_back",
             "browser_press", "browser_get_images",
             "browser_vision", "browser_console", "browser_cdp", "browser_dialog",
-            "todo", "memory",
+            "todo", "memory", "learning_absorption",
             "session_search",
             "execute_code", "delegate_task",
         ],
@@ -351,7 +351,7 @@ TOOLSETS = {
             "browser_press", "browser_get_images",
             "browser_vision", "browser_console", "browser_cdp", "browser_dialog",
             # Planning & memory
-            "todo", "memory",
+            "todo", "memory", "learning_absorption",
             # Session history search
             "session_search",
             # Code execution + delegation


### PR DESCRIPTION
## Summary
- Integrate the Hermes v0.13 retrofit lanes into one reviewable branch: natural background dispatch, learning absorption context/tooling, OpenAI-compatible image generation before FAL fallback, delegation credential reuse, MCP dependency surfacing, disabled-tool visibility, and cron ticker heartbeat reporting.
- Keep the runtime-facing behavior consolidated instead of duplicating route logic across the two original threads.
- PR branch was rebuilt on current upstream `main` by cherry-picking the two local integration commits, then verified on that latest base.

## Verification
- `/home/wutj/.hermes/hermes-agent-v013-20260509/venv/bin/python -m pytest tests/agent/test_bedrock_1m_context.py tests/cron/test_scheduler_mcp_init.py tests/run_agent/test_concurrent_interrupt.py tests/tools/test_delegate.py -q` -> `140 passed`
- `/home/wutj/.hermes/hermes-agent-v013-20260509/venv/bin/python -m pytest tests/gateway/test_cron_ticker_heartbeat.py tests/hermes_cli/test_gateway_service.py tests/gateway/test_status.py tests/gateway/test_natural_dispatch.py tests/tools/test_openai_image_lane.py tests/tools/test_image_generation.py tests/tools/test_delegate.py::TestDelegationCredentialResolution tests/tools/test_delegate.py::TestDelegationProviderIntegration tests/tools/test_learning_absorption_tool.py tests/run_agent/test_learning_capabilities_context.py tests/tools/test_mcp_missing_dependency.py tests/hermes_cli/test_tools_config.py -q` -> `390 passed`
- `/home/wutj/.hermes/hermes-agent-v013-20260509/venv/bin/python -m pytest tests/agent tests/run_agent tests/cron tests/cli tests/acp tests/acp_adapter tests/providers tests/hermes_state -q -n 4` -> `5111 passed, 9 skipped`
- `.venv-ci/bin/python -m pytest tests/tools/test_registry.py tests/tools/test_delegate.py tests/tools/test_learning_absorption_tool.py tests/tools/test_mcp_missing_dependency.py tests/tools/test_openai_image_lane.py tests/tools/test_image_generation.py tests/run_agent/test_learning_capabilities_context.py tests/gateway/test_natural_dispatch.py tests/gateway/test_cron_ticker_heartbeat.py tests/gateway/test_status.py tests/hermes_cli/test_gateway_service.py tests/hermes_cli/test_tools_config.py -q --tb=short -n 4` with clean `HERMES_HOME` -> `527 passed`
- `.venv-ci/bin/python -m pytest tests/e2e/ -v --tb=short` with clean `HERMES_HOME` -> `56 passed, 7 skipped`
- `uv tool run ruff check .` -> passed
- `python scripts/check-windows-footguns.py --all` -> passed
- Contributor attribution check -> passed
- Supply-chain critical-pattern scan -> passed
- `git diff --check` -> passed
- Live gateway was kept on the already verified local live worktree while this PR branch was prepared separately.

## CI status
GitHub Actions for this fork PR are currently `action_required` with no jobs/logs; upstream maintainer approval is required before CI can actually run.