### PR TITLE
fix(title-generator): strip <think>/<reasoning> blocks before saving session title

### DIFF
--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -8,7 +8,7 @@ import logging
 import threading
 from typing import Callable, Optional
 
-from agent.auxiliary_client import call_llm
+from agent.auxiliary_client import call_llm, extract_content_or_reasoning
 
 logger = logging.getLogger(__name__)
 
@@ -62,7 +62,10 @@ def generate_title(
             timeout=timeout,
             main_runtime=main_runtime,
         )
-        title = (response.choices[0].message.content or "").strip()
+        # Strip inline <think>/<reasoning> blocks before titling — thinking
+        # models (MiniMax-M2.7, DeepSeek-R1, Qwen-QwQ) embed reasoning in
+        # message.content and would otherwise leak into the saved title.
+        title = extract_content_or_reasoning(response).strip()
         # Clean up: remove quotes, trailing punctuation, prefixes like "Title: "
         title = title.strip('"\'')
         if title.lower().startswith("title:"):

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -113,6 +113,43 @@ class TestGenerateTitle:
         user_content = captured_kwargs["messages"][1]["content"]
         assert len(user_content) < 1100  # 500 + 500 + formatting
 
+    def test_strips_think_block_from_title(self):
+        """Thinking models embed <think>...</think> in content (issue #18529)."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = (
+            "<think>The user is asking about Docker. Let me think...</think>"
+            "Setting Up Docker Environment"
+        )
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            title = generate_title("docker setup", "first install...")
+            assert title == "Setting Up Docker Environment"
+
+    def test_strips_thinking_tag_variant(self):
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = (
+            "<thinking>reasoning leak</thinking>Kubernetes Pod Debugging"
+        )
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            title = generate_title("k8s issue", "let me check")
+            assert title == "Kubernetes Pod Debugging"
+
+    def test_falls_back_to_reasoning_field_when_content_empty(self):
+        """Reasoning models may put title in message.reasoning when content is empty."""
+        mock_response = MagicMock()
+        mock_response.choices = [MagicMock()]
+        mock_response.choices[0].message.content = ""
+        mock_response.choices[0].message.reasoning = "Reasoning Field Title"
+        mock_response.choices[0].message.reasoning_content = None
+        mock_response.choices[0].message.reasoning_details = None
+
+        with patch("agent.title_generator.call_llm", return_value=mock_response):
+            title = generate_title("q", "a")
+            assert title == "Reasoning Field Title"
+
 
 class TestAutoTitleSession:
     """Tests for auto_title_session() — the sync worker function."""


### PR DESCRIPTION
## Summary

- `agent/title_generator.py` now uses `extract_content_or_reasoning()` instead of reading `response.choices[0].message.content` directly. Thinking models (MiniMax-M2.7, DeepSeek-R1, Qwen-QwQ, etc.) embed `<think>...</think>` blocks in `content`; the helper strips them and also falls back to `message.reasoning*` fields when content is empty.
- 3 new regression tests in `tests/agent/test_title_generator.py` cover the `<think>` variant, the `<thinking>` variant, and the reasoning-field fallback.

Closes #18529.

## Why this is safe

- One-line behavior change reusing the same helper already used by session_search, vision, and web auxiliary callers (`agent/auxiliary_client.py:3907`).
- All 23 existing + new title_generator tests pass.
- Stash-verify: removing the fix causes the 3 new tests to fail with the exact bug-report symptom (raw `<think>` content leaking into the title).

## Test plan

- [x] `pytest tests/agent/test_title_generator.py -q` → 23 passed
- [x] Stash-verify: 3 regression tests fail without the fix, pass with it.