### PR TITLE
fix(auxiliary-client): hoist misplaced system messages to front before dispatch (#20866)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -3482,6 +3482,36 @@ def _convert_openai_images_to_anthropic(messages: list) -> list:
 
 
 
+def _normalize_system_message_position(messages: list) -> list:
+    """Move every system message to the front, preserving relative order.
+
+    Some chat templates (Qwen3.5/3.6, recent DeepSeek-R1 variants, etc.) raise
+    ``System message must be at the beginning`` when a non-system role precedes
+    a system role.  Auxiliary callers occasionally build messages that violate
+    this — e.g. session_search appends a system "instruction" after prior turns.
+    Returns ``messages`` unchanged when already well-ordered to avoid allocating
+    on the hot path.  See issue #20866.
+    """
+    if not messages:
+        return messages
+    first_non_system = None
+    for idx, msg in enumerate(messages):
+        if (msg.get("role") if isinstance(msg, dict) else None) != "system":
+            first_non_system = idx
+            break
+    if first_non_system is None:
+        return messages
+    # If no system message follows a non-system message, ordering is already valid.
+    if not any(
+        isinstance(m, dict) and m.get("role") == "system"
+        for m in messages[first_non_system + 1:]
+    ):
+        return messages
+    system_msgs = [m for m in messages if isinstance(m, dict) and m.get("role") == "system"]
+    other_msgs = [m for m in messages if not (isinstance(m, dict) and m.get("role") == "system")]
+    return system_msgs + other_msgs
+
+
 def _build_call_kwargs(
     provider: str,
     model: str,
@@ -3494,6 +3524,7 @@ def _build_call_kwargs(
     base_url: Optional[str] = None,
 ) -> dict:
     """Build kwargs for .chat.completions.create() with model/provider adjustments."""
+    messages = _normalize_system_message_position(messages)
     kwargs: Dict[str, Any] = {
         "model": model,
         "messages": messages,

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2041,6 +2041,73 @@ class TestBuildCallKwargsToolDedup:
         assert "tools" not in kwargs
 
 
+# ---------------------------------------------------------------------------
+# _normalize_system_message_position — reorder misplaced system messages
+# ---------------------------------------------------------------------------
+
+class TestNormalizeSystemMessagePosition:
+    """_build_call_kwargs must hoist system messages to index 0.
+
+    Qwen3.5/3.6 vLLM templates (and several other providers) raise
+    ``System message must be at the beginning`` when any non-system
+    role precedes a system role.  Auxiliary callers such as
+    session_search can inadvertently build such sequences.  See #20866.
+    """
+
+    def _msgs(self, *roles):
+        return [{"role": r, "content": f"msg-{i}"} for i, r in enumerate(roles)]
+
+    def test_already_ordered_unchanged(self):
+        """system first — ordering preserved."""
+        msgs = self._msgs("system", "user", "assistant")
+        kwargs = _build_call_kwargs(provider="custom", model="qwen3", messages=msgs)
+        result = kwargs["messages"]
+        assert [m["role"] for m in result] == ["system", "user", "assistant"]
+
+    def test_system_after_user_hoisted(self):
+        """system appended after user turns must move to index 0."""
+        msgs = [
+            {"role": "user", "content": "first question"},
+            {"role": "assistant", "content": "first answer"},
+            {"role": "system", "content": "You are a helpful assistant."},
+        ]
+        kwargs = _build_call_kwargs(provider="custom", model="qwen3", messages=msgs)
+        result = kwargs["messages"]
+        assert result[0]["role"] == "system"
+        assert result[1]["role"] == "user"
+        assert result[2]["role"] == "assistant"
+
+    def test_no_system_message_unchanged(self):
+        """no system message — list returned as-is."""
+        msgs = self._msgs("user", "assistant", "user")
+        kwargs = _build_call_kwargs(provider="custom", model="qwen3", messages=msgs)
+        assert [m["role"] for m in kwargs["messages"]] == ["user", "assistant", "user"]
+
+    def test_empty_messages_unchanged(self):
+        kwargs = _build_call_kwargs(provider="custom", model="qwen3", messages=[])
+        assert kwargs["messages"] == []
+
+    def test_multiple_system_messages_all_hoisted(self):
+        """All system messages end up before non-system messages."""
+        msgs = [
+            {"role": "user", "content": "q"},
+            {"role": "system", "content": "sys-1"},
+            {"role": "assistant", "content": "a"},
+            {"role": "system", "content": "sys-2"},
+        ]
+        kwargs = _build_call_kwargs(provider="custom", model="qwen3", messages=msgs)
+        result = kwargs["messages"]
+        system_roles = [m["role"] for m in result if m["role"] == "system"]
+        non_system_start = next(i for i, m in enumerate(result) if m["role"] != "system")
+        assert all(result[i]["role"] == "system" for i in range(non_system_start))
+        assert len(system_roles) == 2
+
+    def test_system_only_messages_unchanged(self):
+        msgs = [{"role": "system", "content": "only system"}]
+        kwargs = _build_call_kwargs(provider="custom", model="qwen3", messages=msgs)
+        assert kwargs["messages"] == msgs
+
+
 @pytest.fixture(autouse=True)
 def _clean_env(monkeypatch):
     """Strip provider env vars so each test starts clean."""


### PR DESCRIPTION
## What does this PR do?

``` jinja2.exceptions.TemplateError: System message must be at the beginning ```

## Root cause

Qwen3.5/3.6 vLLM Jinja templates (and several other providers) raise:

```
jinja2.exceptions.TemplateError: System message must be at the beginning
```

when a non-system role appears before a system role in the messages list. Auxiliary callers (e.g. `session_search`) can inadvertently construct such sequences. ~20 HTTP 400s/hour observed in gateway operation. Closes #20866.

## Fix

Add `_normalize_system_message_position()` that partitions messages into `[system...] + [non-system...]`, preserving relative order within each group. Called at the top of `_build_call_kwargs()` so every auxiliary code path is covered.

**Fast path**: returns the original list object unchanged when ordering is already valid — no allocation on the common case.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

Fixes #20866

<details>
<summary>Original body</summary>

## Summary

``` jinja2.exceptions.TemplateError: System message must be at the beginning ```

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Problem
Qwen3.5/3.6 vLLM Jinja templates (and several other providers) raise:

```
jinja2.exceptions.TemplateError: System message must be at the beginning
```

when a non-system role appears before a system role in the messages list. Auxiliary callers (e.g. `session_search`) can inadvertently construct such sequences. ~20 HTTP 400s/hour observed in gateway operation. Closes #20866.

## Root Cause
`_build_call_kwargs()` passed `messages` to the provider verbatim without enforcing the system-first invariant. No caller-side normalisation existed. The 400s were caught by `error_classifier` as `format_error` and triggered fallback, masking the underlying ordering bug.

## Fix
Add `_normalize_system_message_position()` that partitions messages into `[system...] + [non-system...]`, preserving relative order within each group. Called at the top of `_build_call_kwargs()` so every auxiliary code path is covered.

**Fast path**: returns the original list object unchanged when ordering is already valid — no allocation on the common case.

## Tests
6 new regression tests in `TestNormalizeSystemMessagePosition`:

| Test | Scenario |
|---|---|
| `test_already_ordered_unchanged` | Well-ordered list returned as-is |
| `test_system_after_user_hoisted` | System appended after turns → moved to idx 0 |
| `test_no_system_message_unchanged` | No system message → passthrough |
| `test_empty_messages_unchanged` | Empty list safe |
| `test_multiple_system_messages_all_hoisted` | Multiple system msgs all hoisted |
| `test_system_only_messages_unchanged` | All-system list unchanged |

Stash-verify confirmed: reverting `auxiliary_client.py` alone fails `test_system_after_user_hoisted` (`assert 'user' == 'system'`).

```
pytest tests/agent/test_auxiliary_client.py::TestNormalizeSystemMessagePosition -q
6 passed in 46s
```

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

Fixes #20866

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Run `pytest tests/agent/test_auxiliary_client.py::TestNormalizeSystemMessagePosition -q`.
2. Confirm the scoped behavior described above still holds after the focused checks.
3. Confirm the scoped behavior described above still holds after the focused checks.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_