### PR TITLE
fix(gateway): expand ${VAR} env refs in _load_gateway_config()

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -875,8 +875,14 @@ def _load_gateway_config() -> dict:
     Uses the module-level ``_hermes_home`` (so tests that monkeypatch it
     still see their fixture) and shares the mtime-keyed raw-yaml cache
     from ``hermes_cli.config.read_raw_config`` when the paths match.
+
+    ``${VAR}`` references inside string values are expanded against the
+    process environment so callers (custom_providers base_url,
+    model resolution, hygiene worker, …) see fully-resolved values
+    instead of raw templates.
     """
     config_path = _hermes_home / 'config.yaml'
+    cfg: dict = {}
     try:
         from hermes_cli.config import get_config_path, read_raw_config
         # Fast path: if _hermes_home agrees with the canonical config
@@ -884,18 +890,28 @@ def _load_gateway_config() -> dict:
         # direct read (keeps test fixtures with a monkeypatched
         # _hermes_home working).
         if config_path == get_config_path():
-            return read_raw_config()
+            cfg = read_raw_config()
     except Exception:
-        pass
+        cfg = {}
+
+    if not cfg:
+        try:
+            if config_path.exists():
+                import yaml
+                with open(config_path, 'r', encoding='utf-8') as f:
+                    cfg = yaml.safe_load(f) or {}
+        except Exception:
+            logger.debug("Could not load gateway config from %s", config_path)
+            return {}
+
+    if not cfg:
+        return {}
 
     try:
-        if config_path.exists():
-            import yaml
-            with open(config_path, 'r', encoding='utf-8') as f:
-                return yaml.safe_load(f) or {}
+        from hermes_cli.config import _expand_env_vars
+        return _expand_env_vars(cfg)
     except Exception:
-        logger.debug("Could not load gateway config from %s", config_path)
-    return {}
+        return cfg
 
 
 def _resolve_gateway_model(config: dict | None = None) -> str:

--- a/tests/gateway/test_load_gateway_config_env_expand.py
+++ b/tests/gateway/test_load_gateway_config_env_expand.py
@@ -1,0 +1,95 @@
+"""Regression test for issue #21275.
+
+`gateway.run._load_gateway_config()` previously returned the raw YAML
+verbatim, so `${VAR}` placeholders inside `custom_providers.base_url`,
+model entries, etc. were never expanded. Callers down-stream
+(`get_compatible_custom_providers`, hygiene worker, context-length
+detection) then rejected the templated URLs as invalid.
+
+The fix runs `hermes_cli.config._expand_env_vars` on the loaded dict
+before returning.
+"""
+
+from pathlib import Path
+
+import pytest
+
+import gateway.run as gateway_run
+
+
+@pytest.fixture
+def fake_hermes_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point gateway.run at a throwaway HERMES_HOME with a config.yaml."""
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    return tmp_path
+
+
+def _write_config(home: Path, body: str) -> None:
+    (home / "config.yaml").write_text(body, encoding="utf-8")
+
+
+def test_env_vars_expanded_in_custom_providers_base_url(
+    fake_hermes_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ARC_BASE_URL", "https://arc.example.com/v1")
+    _write_config(
+        fake_hermes_home,
+        """
+custom_providers:
+  - name: arc
+    base_url: ${ARC_BASE_URL}
+""",
+    )
+
+    cfg = gateway_run._load_gateway_config()
+
+    providers = cfg.get("custom_providers")
+    assert isinstance(providers, list) and providers
+    assert providers[0]["base_url"] == "https://arc.example.com/v1"
+
+
+def test_env_vars_expanded_in_model_base_url(
+    fake_hermes_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ARC_BASE_URL", "https://arc.example.com/v1")
+    _write_config(
+        fake_hermes_home,
+        """
+model:
+  default: glm-5.1
+  base_url: ${ARC_BASE_URL}
+""",
+    )
+
+    cfg = gateway_run._load_gateway_config()
+
+    assert cfg["model"]["base_url"] == "https://arc.example.com/v1"
+
+
+def test_undefined_env_var_left_as_template(
+    fake_hermes_home: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """When the env var is unset, the placeholder must survive untouched
+    so downstream validation can emit a clear "missing env" error rather
+    than silently coercing it to an empty string."""
+    monkeypatch.delenv("UNDEFINED_VAR_FOR_TEST", raising=False)
+    _write_config(
+        fake_hermes_home,
+        """
+custom_providers:
+  - name: arc
+    base_url: ${UNDEFINED_VAR_FOR_TEST}
+""",
+    )
+
+    cfg = gateway_run._load_gateway_config()
+
+    assert cfg["custom_providers"][0]["base_url"] == "${UNDEFINED_VAR_FOR_TEST}"
+
+
+def test_missing_config_returns_empty_dict(fake_hermes_home: Path) -> None:
+    cfg = gateway_run._load_gateway_config()
+    assert cfg == {}


### PR DESCRIPTION
## Problem

Custom-provider entries in `~/.hermes/config.yaml` that use env-var templates
(e.g. `base_url: ${ARC_BASE_URL}`) fail URL validation with spurious
`'base_url' value '${ARC_BASE_URL}' is not a valid URL (no scheme or host) — skipped`
warnings and are silently dropped. `model.base_url` in the gateway hygiene
worker and the context-length probe also stays unexpanded, producing
`Could not detect context length for model … at ${ARC_BASE_URL}` log noise.

## Root cause

`gateway.run._load_gateway_config()` calls `hermes_cli.config.read_raw_config()`
(or the YAML fallback when `_hermes_home` is monkeypatched) and returns the
dict verbatim. `read_raw_config()` is intentionally raw — it backs save
round-trips that must preserve the original `${VAR}` templates on disk.

The two other gateway-startup config bridges in `gateway/run.py` (around
lines 340 and 362) already run `_expand_env_vars()` for exactly this reason,
but `_load_gateway_config` was missed when the bridges were factored out, so
every later caller (`get_compatible_custom_providers`, `_resolve_gateway_model`,
hygiene-worker config loads, context-length probe — ~15 call sites) saw the
unexpanded templates.

## Fix

After loading the raw dict, run `_expand_env_vars()` on the returned copy.
`read_raw_config()` already deep-copies before returning, so expanding the
result does not poison the save-round-trip cache.

Undefined env vars are left as-is by `_expand_env_vars()` (existing
behavior), so callers that validate URLs still surface "missing env" cases
clearly instead of seeing an empty string.

## Tests

`tests/gateway/test_load_gateway_config_env_expand.py`:
- `custom_providers.base_url` `${VAR}` expansion
- `model.base_url` `${VAR}` expansion
- undefined `${VAR}` kept verbatim (no silent collapse to `""`)
- missing `config.yaml` returns `{}`

Stash-verified: tests fail without the fix (placeholder survives raw),
pass with it. Adjacent config-suite (79 tests across `test_config.py`,
`test_config_env_bridge_authority.py`, `test_runtime_env_reload_config_authority.py`,
`test_model_command_custom_providers.py`) green.

Closes #21275