### PR TITLE
fix(acp): resolve version from package metadata fallback

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -9,6 +9,7 @@ import contextvars
 import json
 import logging
 import os
+from importlib import metadata as importlib_metadata
 from collections import defaultdict, deque
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -76,10 +77,30 @@ from acp_adapter.tools import build_tool_complete, build_tool_start
 
 logger = logging.getLogger(__name__)
 
-try:
-    from hermes_cli import __version__ as HERMES_VERSION
-except Exception:
-    HERMES_VERSION = "0.0.0"
+def resolve_hermes_version() -> str:
+    """Resolve the Hermes package version from the best available source."""
+    try:
+        from hermes_cli import __version__
+
+        version = str(__version__).strip()
+        if version:
+            return version
+    except Exception:
+        pass
+
+    try:
+        version = importlib_metadata.version("hermes-agent").strip()
+        if version:
+            return version
+    except importlib_metadata.PackageNotFoundError:
+        pass
+    except Exception:
+        pass
+
+    return "0.0.0"
+
+
+HERMES_VERSION = resolve_hermes_version()
 
 # Thread pool for running AIAgent (synchronous) in parallel.
 _executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="acp-agent")

--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -9,6 +9,7 @@ import contextvars
 import json
 import logging
 import os
+from importlib import metadata as importlib_metadata
 from collections import defaultdict, deque
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -85,7 +86,6 @@ from tools.approval import (
 )
 
 logger = logging.getLogger(__name__)
-
 
 def _named_custom_provider_catalogs() -> list[tuple[str, str, list[tuple[str, str]]]]:
     """Return ``(slug, label, [(model_id, description), ...])`` for named endpoints.
@@ -190,10 +190,30 @@ def _named_custom_provider_catalogs() -> list[tuple[str, str, list[tuple[str, st
 
     return catalogs
 
-try:
-    from hermes_cli import __version__ as HERMES_VERSION
-except Exception:
-    HERMES_VERSION = "0.0.0"
+def resolve_hermes_version() -> str:
+    """Resolve the Hermes package version from the best available source."""
+    try:
+        from hermes_cli import __version__
+
+        version = str(__version__).strip()
+        if version:
+            return version
+    except Exception:
+        pass
+
+    try:
+        version = importlib_metadata.version("hermes-agent").strip()
+        if version:
+            return version
+    except importlib_metadata.PackageNotFoundError:
+        pass
+    except Exception:
+        pass
+
+    return "0.0.0"
+
+
+HERMES_VERSION = resolve_hermes_version()
 
 # Thread pool for running AIAgent (synchronous) in parallel.
 _executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="acp-agent")

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -904,7 +904,6 @@ AUTHOR_MAP = {
     "zhuofengwang2003@gmail.com": "coekfung",
     "teknium@noreply.github.com": "teknium1",
     "2114364329@qq.com": "cuyua9",
-    "chris.eth@qq.com": "duyua9",
     "2557058999@qq.com": "Disaster-Terminator",
     "cine.dreamer.one@gmail.com": "LeonSGP43",
     "zyprothh@gmail.com": "Zyproth",

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -904,6 +904,7 @@ AUTHOR_MAP = {
     "zhuofengwang2003@gmail.com": "coekfung",
     "teknium@noreply.github.com": "teknium1",
     "2114364329@qq.com": "cuyua9",
+    "chris.eth@qq.com": "duyua9",
     "2557058999@qq.com": "Disaster-Terminator",
     "cine.dreamer.one@gmail.com": "LeonSGP43",
     "zyprothh@gmail.com": "Zyproth",

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1,6 +1,7 @@
 """Tests for acp_adapter.server — HermesACPAgent ACP server."""
 
 import asyncio
+import builtins
 import os
 from types import SimpleNamespace
 from unittest.mock import MagicMock, AsyncMock, patch
@@ -38,7 +39,7 @@ from acp.schema import (
     UserMessageChunk,
 )
 from acp_adapter.auth import TERMINAL_SETUP_AUTH_METHOD_ID
-from acp_adapter.server import HermesACPAgent, HERMES_VERSION
+from acp_adapter.server import HermesACPAgent, HERMES_VERSION, resolve_hermes_version
 from acp_adapter.session import SessionManager
 from hermes_state import SessionDB
 
@@ -103,6 +104,44 @@ class TestInitialize:
         assert isinstance(resp.agent_info, Implementation)
         assert resp.agent_info.name == "hermes-agent"
         assert resp.agent_info.version == HERMES_VERSION
+
+
+    def test_resolve_hermes_version_uses_package_metadata_when_cli_import_fails(self, monkeypatch):
+        import acp_adapter.server as server_mod
+
+        original_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "hermes_cli":
+                raise RuntimeError("hermes_cli import unavailable")
+            return original_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        monkeypatch.setattr(
+            server_mod.importlib_metadata,
+            "version",
+            lambda package_name: "9.8.7" if package_name == "hermes-agent" else "0.0.0",
+        )
+
+        assert resolve_hermes_version() == "9.8.7"
+
+    def test_resolve_hermes_version_falls_back_when_sources_unavailable(self, monkeypatch):
+        import acp_adapter.server as server_mod
+
+        original_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "hermes_cli":
+                raise RuntimeError("hermes_cli import unavailable")
+            return original_import(name, *args, **kwargs)
+
+        def missing_package(_package_name):
+            raise server_mod.importlib_metadata.PackageNotFoundError
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        monkeypatch.setattr(server_mod.importlib_metadata, "version", missing_package)
+
+        assert resolve_hermes_version() == "0.0.0"
 
     @pytest.mark.asyncio
     async def test_initialize_returns_capabilities(self, agent):

--- a/tests/acp/test_server.py
+++ b/tests/acp/test_server.py
@@ -1,6 +1,7 @@
 """Tests for acp_adapter.server — HermesACPAgent ACP server."""
 
 import asyncio
+import builtins
 import os
 from types import SimpleNamespace
 from unittest.mock import MagicMock, AsyncMock, patch
@@ -40,6 +41,7 @@ from acp_adapter.server import (
     ACP_MAX_MODELS_PER_PROVIDER,
     HermesACPAgent,
     HERMES_VERSION,
+    resolve_hermes_version,
 )
 from acp_adapter.session import SessionManager
 from hermes_state import SessionDB
@@ -99,7 +101,42 @@ class TestInitialize:
         assert resp.protocol_version == acp.PROTOCOL_VERSION
 
 
+    def test_resolve_hermes_version_uses_package_metadata_when_cli_import_fails(self, monkeypatch):
+        import acp_adapter.server as server_mod
 
+        original_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "hermes_cli":
+                raise RuntimeError("hermes_cli import unavailable")
+            return original_import(name, *args, **kwargs)
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        monkeypatch.setattr(
+            server_mod.importlib_metadata,
+            "version",
+            lambda package_name: "9.8.7" if package_name == "hermes-agent" else "0.0.0",
+        )
+
+        assert resolve_hermes_version() == "9.8.7"
+
+    def test_resolve_hermes_version_falls_back_when_sources_unavailable(self, monkeypatch):
+        import acp_adapter.server as server_mod
+
+        original_import = builtins.__import__
+
+        def fake_import(name, *args, **kwargs):
+            if name == "hermes_cli":
+                raise RuntimeError("hermes_cli import unavailable")
+            return original_import(name, *args, **kwargs)
+
+        def missing_package(_package_name):
+            raise server_mod.importlib_metadata.PackageNotFoundError
+
+        monkeypatch.setattr(builtins, "__import__", fake_import)
+        monkeypatch.setattr(server_mod.importlib_metadata, "version", missing_package)
+
+        assert resolve_hermes_version() == "0.0.0"
 
     @pytest.mark.asyncio
     async def test_initialize_advertises_provider_and_terminal_auth_methods(self, agent, monkeypatch):


### PR DESCRIPTION
## Summary

- Add a small `resolve_hermes_version()` helper for ACP server version reporting.
- Keep `hermes_cli.__version__` as the primary source, then fall back to installed package metadata via `importlib.metadata.version("hermes-agent")` before using the conservative `0.0.0` fallback.
- Cover both the package metadata fallback and the unavailable-source fallback in ACP server tests.

## Why

ACP `initialize` and `/version` expose Hermes Agent version information to clients. If importing `hermes_cli` is unavailable in a packaged or import-isolated environment, the server currently reports `0.0.0` even when package metadata contains the installed version.

## Tests

```console
$ uv run --extra dev --extra acp python -m pytest tests/acp/test_server.py -q --tb=short
62 passed in 10.36s
```
