### PR TITLE
fix(plugins): resolve git executable with fallback paths for dashboard runtimes

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -27,6 +27,22 @@ class PluginOperationError(Exception):
     """Recoverable plugin install/update failure (CLI exits; HTTP maps to 4xx)."""
 
 
+def _resolve_git_executable() -> str:
+    """Return the absolute path to a working git executable.
+
+    Tries ``shutil.which("git")`` first, then falls back to common
+    absolute paths so that dashboard/non-interactive runtimes with a
+    reduced ``PATH`` still find git when it is installed.
+    """
+    git = shutil.which("git")
+    if git:
+        return git
+    for candidate in ("/usr/bin/git", "/usr/local/bin/git", "/bin/git"):
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    return "git"
+
+
 # Minimum manifest version this installer understands.
 # Plugins may declare ``manifest_version: 1`` in plugin.yaml;
 # future breaking changes to the manifest schema bump this.
@@ -324,9 +340,10 @@ def _install_plugin_core(identifier: str, *, force: bool) -> tuple[Path, dict, s
     with tempfile.TemporaryDirectory() as tmp:
         tmp_target = Path(tmp) / "plugin"
 
+        git_exe = _resolve_git_executable()
         try:
             result = subprocess.run(
-                ["git", "clone", "--depth", "1", git_url, str(tmp_target)],
+                [git_exe, "clone", "--depth", "1", git_url, str(tmp_target)],
                 capture_output=True,
                 text=True,
                 timeout=60,
@@ -1472,9 +1489,10 @@ def dashboard_update_user_plugin(name: str) -> dict[str, Any]:
 
 
 def _git_pull_plugin_dir(target: Path) -> tuple[bool, str]:
+    git_exe = _resolve_git_executable()
     try:
         result = subprocess.run(
-            ["git", "pull", "--ff-only"],
+            [git_exe, "pull", "--ff-only"],
             capture_output=True,
             text=True,
             timeout=60,


### PR DESCRIPTION
## Bug Description

Installing a plugin from the Dashboard/API can fail with `git is not installed or not in PATH.` even when `git` is installed and available in normal shell sessions. This happens when Hermes Dashboard/API is launched with a reduced `PATH`.

## Root Cause

`hermes_cli/plugins_cmd.py` invokes git as a bare `"git"` in subprocess calls:
- clone path in `_install_plugin_core`
- pull path in `_git_pull_plugin_dir`

If the process `PATH` is minimal, `subprocess.run(["git", ...])` raises `FileNotFoundError` even though git exists at standard absolute locations like `/usr/bin/git`.

## Fix

Add `_resolve_git_executable()` helper that:
- First tries `shutil.which("git")`
- Then falls back to `/usr/bin/git`, `/usr/local/bin/git`, `/bin/git` when executable
- Returns `"git"` as last resort to preserve existing error behavior when git truly does not exist

Apply the resolved executable in both clone and pull paths.

## Impact

- Fixes false-negative install/update failures in dashboard/non-interactive runtimes
- Keeps existing error text when git truly does not exist

## Testing

- Verified helper returns `shutil.which` result when git is in PATH
- Verified fallback to `/usr/bin/git` when `which` returns None but file exists and is executable
- Verified returns bare `"git"` when nothing is found (preserves original error path)

## Related

Fixes #22583