### PR TITLE
fix(tui): stop truncating visible transcript and streaming text

### DIFF
--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -9,7 +9,6 @@ import type { SessionInterruptResponse, SubagentEventPayload } from '../gatewayT
 import { appendToolShelfMessage, isToolShelfMessage } from '../lib/liveProgress.js'
 import { hasReasoningTag, splitReasoning } from '../lib/reasoning.js'
 import {
-  boundedLiveRenderText,
   buildToolTrailLine,
   estimateTokensRough,
   isTransientTrailLine,
@@ -739,7 +738,7 @@ class TurnController {
       this.streamTimer = null
       const raw = this.bufRef.trimStart()
       const visible = hasReasoningTag(raw) ? splitReasoning(raw).text : raw
-      patchTurnState({ streaming: boundedLiveRenderText(visible) })
+      patchTurnState({ streaming: visible })
     }, this.streamDelay)
   }
 

--- a/ui-tui/src/components/appLayout.tsx
+++ b/ui-tui/src/components/appLayout.tsx
@@ -7,7 +7,6 @@ import type { AppLayoutProps } from '../app/interfaces.js'
 import { $isBlocked, $overlayState, patchOverlayState } from '../app/overlayStore.js'
 import { $uiState } from '../app/uiStore.js'
 import { INLINE_MODE, SHOW_FPS } from '../config/env.js'
-import { FULL_RENDER_TAIL_ITEMS } from '../config/limits.js'
 import { PLACEHOLDER } from '../content/placeholders.js'
 import {
   COMPOSER_PROMPT_GAP_WIDTH,
@@ -124,7 +123,6 @@ const TranscriptPane = memo(function TranscriptPane({
                   compact={ui.compact}
                   detailsMode={ui.detailsMode}
                   detailsModeCommandOverride={ui.detailsModeCommandOverride}
-                  limitHistoryRender={row.index < transcript.historyItems.length - FULL_RENDER_TAIL_ITEMS}
                   msg={row.msg}
                   sections={ui.sections}
                   t={ui.theme}

--- a/ui-tui/src/components/messageLine.tsx
+++ b/ui-tui/src/components/messageLine.tsx
@@ -6,14 +6,7 @@ import { sectionMode } from '../domain/details.js'
 import { userDisplay } from '../domain/messages.js'
 import { ROLE } from '../domain/roles.js'
 import { transcriptBodyWidth, transcriptGutterWidth } from '../lib/inputMetrics.js'
-import {
-  boundedHistoryRenderText,
-  boundedLiveRenderText,
-  compactPreview,
-  hasAnsi,
-  isPasteBackedText,
-  stripAnsi
-} from '../lib/text.js'
+import { compactPreview, hasAnsi, isPasteBackedText, stripAnsi } from '../lib/text.js'
 import type { Theme } from '../theme.js'
 import type { ActiveTool, DetailsMode, Msg, SectionVisibility } from '../types.js'
 
@@ -31,7 +24,6 @@ export const MessageLine = memo(function MessageLine({
   detailsMode = 'collapsed',
   detailsModeCommandOverride = false,
   isStreaming = false,
-  limitHistoryRender = false,
   msg,
   sections,
   t,
@@ -145,9 +137,9 @@ export const MessageLine = memo(function MessageLine({
         // Incremental markdown: split at the last stable block boundary so
         // only the in-flight tail re-tokenizes per delta. See
         // streamingMarkdown.tsx for the cost model.
-        <StreamingMd cols={bodyWidth} compact={compact} t={t} text={boundedLiveRenderText(msg.text)} />
+<StreamingMd cols={bodyWidth} compact={compact} t={t} text={msg.text} />
       ) : (
-        <Md cols={bodyWidth} compact={compact} t={t} text={limitHistoryRender ? boundedHistoryRenderText(msg.text) : msg.text} />
+        <Md cols={bodyWidth} compact={compact} t={t} text={msg.text} />
       )
     }
 
@@ -213,7 +205,6 @@ interface MessageLineProps {
   detailsMode?: DetailsMode
   detailsModeCommandOverride?: boolean
   isStreaming?: boolean
-  limitHistoryRender?: boolean
   msg: Msg
   sections?: SectionVisibility
   t: Theme

--- a/ui-tui/src/config/limits.ts
+++ b/ui-tui/src/config/limits.ts
@@ -3,11 +3,11 @@ export const LARGE_PASTE = { chars: 8000, lines: 80 }
 export const LIVE_RENDER_MAX_CHARS = 16_000
 export const LIVE_RENDER_MAX_LINES = 240
 
-// History-render bounds for messages outside FULL_RENDER_TAIL. Each rendered
-// line ≈ 1 Yoga/Text node + inline spans, so this is the dominant lever on
-// cold-mount cost during PageUp catch-up. 16 lines × 25 mounted ≈ 400 nodes
-// — comfortably inside the 16ms per-frame budget. User pages back to
-// recognize, not to read; full re-render once it falls inside the tail.
+// Bounds for virtual-transcript **height estimates** of long assistant rows
+// that are far from the transcript tail (`estimatedMsgHeight` in
+// useMainApp). Cheap offset math for huge sessions; once a row mounts, the
+// real Yoga height overwrites the seed. MessageLine always renders full text
+// for mounted rows (virtualization caps how many mount at once).
 export const HISTORY_RENDER_MAX_CHARS = 800
 export const HISTORY_RENDER_MAX_LINES = 16
 export const FULL_RENDER_TAIL_ITEMS = 8


### PR DESCRIPTION
Virtual history only mounts a bounded window of rows, but MessageLine
still applied boundedHistoryRenderText for any message not in the tail
8 items—so scrolling an older assistant reply into view still showed
only ~800 chars.

- Render full assistant Markdown for all mounted history rows
- Stream the full in-flight buffer (turnController + StreamingMd) instead
  of boundedLiveRenderText tails
- Clarify limits.ts: HISTORY_RENDER_MAX_* + FULL_RENDER_TAIL_ITEMS are for
  estimatedMsgHeight seeds only; Yoga measurement corrects after mount

Co-authored-by: Cursor <cursoragent@cursor.com>
