### PR TITLE
fix(cron): drop None entries from list-form deliver in scheduler

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -356,7 +356,11 @@ def _normalize_deliver_value(deliver) -> str:
     if deliver is None or deliver == "":
         return "local"
     if isinstance(deliver, (list, tuple)):
-        parts = [str(p).strip() for p in deliver if str(p).strip()]
+        parts = [
+            str(p).strip()
+            for p in deliver
+            if p is not None and str(p).strip()
+        ]
         return ",".join(parts) if parts else "local"
     return str(deliver)
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -350,6 +350,28 @@ class TestResolveDeliveryTarget:
 
         assert _resolve_delivery_targets({"deliver": []}) == []
 
+    def test_list_form_with_none_entries_drops_none(self, monkeypatch):
+        """deliver=[None, 'telegram'] must resolve to telegram only.
+
+        ``str(None) == "None"`` is truthy, so a naive ``[str(p).strip() for p
+        in deliver if str(p).strip()]`` filter would join the literal string
+        ``"None"`` into the canonical deliver value (``"None,telegram"``).
+        Downstream then attempts to resolve a platform literally named
+        ``"None"`` and silently fails.  Mirrors the API-boundary fix in
+        ``tools/cronjob_tools._normalize_deliver_param`` (#22521) — defense in
+        depth for jobs persisted before that fix landed or hand-edited
+        jobs.json files.
+        """
+        from cron.scheduler import _resolve_delivery_targets, _normalize_deliver_value
+
+        assert _normalize_deliver_value([None, "telegram"]) == "telegram"
+        assert _normalize_deliver_value([None, None]) == "local"
+        assert _normalize_deliver_value(["telegram", None, "discord"]) == "telegram,discord"
+
+        monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "-9001")
+        targets = _resolve_delivery_targets({"deliver": [None, "telegram"], "origin": None})
+        assert [t["platform"] for t in targets] == ["telegram"]
+
 
 class TestRoutingIntents:
     """``all`` routing intent expands at fire time."""


### PR DESCRIPTION
## What does this PR do?

`cron.scheduler._normalize_deliver_value` normalizes list/tuple `deliver` values into a comma-separated string using:

## Root cause

`cron.scheduler._normalize_deliver_value` normalizes list/tuple `deliver` values into a comma-separated string using:

```python
parts = [str(p).strip() for p in deliver if str(p).strip()]
```

`str(None) == "None"` is truthy, so `None` entries survive the filter. A job with `deliver=[None, "telegram"]` produces the canonical string `"None,telegram"`. The scheduler then passes the literal `"None"` to `_resolve_single_delivery_target`, which silently fails — delivery is silently dropped for that slot.

This fires on any job whose `deliver` field was persisted as a list containing `None`: legacy jobs written before the API-boundary fix (#22521), hand-edited `jobs.json`, or callers that…

## Fix

```diff
-        parts = [str(p).strip() for p in deliver if str(p).strip()]
+        parts = [
+            str(p).strip()
+            for p in deliver
+            if p is not None and str(p).strip()
+        ]
```

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

N/A

<details>
<summary>Original body</summary>

## Summary

`cron.scheduler._normalize_deliver_value` normalizes list/tuple `deliver` values into a comma-separated string using:

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Problem

`cron.scheduler._normalize_deliver_value` normalizes list/tuple `deliver` values into a comma-separated string using:

```python
parts = [str(p).strip() for p in deliver if str(p).strip()]
```

`str(None) == "None"` is truthy, so `None` entries survive the filter. A job with `deliver=[None, "telegram"]` produces the canonical string `"None,telegram"`. The scheduler then passes the literal `"None"` to `_resolve_single_delivery_target`, which silently fails — delivery is silently dropped for that slot.

This fires on any job whose `deliver` field was persisted as a list containing `None`: legacy jobs written before the API-boundary fix (#22521), hand-edited `jobs.json`, or callers that bypassed `_normalize_deliver_param`.

## Root cause

Missing `p is not None` guard in the list comprehension inside `_normalize_deliver_value` — same pattern as the bug fixed at the API boundary in `tools/cronjob_tools._normalize_deliver_param` (#22521). Defense-in-depth: the scheduler should tolerate stale/corrupted persisted data independently of the API layer.

## Fix

```diff
-        parts = [str(p).strip() for p in deliver if str(p).strip()]
+        parts = [
+            str(p).strip()
+            for p in deliver
+            if p is not None and str(p).strip()
+        ]
```

## Tests

`TestResolveDeliveryTarget::test_list_form_with_none_entries_drops_none` covers:
- `_normalize_deliver_value([None, "telegram"]) == "telegram"`
- `_normalize_deliver_value([None, None]) == "local"`
- `_normalize_deliver_value(["telegram", None, "discord"]) == "telegram,discord"`
- End-to-end: `_resolve_delivery_targets({"deliver": [None, "telegram"]})` → only telegram target returned

All assertions fail on `main` (`'None,telegram' == 'telegram'`), pass with fix. Broader regression: 366 passed (`tests/cron/` + `tests/tools/test_cronjob_tools.py`).

## Companion PRs (same bug class)

- API boundary: #22521 (`tools/cronjob_tools._normalize_deliver_param`)
- Skill utils: #22537 (`agent/skill_utils._normalize_string_set`)

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_