### PR TITLE
fix(cli): expand composite toolset when mixed with configurables in platform_toolsets

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -972,6 +972,38 @@ def _get_platform_tools(
             ts for ts in toolset_names
             if ts in configurable_keys and _toolset_allowed_for_platform(ts, platform)
         }
+        # Mixed config: composite toolset alongside configurables (e.g.
+        # ``[hermes-cli, spotify]`` after enabling Spotify via ``hermes
+        # tools``). Without expansion the composite name is silently dropped,
+        # leaving sessions with only the configurable opt-ins and no native
+        # tools. Mirror the else-branch's subset inference, but apply
+        # _DEFAULT_OFF_TOOLSETS only to the implicit expansion — anything the
+        # user explicitly listed (e.g. ``spotify``) must survive.
+        composite_tools = set()
+        for ts_name in toolset_names:
+            if ts_name in configurable_keys or ts_name in plugin_ts_keys:
+                continue
+            if ts_name not in TOOLSETS:
+                continue
+            composite_tools.update(resolve_toolset(ts_name))
+
+        if composite_tools:
+            expanded = set()
+            for ts_key, _, _ in CONFIGURABLE_TOOLSETS:
+                if not _toolset_allowed_for_platform(ts_key, platform):
+                    continue
+                ts_tools = set(resolve_toolset(ts_key))
+                if ts_tools and ts_tools.issubset(composite_tools):
+                    expanded.add(ts_key)
+
+            default_off = set(_DEFAULT_OFF_TOOLSETS)
+            if platform in default_off and platform not in _TOOLSET_PLATFORM_RESTRICTIONS:
+                default_off.remove(platform)
+            if "homeassistant" in default_off and os.getenv("HASS_TOKEN"):
+                default_off.remove("homeassistant")
+            expanded -= default_off
+
+            enabled_toolsets |= expanded
     else:
         # No explicit config — fall back to resolving composite toolset names
         # (e.g. "hermes-cli") to individual tool names and reverse-mapping.

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -119,6 +119,64 @@ def test_get_platform_tools_homeassistant_toolset_off_for_cron_when_hass_token_m
     assert "homeassistant" not in cron_enabled
 
 
+def test_get_platform_tools_expands_composite_when_mixed_with_configurable():
+    """``[hermes-cli, spotify]`` (composite + configurable) must keep the full
+    ``hermes-cli`` toolset alongside the explicit Spotify opt-in. The
+    has_explicit_config branch used to drop ``hermes-cli`` on the floor,
+    leaving sessions with only ``{spotify, kanban}``."""
+    config = {"platform_toolsets": {"cli": ["hermes-cli", "spotify"]}}
+
+    enabled = _get_platform_tools(config, "cli", include_default_mcp_servers=False)
+
+    # Native tools must reappear.
+    for ts in ("terminal", "file", "web", "browser", "memory", "delegation",
+               "code_execution", "todo", "session_search", "skills"):
+        assert ts in enabled, f"{ts} should be enabled when hermes-cli is listed"
+    # User explicitly opted into Spotify — must survive _DEFAULT_OFF_TOOLSETS subtraction.
+    assert "spotify" in enabled
+
+
+def test_get_platform_tools_composite_only_unchanged():
+    """Composite-only config (no configurable in list) must still take the
+    else-branch path and produce the full toolset — guards against the new
+    code accidentally hijacking the composite-only case."""
+    composite_only = _get_platform_tools(
+        {"platform_toolsets": {"cli": ["hermes-cli"]}},
+        "cli",
+        include_default_mcp_servers=False,
+    )
+    default = _get_platform_tools({}, "cli", include_default_mcp_servers=False)
+
+    assert composite_only == default
+
+
+def test_get_platform_tools_configurable_only_no_expansion():
+    """Configurable-only list (no composite) must not pull in unrelated
+    toolsets — guards against the expansion firing when ``composite_tools``
+    is empty."""
+    config = {"platform_toolsets": {"cli": ["terminal", "file"]}}
+
+    enabled = _get_platform_tools(config, "cli", include_default_mcp_servers=False)
+
+    assert "terminal" in enabled
+    assert "file" in enabled
+    # Web shouldn't sneak in via the new expansion path.
+    assert "web" not in enabled
+
+
+def test_get_platform_tools_mixed_does_not_resurrect_default_off():
+    """Expansion must subtract _DEFAULT_OFF_TOOLSETS from the implicit
+    pull-in. Without this, ``hermes-cli`` expansion would re-enable
+    ``moa`` / ``rl`` / ``homeassistant`` for users who never opted in."""
+    config = {"platform_toolsets": {"cli": ["hermes-cli", "terminal"]}}
+
+    enabled = _get_platform_tools(config, "cli", include_default_mcp_servers=False)
+
+    assert "terminal" in enabled
+    assert "moa" not in enabled
+    assert "rl" not in enabled
+
+
 def test_get_platform_tools_preserves_explicit_empty_selection():
     config = {"platform_toolsets": {"cli": []}}
 


### PR DESCRIPTION
## What does this PR do?

Fixes a regression in `_get_platform_tools()` where the `has_explicit_config` branch silently drops the composite toolset name (e.g. `hermes-cli`) whenever the saved list also contains at least one configurable opt-in. The result was sessions losing every native tool — terminal, file, web, browser, vision, todo, skills, delegation, cronjob, memory, etc. — after enabling a single optional integration like Spotify via `hermes tools`.

The branch was added in #2624 (`868b3c07e`) to fix a different bug (default toolsets silently overriding tool deselection), but the new direct-membership filter never expanded composite toolset names that sat alongside the configurable keys — they just fell on the floor.

## Related Issue

Fixes #22601. Likely also resolves the CLI half of #22573 (same `[hermes-cli, terminal, file, memory]` mixed-config trigger; the standalone `_get_platform_tools(config, 'telegram')` test there worked because the telegram entry was composite-only).

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made

`hermes_cli/tools_config.py` — in the `has_explicit_config` branch, after collecting the explicit configurable keys, mirror the else-branch's subset inference for any composite/non-configurable names also present in `toolset_names`. Subtract `_DEFAULT_OFF_TOOLSETS` only from the **implicit** expansion so user-listed default-off keys (e.g. `spotify`, `discord`) explicitly added in the same list survive. Same `homeassistant` / platform-self exemptions as the else branch.

`tests/hermes_cli/test_tools_config.py` — four regression tests:

1. `test_get_platform_tools_expands_composite_when_mixed_with_configurable` — `[hermes-cli, spotify]` resolves to the full hermes-cli toolset *plus* spotify.
2. `test_get_platform_tools_composite_only_unchanged` — composite-only config still goes through the else branch unchanged.
3. `test_get_platform_tools_configurable_only_no_expansion` — configurable-only list (no composite) doesn't accidentally pull in unrelated toolsets via the new path.
4. `test_get_platform_tools_mixed_does_not_resurrect_default_off` — expansion subtracts `_DEFAULT_OFF_TOOLSETS` from the implicit pull-in so `moa` / `rl` don't sneak back in via `hermes-cli` expansion.

## How to Test

```python
from hermes_cli.tools_config import _get_platform_tools

# Bug repro (before fix): only {kanban, spotify}
config = {"platform_toolsets": {"cli": ["hermes-cli", "spotify"]}}
result = sorted(_get_platform_tools(config, "cli", include_default_mcp_servers=False))
# After fix: ['browser', 'clarify', 'code_execution', 'computer_use',
#            'cronjob', 'delegation', 'file', 'image_gen', 'kanban',
#            'memory', 'messaging', 'session_search', 'skills', 'spotify',
#            'terminal', 'todo', 'tts', 'vision', 'web']
```

Or run the targeted suite:

```bash
pytest tests/hermes_cli/test_tools_config.py -v -k "platform_tools or composite"
```

## Checklist

- [x] My code follows the project's coding style
- [x] I have added tests that prove my fix is effective
- [x] All new and existing tests pass locally for changes in `tools_config`
- [x] My changes generate no new warnings
- [x] I have made corresponding changes to the documentation (n/a — internal helper)

## AI Disclosure

This bug was identified and fixed with AI assistance.