### PR TITLE
fix(cron): guard load_jobs against malformed jobs.json shapes

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -407,13 +407,24 @@ def load_jobs() -> List[Dict[str, Any]]:
     try:
         with open(JOBS_FILE, 'r', encoding='utf-8') as f:
             data = json.load(f)
-            return data.get("jobs", [])
+            if not isinstance(data, dict):
+                logger.warning(
+                    "jobs.json root is not a JSON object (got %s); returning empty job list",
+                    type(data).__name__,
+                )
+                return []
+            jobs = data.get("jobs", [])
+            return jobs if isinstance(jobs, list) else []
     except json.JSONDecodeError:
         # Retry with strict=False to handle bare control chars in string values
         try:
             with open(JOBS_FILE, 'r', encoding='utf-8') as f:
                 data = json.loads(f.read(), strict=False)
+                if not isinstance(data, dict):
+                    return []
                 jobs = data.get("jobs", [])
+                if not isinstance(jobs, list):
+                    return []
                 if jobs:
                     # Auto-repair: rewrite with proper escaping
                     save_jobs(jobs)

--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -421,9 +421,17 @@ def load_jobs() -> List[Dict[str, Any]]:
             with open(JOBS_FILE, 'r', encoding='utf-8') as f:
                 data = json.loads(f.read(), strict=False)
                 if not isinstance(data, dict):
+                    logger.warning(
+                        "jobs.json root is not a JSON object (got %s); returning empty job list",
+                        type(data).__name__,
+                    )
                     return []
                 jobs = data.get("jobs", [])
                 if not isinstance(jobs, list):
+                    logger.warning(
+                        "jobs.json 'jobs' field is not a list (got %s); returning empty job list",
+                        type(jobs).__name__,
+                    )
                     return []
                 if jobs:
                     # Auto-repair: rewrite with proper escaping

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -255,6 +255,32 @@ class TestJobCRUD:
         assert job["deliver"] == "local"
 
 
+class TestLoadJobsMalformedShapes:
+    """load_jobs must tolerate jobs.json files whose root is not a dict."""
+
+    @pytest.mark.parametrize("payload", [
+        "[]",
+        '[{"id": "x"}]',
+        "null",
+        '"oops"',
+        "42",
+        "true",
+    ])
+    def test_non_dict_root_returns_empty(self, tmp_cron_dir, payload):
+        jobs_file = tmp_cron_dir / "cron" / "jobs.json"
+        jobs_file.parent.mkdir(parents=True, exist_ok=True)
+        jobs_file.write_text(payload, encoding="utf-8")
+
+        assert load_jobs() == []
+
+    def test_jobs_value_not_a_list_returns_empty(self, tmp_cron_dir):
+        jobs_file = tmp_cron_dir / "cron" / "jobs.json"
+        jobs_file.parent.mkdir(parents=True, exist_ok=True)
+        jobs_file.write_text('{"jobs": "not-a-list"}', encoding="utf-8")
+
+        assert load_jobs() == []
+
+
 class TestUpdateJob:
     def test_update_name(self, tmp_cron_dir):
         job = create_job(prompt="Check server status", schedule="every 1h", name="Old Name")


### PR DESCRIPTION
## Problem

`cron.jobs.load_jobs` calls `data.get(\"jobs\", [])` immediately after `json.load(f)`, assuming the parsed root is always a dict. If `jobs.json` is hand-edited or written by a legacy release in any non-dict shape — a bare list (`[{\"id\": \"x\"}]`), `null`, a scalar, or a string — the call raises `AttributeError` because `data` has no `.get`.

The surrounding `except json.JSONDecodeError` does not catch this, so the error escapes `load_jobs` and corrupts every caller:

- `tools/cronjob_tools.py` (CRUD on cron jobs)
- `hermes_cli/web_server.py` (web UI listing/editing jobs)
- `hermes_cli/cron.py` (CLI listing/inspecting jobs)
- the cron scheduler loop, which silently aborts and stops firing all scheduled jobs.

A single corrupted file therefore disables the whole cron subsystem, not just the bad entry.

## Root cause

`load_jobs` trusts the JSON root shape without an `isinstance(data, dict)` guard. Both the fast path and the auto-repair retry path assume a dict.

## Fix

Add shape guards on both paths. If the parsed JSON is not a dict, log a warning and return \`[]\`. If \`data[\"jobs\"]\` is present but not a list, also return \`[]\`. Callers see a well-formed empty list and the rest of cron keeps running.

\`\`\`python
data = json.load(f)
if not isinstance(data, dict):
    logger.warning(
        \"jobs.json root is not a JSON object (got %s); returning empty job list\",
        type(data).__name__,
    )
    return []
jobs = data.get(\"jobs\", [])
return jobs if isinstance(jobs, list) else []
\`\`\`

## Tests

\`tests/cron/test_jobs.py::TestLoadJobsMalformedShapes\` covers six non-dict roots (\`[]\`, \`[{\"id\": \"x\"}]\`, \`null\`, \`\"oops\"\`, \`42\`, \`true\`) plus the case where \`jobs\` itself is a non-list value. All seven cases are red on main, green with the fix. Full regression on \`tests/cron/\`, \`tests/tools/test_cronjob_tools.py\`, and \`tests/test_timezone.py\`: 392 passed.

## Same bug class

Companion to the shape-guard fix in \`tools/process_registry\` (#22544): both call sites ingest user-influenced JSON and must not assume a particular root shape.