### PR TITLE
fix(image-gen): preserve codex reference image generation patch

### DIFF
--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -20,7 +20,10 @@ Output is saved as PNG under ``$HERMES_HOME/cache/images/``.
 from __future__ import annotations
 
 import logging
-from typing import Any, Dict, List, Optional, Tuple
+import base64
+import mimetypes
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 
 from agent.image_gen_provider import (
     DEFAULT_ASPECT_RATIO,
@@ -161,9 +164,57 @@ def _build_codex_client():
         return None
 
 
-def _collect_image_b64(client: Any, *, prompt: str, size: str, quality: str) -> Optional[str]:
+def _image_ref_to_input_item(reference: str) -> Dict[str, str]:
+    """Convert a local path or URL into a Responses ``input_image`` item."""
+    ref = str(reference or "").strip()
+    if not ref:
+        raise ValueError("reference_images entries must be non-empty strings")
+
+    if ref.startswith(("http://", "https://", "data:image/")):
+        image_url = ref
+    else:
+        path = Path(ref).expanduser()
+        if not path.exists() or not path.is_file():
+            raise ValueError(f"Reference image not found: {ref}")
+        mime = mimetypes.guess_type(path.name)[0] or "image/png"
+        encoded = base64.b64encode(path.read_bytes()).decode("ascii")
+        image_url = f"data:{mime};base64,{encoded}"
+
+    return {"type": "input_image", "image_url": image_url}
+
+
+def _build_input_content(prompt: str, reference_images: Optional[Sequence[str]]) -> List[Dict[str, str]]:
+    content: List[Dict[str, str]] = [{"type": "input_text", "text": prompt}]
+    refs = list(reference_images or [])
+    if len(refs) > 16:
+        raise ValueError("gpt-image reference-image workflows support at most 16 images")
+    content.extend(_image_ref_to_input_item(ref) for ref in refs)
+    return content
+
+
+def _collect_image_b64(
+    client: Any,
+    *,
+    prompt: str,
+    size: str,
+    quality: str,
+    reference_images: Optional[Sequence[str]] = None,
+) -> Optional[str]:
     """Stream a Codex Responses image_generation call and return the b64 image."""
     image_b64: Optional[str] = None
+
+    input_content = _build_input_content(prompt, reference_images)
+    tool: Dict[str, Any] = {
+        "type": "image_generation",
+        "model": API_MODEL,
+        "size": size,
+        "quality": quality,
+        "output_format": "png",
+        "background": "opaque",
+        "partial_images": 1,
+    }
+    if reference_images:
+        tool["action"] = "edit"
 
     with client.responses.stream(
         model=_CODEX_CHAT_MODEL,
@@ -172,17 +223,9 @@ def _collect_image_b64(client: Any, *, prompt: str, size: str, quality: str) -> 
         input=[{
             "type": "message",
             "role": "user",
-            "content": [{"type": "input_text", "text": prompt}],
+            "content": input_content,
         }],
-        tools=[{
-            "type": "image_generation",
-            "model": API_MODEL,
-            "size": size,
-            "quality": quality,
-            "output_format": "png",
-            "background": "opaque",
-            "partial_images": 1,
-        }],
+        tools=[tool],
         tool_choice={
             "type": "allowed_tools",
             "mode": "required",
@@ -306,6 +349,7 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
 
         tier_id, meta = _resolve_model()
         size = _SIZES.get(aspect, _SIZES["square"])
+        reference_images = kwargs.get("reference_images")
 
         client = _build_codex_client()
         if client is None:
@@ -324,6 +368,7 @@ class OpenAICodexImageGenProvider(ImageGenProvider):
                 prompt=prompt,
                 size=size,
                 quality=meta["quality"],
+                reference_images=reference_images,
             )
         except Exception as exc:
             logger.debug("Codex image generation failed", exc_info=True)

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -8,6 +8,7 @@ endpoint.
 
 from __future__ import annotations
 
+import base64
 import importlib
 from pathlib import Path
 from types import SimpleNamespace
@@ -198,6 +199,51 @@ class TestGenerate:
         assert tool["output_format"] == "png"
         assert tool["background"] == "opaque"
         assert tool["partial_images"] == 1
+
+    def test_reference_images_are_sent_as_input_images_and_force_edit_action(self, provider, monkeypatch, tmp_path):
+        monkeypatch.setattr(codex_plugin, "_read_codex_access_token", lambda: "codex-token")
+
+        ref_path = tmp_path / "ref.png"
+        ref_path.write_bytes(bytes.fromhex(_PNG_HEX))
+
+        captured = {}
+
+        def _stream(**kwargs):
+            captured.update(kwargs)
+            output_item = SimpleNamespace(
+                type="image_generation_call",
+                status="generating",
+                id="ig_test",
+                result=_b64_png(),
+            )
+            done_event = SimpleNamespace(type="response.output_item.done", item=output_item)
+            final_response = SimpleNamespace(output=[], status="completed", output_text="")
+            return _FakeStream([done_event], final_response)
+
+        fake_client = SimpleNamespace(responses=SimpleNamespace(stream=_stream))
+        monkeypatch.setattr(codex_plugin, "_build_codex_client", lambda: fake_client)
+
+        result = provider.generate(
+            "turn the same person into a Dali travel photo",
+            aspect_ratio="landscape",
+            reference_images=[str(ref_path)],
+        )
+
+        assert result["success"] is True
+
+        content = captured["input"][0]["content"]
+        assert content[0] == {
+            "type": "input_text",
+            "text": "turn the same person into a Dali travel photo",
+        }
+        assert content[1]["type"] == "input_image"
+        assert content[1]["image_url"].startswith("data:image/png;base64,")
+        encoded = content[1]["image_url"].split(",", 1)[1]
+        assert base64.b64decode(encoded) == ref_path.read_bytes()
+
+        tool = captured["tools"][0]
+        assert tool["type"] == "image_generation"
+        assert tool["action"] == "edit"
 
     def test_partial_image_event_used_when_done_missing(self, provider, monkeypatch):
         """If the stream never emits output_item.done, fall back to the

--- a/tests/tools/test_image_generation.py
+++ b/tests/tools/test_image_generation.py
@@ -363,11 +363,14 @@ class TestAspectRatioNormalization:
 
 class TestRegistryIntegration:
 
-    def test_schema_exposes_only_prompt_and_aspect_ratio_to_agent(self, image_tool):
+    def test_schema_exposes_prompt_aspect_ratio_and_reference_images_to_agent(self, image_tool):
         """The agent-facing schema must stay tight — model selection is a
-        user-level config choice, not an agent-level arg."""
+        user-level config choice, but reference-image workflows need a small
+        explicit input-image surface."""
         props = image_tool.IMAGE_GENERATE_SCHEMA["parameters"]["properties"]
-        assert set(props.keys()) == {"prompt", "aspect_ratio"}
+        assert set(props.keys()) == {"prompt", "aspect_ratio", "reference_images"}
+        assert props["reference_images"]["type"] == "array"
+        assert props["reference_images"]["items"]["type"] == "string"
 
     def test_aspect_ratio_enum_is_three_values(self, image_tool):
         enum = image_tool.IMAGE_GENERATE_SCHEMA["parameters"]["properties"]["aspect_ratio"]["enum"]

--- a/tests/tools/test_image_generation_plugin_dispatch.py
+++ b/tests/tools/test_image_generation_plugin_dispatch.py
@@ -15,11 +15,14 @@ def _reset_registry():
 
 
 class _FakeCodexProvider(ImageGenProvider):
+    last_kwargs = None
+
     @property
     def name(self) -> str:
         return "codex"
 
     def generate(self, prompt, aspect_ratio="landscape", **kwargs):
+        type(self).last_kwargs = kwargs
         return {
             "success": True,
             "image": "/tmp/codex-test.png",
@@ -51,6 +54,30 @@ class TestPluginDispatch:
         assert payload["provider"] == "codex"
         assert payload["image"] == "/tmp/codex-test.png"
         assert payload["aspect_ratio"] == "square"
+
+    def test_dispatch_forwards_reference_images_to_provider(self, monkeypatch, tmp_path):
+        from tools import image_generation_tool
+        from agent import image_gen_registry as registry_module
+        from hermes_cli import plugins as plugins_module
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        (tmp_path / "config.yaml").write_text("image_gen:\n  provider: codex\n")
+
+        provider = _FakeCodexProvider()
+        _FakeCodexProvider.last_kwargs = None
+        monkeypatch.setattr(image_generation_tool, "_read_configured_image_provider", lambda: "codex")
+        monkeypatch.setattr(plugins_module, "_ensure_plugins_discovered", lambda: None)
+        monkeypatch.setattr(registry_module, "get_provider", lambda name: provider if name == "codex" else None)
+
+        dispatched = image_generation_tool._dispatch_to_plugin_provider(
+            "draw cat",
+            "square",
+            reference_images=["/tmp/ref.png"],
+        )
+        payload = json.loads(dispatched)
+
+        assert payload["success"] is True
+        assert _FakeCodexProvider.last_kwargs == {"reference_images": ["/tmp/ref.png"]}
 
     def test_dispatch_reports_missing_registered_provider(self, monkeypatch, tmp_path):
         from tools import image_generation_tool

--- a/tools/image_generation_tool.py
+++ b/tools/image_generation_tool.py
@@ -623,6 +623,7 @@ def image_generate_tool(
     num_images: Optional[int] = None,
     output_format: Optional[str] = None,
     seed: Optional[int] = None,
+    reference_images: Optional[list[str]] = None,
 ) -> str:
     """Generate an image from a text prompt using the configured FAL model.
 
@@ -646,6 +647,7 @@ def image_generate_tool(
             "num_images": num_images,
             "output_format": output_format,
             "seed": seed,
+            "reference_images": reference_images,
         },
         "error": None,
         "success": False,
@@ -682,6 +684,12 @@ def image_generate_tool(
             overrides["num_images"] = num_images
         if output_format is not None:
             overrides["output_format"] = output_format
+
+        if reference_images:
+            raise ValueError(
+                "reference_images are only supported by image_gen plugin providers "
+                "such as openai-codex; the legacy FAL path cannot edit references"
+            )
 
         arguments = _build_fal_payload(
             model_id, prompt, aspect_lc, seed=seed, overrides=overrides,
@@ -873,6 +881,14 @@ IMAGE_GENERATE_SCHEMA = {
                 "description": "The aspect ratio of the generated image. 'landscape' is 16:9 wide, 'portrait' is 16:9 tall, 'square' is 1:1.",
                 "default": DEFAULT_ASPECT_RATIO,
             },
+            "reference_images": {
+                "type": "array",
+                "items": {"type": "string"},
+                "description": (
+                    "Optional local file paths, HTTP(S) URLs, or data URLs to use as "
+                    "reference/input images when the configured backend supports image editing."
+                ),
+            },
         },
         "required": ["prompt"],
     },
@@ -915,7 +931,7 @@ def _read_configured_image_provider():
     return None
 
 
-def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
+def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str, **kwargs):
     """Route the call to a plugin-registered provider when one is selected.
 
     Returns a JSON string on dispatch, or ``None`` to fall through to the
@@ -968,10 +984,10 @@ def _dispatch_to_plugin_provider(prompt: str, aspect_ratio: str):
         })
 
     try:
-        kwargs = {"prompt": prompt, "aspect_ratio": aspect_ratio}
+        call_kwargs = {"prompt": prompt, "aspect_ratio": aspect_ratio, **kwargs}
         if configured_model:
-            kwargs["model"] = configured_model
-        result = provider.generate(**kwargs)
+            call_kwargs["model"] = configured_model
+        result = provider.generate(**call_kwargs)
     except Exception as exc:
         logger.warning(
             "Image gen provider '%s' raised: %s",
@@ -998,16 +1014,22 @@ def _handle_image_generate(args, **kw):
     if not prompt:
         return tool_error("prompt is required for image generation")
     aspect_ratio = args.get("aspect_ratio", DEFAULT_ASPECT_RATIO)
+    reference_images = args.get("reference_images")
 
     # Route to a plugin-registered provider if one is active (and it's
     # not the in-tree FAL path).
-    dispatched = _dispatch_to_plugin_provider(prompt, aspect_ratio)
+    dispatched = _dispatch_to_plugin_provider(
+        prompt,
+        aspect_ratio,
+        reference_images=reference_images,
+    )
     if dispatched is not None:
         return dispatched
 
     return image_generate_tool(
         prompt=prompt,
         aspect_ratio=aspect_ratio,
+        reference_images=reference_images,
     )
 
 


### PR DESCRIPTION
## Summary

Preserve the codex reference-image generation path and associated plugin dispatch regression coverage.

## Changes

- Keep codex reference-image generation inputs wired through the plugin dispatch path.
- Preserve model propagation for the selected image provider.
- Add regression tests for the codex provider and image generation dispatch.

## Validation

- `python -m pytest tests/plugins/image_gen/test_openai_codex_provider.py tests/tools/test_image_generation.py tests/tools/test_image_generation_plugin_dispatch.py -q -o 'addopts='`
  - `78 passed`
