### PR TITLE
fix(run_agent): hydrate memory nudge counter from history in gateway sessions

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -11145,6 +11145,21 @@ class AIAgent:
         if (self._memory_nudge_interval > 0
                 and "memory" in self.valid_tool_names
                 and self._memory_store):
+            # Gateway / messaging-platform sessions construct a fresh AIAgent
+            # per inbound message while the conversation history persists.
+            # Without this hydration the counter starts at 0 every turn and
+            # nudge_interval is never reached (#22357). Only seed when the
+            # in-memory counter is at its initial value, so we never clobber
+            # a counter that the current process has been incrementing.
+            if self._turns_since_memory == 0 and conversation_history:
+                prior_user_turns = sum(
+                    1 for msg in conversation_history
+                    if isinstance(msg, dict) and msg.get("role") == "user"
+                )
+                if prior_user_turns > 0:
+                    self._turns_since_memory = (
+                        prior_user_turns % self._memory_nudge_interval
+                    )
             self._turns_since_memory += 1
             if self._turns_since_memory >= self._memory_nudge_interval:
                 _should_review_memory = True

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5093,6 +5093,42 @@ class TestMemoryNudgeCounterPersistence:
         assert "self._turns_since_memory = 0" not in preamble
         assert "self._iters_since_skill = 0" not in preamble
 
+    def test_hydrates_counter_from_history_in_fresh_agent(self):
+        """Gateway sessions construct a fresh AIAgent per inbound message but
+        keep conversation_history alive across turns (#22357). Without
+        hydration the counter starts at 0 every turn and nudge_interval is
+        never reached. The hydration block must seed _turns_since_memory
+        from prior user turns when the counter is at its initial value."""
+        import inspect
+        src = inspect.getsource(AIAgent.run_conversation)
+        # The hydration block lives inside the memory-nudge gate, before
+        # the unconditional `self._turns_since_memory += 1`.
+        nudge_idx = src.index("self._turns_since_memory += 1")
+        # Capture a window large enough to contain the block (~1k chars back).
+        window = src[max(0, nudge_idx - 2000):nudge_idx]
+        assert "prior_user_turns" in window, (
+            "Counter hydration from conversation_history must precede the "
+            "increment so gateway sessions reach nudge_interval (#22357)."
+        )
+        # Modulo against nudge_interval keeps the counter bounded so a long
+        # backlog doesn't fire memory review for every subsequent turn.
+        assert "% self._memory_nudge_interval" in window
+
+    def test_hydration_guards_against_clobber_and_empty_history(self):
+        """Hydration must only fire when counter is at its initial value and
+        conversation_history is non-empty — otherwise it would clobber a
+        running counter or seed from nothing."""
+        import inspect
+        src = inspect.getsource(AIAgent.run_conversation)
+        nudge_idx = src.index("self._turns_since_memory += 1")
+        window = src[max(0, nudge_idx - 2000):nudge_idx]
+        assert "self._turns_since_memory == 0" in window, (
+            "Hydration guard missing: would clobber a counter the current "
+            "process has been incrementing."
+        )
+        # Truthiness check on conversation_history covers None and [].
+        assert "and conversation_history" in window
+
 
 class TestDeadRetryCode:
     """Unreachable retry_count >= max_retries after raise must not exist."""


### PR DESCRIPTION
## Problem

In gateway / messaging-platform integrations (Discord, Slack, LINE, Telegram, etc.) a fresh `AIAgent` is constructed for every inbound message while `conversation_history` is reloaded from the session store. The result: `self._turns_since_memory` starts at `0` on every turn and the memory-review nudge **never** fires no matter how long the conversation has been going (#22357).

The CLI loop is unaffected because the same agent instance handles the whole conversation, so the in-process counter persists.

## Root cause

`AIAgent.run_conversation()` unconditionally enters its nudge-counter block with the freshly constructed counter at zero. There is no link between the persisted conversation history and the in-memory counter.

## Fix

Before the increment, seed `_turns_since_memory` from the user-role message count in `conversation_history` when the in-process counter is still at its initial value:

```python
if self._turns_since_memory == 0 and conversation_history:
    prior_user_turns = sum(
        1 for msg in conversation_history
        if isinstance(msg, dict) and msg.get("role") == "user"
    )
    if prior_user_turns > 0:
        self._turns_since_memory = (
            prior_user_turns % self._memory_nudge_interval
        )
```

Two guards keep this surgical:
- `self._turns_since_memory == 0` — never clobber a counter the current process has been incrementing (CLI path stays untouched).
- `prior_user_turns % self._memory_nudge_interval` — bound the seed so a long backlog doesn't trigger the nudge for every subsequent turn.

## Tests

`tests/run_agent/test_run_agent.py::TestMemoryNudgeCounterPersistence` gains two source-level invariants:

- `test_hydrates_counter_from_history_in_fresh_agent` — asserts the hydration block (with `prior_user_turns` and `% self._memory_nudge_interval`) precedes the counter increment.
- `test_hydration_guards_against_clobber_and_empty_history` — asserts both guards (`== 0` and `and conversation_history`) are present.

Stash-verify confirms both new tests fail when the hydration block is removed.

```
.venv/bin/python -m pytest tests/run_agent/test_run_agent.py -k MemoryNudge -q
4 passed
```

Closes #22357