### PR TITLE
fix(model-metadata): align hy3-preview static context length with OpenRouter (#22268)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -210,8 +210,10 @@ DEFAULT_CONTEXT_LENGTHS = {
     "grok": 131072,             # catch-all (grok-beta, unknown grok-*)
     # Kimi
     "kimi": 262144,
-    # Tencent — Hy3 Preview (Hunyuan) with 256K context window
-    "hy3-preview": 256000,
+    # Tencent — Hy3 Preview (Hunyuan) with 256K context window.
+    # OpenRouter live metadata reports 262144 (256 * 1024); aligning the
+    # static fallback so cache and fallback agree (issue #22268).
+    "hy3-preview": 262144,
     # Nemotron — NVIDIA's open-weights series (128K context across all sizes)
     "nemotron": 131072,
     # Arcee

--- a/tests/hermes_cli/test_tencent_tokenhub_provider.py
+++ b/tests/hermes_cli/test_tencent_tokenhub_provider.py
@@ -309,7 +309,19 @@ class TestTencentTokenhubContextLength:
     def test_hy3_preview_context_length(self):
         from agent.model_metadata import get_model_context_length
         ctx = get_model_context_length("hy3-preview")
-        assert ctx == 256000
+        # OpenRouter live API returns 262144 (256 * 1024); static fallback
+        # tracks the same value so tests pass whether resolution comes from
+        # live cache or static table (issue #22268).
+        assert ctx == 262144
+
+    def test_hy3_preview_static_fallback_matches_live(self):
+        """Static DEFAULT_CONTEXT_LENGTHS entry must match OpenRouter live (issue #22268).
+
+        Pins the static value so this stays correct even when the live cache
+        is unavailable in test environments (CI without network).
+        """
+        from agent.model_metadata import DEFAULT_CONTEXT_LENGTHS
+        assert DEFAULT_CONTEXT_LENGTHS["hy3-preview"] == 262144
 
 
 # =============================================================================


### PR DESCRIPTION
## Problem
`test_hy3_preview_context_length` asserts `ctx == 256000`, but OpenRouter live metadata for `tencent/hy3-preview` reports `262144` (256 × 1024). The static `DEFAULT_CONTEXT_LENGTHS` fallback in `agent/model_metadata.py` held `256000`, so the assertion flipped depending on whether the live cache was warm. Closes #22268.

## Root cause
`DEFAULT_CONTEXT_LENGTHS["hy3-preview"] = 256000` was authored before OpenRouter exposed the precise 256K boundary. The static fallback diverged from the authoritative live value, producing:

- Intermittent test failures depending on cache warmup.
- A 6 KB slice of dropped context whenever the live cache is unavailable (CI without network, offline runs).

## Fix
Bump the static fallback to `262144` so cache and fallback agree. Comment cites the issue so the magic number isn't mistaken for a round 256000.

## Tests
- Updated `test_hy3_preview_context_length` to assert `262144`.
- Added `test_hy3_preview_static_fallback_matches_live` that asserts against `DEFAULT_CONTEXT_LENGTHS` directly — catches drift even when the live cache shadows the static table.

Stash-verify confirmed: reverting the static value alone fails the new static-table test (`assert 256000 == 262144`).

```
$ pytest tests/hermes_cli/test_tencent_tokenhub_provider.py -q
62 passed in 26.73s
```