### PR TITLE
RAN-1381: add sample revenue deliverables

### DIFF
--- a/docs/revenue-lab/samples/README.md
+++ b/docs/revenue-lab/samples/README.md
@@ -1,0 +1,28 @@
+# First Revenue Offer Sample Deliverables
+
+Issue: RAN-1381  
+Prepared: 2026-05-09  
+Owner: Hermes
+
+These are reusable, public/anonymized sample deliverables Ryan can show before applying or posting for first revenue work. They are intentionally written for a generic local home-services buyer so they can be adapted to HVAC, plumbing, roofing, cleaning, landscaping, dental, med spa, church/nonprofit, or franchise-style niches.
+
+Rules followed:
+
+- Public/sample/anonymized data only.
+- No Life Church confidential data.
+- No client-specific claims without source notes.
+- Each sample includes a buyer deliverable, timeline, and price option.
+
+Files:
+
+1. `market-research-brief-local-home-services.md` — sample market brief for a local HVAC/plumbing-style buyer.
+2. `competitor-analysis-one-pager-local-home-services.md` — sample one-page competitive teardown.
+3. `kpi-dashboard-analysis-sample.md` + `kpi-dashboard-sample-data.csv` — spreadsheet-style KPI sample with formulas and action notes.
+4. `website-audit-snapshot-sample.md` — quick website audit snapshot Ryan can show as a paid discovery deliverable.
+
+Suggested review path for Ryan:
+
+- Skim each sample as if he were a buyer.
+- Decide whether the language feels credible enough to attach to proposals.
+- Choose one niche to customize first.
+- Replace the placeholder brand names and synthetic KPI rows with a real prospect's public information before sending externally.

--- a/docs/revenue-lab/samples/competitor-analysis-one-pager-local-home-services.md
+++ b/docs/revenue-lab/samples/competitor-analysis-one-pager-local-home-services.md
@@ -1,0 +1,74 @@
+# Sample 2 — Competitor Analysis One-Pager
+
+Buyer-facing title: Local Home-Services Competitor Snapshot  
+Sample niche: Residential HVAC / plumbing / mechanical contractor  
+Prepared: 2026-05-09  
+Data status: Public/sample/anonymized; example competitors are archetypes drawn from publicly visible positioning patterns
+
+## Direct answer
+
+A local operator should not try to outspend every franchise, aggregator, and dealer network. The more realistic wedge is to look more trustworthy, more local, and easier to contact on the exact service pages that convert high-intent homeowners.
+
+## Competitive map
+
+| Competitor archetype | Public positioning pattern | Strength | Likely weakness | Counter-position for local buyer |
+|---|---|---|---|---|
+| National franchise HVAC brand | Broad HVAC service, recognizable brand, scheduling convenience | Trust, brand recall, call-center process | May feel less locally personal; messaging can be generic | "Local technicians, named owner, fast response, transparent next step" |
+| Neighborly-style service network | Multi-location service brand with cross-sell ecosystem | Established operating playbook and professional design | Can feel templated across markets | Local proof, neighborhood pages, real project photos |
+| Equipment dealer locator / manufacturer network | Brand-backed dealer credibility | Trust from equipment brand | May rank around equipment but not all urgent service needs | Service-line pages for repair, maintenance, replacement, and financing |
+| Lead aggregator / directory | Reviews, listicles, quote matching | Captures comparison traffic | Buyer may lose margin and relationship control | Build own comparison page and direct booking path |
+| Small independent local shop | Owner-led, local reputation | Authentic and nimble | Website, tracking, and offers often underbuilt | Win on clarity, speed, proof, and follow-up automation |
+
+## Messaging gaps to look for
+
+1. Homepage headline says what the company does, but not why a homeowner should call today.
+2. Emergency service exists, but response expectations are vague.
+3. Reviews are present but not tied to the specific service line.
+4. Financing or maintenance plan is buried.
+5. Service-area pages are thin or duplicated.
+6. Contact forms ask too much before a homeowner gets reassurance.
+7. No visible owner/team credibility.
+8. No clear next step for replacement estimates versus repair calls.
+
+## Suggested one-page buyer recommendations
+
+- Create one clear promise above the fold: service category + location + response expectation + proof.
+- Split service pages by intent: emergency repair, seasonal maintenance, replacement estimate, financing, and service area.
+- Put reviews and proof near CTAs, not only on a separate testimonials page.
+- Add a "What happens after you call" block to reduce friction.
+- Add a maintenance-plan CTA that creates recurring revenue and off-season demand.
+- Track every form/call by source in a simple dashboard before buying more traffic.
+
+## Buyer deliverable
+
+A one-page PDF or Google Doc containing:
+
+- 5-8 competitor/archetype rows.
+- Screenshots or public notes for each competitor.
+- Positioning gap summary.
+- 3 recommended offer tests.
+- 5 copy/CTA fixes the buyer can implement this week.
+
+## Timeline
+
+2 business days for a public-web version. 3-4 business days if including screenshots, review snippets, local map pack notes, and buyer approval language.
+
+## Price option
+
+- One-page competitor snapshot: $350 fixed.
+- Competitor snapshot + annotated screenshots: $600 fixed.
+- Competitor snapshot + rewrite recommendations for homepage/service pages: $950 fixed.
+
+## Source notes
+
+Public pages checked as examples of positioning categories:
+
+- One Hour Heating & Air Conditioning homepage returned public title: "Expert HVAC Near Me | One Hour Heating & Air Conditioning®".
+- Aire Serv homepage was reachable as a public HVAC service network page.
+- Trane residential dealer page returned public title: "Trane® - Dealers".
+- Google Search Central SEO Starter Guide for public guidance on useful, discoverable site content: https://developers.google.com/search/docs/fundamentals/seo-starter-guide
+- SBA market research and competitive analysis guide: https://www.sba.gov/business-guide/plan-your-business/market-research-competitive-analysis
+
+## Caveat
+
+This sample does not name or criticize a real local business. For a paid client version, Ryan can replace the archetypes with actual public competitors and include dated screenshots with source URLs.

--- a/docs/revenue-lab/samples/kpi-dashboard-analysis-sample.md
+++ b/docs/revenue-lab/samples/kpi-dashboard-analysis-sample.md
@@ -1,0 +1,88 @@
+# Sample 3 — KPI / Dashboard Analysis Sample
+
+Buyer-facing title: Local Service Business KPI Snapshot  
+Sample niche: Residential HVAC / plumbing / mechanical contractor  
+Prepared: 2026-05-09  
+Data status: Synthetic/anonymized sample data; no Life Church or client data
+
+Companion spreadsheet-style file: `kpi-dashboard-sample-data.csv`
+
+## Executive summary
+
+This sample shows how Ryan can turn a small business owner's rough monthly numbers into a decision dashboard. The important shift is from "we got leads" to "which channel produced profitable booked jobs, and where are we leaking response time or conversion?"
+
+Using the sample three-month dataset:
+
+- Total leads: 382
+- Total booked jobs: 168
+- Overall booking rate: 44.0%
+- Total revenue: $365,400
+- Total tracked marketing spend: $9,100
+- Revenue per booked job: $2,175
+- Paid-search ROAS: 11.9x revenue/spend
+- Referral/repeat produced the highest booking rate at 70.4%
+- Social/local posts produced the lowest booking rate at 26.7% and slowest response times
+
+## Dashboard view
+
+| Channel | Leads | Booked jobs | Booking rate | Revenue | Spend | Revenue / lead | Revenue / booked job | Avg response |
+|---|---:|---:|---:|---:|---:|---:|---:|---:|
+| Organic search | 144 | 61 | 42.4% | $133,700 | $0 | $928 | $2,192 | 58 min |
+| Paid search | 112 | 38 | 33.9% | $97,500 | $8,200 | $871 | $2,566 | 50 min |
+| Referral/repeat | 81 | 57 | 70.4% | $112,200 | $0 | $1,386 | $1,968 | 31 min |
+| Social/local posts | 45 | 12 | 26.7% | $22,000 | $900 | $489 | $1,833 | 107 min |
+| Total | 382 | 168 | 44.0% | $365,400 | $9,100 | $957 | $2,175 | 61 min |
+
+## Formula examples
+
+Use these in Google Sheets or Excel:
+
+- Booking rate: `=booked_jobs / leads`
+- Revenue per lead: `=revenue / leads`
+- Revenue per booked job: `=revenue / booked_jobs`
+- ROAS: `=revenue / marketing_spend`
+- Response-time flag: `=IF(avg_response_minutes>60,"At risk","OK")`
+- Channel priority score: `(Revenue per lead * Booking rate) - Spend per lead`, normalized by owner capacity
+
+## What the buyer should notice
+
+1. Referral/repeat leads convert far better than cold channels. A simple maintenance-plan or review-referral campaign may be more profitable than buying more ads.
+2. Paid search is not automatically bad. The sample paid-search rows show strong revenue per booked job, but the booking rate trails organic and referral channels.
+3. Social/local posts are not worthless, but they need a different goal: trust-building, seasonal education, recruiting, and retargeting rather than immediate booked jobs.
+4. Response time matters. Channels with slower follow-up often look worse than they are because the operational handoff leaks value.
+5. The dashboard is small enough for an owner to use weekly.
+
+## Recommended next actions
+
+| Priority | Action | Why |
+|---|---|---|
+| 1 | Add source/channel to every call form and intake note | Attribution before more spend |
+| 2 | Call back all web leads in under 15 minutes during business hours | Improve conversion without increasing traffic |
+| 3 | Build a referral/repeat campaign around maintenance and seasonal checkups | Highest sample booking rate |
+| 4 | Split paid search by repair vs replacement intent | Find the high-ticket campaigns |
+| 5 | Review social content goals | Stop judging awareness content only by booked jobs |
+
+## Buyer deliverable
+
+A Google Sheet or Excel workbook with:
+
+- Raw data tab.
+- Monthly KPI summary tab.
+- Channel comparison tab.
+- Red/yellow/green flags.
+- 5-10 action recommendations.
+- Optional Loom walkthrough script.
+
+## Timeline
+
+1-2 business days using exported sample/CSV data. 3-5 business days if Ryan has to clean messy CRM exports, call logs, ad exports, or QuickBooks categories.
+
+## Price option
+
+- Spreadsheet KPI snapshot: $400 fixed.
+- KPI snapshot + executive memo: $650 fixed.
+- KPI dashboard + market/competitor/website audit bundle: $1,500-$2,000.
+
+## Source notes
+
+This specific file uses synthetic/anonymized data only. It is meant to demonstrate structure, formulas, and buyer value. For a paid buyer, Ryan can plug in exports from public ad dashboards, call tracking, CRM, or manually supplied owner data after confirming permission.

--- a/docs/revenue-lab/samples/kpi-dashboard-sample-data.csv
+++ b/docs/revenue-lab/samples/kpi-dashboard-sample-data.csv
@@ -1,0 +1,13 @@
+month,channel,leads,booked_jobs,revenue,marketing_spend,avg_response_minutes,notes
+2026-01,Organic search,42,18,37800,0,68,Sample/anonymized values
+2026-01,Paid search,33,11,28600,2400,54,Sample/anonymized values
+2026-01,Referral/repeat,24,17,33150,0,34,Sample/anonymized values
+2026-01,Social/local posts,12,3,5400,250,120,Sample/anonymized values
+2026-02,Organic search,47,20,43000,0,61,Sample/anonymized values
+2026-02,Paid search,38,13,32500,2700,49,Sample/anonymized values
+2026-02,Referral/repeat,27,19,37050,0,31,Sample/anonymized values
+2026-02,Social/local posts,15,4,7600,300,105,Sample/anonymized values
+2026-03,Organic search,55,23,52900,0,45,Sample/anonymized values
+2026-03,Paid search,41,14,36400,3100,46,Sample/anonymized values
+2026-03,Referral/repeat,30,21,42000,0,27,Sample/anonymized values
+2026-03,Social/local posts,18,5,9000,350,96,Sample/anonymized values

--- a/docs/revenue-lab/samples/market-research-brief-local-home-services.md
+++ b/docs/revenue-lab/samples/market-research-brief-local-home-services.md
@@ -1,0 +1,95 @@
+# Sample 1 — Market Research Brief
+
+Buyer-facing title: Local HVAC/Plumbing Growth Brief: Dane County, WI example  
+Sample niche: Residential HVAC, plumbing, and mechanical trades  
+Prepared: 2026-05-09  
+Data status: Public/sample/anonymized; not client-confidential
+
+## Executive summary
+
+A local home-services company in Dane County is operating in a market with a meaningful concentration of mechanical contractors and above-state-average employer scale. The public Census County Business Patterns data shows 131 Dane County establishments in NAICS 238220 (Plumbing, Heating, and Air-Conditioning Contractors), with 3,073 employees and $253.962M in annual payroll in 2022. That equals roughly 23.5 employees per establishment and about $82.6K annual payroll per employee, materially higher than the Wisconsin statewide averages for the same NAICS category.
+
+The practical takeaway: this is not a tiny solo-operator market. A buyer should expect active competition, but also enough demand to support specialization, recurring maintenance plans, review-driven local SEO, and conversion-focused service pages.
+
+## Core question
+
+Can a local home-services business justify a focused 30-day growth sprint before investing in a larger marketing retainer?
+
+## Demand and market signals
+
+| Signal | What it suggests | Evidence |
+|---|---|---|
+| 131 local establishments in the category | Enough local competition to benchmark messaging and offers | U.S. Census CBP 2022, Dane County, NAICS 238220 |
+| 3,073 employees in the category | Market has scaled operators, not only one-person shops | U.S. Census CBP 2022 |
+| $253.962M annual payroll | Labor capacity and wage base indicate meaningful service volume | U.S. Census CBP 2022 |
+| Dane County has 6.7% of WI establishments but 13.7% of WI employees in this NAICS | Local operators appear larger than state average | Derived from Census CBP 2022 |
+| Google's SEO guidance emphasizes helpful, people-first content and crawlable pages | Local service pages should be specific, useful, and technically readable | Google Search Central SEO Starter Guide |
+| U.S. Department of Energy publishes consumer guidance on air conditioning and efficiency | Public education content can support trust-building service pages | Energy.gov Energy Saver |
+
+## Buyer pain points to test
+
+1. Lead quality: calls may be seasonal, urgent, and unevenly distributed.
+2. Trust: homeowners need confidence before requesting emergency or high-ticket service.
+3. Local search competition: multiple operators can compete for the same emergency and replacement keywords.
+4. Conversion leakage: traffic is wasted when service pages lack proof, clear areas served, financing/maintenance options, or fast contact paths.
+5. Measurement: owners often know revenue but not which services, channels, or pages produce profitable calls.
+
+## Recommended 30-day sprint
+
+Week 1: Public-market scan and competitor map.
+
+- Define target geography and 3-5 service lines.
+- Pull public market/category indicators.
+- Identify 5-8 direct/indirect competitors.
+- Capture positioning, offers, reviews/proof, content gaps, and CTAs.
+
+Week 2: Website and conversion audit.
+
+- Audit homepage, service pages, emergency pages, contact paths, reviews, and local trust signals.
+- Identify quick copy, CTA, and measurement fixes.
+
+Week 3: KPI/dashboard setup.
+
+- Build spreadsheet-style dashboard using synthetic/sample structure first, then buyer-provided numbers if available.
+- Track leads, booked jobs, revenue, close rate, average ticket, channel, and response time.
+
+Week 4: Action plan.
+
+- Deliver top 10 fixes ranked by revenue impact, speed, confidence, and owner effort.
+- Include offer tests: maintenance plan CTA, replacement estimate CTA, emergency service CTA, review proof block, neighborhood service pages.
+
+## Buyer deliverable
+
+A 6-8 page PDF/Google Doc with:
+
+- Market snapshot.
+- Competitive set table.
+- Buyer persona and demand triggers.
+- Channel and offer recommendations.
+- 30-day test plan.
+- Source appendix.
+
+## Timeline
+
+3 business days for a sample/public-data version. 5 business days if customized with buyer interviews, exported CRM data, or ad/search-console data.
+
+## Price option
+
+- Starter sample/customized brief: $450 fixed.
+- Deeper local-market + competitor scan: $900 fixed.
+- Add KPI dashboard and website audit: bundle at $1,500-$2,000.
+
+## Source notes
+
+Public sources checked for this sample:
+
+- U.S. Census Bureau, 2022 County Business Patterns API, NAICS2017 238220 for Dane County, Wisconsin: 131 establishments, 3,073 employees, $253.962M annual payroll.
+- U.S. Census Bureau, 2022 County Business Patterns API, NAICS2017 238220 for Wisconsin: 1,954 establishments, 22,499 employees, $1.700878B annual payroll.
+- U.S. Census Bureau, 2022 County Business Patterns API, NAICS2017 238220 for United States: 109,601 establishments, 1,176,759 employees, $82.235079B annual payroll.
+- SBA market research and competitive analysis guide: https://www.sba.gov/business-guide/plan-your-business/market-research-competitive-analysis
+- Google Search Central SEO Starter Guide: https://developers.google.com/search/docs/fundamentals/seo-starter-guide
+- Energy.gov Energy Saver air conditioning guidance: https://www.energy.gov/energysaver/air-conditioning
+
+## Confidence and caveats
+
+High confidence in the public Census figures fetched through the Census API. Medium confidence in market interpretation because the sample does not include private revenue, call volume, review data, ad spend, or buyer CRM exports. This is a credible pre-sales sample, not a final market-sizing study.

--- a/docs/revenue-lab/samples/website-audit-snapshot-sample.md
+++ b/docs/revenue-lab/samples/website-audit-snapshot-sample.md
@@ -1,0 +1,96 @@
+# Sample 4 — Website Audit Snapshot
+
+Buyer-facing title: 15-Minute Website Revenue Leak Snapshot  
+Sample niche: Local home-services business  
+Prepared: 2026-05-09  
+Data status: Sample/anonymized; based on public website audit categories, not a confidential client site
+
+## Direct answer
+
+A local service website does not need to be beautiful before it can make more money. It needs to answer four buyer questions quickly:
+
+1. Do you solve my problem?
+2. Do you serve my area?
+3. Can I trust you in my home or business?
+4. What should I do next?
+
+This snapshot is designed as a fast, paid diagnostic Ryan can produce from public pages before proposing a deeper website, SEO, or dashboard project.
+
+## Snapshot scorecard
+
+| Area | Sample finding | Revenue risk | Quick fix |
+|---|---|---|---|
+| Above-the-fold clarity | Headline says "quality service" but not specific service + location + urgent promise | High | Rewrite headline: "HVAC repair and replacement in [City] — schedule same-day service" |
+| Primary CTA | Phone number exists, but form CTA is below the fold | High | Add sticky mobile call button and one short request form near top |
+| Trust proof | Reviews are on a separate page only | Medium | Add 2-3 review snippets near the hero and service CTAs |
+| Service pages | Repair, replacement, maintenance, and emergency service share one generic page | High | Split by intent and answer buyer-specific questions |
+| Local relevance | Service areas listed in footer, but no contextual local copy | Medium | Add concise city/service-area sections with unique proof and examples |
+| Speed/performance | Large hero images are common on service sites and can slow mobile pages | Medium | Compress images, defer noncritical scripts, run PageSpeed/Lighthouse before/after |
+| Measurement | Forms and calls may not be tagged by source or service line | High | Add UTM/source fields, call tracking labels, and a weekly KPI dashboard |
+| Offer clarity | Maintenance plan or financing is not visible near replacement/repair CTAs | Medium | Put the offer next to relevant decision points |
+
+## Buyer-facing notes
+
+### What is probably costing leads
+
+The site may be receiving enough traffic, but buyers have to work too hard to know whether the company is the right fit. The biggest likely leaks are generic copy, weak service-specific proof, and unclear next steps on mobile.
+
+### What to fix first
+
+1. Rewrite the homepage hero for specificity.
+2. Add one-click mobile call and short form paths.
+3. Add proof beside the CTA, not buried elsewhere.
+4. Split high-intent service pages.
+5. Track calls/forms by source and service line.
+
+### Example improved hero block
+
+Headline: HVAC repair and replacement in [City] without the runaround  
+Subhead: Local technicians, clear arrival windows, and repair/replacement options explained before work begins.  
+Primary CTA: Schedule service  
+Secondary CTA: Call now  
+Proof line: 4.8-star average from local homeowners + licensed/insured team  
+Trust block: Emergency service, maintenance plans, financing options, service areas
+
+## Recommended 7-day action plan
+
+Day 1: Capture current screenshots, page titles, CTAs, and form/call paths.  
+Day 2: Rewrite homepage hero and top service-page CTA blocks.  
+Day 3: Add proof snippets and "what happens next" section.  
+Day 4: Split or outline repair/replacement/maintenance/emergency pages.  
+Day 5: Add tracking fields and dashboard structure.  
+Day 6: Run technical checks and compress obvious image/script bloat.  
+Day 7: Review before/after with owner and choose next offer test.
+
+## Buyer deliverable
+
+A 3-5 page PDF/Google Doc with:
+
+- Scorecard table.
+- Annotated screenshots.
+- Top 10 revenue leaks.
+- Rewrite examples.
+- 7-day action plan.
+- Optional prioritized implementation backlog.
+
+## Timeline
+
+Same day for a quick public-site snapshot. 2 business days for annotated screenshots and rewrite examples. 3-5 business days if bundled with implementation-ready copy and dashboard setup.
+
+## Price option
+
+- Quick snapshot: $250 fixed.
+- Annotated audit + rewrite examples: $500 fixed.
+- Audit + implementation backlog + KPI dashboard setup: $900-$1,200 fixed.
+
+## Source notes
+
+Public guidance used for audit categories:
+
+- Google Search Central SEO Starter Guide for content clarity, crawlability, and useful page guidance: https://developers.google.com/search/docs/fundamentals/seo-starter-guide
+- PageSpeed Insights as a public performance testing tool: https://pagespeed.web.dev/ is commonly used; if tool access is blocked, use Lighthouse in Chrome DevTools.
+- Energy.gov consumer education pages as an example of public educational content that can inspire service-page trust content: https://www.energy.gov/energysaver/air-conditioning
+
+## Caveat
+
+This is a sample snapshot, not a live audit of a named business. For a paid buyer, Ryan should use dated screenshots, public URLs, and a short disclaimer that findings are based on externally visible pages unless the buyer provides analytics access.


### PR DESCRIPTION
## Summary
- Adds four reusable public/anonymized sample deliverables for Ryan's first revenue offers.
- Includes market research brief, competitor one-pager, KPI/spreadsheet sample, and website audit snapshot.
- Each sample includes buyer deliverable, timeline, and price option.

## Verification
- Parsed KPI CSV and validated totals: 382 leads, 168 booked jobs, 65,400 revenue, ,100 spend.
- Checked all four sample documents include Buyer deliverable, Timeline, and Price option sections.
- Confirmed samples explicitly avoid Life Church/client-confidential data and use public/sample/anonymized data.

Linear: RAN-1381