### PR TITLE
feat(web): add new local markdown web_extract plugin using Camofox

### DIFF
--- a/agent/web_search_provider.py
+++ b/agent/web_search_provider.py
@@ -129,6 +129,17 @@ class WebSearchProvider(abc.ABC):
         """
         return False
 
+    def requires_llm_processing(self) -> bool:
+        """Return True if extracted content should be post-processed by auxiliary LLM.
+
+        Most providers return raw HTML/text that benefits from LLM
+        summarization (extracting key points, reducing token count).
+        Providers that return clean, deterministic content (e.g. Camofox
+        with accessibility-snapshot Markdown) should override this to
+        return False, bypassing the auxiliary-model step.
+        """
+        return True
+
     def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
         """Execute a web search.
 

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -317,6 +317,17 @@ browser:
   inactivity_timeout: 120
 
 # =============================================================================
+# Web Tool Configuration
+# =============================================================================
+# Configure web_search and web_extract backend selection.
+# web.backend is the shared fallback for search-capable providers.
+# Use per-capability keys when search and extraction should use different backends.
+web:
+  backend: ""            # shared fallback: firecrawl | searxng | parallel | tavily | exa
+  search_backend: ""     # e.g. "searxng" for self-hosted search
+  extract_backend: ""    # e.g. "camofox" for local browser-backed web_extract
+
+# =============================================================================
 # Tool Loop Guardrails
 # =============================================================================
 # Soft warnings are enabled by default. They append guidance to repeated failed

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -672,7 +672,7 @@ DEFAULT_CONFIG = {
     "web": {
         "backend": "",           # shared fallback — applies to both search and extract
         "search_backend": "",    # per-capability override for web_search (e.g. "searxng")
-        "extract_backend": "",   # per-capability override for web_extract (e.g. "native")
+        "extract_backend": "",   # per-capability override for web_extract (e.g. "camofox")
     },
 
     "browser": {
@@ -2335,7 +2335,7 @@ OPTIONAL_ENV_VARS = {
         "description": "Camofox browser server URL for local anti-detection browsing (e.g. http://localhost:9377)",
         "prompt": "Camofox server URL",
         "url": "https://github.com/jo-inc/camofox-browser",
-        "tools": ["browser_navigate", "browser_click"],
+        "tools": ["browser_navigate", "browser_click", "web_extract"],
         "password": False,
         "category": "tool",
     },

--- a/plugins/web/camofox/__init__.py
+++ b/plugins/web/camofox/__init__.py
@@ -1,0 +1,15 @@
+"""Camofox web extraction plugin — bundled, auto-loaded.
+
+Backed by a local Camofox REST API server. Extract-only (no search).
+Returns deterministic Markdown derived from accessibility snapshots,
+bypassing the auxiliary-LLM summarization step.
+"""
+
+from __future__ import annotations
+
+from plugins.web.camofox.provider import CamofoxWebSearchProvider
+
+
+def register(ctx) -> None:
+    """Register the Camofox provider with the plugin context."""
+    ctx.register_web_search_provider(CamofoxWebSearchProvider())

--- a/plugins/web/camofox/plugin.yaml
+++ b/plugins/web/camofox/plugin.yaml
@@ -1,0 +1,7 @@
+name: web-camofox
+version: 1.0.0
+description: "Camofox local web extraction via accessibility snapshots. Returns deterministic Markdown without LLM post-processing. Requires a running Camofox server (CAMOFOX_URL)."
+author: NousResearch
+kind: backend
+provides_web_providers:
+  - camofox

--- a/plugins/web/camofox/provider.py
+++ b/plugins/web/camofox/provider.py
@@ -1,0 +1,353 @@
+"""Camofox web extraction — plugin form.
+
+Subclasses :class:`agent.web_search_provider.WebSearchProvider`. Talks to a
+local Camofox REST API server, creates one ephemeral session per URL,
+renders the accessibility snapshot to deterministic Markdown, and returns
+web-tool result objects.
+
+Camofox differs from other extract providers in three ways:
+
+1. **No LLM post-processing.** The returned Markdown is already clean and
+   deterministic — ``requires_llm_processing()`` returns False so the
+   dispatcher skips the auxiliary-model summarization step.
+
+2. **Per-URL policy gates.** Each URL is checked against the website
+   access policy before extraction. Blocked URLs return a policy-blocked
+   result rather than raising.
+
+3. **Interrupt checks.** Extraction can be interrupted mid-batch; each
+   URL is checked before dispatch so a cancelled batch doesn't waste
+   Camofox sessions.
+
+4. **Result guarding.** Results are validated (URL safety, redirect
+   policy re-check) before being returned to the caller.
+
+Config keys this provider responds to::
+
+    web:
+      extract_backend: "camofox"     # explicit per-capability
+      backend: "camofox"             # shared fallback
+
+Env vars::
+
+    CAMOFOX_URL=...    # URL of the Camofox REST API server
+
+The previous in-tree implementation lived at
+``tools.camofox_web_extract`` with a special-case branch in
+``tools/web_tools.py``; this file is the canonical replacement.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import uuid
+from typing import Any, Dict, List
+
+import requests
+
+from agent.web_search_provider import WebSearchProvider
+
+logger = logging.getLogger(__name__)
+
+_HEALTH_TIMEOUT = (3, 3)
+_TAB_TIMEOUT = (10, 60)
+_WAIT_TIMEOUT = (5, 15)
+_SNAPSHOT_TIMEOUT = (10, 60)
+_CLEANUP_TIMEOUT = (3, 10)
+
+
+def _get_camofox_url() -> str:
+    return os.getenv("CAMOFOX_URL", "").strip().rstrip("/")
+
+
+def _camofox_health_check() -> bool:
+    """Return True when the Camofox server is reachable."""
+    base = _get_camofox_url()
+    if not base:
+        return False
+    try:
+        response = requests.get(f"{base}/health", timeout=_HEALTH_TIMEOUT)
+        return response.status_code == 200
+    except Exception:
+        return False
+
+
+def _extract_single(url: str) -> Dict[str, Any]:
+    """Extract a single URL through an ephemeral Camofox tab."""
+    from tools.web_accessibility_markdown import render_accessibility_markdown
+
+    base = _get_camofox_url()
+    if not base:
+        return _error_result(url, "CAMOFOX_URL is not configured")
+
+    user_id = f"web_extract_{uuid.uuid4().hex[:12]}"
+    session_key = f"extract_{uuid.uuid4().hex[:12]}"
+    tab_id = ""
+
+    try:
+        tab_response = requests.post(
+            f"{base}/tabs",
+            json={"userId": user_id, "sessionKey": session_key, "url": url},
+            timeout=_TAB_TIMEOUT,
+        )
+        tab_response.raise_for_status()
+        tab_data = _safe_json(tab_response)
+        tab_id = str(tab_data.get("tabId") or tab_data.get("id") or "")
+        if not tab_id:
+            raise RuntimeError("Camofox did not return a tabId")
+
+        _best_effort_wait(base, tab_id, user_id)
+
+        snapshot_response = requests.get(
+            f"{base}/tabs/{tab_id}/snapshot",
+            params={"userId": user_id},
+            timeout=_SNAPSHOT_TIMEOUT,
+        )
+        snapshot_response.raise_for_status()
+        snapshot_data = _safe_json(snapshot_response)
+        snapshot_text = str(snapshot_data.get("snapshot") or "")
+
+        final_url = (
+            snapshot_data.get("url")
+            or snapshot_data.get("finalUrl")
+            or snapshot_data.get("sourceURL")
+            or tab_data.get("url")
+            or url
+        )
+        title = str(snapshot_data.get("title") or tab_data.get("title") or "")
+        markdown = render_accessibility_markdown(
+            snapshot_text,
+            url=str(final_url),
+            title=title,
+            emit_refs=False,
+            emit_controls=False,
+        )
+
+        return {
+            "url": str(final_url),
+            "title": title,
+            "content": markdown,
+            "raw_content": markdown,
+            "metadata": {
+                "sourceURL": str(final_url),
+                "extractor": "camofox",
+            },
+        }
+    except Exception as exc:
+        logger.debug("Camofox extraction failed for %s: %s", url, exc)
+        return _error_result(url, str(exc))
+    finally:
+        _cleanup_session(base, user_id, session_key)
+
+
+def _best_effort_wait(base: str, tab_id: str, user_id: str) -> None:
+    """Call Camofox readiness wait when available; ignore unsupported routes."""
+    try:
+        response = requests.post(
+            f"{base}/tabs/{tab_id}/wait",
+            json={"userId": user_id},
+            timeout=_WAIT_TIMEOUT,
+        )
+        if response.status_code in (404, 405):
+            return
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        logger.debug("Camofox wait unavailable/failed for tab %s: %s", tab_id, exc)
+    except Exception as exc:
+        logger.debug("Camofox wait failed for tab %s: %s", tab_id, exc)
+
+
+def _cleanup_session(base: str, user_id: str, session_key: str) -> None:
+    if not base:
+        return
+    try:
+        requests.delete(
+            f"{base}/sessions/{user_id}",
+            json={"userId": user_id, "sessionKey": session_key},
+            timeout=_CLEANUP_TIMEOUT,
+        )
+    except Exception as exc:
+        logger.debug("Camofox session cleanup failed for %s: %s", user_id, exc)
+
+
+def _safe_json(response: requests.Response) -> Dict[str, Any]:
+    try:
+        data = response.json()
+    except ValueError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _error_result(url: str, error: str) -> Dict[str, Any]:
+    return {
+        "url": url,
+        "title": "",
+        "content": "",
+        "raw_content": "",
+        "error": error,
+    }
+
+
+def _policy_blocked_result(url: str, blocked: Dict[str, Any], title: str = "") -> Dict[str, Any]:
+    """Build a result dict for a URL blocked by website access policy."""
+    return {
+        "url": url,
+        "title": title,
+        "content": "",
+        "raw_content": "",
+        "error": blocked["message"],
+        "blocked_by_policy": {
+            "host": blocked["host"],
+            "rule": blocked["rule"],
+            "source": blocked["source"],
+        },
+    }
+
+
+def _unsafe_url_result(url: str, title: str = "") -> Dict[str, Any]:
+    """Build a result dict for a URL that targets a private/internal address."""
+    return {
+        "url": url,
+        "title": title,
+        "content": "",
+        "raw_content": "",
+        "error": "Blocked: URL targets a private or internal network address",
+    }
+
+
+def _guard_extract_result(result: Dict[str, Any], requested_url: str) -> Dict[str, Any]:
+    """Apply final URL guards before exposing Camofox-extracted content.
+
+    Re-checks SSRF safety and website-access policy on the final URL
+    (which may differ from the requested URL due to server-side redirects).
+    """
+    from tools.url_safety import is_safe_url
+    from tools.website_policy import check_website_access
+
+    final_url = str(result.get("url") or requested_url)
+    title = str(result.get("title") or "")
+    has_content = bool(result.get("content") or result.get("raw_content"))
+
+    # Preserve backend per-URL errors that do not expose content.
+    if result.get("error") and not has_content:
+        result.setdefault("url", final_url)
+        result.setdefault("title", title)
+        result.setdefault("content", "")
+        result.setdefault("raw_content", "")
+        return result
+
+    if not is_safe_url(final_url):
+        return _unsafe_url_result(final_url, title)
+
+    blocked = check_website_access(final_url)
+    if blocked:
+        logger.info(
+            "Blocked redirected Camofox web_extract for %s by rule %s",
+            blocked["host"], blocked["rule"],
+        )
+        return _policy_blocked_result(final_url, blocked, title)
+
+    result["url"] = final_url
+    result.setdefault("title", title)
+    return result
+
+
+class CamofoxWebSearchProvider(WebSearchProvider):
+    """Camofox extract-only provider.
+
+    Async extract with per-URL policy gates, interrupt checks, and
+    result guarding. Bypasses LLM post-processing since Camofox returns
+    deterministic Markdown from accessibility snapshots.
+    """
+
+    @property
+    def name(self) -> str:
+        return "camofox"
+
+    @property
+    def display_name(self) -> str:
+        return "Camofox"
+
+    def is_available(self) -> bool:
+        """Return True when a configured Camofox server is reachable."""
+        return _camofox_health_check()
+
+    def supports_search(self) -> bool:
+        return False
+
+    def supports_extract(self) -> bool:
+        return True
+
+    def requires_llm_processing(self) -> bool:
+        """Camofox returns deterministic Markdown — skip LLM summarization."""
+        return False
+
+    async def extract(self, urls: List[str], **kwargs: Any) -> List[Dict[str, Any]]:
+        """Extract content from one or more URLs via Camofox.
+
+        Handles per-URL policy gates, interrupt checks, and result
+        guarding internally. One URL's failure does not kill the batch.
+        """
+        from tools.interrupt import is_interrupted as _is_interrupted
+        from tools.website_policy import check_website_access
+
+        logger.info("Camofox extract: %d URL(s)", len(urls))
+
+        result_slots: List[Dict[str, Any] | None] = [None] * len(urls)
+        extract_urls: List[str] = []
+        extract_indices: List[int] = []
+
+        for idx, url in enumerate(urls):
+            if _is_interrupted():
+                result_slots[idx] = {
+                    "url": url, "title": "", "content": "",
+                    "raw_content": "", "error": "Interrupted",
+                }
+                continue
+
+            blocked = check_website_access(url)
+            if blocked:
+                logger.info(
+                    "Blocked Camofox web_extract for %s by rule %s",
+                    blocked["host"], blocked["rule"],
+                )
+                result_slots[idx] = _policy_blocked_result(url, blocked)
+                continue
+
+            extract_indices.append(idx)
+            extract_urls.append(url)
+
+        if extract_urls:
+            tasks = [asyncio.to_thread(_extract_single, url) for url in extract_urls]
+            extracted = list(await asyncio.gather(*tasks))
+            for idx, extracted_result in zip(extract_indices, extracted):
+                result_slots[idx] = _guard_extract_result(
+                    extracted_result, urls[idx]
+                )
+            # Handle the unlikely case where gather returns fewer results
+            for idx in extract_indices[len(extracted):]:
+                result_slots[idx] = {
+                    "url": urls[idx],
+                    "title": "",
+                    "content": "",
+                    "raw_content": "",
+                    "error": "Camofox extraction returned no result for this URL",
+                }
+
+        return [r for r in result_slots if r is not None]
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Camofox",
+            "badge": "local",
+            "tag": "Local accessibility-snapshot extraction. No API key — requires a running Camofox server.",
+            "env_vars": [
+                {
+                    "key": "CAMOFOX_URL",
+                    "prompt": "Camofox server URL",
+                    "url": "",
+                },
+            ],
+        }

--- a/tests/tools/test_camofox_web_extract.py
+++ b/tests/tools/test_camofox_web_extract.py
@@ -1,0 +1,163 @@
+"""Tests for Camofox-backed web_extract plugin."""
+
+from __future__ import annotations
+
+import asyncio
+
+
+class MockResponse:
+    def __init__(self, data=None, status_code=200, error: Exception | None = None):
+        self._data = data or {}
+        self.status_code = status_code
+        self._error = error
+
+    def json(self):
+        return self._data
+
+    def raise_for_status(self):
+        if self._error:
+            raise self._error
+        if self.status_code >= 400:
+            raise RuntimeError(f"HTTP {self.status_code}")
+
+
+SNAPSHOT = """
+- document:
+  - heading "Example Domain" [level=1] [ref=e1]
+  - paragraph: This domain is for examples.
+  - link "Learn more" [ref=e2]:
+    - /url: https://iana.org/domains/example
+  - button "Accept cookies" [ref=e3]
+"""
+
+
+def test_camofox_provider_available_requires_configured_healthy_server(monkeypatch):
+    from plugins.web.camofox.provider import CamofoxWebSearchProvider
+
+    provider = CamofoxWebSearchProvider()
+
+    monkeypatch.delenv("CAMOFOX_URL", raising=False)
+    assert provider.is_available() is False
+
+    monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+    monkeypatch.setattr(
+        "plugins.web.camofox.provider.requests.get",
+        lambda *args, **kwargs: MockResponse({"ok": True}, status_code=200),
+    )
+    assert provider.is_available() is True
+
+    monkeypatch.setattr(
+        "plugins.web.camofox.provider.requests.get",
+        lambda *args, **kwargs: MockResponse({"ok": False}, status_code=503),
+    )
+    assert provider.is_available() is False
+
+
+def test_camofox_provider_extract_creates_tab_reads_snapshot_and_cleans_up(monkeypatch):
+    from plugins.web.camofox.provider import CamofoxWebSearchProvider, _extract_single
+
+    calls = []
+
+    def fake_post(url, json=None, timeout=None):
+        calls.append(("post", url, json, timeout))
+        if url.endswith("/tabs"):
+            return MockResponse({"tabId": "tab-123", "title": "Example Domain"})
+        if url.endswith("/tabs/tab-123/wait"):
+            return MockResponse({"ok": True})
+        raise AssertionError(f"unexpected POST {url}")
+
+    def fake_get(url, params=None, timeout=None):
+        calls.append(("get", url, params, timeout))
+        assert url == "http://localhost:9377/tabs/tab-123/snapshot"
+        return MockResponse({
+            "snapshot": SNAPSHOT,
+            "title": "Example Domain",
+            "url": "https://example.com/",
+        })
+
+    def fake_delete(url, json=None, timeout=None):
+        calls.append(("delete", url, json, timeout))
+        return MockResponse({"ok": True})
+
+    monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377/")
+    monkeypatch.setattr("plugins.web.camofox.provider.requests.post", fake_post)
+    monkeypatch.setattr("plugins.web.camofox.provider.requests.get", fake_get)
+    monkeypatch.setattr("plugins.web.camofox.provider.requests.delete", fake_delete)
+
+    result = _extract_single("https://example.com/")
+
+    assert result["url"] == "https://example.com/"
+    assert result["title"] == "Example Domain"
+    assert "# Example Domain" in result["content"]
+    assert "[Learn more](https://iana.org/domains/example)" in result["content"]
+    assert "Accept cookies" not in result["content"]
+    assert "ref=e" not in result["content"]
+    assert result["raw_content"] == result["content"]
+    assert result["metadata"]["extractor"] == "camofox"
+    assert any(call[0] == "delete" and call[1] == "http://localhost:9377/sessions/" + call[2]["userId"] for call in calls)
+
+
+def test_camofox_provider_extract_single_returns_per_url_error_and_still_cleans_up(monkeypatch):
+    from plugins.web.camofox.provider import _extract_single
+
+    deletes = []
+
+    def fake_post(url, json=None, timeout=None):
+        return MockResponse(status_code=500)
+
+    def fake_delete(url, json=None, timeout=None):
+        deletes.append((url, json))
+        return MockResponse({"ok": True})
+
+    monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+    monkeypatch.setattr("plugins.web.camofox.provider.requests.post", fake_post)
+    monkeypatch.setattr("plugins.web.camofox.provider.requests.delete", fake_delete)
+
+    result = _extract_single("https://bad.example/")
+
+    assert result["url"] == "https://bad.example/"
+    assert result["title"] == ""
+    assert result["content"] == ""
+    assert "error" in result
+    assert deletes, "ephemeral Camofox session should be cleaned up even after failure"
+
+
+def test_camofox_provider_extract_batches_without_cross_url_failure(monkeypatch):
+    from plugins.web.camofox.provider import CamofoxWebSearchProvider
+
+    def fake_single(url):
+        if "bad" in url:
+            return {"url": url, "title": "", "content": "", "error": "boom"}
+        return {"url": url, "title": "OK", "content": "# OK", "raw_content": "# OK"}
+
+    def fake_check_website_access(url):
+        return None
+
+    def fake_is_safe_url(url):
+        return True
+
+    monkeypatch.setattr("plugins.web.camofox.provider._extract_single", fake_single)
+    monkeypatch.setattr("tools.website_policy.check_website_access", fake_check_website_access)
+    monkeypatch.setattr("tools.url_safety.is_safe_url", fake_is_safe_url)
+
+    provider = CamofoxWebSearchProvider()
+    results = asyncio.run(provider.extract(["https://ok.example/", "https://bad.example/"]))
+
+    assert results[0]["content"] == "# OK"
+    assert results[1]["error"] == "boom"
+
+
+def test_camofox_provider_requires_llm_processing_returns_false():
+    from plugins.web.camofox.provider import CamofoxWebSearchProvider
+
+    provider = CamofoxWebSearchProvider()
+    assert provider.requires_llm_processing() is False
+
+
+def test_camofox_provider_supports_extract_but_not_search():
+    from plugins.web.camofox.provider import CamofoxWebSearchProvider
+
+    provider = CamofoxWebSearchProvider()
+    assert provider.supports_search() is False
+    assert provider.supports_extract() is True
+    assert provider.supports_crawl() is False

--- a/tests/tools/test_web_accessibility_markdown.py
+++ b/tests/tools/test_web_accessibility_markdown.py
@@ -1,0 +1,319 @@
+"""Tests for deterministic accessibility snapshot to Markdown rendering."""
+
+from __future__ import annotations
+
+
+SNAPSHOT = """
+- document:
+  - heading "Example Domain" [level=1] [ref=e1]
+  - paragraph: This domain is for use in documentation examples without needing permission.
+  - link "Learn more" [ref=e2]:
+    - /url: https://iana.org/domains/example
+  - button "Accept cookies" [ref=e3]
+  - textbox "Search" [ref=e4]
+"""
+
+DOCS_SNAPSHOT = """
+- generic:
+  - navigation "Main":
+    - link "Docs" [ref=e1]:
+      - /url: /docs/user-stories
+  - main:
+    - article:
+      - heading "Hermes Agent" [level=1]
+      - paragraph:
+        - text: The self-improving AI agent built by
+        - link "Nous Research" [ref=e2]:
+          - /url: https://nousresearch.com
+        - text: . The only agent with a built-in learning loop.
+      - generic:
+        - link "Get Started →" [ref=e3]:
+          - /url: /docs/getting-started/installation
+      - heading "InstallDirect link to Install" [level=2]:
+        - text: Install
+        - link "Direct link to Install" [ref=e4]:
+          - /url: "#install"
+          - text: "#"
+      - paragraph:
+        - strong: Linux / macOS / WSL2
+      - generic:
+        - code:
+          - generic: curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+          - button "Copy code to clipboard" [ref=e5]
+      - paragraph:
+        - strong: Windows (native, PowerShell)
+        - text: —
+        - emphasis:
+          - text: early beta,
+          - link "details →" [ref=e6]:
+            - /url: /docs/user-guide/windows-native
+      - paragraph:
+        - text: See the full
+        - strong:
+          - link "Installation Guide" [ref=e7]:
+            - /url: /docs/getting-started/installation
+        - text: for details.
+      - heading "Quick LinksDirect link to Quick Links" [level=2]:
+        - text: Quick Links
+        - link "Direct link to Quick Links" [ref=e8]:
+          - /url: "#quick-links"
+          - text: "#"
+      - table:
+        - rowgroup:
+          - row "🚀 Installation Install in 60 seconds on Linux, macOS, WSL2, or native Windows (early beta)":
+            - cell "🚀 Installation":
+              - text: 🚀
+              - strong:
+                - link "Installation" [ref=e9]:
+                  - /url: /docs/getting-started/installation
+            - cell "Install in 60 seconds on Linux, macOS, WSL2, or native Windows (early beta)"
+"""
+
+GITHUB_REPO_SNAPSHOT = """
+- main:
+  - generic:
+    - link "NousResearch" [ref=e1]:
+      - /url: /NousResearch
+    - strong:
+      - link "hermes-agent" [ref=e2]:
+        - /url: /NousResearch/hermes-agent
+    - list:
+      - listitem:
+        - link "You must be signed in to change notification settings" [ref=e3]:
+          - /url: /login?return_to=%2FNousResearch%2Fhermes-agent
+          - text: Notifications
+      - listitem:
+        - link "Fork 21.8k" [ref=e4]:
+          - /url: /login?return_to=%2FNousResearch%2Fhermes-agent
+  - generic:
+    - heading "NousResearch/hermes-agent" [level=1]
+    - table "Folders and files":
+      - rowgroup:
+        - row "Name Last commit message Last commit date":
+          - columnheader "Name"
+          - columnheader "Last commit message"
+          - columnheader "Last commit date"
+        - row ".github, (Directory) ci: run docker build May 9, 2026":
+          - cell ".github, (Directory)":
+            - link ".github, (Directory)" [ref=e5]:
+              - /url: /NousResearch/hermes-agent/tree/main/.github
+              - text: .github
+          - cell "ci: run docker build"
+          - cell "May 9, 2026"
+"""
+
+
+def test_renders_headings_paragraphs_and_links_without_refs_or_controls():
+    from tools.web_accessibility_markdown import render_accessibility_markdown
+
+    markdown = render_accessibility_markdown(SNAPSHOT)
+
+    assert "# Example Domain" in markdown
+    assert "This domain is for use in documentation examples" in markdown
+    assert "[Learn more](https://iana.org/domains/example)" in markdown
+    assert "ref=e" not in markdown
+    assert "[e2]" not in markdown
+    assert "Accept cookies" not in markdown
+    assert "Search" not in markdown
+
+
+def test_can_emit_refs_and_controls_for_future_reuse():
+    from tools.web_accessibility_markdown import render_accessibility_markdown
+
+    markdown = render_accessibility_markdown(
+        SNAPSHOT,
+        emit_refs=True,
+        emit_controls=True,
+    )
+
+    assert "# Example Domain [e1]" in markdown
+    assert "[Learn more](https://iana.org/domains/example) [e2]" in markdown
+    assert '<button "Accept cookies" [e3]>' in markdown
+    assert '<textbox "Search" [e4]>' in markdown
+
+
+def test_strips_legacy_at_refs_when_refs_are_disabled():
+    from tools.web_accessibility_markdown import render_accessibility_markdown
+
+    markdown = render_accessibility_markdown('- link "Docs" @e12:\n  - /url: https://example.com/docs')
+
+    assert markdown == "[Docs](https://example.com/docs)"
+    assert "@e12" not in markdown
+
+
+def test_non_ascii_snapshot_text_is_not_mojibaked():
+    from tools.web_accessibility_markdown import render_accessibility_markdown
+
+    markdown = render_accessibility_markdown('- heading "Être Free" [level=1]')
+
+    assert markdown == "# Être Free"
+
+
+def test_unknown_or_malformed_roles_return_safe_text_without_crashing():
+    from tools.web_accessibility_markdown import render_accessibility_markdown
+
+    markdown = render_accessibility_markdown(
+        '- application "Metrics" [ref=e8]\n'
+        '  - meter "CPU 42%"\n'
+        '  - garbled line without a useful role\n'
+    )
+
+    assert "Metrics" in markdown
+    assert "CPU 42%" in markdown
+    assert "ref=e8" not in markdown
+
+
+def test_renders_main_content_without_global_navigation_noise():
+    from tools.web_accessibility_markdown import render_accessibility_markdown
+
+    markdown = render_accessibility_markdown(DOCS_SNAPSHOT)
+
+    assert markdown.startswith("# Hermes Agent")
+    assert "[Docs](/docs/user-stories)" not in markdown
+    assert "Main" not in markdown
+
+
+def test_merges_inline_paragraph_fragments_and_punctuation():
+    from tools.web_accessibility_markdown import render_accessibility_markdown
+
+    markdown = render_accessibility_markdown(DOCS_SNAPSHOT)
+
+    assert "The self-improving AI agent built by [Nous Research](https://nousresearch.com). The only agent" in markdown
+    assert "built by\n[Nous Research]" not in markdown
+    assert "https://nousresearch.com) ." not in markdown
+    assert "**Windows (native, PowerShell)** — *early beta, [details →](/docs/user-guide/windows-native)*" in markdown
+    assert "See the full **[Installation Guide](/docs/getting-started/installation)** for details." in markdown
+
+
+def test_strips_docusaurus_direct_anchor_noise_from_headings():
+    from tools.web_accessibility_markdown import render_accessibility_markdown
+
+    markdown = render_accessibility_markdown(DOCS_SNAPSHOT)
+
+    assert "## Install" in markdown
+    assert "## Quick Links" in markdown
+    assert "Direct link to" not in markdown
+    assert "\n#\n" not in markdown
+    assert "InstallDirect" not in markdown
+
+
+def test_renders_code_blocks_and_table_rows_compactly():
+    from tools.web_accessibility_markdown import render_accessibility_markdown
+
+    markdown = render_accessibility_markdown(DOCS_SNAPSHOT)
+
+    assert "```\ncurl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash\n```" in markdown
+    assert "- 🚀 **[Installation](/docs/getting-started/installation)**: Install in 60 seconds on Linux" in markdown
+    assert "🚀 Installation Install in 60 seconds" not in markdown
+
+
+def test_drops_github_repo_action_preamble_before_primary_heading():
+    from tools.web_accessibility_markdown import render_accessibility_markdown
+
+    markdown = render_accessibility_markdown(GITHUB_REPO_SNAPSHOT)
+
+    assert markdown.startswith("# NousResearch/hermes-agent")
+    assert "Notifications" not in markdown
+    assert "Fork 21.8k" not in markdown
+    assert "| [.github](/NousResearch/hermes-agent/tree/main/.github) | ci: run docker build | May 9, 2026 |" in markdown
+
+
+def test_renders_plain_lists_without_blank_lines_between_items():
+    from tools.web_accessibility_markdown import render_accessibility_markdown
+
+    markdown = render_accessibility_markdown(
+        '- main:\n'
+        '  - list:\n'
+        '    - listitem: First item\n'
+        '    - listitem: Second item\n'
+    )
+
+    assert markdown == "- First item\n- Second item"
+
+
+def test_preserves_repeated_content_and_code_lines():
+    from tools.web_accessibility_markdown import render_accessibility_markdown
+
+    markdown = render_accessibility_markdown(
+        '- main:\n'
+        '  - paragraph: echo\n'
+        '  - paragraph: echo\n'
+        '  - code:\n'
+        '    - generic: repeat\n'
+        '    - generic: repeat\n'
+    )
+
+    assert markdown.count("echo") == 2
+    assert "```\nrepeat\nrepeat\n```" in markdown
+
+
+def test_preserves_meaningful_image_alt_text():
+    from tools.web_accessibility_markdown import render_accessibility_markdown
+
+    markdown = render_accessibility_markdown('- main:\n  - img "Architecture diagram"\n')
+
+    assert markdown == "![Architecture diagram]"
+
+
+def test_strips_private_use_glyph_only_text():
+    from tools.web_accessibility_markdown import render_accessibility_markdown
+
+    markdown = render_accessibility_markdown(
+        '- main:\n'
+        '  - heading "Real content" [level=1]\n'
+        '  - paragraph: \ue001\n'
+        '  - paragraph: Body text\n'
+    )
+
+    assert markdown == "# Real content\n\nBody text"
+
+
+def test_skips_javascript_links_in_document_output():
+    from tools.web_accessibility_markdown import render_accessibility_markdown
+
+    markdown = render_accessibility_markdown(
+        '- main:\n'
+        '  - link "Open menu" [ref=e1]:\n'
+        '    - /url: javascript:void(0)\n'
+        '  - link "Real link" [ref=e2]:\n'
+        '    - /url: https://example.com\n'
+    )
+
+    assert "javascript:" not in markdown
+    assert "Open menu" not in markdown
+    assert markdown == "[Real link](https://example.com)"
+
+
+def test_keeps_javascript_links_when_refs_are_explicitly_requested():
+    from tools.web_accessibility_markdown import render_accessibility_markdown
+
+    markdown = render_accessibility_markdown(
+        '- main:\n'
+        '  - link "Open menu" [ref=e1]:\n'
+        '    - /url: javascript:void(0)\n',
+        emit_refs=True,
+    )
+
+    assert markdown == "[Open menu](javascript:void(0)) [e1]"
+
+
+def test_skips_footer_toolbar_and_menu_chrome_without_main_landmark():
+    from tools.web_accessibility_markdown import render_accessibility_markdown
+
+    markdown = render_accessibility_markdown(
+        '- document:\n'
+        '  - toolbar:\n'
+        '    - button "Refresh" [ref=e1]\n'
+        '  - menu:\n'
+        '    - menuitem "Account" [ref=e2]\n'
+        '  - heading "Article" [level=1]\n'
+        '  - paragraph: Body\n'
+        '  - contentinfo:\n'
+        '    - link "Privacy" [ref=e3]:\n'
+        '      - /url: /privacy\n'
+    )
+
+    assert markdown == "# Article\n\nBody"
+    assert "Refresh" not in markdown
+    assert "Account" not in markdown
+    assert "Privacy" not in markdown

--- a/tests/tools/test_web_providers_searxng.py
+++ b/tests/tools/test_web_providers_searxng.py
@@ -321,7 +321,7 @@ class TestSearXNGOnlyExtractCrawlErrors:
         monkeypatch.setattr(web_tools, "_is_tool_gateway_ready", lambda: False)
         monkeypatch.setattr(web_tools, "check_firecrawl_api_key", lambda: False)
         monkeypatch.setattr(web_tools, "is_safe_url", lambda url: True)
-        monkeypatch.setattr(web_tools, "check_website_access", lambda url: None)
+        monkeypatch.setattr("tools.website_policy.check_website_access", lambda url: None)
         monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False, raising=False)
 
         import json
@@ -335,6 +335,9 @@ class TestSearXNGOnlyExtractCrawlErrors:
     def test_web_extract_searxng_returns_clear_error(self, monkeypatch):
         import asyncio
         from tools import web_tools
+        from agent.web_search_registry import register_provider
+        from plugins.web.camofox.provider import CamofoxWebSearchProvider
+        register_provider(CamofoxWebSearchProvider())
 
         monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "searxng"})
         monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
@@ -349,3 +352,163 @@ class TestSearXNGOnlyExtractCrawlErrors:
         result = json.loads(result_str)
         assert result["success"] is False
         assert "search-only" in result["error"].lower() or "SearXNG" in result["error"]
+
+    def test_web_extract_searxng_search_with_camofox_extract_backend(self, monkeypatch):
+        import asyncio
+        from tools import web_tools
+        from agent.web_search_registry import register_provider
+        from plugins.web.camofox.provider import CamofoxWebSearchProvider
+        register_provider(CamofoxWebSearchProvider())
+
+        async def fake_camofox_extract(self, urls, **kwargs):
+            return [{
+                "url": urls[0],
+                "title": "Example Domain",
+                "content": "# Example Domain\n\n[Learn more](https://iana.org/domains/example)",
+                "raw_content": "# Example Domain\n\n[Learn more](https://iana.org/domains/example)",
+                "metadata": {"extractor": "camofox"},
+            }]
+
+        async def fail_llm_processing(*args, **kwargs):
+            raise AssertionError("Camofox deterministic extraction must skip LLM cleanup")
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {
+            "backend": "searxng",
+            "extract_backend": "camofox",
+        })
+        monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        from plugins.web.camofox.provider import CamofoxWebSearchProvider
+        monkeypatch.setattr(CamofoxWebSearchProvider, "is_available", lambda self: True)
+        monkeypatch.setattr(CamofoxWebSearchProvider, "extract", fake_camofox_extract, raising=False)
+        monkeypatch.setattr(web_tools, "check_auxiliary_model", lambda: True)
+        monkeypatch.setattr(web_tools, "process_content_with_llm", fail_llm_processing)
+        monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False, raising=False)
+
+        result_str = asyncio.get_event_loop().run_until_complete(
+            web_tools.web_extract_tool(["https://example.com/"], use_llm_processing=True)
+        )
+        result = json.loads(result_str)
+
+        assert result["results"][0]["title"] == "Example Domain"
+        assert "# Example Domain" in result["results"][0]["content"]
+        assert "ref=e" not in result["results"][0]["content"]
+
+    def test_search_backend_stays_searxng_when_extract_backend_is_camofox(self, monkeypatch):
+        from tools import web_tools
+        from agent.web_search_registry import register_provider
+        from plugins.web.camofox.provider import CamofoxWebSearchProvider
+        register_provider(CamofoxWebSearchProvider())
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {
+            "backend": "searxng",
+            "extract_backend": "camofox",
+        })
+        monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
+        monkeypatch.setenv("CAMOFOX_URL", "http://localhost:9377")
+        from plugins.web.camofox.provider import CamofoxWebSearchProvider
+        monkeypatch.setattr(CamofoxWebSearchProvider, "is_available", lambda self: True)
+
+        assert web_tools._get_search_backend() == "searxng"
+
+    def test_camofox_extract_backend_blocks_policy_before_fetch(self, monkeypatch):
+        import asyncio
+        from tools import web_tools
+        from agent.web_search_registry import register_provider
+        from plugins.web.camofox.provider import CamofoxWebSearchProvider
+        register_provider(CamofoxWebSearchProvider())
+
+        def fail_extract_single(url):
+            raise AssertionError("blocked policy URL must not be sent to Camofox")
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"extract_backend": "camofox"})
+        monkeypatch.setattr(CamofoxWebSearchProvider, "is_available", lambda self: True)
+        monkeypatch.setattr("plugins.web.camofox.provider._extract_single", fail_extract_single)
+        monkeypatch.setattr(web_tools, "check_auxiliary_model", lambda: False)
+        monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False, raising=False)
+        monkeypatch.setattr("tools.website_policy.check_website_access", lambda url: {
+            "message": "Blocked by policy",
+            "host": "example.com",
+            "rule": "example.com",
+            "source": "test",
+        })
+
+        result_str = asyncio.get_event_loop().run_until_complete(
+            web_tools.web_extract_tool(["https://example.com/"])
+        )
+        result = json.loads(result_str)
+
+        assert result["results"][0]["content"] == ""
+        assert result["results"][0]["error"] == "Blocked by policy"
+        assert result["results"][0]["blocked_by_policy"]["host"] == "example.com"
+
+    def test_camofox_extract_backend_blocks_unsafe_final_url(self, monkeypatch):
+        import asyncio
+        from tools import web_tools
+        from agent.web_search_registry import register_provider
+        from plugins.web.camofox.provider import CamofoxWebSearchProvider
+        register_provider(CamofoxWebSearchProvider())
+
+        def fake_extract_single(url):
+            return {
+                "url": "http://127.0.0.1/private",
+                "title": "Private",
+                "content": "secret local content",
+                "raw_content": "secret local content",
+            }
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"extract_backend": "camofox"})
+        monkeypatch.setattr(CamofoxWebSearchProvider, "is_available", lambda self: True)
+        monkeypatch.setattr("plugins.web.camofox.provider._extract_single", fake_extract_single)
+        monkeypatch.setattr(web_tools, "check_auxiliary_model", lambda: False)
+        monkeypatch.setattr("tools.website_policy.check_website_access", lambda url: None)
+        monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False, raising=False)
+
+        result_str = asyncio.get_event_loop().run_until_complete(
+            web_tools.web_extract_tool(["https://example.com/"])
+        )
+        result = json.loads(result_str)
+
+        assert result["results"][0]["content"] == ""
+        assert "private or internal" in result["results"][0]["error"]
+
+    def test_camofox_extract_backend_blocks_policy_on_final_url(self, monkeypatch):
+        import asyncio
+        from tools import web_tools
+        from agent.web_search_registry import register_provider
+        from plugins.web.camofox.provider import CamofoxWebSearchProvider
+        register_provider(CamofoxWebSearchProvider())
+
+        def fake_extract_single(url):
+            return {
+                "url": "https://example.com/final",
+                "title": "Blocked",
+                "content": "blocked content",
+                "raw_content": "blocked content",
+            }
+
+        def fake_policy(url):
+            if url == "https://example.com/final":
+                return {
+                    "message": "Blocked final URL",
+                    "host": "example.com",
+                    "rule": "/final",
+                    "source": "test",
+                }
+            return None
+
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"extract_backend": "camofox"})
+        monkeypatch.setattr(CamofoxWebSearchProvider, "is_available", lambda self: True)
+        monkeypatch.setattr("plugins.web.camofox.provider._extract_single", fake_extract_single)
+        monkeypatch.setattr(web_tools, "check_auxiliary_model", lambda: False)
+        monkeypatch.setattr("tools.website_policy.check_website_access", fake_policy)
+        monkeypatch.setattr("tools.interrupt.is_interrupted", lambda: False, raising=False)
+
+        result_str = asyncio.get_event_loop().run_until_complete(
+            web_tools.web_extract_tool(["https://example.com/"])
+        )
+        result = json.loads(result_str)
+
+        assert result["results"][0]["content"] == ""
+        assert result["results"][0]["error"] == "Blocked final URL"
+        assert result["results"][0]["blocked_by_policy"]["host"] == "example.com"

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -396,6 +396,52 @@ class TestBackendSelection:
              patch.dict(os.environ, {"PARALLEL_API_KEY": "test-key"}):
             assert _get_backend() == "parallel"
 
+    def test_extract_backend_camofox_uses_per_capability_override_when_available(self):
+        """web.extract_backend=camofox selects Camofox for extraction only."""
+        import tools.web_tools as web_tools
+        from agent.web_search_registry import register_provider
+        from plugins.web.camofox.provider import CamofoxWebSearchProvider
+        register_provider(CamofoxWebSearchProvider())
+        from plugins.web.camofox.provider import CamofoxWebSearchProvider
+        with patch("tools.web_tools._load_web_config", return_value={"extract_backend": "camofox"}), \
+             patch.object(CamofoxWebSearchProvider, "is_available", return_value=True), \
+             patch("tools.web_tools._is_tool_gateway_ready", return_value=False):
+            assert web_tools._get_extract_backend() == "camofox"
+
+    def test_camofox_is_not_a_search_backend_even_when_configured(self):
+        """Camofox must not be selected for web_search."""
+        import tools.web_tools as web_tools
+        from agent.web_search_registry import register_provider
+        from plugins.web.camofox.provider import CamofoxWebSearchProvider
+        register_provider(CamofoxWebSearchProvider())
+        from plugins.web.camofox.provider import CamofoxWebSearchProvider
+        with patch("tools.web_tools._load_web_config", return_value={"search_backend": "camofox"}), \
+             patch.object(CamofoxWebSearchProvider, "is_available", return_value=True), \
+             patch("tools.web_tools._is_tool_gateway_ready", return_value=False):
+            assert web_tools._get_search_backend() != "camofox"
+
+    def test_check_web_api_key_accepts_camofox_extract_backend(self):
+        """A configured Camofox extract backend should make web_extract available."""
+        import tools.web_tools as web_tools
+        from agent.web_search_registry import register_provider
+        from plugins.web.camofox.provider import CamofoxWebSearchProvider
+        register_provider(CamofoxWebSearchProvider())
+        from plugins.web.camofox.provider import CamofoxWebSearchProvider
+        with patch("tools.web_tools._load_web_config", return_value={"extract_backend": "camofox"}), \
+             patch.object(CamofoxWebSearchProvider, "is_available", return_value=True):
+            assert web_tools.check_web_api_key() is True
+
+    def test_is_backend_available_camofox_delegates_to_camofox_availability(self):
+        import tools.web_tools as web_tools
+        from agent.web_search_registry import register_provider
+        from plugins.web.camofox.provider import CamofoxWebSearchProvider
+        register_provider(CamofoxWebSearchProvider())
+        from plugins.web.camofox.provider import CamofoxWebSearchProvider
+
+        with patch.object(CamofoxWebSearchProvider, "is_available", side_effect=[True, False]):
+            assert web_tools._is_backend_available("camofox") is True
+            assert web_tools._is_backend_available("camofox") is False
+
 
 class TestParallelClientConfig:
     """Test suite for Parallel client initialization."""
@@ -646,3 +692,9 @@ def test_web_requires_env_includes_exa_key():
     from tools.web_tools import _web_requires_env
 
     assert "EXA_API_KEY" in _web_requires_env()
+
+
+def test_web_requires_env_includes_camofox_url_for_camofox_extract_backend():
+    from tools.web_tools import _web_requires_env
+
+    assert "CAMOFOX_URL" in _web_requires_env()

--- a/tools/web_accessibility_markdown.py
+++ b/tools/web_accessibility_markdown.py
@@ -1,0 +1,1870 @@
+"""Deterministic Markdown renderer for browser accessibility snapshots.
+
+This module converts Playwright accessibility snapshots into clean, readable
+Markdown. It is intentionally dependency-free and used by Camofox-backed
+web extraction (not browser tools), so the default output strips actionable
+refs and controls.
+
+Architecture:
+- Phase 0: Parse accessibility tree with robust escape handling
+- Phase 1: Multi-pass rendering with normalization and transforms
+- Phase 2: Markdown-safe inline formatting
+- Phase 3: Structural improvements (tables, lists, etc.)
+- Phase 4: Polish (consent dialogs, chrome compaction)
+"""
+
+from __future__ import annotations
+
+import ast
+import re
+from dataclasses import dataclass, field
+from typing import Optional
+from urllib.parse import parse_qs, urlencode, urlparse, urlunparse
+
+
+# ============================================================================
+# Phase 0: Parser helpers
+# ============================================================================
+
+
+def _decode_accessible_string_escapes(value: str) -> str:
+    """Decode escape sequences in accessibility strings.
+
+    Handles \\n, \\t, \\\\, \\", \\' explicitly. Unknown escapes kept literally.
+    This is safer than ast.literal_eval which can fail on non-Python escapes.
+    """
+    if not value:
+        return ""
+
+    result = []
+    i = 0
+    while i < len(value):
+        if value[i] == "\\" and i + 1 < len(value):
+            next_char = value[i + 1]
+            if next_char == "n":
+                result.append("\n")
+                i += 2
+            elif next_char == "t":
+                result.append("\t")
+                i += 2
+            elif next_char == "\\":
+                result.append("\\")
+                i += 2
+            elif next_char == '"':
+                result.append('"')
+                i += 2
+            elif next_char == "'":
+                result.append("'")
+                i += 2
+            else:
+                # Unknown escape, keep literally
+                result.append(value[i])
+                i += 1
+        else:
+            result.append(value[i])
+            i += 1
+
+    return "".join(result)
+
+
+def _unquote_aria_snapshot_key(key: str) -> str:
+    """Unwrap YAML-quoted ariaSnapshot keys without treating inner colons as separators.
+
+    Handles:
+    - "text: with colon" -> text: with colon
+    - 'O\\'Brien' -> O'Brien
+    - heading -> heading (bare)
+    """
+    key = (key or "").strip()
+    if len(key) >= 2 and key[0] == '"' and key[-1] == '"':
+        return _decode_accessible_string_escapes(key[1:-1])
+    if len(key) >= 2 and key[0] == "'" and key[-1] == "'":
+        return key[1:-1].replace("''", "'")
+    return key
+
+
+def _split_unquoted_colon(text: str) -> tuple[str, str]:
+    """Split a Playwright ariaSnapshot map-ish line on the first structural colon.
+
+    Respects:
+    - Quoted strings (single/double)
+    - Escaped quotes
+    - Bracket depth [...]
+    """
+    escaped = False
+    quote: Optional[str] = None
+    bracket_depth = 0
+
+    for idx, ch in enumerate(text):
+        if escaped:
+            escaped = False
+            continue
+        if ch == "\\":
+            escaped = True
+            continue
+        if quote:
+            if ch == quote:
+                quote = None
+            continue
+        if ch in {'"', "'"}:
+            quote = ch
+            continue
+        if ch == "[":
+            bracket_depth += 1
+            continue
+        if ch == "]" and bracket_depth:
+            bracket_depth -= 1
+            continue
+        if ch == ":" and bracket_depth == 0:
+            return text[:idx].strip(), text[idx + 1:].strip()
+
+    return text.strip(), ""
+
+
+def _parse_quoted_name(rest: str) -> tuple[str, str]:
+    """Parse a quoted name from the rest of a line.
+
+    Returns: (name, remaining_text)
+    """
+    if not rest.startswith('"'):
+        return "", rest
+
+    # Find matching close quote, handling escapes
+    i = 1
+    name_chars = []
+    while i < len(rest):
+        ch = rest[i]
+        if ch == "\\" and i + 1 < len(rest):
+            next_ch = rest[i + 1]
+            if next_ch == "n":
+                name_chars.append("\n")
+                i += 2
+            elif next_ch == "t":
+                name_chars.append("\t")
+                i += 2
+            elif next_ch in ('"', "'", "\\"):
+                name_chars.append(next_ch)
+                i += 2
+            else:
+                name_chars.append(ch)
+                i += 1
+        elif ch == '"':
+            # Found close quote
+            name = "".join(name_chars)
+            remaining = rest[i + 1:].strip()
+            return name, remaining
+        else:
+            name_chars.append(ch)
+            i += 1
+
+    # No close quote found, return what we have
+    return "".join(name_chars), ""
+
+
+def _parse_regex_name(rest: str) -> tuple[str, str, str]:
+    """Parse a regex name like /^pattern/ from the rest of a line.
+
+    Returns: (role, name, remaining_text)
+    Note: This is a simplified version. The actual role is extracted elsewhere.
+    """
+    if not rest.startswith("/"):
+        return "", "", rest
+
+    # Find matching close slash, handling escapes
+    i = 1
+    while i < len(rest):
+        if rest[i] == "\\" and i + 1 < len(rest):
+            i += 2  # Skip escaped char
+        elif rest[i] == "/":
+            # Found close slash
+            name = rest[:i + 1]
+            remaining = rest[i + 1:].strip()
+            return "", name, remaining
+        else:
+            i += 1
+
+    # No close slash found
+    return "", rest, ""
+
+
+_KNOWN_ARIA_ROLES = {
+    "fragment", "page", "document", "application", "main", "article", "region", "section", "group",
+    "generic", "none", "presentation", "banner", "navigation", "contentinfo", "complementary",
+    "toolbar", "menu", "menubar", "tablist", "tabpanel", "dialog", "alertdialog", "search", "form",
+    "feed", "log", "marquee", "math", "timer", "tooltip", "heading", "paragraph", "text", "caption",
+    "status", "alert", "note", "time", "blockquote", "figure", "list", "listitem", "link", "img",
+    "image", "iframe", "table", "grid", "tree", "treegrid", "treeitem", "row", "rowgroup", "cell",
+    "gridcell", "columnheader", "rowheader", "code", "pre", "strong", "emphasis", "em", "italic",
+    "button", "textbox", "searchbox", "combobox", "checkbox", "radio", "radiogroup", "switch",
+    "menuitem", "menuitemcheckbox", "menuitemradio", "tab", "option", "listbox", "slider",
+    "spinbutton", "meter", "progressbar", "scrollbar", "separator", "term", "definition",
+    "deletion", "insertion", "subscript", "superscript",
+}
+
+
+def _is_known_aria_role(role: str) -> bool:
+    """Check if a role is a known ARIA role."""
+    return role in _KNOWN_ARIA_ROLES
+
+
+# Regex patterns for parsing
+_ROLE_RE = re.compile(
+    r"^\s*(?:-\s*)?['\"]?(?P<role>[A-Za-z][\w-]*)['\"]?"
+    r"(?P<rest>.*)$"
+)
+_QUOTED_NAME_RE = re.compile(r'"((?:[^"\\]|\\.)*)"')
+_REF_RE = re.compile(r"\[(?:ref=)?(?P<ref>e\d+)\]|(?<!\S)@(?P<atref>e\d+)(?=\s|:|$)")
+_LEVEL_RE = re.compile(r"\[level=(?P<level>\d+)\]")
+_URL_RE = re.compile(r"^\s*(?:-\s*)?/url:\s*(?P<url>.+?)\s*$")
+_COLON_TEXT_RE = re.compile(r"^\s*(?:\[[^\]]+\]\s*)*:\s*(?P<text>.+?)\s*$")
+_VALUE_RE = re.compile(r":\s*value:\s*(?P<value>.+?)\s*$", re.IGNORECASE)
+_STATE_RE = re.compile(r"\[(?P<state>[^\]]+)\]")
+
+_CONTROL_ROLES = {
+    "button",
+    "textbox",
+    "searchbox",
+    "combobox",
+    "checkbox",
+    "radio",
+    "switch",
+    "slider",
+    "spinbutton",
+    "menuitem",
+    "menuitemcheckbox",
+    "menuitemradio",
+    "option",
+    "tab",
+}
+_CONTAINER_ROLES = {
+    "root",
+    "document",
+    "main",
+    "article",
+    "section",
+    "group",
+    "region",
+    "generic",
+    "list",
+    "rowgroup",
+    "iframe",  # Phase 3.14
+}
+_SKIP_SUBTREE_ROLES = {
+    "navigation",
+    "banner",
+    "contentinfo",
+    "complementary",
+    "search",
+    "toolbar",
+    "menu",
+    "menubar",
+}
+_INLINE_ROLES = {
+    "text",
+    "strong",
+    "emphasis",
+    "em",
+    "italic",
+    "deletion",
+    "term",
+    "definition",
+    "caption",
+    "meter",
+    "progressbar",  # Phase 3.13
+    "generic",
+    "cell",
+    "gridcell",  # Phase 3.15
+    "columnheader",
+    "rowheader",  # Phase 3.15
+}
+_IMAGE_ROLES = {"img", "image"}
+_TRACKING_QUERY_KEYS = {"fbclid", "gclid", "mc_cid", "mc_eid"}  # Phase 3.5
+
+
+@dataclass
+class _Item:
+    role: str
+    text: str
+    ref: str = ""
+    level: int = 0
+    url: str = ""
+    indent: int = 0
+    children: list["_Item"] = field(default_factory=list)
+    value: str = ""  # Phase 2.7: Control value
+    states: list[str] = field(default_factory=list)  # Phase 2.7: Control states
+    props: dict = field(default_factory=dict)  # Phase 2.3: Props like class
+    meta: dict = field(default_factory=dict)  # Phase 3.7: Metadata
+    parent: Optional["_Item"] = None  # Phase 4.1: Parent reference
+
+
+def render_accessibility_markdown(
+    snapshot_text: str,
+    *,
+    url: str = "",
+    title: str = "",
+    emit_refs: bool = False,
+    emit_controls: bool = False,
+) -> str:
+    """Render accessibility snapshot text to stable Markdown.
+
+    The caller owns the source contract. Camofox extraction passes accessibility
+    snapshots here; other web backends do not route through this renderer.
+    """
+    if not isinstance(snapshot_text, str):
+        return ""
+
+    text = snapshot_text.strip()
+    if not text:
+        return ""
+
+    # Phase 0: Parse tree
+    root = _parse_tree(text)
+
+    # Phase 3.7: Annotate tree
+    _annotate_tree(root)
+
+    # Phase 3.6: Reorder children for readability
+    content_nodes = _select_content_nodes(root)
+
+    # Phase 1: Render with multi-pass pipeline
+    blocks = _render_nodes(content_nodes, emit_refs=emit_refs, emit_controls=emit_controls)
+
+    # Phase 1.1-1.2: Normalize and transform
+    output = _join_blocks(blocks)
+
+    # Phase 1.3: Handle title
+    if title:
+        output = _handle_title(output, title)
+
+    return output
+
+
+# ============================================================================
+# Parsing
+# ============================================================================
+
+
+def _parse_tree(text: str) -> _Item:
+    root = _Item(role="root", text="", indent=-1)
+    stack: list[_Item] = [root]
+
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        node = _parse_line(line)
+        if node is None:
+            continue
+        while stack and node.indent <= stack[-1].indent:
+            stack.pop()
+        node.parent = stack[-1]  # Phase 4.1: Set parent reference
+        stack[-1].children.append(node)
+        stack.append(node)
+
+    return root
+
+
+def _has_descendant_role(node: _Item, role: str) -> bool:
+    """Check if a node or any of its descendants has a specific role."""
+    if node.role == role:
+        return True
+    for child in node.children:
+        if _has_descendant_role(child, role):
+            return True
+    return False
+
+
+def _parse_line(line: str) -> Optional[_Item]:
+    indent = len(line) - len(line.lstrip(" "))
+    url_match = _URL_RE.match(line)
+    if url_match:
+        return _Item(role="/url", text="", url=_clean_url(url_match.group("url")), indent=indent)
+
+    parsed = _parse_role_line(line)
+    if parsed:
+        parsed.indent = indent
+    return parsed
+
+
+def _parse_role_line(line: str) -> Optional[_Item]:
+    match = _ROLE_RE.match(line)
+    if not match:
+        return None
+
+    role = match.group("role").lower()
+    rest = match.group("rest") or ""
+    if role == "url":
+        return None
+
+    # Phase 0.3: Use structural colon splitting
+    key_part, value_part = _split_unquoted_colon(line.strip().lstrip("- ").strip())
+
+    # Phase 0.2: Unquote the key
+    unquoted_key = _unquote_aria_snapshot_key(key_part)
+
+    # Try to parse quoted name from rest
+    quoted = _QUOTED_NAME_RE.search(rest)
+    if quoted:
+        raw_name = quoted.group(1)
+        if "\\" in raw_name:
+            # Phase 0.1: Use robust escape decoder
+            name = _decode_accessible_string_escapes(raw_name)
+        else:
+            name = raw_name
+    else:
+        # Try colon text
+        colon = _COLON_TEXT_RE.search(rest)
+        if colon:
+            name = colon.group("text")
+        else:
+            # Check for value: pattern
+            value_match = _VALUE_RE.search(rest)
+            if value_match:
+                name = ""
+            elif role not in _CONTAINER_ROLES:
+                # Last-resort: remove metadata/ref fragments and keep useful prose.
+                name = re.sub(r"\[[^\]]+\]", "", rest).strip(" :-'")
+            else:
+                name = ""
+
+    # Phase 2.7: Parse value and states
+    value = ""
+    states = []
+    value_match = _VALUE_RE.search(rest)
+    if value_match:
+        raw_value = value_match.group("value").strip()
+        # Unquote if needed
+        if (raw_value.startswith('"') and raw_value.endswith('"')) or \
+           (raw_value.startswith("'") and raw_value.endswith("'")):
+            value = _decode_accessible_string_escapes(raw_value[1:-1])
+        else:
+            value = raw_value
+
+    # Parse states like [checked], [disabled], [expanded]
+    for state_match in _STATE_RE.finditer(rest):
+        state_text = state_match.group("state").strip()
+        # Skip ref, level, nth, cursor
+        if state_text.startswith("ref=") or state_text.startswith("level=") or \
+           state_text.startswith("nth=") or state_text.startswith("cursor="):
+            continue
+        if state_text and state_text not in ("checked=false", "checked: false"):
+            states.append(state_text)
+
+    # Phase 2.3: Parse props like [class="language-python"]
+    props = {}
+    prop_match = re.search(r'\[class="([^"]+)"\]', rest)
+    if prop_match:
+        props["class"] = prop_match.group(1)
+
+    if not name and role not in _CONTAINER_ROLES:
+        # Last-resort: remove metadata/ref fragments and keep useful prose.
+        name = re.sub(r"\[[^\]]+\]", "", rest).strip(" :-'")
+
+    ref_match = _REF_RE.search(rest)
+    ref = ""
+    if ref_match:
+        ref = ref_match.group("ref") or ref_match.group("atref") or ""
+
+    level_match = _LEVEL_RE.search(rest)
+    level = 0
+    if level_match:
+        try:
+            level = max(1, min(6, int(level_match.group("level"))))
+        except ValueError:
+            level = 0
+
+    # Phase 0.5: Validate role (skip unknown roles without browser markers)
+    if not _is_known_aria_role(role) and not ref and level == 0 and not states:
+        # Unknown role with no markers, skip it
+        return None
+
+    return _Item(
+        role=role,
+        text=_strip_refs(name).strip(),
+        ref=ref,
+        level=level,
+        value=value,
+        states=states,
+        props=props,
+    )
+
+
+# ============================================================================
+# Phase 3.7: Tree annotation
+# ============================================================================
+
+
+def _annotate_tree(node: _Item, depth: int = 0) -> None:
+    """Annotate tree with metadata for rendering."""
+    if node.role == "listitem":
+        node.meta["list_depth"] = depth
+
+    # Check for explicit table headers
+    if node.role == "table":
+        has_header = any(
+            cell.role in {"columnheader", "rowheader"}
+            for row in _find_nodes(node, "row")
+            for cell in row.children
+            if cell.role in {"cell", "columnheader", "rowheader", "gridcell"}
+        )
+        node.meta["has_explicit_header"] = has_header
+
+    # Detect code language
+    if node.role in {"code", "pre"}:
+        lang = _code_language_label(node)
+        if lang:
+            node.meta["language"] = lang
+
+    for child in node.children:
+        _annotate_tree(child, depth + 1 if node.role == "listitem" else depth)
+
+
+# ============================================================================
+# Phase 3.6: Readable ordering
+# ============================================================================
+
+
+def _select_content_nodes(root: _Item) -> list[_Item]:
+    mains = _find_nodes(root, "main")
+    if mains:
+        return _ordered_readable_children(mains)
+    articles = _find_nodes(root, "article")
+    if articles:
+        return _ordered_readable_children(articles)
+    return _ordered_readable_children(root.children)
+
+
+def _ordered_readable_children(children: list[_Item]) -> list[_Item]:
+    """Reorder children: main/article first, then sections, then chrome."""
+    _CHROME_ROLES = {"banner", "navigation", "search", "form", "complementary", "toolbar", "menu", "menubar"}
+    _PRIMARY_ROLES = {"main", "article"}
+    _SECONDARY_ROLES = {"section", "region", "group"}
+
+    def priority(node: _Item) -> int:
+        if node.role in _PRIMARY_ROLES:
+            return 0
+        if node.role in _SECONDARY_ROLES:
+            return 1
+        if node.role in _CHROME_ROLES or node.role == "contentinfo":
+            return 2
+        return 1
+
+    # Stable sort by priority
+    return sorted(children, key=priority)
+
+
+def _find_nodes(node: _Item, role: str) -> list[_Item]:
+    found: list[_Item] = []
+    if node.role == role:
+        found.append(node)
+    for child in node.children:
+        found.extend(_find_nodes(child, role))
+    return found
+
+
+# ============================================================================
+# Phase 4.1: Chrome compaction
+# ============================================================================
+
+
+def _compact_item_nodes(node: _Item) -> list[_Item]:
+    """Recursively collect links and controls from a chrome node."""
+    if node.role == "link" or node.role in _CONTROL_ROLES:
+        return [node]
+    items = []
+    for child in node.children:
+        items.extend(_compact_item_nodes(child))
+    return items
+
+
+def _chrome_title(node: _Item) -> str:
+    """Generate a title for compacted chrome sections."""
+    if node.role == "banner":
+        return "Header"
+    if node.role == "contentinfo":
+        return "Footer"
+    if node.role in {"menu", "menubar", "toolbar"}:
+        return "Navigation"
+    if node.role == "search":
+        return "Search"
+    if node.role == "form":
+        return "Form"
+    # navigation or other
+    return node.role.replace("-", " ").title()
+
+
+def _compact_chrome_node(node: _Item, *, emit_refs: bool, emit_controls: bool) -> Optional[list[str]]:
+    """Compact chrome sections (nav, banner, etc.) into a single-line summary.
+    
+    Returns rendered lines or None if not compactable.
+    """
+    _CHROME_ROLES = {"banner", "navigation", "toolbar", "menu", "menubar", "contentinfo", "search", "form"}
+    
+    if node.role not in _CHROME_ROLES:
+        return None
+    
+    # Don't compact if emit_controls is True (user wants full detail)
+    if emit_controls:
+        return None
+    
+    # Check if this chrome node is a direct child of a document with no main content
+    # In that case, skip chrome entirely (return empty list)
+    if node.parent and node.parent.role == "document":
+        has_main = _has_descendant_role(node.parent, "main")
+        if not has_main:
+            return []  # Skip chrome entirely
+    
+    # Collect items
+    items = _compact_item_nodes(node)
+    if not items:
+        return None
+    
+    # Don't compact if there's substantive block content
+    if _has_substantive_block_content(node):
+        return None
+    
+    # Render items
+    rendered_items = []
+    seen = set()
+    for item in items:
+        text = _inline_fragment(item, emit_refs=emit_refs)
+        if not text:
+            continue
+        key = text.strip().lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        rendered_items.append(text)
+    
+    if not rendered_items:
+        return None
+    
+    # Cap at 6 items if more than 8
+    if not emit_refs and len(rendered_items) > 8:
+        rendered_items = rendered_items[:6] + [f"… {len(rendered_items) - 6} more"]
+    
+    title = _chrome_title(node)
+    return [f"## {title}", "- " + ", ".join(rendered_items)]
+
+
+def _has_substantive_block_content(node: _Item) -> bool:
+    """Check if a node contains substantive block content (not just chrome)."""
+    if node.role in {"main", "article", "paragraph", "blockquote", "table", "grid", "treegrid", "code", "pre"}:
+        return True
+    if node.role == "heading" and _clean_ui_text(node.text):
+        return True
+    if node.role == "listitem":
+        text = _clean_ui_text(node.text)
+        if len(text) > 80:
+            return True
+        for child in node.children:
+            if child.role in {"paragraph", "code", "pre", "table", "grid", "treegrid"}:
+                return True
+    for child in node.children:
+        if _has_substantive_block_content(child):
+            return True
+    return False
+
+
+# ============================================================================
+# Phase 4.2: Consent dialog detection
+# ============================================================================
+
+
+def _is_consent_node(node: _Item) -> bool:
+    """Check if a node is a cookie/privacy consent dialog."""
+    if node.role not in {"dialog", "alertdialog"}:
+        return False
+    
+    text = (node.text or "").lower()
+    consent_keywords = ["cookie", "consent", "privacy", "legitimate interest"]
+    if not any(keyword in text for keyword in consent_keywords):
+        return False
+    
+    # Check for accept/reject controls
+    controls = []
+    for child in _compact_item_nodes(node):
+        if child.role in _CONTROL_ROLES:
+            controls.append(_clean_ui_text(child.text).lower())
+    
+    action_keywords = ["accept", "reject", "manage", "choices", "options"]
+    return any(any(keyword in label for keyword in action_keywords) for label in controls)
+
+
+def _render_consent_node(node: _Item, *, emit_refs: bool, emit_controls: bool) -> Optional[list[str]]:
+    """Render consent dialogs compactly.
+    
+    Returns rendered lines or None if not a consent dialog.
+    """
+    if not _is_consent_node(node):
+        return None
+    
+    # Collect text parts
+    text_parts = []
+    controls = []
+    
+    def walk(current: _Item) -> None:
+        if current.role in _CONTROL_ROLES:
+            rendered = _render_control(current, emit_refs=emit_refs)
+            if rendered:
+                controls.append(rendered)
+            return
+        if current.role in {"heading", "paragraph", "text", "caption", "status", "alert", "note"}:
+            text = _inline_text(current.children, emit_refs=emit_refs) if current.children else _clean_ui_text(current.text)
+            if text:
+                text_parts.append(text)
+            return
+        for child in current.children:
+            walk(child)
+    
+    walk(node)
+    
+    lines = ["## Consent"]
+    
+    # Join unique text parts with em-dash
+    unique_parts = []
+    seen = set()
+    for part in text_parts:
+        normalized = part.strip()
+        if normalized and normalized.lower() not in seen:
+            seen.add(normalized.lower())
+            unique_parts.append(normalized)
+    
+    if unique_parts:
+        lines.append(" — ".join(unique_parts))
+    
+    # Add controls if emit_controls is True
+    if emit_controls:
+        seen_controls = set()
+        for control in controls:
+            if control not in seen_controls:
+                seen_controls.add(control)
+                lines.append(control)
+    
+    return lines
+
+
+# ============================================================================
+# Phase 3.8: Term-definition pairs
+# ============================================================================
+
+
+def _render_term_definition_pair(term: _Item, definition: _Item, *, emit_refs: bool) -> Optional[str]:
+    """Render a term-definition pair as **term:** definition.
+    
+    Returns rendered text or None if invalid.
+    """
+    term_text = _inline_text(term.children, emit_refs=emit_refs) if term.children else _clean_ui_text(term.text)
+    definition_text = _inline_text(definition.children, emit_refs=emit_refs) if definition.children else _clean_ui_text(definition.text)
+    
+    if not term_text or not definition_text:
+        return None
+    
+    # Remove trailing colon from term if present
+    term_text = term_text.rstrip(":")
+    
+    return f"**{term_text}:** {definition_text}"
+
+
+# ============================================================================
+# Rendering
+# ============================================================================
+
+
+def _render_nodes(nodes: list[_Item], *, emit_refs: bool, emit_controls: bool) -> list[str]:
+    blocks: list[str] = []
+    pending_inline: list[str] = []
+    
+    def flush_inline():
+        if pending_inline:
+            # Join inline fragments with proper spacing
+            text = _format_inline_spacing(pending_inline)
+            if text:
+                blocks.append(text)
+            pending_inline.clear()
+    
+    i = 0
+    while i < len(nodes):
+        node = nodes[i]
+        
+        # Phase 3.8: Detect term-definition pairs
+        if node.role == "term" and i + 1 < len(nodes) and nodes[i + 1].role == "definition":
+            flush_inline()  # Flush any pending inline content first
+            term_node = node
+            definition_node = nodes[i + 1]
+            pair_result = _render_term_definition_pair(term_node, definition_node, emit_refs=emit_refs)
+            if pair_result:
+                blocks.append(pair_result)
+                i += 2  # Skip both term and definition
+                continue
+        
+        # Phase 3.9: Batch consecutive inline fragments
+        # Only batch truly inline content (text, formatting), not links or code blocks
+        _INLINE_FRAGMENT_ROLES = {"text", "strong", "emphasis", "em", "italic", 
+                                   "deletion", "insertion", "subscript", "superscript"}
+        if emit_controls:
+            _INLINE_FRAGMENT_ROLES.update(_CONTROL_ROLES)
+        
+        if node.role in _INLINE_FRAGMENT_ROLES:
+            # Render inline fragment and add to pending batch
+            fragment = _inline_fragment(node, emit_refs=emit_refs)
+            if fragment:
+                pending_inline.append(fragment)
+                i += 1
+                continue
+            # If fragment is empty (e.g., skipped control), fall through to normal rendering
+        
+        # Not an inline fragment - flush pending and render normally
+        flush_inline()
+        blocks.extend(_render_node(node, emit_refs=emit_refs, emit_controls=emit_controls))
+        i += 1
+    
+    # Flush any remaining inline content
+    flush_inline()
+    return blocks
+
+
+def _render_node(node: _Item, *, emit_refs: bool, emit_controls: bool) -> list[str]:
+    role = node.role
+
+    # Phase 4.2: Consent dialog detection (before generic dialog handling)
+    if role in {"dialog", "alertdialog"}:
+        consent_result = _render_consent_node(node, emit_refs=emit_refs, emit_controls=emit_controls)
+        if consent_result is not None:
+            return consent_result
+
+    # Phase 4.1: Chrome compaction (before generic chrome handling)
+    _CHROME_ROLES = {"banner", "navigation", "toolbar", "menu", "menubar", "contentinfo", "search", "form"}
+    if role in _CHROME_ROLES:
+        chrome_result = _compact_chrome_node(node, emit_refs=emit_refs, emit_controls=emit_controls)
+        if chrome_result is not None:
+            return chrome_result
+
+    # Phase 3.13: Handle meter/progressbar
+    if role in {"meter", "progressbar"}:
+        label = _clean_ui_text(node.text)
+        value_text = _clean_ui_text(node.value) if node.value else ""
+        if label and value_text:
+            text = f"{label}: {value_text}"
+        elif label:
+            text = label
+        elif value_text:
+            text = value_text
+        else:
+            return []
+        if emit_refs and node.ref:
+            text = f"{text} [{node.ref}]"
+        return [text] if text else []
+
+    if role == "list":
+        rendered_items = []
+        for child in node.children:
+            if child.role == "listitem":
+                # Phase 3.1: Check for task list
+                task_parts = _task_listitem_parts(child, emit_refs=emit_refs, emit_controls=emit_controls)
+                if task_parts:
+                    marker, text, control = task_parts
+                    rendered = f"{marker} {text}"
+                    if emit_controls and control:
+                        rendered = f"{rendered} {control}"
+                    depth = child.meta.get("list_depth", 0)
+                    indent = "  " * depth
+                    rendered_items.append(f"{indent}- {rendered}")
+                else:
+                    text = _inline_text(child.children, emit_refs=emit_refs) or _clean_inline(child.text)
+                    if text:
+                        depth = child.meta.get("list_depth", 0)
+                        indent = "  " * depth
+                        rendered_items.append(f"{indent}- {text}")
+            else:
+                rendered_items.extend(_render_node(child, emit_refs=emit_refs, emit_controls=emit_controls))
+        return ["\n".join(rendered_items)] if rendered_items else []
+
+    # Phase 3.4: Image markdown syntax
+    if role in _IMAGE_ROLES:
+        text = _clean_inline(node.text)
+        if not text:
+            return []
+        url = _node_url(node)
+        if url:
+            # Phase 3.5: Sanitize URL
+            url = _sanitize_display_href(url)
+            return [f"![{text}]({url})"]
+        else:
+            return [f"![{text}]"]
+
+    if role == "/url" or role in _SKIP_SUBTREE_ROLES:
+        return []
+
+    # Phase 2.7: Enhanced control rendering
+    if role in _CONTROL_ROLES:
+        if not emit_controls:
+            return []
+        return [_render_control(node, emit_refs=emit_refs)]
+
+    if role == "heading":
+        text = _heading_text(node)
+        if not text:
+            return []
+        # Phase 2.1: Escape markdown
+        text = _escape_md_text(text)
+        ref = f" [{node.ref}]" if emit_refs and node.ref else ""
+        return [f"{'#' * (node.level or 2)} {text}{ref}"]
+
+    if role == "paragraph":
+        text = _inline_text(node.children, emit_refs=emit_refs) or _clean_inline(node.text)
+        # Phase 2.1: Escape markdown
+        if text:
+            text = _escape_md_block_text(text)
+        return [text] if text else []
+
+    # Phase 3.3: Blockquote
+    if role == "blockquote":
+        text = _inline_text(node.children, emit_refs=emit_refs) or _clean_inline(node.text)
+        if text:
+            lines = text.split("\n")
+            return [f"> {line}" for line in lines]
+        return []
+
+    if role == "link":
+        rendered = _render_link(node, emit_refs=emit_refs)
+        return [rendered] if rendered else []
+
+    # Phase 2.3: Enhanced code block rendering
+    if role in {"code", "pre"}:
+        code = _code_block_text(node)
+        if not code:
+            return []
+
+        # Phase 1.6: Decode escape sequences
+        code = _decode_accessible_string_escapes(code)
+
+        # Phase 1.7: Strip refs from code
+        code_lines = [_clean_code_line(line) for line in code.split("\n")]
+        code = "\n".join(line for line in code_lines if line or not code_lines)
+
+        # Phase 3.12: Check if substantive
+        if not _looks_like_substantive_code_lines(code_lines):
+            return []
+
+        # Phase 2.3: Dynamic fence and language
+        fence = _code_fence_for(code)
+        lang = node.meta.get("language", "")
+        fence_line = f"{fence}{lang}" if lang else fence
+
+        return [f"{fence_line}\n{code}\n{fence}"]
+
+    # Phase 3.10: Three-tier table rendering
+    if role in {"table", "grid", "treegrid"}:
+        return _render_table_enhanced(node, emit_refs=emit_refs)
+
+    if role == "listitem":
+        # Phase 3.1: Check for task list
+        task_parts = _task_listitem_parts(node, emit_refs=emit_refs, emit_controls=emit_controls)
+        if task_parts:
+            marker, text, control = task_parts
+            rendered = f"{marker} {text}"
+            if emit_controls and control:
+                rendered = f"{rendered} {control}"
+            depth = node.meta.get("list_depth", 0)
+            indent = "  " * depth
+            return [f"{indent}- {rendered}"]
+        else:
+            text = _inline_text(node.children, emit_refs=emit_refs) or _clean_inline(node.text)
+            if text:
+                depth = node.meta.get("list_depth", 0)
+                indent = "  " * depth
+                return [f"{indent}- {text}"]
+            return []
+
+    if role == "row":
+        row = _render_row(node, emit_refs=emit_refs)
+        return [row] if row else []
+
+    if role in _CONTAINER_ROLES:
+        # Containers are structural; their accessible names are usually UI chrome.
+        return _render_nodes(node.children, emit_refs=emit_refs, emit_controls=emit_controls)
+
+    if role == "application":
+        blocks = [_clean_inline(node.text)] if node.text else []
+        blocks.extend(_render_nodes(node.children, emit_refs=emit_refs, emit_controls=emit_controls))
+        return [block for block in blocks if block]
+
+    # Phase 2.4: Handle inline formatting roles
+    if role in {"strong"}:
+        text = _inline_text(node.children, emit_refs=emit_refs) if node.children else _clean_inline(node.text)
+        return [f"**{text}**"] if text else []
+
+    if role in {"emphasis", "em", "italic"}:
+        text = _inline_text(node.children, emit_refs=emit_refs) if node.children else _clean_inline(node.text)
+        return [f"*{text}*"] if text else []
+
+    if role == "deletion":
+        text = _inline_text(node.children, emit_refs=emit_refs) if node.children else _clean_inline(node.text)
+        return [f"~~{text}~~"] if text else []
+
+    if role in _INLINE_ROLES:
+        text = _inline_text(node.children, emit_refs=emit_refs) if node.children else _clean_inline(node.text)
+        return [text] if text else []
+
+    if node.children:
+        return _render_nodes(node.children, emit_refs=emit_refs, emit_controls=emit_controls)
+
+    text = _clean_inline(node.text)
+    return [text] if text else []
+
+
+# ============================================================================
+# Phase 3.1: Task list support
+# ============================================================================
+
+
+def _task_listitem_parts(node: _Item, *, emit_refs: bool, emit_controls: bool) -> Optional[tuple[str, str, str]]:
+    """Detect checkbox child and return task list parts.
+
+    Returns: (marker, text, control) or None
+    """
+    checkbox = next((child for child in node.children if child.role == "checkbox"), None)
+    if not checkbox:
+        return None
+
+    # Get text from other children
+    text_children = [child for child in node.children if child.role != "checkbox"]
+    text = _inline_text(text_children, emit_refs=emit_refs) or _clean_inline(node.text)
+    if not text:
+        return None
+
+    # Check if checked
+    checked = _checkbox_checked(checkbox)
+    marker = "[x]" if checked else "[ ]"
+
+    # Generate control string if needed
+    control = _render_control(checkbox, emit_refs=emit_refs) if emit_controls else ""
+
+    return marker, text, control
+
+
+def _checkbox_checked(node: _Item) -> bool:
+    """Check if a checkbox node is checked."""
+    states_lower = {s.lower() for s in node.states}
+    if "checked=false" in states_lower or "checked: false" in states_lower:
+        return False
+    return "checked" in states_lower or "checked=true" in states_lower or "checked: true" in states_lower
+
+
+# ============================================================================
+# Phase 3.10: Three-tier table rendering
+# ============================================================================
+
+
+def _render_table_enhanced(node: _Item, *, emit_refs: bool) -> list[str]:
+    """Render table with three-tier system: definition, header, layout."""
+    rows = _find_nodes(node, "row")
+    if not rows:
+        return []
+
+    # Try definition table first (2-column key-value pairs)
+    definition_rows = _render_definition_table_rows(node, emit_refs=emit_refs)
+    if definition_rows:
+        return definition_rows
+
+    # Try header table (markdown table format)
+    header_rows = _render_header_table_rows(node, emit_refs=emit_refs)
+    if header_rows:
+        # Add table label if present
+        if node.text:
+            label = _clean_inline(node.text)
+            if label:
+                return [f"**{label}**", ""] + header_rows
+        return header_rows
+
+    # Fallback to layout table (definition list format)
+    lines = []
+    for row in rows:
+        rendered = _render_table_row(row, emit_refs=emit_refs)
+        if rendered:
+            lines.append(rendered)
+    return lines if lines else []
+
+
+def _render_definition_table_rows(node: _Item, *, emit_refs: bool) -> Optional[list[str]]:
+    """Render 2-column definition table as **label:** value."""
+    rows = _find_nodes(node, "row")
+    if not rows:
+        return None
+
+    rendered = []
+    for row in rows:
+        cells = [child for child in row.children if child.role in {"cell", "columnheader", "rowheader", "gridcell"}]
+        if len(cells) != 2:
+            return None  # Not a 2-column table
+
+        # Skip header rows
+        if all(cell.role == "columnheader" for cell in cells):
+            continue
+
+        label = _inline_text([cells[0]])
+        value = _inline_text([cells[1]])
+
+        if not label or not value:
+            return None
+
+        # Check if it looks like a definition (label ends with : or is rowheader)
+        is_definition = label.endswith(":") or cells[0].role == "rowheader"
+        label = label.rstrip(":").strip()
+
+        if not is_definition or len(label) > 48:
+            return None
+
+        rendered.append(f"**{label}:** {value}")
+
+    return rendered if len(rendered) >= 2 else None
+
+
+def _render_header_table_rows(node: _Item, *, emit_refs: bool) -> Optional[list[str]]:
+    """Render table with explicit or inferred headers as markdown table."""
+    rows = _find_nodes(node, "row")
+    if not rows:
+        return None
+
+    # Extract all rows with cells
+    table_rows = []
+    for row in rows:
+        cells = [child for child in row.children if child.role in {"cell", "columnheader", "rowheader", "gridcell"}]
+        if not cells:
+            continue
+
+        cell_texts = []
+        for cell in cells:
+            text = _inline_text([cell]) or _clean_inline(cell.text)
+            cell_texts.append(text)
+
+        table_rows.append((cells, cell_texts))
+
+    if len(table_rows) < 2:
+        return None
+
+    # Check for explicit headers
+    has_explicit = node.meta.get("has_explicit_header", False)
+    if has_explicit:
+        # First row is header
+        header_cells, header_texts = table_rows[0]
+        data_rows = table_rows[1:]
+    else:
+        # Check if first row looks like headers
+        first_cells, first_texts = table_rows[0]
+        if _looks_like_inferred_header(first_texts):
+            header_cells, header_texts = first_cells, first_texts
+            data_rows = table_rows[1:]
+        else:
+            return None  # No headers detected
+
+    # Build markdown table
+    width = len(header_texts)
+    lines = []
+
+    # Header row
+    escaped_headers = [_escape_table_cell(t) for t in header_texts]
+    lines.append("| " + " | ".join(escaped_headers) + " |")
+
+    # Separator
+    lines.append("| " + " | ".join(["---"] * width) + " |")
+
+    # Data rows
+    for cells, texts in data_rows:
+        # Pad to width
+        padded = texts + [""] * (width - len(texts))
+        escaped = [_escape_table_cell(t) for t in padded[:width]]
+        lines.append("| " + " | ".join(escaped) + " |")
+
+    return lines
+
+
+def _escape_table_cell(text: str) -> str:
+    """Escape pipe characters in table cells."""
+    return (text or "").replace("|", "\\|")
+
+
+def _looks_like_inferred_header(texts: list[str]) -> bool:
+    """Check if a row looks like a header (short text, no numbers)."""
+    if not texts:
+        return False
+    for text in texts:
+        if not text:
+            continue
+        # Header cells are typically short and don't look like data
+        if len(text) > 40:
+            return False
+        # Check if it looks like numeric data
+        if re.match(r"^\d+\.?\d*$", text.strip()):
+            return False
+    return True
+
+
+def _heading_text(node: _Item) -> str:
+    non_anchor_children = [child for child in node.children if not _is_direct_anchor_link(child)]
+    child_text = _inline_text(non_anchor_children)
+    text = child_text or node.text
+    # Phase 1.4: Clean heading text
+    text = _clean_heading_text(text)
+    text = _clean_inline(text)
+    return text
+
+
+def _render_link(node: _Item, *, emit_refs: bool) -> str:
+    url = _node_url(node)
+    text = _link_text(node)
+    if not text or _should_skip_link(text, url, emit_refs=emit_refs):
+        return ""
+
+    # Phase 3.11: Filter low-value links
+    if not emit_refs and _is_low_value_document_action_link(text):
+        return ""
+
+    # Phase 3.5: Sanitize URL
+    if url:
+        url = _sanitize_display_href(url)
+        # Phase 2.1: Escape brackets in link text
+        text = _escape_md_link_label(text)
+        ref = f" [{node.ref}]" if emit_refs and node.ref else ""
+        return f"[{text}]({url}){ref}"
+    ref = f" [{node.ref}]" if emit_refs and node.ref else ""
+    return f"{text}{ref}"
+
+
+# Phase 2.7: Enhanced control rendering
+def _render_control(node: _Item, *, emit_refs: bool) -> str:
+    text = _clean_ui_text(node.text)
+    quoted = f'"{text}"' if text else "(unlabeled)"
+    ref = f" [{node.ref}]" if emit_refs and node.ref else (" no ref" if emit_refs else "")
+
+    parts = [node.role, quoted]
+    if ref:
+        parts.append(ref.strip())
+
+    # Add value if present
+    if node.value:
+        value_clean = _clean_ui_text(node.value)
+        parts.append(f'value="{value_clean}"')
+
+    # Add states
+    for state in node.states:
+        if state:
+            parts.append(state)
+
+    return "<" + " ".join(parts) + ">"
+
+
+def _render_table(node: _Item, *, emit_refs: bool) -> str:
+    """Legacy table renderer for backward compatibility."""
+    rows = _find_nodes(node, "row")
+    lines: list[str] = []
+    for row in rows:
+        rendered = _render_table_row(row, emit_refs=emit_refs)
+        if rendered:
+            lines.append(rendered)
+    return "\n".join(lines)
+
+
+def _render_table_row(row: _Item, *, emit_refs: bool) -> str:
+    cells = [child for child in row.children if child.role in {"cell", "columnheader", "rowheader", "gridcell"}]
+    if cells and all(cell.role == "columnheader" for cell in cells):
+        return ""
+
+    if len(cells) >= 2:
+        first = _inline_text([cells[0]])
+        rest = _clean_inline(" — ".join(filter(None, (_inline_text([cell]) for cell in cells[1:]))))
+        if first and rest:
+            return f"- {first}: {rest}"
+        if first:
+            return f"- {first}"
+
+    # Phase 3.15: Handle nested tables
+    nested_tables = [child for child in row.children if child.role in {"table", "grid", "treegrid"}]
+    if nested_tables:
+        lines = []
+        for nested in nested_tables:
+            lines.extend(_render_table_enhanced(nested, emit_refs=emit_refs))
+        if lines:
+            return "\n".join(lines)
+
+    text = _inline_text(row.children) or _clean_inline(row.text)
+    return f"- {text}" if text else ""
+
+
+def _render_row(node: _Item, *, emit_refs: bool) -> str:
+    return _render_table_row(node, emit_refs=emit_refs)
+
+
+# ============================================================================
+# Inline text
+# ============================================================================
+
+
+def _inline_text(nodes: list[_Item], *, emit_refs: bool = False) -> str:
+    fragments: list[str] = []
+    for node in nodes:
+        fragment = _inline_fragment(node, emit_refs=emit_refs)
+        if fragment:
+            fragments.append(fragment)
+    # Phase 2.5: Smart spacing
+    return _format_inline_spacing(fragments)
+
+
+def _inline_fragment(node: _Item, *, emit_refs: bool = False) -> str:
+    role = node.role
+    if role == "/url" or role in _CONTROL_ROLES or role in _SKIP_SUBTREE_ROLES:
+        return ""
+    if role in _IMAGE_ROLES:
+        text = _clean_inline(node.text)
+        if not text:
+            return ""
+        url = _node_url(node)
+        if url:
+            url = _sanitize_display_href(url)
+            return f"![{text}]({url})"
+        return f"![{text}]"
+    if role == "link":
+        return _render_link(node, emit_refs=emit_refs)
+
+    # Phase 2.2: Smart inline code
+    if role in {"code", "pre"}:
+        text = _plain_text(node).strip()
+        text = _decode_accessible_string_escapes(text)
+        return _inline_code_markdown(text) if text else ""
+
+    # Phase 2.4: Inline formatting
+    if role == "strong":
+        text = _inline_text(node.children, emit_refs=emit_refs) if node.children else _clean_inline(node.text)
+        return f"**{text}**" if text else ""
+
+    if role in {"emphasis", "em", "italic"}:
+        text = _inline_text(node.children, emit_refs=emit_refs) if node.children else _clean_inline(node.text)
+        return f"*{text}*" if text else ""
+
+    if role == "deletion":
+        text = _inline_text(node.children, emit_refs=emit_refs) if node.children else _clean_inline(node.text)
+        return f"~~{text}~~" if text else ""
+
+    if role in _INLINE_ROLES or role in _CONTAINER_ROLES or role == "application":
+        child_text = _inline_text(node.children, emit_refs=emit_refs) if node.children else ""
+        text = child_text or node.text
+        return _clean_inline(text)
+    if node.children:
+        return _inline_text(node.children, emit_refs=emit_refs)
+    return _clean_inline(node.text)
+
+
+# ============================================================================
+# Phase 2.3: Code block helpers
+# ============================================================================
+
+
+def _code_block_text(node: _Item) -> str:
+    """Extract text from code/pre node, handling line-number gutters."""
+    # Phase 3.12: Check for line-number gutter pattern
+    row_children = [child for child in node.children if child.role == "row"]
+    if row_children:
+        # Check if first column is sequential numbers
+        rows = []
+        for row in row_children:
+            cells = [child for child in row.children if child.role in {"cell", "gridcell"}]
+            if len(cells) >= 2:
+                rows.append(cells)
+
+        if rows and all(len(r) >= 2 for r in rows):
+            # Check if first column is sequential numbers
+            first_col = [r[0].text.strip() for r in rows]
+            if all(str(i + 1) == first_col[i] for i in range(len(first_col))):
+                # Extract code from second column
+                code_lines = [_plain_text(r[1]) for r in rows]
+                return "\n".join(code_lines)
+
+    # Fallback to plain text extraction
+    return _plain_text(node)
+
+
+def _code_fence_for(text: str) -> str:
+    """Generate fence with enough backticks to wrap the content."""
+    max_run = _max_backtick_run(text)
+    return "`" * max(3, max_run + 1)
+
+
+def _code_language_label(node: _Item) -> str:
+    """Extract language from node props or class."""
+    # Check props
+    class_attr = node.props.get("class", "")
+    if class_attr:
+        # Look for language-* or lang-* pattern
+        match = re.search(r"(?:language|lang)-([a-zA-Z0-9_+.#-]{1,32})", class_attr)
+        if match:
+            return match.group(1).strip("._-").lower()
+
+    # Check label
+    if node.text:
+        match = re.match(r"^(?:(?:language|lang)-)?([a-zA-Z0-9_+.#-]{1,32})$", node.text.strip())
+        if match:
+            return match.group(1).strip("._-").lower()
+
+    return ""
+
+
+def _looks_like_substantive_code_lines(lines: list[str]) -> bool:
+    """Check if code lines look substantive (not just numbers or empty)."""
+    nonempty = [line for line in lines if line.strip()]
+    if not nonempty:
+        return False
+    # Check if all lines are just numbers
+    if all(re.match(r"^\d+\.?\d*$", line.strip()) for line in nonempty):
+        return False
+    # Check if any line has code-like characters
+    return any(re.search(r"[A-Za-z_{}()[\];=+\-*/<>:'\"`]", line) for line in nonempty)
+
+
+def _plain_text(node: _Item) -> str:
+    fragments: list[str] = []
+    if node.text and node.role not in _CONTROL_ROLES and node.role not in _IMAGE_ROLES and node.role != "/url":
+        fragments.append(_clean_inline(node.text))
+    for child in node.children:
+        if child.role in _CONTROL_ROLES or child.role in _IMAGE_ROLES or child.role == "/url":
+            continue
+        text = _plain_text(child)
+        if text:
+            fragments.append(text)
+    return "\n".join(fragments)
+
+
+def _link_text(node: _Item) -> str:
+    child_text = _inline_text([child for child in node.children if child.role != "/url"])
+    text = child_text or node.text
+    text = re.sub(r"\s*\(opens in new tab\)\s*", "", text)
+    return _clean_inline(text)
+
+
+def _node_url(node: _Item) -> str:
+    for child in node.children:
+        if child.role == "/url" and child.url:
+            return child.url
+    return node.url
+
+
+def _is_direct_anchor_link(node: _Item) -> bool:
+    if node.role != "link":
+        return False
+    text = _clean_inline(node.text)
+    url = _node_url(node)
+    return text.startswith("Direct link to ") and url.startswith("#")
+
+
+def _should_skip_link(text: str, url: str, *, emit_refs: bool = False) -> bool:
+    if _is_skip_link_text(text) and url.startswith("#"):
+        return True
+    if text.startswith("Direct link to ") and url.startswith("#"):
+        return True
+    if _is_javascript_href(url) and not emit_refs:
+        return True
+    return False
+
+
+def _is_skip_link_text(text: str) -> bool:
+    return text.lower().startswith("skip to ")
+
+
+def _is_javascript_href(url: str) -> bool:
+    return _clean_url(url).casefold().startswith("javascript:")
+
+
+# Phase 3.11: Low-value document action links
+_LOW_VALUE_DOCUMENT_ACTION_LINKS = {
+    "upvote", "hide", "fork", "star", "watch", "subscribe", "sign in", "login",
+    "edit this page", "report an issue", "view source",
+}
+
+
+def _is_low_value_document_action_link(text: str) -> bool:
+    """Check if link text is a low-value document action."""
+    return text.lower().strip() in _LOW_VALUE_DOCUMENT_ACTION_LINKS
+
+
+# ============================================================================
+# Phase 1: Multi-pass pipeline
+# ============================================================================
+
+
+def _join_blocks(blocks: list[str]) -> str:
+    """Join blocks with normalization and transforms."""
+    # Phase 1.1: Normalize - but preserve block structure
+    lines = []
+    for block in blocks:
+        if block:
+            lines.extend(block.split("\n"))
+            lines.append("")  # Add blank line after each block
+
+    normalized = _normalize_rendered_lines_preserve_blocks(lines)
+
+    # Phase 1.2: Apply transforms
+    transformed = _apply_block_transforms(normalized)
+
+    # Drop preamble before primary heading
+    transformed = _drop_preamble_before_primary_heading(transformed)
+
+    # Join
+    output = "\n".join(transformed).strip()
+    output = re.sub(r"\n{3,}", "\n\n", output)
+    return output
+
+
+def _normalize_rendered_lines_preserve_blocks(lines: list[str]) -> list[str]:
+    """Normalize lines while preserving blank line structure between blocks."""
+    normalized = []
+    previous_blank = False
+    in_code_block = False
+    code_fence = ""
+
+    for line in lines:
+        line = (line or "").rstrip()
+
+        # Track code block boundaries
+        if line.strip().startswith("```"):
+            if not in_code_block:
+                in_code_block = True
+                code_fence = line.strip()
+            elif line.strip() == code_fence:
+                in_code_block = False
+                code_fence = ""
+
+        # Inside code blocks, never dedup - just append
+        if in_code_block:
+            normalized.append(line)
+            previous_blank = False
+            continue
+
+        if not line:
+            if not previous_blank:
+                normalized.append("")
+            previous_blank = True
+            continue
+
+        # Only dedup within same paragraph (no blank line between)
+        if normalized and not previous_blank and normalized[-1].lower() == line.lower():
+            continue
+
+        normalized.append(line)
+        previous_blank = False
+
+    # Trim leading/trailing blanks
+    while normalized and not normalized[0]:
+        normalized.pop(0)
+    while normalized and not normalized[-1]:
+        normalized.pop()
+
+    return normalized
+
+
+def _apply_block_transforms(lines: list[str]) -> list[str]:
+    """Apply post-render transforms to lines."""
+    transformed = []
+    i = 0
+
+    while i < len(lines):
+        line = lines[i]
+
+        # Drop single-char junk lines
+        if line.strip() in {"|", "•", "·", "›", "»"}:
+            i += 1
+            continue
+
+        # Strip skip-to links
+        if re.match(r"^\s*\[Skip to [^\]]+\]\(#[^)]+\)", line, re.IGNORECASE):
+            i += 1
+            continue
+
+        # Expand dense links
+        expanded = _expand_dense_markdown_link_line(line)
+        if expanded:
+            transformed.extend(expanded)
+            i += 1
+            continue
+
+        transformed.append(line)
+        i += 1
+
+    return transformed
+
+
+def _expand_dense_markdown_link_line(line: str) -> Optional[list[str]]:
+    """Expand lines with 3+ dense markdown links into bullet list."""
+    text = (line or "").strip()
+    if len(text) < 120:
+        return None
+    if text.startswith(("- ", "#", "|")) or re.match(r"^\d+\.", text):
+        return None
+
+    link_re = re.compile(r"!?\[[^\]\n]+\]\([^\)\n]+\)")
+    matches = list(link_re.finditer(text))
+    if len(matches) < 3:
+        return None
+
+    # Check if there's prose before first link
+    first_prefix = text[:matches[0].start()]
+    if first_prefix and re.search(r"[A-Za-z]{3,}", first_prefix):
+        return None
+
+    # Expand to bullet list
+    segments = []
+    for idx, match in enumerate(matches):
+        start = match.start()
+        if idx == 0 and start <= 24:
+            start = 0
+        end = matches[idx + 1].start() if idx + 1 < len(matches) else len(text)
+        segment = text[start:end].strip(" ,;—")
+        if segment:
+            segments.append(f"- {segment}")
+
+    return segments if segments else None
+
+
+def _handle_title(output: str, title: str) -> str:
+    """Handle title: prepend if missing, dedup if present."""
+    lines = output.split("\n") if output else []
+
+    # Check if title already present
+    title_heading = f"# {title.strip()}"
+    for line in lines:
+        if line.strip().lower() == title_heading.lower():
+            return output  # Already present
+
+    # Prepend title
+    if lines:
+        return f"{title_heading}\n\n{output}"
+    return title_heading
+
+
+# ============================================================================
+# Phase 1.4: UI chrome cleaning
+# ============================================================================
+
+
+def _clean_ui_text(text: str) -> str:
+    """Clean UI chrome from text."""
+    if not text:
+        return ""
+
+    text = str(text).strip()
+    if not text:
+        return ""
+
+    # Strip "Copy code to clipboard"
+    text = re.sub(r"\s+Copy code to clipboard\s*$", "", text, flags=re.IGNORECASE)
+
+    # Strip "Direct link to X" pattern
+    match = re.match(r"^(?P<head>.+?)\s*Direct link to\s+(?P<target>.+)$", text, re.IGNORECASE)
+    if match:
+        head = match.group("head").strip()
+        target = match.group("target").strip()
+        if head and target and head.lower() == target.lower():
+            text = head
+
+    # Strip "Link for X" pattern
+    match = re.match(r"^(?P<head>.+?)\s*Link for\s+(?P<target>.+)$", text, re.IGNORECASE)
+    if match:
+        head = match.group("head").strip()
+        target = match.group("target").strip()
+        if head and target and head.lower() == target.lower():
+            text = head
+
+    return text
+
+
+def _clean_heading_text(text: str) -> str:
+    """Clean heading text, removing anchor links."""
+    text = _clean_ui_text(text)
+    if not text:
+        return ""
+
+    # Strip "Go to slug" pattern
+    match = re.match(r"^(?P<head>.+?)\s*Go to\s+(?P<target>[a-z0-9][a-z0-9-]{1,80})$", text, re.IGNORECASE)
+    if match:
+        head = match.group("head").strip()
+        target = match.group("target").lower()
+        slug = re.sub(r"[^a-z0-9]+", "-", head.lower()).strip("-")
+        if head and target and (slug == target or target in slug.split("-")):
+            text = head
+
+    return text
+
+
+def _clean_code_line(line: str) -> str:
+    """Clean a code line by stripping refs and UI chrome."""
+    line = re.sub(r"\s*\[(?:ref=)?e\d+\]\s*", " ", line)
+    line = re.sub(r"\s*\[nth=\d+\]\s*", " ", line)
+    line = re.sub(r"\s*\[cursor=pointer\]\s*", " ", line)
+    line = re.sub(r"\s+Copy code to clipboard\s*$", "", line, flags=re.IGNORECASE)
+    return line.rstrip()
+
+
+# ============================================================================
+# Phase 2: Markdown safety
+# ============================================================================
+
+
+def _escape_md_text(text: str) -> str:
+    """Escape markdown syntax at the start of text."""
+    if not text:
+        return text
+
+    # Escape leading markdown syntax
+    if text[0] in {"#", ">"}:
+        return "\\" + text
+    if text.startswith(("- ", "* ", "+ ")):
+        return "\\" + text
+    if re.match(r"^\d+[.)]\s", text):
+        return "\\" + text
+    if text in {"---", "***", "___"}:
+        return "\\" + text
+
+    return text
+
+
+def _escape_md_block_text(text: str) -> str:
+    """Escape markdown syntax including table pipes."""
+    escaped = _escape_md_text(text)
+    if escaped == text and text.startswith("|"):
+        return "\\" + text
+    return escaped
+
+
+def _escape_md_link_label(text: str) -> str:
+    """Escape brackets in link text."""
+    return (text or "").replace("[", "\\[").replace("]", "\\]")
+
+
+def _max_backtick_run(text: str) -> int:
+    """Find the longest run of backticks in text."""
+    return max((len(m.group(0)) for m in re.finditer(r"`+", text or "")), default=0)
+
+
+def _inline_code_markdown(text: str) -> str:
+    """Wrap text in backticks, using enough to not conflict."""
+    if not text:
+        return ""
+    run = _max_backtick_run(text)
+    ticks = "`" * max(1, run + 1)
+    if run:
+        return f"{ticks} {text} {ticks}"
+    return f"{ticks}{text}{ticks}"
+
+
+# Phase 2.5: Smart inline spacing
+def _format_inline_spacing(parts: list[str]) -> str:
+    """Format inline fragments with proper spacing."""
+    if not parts:
+        return ""
+
+    result = ""
+    no_space_before = set(".,;:!?)]}…")
+    no_space_after = set("([{¿¡")
+
+    for raw_part in parts:
+        part = _clean_inline(raw_part)
+        if not part:
+            continue
+
+        if not result:
+            result = part
+            continue
+
+        # Check if we need space
+        if part[0] in no_space_before or result[-1] in no_space_after:
+            result += part
+        else:
+            result += " " + part
+
+    return result.strip()
+
+
+# ============================================================================
+# Phase 3.5: URL sanitization
+# ============================================================================
+
+
+def _sanitize_display_href(href: str) -> str:
+    """Remove tracking parameters from URLs."""
+    raw = href or ""
+    if not raw or "?" not in raw:
+        return raw
+
+    try:
+        parsed = urlparse(raw)
+        params = parse_qs(parsed.query, keep_blank_values=True)
+
+        # Filter out tracking params
+        filtered = {}
+        changed = False
+        for key, values in params.items():
+            key_lower = key.lower()
+            if key_lower.startswith("utm_") or key_lower in _TRACKING_QUERY_KEYS:
+                changed = True
+                continue
+            filtered[key] = values
+
+        if not changed:
+            return raw
+
+        # Rebuild query string
+        new_query = urlencode(filtered, doseq=True)
+        new_parsed = parsed._replace(query=new_query)
+        return urlunparse(new_parsed)
+
+    except Exception:
+        return raw
+
+
+# ============================================================================
+# Cleanup helpers
+# ============================================================================
+
+
+def _drop_preamble_before_primary_heading(blocks: list[str]) -> list[str]:
+    for idx, block in enumerate(blocks):
+        if block.startswith("# "):
+            return blocks[idx:]
+    return blocks
+
+
+def _clean_inline(text: str) -> str:
+    text = _strip_refs(str(text or ""))
+    text = text.replace("\u00a0", " ")
+    text = re.sub(r"\s+", " ", text).strip()
+    if _is_private_use_symbol_junk(text):
+        return ""
+    text = re.sub(r"\s+([.,;:!?])", r"\1", text)
+    text = re.sub(r"\(\s+", "(", text)
+    text = re.sub(r"\s+\)", ")", text)
+    text = text.replace(") .", ").")
+    text = text.replace("] .", "].")
+    text = text.replace("` .", "`.")
+    return text.strip()
+
+
+def _is_private_use_symbol_junk(text: str) -> bool:
+    compact = "".join(ch for ch in (text or "") if not ch.isspace())
+    if not compact:
+        return False
+    return all(
+        "\ue000" <= ch <= "\uf8ff"
+        or "\U000f0000" <= ch <= "\U000ffffd"
+        or "\U00100000" <= ch <= "\U0010fffd"
+        for ch in compact
+    )
+
+
+def _clean_url(url: str) -> str:
+    url = str(url or "").strip()
+    if (url.startswith('"') and url.endswith('"')) or (url.startswith("'") and url.endswith("'")):
+        url = url[1:-1]
+    return url.strip()
+
+
+def _strip_refs(text: str) -> str:
+    """Strip ref annotations, preserving numeric citations."""
+    return _REF_RE.sub("", text).strip()

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -117,6 +117,9 @@ import sys
 
 logger = logging.getLogger(__name__)
 
+_SEARCH_BACKENDS = ("parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai")
+_EXTRACT_BACKENDS = _SEARCH_BACKENDS + ("camofox",)
+
 
 # ─── Backend Selection ────────────────────────────────────────────────────────
 
@@ -140,7 +143,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in {"parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "xai"}:
+    if configured in _SEARCH_BACKENDS:
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -197,7 +200,8 @@ def _get_capability_backend(capability: str) -> str:
     """
     cfg = _load_web_config()
     specific = (cfg.get(f"{capability}_backend") or "").lower().strip()
-    if specific and _is_backend_available(specific):
+    allowed = _EXTRACT_BACKENDS if capability == "extract" else _SEARCH_BACKENDS
+    if specific in allowed and _is_backend_available(specific):
         return specific
     return _get_backend()
 
@@ -228,6 +232,15 @@ def _is_backend_available(backend: str) -> bool:
             return has_xai_credentials()
         except Exception:
             return False
+    if backend == "camofox":
+        # Use the registry provider's is_available() for consistent behavior
+        # across the plugin lifecycle (health checks, config, register/unregister)
+        try:
+            from agent.web_search_registry import get_provider
+            provider = get_provider("camofox")
+            return provider is not None and provider.is_available()
+        except Exception:
+            return False
     return False
 
 
@@ -244,6 +257,32 @@ def _ddgs_package_importable() -> bool:
         return True
     except ImportError:
         return False
+
+
+def _policy_blocked_result(url: str, blocked: Dict[str, Any], title: str = "") -> Dict[str, Any]:
+    return {
+        "url": url,
+        "title": title,
+        "content": "",
+        "raw_content": "",
+        "error": blocked["message"],
+        "blocked_by_policy": {
+            "host": blocked["host"],
+            "rule": blocked["rule"],
+            "source": blocked["source"],
+        },
+    }
+
+
+def _unsafe_url_result(url: str, title: str = "") -> Dict[str, Any]:
+    return {
+        "url": url,
+        "title": title,
+        "content": "",
+        "raw_content": "",
+        "error": "Blocked: URL targets a private or internal network address",
+    }
+
 
 # ─── Firecrawl Client ────────────────────────────────────────────────────────
 
@@ -277,6 +316,7 @@ def _web_requires_env() -> list[str]:
         "TOOL_GATEWAY_DOMAIN",
         "TOOL_GATEWAY_SCHEME",
         "TOOL_GATEWAY_USER_TOKEN",
+        "CAMOFOX_URL",
     ]
 
 
@@ -909,6 +949,7 @@ async def web_extract_tool(
     
     try:
         logger.info("Extracting content from %d URL(s)", len(urls))
+        skip_llm_processing = False
 
         # ── SSRF protection — filter out private/internal URLs before any backend ──
         safe_urls = []
@@ -928,13 +969,13 @@ async def web_extract_tool(
         else:
             backend = _get_extract_backend()
 
-            # All seven providers (brave-free, ddgs, searxng, exa, parallel,
-            # tavily, firecrawl) now live as plugins. The dispatcher is a
-            # registry lookup + delegation. Some providers' extract() is
-            # async (parallel, firecrawl), others sync (exa, tavily) — we
-            # detect coroutine functions and await; sync functions run
-            # inline (the policy gate, SSRF re-check, etc. live inside the
-            # provider itself for the firecrawl per-URL loop).
+            # All extract providers (camofox, brave-free, ddgs, searxng, exa,
+            # parallel, tavily, firecrawl, xai) now live as plugins. The
+            # dispatcher is a registry lookup + delegation. Some providers'
+            # extract() is async (parallel, firecrawl, camofox), others sync
+            # (exa, tavily) — we detect coroutine functions and await; sync
+            # functions run inline (the policy gate, SSRF re-check, etc. live
+            # inside the provider itself for per-URL loops).
             from agent.web_search_registry import (
                 get_active_extract_provider,
                 get_provider as _wsp_get_provider,
@@ -955,8 +996,8 @@ async def web_extract_tool(
                             "error": (
                                 f"{provider.display_name} is a search-only "
                                 "backend and cannot extract URL content. "
-                                "Set web.extract_backend to firecrawl, "
-                                "tavily, exa, or parallel."
+                                "Set web.extract_backend to camofox, "
+                                "firecrawl, tavily, exa, or parallel."
                             ),
                         },
                         ensure_ascii=False,
@@ -968,18 +1009,24 @@ async def web_extract_tool(
                             "success": False,
                             "error": (
                                 "No web extract provider configured. "
-                                "Set web.extract_backend to firecrawl, "
-                                "tavily, exa, or parallel."
+                                "Set web.extract_backend to camofox, "
+                                "firecrawl, tavily, exa, or parallel."
                             ),
                         },
                         ensure_ascii=False,
                     )
 
+            # Check if provider requires LLM post-processing.
+            # Providers like Camofox return deterministic Markdown and
+            # should bypass the auxiliary-model summarization step.
+            if not provider.requires_llm_processing():
+                skip_llm_processing = True
+
             logger.info(
                 "Web extract via %s: %d URL(s)", provider.name, len(safe_urls)
             )
 
-            # Async-or-sync dispatch: parallel + firecrawl have async
+            # Async-or-sync dispatch: parallel + firecrawl + camofox have async
             # extract(); exa + tavily are sync.
             import inspect
             if inspect.iscoroutinefunction(provider.extract):
@@ -1005,8 +1052,10 @@ async def web_extract_tool(
         effective_model = model or _get_default_summarizer_model()
         auxiliary_available = check_auxiliary_model()
         
-        # Process each result with LLM if enabled
-        if use_llm_processing and auxiliary_available:
+        # Process each result with LLM if enabled. Camofox extraction already
+        # returns deterministic cleaned Markdown and intentionally skips LLM
+        # rewriting even when callers pass use_llm_processing=True.
+        if use_llm_processing and auxiliary_available and not skip_llm_processing:
             logger.info("Processing extracted content with LLM (parallel)...")
             debug_call_data["processing_applied"].append("llm_processing")
             
@@ -1078,9 +1127,11 @@ async def web_extract_tool(
                 else:
                     logger.warning("%s (no content to process)", url)
         else:
-            if use_llm_processing and not auxiliary_available:
+            if use_llm_processing and not auxiliary_available and not skip_llm_processing:
                 logger.warning("LLM processing requested but no auxiliary model available, returning raw content")
                 debug_call_data["processing_applied"].append("llm_processing_unavailable")
+            elif skip_llm_processing:
+                debug_call_data["processing_applied"].append("camofox_deterministic_markdown")
             # Print summary of extracted pages for debugging (original behavior)
             for result in response.get('results', []):
                 url = result.get('url', 'Unknown URL')
@@ -1365,14 +1416,18 @@ async def web_crawl_tool(
 
 # Convenience function to check Firecrawl credentials
 def check_web_api_key() -> bool:
-    """Check whether the configured web backend is available."""
-    configured = _load_web_config().get("backend", "").lower().strip()
-    if configured in {"exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs"}:
+    """Check whether at least one configured web capability backend is available."""
+    cfg = _load_web_config()
+
+    for capability, allowed in (("search", _SEARCH_BACKENDS), ("extract", _EXTRACT_BACKENDS)):
+        specific = (cfg.get(f"{capability}_backend") or "").lower().strip()
+        if specific in allowed and _is_backend_available(specific):
+            return True
+
+    configured = (cfg.get("backend") or "").lower().strip()
+    if configured in _SEARCH_BACKENDS:
         return _is_backend_available(configured)
-    return any(
-        _is_backend_available(backend)
-        for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs")
-    )
+    return any(_is_backend_available(backend) for backend in _SEARCH_BACKENDS)
 
 
 def check_auxiliary_model() -> bool:

--- a/website/docs/integrations/index.md
+++ b/website/docs/integrations/index.md
@@ -22,23 +22,25 @@ Hermes supports multiple AI inference providers out of the box. Use `hermes mode
 
 ## Web Search Backends
 
-The `web_search` and `web_extract` tools support four backend providers, configured via `config.yaml` or `hermes tools`:
+The `web_search` and `web_extract` tools support multiple backend providers, configured via `config.yaml` or `hermes tools`. Search and extraction can use different providers through `web.search_backend` and `web.extract_backend`:
 
 | Backend | Env Var | Search | Extract | Crawl |
 |---------|---------|--------|---------|-------|
 | **Firecrawl** (default) | `FIRECRAWL_API_KEY` | ✔ | ✔ | ✔ |
+| **SearXNG** | `SEARXNG_URL` | ✔ | — | — |
+| **Camofox** | `CAMOFOX_URL` | — | ✔ | — |
 | **Parallel** | `PARALLEL_API_KEY` | ✔ | ✔ | — |
 | **Tavily** | `TAVILY_API_KEY` | ✔ | ✔ | ✔ |
 | **Exa** | `EXA_API_KEY` | ✔ | ✔ | — |
 
 Quick setup example:
-
 ```yaml
 web:
-  backend: firecrawl    # firecrawl | parallel | tavily | exa
+  search_backend: searxng
+  extract_backend: camofox
 ```
 
-If `web.backend` is not set, the backend is auto-detected from whichever API key is available. Self-hosted Firecrawl is also supported via `FIRECRAWL_API_URL`.
+If `web.backend` is not set, the backend is auto-detected from search-capable credentials. Camofox is extract-only, so set `web.extract_backend: camofox` explicitly when you want local browser-backed extraction.
 
 ## Browser Automation
 

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -137,7 +137,7 @@ For native Anthropic auth, Hermes prefers Claude Code's own credential files whe
 | `BROWSER_USE_API_KEY` | Browser Use cloud browser API key ([browser-use.com](https://browser-use.com/)) |
 | `FIRECRAWL_BROWSER_TTL` | Firecrawl browser session TTL in seconds (default: 300) |
 | `BROWSER_CDP_URL` | Chrome DevTools Protocol URL for local browser (set via `/browser connect`, e.g. `ws://localhost:9222`) |
-| `CAMOFOX_URL` | Camofox local anti-detection browser URL (default: `http://localhost:9377`) |
+| `CAMOFOX_URL` | Camofox local anti-detection browser URL for browser tools and optional Camofox-backed `web_extract` (default: `http://localhost:9377`) |
 | `CAMOFOX_USER_ID` | Optional externally managed Camofox user ID for shared visible sessions |
 | `CAMOFOX_SESSION_KEY` | Optional Camofox session key used when creating tabs for `CAMOFOX_USER_ID` |
 | `CAMOFOX_ADOPT_EXISTING_TAB` | Set to `true` to reuse an existing Camofox tab before creating a new one |

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -1466,28 +1466,30 @@ Environment scrubbing (strips `*_API_KEY`, `*_TOKEN`, `*_SECRET`, `*_PASSWORD`, 
 
 ## Web Search Backends
 
-The `web_search`, `web_extract`, and `web_crawl` tools support five backend providers. Configure the backend in `config.yaml` or via `hermes tools`:
-
+The `web_search`, `web_extract`, and `web_crawl` tools support overlapping backend providers. Configure a shared fallback in `config.yaml`, or split search and extraction with per-capability keys:
 ```yaml
 web:
-  backend: firecrawl    # firecrawl | searxng | parallel | tavily | exa
+  backend: firecrawl    # shared fallback: firecrawl | searxng | parallel | tavily | exa
 
-  # Or use per-capability keys to mix providers (e.g. free search + paid extract):
+  # Or mix providers, e.g. free/local search + local browser-backed extract:
   search_backend: "searxng"
-  extract_backend: "firecrawl"
+  extract_backend: "camofox"
 ```
 
 | Backend | Env Var | Search | Extract | Crawl |
 |---------|---------|--------|---------|-------|
 | **Firecrawl** (default) | `FIRECRAWL_API_KEY` | ✔ | ✔ | ✔ |
 | **SearXNG** | `SEARXNG_URL` | ✔ | — | — |
+| **Camofox** | `CAMOFOX_URL` | — | ✔ | — |
 | **Parallel** | `PARALLEL_API_KEY` | ✔ | ✔ | — |
 | **Tavily** | `TAVILY_API_KEY` | ✔ | ✔ | ✔ |
 | **Exa** | `EXA_API_KEY` | ✔ | ✔ | — |
 
-**Backend selection:** If `web.backend` is not set, the backend is auto-detected from available API keys. If only `SEARXNG_URL` is set, SearXNG is used. If only `EXA_API_KEY` is set, Exa is used. If only `TAVILY_API_KEY` is set, Tavily is used. If only `PARALLEL_API_KEY` is set, Parallel is used. Otherwise Firecrawl is the default.
+**Backend selection:** If `web.backend` is not set, the backend is auto-detected from available search-capable credentials. If only `SEARXNG_URL` is set, SearXNG is used. If only `EXA_API_KEY` is set, Exa is used. If only `TAVILY_API_KEY` is set, Tavily is used. If only `PARALLEL_API_KEY` is set, Parallel is used. Otherwise Firecrawl is the default. Camofox is not auto-selected from `CAMOFOX_URL` alone because it cannot search; set `web.extract_backend: "camofox"` explicitly.
 
-**SearXNG** is a free, self-hosted, privacy-respecting metasearch engine that queries 70+ search engines. No API key needed — just set `SEARXNG_URL` to your instance (e.g., `http://localhost:8080`). SearXNG is search-only; `web_extract` and `web_crawl` require a separate extract provider (set `web.extract_backend`). See the [Web Search setup guide](/docs/user-guide/features/web-search) for Docker setup instructions.
+**SearXNG** is a free, self-hosted, privacy-respecting metasearch engine that queries 70+ search engines. No API key needed — just set `SEARXNG_URL` to your instance (e.g., `http://localhost:8080`). SearXNG is search-only; `web_extract` needs a separate extract provider (set `web.extract_backend`). See the [Web Search setup guide](/docs/user-guide/features/web-search) for Docker setup instructions.
+
+**Camofox** is a local browser-backed `web_extract` provider. Set `CAMOFOX_URL` and `web.extract_backend: "camofox"` to render Camofox accessibility snapshots into deterministic Markdown without auxiliary LLM rewriting. It is extract-only and does not support `web_search` or `web_crawl`.
 
 **Self-hosted Firecrawl:** Set `FIRECRAWL_API_URL` to point at your own instance. When a custom URL is set, the API key becomes optional (set `USE_DB_AUTHENTICATION=*** on the server to disable auth).
 

--- a/website/docs/user-guide/features/browser.md
+++ b/website/docs/user-guide/features/browser.md
@@ -189,6 +189,16 @@ Or configure via `hermes tools` → Browser Automation → Camofox.
 
 When `CAMOFOX_URL` is set, all browser tools automatically route through Camofox instead of Browserbase or agent-browser.
 
+The same Camofox server can also provide local browser-backed `web_extract` results. This is configured separately from browser automation:
+
+```yaml
+web:
+  search_backend: "searxng"   # or another search backend
+  extract_backend: "camofox"  # web_extract only
+```
+
+That path opens temporary Camofox tabs, captures accessibility snapshots, and returns deterministic Markdown without auxiliary LLM rewriting. Camofox is not a search or crawl backend, so do not set `web.backend: "camofox"`.
+
 #### Persistent browser sessions
 
 By default, each Camofox session gets a random identity — cookies and logins don't survive across agent restarts. To enable persistent browser sessions, add the following to `~/.hermes/config.yaml`:

--- a/website/docs/user-guide/features/web-search.md
+++ b/website/docs/user-guide/features/web-search.md
@@ -1,6 +1,6 @@
 ---
 title: Web Search & Extract
-description: Search the web, extract page content, and crawl websites with multiple backend providers — including free self-hosted SearXNG.
+description: Search the web, extract page content, and crawl websites with multiple backend providers — including free self-hosted SearXNG and Camofox extraction.
 sidebar_label: Web Search
 sidebar_position: 6
 ---
@@ -12,7 +12,7 @@ Hermes Agent includes two model-callable web tools backed by multiple providers:
 - **`web_search`** — search the web and return ranked results
 - **`web_extract`** — fetch and extract readable content from one or more URLs (with built-in deep-crawl support when the backend provides it)
 
-Both are configured through a single backend selection. Providers are chosen via `hermes tools` or set directly in `config.yaml`. Recursive crawling capabilities (Firecrawl/Tavily) are exposed through `web_extract` rather than as a separate `web_crawl` tool.
+The tools share the same web configuration, but provider support differs by capability. Use `web.backend` for a shared default, or split search and extraction with `web.search_backend` and `web.extract_backend`. Recursive crawling capabilities (Firecrawl/Tavily) are exposed through `web_extract` rather than as a separate `web_crawl` tool.
 
 ## Backends
 
@@ -22,6 +22,7 @@ Both are configured through a single backend selection. Providers are chosen via
 | **SearXNG** | `SEARXNG_URL` | ✔ | — | — | ✔ Free (self-hosted) |
 | **Brave Search (free tier)** | `BRAVE_SEARCH_API_KEY` | ✔ | — | — | 2 000 queries/mo |
 | **DDGS (DuckDuckGo)** | — (no key) | ✔ | — | — | ✔ Free |
+| **Camofox** | `CAMOFOX_URL` | — | ✔ | — | ✔ Free (self-hosted) |
 | **Tavily** | `TAVILY_API_KEY` | ✔ | ✔ | ✔ | 1 000 searches/mo |
 | **Exa** | `EXA_API_KEY` | ✔ | ✔ | — | 1 000 searches/mo |
 | **Parallel** | `PARALLEL_API_KEY` | ✔ | ✔ | — | Paid |
@@ -29,7 +30,7 @@ Both are configured through a single backend selection. Providers are chosen via
 
 Brave Search, DDGS, and xAI are **search-only** — pair any of them with Firecrawl/Tavily/Exa/Parallel when you also need `web_extract`. DDGS uses the [`ddgs` Python package](https://pypi.org/project/ddgs/) under the hood; if it isn't already installed, run `pip install ddgs` (or let Hermes lazy-install it on first use). xAI runs Grok's server-side `web_search` tool on the Responses API — results are LLM-generated rather than index-backed, so titles, descriptions, and URL choice are all model output (see the [trust-model caveat](#xai-grok) below).
 
-**Per-capability split:** you can use different providers for search and extract independently — for example SearXNG (free) for search and Firecrawl for extract. See [Per-capability configuration](#per-capability-configuration) below.
+**Per-capability split:** you can use different providers for search and extract independently — for example SearXNG for search and Camofox or Firecrawl for extract. See [Per-capability configuration](#per-capability-configuration) below.
 
 :::tip Nous Subscribers
 If you have a paid [Nous Portal](https://portal.nousresearch.com) subscription, web search and extract are available through the **[Tool Gateway](tool-gateway.md)** via managed Firecrawl — no API key needed. New installs can run `hermes setup --portal` to log in and turn on all gateway tools at once; existing installs can flip just web via `hermes tools`.
@@ -113,7 +114,7 @@ When `FIRECRAWL_API_URL` is set, the API key is optional (disable server auth wi
 
 SearXNG is a privacy-respecting, open-source metasearch engine that aggregates results from 70+ search engines. **No API key required** — just point Hermes at a running SearXNG instance.
 
-SearXNG is **search-only** — `web_extract` (including its crawl modes) requires a separate extract provider.
+SearXNG is **search-only** — `web_extract` needs a separate extract provider such as Camofox, Firecrawl, Tavily, Exa, or Parallel. Deep-crawl modes require a crawl-capable extract backend such as Firecrawl or Tavily.
 
 #### Option A — Self-host with Docker (recommended)
 
@@ -228,10 +229,40 @@ SearXNG handles search; you need a separate provider for `web_extract` (includin
 # ~/.hermes/config.yaml
 web:
   search_backend: "searxng"
-  extract_backend: "firecrawl"   # or tavily, exa, parallel
+  extract_backend: "camofox"   # or firecrawl, tavily, exa, parallel
 ```
 
-With this config, Hermes uses SearXNG for all search queries and Firecrawl for URL extraction — combining free search with high-quality extraction.
+With this config, Hermes uses SearXNG for all search queries and Camofox for URL extraction — a fully local web-search-and-extract stack when both services are self-hosted.
+
+---
+
+### Camofox extract (local, browser-backed)
+
+Camofox can back `web_extract` without changing your `web_search` backend. It opens each requested URL in a temporary Camofox tab, waits for the page when the Camofox server supports the wait endpoint, captures the accessibility snapshot, and renders that snapshot into deterministic Markdown.
+
+1. Start a Camofox server. See [Browser Automation → Camofox local mode](/docs/user-guide/features/browser#camofox-local-mode) for Docker and local setup.
+2. Point Hermes at the server:
+
+```bash
+# ~/.hermes/.env
+CAMOFOX_URL=http://localhost:9377
+```
+
+3. Use Camofox only for extraction:
+
+```yaml
+# ~/.hermes/config.yaml
+web:
+  search_backend: "searxng"   # or another search backend
+  extract_backend: "camofox"  # web_extract only
+```
+
+Notes:
+
+- `camofox` is extract-only. Do not set `web.backend: "camofox"`; use `web.extract_backend: "camofox"`.
+- `web_extract` output is deterministic Markdown from the browser accessibility snapshot. The Camofox path intentionally skips auxiliary LLM rewriting, even when LLM processing is requested.
+- Browser-backed redirects are still checked before content is exposed: Hermes applies SSRF and website blocklist checks before Camofox fetches the URL and again after Camofox reports the final URL.
+- Deep-crawl modes are not supported through Camofox; use Firecrawl or Tavily for crawling.
 
 ---
 
@@ -333,15 +364,17 @@ web:
   backend: "searxng"   # firecrawl | searxng | brave-free | ddgs | tavily | exa | parallel | xai
 ```
 
+`web.backend` is a shared fallback and only accepts search-capable backends. Camofox is intentionally not valid here because it cannot search; configure it through `web.extract_backend` instead.
+
 ### Per-capability configuration
 
-Use different providers for search vs extract. This lets you combine free search (SearXNG) with a paid extract provider, or vice versa:
+Use different providers for search vs extract. This lets you combine free search (SearXNG) with a local or paid extract provider:
 
 ```yaml
 # ~/.hermes/config.yaml
 web:
   search_backend: "searxng"     # used by web_search
-  extract_backend: "firecrawl"  # used by web_extract (and its deep-crawl modes)
+  extract_backend: "camofox"    # used by web_extract; use firecrawl/tavily for deep-crawl modes
 ```
 
 When per-capability keys are empty, both fall through to `web.backend`. When `web.backend` is also empty, the backend is auto-detected from whichever API key/URL is present.
@@ -364,6 +397,8 @@ If no backend is explicitly configured, Hermes picks the first available one bas
 | `SEARXNG_URL` | searxng |
 
 xAI Web Search is **not** in the auto-detection chain — having `XAI_API_KEY` set (or being signed in via xAI Grok OAuth) does not automatically route web traffic through xAI, since those credentials are also used for inference / TTS / image gen and the user may want a different backend for web. Opt in explicitly with `web.backend: "xai"`.
+
+Camofox is not auto-selected from `CAMOFOX_URL` alone because it cannot handle search. Set `web.extract_backend: "camofox"` explicitly.
 
 ---
 
@@ -407,8 +442,10 @@ SearXNG cannot extract URL content. Set `web.extract_backend` to a provider that
 ```yaml
 web:
   search_backend: "searxng"
-  extract_backend: "firecrawl"  # or tavily / exa / parallel
+  extract_backend: "camofox"  # or firecrawl / tavily / exa / parallel
 ```
+
+If you choose Camofox, also set `CAMOFOX_URL` and make sure the Camofox server is running.
 
 ### SearXNG returns 0 results
 


### PR DESCRIPTION
## What does this PR do?

Adds a local Camofox-backed `web_extract` backend.

The problem: users can already run local/private search through SearXNG, but URL extraction still needs a separate cloud or API-backed extractor. This PR lets Hermes route search and extraction independently, so a fully local stack can use SearXNG for `web_search` and releveraging Camofox for browser-backed `web_extract`:

```yaml
web:
  search_backend: "searxng"
  extract_backend: "camofox"
```

**The approach:** Camofox is registered as an extract-only plugin (`supports_search=False, supports_extract=True`). The provider talks to the Camofox REST API, opens ephemeral tabs, captures accessibility snapshots, and renders deterministic Markdown — no LLM rewriting needed. Registry-based dispatch means no special-case branches in `web_tools.py`. Existing SSRF and website-policy checks still run before browser fetches and again on final/redirected URLs before content is exposed.

## Related Issue

No linked issue for this focused backend addition.

Fixes #

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

### Plugin Architecture
- `plugins/web/camofox/__init__.py` — Plugin entry point. Registers `CamofoxWebSearchProvider` via `ctx.register_web_search_provider()`.
- `plugins/web/camofox/provider.py` — Full `WebSearchProvider` subclass: ephemeral tab lifecycle, snapshot capture, deterministic Markdown rendering, per-URL policy gates, SSRF re-checks, interrupt handling. `requires_llm_processing()` returns `False` so the dispatcher skips auxiliary-model summarization.
- `plugins/web/camofox/plugin.yaml` — Plugin manifest (`kind: backend`, `provides_web_providers: [camofox]`).

### Base Class Extension
- `agent/web_search_provider.py` — Added `requires_llm_processing()` hook (default `True`). Providers returning clean, deterministic content override to `False`.

### Dispatcher & Config
- `tools/web_tools.py` — Per-capability backend split (`_SEARCH_BACKENDS` / `_EXTRACT_BACKENDS`), registry-based availability check for `camofox`, `requires_llm_processing()` wiring so Camofox results bypass LLM post-processing, updated error messages listing `camofox` as a valid extract backend.
- `hermes_cli/config.py` — `CAMOFOX_URL` tool metadata now includes `web_extract`.
- `cli-config.yaml.example` — Documents `web.backend`, `web.search_backend`, `web.extract_backend` with Camofox example.

### Deterministic Renderer
- `tools/web_accessibility_markdown.py` (~1870 lines, 70 functions) — Dependency-free accessibility-snapshot-to-Markdown renderer. Multi-pass pipeline: escape decoding, YAML key expansion, block transforms, 3-tier tables, chrome compaction, consent dialog handling. Strips all refs/control syntax for clean `web_extract` output.

### Documentation
- `website/docs/user-guide/features/web-search.md` — Camofox as extract-only backend, SearXNG + Camofox local setup guide.
- `website/docs/user-guide/features/browser.md` — Same Camofox server can back `web_extract` separately from browser automation.
- `website/docs/user-guide/configuration.md` — Backend capability tables and config examples for Camofox.
- `website/docs/integrations/index.md` — Updated integrations backend matrix.
- `website/docs/reference/environment-variables.md` — `CAMOFOX_URL` serves both browser tools and `web_extract`.

### Tests (107 tests across 4 files)
- `tests/tools/test_camofox_web_extract.py` — Plugin lifecycle, tab creation/cleanup, snapshot rendering, error paths, availability checks.
- `tests/tools/test_web_accessibility_markdown.py` — Renderer structure, whitespace compaction, refs/control stripping, code/list/table rendering, Docusaurus cleanup.
- `tests/tools/test_web_tools_config.py` — Backend selection, per-capability routing, Camofox extract-only validation.
- `tests/tools/test_web_providers_searxng.py` — Search-only backend errors, safety/policy handling.


## How to Test

Configure Camofox extraction:

```bash
export CAMOFOX_URL=http://localhost:9377
```

```yaml
web:
  search_backend: "searxng"
  extract_backend: "camofox"
```

Run `web_extract` against a simple page and verify deterministic Markdown with no refs/control syntax:

```python
from tools.web_tools import web_extract_tool
# async call, e.g. web_extract_tool(["https://example.com/"], use_llm_processing=True)
```

Run the focused regression suite:

```bash
scripts/run_tests.sh \
  tests/tools/test_web_tools_config.py \
  tests/tools/test_web_providers_searxng.py \
  tests/tools/test_camofox_web_extract.py \
  tests/tools/test_web_accessibility_markdown.py -q
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (fix(scope):, feat(scope):, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run pytest tests/ -q and all tests pass
  - Focused web/Camofox regression suite passes with the canonical `scripts/run_tests.sh` wrapper.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, docs/, docstrings) — or N/A
- [x] I've updated cli-config.yaml.example if I added/changed config keys — or N/A
- [x] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows — N/A: no contributor workflow changes
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — uses stdlib/httpx/path-neutral code; Camofox service availability is environment-dependent
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A: no public tool arguments changed; `CAMOFOX_URL` metadata now includes `web_extract`

## Screenshots / Logs

Focused regression suite from the current verification pass:

```text
scripts/run_tests.sh tests/tools/test_web_tools_config.py tests/tools/test_web_providers.py tests/tools/test_web_providers_searxng.py tests/tools/test_web_providers_brave_free.py tests/tools/test_web_providers_ddgs.py tests/tools/test_web_tools_tavily.py tests/tools/test_website_policy.py tests/tools/test_camofox_web_extract.py tests/tools/test_web_accessibility_markdown.py -q
190 passed in 3.41s
```

Cross-platform footgun scan:

```text
python scripts/check-windows-footguns.py --diff origin/main
✓ No Windows footguns found (8 file(s) scanned).
```

Python smoke run from the committed branch/repository, using the same Camofox endpoint configured for the local Hermes agent:

```text
repo: /root/work/hermes-agent-upstream-camofox-web-extract
CAMOFOX_URL: http://10.2.2.2:9377
health: 200 {"ok":true,"engine":"cloakbrowser","browserConnected":true,"browserRunning":true}
web_extract results: 3 URLs, all error=null
full JSON saved during verification: /tmp/camofox-web-extract-python-output.json
```

The smoke calls `tools.web_tools.web_extract_tool(...)` from this branch and temporarily selects `web.extract_backend: "camofox"` in-process so the real local-agent config is not mutated.

Hermes docs:

````md
# Hermes Agent

The self-improving AI agent built by [Nous Research](https://nousresearch.com). The only agent with a built-in learning loop — it creates skills from experience, improves them during use, nudges itself to persist knowledge, and builds a deepening model of who you are across sessions.

[Get Started →](/docs/getting-started/installation)

[View on GitHub](https://github.com/NousResearch/hermes-agent)

## Install

Linux / macOS / WSL2

```
curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
```

Windows (native, PowerShell) — early beta, [details →](/docs/user-guide/windows-native)

```
irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1 | iex
```

Android (Termux) — same curl one-liner as Linux; the installer auto-detects Termux.

See the full [Installation Guide](/docs/getting-started/installation) for what the installer does, the per-user vs root layout, and Windows-specific notes.

## What is Hermes Agent?

It's not a coding copilot tethered to an IDE or a chatbot wrapper around a single API. It's an autonomous agent that gets more capable the longer it runs. It lives wherever you put it — a $5 VPS, a GPU cluster, or serverless infrastructure (Daytona, Modal) that costs nearly nothing when idle. Talk to it from Telegram while it works on a cloud VM you never SSH into yourself. It's not tied to your laptop.

## Quick Links

- 🚀 [Installation](/docs/getting-started/installation): Install in 60 seconds on Linux, macOS, WSL2, or native Windows (early beta)
- 📖 [Quickstart Tutorial](/docs/getting-started/quickstart): Your first conversation and key features to try
- 🗺️ [Learning Path](/docs/getting-started/learning-path): Find the right docs for your experience level

...
````

Hermes GitHub repository:

````md
# NousResearch/hermes-agent

[992 Branches](/NousResearch/hermes-agent/branches)

[12 Tags](/NousResearch/hermes-agent/tags)

## Folders and files

- Latest commit [kshitijk4poor](/kshitijk4poor) [kshitijk4poor](/NousResearch/hermes-agent/commits?author=kshitijk4poor) [chore: add nik1t7n to AUTHOR_MAP](/NousResearch/hermes-agent/commit/f6d45e5df49c85c87a3f2ec44f9e92e233019622) [f6d45e5](/NousResearch/hermes-agent/commit/f6d45e5df49c85c87a3f2ec44f9e92e233019622) · May 9, 2026, 1:34 PM GMT+2 History [7,810 Commits](/NousResearch/hermes-agent/commits/main/)
- [.github](/NousResearch/hermes-agent/tree/main/.github): [ci: run docker build on PRs + smoke test arm64](/NousResearch/hermes-agent/commit/93679ef27d74d7d8430b603acb9d0bdc3b1e7607) — May 9, 202616 hours ago
- [.plans](/NousResearch/hermes-agent/tree/main/.plans): [Merge PR](/NousResearch/hermes-agent/commit/586fe5d62d0709df43131f88ecd62b1b6d4b0043) [#724](https://github.com/NousResearch/hermes-agent/pull/724) [: feat: --yolo flag to bypass all approval prompts](/NousResearch/hermes-agent/commit/586fe5d62d0709df43131f88ecd62b1b6d4b0043) — Mar 11, 20262 months ago
- [acp_adapter](/NousResearch/hermes-agent/tree/main/acp_adapter): [fix(entry-points): guard hermes_bootstrap import so partial updates d…](/NousResearch/hermes-agent/commit/26bac67ef90d99646b491f5df4ef3856abb072ad) — May 8, 202617 hours ago
- [acp_registry](/NousResearch/hermes-agent/tree/main/acp_registry): [feat: restore ACP server implementation from PR](/NousResearch/hermes-agent/commit/25481d42863c7121180330c5abe6e50f7dd480d7) [#949](https://github.com/NousResearch/hermes-agent/pull/949) [(](/NousResearch/hermes-agent/commit/25481d42863c7121180330c5abe6e50f7dd480d7) [#1254](https://github.com/NousResearch/hermes-agent/pull/1254) [)](/NousResearch/hermes-agent/commit/25481d42863c7121180330c5abe6e50f7dd480d7) — Mar 14, 20262 months ago

...
````

Renderer assertions covered:

```text
- Hermes docs output starts at # Hermes Agent and keeps install commands as fenced code blocks
- Docusaurus Direct link anchor noise is absent
- prose fragments are joined into normal paragraphs
- GitHub output reaches the repo heading and file/folder list, with refs/control syntax stripped
- Hacker News output preserves story links, domains, points, users, relative times, and comment links
- Camofox refs/control syntax is absent from public web_extract content
```

