### PR TITLE
fix(browser): set AGENT_BROWSER_ARGS for --no-sandbox bypass

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -755,6 +755,7 @@ AUTHOR_MAP = {
     "17683456+wanazhar@users.noreply.github.com": "wanazhar",
     "26782336+cixuuz@users.noreply.github.com": "cixuuz",
     "aleksandr.pasevin@openzeppelin.com": "pasevin",
+    "pasevin@gmail.com": "pasevin",
     "ubuntu@localhost.localdomain": "holynn-q",
     "holynn@placeholder.local": "holynn-q",
     "agent@hermes.local": "jacdevos",

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1811,11 +1811,6 @@ def _run_browser_command(
     else:
         cmd_prefix = [browser_cmd]
 
-    cmd_parts = cmd_prefix + backend_args + [
-        "--json",
-        command
-    ] + args
-
     try:
         # Give each task its own socket directory to prevent concurrency conflicts.
         # Without this, parallel workers fight over the same default socket path,
@@ -1852,8 +1847,8 @@ def _run_browser_command(
         # - Ubuntu 23.10+ / AppArmor systems: unprivileged user namespaces
         #   are restricted, causing Chromium to exit with "No usable sandbox"
         #   even for non-root users running under systemd or containers.
+        _needs_sandbox_bypass = False
         if "AGENT_BROWSER_CHROME_FLAGS" not in browser_env:
-            _needs_sandbox_bypass = False
             if hasattr(os, "geteuid") and os.geteuid() == 0:
                 _needs_sandbox_bypass = True
                 logger.debug("browser: running as root — injecting --no-sandbox")
@@ -1874,6 +1869,15 @@ def _run_browser_command(
                 browser_env["AGENT_BROWSER_CHROME_FLAGS"] = (
                     "--no-sandbox --disable-dev-shm-usage"
                 )
+                if "AGENT_BROWSER_ARGS" not in browser_env:
+                    browser_env["AGENT_BROWSER_ARGS"] = (
+                        "--no-sandbox,--disable-dev-shm-usage"
+                    )
+
+        cmd_parts = cmd_prefix + backend_args + [
+            "--json",
+            command
+        ] + args
 
         # Use temp files for stdout/stderr instead of pipes.
         # agent-browser starts a background daemon that inherits file


### PR DESCRIPTION
## Problem

The existing AppArmor/root sandbox detection (commit `74c1b946e`, issue #15765) sets `AGENT_BROWSER_CHROME_FLAGS` in the subprocess env when `--no-sandbox` is needed. `AGENT_BROWSER_CHROME_FLAGS` is not a variable that agent-browser reads — it is a Hermes-internal guard variable and is silently ignored by the binary.

agent-browser 0.26+ reads `AGENT_BROWSER_ARGS` (comma-separated) for Chrome launch flags. That variable was never being set by the auto-detection code.

**Result:** on Ubuntu 23.10+ and other AppArmor-restricted hosts (`/proc/sys/kernel/apparmor_restrict_unprivileged_userns == 1`), the detection fires correctly but Chrome still exits with:

```
FATAL: No usable sandbox! ... unprivileged user namespaces disabled
```

A secondary issue: `_needs_sandbox_bypass` was declared inside the `AGENT_BROWSER_CHROME_FLAGS` guard, leaving it uninitialized when that guard is skipped. `cmd_parts` was also constructed before `browser_env` existed.

## Fix

- Set `AGENT_BROWSER_ARGS=--no-sandbox,--disable-dev-shm-usage` when sandbox bypass is detected (alongside `AGENT_BROWSER_CHROME_FLAGS` which is retained as a Hermes-internal skip guard for backward compat).
- Move `_needs_sandbox_bypass = False` outside the `AGENT_BROWSER_CHROME_FLAGS` guard.
- Move `cmd_parts` construction inside the `try` block where `browser_env` is available.

## Verification

Tested on Ubuntu 24.04 with `apparmor_restrict_unprivileged_userns = 1`, no system Chrome, Playwright Chromium at `~/.cache/ms-playwright`. After the fix, `browser_navigate` succeeds using the native agent-browser daemon path without any CDP workaround.

The agent-browser binary itself correctly inherits `AGENT_BROWSER_ARGS` from the caller's environment into the daemon child — confirmed via `/proc/<pid>/environ` on a clean reproduction. The entire issue was the wrong variable name on the Hermes side.
