### PR TITLE
fix(agent): skip Ollama/GLM workaround for custom provider + fix stale drain timeout tip

### DIFF
--- a/hermes_cli/tips.py
+++ b/hermes_cli/tips.py
@@ -451,7 +451,7 @@ TIPS = [
     # --- Gateway Behavior Env Vars ---
     'HERMES_GATEWAY_BUSY_ACK_ENABLED=false silences the ⚡/⏳/⏩ ack messages when a user messages a busy agent.',
     'HERMES_AGENT_NOTIFY_INTERVAL (default 180s) sets how often the gateway pings with progress on long turns.',
-    'HERMES_RESTART_DRAIN_TIMEOUT (default 900s) caps how long /restart waits for in-flight runs before forcing.',
+    'HERMES_RESTART_DRAIN_TIMEOUT (default 180s) caps how long /restart waits for in-flight runs before forcing.',
     'HERMES_CHECKPOINT_TIMEOUT (default 30s) caps filesystem checkpoint creation — raise it on huge monorepos.',
 
     # --- Auxiliary Tasks & Image Generation ---

--- a/run_agent.py
+++ b/run_agent.py
@@ -3372,6 +3372,11 @@ class AIAgent:
 
     def _is_ollama_glm_backend(self) -> bool:
         """Detect the narrow backend family affected by Ollama/GLM stop misreports."""
+        # Explicit "custom" provider means the user pointed Hermes at their own
+        # proxy (LiteLLM, OpenAI-compatible gateway, etc.) — not raw Ollama.
+        # Skip the Ollama/GLM workaround to avoid false positives on private IPs.
+        if self.provider == "custom":
+            return False
         model_lower = (self.model or "").lower()
         provider_lower = (self.provider or "").lower()
         if "glm" not in model_lower and provider_lower != "zai":


### PR DESCRIPTION
## Changes

### 1. Skip Ollama/GLM workaround when provider is `"custom"` (`run_agent.py`)

`_is_ollama_glm_backend()` incorrectly returns `True` when the user configures `provider: "custom"` pointing to a LiteLLM proxy (or any OpenAI-compatible gateway) on a private IP with a GLM model name. The detection logic only checks:

1. `"glm"` in the model name → matches
2. `is_local_endpoint(base_url)` → matches any RFC-1918 private IP

It does **not** check whether the provider is explicitly set to `"custom"`.

**Impact:**
- Normal `finish_reason: "stop"` responses are treated as truncated
- Hermes retries continuations up to 3 times (160+ seconds per response)
- GLM models sometimes switch to Chinese during confused continuations
- Gateway restarts can crash with exit code 75 (TEMPFAIL) during these retry loops

### 2. Fix stale `HERMES_RESTART_DRAIN_TIMEOUT` tip (`tips.py`)

Tip said "default 900s" but the actual default in `config.py` is `180s`.

## Reproduction (bug 1)

```yaml
# config.yaml
model:
  default: glm-5.1
  provider: custom
  base_url: http://192.168.x.x:4000/v1  # LiteLLM proxy
```

Any response with tool calls in history triggers the false positive.

## Testing

- [x] Manually tested on live setup (LiteLLM proxy + GLM-5.1)
- [x] Gateway no longer crashes on restart
- [x] Responses no longer incorrectly continued as truncated
- [x] No Chinese output from continuation confusion