### PR TITLE
feat(cli): add safe proactive synthesis and cron controls

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -144,6 +144,20 @@ model:
 # worktree: false   # Default — only create when -w flag is passed
 
 # =============================================================================
+# Cron Delivery Formatting
+# =============================================================================
+# Controls how cron job outputs are wrapped when delivered to chat platforms.
+# Set wrap_response: false to send raw job output only.
+# wrap_style: compact keeps Telegram/Slack notifications short; classic restores
+# the old verbose "Cronjob Response" wrapper.
+# action_buttons adds Telegram inline controls (Stop, More Info) to cron outputs.
+#
+# cron:
+#   wrap_response: true
+#   wrap_style: compact     # compact | classic
+#   action_buttons: true    # Telegram only; set false to disable inline controls
+
+# =============================================================================
 # Terminal Tool Configuration
 # =============================================================================
 # Choose ONE of the following terminal configurations by uncommenting it.

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -578,7 +578,11 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
         runtime_adapter = (adapters or {}).get(platform)
         delivered = False
         if runtime_adapter is not None and loop is not None and getattr(loop, "is_running", lambda: False)():
-            send_metadata = {"thread_id": thread_id} if thread_id else None
+            send_metadata = {"thread_id": thread_id} if thread_id else {}
+            if job.get("_proactive_controls"):
+                send_metadata["proactive_controls"] = job.get("_proactive_controls")
+            if not send_metadata:
+                send_metadata = None
             try:
                 # Send cleaned text (MEDIA tags stripped) — not the raw content
                 text_to_send = cleaned_delivery_content.strip()
@@ -1746,9 +1750,23 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
                     should_deliver = False
 
                 delivery_error = None
+                delivery_job = job
+                if should_deliver and success:
+                    try:
+                        from hermes_cli.proactive import prepare_delivery_controls
+                        controls = prepare_delivery_controls(
+                            job=job,
+                            message=deliver_content,
+                            output_doc=output,
+                        )
+                        if controls:
+                            delivery_job = dict(job)
+                            delivery_job["_proactive_controls"] = controls
+                    except Exception as controls_exc:
+                        logger.debug("Job '%s': proactive controls unavailable: %s", job["id"], controls_exc)
                 if should_deliver:
                     try:
-                        delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
+                        delivery_error = _deliver_result(delivery_job, deliver_content, adapters=adapters, loop=loop)
                     except Exception as de:
                         delivery_error = str(de)
                         logger.error("Delivery failed for job %s: %s", job["id"], de)

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -478,6 +478,52 @@ def _send_media_via_adapter(
             logger.warning("Job '%s': failed to send media %s: %s", job.get("id", "?"), media_path, e)
 
 
+def _cron_display_text(value: object, fallback: str = "cron job") -> str:
+    """Return a single-line, markdown-safe-enough label for cron wrappers."""
+
+    text = " ".join(str(value or fallback).split()).strip() or fallback
+    return text.replace("```", "'''")
+
+
+def _format_cron_delivery(job: dict, content: str, style: str = "compact") -> str:
+    """Format a delivered cron response.
+
+    ``compact`` is optimized for Telegram/mobile scanability: bold job name,
+    monospace job id, and no noisy separator/footer. ``classic`` preserves the
+    old verbose wrapper for users who want it.
+    """
+
+    task_name = _cron_display_text(job.get("name") or job.get("id"))
+    job_id = _cron_display_text(job.get("id", ""), fallback="unknown")
+    body = (content or "").strip()
+
+    if style == "classic":
+        return (
+            f"Cronjob Response: {task_name}\n"
+            f"(job_id: {job_id})\n"
+            f"-------------\n\n"
+            f"{body}\n\n"
+            f"To stop or manage this job, send me a new message (e.g. \"stop reminder {task_name}\")."
+        )
+
+    parts = [f"⏰ **{task_name}**", f"`job_id: {job_id}`"]
+    if body:
+        parts.append(body)
+    return "\n\n".join(parts).strip()
+
+
+def _cron_action_buttons(job: dict) -> list[dict[str, str]]:
+    """Return compact Telegram inline-button metadata for a delivered cron."""
+
+    job_id = str(job.get("id", "")).strip()
+    if not job_id:
+        return []
+    return [
+        {"text": "Stop", "callback_data": f"cj:stop:{job_id}"},
+        {"text": "More Info", "callback_data": f"cj:info:{job_id}"},
+    ]
+
+
 def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Optional[str]:
     """
     Deliver job output to the configured target(s) (origin chat, specific platform, etc.).
@@ -504,22 +550,19 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
     # is a cron delivery.  Wrapping is on by default; set cron.wrap_response: false
     # in config.yaml for clean output.
     wrap_response = True
+    wrap_style = "compact"
+    action_buttons = True
     try:
         user_cfg = load_config()
-        wrap_response = user_cfg.get("cron", {}).get("wrap_response", True)
+        cron_cfg = user_cfg.get("cron", {})
+        wrap_response = cron_cfg.get("wrap_response", True)
+        wrap_style = cron_cfg.get("wrap_style", "compact")
+        action_buttons = cron_cfg.get("action_buttons", True)
     except Exception:
         pass
 
     if wrap_response:
-        task_name = job.get("name", job["id"])
-        job_id = job.get("id", "")
-        delivery_content = (
-            f"Cronjob Response: {task_name}\n"
-            f"(job_id: {job_id})\n"
-            f"-------------\n\n"
-            f"{content}\n\n"
-            f"To stop or manage this job, send me a new message (e.g. \"stop reminder {task_name}\")."
-        )
+        delivery_content = _format_cron_delivery(job, content, style=wrap_style)
     else:
         delivery_content = content
 
@@ -573,16 +616,21 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
             delivery_errors.append(msg)
             continue
 
+        telegram_buttons = []
+        if action_buttons and platform_name.lower() == "telegram" and not job.get("_proactive_controls"):
+            telegram_buttons = _cron_action_buttons(job)
+        send_metadata = {"thread_id": thread_id} if thread_id else {}
+        if telegram_buttons:
+            send_metadata["telegram_inline_buttons"] = telegram_buttons
+        if job.get("_proactive_controls"):
+            send_metadata["proactive_controls"] = job.get("_proactive_controls")
+        send_metadata = send_metadata or None
+
         # Prefer the live adapter when the gateway is running — this supports E2EE
         # rooms (e.g. Matrix) where the standalone HTTP path cannot encrypt.
         runtime_adapter = (adapters or {}).get(platform)
         delivered = False
         if runtime_adapter is not None and loop is not None and getattr(loop, "is_running", lambda: False)():
-            send_metadata = {"thread_id": thread_id} if thread_id else {}
-            if job.get("_proactive_controls"):
-                send_metadata["proactive_controls"] = job.get("_proactive_controls")
-            if not send_metadata:
-                send_metadata = None
             try:
                 # Send cleaned text (MEDIA tags stripped) — not the raw content
                 text_to_send = cleaned_delivery_content.strip()
@@ -628,7 +676,16 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
 
         if not delivered:
             # Standalone path: run the async send in a fresh event loop (safe from any thread)
-            coro = _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files)
+            send_kwargs = {"thread_id": thread_id, "media_files": media_files}
+            if telegram_buttons:
+                send_kwargs["telegram_inline_buttons"] = telegram_buttons
+            coro = _send_to_platform(
+                platform,
+                pconfig,
+                chat_id,
+                cleaned_delivery_content,
+                **send_kwargs,
+            )
             try:
                 result = asyncio.run(coro)
             except RuntimeError:
@@ -638,7 +695,16 @@ def _deliver_result(job: dict, content: str, adapters=None, loop=None) -> Option
                 # fresh thread that has no running loop.
                 coro.close()
                 with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-                    future = pool.submit(asyncio.run, _send_to_platform(platform, pconfig, chat_id, cleaned_delivery_content, thread_id=thread_id, media_files=media_files))
+                    future = pool.submit(
+                        asyncio.run,
+                        _send_to_platform(
+                            platform,
+                            pconfig,
+                            chat_id,
+                            cleaned_delivery_content,
+                            **send_kwargs,
+                        ),
+                    )
                     result = future.result(timeout=30)
             except Exception as e:
                 msg = f"delivery to {platform_name}:{chat_id} failed: {e}"

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -14,6 +14,7 @@ import os
 import tempfile
 import html as _html
 import re
+from datetime import datetime, timezone
 from typing import Dict, List, Optional, Any
 
 logger = logging.getLogger(__name__)
@@ -374,6 +375,31 @@ class TelegramAdapter(BasePlatformAdapter):
             return None
         reply_to = metadata.get("telegram_reply_to_message_id")
         return int(reply_to) if reply_to is not None else None
+
+    @staticmethod
+    def _build_proactive_controls_keyboard(controls: Optional[Dict[str, Any]]):
+        if not controls:
+            return None
+        nudge_id = str(controls.get("nudge_id") or "").strip()
+        if not nudge_id:
+            return None
+        labels = {
+            "do": "Do it",
+            "more": "More Info",
+            "later": "Later",
+            "not": "Not useful",
+            "dont": "Don't nudge this",
+        }
+        wanted = controls.get("buttons") or ["do", "more", "later", "not", "dont"]
+        buttons = [
+            InlineKeyboardButton(labels[action], callback_data=f"pa:{action}:{nudge_id}")
+            for action in wanted
+            if action in labels
+        ]
+        if not buttons:
+            return None
+        rows = [buttons[i : i + 2] for i in range(0, len(buttons), 2)]
+        return InlineKeyboardMarkup(rows)
 
     @classmethod
     def _reply_to_message_id_for_send(
@@ -1353,6 +1379,9 @@ class TelegramAdapter(BasePlatformAdapter):
             
             message_ids = []
             thread_id = self._metadata_thread_id(metadata)
+            proactive_reply_markup = self._build_proactive_controls_keyboard(
+                metadata.get("proactive_controls") if metadata else None
+            )
             
             try:
                 from telegram.error import NetworkError as _NetErr
@@ -1398,6 +1427,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                 text=chunk,
                                 parse_mode=ParseMode.MARKDOWN_V2,
                                 reply_to_message_id=reply_to_id,
+                                reply_markup=proactive_reply_markup if i == 0 else None,
                                 **thread_kwargs,
                                 **self._link_preview_kwargs(),
                             )
@@ -1411,6 +1441,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                     text=plain_chunk,
                                     parse_mode=None,
                                     reply_to_message_id=reply_to_id,
+                                    reply_markup=proactive_reply_markup if i == 0 else None,
                                     **thread_kwargs,
                                     **self._link_preview_kwargs(),
                                 )
@@ -2268,6 +2299,89 @@ class TelegramAdapter(BasePlatformAdapter):
                         await self._bot.send_message(**send_kwargs)
                 except Exception as exc:
                     logger.error("[%s] slash-confirm callback failed: %s", self.name, exc, exc_info=True)
+            return
+
+        # --- Proactive nudge callbacks (pa:action:nudge_id) ---
+        if data.startswith("pa:"):
+            parts = data.split(":", 2)
+            if len(parts) != 3:
+                await query.answer(text="Invalid proactive action.")
+                return
+            action, nudge_id = parts[1], parts[2]
+            caller_id = str(getattr(query.from_user, "id", ""))
+            if not self._is_callback_user_authorized(
+                caller_id,
+                chat_id=query_chat_id,
+                chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                user_name=query_user_name,
+            ):
+                await query.answer(text="⛔ You are not authorized to control this nudge.")
+                return
+
+            try:
+                from hermes_cli.proactive import handle_proactive_feedback
+                feedback = handle_proactive_feedback(nudge_id, action)
+            except Exception as exc:
+                logger.error("[%s] proactive feedback callback failed: %s", self.name, exc, exc_info=True)
+                await query.answer(text="Could not update this nudge.")
+                return
+
+            await query.answer(text=str(feedback.get("ack") or "Noted."))
+            try:
+                await query.edit_message_reply_markup(reply_markup=None)
+            except Exception:
+                pass
+
+            if feedback.get("followup") and query.message:
+                send_kwargs: Dict[str, Any] = {
+                    "chat_id": int(query.message.chat_id),
+                    "text": str(feedback["followup"]),
+                    "parse_mode": ParseMode.MARKDOWN,
+                    **self._link_preview_kwargs(),
+                }
+                if query_thread_id is not None:
+                    send_kwargs.update(
+                        self._thread_kwargs_for_send(
+                            str(query.message.chat_id),
+                            str(query_thread_id),
+                            {"thread_id": str(query_thread_id)},
+                        )
+                    )
+                await self._bot.send_message(**send_kwargs)
+
+            if feedback.get("agent_prompt") and query.message:
+                message = query.message
+                chat = getattr(message, "chat", None)
+                from_user = getattr(query, "from_user", None)
+                chat_id_value = str(getattr(chat, "id", getattr(message, "chat_id", "")))
+                chat_type_value = str(getattr(chat, "type", "private"))
+                chat_type = "dm"
+                if chat_type_value in {str(getattr(ChatType, "GROUP", "group")), "group"}:
+                    chat_type = "group"
+                elif chat_type_value in {str(getattr(ChatType, "SUPERGROUP", "supergroup")), "supergroup"}:
+                    chat_type = "group"
+                elif chat_type_value in {str(getattr(ChatType, "CHANNEL", "channel")), "channel"}:
+                    chat_type = "channel"
+                source = self.build_source(
+                    chat_id=chat_id_value,
+                    chat_name=(getattr(chat, "title", None) or getattr(chat, "full_name", None)),
+                    chat_type=chat_type,
+                    user_id=str(getattr(from_user, "id", chat_id_value)),
+                    user_name=getattr(from_user, "full_name", None) or getattr(from_user, "first_name", None),
+                    thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                )
+                event = MessageEvent(
+                    text=str(feedback["agent_prompt"]),
+                    message_type=MessageType.TEXT,
+                    source=source,
+                    raw_message=message,
+                    message_id=f"{getattr(message, 'message_id', '0')}:proactive:{nudge_id}",
+                    reply_to_message_id=str(getattr(message, "message_id", "")) or None,
+                    reply_to_text=getattr(message, "text", None),
+                    timestamp=getattr(message, "date", None) or datetime.now(timezone.utc),
+                )
+                await self.handle_message(event)
             return
 
         # --- Update prompt callbacks ---

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -377,29 +377,49 @@ class TelegramAdapter(BasePlatformAdapter):
         return int(reply_to) if reply_to is not None else None
 
     @staticmethod
-    def _build_proactive_controls_keyboard(controls: Optional[Dict[str, Any]]):
-        if not controls:
+    def _inline_keyboard_from_metadata(metadata: Optional[Dict[str, Any]]):
+        """Build optional Telegram inline keyboard from gateway metadata."""
+
+        metadata = metadata or {}
+        controls = metadata.get("proactive_controls")
+        if controls:
+            nudge_id = str(controls.get("nudge_id") or "").strip()
+            if not nudge_id:
+                return None
+            labels = {
+                "do": "Do it",
+                "more": "More Info",
+                "later": "Later",
+                "not": "Not useful",
+                "dont": "Don't nudge this",
+            }
+            wanted = controls.get("buttons") or ["do", "more", "later", "not", "dont"]
+            buttons = [
+                InlineKeyboardButton(labels[action], callback_data=f"pa:{action}:{nudge_id}")
+                for action in wanted
+                if action in labels
+            ]
+            rows = [buttons[i : i + 2] for i in range(0, len(buttons), 2)]
+            return InlineKeyboardMarkup(rows) if rows else None
+
+        raw_buttons = metadata.get("telegram_inline_buttons") or []
+        if not isinstance(raw_buttons, list):
             return None
-        nudge_id = str(controls.get("nudge_id") or "").strip()
-        if not nudge_id:
-            return None
-        labels = {
-            "do": "Do it",
-            "more": "More Info",
-            "later": "Later",
-            "not": "Not useful",
-            "dont": "Don't nudge this",
-        }
-        wanted = controls.get("buttons") or ["do", "more", "later", "not", "dont"]
-        buttons = [
-            InlineKeyboardButton(labels[action], callback_data=f"pa:{action}:{nudge_id}")
-            for action in wanted
-            if action in labels
-        ]
-        if not buttons:
-            return None
-        rows = [buttons[i : i + 2] for i in range(0, len(buttons), 2)]
-        return InlineKeyboardMarkup(rows)
+        # Accept either a flat button list or a list of rows.
+        rows = raw_buttons if raw_buttons and isinstance(raw_buttons[0], list) else [raw_buttons]
+        keyboard = []
+        for row in rows:
+            button_row = []
+            for button in row:
+                if not isinstance(button, dict):
+                    continue
+                text = str(button.get("text", "")).strip()
+                callback_data = str(button.get("callback_data", "")).strip()
+                if text and callback_data:
+                    button_row.append(InlineKeyboardButton(text, callback_data=callback_data))
+            if button_row:
+                keyboard.append(button_row)
+        return InlineKeyboardMarkup(keyboard) if keyboard else None
 
     @classmethod
     def _reply_to_message_id_for_send(
@@ -1379,9 +1399,7 @@ class TelegramAdapter(BasePlatformAdapter):
             
             message_ids = []
             thread_id = self._metadata_thread_id(metadata)
-            proactive_reply_markup = self._build_proactive_controls_keyboard(
-                metadata.get("proactive_controls") if metadata else None
-            )
+            reply_markup = self._inline_keyboard_from_metadata(metadata)
             
             try:
                 from telegram.error import NetworkError as _NetErr
@@ -1427,7 +1445,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                 text=chunk,
                                 parse_mode=ParseMode.MARKDOWN_V2,
                                 reply_to_message_id=reply_to_id,
-                                reply_markup=proactive_reply_markup if i == 0 else None,
+                                reply_markup=reply_markup if i == len(chunks) - 1 else None,
                                 **thread_kwargs,
                                 **self._link_preview_kwargs(),
                             )
@@ -1441,7 +1459,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                     text=plain_chunk,
                                     parse_mode=None,
                                     reply_to_message_id=reply_to_id,
-                                    reply_markup=proactive_reply_markup if i == 0 else None,
+                                    reply_markup=reply_markup if i == len(chunks) - 1 else None,
                                     **thread_kwargs,
                                     **self._link_preview_kwargs(),
                                 )
@@ -2119,6 +2137,186 @@ class TelegramAdapter(BasePlatformAdapter):
             # Catch-all (e.g. page counter button "mx:noop")
             await query.answer()
 
+    @staticmethod
+    def _cron_primary_keyboard(job_id: str, paused: bool = False):
+        primary_label = "Resume" if paused else "Stop"
+        primary_action = "resume" if paused else "stop"
+        return InlineKeyboardMarkup([[
+            InlineKeyboardButton(primary_label, callback_data=f"cj:{primary_action}:{job_id}"),
+            InlineKeyboardButton("More Info", callback_data=f"cj:info:{job_id}"),
+        ]])
+
+    @staticmethod
+    def _cron_info_keyboard(job_id: str, paused: bool = False):
+        primary_label = "Resume" if paused else "Stop"
+        primary_action = "resume" if paused else "stop"
+        return InlineKeyboardMarkup([
+            [
+                InlineKeyboardButton("Run Now", callback_data=f"cj:run:{job_id}"),
+                InlineKeyboardButton("Last Output", callback_data=f"cj:output:{job_id}"),
+            ],
+            [
+                InlineKeyboardButton("Edit Schedule", callback_data=f"cj:edit:{job_id}"),
+                InlineKeyboardButton(primary_label, callback_data=f"cj:{primary_action}:{job_id}"),
+            ],
+        ])
+
+    @staticmethod
+    def _short_cron_value(value: object, limit: int = 500) -> str:
+        text = " ".join(str(value or "").split()).strip()
+        return text if len(text) <= limit else text[: limit - 1].rstrip() + "…"
+
+    @classmethod
+    def _format_cron_job_info(cls, job: dict) -> str:
+        name = _html.escape(cls._short_cron_value(job.get("name") or job.get("id") or "cron job", 120))
+        job_id = _html.escape(str(job.get("id", "unknown")))
+        status = "Paused" if job.get("enabled") is False else "Active"
+        schedule = _html.escape(cls._short_cron_value(job.get("schedule") or "unscheduled", 120))
+        next_run = _html.escape(cls._short_cron_value(job.get("next_run_at") or "unknown", 120))
+        last_run = _html.escape(cls._short_cron_value(job.get("last_run_at") or "never", 120))
+        deliver = _html.escape(cls._short_cron_value(job.get("deliver") or "local", 120))
+        mode = "script-only" if job.get("no_agent") else "agent"
+        toolsets = job.get("enabled_toolsets") or []
+        toolsets_text = ", ".join(map(str, toolsets)) if toolsets else "default"
+        prompt = _html.escape(cls._short_cron_value(job.get("prompt") or job.get("script") or "", 700))
+        return (
+            f"<b>{name}</b>\n"
+            f"<code>job_id: {job_id}</code>\n\n"
+            f"Status: {status}\n"
+            f"Schedule: {schedule}\n"
+            f"Next: {next_run}\n"
+            f"Last: {last_run}\n"
+            f"Deliver: {deliver}\n"
+            f"Mode: {_html.escape(mode)} · Tools: {_html.escape(toolsets_text)}\n\n"
+            f"<b>Prompt / script</b>\n{prompt or '<i>empty</i>'}"
+        )
+
+    @classmethod
+    def _format_cron_last_output(cls, job: dict) -> str:
+        from cron.jobs import OUTPUT_DIR
+
+        job_id = str(job.get("id", ""))
+        job_output_dir = OUTPUT_DIR / job_id
+        if not job_id or not job_output_dir.exists():
+            return "No saved output for this cron job yet."
+        output_files = sorted(job_output_dir.glob("*.md"), key=lambda p: p.stat().st_mtime, reverse=True)
+        if not output_files:
+            return "No saved output for this cron job yet."
+        latest = output_files[0]
+        try:
+            content = latest.read_text(encoding="utf-8", errors="replace")
+        except Exception as exc:
+            return f"Could not read last output: {_html.escape(str(exc))}"
+        trimmed = cls._short_cron_value(content, 1800)
+        return f"<b>Last output</b>\n<code>{_html.escape(latest.name)}</code>\n\n<pre>{_html.escape(trimmed)}</pre>"
+
+    async def _send_cron_callback_message(self, query, text: str, reply_markup=None, parse_mode=None) -> None:
+        if not query.message:
+            return
+        kwargs: Dict[str, Any] = {
+            "chat_id": int(query.message.chat_id),
+            "text": text,
+            "parse_mode": parse_mode or ParseMode.HTML,
+            "reply_markup": reply_markup,
+            **self._link_preview_kwargs(),
+        }
+        thread_id = getattr(query.message, "message_thread_id", None)
+        if thread_id is not None:
+            kwargs.update(
+                self._thread_kwargs_for_send(
+                    str(query.message.chat_id),
+                    str(thread_id),
+                    {"thread_id": str(thread_id)},
+                )
+            )
+        await self._bot.send_message(**kwargs)
+
+    async def _handle_cron_job_callback(self, query, data: str, *, query_chat_id, query_chat_type, query_thread_id, query_user_name) -> None:
+        parts = data.split(":", 2)
+        if len(parts) != 3:
+            await query.answer(text="Invalid cron action.")
+            return
+        action, job_id = parts[1], parts[2]
+        caller_id = str(getattr(query.from_user, "id", ""))
+        if not self._is_callback_user_authorized(
+            caller_id,
+            chat_id=query_chat_id,
+            chat_type=str(query_chat_type) if query_chat_type is not None else None,
+            thread_id=str(query_thread_id) if query_thread_id is not None else None,
+            user_name=query_user_name,
+        ):
+            await query.answer(text="⛔ You are not authorized to manage this cron job.")
+            return
+
+        from cron.jobs import get_job, pause_job, resume_job, trigger_job
+
+        if action == "stop":
+            job = pause_job(job_id, reason="Stopped from Telegram cron button")
+            if not job:
+                await query.answer(text="Cron job not found.")
+                return
+            await query.answer(text="Stopped cron job.")
+            try:
+                await query.edit_message_reply_markup(reply_markup=self._cron_primary_keyboard(job_id, paused=True))
+            except Exception:
+                pass
+            return
+
+        if action == "resume":
+            job = resume_job(job_id)
+            if not job:
+                await query.answer(text="Cron job not found.")
+                return
+            await query.answer(text="Resumed cron job.")
+            try:
+                await query.edit_message_reply_markup(reply_markup=self._cron_primary_keyboard(job_id, paused=False))
+            except Exception:
+                pass
+            return
+
+        job = get_job(job_id)
+        if not job and action not in {"run"}:
+            await query.answer(text="Cron job not found.")
+            return
+        paused = bool(job and job.get("enabled") is False)
+
+        if action == "info":
+            await query.answer(text="Cron info")
+            await self._send_cron_callback_message(
+                query,
+                self._format_cron_job_info(job),
+                reply_markup=self._cron_info_keyboard(job_id, paused=paused),
+            )
+            return
+
+        if action == "output":
+            await query.answer(text="Last output")
+            await self._send_cron_callback_message(
+                query,
+                self._format_cron_last_output(job),
+                reply_markup=self._cron_info_keyboard(job_id, paused=paused),
+            )
+            return
+
+        if action == "run":
+            job = trigger_job(job_id)
+            if not job:
+                await query.answer(text="Cron job not found.")
+                return
+            await query.answer(text="Scheduled to run on the next tick.")
+            return
+
+        if action == "edit":
+            await query.answer(text="Edit from chat")
+            await self._send_cron_callback_message(
+                query,
+                f"To edit this cron, use:\n<code>hermes cron edit {_html.escape(job_id)}</code>",
+                reply_markup=self._cron_info_keyboard(job_id, paused=paused),
+            )
+            return
+
+        await query.answer(text="Unknown cron action.")
+
     async def _handle_callback_query(
         self, update: "Update", context: "ContextTypes.DEFAULT_TYPE"
     ) -> None:
@@ -2299,6 +2497,18 @@ class TelegramAdapter(BasePlatformAdapter):
                         await self._bot.send_message(**send_kwargs)
                 except Exception as exc:
                     logger.error("[%s] slash-confirm callback failed: %s", self.name, exc, exc_info=True)
+            return
+
+        # --- Cron job management callbacks ---
+        if data.startswith("cj:"):
+            await self._handle_cron_job_callback(
+                query,
+                data,
+                query_chat_id=query_chat_id,
+                query_chat_type=query_chat_type,
+                query_thread_id=query_thread_id,
+                query_user_name=query_user_name,
+            )
             return
 
         # --- Proactive nudge callbacks (pa:action:nudge_id) ---

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9662,6 +9662,14 @@ def main():
     )
     proactive_prompt.add_argument("--json", action="store_true", help="Print JSON output")
 
+    proactive_scan = proactive_subparsers.add_parser(
+        "scan",
+        help="Run the fast structured proactive signal scanner",
+    )
+    proactive_scan.add_argument("--lookback-days", type=int, default=7)
+    proactive_scan.add_argument("--max-sessions", type=int, default=30)
+    proactive_scan.add_argument("--json", action="store_true", help="Print JSON output")
+
     proactive_install = proactive_subparsers.add_parser(
         "install",
         help="Create or update the safe proactive synthesis cron job",

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -17,6 +17,8 @@ Usage:
     hermes cron                # Manage cron jobs
     hermes cron list           # List cron jobs
     hermes cron status         # Check if cron scheduler is running
+    hermes proactive prompt    # Print safe proactive reflection prompt
+    hermes proactive install   # Install safe proactive synthesis cron job
     hermes doctor              # Check configuration and dependencies
     hermes honcho setup                    # Configure Honcho AI memory integration
     hermes honcho status                   # Show Honcho config and connection status
@@ -5256,6 +5258,13 @@ def cmd_cron(args):
     cron_command(args)
 
 
+def cmd_proactive(args):
+    """Safe proactive reflection helpers."""
+    from hermes_cli.proactive import cmd_proactive as proactive_command
+
+    return proactive_command(args)
+
+
 def cmd_webhook(args):
     """Webhook subscription management."""
     from hermes_cli.webhook import webhook_command
@@ -8881,7 +8890,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "config", "cron", "curator", "dashboard", "debug", "doctor",
         "dump", "fallback", "gateway", "hooks", "import", "insights",
         "kanban", "login", "logout", "logs", "mcp", "memory", "model",
-        "pairing", "plugins", "profile", "sessions", "setup", "skills",
+        "pairing", "plugins", "proactive", "profile", "sessions", "setup", "skills",
         "slack", "status", "tools", "uninstall", "update", "version",
         "webhook", "whatsapp", "chat",
         # Help-ish invocations — plugin commands not being listed in
@@ -9628,6 +9637,60 @@ def main():
     _add_accept_hooks_flag(cron_tick)
     _add_accept_hooks_flag(cron_parser)
     cron_parser.set_defaults(func=cmd_cron)
+
+    # =========================================================================
+    # proactive command
+    # =========================================================================
+    proactive_parser = subparsers.add_parser(
+        "proactive",
+        help="Safe proactive reflection setup",
+        description="Build or install the safe proactive synthesis cron job",
+    )
+    proactive_subparsers = proactive_parser.add_subparsers(dest="proactive_command")
+
+    proactive_prompt = proactive_subparsers.add_parser(
+        "prompt",
+        help="Print the prompt used by the proactive synthesis cron job",
+    )
+    proactive_prompt.add_argument("--lookback-days", type=int, default=7)
+    proactive_prompt.add_argument("--max-sessions", type=int, default=30)
+    proactive_prompt.add_argument(
+        "--min-confidence",
+        choices=["medium", "high"],
+        default="high",
+        help="Minimum confidence before the job messages the user",
+    )
+    proactive_prompt.add_argument("--json", action="store_true", help="Print JSON output")
+
+    proactive_install = proactive_subparsers.add_parser(
+        "install",
+        help="Create or update the safe proactive synthesis cron job",
+    )
+    proactive_install.add_argument(
+        "--schedule",
+        default="0 9 * * *",
+        help="Schedule like 'every 4h' or '0 9 * * *' (default: daily at 09:00)",
+    )
+    proactive_install.add_argument(
+        "--deliver",
+        default="local",
+        help="Cron delivery target (default: local; use telegram/origin/etc. to message proactively)",
+    )
+    proactive_install.add_argument("--lookback-days", type=int, default=7)
+    proactive_install.add_argument("--max-sessions", type=int, default=30)
+    proactive_install.add_argument(
+        "--min-confidence",
+        choices=["medium", "high"],
+        default="high",
+        help="Minimum confidence before the job messages the user",
+    )
+    proactive_install.add_argument(
+        "--paused",
+        action="store_true",
+        help="Create/update the job but leave it paused for review",
+    )
+    proactive_install.add_argument("--json", action="store_true", help="Print JSON output")
+    proactive_parser.set_defaults(func=cmd_proactive)
 
     # =========================================================================
     # webhook command

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9670,6 +9670,23 @@ def main():
     proactive_scan.add_argument("--max-sessions", type=int, default=30)
     proactive_scan.add_argument("--json", action="store_true", help="Print JSON output")
 
+    proactive_evolve = proactive_subparsers.add_parser(
+        "evolve",
+        help="Review feedback and propose safe self-evolution changes",
+    )
+    proactive_evolve.add_argument("--json", action="store_true", help="Print JSON output")
+    proactive_evolve.add_argument(
+        "--write",
+        action="store_true",
+        help="Write a markdown self-evolution report under ~/.hermes/proactive/",
+    )
+
+    proactive_export = proactive_subparsers.add_parser(
+        "export-learning",
+        help="Print privacy-safe aggregate proactive feedback for upstream learning",
+    )
+    proactive_export.add_argument("--json", action="store_true", default=True, help="Print JSON output")
+
     proactive_install = proactive_subparsers.add_parser(
         "install",
         help="Create or update the safe proactive synthesis cron job",

--- a/hermes_cli/proactive.py
+++ b/hermes_cli/proactive.py
@@ -9,6 +9,7 @@ act externally.
 from __future__ import annotations
 
 import json
+import hashlib
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -25,6 +26,8 @@ DEFAULT_DELIVER = "local"
 # so cron runs do not wander for minutes through session_search.
 DEFAULT_ENABLED_TOOLSETS = ["memory"]
 DEFAULT_SCANNER_SCRIPT = "proactive_signal_scan.py"
+DEFAULT_COOLDOWN_HOURS = 72
+DEFAULT_SNOOZE_HOURS = 24
 _ALLOWED_CONFIDENCE = {"medium", "high"}
 _MAX_EXCERPT_CHARS = 280
 
@@ -124,6 +127,268 @@ def _signal_key(signal: Dict[str, Any]) -> tuple:
         signal.get("session_id"),
         _clip(signal.get("excerpt"), 100).lower(),
     )
+
+
+def _ledger_path() -> Path:
+    return get_hermes_home() / "proactive" / "ledger.json"
+
+
+def _load_ledger() -> Dict[str, Any]:
+    path = _ledger_path()
+    if not path.exists():
+        return {"version": 1, "nudges": [], "feedback": []}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            raise ValueError("ledger root is not an object")
+        data.setdefault("version", 1)
+        data.setdefault("nudges", [])
+        data.setdefault("feedback", [])
+        if not isinstance(data["nudges"], list):
+            data["nudges"] = []
+        if not isinstance(data["feedback"], list):
+            data["feedback"] = []
+        return data
+    except Exception:
+        corrupt = path.with_suffix(f".corrupt-{int(time.time())}.json")
+        try:
+            path.replace(corrupt)
+        except Exception:
+            pass
+        return {"version": 1, "nudges": [], "feedback": []}
+
+
+def _save_ledger(ledger: Dict[str, Any]) -> None:
+    path = _ledger_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(ledger, indent=2, sort_keys=True), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _signal_fingerprint(signal: Dict[str, Any]) -> str:
+    basis = "|".join(
+        [
+            _clip(signal.get("kind"), 80).lower(),
+            _clip(signal.get("source"), 80).lower(),
+            _clip(signal.get("session_id"), 120).lower(),
+            _clip(signal.get("excerpt"), 220).lower(),
+        ]
+    )
+    return hashlib.sha256(basis.encode("utf-8", "replace")).hexdigest()[:16]
+
+
+def _top_signal(scan_report: Dict[str, Any]) -> Dict[str, Any]:
+    signals = scan_report.get("signals") or []
+    if signals and isinstance(signals[0], dict):
+        return dict(signals[0])
+    errors = scan_report.get("scan_errors") or []
+    if errors:
+        return {
+            "kind": "scan_error",
+            "mode": "already_checked",
+            "reason": "proactive scanner reported an error",
+            "excerpt": _clip(errors[0]),
+        }
+    return {"kind": "unknown", "mode": "ask_to_investigate", "reason": "proactive nudge", "excerpt": ""}
+
+
+def apply_ledger_filters(
+    report: Dict[str, Any],
+    *,
+    now: float | None = None,
+    cooldown_hours: int = DEFAULT_COOLDOWN_HOURS,
+) -> Dict[str, Any]:
+    """Suppress recently nudged, snoozed, or explicitly muted signals."""
+
+    now = time.time() if now is None else float(now)
+    cooldown_secs = max(0, int(cooldown_hours)) * 3600
+    ledger = _load_ledger()
+    nudges = [n for n in ledger.get("nudges", []) if isinstance(n, dict)]
+    filtered = json.loads(json.dumps(report))
+    kept: List[Dict[str, Any]] = []
+    suppressed: List[Dict[str, Any]] = []
+
+    for signal in filtered.get("signals") or []:
+        if not isinstance(signal, dict):
+            continue
+        fp = _signal_fingerprint(signal)
+        match = None
+        reason = ""
+        for nudge in reversed(nudges):
+            if nudge.get("fingerprint") != fp:
+                continue
+            if nudge.get("muted") or nudge.get("last_feedback") in {"dont", "not"}:
+                match, reason = nudge, "muted"
+                break
+            snoozed_until = float(nudge.get("snoozed_until") or 0)
+            if snoozed_until > now:
+                match, reason = nudge, "snoozed"
+                break
+            created_at = float(nudge.get("created_at") or 0)
+            if cooldown_secs and created_at and now - created_at < cooldown_secs:
+                match, reason = nudge, "cooldown"
+                break
+        if match:
+            suppressed.append({"nudge_id": match.get("id"), "reason": reason, "signal": signal})
+        else:
+            kept.append(signal)
+
+    filtered["signals"] = kept
+    if suppressed:
+        filtered["suppressed_by_ledger"] = suppressed
+    filtered["wakeAgent"] = bool(kept or filtered.get("scan_errors"))
+    return filtered
+
+
+def record_proactive_nudge(
+    *,
+    job: Dict[str, Any],
+    message: str,
+    scan_report: Dict[str, Any],
+    now: float | None = None,
+) -> Dict[str, Any]:
+    """Persist a delivered proactive nudge so future scans can cool it down."""
+
+    now = time.time() if now is None else float(now)
+    signal = _top_signal(scan_report)
+    fingerprint = _signal_fingerprint(signal)
+    nudge_id = hashlib.sha256(
+        f"{fingerprint}|{now:.6f}|{_clip(message, 200)}".encode("utf-8", "replace")
+    ).hexdigest()[:12]
+    nudge = {
+        "id": nudge_id,
+        "created_at": now,
+        "job_id": job.get("id"),
+        "job_name": job.get("name"),
+        "message": _clip(message, 800),
+        "fingerprint": fingerprint,
+        "signal": signal,
+        "status": "sent",
+    }
+    ledger = _load_ledger()
+    ledger.setdefault("nudges", []).append(nudge)
+    _save_ledger(ledger)
+    return nudge
+
+
+def proactive_controls_for_nudge(nudge: Dict[str, Any]) -> Dict[str, Any]:
+    return {
+        "nudge_id": nudge.get("id"),
+        "buttons": ["do", "more", "later", "not", "dont"],
+    }
+
+
+def _find_nudge(ledger: Dict[str, Any], nudge_id: str) -> Dict[str, Any] | None:
+    for nudge in ledger.get("nudges", []):
+        if isinstance(nudge, dict) and str(nudge.get("id")) == str(nudge_id):
+            return nudge
+    return None
+
+
+def _detail_card(nudge: Dict[str, Any]) -> str:
+    signal = nudge.get("signal") or {}
+    return (
+        "**Why this surfaced**\n"
+        f"- Type: `{_clip(signal.get('kind'), 80)}`\n"
+        f"- Reason: {_clip(signal.get('reason'), 180)}\n"
+        f"- Source: {_clip(signal.get('source') or signal.get('session_id') or 'local scan', 120)}\n"
+        f"- Evidence: {_clip(signal.get('excerpt'), 360)}\n\n"
+        "**Suggested next action**\n"
+        f"{_clip(nudge.get('message'), 500)}\n\n"
+        "I can work internally from this. I still need explicit approval before sending, posting, emailing, buying, scheduling, or changing external systems."
+    )
+
+
+def _agent_prompt_for_nudge(nudge: Dict[str, Any]) -> str:
+    signal = nudge.get("signal") or {}
+    return (
+        "User tapped Do it on a proactive Hermes nudge. Execute the internal next step now.\n\n"
+        f"Original nudge: {_clip(nudge.get('message'), 700)}\n"
+        f"Signal type: {_clip(signal.get('kind'), 80)}\n"
+        f"Reason: {_clip(signal.get('reason'), 220)}\n"
+        f"Evidence: {_clip(signal.get('excerpt'), 600)}\n\n"
+        "Do not send, post, email, buy, schedule with other people, delete, or modify external systems without explicit approval in this chat. "
+        "Draft, inspect, summarize, or prepare internal work as appropriate, then report the concrete result."
+    )
+
+
+def handle_proactive_feedback(
+    nudge_id: str,
+    action: str,
+    *,
+    now: float | None = None,
+) -> Dict[str, Any]:
+    """Apply feedback from proactive inline buttons and return UI instructions."""
+
+    now = time.time() if now is None else float(now)
+    action = str(action or "").lower().strip()
+    ledger = _load_ledger()
+    nudge = _find_nudge(ledger, nudge_id)
+    if not nudge:
+        return {"ok": False, "ack": "This proactive nudge expired."}
+
+    nudge["last_feedback"] = action
+    nudge["last_feedback_at"] = now
+    event = {"nudge_id": nudge_id, "action": action, "timestamp": now}
+    ledger.setdefault("feedback", []).append(event)
+
+    result: Dict[str, Any]
+    if action == "more":
+        result = {"ok": True, "ack": "More info", "followup": _detail_card(nudge)}
+    elif action == "later":
+        nudge["snoozed_until"] = now + DEFAULT_SNOOZE_HOURS * 3600
+        result = {"ok": True, "ack": "Snoozed for later."}
+    elif action == "not":
+        nudge["status"] = "not_useful"
+        result = {"ok": True, "ack": "Got it — I’ll tune this down."}
+    elif action == "dont":
+        nudge["muted"] = True
+        nudge["status"] = "muted"
+        result = {"ok": True, "ack": "Got it — I won't nudge this again."}
+    elif action == "do":
+        nudge["status"] = "accepted"
+        result = {"ok": True, "ack": "Starting.", "agent_prompt": _agent_prompt_for_nudge(nudge)}
+    else:
+        result = {"ok": False, "ack": "Unknown proactive action."}
+
+    _save_ledger(ledger)
+    return result
+
+
+def extract_scan_report_from_text(text: str) -> Dict[str, Any] | None:
+    """Extract the JSON proactive scan embedded in a cron output document."""
+
+    marker = "## Proactive signal scan"
+    idx = str(text or "").find(marker)
+    if idx < 0:
+        return None
+    json_start = str(text).find("{", idx)
+    if json_start < 0:
+        return None
+    try:
+        report, _end = json.JSONDecoder().raw_decode(str(text)[json_start:])
+    except Exception:
+        return None
+    return report if isinstance(report, dict) else None
+
+
+def prepare_delivery_controls(
+    *,
+    job: Dict[str, Any],
+    message: str,
+    output_doc: str,
+    now: float | None = None,
+) -> Dict[str, Any] | None:
+    """Record a proactive delivery and return Telegram/adapter controls metadata."""
+
+    if job.get("name") != DEFAULT_JOB_NAME and job.get("script") != DEFAULT_SCANNER_SCRIPT:
+        return None
+    scan_report = extract_scan_report_from_text(output_doc)
+    if not scan_report:
+        return None
+    nudge = record_proactive_nudge(job=job, message=message, scan_report=scan_report, now=now)
+    return proactive_controls_for_nudge(nudge)
 
 
 def build_reflection_prompt(
@@ -420,7 +685,7 @@ def _ensure_scanner_script() -> str:
 def cmd_scan_script() -> int:
     """Entrypoint used by the cron pre-run scanner script."""
 
-    report = collect_proactive_signals()
+    report = apply_ledger_filters(collect_proactive_signals())
     print(render_signal_scan(report, include_wake_gate=True))
     return 0
 
@@ -538,9 +803,11 @@ def cmd_proactive(args) -> int:
         return 0
 
     if subcmd == "scan":
-        report = collect_proactive_signals(
-            lookback_days=getattr(args, "lookback_days", 7),
-            max_sessions=getattr(args, "max_sessions", 30),
+        report = apply_ledger_filters(
+            collect_proactive_signals(
+                lookback_days=getattr(args, "lookback_days", 7),
+                max_sessions=getattr(args, "max_sessions", 30),
+            )
         )
         if getattr(args, "json", False):
             print(json.dumps(report, indent=2, sort_keys=True))

--- a/hermes_cli/proactive.py
+++ b/hermes_cli/proactive.py
@@ -1,0 +1,207 @@
+"""Safe proactive reflection helpers for Hermes.
+
+This module intentionally does not make the agent proactive by itself. It builds
+and installs a cron prompt with strong safety boundaries so users can opt in to
+periodic synthesis without granting the job permission to act externally.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any, Dict, Literal
+
+from cron.jobs import create_job, list_jobs, update_job
+
+DEFAULT_JOB_NAME = "Proactive synthesis / safe nudges"
+DEFAULT_SCHEDULE = "0 9 * * *"
+DEFAULT_DELIVER = "local"
+DEFAULT_ENABLED_TOOLSETS = ["session_search", "memory", "todo"]
+_ALLOWED_CONFIDENCE = {"medium", "high"}
+
+
+@dataclass(frozen=True)
+class ProactivePromptOptions:
+    lookback_days: int = 7
+    max_sessions: int = 30
+    min_confidence: Literal["medium", "high"] = "high"
+
+    def normalized(self) -> "ProactivePromptOptions":
+        lookback_days = max(1, min(int(self.lookback_days), 90))
+        max_sessions = max(1, min(int(self.max_sessions), 200))
+        min_confidence = str(self.min_confidence or "high").lower()
+        if min_confidence not in _ALLOWED_CONFIDENCE:
+            min_confidence = "high"
+        return ProactivePromptOptions(
+            lookback_days=lookback_days,
+            max_sessions=max_sessions,
+            min_confidence=min_confidence,  # type: ignore[arg-type]
+        )
+
+
+def build_reflection_prompt(
+    *,
+    lookback_days: int = 7,
+    max_sessions: int = 30,
+    min_confidence: str = "high",
+) -> str:
+    """Build the self-contained prompt used by the proactive cron job.
+
+    The prompt is deliberately conservative: it asks Hermes to synthesize recent
+    interactions, but to return ``[SILENT]`` unless there is one concrete,
+    safe, timely thing worth sending to the user.
+    """
+
+    opts = ProactivePromptOptions(
+        lookback_days=lookback_days,
+        max_sessions=max_sessions,
+        min_confidence=min_confidence,  # type: ignore[arg-type]
+    ).normalized()
+
+    return f"""You are Hermes running a safe proactive reflection pass.
+
+Purpose:
+- Synthesize Charles/user interactions from the last {opts.lookback_days} days across recent sessions.
+- Look for one useful, timely, low-risk proactive nudge Hermes should send without waiting to be asked.
+- Use session_search first: browse recent sessions, then search targeted terms if needed. Review up to {opts.max_sessions} relevant sessions.
+
+Safety policy:
+- Send at most one proactive message.
+- Only message when you have {opts.min_confidence} confidence that it is useful, timely, and wanted.
+- Prefer tiny, concrete nudges: a dropped ball, a blocker, a follow-up the user asked for, a safe reminder, or a concise synthesis that reduces cognitive load.
+- Do not send emails, posts, DMs, calendar invites, payments, public messages, file deletes, or irreversible/external actions.
+- Ask before any action involving money, reputation, external recipients, calendars with other people, destructive changes, or private data sharing.
+- Do not expose private transcript details, secrets, tokens, credentials, customer data, or internal paths.
+- Do not nag about paused/on-hold work, stale ambitions, or low-confidence guesses.
+- If the user has recently said not to be nudged about something, treat that as binding.
+- If a proactive message would be longer than a short text, compress it to one action and offer "More Info".
+
+Output rules:
+- If there is nothing worth sending, start your final response with exactly: [SILENT]
+- If there is something worth sending, send only the user-facing message. No audit log, no analysis, no wrapper.
+- Keep it under 80 words unless the situation is urgent.
+- Include one obvious next action when possible.
+""".strip()
+
+
+def _find_existing_job() -> Dict[str, Any] | None:
+    for job in list_jobs(include_disabled=True):
+        if job.get("name") == DEFAULT_JOB_NAME:
+            return job
+    return None
+
+
+def install_proactive_job(
+    *,
+    schedule: str = DEFAULT_SCHEDULE,
+    deliver: str = DEFAULT_DELIVER,
+    lookback_days: int = 7,
+    max_sessions: int = 30,
+    min_confidence: str = "high",
+    paused: bool = False,
+) -> Dict[str, Any]:
+    """Create or update the built-in proactive synthesis cron job.
+
+    Returns a small report with ``action`` (created/updated/created_paused) and
+    the resulting job dict. The job is idempotent by name so repeated installs
+    tune the same schedule/prompt instead of creating duplicates.
+    """
+
+    prompt = build_reflection_prompt(
+        lookback_days=lookback_days,
+        max_sessions=max_sessions,
+        min_confidence=min_confidence,
+    )
+    existing = _find_existing_job()
+    updates = {
+        "schedule": schedule,
+        "prompt": prompt,
+        "name": DEFAULT_JOB_NAME,
+        "deliver": deliver,
+        "enabled_toolsets": list(DEFAULT_ENABLED_TOOLSETS),
+    }
+
+    if existing:
+        job = update_job(existing["id"], updates)
+        action = "updated"
+    else:
+        job = create_job(
+            prompt=prompt,
+            schedule=schedule,
+            name=DEFAULT_JOB_NAME,
+            deliver=deliver,
+            enabled_toolsets=list(DEFAULT_ENABLED_TOOLSETS),
+        )
+        action = "created"
+
+    if paused and job:
+        job = update_job(
+            job["id"],
+            {
+                "enabled": False,
+                "state": "paused",
+                "paused_reason": "created paused for review",
+            },
+        )
+        action = "created_paused" if action == "created" else "updated_paused"
+
+    return {"action": action, "job": job}
+
+
+def _print_report(report: Dict[str, Any], *, as_json: bool = False) -> None:
+    if as_json:
+        print(json.dumps(report, indent=2, sort_keys=True))
+        return
+
+    action = report.get("action", "ok")
+    job = report.get("job") or {}
+    print(f"Proactive synthesis job {action}.")
+    if job:
+        print(f"  ID: {job.get('id') or job.get('job_id')}")
+        print(f"  Name: {job.get('name')}")
+        print(f"  Schedule: {job.get('schedule_display') or job.get('schedule')}")
+        print(f"  Deliver: {job.get('deliver')}")
+        print(f"  State: {job.get('state')}")
+
+
+def cmd_proactive(args) -> int:
+    """CLI entrypoint for ``hermes proactive``."""
+
+    subcmd = getattr(args, "proactive_command", None) or "prompt"
+    if subcmd == "prompt":
+        prompt = build_reflection_prompt(
+            lookback_days=getattr(args, "lookback_days", 7),
+            max_sessions=getattr(args, "max_sessions", 30),
+            min_confidence=getattr(args, "min_confidence", "high"),
+        )
+        if getattr(args, "json", False):
+            print(
+                json.dumps(
+                    {
+                        "lookback_days": max(1, min(int(getattr(args, "lookback_days", 7)), 90)),
+                        "max_sessions": max(1, min(int(getattr(args, "max_sessions", 30)), 200)),
+                        "min_confidence": str(getattr(args, "min_confidence", "high") or "high").lower(),
+                        "prompt": prompt,
+                    },
+                    indent=2,
+                    sort_keys=True,
+                )
+            )
+        else:
+            print(prompt)
+        return 0
+
+    if subcmd == "install":
+        report = install_proactive_job(
+            schedule=getattr(args, "schedule", DEFAULT_SCHEDULE),
+            deliver=getattr(args, "deliver", DEFAULT_DELIVER),
+            lookback_days=getattr(args, "lookback_days", 7),
+            max_sessions=getattr(args, "max_sessions", 30),
+            min_confidence=getattr(args, "min_confidence", "high"),
+            paused=getattr(args, "paused", False),
+        )
+        _print_report(report, as_json=getattr(args, "json", False))
+        return 0
+
+    print("Usage: hermes proactive [prompt|install]")
+    return 2

--- a/hermes_cli/proactive.py
+++ b/hermes_cli/proactive.py
@@ -1,23 +1,61 @@
-"""Safe proactive reflection helpers for Hermes.
+"""Safe proactive personal-assistant helpers for Hermes.
 
 This module intentionally does not make the agent proactive by itself. It builds
-and installs a cron prompt with strong safety boundaries so users can opt in to
-periodic synthesis without granting the job permission to act externally.
+and installs a cron job with a fast structured signal scan plus a small judgment
+prompt so users can opt in to periodic synthesis without granting permission to
+act externally.
 """
 
 from __future__ import annotations
 
 import json
+import time
 from dataclasses import dataclass
-from typing import Any, Dict, Literal
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Literal
 
 from cron.jobs import create_job, list_jobs, update_job
+from hermes_constants import get_hermes_home
 
 DEFAULT_JOB_NAME = "Proactive synthesis / safe nudges"
 DEFAULT_SCHEDULE = "0 9 * * *"
 DEFAULT_DELIVER = "local"
-DEFAULT_ENABLED_TOOLSETS = ["session_search", "memory", "todo"]
+# The pre-run scanner handles session search. Keep the agent's tool surface small
+# so cron runs do not wander for minutes through session_search.
+DEFAULT_ENABLED_TOOLSETS = ["memory"]
+DEFAULT_SCANNER_SCRIPT = "proactive_signal_scan.py"
 _ALLOWED_CONFIDENCE = {"medium", "high"}
+_MAX_EXCERPT_CHARS = 280
+
+_SCAN_BUCKETS = [
+    {
+        "kind": "content_opportunity",
+        "query": '"meeting notes" OR speech OR "sales team" OR critique OR "X posts" OR delivery OR Notion',
+        "mode": "offer_to_produce",
+        "reason": "fresh notes/content may create a useful draft, critique, or synthesis opportunity",
+    },
+    {
+        "kind": "blocker_or_waiting",
+        "query": 'blocked OR blocker OR waiting OR failed OR failure OR TestFlight OR "Xcode ready" OR gateway',
+        "mode": "ask_or_checked",
+        "reason": "possible blocker or waiting item that may need a next action",
+    },
+    {
+        "kind": "follow_up_or_watch",
+        "query": '"want me" OR "look into" OR "follow up" OR reminder OR proactive OR "More Info"',
+        "mode": "ask_to_investigate",
+        "reason": "possible user-requested follow-up, watch item, or permission-shaped opportunity",
+    },
+    {
+        "kind": "external_risk",
+        "query": 'Stripe OR payment OR purchase OR order OR email OR post OR DM OR calendar OR "App Store Connect"',
+        "mode": "ask_first",
+        "reason": "external/money/reputation risk; draft or ask only, never act externally",
+    },
+]
+
+_SUPPRESSION_QUERY = 'OwnerPath OR "on hold" OR paused OR "do not nudge" OR "don\'t nudge" OR "not useful"'
 
 
 @dataclass(frozen=True)
@@ -39,6 +77,55 @@ class ProactivePromptOptions:
         )
 
 
+def _clip(value: Any, limit: int = _MAX_EXCERPT_CHARS) -> str:
+    text = " ".join(str(value or "").replace("\r", " ").replace("\n", " ").split())
+    if len(text) <= limit:
+        return text
+    return text[: limit - 1].rstrip() + "…"
+
+
+def _looks_machine_text(value: Any) -> bool:
+    text = _clip(value, 500).lstrip()
+    lower = text.lower()
+    if not text:
+        return True
+    if text.startswith(("{", "[{", "[TOOL]", "[Called:")):
+        return True
+    machine_markers = (
+        '"success":',
+        '"call_id"',
+        '"tool_call_id"',
+        '"bytes_written"',
+        '"exit_code"',
+        '"files_modified"',
+        "response_item_id",
+        "tool_use",
+    )
+    return any(marker in lower for marker in machine_markers)
+
+
+def _iso(ts: Any) -> str | None:
+    try:
+        return datetime.fromtimestamp(float(ts), tz=timezone.utc).isoformat()
+    except Exception:
+        return None
+
+
+def _recent(ts: Any, cutoff: float) -> bool:
+    try:
+        return float(ts) >= cutoff
+    except Exception:
+        return True
+
+
+def _signal_key(signal: Dict[str, Any]) -> tuple:
+    return (
+        signal.get("kind"),
+        signal.get("session_id"),
+        _clip(signal.get("excerpt"), 100).lower(),
+    )
+
+
 def build_reflection_prompt(
     *,
     lookback_days: int = 7,
@@ -47,9 +134,9 @@ def build_reflection_prompt(
 ) -> str:
     """Build the self-contained prompt used by the proactive cron job.
 
-    The prompt is deliberately conservative: it asks Hermes to synthesize recent
-    interactions, but to return ``[SILENT]`` unless there is one concrete,
-    safe, timely thing worth sending to the user.
+    The cron job injects structured script output before this prompt. The model's
+    job is judgment, not open-ended research: decide whether to send one tiny
+    proactive PA-style message or stay silent.
     """
 
     opts = ProactivePromptOptions(
@@ -58,7 +145,9 @@ def build_reflection_prompt(
         min_confidence=min_confidence,  # type: ignore[arg-type]
     ).normalized()
 
-    return f"""You are Hermes running a safe proactive reflection pass for Charles.
+    return f"""You are Hermes running a safe proactive personal-assistant pass for Charles.
+
+You should receive a structured "Proactive signal scan" in the script output above. Use that scan as your primary context. Do not wander through session history; the scanner already did the broad pass. If the scan has no strong candidate, say nothing.
 
 Role:
 - Act like a friendly, competent personal assistant, not an alert bot.
@@ -68,11 +157,10 @@ Outcome:
 - Either send one sharp, useful nudge Charles would be glad to receive, or say nothing.
 - Silence is the correct answer unless the best candidate clears the bar.
 
-Discovery:
-1. Use session_search first: browse recent sessions, then search targeted terms if needed. Review up to {opts.max_sessions} relevant sessions from the last {opts.lookback_days} days.
-2. Check current todos if available, but do not treat a stale todo as enough by itself.
-3. Use memory/user preferences as binding constraints, especially paused/on-hold work and topics Charles said not to nudge.
-4. Infer what Hermes has access to from available tools and prior sessions; do not pretend to have access you have not verified.
+Discovery already performed:
+- Recent sessions: up to {opts.max_sessions} sessions from the last {opts.lookback_days} days.
+- Signal buckets: content opportunities, blockers/waiting items, follow-ups/watch items, external-risk items, cron health, and suppressed topics.
+- Available access/boundaries are listed in the scan. Do not pretend Hermes has access that the scan did not verify.
 
 Proactive modes:
 - Already checked: "I looked into X because I thought it would help; here's the useful bit."
@@ -116,6 +204,227 @@ Output rules:
 """.strip()
 
 
+def collect_proactive_signals(
+    *,
+    lookback_days: int = 7,
+    max_sessions: int = 30,
+) -> Dict[str, Any]:
+    """Collect fast, structured proactive signals without invoking an LLM.
+
+    This intentionally uses local state and cron metadata instead of the
+    ``session_search`` tool so scheduled proactive runs stay bounded and cheap.
+    """
+
+    opts = ProactivePromptOptions(lookback_days=lookback_days, max_sessions=max_sessions).normalized()
+    now = time.time()
+    cutoff = now - opts.lookback_days * 86400
+    report: Dict[str, Any] = {
+        "generated_at": datetime.fromtimestamp(now, tz=timezone.utc).isoformat(),
+        "lookback_days": opts.lookback_days,
+        "max_sessions": opts.max_sessions,
+        "available_access": [
+            "local Hermes session history (state.db)",
+            "local Hermes cron job metadata",
+            "built-in memory/user preferences available to the judge",
+        ],
+        "boundaries": {
+            "can_observe": True,
+            "can_summarize": True,
+            "can_draft_internally": True,
+            "must_ask_before_external_action": True,
+            "external_send_allowed_from_cron": False,
+        },
+        "recent_sessions": [],
+        "signals": [],
+        "suppressed_topics": [],
+        "scan_errors": [],
+    }
+
+    seen: set[tuple] = set()
+
+    def add_signal(signal: Dict[str, Any]) -> None:
+        key = _signal_key(signal)
+        if key in seen:
+            return
+        seen.add(key)
+        report["signals"].append(signal)
+
+    try:
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            sessions = db.list_sessions_rich(
+                limit=opts.max_sessions,
+                order_by_last_active=True,
+                include_children=False,
+                exclude_sources=["cron"],
+            )
+        except TypeError:
+            # Older/mocked SessionDB implementations may not accept newer args.
+            sessions = db.search_sessions(limit=opts.max_sessions)
+        for session in sessions:
+            ts = session.get("last_active") or session.get("started_at")
+            if not _recent(ts, cutoff):
+                continue
+            report["recent_sessions"].append(
+                {
+                    "id": session.get("id"),
+                    "source": session.get("source"),
+                    "title": session.get("title"),
+                    "last_active": _iso(ts),
+                    "preview": _clip(session.get("preview"), 160),
+                }
+            )
+
+        for bucket in _SCAN_BUCKETS:
+            try:
+                matches = db.search_messages(
+                    bucket["query"],
+                    role_filter=["user", "assistant"],
+                    exclude_sources=["cron"],
+                    limit=max(20, opts.max_sessions * 2),
+                )
+            except Exception as exc:
+                report["scan_errors"].append(f"{bucket['kind']} search failed: {exc}")
+                continue
+            for match in matches:
+                ts = match.get("timestamp") or match.get("session_started")
+                if not _recent(ts, cutoff):
+                    continue
+                snippet = str(match.get("snippet") or "").strip()
+                context_text = " ".join(
+                    _clip((ctx or {}).get("content"), 120)
+                    for ctx in (match.get("context") or [])
+                    if (ctx or {}).get("content") and not _looks_machine_text((ctx or {}).get("content"))
+                ).strip()
+                if _looks_machine_text(snippet) and not context_text:
+                    continue
+                content = context_text if _looks_machine_text(snippet) else (snippet or context_text)
+                if not content:
+                    continue
+                add_signal(
+                    {
+                        "kind": bucket["kind"],
+                        "mode": bucket["mode"],
+                        "reason": bucket["reason"],
+                        "session_id": match.get("session_id"),
+                        "source": match.get("source"),
+                        "timestamp": _iso(ts),
+                        "excerpt": _clip(content),
+                    }
+                )
+                if len(report["signals"]) >= 12:
+                    break
+            if len(report["signals"]) >= 12:
+                break
+
+        try:
+            suppressed = db.search_messages(
+                _SUPPRESSION_QUERY,
+                role_filter=["user", "assistant"],
+                exclude_sources=["cron"],
+                limit=20,
+            )
+            for match in suppressed:
+                ts = match.get("timestamp") or match.get("session_started")
+                if not _recent(ts, cutoff):
+                    continue
+                snippet = str(match.get("snippet") or "").strip()
+                context_text = " ".join(
+                    _clip((ctx or {}).get("content"), 120)
+                    for ctx in (match.get("context") or [])
+                    if (ctx or {}).get("content") and not _looks_machine_text((ctx or {}).get("content"))
+                ).strip()
+                if _looks_machine_text(snippet) and not context_text:
+                    continue
+                excerpt = context_text if _looks_machine_text(snippet) else (snippet or context_text)
+                if not excerpt:
+                    continue
+                report["suppressed_topics"].append(
+                    {
+                        "session_id": match.get("session_id"),
+                        "source": match.get("source"),
+                        "timestamp": _iso(ts),
+                        "excerpt": _clip(excerpt, 220),
+                    }
+                )
+                if len(report["suppressed_topics"]) >= 5:
+                    break
+        except Exception as exc:
+            report["scan_errors"].append(f"suppression search failed: {exc}")
+    except Exception as exc:
+        report["scan_errors"].append(f"session scan unavailable: {exc}")
+
+    try:
+        for job in list_jobs(include_disabled=True):
+            last_error = job.get("last_error")
+            delivery_error = job.get("last_delivery_error")
+            last_status = str(job.get("last_status") or "").lower()
+            state = str(job.get("state") or "").lower()
+            if last_error or delivery_error or last_status in {"error", "failed"} or state in {"error", "failed"}:
+                add_signal(
+                    {
+                        "kind": "cron_failure",
+                        "mode": "already_checked",
+                        "reason": "scheduled job reports an error or failed delivery",
+                        "job_id": job.get("id"),
+                        "name": job.get("name"),
+                        "state": job.get("state"),
+                        "last_status": job.get("last_status"),
+                        "excerpt": _clip(last_error or delivery_error or "cron job failed"),
+                    }
+                )
+    except Exception as exc:
+        report["scan_errors"].append(f"cron scan unavailable: {exc}")
+
+    # Keep prompt injection compact and stable.
+    report["recent_sessions"] = report["recent_sessions"][:10]
+    report["signals"] = report["signals"][:12]
+    report["suppressed_topics"] = report["suppressed_topics"][:5]
+    report["wakeAgent"] = bool(report["signals"] or report["scan_errors"])
+    return report
+
+
+def render_signal_scan(report: Dict[str, Any], *, include_wake_gate: bool = True) -> str:
+    """Render a scan report for cron script stdout.
+
+    The scheduler treats a final JSON line with ``{"wakeAgent": false}`` as a
+    gate to skip the LLM entirely, so keep that object as the last non-empty line.
+    """
+
+    wake = bool(report.get("wakeAgent", True))
+    if include_wake_gate and not wake:
+        return json.dumps({"wakeAgent": False}, sort_keys=True)
+    body = "## Proactive signal scan\n" + json.dumps(report, indent=2, sort_keys=True)
+    if include_wake_gate:
+        body += "\n" + json.dumps({"wakeAgent": wake}, sort_keys=True)
+    return body
+
+
+def _ensure_scanner_script() -> str:
+    scripts_dir = get_hermes_home() / "scripts"
+    scripts_dir.mkdir(parents=True, exist_ok=True)
+    path = scripts_dir / DEFAULT_SCANNER_SCRIPT
+    module_root = Path(__file__).resolve().parents[1]
+    path.write_text(
+        "import sys\n"
+        f"sys.path.insert(0, {str(module_root)!r})\n"
+        "from hermes_cli.proactive import cmd_scan_script\n"
+        "raise SystemExit(cmd_scan_script())\n",
+        encoding="utf-8",
+    )
+    return DEFAULT_SCANNER_SCRIPT
+
+
+def cmd_scan_script() -> int:
+    """Entrypoint used by the cron pre-run scanner script."""
+
+    report = collect_proactive_signals()
+    print(render_signal_scan(report, include_wake_gate=True))
+    return 0
+
+
 def _find_existing_job() -> Dict[str, Any] | None:
     for job in list_jobs(include_disabled=True):
         if job.get("name") == DEFAULT_JOB_NAME:
@@ -144,12 +453,14 @@ def install_proactive_job(
         max_sessions=max_sessions,
         min_confidence=min_confidence,
     )
+    script = _ensure_scanner_script()
     existing = _find_existing_job()
     updates = {
         "schedule": schedule,
         "prompt": prompt,
         "name": DEFAULT_JOB_NAME,
         "deliver": deliver,
+        "script": script,
         "enabled_toolsets": list(DEFAULT_ENABLED_TOOLSETS),
     }
 
@@ -162,6 +473,7 @@ def install_proactive_job(
             schedule=schedule,
             name=DEFAULT_JOB_NAME,
             deliver=deliver,
+            script=script,
             enabled_toolsets=list(DEFAULT_ENABLED_TOOLSETS),
         )
         action = "created"
@@ -194,6 +506,8 @@ def _print_report(report: Dict[str, Any], *, as_json: bool = False) -> None:
         print(f"  Schedule: {job.get('schedule_display') or job.get('schedule')}")
         print(f"  Deliver: {job.get('deliver')}")
         print(f"  State: {job.get('state')}")
+        print(f"  Script: {job.get('script')}")
+        print(f"  Toolsets: {', '.join(job.get('enabled_toolsets') or []) or 'default'}")
 
 
 def cmd_proactive(args) -> int:
@@ -223,6 +537,17 @@ def cmd_proactive(args) -> int:
             print(prompt)
         return 0
 
+    if subcmd == "scan":
+        report = collect_proactive_signals(
+            lookback_days=getattr(args, "lookback_days", 7),
+            max_sessions=getattr(args, "max_sessions", 30),
+        )
+        if getattr(args, "json", False):
+            print(json.dumps(report, indent=2, sort_keys=True))
+        else:
+            print(render_signal_scan(report, include_wake_gate=False))
+        return 0
+
     if subcmd == "install":
         report = install_proactive_job(
             schedule=getattr(args, "schedule", DEFAULT_SCHEDULE),
@@ -235,5 +560,5 @@ def cmd_proactive(args) -> int:
         _print_report(report, as_json=getattr(args, "json", False))
         return 0
 
-    print("Usage: hermes proactive [prompt|install]")
+    print("Usage: hermes proactive [prompt|scan|install]")
     return 2

--- a/hermes_cli/proactive.py
+++ b/hermes_cli/proactive.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import json
 import hashlib
+import re
 import time
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -33,32 +34,76 @@ _MAX_EXCERPT_CHARS = 280
 
 _SCAN_BUCKETS = [
     {
+        "kind": "blocker_or_waiting",
+        "area": "projects",
+        "query": 'blocked OR blocker OR waiting OR failed OR failure OR stuck OR "Xcode ready" OR TestFlight OR gateway OR deploy OR shipping',
+        "mode": "ask_or_checked",
+        "reason": "possible blocker or waiting item that may need one concrete next action",
+        "score": 80,
+    },
+    {
+        "kind": "decision_needed",
+        "area": "decisions",
+        "query": 'decide OR decision OR choose OR approval OR approve OR "which one" OR "should we" OR "what do you think" OR option OR tradeoff',
+        "mode": "ask_smart_question",
+        "reason": "possible decision point where a good question could unblock Charles or prevent rework",
+        "score": 76,
+    },
+    {
+        "kind": "commitment_or_followup",
+        "area": "follow_up",
+        "query": '"I will" OR "I’ll" OR "remind me" OR "follow up" OR "circle back" OR "waiting on" OR "next step" OR "want me to" OR "look into"',
+        "mode": "ask_to_investigate",
+        "reason": "possible user-requested follow-up, watch item, or permission-shaped assistant opportunity",
+        "score": 72,
+    },
+    {
         "kind": "content_opportunity",
-        "query": '"meeting notes" OR speech OR "sales team" OR critique OR "X posts" OR delivery OR Notion',
+        "area": "content",
+        "query": '"meeting notes" OR speech OR "sales team" OR critique OR "X posts" OR delivery OR Notion OR draft OR framework OR content',
         "mode": "offer_to_produce",
         "reason": "fresh notes/content may create a useful draft, critique, or synthesis opportunity",
+        "score": 66,
     },
     {
-        "kind": "blocker_or_waiting",
-        "query": 'blocked OR blocker OR waiting OR failed OR failure OR TestFlight OR "Xcode ready" OR gateway',
-        "mode": "ask_or_checked",
-        "reason": "possible blocker or waiting item that may need a next action",
-    },
-    {
-        "kind": "follow_up_or_watch",
-        "query": '"want me" OR "look into" OR "follow up" OR reminder OR proactive OR "More Info"',
-        "mode": "ask_to_investigate",
-        "reason": "possible user-requested follow-up, watch item, or permission-shaped opportunity",
+        "kind": "personal_logistics",
+        "area": "personal",
+        "query": 'family OR house OR home OR kids OR school OR appointment OR reservation OR travel OR dinner OR errands OR contractor OR install',
+        "mode": "ask_smart_question",
+        "reason": "possible personal/logistics item where a small assistant question or next step could help",
+        "score": 58,
     },
     {
         "kind": "external_risk",
-        "query": 'Stripe OR payment OR purchase OR order OR email OR post OR DM OR calendar OR "App Store Connect"',
+        "area": "external_risk",
+        "query": 'Stripe OR payment OR purchase OR order OR email OR post OR DM OR calendar OR "App Store Connect" OR publish OR send',
         "mode": "ask_first",
         "reason": "external/money/reputation risk; draft or ask only, never act externally",
+        "score": 62,
     },
 ]
 
 _SUPPRESSION_QUERY = 'OwnerPath OR "on hold" OR paused OR "do not nudge" OR "don\'t nudge" OR "not useful"'
+
+_META_PROACTIVITY_RE = re.compile(
+    r"\b(proactive|proactivity|nudge|nudges|more info|do it|not useful|don't nudge|dont nudge|feedback buttons?)\b",
+    re.I,
+)
+
+_LOG_INTERESTING_RE = re.compile(r"(error|exception|traceback|failed|timeout|conflict|delivery|unauthorized|context overflow)", re.I)
+_LOG_NOISE_RE = re.compile(r"(DEBUG|heartbeat|typing action|inbound message:|Suppressing normal final send)", re.I)
+_INTERNAL_SUMMARY_RE = re.compile(r"(context compaction|reference only|completed actions|active task|handoff)", re.I)
+_SIGNAL_KIND_SCORE = {
+    "cron_failure": 95,
+    "gateway_log_watch": 82,
+    "state_decision_needed": 80,
+    "blocker_or_waiting": 80,
+    "decision_needed": 76,
+    "commitment_or_followup": 72,
+    "external_risk": 62,
+    "content_opportunity": 66,
+    "personal_logistics": 58,
+}
 
 
 @dataclass(frozen=True)
@@ -92,6 +137,8 @@ def _looks_machine_text(value: Any) -> bool:
     lower = text.lower()
     if not text:
         return True
+    if _INTERNAL_SUMMARY_RE.search(text):
+        return True
     if text.startswith(("{", "[{", "[TOOL]", "[Called:")):
         return True
     machine_markers = (
@@ -101,10 +148,44 @@ def _looks_machine_text(value: Any) -> bool:
         '"bytes_written"',
         '"exit_code"',
         '"files_modified"',
+        '"signals":',
+        '"kind":',
         "response_item_id",
         "tool_use",
+        "diff --git",
+        "@@",
+        "tmp_path",
+        "monkeypatch",
+        "\\\\n+",
+        "## active state",
+        "mcp_link_cli",
     )
     return any(marker in lower for marker in machine_markers)
+
+
+def _looks_meta_proactivity_text(value: Any) -> bool:
+    """Avoid letting self-improvement chatter become the proactive nudge."""
+
+    text = _clip(value, 700)
+    if not text:
+        return False
+    if not _META_PROACTIVITY_RE.search(text):
+        return False
+    operational_markers = (
+        "wfg",
+        "spark",
+        "slack",
+        "testflight",
+        "xcode",
+        "smoothcurb",
+        "stripe",
+        "ticktick",
+        "cron failed",
+        "gateway conflict",
+        "meeting notes",
+        "sales team",
+    )
+    return not any(marker in text.lower() for marker in operational_markers)
 
 
 def _iso(ts: Any) -> str | None:
@@ -124,9 +205,154 @@ def _recent(ts: Any, cutoff: float) -> bool:
 def _signal_key(signal: Dict[str, Any]) -> tuple:
     return (
         signal.get("kind"),
-        signal.get("session_id"),
+        signal.get("session_id") or signal.get("name") or signal.get("source"),
         _clip(signal.get("excerpt"), 100).lower(),
     )
+
+
+def _signal_score(signal: Dict[str, Any]) -> int:
+    try:
+        base = int(signal.get("score") or _SIGNAL_KIND_SCORE.get(str(signal.get("kind")), 40))
+    except Exception:
+        base = 40
+    mode = str(signal.get("mode") or "")
+    if mode == "ask_smart_question":
+        base += 4
+    if signal.get("timestamp"):
+        base += 1
+    return base
+
+
+def _rank_signals(signals: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    ranked = []
+    for idx, signal in enumerate(signals):
+        item = dict(signal)
+        item.setdefault("score", _signal_score(item))
+        ranked.append((idx, item))
+    ranked.sort(key=lambda pair: (-_signal_score(pair[1]), pair[0]))
+    return [item for _idx, item in ranked]
+
+
+def _read_home_file(name: str, limit: int = 800) -> str:
+    try:
+        path = get_hermes_home() / name
+        if not path.exists():
+            return ""
+        return _clip(path.read_text(encoding="utf-8", errors="ignore"), limit)
+    except Exception:
+        return ""
+
+
+def _extract_section(text: str, heading: str) -> str:
+    marker = f"## {heading}"
+    idx = text.find(marker)
+    if idx < 0:
+        return ""
+    rest = text[idx + len(marker):]
+    next_heading = re.search(r"\n##\s+", rest)
+    return rest[: next_heading.start()].strip() if next_heading else rest.strip()
+
+
+def _profile_context_snapshot() -> Dict[str, str]:
+    state = _read_home_file("proactive-state.md", 1800)
+    heartbeat = _read_home_file("HEARTBEAT.md", 900)
+    return {
+        "proactive_state": state,
+        "heartbeat_rules": heartbeat,
+    }
+
+
+def _signals_from_profile_context(context: Dict[str, str]) -> List[Dict[str, Any]]:
+    signals: List[Dict[str, Any]] = []
+    blocked = _extract_section(context.get("proactive_state", ""), "Blocked / Needs Decision")
+    for line in blocked.splitlines():
+        text = line.strip().lstrip("- ").strip()
+        if not text or text.lower().startswith("none") or _looks_meta_proactivity_text(text):
+            continue
+        signals.append(
+            {
+                "kind": "state_decision_needed",
+                "area": "decisions",
+                "mode": "ask_smart_question",
+                "reason": "proactive state lists a blocked item or decision Charles may need to resolve",
+                "source": "proactive-state.md",
+                "excerpt": _clip(text),
+                "score": _SIGNAL_KIND_SCORE["state_decision_needed"],
+            }
+        )
+    return signals
+
+
+def _log_health_signals(limit: int = 3) -> List[Dict[str, Any]]:
+    signals: List[Dict[str, Any]] = []
+    log_dir = get_hermes_home() / "logs"
+    for name in ("gateway.log", "errors.log", "agent.log"):
+        path = log_dir / name
+        if not path.exists():
+            continue
+        try:
+            lines = path.read_text(encoding="utf-8", errors="ignore").splitlines()[-300:]
+        except Exception:
+            continue
+        for line in lines:
+            if _LOG_NOISE_RE.search(line) or not _LOG_INTERESTING_RE.search(line):
+                continue
+            signals.append(
+                {
+                    "kind": "gateway_log_watch",
+                    "area": "system_health",
+                    "mode": "already_checked",
+                    "reason": "recent Hermes logs contain a possible issue worth verifying before it affects Charles",
+                    "source": name,
+                    "excerpt": _clip(line, 260),
+                    "score": _SIGNAL_KIND_SCORE["gateway_log_watch"],
+                }
+            )
+            if len(signals) >= limit:
+                return signals
+    return signals
+
+
+def _custom_profile_signals(limit: int = 12) -> List[Dict[str, Any]]:
+    """Load optional profile-local signals from ~/.hermes/proactive/signals.json.
+
+    This is the escape hatch for user-specific scanners (email/calendar/business
+    metrics/TickTick/WFG/etc.) without hardcoding private integrations upstream.
+    Shape: {"signals": [{"kind": ..., "excerpt": ..., "mode": ...}]} or a raw list.
+    """
+
+    path = get_hermes_home() / "proactive" / "signals.json"
+    if not path.exists():
+        return []
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return []
+    items = raw.get("signals") if isinstance(raw, dict) else raw
+    if not isinstance(items, list):
+        return []
+    signals: List[Dict[str, Any]] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        excerpt = _clip(item.get("excerpt") or item.get("detail") or item.get("title"), 360)
+        if not excerpt or _looks_machine_text(excerpt) or _looks_meta_proactivity_text(excerpt):
+            continue
+        signal = {
+            "kind": _clip(item.get("kind") or "custom_profile_signal", 80),
+            "area": _clip(item.get("area") or "custom", 80),
+            "mode": _clip(item.get("mode") or "ask_to_investigate", 80),
+            "reason": _clip(item.get("reason") or "profile-local proactive signal", 220),
+            "source": _clip(item.get("source") or "proactive/signals.json", 120),
+            "excerpt": excerpt,
+            "score": int(item.get("score") or 70),
+        }
+        if item.get("action"):
+            signal["suggested_action"] = _clip(item.get("action"), 260)
+        signals.append(signal)
+        if len(signals) >= limit:
+            break
+    return signals
 
 
 def _ledger_path() -> Path:
@@ -436,8 +662,10 @@ Proactive modes:
 High-signal candidates, in order:
 - A time-sensitive blocker that prevents a project from shipping and has one obvious next action.
 - A user-requested follow-up/reminder/watch item that is now due or newly relevant.
+- A smart question that would unblock Charles, clarify a decision, or prevent rework.
 - A system/job/integration failure Charles likely expects Hermes to notice.
 - A fresh artifact or conversation that creates an obvious assistant opportunity, e.g. meeting notes → sales coaching critique or X post drafts.
+- A useful pattern across work, content, family/personal logistics, tools, inbox, calendar, tasks, sales ops, or projects — not just WFG/source health.
 - A near-term commitment Charles explicitly owns.
 - A concise synthesis that prevents repeated work or a dropped ball.
 
@@ -446,6 +674,8 @@ Do not send low-value nudges:
 - No stale ambitions, paused/on-hold work, or old projects unless Charles recently reopened them.
 - No "test this sometime" unless it is blocking something Charles is actively trying to ship.
 - No nudges based only on one vague mention, weak inference, or your desire to be helpful.
+- Do not nudge Charles about making Hermes more proactive, adding buttons, feedback schemas, or other meta-Hermes improvements from this cron; those belong in the active chat/PR workflow, not random proactive messages.
+- Prefer real-world operational signals over conversation meta: WFG/source quality shifts, broken jobs, waiting blockers, deadlines, customer-impacting issues, or a concrete draft/synthesis opportunity.
 
 Safety policy:
 - Send at most one proactive message.
@@ -490,6 +720,9 @@ def collect_proactive_signals(
         "available_access": [
             "local Hermes session history (state.db)",
             "local Hermes cron job metadata",
+            "local Hermes profile state files (proactive-state.md, HEARTBEAT.md)",
+            "local Hermes logs for health signals",
+            "optional profile-local proactive/signals.json for user-specific scanners",
             "built-in memory/user preferences available to the judge",
         ],
         "boundaries": {
@@ -500,6 +733,7 @@ def collect_proactive_signals(
             "external_send_allowed_from_cron": False,
         },
         "recent_sessions": [],
+        "assistant_context": _profile_context_snapshot(),
         "signals": [],
         "suppressed_topics": [],
         "scan_errors": [],
@@ -508,11 +742,20 @@ def collect_proactive_signals(
     seen: set[tuple] = set()
 
     def add_signal(signal: Dict[str, Any]) -> None:
+        signal = dict(signal)
+        signal.setdefault("score", _signal_score(signal))
         key = _signal_key(signal)
         if key in seen:
             return
         seen.add(key)
         report["signals"].append(signal)
+
+    for signal in _signals_from_profile_context(report["assistant_context"]):
+        add_signal(signal)
+    for signal in _custom_profile_signals():
+        add_signal(signal)
+    for signal in _log_health_signals():
+        add_signal(signal)
 
     try:
         from hermes_state import SessionDB
@@ -566,22 +809,24 @@ def collect_proactive_signals(
                 if _looks_machine_text(snippet) and not context_text:
                     continue
                 content = context_text if _looks_machine_text(snippet) else (snippet or context_text)
-                if not content:
+                if not content or _looks_meta_proactivity_text(content):
                     continue
                 add_signal(
                     {
                         "kind": bucket["kind"],
+                        "area": bucket.get("area"),
                         "mode": bucket["mode"],
                         "reason": bucket["reason"],
                         "session_id": match.get("session_id"),
                         "source": match.get("source"),
                         "timestamp": _iso(ts),
                         "excerpt": _clip(content),
+                        "score": bucket.get("score"),
                     }
                 )
-                if len(report["signals"]) >= 12:
+                if len(report["signals"]) >= 80:
                     break
-            if len(report["signals"]) >= 12:
+            if len(report["signals"]) >= 80:
                 break
 
         try:
@@ -631,6 +876,7 @@ def collect_proactive_signals(
                 add_signal(
                     {
                         "kind": "cron_failure",
+                        "area": "system_health",
                         "mode": "already_checked",
                         "reason": "scheduled job reports an error or failed delivery",
                         "job_id": job.get("id"),
@@ -638,6 +884,7 @@ def collect_proactive_signals(
                         "state": job.get("state"),
                         "last_status": job.get("last_status"),
                         "excerpt": _clip(last_error or delivery_error or "cron job failed"),
+                        "score": _SIGNAL_KIND_SCORE["cron_failure"],
                     }
                 )
     except Exception as exc:
@@ -645,7 +892,7 @@ def collect_proactive_signals(
 
     # Keep prompt injection compact and stable.
     report["recent_sessions"] = report["recent_sessions"][:10]
-    report["signals"] = report["signals"][:12]
+    report["signals"] = _rank_signals(report["signals"])[:12]
     report["suppressed_topics"] = report["suppressed_topics"][:5]
     report["wakeAgent"] = bool(report["signals"] or report["scan_errors"])
     return report

--- a/hermes_cli/proactive.py
+++ b/hermes_cli/proactive.py
@@ -58,23 +58,42 @@ def build_reflection_prompt(
         min_confidence=min_confidence,  # type: ignore[arg-type]
     ).normalized()
 
-    return f"""You are Hermes running a safe proactive reflection pass.
+    return f"""You are Hermes running a safe proactive reflection pass for Charles.
 
-Purpose:
-- Synthesize Charles/user interactions from the last {opts.lookback_days} days across recent sessions.
-- Look for one useful, timely, low-risk proactive nudge Hermes should send without waiting to be asked.
-- Use session_search first: browse recent sessions, then search targeted terms if needed. Review up to {opts.max_sessions} relevant sessions.
+Outcome:
+- Either send one sharp, useful nudge Charles would be glad to receive, or say nothing.
+- Silence is the correct answer unless the best candidate clears the bar.
+
+Discovery:
+1. Use session_search first: browse recent sessions, then search targeted terms if needed. Review up to {opts.max_sessions} relevant sessions from the last {opts.lookback_days} days.
+2. Check current todos if available, but do not treat a stale todo as enough by itself.
+3. Use memory/user preferences as binding constraints, especially paused/on-hold work and topics Charles said not to nudge.
+
+High-signal candidates, in order:
+- A time-sensitive blocker that prevents a project from shipping and has one obvious next action.
+- A user-requested follow-up/reminder/watch item that is now due or newly relevant.
+- A system/job/integration failure Charles likely expects Hermes to notice.
+- A near-term commitment Charles explicitly owns.
+- A concise synthesis that prevents repeated work or a dropped ball.
+
+Do not send low-value nudges:
+- No generic summaries, status theater, "you might want to", or obvious reminders.
+- No stale ambitions, paused/on-hold work, or old projects unless Charles recently reopened them.
+- No "test this sometime" unless it is blocking something Charles is actively trying to ship.
+- No nudges based only on one vague mention, weak inference, or your desire to be helpful.
 
 Safety policy:
 - Send at most one proactive message.
 - Only message when you have {opts.min_confidence} confidence that it is useful, timely, and wanted.
-- Prefer tiny, concrete nudges: a dropped ball, a blocker, a follow-up the user asked for, a safe reminder, or a concise synthesis that reduces cognitive load.
 - Do not send emails, posts, DMs, calendar invites, payments, public messages, file deletes, or irreversible/external actions.
 - Ask before any action involving money, reputation, external recipients, calendars with other people, destructive changes, or private data sharing.
 - Do not expose private transcript details, secrets, tokens, credentials, customer data, or internal paths.
-- Do not nag about paused/on-hold work, stale ambitions, or low-confidence guesses.
-- If the user has recently said not to be nudged about something, treat that as binding.
 - If a proactive message would be longer than a short text, compress it to one action and offer "More Info".
+
+Quality gate before final:
+- Would Charles plausibly reply "that is not good enough" or "why are you telling me this"? If yes, output [SILENT].
+- Is the next action concrete enough to do in one reply? If not, output [SILENT].
+- Is this materially better than waiting for Charles to ask? If not, output [SILENT].
 
 Output rules:
 - If there is nothing worth sending, start your final response with exactly: [SILENT]

--- a/hermes_cli/proactive.py
+++ b/hermes_cli/proactive.py
@@ -60,6 +60,10 @@ def build_reflection_prompt(
 
     return f"""You are Hermes running a safe proactive reflection pass for Charles.
 
+Role:
+- Act like a friendly, competent personal assistant, not an alert bot.
+- Learn from recent conversations when to scan, when to stay quiet, and when to ask before spending effort.
+
 Outcome:
 - Either send one sharp, useful nudge Charles would be glad to receive, or say nothing.
 - Silence is the correct answer unless the best candidate clears the bar.
@@ -68,11 +72,19 @@ Discovery:
 1. Use session_search first: browse recent sessions, then search targeted terms if needed. Review up to {opts.max_sessions} relevant sessions from the last {opts.lookback_days} days.
 2. Check current todos if available, but do not treat a stale todo as enough by itself.
 3. Use memory/user preferences as binding constraints, especially paused/on-hold work and topics Charles said not to nudge.
+4. Infer what Hermes has access to from available tools and prior sessions; do not pretend to have access you have not verified.
+
+Proactive modes:
+- Already checked: "I looked into X because I thought it would help; here's the useful bit."
+- Ask to investigate: "I thought of X; want me to look into it?" Use this when helpfulness is plausible but uncertain.
+- Offer to produce: "I saw Y; I can draft/critique/synthesize Z if you want." Use this for content, meeting notes, coaching, and planning.
+- Silent: no message when the idea is weak, stale, intrusive, or not worth interrupting Charles.
 
 High-signal candidates, in order:
 - A time-sensitive blocker that prevents a project from shipping and has one obvious next action.
 - A user-requested follow-up/reminder/watch item that is now due or newly relevant.
 - A system/job/integration failure Charles likely expects Hermes to notice.
+- A fresh artifact or conversation that creates an obvious assistant opportunity, e.g. meeting notes → sales coaching critique or X post drafts.
 - A near-term commitment Charles explicitly owns.
 - A concise synthesis that prevents repeated work or a dropped ball.
 
@@ -85,8 +97,9 @@ Do not send low-value nudges:
 Safety policy:
 - Send at most one proactive message.
 - Only message when you have {opts.min_confidence} confidence that it is useful, timely, and wanted.
-- Do not send emails, posts, DMs, calendar invites, payments, public messages, file deletes, or irreversible/external actions.
+- NEVER send anything outside Hermes/the configured delivery system. Do not email, post, DM, submit forms, call APIs that publish, schedule meetings, pay, buy, delete, or modify external systems from this cron.
 - Ask before any action involving money, reputation, external recipients, calendars with other people, destructive changes, or private data sharing.
+- Drafting internally is allowed when low-risk; external sending is never allowed without explicit user approval in a normal interactive session.
 - Do not expose private transcript details, secrets, tokens, credentials, customer data, or internal paths.
 - If a proactive message would be longer than a short text, compress it to one action and offer "More Info".
 

--- a/hermes_cli/proactive.py
+++ b/hermes_cli/proactive.py
@@ -12,6 +12,7 @@ import json
 import hashlib
 import re
 import time
+from collections import Counter, defaultdict
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -392,6 +393,238 @@ def _save_ledger(ledger: Dict[str, Any]) -> None:
     tmp.replace(path)
 
 
+def _preferences_path() -> Path:
+    return get_hermes_home() / "proactive" / "preferences.json"
+
+
+def _replay_evals_path() -> Path:
+    return get_hermes_home() / "proactive" / "replay_evals.jsonl"
+
+
+def _safe_metric_label(value: Any, fallback: str = "unknown") -> str:
+    text = str(value or fallback).strip().lower()
+    text = re.sub(r"[^a-z0-9_.:-]+", "_", text).strip("_")
+    return _clip(text or fallback, 80)
+
+
+def _default_preferences() -> Dict[str, Any]:
+    return {
+        "version": 1,
+        "updated_at": None,
+        "kind_weights": {},
+        "area_weights": {},
+        "mode_weights": {},
+        "guardrails": {
+            "allow_auto_code_edits": False,
+            "allow_auto_prompt_edits": False,
+            "allow_external_actions": False,
+            "export_raw_text": False,
+        },
+    }
+
+
+def load_proactive_preferences() -> Dict[str, Any]:
+    """Load profile-local adaptive proactive preferences.
+
+    This file is deliberately local/profile-scoped. It learns a user's nudge
+    preferences from button feedback without turning private text into global
+    training data.
+    """
+
+    path = _preferences_path()
+    prefs = _default_preferences()
+    if not path.exists():
+        return prefs
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            raise ValueError("preferences root is not an object")
+    except Exception:
+        corrupt = path.with_suffix(f".corrupt-{int(time.time())}.json")
+        try:
+            path.replace(corrupt)
+        except Exception:
+            pass
+        return prefs
+    for key, value in data.items():
+        prefs[key] = value
+    for key in ("kind_weights", "area_weights", "mode_weights"):
+        if not isinstance(prefs.get(key), dict):
+            prefs[key] = {}
+    if not isinstance(prefs.get("guardrails"), dict):
+        prefs["guardrails"] = _default_preferences()["guardrails"]
+    else:
+        merged_guardrails = _default_preferences()["guardrails"]
+        merged_guardrails.update(prefs["guardrails"])
+        prefs["guardrails"] = merged_guardrails
+    prefs["version"] = 1
+    return prefs
+
+
+def _save_proactive_preferences(prefs: Dict[str, Any]) -> None:
+    path = _preferences_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    prefs = dict(prefs)
+    prefs["updated_at"] = datetime.fromtimestamp(time.time(), tz=timezone.utc).isoformat()
+    tmp = path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(prefs, indent=2, sort_keys=True), encoding="utf-8")
+    tmp.replace(path)
+
+
+def _preference_entry(prefs: Dict[str, Any], namespace: str, key: Any) -> Dict[str, Any]:
+    store = prefs.setdefault(namespace, {})
+    safe_key = _safe_metric_label(key)
+    entry = store.setdefault(
+        safe_key,
+        {
+            "shown": 0,
+            "accepted": 0,
+            "more": 0,
+            "later": 0,
+            "not_useful": 0,
+            "muted": 0,
+            "score_adjustment": 0,
+            "cooldown_hours": DEFAULT_COOLDOWN_HOURS,
+        },
+    )
+    if not isinstance(entry, dict):
+        entry = {}
+        store[safe_key] = entry
+    entry.setdefault("shown", 0)
+    entry.setdefault("accepted", 0)
+    entry.setdefault("more", 0)
+    entry.setdefault("later", 0)
+    entry.setdefault("not_useful", 0)
+    entry.setdefault("muted", 0)
+    entry.setdefault("score_adjustment", 0)
+    entry.setdefault("cooldown_hours", DEFAULT_COOLDOWN_HOURS)
+    return entry
+
+
+def _feedback_delta(action: str) -> int:
+    return {
+        "do": 12,
+        "more": 4,
+        "later": -2,
+        "not": -14,
+        "dont": -18,
+    }.get(action, 0)
+
+
+def _clamp_int(value: Any, low: int, high: int) -> int:
+    try:
+        number = int(value)
+    except Exception:
+        number = 0
+    return max(low, min(high, number))
+
+
+def update_proactive_preferences_from_feedback(
+    nudge: Dict[str, Any],
+    action: str,
+    *,
+    now: float | None = None,
+) -> Dict[str, Any]:
+    """Update local adaptive weights from one feedback event."""
+
+    action = str(action or "").lower().strip()
+    if action not in {"do", "more", "later", "not", "dont"}:
+        return load_proactive_preferences()
+    now = time.time() if now is None else float(now)
+    signal = nudge.get("signal") or {}
+    prefs = load_proactive_preferences()
+    delta = _feedback_delta(action)
+    targets = (
+        ("kind_weights", signal.get("kind") or "unknown"),
+        ("area_weights", signal.get("area") or "unknown"),
+        ("mode_weights", signal.get("mode") or "unknown"),
+    )
+    for namespace, key in targets:
+        entry = _preference_entry(prefs, namespace, key)
+        entry["shown"] = int(entry.get("shown") or 0) + 1
+        if action == "do":
+            entry["accepted"] = int(entry.get("accepted") or 0) + 1
+            entry["cooldown_hours"] = max(12, int(entry.get("cooldown_hours") or DEFAULT_COOLDOWN_HOURS) - 12)
+        elif action == "more":
+            entry["more"] = int(entry.get("more") or 0) + 1
+        elif action == "later":
+            entry["later"] = int(entry.get("later") or 0) + 1
+            entry["cooldown_hours"] = min(336, int(entry.get("cooldown_hours") or DEFAULT_COOLDOWN_HOURS) + 12)
+        elif action == "not":
+            entry["not_useful"] = int(entry.get("not_useful") or 0) + 1
+            entry["cooldown_hours"] = min(336, int(entry.get("cooldown_hours") or DEFAULT_COOLDOWN_HOURS) + 24)
+        elif action == "dont":
+            entry["muted"] = int(entry.get("muted") or 0) + 1
+            entry["cooldown_hours"] = min(720, int(entry.get("cooldown_hours") or DEFAULT_COOLDOWN_HOURS) + 72)
+        entry["score_adjustment"] = _clamp_int(int(entry.get("score_adjustment") or 0) + delta, -40, 40)
+        entry["last_feedback"] = action
+        entry["last_feedback_at"] = now
+    _save_proactive_preferences(prefs)
+    return prefs
+
+
+def _preference_adjustment(prefs: Dict[str, Any], signal: Dict[str, Any]) -> int:
+    adjustment = 0
+    for namespace, key in (
+        ("kind_weights", signal.get("kind")),
+        ("area_weights", signal.get("area")),
+        ("mode_weights", signal.get("mode")),
+    ):
+        entry = (prefs.get(namespace) or {}).get(_safe_metric_label(key)) or {}
+        try:
+            adjustment += int(entry.get("score_adjustment") or 0)
+        except Exception:
+            pass
+    return _clamp_int(adjustment, -60, 60)
+
+
+def apply_adaptive_preferences(report: Dict[str, Any]) -> Dict[str, Any]:
+    """Apply learned local preferences to signal scores without mutating input."""
+
+    adapted = json.loads(json.dumps(report or {}))
+    prefs = load_proactive_preferences()
+    ranked: List[tuple[int, Dict[str, Any]]] = []
+    for idx, signal in enumerate(adapted.get("signals") or []):
+        if not isinstance(signal, dict):
+            continue
+        base = _signal_score(signal)
+        adjustment = _preference_adjustment(prefs, signal)
+        item = dict(signal)
+        item["base_score"] = base
+        if adjustment:
+            item["adaptive_score_adjustment"] = adjustment
+        item["score"] = _clamp_int(base + adjustment, 0, 120)
+        ranked.append((idx, item))
+    ranked.sort(key=lambda pair: (-int(pair[1].get("score") or 0), pair[0]))
+    adapted["signals"] = [item for _idx, item in ranked]
+    adapted["adaptive_preferences"] = {
+        "version": prefs.get("version", 1),
+        "applied": True,
+    }
+    adapted["wakeAgent"] = bool(adapted.get("signals") or adapted.get("scan_errors"))
+    return adapted
+
+
+def _append_replay_eval(nudge: Dict[str, Any], action: str, *, now: float | None = None) -> None:
+    """Append a sanitized replay-eval example for future quality checks."""
+
+    now = time.time() if now is None else float(now)
+    signal = nudge.get("signal") or {}
+    row = {
+        "timestamp": now,
+        "kind": _safe_metric_label(signal.get("kind")),
+        "area": _safe_metric_label(signal.get("area")),
+        "mode": _safe_metric_label(signal.get("mode")),
+        "action": _safe_metric_label(action),
+        "outcome": "helpful" if action in {"do", "more"} else "negative" if action in {"not", "dont"} else "defer",
+        "score": _clamp_int(signal.get("score") or _signal_score(signal), 0, 120),
+    }
+    path = _replay_evals_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(row, sort_keys=True) + "\n")
+
+
 def _signal_fingerprint(signal: Dict[str, Any]) -> str:
     basis = "|".join(
         [
@@ -578,6 +811,13 @@ def handle_proactive_feedback(
     else:
         result = {"ok": False, "ack": "Unknown proactive action."}
 
+    if result.get("ok") and action in {"do", "more", "later", "not", "dont"}:
+        try:
+            update_proactive_preferences_from_feedback(nudge, action, now=now)
+            _append_replay_eval(nudge, action, now=now)
+        except Exception as exc:
+            result["learning_warning"] = _clip(exc, 180)
+
     _save_ledger(ledger)
     return result
 
@@ -615,6 +855,208 @@ def prepare_delivery_controls(
         return None
     nudge = record_proactive_nudge(job=job, message=message, scan_report=scan_report, now=now)
     return proactive_controls_for_nudge(nudge)
+
+
+def _feedback_events_with_nudges(ledger: Dict[str, Any]) -> List[tuple[Dict[str, Any], Dict[str, Any]]]:
+    by_id = {
+        str(nudge.get("id")): nudge
+        for nudge in ledger.get("nudges", [])
+        if isinstance(nudge, dict) and nudge.get("id")
+    }
+    pairs: List[tuple[Dict[str, Any], Dict[str, Any]]] = []
+    for event in ledger.get("feedback", []) or []:
+        if not isinstance(event, dict):
+            continue
+        nudge = by_id.get(str(event.get("nudge_id")))
+        if nudge:
+            pairs.append((event, nudge))
+    return pairs
+
+
+def export_privacy_safe_learning(*, now: float | None = None) -> Dict[str, Any]:
+    """Export anonymized aggregate feedback only — no messages, excerpts, IDs, or paths."""
+
+    now = time.time() if now is None else float(now)
+    ledger = _load_ledger()
+    totals = {"nudges": len([n for n in ledger.get("nudges", []) if isinstance(n, dict)]), "feedback": 0}
+    by_kind: Dict[str, Counter] = defaultdict(Counter)
+    by_area: Dict[str, Counter] = defaultdict(Counter)
+    by_mode: Dict[str, Counter] = defaultdict(Counter)
+    by_action: Counter = Counter()
+    for event, nudge in _feedback_events_with_nudges(ledger):
+        action = _safe_metric_label(event.get("action"))
+        signal = nudge.get("signal") or {}
+        totals["feedback"] += 1
+        by_action[action] += 1
+        by_kind[_safe_metric_label(signal.get("kind"))][action] += 1
+        by_area[_safe_metric_label(signal.get("area"))][action] += 1
+        by_mode[_safe_metric_label(signal.get("mode"))][action] += 1
+    return {
+        "version": 1,
+        "privacy_safe": True,
+        "generated_at": datetime.fromtimestamp(now, tz=timezone.utc).isoformat(),
+        "redaction_policy": "aggregate counts only; no raw messages, excerpts, session IDs, nudge IDs, paths, or customer data",
+        "totals": totals,
+        "by_action": dict(by_action),
+        "by_kind": {k: dict(v) for k, v in sorted(by_kind.items())},
+        "by_area": {k: dict(v) for k, v in sorted(by_area.items())},
+        "by_mode": {k: dict(v) for k, v in sorted(by_mode.items())},
+    }
+
+
+def validate_self_evolution_change(change: Dict[str, Any]) -> Dict[str, Any]:
+    """Guardrail self-evolution changes before any automated application."""
+
+    if not isinstance(change, dict):
+        return {"ok": False, "reason": "change must be an object", "requires_user_approval": True}
+    raw_private_keys = {"raw_text", "message", "excerpt", "session_id", "nudge_id", "private_data", "customer_data"}
+    if any(key in change for key in raw_private_keys):
+        return {"ok": False, "reason": "change contains raw/private fields", "requires_user_approval": True}
+    change_type = str(change.get("type") or "").strip().lower()
+    if change_type in {"code_edit", "prompt_edit", "external_action", "send", "post", "email", "delete", "buy", "schedule"}:
+        return {"ok": False, "reason": "self-evolution cannot perform code/prompt/external actions silently", "requires_user_approval": True}
+    if change_type in {"kind_weight", "area_weight", "mode_weight"}:
+        delta = change.get("delta", change.get("score_adjustment", 0))
+        try:
+            delta_int = int(delta)
+        except Exception:
+            return {"ok": False, "reason": "weight change needs an integer delta", "requires_user_approval": True}
+        if -40 <= delta_int <= 40:
+            return {"ok": True, "reason": "bounded local preference tuning", "requires_user_approval": False}
+        return {"ok": False, "reason": "weight delta outside safe bounds", "requires_user_approval": True}
+    if change_type == "cooldown":
+        try:
+            hours = int(change.get("hours"))
+        except Exception:
+            return {"ok": False, "reason": "cooldown needs integer hours", "requires_user_approval": True}
+        if 0 <= hours <= 720:
+            return {"ok": True, "reason": "bounded local cooldown tuning", "requires_user_approval": False}
+        return {"ok": False, "reason": "cooldown outside safe bounds", "requires_user_approval": True}
+    if change_type in {"skill_proposal", "propose_skill"}:
+        return {"ok": False, "reason": "skill creation requires user approval", "requires_user_approval": True}
+    return {"ok": False, "reason": "unknown self-evolution change type", "requires_user_approval": True}
+
+
+def build_self_evolution_report(*, now: float | None = None) -> Dict[str, Any]:
+    """Review feedback and propose safe local improvements without editing code/prompts."""
+
+    now = time.time() if now is None else float(now)
+    ledger = _load_ledger()
+    prefs = load_proactive_preferences()
+    action_counts: Counter = Counter()
+    accepted_by_kind: Counter = Counter()
+    negative_by_kind: Counter = Counter()
+    accepted_by_workflow: Counter = Counter()
+    for event, nudge in _feedback_events_with_nudges(ledger):
+        action = _safe_metric_label(event.get("action"))
+        action_counts[action] += 1
+        signal = nudge.get("signal") or {}
+        kind = _safe_metric_label(signal.get("kind"))
+        area = _safe_metric_label(signal.get("area"))
+        workflow = f"{kind}:{area}"
+        if action in {"do", "more"}:
+            accepted_by_kind[kind] += 1
+            accepted_by_workflow[workflow] += 1
+        elif action in {"not", "dont"}:
+            negative_by_kind[kind] += 1
+
+    recommendations: List[Dict[str, Any]] = []
+    for kind, count in accepted_by_kind.items():
+        if count >= 2:
+            change = {"type": "kind_weight", "kind": kind, "delta": min(12, count * 3)}
+            verdict = validate_self_evolution_change(change)
+            recommendations.append({**change, **verdict, "reason": f"accepted {count} recent nudges of this kind"})
+    for kind, count in negative_by_kind.items():
+        if count >= 1:
+            change = {"type": "kind_weight", "kind": kind, "delta": -min(18, count * 6)}
+            verdict = validate_self_evolution_change(change)
+            recommendations.append({**change, **verdict, "reason": f"negative feedback on {count} recent nudges of this kind"})
+            cooldown = {"type": "cooldown", "kind": kind, "hours": min(336, DEFAULT_COOLDOWN_HOURS + count * 24)}
+            recommendations.append({**cooldown, **validate_self_evolution_change(cooldown), "reason": "increase cooldown after negative feedback"})
+
+    skill_proposals: List[Dict[str, Any]] = []
+    for workflow, count in accepted_by_workflow.items():
+        if count < 3:
+            continue
+        kind, area = workflow.split(":", 1)
+        skill_proposals.append(
+            {
+                "action": "propose_skill",
+                "type": "skill_proposal",
+                "requires_user_approval": True,
+                "trigger_kind": kind,
+                "area": area,
+                "accepted_count": count,
+                "title": f"Proactive workflow: {kind}",
+                "draft_outline": [
+                    "Trigger when this signal kind appears repeatedly and the user accepts help.",
+                    "Gather only the minimum local evidence needed.",
+                    "Draft or analyze internally first; ask before external action.",
+                    "Verify output before messaging the user.",
+                ],
+            }
+        )
+
+    return {
+        "version": 1,
+        "generated_at": datetime.fromtimestamp(now, tz=timezone.utc).isoformat(),
+        "summary": {
+            "nudges": len([n for n in ledger.get("nudges", []) if isinstance(n, dict)]),
+            "feedback": sum(action_counts.values()),
+            "accepted": action_counts.get("do", 0),
+            "more_info": action_counts.get("more", 0),
+            "snoozed": action_counts.get("later", 0),
+            "not_useful": action_counts.get("not", 0),
+            "muted": action_counts.get("dont", 0),
+        },
+        "privacy": {
+            "raw_text_included": False,
+            "safe_for_global_aggregate": True,
+            "note": "Report uses aggregate counts and sanitized signal labels only.",
+        },
+        "preferences": {
+            "version": prefs.get("version", 1),
+            "kinds_tracked": len(prefs.get("kind_weights") or {}),
+            "areas_tracked": len(prefs.get("area_weights") or {}),
+            "modes_tracked": len(prefs.get("mode_weights") or {}),
+        },
+        "recommendations": recommendations,
+        "skill_proposals": skill_proposals,
+        "global_learning_export": export_privacy_safe_learning(now=now),
+    }
+
+
+def render_self_evolution_report(report: Dict[str, Any]) -> str:
+    summary = report.get("summary") or {}
+    lines = [
+        "## Proactive self-evolution report",
+        f"Generated: {report.get('generated_at')}",
+        "",
+        f"Feedback: {summary.get('feedback', 0)} | Accepted: {summary.get('accepted', 0)} | Not useful: {summary.get('not_useful', 0)} | Muted: {summary.get('muted', 0)}",
+        "",
+    ]
+    recs = report.get("recommendations") or []
+    if recs:
+        lines.append("### Safe local tuning")
+        for rec in recs[:8]:
+            lines.append(f"- {rec.get('type')}: {rec.get('kind') or rec.get('area') or rec.get('mode')} ({rec.get('reason')})")
+        lines.append("")
+    proposals = report.get("skill_proposals") or []
+    if proposals:
+        lines.append("### Skill proposals requiring approval")
+        for proposal in proposals[:5]:
+            lines.append(f"- {proposal.get('title')} — accepted {proposal.get('accepted_count')} times")
+        lines.append("")
+    lines.append("Privacy: aggregate labels only; no raw messages/excerpts/session IDs included.")
+    return "\n".join(lines).strip()
+
+
+def write_self_evolution_report(report: Dict[str, Any] | None = None) -> Path:
+    report = build_self_evolution_report() if report is None else report
+    path = get_hermes_home() / "proactive" / "self-evolution-report.md"
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(render_self_evolution_report(report), encoding="utf-8")
+    return path
 
 
 def build_reflection_prompt(
@@ -892,7 +1334,9 @@ def collect_proactive_signals(
 
     # Keep prompt injection compact and stable.
     report["recent_sessions"] = report["recent_sessions"][:10]
-    report["signals"] = _rank_signals(report["signals"])[:12]
+    report["signals"] = _rank_signals(report["signals"])
+    report = apply_adaptive_preferences(report)
+    report["signals"] = report["signals"][:12]
     report["suppressed_topics"] = report["suppressed_topics"][:5]
     report["wakeAgent"] = bool(report["signals"] or report["scan_errors"])
     return report
@@ -1062,6 +1506,23 @@ def cmd_proactive(args) -> int:
             print(render_signal_scan(report, include_wake_gate=False))
         return 0
 
+    if subcmd == "evolve":
+        report = build_self_evolution_report()
+        if getattr(args, "write", False):
+            path = write_self_evolution_report(report)
+            report["written_to"] = str(path)
+        if getattr(args, "json", False):
+            print(json.dumps(report, indent=2, sort_keys=True))
+        else:
+            print(render_self_evolution_report(report))
+            if report.get("written_to"):
+                print(f"\nWritten to: {report['written_to']}")
+        return 0
+
+    if subcmd == "export-learning":
+        print(json.dumps(export_privacy_safe_learning(), indent=2, sort_keys=True))
+        return 0
+
     if subcmd == "install":
         report = install_proactive_job(
             schedule=getattr(args, "schedule", DEFAULT_SCHEDULE),
@@ -1074,5 +1535,5 @@ def cmd_proactive(args) -> int:
         _print_report(report, as_json=getattr(args, "json", False))
         return 0
 
-    print("Usage: hermes proactive [prompt|scan|install]")
+    print("Usage: hermes proactive [prompt|scan|evolve|export-learning|install]")
     return 2

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -7,7 +7,7 @@ from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
 
-from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt
+from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, _format_cron_delivery, _cron_action_buttons, run_job, SILENT_MARKER, _build_job_prompt
 from tools.env_passthrough import clear_env_passthrough
 from tools.credential_files import clear_credential_files
 
@@ -441,10 +441,9 @@ class TestRoutingIntents:
 
 
 class TestDeliverResultWrapping:
-    """Verify that cron deliveries are wrapped with header/footer and no longer mirrored."""
+    """Verify compact cron delivery wrapping and Telegram controls."""
 
-    def test_delivery_wraps_content_with_header_and_footer(self):
-        """Delivered content should include task name header and agent-invisible note."""
+    def test_delivery_wraps_content_with_compact_markdown_header_and_buttons(self):
         from gateway.config import Platform
 
         pconfig = MagicMock()
@@ -464,14 +463,17 @@ class TestDeliverResultWrapping:
 
         send_mock.assert_called_once()
         sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
-        assert "Cronjob Response: daily-report" in sent_content
-        assert "(job_id: test-job)" in sent_content
-        assert "-------------" in sent_content
+        assert sent_content.startswith("⏰ **daily-report**")
+        assert "`job_id: test-job`" in sent_content
         assert "Here is today's summary." in sent_content
-        assert "To stop or manage this job" in sent_content
+        assert "Cronjob Response:" not in sent_content
+        assert "-------------" not in sent_content
+        assert send_mock.call_args.kwargs["telegram_inline_buttons"] == [
+            {"text": "Stop", "callback_data": "cj:stop:test-job"},
+            {"text": "More Info", "callback_data": "cj:info:test-job"},
+        ]
 
     def test_delivery_uses_job_id_when_no_name(self):
-        """When a job has no name, the wrapper should fall back to job id."""
         from gateway.config import Platform
 
         pconfig = MagicMock()
@@ -489,7 +491,73 @@ class TestDeliverResultWrapping:
             _deliver_result(job, "Output.")
 
         sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
-        assert "Cronjob Response: abc-123" in sent_content
+        assert sent_content.startswith("⏰ **abc-123**")
+        assert "`job_id: abc-123`" in sent_content
+
+    def test_delivery_supports_classic_wrap_style(self):
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("cron.scheduler.load_config", return_value={"cron": {"wrap_style": "classic"}}):
+            job = {
+                "id": "test-job",
+                "name": "daily-report",
+                "deliver": "origin",
+                "origin": {"platform": "telegram", "chat_id": "123"},
+            }
+            _deliver_result(job, "Here is today's summary.")
+
+        sent_content = send_mock.call_args.kwargs.get("content") or send_mock.call_args[0][-1]
+        assert "Cronjob Response: daily-report" in sent_content
+        assert "(job_id: test-job)" in sent_content
+        assert "-------------" in sent_content
+        assert "To stop or manage this job" in sent_content
+
+    def test_format_cron_delivery_sanitizes_multiline_job_names(self):
+        rendered = _format_cron_delivery(
+            {"id": "job-1", "name": "nightly\n```weird```"},
+            "Done.",
+        )
+
+        assert rendered.startswith("⏰ **nightly '''weird'''**")
+        assert "```weird```" not in rendered
+        assert "\n```weird```" not in rendered
+
+    def test_cron_action_buttons_use_pause_not_delete(self):
+        assert _cron_action_buttons({"id": "abc-123", "enabled": True}) == [
+            {"text": "Stop", "callback_data": "cj:stop:abc-123"},
+            {"text": "More Info", "callback_data": "cj:info:abc-123"},
+        ]
+
+    def test_cron_action_buttons_skip_jobs_without_ids(self):
+        assert _cron_action_buttons({}) == []
+
+    def test_delivery_action_buttons_can_be_disabled(self):
+        from gateway.config import Platform
+
+        pconfig = MagicMock()
+        pconfig.enabled = True
+        mock_cfg = MagicMock()
+        mock_cfg.platforms = {Platform.TELEGRAM: pconfig}
+
+        with patch("gateway.config.load_gateway_config", return_value=mock_cfg), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})) as send_mock, \
+             patch("cron.scheduler.load_config", return_value={"cron": {"action_buttons": False}}):
+            job = {
+                "id": "test-job",
+                "name": "daily-report",
+                "deliver": "origin",
+                "origin": {"platform": "telegram", "chat_id": "123"},
+            }
+            _deliver_result(job, "Summary.")
+
+        assert "telegram_inline_buttons" not in send_mock.call_args.kwargs
 
     def test_delivery_skips_wrapping_when_config_disabled(self):
         """When cron.wrap_response is false, deliver raw content without header/footer."""

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -441,3 +441,101 @@ class TestTelegramApprovalCallback:
         query.answer.assert_called_once()
         query.edit_message_text.assert_called_once()
         assert (tmp_path / ".update_response").read_text() == "n"
+
+
+class TestTelegramProactiveButtons:
+    @pytest.mark.asyncio
+    async def test_send_adds_proactive_control_buttons_to_first_chunk(self):
+        adapter = _make_adapter()
+        mock_msg = MagicMock()
+        mock_msg.message_id = 99
+        adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+        result = await adapter.send(
+            "12345",
+            "Tiny proactive nudge",
+            metadata={
+                "proactive_controls": {
+                    "nudge_id": "abc123def456",
+                    "buttons": ["do", "more", "later", "not", "dont"],
+                }
+            },
+        )
+
+        assert result.success is True
+        kwargs = adapter._bot.send_message.call_args.kwargs
+        assert kwargs["reply_markup"] is not None
+        from gateway.platforms import telegram as telegram_mod
+        recent_buttons = telegram_mod.InlineKeyboardButton.call_args_list[-5:]
+        labels = [call.args[0] for call in recent_buttons]
+        data = [call.kwargs.get("callback_data") for call in recent_buttons]
+        assert "Do it" in labels
+        assert "More Info" in labels
+        assert "pa:do:abc123def456" in data
+        assert "pa:more:abc123def456" in data
+
+    @pytest.mark.asyncio
+    async def test_more_info_callback_sends_detail_card(self, tmp_path, monkeypatch):
+        adapter = _make_adapter()
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "111")
+
+        query = AsyncMock()
+        query.data = "pa:more:n1"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.message.message_id = 99
+        query.message.message_thread_id = None
+        query.message.chat.type = "private"
+        query.from_user = MagicMock()
+        query.from_user.id = 111
+        query.from_user.first_name = "Charles"
+        query.answer = AsyncMock()
+        query.edit_message_reply_markup = AsyncMock()
+        update = MagicMock()
+        update.callback_query = query
+
+        with patch("hermes_cli.proactive.handle_proactive_feedback", return_value={"ok": True, "ack": "More info", "followup": "Why this surfaced: X"}):
+            await adapter._handle_callback_query(update, MagicMock())
+
+        query.answer.assert_called_once()
+        adapter._bot.send_message.assert_called_once()
+        assert "Why this surfaced" in adapter._bot.send_message.call_args.kwargs["text"]
+
+    @pytest.mark.asyncio
+    async def test_do_it_callback_enqueues_agent_prompt(self, tmp_path, monkeypatch):
+        adapter = _make_adapter()
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "111")
+        handled = []
+
+        async def fake_handle(event):
+            handled.append(event)
+
+        adapter.handle_message = fake_handle
+        query = AsyncMock()
+        query.data = "pa:do:n2"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.message.message_id = 100
+        query.message.message_thread_id = None
+        query.message.chat.id = 12345
+        query.message.chat.title = None
+        query.message.chat.full_name = "Charles"
+        query.message.chat.type = "private"
+        query.message.chat.is_forum = False
+        query.message.text = "Original proactive nudge"
+        query.from_user = MagicMock()
+        query.from_user.id = 111
+        query.from_user.first_name = "Charles"
+        query.from_user.full_name = "Charles McDowell"
+        query.answer = AsyncMock()
+        query.edit_message_reply_markup = AsyncMock()
+        update = MagicMock()
+        update.callback_query = query
+
+        with patch("hermes_cli.proactive.handle_proactive_feedback", return_value={"ok": True, "ack": "Starting", "agent_prompt": "User tapped Do it. Draft internally."}):
+            await adapter._handle_callback_query(update, MagicMock())
+
+        query.answer.assert_called_once()
+        assert handled
+        assert handled[0].text == "User tapped Do it. Draft internally."
+        assert handled[0].source.user_id == "111"

--- a/tests/gateway/test_telegram_approval_buttons.py
+++ b/tests/gateway/test_telegram_approval_buttons.py
@@ -539,3 +539,123 @@ class TestTelegramProactiveButtons:
         assert handled
         assert handled[0].text == "User tapped Do it. Draft internally."
         assert handled[0].source.user_id == "111"
+
+
+class TestTelegramCronButtons:
+    @pytest.mark.asyncio
+    async def test_send_adds_cron_management_buttons_to_last_chunk(self):
+        adapter = _make_adapter()
+        mock_msg = MagicMock()
+        mock_msg.message_id = 88
+        adapter._bot.send_message = AsyncMock(return_value=mock_msg)
+
+        result = await adapter.send(
+            "12345",
+            "Cron output",
+            metadata={
+                "telegram_inline_buttons": [
+                    {"text": "Stop", "callback_data": "cj:stop:job-1"},
+                    {"text": "More Info", "callback_data": "cj:info:job-1"},
+                ]
+            },
+        )
+
+        assert result.success is True
+        kwargs = adapter._bot.send_message.call_args.kwargs
+        assert kwargs["reply_markup"] is not None
+        from gateway.platforms import telegram as telegram_mod
+        recent_buttons = telegram_mod.InlineKeyboardButton.call_args_list[-2:]
+        labels = [call.args[0] for call in recent_buttons]
+        data = [call.kwargs.get("callback_data") for call in recent_buttons]
+        assert labels == ["Stop", "More Info"]
+        assert data == ["cj:stop:job-1", "cj:info:job-1"]
+
+    @pytest.mark.asyncio
+    async def test_stop_callback_pauses_job_and_flips_to_resume(self, monkeypatch):
+        adapter = _make_adapter()
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "111")
+        query = AsyncMock()
+        query.data = "cj:stop:job-1"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.message.message_thread_id = None
+        query.message.chat.type = "private"
+        query.from_user = MagicMock()
+        query.from_user.id = 111
+        query.from_user.first_name = "Charles"
+        query.answer = AsyncMock()
+        query.edit_message_reply_markup = AsyncMock()
+        update = MagicMock()
+        update.callback_query = query
+
+        with patch("cron.jobs.pause_job", return_value={"id": "job-1", "enabled": False, "name": "Morning"}) as pause_mock:
+            await adapter._handle_callback_query(update, MagicMock())
+
+        pause_mock.assert_called_once_with("job-1", reason="Stopped from Telegram cron button")
+        query.answer.assert_called_once()
+        assert "Stopped" in query.answer.call_args.kwargs["text"]
+        query.edit_message_reply_markup.assert_called_once()
+        from gateway.platforms import telegram as telegram_mod
+        assert any(call.args[0] == "Resume" and call.kwargs.get("callback_data") == "cj:resume:job-1" for call in telegram_mod.InlineKeyboardButton.call_args_list)
+
+    @pytest.mark.asyncio
+    async def test_more_info_callback_sends_compact_job_card(self, monkeypatch):
+        adapter = _make_adapter()
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "111")
+        query = AsyncMock()
+        query.data = "cj:info:job-1"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.message.message_thread_id = None
+        query.message.chat.type = "private"
+        query.from_user = MagicMock()
+        query.from_user.id = 111
+        query.from_user.first_name = "Charles"
+        query.answer = AsyncMock()
+        update = MagicMock()
+        update.callback_query = query
+
+        job = {
+            "id": "job-1",
+            "name": "Morning check-in",
+            "enabled": True,
+            "schedule": "0 8 * * *",
+            "deliver": "origin",
+            "last_run_at": "2026-05-09T12:00:00Z",
+            "next_run_at": "2026-05-10T13:00:00Z",
+            "prompt": "Find the one useful thing to nudge Charles about.",
+        }
+        with patch("cron.jobs.get_job", return_value=job):
+            await adapter._handle_callback_query(update, MagicMock())
+
+        query.answer.assert_called_once()
+        adapter._bot.send_message.assert_called_once()
+        kwargs = adapter._bot.send_message.call_args.kwargs
+        assert "Morning check-in" in kwargs["text"]
+        assert "job-1" in kwargs["text"]
+        assert "Find the one useful thing" in kwargs["text"]
+        assert kwargs["reply_markup"] is not None
+
+    @pytest.mark.asyncio
+    async def test_run_callback_triggers_job_next_tick(self, monkeypatch):
+        adapter = _make_adapter()
+        monkeypatch.setenv("TELEGRAM_ALLOWED_USERS", "111")
+        query = AsyncMock()
+        query.data = "cj:run:job-1"
+        query.message = MagicMock()
+        query.message.chat_id = 12345
+        query.message.message_thread_id = None
+        query.message.chat.type = "private"
+        query.from_user = MagicMock()
+        query.from_user.id = 111
+        query.from_user.first_name = "Charles"
+        query.answer = AsyncMock()
+        update = MagicMock()
+        update.callback_query = query
+
+        with patch("cron.jobs.trigger_job", return_value={"id": "job-1", "name": "Morning"}) as trigger_mock:
+            await adapter._handle_callback_query(update, MagicMock())
+
+        trigger_mock.assert_called_once_with("job-1")
+        query.answer.assert_called_once()
+        assert "next tick" in query.answer.call_args.kwargs["text"]

--- a/tests/hermes_cli/test_proactive.py
+++ b/tests/hermes_cli/test_proactive.py
@@ -88,6 +88,107 @@ def test_collect_proactive_signals_returns_structured_scan(monkeypatch):
     assert json.loads(rendered.splitlines()[-1]) == {"wakeAgent": True}
 
 
+def test_proactive_ledger_suppresses_recently_nudged_signal(tmp_path, monkeypatch):
+    monkeypatch.setattr(proactive, "get_hermes_home", lambda: tmp_path)
+    now = 1_700_000_000.0
+    report = {
+        "wakeAgent": True,
+        "signals": [
+            {
+                "kind": "content_opportunity",
+                "mode": "offer_to_produce",
+                "reason": "fresh notes",
+                "session_id": "s1",
+                "source": "telegram",
+                "excerpt": "meeting notes included a sales speech critique opportunity",
+            }
+        ],
+        "suppressed_topics": [],
+        "scan_errors": [],
+    }
+
+    nudge = proactive.record_proactive_nudge(
+        job={"id": "job1", "name": proactive.DEFAULT_JOB_NAME},
+        message="Want me to polish the strongest two X drafts?",
+        scan_report=report,
+        now=now,
+    )
+    filtered = proactive.apply_ledger_filters(report, now=now + 60)
+
+    assert nudge["id"]
+    assert filtered["signals"] == []
+    assert filtered["wakeAgent"] is False
+    assert filtered["suppressed_by_ledger"][0]["nudge_id"] == nudge["id"]
+
+
+def test_proactive_feedback_more_info_later_and_do_not_nudge(tmp_path, monkeypatch):
+    monkeypatch.setattr(proactive, "get_hermes_home", lambda: tmp_path)
+    report = {
+        "signals": [
+            {
+                "kind": "blocker_or_waiting",
+                "mode": "ask_or_checked",
+                "reason": "possible blocker",
+                "session_id": "s2",
+                "source": "telegram",
+                "excerpt": "TestFlight blocked until Xcode ready",
+            }
+        ],
+        "suppressed_topics": [],
+        "scan_errors": [],
+    }
+    nudge = proactive.record_proactive_nudge(
+        job={"id": "job2", "name": proactive.DEFAULT_JOB_NAME},
+        message="TestFlight is still blocked. Want me to continue once Xcode is ready?",
+        scan_report=report,
+        now=1_700_000_000.0,
+    )
+
+    more = proactive.handle_proactive_feedback(nudge["id"], "more", now=1_700_000_010.0)
+    assert more["ok"] is True
+    assert "Why this surfaced" in more["followup"]
+    assert "TestFlight blocked" in more["followup"]
+
+    later = proactive.handle_proactive_feedback(nudge["id"], "later", now=1_700_000_020.0)
+    assert later["ok"] is True
+    assert "snoozed" in later["ack"].lower()
+
+    hidden = proactive.handle_proactive_feedback(nudge["id"], "dont", now=1_700_000_030.0)
+    assert hidden["ok"] is True
+    assert "won't nudge" in hidden["ack"].lower()
+    filtered = proactive.apply_ledger_filters(report, now=1_700_000_040.0)
+    assert filtered["signals"] == []
+
+
+def test_proactive_do_it_feedback_builds_safe_agent_prompt(tmp_path, monkeypatch):
+    monkeypatch.setattr(proactive, "get_hermes_home", lambda: tmp_path)
+    nudge = proactive.record_proactive_nudge(
+        job={"id": "job3", "name": proactive.DEFAULT_JOB_NAME},
+        message="Want me to polish the strongest two X drafts?",
+        scan_report={
+            "signals": [
+                {
+                    "kind": "content_opportunity",
+                    "mode": "offer_to_produce",
+                    "reason": "fresh notes/content may create a useful draft",
+                    "session_id": "s3",
+                    "source": "telegram",
+                    "excerpt": "sales-meeting speech critique and X drafts are ready",
+                }
+            ]
+        },
+        now=1_700_000_000.0,
+    )
+
+    result = proactive.handle_proactive_feedback(nudge["id"], "do", now=1_700_000_001.0)
+
+    assert result["ok"] is True
+    assert "starting" in result["ack"].lower()
+    assert "agent_prompt" in result
+    assert "User tapped Do it" in result["agent_prompt"]
+    assert "Do not send, post, email" in result["agent_prompt"]
+
+
 def test_render_signal_scan_wake_gate_can_skip_agent():
     rendered = proactive.render_signal_scan({"wakeAgent": False, "signals": []})
     assert rendered == '{"wakeAgent": false}'

--- a/tests/hermes_cli/test_proactive.py
+++ b/tests/hermes_cli/test_proactive.py
@@ -1,6 +1,7 @@
 import json
-
-import pytest
+import sys
+import time
+import types
 
 from hermes_cli import proactive
 
@@ -12,7 +13,7 @@ def test_build_reflection_prompt_is_safe_and_silent_by_default():
         min_confidence="high",
     )
 
-    assert "session_search" in prompt
+    assert "Proactive signal scan" in prompt
     assert "last 5 days" in prompt
     assert "up to 12" in prompt
     assert "[SILENT]" in prompt
@@ -27,6 +28,69 @@ def test_build_reflection_prompt_is_safe_and_silent_by_default():
     assert "Silence is the correct answer unless the best candidate clears the bar" in prompt
     assert "No generic summaries, status theater" in prompt
     assert "Would Charles plausibly reply" in prompt
+
+
+def test_collect_proactive_signals_returns_structured_scan(monkeypatch):
+    now = time.time()
+
+    class FakeDB:
+        def list_sessions_rich(self, **kwargs):
+            return [
+                {
+                    "id": "s1",
+                    "source": "telegram",
+                    "title": "Sales meeting notes",
+                    "last_active": now,
+                    "preview": "Charles added meeting notes with a sales-team speech",
+                }
+            ]
+
+        def search_messages(self, query, **kwargs):
+            if "meeting notes" in query:
+                return [
+                        {
+                            "session_id": "s1",
+                            "source": "telegram",
+                            "timestamp": now,
+                            "content": "meeting notes included a sales team speech and delivery coaching opportunity",
+                            "snippet": "meeting notes included a sales team speech and delivery coaching opportunity",
+                        }
+                ]
+            if "OwnerPath" in query:
+                return [
+                        {
+                            "session_id": "s2",
+                            "source": "telegram",
+                            "timestamp": now,
+                            "content": "OwnerPath is on hold; do not nudge",
+                            "snippet": "OwnerPath is on hold; do not nudge",
+                        }
+                ]
+            return []
+
+    monkeypatch.setitem(sys.modules, "hermes_state", types.SimpleNamespace(SessionDB=FakeDB))
+    monkeypatch.setattr(
+        proactive,
+        "list_jobs",
+        lambda include_disabled=True: [
+            {"id": "j1", "name": "Broken cron", "last_error": "boom", "state": "scheduled"}
+        ],
+    )
+
+    report = proactive.collect_proactive_signals(lookback_days=2, max_sessions=5)
+
+    assert report["wakeAgent"] is True
+    assert report["recent_sessions"][0]["id"] == "s1"
+    assert {s["kind"] for s in report["signals"]} >= {"content_opportunity", "cron_failure"}
+    assert report["suppressed_topics"]
+    rendered = proactive.render_signal_scan(report)
+    assert "## Proactive signal scan" in rendered
+    assert json.loads(rendered.splitlines()[-1]) == {"wakeAgent": True}
+
+
+def test_render_signal_scan_wake_gate_can_skip_agent():
+    rendered = proactive.render_signal_scan({"wakeAgent": False, "signals": []})
+    assert rendered == '{"wakeAgent": false}'
 
 
 def test_install_creates_idempotent_cron_job(monkeypatch):
@@ -44,6 +108,7 @@ def test_install_creates_idempotent_cron_job(monkeypatch):
             "prompt": kwargs["prompt"],
             "schedule_display": kwargs["schedule"],
             "deliver": kwargs["deliver"],
+            "script": kwargs["script"],
             "enabled_toolsets": kwargs["enabled_toolsets"],
             "state": "scheduled",
         }
@@ -58,6 +123,7 @@ def test_install_creates_idempotent_cron_job(monkeypatch):
     monkeypatch.setattr(proactive, "list_jobs", fake_list_jobs)
     monkeypatch.setattr(proactive, "create_job", fake_create_job)
     monkeypatch.setattr(proactive, "update_job", fake_update_job)
+    monkeypatch.setattr(proactive, "_ensure_scanner_script", lambda: "proactive_signal_scan.py")
 
     first = proactive.install_proactive_job(
         schedule="0 9 * * *",
@@ -77,7 +143,8 @@ def test_install_creates_idempotent_cron_job(monkeypatch):
     assert calls[0][0] == "create"
     created = calls[0][1]
     assert created["name"] == proactive.DEFAULT_JOB_NAME
-    assert created["enabled_toolsets"] == ["session_search", "memory", "todo"]
+    assert created["script"] == "proactive_signal_scan.py"
+    assert created["enabled_toolsets"] == ["memory"]
     assert "last 3 days" in created["prompt"]
     assert created["deliver"] == "telegram"
 
@@ -85,6 +152,7 @@ def test_install_creates_idempotent_cron_job(monkeypatch):
     assert calls[1][1] == "abc123"
     assert calls[1][2]["schedule"] == "0 10 * * *"
     assert calls[1][2]["deliver"] == "local"
+    assert calls[1][2]["script"] == "proactive_signal_scan.py"
     assert "last 7 days" in calls[1][2]["prompt"]
 
 
@@ -93,6 +161,7 @@ def test_install_can_create_paused_job(monkeypatch):
     updates = []
 
     monkeypatch.setattr(proactive, "list_jobs", lambda include_disabled=True: [])
+    monkeypatch.setattr(proactive, "_ensure_scanner_script", lambda: "proactive_signal_scan.py")
 
     def fake_create_job(**kwargs):
         job = {"id": "paused1", "name": kwargs["name"], "state": "scheduled", "enabled": True}
@@ -110,6 +179,7 @@ def test_install_can_create_paused_job(monkeypatch):
 
     assert result["action"] == "created_paused"
     assert updates == [("paused1", {"enabled": False, "state": "paused", "paused_reason": "created paused for review"})]
+    assert created_jobs[0]["script"] == "proactive_signal_scan.py"
 
 
 def test_cli_prompt_outputs_json_when_requested(capsys):

--- a/tests/hermes_cli/test_proactive.py
+++ b/tests/hermes_cli/test_proactive.py
@@ -1,0 +1,127 @@
+import json
+
+import pytest
+
+from hermes_cli import proactive
+
+
+def test_build_reflection_prompt_is_safe_and_silent_by_default():
+    prompt = proactive.build_reflection_prompt(
+        lookback_days=5,
+        max_sessions=12,
+        min_confidence="high",
+    )
+
+    assert "session_search" in prompt
+    assert "last 5 days" in prompt
+    assert "up to 12" in prompt
+    assert "[SILENT]" in prompt
+    assert "at most one proactive message" in prompt
+    assert "Do not send emails, posts, DMs, calendar invites" in prompt
+    assert "Ask before" in prompt
+    assert "high confidence" in prompt
+
+
+def test_install_creates_idempotent_cron_job(monkeypatch):
+    calls = []
+    jobs = []
+
+    def fake_list_jobs(include_disabled=True):
+        return list(jobs)
+
+    def fake_create_job(**kwargs):
+        calls.append(("create", kwargs))
+        job = {
+            "id": "abc123",
+            "name": kwargs["name"],
+            "prompt": kwargs["prompt"],
+            "schedule_display": kwargs["schedule"],
+            "deliver": kwargs["deliver"],
+            "enabled_toolsets": kwargs["enabled_toolsets"],
+            "state": "scheduled",
+        }
+        jobs.append(job)
+        return job
+
+    def fake_update_job(job_id, updates):
+        calls.append(("update", job_id, updates))
+        jobs[0].update(updates)
+        return dict(jobs[0])
+
+    monkeypatch.setattr(proactive, "list_jobs", fake_list_jobs)
+    monkeypatch.setattr(proactive, "create_job", fake_create_job)
+    monkeypatch.setattr(proactive, "update_job", fake_update_job)
+
+    first = proactive.install_proactive_job(
+        schedule="0 9 * * *",
+        deliver="telegram",
+        lookback_days=3,
+        max_sessions=20,
+    )
+    second = proactive.install_proactive_job(
+        schedule="0 10 * * *",
+        deliver="local",
+        lookback_days=7,
+        max_sessions=40,
+    )
+
+    assert first["action"] == "created"
+    assert second["action"] == "updated"
+    assert calls[0][0] == "create"
+    created = calls[0][1]
+    assert created["name"] == proactive.DEFAULT_JOB_NAME
+    assert created["enabled_toolsets"] == ["session_search", "memory", "todo"]
+    assert "last 3 days" in created["prompt"]
+    assert created["deliver"] == "telegram"
+
+    assert calls[1][0] == "update"
+    assert calls[1][1] == "abc123"
+    assert calls[1][2]["schedule"] == "0 10 * * *"
+    assert calls[1][2]["deliver"] == "local"
+    assert "last 7 days" in calls[1][2]["prompt"]
+
+
+def test_install_can_create_paused_job(monkeypatch):
+    created_jobs = []
+    updates = []
+
+    monkeypatch.setattr(proactive, "list_jobs", lambda include_disabled=True: [])
+
+    def fake_create_job(**kwargs):
+        job = {"id": "paused1", "name": kwargs["name"], "state": "scheduled", "enabled": True}
+        created_jobs.append(kwargs)
+        return job
+
+    def fake_update_job(job_id, update):
+        updates.append((job_id, update))
+        return {"id": job_id, **update}
+
+    monkeypatch.setattr(proactive, "create_job", fake_create_job)
+    monkeypatch.setattr(proactive, "update_job", fake_update_job)
+
+    result = proactive.install_proactive_job(paused=True)
+
+    assert result["action"] == "created_paused"
+    assert updates == [("paused1", {"enabled": False, "state": "paused", "paused_reason": "created paused for review"})]
+
+
+def test_cli_prompt_outputs_json_when_requested(capsys):
+    rc = proactive.cmd_proactive(
+        type(
+            "Args",
+            (),
+            {
+                "proactive_command": "prompt",
+                "lookback_days": 2,
+                "max_sessions": 9,
+                "min_confidence": "medium",
+                "json": True,
+            },
+        )()
+    )
+
+    assert rc == 0
+    payload = json.loads(capsys.readouterr().out)
+    assert payload["lookback_days"] == 2
+    assert payload["max_sessions"] == 9
+    assert "medium confidence" in payload["prompt"]

--- a/tests/hermes_cli/test_proactive.py
+++ b/tests/hermes_cli/test_proactive.py
@@ -20,6 +20,9 @@ def test_build_reflection_prompt_is_safe_and_silent_by_default():
     assert "Do not send emails, posts, DMs, calendar invites" in prompt
     assert "Ask before" in prompt
     assert "high confidence" in prompt
+    assert "Silence is the correct answer unless the best candidate clears the bar" in prompt
+    assert "No generic summaries, status theater" in prompt
+    assert "Would Charles plausibly reply" in prompt
 
 
 def test_install_creates_idempotent_cron_job(monkeypatch):

--- a/tests/hermes_cli/test_proactive.py
+++ b/tests/hermes_cli/test_proactive.py
@@ -27,6 +27,10 @@ def test_build_reflection_prompt_is_safe_and_silent_by_default():
     assert "meeting notes" in prompt
     assert "Silence is the correct answer unless the best candidate clears the bar" in prompt
     assert "No generic summaries, status theater" in prompt
+    assert "meta-Hermes" in prompt
+    assert "WFG/source quality shifts" in prompt
+    assert "smart question" in prompt
+    assert "family/personal logistics" in prompt
     assert "Would Charles plausibly reply" in prompt
 
 
@@ -86,6 +90,138 @@ def test_collect_proactive_signals_returns_structured_scan(monkeypatch):
     rendered = proactive.render_signal_scan(report)
     assert "## Proactive signal scan" in rendered
     assert json.loads(rendered.splitlines()[-1]) == {"wakeAgent": True}
+
+
+def test_collect_proactive_signals_ignores_meta_proactivity_chatter(monkeypatch):
+    now = time.time()
+
+    class FakeDB:
+        def list_sessions_rich(self, **kwargs):
+            return [
+                {
+                    "id": "meta-session",
+                    "source": "telegram",
+                    "title": "Making Hermes proactive",
+                    "last_active": now,
+                    "preview": "Add More Info and Not useful feedback buttons",
+                }
+            ]
+
+        def search_messages(self, query, **kwargs):
+            if "want me" in query or "More Info" in query:
+                return [
+                    {
+                        "session_id": "meta-session",
+                        "source": "telegram",
+                        "timestamp": now,
+                        "snippet": "Add Do it, More Info, Not useful, and Don't nudge this buttons to proactive messages",
+                    }
+                ]
+            return []
+
+    monkeypatch.setitem(sys.modules, "hermes_state", types.SimpleNamespace(SessionDB=FakeDB))
+    monkeypatch.setattr(proactive, "list_jobs", lambda include_disabled=True: [])
+
+    report = proactive.collect_proactive_signals(lookback_days=2, max_sessions=5)
+
+    assert report["signals"] == []
+    assert report["wakeAgent"] is False
+
+
+def test_collect_proactive_signals_surfaces_profile_decisions(tmp_path, monkeypatch):
+    (tmp_path / "proactive-state.md").write_text(
+        "# State\n\n## Blocked / Needs Decision\n- Choose whether to ship the dashboard as a draft PR or split it first.\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "HEARTBEAT.md").write_text("Ask smart questions when useful.", encoding="utf-8")
+
+    class FakeDB:
+        def list_sessions_rich(self, **kwargs):
+            return []
+
+        def search_messages(self, query, **kwargs):
+            return []
+
+    monkeypatch.setattr(proactive, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setitem(sys.modules, "hermes_state", types.SimpleNamespace(SessionDB=FakeDB))
+    monkeypatch.setattr(proactive, "list_jobs", lambda include_disabled=True: [])
+
+    report = proactive.collect_proactive_signals(lookback_days=2, max_sessions=5)
+
+    assert report["wakeAgent"] is True
+    assert report["assistant_context"]["proactive_state"]
+    assert report["signals"][0]["kind"] == "state_decision_needed"
+    assert report["signals"][0]["mode"] == "ask_smart_question"
+    assert "dashboard" in report["signals"][0]["excerpt"]
+
+
+def test_collect_proactive_signals_ranks_cron_failures_over_content(monkeypatch):
+    now = time.time()
+
+    class FakeDB:
+        def list_sessions_rich(self, **kwargs):
+            return []
+
+        def search_messages(self, query, **kwargs):
+            if "meeting notes" in query:
+                return [
+                    {
+                        "session_id": "content",
+                        "source": "telegram",
+                        "timestamp": now,
+                        "snippet": "meeting notes include a decent content opportunity",
+                    }
+                ]
+            return []
+
+    monkeypatch.setitem(sys.modules, "hermes_state", types.SimpleNamespace(SessionDB=FakeDB))
+    monkeypatch.setattr(proactive, "list_jobs", lambda include_disabled=True: [
+        {"id": "bad", "name": "Broken job", "last_error": "delivery failed", "state": "scheduled"}
+    ])
+
+    report = proactive.collect_proactive_signals(lookback_days=2, max_sessions=5)
+
+    assert report["signals"][0]["kind"] == "cron_failure"
+    assert {signal["kind"] for signal in report["signals"]} >= {"cron_failure", "content_opportunity"}
+
+
+def test_collect_proactive_signals_loads_profile_local_custom_signals(tmp_path, monkeypatch):
+    signal_dir = tmp_path / "proactive"
+    signal_dir.mkdir()
+    (signal_dir / "signals.json").write_text(
+        json.dumps(
+            {
+                "signals": [
+                    {
+                        "kind": "calendar_question",
+                        "area": "calendar",
+                        "mode": "ask_smart_question",
+                        "reason": "upcoming meeting needs a prep choice",
+                        "excerpt": "Tomorrow's ops meeting has no agenda; ask whether to draft a 3-bullet prep note.",
+                        "score": 88,
+                    }
+                ]
+            }
+        ),
+        encoding="utf-8",
+    )
+
+    class FakeDB:
+        def list_sessions_rich(self, **kwargs):
+            return []
+
+        def search_messages(self, query, **kwargs):
+            return []
+
+    monkeypatch.setattr(proactive, "get_hermes_home", lambda: tmp_path)
+    monkeypatch.setitem(sys.modules, "hermes_state", types.SimpleNamespace(SessionDB=FakeDB))
+    monkeypatch.setattr(proactive, "list_jobs", lambda include_disabled=True: [])
+
+    report = proactive.collect_proactive_signals(lookback_days=2, max_sessions=5)
+
+    assert report["signals"][0]["kind"] == "calendar_question"
+    assert report["signals"][0]["area"] == "calendar"
+    assert "ops meeting" in report["signals"][0]["excerpt"]
 
 
 def test_proactive_ledger_suppresses_recently_nudged_signal(tmp_path, monkeypatch):

--- a/tests/hermes_cli/test_proactive.py
+++ b/tests/hermes_cli/test_proactive.py
@@ -17,9 +17,13 @@ def test_build_reflection_prompt_is_safe_and_silent_by_default():
     assert "up to 12" in prompt
     assert "[SILENT]" in prompt
     assert "at most one proactive message" in prompt
-    assert "Do not send emails, posts, DMs, calendar invites" in prompt
+    assert "NEVER send anything outside Hermes/the configured delivery system" in prompt
+    assert "Drafting internally is allowed" in prompt
     assert "Ask before" in prompt
     assert "high confidence" in prompt
+    assert "personal assistant" in prompt
+    assert "Proactive modes" in prompt
+    assert "meeting notes" in prompt
     assert "Silence is the correct answer unless the best candidate clears the bar" in prompt
     assert "No generic summaries, status theater" in prompt
     assert "Would Charles plausibly reply" in prompt

--- a/tests/hermes_cli/test_proactive.py
+++ b/tests/hermes_cli/test_proactive.py
@@ -439,3 +439,162 @@ def test_cli_prompt_outputs_json_when_requested(capsys):
     assert payload["lookback_days"] == 2
     assert payload["max_sessions"] == 9
     assert "medium confidence" in payload["prompt"]
+
+
+def test_feedback_updates_adaptive_preferences_and_reranks_future_signals(tmp_path, monkeypatch):
+    monkeypatch.setattr(proactive, "get_hermes_home", lambda: tmp_path)
+    now = 1_700_000_000.0
+    nudge = proactive.record_proactive_nudge(
+        job={"id": "job-a", "name": proactive.DEFAULT_JOB_NAME},
+        message="Want me to turn the meeting notes into a short coaching draft?",
+        scan_report={
+            "signals": [
+                {
+                    "kind": "content_opportunity",
+                    "area": "content",
+                    "mode": "offer_to_produce",
+                    "reason": "accepted content draft pattern",
+                    "source": "telegram",
+                    "excerpt": "private meeting notes should not become global training text",
+                    "score": 50,
+                }
+            ]
+        },
+        now=now,
+    )
+
+    proactive.handle_proactive_feedback(nudge["id"], "do", now=now + 1)
+    prefs = proactive.load_proactive_preferences()
+
+    assert prefs["kind_weights"]["content_opportunity"]["score_adjustment"] > 0
+    assert prefs["kind_weights"]["content_opportunity"]["accepted"] == 1
+
+    report = {
+        "wakeAgent": True,
+        "signals": [
+            {"kind": "content_opportunity", "area": "content", "mode": "offer_to_produce", "excerpt": "content", "score": 50},
+            {"kind": "decision_needed", "area": "decisions", "mode": "ask_smart_question", "excerpt": "decision", "score": 52},
+        ],
+    }
+    adapted = proactive.apply_adaptive_preferences(report)
+
+    assert adapted["signals"][0]["kind"] == "content_opportunity"
+    assert adapted["signals"][0]["adaptive_score_adjustment"] > 0
+
+
+def test_negative_feedback_tunes_down_future_signals_without_mutating_raw_report(tmp_path, monkeypatch):
+    monkeypatch.setattr(proactive, "get_hermes_home", lambda: tmp_path)
+    now = 1_700_000_000.0
+    nudge = proactive.record_proactive_nudge(
+        job={"id": "job-b", "name": proactive.DEFAULT_JOB_NAME},
+        message="Want me to draft content from this?",
+        scan_report={
+            "signals": [
+                {
+                    "kind": "content_opportunity",
+                    "area": "content",
+                    "mode": "offer_to_produce",
+                    "reason": "weak content idea",
+                    "source": "telegram",
+                    "excerpt": "private draft context",
+                    "score": 80,
+                }
+            ]
+        },
+        now=now,
+    )
+
+    proactive.handle_proactive_feedback(nudge["id"], "not", now=now + 1)
+    report = {"wakeAgent": True, "signals": [{"kind": "content_opportunity", "area": "content", "excerpt": "new item", "score": 80}]}
+    adapted = proactive.apply_adaptive_preferences(report)
+
+    assert report["signals"][0]["score"] == 80
+    assert adapted["signals"][0]["score"] < 80
+    assert adapted["signals"][0]["adaptive_score_adjustment"] < 0
+
+
+def test_self_evolution_report_proposes_bounded_changes_and_skill_candidates(tmp_path, monkeypatch):
+    monkeypatch.setattr(proactive, "get_hermes_home", lambda: tmp_path)
+    now = 1_700_000_000.0
+    for idx in range(3):
+        nudge = proactive.record_proactive_nudge(
+            job={"id": f"job-{idx}", "name": proactive.DEFAULT_JOB_NAME},
+            message=f"Want me to prepare the WFG call-quality sample #{idx}?",
+            scan_report={
+                "signals": [
+                    {
+                        "kind": "source_quality_watch",
+                        "area": "sales_ops",
+                        "mode": "ask_to_investigate",
+                        "reason": "accepted repeat workflow",
+                        "source": "profile-local",
+                        "excerpt": f"Sensitive WFG transcript detail #{idx}",
+                        "suggested_action": "pull a transcript sample and classify source quality",
+                        "score": 90,
+                    }
+                ]
+            },
+            now=now + idx,
+        )
+        proactive.handle_proactive_feedback(nudge["id"], "do", now=now + idx + 10)
+
+    report = proactive.build_self_evolution_report(now=now + 86_400)
+
+    assert report["summary"]["accepted"] == 3
+    assert report["recommendations"]
+    assert report["skill_proposals"]
+    assert report["skill_proposals"][0]["action"] == "propose_skill"
+    dumped = json.dumps(report)
+    assert "Sensitive WFG transcript detail" not in dumped
+    assert "Want me to prepare" not in dumped
+    assert all(item["requires_user_approval"] for item in report["skill_proposals"])
+
+
+def test_privacy_safe_learning_export_contains_only_aggregates(tmp_path, monkeypatch):
+    monkeypatch.setattr(proactive, "get_hermes_home", lambda: tmp_path)
+    nudge = proactive.record_proactive_nudge(
+        job={"id": "job-private", "name": proactive.DEFAULT_JOB_NAME},
+        message="Private TestFlight blocker for Charles involving internal paths",
+        scan_report={
+            "signals": [
+                {
+                    "kind": "blocker_or_waiting",
+                    "area": "projects",
+                    "mode": "ask_to_investigate",
+                    "reason": "private blocker",
+                    "source": "telegram",
+                    "session_id": "secret-session-id",
+                    "excerpt": "/Users/bots/private/path and customer detail",
+                }
+            ]
+        },
+        now=1_700_000_000.0,
+    )
+    proactive.handle_proactive_feedback(nudge["id"], "do", now=1_700_000_001.0)
+
+    export = proactive.export_privacy_safe_learning()
+    dumped = json.dumps(export)
+
+    assert export["privacy_safe"] is True
+    assert export["totals"]["feedback"] == 1
+    assert export["by_kind"]["blocker_or_waiting"]["do"] == 1
+    assert "TestFlight" not in dumped
+    assert "/Users/bots" not in dumped
+    assert "secret-session-id" not in dumped
+    assert "Private" not in dumped
+
+
+def test_self_evolution_guardrails_reject_unsafe_or_private_changes():
+    assert proactive.validate_self_evolution_change({"type": "kind_weight", "kind": "content_opportunity", "delta": 3})["ok"] is True
+    assert proactive.validate_self_evolution_change({"type": "cooldown", "kind": "content_opportunity", "hours": 96})["ok"] is True
+
+    unsafe = [
+        {"type": "code_edit", "path": "run_agent.py"},
+        {"type": "prompt_edit", "text": "silently change the live prompt"},
+        {"type": "external_action", "target": "email"},
+        {"type": "kind_weight", "kind": "content", "raw_text": "private user text"},
+    ]
+    for change in unsafe:
+        result = proactive.validate_self_evolution_change(change)
+        assert result["ok"] is False
+        assert result["requires_user_approval"] is True

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -48,7 +48,22 @@ def _make_config():
 def _install_telegram_mock(monkeypatch, bot):
     parse_mode = SimpleNamespace(MARKDOWN_V2="MarkdownV2", HTML="HTML")
     constants_mod = SimpleNamespace(ParseMode=parse_mode)
-    telegram_mod = SimpleNamespace(Bot=lambda token: bot, constants=constants_mod)
+
+    class InlineKeyboardButton:
+        def __init__(self, text, callback_data=None):
+            self.text = text
+            self.callback_data = callback_data
+
+    class InlineKeyboardMarkup:
+        def __init__(self, inline_keyboard):
+            self.inline_keyboard = inline_keyboard
+
+    telegram_mod = SimpleNamespace(
+        Bot=lambda token: bot,
+        constants=constants_mod,
+        InlineKeyboardButton=InlineKeyboardButton,
+        InlineKeyboardMarkup=InlineKeyboardMarkup,
+    )
     monkeypatch.setitem(sys.modules, "telegram", telegram_mod)
     monkeypatch.setitem(sys.modules, "telegram.constants", constants_mod)
 
@@ -674,6 +689,27 @@ class TestSendTelegramHtmlDetection:
 
         kwargs = bot.send_message.await_args.kwargs
         assert kwargs["disable_web_page_preview"] is True
+
+    def test_inline_buttons_attach_reply_markup(self, monkeypatch):
+        bot = self._make_bot()
+        _install_telegram_mock(monkeypatch, bot)
+
+        asyncio.run(
+            _send_telegram(
+                "tok",
+                "123",
+                "Cron output",
+                telegram_inline_buttons=[
+                    {"text": "Stop", "callback_data": "cj:stop:job-1"},
+                    {"text": "More Info", "callback_data": "cj:info:job-1"},
+                ],
+            )
+        )
+
+        kwargs = bot.send_message.await_args.kwargs
+        markup = kwargs["reply_markup"]
+        assert [button.text for button in markup.inline_keyboard[0]] == ["Stop", "More Info"]
+        assert [button.callback_data for button in markup.inline_keyboard[0]] == ["cj:stop:job-1", "cj:info:job-1"]
 
     def test_html_with_code_and_pre_tags(self, monkeypatch):
         bot = self._make_bot()

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -511,7 +511,7 @@ async def _send_via_adapter(
     }
 
 
-async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False):
+async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None, media_files=None, force_document=False, telegram_inline_buttons=None):
     """Route a message to the appropriate platform sender.
 
     Long messages are automatically chunked to fit within platform limits
@@ -581,14 +581,19 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         disable_link_previews = bool(getattr(pconfig, "extra", {}) and pconfig.extra.get("disable_link_previews"))
         for i, chunk in enumerate(chunks):
             is_last = (i == len(chunks) - 1)
+            telegram_kwargs = {
+                "media_files": media_files if is_last else [],
+                "thread_id": thread_id,
+                "disable_link_previews": disable_link_previews,
+                "force_document": force_document,
+            }
+            if telegram_inline_buttons and is_last:
+                telegram_kwargs["telegram_inline_buttons"] = telegram_inline_buttons
             result = await _send_telegram(
                 pconfig.token,
                 chat_id,
                 chunk,
-                media_files=media_files if is_last else [],
-                thread_id=thread_id,
-                disable_link_previews=disable_link_previews,
-                force_document=force_document,
+                **telegram_kwargs,
             )
             if isinstance(result, dict) and result.get("error"):
                 return result
@@ -750,7 +755,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     return last_result
 
 
-async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, force_document=False):
+async def _send_telegram(token, chat_id, message, media_files=None, thread_id=None, disable_link_previews=False, force_document=False, telegram_inline_buttons=None):
     """Send via Telegram Bot API (one-shot, no polling needed).
 
     Applies markdown→MarkdownV2 formatting (same as the gateway adapter)
@@ -808,6 +813,18 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                 thread_kwargs["message_thread_id"] = effective_thread_id
         if disable_link_previews:
             thread_kwargs["disable_web_page_preview"] = True
+        if telegram_inline_buttons:
+            from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+            buttons = [
+                InlineKeyboardButton(
+                    str(button.get("text", "")),
+                    callback_data=str(button.get("callback_data", "")),
+                )
+                for button in telegram_inline_buttons
+                if button.get("text") and button.get("callback_data")
+            ]
+            if buttons:
+                thread_kwargs["reply_markup"] = InlineKeyboardMarkup([buttons])
 
         last_msg = None
         warnings = []

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -47,6 +47,7 @@ hermes [global-options] <command> [subcommand/options]
 | `hermes login` / `logout` | **Deprecated** — use `hermes auth` instead. |
 | `hermes status` | Show agent, auth, and platform status. |
 | `hermes cron` | Inspect and tick the cron scheduler. |
+| `hermes proactive` | Build or install a safe proactive synthesis cron job. |
 | `hermes kanban` | Multi-profile collaboration board (tasks, links, dispatcher). |
 | `hermes webhook` | Manage dynamic webhook subscriptions for event-driven activation. |
 | `hermes hooks` | Inspect, approve, or remove shell-script hooks declared in `config.yaml`. |
@@ -337,6 +338,31 @@ hermes cron <list|create|edit|pause|resume|run|remove|status|tick>
 | `remove` | Delete a scheduled job. |
 | `status` | Check whether the cron scheduler is running. |
 | `tick` | Run due jobs once and exit. |
+
+## `hermes proactive`
+
+```bash
+hermes proactive <prompt|install>
+```
+
+Creates a conservative synthesis prompt for a recurring cron job that reviews recent sessions and only messages the user when there is one safe, timely, high-confidence nudge. If nothing is worth saying, the prompt tells the cron agent to return `[SILENT]`, which suppresses delivery while still saving output locally for audit.
+
+| Subcommand | Description |
+|------------|-------------|
+| `prompt` | Print the prompt used by the proactive synthesis cron job. |
+| `install` | Create or update the idempotent `Proactive synthesis / safe nudges` cron job. |
+
+Common options:
+
+| Option | Description |
+|--------|-------------|
+| `--schedule` | Install schedule, e.g. `every 4h` or `0 9 * * *` (default: daily at 09:00). |
+| `--deliver` | Cron delivery target. Defaults to `local`; set `telegram`, `origin`, etc. to proactively message. |
+| `--lookback-days` | Recent interaction window to inspect (clamped to 1–90). |
+| `--max-sessions` | Maximum recent sessions to review (clamped to 1–200). |
+| `--min-confidence` | `high` (default) or `medium` threshold before messaging. |
+| `--paused` | Install/update the cron job but leave it paused for review. |
+| `--json` | Print machine-readable output. |
 
 ## `hermes kanban`
 

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -342,15 +342,16 @@ hermes cron <list|create|edit|pause|resume|run|remove|status|tick>
 ## `hermes proactive`
 
 ```bash
-hermes proactive <prompt|install>
+hermes proactive <prompt|scan|install>
 ```
 
-Creates a conservative synthesis prompt for a recurring cron job that reviews recent sessions and only messages the user when there is one safe, timely, high-confidence nudge. If nothing is worth saying, the prompt tells the cron agent to return `[SILENT]`, which suppresses delivery while still saving output locally for audit.
+Creates a conservative personal-assistant-style cron job that first runs a fast structured signal scan, then asks the agent to judge whether exactly one safe, timely, high-confidence nudge is worth sending. If the scanner finds no candidate, it emits a wake gate so the cron job skips the LLM entirely. If the judge finds nothing worth interrupting the user for, it returns `[SILENT]`.
 
 | Subcommand | Description |
 |------------|-------------|
-| `prompt` | Print the prompt used by the proactive synthesis cron job. |
-| `install` | Create or update the idempotent `Proactive synthesis / safe nudges` cron job. |
+| `prompt` | Print the judgment prompt used by the proactive synthesis cron job. |
+| `scan` | Run the fast local signal scanner and print structured signals. |
+| `install` | Create or update the idempotent `Proactive synthesis / safe nudges` cron job, including its pre-run scanner script. |
 
 Common options:
 


### PR DESCRIPTION
## What does this PR do?

Adds a conservative, opt-in proactive assistant surface and makes recurring cron nudges manageable from Telegram instead of turning every scheduled message into another chat chore.

The proactive flow is safety-first:

- `hermes proactive prompt` prints the self-contained reflection prompt for review.
- `hermes proactive scan` runs the fast local signal scanner and returns structured candidates.
- `hermes proactive install` creates or updates one idempotent cron job named `Proactive synthesis / safe nudges`.
- `hermes proactive evolve` reviews feedback and proposes safe local tuning / skill candidates without silently editing code or prompts.
- `hermes proactive export-learning` prints privacy-safe aggregate feedback counts for upstream learning without raw user text, session IDs, excerpts, paths, or customer data.
- The cron job uses a pre-run scanner as a wake gate, limits itself to at most one high-confidence nudge, blocks external/public/destructive actions, and returns `[SILENT]` when there is nothing worth interrupting the user for.
- Default delivery remains `local`; users must explicitly choose `telegram`, `origin`, etc. to make it message them.

It also improves cron delivery UX:

- Cron outputs now default to a compact wrapper: bold job name, monospace job id, no noisy `Cronjob Response:` block.
- Telegram cron deliveries get inline controls: **Stop** and **More Info**.
- **Stop** pauses the job instead of deleting it, then flips the original message control to **Resume**.
- **More Info** sends a compact job card with schedule, status, delivery, last/next run, and prompt/script preview.
- The info card exposes **Run Now**, **Last Output**, **Edit Schedule**, and Stop/Resume controls.
- `cron.wrap_response: false` still sends raw output only.
- `cron.wrap_style: classic` restores the old wrapper.
- `cron.action_buttons: false` disables Telegram inline controls.

This is related to, but narrower/different from, #5251 (`self_nudge`): that PR is one-shot in-session follow-up. This PR is recurring cross-session synthesis through cron, plus chat-native management for the cron outputs it creates.

## Related Issue

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `hermes_cli/proactive.py`
  - Adds prompt builder with explicit proactive safety policy.
  - Adds fast structured signal scanner and wake-gate script generation.
  - Adds idempotent cron installer/updater.
  - Adds `prompt`, `scan`, `install`, `evolve`, and `export-learning` CLI handlers with JSON output support.
  - Adds profile-local adaptive preferences from feedback buttons (`preferences.json`).
  - Adds sanitized replay-eval examples (`replay_evals.jsonl`), privacy-safe aggregate export, self-evolution reports, and guardrails that block silent code/prompt/external actions.
- `hermes_cli/main.py`
  - Registers the top-level `hermes proactive` command.
  - Adds `prompt`, `scan`, `install`, `evolve`, and `export-learning` subcommands.
- `cron/scheduler.py`
  - Adds compact/default cron delivery formatting.
  - Preserves `cron.wrap_response: false` raw-output behavior.
  - Adds `cron.wrap_style: classic` fallback for the old wrapper.
  - Adds Telegram cron button metadata for delivered jobs.
- `gateway/platforms/telegram.py`
  - Supports generic metadata-driven inline keyboards.
  - Handles cron callback actions for Stop, Resume, More Info, Run Now, Last Output, and Edit Schedule guidance.
  - Reuses existing callback authorization checks before mutating cron jobs.
- `tools/send_message_tool.py`
  - Supports Telegram inline buttons in the standalone send path used by cron delivery.
- `cli-config.yaml.example`
  - Documents `cron.wrap_response`, `cron.wrap_style`, and `cron.action_buttons`.
- Tests
  - Covers proactive prompt/scan/install behavior.
  - Covers compact cron delivery wrapping and button metadata.
  - Covers Telegram cron callbacks and standalone Telegram inline-button sends.

## How to Test

1. Review the prompt without creating a cron job:
   ```bash
   hermes proactive prompt --lookback-days 7 --max-sessions 30
   ```
2. Run the fast scanner without installing anything:
   ```bash
   hermes proactive scan --lookback-hours 48 --json
   ```
3. Install a paused local-only job for review:
   ```bash
   hermes proactive install --schedule '0 9 * * *' --deliver local --paused
   ```
4. When ready to proactively message a configured home channel, install/update with an explicit delivery target:
   ```bash
   hermes proactive install --schedule 'every 4h' --deliver telegram
   ```
5. For Telegram-delivered cron jobs, use the inline **Stop** / **More Info** controls on the delivered cron message.
6. Review the self-evolution loop after feedback exists:
   ```bash
   hermes proactive evolve --json
   hermes proactive evolve --write
   hermes proactive export-learning
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.2 arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A — this PR does not add a skill.

## Screenshots / Logs

Focused verification for this PR:

```text
python -m py_compile cron/scheduler.py gateway/platforms/telegram.py tools/send_message_tool.py hermes_cli/proactive.py

scripts/run_tests.sh tests/hermes_cli/test_proactive.py tests/gateway/test_telegram_approval_buttons.py tests/cron/test_scheduler.py::TestDeliverResultWrapping -q
55 passed in 0.81s

scripts/run_tests.sh tests/hermes_cli/test_proactive.py tests/hermes_cli/test_argparse_flag_propagation.py tests/gateway/test_telegram_approval_buttons.py tests/cron/test_scheduler.py -q
180 passed in 1.77s
```

Dry-run cron formatting sample:

```text
⏰ **Morning check-in / loose-end catcher**

`job_id: 97fe4d28ac90`

Morning reset — one concrete loose end surfaced.

[Stop] [More Info]
```

CLI smoke tests from earlier commits:

```text
python -m hermes_cli.main proactive prompt --lookback-days 2 --max-sessions 9 --min-confidence medium --json
# JSON parsed; prompt contained [SILENT]

HERMES_HOME=$(mktemp -d) python -m hermes_cli.main proactive install --schedule 'every 12h' --deliver local --paused --json
# action: created_paused; state: paused; deliver: local
```

Broader suite note:

```text
scripts/run_tests.sh tests/hermes_cli -q
4038 passed, 8 skipped, 13 failed
```

The sampled failures reproduced on clean `origin/main` in `/tmp/hermes-agent-clean`:

```text
scripts/run_tests.sh \
  tests/hermes_cli/test_gateway_wsl.py::TestSupportsSystemdServicesWSL::test_wsl_with_systemd \
  tests/hermes_cli/test_model_switch_custom_providers.py::test_list_authenticated_providers_groups_same_endpoint \
  tests/hermes_cli/test_tencent_tokenhub_provider.py::TestTencentTokenhubContextLength::test_hy3_preview_context_length -q
3 failed
```

