### PR TITLE
fix(gateway): macOS fallback for _get_process_start_time

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -109,13 +109,39 @@ def _get_scope_lock_path(scope: str, identity: str) -> Path:
 
 
 def _get_process_start_time(pid: int) -> Optional[int]:
-    """Return the kernel start time for a process when available."""
+    """Return the kernel start time for a process when available.
+
+    Linux: read field 22 of ``/proc/<pid>/stat`` (clock ticks since boot).
+
+    macOS / BSD (no procfs): fall back to ``ps -p <pid> -o lstart=`` and
+    convert the wall-clock timestamp to an epoch integer.  Without this
+    fallback every gateway lock on macOS records ``start_time=null`` and
+    the PID-reuse guard never activates -- see #21613.
+    """
     stat_path = Path(f"/proc/{pid}/stat")
     try:
         # Field 22 in /proc/<pid>/stat is process start time (clock ticks).
         return int(stat_path.read_text(encoding="utf-8").split()[21])
     except (FileNotFoundError, IndexError, PermissionError, ValueError, OSError):
-        return None
+        pass
+
+    try:
+        import subprocess
+        from datetime import datetime
+        out = subprocess.check_output(
+            ["ps", "-p", str(pid), "-o", "lstart="],
+            stderr=subprocess.DEVNULL,
+            text=True,
+            timeout=2,
+        ).strip()
+        if out:
+            normalized = " ".join(out.split())
+            dt = datetime.strptime(normalized, "%a %b %d %H:%M:%S %Y")
+            return int(dt.timestamp())
+    except (FileNotFoundError, subprocess.SubprocessError, ValueError, OSError):
+        pass
+
+    return None
 
 
 def get_process_start_time(pid: int) -> Optional[int]:

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -787,3 +787,67 @@ class TestPlannedStopMarker:
         ok = status.write_planned_stop_marker(target_pid=12345)
 
         assert ok is False
+
+
+class TestGetProcessStartTime:
+    """Cross-platform PID start-time lookup (regression for #21613).
+
+    macOS / BSD have no /proc filesystem, so the original Linux-only
+    implementation always returned None there.  That made every gateway lock
+    record ``start_time=null`` and disabled the PID-reuse guard, so a stale
+    Telegram bot lock could permanently block a fresh gateway from starting.
+    """
+
+    def test_linux_proc_path_returns_field_22(self, monkeypatch):
+        fields = ["0"] * 52
+        fields[21] = "987654321"
+        proc_line = " ".join(fields)
+
+        def fake_read_text(self, *args, **kwargs):
+            if str(self).startswith("/proc/"):
+                return proc_line
+            raise FileNotFoundError(self)
+
+        monkeypatch.setattr(Path, "read_text", fake_read_text)
+
+        assert status._get_process_start_time(4321) == 987654321
+
+    def test_macos_falls_back_to_ps_lstart(self, monkeypatch):
+        def raise_not_found(self, *args, **kwargs):
+            raise FileNotFoundError(self)
+
+        monkeypatch.setattr(Path, "read_text", raise_not_found)
+
+        captured = {}
+
+        def fake_check_output(cmd, **kwargs):
+            captured["cmd"] = cmd
+            return "Fri May  9 10:23:45 2026\n"
+
+        import subprocess as _subprocess
+        monkeypatch.setattr(_subprocess, "check_output", fake_check_output)
+
+        from datetime import datetime
+        expected = int(datetime.strptime(
+            "Fri May 9 10:23:45 2026", "%a %b %d %H:%M:%S %Y"
+        ).timestamp())
+
+        result = status._get_process_start_time(4321)
+
+        assert result == expected
+        assert captured["cmd"] == ["ps", "-p", "4321", "-o", "lstart="]
+
+    def test_returns_none_when_proc_and_ps_both_fail(self, monkeypatch):
+        def raise_not_found(self, *args, **kwargs):
+            raise FileNotFoundError(self)
+
+        monkeypatch.setattr(Path, "read_text", raise_not_found)
+
+        import subprocess as _subprocess
+
+        def raise_called_process(*args, **kwargs):
+            raise _subprocess.CalledProcessError(1, args[0])
+
+        monkeypatch.setattr(_subprocess, "check_output", raise_called_process)
+
+        assert status._get_process_start_time(4321) is None


### PR DESCRIPTION
## Summary
On macOS / BSD there is no `/proc` filesystem, so the original Linux-only implementation of `_get_process_start_time` always returned `None`.  That made every gateway lock record `start_time=null` and disabled the PID-reuse guard, so a stale Telegram bot lock could permanently block a fresh gateway from starting.

Add a portable fallback: when the `/proc` read fails, shell out to `ps -p <pid> -o lstart=` and convert the wall-clock timestamp to an epoch integer.  Linux behaviour is unchanged.

Unit divergence (clock ticks vs epoch seconds) is acceptable because `start_time` is only ever compared for equality against itself on the same host.

Closes #21613

## Test plan
- [x] New regression tests in `tests/gateway/test_status.py::TestGetProcessStartTime` cover Linux `/proc` path, macOS `ps` fallback, and both-paths-fail returning `None`
- [x] Stash-verified: macOS fallback test fails on baseline, passes with the fix
- [x] Full `tests/gateway/test_status.py` suite: 45 passed (one unrelated flaky timeout in `TestPlannedStopMarker` clears on retry)