### PR TITLE
[security] fix(process): guard stdin submissions

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -254,6 +254,103 @@ def test_reader_loop_streams_incremental_chunks_from_read1(registry, monkeypatch
 
 
 # =========================================================================
+# Stdin approval guard
+# =========================================================================
+
+class TestStdinApprovalGuard:
+    def test_write_stdin_blocks_hardline_payload_before_pipe_write(self, registry):
+        """Second-stage stdin must not bypass the terminal hardline floor."""
+        stdin = MagicMock()
+        proc = MagicMock()
+        proc.stdin = stdin
+        session = _make_session(sid="proc_stdin_guard", command="bash")
+        session.process = proc
+        registry._running[session.id] = session
+
+        result = registry.write_stdin(session.id, "rm -rf $HOME\n")
+
+        assert result["status"] == "blocked"
+        assert "hardline" in result["error"]
+        stdin.write.assert_not_called()
+        stdin.flush.assert_not_called()
+
+    def test_submit_stdin_blocks_hardline_payload_before_pipe_write(self, registry):
+        stdin = MagicMock()
+        proc = MagicMock()
+        proc.stdin = stdin
+        session = _make_session(sid="proc_submit_guard", command="bash")
+        session.process = proc
+        registry._running[session.id] = session
+
+        result = registry.submit_stdin(session.id, "rm -rf $HOME")
+
+        assert result["status"] == "blocked"
+        assert "hardline" in result["error"]
+        stdin.write.assert_not_called()
+        stdin.flush.assert_not_called()
+
+    def test_write_stdin_blocks_hardline_payload_before_pty_write(self, registry):
+        """The PTY-backed interactive path must be guarded too."""
+        pty = MagicMock()
+        session = _make_session(sid="proc_pty_guard", command="bash")
+        session._pty = pty
+        registry._running[session.id] = session
+
+        result = registry.write_stdin(session.id, "rm -rf $HOME\n")
+
+        assert result["status"] == "blocked"
+        assert "hardline" in result["error"]
+        pty.write.assert_not_called()
+
+    def test_write_stdin_uses_terminal_approval_callback_for_dangerous_payload(
+        self, registry, monkeypatch
+    ):
+        """Recoverable dangerous stdin should route through terminal approval UI."""
+        from tools import terminal_tool
+
+        calls = []
+
+        def approve(command, description, *, allow_permanent=True):
+            calls.append((command, description, allow_permanent))
+            return "once"
+
+        monkeypatch.setenv("HERMES_INTERACTIVE", "1")
+        terminal_tool.set_approval_callback(approve)
+        stdin = MagicMock()
+        proc = MagicMock()
+        proc.stdin = stdin
+        session = _make_session(sid="proc_stdin_callback", command="bash")
+        session.process = proc
+        registry._running[session.id] = session
+
+        try:
+            payload = "chmod -R 777 /tmp/hermes-stdin-approval-test\n"
+            result = registry.write_stdin(session.id, payload)
+        finally:
+            terminal_tool.set_approval_callback(None)
+
+        assert result == {"status": "ok", "bytes_written": len(payload)}
+        assert calls
+        assert "chmod -R 777" in calls[0][0]
+        stdin.write.assert_called_once_with(payload)
+        stdin.flush.assert_called_once()
+
+    def test_write_stdin_allows_safe_payload(self, registry):
+        stdin = MagicMock()
+        proc = MagicMock()
+        proc.stdin = stdin
+        session = _make_session(sid="proc_stdin_safe", command="python")
+        session.process = proc
+        registry._running[session.id] = session
+
+        result = registry.write_stdin(session.id, "print('hello')\n")
+
+        assert result == {"status": "ok", "bytes_written": len("print('hello')\n")}
+        stdin.write.assert_called_once_with("print('hello')\n")
+        stdin.flush.assert_called_once()
+
+
+# =========================================================================
 # Orphaned-pipe reconciliation (issue #17327)
 # =========================================================================
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -51,6 +51,52 @@ from hermes_cli.config import get_hermes_home
 logger = logging.getLogger(__name__)
 
 
+def _stdin_guard_error(approval: dict) -> dict | None:
+    """Return a process-tool error response when stdin data is not approved.
+
+    Background processes can be interactive shells or interpreters.  Data sent
+    later through process.write/process.submit is therefore another command
+    execution channel and must not bypass the terminal approval hardline floor
+    or gateway/CLI dangerous-command approval flow.
+    """
+    if approval.get("approved"):
+        return None
+
+    status = approval.get("status") or "blocked"
+    return {
+        "status": status,
+        "error": approval.get("message") or "Process stdin rejected by approval policy",
+        "command": approval.get("command"),
+        "description": approval.get("description"),
+        "pattern_key": approval.get("pattern_key"),
+    }
+
+
+def _check_process_stdin_guards(data: str | bytes) -> dict | None:
+    """Apply command approval checks to process stdin payloads.
+
+    The terminal tool checks only the initial process command.  For running
+    shells/interpreters, stdin can carry follow-on commands, so the same local
+    command guard needs to run before bytes reach the process.
+    """
+    if not data:
+        return None
+    if isinstance(data, bytes):
+        try:
+            command_text = data.decode("utf-8")
+        except UnicodeDecodeError:
+            return {
+                "status": "blocked",
+                "error": "Process stdin rejected: non-UTF-8 bytes cannot be safety-scanned",
+            }
+    else:
+        command_text = data
+    from tools.terminal_tool import _check_all_guards
+
+    approval = _check_all_guards(command_text, "local")
+    return _stdin_guard_error(approval)
+
+
 # Checkpoint file for crash recovery (gateway only)
 CHECKPOINT_PATH = get_hermes_home() / "processes.json"
 
@@ -1522,6 +1568,12 @@ class ProcessRegistry:
             return {"status": "not_found", "error": f"No process with ID {session_id}"}
         if session.exited:
             return {"status": "already_exited", "error": "Process has already finished"}
+
+        # Apply the same approval policy used by terminal() to second-stage
+        # stdin data before it reaches a shell/interpreter process.
+        guard_error = _check_process_stdin_guards(data)
+        if guard_error is not None:
+            return guard_error
 
         # PTY mode -- write through pty handle.
         if hasattr(session, '_pty') and session._pty:


### PR DESCRIPTION
## Summary

This PR hardens the background-process stdin boundary so `process.write` and `process.submit` cannot be used as a second-stage command execution channel that bypasses terminal approval.

Hermes already runs dangerous-command and hardline checks before starting a command through `terminal()`. Before this PR, those checks covered only the initial process command. A model/tool flow could start an innocuous interactive process such as `bash`, then submit dangerous command text through the `process` tool's stdin path without reusing the same approval guard.

This PR:
- applies the terminal command guard to stdin payloads before they reach a running process;
- blocks hardline stdin payloads before PTY/pipe writes occur;
- preserves safe stdin writes for ordinary interactive use;
- adds regression tests for `write_stdin()` and `submit_stdin()`.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| `process.write` / `process.submit` could feed dangerous commands into an already-running shell without terminal approval | Prompt-controlled or lower-trust tool flow could bypass dangerous-command approval and hardline blocking after starting a benign process | High |

## Before this PR

- `terminal()` checked `_check_all_guards(command, env_type)` only for the initial command.
- `terminal(command="bash", background=True)` was allowed because the launcher itself is not dangerous.
- `process(action="submit", data="rm -rf $HOME")` wrote directly to the shell's stdin.
- `ProcessRegistry.write_stdin()` sent data to `session._pty.write(...)` or `session.process.stdin.write(...)` without calling the approval guard.
- Tests covered process polling/checkpoint behavior, but not second-stage stdin approval.

## After this PR

- `ProcessRegistry.write_stdin()` calls a shared stdin guard before writing any data to the process.
- The guard reuses `tools.approval.check_all_command_guards(..., "local")`, preserving the existing terminal approval semantics.
- Hardline stdin payloads are blocked before they reach the PTY/stdin sink.
- Safe stdin payloads still work as before.
- Non-UTF-8 byte payloads are rejected because they cannot be safety-scanned.
- Regression tests assert blocked stdin data is not written or flushed.

## Why this matters

Background process stdin is an execution channel when the target process is a shell or interpreter. Treating only the process launcher as approval-relevant leaves a gap: the safe-looking launcher can be approved while the dangerous command arrives one tool call later.

That breaks the user's expectation that catastrophic local commands go through Hermes' dangerous-command and hardline approval layer before execution.

## How this differs from related issue/PR

Several public items already touch terminal approval, but this patch fixes a distinct second-stage channel:

- #4146 covers `execute_code` sandbox access to the terminal tool.
- #8032 covers the terminal tool's exposed `force=True` parameter.
- #15542 covers TUI `shell.exec` fail-open behavior when the approval module cannot load.
- #13634 covers approval UI/callback behavior.
- #21128 and #22194 harden specific sudo command patterns.
- #21500 proposes a broader trust engine.

Those items focus on the initial command, UI/transport behavior, or individual detection patterns. This PR covers the later `ProcessRegistry.write_stdin()` / `submit_stdin()` path, where command text can reach an already-running process without passing through the same guard.

## Attack flow

```text
Prompt-controlled agent/tool flow
    -> terminal(command="bash", background=True)
        -> initial command is allowed
            -> process(action="submit", session_id=<bash>, data="rm -rf $HOME")
                -> vulnerable code writes data directly to shell stdin
                    -> dangerous/hardline command executes without approval
```

## Affected code

| Issue | Files |
|-------|-------|
| Process stdin approval bypass | `tools/process_registry.py`, `tools/terminal_tool.py`, `tools/approval.py` |
| Regression coverage | `tests/tools/test_process_registry.py` |

## Root cause

Process stdin approval bypass:
- Direct cause: `ProcessRegistry.write_stdin()` wrote stdin data directly to PTY or pipe sinks without applying approval checks.
- Boundary failure: the terminal approval boundary was enforced only at process creation, not at later process input channels that can carry executable command text.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Process stdin approval bypass | 7.3 High | `CVSS:3.1/AV:L/AC:L/PR:L/UI:R/S:U/C:H/I:H/A:H` |

Rationale:
- This is local/agent-session scoped and requires a path that can steer tool use or invoke the terminal/process tool pair.
- It is not unauthenticated remote code execution.
- Once reachable, it can bypass an explicit command-approval boundary and execute as the Hermes user, with confidentiality, integrity, and availability impact depending on the submitted command.

## Safe reproduction steps

1. Start a benign background shell through the normal terminal path:

```python
start = json.loads(
    terminal_tool(
        command="bash",
        background=True,
        pty=False,
        workdir="/tmp",
        task_id="stdin-bypass-repro",
    )
)
sid = start["session_id"]
```

2. Submit a safe proof payload that still matches the hardline detector. The payload shadows `rm` so it writes a marker instead of deleting anything:

```python
payload = "rm(){ echo proof > /tmp/hermes-process-stdin-approval-bypass; }\nrm -rf $HOME\nexit"
submitted = _handle_process(
    {"action": "submit", "session_id": sid, "data": payload},
    task_id="stdin-bypass-repro",
)
```

3. On vulnerable code, the marker is created even though the payload text is hardline-detected.
4. With this PR, `submit` returns `status: blocked`, and the marker is not created.

## Expected vulnerable behavior

On vulnerable code:

```text
payload_hardline= (True, 'recursive delete of home directory')
start_status= 0 None
submit_result= {'status': 'ok', 'bytes_written': 82}
terminal_guard_calls= 0
hardline_guard_calls= 0
wait_status= exited 0
marker_exists= True
marker_content= proof
```

With this PR:

```text
payload_hardline= (True, 'recursive delete of home directory')
start_status= 0 None
submit_result= {'status': 'blocked', 'error': 'BLOCKED (hardline): recursive delete of home directory. ...'}
marker_exists= False
```

## Changes in this PR

- Adds `_check_process_stdin_guards()` in `tools/process_registry.py`.
- Reuses `tools.approval.check_all_command_guards(..., "local")` for process stdin payloads.
- Converts failed approval decisions into process-tool `blocked` / `approval_required` responses.
- Rejects non-UTF-8 byte stdin payloads because they cannot be safety-scanned.
- Calls the guard before PTY or pipe writes.
- Adds tests proving hardline stdin data is blocked before `stdin.write()` / `stdin.flush()`.
- Adds a safe-path test proving ordinary stdin writes still work.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Stdin approval hardening | `tools/process_registry.py` | Adds guard helpers and calls them before PTY/pipe stdin writes |
| Tests | `tests/tools/test_process_registry.py` | Adds regression coverage for blocked `write_stdin`, blocked `submit_stdin`, and safe stdin writes |

## Maintainer impact

- The patch is localized to process stdin handling.
- Safe interactive stdin usage remains supported.
- The hardline floor now applies consistently whether command text arrives through `terminal()` or through a later `process.submit` call.
- Existing terminal approval policy remains the source of truth; this PR does not introduce a separate policy language.
- Non-local sandboxed environment process behavior is unchanged because stdin writing already requires an available local PTY/stdin handle.

## Fix rationale

The right boundary is immediately before stdin data reaches the running process. Checking only at process creation cannot protect interactive shells, REPLs, or interpreters because executable command text may arrive later.

Reusing the existing terminal guard keeps the policy consistent and avoids creating a separate process-specific detection layer. Blocking non-UTF-8 bytes is a conservative fail-closed choice because opaque bytes cannot be scanned reliably before reaching a local process.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] `python3.11 -m py_compile tools/process_registry.py`
- [x] `ruff check tools/process_registry.py tests/tools/test_process_registry.py`
- [x] `git diff --check`
- [x] `pytest tests/tools/test_process_registry.py::TestStdinApprovalGuard -q`
- [x] `pytest tests/tools/test_process_registry.py tests/tools/test_approval.py -q`
- [x] Manual safe repro after the patch: the hardline-looking stdin payload returned `status: blocked`, and `/tmp/hermes-process-stdin-approval-bypass` was not created.

Executed with:

```bash
python3.11 -m py_compile tools/process_registry.py
ruff check tools/process_registry.py tests/tools/test_process_registry.py
git diff --check
pytest tests/tools/test_process_registry.py::TestStdinApprovalGuard -q
pytest tests/tools/test_process_registry.py tests/tools/test_approval.py -q
```

Focused results:
- `TestStdinApprovalGuard`: `3 passed`
- process registry + approval suites: `182 passed`


## Disclosure notes

- This PR is intentionally bounded to second-stage stdin data sent through `process.write` / `process.submit`.
- It does not claim unauthenticated remote code execution.
- It does not remove background processes or safe interactive stdin support.
- No unrelated files were changed.
