### PR TITLE
fix(tools): expand composite platform toolsets alongside explicit configurable keys

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -972,6 +972,43 @@ def _get_platform_tools(
             ts for ts in toolset_names
             if ts in configurable_keys and _toolset_allowed_for_platform(ts, platform)
         }
+        # Explicit configurable keys sit alongside a composite (e.g. ``hermes-cli``
+        # + ``spotify``).  The direct-membership branch alone drops the composite:
+        # native toolsets never get subset-inferred (#22601).  Merge inferred
+        # configurable keys from any *non-configurable* listed toolsets that
+        # resolve to concrete tools (composite bundles, platform defaults).  Do
+        # not apply ``_DEFAULT_OFF_TOOLSETS`` to explicitly listed keys — only to
+        # inferred ones, matching the non-explicit branch semantics.
+        extras_universe: Set[str] = set()
+        for ts_name in toolset_names:
+            if ts_name in configurable_keys:
+                continue
+            if ts_name == "no_mcp":
+                continue
+            if ts_name in plugin_ts_keys:
+                continue
+            resolved = resolve_toolset(ts_name)
+            if not resolved:
+                continue
+            extras_universe.update(resolved)
+
+        if extras_universe:
+            inferred_from_composite = set()
+            for ts_key, _, _ in CONFIGURABLE_TOOLSETS:
+                if not _toolset_allowed_for_platform(ts_key, platform):
+                    continue
+                ts_tools = set(resolve_toolset(ts_key))
+                if ts_tools and ts_tools.issubset(extras_universe):
+                    inferred_from_composite.add(ts_key)
+
+            default_off = set(_DEFAULT_OFF_TOOLSETS)
+            if platform in default_off and platform not in _TOOLSET_PLATFORM_RESTRICTIONS:
+                default_off.remove(platform)
+            if "homeassistant" in default_off and os.getenv("HASS_TOKEN"):
+                default_off.remove("homeassistant")
+
+            inferred_from_composite -= default_off
+            enabled_toolsets |= inferred_from_composite
     else:
         # No explicit config — fall back to resolving composite toolset names
         # (e.g. "hermes-cli") to individual tool names and reverse-mapping.

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -771,6 +771,19 @@ def test_save_platform_tools_preserves_mcp_server_names():
     assert "another-mcp" in saved
 
 
+def test_get_platform_tools_composite_alongside_configurable_restores_core():
+    """Regression #22601: composite + explicit configurable must not drop native toolsets.
+
+    Saving e.g. ``hermes-cli`` next to ``spotify`` after toggling an opt-in must
+    still subset-resolve the CLI bundle — not leave only the explicit keys.
+    """
+    config = {"platform_toolsets": {"cli": ["hermes-cli", "spotify"]}}
+    enabled = _get_platform_tools(config, "cli", include_default_mcp_servers=False)
+    assert "spotify" in enabled
+    assert "terminal" in enabled
+    assert "web" in enabled
+
+
 def test_get_platform_tools_recovers_non_configurable_toolsets_from_composite():
     """Non-configurable toolsets whose tools are in the composite but not in
     CONFIGURABLE_TOOLSETS should still appear in the result.


### PR DESCRIPTION
## Summary

When `platform_toolsets[<platform>]` mixes a composite bundle name (e.g. `hermes-cli`) with at least one configurable toolset key, `_get_platform_tools()` took the explicit-config branch but never subset-resolved native toolsets from the composite. The session effectively lost core tools (`terminal`, `file`, `web`, etc.) except the explicitly listed keys and plugins/MCP fallback.

Merge subset inference from any listed non-configurable names that resolve to a non-empty tool universe, then union with direct configurable membership. Apply `_DEFAULT_OFF_TOOLSETS` only to **inferred** keys so explicit opt-ins (e.g. `spotify`) stay enabled.

Fixes #22601  
Related discussion: likely same class of regression as #22573 on a different repro path.

## Test plan

- [x] `pytest tests/hermes_cli/test_tools_config.py -q`
- New regression: `test_get_platform_tools_composite_alongside_configurable_restores_core` (`hermes-cli` + `spotify` keeps `terminal` / `web` and `spotify`).