### PR TITLE
fix(gateway): refresh runtime argv metadata

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -407,10 +407,12 @@ def write_runtime_status(
     """Persist gateway runtime health information for diagnostics/status."""
     path = _get_runtime_status_path()
     payload = _read_json_file(path) or _build_runtime_status_record()
+    current_record = _build_pid_record()
     payload.setdefault("platforms", {})
-    payload.setdefault("kind", _GATEWAY_KIND)
-    payload["pid"] = os.getpid()
-    payload["start_time"] = _get_process_start_time(os.getpid())
+    payload["kind"] = current_record["kind"]
+    payload["pid"] = current_record["pid"]
+    payload["argv"] = current_record["argv"]
+    payload["start_time"] = current_record["start_time"]
     payload["updated_at"] = _utc_now_iso()
 
     if gateway_state is not _UNSET:

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -287,6 +287,30 @@ class TestGatewayRuntimeStatus:
         assert payload["pid"] == os.getpid(), "PID should be overwritten, not preserved via setdefault"
         assert payload["start_time"] != 1000.0, "start_time should be overwritten on restart"
 
+    def test_write_runtime_status_overwrites_stale_argv_on_restart(self, tmp_path, monkeypatch):
+        """Regression: gateway_state.json must not keep the previous launch argv."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        state_path = tmp_path / "gateway_state.json"
+        state_path.write_text(json.dumps({
+            "pid": 99999,
+            "start_time": 1000.0,
+            "kind": "hermes-gateway",
+            "argv": ["/old/path/hermes", "gateway", "run"],
+            "platforms": {},
+            "updated_at": "2025-01-01T00:00:00Z",
+        }))
+
+        monkeypatch.setattr(status.sys, "argv", ["/new/path/hermes", "gateway", "run"])
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 2000)
+
+        status.write_runtime_status(gateway_state="running")
+
+        payload = status.read_runtime_status()
+        assert payload["argv"] == ["/new/path/hermes", "gateway", "run"]
+        assert payload["pid"] == os.getpid()
+        assert payload["start_time"] == 2000
+
     def test_write_runtime_status_records_platform_failure(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 


### PR DESCRIPTION
## What does this PR do?

Fixes stale `argv` metadata in `gateway_state.json` when the gateway keeps updating runtime status after the launch command path has changed.

Before this change, `write_runtime_status()` refreshed `pid`, `start_time`, and `updated_at`, but left any existing `argv` field untouched. That meant a status file created by an older launch path could keep reporting the old command line even after a later gateway run wrote fresh runtime state. This is exactly the failure mode from #22560: diagnostics read a live PID with a stale argv.

This change makes runtime status writes refresh the full launch identity from `_build_pid_record()`, including `argv`, and adds a regression test that reproduces the stale-path scenario directly.

## Related Issue

Fixes #22560

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated [gateway/status.py](/mnt/d/hermes-agent/gateway/status.py) so `write_runtime_status()` now refreshes `kind`, `pid`, `argv`, and `start_time` from the current `_build_pid_record()` instead of only partially overwriting stale metadata.
- Added a regression test in [tests/gateway/test_status.py](/mnt/d/hermes-agent/tests/gateway/test_status.py) that preloads `gateway_state.json` with an old binary path in `argv`, simulates a new launch path via `sys.argv`, and verifies the runtime status write replaces the stale argv.

## How to Reproduce

Before the fix:

1. Create `gateway_state.json` with stale launch metadata such as:
   `{"pid": 99999, "kind": "hermes-gateway", "argv": ["/old/path/hermes", "gateway", "run"], "start_time": 1000.0, "platforms": {}, "updated_at": "..."}`
2. Start a newer gateway process from a different path, e.g. `["/new/path/hermes", "gateway", "run"]`
3. Call `write_runtime_status(gateway_state="running")`
4. Observe that `pid` and `updated_at` change, but `argv` incorrectly remains `["/old/path/hermes", "gateway", "run"]`

After the fix:

1. Repeat the same setup
2. Call `write_runtime_status(gateway_state="running")`
3. Confirm `gateway_state.json` now reports the current launch argv, e.g. `["/new/path/hermes", "gateway", "run"]`

## How to Test

1. Run `python3 -m pytest -q tests/gateway/test_status.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `python3 -m pytest -q tests/gateway/test_status.py` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL Ubuntu / Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

`python3 -m pytest -q tests/gateway/test_status.py`

`43 passed in 28.69s`
