### PR TITLE
feat: add comms policy MCP server

### DIFF
--- a/mcp_servers/__init__.py
+++ b/mcp_servers/__init__.py
@@ -1,0 +1,1 @@
+"""Built-in MCP servers shipped with Hermes Agent."""

--- a/mcp_servers/comms_policy.py
+++ b/mcp_servers/comms_policy.py
@@ -1,0 +1,713 @@
+"""Telegram / Comms Policy MCP server.
+
+This stdio MCP server centralizes Brandon-style concise notification formatting,
+SQLite-backed dedupe state, and stale-alert suppression for Hermes automations.
+It intentionally delegates actual delivery to the existing ``send_message`` tool
+implementation so credentials and platform routing stay in one place.
+
+Usage:
+    python -m mcp_servers.comms_policy
+
+Hermes config snippet:
+    mcp_servers:
+      comms_policy:
+        command: python
+        args: ["-m", "mcp_servers.comms_policy"]
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import sqlite3
+import sys
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger("hermes.mcp_servers.comms_policy")
+
+try:
+    from mcp.server.fastmcp import FastMCP
+
+    _MCP_SERVER_AVAILABLE = True
+except ImportError:  # pragma: no cover - exercised by tests via monkeypatchable fallback
+    FastMCP = None  # type: ignore[assignment,misc]
+    _MCP_SERVER_AVAILABLE = False
+
+DEFAULT_DEDUPE_WINDOW_SECONDS = 60 * 60
+DEFAULT_STALE_AFTER_SECONDS = 60 * 30
+MAX_MESSAGE_CHARS = 1600
+
+
+@dataclass(frozen=True)
+class PolicyResult:
+    """Result from policy evaluation before delivery."""
+
+    allowed: bool
+    reason: str
+    dedupe_key: str
+    message_hash: str
+    last_sent_at: Optional[float] = None
+    age_seconds: Optional[float] = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "allowed": self.allowed,
+            "reason": self.reason,
+            "dedupe_key": self.dedupe_key,
+            "message_hash": self.message_hash,
+            "last_sent_at": self.last_sent_at,
+            "age_seconds": self.age_seconds,
+        }
+
+
+def _get_hermes_home() -> Path:
+    try:
+        from hermes_constants import get_hermes_home
+
+        return get_hermes_home()
+    except Exception:
+        return Path(os.environ.get("HERMES_HOME", Path.home() / ".hermes")).expanduser()
+
+
+def default_db_path() -> Path:
+    """Return the profile-scoped SQLite DB path for comms policy state."""
+
+    return _get_hermes_home() / "comms_policy" / "notifications.sqlite"
+
+
+def _connect(db_path: Optional[Path] = None) -> sqlite3.Connection:
+    path = db_path or default_db_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA busy_timeout=5000")
+    _init_db(conn)
+    return conn
+
+
+def _init_db(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS notifications (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            target TEXT NOT NULL,
+            category TEXT NOT NULL,
+            dedupe_key TEXT NOT NULL,
+            message_hash TEXT NOT NULL,
+            message TEXT NOT NULL,
+            status TEXT NOT NULL,
+            reason TEXT NOT NULL DEFAULT '',
+            event_ts REAL,
+            queued_at REAL NOT NULL,
+            sent_at REAL,
+            metadata_json TEXT NOT NULL DEFAULT '{}'
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_notifications_lookup
+        ON notifications (target, dedupe_key, message_hash, sent_at DESC, queued_at DESC)
+        """
+    )
+    conn.execute(
+        """
+        CREATE INDEX IF NOT EXISTS idx_notifications_queue
+        ON notifications (status, queued_at)
+        """
+    )
+    conn.commit()
+
+
+def _json(data: dict[str, Any]) -> str:
+    return json.dumps(data, ensure_ascii=False, sort_keys=True)
+
+
+def _message_hash(message: str) -> str:
+    return hashlib.sha256(message.encode("utf-8")).hexdigest()
+
+
+def _normalize_text(text: Any) -> str:
+    return " ".join(str(text or "").strip().split())
+
+
+def _stable_key(*parts: Any) -> str:
+    normalized = "|".join(_normalize_text(part).lower() for part in parts if part is not None)
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:24]
+
+
+def _coerce_int(value: Any, *, default: int, minimum: int = 0, maximum: int = 30 * 24 * 3600) -> int:
+    try:
+        coerced = int(value)
+    except (TypeError, ValueError):
+        coerced = default
+    return max(minimum, min(coerced, maximum))
+
+
+def _clip(text: str, limit: int = MAX_MESSAGE_CHARS) -> str:
+    if len(text) <= limit:
+        return text
+    return text[: max(0, limit - 1)].rstrip() + "…"
+
+
+def _bullet_lines(items: Any, *, max_items: int = 4) -> list[str]:
+    if not items:
+        return []
+    if isinstance(items, str):
+        raw_items = [line.strip(" -•\t") for line in items.splitlines() if line.strip()]
+    elif isinstance(items, (list, tuple)):
+        raw_items = [_normalize_text(item) for item in items if _normalize_text(item)]
+    else:
+        raw_items = [_normalize_text(items)]
+    return [f"• {item}" for item in raw_items[:max_items] if item]
+
+
+def format_success_notice(
+    title: str,
+    details: Any = None,
+    *,
+    task_id: str = "",
+    next_step: str = "",
+) -> str:
+    """Format a concise Telegram success notice."""
+
+    lines = [f"✅ {_normalize_text(title) or 'Done'}"]
+    if task_id:
+        lines.append(f"Task: {task_id}")
+    lines.extend(_bullet_lines(details))
+    if next_step:
+        lines.append(f"Next: {_normalize_text(next_step)}")
+    return _clip("\n".join(lines))
+
+
+def format_failure_notice(
+    title: str,
+    error: Any = None,
+    *,
+    task_id: str = "",
+    next_step: str = "",
+) -> str:
+    """Format a concise Telegram failure / Kanban error notice."""
+
+    lines = [f"❌ {_normalize_text(title) or 'Failed'}"]
+    if task_id:
+        lines.append(f"Task: {task_id}")
+    if error:
+        lines.append(f"Error: {_normalize_text(error)}")
+    if next_step:
+        lines.append(f"Next: {_normalize_text(next_step)}")
+    return _clip("\n".join(lines))
+
+
+def format_briefing(
+    title: str,
+    items: Any = None,
+    *,
+    footer: str = "",
+) -> str:
+    """Format a concise briefing for Telegram."""
+
+    lines = [f"📋 {_normalize_text(title) or 'Briefing'}"]
+    lines.extend(_bullet_lines(items, max_items=8))
+    if footer:
+        lines.append(_normalize_text(footer))
+    return _clip("\n".join(lines))
+
+
+def format_ready_question(question: str, *, context: Any = None) -> str:
+    """Format a ready-question convention for Kanban/human decisions."""
+
+    lines = [f"❓ {_normalize_text(question) or 'Decision needed'}"]
+    lines.extend(_bullet_lines(context, max_items=3))
+    lines.append("Reply with the choice or details.")
+    return _clip("\n".join(lines))
+
+
+def evaluate_policy(
+    *,
+    target: str,
+    category: str,
+    message: str,
+    dedupe_key: str = "",
+    dedupe_window_seconds: int = DEFAULT_DEDUPE_WINDOW_SECONDS,
+    event_ts: Optional[float] = None,
+    stale_after_seconds: int = DEFAULT_STALE_AFTER_SECONDS,
+    now: Optional[float] = None,
+    db_path: Optional[Path] = None,
+) -> PolicyResult:
+    """Return whether a notification should be sent under dedupe/stale policy."""
+
+    now_ts = time.time() if now is None else float(now)
+    target = _normalize_text(target) or "telegram"
+    category = _normalize_text(category) or "notice"
+    message_hash = _message_hash(message)
+    dedupe_key = _normalize_text(dedupe_key) or _stable_key(target, category, message)
+    dedupe_window_seconds = _coerce_int(
+        dedupe_window_seconds,
+        default=DEFAULT_DEDUPE_WINDOW_SECONDS,
+        maximum=30 * 24 * 3600,
+    )
+    stale_after_seconds = _coerce_int(
+        stale_after_seconds,
+        default=DEFAULT_STALE_AFTER_SECONDS,
+        maximum=30 * 24 * 3600,
+    )
+
+    age_seconds = None
+    if event_ts is not None and stale_after_seconds > 0:
+        age_seconds = max(0.0, now_ts - float(event_ts))
+        if age_seconds > stale_after_seconds:
+            return PolicyResult(
+                allowed=False,
+                reason="stale",
+                dedupe_key=dedupe_key,
+                message_hash=message_hash,
+                age_seconds=age_seconds,
+            )
+
+    with _connect(db_path) as conn:
+        row = conn.execute(
+            """
+            SELECT sent_at, queued_at FROM notifications
+            WHERE target = ? AND dedupe_key = ? AND message_hash = ?
+              AND status IN ('sent', 'queued')
+            ORDER BY COALESCE(sent_at, queued_at) DESC
+            LIMIT 1
+            """,
+            (target, dedupe_key, message_hash),
+        ).fetchone()
+
+    if row:
+        last = row["sent_at"] if row["sent_at"] is not None else row["queued_at"]
+        if last is not None and now_ts - float(last) < dedupe_window_seconds:
+            return PolicyResult(
+                allowed=False,
+                reason="duplicate",
+                dedupe_key=dedupe_key,
+                message_hash=message_hash,
+                last_sent_at=float(last),
+                age_seconds=age_seconds,
+            )
+
+    return PolicyResult(
+        allowed=True,
+        reason="allowed",
+        dedupe_key=dedupe_key,
+        message_hash=message_hash,
+        age_seconds=age_seconds,
+    )
+
+
+def record_notification(
+    *,
+    target: str,
+    category: str,
+    dedupe_key: str,
+    message_hash: str,
+    message: str,
+    status: str,
+    reason: str = "",
+    event_ts: Optional[float] = None,
+    now: Optional[float] = None,
+    metadata: Optional[dict[str, Any]] = None,
+    db_path: Optional[Path] = None,
+) -> int:
+    now_ts = time.time() if now is None else float(now)
+    sent_at = now_ts if status == "sent" else None
+    with _connect(db_path) as conn:
+        cur = conn.execute(
+            """
+            INSERT INTO notifications (
+                target, category, dedupe_key, message_hash, message, status,
+                reason, event_ts, queued_at, sent_at, metadata_json
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                target,
+                category,
+                dedupe_key,
+                message_hash,
+                message,
+                status,
+                reason,
+                event_ts,
+                now_ts,
+                sent_at,
+                _json(metadata or {}),
+            ),
+        )
+        conn.commit()
+        return int(cur.lastrowid)
+
+
+def check_last_sent_record(
+    *,
+    target: str = "telegram",
+    message: str = "",
+    dedupe_key: str = "",
+    category: str = "notice",
+    db_path: Optional[Path] = None,
+) -> dict[str, Any]:
+    target = _normalize_text(target) or "telegram"
+    category = _normalize_text(category) or "notice"
+    if not dedupe_key:
+        dedupe_key = _stable_key(target, category, message) if message else ""
+    msg_hash = _message_hash(message) if message else ""
+    where = ["target = ?"]
+    args: list[Any] = [target]
+    if dedupe_key:
+        where.append("dedupe_key = ?")
+        args.append(dedupe_key)
+    if msg_hash:
+        where.append("message_hash = ?")
+        args.append(msg_hash)
+    where.append("status IN ('sent', 'queued')")
+    with _connect(db_path) as conn:
+        row = conn.execute(
+            f"""
+            SELECT * FROM notifications
+            WHERE {' AND '.join(where)}
+            ORDER BY COALESCE(sent_at, queued_at) DESC
+            LIMIT 1
+            """,
+            args,
+        ).fetchone()
+    if not row:
+        return {"found": False, "target": target, "dedupe_key": dedupe_key}
+    data = dict(row)
+    data["found"] = True
+    try:
+        data["metadata"] = json.loads(data.pop("metadata_json") or "{}")
+    except json.JSONDecodeError:
+        data["metadata"] = {}
+    return data
+
+
+def dedupe_notification_policy(
+    *,
+    target: str = "telegram",
+    message: str,
+    dedupe_key: str = "",
+    category: str = "notice",
+    dedupe_window_seconds: int = DEFAULT_DEDUPE_WINDOW_SECONDS,
+    event_ts: Optional[float] = None,
+    stale_after_seconds: int = DEFAULT_STALE_AFTER_SECONDS,
+    now: Optional[float] = None,
+    db_path: Optional[Path] = None,
+) -> dict[str, Any]:
+    result = evaluate_policy(
+        target=target,
+        category=category,
+        message=message,
+        dedupe_key=dedupe_key,
+        dedupe_window_seconds=dedupe_window_seconds,
+        event_ts=event_ts,
+        stale_after_seconds=stale_after_seconds,
+        now=now,
+        db_path=db_path,
+    )
+    if not result.allowed:
+        notification_id = record_notification(
+            target=_normalize_text(target) or "telegram",
+            category=_normalize_text(category) or "notice",
+            dedupe_key=result.dedupe_key,
+            message_hash=result.message_hash,
+            message=message,
+            status="suppressed",
+            reason=result.reason,
+            event_ts=event_ts,
+            now=now,
+            db_path=db_path,
+        )
+    else:
+        notification_id = None
+    payload = result.to_dict()
+    payload.update(
+        {
+            "should_send": result.allowed,
+            "suppressed": not result.allowed,
+            "notification_id": notification_id,
+        }
+    )
+    return payload
+
+
+def _send_via_existing_tool(target: str, message: str) -> dict[str, Any]:
+    """Deliver through Hermes' existing send_message tool to avoid secret duplication."""
+
+    try:
+        from tools.send_message_tool import send_message_tool
+
+        raw = send_message_tool({"action": "send", "target": target, "message": message})
+        try:
+            parsed = json.loads(raw)
+        except (TypeError, json.JSONDecodeError):
+            parsed = {"raw": raw}
+        if isinstance(parsed, dict):
+            return parsed
+        return {"result": parsed}
+    except Exception as exc:
+        logger.exception("send_message delivery failed")
+        return {"error": str(exc)}
+
+
+def send_policy_notice(
+    *,
+    target: str = "telegram",
+    category: str,
+    message: str,
+    dedupe_key: str = "",
+    dedupe_window_seconds: int = DEFAULT_DEDUPE_WINDOW_SECONDS,
+    event_ts: Optional[float] = None,
+    stale_after_seconds: int = DEFAULT_STALE_AFTER_SECONDS,
+    dry_run: bool = False,
+    now: Optional[float] = None,
+    sender: Optional[Callable[[str, str], dict[str, Any]]] = None,
+    metadata: Optional[dict[str, Any]] = None,
+    db_path: Optional[Path] = None,
+) -> dict[str, Any]:
+    target = _normalize_text(target) or "telegram"
+    category = _normalize_text(category) or "notice"
+    policy = evaluate_policy(
+        target=target,
+        category=category,
+        message=message,
+        dedupe_key=dedupe_key,
+        dedupe_window_seconds=dedupe_window_seconds,
+        event_ts=event_ts,
+        stale_after_seconds=stale_after_seconds,
+        now=now,
+        db_path=db_path,
+    )
+    if not policy.allowed:
+        notification_id = record_notification(
+            target=target,
+            category=category,
+            dedupe_key=policy.dedupe_key,
+            message_hash=policy.message_hash,
+            message=message,
+            status="suppressed",
+            reason=policy.reason,
+            event_ts=event_ts,
+            now=now,
+            metadata=metadata,
+            db_path=db_path,
+        )
+        payload = policy.to_dict()
+        payload.update({"sent": False, "suppressed": True, "notification_id": notification_id, "message": message})
+        return payload
+
+    delivery: dict[str, Any] = {"dry_run": True} if dry_run else (sender or _send_via_existing_tool)(target, message)
+    status = "sent" if "error" not in delivery and not dry_run else "queued" if dry_run else "failed"
+    reason = "dry_run" if dry_run else str(delivery.get("error", ""))
+    notification_id = record_notification(
+        target=target,
+        category=category,
+        dedupe_key=policy.dedupe_key,
+        message_hash=policy.message_hash,
+        message=message,
+        status=status,
+        reason=reason,
+        event_ts=event_ts,
+        now=now,
+        metadata=metadata,
+        db_path=db_path,
+    )
+    payload = policy.to_dict()
+    payload.update(
+        {
+            "sent": status == "sent",
+            "queued": status == "queued",
+            "suppressed": False,
+            "notification_id": notification_id,
+            "message": message,
+            "delivery": delivery,
+        }
+    )
+    return payload
+
+
+def build_server() -> Any:
+    """Build and return the FastMCP server instance."""
+
+    if not _MCP_SERVER_AVAILABLE or FastMCP is None:
+        raise RuntimeError("MCP SDK not available. Install with: pip install mcp")
+
+    mcp = FastMCP("hermes-comms-policy")
+
+    @mcp.tool()
+    def send_success_notice(
+        title: str,
+        details: Any = None,
+        target: str = "telegram",
+        task_id: str = "",
+        next_step: str = "",
+        dedupe_key: str = "",
+        dedupe_window_seconds: int = DEFAULT_DEDUPE_WINDOW_SECONDS,
+        event_ts: Optional[float] = None,
+        stale_after_seconds: int = DEFAULT_STALE_AFTER_SECONDS,
+        dry_run: bool = False,
+    ) -> str:
+        """Format, dedupe, and send a concise success notice."""
+
+        message = format_success_notice(title, details, task_id=task_id, next_step=next_step)
+        return _json(
+            send_policy_notice(
+                target=target,
+                category="success",
+                message=message,
+                dedupe_key=dedupe_key or _stable_key("success", task_id, title, message),
+                dedupe_window_seconds=dedupe_window_seconds,
+                event_ts=event_ts,
+                stale_after_seconds=stale_after_seconds,
+                dry_run=dry_run,
+                metadata={"title": title, "task_id": task_id},
+            )
+        )
+
+    @mcp.tool()
+    def send_failure_notice(
+        title: str,
+        error: Any = None,
+        target: str = "telegram",
+        task_id: str = "",
+        next_step: str = "",
+        dedupe_key: str = "",
+        dedupe_window_seconds: int = DEFAULT_DEDUPE_WINDOW_SECONDS,
+        event_ts: Optional[float] = None,
+        stale_after_seconds: int = DEFAULT_STALE_AFTER_SECONDS,
+        dry_run: bool = False,
+    ) -> str:
+        """Format, dedupe, and send a concise failure / Kanban error notice."""
+
+        message = format_failure_notice(title, error, task_id=task_id, next_step=next_step)
+        return _json(
+            send_policy_notice(
+                target=target,
+                category="failure",
+                message=message,
+                dedupe_key=dedupe_key or _stable_key("failure", task_id, title, error),
+                dedupe_window_seconds=dedupe_window_seconds,
+                event_ts=event_ts,
+                stale_after_seconds=stale_after_seconds,
+                dry_run=dry_run,
+                metadata={"title": title, "task_id": task_id},
+            )
+        )
+
+    @mcp.tool()
+    def send_briefing(
+        title: str,
+        items: Any = None,
+        target: str = "telegram",
+        footer: str = "",
+        dedupe_key: str = "",
+        dedupe_window_seconds: int = DEFAULT_DEDUPE_WINDOW_SECONDS,
+        event_ts: Optional[float] = None,
+        stale_after_seconds: int = DEFAULT_STALE_AFTER_SECONDS,
+        dry_run: bool = False,
+    ) -> str:
+        """Format, dedupe, and send a concise Telegram-style briefing."""
+
+        message = format_briefing(title, items, footer=footer)
+        return _json(
+            send_policy_notice(
+                target=target,
+                category="briefing",
+                message=message,
+                dedupe_key=dedupe_key or _stable_key("briefing", title, message),
+                dedupe_window_seconds=dedupe_window_seconds,
+                event_ts=event_ts,
+                stale_after_seconds=stale_after_seconds,
+                dry_run=dry_run,
+                metadata={"title": title},
+            )
+        )
+
+    @mcp.tool()
+    def queue_notification(
+        message: str,
+        target: str = "telegram",
+        category: str = "notice",
+        dedupe_key: str = "",
+        dedupe_window_seconds: int = DEFAULT_DEDUPE_WINDOW_SECONDS,
+        event_ts: Optional[float] = None,
+        stale_after_seconds: int = DEFAULT_STALE_AFTER_SECONDS,
+    ) -> str:
+        """Queue a notification after applying duplicate/stale suppression."""
+
+        result = send_policy_notice(
+            target=target,
+            category=category,
+            message=_clip(message),
+            dedupe_key=dedupe_key,
+            dedupe_window_seconds=dedupe_window_seconds,
+            event_ts=event_ts,
+            stale_after_seconds=stale_after_seconds,
+            dry_run=True,
+        )
+        return _json(result)
+
+    @mcp.tool()
+    def dedupe_notification(
+        message: str,
+        target: str = "telegram",
+        category: str = "notice",
+        dedupe_key: str = "",
+        dedupe_window_seconds: int = DEFAULT_DEDUPE_WINDOW_SECONDS,
+        event_ts: Optional[float] = None,
+        stale_after_seconds: int = DEFAULT_STALE_AFTER_SECONDS,
+    ) -> str:
+        """Check whether a notification is duplicate or stale before sending."""
+
+        return _json(
+            dedupe_notification_policy(
+                target=target,
+                category=category,
+                message=_clip(message),
+                dedupe_key=dedupe_key,
+                dedupe_window_seconds=dedupe_window_seconds,
+                event_ts=event_ts,
+                stale_after_seconds=stale_after_seconds,
+            )
+        )
+
+    @mcp.tool()
+    def check_last_sent(
+        target: str = "telegram",
+        message: str = "",
+        dedupe_key: str = "",
+        category: str = "notice",
+    ) -> str:
+        """Return the latest stored notification matching target/key/message."""
+
+        return _json(check_last_sent_record(target=target, message=message, dedupe_key=dedupe_key, category=category))
+
+    @mcp.tool()
+    def format_ready_question_notice(question: str, context: Any = None) -> str:
+        """Format Brandon's concise ready-question convention without sending."""
+
+        return _json({"message": format_ready_question(question, context=context)})
+
+    return mcp
+
+
+def main() -> int:
+    logging.basicConfig(level=os.getenv("HERMES_COMMS_POLICY_LOG_LEVEL", "WARNING"))
+    try:
+        server = build_server()
+    except RuntimeError as exc:
+        print(str(exc), file=sys.stderr)
+        return 1
+    server.run()
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,7 +178,7 @@ hermes_cli = ["web_dist/**/*"]
 gateway = ["assets/**/*"]
 
 [tool.setuptools.packages.find]
-include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]
+include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*", "mcp_servers", "mcp_servers.*"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_comms_policy_mcp.py
+++ b/tests/test_comms_policy_mcp.py
@@ -1,0 +1,204 @@
+import inspect
+import json
+from pathlib import Path
+
+import pytest
+
+import mcp_servers.comms_policy as policy
+
+
+@pytest.fixture(autouse=True)
+def _isolate_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    try:
+        import hermes_constants
+
+        monkeypatch.setattr(hermes_constants, "get_hermes_home", lambda: tmp_path)
+    except Exception:
+        pass
+    return tmp_path
+
+
+class _FakeTool:
+    def __init__(self, fn):
+        self.name = fn.__name__
+        self.description = inspect.getdoc(fn) or ""
+        self.fn = fn
+
+
+class _FakeToolManager:
+    def __init__(self):
+        self._tools = {}
+
+    def add_tool(self, fn):
+        self._tools[fn.__name__] = _FakeTool(fn)
+
+    def list_tools(self):
+        return list(self._tools.values())
+
+
+class _FakeFastMCP:
+    def __init__(self, *args, **kwargs):
+        self._tool_manager = _FakeToolManager()
+
+    def tool(self):
+        def decorator(fn):
+            self._tool_manager.add_tool(fn)
+            return fn
+
+        return decorator
+
+    def run(self):
+        return None
+
+
+def test_success_failure_and_ready_question_formatting_is_concise():
+    success = policy.format_success_notice(
+        "Kanban task complete",
+        ["tests pass", "PR opened"],
+        task_id="t_abc123",
+        next_step="Review PR",
+    )
+    assert success == "✅ Kanban task complete\nTask: t_abc123\n• tests pass\n• PR opened\nNext: Review PR"
+
+    failure = policy.format_failure_notice(
+        "Kanban worker failed",
+        "pytest timed out after 60s",
+        task_id="t_abc123",
+        next_step="Retry targeted tests",
+    )
+    assert failure == (
+        "❌ Kanban worker failed\n"
+        "Task: t_abc123\n"
+        "Error: pytest timed out after 60s\n"
+        "Next: Retry targeted tests"
+    )
+
+    question = policy.format_ready_question("Deploy now?", context=["staging passed", "prod is quiet"])
+    assert question == "❓ Deploy now?\n• staging passed\n• prod is quiet\nReply with the choice or details."
+
+
+def test_identical_notifications_are_deduped_with_sqlite_state(tmp_path):
+    db_path = tmp_path / "notifications.sqlite"
+    sent = []
+
+    def sender(target, message):
+        sent.append((target, message))
+        return {"ok": True, "message_id": len(sent)}
+
+    first = policy.send_policy_notice(
+        target="telegram",
+        category="success",
+        message="✅ Backup complete",
+        dedupe_key="backup:daily",
+        now=1000,
+        sender=sender,
+        db_path=db_path,
+    )
+    assert first["sent"] is True
+    assert first["suppressed"] is False
+
+    second = policy.send_policy_notice(
+        target="telegram",
+        category="success",
+        message="✅ Backup complete",
+        dedupe_key="backup:daily",
+        now=1010,
+        sender=sender,
+        db_path=db_path,
+    )
+    assert second["sent"] is False
+    assert second["suppressed"] is True
+    assert second["reason"] == "duplicate"
+    assert sent == [("telegram", "✅ Backup complete")]
+
+    last = policy.check_last_sent_record(
+        target="telegram",
+        message="✅ Backup complete",
+        dedupe_key="backup:daily",
+        db_path=db_path,
+    )
+    assert last["found"] is True
+    assert last["status"] == "sent"
+    assert last["reason"] == ""
+
+
+def test_stale_event_is_suppressed_and_not_delivered(tmp_path):
+    sent = []
+
+    result = policy.send_policy_notice(
+        target="telegram",
+        category="failure",
+        message="❌ Worker failed",
+        dedupe_key="worker:t_123",
+        event_ts=1000,
+        stale_after_seconds=60,
+        now=1120,
+        sender=lambda target, message: sent.append((target, message)) or {"ok": True},
+        db_path=tmp_path / "notifications.sqlite",
+    )
+
+    assert result["sent"] is False
+    assert result["suppressed"] is True
+    assert result["reason"] == "stale"
+    assert result["age_seconds"] == 120
+    assert sent == []
+
+
+def test_queue_notification_records_queued_and_prevents_duplicate_send(tmp_path):
+    db_path = tmp_path / "notifications.sqlite"
+
+    queued = policy.send_policy_notice(
+        target="telegram",
+        category="briefing",
+        message="📋 Morning brief\n• Item A",
+        dedupe_key="brief:morning",
+        dry_run=True,
+        now=1000,
+        db_path=db_path,
+    )
+    assert queued["queued"] is True
+    assert queued["sent"] is False
+
+    duplicate = policy.dedupe_notification_policy(
+        target="telegram",
+        category="briefing",
+        message="📋 Morning brief\n• Item A",
+        dedupe_key="brief:morning",
+        now=1001,
+        db_path=db_path,
+    )
+    assert duplicate["should_send"] is False
+    assert duplicate["reason"] == "duplicate"
+
+
+def test_mcp_server_registers_expected_tools(monkeypatch):
+    monkeypatch.setattr(policy, "FastMCP", _FakeFastMCP)
+    monkeypatch.setattr(policy, "_MCP_SERVER_AVAILABLE", True)
+
+    server = policy.build_server()
+    names = {tool.name for tool in server._tool_manager.list_tools()}
+
+    assert {
+        "send_success_notice",
+        "send_failure_notice",
+        "send_briefing",
+        "dedupe_notification",
+        "check_last_sent",
+        "queue_notification",
+        "format_ready_question_notice",
+    } <= names
+
+    response = server._tool_manager._tools["send_success_notice"].fn(
+        title="Tests passed",
+        details=["5 passed"],
+        dedupe_key="tests:passed",
+        dry_run=True,
+    )
+    payload = json.loads(response)
+    assert payload["queued"] is True
+    assert payload["message"] == "✅ Tests passed\n• 5 passed"
+
+
+def test_default_state_path_is_profile_scoped(tmp_path):
+    assert policy.default_db_path() == Path(tmp_path) / "comms_policy" / "notifications.sqlite"

--- a/website/docs/guides/comms-policy-mcp.md
+++ b/website/docs/guides/comms-policy-mcp.md
@@ -1,0 +1,93 @@
+# Telegram / Comms Policy MCP server
+
+Hermes ships a small stdio MCP server for Brandon-style notification policy:
+concise Telegram formatting, SQLite-backed dedupe, and stale-alert suppression.
+It delegates actual delivery to Hermes' existing `send_message` tool, so Telegram
+secrets, home-channel routing, and platform adapters stay in the normal gateway
+configuration instead of being duplicated in MCP config.
+
+## Tools
+
+When configured under the server name `comms_policy`, Hermes discovers these as
+`mcp_comms_policy_*` tools after restart:
+
+- `send_success_notice` — format, dedupe, and send a concise success notice.
+- `send_failure_notice` — format, dedupe, and send a concise failure / Kanban
+  error notice.
+- `send_briefing` — format, dedupe, and send a concise briefing.
+- `dedupe_notification` — check whether a message is duplicate or stale.
+- `check_last_sent` — inspect durable dedupe state for a target/key/message.
+- `queue_notification` — store an allowed notification without sending yet.
+- `format_ready_question_notice` — render the ready-question convention without
+  sending.
+
+## Configuration
+
+Add this to `~/.hermes/config.yaml`:
+
+```yaml
+mcp_servers:
+  comms_policy:
+    command: python
+    args: ["-m", "mcp_servers.comms_policy"]
+    timeout: 30
+    connect_timeout: 30
+```
+
+If Hermes is installed in a virtual environment and `python` does not resolve to
+that environment, set `command` to the absolute venv interpreter path instead.
+No Telegram token or chat ID belongs in this snippet; delivery uses the existing
+Hermes gateway/send_message configuration.
+
+Restart Hermes, then check discovery:
+
+```bash
+hermes mcp list
+hermes mcp test comms_policy
+```
+
+In a new agent session, the discovered tools are available with the
+`mcp_comms_policy_` prefix.
+
+## State
+
+Dedupe state is stored in a profile-scoped SQLite database:
+
+```text
+$HERMES_HOME/comms_policy/notifications.sqlite
+```
+
+Rows record target, category, dedupe key, SHA-256 message hash, status
+(`sent`, `queued`, `suppressed`, or `failed`), event timestamp, queued time, sent
+time, and JSON metadata. Repeated identical notifications within the dedupe
+window are suppressed, and notifications whose event timestamp is older than
+`stale_after_seconds` are suppressed as stale.
+
+## Formatting conventions
+
+Success:
+
+```text
+✅ Backup complete
+Task: t_123
+• 14 files copied
+Next: Verify offsite sync
+```
+
+Failure / Kanban error:
+
+```text
+❌ Kanban worker failed
+Task: t_123
+Error: pytest timed out
+Next: Retry with a narrower test target
+```
+
+Ready question:
+
+```text
+❓ Which target should receive the briefing?
+• Telegram home
+• Discord weekly review
+Reply with the choice or details.
+```


### PR DESCRIPTION
## Summary\n- add a built-in Telegram / Comms Policy MCP stdio server with success, failure, briefing, dedupe, last-sent, queue, and ready-question tools\n- store durable notification state in profile-scoped SQLite and delegate delivery through the existing send_message tool so secrets are not duplicated\n- document the Hermes MCP config snippet and verification steps\n\n## Tests\n- python -m pytest tests/test_comms_policy_mcp.py -q -o 'addopts='\n- python -m py_compile mcp_servers/comms_policy.py mcp_servers/__init__.py\n- python -m pytest tests/test_mcp_serve.py tests/test_comms_policy_mcp.py -q -o 'addopts='\n- python -m ruff check mcp_servers/comms_policy.py tests/test_comms_policy_mcp.py pyproject.toml