### PR TITLE
feat: route session memory through configured sinks

### DIFF
--- a/agent/memory_router.py
+++ b/agent/memory_router.py
@@ -1,0 +1,419 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import shlex
+import subprocess
+import threading
+import unicodedata
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Literal, Optional
+
+logger = logging.getLogger(__name__)
+
+# Session-scoped dedupe cache for the current process.
+_ROUTING_CACHE: dict[str, set[str]] = {}
+_ROUTING_CACHE_LOCK = threading.Lock()
+
+
+InvocationMode = Literal["manual", "pre_compress", "session_end"]
+
+
+def canonicalize_text(text: str) -> str:
+    """Return a stable text form for dedupe comparisons."""
+    if not isinstance(text, str):
+        return ""
+    text = unicodedata.normalize("NFKC", text)
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    text = text.strip()
+    text = re.sub(r"[ \t]+", " ", text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.lower()
+
+
+def canonical_payload(destination: str, entry_kind: str, canonical_text: str, source_id: str = "") -> dict[str, str]:
+    """Build the stable payload used for fingerprinting."""
+    return {
+        "destination": destination,
+        "entry_kind": entry_kind,
+        "canonical_text": canonical_text,
+        "source_id": source_id,
+    }
+
+
+def fingerprint_payload(payload: dict[str, str]) -> str:
+    """Return a stable SHA-256 fingerprint for a canonical payload."""
+    encoded = json.dumps(payload, ensure_ascii=False, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(encoded).hexdigest()
+
+
+def fingerprint_candidate(
+    destination: str,
+    entry_kind: str,
+    text: str,
+    source_id: str = "",
+) -> tuple[str, str]:
+    canonical_text = canonicalize_text(text)
+    payload = canonical_payload(destination, entry_kind, canonical_text, source_id)
+    return canonical_text, fingerprint_payload(payload)
+
+
+def has_seen(session_id: str, fingerprint: str) -> bool:
+    with _ROUTING_CACHE_LOCK:
+        return fingerprint in _ROUTING_CACHE.get(session_id or "__global__", set())
+
+
+def mark_seen(session_id: str, fingerprint: str) -> None:
+    with _ROUTING_CACHE_LOCK:
+        _ROUTING_CACHE.setdefault(session_id or "__global__", set()).add(fingerprint)
+
+
+def clear_seen(session_id: str) -> None:
+    with _ROUTING_CACHE_LOCK:
+        _ROUTING_CACHE.pop(session_id or "__global__", None)
+
+
+def _collect_text(messages: list[dict[str, Any]], candidate_window: int | None = None) -> str:
+    if not messages:
+        return ""
+
+    window = messages[-candidate_window:] if candidate_window else messages
+    try:
+        from plugins.memory.mempalace import _extract_pre_compress_content
+    except Exception:
+        _extract_pre_compress_content = None  # type: ignore[assignment]
+
+    if _extract_pre_compress_content is not None:
+        try:
+            return _extract_pre_compress_content(window, max_chars=4000)
+        except Exception as exc:
+            logger.debug("MemPalace extraction unavailable: %s", exc)
+
+    parts: list[str] = []
+    for msg in window:
+        role = str(msg.get("role", ""))
+        if role not in {"user", "assistant"}:
+            continue
+        content = msg.get("content", "")
+        if isinstance(content, list):
+            text_parts = [
+                p.get("text", "")
+                for p in content
+                if isinstance(p, dict) and p.get("type") == "text"
+            ]
+            content = "\n".join(text_parts)
+        if not isinstance(content, str):
+            continue
+        content = content.strip()
+        if not content:
+            continue
+        if role == "system":
+            continue
+        if role == "user" and "[CONTEXT COMPACTION" in content:
+            continue
+        label = "USER" if role == "user" else "ASSISTANT" if role == "assistant" else role.upper()
+        parts.append(f"[{label}] {content[:800]}")
+    combined = "\n".join(parts)
+    return combined[:4000]
+
+
+def _classify_native_target(text: str) -> str:
+    preference_markers = (
+        r"\bi prefer\b",
+        r"\bi like\b",
+        r"\bi want\b",
+        r"\bplease remember\b",
+        r"\bremember that\b",
+        r"\bmy preference\b",
+        r"\bdo not\b",
+        r"\bdon't\b",
+        r"\balways\b",
+        r"\bnever\b",
+    )
+    if any(re.search(pat, text, re.IGNORECASE) for pat in preference_markers):
+        return "user"
+    return "memory"
+
+
+def _entry_kind_for_target(target: str, text: str) -> str:
+    if target == "user":
+        return "preference"
+    if re.search(r"\bdecision\b|\bdecided\b|\bchose\b", text, re.IGNORECASE):
+        return "decision"
+    if re.search(r"\bopen question\b|\bquestion\b|\btodo\b", text, re.IGNORECASE):
+        return "open_question"
+    return "operational_fact"
+
+
+def _resolve_mempalace_config(config: dict[str, Any] | None = None) -> tuple[str, list[tuple[list[re.Pattern], str, str]]]:
+    config = config or {}
+    mp_cfg = config.get("mempalace", {}) if isinstance(config.get("mempalace", {}), dict) else {}
+    palace_path = os.environ.get("MEMPALACE_PALACE_PATH", "").strip()
+    if not palace_path and isinstance(mp_cfg, dict):
+        configured_path = str(mp_cfg.get("palace_path", "")).strip()
+        if configured_path:
+            palace_path = os.path.expanduser(configured_path)
+    if not palace_path:
+        palace_path = str(Path.home() / ".mempalace" / "palace")
+
+    routing_rules: list[tuple[list[re.Pattern], str, str]] = []
+    try:
+        from plugins.memory.mempalace import _compile_user_rules
+        if isinstance(mp_cfg, dict):
+            routing_rules = _compile_user_rules(mp_cfg.get("routing_rules", []) or [])
+    except Exception as exc:
+        logger.debug("MemPalace routing rules unavailable: %s", exc)
+    return palace_path, routing_rules
+
+
+def _mempalace_route(content: str, invocation_mode: InvocationMode, config: dict[str, Any] | None = None) -> dict[str, Any]:
+    try:
+        from plugins.memory.mempalace import _add_drawer, _route_content
+    except Exception as exc:
+        logger.debug("MemPalace unavailable; skipping sink: %s", exc)
+        return {"success": True, "mode": "disabled", "reason": f"MemPalace unavailable: {exc}"}
+
+    palace_path, routing_rules = _resolve_mempalace_config(config)
+    wing, room = _route_content(content, routing_rules)
+    return _add_drawer(
+        palace_path,
+        wing=wing,
+        room=room,
+        content=content,
+        added_by=f"hermes-router:{invocation_mode}",
+    )
+
+
+def _resolve_cca_lite_bridge(config: dict[str, Any] | None = None) -> tuple[str, Path | None]:
+    config = config or {}
+    cca_cfg = config.get("cca_lite", {}) if isinstance(config.get("cca_lite", {}), dict) else {}
+
+    command = os.environ.get("HERMES_CCA_LITE_COMMAND", "").strip()
+    if not command and isinstance(cca_cfg, dict):
+        command = str(cca_cfg.get("command", "")).strip()
+
+    inbox_path: Path | None = None
+    raw_path = os.environ.get("HERMES_CCA_LITE_INBOX_PATH", "").strip()
+    if not raw_path and isinstance(cca_cfg, dict):
+        raw_path = str(cca_cfg.get("inbox_path", "")).strip()
+    if not raw_path and isinstance(cca_cfg, dict):
+        repo_root = str(cca_cfg.get("repo_root", "")).strip()
+        if repo_root:
+            raw_path = str(Path(repo_root).expanduser() / "docs/cca-lite/hermes-memory-inbox.json")
+    if not raw_path:
+        fallback_repo = Path(__file__).resolve().parents[2] / "cca-repo" / "docs/cca-lite/hermes-memory-inbox.json"
+        if fallback_repo.exists() or fallback_repo.parent.exists():
+            raw_path = str(fallback_repo)
+    if raw_path:
+        inbox_path = Path(os.path.expanduser(raw_path))
+    return command, inbox_path
+
+
+def _append_json_item(path: Path, item: dict[str, Any]) -> dict[str, Any]:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    payload: Any = []
+    if path.exists():
+        try:
+            payload = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:
+            payload = []
+
+    appended = False
+    if isinstance(payload, list):
+        seen_ids = {str(entry.get("id", "")) for entry in payload if isinstance(entry, dict)}
+        if item["id"] not in seen_ids:
+            payload.append(item)
+            appended = True
+    elif isinstance(payload, dict):
+        entries = payload.setdefault("entries", [])
+        if isinstance(entries, list):
+            seen_ids = {str(entry.get("id", "")) for entry in entries if isinstance(entry, dict)}
+            if item["id"] not in seen_ids:
+                entries.append(item)
+                appended = True
+    else:
+        payload = [item]
+        appended = True
+
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    tmp_path.write_text(json.dumps(payload, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    tmp_path.replace(path)
+    return {"success": True, "appended": appended, "path": str(path)}
+
+
+def _route_to_cca_lite(
+    *,
+    session_id: str,
+    invocation_mode: InvocationMode,
+    source_event: str,
+    entry_kind: str,
+    text: str,
+    canonical_text: str,
+    fingerprint: str,
+    config: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    command, inbox_path = _resolve_cca_lite_bridge(config)
+    payload = {
+        "id": fingerprint,
+        "kind": entry_kind,
+        "text": text,
+        "canonical_text": canonical_text,
+        "captured_at": datetime.now().isoformat(),
+        "source": source_event or invocation_mode,
+        "session_id": session_id,
+        "content_hash": f"sha256:{fingerprint}",
+        "invocation_mode": invocation_mode,
+    }
+
+    if command:
+        try:
+            completed = subprocess.run(
+                shlex.split(command),
+                input=json.dumps(payload, ensure_ascii=False).encode("utf-8"),
+                check=False,
+                capture_output=True,
+                timeout=30,
+            )
+            if completed.returncode == 0:
+                return {"success": True, "mode": "command", "command": command}
+            return {
+                "success": False,
+                "mode": "command",
+                "command": command,
+                "error": completed.stderr.decode("utf-8", errors="replace") or completed.stdout.decode("utf-8", errors="replace") or "cca-lite command failed",
+            }
+        except Exception as exc:
+            return {"success": False, "mode": "command", "command": command, "error": str(exc)}
+
+    if inbox_path is None:
+        return {"success": True, "mode": "disabled", "reason": "cca-lite bridge not configured"}
+
+    return _append_json_item(inbox_path, payload)
+
+
+def route_memory_candidates(
+    *,
+    invocation_mode: InvocationMode,
+    session_id: str,
+    messages: list[dict[str, Any]],
+    memory_store: Any = None,
+    memory_enabled: bool = False,
+    user_profile_enabled: bool = False,
+    source_event: str = "",
+    candidate_window: int | None = None,
+    config: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Route a session slice into native memory, MemPalace, and cca-lite."""
+    session_key = session_id or "__global__"
+    config = config or {}
+    content = _collect_text(messages, candidate_window=candidate_window)
+    canonical_text = canonicalize_text(content)
+    if not canonical_text:
+        return {
+            "ok": True,
+            "mode": invocation_mode,
+            "session_id": session_id,
+            "routed": [],
+            "suppressed": [],
+            "failed": [],
+            "summary": "No durable memory candidates found.",
+        }
+
+    native_target = _classify_native_target(canonical_text)
+    native_kind = _entry_kind_for_target(native_target, canonical_text)
+    mempalace_kind = _entry_kind_for_target("memory", canonical_text)
+    cca_kind = native_kind
+
+    routed: list[dict[str, Any]] = []
+    suppressed: list[dict[str, Any]] = []
+    failed: list[dict[str, Any]] = []
+
+    def _route_destination(destination: str, entry_kind: str, writer) -> None:
+        _, fingerprint = fingerprint_candidate(destination, entry_kind, canonical_text, session_key)
+        if has_seen(session_key, fingerprint):
+            suppressed.append({
+                "destination": destination,
+                "entry_kind": entry_kind,
+                "fingerprint": fingerprint,
+                "reason": "session_duplicate",
+            })
+            return
+
+        result = writer(fingerprint)
+        if result.get("success"):
+            status = "no_op" if result.get("mode") == "disabled" else ("written" if result.get("appended", True) else "no_op")
+            routed.append({
+                "destination": destination,
+                "entry_kind": entry_kind,
+                "fingerprint": fingerprint,
+                "status": status,
+            })
+            mark_seen(session_key, fingerprint)
+            return
+
+        failed.append({
+            "destination": destination,
+            "error": result.get("error", "unknown error"),
+        })
+
+    if memory_store is not None:
+        def _write_native(_: str) -> dict[str, Any]:
+            if native_target == "user" and not user_profile_enabled:
+                return {"success": True, "mode": "disabled", "reason": "user profile disabled"}
+            if native_target == "memory" and not memory_enabled:
+                return {"success": True, "mode": "disabled", "reason": "memory store disabled"}
+            try:
+                return memory_store.add(native_target, content)
+            except Exception as exc:
+                return {"success": False, "error": str(exc)}
+
+        _route_destination("native_memory", native_kind, _write_native)
+
+    def _write_mempalace(_: str) -> dict[str, Any]:
+        try:
+            return _mempalace_route(content, invocation_mode, config=config)
+        except Exception as exc:
+            return {"success": False, "error": str(exc)}
+
+    _route_destination("mempalace", mempalace_kind, _write_mempalace)
+
+    def _write_cca_lite(fingerprint: str) -> dict[str, Any]:
+        try:
+            return _route_to_cca_lite(
+                session_id=session_id,
+                invocation_mode=invocation_mode,
+                source_event=source_event,
+                entry_kind=cca_kind,
+                text=content,
+                canonical_text=canonical_text,
+                fingerprint=fingerprint,
+                config=config,
+            )
+        except Exception as exc:
+            return {"success": False, "error": str(exc)}
+
+    _route_destination("cca_lite", cca_kind, _write_cca_lite)
+
+    written = len([item for item in routed if item.get("status") == "written"])
+    skipped = len([item for item in routed if item.get("status") != "written"])
+    summary_bits = [f"{written} written"]
+    if skipped:
+        summary_bits.append(f"{skipped} skipped")
+    if suppressed:
+        summary_bits.append(f"{len(suppressed)} suppressed")
+    if failed:
+        summary_bits.append(f"{len(failed)} failed")
+    return {
+        "ok": not failed,
+        "mode": invocation_mode,
+        "session_id": session_id,
+        "routed": routed,
+        "suppressed": suppressed,
+        "failed": failed,
+        "summary": "; ".join(summary_bits),
+        "content": content,
+    }

--- a/cli.py
+++ b/cli.py
@@ -12649,6 +12649,17 @@ def main(
         toolsets_list = sorted(_get_platform_tools(CLI_CONFIG, "cli"))
     
     parsed_skills = _parse_skills_argument(skills)
+    config_always_load = [] if ignore_rules else _parse_skills_argument(
+        CLI_CONFIG.get("skills", {}).get("always_load", [])
+    )
+    if config_always_load:
+        merged_skills = []
+        seen_skills = set()
+        for skill_name in [*config_always_load, *parsed_skills]:
+            if skill_name and skill_name not in seen_skills:
+                seen_skills.add(skill_name)
+                merged_skills.append(skill_name)
+        parsed_skills = merged_skills
 
     # Create CLI instance
     cli = HermesCLI(

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -11325,6 +11325,30 @@ Examples:
 
     _processed_argv = _coalesce_session_name_args(sys.argv[1:])
 
+    # Merge config-level always-load skills into the session startup path so
+    # they behave like preloaded skills for every agent session.
+    def _normalize_skill_list(raw_value):
+        if not raw_value:
+            return []
+        if isinstance(raw_value, (list, tuple)):
+            normalized = []
+            for item in raw_value:
+                normalized.extend(
+                    part.strip() for part in str(item).split(",") if part.strip()
+                )
+            return normalized
+        return [part.strip() for part in str(raw_value).split(",") if part.strip()]
+
+    try:
+        from hermes_cli.config import load_config
+
+        _startup_cfg = load_config()
+        _always_load = _normalize_skill_list(
+            (_startup_cfg.get("skills", {}) or {}).get("always_load", [])
+        )
+    except Exception:
+        _always_load = []
+
     # ── Defensive subparser routing (bpo-9338 workaround) ───────────
     # On some Python versions (notably <3.11), argparse fails to route
     # subcommand tokens when the parent parser has nargs='?' optional
@@ -11370,6 +11394,17 @@ Examples:
     if args.version:
         cmd_version(args)
         return
+
+    if _always_load and not getattr(args, "ignore_user_config", False) and not getattr(args, "ignore_rules", False):
+        current_skills = _normalize_skill_list(getattr(args, "skills", None))
+        merged_skills = []
+        seen_skills = set()
+        for skill_name in [*_always_load, *current_skills]:
+            if skill_name and skill_name not in seen_skills:
+                seen_skills.add(skill_name)
+                merged_skills.append(skill_name)
+        if merged_skills:
+            args.skills = merged_skills
 
     # Discover Python plugins and register shell hooks once, before any
     # command that can fire lifecycle hooks.  Both are idempotent; gated

--- a/run_agent.py
+++ b/run_agent.py
@@ -5035,14 +5035,54 @@ class AIAgent:
             "budget_max": self.iteration_budget.max_total,
         }
 
+    def route_memory_session(
+        self,
+        messages: list = None,
+        *,
+        invocation_mode: str = "manual",
+        source_event: str = "",
+        candidate_window: int | None = None,
+    ) -> dict:
+        """Route a session slice through native memory, MemPalace, and cca-lite."""
+        try:
+            from agent.memory_router import route_memory_candidates
+            try:
+                from hermes_cli.config import load_config
+                config = load_config()
+            except Exception:
+                config = {}
+            return route_memory_candidates(
+                invocation_mode=invocation_mode,  # type: ignore[arg-type]
+                session_id=self.session_id or "",
+                messages=messages or [],
+                memory_store=self._memory_store,
+                memory_enabled=self._memory_enabled,
+                user_profile_enabled=self._user_profile_enabled,
+                source_event=source_event,
+                candidate_window=candidate_window,
+                config=config,
+            )
+        except Exception as exc:
+            logger.debug("memory routing failed: %s", exc)
+            return {
+                "ok": False,
+                "mode": invocation_mode,
+                "session_id": self.session_id or "",
+                "routed": [],
+                "suppressed": [],
+                "failed": [{"destination": "router", "error": str(exc)}],
+                "summary": f"memory routing failed: {exc}",
+            }
+
     def shutdown_memory_provider(self, messages: list = None) -> None:
         """Shut down the memory provider and context engine — call at actual session boundaries.
 
-        This calls on_session_end() then shutdown_all() on the memory
-        manager, and on_session_end() on the context engine.
+        This routes memory one last time, then shuts down the memory manager
+        and context engine.
         NOT called per-turn — only at CLI exit, /reset, gateway
         session expiry, etc.
         """
+        self.route_memory_session(messages or [], invocation_mode="session_end", source_event="shutdown")
         if self._memory_manager:
             try:
                 self._memory_manager.on_session_end(messages or [])
@@ -5052,6 +5092,11 @@ class AIAgent:
                 self._memory_manager.shutdown_all()
             except Exception:
                 pass
+        try:
+            from agent.memory_router import clear_seen
+            clear_seen(self.session_id or "")
+        except Exception:
+            pass
         # Notify context engine of session end (flush DAG, close DBs, etc.)
         if hasattr(self, "context_compressor") and self.context_compressor:
             try:
@@ -5067,10 +5112,16 @@ class AIAgent:
         Called when session_id rotates (e.g. /new, context compression);
         providers keep their state and continue running under the old
         session_id — they just flush pending extraction now."""
+        self.route_memory_session(messages or [], invocation_mode="session_end", source_event="session_rotate")
         if not self._memory_manager:
             return
         try:
             self._memory_manager.on_session_end(messages or [])
+        except Exception:
+            pass
+        try:
+            from agent.memory_router import clear_seen
+            clear_seen(self.session_id or "")
         except Exception:
             pass
 
@@ -9605,7 +9656,12 @@ class AIAgent:
             focus_topic,
         )
 
-        # Notify external memory provider before compression discards context
+        # Route durable memory before compression discards context.
+        self.route_memory_session(
+            messages,
+            invocation_mode="pre_compress",
+            source_event="compression",
+        )
         if self._memory_manager:
             try:
                 self._memory_manager.on_pre_compress(messages)

--- a/tests/agent/test_memory_router.py
+++ b/tests/agent/test_memory_router.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from agent.memory_router import route_memory_candidates
+
+
+class _FakeMemoryStore:
+    def __init__(self):
+        self.calls: list[tuple[str, str]] = []
+
+    def add(self, target: str, content: str):
+        self.calls.append((target, content))
+        return {"success": True}
+
+
+def test_route_memory_candidates_ignores_tool_messages() -> None:
+    store = _FakeMemoryStore()
+    messages = [
+        {"role": "user", "content": "Repo state changed after the migration."},
+        {"role": "tool", "content": "secret-token should never be persisted"},
+        {"role": "assistant", "content": "Noted."},
+    ]
+
+    result = route_memory_candidates(
+        invocation_mode="manual",
+        session_id="sess-1",
+        messages=messages,
+        memory_store=store,
+        memory_enabled=True,
+        user_profile_enabled=False,
+        config={},
+    )
+
+    assert result["ok"] is True
+    assert store.calls == [("memory", "[USER] Repo state changed after the migration.\n[ASSISTANT] Noted.")]
+    assert "secret-token" not in result["content"]
+
+
+def test_route_memory_candidates_respects_disabled_user_profile() -> None:
+    store = _FakeMemoryStore()
+    messages = [
+        {"role": "user", "content": "Please remember that I prefer concise responses."},
+        {"role": "assistant", "content": "Got it."},
+    ]
+
+    result = route_memory_candidates(
+        invocation_mode="manual",
+        session_id="sess-2",
+        messages=messages,
+        memory_store=store,
+        memory_enabled=True,
+        user_profile_enabled=False,
+        config={},
+    )
+
+    assert result["ok"] is True
+    assert store.calls == []
+    native = next(item for item in result["routed"] if item["destination"] == "native_memory")
+    assert native["status"] == "no_op"

--- a/tests/cli/test_cli_preloaded_skills.py
+++ b/tests/cli/test_cli_preloaded_skills.py
@@ -92,6 +92,35 @@ def test_main_applies_preloaded_skills_to_system_prompt(monkeypatch):
     assert cli_obj.preloaded_skills == ["hermes-agent-dev", "github-auth"]
 
 
+def test_main_auto_loads_skills_from_config(monkeypatch):
+    import cli as cli_mod
+
+    seen = {}
+
+    def fake_prompt(skills, task_id=None):
+        seen["skills"] = list(skills)
+        return ("", list(skills), [])
+
+    monkeypatch.setattr(cli_mod, "HermesCLI", lambda **kwargs: _DummyCLI(**kwargs))
+    monkeypatch.setattr(cli_mod, "build_preloaded_skills_prompt", fake_prompt)
+    monkeypatch.setattr(
+        cli_mod,
+        "CLI_CONFIG",
+        {
+            "skills": {"always_load": ["memory-first-recall"]},
+            "model": {"default": "anthropic/claude-opus-4.6", "provider": "auto"},
+            "display": {"compact": False, "tool_progress": "all"},
+            "agent": {},
+            "terminal": {"env_type": "local"},
+        },
+    )
+
+    with pytest.raises(SystemExit):
+        cli_mod.main(list_tools=True)
+
+    assert seen["skills"] == ["memory-first-recall"]
+
+
 def test_main_raises_for_unknown_preloaded_skill(monkeypatch):
     import cli as cli_mod
 

--- a/tests/run_agent/test_session_memory_routing.py
+++ b/tests/run_agent/test_session_memory_routing.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+from run_agent import AIAgent
+
+
+class _FakeContextCompressor:
+    def __init__(self):
+        self.compress = MagicMock(return_value=[{"role": "assistant", "content": "summary"}])
+        self.on_session_end = MagicMock()
+        self._last_summary_error = None
+        self._last_aux_model_failure_model = None
+        self._last_aux_model_failure_error = None
+        self.compression_count = 1
+        self.last_prompt_tokens = 0
+        self.last_completion_tokens = 0
+
+
+def _make_agent() -> AIAgent:
+    agent = object.__new__(AIAgent)
+    agent.session_id = "sess-123"
+    agent.model = "test-model"
+    agent.route_memory_session = MagicMock(return_value={"ok": True})
+    agent._memory_manager = MagicMock()
+    agent.context_compressor = _FakeContextCompressor()
+    agent._todo_store = MagicMock()
+    agent._todo_store.format_for_injection.return_value = ""
+    agent._session_db = None
+    agent._invalidate_system_prompt = MagicMock()
+    agent._build_system_prompt = MagicMock(return_value="system")
+    agent._emit_warning = MagicMock()
+    agent._cached_system_prompt = None
+    agent.tools = []
+    agent.log_prefix = ""
+    agent._vprint = MagicMock()
+    return agent
+
+
+def test_shutdown_memory_provider_still_flushes_memory_manager() -> None:
+    agent = _make_agent()
+    messages = [{"role": "user", "content": "Remember this."}]
+
+    AIAgent.shutdown_memory_provider(agent, messages)
+
+    agent.route_memory_session.assert_called_once_with(messages, invocation_mode="session_end", source_event="shutdown")
+    agent._memory_manager.on_session_end.assert_called_once_with(messages)
+    agent._memory_manager.shutdown_all.assert_called_once_with()
+    agent.context_compressor.on_session_end.assert_called_once_with("sess-123", messages)
+
+
+def test_compress_context_still_notifies_memory_manager_pre_compress() -> None:
+    agent = _make_agent()
+    messages = [{"role": "user", "content": "Important context."}]
+
+    compressed, new_system_prompt = AIAgent._compress_context(
+        agent,
+        messages,
+        "system",
+        approx_tokens=123,
+    )
+
+    agent.route_memory_session.assert_called_once_with(
+        messages,
+        invocation_mode="pre_compress",
+        source_event="compression",
+    )
+    agent._memory_manager.on_pre_compress.assert_called_once_with(messages)
+    assert compressed == [{"role": "assistant", "content": "summary"}]
+    assert new_system_prompt == "system"


### PR DESCRIPTION
## Summary
- auto-load configured always_load skills in both CLI entry paths
- route session memory through native memory, MemPalace, and cca-lite at session boundaries
- preserve memory-manager lifecycle hooks and add regression tests for routing behavior

## Test Plan
- ~/.hermes/hermes-agent/venv/bin/python -m py_compile cli.py hermes_cli/main.py run_agent.py agent/memory_router.py tests/cli/test_cli_preloaded_skills.py tests/agent/test_memory_router.py tests/run_agent/test_session_memory_routing.py
- ~/.hermes/hermes-agent/venv/bin/python -m pytest tests/cli/test_cli_preloaded_skills.py tests/agent/test_memory_provider.py tests/agent/test_memory_router.py tests/run_agent/test_session_memory_routing.py -q -o addopts=''