### PR TITLE
fix: always redact status API keys

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -89,7 +89,6 @@ from hermes_constants import is_termux as _is_termux
 
 def show_status(args):
     """Show status of all Hermes Agent components."""
-    show_all = getattr(args, 'all', False)
     deep = getattr(args, 'deep', False)
 
     print()
@@ -165,12 +164,12 @@ def show_status(args):
             continue
         value = _resolve_env(env_ref)
         has_key = bool(value)
-        display = redact_key(value) if not show_all else value
+        display = redact_key(value)
         print(f"  {name:<12}  {check_mark(has_key)} {display}")
 
     from hermes_cli.auth import get_anthropic_key
     anthropic_value = get_anthropic_key()
-    anthropic_display = redact_key(anthropic_value) if not show_all else anthropic_value
+    anthropic_display = redact_key(anthropic_value)
     print(f"  {'Anthropic':<12}  {check_mark(bool(anthropic_value))} {anthropic_display}")
 
     # =========================================================================

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -5,13 +5,40 @@ from hermes_cli.status import show_status
 
 def test_show_status_includes_tavily_key(monkeypatch, capsys, tmp_path):
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
-    monkeypatch.setenv("TAVILY_API_KEY", "tvly-1234567890abcdef")
+    monkeypatch.setenv("TAVILY_API_KEY", "tvly-1...cdef")
 
     show_status(SimpleNamespace(all=False, deep=False))
 
     output = capsys.readouterr().out
     assert "Tavily" in output
     assert "tvly...cdef" in output
+
+
+def test_show_status_all_does_not_print_raw_api_keys(monkeypatch, capsys, tmp_path):
+    import hermes_cli.auth as auth_mod
+
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("TAVILY_API_KEY", "tvly-dev-secret-value-that-must-not-print")
+    monkeypatch.setenv("OPENROUTER_API_KEY", "openrouter-test-value-that-must-not-print")
+    monkeypatch.setattr(
+        auth_mod,
+        "get_anthropic_key",
+        lambda: "anthropic-test-value-that-must-not-print",
+        raising=False,
+    )
+
+    show_status(SimpleNamespace(all=True, deep=False))
+
+    output = capsys.readouterr().out
+    assert "Tavily" in output
+    assert "OpenRouter" in output
+    assert "Anthropic" in output
+    assert "tvly-dev-secret-value-that-must-not-print" not in output
+    assert "openrouter-test-value-that-must-not-print" not in output
+    assert "anthropic-test-value-that-must-not-print" not in output
+    assert "tvly...rint" in output
+    assert "open...rint" in output
+    assert "anth...rint" in output
 
 
 def test_show_status_termux_gateway_section_skips_systemctl(monkeypatch, capsys, tmp_path):


### PR DESCRIPTION
## Summary
- Always redact API keys in `hermes status`, including when `--all` is passed.
- Remove the now-unused `show_all` local from the status command.
- Add regression coverage for OpenRouter, Tavily, and Anthropic key sources.

## Why
`hermes status --all` previously printed raw API key values. Status output is often pasted into support/debugging contexts, so `--all` should not bypass secret redaction.

## Test plan
- `git diff --check`
- added-line security scan for common secret/shell/eval patterns
- `/home/ubuntu/.hermes/hermes-agent/venv/bin/python -m py_compile hermes_cli/status.py`
- `/home/ubuntu/.hermes/hermes-agent/venv/bin/python -m pytest tests/hermes_cli/test_status.py -q -o 'addopts='`
- `ruff check hermes_cli/status.py tests/hermes_cli/test_status.py`
