### PR TITLE
fix(dingtalk): clarify webhook media behavior

### DIFF
--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -886,6 +886,65 @@ class DingTalkAdapter(BasePlatformAdapter):
         """DingTalk does not support typing indicators."""
         pass
 
+    async def send_image(
+        self,
+        chat_id: str,
+        image_url: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send an image via DingTalk markdown.
+
+        DingTalk's session webhook only supports text/markdown payloads, not
+        native image/file attachments. For remote image URLs, render the image
+        inline with markdown so the user still sees the image. Local files need
+        OpenAPI media upload and are handled separately.
+        """
+        image_block = f"![image]({image_url})"
+        content = f"{caption}\n\n{image_block}" if caption else image_block
+        return await self.send(
+            chat_id=chat_id,
+            content=content,
+            reply_to=reply_to,
+            metadata=metadata,
+        )
+
+    async def send_image_file(
+        self,
+        chat_id: str,
+        image_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs,
+    ) -> SendResult:
+        """DingTalk webhook replies cannot send local image files directly."""
+        return SendResult(
+            success=False,
+            error=(
+                "DingTalk session webhook replies do not support local image uploads. "
+                "Only markdown/text replies are supported without OpenAPI media upload."
+            ),
+        )
+
+    async def send_document(
+        self,
+        chat_id: str,
+        file_path: str,
+        caption: Optional[str] = None,
+        file_name: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs,
+    ) -> SendResult:
+        """DingTalk webhook replies cannot send local file attachments directly."""
+        return SendResult(
+            success=False,
+            error=(
+                "DingTalk session webhook replies do not support local file attachments. "
+                "Only markdown/text replies are supported without OpenAPI message send."
+            ),
+        )
+
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Return basic info about a DingTalk conversation."""
         return {

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -223,6 +223,51 @@ class TestSend:
         assert result.success is False
         assert "400" in result.error
 
+    @pytest.mark.asyncio
+    async def test_send_image_renders_markdown_image(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = "OK"
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        adapter._http_client = mock_client
+
+        result = await adapter.send_image(
+            "chat-123",
+            "https://example.com/demo.png",
+            caption="Screenshot",
+            metadata={"session_webhook": "https://dingtalk.example/webhook"},
+        )
+
+        assert result.success is True
+        payload = mock_client.post.call_args.kwargs["json"]
+        assert payload["msgtype"] == "markdown"
+        assert payload["markdown"]["text"] == "Screenshot\n\n![image](https://example.com/demo.png)"
+
+    @pytest.mark.asyncio
+    async def test_send_image_file_returns_explicit_unsupported_error(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+
+        result = await adapter.send_image_file("chat-123", "/tmp/demo.png")
+
+        assert result.success is False
+        assert "do not support local image uploads" in result.error
+
+    @pytest.mark.asyncio
+    async def test_send_document_returns_explicit_unsupported_error(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+
+        result = await adapter.send_document("chat-123", "/tmp/demo.pdf")
+
+        assert result.success is False
+        assert "do not support local file attachments" in result.error
+
 
 # ---------------------------------------------------------------------------
 # Connect / disconnect


### PR DESCRIPTION
## What does this PR do?

Fixes DingTalk's misleading outbound media behavior on the session-webhook reply path.

Before this change, `DingTalkAdapter` inherited the base `send_image_file()` and `send_document()` fallbacks from [gateway/platforms/base.py](/mnt/d/hermes-agent/gateway/platforms/base.py). Those fallbacks do **not** upload native media; they simply send text like:

- `🖼️ Image: /tmp/demo.png`
- `📎 File: /tmp/demo.pdf`

That created the exact confusion reported in #22487:

- gateway logs looked like DingTalk was "sending an image/file"
- the user did not receive a real image/file attachment
- local media paths were silently degraded into plain text

This PR makes the adapter reflect the real capability boundary of the current DingTalk reply path:

- remote image URLs are rendered as DingTalk markdown images
- local image/file sends return an explicit unsupported error instead of pretending to work

This is intentionally **not** a full OpenAPI media-upload implementation. The current DingTalk adapter primarily replies via `session_webhook`, and that path is only reliable for markdown/text. Native local media upload would require a separate OpenAPI send flow.

## Related Issue

Related to #22487

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added a DingTalk-specific [send_image()](/mnt/d/hermes-agent/gateway/platforms/dingtalk.py) override that renders remote image URLs using DingTalk markdown image syntax.
- Added DingTalk-specific [send_image_file()](/mnt/d/hermes-agent/gateway/platforms/dingtalk.py) and [send_document()](/mnt/d/hermes-agent/gateway/platforms/dingtalk.py) overrides that return explicit unsupported errors for local media on the session-webhook path.
- Added regression tests in [tests/gateway/test_dingtalk.py](/mnt/d/hermes-agent/tests/gateway/test_dingtalk.py) covering:
  - markdown image rendering for remote image URLs
  - explicit unsupported errors for local image sends
  - explicit unsupported errors for local document sends
  - existing webhook send behavior still working for normal markdown replies

## How to Reproduce

Before the fix:

1. Configure DingTalk and let the agent produce a local media tag such as `MEDIA:/tmp/demo.png`
2. Let the gateway route that through `send_image_file()`
3. Observe that DingTalk does not receive a real image attachment
4. The adapter falls back to a plain-text message like `🖼️ Image: /tmp/demo.png`, which looks like a successful media send from the logs but is not one

After the fix:

1. Remote image URL replies such as `https://example.com/demo.png` are sent as DingTalk markdown images
2. Local image/file sends fail explicitly with a clear unsupported error instead of silently degrading into fake attachment text

## How to Test

1. Run:
   `python3 -m pytest -q tests/gateway/test_dingtalk.py -k "send_image_renders_markdown_image or send_image_file_returns_explicit_unsupported_error or send_document_returns_explicit_unsupported_error or test_send_posts_to_webhook or test_send_fails_without_webhook or test_send_uses_cached_webhook or test_send_handles_http_error"`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run the targeted DingTalk send-path tests and they pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL Ubuntu / Linux

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

`python3 -m pytest -q tests/gateway/test_dingtalk.py -k "send_image_renders_markdown_image or send_image_file_returns_explicit_unsupported_error or send_document_returns_explicit_unsupported_error or test_send_posts_to_webhook or test_send_fails_without_webhook or test_send_uses_cached_webhook or test_send_handles_http_error"`

`7 passed in 21.81s`
