### PR TITLE
fix(memory): probe hindsight_client import in is_available (#18875)

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -99,6 +99,25 @@ def _check_local_runtime() -> tuple[bool, str | None]:
         return False, str(exc)
 
 
+def _check_cloud_client() -> tuple[bool, str | None]:
+    """Return whether the ``hindsight_client`` cloud SDK imports cleanly.
+
+    The Docker image and ``pyproject.toml`` do not declare ``hindsight-client``
+    as a hard dependency. When ``memory.provider`` is flipped to ``hindsight``
+    on a stock install the cloud / local_external code paths used to call
+    ``from hindsight_client import Hindsight`` lazily inside ``_get_client``,
+    which crashed the gateway with ``ModuleNotFoundError`` and triggered an
+    infinite Docker restart loop (see #18875). Detecting the missing client
+    in ``is_available()`` lets ``MemoryManager`` decline to register the
+    provider so the agent boots with the built-in memory backend instead.
+    """
+    try:
+        importlib.import_module("hindsight_client")
+        return True, None
+    except Exception as exc:
+        return False, str(exc)
+
+
 # ---------------------------------------------------------------------------
 # Hindsight API capability probe — mirrors hindsight-integrations/openclaw.
 # ---------------------------------------------------------------------------
@@ -597,14 +616,19 @@ class HindsightMemoryProvider(MemoryProvider):
                 available, _ = _check_local_runtime()
                 return available
             if mode == "local_external":
-                return True
+                # local_external talks to a self-hosted Hindsight API via the
+                # cloud SDK — without ``hindsight_client`` the lazy import in
+                # ``_get_client`` crashes the gateway. See #18875.
+                return _check_cloud_client()[0]
             has_key = bool(
                 cfg.get("apiKey")
                 or cfg.get("api_key")
                 or os.environ.get("HINDSIGHT_API_KEY", "")
             )
             has_url = bool(cfg.get("api_url") or os.environ.get("HINDSIGHT_API_URL", ""))
-            return has_key or has_url
+            if not (has_key or has_url):
+                return False
+            return _check_cloud_client()[0]
         except Exception:
             return False
 

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1381,6 +1381,10 @@ class TestAvailability:
             lambda: tmp_path / "nonexistent",
         )
         monkeypatch.setenv("HINDSIGHT_API_KEY", "test-key")
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.importlib.import_module",
+            lambda name: object(),
+        )
         p = HindsightMemoryProvider()
         assert p.is_available()
 
@@ -1415,6 +1419,10 @@ class TestAvailability:
         monkeypatch.setattr(
             "plugins.memory.hindsight.get_hermes_home",
             lambda: tmp_path,
+        )
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.importlib.import_module",
+            lambda name: object(),
         )
 
         p = HindsightMemoryProvider()
@@ -1460,6 +1468,70 @@ class TestAvailability:
         p = HindsightMemoryProvider()
         p.initialize(session_id="test-session", hermes_home=str(tmp_path), platform="cli")
         assert p._mode == "disabled"
+
+    def test_cloud_unavailable_when_client_import_fails(self, tmp_path, monkeypatch):
+        """Regression test for #18875.
+
+        Cloud mode without ``hindsight_client`` installed used to slip past
+        ``is_available()`` (which only checked api_key/api_url), then crash the
+        gateway with ``ModuleNotFoundError`` deep inside ``_get_client``.
+        ``is_available()`` must probe the SDK import so ``MemoryManager``
+        declines to register the provider.
+        """
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home",
+            lambda: tmp_path / "nonexistent",
+        )
+        monkeypatch.setenv("HINDSIGHT_API_KEY", "test-key")
+
+        def _raise(_name):
+            raise ModuleNotFoundError("No module named 'hindsight_client'")
+
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.importlib.import_module",
+            _raise,
+        )
+        p = HindsightMemoryProvider()
+        assert not p.is_available()
+
+    def test_local_external_unavailable_when_client_import_fails(
+        self, tmp_path, monkeypatch
+    ):
+        """Regression test for #18875 — local_external also uses the cloud SDK."""
+        config_path = tmp_path / "hindsight" / "config.json"
+        config_path.parent.mkdir(parents=True, exist_ok=True)
+        config_path.write_text(json.dumps({
+            "mode": "local_external",
+            "api_url": "http://localhost:8080",
+        }))
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home",
+            lambda: tmp_path,
+        )
+
+        def _raise(_name):
+            raise ModuleNotFoundError("No module named 'hindsight_client'")
+
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.importlib.import_module",
+            _raise,
+        )
+        p = HindsightMemoryProvider()
+        assert not p.is_available()
+
+    def test_cloud_available_when_client_imports_cleanly(self, tmp_path, monkeypatch):
+        """Cloud mode with api key + importable client is still available."""
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.get_hermes_home",
+            lambda: tmp_path / "nonexistent",
+        )
+        monkeypatch.setenv("HINDSIGHT_API_KEY", "test-key")
+        monkeypatch.setattr(
+            "plugins.memory.hindsight.importlib.import_module",
+            lambda name: object(),
+        )
+        p = HindsightMemoryProvider()
+        assert p.is_available()
 
 
 class TestSharedEventLoopLifecycle:


### PR DESCRIPTION
## Summary

`HindsightMemoryProvider.is_available()` previously returned `True` for cloud mode whenever an `api_key` / `api_url` was configured, and unconditionally `True` for `local_external` mode. Both modes still need the optional `hindsight-client` SDK at runtime — when the package is missing the lazy `from hindsight_client import Hindsight` inside `_get_client()` raises `ModuleNotFoundError`, crashing the gateway and triggering an infinite Docker restart loop.

This patch:

- Adds `_check_cloud_client()` helper that probes `importlib.import_module("hindsight_client")` and returns `(ok, reason)`, mirroring the existing `_check_local_runtime()` pattern.
- Wires the probe into `is_available()` for both `cloud` and `local_external` modes so `MemoryManager` declines to register the provider when the SDK is missing — the agent now boots cleanly with the built-in memory backend instead of restart-looping.

Cloud auth still requires `api_key` / `api_url` (no behavior change for users with the SDK already installed and credentials configured).

Closes #18875.

## Test plan

- [x] New regression tests in `TestAvailability`:
  - `test_cloud_unavailable_when_client_import_fails` — fails on `main`, passes on this branch (stash-verified).
  - `test_local_external_unavailable_when_client_import_fails` — fails on `main`, passes on this branch.
  - `test_cloud_available_when_client_imports_cleanly` — guards happy path.
- [x] Updated existing `test_available_with_api_key` and `test_available_with_snake_case_api_key_in_config` to monkeypatch `import_module` so they exercise the new probe.
- [x] `pytest tests/plugins/memory/test_hindsight_provider.py` — 99 passed.
- [x] `pytest tests/plugins/memory/ tests/agent/test_memory_session_switch.py` — 175 passed.