### PR TITLE
fix(tools): expand composite toolsets in has_explicit_config branch

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -972,6 +972,36 @@ def _get_platform_tools(
             ts for ts in toolset_names
             if ts in configurable_keys and _toolset_allowed_for_platform(ts, platform)
         }
+        # Also expand any composite toolset names (e.g. "hermes-cli") that appear
+        # alongside explicit configurable keys.  Composites are not in
+        # configurable_keys so the filter above silently drops them, causing the
+        # entire native toolset to disappear (issue #22601).
+        composite_names = [
+            ts for ts in toolset_names
+            if ts not in configurable_keys
+            and ts not in plugin_ts_keys
+            and ts in TOOLSETS
+        ]
+        if composite_names:
+            composite_tools: set = set()
+            for ts_name in composite_names:
+                composite_tools.update(resolve_toolset(ts_name))
+            for ts_key, _, _ in CONFIGURABLE_TOOLSETS:
+                if not _toolset_allowed_for_platform(ts_key, platform):
+                    continue
+                ts_tools = set(resolve_toolset(ts_key))
+                if ts_tools and ts_tools.issubset(composite_tools):
+                    enabled_toolsets.add(ts_key)
+            # Strip _DEFAULT_OFF_TOOLSETS from the composite-inferred portion,
+            # but keep any keys the user explicitly listed in toolset_names
+            # (e.g. [hermes-cli, spotify] must preserve spotify).
+            explicit_configurable = {ts for ts in toolset_names if ts in configurable_keys}
+            default_off = set(_DEFAULT_OFF_TOOLSETS)
+            if platform in default_off and platform not in _TOOLSET_PLATFORM_RESTRICTIONS:
+                default_off.remove(platform)
+            if "homeassistant" in default_off and os.getenv("HASS_TOKEN"):
+                default_off.remove("homeassistant")
+            enabled_toolsets -= (default_off - explicit_configurable)
     else:
         # No explicit config — fall back to resolving composite toolset names
         # (e.g. "hermes-cli") to individual tool names and reverse-mapping.

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -925,3 +925,41 @@ def test_reconfigure_browser_provider_overwrites_stale_use_gateway():
     provider = {"name": "Browserbase", "browser_provider": "browserbase", "env_vars": []}
     _reconfigure_provider(provider, config)
     assert config["browser"]["use_gateway"] is False
+
+
+def test_get_platform_tools_composite_plus_configurable_keeps_composite_tools():
+    """Regression test for issue #22601.
+
+    When platform_toolsets contains a composite name (e.g. "hermes-cli") *and*
+    at least one configurable key (e.g. "spotify"), _get_platform_tools must
+    still expand the composite — not silently drop it.
+
+    Before the fix the has_explicit_config branch only admitted configurable
+    keys, so "hermes-cli" was dropped and the session had only {spotify, kanban}.
+    """
+    config = {
+        "platform_toolsets": {
+            "cli": ["hermes-cli", "spotify"],
+        }
+    }
+
+    # spotify is in _DEFAULT_OFF_TOOLSETS but was explicitly listed — must stay.
+    enabled = _get_platform_tools(config, "cli", include_default_mcp_servers=False)
+
+    # Core toolsets that hermes-cli expands into must all be present.
+    for core_ts in ("terminal", "web", "file", "memory"):
+        assert core_ts in enabled, f"Expected '{core_ts}' in enabled but got: {sorted(enabled)}"
+
+    # The explicit configurable key must also survive.
+    assert "spotify" in enabled, f"Expected 'spotify' in enabled but got: {sorted(enabled)}"
+
+
+def test_get_platform_tools_composite_only_unaffected():
+    """Composite-only list (no configurable keys) must still work as before."""
+    config_composite = {"platform_toolsets": {"cli": ["hermes-cli"]}}
+    config_default = {}
+
+    enabled_composite = _get_platform_tools(config_composite, "cli", include_default_mcp_servers=False)
+    enabled_default = _get_platform_tools(config_default, "cli", include_default_mcp_servers=False)
+
+    assert enabled_composite == enabled_default


### PR DESCRIPTION
## Problem

When `platform_toolsets[<platform>]` contains both a composite name (e.g. `hermes-cli`) **and** at least one configurable key (e.g. `spotify`), `_get_platform_tools()` silently discards the composite. The session ends up with only `{spotify, kanban}` — every native tool (`terminal`, `file`, `web`, `memory`, `browser`, `vision`, etc.) disappears.

Reproduced at `origin/main` `f6d45e5df`:

```python
# platform_toolsets.cli: [hermes-cli, spotify]
sorted(_get_platform_tools(cfg, 'cli', include_default_mcp_servers=False))
# → ['kanban', 'spotify']   ← terminal missing
```

## Root cause

The `has_explicit_config` branch (introduced in #2624 / `868b3c07e`) filters `toolset_names` to members of `configurable_keys` only. Composite names like `hermes-cli` are **not** in `configurable_keys`, so they fall through the filter silently.

## Fix

After the direct-membership filter, collect any composite names from `toolset_names` that are absent from `configurable_keys` and `plugin_ts_keys`. Expand those composites via `resolve_toolset()` and use the same subset-inference logic as the `else`-branch to back-map to configurable keys. `_DEFAULT_OFF_TOOLSETS` is subtracted from the inferred portion while explicitly-listed keys (like `spotify`) are preserved.

## Tests

Two new tests in `tests/hermes_cli/test_tools_config.py`:

- **`test_get_platform_tools_composite_plus_configurable_keeps_composite_tools`** — config `["hermes-cli", "spotify"]` → `terminal`, `web`, `file`, `memory` **and** `spotify` all present. Stash-verified: FAILS without fix (got `['kanban', 'spotify']`), PASSES with fix.
- **`test_get_platform_tools_composite_only_unaffected`** — composite-only list still equals the unconfigured default.

**63/63** tests green in `tests/hermes_cli/test_tools_config.py`.

Closes #22601.
Related: #22573 (same symptom, different trigger path).