### PR TITLE
feat(skills): add web-3d workflow skill

### DIFF
--- a/skills/creative/web-3d/SKILL.md
+++ b/skills/creative/web-3d/SKILL.md
@@ -1,0 +1,311 @@
+---
+name: web-3d
+description: "Interactive 3D surfaces for the web: choose between vanilla Three.js, React Three Fiber, or adjacent Hermes skills, then implement and verify the result inside a real web stack."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [webgl, 3d, threejs, react-three-fiber, gltf, shaders, frontend, interactive, ui]
+    related_skills: [p5js, blender-mcp, touchdesigner-mcp, claude-design]
+    requires_toolsets: [terminal]
+---
+
+# Web 3D
+
+Build and debug interactive 3D surfaces for the web using the repo's real stack.
+
+This skill is for one specific problem:
+
+- **shipping or prototyping interactive 3D inside a web product**
+
+That includes:
+
+- hero sections
+- product scenes
+- model viewers
+- shader-backed app surfaces
+- React-owned 3D components
+- standalone demos that are meant to become web UI later
+
+This skill is **not** a general 3D skill and **not** a replacement for other creative skills.
+
+It is a workflow layer:
+
+- it classifies the request
+- chooses the right implementation path
+- composes with adjacent skills when needed
+- implements and verifies the result using Hermes' existing file, terminal, and browser surfaces
+
+## Relationship to other creative skills
+
+This skill complements existing creative skills instead of replacing them:
+
+- `p5js` -> browser-based generative art, sketches, shaders, and creative coding
+- `blender-mcp` -> 3D content creation and DCC-driven scene authoring
+- `touchdesigner-mcp` -> real-time operator-network workflows and installation-style visuals
+- `claude-design` / `sketch` -> design exploration and non-3D artifact work
+- `popular-web-designs` -> visual vocabulary and design reference material
+
+Use `web-3d` when the central problem is **3D implementation inside a web stack**, not asset authoring, generative art, or general design exploration.
+
+## When to use
+
+Use when the user wants:
+
+- interactive 3D inside a website or web app
+- a 3D landing-page hero
+- a product visualization surface
+- a model viewer for `.glb` / `.gltf`
+- pointer-reactive, scroll-reactive, or shader-based 3D UI
+- a React component that owns a 3D canvas
+- a standalone browser demo that will likely become app UI later
+
+## When NOT to use
+
+- **Pure generative art, browser sketch, or canvas-first experimentation** -> use `p5js`
+- **3D scene authoring, modeling, rigging, animation, or material work in a DCC** -> use `blender-mcp`
+- **Real-time installation / VJ / operator-graph work** -> use `touchdesigner-mcp`
+- **Static mockups, non-3D prototypes, or general HTML design exploration** -> use `claude-design` or `sketch`
+- **A diagram, not a scene** -> use `architecture-diagram`, `concept-diagrams`, or `excalidraw`
+
+## Core idea
+
+This skill does four things:
+
+1. Classify the request
+2. Choose the right implementation path
+3. Implement using the repo's actual stack
+4. Verify visual correctness, console health, cleanup, and performance
+
+Do not reduce this to "install three and start coding."
+
+The highest-value behavior is choosing the right implementation path:
+
+- `p5js` vs `three`
+- `three` vs `@react-three/fiber`
+- web implementation vs asset-authoring handoff
+- standalone demo vs real repo integration
+
+## Decision rules
+
+See `references/decision-rules.md` for full detail.
+
+### Choose `react-three-fiber` when
+
+- the repo already uses React
+- the 3D scene must live inside component state
+- the surface needs to interact with UI controls, route state, or application data
+- the result should be reusable as a component instead of a page-local script
+
+### Choose vanilla `three` when
+
+- the project is standalone or framework-light
+- a single isolated canvas is enough
+- low-level control matters more than React composition
+- the result should be a minimal viewer / hero / demo with explicit render-loop ownership
+
+### Choose `p5js` instead when
+
+- the request is generative-art-first, scene-graph-second
+- the main value is motion language, particles, noise, or visual experimentation
+- exact scene hierarchy, loaders, or reusable 3D UI components are not important
+
+### Choose `blender-mcp` before web integration when
+
+- the scene itself still needs to be authored
+- the user needs meshes, cameras, materials, or animation built first
+- the web task is mainly "display an authored 3D asset" instead of "design the 3D system"
+
+### Choose `touchdesigner-mcp` instead when
+
+- the work is operator-network-based
+- the output is installation/performance-oriented
+- the environment is closer to real-time media systems than product UI
+
+## Delivery modes
+
+This skill should support four concrete output modes:
+
+1. **Standalone viewer**
+   - one local HTML file or a tiny Vite page
+   - good for demos, viewers, and spikes
+2. **Repo-integrated React component**
+   - `SceneHero.tsx`, `ModelViewer.tsx`, `InteractiveCanvas.tsx`
+   - good for real product work
+3. **Framework page/section integration**
+   - Vite / Next / Astro / similar app surface
+   - a section, route, or hero inside an existing product
+4. **Asset-backed model surface**
+   - `.glb` / `.gltf` viewer with lights, camera, controls, fallback, and performance constraints
+
+Choose the smallest mode that fits the request.
+Do not widen scope just because a neighboring creative skill exists.
+
+## Workflow
+
+```
+INSPECT -> CLASSIFY -> CHOOSE PATH -> BUILD MINIMUM -> ADD INTERACTION -> VERIFY -> TIGHTEN
+```
+
+### Step 1 - Inspect the repo and runtime
+
+Before writing code, determine:
+
+- framework: React / Vite / Next / Astro / plain HTML
+- package manager: npm / pnpm / yarn / bun
+- whether SSR is involved
+- whether 3D must coexist with an existing design system
+- where the surface lives: page, section, component, modal, hero, viewer
+- whether assets already exist (`.glb`, `.gltf`, textures, HDRIs)
+
+If the task is in an existing repo, build in that repo's real stack. Do not force a standalone HTML artifact if the real target is a component or page.
+
+### Step 2 - Classify the surface
+
+Decide what kind of thing this is:
+
+- hero section
+- model viewer
+- product scene
+- background surface
+- shader-first ambient layer
+- data-driven interactive scene
+- marketing/demo artifact
+
+The classification should change the implementation:
+
+- a hero section needs strong composition and graceful fallback
+- a viewer needs camera, controls, and asset hygiene
+- a product scene needs responsiveness and UI coexistence
+- a shader surface needs performance discipline and progressive enhancement
+
+### Step 3 - Choose the implementation path
+
+Use:
+
+- `references/react-three-fiber.md`
+- `references/vanilla-three.md`
+- `references/ssr-and-frameworks.md`
+
+Do not mix paradigms casually. Pick one render ownership model and commit:
+
+- R3F component tree
+- vanilla Three.js loop
+- adjacent skill handoff when this is not the right owner
+
+### Step 4 - Build the minimum render path first
+
+Before polish:
+
+- get a canvas rendering
+- establish camera + scene + renderer
+- confirm resize behavior
+- confirm render loop ownership
+- confirm unmount/cleanup path
+
+No postprocessing, fancy materials, or elaborate controls until the minimum scene is stable.
+
+### Step 5 - Add the real product layer
+
+Then add what the brief actually needs:
+
+- lights
+- controls
+- assets
+- interactions
+- shader passes
+- UI coordination
+- scroll or pointer response
+
+Do not add everything just because the library allows it.
+
+### Step 6 - Verify aggressively
+
+Use the browser toolset when available.
+
+Always check:
+
+- visual output
+- browser console
+- resize behavior
+- asset loading
+- SSR/hydration safety
+- cleanup/dispose path
+- performance on the intended surface
+
+See `references/verification-checklist.md`.
+
+### Step 7 - Tighten and simplify
+
+Before declaring success:
+
+- remove unnecessary abstractions
+- cap pixel density when needed
+- dispose textures/materials/geometries correctly
+- reduce asset weight if the scene is too heavy
+- ensure there is a non-WebGL or low-power fallback when the surface is user-facing
+
+## Default implementation standards
+
+- Prefer **existing repo stack** over standalone HTML when the task lives in an app
+- Prefer **component boundaries** over global script blobs in React repos
+- Prefer **one clear surface** over multiple competing canvases
+- Prefer **small scene graphs** over ornamental complexity
+- Prefer **real verification** over source-only confidence
+
+## Verification checklist
+
+Before returning work:
+
+- [ ] Scene renders without console errors
+- [ ] Canvas resizes correctly
+- [ ] No obvious SSR or hydration crash path
+- [ ] Controls and interactions work as intended
+- [ ] Assets load from correct paths
+- [ ] Cleanup/dispose path exists
+- [ ] Performance is acceptable on the target surface
+- [ ] A fallback exists if the surface is public-facing
+
+Load `references/verification-checklist.md` for the detailed list.
+
+## Common failure modes
+
+- importing browser-only code into SSR path
+- creating multiple render loops accidentally
+- leaking geometry, material, texture, or controls on remount
+- rendering at unbounded DPR on laptops/phones
+- shipping a 3D scene that visually fights the page around it
+- using 3D where 2D motion or CSS would have solved the problem better
+- forcing `three` into a repo where `R3F` is the better integration layer
+- forcing `R3F` into a tiny standalone demo where plain `three` is simpler
+- absorbing adjacent skills instead of routing to them
+
+## File map
+
+```
+SKILL.md
+references/
+  decision-rules.md
+  vanilla-three.md
+  react-three-fiber.md
+  gltf-assets.md
+  ssr-and-frameworks.md
+  performance-and-debugging.md
+  verification-checklist.md
+templates/
+  standalone-viewer.html
+  react-scene-component.tsx
+scripts/
+  setup.sh
+  serve.sh
+```
+
+## Usage pattern
+
+1. Read the repo and classify the request
+2. Load the most relevant reference file(s), not all of them
+3. Build the smallest correct path
+4. Verify with browser + console
+5. Only then add finish and polish

--- a/skills/creative/web-3d/SKILL.md
+++ b/skills/creative/web-3d/SKILL.md
@@ -42,9 +42,9 @@ It is a workflow layer:
 
 This skill complements existing creative skills instead of replacing them:
 
-- `p5js` -> browser-based generative art, sketches, shaders, and creative coding
-- `blender-mcp` -> 3D content creation and DCC-driven scene authoring
-- `touchdesigner-mcp` -> real-time operator-network workflows and installation-style visuals
+- `p5js` -> browser-native generative art, sketch-style WebGL, shaders, and creative coding
+- `blender-mcp` -> upstream 3D asset and scene authoring before web integration
+- `touchdesigner-mcp` -> alternative real-time media workflow for operator-network and installation-style visuals
 - `claude-design` / `sketch` -> design exploration and non-3D artifact work
 - `popular-web-designs` -> visual vocabulary and design reference material
 
@@ -118,11 +118,15 @@ See `references/decision-rules.md` for full detail.
 - the user needs meshes, cameras, materials, or animation built first
 - the web task is mainly "display an authored 3D asset" instead of "design the 3D system"
 
+Treat `blender-mcp` as an upstream authoring handoff, not as an alternative web implementation path.
+
 ### Choose `touchdesigner-mcp` instead when
 
 - the work is operator-network-based
 - the output is installation/performance-oriented
 - the environment is closer to real-time media systems than product UI
+
+Treat `touchdesigner-mcp` as an adjacent medium, not as the normal owner for product-web 3D.
 
 ## Delivery modes
 

--- a/skills/creative/web-3d/references/decision-rules.md
+++ b/skills/creative/web-3d/references/decision-rules.md
@@ -1,0 +1,110 @@
+# Decision Rules
+
+This skill only makes sense if it chooses the right path instead of flattening every request into "install Three.js."
+
+## Primary split
+
+### `p5js`
+
+Choose `p5js` when the user wants:
+
+- generative visuals
+- browser art
+- particles / noise / flow fields
+- sketch-like experimentation
+- shaders as visual art rather than product UI infrastructure
+
+Do **not** force `three` just because something is "3D." If the scene is artistic, procedural, and mostly self-contained, `p5js` is usually the better Hermes-native fit.
+
+### `three`
+
+Choose vanilla `three` when:
+
+- the result is a standalone scene or viewer
+- the repo is framework-light or plain web
+- render-loop ownership should stay explicit
+- you want minimal abstraction between scene code and WebGL output
+
+Good fits:
+
+- small model viewer
+- isolated hero section
+- one-canvas microsite surface
+- low-abstraction prototype
+
+### `@react-three/fiber`
+
+Choose `R3F` when:
+
+- the repo already uses React
+- the scene must coexist with app state
+- the surface should be a real component
+- interactivity is tied to normal UI/state flows
+- composition with existing layout/components matters
+
+Good fits:
+
+- React landing page hero
+- componentized product visualization
+- interactive feature section
+- model viewer integrated with filters or UI controls
+
+### `blender-mcp`
+
+Choose `blender-mcp` first when:
+
+- authored assets are the real missing piece
+- modeling, animation, material tuning, or camera work still needs to happen
+- the web layer is mostly a presentation shell around the asset
+
+Typical split:
+
+- Blender creates the asset
+- `web-3d` integrates and presents it on the web
+
+### `touchdesigner-mcp`
+
+Choose `touchdesigner-mcp` when:
+
+- the work is about operator networks
+- performance art / installation / live VJ logic is central
+- the output is not naturally a product-UI surface
+
+## Standalone vs repo implementation
+
+### Standalone artifact
+
+Prefer a standalone artifact when:
+
+- the user asks for a demo, spike, or proof of concept
+- there is no existing repo
+- the result is meant to be shared visually before integration
+
+### Repo implementation
+
+Prefer repo implementation when:
+
+- the request clearly targets an existing app
+- the scene must live in production code
+- design system, layout, or framework constraints are already real
+
+Do not generate a detached HTML proof when the real problem is "put this in our app."
+
+## Surface taxonomy
+
+Classify the request before choosing code shape:
+
+- **Hero surface**: needs composition, fallback, restrained motion
+- **Viewer**: needs asset normalization, controls, camera discipline
+- **Background surface**: needs low distraction and strong performance discipline
+- **Feature section**: needs harmony with surrounding UI
+- **Product scene**: needs state coordination and component reuse
+- **Shader surface**: needs careful performance constraints and progressive enhancement
+
+## Anti-patterns
+
+- Choosing `three` for every 3D mention
+- Treating `R3F` as mandatory inside every React repo
+- Using a heavy model viewer where a 2D motion layer would suffice
+- Building asset-authoring logic inside a web-surface skill
+- Re-implementing `p5js` workflows under a new name

--- a/skills/creative/web-3d/references/gltf-assets.md
+++ b/skills/creative/web-3d/references/gltf-assets.md
@@ -1,0 +1,49 @@
+# glTF / GLB Assets
+
+If the request involves real 3D assets, treat asset hygiene as part of the implementation, not an afterthought.
+
+## Before loading
+
+Check:
+
+- file format: `.glb` vs `.gltf`
+- texture locations
+- approximate file size
+- whether the asset is already web-ready
+- whether the model needs authoring fixes before integration
+
+If the asset is not ready, the right move may be `blender-mcp` first.
+
+## Common problems
+
+- model origin is far from center
+- scale is wildly off
+- textures fail due to wrong relative paths
+- asset is too large for interactive web use
+- material setup looks wrong under web lighting
+- mobile perf collapses due to geometry/texture weight
+
+## Integration rules
+
+- normalize scale and framing
+- establish a default camera that shows the asset immediately
+- keep lights simple first
+- do not blame the web layer for broken source assets
+
+## Viewer defaults
+
+- sane camera distance
+- at least one key light + fill
+- neutral environment/background
+- optional controls only when appropriate
+- loading / fallback state
+
+## Performance posture
+
+Be suspicious of:
+
+- huge textures
+- too many draw calls
+- baked detail that should have been simplified
+
+If the model is public-facing, optimize before polishing the page around it.

--- a/skills/creative/web-3d/references/performance-and-debugging.md
+++ b/skills/creative/web-3d/references/performance-and-debugging.md
@@ -1,0 +1,61 @@
+# Performance and Debugging
+
+Interactive 3D web work can look correct and still be unusable. Verification must include performance.
+
+## Default performance rules
+
+- cap DPR
+- keep scene graphs small
+- prefer fewer lights
+- avoid expensive postprocessing until needed
+- do not load oversized assets casually
+
+## Start simple
+
+Before optimizing:
+
+- remove postprocessing
+- reduce light count
+- simplify geometry
+- turn off controls if they are not required
+- test with one asset only
+
+## Console first
+
+Always inspect browser console output.
+
+Look for:
+
+- WebGL context loss
+- failed asset fetches
+- shader compile errors
+- hydration/runtime errors
+- warnings caused by repeated mounts
+
+## Visual symptoms and likely causes
+
+- **Black canvas** -> camera, lighting, or shader failure
+- **White/unstyled fallback only** -> client boundary not mounting
+- **Jank on laptop fans** -> DPR too high or scene too heavy
+- **Works once, breaks on navigation** -> cleanup leak
+- **Model invisible** -> scale, framing, near/far planes, or asset origin issue
+
+## Cleanup checklist
+
+- stop animation loop
+- dispose controls
+- dispose geometries
+- dispose materials
+- dispose textures when custom-managed
+- remove event listeners
+
+## Mobile / lower-power posture
+
+For public-facing surfaces:
+
+- reduce DPR
+- simplify materials
+- reduce postprocessing
+- provide a graceful fallback
+
+If the page's value survives without 3D, the fallback should still feel intentional.

--- a/skills/creative/web-3d/references/react-three-fiber.md
+++ b/skills/creative/web-3d/references/react-three-fiber.md
@@ -1,0 +1,87 @@
+# React Three Fiber
+
+Use `@react-three/fiber` when the 3D surface belongs inside a React app as a real component.
+
+## Choose R3F when
+
+- the repo already uses React
+- the scene should compose with normal components
+- state or props should drive the scene
+- the canvas belongs to a route, section, or reusable component
+
+## Do not choose R3F just because React exists
+
+If the task is a tiny isolated spike, vanilla `three` may still be simpler.
+
+## Minimum component structure
+
+```tsx
+import { Canvas } from "@react-three/fiber";
+
+function SceneContents() {
+  return (
+    <mesh>
+      <boxGeometry args={[1, 1, 1]} />
+      <meshStandardMaterial color="#ffffff" />
+    </mesh>
+  );
+}
+
+export function SceneHero() {
+  return (
+    <Canvas dpr={[1, 2]} camera={{ position: [0, 0, 4], fov: 45 }}>
+      <ambientLight intensity={0.5} />
+      <directionalLight position={[2, 2, 2]} intensity={1.2} />
+      <SceneContents />
+    </Canvas>
+  );
+}
+```
+
+## Integration rules
+
+- Keep 3D concerns in a dedicated component boundary
+- Do not spread scene setup across random UI files
+- Keep canvas sizing explicit
+- Treat `Canvas` as infrastructure, not a casual decoration
+
+## State rules
+
+- Use props/state for real UI coupling
+- Do not push every animation detail into React state
+- Avoid causing React rerenders at frame rate
+
+Per-frame animation belongs inside the render loop, not normal app state.
+
+## Suspense and loaders
+
+If using asset loaders:
+
+- isolate loading states
+- do not block unrelated page UI unnecessarily
+- provide a visible fallback if the surface is important
+
+## Controls
+
+Only add controls if:
+
+- the user explicitly needs scene manipulation
+- the viewer metaphor requires it
+
+Do not put `OrbitControls` on a marketing hero unless it improves the brief.
+
+## Cleanup posture
+
+R3F handles some lifecycle cleanup, but you still need discipline:
+
+- unmount scene-local listeners
+- clean custom resources
+- verify remount behavior
+- ensure controls/helpers are not leaked
+
+## Best fits
+
+- product hero in React app
+- model viewer with UI filters
+- section-level interactive 3D
+- reusable 3D UI component

--- a/skills/creative/web-3d/references/ssr-and-frameworks.md
+++ b/skills/creative/web-3d/references/ssr-and-frameworks.md
@@ -1,0 +1,56 @@
+# SSR and Frameworks
+
+Web 3D often fails at framework boundaries, not inside the scene itself.
+
+## Rule zero
+
+If a framework renders on the server, never assume WebGL/browser APIs are safe at import time.
+
+## What to check
+
+- Is this Vite client-only?
+- Is this Next.js with SSR?
+- Is this Astro with islands?
+- Is the component mounted only on the client?
+
+## Framework posture
+
+### Vite / client-only React
+
+Usually straightforward.
+
+Main concerns:
+
+- component boundaries
+- asset paths
+- cleanup/remount behavior
+
+### Next.js
+
+Be careful with:
+
+- browser-only imports
+- client component boundaries
+- dynamic imports for heavy 3D surfaces
+- hydration mismatch risks
+
+### Astro
+
+Decide whether the 3D surface is:
+
+- a plain client-side script
+- a React island
+- a deferred enhancement
+
+Do not overcomplicate a simple page with a full app boundary if a small client-only surface will do.
+
+## Safe mental model
+
+The 3D surface is usually a client-only island. Treat it that way unless proven otherwise.
+
+## Common failures
+
+- touching `window` during SSR
+- importing browser-only code too high in the tree
+- assuming assets resolve the same way in dev and build
+- mounting/unmounting canvases without cleanup

--- a/skills/creative/web-3d/references/vanilla-three.md
+++ b/skills/creative/web-3d/references/vanilla-three.md
@@ -1,0 +1,95 @@
+# Vanilla Three.js
+
+Use vanilla `three` when the result is a standalone web surface or when explicit render-loop ownership is more important than framework composition.
+
+## Minimum structure
+
+Build this first:
+
+1. scene
+2. camera
+3. renderer
+4. one visible object
+5. resize handling
+6. deterministic cleanup
+
+Do not start with loaders, postprocessing, or controls.
+
+## Minimum file shape
+
+```js
+import * as THREE from "three";
+
+const scene = new THREE.Scene();
+
+const camera = new THREE.PerspectiveCamera(45, width / height, 0.1, 100);
+camera.position.set(0, 0, 4);
+
+const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: true });
+renderer.setSize(width, height);
+renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+
+const geometry = new THREE.BoxGeometry(1, 1, 1);
+const material = new THREE.MeshStandardMaterial({ color: 0xffffff });
+const mesh = new THREE.Mesh(geometry, material);
+scene.add(mesh);
+
+function frame() {
+  renderer.render(scene, camera);
+  requestAnimationFrame(frame);
+}
+
+frame();
+```
+
+## Required concerns
+
+### Resize
+
+Always update:
+
+- renderer size
+- camera aspect
+- camera projection matrix
+
+### DPR discipline
+
+Never leave DPR uncapped on user-facing surfaces.
+
+Default:
+
+```js
+renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+```
+
+Drop to `1.5` or `1` if perf is marginal.
+
+### Cleanup
+
+When the scene is destroyed:
+
+- cancel animation loop
+- remove listeners
+- dispose geometry
+- dispose material
+- dispose textures
+- dispose controls if present
+- dispose renderer if the surface unmounts permanently
+
+### Controls
+
+Add controls only if the task actually needs them.
+
+Orbiting everything by default is lazy and often harms composition.
+
+## Good use cases
+
+- model viewer
+- isolated hero
+- microsite scene
+- small shader-backed section
+
+## Bad use cases
+
+- React component systems needing deep state integration
+- complex UI/state choreography where `R3F` is cleaner

--- a/skills/creative/web-3d/references/verification-checklist.md
+++ b/skills/creative/web-3d/references/verification-checklist.md
@@ -1,0 +1,42 @@
+# Verification Checklist
+
+Use this after implementation. Do not stop at "it compiled."
+
+## Visual
+
+- [ ] The scene appears immediately
+- [ ] The composition matches the brief
+- [ ] The 3D surface belongs to the page instead of fighting it
+- [ ] The camera framing is intentional
+- [ ] Lighting is readable and not accidental
+
+## Behavior
+
+- [ ] Resize works
+- [ ] Interactions work
+- [ ] Controls, if present, feel justified
+- [ ] No duplicate canvases or ghost surfaces appear after navigation/remount
+
+## Console
+
+- [ ] No uncaught runtime errors
+- [ ] No failed asset fetches
+- [ ] No WebGL/shader warnings that indicate broken output
+
+## Integration
+
+- [ ] No SSR or hydration crash path
+- [ ] Asset paths work in the actual project structure
+- [ ] The 3D surface respects existing layout and design constraints
+
+## Cleanup
+
+- [ ] Unmount/remount does not leak or duplicate
+- [ ] Resources are disposed when appropriate
+
+## Performance
+
+- [ ] Acceptable on the target machine/surface
+- [ ] DPR is capped when needed
+- [ ] Scene complexity is justified
+- [ ] There is a fallback if the surface is public-facing

--- a/skills/creative/web-3d/scripts/serve.sh
+++ b/skills/creative/web-3d/scripts/serve.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# web-3d skill - local static server for demos/assets
+
+set -euo pipefail
+
+PORT="${1:-8080}"
+DIR="${2:-.}"
+
+echo "Serving $(cd "$DIR" && pwd) at http://localhost:$PORT"
+cd "$DIR"
+python3 -m http.server "$PORT"

--- a/skills/creative/web-3d/scripts/setup.sh
+++ b/skills/creative/web-3d/scripts/setup.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# web-3d skill - lightweight setup check
+
+set -euo pipefail
+
+echo "=== web-3d setup check ==="
+echo ""
+
+if command -v node >/dev/null 2>&1; then
+  echo "[OK] Node.js: $(node -v)"
+else
+  echo "[WARN] Node.js not found"
+fi
+
+if command -v npm >/dev/null 2>&1; then
+  echo "[OK] npm: $(npm -v)"
+else
+  echo "[WARN] npm not found"
+fi
+
+if command -v python3 >/dev/null 2>&1; then
+  echo "[OK] python3: $(python3 --version 2>&1)"
+else
+  echo "[WARN] python3 not found"
+fi
+
+echo ""
+echo "Typical package set:"
+echo "  npm install three"
+echo "  npm install @react-three/fiber"
+echo ""
+echo "Install only what the target repo and implementation path actually need."

--- a/skills/creative/web-3d/templates/react-scene-component.tsx
+++ b/skills/creative/web-3d/templates/react-scene-component.tsx
@@ -1,0 +1,23 @@
+import { Canvas } from "@react-three/fiber";
+
+function SceneContents() {
+  return (
+    <mesh rotation={[0.4, 0.4, 0]}>
+      <torusKnotGeometry args={[0.75, 0.24, 180, 24]} />
+      <meshStandardMaterial color="#d9e7ff" roughness={0.28} metalness={0.2} />
+    </mesh>
+  );
+}
+
+export function SceneHero() {
+  return (
+    <div style={{ width: "100%", height: "100%" }}>
+      <Canvas dpr={[1, 2]} camera={{ position: [0, 0, 4], fov: 45 }}>
+        <color attach="background" args={["#0a0c10"]} />
+        <ambientLight intensity={0.65} />
+        <directionalLight position={[2, 2, 2]} intensity={1.2} />
+        <SceneContents />
+      </Canvas>
+    </div>
+  );
+}

--- a/skills/creative/web-3d/templates/standalone-viewer.html
+++ b/skills/creative/web-3d/templates/standalone-viewer.html
@@ -1,0 +1,86 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Web 3D Viewer</title>
+  <style>
+    * { box-sizing: border-box; }
+    html, body { margin: 0; height: 100%; background: #0a0c10; color: #f4f4f4; }
+    body { font-family: system-ui, sans-serif; }
+    #app { position: fixed; inset: 0; }
+    .label {
+      position: fixed;
+      left: 16px;
+      top: 16px;
+      z-index: 2;
+      padding: 10px 12px;
+      border-radius: 10px;
+      background: rgba(0, 0, 0, 0.45);
+      backdrop-filter: blur(8px);
+      font-size: 12px;
+      letter-spacing: 0.02em;
+    }
+  </style>
+</head>
+<body>
+  <div class="label">Replace this starter with the real scene.</div>
+  <div id="app"></div>
+  <script type="module">
+    import * as THREE from "https://esm.sh/three@0.180.0";
+
+    const mount = document.getElementById("app");
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color("#0a0c10");
+
+    const camera = new THREE.PerspectiveCamera(45, innerWidth / innerHeight, 0.1, 100);
+    camera.position.set(0, 0, 4);
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setPixelRatio(Math.min(devicePixelRatio || 1, 2));
+    renderer.setSize(innerWidth, innerHeight);
+    mount.appendChild(renderer.domElement);
+
+    const ambient = new THREE.AmbientLight(0xffffff, 0.65);
+    const key = new THREE.DirectionalLight(0xffffff, 1.2);
+    key.position.set(2, 2, 2);
+    scene.add(ambient, key);
+
+    const geometry = new THREE.TorusKnotGeometry(0.75, 0.24, 180, 24);
+    const material = new THREE.MeshStandardMaterial({
+      color: "#d9e7ff",
+      roughness: 0.28,
+      metalness: 0.2,
+    });
+    const mesh = new THREE.Mesh(geometry, material);
+    scene.add(mesh);
+
+    let raf = 0;
+
+    function resize() {
+      camera.aspect = innerWidth / innerHeight;
+      camera.updateProjectionMatrix();
+      renderer.setSize(innerWidth, innerHeight);
+      renderer.setPixelRatio(Math.min(devicePixelRatio || 1, 2));
+    }
+
+    function frame() {
+      mesh.rotation.y += 0.008;
+      mesh.rotation.x += 0.003;
+      renderer.render(scene, camera);
+      raf = requestAnimationFrame(frame);
+    }
+
+    addEventListener("resize", resize);
+    frame();
+
+    // Replace with more complete cleanup if you convert this into a framework component.
+    window.addEventListener("beforeunload", () => {
+      cancelAnimationFrame(raf);
+      geometry.dispose();
+      material.dispose();
+      renderer.dispose();
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
 ## Summary

  Adds a new bundled skill: `web-3d`.

  `web-3d` covers interactive 3D surfaces inside real web products:
  - 3D hero sections
  - product scenes
  - model viewers
  - shader-backed app surfaces
  - React-owned 3D components
  - standalone demos that are meant to become web UI later

  ## Why

  Hermes already has strong adjacent skills:
  - `p5js` for browser-based generative art and sketch-style WebGL work
  - `blender-mcp` for DCC-side 3D authoring
  - `touchdesigner-mcp` for real-time operator-network workflows
  - `claude-design` / `sketch` for broader design exploration

  What was missing is a workflow layer whose main concern is interactive 3D implementation inside a real web stack.

  This skill fills that gap without introducing a new tool or replacing the existing creative skills.

  ## Included

  - `skills/creative/web-3d/SKILL.md`
  - routing guidance in `references/decision-rules.md`
  - implementation guidance for:
    - vanilla Three.js
    - React Three Fiber
    - SSR/framework boundaries
    - glTF assets
    - performance/debugging
    - verification
  - starter templates and lightweight helper scripts

  ## Validation

  - `git diff --check`
  - `bash -n skills/creative/web-3d/scripts/setup.sh`
  - `bash -n skills/creative/web-3d/scripts/serve.sh`
