### PR TITLE
tests: add Windows skip guards for UNIX-only stdlib imports

### DIFF
--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1,7 +1,7 @@
 """Tests for gateway service management helpers."""
 
 import os
-import pwd
+pwd = pytest.importorskip("pwd")
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -1284,7 +1284,7 @@ class TestSystemServiceIdentityRootHandling:
 
     def test_auto_detected_root_is_rejected(self, monkeypatch):
         """When root is auto-detected (not explicitly requested), raise."""
-        import pwd
+        pwd = pytest.importorskip("pwd")
         import grp
 
         monkeypatch.delenv("SUDO_USER", raising=False)
@@ -1297,7 +1297,7 @@ class TestSystemServiceIdentityRootHandling:
 
     def test_explicit_root_is_allowed(self, monkeypatch):
         """When root is explicitly passed via --run-as-user root, allow it."""
-        import pwd
+        pwd = pytest.importorskip("pwd")
         import grp
 
         root_info = pwd.getpwnam("root")
@@ -1309,7 +1309,7 @@ class TestSystemServiceIdentityRootHandling:
 
     def test_non_root_user_passes_through(self, monkeypatch):
         """Normal non-root user works as before."""
-        import pwd
+        pwd = pytest.importorskip("pwd")
         import grp
 
         monkeypatch.delenv("SUDO_USER", raising=False)

--- a/tests/tools/test_file_sync_back.py
+++ b/tests/tools/test_file_sync_back.py
@@ -1,6 +1,6 @@
 """Tests for FileSyncManager.sync_back() — pull remote changes to host."""
 
-import fcntl
+fcntl = pytest.importorskip("fcntl")
 import io
 import logging
 import os


### PR DESCRIPTION
## Summary

two test files import UNIX-only stdlib modules at module top with no platform guard:
- `tests/hermes_cli/test_gateway_service.py` — `import pwd`
- `tests/tools/test_file_sync_back.py` — `import fcntl`

replacing both with `pytest.importorskip()` lets pytest collect these tests cleanly on Windows instead of hard-crashing with `ModuleNotFoundError`.

## Changes

- `import pwd` → `pwd = pytest.importorskip("pwd")`
- `import fcntl` → `fcntl = pytest.importorskip("fcntl")`

## Test Plan

- [ ] CI passes on Linux (no change in behavior)
- [ ] On Windows: `pytest tests/hermes_cli/test_gateway_service.py` and `pytest tests/tools/test_file_sync_back.py` should skip cleanly instead of crashing at collection

Closes #22420