### PR TITLE
fix(checkpoint): guard _touch_project against non-dict project metadata

### DIFF
--- a/tests/tools/test_checkpoint_manager.py
+++ b/tests/tools/test_checkpoint_manager.py
@@ -21,6 +21,7 @@ from tools.checkpoint_manager import (
     _store_path,
     _ref_name,
     _project_meta_path,
+    _touch_project,
     format_checkpoint_list,
     DEFAULT_EXCLUDES,
     CHECKPOINT_BASE,
@@ -606,6 +607,43 @@ class TestErrorResilience:
             raise OSError("git exploded")
         monkeypatch.setattr("tools.checkpoint_manager._run_git", broken_run_git)
         assert mgr.ensure_checkpoint(str(work_dir), "test") is False
+
+
+class TestTouchProjectMalformedMeta:
+    """_touch_project must not raise when the project metadata file is corrupted.
+
+    The try/except in _touch_project only catches ``(OSError, ValueError)``.
+    When ``json.load`` succeeds but returns a non-dict (e.g. a list ``[]``,
+    ``null``, or a scalar), the subsequent ``meta["workdir"] = ...`` raises
+    ``TypeError: list indices must be integers…``.  This TypeError propagates
+    uncaught out of ``_touch_project`` and up through ``_take`` into
+    ``ensure_checkpoint``, where it is swallowed by the broad ``except
+    Exception`` safety net — but the effect is that the checkpoint is silently
+    skipped for the entire session.
+
+    Fix: add ``if not isinstance(meta, dict): meta = {}`` after parsing,
+    mirroring the same guard already present in ``_list_projects``.
+    """
+
+    @pytest.mark.parametrize("payload", ["[]", "null", "42", '"oops"'])
+    def test_non_dict_meta_does_not_raise(self, tmp_path, payload):
+        store = tmp_path / "store"
+        workdir = str(tmp_path / "project")
+        _init_store(store, workdir)
+
+        dir_hash = _project_hash(workdir)
+        meta_path = _project_meta_path(store, dir_hash)
+        meta_path.parent.mkdir(parents=True, exist_ok=True)
+        meta_path.write_text(payload, encoding="utf-8")
+
+        # Must not raise TypeError
+        _touch_project(store, workdir)
+
+        # Metadata file should now be a valid dict with last_touch updated
+        data = json.loads(meta_path.read_text(encoding="utf-8"))
+        assert isinstance(data, dict)
+        assert "last_touch" in data
+        assert "workdir" in data
 
 
 # =========================================================================

--- a/tools/checkpoint_manager.py
+++ b/tools/checkpoint_manager.py
@@ -482,6 +482,8 @@ def _touch_project(store: Path, working_dir: str) -> None:
         meta = json.loads(meta_path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
         meta = {}
+    if not isinstance(meta, dict):
+        meta = {}
     meta["workdir"] = str(_normalize_path(working_dir))
     meta["last_touch"] = time.time()
     meta.setdefault("created_at", meta["last_touch"])


### PR DESCRIPTION
## Problem

`tools.checkpoint_manager._touch_project` parses the project metadata file with `json.loads`, then immediately subscript-assigns into the result:

```python
try:
    meta = json.loads(meta_path.read_text(encoding="utf-8"))
except (OSError, ValueError):
    meta = {}
meta["workdir"] = str(_normalize_path(working_dir))  # ← crashes if meta is a list
```

When the file parses successfully but returns a non-dict (`[]`, `null`, `42`, etc. — from a corrupted or truncated write), `json.loads` does **not** raise, the `except (OSError, ValueError)` clause is skipped, and `meta["workdir"] = ...` raises `TypeError: list indices must be integers or slices, not str`.

This `TypeError` is not caught in `_touch_project` or `_take`. It propagates to `ensure_checkpoint`'s broad `except Exception` safety net, which silently returns `False` — disabling all checkpoints for the affected working directory for the entire session, with no user-visible error.

## Root cause

Missing `isinstance(meta, dict)` guard after `json.loads`. The same guard is already present in `_list_projects` (line 506 of the same file) but was omitted in `_touch_project`. Same pattern as fixes in `cron/jobs.py` (#22569) and `tools/process_registry.py` (#22544).

## Fix

```diff
     try:
         meta = json.loads(meta_path.read_text(encoding="utf-8"))
     except (OSError, ValueError):
         meta = {}
+    if not isinstance(meta, dict):
+        meta = {}
     meta["workdir"] = str(_normalize_path(working_dir))
```

Two lines, matching the existing guard in `_list_projects`.

## Tests

`TestTouchProjectMalformedMeta` covers four non-dict payloads (`[]`, `null`, `42`, `"oops"`):
- Writes corrupted metadata to `<store>/projects/<hash>.json`
- Calls `_touch_project` — asserts **no exception raised**
- Asserts metadata file is rewritten as a valid dict with `last_touch` and `workdir` present

All four cases fail on `main` with `TypeError`, pass with the fix. Full `tests/tools/test_checkpoint_manager.py` regression: 77 passed.