### PR TITLE
fix(context-refs): harden URL fetch parsing for null payloads

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -319,10 +319,11 @@ async def _default_url_fetcher(url: str) -> str:
 
     raw = await web_extract_tool([url], format="markdown", use_llm_processing=True)
     payload = json.loads(raw)
-    docs = payload.get("data", {}).get("documents", [])
+    data = payload.get("data") or {}
+    docs = data.get("documents") or []
     if not docs:
         return ""
-    doc = docs[0]
+    doc = docs[0] or {}
     return str(doc.get("content") or doc.get("raw_content") or "").strip()
 
 

--- a/tests/agent/test_context_references.py
+++ b/tests/agent/test_context_references.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import asyncio
+import json
+import os
 import subprocess
 from pathlib import Path
 from unittest.mock import patch
@@ -314,6 +316,8 @@ async def test_blocks_sensitive_home_and_hermes_paths(tmp_path: Path, monkeypatc
 
     monkeypatch.setenv("HOME", str(tmp_path))
     monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    if os.name == "nt":
+        monkeypatch.setenv("USERPROFILE", str(tmp_path))
 
     hermes_env = tmp_path / ".hermes" / ".env"
     hermes_env.parent.mkdir(parents=True)
@@ -334,3 +338,39 @@ async def test_blocks_sensitive_home_and_hermes_paths(tmp_path: Path, monkeypatc
     assert "API_KEY=super-secret" not in result.message
     assert "PRIVATE-KEY" not in result.message
     assert any("sensitive credential" in warning for warning in result.warnings)
+
+
+@pytest.mark.asyncio
+async def test_default_url_fetcher_handles_null_data():
+    from agent import context_references
+
+    async def fake_extract(*args, **kwargs):
+        return json.dumps({"data": None})
+
+    with patch("tools.web_tools.web_extract_tool", fake_extract):
+        out = await context_references._default_url_fetcher("https://example.com/doc")
+    assert out == ""
+
+
+@pytest.mark.asyncio
+async def test_default_url_fetcher_handles_null_documents():
+    from agent import context_references
+
+    async def fake_extract(*args, **kwargs):
+        return json.dumps({"data": {"documents": None}})
+
+    with patch("tools.web_tools.web_extract_tool", fake_extract):
+        out = await context_references._default_url_fetcher("https://example.com/doc")
+    assert out == ""
+
+
+@pytest.mark.asyncio
+async def test_default_url_fetcher_handles_null_first_document():
+    from agent import context_references
+
+    async def fake_extract(*args, **kwargs):
+        return json.dumps({"data": {"documents": [None]}})
+
+    with patch("tools.web_tools.web_extract_tool", fake_extract):
+        out = await context_references._default_url_fetcher("https://example.com/doc")
+    assert out == ""


### PR DESCRIPTION
## Summary
- Harden `_default_url_fetcher` in `agent/context_references.py` when `web_extract_tool` returns JSON with `data: null`, `documents: null`, or a null first document entry.
- Use `or {}` / `or []` (and `docs[0] or {}`) before chained `.get(...)` to avoid `AttributeError` on `NoneType`.
- Add async regression tests that patch `web_extract_tool`.
- Fix flaky `test_blocks_sensitive_home_and_hermes_paths` on Windows by also setting `USERPROFILE` when `HOME` is mocked (matches `Path.expanduser` behavior).

## Test plan
- `python -m pytest tests/agent/test_context_references.py -q -n 4`

Closes #22508