### PR TITLE
feat(gateway): cleanup_progress polish — single bubble, commentary, approval, cross-restart

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2759,7 +2759,14 @@ class BasePlatformAdapter(ABC):
 
             # Default behavior for non-photo follow-ups: interrupt the running agent
             logger.debug("[%s] New message while session %s is active — triggering interrupt", self.name, session_key)
-            self._pending_messages[session_key] = event
+            # Merge text follow-ups so simultaneous queued user messages
+            # don't clobber each other.  Falls back to overwrite for non-text.
+            if event.message_type == MessageType.TEXT:
+                merge_pending_message_event(
+                    self._pending_messages, session_key, event, merge_text=True
+                )
+            else:
+                self._pending_messages[session_key] = event
             # Signal the interrupt (the processing task checks this)
             self._active_sessions[session_key].set()
             return  # Don't process now - will be handled after current task finishes

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1148,6 +1148,26 @@ class GatewayRunner:
         self._pending_native_image_paths_by_session: Dict[str, List[str]] = {}
         self._busy_ack_ts: Dict[str, float] = {}  # last busy-ack timestamp per session (debounce)
         self._session_run_generation: Dict[str, int] = {}
+        # Per-session message IDs that need to be cleaned at the start of
+        # the next turn for that session.  Used by ``cleanup_progress`` to
+        # delete the "⚠️ Gateway shutting down" notice across the gateway
+        # restart boundary — the cleanup path normally fires on final
+        # response delivery, which doesn't happen for an interrupted run.
+        # Loaded from disk on init so notices survive the restart and get
+        # removed when the user sends their next message.
+        self._cross_restart_cleanup_path = _hermes_home / ".cross_restart_cleanup.json"
+        self._cross_restart_cleanup: Dict[str, List[Dict[str, Any]]] = {}
+        try:
+            if self._cross_restart_cleanup_path.exists():
+                import json as _json
+                self._cross_restart_cleanup = _json.loads(
+                    self._cross_restart_cleanup_path.read_text(encoding="utf-8")
+                ) or {}
+                if not isinstance(self._cross_restart_cleanup, dict):
+                    self._cross_restart_cleanup = {}
+        except Exception as _e:
+            logger.debug("Failed to load cross-restart cleanup file: %s", _e)
+            self._cross_restart_cleanup = {}
         # LRU cache of live SessionSources keyed by session_key. Used by
         # fallback routing paths (shutdown notifications, synthetic
         # background-process events) when the persisted origin is missing
@@ -2720,6 +2740,21 @@ class GatewayRunner:
                     )
                     continue
 
+                # Register the notice for cleanup_progress on the next turn.
+                # The agent was interrupted, so the normal end-of-turn cleanup
+                # didn't fire — persist the id and drain it when the user
+                # comes back and starts a fresh turn for this session.
+                try:
+                    _mid = getattr(result, "message_id", None) if result is not None else None
+                    if _mid:
+                        self._cross_restart_cleanup.setdefault(session_key, []).append({
+                            "chat_id": str(chat_id),
+                            "message_id": str(_mid),
+                            "platform": platform_str,
+                        })
+                except Exception as _reg_err:
+                    logger.debug("shutdown-notice cleanup registration failed: %s", _reg_err)
+
                 notified.add(dedup_key)
                 logger.info(
                     "Sent shutdown notification to active chat %s:%s",
@@ -2781,6 +2816,18 @@ class GatewayRunner:
                     home.chat_id,
                     e,
                 )
+
+        # Persist the cross-restart cleanup ledger so notice IDs survive the
+        # gateway-restart boundary.  Drained on next inbound message for the
+        # session — see _handle_message_with_agent.
+        try:
+            import json as _json
+            self._cross_restart_cleanup_path.write_text(
+                _json.dumps(self._cross_restart_cleanup),
+                encoding="utf-8",
+            )
+        except Exception as _wp:
+            logger.debug("Failed to persist cross-restart cleanup file: %s", _wp)
 
     def _finalize_shutdown_agents(self, active_agents: Dict[str, Any]) -> None:
         for agent in active_agents.values():
@@ -13510,6 +13557,29 @@ class GatewayRunner:
             _cleanup_progress = False
             _cleanup_adapter = None
         _cleanup_msg_ids: List[str] = []
+        # Drain any cross-restart shutdown notices for this session so they
+        # get cleaned with this turn's other temporary bubbles.  No-op when
+        # cleanup_progress is disabled or the session has no pending IDs.
+        if _cleanup_progress and session_key:
+            try:
+                _persisted = self._cross_restart_cleanup.pop(session_key, [])
+                for _entry in _persisted:
+                    _mid = _entry.get("message_id") if isinstance(_entry, dict) else None
+                    if _mid:
+                        _cleanup_msg_ids.append(str(_mid))
+                if _persisted:
+                    # Persist the trimmed ledger so the same id isn't
+                    # re-deleted in a later turn.
+                    try:
+                        import json as _json
+                        self._cross_restart_cleanup_path.write_text(
+                            _json.dumps(self._cross_restart_cleanup),
+                            encoding="utf-8",
+                        )
+                    except Exception:
+                        pass
+            except Exception as _pe:
+                logger.debug("cross-restart cleanup drain failed: %s", _pe)
         # First-touch onboarding latch: fires at most once per run, even if
         # several tools exceed the threshold.
         long_tool_hint_fired = [False]

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2388,7 +2388,9 @@ class GatewayRunner:
         adapter = self.adapters.get(event.source.platform)
         if not adapter:
             return
-        merge_pending_message_event(adapter._pending_messages, session_key, event)
+        merge_pending_message_event(
+            adapter._pending_messages, session_key, event, merge_text=True
+        )
 
     async def _handle_active_session_busy_message(self, event: MessageEvent, session_key: str) -> bool:
         # --- Authorization gate (#17775) ---
@@ -2470,8 +2472,14 @@ class GatewayRunner:
         # current run finishes (or is interrupted).  Skip this for a
         # successful steer — the text already landed inside the run and
         # must NOT also be replayed as a next-turn user message.
+        # ``merge_text=True`` matches the rapid-follow-up path in
+        # _handle_message (5620/5640) so two text messages queued during
+        # the same busy turn append instead of the later one clobbering
+        # the earlier — preserves user intent in queue mode.
         if not steered:
-            merge_pending_message_event(adapter._pending_messages, session_key, event)
+            merge_pending_message_event(
+                adapter._pending_messages, session_key, event, merge_text=True
+            )
 
         is_queue_mode = effective_mode == "queue"
         is_steer_mode = effective_mode == "steer"

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13718,6 +13718,16 @@ class GatewayRunner:
                         # order. Mirrors GatewayStreamConsumer.on_segment_break
                         # on the content side. (Issue: tool + content
                         # linearization regression after PR #7885.)
+                        #
+                        # Skip the reset when ``cleanup_progress`` is on: every
+                        # progress / commentary / status line will be deleted
+                        # at end-of-turn anyway, so out-of-order linearization
+                        # is invisible to the user.  Keeping a single growing
+                        # bubble is the cleaner UX in this mode — one chat
+                        # entry that updates in place instead of N stranded
+                        # bubbles between content streams.
+                        if _cleanup_progress:
+                            continue
                         progress_msg_id = None
                         progress_lines = []
                         last_progress_msg[0] = None
@@ -14064,6 +14074,15 @@ class GatewayRunner:
                             def _stream_delta_cb(text: str) -> None:
                                 if _run_still_current():
                                     _stream_consumer.on_delta(text)
+                        # cleanup_progress + single-bubble: route commentary
+                        # into the tool-progress queue so commentary lands in
+                        # the same bubble that gets deleted at end of turn.
+                        # The italics + 💭 prefix keeps commentary visually
+                        # distinct from tool lines while sharing the bubble.
+                        if _cleanup_progress and progress_queue is not None:
+                            def _commentary_to_queue(_text: str) -> None:
+                                progress_queue.put(f"💭 _{_text}_")
+                            _stream_consumer.set_commentary_redirect(_commentary_to_queue)
                         stream_consumer_holder[0] = _stream_consumer
                 except Exception as _sc_err:
                     logger.debug("Could not set up stream consumer: %s", _sc_err)
@@ -15287,6 +15306,17 @@ class GatewayRunner:
                     _previewed,
                 )
                 response["already_sent"] = True
+
+        # Pull in commentary bubble IDs from the stream consumer so they get
+        # deleted alongside tool progress / "Still working..." / status calls.
+        # Without this, mid-tool-loop commentary like "DuckDuckGo blocked,
+        # trying Wikipedia." persists past cleanup_progress and clutters the
+        # chat after the final response lands.
+        if _cleanup_progress and _sc is not None:
+            try:
+                _cleanup_msg_ids.extend(_sc.commentary_message_ids)
+            except Exception as _ce:
+                logger.debug("commentary id capture failed: %s", _ce)
 
         # Schedule deletion of tracked temporary progress bubbles after the
         # final response lands. Failed runs skip this so bubbles remain as

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14361,6 +14361,19 @@ class GatewayRunner:
                             _loop_for_step,
                         ).result(timeout=15)
                         if _approval_result.success:
+                            # Register the approval bubble (the prompt + the
+                            # subsequent edit-in-place "✅ Approved …" ack) for
+                            # cleanup_progress deletion so the chat doesn't
+                            # accumulate "Approved permanently by …" lines
+                            # after every dangerous-command ask.  The message
+                            # is edited in place when resolved, so a single
+                            # message_id covers both states.
+                            try:
+                                _ap_mid = getattr(_approval_result, "message_id", None)
+                                if _cleanup_progress and _ap_mid:
+                                    _cleanup_msg_ids.append(str(_ap_mid))
+                            except Exception:
+                                pass
                             return
                         logger.warning(
                             "Button-based approval failed (send returned error), falling back to text: %s",

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13671,15 +13671,29 @@ class GatewayRunner:
             # "all" / "new" modes: short preview, respects tool_preview_length
             # config (defaults to 40 chars when unset to keep gateway messages
             # compact — unlike CLI spinners, these persist as permanent messages).
+            #
+            # Wrap the tool descriptor in inline-code backticks under
+            # ``cleanup_progress`` so the system-process portion renders in
+            # monospace on platforms that honour Markdown — visually marks
+            # tool activity as distinct from the model's natural reply.
+            # Backticks inside *preview* would close the inline-code span;
+            # swap them for single quotes first so the bubble stays valid.
             if preview:
                 from agent.display import get_tool_preview_max_len
                 _pl = get_tool_preview_max_len()
                 _cap = _pl if _pl > 0 else 40
                 if len(preview) > _cap:
                     preview = preview[:_cap - 3] + "..."
-                msg = f"{emoji} {tool_name}: \"{preview}\""
+                if _cleanup_progress:
+                    _safe_preview = preview.replace("`", "'")
+                    msg = f"{emoji} `{tool_name}: \"{_safe_preview}\"`"
+                else:
+                    msg = f"{emoji} {tool_name}: \"{preview}\""
             else:
-                msg = f"{emoji} {tool_name}..."
+                msg = (
+                    f"{emoji} `{tool_name}...`" if _cleanup_progress
+                    else f"{emoji} {tool_name}..."
+                )
             
             # Dedup: collapse consecutive identical progress messages.
             # Common with execute_code where models iterate with the same

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -21,7 +21,7 @@ import queue
 import re
 import time
 from dataclasses import dataclass
-from typing import Any, Optional
+from typing import Any, Callable, List, Optional
 
 logger = logging.getLogger("gateway.stream_consumer")
 
@@ -115,6 +115,19 @@ class GatewayStreamConsumer:
         # openclaw/openclaw#72038.
         self._message_created_ts: Optional[float] = None
         self._already_sent = False
+        # Message IDs of interim assistant commentary bubbles sent during
+        # this stream.  Exposed via :pyattr:`commentary_message_ids` so the
+        # gateway can include them in ``cleanup_progress`` deletion at end
+        # of turn.  Without this, mid-tool-loop commentary like
+        # "DuckDuckGo blocked, trying Wikipedia." leaks past cleanup.
+        self._commentary_msg_ids: List[str] = []
+        # Optional sink for commentary text.  When set by the gateway (in
+        # ``cleanup_progress`` mode), ``_send_commentary`` calls this with
+        # the cleaned text instead of sending a separate platform message,
+        # so commentary lands inside the same single tool-progress bubble.
+        # Falls back to the normal adapter.send path on exception or when
+        # unset.
+        self._commentary_redirect: Optional[Callable[[str], None]] = None
         self._edit_supported = True  # Disabled when progressive edits are no longer usable
         self._last_edit_time = 0.0
         self._last_sent_text = ""   # Track last-sent text to skip redundant edits
@@ -145,6 +158,26 @@ class GatewayStreamConsumer:
     def final_response_sent(self) -> bool:
         """True when the stream consumer delivered the final assistant reply."""
         return self._final_response_sent
+
+    @property
+    def commentary_message_ids(self) -> List[str]:
+        """IDs of interim commentary messages sent during this stream.
+
+        Consumed by the gateway's ``cleanup_progress`` path so commentary
+        bubbles are deleted alongside tool progress when the final response
+        lands.  Returns a copy so callers can mutate freely.
+        """
+        return list(self._commentary_msg_ids)
+
+    def set_commentary_redirect(self, redirect: Optional[Callable[[str], None]]) -> None:
+        """Route commentary text to *redirect* instead of a separate send.
+
+        When set, ``_send_commentary`` invokes the callback with the cleaned
+        commentary text and skips the platform send entirely.  Used by the
+        gateway in single-bubble mode (``cleanup_progress``) so commentary
+        appends into the tool-progress bubble rather than spawning its own.
+        """
+        self._commentary_redirect = redirect
 
     def on_segment_break(self) -> None:
         """Finalize the current stream segment and start a fresh message."""
@@ -758,6 +791,18 @@ class GatewayStreamConsumer:
         text = self._clean_for_display(text)
         if not text.strip():
             return False
+        # Single-bubble redirect: when ``cleanup_progress`` is on the gateway
+        # routes commentary into the tool-progress queue so all ephemeral
+        # chatter shares one bubble.  Returns True without a platform send.
+        # Exceptions in the redirect fall through to the normal send path.
+        if self._commentary_redirect is not None:
+            try:
+                self._commentary_redirect(text.strip())
+                return True
+            except Exception as exc:
+                logger.debug(
+                    "commentary redirect failed, falling back to send: %s", exc,
+                )
         try:
             result = await self.adapter.send(
                 chat_id=self.chat_id,
@@ -774,6 +819,8 @@ class GatewayStreamConsumer:
                 # stale tool bubble above it so the next tool starts a
                 # new bubble below.
                 self._notify_new_message()
+                if result.message_id:
+                    self._commentary_msg_ids.append(str(result.message_id))
             return result.success
         except Exception as e:
             logger.error("Commentary send error: %s", e)

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -552,3 +552,46 @@ class TestBusySessionOnboardingHint:
         assert "/busy interrupt" in content
         # Must NOT tell the user to /busy queue when they're already on queue.
         assert "/busy queue" not in content
+
+    @pytest.mark.asyncio
+    async def test_queue_mode_appends_text_messages(self, tmp_path, monkeypatch):
+        """Two queued text messages must append, not overwrite each other.
+
+        Regression: ``_handle_active_session_busy_message`` previously called
+        ``merge_pending_message_event`` without ``merge_text=True``, so the
+        second message in queue mode silently clobbered the first — losing
+        user intent.  See run.py site near the "Store the message so it's
+        processed as the next turn" comment.
+        """
+        import gateway.run as _gr
+
+        monkeypatch.setattr(_gr, "_hermes_home", tmp_path)
+        monkeypatch.setattr(_gr, "_load_gateway_config", lambda: {})
+
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "queue"
+        adapter = _make_adapter()
+
+        first = _make_event(text="search the web")
+        # Reuse the first event's source so both events route to the same
+        # adapter slot (the runner.adapters dict is keyed on source.platform,
+        # which is a MagicMock instance — different MagicMock per _make_event
+        # would land in separate adapter slots).
+        second = MessageEvent(
+            text="and tell me about KOOMPI OS",
+            message_type=MessageType.TEXT,
+            source=first.source,
+            message_id="msg2",
+        )
+        sk = build_session_key(first.source)
+
+        runner.adapters[first.source.platform] = adapter
+        runner._running_agents[sk] = MagicMock()
+
+        await runner._handle_active_session_busy_message(first, sk)
+        await runner._handle_active_session_busy_message(second, sk)
+
+        pending = adapter._pending_messages.get(sk)
+        assert pending is not None, "queued event should exist"
+        assert "search the web" in pending.text
+        assert "and tell me about KOOMPI OS" in pending.text

--- a/tests/gateway/test_run_cleanup_progress.py
+++ b/tests/gateway/test_run_cleanup_progress.py
@@ -365,3 +365,102 @@ async def test_cleanup_chains_with_existing_callback(monkeypatch, tmp_path):
     # deletes at least one progress bubble.
     assert pre_existing_fired == [True]
     assert len(adapter.deleted) >= 1
+
+
+@pytest.mark.asyncio
+async def test_cleanup_includes_cross_restart_persisted_ids(monkeypatch, tmp_path):
+    """Cross-restart shutdown notice ids drain into the next turn's cleanup.
+
+    When a turn is interrupted by gateway shutdown, the in-memory
+    cleanup_msg_ids never makes it to the cleanup callback.  The notice id
+    is persisted to ~/.hermes/.cross_restart_cleanup.json on shutdown and
+    must be drained at the start of the next turn so cleanup_progress
+    deletes the now-stale notice.
+    """
+    adapter = CleanupCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = _install_fakes(monkeypatch, ProgressAgent, cleanup_on=True)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    source = SessionSource(platform=Platform.TELEGRAM, chat_id="-1001")
+    session_key = "agent:main:telegram:group:-1001"
+
+    # Pre-seed a persisted shutdown notice id, mimicking the state after
+    # _notify_active_sessions_of_shutdown has run.
+    runner._cross_restart_cleanup_path = tmp_path / ".cross_restart_cleanup.json"
+    runner._cross_restart_cleanup = {
+        session_key: [
+            {"chat_id": "-1001", "message_id": "9999", "platform": "telegram"}
+        ]
+    }
+
+    result = await runner._run_agent(
+        message="hello",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-1",
+        session_key=session_key,
+    )
+
+    assert result["final_response"] == "done"
+    cb = adapter.pop_post_delivery_callback(session_key)
+    assert callable(cb)
+    cb()
+    for _ in range(20):
+        await asyncio.sleep(0.01)
+        if any(d["message_id"] == "9999" for d in adapter.deleted):
+            break
+
+    # The persisted shutdown-notice id was deleted alongside the
+    # in-turn tool-progress bubble.
+    deleted_ids = [d["message_id"] for d in adapter.deleted]
+    assert "9999" in deleted_ids, f"persisted notice not cleaned: deleted={deleted_ids}"
+    # The in-memory ledger was popped so the same id isn't re-deleted next turn.
+    assert session_key not in runner._cross_restart_cleanup
+
+
+@pytest.mark.asyncio
+async def test_progress_lines_use_inline_code_when_cleanup_on(monkeypatch, tmp_path):
+    """With cleanup_progress on, tool-progress lines wrap the descriptor in
+    backticks so the system-process portion renders in monospace.
+
+    Off → plain text, preserves legacy formatting.
+    """
+    # Cleanup on → expect backticks
+    adapter_on = CleanupCaptureAdapter()
+    runner_on = _make_runner(adapter_on)
+    gateway_run = _install_fakes(monkeypatch, ProgressAgent, cleanup_on=True)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    src = SessionSource(platform=Platform.TELEGRAM, chat_id="-1001")
+    await runner_on._run_agent(
+        message="hi", context_prompt="", history=[], source=src,
+        session_id="sess-1", session_key="agent:main:telegram:group:-1001",
+    )
+
+    on_payload = "\n".join(
+        s["content"] for s in adapter_on.sent if isinstance(s["content"], str)
+    ) + "\n".join(
+        e["content"] for e in adapter_on.edits if isinstance(e["content"], str)
+    )
+    assert "`terminal:" in on_payload, f"expected backtick-wrapped tool line, got:\n{on_payload}"
+
+    # Cleanup off → expect plain text (no backticks around descriptor)
+    adapter_off = CleanupCaptureAdapter()
+    runner_off = _make_runner(adapter_off)
+    gateway_run = _install_fakes(monkeypatch, ProgressAgent, cleanup_on=False)
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+
+    await runner_off._run_agent(
+        message="hi", context_prompt="", history=[], source=src,
+        session_id="sess-1", session_key="agent:main:telegram:group:-1001",
+    )
+
+    off_payload = "\n".join(
+        s["content"] for s in adapter_off.sent if isinstance(s["content"], str)
+    ) + "\n".join(
+        e["content"] for e in adapter_off.edits if isinstance(e["content"], str)
+    )
+    assert "terminal: \"pwd\"" in off_payload
+    assert "`terminal:" not in off_payload

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -1493,3 +1493,63 @@ class TestOnNewMessageCallback:
         await consumer.run()
 
         assert consumer.already_sent is True
+
+
+class TestCommentaryRedirectAndCleanup:
+    """commentary_message_ids + set_commentary_redirect surface area."""
+
+    @pytest.mark.asyncio
+    async def test_commentary_message_ids_capture_send(self):
+        """When commentary is sent normally, its id is recorded for cleanup."""
+        adapter = MagicMock()
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="cm_1"))
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        consumer = GatewayStreamConsumer(adapter, "chat", StreamConsumerConfig())
+        ok = await consumer._send_commentary("looking up the docs")
+
+        assert ok is True
+        assert consumer.commentary_message_ids == ["cm_1"]
+        # Defensive copy: mutation by callers doesn't affect internal state.
+        consumer.commentary_message_ids.append("hijack")
+        assert consumer.commentary_message_ids == ["cm_1"]
+
+    @pytest.mark.asyncio
+    async def test_commentary_redirect_skips_adapter_send(self):
+        """When a redirect is set, the adapter is not called."""
+        adapter = MagicMock()
+        adapter.send = AsyncMock()  # would record any call
+
+        consumer = GatewayStreamConsumer(adapter, "chat", StreamConsumerConfig())
+        captured: list = []
+        consumer.set_commentary_redirect(captured.append)
+
+        ok = await consumer._send_commentary("looking up the docs")
+
+        assert ok is True
+        assert captured == ["looking up the docs"]
+        adapter.send.assert_not_called()
+        # Redirect path doesn't populate the cleanup list — there's no
+        # adapter message to delete.
+        assert consumer.commentary_message_ids == []
+
+    @pytest.mark.asyncio
+    async def test_commentary_redirect_exception_falls_back_to_send(self):
+        """If the redirect raises, we fall back to a normal adapter.send."""
+        adapter = MagicMock()
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="cm_2"))
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        consumer = GatewayStreamConsumer(adapter, "chat", StreamConsumerConfig())
+
+        def boom(_text: str) -> None:
+            raise RuntimeError("redirect crashed")
+
+        consumer.set_commentary_redirect(boom)
+
+        ok = await consumer._send_commentary("looking up the docs")
+
+        assert ok is True
+        adapter.send.assert_awaited_once()
+        # Fallback send populates the cleanup list as usual.
+        assert consumer.commentary_message_ids == ["cm_2"]


### PR DESCRIPTION
## Summary

Builds on #21186's `cleanup_progress` foundation to fix the remaining ways the gateway leaks ephemeral chat noise into Telegram group conversations during/after a multi-tool run. Also fixes an unrelated queue-mode bug we found while exercising the same code path.

When `display.platforms.<plat>.cleanup_progress: true`, the chat now ends a turn with **only the user's prompt + the model's final answer** — no surviving "Approved permanently", "DuckDuckGo blocked, trying Wikipedia", "⚠️ Gateway shutting down", or stranded tool-progress bubbles between content streams.

## Commits (each addresses one concern)

1. `fix(gateway): preserve queued text messages in busy_input_mode=queue` — three call sites passed queued events to `merge_pending_message_event` without `merge_text=True`, so a second text message during a busy turn silently overwrote the first. Aligns with the rapid-follow-up paths in `_handle_message` that already pass `merge_text=True`.

2. `feat(stream_consumer): expose commentary_message_ids + redirect hook` — captures every successful `_send_commentary` id in `_commentary_msg_ids`, surfaced via a `commentary_message_ids` property. Adds `set_commentary_redirect(callback)` so callers can route commentary text to a sink instead of a separate platform send.

3. `feat(gateway): coalesce ephemeral chatter into one bubble under cleanup_progress` — when the flag is on:
   - The `__reset__` close-the-bubble marker is skipped so all tool calls accumulate in **one growing bubble** for the whole turn (out-of-order linearization is invisible since the bubble is deleted at end-of-turn).
   - Stream-consumer commentary is redirected into the same progress queue (italics + 💭 prefix), so AI mid-tool thoughts share the bubble.
   - Stream-consumer's `commentary_message_ids` is unioned into `_cleanup_msg_ids` as a safety net for cases where redirect isn't wired.

4. `feat(gateway): include approval ack in cleanup_progress` — registers the inline-keyboard approval bubble's id with `_cleanup_msg_ids` after `send_exec_approval` succeeds. The button resolution edits the message in place ("✅ Approved permanently by …"), so a single id covers both the prompt and the resolved ack.

5. `feat(gateway): persist shutdown notices for cleanup across gateway restart` — the in-memory cleanup never fires for an interrupted run, so "⚠️ Gateway shutting down" survives restarts. After each successful notice send, persists `(session_key, chat_id, message_id, platform)` to `~/.hermes/.cross_restart_cleanup.json` and drains the matching session_key into `_cleanup_msg_ids` at the start of the next turn. No-op when `cleanup_progress` is off.

6. `feat(gateway): mono-format tool progress lines under cleanup_progress` — wraps the tool descriptor in inline-code backticks when the flag is on so the system-process portion renders monospace on platforms that honour Markdown. Backticks inside the preview are swapped for single quotes to keep the inline-code span valid. Plain-text format unchanged when the flag is off — default behaviour preserved.

7. `test(gateway): cover commentary redirect, cross-restart cleanup, mono format` — three new test classes exercising the additions:
   - `TestCommentaryRedirectAndCleanup`: capture-on-send, redirect-skips-send, redirect-exception-fallback.
   - `test_cleanup_includes_cross_restart_persisted_ids`: pre-seeds the ledger, asserts the persisted notice id is deleted alongside in-turn bubbles and popped from the ledger.
   - `test_progress_lines_use_inline_code_when_cleanup_on`: backtick wrapping when on, plain text when off.
   - Plus a regression test in `test_busy_session_ack.py` for the queue-merge fix.

## Default behaviour

Every change is gated on the existing `cleanup_progress` flag (or, for the queue-merge fix, on `merge_text=True` which is already the de-facto contract for the rapid-follow-up paths). With `cleanup_progress: false` (the default), nothing changes from current `main`.

## Test plan

- [x] 163 tests pass across `test_stream_consumer.py`, `test_run_cleanup_progress.py`, `test_busy_session_ack.py`, `test_post_delivery_callback_chaining.py`, `test_telegram_approval_buttons.py`, `test_display_config.py`.
- [x] No new test failures in the broader `tests/gateway/` suite (some flakiness in `test_approve_deny_commands.py::TestBlockingApprovalE2E` reproduces on clean `main` and is pre-existing).
- [x] Manual end-to-end: ran the gateway on Telegram with `cleanup_progress: true` and `busy_input_mode: queue`. Multi-tool runs produce one growing bubble that disappears with the final answer; queued follow-ups append rather than overwriting; gateway restarts no longer leave shutdown spam.

## Notes

- The `.cross_restart_cleanup.json` file is created next to other gateway state in `~/.hermes/`. Safe to delete; the gateway recreates it on next shutdown.
- No public API removed. `set_commentary_redirect` and `commentary_message_ids` are additive.