### PR TITLE
fix(gateway): refresh argv and kind on every write_runtime_status call

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -483,8 +483,12 @@ def write_runtime_status(
     path = _get_runtime_status_path()
     payload = _read_json_file(path) or _build_runtime_status_record()
     payload.setdefault("platforms", {})
-    payload.setdefault("kind", _GATEWAY_KIND)
+    # Identity fields must be refreshed on every write — the previous payload
+    # may have been written by a different process (different argv after an
+    # upstream binary path change, e.g. brew → venv handoff in #22560).
+    payload["kind"] = _GATEWAY_KIND
     payload["pid"] = os.getpid()
+    payload["argv"] = list(sys.argv)
     payload["start_time"] = _get_process_start_time(os.getpid())
     payload["updated_at"] = _utc_now_iso()
 

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -287,6 +287,35 @@ class TestGatewayRuntimeStatus:
         assert payload["pid"] == os.getpid(), "PID should be overwritten, not preserved via setdefault"
         assert payload["start_time"] != 1000.0, "start_time should be overwritten on restart"
 
+    def test_write_runtime_status_overwrites_stale_argv_on_restart(self, tmp_path, monkeypatch):
+        """Regression #22560: argv preserved across restarts even after the
+        upstream binary path changed (e.g. brew uninstall → venv handoff)."""
+        import sys
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        # Simulate a state file written by a previous process whose argv[0]
+        # points at a binary path that no longer exists.
+        stale_argv = ["/opt/homebrew/bin/hermes", "gateway", "run"]
+        state_path = tmp_path / "gateway_state.json"
+        state_path.write_text(json.dumps({
+            "pid": 99999,
+            "start_time": 1000.0,
+            "kind": "hermes-gateway",
+            "argv": stale_argv,
+            "platforms": {},
+            "updated_at": "2025-01-01T00:00:00Z",
+        }))
+
+        status.write_runtime_status(gateway_state="running")
+
+        payload = status.read_runtime_status()
+        assert payload["argv"] == list(sys.argv), (
+            "argv should reflect the running process's sys.argv, not stale "
+            "metadata inherited from a prior process"
+        )
+        assert payload["argv"] != stale_argv
+
     def test_write_runtime_status_records_platform_failure(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 


### PR DESCRIPTION
## Problem

After a process restart (e.g. `brew` → `venv` binary path change, as in #22560), the next call to `write_runtime_status()` read the existing `gateway_state.json` and merged into it **without refreshing identity fields**.  `argv` retained the stale path from the previous process; `kind` was protected by `setdefault` so it was never overwritten even when wrong.

## Root cause

`write_runtime_status()` only explicitly refreshed `pid` and `start_time`.  `argv` was silently inherited from the prior payload; `kind` used `setdefault("kind", _GATEWAY_KIND)` which is a no-op when the key already exists.

## Fix

Two minimal changes in `gateway/status.py`:

```python
# was: payload.setdefault("kind", _GATEWAY_KIND)
payload["kind"] = _GATEWAY_KIND

# added:
payload["argv"] = list(sys.argv)
```

Identity fields are now refreshed unconditionally on every write, regardless of what the persisted file contained.

## Tests

Added `TestGatewayRuntimeStatus.test_write_runtime_status_overwrites_stale_argv_on_restart` in `tests/gateway/test_status.py`:

- Seeds `gateway_state.json` with a stale `argv` / `kind` pair from a simulated prior process
- Calls `write_runtime_status()`
- Asserts persisted values match the live process (`list(sys.argv)`)

**Stash-verified:** test fails without the fix, passes with it.  
**43/43** tests green in `tests/gateway/test_status.py`.