### PR TITLE
fix(telegram): honor message.quote for partial-quote reply context

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -4012,12 +4012,28 @@ class TelegramAdapter(BasePlatformAdapter):
             chat_topic=chat_topic,
         )
         
-        # Extract reply context if this message is a reply
+        # Extract reply context if this message is a reply.
+        # Prefer Telegram's native partial quote (message.quote, TextQuote)
+        # so a user replying to a single selected substring of a prior
+        # multi-section message doesn't get the whole replied-to message
+        # injected into the agent's context — which can cause the agent
+        # to act on unrelated actionable-looking text the user didn't
+        # quote (#22619). Fall back to the full replied-to message text
+        # / caption when no native quote is present.
         reply_to_id = None
         reply_to_text = None
         if message.reply_to_message:
             reply_to_id = str(message.reply_to_message.message_id)
-            reply_to_text = message.reply_to_message.text or message.reply_to_message.caption or None
+            quote = getattr(message, "quote", None)
+            quote_text = getattr(quote, "text", None) if quote is not None else None
+            if quote_text:
+                reply_to_text = quote_text
+            else:
+                reply_to_text = (
+                    message.reply_to_message.text
+                    or message.reply_to_message.caption
+                    or None
+                )
 
         # Per-channel/topic ephemeral prompt
         from gateway.platforms.base import resolve_channel_prompt

--- a/tests/gateway/test_telegram_reply_quote.py
+++ b/tests/gateway/test_telegram_reply_quote.py
@@ -1,0 +1,144 @@
+"""Tests for Telegram native partial-quote handling in _build_message_event.
+
+When a Telegram user replies using Telegram's native quote feature to
+select only part of a prior message, the adapter must use ``message.quote.text``
+(the user-selected substring) rather than ``message.reply_to_message.text``
+(the entire replied-to message). Otherwise the agent receives the full prior
+message as ``reply_to_text``, which can cause it to act on unrelated
+actionable-looking text the user did not quote (#22619).
+"""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from gateway.config import PlatformConfig
+
+
+def _ensure_telegram_mock():
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+
+    telegram_mod = MagicMock()
+    telegram_mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    telegram_mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    telegram_mod.constants.ChatType.GROUP = "group"
+    telegram_mod.constants.ChatType.SUPERGROUP = "supergroup"
+    telegram_mod.constants.ChatType.CHANNEL = "channel"
+    telegram_mod.constants.ChatType.PRIVATE = "private"
+
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, telegram_mod)
+
+
+_ensure_telegram_mock()
+
+from gateway.platforms.telegram import TelegramAdapter  # noqa: E402
+
+
+def _make_adapter():
+    return TelegramAdapter(PlatformConfig(enabled=True, token="***", extra={}))
+
+
+def _make_message(
+    text="follow-up",
+    reply_to_text=None,
+    reply_to_caption=None,
+    reply_to_id=42,
+    quote_text=None,
+):
+    chat = SimpleNamespace(id=111, type="private", title=None, full_name="Alice")
+    user = SimpleNamespace(id=42, full_name="Alice")
+
+    reply_to_message = None
+    if reply_to_text is not None or reply_to_caption is not None:
+        reply_to_message = SimpleNamespace(
+            message_id=reply_to_id,
+            text=reply_to_text,
+            caption=reply_to_caption,
+        )
+
+    quote = None
+    if quote_text is not None:
+        quote = SimpleNamespace(text=quote_text)
+
+    return SimpleNamespace(
+        chat=chat,
+        from_user=user,
+        text=text,
+        message_thread_id=None,
+        message_id=1001,
+        reply_to_message=reply_to_message,
+        quote=quote,
+        date=None,
+        forum_topic_created=None,
+    )
+
+
+def test_native_partial_quote_used_as_reply_to_text():
+    """When ``message.quote`` is present, prefer the selected substring."""
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter()
+    msg = _make_message(
+        text="mark this one as done",
+        reply_to_text=(
+            "Briefing:\n- Item A: deploy fix\n- Item B: rotate keys\n- Item C: update docs"
+        ),
+        quote_text="Item B: rotate keys",
+    )
+
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.reply_to_text == "Item B: rotate keys"
+    assert event.reply_to_message_id == "42"
+
+
+def test_full_reply_text_used_when_no_native_quote():
+    """No ``message.quote`` → fall back to the whole replied-to message text."""
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter()
+    msg = _make_message(
+        text="thanks",
+        reply_to_text="Whole prior message body",
+        quote_text=None,
+    )
+
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.reply_to_text == "Whole prior message body"
+    assert event.reply_to_message_id == "42"
+
+
+def test_caption_fallback_when_no_quote_and_no_text():
+    """Replied-to media message: caption is used when text is absent."""
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter()
+    msg = _make_message(
+        text="see this",
+        reply_to_text=None,
+        reply_to_caption="Photo caption from earlier",
+        quote_text=None,
+    )
+
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.reply_to_text == "Photo caption from earlier"
+
+
+def test_empty_quote_text_falls_back_to_full_reply():
+    """Defensive: a present-but-empty quote.text shouldn't blank the prefix."""
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter()
+    msg = _make_message(
+        text="follow-up",
+        reply_to_text="Prior message body",
+        quote_text="",
+    )
+
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.reply_to_text == "Prior message body"


### PR DESCRIPTION
## Summary

When a Telegram user replies using Telegram's native partial-quote feature (selecting a substring of a prior message), `_build_message_event` was injecting the **entire** replied-to message into `reply_to_text`. Now it prefers `message.quote.text` (the user-selected substring) and falls back to the full replied-to message only when no native quote is present.

## The bug

`gateway/platforms/telegram.py::_build_message_event` extracted reply context as:

```python
if message.reply_to_message:
    reply_to_id = str(message.reply_to_message.message_id)
    reply_to_text = message.reply_to_message.text or message.reply_to_message.caption or None
```

`message.reply_to_message.text` is always the full prior message body. If Hermes sent a multi-section message and the user replied to one quoted bullet with "mark this one as done", the agent saw:

```text
[Replying to: "<entire previous Hermes message — every bullet>"]

mark this one as done
```

`python-telegram-bot >=21` exposes `Message.quote: Optional[TextQuote]` which carries `TextQuote.text` for the user-selected substring (PTB docs: *"For replies that quote part of the original message, the quoted part of the message."*). The repo pins `python-telegram-bot[webhooks]>=22.6,<23` ([pyproject.toml:58](pyproject.toml)) so `quote` is reliably available — the production code just wasn't reading it.

## The fix

Read `getattr(message, "quote", None)` and prefer `quote.text` when truthy. Fall back to `reply_to_message.text or reply_to_message.caption` for replies without a native quote (older PTB, or replies that don't select a substring) and for replied-to media messages where only the caption is set.

`getattr` + `is not None` checks keep the path safe if `quote` is ever absent or empty.

## Test plan

- [x] Focused regression: [tests/gateway/test_telegram_reply_quote.py](tests/gateway/test_telegram_reply_quote.py) — 4 tests covering the partial-quote path, no-quote fallback, caption fallback, and an empty-string `quote.text` defensive case
- [x] Adjacent suite: `tests/gateway/test_dm_topics.py`, `test_telegram_reply_mode.py`, `test_reply_to_injection.py` (70 tests passed)
- [x] Regression guard: with the fix reverted, `test_native_partial_quote_used_as_reply_to_text` fails with `AssertionError: 'Briefing:\\n- Item A:...' == 'Item B: rotate keys'` — proves the test exercises the new code path

Run focused tests:

```
uv run --with pytest --with pytest-xdist --with pytest-asyncio python3 -m pytest \
  tests/gateway/test_telegram_reply_quote.py -v
```

## Related

- Fixes #22619
- Builds on the reply-context plumbing introduced in #1594; only the inbound extraction site is changed, the `MessageEvent` schema and downstream `_prepare_inbound_message_text` injection are unchanged.

> Sibling code paths that may need the same fix: none in this adapter — `_build_message_event` is the single inbound extraction site for Telegram updates. Other adapters (Discord, Slack, Matrix, etc.) have their own reply-context paths and would need a per-platform check before extending.