### PR TITLE
fix(session_search): use original session ID for content retrieval

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -560,3 +560,82 @@ class TestSessionSearch:
         assert entry["source"] == "api_server", (
             f"source should be parent's 'api_server', got {entry['source']!r}"
         )
+
+    def test_content_fetched_from_child_when_match_came_from_child(self):
+        """Regression for #22150: when FTS5 hits a delegation/compression child
+        session, content for summarization must come from that child — not the
+        resolved parent — because the matched text only lives in the child.
+        """
+        from unittest.mock import MagicMock, AsyncMock, patch as _patch
+        from tools.session_search_tool import session_search
+
+        mock_db = MagicMock()
+        mock_db.search_messages.return_value = [
+            {
+                "session_id": "child_sid",
+                "content": "discussion about headless-chatgpt setup",
+                "source": "cli",
+                "session_started": 1709400000,
+                "model": "gpt-4o-mini",
+            },
+        ]
+
+        def _get_session(session_id):
+            if session_id == "child_sid":
+                return {
+                    "id": "child_sid",
+                    "parent_session_id": "parent_sid",
+                    "source": "cli",
+                    "started_at": 1709400000,
+                    "model": "gpt-4o-mini",
+                }
+            if session_id == "parent_sid":
+                return {
+                    "id": "parent_sid",
+                    "parent_session_id": None,
+                    "source": "cli",
+                    "started_at": 1709300000,
+                    "model": "gpt-4o-mini",
+                }
+            return None
+
+        mock_db.get_session.side_effect = _get_session
+
+        def _messages_for(sid):
+            if sid == "child_sid":
+                return [
+                    {"role": "user", "content": "let's set up headless-chatgpt"},
+                    {"role": "assistant", "content": "ok, here's how"},
+                ]
+            if sid == "parent_sid":
+                return [
+                    {"role": "user", "content": "delegated a task"},
+                    {"role": "assistant", "content": "result delivered"},
+                ]
+            return []
+
+        mock_db.get_messages_as_conversation.side_effect = _messages_for
+
+        with _patch(
+            "tools.session_search_tool.async_call_llm",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("no provider"),
+        ):
+            result = json.loads(
+                session_search(query="headless-chatgpt", db=mock_db)
+            )
+
+        called_sids = [c.args[0] for c in mock_db.get_messages_as_conversation.call_args_list]
+        assert "child_sid" in called_sids, (
+            f"content retrieval must use the child session where the match lives, "
+            f"got calls for: {called_sids}"
+        )
+        assert "parent_sid" not in called_sids, (
+            f"content retrieval must NOT fetch parent's messages, got calls for: {called_sids}"
+        )
+
+        assert result["success"] is True
+        assert result["count"] == 1
+        entry = result["results"][0]
+        assert entry["session_id"] == "parent_sid"
+        assert "headless-chatgpt" in entry["summary"]

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -427,7 +427,14 @@ def session_search(
                 continue
             if resolved_sid not in seen_sessions:
                 result = dict(result)
+                # Surface the resolved parent ID for display/dedup so callers
+                # see the canonical conversation, but remember the child where
+                # the FTS5 hit actually lives for content retrieval. Without
+                # this, get_messages_as_conversation() below would fetch the
+                # parent's messages — which often don't contain the matched
+                # text when the hit comes from a delegation/compression child.
                 result["session_id"] = resolved_sid
+                result["content_session_id"] = raw_sid
                 seen_sessions[resolved_sid] = result
             if len(seen_sessions) >= limit:
                 break
@@ -436,7 +443,8 @@ def session_search(
         tasks = []
         for session_id, match_info in seen_sessions.items():
             try:
-                messages = db.get_messages_as_conversation(session_id)
+                content_sid = match_info.get("content_session_id", session_id)
+                messages = db.get_messages_as_conversation(content_sid)
                 if not messages:
                     continue
                 session_meta = db.get_session(session_id) or {}


### PR DESCRIPTION
## Summary

- When FTS5 matches a child (delegation/compression) session, `_resolve_to_parent` returns the canonical parent ID for display. The old code then called `get_messages_as_conversation(parent_id)`, fetching messages from the parent — which often doesn't contain the matched text.
- Fix introduces an internal `content_session_id` field set to the raw child session ID. Content retrieval now uses `content_session_id` while `session_id` still surfaces the parent for dedup/display.
- Adds regression test (`test_content_fetched_from_child_when_match_came_from_child`) that fails without the fix and passes with it.

## Test plan

- [x] `stash-verify` confirmed: test fails without fix, passes with fix
- [x] `scripts/run_tests.sh tests/tools/test_session_search.py` → 39 passed
- [x] Existing tests for parent-sid display (`test_source_from_resolved_parent_not_fts5_child`) still pass

Closes #22150