### PR TITLE
fix(memory): harden recall router integration

### DIFF
--- a/agent/memory_manager.py
+++ b/agent/memory_manager.py
@@ -301,6 +301,44 @@ class MemoryManager:
                 )
         return "\n\n".join(parts)
 
+    def recall_now_all(
+        self,
+        query: str,
+        *,
+        mode: str = "auto",
+        depth: str = "light",
+        sources: Optional[List[str]] = None,
+        budget: str = "tiny",
+        provenance: str = "ids",
+        session_id: str = "",
+    ) -> str:
+        """Collect current-turn recall using explicit strategy metadata.
+
+        ``mode/depth/sources/budget/provenance`` let providers keep automatic
+        recall cheap and separate from manual/deep recall.  Providers that do
+        not implement ``recall_now`` inherit a prefetch-compatible default.
+        """
+        parts = []
+        for provider in self._providers:
+            try:
+                result = provider.recall_now(
+                    query,
+                    mode=mode,
+                    depth=depth,
+                    sources=sources,
+                    budget=budget,
+                    provenance=provenance,
+                    session_id=session_id,
+                )
+                if result and result.strip():
+                    parts.append(result)
+            except Exception as e:
+                logger.debug(
+                    "Memory provider '%s' recall_now failed (non-fatal): %s",
+                    provider.name, e,
+                )
+        return "\n\n".join(parts)
+
     def queue_prefetch_all(self, query: str, *, session_id: str = "") -> None:
         """Queue background prefetch on all providers for the next turn."""
         for provider in self._providers:

--- a/agent/memory_provider.py
+++ b/agent/memory_provider.py
@@ -103,6 +103,25 @@ class MemoryProvider(ABC):
         """
         return ""
 
+    def recall_now(
+        self,
+        query: str,
+        *,
+        mode: str = "auto",
+        depth: str = "light",
+        sources: Optional[List[str]] = None,
+        budget: str = "tiny",
+        provenance: str = "ids",
+        session_id: str = "",
+    ) -> str:
+        """Current-turn recall with explicit strategy metadata.
+
+        Providers can override this to distinguish cheap automatic recall from
+        manual/deep recall.  The default preserves backward compatibility by
+        delegating to ``prefetch()``.
+        """
+        return self.prefetch(query, session_id=session_id)
+
     def queue_prefetch(self, query: str, *, session_id: str = "") -> None:
         """Queue a background recall for the NEXT turn.
 

--- a/agent/memory_router.py
+++ b/agent/memory_router.py
@@ -1,0 +1,260 @@
+"""Lightweight recall routing for external memory providers.
+
+The router decides whether the current turn should pay the cost/noise of
+external-memory prefetch.  It is intentionally fed a *small, clean* context:
+current user text, a bounded recent-turn window, and lightweight platform/session
+metadata.  It never receives tool outputs, injected memory-context blocks, or the
+full transcript.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import re
+from dataclasses import dataclass, field
+from typing import Any, Dict, Iterable, List, Mapping, Optional
+
+from agent.memory_manager import sanitize_context
+
+logger = logging.getLogger(__name__)
+
+_SHORT_ACK_RE = re.compile(
+    r"^\s*(ok|okay|好的?|嗯+|唔+|收到|了解|继续|行|可以|是的|对|哈哈+|233+|草|[👍👌🙏😂🤣❤️💜~～。！？!?.\s]+)\s*$",
+    re.IGNORECASE,
+)
+_PAST_REFERENCE_RE = re.compile(
+    r"(上次|之前|以前|刚刚|前面|当时|继续(那个|上次)?|我们(讨论|说|决定|聊)过|remember|last time|previously|earlier)",
+    re.IGNORECASE,
+)
+_EVIDENCE_RE = re.compile(
+    r"(原文|证据|记录|消息|transcript|quote|verbatim|怎么说的|当时.*为什么|查一下历史|找一下)",
+    re.IGNORECASE,
+)
+_LONG_TERM_RE = re.compile(
+    r"(记忆|图记忆|Graphiti|memory|recall|Hermes|配置|认证|权限|gateway|APISIX|SpiceDB|session_search|provider|prefetch|MCP|服务器|偏好|身份|关系|决策|架构)",
+    re.IGNORECASE,
+)
+
+_DEPTH_ORDER = {"none": 0, "light": 1, "standard": 2, "deep": 3, "evidence": 4}
+_BUDGET_ORDER = {"tiny": 0, "small": 1, "medium": 2, "large": 3}
+
+
+@dataclass
+class RecallDecision:
+    should_recall: bool
+    query: str = ""
+    depth: str = "none"
+    sources: List[str] = field(default_factory=list)
+    budget: str = "tiny"
+    provenance: str = "ids"
+    reason: str = ""
+    mode: str = "auto"
+    decision_source: str = "heuristic"
+
+    def normalized(self, *, max_depth: str = "standard", max_budget: str = "small") -> "RecallDecision":
+        depth = self.depth if self.depth in _DEPTH_ORDER else "light"
+        budget = self.budget if self.budget in _BUDGET_ORDER else "tiny"
+        if _DEPTH_ORDER[depth] > _DEPTH_ORDER.get(max_depth, 2):
+            depth = max_depth
+        if _BUDGET_ORDER[budget] > _BUDGET_ORDER.get(max_budget, 1):
+            budget = max_budget
+        sources = [s for s in (self.sources or []) if isinstance(s, str)]
+        if not sources and self.should_recall:
+            sources = ["graph"]
+        return RecallDecision(
+            should_recall=bool(self.should_recall),
+            query=(self.query or "").strip(),
+            depth=depth,
+            sources=sources,
+            budget=budget,
+            provenance=self.provenance or "ids",
+            reason=(self.reason or "").strip(),
+            mode=self.mode or "auto",
+            decision_source=self.decision_source or "heuristic",
+        )
+
+
+def stable_recall_key(query: str, *, mode: str = "auto", depth: str = "light", sources: Optional[Iterable[str]] = None) -> str:
+    """Return a compact key for duplicate-suppression of equivalent recall work."""
+    norm_query = re.sub(r"\s+", " ", sanitize_context(query or "").strip().lower())[:500]
+    norm_sources = ",".join(sorted(str(s).strip().lower() for s in (sources or []) if str(s).strip()))
+    payload = f"{mode}|{depth}|{norm_sources}|{norm_query}"
+    return hashlib.sha256(payload.encode("utf-8", "ignore")).hexdigest()[:16]
+
+
+def build_recall_gate_context(
+    current_message: str,
+    recent_messages: Iterable[Mapping[str, Any]] = (),
+    *,
+    platform_context: Optional[Mapping[str, Any]] = None,
+    session_metadata: Optional[Mapping[str, Any]] = None,
+    max_turns: int = 6,
+    max_chars: int = 4000,
+) -> Dict[str, Any]:
+    """Build the small, clean context used by the recall gate.
+
+    Only user/assistant text snippets are included; tool messages and injected
+    memory-context blocks are stripped.  This keeps the judge from seeing stale
+    recall output and prevents recursive recall amplification.
+    """
+    clean_current = sanitize_context(current_message or "").strip()
+    turns: List[Dict[str, str]] = []
+    for msg in list(recent_messages or [])[-max_turns:]:
+        role = msg.get("role")
+        if role not in {"user", "assistant"}:
+            continue
+        content = msg.get("content", "")
+        if not isinstance(content, str):
+            continue
+        content = sanitize_context(content).strip()
+        if not content:
+            continue
+        turns.append({"role": str(role), "text": content[:1000]})
+
+    ctx: Dict[str, Any] = {
+        "current_message": clean_current[:2000],
+        "recent_turns": turns,
+        "platform_context": dict(platform_context or {}),
+        "session_metadata": dict(session_metadata or {}),
+    }
+    encoded = json.dumps(ctx, ensure_ascii=False)
+    if len(encoded) > max_chars:
+        # Keep current message and metadata, shrink recent turns first.
+        while turns and len(json.dumps(ctx, ensure_ascii=False)) > max_chars:
+            turns.pop(0)
+        ctx["recent_turns"] = turns
+    return ctx
+
+
+def heuristic_recall_decision(current_message: str) -> RecallDecision:
+    """Cheap local fallback/first pass for recall routing."""
+    text = sanitize_context(current_message or "").strip()
+    if not text or _SHORT_ACK_RE.match(text):
+        return RecallDecision(False, reason="short acknowledgement/no recall signal")
+
+    sources = ["graph"]
+    depth = "none"
+    budget = "tiny"
+    reason = ""
+
+    if _EVIDENCE_RE.search(text):
+        depth = "standard"  # auto gate is capped; manual/user recall can go deeper.
+        sources = ["graph", "session_fts"]
+        budget = "small"
+        reason = "explicit historical/evidence reference"
+    elif _PAST_REFERENCE_RE.search(text):
+        depth = "standard"
+        sources = ["graph", "session_fts"]
+        budget = "small"
+        reason = "past-reference cue"
+    elif _LONG_TERM_RE.search(text):
+        depth = "light"
+        sources = ["graph"]
+        reason = "long-term project/memory cue"
+
+    if depth == "none":
+        return RecallDecision(False, reason="no recall cue")
+    return RecallDecision(
+        True,
+        query=text,
+        depth=depth,
+        sources=sources,
+        budget=budget,
+        provenance="ids",
+        reason=reason,
+    )
+
+
+def _parse_json_object(text: str) -> Dict[str, Any]:
+    text = (text or "").strip()
+    if not text:
+        return {}
+    try:
+        return json.loads(text)
+    except Exception:
+        pass
+    match = re.search(r"\{[\s\S]*\}", text)
+    if not match:
+        return {}
+    try:
+        return json.loads(match.group(0))
+    except Exception:
+        return {}
+
+
+def llm_recall_decision(gate_context: Mapping[str, Any], *, timeout: float = 8.0) -> Optional[RecallDecision]:
+    """Ask the configured cheap auxiliary model to classify recall need.
+
+    The prompt is intentionally narrow and JSON-only.  Failures return None so
+    callers can fall back to heuristics without delaying the main turn.
+    """
+    try:
+        from agent.auxiliary_client import call_llm
+
+        system = (
+            "You are a lightweight recall gate for an AI agent. Decide whether "
+            "the current user turn needs external memory recall. Use only the "
+            "provided clean gate context. Do not answer the user. Return compact "
+            "JSON with keys: should_recall boolean, query string, depth one of "
+            "none/light/standard, sources array using graph or session_fts, "
+            "budget tiny or small, provenance ids, reason string. Automatic recall "
+            "must stay cheap: never choose deep/evidence/verbatim."
+        )
+        user = json.dumps(gate_context, ensure_ascii=False)
+        response = call_llm(
+            task="memory_recall",
+            messages=[{"role": "system", "content": system}, {"role": "user", "content": user}],
+            temperature=0,
+            max_tokens=220,
+            timeout=timeout,
+        )
+        content = response.choices[0].message.content
+        data = _parse_json_object(content)
+        if not data:
+            return None
+        return RecallDecision(
+            should_recall=bool(data.get("should_recall")),
+            query=str(data.get("query") or gate_context.get("current_message") or ""),
+            depth=str(data.get("depth") or "light"),
+            sources=list(data.get("sources") or []),
+            budget=str(data.get("budget") or "tiny"),
+            provenance=str(data.get("provenance") or "ids"),
+            reason=str(data.get("reason") or ""),
+            decision_source="llm",
+        )
+    except Exception as exc:
+        logger.debug("memory recall LLM gate failed; falling back to heuristic: %s", exc)
+        return None
+
+
+def decide_recall(
+    gate_context: Mapping[str, Any],
+    *,
+    strategy: str = "heuristic",
+    max_depth: str = "standard",
+    max_budget: str = "small",
+    timeout: float = 8.0,
+) -> RecallDecision:
+    """Return a normalized auto-recall decision.
+
+    strategy:
+      - heuristic: local rules only
+      - llm: cheap auxiliary model, falling back to heuristic on failure
+      - hybrid: heuristic first; if it says no, ask the cheap model
+    """
+    current = str(gate_context.get("current_message") or "")
+    heuristic = heuristic_recall_decision(current)
+    strategy = (strategy or "heuristic").strip().lower()
+
+    if strategy == "heuristic":
+        return heuristic.normalized(max_depth=max_depth, max_budget=max_budget)
+
+    if strategy == "hybrid" and heuristic.should_recall:
+        return heuristic.normalized(max_depth=max_depth, max_budget=max_budget)
+
+    llm_decision = llm_recall_decision(gate_context, timeout=timeout)
+    if llm_decision is not None:
+        return llm_decision.normalized(max_depth=max_depth, max_budget=max_budget)
+    return heuristic.normalized(max_depth=max_depth, max_budget=max_budget)

--- a/agent/memory_router.py
+++ b/agent/memory_router.py
@@ -39,6 +39,32 @@ _LONG_TERM_RE = re.compile(
 
 _DEPTH_ORDER = {"none": 0, "light": 1, "standard": 2, "deep": 3, "evidence": 4}
 _BUDGET_ORDER = {"tiny": 0, "small": 1, "medium": 2, "large": 3}
+_SENSITIVE_METADATA_KEY_RE = re.compile(r"(user|chat|thread|session|gateway).*(_?id|key)$|^.*_id$", re.IGNORECASE)
+
+
+def _sanitize_gate_metadata(metadata: Optional[Mapping[str, Any]]) -> Dict[str, Any]:
+    """Return low-risk platform/session metadata for the optional LLM gate.
+
+    The gate only needs coarse routing hints.  Preserve labels such as platform,
+    but hash stable identifiers so auxiliary providers never see raw Discord /
+    Telegram / gateway IDs.
+    """
+    safe: Dict[str, Any] = {}
+    for key, value in dict(metadata or {}).items():
+        key_str = str(key)
+        if value is None:
+            safe[key_str] = ""
+            continue
+        value_str = str(value)
+        if _SENSITIVE_METADATA_KEY_RE.search(key_str):
+            if value_str:
+                digest = hashlib.sha256(value_str.encode("utf-8", "ignore")).hexdigest()[:12]
+                safe[key_str] = f"sha256:{digest}"
+            else:
+                safe[key_str] = ""
+        else:
+            safe[key_str] = value
+    return safe
 
 
 @dataclass
@@ -116,8 +142,8 @@ def build_recall_gate_context(
     ctx: Dict[str, Any] = {
         "current_message": clean_current[:2000],
         "recent_turns": turns,
-        "platform_context": dict(platform_context or {}),
-        "session_metadata": dict(session_metadata or {}),
+        "platform_context": _sanitize_gate_metadata(platform_context),
+        "session_metadata": _sanitize_gate_metadata(session_metadata),
     }
     encoded = json.dumps(ctx, ensure_ascii=False)
     if len(encoded) > max_chars:
@@ -125,6 +151,15 @@ def build_recall_gate_context(
         while turns and len(json.dumps(ctx, ensure_ascii=False)) > max_chars:
             turns.pop(0)
         ctx["recent_turns"] = turns
+    if len(json.dumps(ctx, ensure_ascii=False)) > max_chars:
+        # Very long current turns can exceed the cap even with no history.
+        # Preserve the beginning of the user's message and leave room for
+        # metadata/JSON framing rather than leaking an unbounded gate prompt.
+        overhead_ctx = dict(ctx)
+        overhead_ctx["current_message"] = ""
+        overhead = len(json.dumps(overhead_ctx, ensure_ascii=False))
+        budget = max(0, max_chars - overhead - 32)
+        ctx["current_message"] = ctx["current_message"][:budget]
     return ctx
 
 

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -757,6 +757,18 @@ DEFAULT_CONFIG = {
             "extra_body": {},
             "max_concurrency": 3,  # Clamp parallel summaries to avoid request-burst 429s on small providers
         },
+        # Memory recall gate — cheap current-turn judge for external memory
+        # prefetch.  It sees only a sanitized current message + bounded recent
+        # window, never full transcripts/tool outputs.  Explicit Codex mini is
+        # cheap when available; failures fall back to local heuristics.
+        "memory_recall": {
+            "provider": "codex",
+            "model": "gpt-5.1-codex-mini",
+            "base_url": "",
+            "api_key": "",
+            "timeout": 8,
+            "extra_body": {},
+        },
         "skills_hub": {
             "provider": "auto",
             "model": "",
@@ -987,6 +999,17 @@ DEFAULT_CONFIG = {
         # "hindsight", "holographic", "retaindb", "byterover".
         # Only ONE external provider is allowed at a time.
         "provider": "",
+        "recall_router": {
+            "enabled": True,
+            # heuristic = local rules only; hybrid = rules first, cheap LLM only
+            # when rules say no; llm = cheap LLM every turn with heuristic fallback.
+            "strategy": "hybrid",
+            "recent_turns": 6,
+            "max_context_chars": 4000,
+            "max_depth": "standard",   # automatic recall never goes deep/evidence
+            "max_budget": "small",
+            "dedupe_ttl_turns": 2,
+        },
     },
 
     # Subagent delegation — override the provider:model used by delegate_task

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1001,11 +1001,13 @@ DEFAULT_CONFIG = {
         "provider": "",
         "recall_router": {
             "enabled": True,
-            # heuristic = local rules only; hybrid = rules first, cheap LLM only
-            # when rules say no; llm = cheap LLM every turn with heuristic fallback.
-            "strategy": "hybrid",
+            # heuristic = local rules only. hybrid/llm may send sanitized current
+            # and recent turn text (with platform/session IDs hashed) to the
+            # auxiliary memory_recall model; opt in if you want semantic gating.
+            "strategy": "heuristic",
             "recent_turns": 6,
             "max_context_chars": 4000,
+            "timeout": 8.0,
             "max_depth": "standard",   # automatic recall never goes deep/evidence
             "max_budget": "small",
             "dedupe_ttl_turns": 2,

--- a/run_agent.py
+++ b/run_agent.py
@@ -9902,7 +9902,7 @@ class AIAgent:
             )
             try:
                 _payload = json.loads(result)
-                _key = _payload.get("recall_key")
+                _key = _payload.get("auto_recall_key") or _payload.get("recall_key")
                 if _key:
                     _recent = getattr(self, "_memory_recall_recent_keys", {}) or {}
                     _recent[_key] = self._user_turn_count
@@ -10555,7 +10555,7 @@ class AIAgent:
                 )
                 try:
                     _payload = json.loads(function_result)
-                    _key = _payload.get("recall_key")
+                    _key = _payload.get("auto_recall_key") or _payload.get("recall_key")
                     if _key:
                         _recent = getattr(self, "_memory_recall_recent_keys", {}) or {}
                         _recent[_key] = self._user_turn_count
@@ -11453,9 +11453,10 @@ class AIAgent:
                     )
                     _decision = decide_recall(
                         _gate_ctx,
-                        strategy=str(_router_cfg.get("strategy", "hybrid") or "hybrid"),
+                        strategy=str(_router_cfg.get("strategy", "heuristic") or "heuristic"),
                         max_depth=str(_router_cfg.get("max_depth", "standard") or "standard"),
                         max_budget=str(_router_cfg.get("max_budget", "small") or "small"),
+                        timeout=float(_router_cfg.get("timeout", 8.0) or 8.0),
                     )
                     if _decision.should_recall:
                         _recall_query = _decision.query or _query
@@ -11469,15 +11470,33 @@ class AIAgent:
                         _recent = getattr(self, "_memory_recall_recent_keys", {})
                         _last_seen = _recent.get(_recall_key)
                         if _last_seen is None or (self._user_turn_count - int(_last_seen)) > _ttl:
-                            _ext_prefetch_cache = self._memory_manager.recall_now_all(
-                                _recall_query,
-                                mode="auto",
-                                depth=_decision.depth,
-                                sources=_decision.sources,
-                                budget=_decision.budget,
-                                provenance=_decision.provenance,
-                                session_id=self.session_id or "",
-                            ) or ""
+                            _wants_session = any(
+                                _src in ("session_fts", "session_summary")
+                                for _src in (_decision.sources or [])
+                            )
+                            if _wants_session:
+                                from tools.recall_tool import recall as _recall_tool
+                                _ext_prefetch_cache = _recall_tool(
+                                    _recall_query,
+                                    mode="auto",
+                                    depth=_decision.depth,
+                                    sources=_decision.sources,
+                                    budget=_decision.budget,
+                                    provenance=_decision.provenance,
+                                    memory_manager=self._memory_manager,
+                                    db=self._session_db,
+                                    current_session_id=self.session_id,
+                                ) or ""
+                            else:
+                                _ext_prefetch_cache = self._memory_manager.recall_now_all(
+                                    _recall_query,
+                                    mode="auto",
+                                    depth=_decision.depth,
+                                    sources=_decision.sources,
+                                    budget=_decision.budget,
+                                    provenance=_decision.provenance,
+                                    session_id=self.session_id or "",
+                                ) or ""
                             _recent[_recall_key] = self._user_turn_count
                             # Clear old duplicate-suppression entries so the
                             # router does not permanently suppress a topic.

--- a/run_agent.py
+++ b/run_agent.py
@@ -1879,6 +1879,7 @@ class AIAgent:
         self._memory_nudge_interval = 10
         self._turns_since_memory = 0
         self._iters_since_skill = 0
+        mem_config = {}
         if not skip_memory:
             try:
                 mem_config = _agent_cfg.get("memory", {})
@@ -1900,6 +1901,11 @@ class AIAgent:
         # Memory provider plugin (external — one at a time, alongside built-in)
         # Reads memory.provider from config to select which plugin to activate.
         self._memory_manager = None
+        _recall_router_cfg = mem_config.get("recall_router", {}) if isinstance(mem_config, dict) else {}
+        if not isinstance(_recall_router_cfg, dict):
+            _recall_router_cfg = {}
+        self._memory_recall_router_cfg = _recall_router_cfg
+        self._memory_recall_recent_keys = {}
         if not skip_memory:
             try:
                 _mem_provider_name = mem_config.get("provider", "") if mem_config else ""
@@ -11353,18 +11359,97 @@ class AIAgent:
             except Exception:
                 pass
 
-        # External memory provider: prefetch once before the tool loop.
+        # External memory provider: recall once before the tool loop.
         # Reuse the cached result on every iteration to avoid re-calling
-        # prefetch_all() on each tool call (10 tool calls = 10x latency + cost).
+        # provider recall on each tool call (10 tool calls = 10x latency + cost).
         # Use original_user_message (clean input) — user_message may contain
         # injected skill content that bloats / breaks provider queries.
         _ext_prefetch_cache = ""
         if self._memory_manager:
             try:
                 _query = original_user_message if isinstance(original_user_message, str) else ""
-                _ext_prefetch_cache = self._memory_manager.prefetch_all(_query) or ""
-            except Exception:
-                pass
+                _router_cfg = getattr(self, "_memory_recall_router_cfg", {}) or {}
+                _router_enabled = str(_router_cfg.get("enabled", True)).lower() not in ("0", "false", "no", "off")
+                if not _router_enabled:
+                    _ext_prefetch_cache = self._memory_manager.prefetch_all(
+                        _query, session_id=self.session_id or "") or ""
+                else:
+                    from agent.memory_router import (
+                        build_recall_gate_context,
+                        decide_recall,
+                        stable_recall_key,
+                    )
+
+                    _platform_ctx = {
+                        "platform": self.platform or "cli",
+                        "user_id": self._user_id or "",
+                        "chat_id": self._chat_id or "",
+                        "thread_id": self._thread_id or "",
+                        "gateway_session_key": self._gateway_session_key or "",
+                    }
+                    _session_meta = {
+                        "session_id": self.session_id or "",
+                        "turn_number": self._user_turn_count,
+                    }
+                    _gate_ctx = build_recall_gate_context(
+                        _query,
+                        messages[:current_turn_user_idx],
+                        platform_context=_platform_ctx,
+                        session_metadata=_session_meta,
+                        max_turns=int(_router_cfg.get("recent_turns", 6) or 6),
+                        max_chars=int(_router_cfg.get("max_context_chars", 4000) or 4000),
+                    )
+                    _decision = decide_recall(
+                        _gate_ctx,
+                        strategy=str(_router_cfg.get("strategy", "hybrid") or "hybrid"),
+                        max_depth=str(_router_cfg.get("max_depth", "standard") or "standard"),
+                        max_budget=str(_router_cfg.get("max_budget", "small") or "small"),
+                    )
+                    if _decision.should_recall:
+                        _recall_query = _decision.query or _query
+                        _recall_key = stable_recall_key(
+                            _recall_query,
+                            mode="auto",
+                            depth=_decision.depth,
+                            sources=_decision.sources,
+                        )
+                        _ttl = max(0, int(_router_cfg.get("dedupe_ttl_turns", 2) or 0))
+                        _recent = getattr(self, "_memory_recall_recent_keys", {})
+                        _last_seen = _recent.get(_recall_key)
+                        if _last_seen is None or (self._user_turn_count - int(_last_seen)) > _ttl:
+                            _ext_prefetch_cache = self._memory_manager.recall_now_all(
+                                _recall_query,
+                                mode="auto",
+                                depth=_decision.depth,
+                                sources=_decision.sources,
+                                budget=_decision.budget,
+                                provenance=_decision.provenance,
+                                session_id=self.session_id or "",
+                            ) or ""
+                            _recent[_recall_key] = self._user_turn_count
+                            # Clear old duplicate-suppression entries so the
+                            # router does not permanently suppress a topic.
+                            for _k, _turn in list(_recent.items()):
+                                try:
+                                    if self._user_turn_count - int(_turn) > max(_ttl, 1) + 2:
+                                        _recent.pop(_k, None)
+                                except Exception:
+                                    _recent.pop(_k, None)
+                            self._memory_recall_recent_keys = _recent
+                        else:
+                            logger.debug(
+                                "Suppressed duplicate auto memory recall key=%s depth=%s sources=%s",
+                                _recall_key,
+                                _decision.depth,
+                                _decision.sources,
+                            )
+            except Exception as _recall_err:
+                logger.debug("Memory recall router failed; falling back to provider prefetch: %s", _recall_err)
+                try:
+                    _ext_prefetch_cache = self._memory_manager.prefetch_all(
+                        _query, session_id=self.session_id or "") or ""
+                except Exception:
+                    pass
 
         while (api_call_count < self.max_iterations and self.iteration_budget.remaining > 0) or self._budget_grace_call:
             # Reset per-turn checkpoint dedup so each iteration can take one snapshot

--- a/run_agent.py
+++ b/run_agent.py
@@ -9885,6 +9885,31 @@ class AIAgent:
                 db=self._session_db,
                 current_session_id=self.session_id,
             )
+        elif function_name == "recall":
+            from tools.recall_tool import recall as _recall_tool
+            result = _recall_tool(
+                query=function_args.get("query", ""),
+                mode=function_args.get("mode", "manual"),
+                depth=function_args.get("depth", "standard"),
+                sources=function_args.get("sources"),
+                budget=function_args.get("budget", "medium"),
+                provenance=function_args.get("provenance", "ids"),
+                role_filter=function_args.get("role_filter"),
+                limit=function_args.get("limit"),
+                memory_manager=self._memory_manager,
+                db=self._session_db,
+                current_session_id=self.session_id,
+            )
+            try:
+                _payload = json.loads(result)
+                _key = _payload.get("recall_key")
+                if _key:
+                    _recent = getattr(self, "_memory_recall_recent_keys", {}) or {}
+                    _recent[_key] = self._user_turn_count
+                    self._memory_recall_recent_keys = _recent
+            except Exception:
+                pass
+            return result
         elif function_name == "memory":
             target = function_args.get("target", "memory")
             from tools.memory_tool import memory_tool as _memory_tool
@@ -10513,6 +10538,33 @@ class AIAgent:
                 tool_duration = time.time() - tool_start_time
                 if self._should_emit_quiet_tool_messages():
                     self._vprint(f"  {_get_cute_tool_message_impl('session_search', function_args, tool_duration, result=function_result)}")
+            elif function_name == "recall":
+                from tools.recall_tool import recall as _recall_tool
+                function_result = _recall_tool(
+                    query=function_args.get("query", ""),
+                    mode=function_args.get("mode", "manual"),
+                    depth=function_args.get("depth", "standard"),
+                    sources=function_args.get("sources"),
+                    budget=function_args.get("budget", "medium"),
+                    provenance=function_args.get("provenance", "ids"),
+                    role_filter=function_args.get("role_filter"),
+                    limit=function_args.get("limit"),
+                    memory_manager=self._memory_manager,
+                    db=self._session_db,
+                    current_session_id=self.session_id,
+                )
+                try:
+                    _payload = json.loads(function_result)
+                    _key = _payload.get("recall_key")
+                    if _key:
+                        _recent = getattr(self, "_memory_recall_recent_keys", {}) or {}
+                        _recent[_key] = self._user_turn_count
+                        self._memory_recall_recent_keys = _recent
+                except Exception:
+                    pass
+                tool_duration = time.time() - tool_start_time
+                if self._should_emit_quiet_tool_messages():
+                    self._vprint(f"  {_get_cute_tool_message_impl('recall', function_args, tool_duration, result=function_result)}")
             elif function_name == "memory":
                 target = function_args.get("target", "memory")
                 from tools.memory_tool import memory_tool as _memory_tool

--- a/tests/agent/test_memory_router.py
+++ b/tests/agent/test_memory_router.py
@@ -41,15 +41,32 @@ def test_gate_context_strips_memory_blocks_and_tool_messages():
             {"role": "tool", "content": "tool output should not be included"},
             {"role": "assistant", "content": "answer"},
         ],
-        platform_context={"platform": "discord"},
+        platform_context={"platform": "discord", "user_id": "raw-user-123"},
         session_metadata={"session_id": "s1"},
     )
 
     dumped = json.dumps(ctx, ensure_ascii=False)
     assert "SECRET" not in dumped
     assert "tool output" not in dumped
+    assert "raw-user-123" not in dumped
+    assert "\"s1\"" not in dumped
+    assert ctx["platform_context"]["user_id"].startswith("sha256:")
+    assert ctx["session_metadata"]["session_id"].startswith("sha256:")
     assert "visible" in dumped
     assert ctx["platform_context"]["platform"] == "discord"
+
+
+def test_gate_context_caps_long_current_message():
+    ctx = build_recall_gate_context(
+        "x" * 5000,
+        [{"role": "assistant", "content": "y" * 5000}],
+        platform_context={"platform": "discord"},
+        max_chars=500,
+    )
+
+    assert len(json.dumps(ctx, ensure_ascii=False)) <= 500
+    assert ctx["recent_turns"] == []
+    assert len(ctx["current_message"]) < 5000
 
 
 def test_heuristic_skips_short_ack_and_routes_project_memory():
@@ -59,6 +76,15 @@ def test_heuristic_skips_short_ack_and_routes_project_memory():
     assert decision.should_recall is True
     assert decision.depth == "light"
     assert decision.sources == ["graph"]
+
+
+def test_default_recall_router_is_privacy_preserving_heuristic():
+    from hermes_cli.config import DEFAULT_CONFIG
+
+    cfg = DEFAULT_CONFIG["memory"]["recall_router"]
+    assert cfg["enabled"] is True
+    assert cfg["strategy"] == "heuristic"
+    assert cfg["timeout"] == 8.0
 
 
 def test_heuristic_caps_evidence_to_standard_for_auto():

--- a/tests/agent/test_memory_router.py
+++ b/tests/agent/test_memory_router.py
@@ -1,0 +1,106 @@
+import json
+
+from agent.memory_provider import MemoryProvider
+from agent.memory_router import (
+    build_recall_gate_context,
+    decide_recall,
+    heuristic_recall_decision,
+    stable_recall_key,
+)
+from agent.memory_manager import MemoryManager
+
+
+class DummyProvider(MemoryProvider):
+    name = "dummy"
+
+    def __init__(self):
+        self.calls = []
+
+    def is_available(self):
+        return True
+
+    def initialize(self, session_id: str, **kwargs):
+        pass
+
+    def get_tool_schemas(self):
+        return []
+
+    def prefetch(self, query: str, *, session_id: str = "") -> str:
+        return f"prefetch:{query}:{session_id}"
+
+    def recall_now(self, query: str, **kwargs) -> str:
+        self.calls.append((query, kwargs))
+        return json.dumps({"query": query, "kwargs": kwargs}, ensure_ascii=False)
+
+
+def test_gate_context_strips_memory_blocks_and_tool_messages():
+    ctx = build_recall_gate_context(
+        "继续图记忆 recall",
+        [
+            {"role": "user", "content": "hello <memory-context>SECRET</memory-context> visible"},
+            {"role": "tool", "content": "tool output should not be included"},
+            {"role": "assistant", "content": "answer"},
+        ],
+        platform_context={"platform": "discord"},
+        session_metadata={"session_id": "s1"},
+    )
+
+    dumped = json.dumps(ctx, ensure_ascii=False)
+    assert "SECRET" not in dumped
+    assert "tool output" not in dumped
+    assert "visible" in dumped
+    assert ctx["platform_context"]["platform"] == "discord"
+
+
+def test_heuristic_skips_short_ack_and_routes_project_memory():
+    assert heuristic_recall_decision("好的").should_recall is False
+
+    decision = heuristic_recall_decision("Graphiti 的 recall gate 设计")
+    assert decision.should_recall is True
+    assert decision.depth == "light"
+    assert decision.sources == ["graph"]
+
+
+def test_heuristic_caps_evidence_to_standard_for_auto():
+    decision = decide_recall(
+        {"current_message": "找一下之前认证层的原文证据"},
+        strategy="heuristic",
+        max_depth="standard",
+        max_budget="small",
+    )
+    assert decision.should_recall is True
+    assert decision.depth == "standard"
+    assert decision.sources == ["graph", "session_fts"]
+    assert decision.budget == "small"
+
+
+def test_stable_recall_key_normalizes_whitespace_and_sources():
+    a = stable_recall_key("Graphiti   recall", depth="light", sources=["session_fts", "graph"])
+    b = stable_recall_key("graphiti recall", depth="light", sources=["graph", "session_fts"])
+    assert a == b
+
+
+def test_memory_manager_recall_now_passes_strategy_metadata():
+    provider = DummyProvider()
+    manager = MemoryManager()
+    manager.add_provider(provider)
+
+    result = manager.recall_now_all(
+        "Graphiti recall",
+        mode="auto",
+        depth="standard",
+        sources=["graph", "session_fts"],
+        budget="small",
+        provenance="ids",
+        session_id="session-1",
+    )
+
+    assert "Graphiti recall" in result
+    assert provider.calls[0][0] == "Graphiti recall"
+    kwargs = provider.calls[0][1]
+    assert kwargs["mode"] == "auto"
+    assert kwargs["depth"] == "standard"
+    assert kwargs["sources"] == ["graph", "session_fts"]
+    assert kwargs["budget"] == "small"
+    assert kwargs["provenance"] == "ids"
+    assert kwargs["session_id"] == "session-1"

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -5187,3 +5187,21 @@ class TestMemoryProviderTurnStart:
         import inspect
         src = inspect.getsource(AIAgent.run_conversation)
         assert "on_turn_start(self._user_turn_count" in src
+
+    def test_auto_recall_session_sources_route_through_unified_recall(self):
+        """Regression guard: auto decisions that request session sources must execute them."""
+        import inspect
+        src = inspect.getsource(AIAgent.run_conversation)
+        assert "_src in (\"session_fts\", \"session_summary\")" in src
+        assert "from tools.recall_tool import recall as _recall_tool" in src
+        assert "db=self._session_db" in src
+        assert "self._memory_manager.recall_now_all" in src
+        assert "timeout=float(_router_cfg.get(\"timeout\", 8.0) or 8.0)" in src
+
+    def test_manual_recall_marks_auto_key_for_dedupe(self):
+        """Manual recall should suppress the equivalent auto recall key for a few turns."""
+        import inspect
+        src = inspect.getsource(AIAgent._invoke_tool)
+        assert "auto_recall_key" in src
+        src_sequential = inspect.getsource(AIAgent._execute_tool_calls_sequential)
+        assert "auto_recall_key" in src_sequential

--- a/tests/tools/test_recall_tool.py
+++ b/tests/tools/test_recall_tool.py
@@ -49,6 +49,16 @@ def test_recall_standard_routes_graph_and_session_search(monkeypatch):
     assert data["results"]["graph"] == "graph memory hit"
     assert data["results"]["sessions"]["results"][0]["summary"] == "session hit"
     assert data["recall_key"]
+    assert data["auto_recall_key"]
+    assert data["auto_recall_key"] != data["recall_key"]
+
+
+def test_recall_auto_key_matches_manual_query_for_auto_suppression():
+    manager = DummyMemoryManager()
+    manual = json.loads(recall("Graphiti auth", depth="light", memory_manager=manager))
+    auto = json.loads(recall("Graphiti auth", mode="auto", depth="light", memory_manager=manager))
+
+    assert manual["auto_recall_key"] == auto["recall_key"]
 
 
 def test_recall_reports_missing_sources():
@@ -80,3 +90,16 @@ def test_recall_budget_clamps_session_limit(monkeypatch):
 
     assert data["success"] is True
     assert seen["limit"] == 1
+
+
+def test_recall_surfaces_nested_session_failure(monkeypatch):
+    def fake_session_search(**kwargs):
+        return json.dumps({"success": False, "error": "fts unavailable"})
+
+    monkeypatch.setattr("tools.session_search_tool.session_search", fake_session_search)
+    raw = recall("history", depth="standard", sources=["session_fts"], db=object())
+    data = json.loads(raw)
+
+    assert data["success"] is False
+    assert data["results"]["sessions"]["success"] is False
+    assert "session recall returned unsuccessful result" in data["errors"]

--- a/tests/tools/test_recall_tool.py
+++ b/tests/tools/test_recall_tool.py
@@ -1,0 +1,82 @@
+import json
+
+from tools.recall_tool import recall
+
+
+class DummyMemoryManager:
+    def __init__(self):
+        self.calls = []
+
+    def recall_now_all(self, query, **kwargs):
+        self.calls.append((query, kwargs))
+        return "graph memory hit"
+
+
+def test_recall_light_defaults_to_graph_when_provider_available():
+    manager = DummyMemoryManager()
+    raw = recall("Graphiti auth", depth="light", memory_manager=manager, db=None)
+    data = json.loads(raw)
+
+    assert data["success"] is True
+    assert data["sources"] == ["graph"]
+    assert data["results"]["graph"] == "graph memory hit"
+    assert manager.calls[0][1]["mode"] == "manual"
+    assert manager.calls[0][1]["depth"] == "light"
+
+
+def test_recall_standard_routes_graph_and_session_search(monkeypatch):
+    manager = DummyMemoryManager()
+
+    def fake_session_search(**kwargs):
+        return json.dumps({"success": True, "results": [{"summary": "session hit"}]})
+
+    monkeypatch.setattr("tools.session_search_tool.session_search", fake_session_search)
+    raw = recall(
+        "recall router",
+        depth="standard",
+        sources=["graph", "session_fts"],
+        budget="small",
+        limit=5,
+        memory_manager=manager,
+        db=object(),
+        current_session_id="s1",
+    )
+    data = json.loads(raw)
+
+    assert data["success"] is True
+    assert data["budget"] == "small"
+    assert data["sources"] == ["graph", "session_fts"]
+    assert data["results"]["graph"] == "graph memory hit"
+    assert data["results"]["sessions"]["results"][0]["summary"] == "session hit"
+    assert data["recall_key"]
+
+
+def test_recall_reports_missing_sources():
+    raw = recall("history", depth="deep", sources=["graph", "session_summary"])
+    data = json.loads(raw)
+
+    assert data["success"] is False
+    assert "graph source requested" in "\n".join(data["errors"])
+    assert "session source requested" in "\n".join(data["errors"])
+
+
+def test_recall_budget_clamps_session_limit(monkeypatch):
+    seen = {}
+
+    def fake_session_search(**kwargs):
+        seen.update(kwargs)
+        return json.dumps({"success": True, "results": []})
+
+    monkeypatch.setattr("tools.session_search_tool.session_search", fake_session_search)
+    raw = recall(
+        "history",
+        depth="deep",
+        sources=["session_summary"],
+        budget="tiny",
+        limit=5,
+        db=object(),
+    )
+    data = json.loads(raw)
+
+    assert data["success"] is True
+    assert seen["limit"] == 1

--- a/tools/recall_tool.py
+++ b/tools/recall_tool.py
@@ -1,0 +1,208 @@
+"""Unified recall tool for graph memory + session history.
+
+This is a routing layer, not a new memory store.  It lets the model ask for
+manual recall with explicit depth/source/budget/provenance while keeping the
+heavy parts opt-in.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, Iterable, List, Optional
+
+from agent.memory_router import stable_recall_key
+from tools.registry import registry, tool_error
+
+_DEPTH_ORDER = {"light": 1, "standard": 2, "deep": 3, "evidence": 4}
+_BUDGET_LIMITS = {"tiny": 1, "small": 2, "medium": 3, "large": 5}
+_VALID_SOURCES = {"graph", "session_fts", "session_summary"}
+
+
+def _as_list(value: Any) -> List[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [p.strip() for p in value.split(",") if p.strip()]
+    if isinstance(value, Iterable):
+        return [str(p).strip() for p in value if str(p).strip()]
+    return []
+
+
+def _normalize_depth(depth: str) -> str:
+    depth = (depth or "standard").strip().lower()
+    return depth if depth in _DEPTH_ORDER else "standard"
+
+
+def _normalize_budget(budget: str) -> str:
+    budget = (budget or "medium").strip().lower()
+    return budget if budget in _BUDGET_LIMITS else "medium"
+
+
+def _default_sources(depth: str, *, has_memory_manager: bool) -> List[str]:
+    sources: List[str] = []
+    if has_memory_manager:
+        sources.append("graph")
+    if _DEPTH_ORDER.get(depth, 2) >= _DEPTH_ORDER["standard"]:
+        sources.append("session_summary" if depth in {"deep", "evidence"} else "session_fts")
+    return sources or (["session_summary"] if depth in {"deep", "evidence"} else ["session_fts"])
+
+
+def recall(
+    query: str,
+    *,
+    mode: str = "manual",
+    depth: str = "standard",
+    sources: Optional[List[str]] = None,
+    budget: str = "medium",
+    provenance: str = "ids",
+    role_filter: Optional[str] = None,
+    limit: Optional[int] = None,
+    memory_manager=None,
+    db=None,
+    current_session_id: Optional[str] = None,
+) -> str:
+    """Route a recall request across provider memory and session history."""
+    query = (query or "").strip()
+    if not query:
+        return tool_error("recall requires a non-empty query", success=False)
+
+    depth = _normalize_depth(depth)
+    budget = _normalize_budget(budget)
+    mode = (mode or "manual").strip().lower()
+    provenance = (provenance or "ids").strip().lower()
+
+    normalized_sources = [s for s in _as_list(sources) if s in _VALID_SOURCES]
+    if not normalized_sources:
+        normalized_sources = _default_sources(depth, has_memory_manager=bool(memory_manager))
+
+    max_limit = _BUDGET_LIMITS[budget]
+    if limit is None:
+        limit = max_limit
+    try:
+        limit = int(limit)
+    except (TypeError, ValueError):
+        limit = max_limit
+    limit = max(1, min(limit, max_limit, 5))
+
+    results: Dict[str, Any] = {}
+    errors: List[str] = []
+
+    if "graph" in normalized_sources:
+        if memory_manager is None:
+            errors.append("graph source requested but no external memory provider is active")
+        else:
+            try:
+                graph_text = memory_manager.recall_now_all(
+                    query,
+                    mode=mode,
+                    depth=depth,
+                    sources=normalized_sources,
+                    budget=budget,
+                    provenance=provenance,
+                    session_id=current_session_id or "",
+                )
+                if graph_text and graph_text.strip():
+                    results["graph"] = graph_text
+                else:
+                    results["graph"] = ""
+            except Exception as exc:  # pragma: no cover - defensive fail-open
+                errors.append(f"graph recall failed: {exc}")
+
+    wants_session = any(s in normalized_sources for s in ("session_fts", "session_summary"))
+    if wants_session:
+        if db is None:
+            errors.append("session source requested but session database is not available")
+        else:
+            try:
+                from tools.session_search_tool import session_search
+
+                # session_search currently returns summaries for queried history.
+                # `session_fts` is treated as the standard, bounded session-history
+                # backend until a raw metadata-only backend lands.
+                raw = session_search(
+                    query=query,
+                    role_filter=role_filter,
+                    limit=limit,
+                    db=db,
+                    current_session_id=current_session_id,
+                )
+                try:
+                    results["sessions"] = json.loads(raw)
+                except Exception:
+                    results["sessions"] = raw
+            except Exception as exc:  # pragma: no cover - defensive fail-open
+                errors.append(f"session recall failed: {exc}")
+
+    recall_key = stable_recall_key(query, mode=mode, depth=depth, sources=normalized_sources)
+    return json.dumps(
+        {
+            "success": bool(results) and not (errors and not results),
+            "query": query,
+            "mode": mode,
+            "depth": depth,
+            "sources": normalized_sources,
+            "budget": budget,
+            "provenance": provenance,
+            "recall_key": recall_key,
+            "results": results,
+            "errors": errors,
+        },
+        ensure_ascii=False,
+    )
+
+
+def check_recall_requirements() -> bool:
+    # run_agent injects db/memory_manager at call time; exposing the tool is safe
+    # whenever the session_search toolset is enabled.
+    return True
+
+
+RECALL_SCHEMA = {
+    "name": "recall",
+    "description": (
+        "Unified explicit recall across external memory providers and past sessions. "
+        "Use when you need more context than the automatic lightweight memory prefetch provided. "
+        "Choose depth='light' for graph/background facts, 'standard' for graph + bounded session hits, "
+        "'deep' for session_search-style historical summaries, and 'evidence' when the user asks for source/provenance. "
+        "Manual recall is never duplicate-suppressed; it also marks the recall key so automatic recall does not immediately repeat it."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string", "description": "Recall query. Use OR between keywords for broad session history search."},
+            "mode": {"type": "string", "enum": ["manual", "user", "auto"], "default": "manual"},
+            "depth": {"type": "string", "enum": ["light", "standard", "deep", "evidence"], "default": "standard"},
+            "sources": {
+                "type": "array",
+                "items": {"type": "string", "enum": ["graph", "session_fts", "session_summary"]},
+                "description": "Sources to query. Omit for depth-based defaults.",
+            },
+            "budget": {"type": "string", "enum": ["tiny", "small", "medium", "large"], "default": "medium"},
+            "provenance": {"type": "string", "enum": ["none", "ids", "links", "verbatim"], "default": "ids"},
+            "role_filter": {"type": "string", "description": "Optional session role filter, e.g. 'user,assistant'."},
+            "limit": {"type": "integer", "description": "Max session results; clamped by budget and hard-capped at 5."},
+        },
+        "required": ["query"],
+    },
+}
+
+
+registry.register(
+    name="recall",
+    toolset="session_search",
+    schema=RECALL_SCHEMA,
+    handler=lambda args, **kw: recall(
+        query=args.get("query") or "",
+        mode=args.get("mode", "manual"),
+        depth=args.get("depth", "standard"),
+        sources=args.get("sources"),
+        budget=args.get("budget", "medium"),
+        provenance=args.get("provenance", "ids"),
+        role_filter=args.get("role_filter"),
+        limit=args.get("limit"),
+        db=kw.get("db"),
+        current_session_id=kw.get("current_session_id"),
+    ),
+    check_fn=check_recall_requirements,
+    emoji="🧠",
+)

--- a/tools/recall_tool.py
+++ b/tools/recall_tool.py
@@ -127,16 +127,20 @@ def recall(
                     current_session_id=current_session_id,
                 )
                 try:
-                    results["sessions"] = json.loads(raw)
+                    session_payload = json.loads(raw)
+                    results["sessions"] = session_payload
+                    if isinstance(session_payload, dict) and session_payload.get("success") is False:
+                        errors.append("session recall returned unsuccessful result")
                 except Exception:
                     results["sessions"] = raw
             except Exception as exc:  # pragma: no cover - defensive fail-open
                 errors.append(f"session recall failed: {exc}")
 
     recall_key = stable_recall_key(query, mode=mode, depth=depth, sources=normalized_sources)
+    auto_recall_key = stable_recall_key(query, mode="auto", depth=depth, sources=normalized_sources)
     return json.dumps(
         {
-            "success": bool(results) and not (errors and not results),
+            "success": bool(results) and not errors,
             "query": query,
             "mode": mode,
             "depth": depth,
@@ -144,6 +148,7 @@ def recall(
             "budget": budget,
             "provenance": provenance,
             "recall_key": recall_key,
+            "auto_recall_key": auto_recall_key,
             "results": results,
             "errors": errors,
         },
@@ -152,9 +157,16 @@ def recall(
 
 
 def check_recall_requirements() -> bool:
-    # run_agent injects db/memory_manager at call time; exposing the tool is safe
-    # whenever the session_search toolset is enabled.
-    return True
+    # Keep the session_search toolset availability aligned with the concrete
+    # session_search backend.  recall can still use graph-only paths at runtime
+    # through AIAgent's special dispatch, but its public tool schema lives in
+    # the session_search toolset and should not make that toolset appear
+    # available earlier than session_search itself.
+    try:
+        from tools.session_search_tool import check_session_search_requirements
+        return check_session_search_requirements()
+    except Exception:
+        return False
 
 
 RECALL_SCHEMA = {
@@ -200,6 +212,7 @@ registry.register(
         provenance=args.get("provenance", "ids"),
         role_filter=args.get("role_filter"),
         limit=args.get("limit"),
+        memory_manager=kw.get("memory_manager"),
         db=kw.get("db"),
         current_session_id=kw.get("current_session_id"),
     ),


### PR DESCRIPTION
## Summary

Harden the lightweight recall router and unified recall tool integration so automatic and manual recall behave consistently and privacy-preservingly.

## Changes

- Add lightweight recall routing for bounded memory/session recall decisions.
- Route auto decisions that request `session_fts` / `session_summary` through unified `recall(...)`.
- Add `auto_recall_key` so manual recall suppresses equivalent auto recall in the TTL window.
- Hash sensitive platform/session metadata before optional LLM recall gating.
- Default the recall router to privacy-preserving `heuristic` strategy.
- Surface nested session-search failures as top-level recall failures.
- Cap oversized gate context inputs, including `current_message`.

## Validation

- `python -m pytest tests/agent/test_memory_router.py tests/tools/test_recall_tool.py tests/run_agent/test_run_agent.py::TestMemoryProviderTurnStart -q -o 'addopts='`
- memory-related suite: `248 passed`
- `python -m py_compile ...`
- `git diff --check main...HEAD`
- Security scan on diff: no hardcoded secrets / shell injection / eval-exec / unsafe pickle / SQL injection patterns found.
