### PR TITLE
feat(pricing): support user-supplied pricing_overrides in config.yaml

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -559,6 +559,93 @@ def _normalize_anthropic_model_name(model: str) -> str:
     return name
 
 
+def _load_user_pricing_overrides() -> list:
+    """Read the ``pricing_overrides:`` list from ``~/.hermes/config.yaml``.
+
+    Returns an empty list when the key is absent, the config can't be
+    loaded, or the value isn't a list. Imports ``load_config`` lazily so
+    that ``agent.usage_pricing`` doesn't pull in the CLI config module at
+    import time (which would invert the dependency direction).
+    """
+    try:
+        from hermes_cli.config import load_config
+    except Exception:
+        return []
+    try:
+        cfg = load_config()
+    except Exception:
+        return []
+    raw = cfg.get("pricing_overrides") if isinstance(cfg, dict) else None
+    return raw if isinstance(raw, list) else []
+
+
+def _entry_from_user_override(entry: Dict[str, Any]) -> Optional[PricingEntry]:
+    """Build a ``PricingEntry`` from one ``pricing_overrides`` list item.
+
+    Requires ``input_per_million`` and ``output_per_million``. Other rate
+    fields are optional. Bad / missing required fields produce ``None``.
+    """
+    if not isinstance(entry, dict):
+        return None
+    ipm = _to_decimal(entry.get("input_per_million"))
+    opm = _to_decimal(entry.get("output_per_million"))
+    if ipm is None or opm is None:
+        return None
+    source_url = entry.get("source_url")
+    pricing_version = entry.get("pricing_version")
+    return PricingEntry(
+        input_cost_per_million=ipm,
+        output_cost_per_million=opm,
+        cache_read_cost_per_million=_to_decimal(entry.get("cache_read_per_million")),
+        cache_write_cost_per_million=_to_decimal(entry.get("cache_write_per_million")),
+        request_cost=_to_decimal(entry.get("request_cost")),
+        source="user_override",
+        source_url=str(source_url) if isinstance(source_url, str) else None,
+        pricing_version=str(pricing_version) if isinstance(pricing_version, str) else None,
+    )
+
+
+def _lookup_user_override_pricing(route: BillingRoute) -> Optional[PricingEntry]:
+    """Match the first ``pricing_overrides`` entry whose ``provider`` matches
+    ``route.provider`` and whose ``model`` matches either the full
+    ``route.model`` or its last path segment (basename).
+
+    Provider strings of the form ``custom:<name>`` are preserved by
+    ``resolve_billing_route``; for those, ``route.model`` is the basename
+    (e.g. ``kimi-k2p6``). For ``provider == "custom"`` (no suffix),
+    ``route.model`` is the full id (e.g. ``accounts/fireworks/models/kimi-k2p6``).
+    Matching against both forms means users don't have to think about
+    that distinction.
+    """
+    overrides = _load_user_pricing_overrides()
+    if not overrides:
+        return None
+    target_provider = (route.provider or "").lower()
+    target_model = (route.model or "").lower()
+    target_basename = target_model.rsplit("/", 1)[-1]
+    for raw in overrides:
+        if not isinstance(raw, dict):
+            continue
+        ep = str(raw.get("provider", "")).strip().lower()
+        em = str(raw.get("model", "")).strip().lower()
+        if not ep or not em:
+            continue
+        if ep != target_provider:
+            continue
+        em_basename = em.rsplit("/", 1)[-1]
+        # Match either form on either side: lets users write the full
+        # "accounts/.../kimi-k2p6" or just "kimi-k2p6" without caring
+        # which form their custom_providers setup routes with.
+        if em != target_model and em_basename != target_model and em != target_basename:
+            continue
+        entry = _entry_from_user_override(raw)
+        if entry is not None:
+            return entry
+        # Bad entry (missing required rates) — keep scanning so a single
+        # malformed item doesn't mask a later valid one for the same model.
+    return None
+
+
 def _lookup_official_docs_pricing(route: BillingRoute) -> Optional[PricingEntry]:
     model = route.model.lower()
     # Direct lookup first
@@ -644,6 +731,13 @@ def get_pricing_entry(
             source="none",
             pricing_version="included-route",
         )
+    # User-supplied overrides win over all auto-discovery sources. This is
+    # the supported escape hatch for providers without a pricing API
+    # (e.g. Fireworks) and for keeping rates current when the bundled
+    # ``_OFFICIAL_DOCS_PRICING`` snapshot lags behind a vendor change.
+    user_entry = _lookup_user_override_pricing(route)
+    if user_entry is not None:
+        return user_entry
     if route.provider == "openrouter":
         return _openrouter_pricing_entry(route)
     if route.base_url:

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -96,6 +96,45 @@ model:
 #         stale_timeout_seconds: 1800  # Longer non-stream stale timeout for slow large-context turns
 
 # =============================================================================
+# Pricing Overrides (cost reporting for any model/provider)
+# =============================================================================
+# Hermes derives per-turn cost from token counts × pricing. For providers
+# that don't expose pricing through their API (e.g. Fireworks AI) and for
+# any model not in the bundled docs snapshot, declare prices here. Entries
+# win over auto-discovery so you can also use this to fix stale defaults.
+#
+# Match keys:
+#   provider:  the provider string Hermes resolves to. For models served
+#              by a custom_providers entry named "fireworks", it's
+#              "custom:fireworks". Run `hermes config show` to confirm.
+#   model:     match against either the full model id
+#              ("accounts/fireworks/models/kimi-k2p6") OR its basename
+#              ("kimi-k2p6"). Either form works.
+#
+# Rate fields (USD per 1M tokens unless noted):
+#   input_per_million        required
+#   output_per_million       required
+#   cache_read_per_million   optional
+#   cache_write_per_million  optional
+#   request_cost             optional — flat USD per request
+#   source_url               optional — free-form, helps audits
+#   pricing_version          optional — free-form label
+#
+# pricing_overrides:
+#   - provider: custom:fireworks
+#     model: kimi-k2p6
+#     input_per_million: 0.95
+#     output_per_million: 4.00
+#     cache_read_per_million: 0.16
+#     source_url: https://docs.fireworks.ai/serverless/pricing
+#     pricing_version: fireworks-2026-05
+#   - provider: custom:fireworks
+#     model: glm-5p1
+#     input_per_million: 1.40
+#     output_per_million: 4.40
+#     cache_read_per_million: 0.26
+
+# =============================================================================
 # OpenRouter Provider Routing (only applies when using OpenRouter)
 # =============================================================================
 # Control how requests are routed across providers on OpenRouter.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2911,7 +2911,7 @@ _KNOWN_ROOT_KEYS = {
     "fallback_providers", "credential_pool_strategies", "toolsets",
     "agent", "terminal", "display", "compression", "delegation",
     "auxiliary", "custom_providers", "context", "memory", "gateway",
-    "sessions",
+    "sessions", "pricing_overrides",
 }
 
 # Valid fields inside a custom_providers list entry

--- a/tests/agent/test_usage_pricing.py
+++ b/tests/agent/test_usage_pricing.py
@@ -190,3 +190,117 @@ def test_custom_endpoint_models_api_pricing_is_supported(monkeypatch):
 
     assert float(entry.input_cost_per_million) == 0.5
     assert float(entry.output_cost_per_million) == 2.0
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# pricing_overrides — user-supplied prices win over auto-discovery sources.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def test_pricing_overrides_resolve_for_custom_provider(monkeypatch):
+    """A user override for a custom_providers-routed model (e.g. Fireworks)
+    should resolve via get_pricing_entry, even though Fireworks has no
+    pricing API and isn't in the bundled docs snapshot."""
+    monkeypatch.setattr(
+        "agent.usage_pricing._load_user_pricing_overrides",
+        lambda: [
+            {
+                "provider": "custom:fireworks",
+                "model": "kimi-k2p6",
+                "input_per_million": 0.95,
+                "output_per_million": 4.00,
+                "cache_read_per_million": 0.16,
+                "source_url": "https://docs.fireworks.ai/serverless/pricing",
+            }
+        ],
+    )
+
+    entry = get_pricing_entry(
+        "accounts/fireworks/models/kimi-k2p6",
+        provider="custom:fireworks",
+        base_url="https://api.fireworks.ai/inference/v1",
+    )
+
+    assert entry is not None
+    assert entry.source == "user_override"
+    assert float(entry.input_cost_per_million) == 0.95
+    assert float(entry.output_cost_per_million) == 4.00
+    assert float(entry.cache_read_cost_per_million) == 0.16
+
+
+def test_pricing_overrides_match_full_model_id_or_basename(monkeypatch):
+    """The matcher should accept either the full slash-prefixed id or the
+    basename, so users don't have to know which form Hermes routes with
+    for their particular custom_providers configuration."""
+    monkeypatch.setattr(
+        "agent.usage_pricing._load_user_pricing_overrides",
+        lambda: [
+            {
+                # Full id form
+                "provider": "custom:fireworks",
+                "model": "accounts/fireworks/models/kimi-k2p6",
+                "input_per_million": 1.0,
+                "output_per_million": 2.0,
+            }
+        ],
+    )
+
+    # Basename form on the route should still hit the full-id override.
+    entry = get_pricing_entry(
+        "accounts/fireworks/models/kimi-k2p6",
+        provider="custom:fireworks",
+        base_url="https://api.fireworks.ai/inference/v1",
+    )
+    assert entry is not None
+    assert float(entry.input_cost_per_million) == 1.0
+
+
+def test_pricing_overrides_take_precedence_over_docs_snapshot(monkeypatch):
+    """When both a user override and a bundled snapshot entry exist for the
+    same (provider, model), the override wins. This is the supported way
+    to correct stale rates without waiting for a Hermes release."""
+    monkeypatch.setattr(
+        "agent.usage_pricing._load_user_pricing_overrides",
+        lambda: [
+            {
+                "provider": "anthropic",
+                "model": "claude-opus-4-7",
+                "input_per_million": 99.0,  # absurd value to prove override wins
+                "output_per_million": 99.0,
+            }
+        ],
+    )
+
+    entry = get_pricing_entry("claude-opus-4-7", provider="anthropic")
+
+    assert entry is not None
+    assert entry.source == "user_override"
+    assert float(entry.input_cost_per_million) == 99.0
+
+
+def test_pricing_overrides_skip_entries_missing_required_fields(monkeypatch):
+    """Entries without input_per_million OR output_per_million are skipped
+    silently — we don't want a single bad entry to mask later valid ones
+    or crash cost computation."""
+    monkeypatch.setattr(
+        "agent.usage_pricing._load_user_pricing_overrides",
+        lambda: [
+            {"provider": "custom:fireworks", "model": "kimi-k2p6"},  # no rates
+            {
+                "provider": "custom:fireworks",
+                "model": "kimi-k2p6",
+                "input_per_million": 0.95,
+                "output_per_million": 4.00,
+            },
+        ],
+    )
+
+    entry = get_pricing_entry(
+        "accounts/fireworks/models/kimi-k2p6",
+        provider="custom:fireworks",
+        base_url="https://api.fireworks.ai/inference/v1",
+    )
+
+    # The first (incomplete) entry should be skipped; the second wins.
+    assert entry is not None
+    assert float(entry.input_cost_per_million) == 0.95


### PR DESCRIPTION
## What does this PR do?

Adds a `pricing_overrides:` list at `config.yaml` root so users can declare per-million-token costs for any `(provider, model)` pair.

This closes the gap where models served via `custom_providers` (e.g. Fireworks AI) yield correct token counts in `hermes insights` and `display.show_cost` but **no dollar amount**, because:

- their OpenAI-compatible `/models` endpoints don't include pricing fields,
- they're not in the bundled `_OFFICIAL_DOCS_PRICING` snapshot, and
- there's no provider-side pricing API to fetch from.

User-supplied overrides also double as the supported way to **fix stale rates** in the bundled snapshot without waiting for a Hermes release.

## Related Issue

No prior issue — happy to file one and link if preferred.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- `agent/usage_pricing.py`: added `_load_user_pricing_overrides`, `_entry_from_user_override`, `_lookup_user_override_pricing`, and the call site in `get_pricing_entry`. Overrides win over OpenRouter / custom-endpoint `/models` fetchers / docs snapshot, but not over `subscription_included` routes.
- `hermes_cli/config.py`: registered `pricing_overrides` in `_KNOWN_ROOT_KEYS` so the validator doesn't flag it as an unknown root key.
- `cli-config.yaml.example`: documented the schema with a Fireworks example.
- `tests/agent/test_usage_pricing.py`: 4 new tests covering happy path, full-id vs basename matching, override-wins-over-snapshot, and bad-entry handling.

### Schema

```yaml
pricing_overrides:
  - provider: custom:fireworks         # match resolve_billing_route().provider
    model: kimi-k2p6                   # match full id OR basename — either form works
    input_per_million: 0.95            # required
    output_per_million: 4.00           # required
    cache_read_per_million: 0.16       # optional
    cache_write_per_million: null      # optional
    request_cost: null                 # optional — flat USD per request
    source_url: https://docs.fireworks.ai/serverless/pricing  # optional
    pricing_version: fireworks-2026-05 # optional, free-form label
```

### Design notes

- **Lazy import of `hermes_cli.config.load_config`** in the new loader to avoid pulling the CLI config module into `agent.usage_pricing` at import time.
- **Provider match is exact** (case-insensitive); **model match accepts either the full id or basename** on either side, because `resolve_billing_route` keeps the full id for `provider="custom"` but splits to the basename for `provider="custom:<name>"`. Letting either form match removes a footgun.
- **Malformed entries are skipped silently** — a single bad item must not mask later valid items or crash cost computation.
- **`source="user_override"`** was already declared in the `CostSource` literal but never populated; this is the first call site.

## How to Test

1. Configure a custom provider (e.g. Fireworks):
   ```yaml
   custom_providers:
     - name: fireworks
       base_url: https://api.fireworks.ai/inference/v1
       key_env: FIREWORKS_API_KEY
   model:
     provider: custom:fireworks
     default: accounts/fireworks/models/kimi-k2p6
   pricing_overrides:
     - provider: custom:fireworks
       model: kimi-k2p6
       input_per_million: 0.95
       output_per_million: 4.00
       cache_read_per_million: 0.16
   display:
     show_cost: true
   ```
2. `hermes -z "say hi"` — token + cost figures should now display, with cost computed from the override.
3. `pytest tests/agent/test_usage_pricing.py -q` — all 13 tests pass (9 existing + 4 new).

Tested manually on Ubuntu 22.04 (WSL2 on Windows 11) against Hermes Agent v0.13.0 with Fireworks Kimi-K2.6 and GLM-5.1.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this feature
- [x] I've run `pytest tests/agent/ tests/hermes_cli/ -q` — only one pre-existing unrelated failure (`tests/hermes_cli/test_tencent_tokenhub_provider.py::test_hy3_preview_context_length`, asserts 256000 vs 262144, fails on clean main as well)
- [x] I've added tests for my changes
- [x] I've tested on my platform: Ubuntu 22.04 (WSL2 on Windows 11)

### Documentation & Housekeeping

- [x] I've updated `cli-config.yaml.example` for the new config key
- [x] N/A: no architecture or workflow changes
- [x] Cross-platform: pure Python, uses only stdlib + existing project deps
- [x] N/A: no tool descriptions/schemas changed
