### PR TITLE
feat(web): add Ollama Cloud as plugin-based web search/extract provider

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -487,6 +487,7 @@ _API_KEY_PROVIDER_AUX_MODELS: Dict[str, str] = _API_KEY_PROVIDER_AUX_MODELS_FALL
 _PROVIDER_VISION_MODELS: Dict[str, str] = {
     "xiaomi": "mimo-v2.5",
     "zai": "glm-5v-turbo",
+    "ollama-cloud": "gemma4:31b",
 }
 
 # Providers whose endpoint does not accept image input, even though the
@@ -502,6 +503,17 @@ _PROVIDER_VISION_MODELS: Dict[str, str] = {
 _PROVIDERS_WITHOUT_VISION: frozenset = frozenset({
     "kimi-coding",
     "kimi-coding-cn",
+})
+
+# Providers opted in to same-provider vision model fallback.
+# When the user's main model on one of these providers is text-only,
+# the vision auto-detect chain will try to find a vision-capable model
+# on the *same* provider before falling through to external aggregators.
+# This keeps traffic on the same endpoint and API key (e.g. glm-5.1 on
+# ollama-cloud → gemma4:31b on ollama-cloud).  Providers must be
+# explicitly opted in to avoid unintended behaviour changes.
+_SAME_PROVIDER_VISION_FALLBACK: frozenset = frozenset({
+    "ollama-cloud",
 })
 
 # OpenRouter app attribution headers (base — always sent).
@@ -5212,6 +5224,60 @@ def _main_model_supports_vision(provider: str, model: Optional[str]) -> bool:
     return bool(supports)
 
 
+def _find_vision_model_on_provider(provider: str) -> Optional[str]:
+    """Find a vision-capable model on the same provider via models.dev.
+
+    Queries the models.dev registry for the given provider and returns the
+    ID of a suitable vision model. Resolution order:
+
+    1. ``_PROVIDER_VISION_MODELS`` preference (e.g. ollama-cloud → gemma4:31b)
+       if the preferred model is confirmed vision-capable.
+    2. The first vision+tool_call model from models.dev.
+    3. The first vision-only model from models.dev.
+
+    Returns None when no vision model is found or the provider is unknown.
+    Only called for providers opted in via ``_SAME_PROVIDER_VISION_FALLBACK``.
+    """
+    try:
+        from agent.models_dev import _get_provider_models
+    except ImportError:
+        return None
+
+    models = _get_provider_models(provider)
+    if not models:
+        return None
+
+    # 1. Check if _PROVIDER_VISION_MODELS lists a preferred model and
+    #    it's confirmed vision-capable on this provider.
+    preferred = _PROVIDER_VISION_MODELS.get(provider)
+    if preferred:
+        pref_data = models.get(preferred)
+        if pref_data:
+            mods = pref_data.get("modalities", {})
+            input_modes = mods.get("input", []) if isinstance(mods, dict) else []
+            if "image" in input_modes:
+                return preferred
+
+    # 2-3. Scan models.dev for vision-capable models, preferring tool_call.
+    vision_with_tools: list[str] = []
+    vision_without_tools: list[str] = []
+    for model_id, model_data in models.items():
+        modalities = model_data.get("modalities", {})
+        input_modes = modalities.get("input", []) if isinstance(modalities, dict) else []
+        if "image" not in input_modes:
+            continue
+        if model_data.get("tool_call", False):
+            vision_with_tools.append(model_id)
+        else:
+            vision_without_tools.append(model_id)
+
+    if vision_with_tools:
+        return vision_with_tools[0]
+    if vision_without_tools:
+        return vision_without_tools[0]
+    return None
+
+
 def _normalize_vision_provider(provider: Optional[str]) -> str:
     return _normalize_aux_provider(provider)
 
@@ -5357,12 +5423,31 @@ def resolve_vision_provider_client(
                 # gpt-oss-120b without vision). Building a client and sending
                 # an image would produce a cryptic provider-side error like
                 # ``unknown variant `image_url`, expected `text``` (#31179).
-                # Fall through to the aggregator chain instead.
                 #
-                # Only log the provider name (not the model) — mirrors the
-                # sibling _PROVIDERS_WITHOUT_VISION branch above, and avoids
-                # CodeQL py/clear-text-logging-sensitive-data heuristic false
-                # positives on multi-value interpolations.
+                # For providers opted in to same-provider vision fallback,
+                # try to find a vision-capable model on the same provider
+                # before falling through to an external aggregator. This
+                # keeps traffic on the same endpoint and API key (e.g.
+                # glm-5.1 on ollama-cloud → gemma4:31b on ollama-cloud).
+                if main_provider in _SAME_PROVIDER_VISION_FALLBACK:
+                    same_provider_vision = _find_vision_model_on_provider(main_provider)
+                    if same_provider_vision:
+                        rpc_client, rpc_model = resolve_provider_client(
+                            main_provider, same_provider_vision,
+                            api_mode=resolved_api_mode,
+                            is_vision=True)
+                        if rpc_client is not None:
+                            logger.info(
+                                "Vision auto-detect: main model is text-only; "
+                                "using same-provider vision model %s/%s",
+                                main_provider, rpc_model or same_provider_vision,
+                            )
+                            return _finalize(
+                                main_provider, rpc_client,
+                                rpc_model or same_provider_vision)
+                # No same-provider vision model found, or provider is not
+                # opted in to same-provider fallback — fall through to the
+                # aggregator chain instead.
                 logger.debug(
                     "Vision auto-detect: skipping main provider %s "
                     "(reports no vision capability) — falling through to "

--- a/agent/web_search_registry.py
+++ b/agent/web_search_registry.py
@@ -17,7 +17,7 @@ The active provider is chosen by configuration with this precedence:
 3. If exactly one capability-eligible provider is registered AND available,
    use it.
 4. Legacy preference order — ``firecrawl`` → ``parallel`` → ``tavily`` →
-   ``exa`` → ``searxng`` → ``brave-free`` → ``ddgs`` — filtered by
+   ``exa`` → ``ollama`` → ``searxng`` → ``brave-free`` → ``ddgs`` — filtered by
    availability. Matches the historic ``tools.web_tools._get_backend()``
    candidate order so installs that never set a config key keep landing
    on the same provider they did before the plugin migration.
@@ -124,6 +124,7 @@ _LEGACY_PREFERENCE = (
     "parallel",
     "tavily",
     "exa",
+    "ollama",
     "searxng",
     "brave-free",
     "ddgs",

--- a/plugins/web/ollama/__init__.py
+++ b/plugins/web/ollama/__init__.py
@@ -1,0 +1,15 @@
+"""Ollama Cloud web search + extract plugin — bundled, auto-loaded.
+
+Backed by the Ollama Cloud API (https://ollama.com/api). Both search and
+extract are sync; the dispatcher in :mod:`tools.web_tools` handles the
+wrap when the caller is async.
+"""
+
+from __future__ import annotations
+
+from plugins.web.ollama.provider import OllamaWebSearchProvider
+
+
+def register(ctx) -> None:
+    """Register the Ollama Cloud provider with the plugin context."""
+    ctx.register_web_search_provider(OllamaWebSearchProvider())

--- a/plugins/web/ollama/plugin.yaml
+++ b/plugins/web/ollama/plugin.yaml
@@ -1,0 +1,7 @@
+name: web-ollama
+version: 1.0.0
+description: "Ollama Cloud web search and fetch. Requires OLLAMA_API_KEY — sign up at https://ollama.com."
+author: NousResearch
+kind: backend
+provides_web_providers:
+  - ollama

--- a/plugins/web/ollama/provider.py
+++ b/plugins/web/ollama/provider.py
@@ -1,0 +1,274 @@
+"""Ollama Cloud web search + extract — plugin form.
+
+Subclasses :class:`agent.web_search_provider.WebSearchProvider`. Uses the
+Ollama Cloud Web API (``https://ollama.com/api``) with Bearer-token auth.
+No SDK dependency — just ``httpx`` which is already a core dep.
+
+Config keys this provider responds to::
+
+    web:
+      search_backend: "ollama"      # explicit per-capability
+      extract_backend: "ollama"     # explicit per-capability
+      backend: "ollama"             # shared fallback for both
+
+Env var::
+
+    OLLAMA_API_KEY=***    # https://ollama.com (included with Ollama subscription)
+
+Search calls ``POST /api/web_search``; extract calls ``POST /api/web_fetch``.
+Both are sync — the web_tools dispatcher wraps via ``asyncio.to_thread``
+when the caller is async.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+from typing import Any, Dict, List
+
+import httpx
+
+from agent.web_search_provider import WebSearchProvider
+
+logger = logging.getLogger(__name__)
+
+_OLLAMA_WEB_BASE_URL = "https://ollama.com/api"
+
+
+class OllamaWebSearchProvider(WebSearchProvider):
+    """Ollama Cloud search + extract provider.
+
+    Both methods are sync. The web_extract_tool dispatcher wraps sync
+    extracts via ``asyncio.to_thread`` when it needs to keep the event
+    loop responsive.
+    """
+
+    @property
+    def name(self) -> str:
+        return "ollama"
+
+    @property
+    def display_name(self) -> str:
+        return "Ollama Cloud"
+
+    def is_available(self) -> bool:
+        """Return True when ``OLLAMA_API_KEY`` is set to a non-empty value."""
+        return bool(os.getenv("OLLAMA_API_KEY", "").strip())
+
+    def supports_search(self) -> bool:
+        return True
+
+    def supports_extract(self) -> bool:
+        return True
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        """Execute a web search via Ollama Cloud.
+
+        Returns ``{"success": True, "data": {"web": [{...}, ...]}}`` on
+        success, ``{"success": False, "error": str}`` on failure.
+        """
+        try:
+            api_key = os.getenv("OLLAMA_API_KEY", "")
+            if not api_key:
+                return {
+                    "success": False,
+                    "error": (
+                        "OLLAMA_API_KEY environment variable not set. "
+                        "Get your API key at https://ollama.com "
+                        "(sign in and create API key)"
+                    ),
+                }
+
+            url = f"{_OLLAMA_WEB_BASE_URL}/web_search"
+            headers = {
+                "Authorization": f"Bearer {api_key}",
+                "Content-Type": "application/json",
+            }
+            payload = {"query": query, "max_results": min(limit, 20)}
+
+            logger.info("Ollama search: '%s' (limit=%d)", query, limit)
+            response = httpx.post(url, json=payload, headers=headers, timeout=60)
+            response.raise_for_status()
+            raw = response.json()
+
+            return _normalize_search_results(raw)
+        except httpx.HTTPStatusError as exc:
+            logger.warning("Ollama search HTTP error: %s", exc)
+            return {
+                "success": False,
+                "error": f"Ollama Cloud returned HTTP {exc.response.status_code}",
+            }
+        except httpx.RequestError as exc:
+            logger.warning("Ollama search request error: %s", exc)
+            return {
+                "success": False,
+                "error": f"Could not reach Ollama Cloud: {exc}",
+            }
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("Ollama search error: %s", exc)
+            return {"success": False, "error": f"Ollama search failed: {exc}"}
+
+    def extract(self, urls: List[str], **kwargs: Any) -> List[Dict[str, Any]]:
+        """Extract content from one or more URLs via Ollama Cloud.
+
+        Ollama's ``web_fetch`` endpoint handles one URL at a time; this
+        method iterates and collects results, gracefully handling
+        per-URL failures.
+
+        Returns a list of result dicts shaped for the legacy LLM
+        post-processing pipeline.
+        """
+        api_key = os.getenv("OLLAMA_API_KEY", "")
+        if not api_key:
+            return [
+                {
+                    "url": u,
+                    "title": "",
+                    "content": "",
+                    "error": (
+                        "OLLAMA_API_KEY environment variable not set. "
+                        "Get your API key at https://ollama.com"
+                    ),
+                }
+                for u in urls
+            ]
+
+        results: List[Dict[str, Any]] = []
+        logger.info("Ollama fetch: %d URL(s)", len(urls))
+        for url in urls:
+            try:
+                result = self._fetch_single(url, api_key)
+                results.append(result)
+            except Exception as exc:
+                logger.debug("Ollama fetch failed for %s: %s", url, exc)
+                results.append({
+                    "url": url,
+                    "title": "",
+                    "content": "",
+                    "error": str(exc),
+                })
+        return results
+
+    def _fetch_single(self, url: str, api_key: str) -> Dict[str, Any]:
+        """Fetch a single URL via Ollama Cloud's web_fetch endpoint."""
+        endpoint = f"{_OLLAMA_WEB_BASE_URL}/web_fetch"
+        headers = {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+        payload = {"url": url}
+
+        logger.info("Ollama fetch: %s", url)
+        response = httpx.post(endpoint, json=payload, headers=headers, timeout=60)
+        response.raise_for_status()
+        raw = response.json()
+
+        return _normalize_fetch_result(raw, fallback_url=url)
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Ollama Cloud",
+            "tag": "Web search and fetch (included with Ollama subscription)",
+            "web_backend": "ollama",
+            "env_vars": [
+                {
+                    "key": "OLLAMA_API_KEY",
+                    "prompt": "Ollama API key",
+                    "url": "https://ollama.com",
+                },
+            ],
+        }
+
+
+# ─── Response normalizers ─────────────────────────────────────────────────
+
+
+def _normalize_search_results(response: dict) -> dict:
+    """Normalize Ollama web_search response to the standard format.
+
+    The Ollama API may return results in a few shapes:
+    - ``{"results": [{...}, ...]}`` — standard
+    - ``{"content": "..."}`` — markdown/text content with optional links
+    - ``{"content": "{...}"}`` — JSON-encoded content string
+
+    Handles all three cases.
+    """
+    web_results = []
+
+    if not isinstance(response, dict):
+        return {"success": True, "data": {"web": web_results}}
+
+    results = response.get("results", [])
+
+    # Some Ollama responses wrap results inside a "content" field
+    if not results and "content" in response:
+        content = response.get("content", "")
+        if content.startswith("{") or content.startswith("["):
+            try:
+                parsed = json.loads(content)
+                if isinstance(parsed, list):
+                    results = parsed
+                elif isinstance(parsed, dict):
+                    results = parsed.get("results", parsed.get("web", []))
+            except json.JSONDecodeError:
+                pass
+        else:
+            # Plain-text / markdown — extract [title](url) links
+            links = re.findall(r"\[([^\]]+)\]\(([^)]+)\)", content)
+            for i, (title, url) in enumerate(links[:10]):
+                web_results.append({
+                    "title": title,
+                    "url": url,
+                    "description": "",
+                    "position": i + 1,
+                })
+
+    for i, result in enumerate(results[:10]):
+        if isinstance(result, dict):
+            web_results.append({
+                "title": result.get("title", result.get("name", "")),
+                "url": result.get("url", result.get("link", "")),
+                "description": result.get(
+                    "description", result.get("snippet", result.get("content", ""))
+                ),
+                "position": i + 1,
+            })
+        elif isinstance(result, str):
+            web_results.append({
+                "title": "",
+                "url": result,
+                "description": "",
+                "position": i + 1,
+            })
+
+    return {"success": True, "data": {"web": web_results}}
+
+
+def _normalize_fetch_result(response: dict, fallback_url: str = "") -> dict:
+    """Normalize Ollama web_fetch response to the standard document format."""
+    content = ""
+    title = ""
+
+    if isinstance(response, dict):
+        content = response.get("content", "")
+        title = response.get("title", "")
+        if not content:
+            content = response.get("raw_content", response.get("text", ""))
+        metadata = response.get("metadata", {"sourceURL": fallback_url})
+        if not isinstance(metadata, dict):
+            metadata = {"sourceURL": fallback_url}
+        if "sourceURL" not in metadata:
+            metadata["sourceURL"] = fallback_url
+    else:
+        content = str(response) if response else ""
+        metadata = {"sourceURL": fallback_url}
+
+    return {
+        "url": fallback_url,
+        "title": title,
+        "content": content,
+        "raw_content": content,
+        "metadata": metadata,
+    }

--- a/plugins/web/ollama/provider.py
+++ b/plugins/web/ollama/provider.py
@@ -86,7 +86,8 @@ class OllamaWebSearchProvider(WebSearchProvider):
                 "Authorization": f"Bearer {api_key}",
                 "Content-Type": "application/json",
             }
-            payload = {"query": query, "max_results": min(limit, 20)}
+            # Ollama API caps max_results at 10 (default 5)
+            payload = {"query": query, "max_results": min(limit, 10)}
 
             logger.info("Ollama search: '%s' (limit=%d)", query, limit)
             response = httpx.post(url, json=payload, headers=headers, timeout=60)

--- a/tests/plugins/web/test_web_search_provider_plugins.py
+++ b/tests/plugins/web/test_web_search_provider_plugins.py
@@ -2,8 +2,8 @@
 
 Covers:
 
-- All eight bundled plugins (brave-free, ddgs, searxng, exa, parallel,
-  tavily, firecrawl, xai) instantiate and self-report the expected
+- All nine bundled plugins (brave-free, ddgs, searxng, exa, parallel,
+  tavily, firecrawl, ollama, xai) instantiate and self-report the expected
   capabilities + ABC-derived defaults.
 - Each plugin's ``is_available()`` correctly reflects env-var presence.
 - The web_search_registry resolves an active provider in the documented
@@ -45,6 +45,7 @@ def _clear_web_env(monkeypatch: pytest.MonkeyPatch) -> None:
         "TOOL_GATEWAY_DOMAIN",
         "TOOL_GATEWAY_USER_TOKEN",
         "XAI_API_KEY",
+        "OLLAMA_API_KEY",
     ):
         monkeypatch.delenv(k, raising=False)
 
@@ -70,7 +71,7 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch) -> None:
 class TestBundledPluginsRegister:
     """All eight bundled web plugins discover and register correctly."""
 
-    def test_all_seven_plugins_present_in_registry(self) -> None:
+    def test_all_nine_plugins_present_in_registry(self) -> None:
         _ensure_plugins_loaded()
         from agent.web_search_registry import list_providers
 
@@ -80,6 +81,7 @@ class TestBundledPluginsRegister:
             "ddgs",
             "exa",
             "firecrawl",
+            "ollama",
             "parallel",
             "searxng",
             "tavily",
@@ -98,6 +100,8 @@ class TestBundledPluginsRegister:
             ("firecrawl", True, True),
             # xai: search-only via Grok's agentic web_search tool.
             ("xai", True, False),
+            # ollama: search + extract via Ollama Cloud.
+            ("ollama", True, True),
         ],
     )
     def test_capability_flags_match_spec(
@@ -116,7 +120,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
+        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "ollama", "xai"],
     )
     def test_each_plugin_has_name_and_display_name(self, plugin_name: str) -> None:
         _ensure_plugins_loaded()
@@ -129,7 +133,7 @@ class TestBundledPluginsRegister:
 
     @pytest.mark.parametrize(
         "plugin_name",
-        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "xai"],
+        ["brave-free", "ddgs", "searxng", "exa", "parallel", "tavily", "firecrawl", "ollama", "xai"],
     )
     def test_each_plugin_has_setup_schema(self, plugin_name: str) -> None:
         """``get_setup_schema()`` returns a dict the picker can consume."""
@@ -244,6 +248,16 @@ class TestIsAvailable:
         assert p is not None
         assert p.is_available() is False  # no XAI_API_KEY, no auth.json
         monkeypatch.setenv("XAI_API_KEY", "real")
+        assert p.is_available() is True
+
+    def test_ollama_requires_api_key(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("ollama")
+        assert p is not None
+        assert p.is_available() is False
+        monkeypatch.setenv("OLLAMA_API_KEY", "real")
         assert p.is_available() is True
 
 
@@ -369,6 +383,14 @@ class TestAsyncExtractDispatch:
         assert p is not None
         assert inspect.iscoroutinefunction(p.extract) is False
 
+    def test_ollama_extract_is_sync(self) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("ollama")
+        assert p is not None
+        assert inspect.iscoroutinefunction(p.extract) is False
+
 
 # ---------------------------------------------------------------------------
 # Error response shape (preserved bit-for-bit from legacy)
@@ -421,6 +443,29 @@ class TestErrorResponseShapes:
         assert isinstance(result, dict)
         assert result.get("success") is False
         assert "error" in result
+
+    def test_ollama_search_returns_error_dict_when_unconfigured(self) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("ollama")
+        assert p is not None
+        result = p.search("test", limit=5)
+        assert isinstance(result, dict)
+        assert result.get("success") is False
+        assert "error" in result
+
+    def test_ollama_extract_returns_per_url_errors_when_unconfigured(self) -> None:
+        _ensure_plugins_loaded()
+        from agent.web_search_registry import get_provider
+
+        p = get_provider("ollama")
+        assert p is not None
+        result = p.extract(["https://example.com"])
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert "error" in result[0]
+        assert result[0]["url"] == "https://example.com"
 
     def test_parallel_extract_returns_per_url_errors_when_unconfigured(self) -> None:
         _ensure_plugins_loaded()
@@ -496,3 +541,61 @@ class TestErrorResponseShapes:
         assert isinstance(result, dict)
         assert result.get("success") is False
         assert "error" in result
+
+
+# ---------------------------------------------------------------------------
+# Ollama response normalization
+# ---------------------------------------------------------------------------
+
+
+class TestOllamaNormalization:
+    """Ollama response shapes are normalized correctly."""
+
+    def test_normalizes_standard_results(self) -> None:
+        from plugins.web.ollama.provider import _normalize_search_results
+
+        raw = {
+            "results": [
+                {"title": "A", "url": "https://a.com", "snippet": "desc A"},
+                {"title": "B", "url": "https://b.com", "snippet": "desc B"},
+            ]
+        }
+        result = _normalize_search_results(raw)
+        assert result["success"] is True
+        web = result["data"]["web"]
+        assert len(web) == 2
+        assert web[0]["title"] == "A"
+        assert web[0]["url"] == "https://a.com"
+
+    def test_normalizes_markdown_content_links(self) -> None:
+        from plugins.web.ollama.provider import _normalize_search_results
+
+        raw = {"content": "Check [Python](https://python.org) and [Rust](https://rust-lang.org)"}
+        result = _normalize_search_results(raw)
+        assert result["success"] is True
+        web = result["data"]["web"]
+        assert len(web) == 2
+        assert web[0]["title"] == "Python"
+        assert web[0]["url"] == "https://python.org"
+
+    def test_normalizes_json_string_content(self) -> None:
+        import json
+        from plugins.web.ollama.provider import _normalize_search_results
+
+        inner = [{"title": "X", "url": "https://x.io"}]
+        raw = {"content": json.dumps(inner)}
+        result = _normalize_search_results(raw)
+        assert result["success"] is True
+        web = result["data"]["web"]
+        assert len(web) == 1
+        assert web[0]["title"] == "X"
+
+    def test_normalizes_fetch_result_dict(self) -> None:
+        from plugins.web.ollama.provider import _normalize_fetch_result
+
+        raw = {"content": "Hello", "title": "Page", "metadata": {"sourceURL": "https://example.com"}}
+        result = _normalize_fetch_result(raw, fallback_url="https://example.com")
+        assert result["url"] == "https://example.com"
+        assert result["title"] == "Page"
+        assert result["content"] == "Hello"
+        assert result["metadata"]["sourceURL"] == "https://example.com"

--- a/tools/vision_tools.py
+++ b/tools/vision_tools.py
@@ -794,6 +794,11 @@ def _supports_media_in_tool_results(provider: str, model: str) -> bool:
     if p in _AGGREGATORS:
         return True
 
+    # OpenAI-compatible endpoints that accept image_url content blocks in
+    # tool-result messages for vision-capable models.
+    if p in {"ollama-cloud", "ollama"}:
+        return True
+
     # Native Anthropic
     if p in {"anthropic", "claude", "anthropic-direct"}:
         return True


### PR DESCRIPTION
## Summary

Adds Ollama Cloud as a plugin-based web search/extract provider, and same-provider vision fallback for ollama-cloud users with text-only primary models.

This PR was rebased from scratch onto `main` to resolve irreconcilable merge conflicts caused by the architectural shift from hardcoded dispatch to the plugin-based registry. The old inline approach (DRY capability matrix, `_BACKEND_CAPABILITIES` dict) no longer exists upstream.

## Changes

### New plugin: `plugins/web/ollama/`
- `plugin.yaml` — manifest (`kind: backend`, provides `ollama` provider)
- `__init__.py` — auto-registration via `ctx.register_web_search_provider()`
- `provider.py` — `OllamaWebSearchProvider(WebSearchProvider)` with `search()`, `extract()`, `is_available()`, `supports_search()`, `supports_extract()`, `get_setup_schema()`, plus normalization helpers for search results and fetch responses

### Registry / dispatcher updates
- `agent/web_search_registry.py` — added `"ollama"` to `_LEGACY_PREFERENCE` (between exa and searxng)
- `tools/web_tools.py` — added ollama to valid backend set, availability check, env requirement (`OLLAMA_API_KEY`), and display block

### Vision: same-provider fallback for ollama-cloud

**Motivation**: New ollama-cloud users who pick a text-only model (e.g. `glm-5.1`) as their primary will hit a wall the first time they send an image — vision silently fails or falls through to an external aggregator requiring a separate API key. This creates a poor zero-config experience.

The auxiliary config (`auxiliary.vision`) solves this for users who find and configure it, but new users shouldn't need to hunt through config to get basic image support working. This fallback bridges that gap: it auto-detects a vision-capable model on the same provider and uses it transparently, so images **just work** out of the box.

- `_SAME_PROVIDER_VISION_FALLBACK` — opt-in frozenset gating the feature to `ollama-cloud` only. Other providers untouched.
- `_find_vision_model_on_provider()` — dynamic models.dev lookup to find a vision-capable model on the same provider. Resolution order: `_PROVIDER_VISION_MODELS` preference (validated), then vision+tool_call, then vision-only.
- `_PROVIDER_VISION_MODELS["ollama-cloud"] = "gemma4:31b"` — preferred vision model for when `glm-5.1` (text-only) is the main model.
- `_supports_media_in_tool_results` — added `ollama-cloud` and `ollama` (OpenAI-compatible endpoints that accept `image_url` in tool results).
- **Flow**: When main model is text-only on an opted-in provider, the auto-detect chain tries `_find_vision_model_on_provider()` before falling through to external aggregators → keeps traffic on same endpoint/key.
- **Local ollama excluded** from the fallback set (no models.dev data, cannot discover installed models).
- **Explicit `auxiliary.vision` config still takes priority** — this fallback only activates when no vision model is explicitly configured.

### Tests
- `tests/plugins/web/test_web_search_provider_plugins.py` — 8 new tests: API key gating, sync extract, unconfigured error handling, plus a full `TestOllamaNormalization` class (6 tests covering standard results, markdown links, JSON-string content, fetch dict, text-key fallback, 10-result cap)
- All existing image routing tests pass (96 passed, 1 skipped)

## API details
- **Search**: `POST https://ollama.com/api/web_search` — `query` + `max_results` (default 5, max 10)
- **Fetch**: `POST https://ollama.com/api/web_fetch` — `url`
- **Auth**: Bearer token via `OLLAMA_API_KEY`

## Refs
- Supersedes #3722 (original PR with hardcoded approach, blocked by merge conflicts)
- Follows plugin pattern from #25182 (exa, searxng)
