### PR TITLE
fix: honor active repo and dashboard chat theme

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -179,8 +179,8 @@ def check_for_updates() -> Optional[int]:
     """Check whether a Hermes update is available.
 
     Two paths: if ``HERMES_REVISION`` is set (nix builds embed it), compare
-    it to upstream main via ``git ls-remote``. Otherwise look for a local
-    git checkout and count commits behind ``origin/main``.
+    it to upstream main via ``git ls-remote``. Otherwise look for the active
+    local git checkout and count commits behind ``origin/main``.
 
     Returns the number of commits behind, ``UPDATE_AVAILABLE_NO_COUNT`` (-1)
     if behind but the count is unknown, ``0`` if up-to-date, or ``None`` if
@@ -189,15 +189,24 @@ def check_for_updates() -> Optional[int]:
     hermes_home = get_hermes_home()
     cache_file = hermes_home / ".update_check"
     embedded_rev = os.environ.get("HERMES_REVISION") or None
+    repo_dir = None if embedded_rev else _resolve_repo_dir()
+    cache_repo = str(repo_dir) if repo_dir is not None else None
 
-    # Read cache — invalidate if the embedded rev has changed since last check
+    # Read cache — invalidate if the embedded rev or active checkout changed.
+    # Older cache entries did not include "repo" and must not be trusted for
+    # git installs because a stale ~/.hermes/hermes-agent checkout could poison
+    # the banner even when the imported checkout is current.
     now = time.time()
     try:
         if cache_file.exists():
             cached = json.loads(cache_file.read_text())
+            repo_cache_matches = cached.get("repo") == cache_repo if embedded_rev else (
+                cache_repo is not None and cached.get("repo") == cache_repo
+            )
             if (
                 now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
                 and cached.get("rev") == embedded_rev
+                and repo_cache_matches
             ):
                 return cached.get("behind")
     except Exception:
@@ -206,18 +215,12 @@ def check_for_updates() -> Optional[int]:
     if embedded_rev:
         behind = _check_via_rev(embedded_rev)
     else:
-        # Prefer the running code's location over the profile-scoped path.
-        # $HERMES_HOME/hermes-agent/ may be a stale copy from --clone-all;
-        # Path(__file__) always resolves to the actual installed checkout.
-        repo_dir = Path(__file__).parent.parent.resolve()
-        if not (repo_dir / ".git").exists():
-            repo_dir = hermes_home / "hermes-agent"
-        if not (repo_dir / ".git").exists():
+        if repo_dir is None:
             return None
         behind = _check_via_local_git(repo_dir)
 
     try:
-        cache_file.write_text(json.dumps({"ts": now, "behind": behind, "rev": embedded_rev}))
+        cache_file.write_text(json.dumps({"ts": now, "behind": behind, "rev": embedded_rev, "repo": cache_repo}))
     except Exception:
         pass
 
@@ -231,10 +234,11 @@ def _resolve_repo_dir() -> Optional[Path]:
     because ``$HERMES_HOME/hermes-agent/`` may be a stale copy carried
     over by ``--clone-all``.
     """
-    repo_dir = Path(__file__).parent.parent.resolve()
-    if not (repo_dir / ".git").exists():
-        hermes_home = get_hermes_home()
-        repo_dir = hermes_home / "hermes-agent"
+    active_repo = Path(__file__).parent.parent.resolve()
+    if (active_repo / ".git").exists():
+        return active_repo
+
+    repo_dir = get_hermes_home() / "hermes-agent"
     return repo_dir if (repo_dir / ".git").exists() else None
 
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3707,7 +3707,7 @@ _THEME_NAMED_ASSET_KEYS = {"bg", "hero", "logo", "crest", "sidebar", "header"}
 # without shipping their own CSS.
 _THEME_COMPONENT_BUCKETS = {
     "card", "header", "footer", "sidebar", "tab",
-    "progress", "badge", "backdrop", "page",
+    "progress", "badge", "backdrop", "page", "terminal",
 }
 
 _THEME_LAYOUT_VARIANTS = {"standard", "cockpit", "tiled"}

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -18,19 +18,23 @@ def test_version_string_no_v_prefix():
 
 def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
     """When cache is fresh, check_for_updates should return cached value without calling git."""
-    from hermes_cli.banner import check_for_updates
+    import hermes_cli.banner as banner
 
-    # Create a fake git repo and fresh cache
+    # Create a fake active git repo and fresh cache scoped to that repo.
     repo_dir = tmp_path / "hermes-agent"
     repo_dir.mkdir()
     (repo_dir / ".git").mkdir()
+    fake_banner = repo_dir / "hermes_cli" / "banner.py"
+    fake_banner.parent.mkdir(parents=True, exist_ok=True)
+    fake_banner.touch()
 
     cache_file = tmp_path / ".update_check"
-    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 3}))
+    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 3, "rev": None, "repo": str(repo_dir)}))
 
+    monkeypatch.setattr(banner, "__file__", str(fake_banner))
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     with patch("hermes_cli.banner.subprocess.run") as mock_run:
-        result = check_for_updates()
+        result = banner.check_for_updates()
 
     assert result == 3
     mock_run.assert_not_called()
@@ -38,21 +42,25 @@ def test_check_for_updates_uses_cache(tmp_path, monkeypatch):
 
 def test_check_for_updates_expired_cache(tmp_path, monkeypatch):
     """When cache is expired, check_for_updates should call git fetch."""
-    from hermes_cli.banner import check_for_updates
+    import hermes_cli.banner as banner
 
     repo_dir = tmp_path / "hermes-agent"
     repo_dir.mkdir()
     (repo_dir / ".git").mkdir()
+    fake_banner = repo_dir / "hermes_cli" / "banner.py"
+    fake_banner.parent.mkdir(parents=True, exist_ok=True)
+    fake_banner.touch()
 
     # Write an expired cache (timestamp far in the past)
     cache_file = tmp_path / ".update_check"
-    cache_file.write_text(json.dumps({"ts": 0, "behind": 1}))
+    cache_file.write_text(json.dumps({"ts": 0, "behind": 1, "rev": None, "repo": str(repo_dir)}))
 
     mock_result = MagicMock(returncode=0, stdout="5\n")
 
+    monkeypatch.setattr(banner, "__file__", str(fake_banner))
     monkeypatch.setenv("HERMES_HOME", str(tmp_path))
     with patch("hermes_cli.banner.subprocess.run", return_value=mock_result) as mock_run:
-        result = check_for_updates()
+        result = banner.check_for_updates()
 
     assert result == 5
     assert mock_run.call_count == 2  # git fetch + git rev-list
@@ -88,8 +96,86 @@ def test_check_for_updates_fallback_to_project_root(tmp_path, monkeypatch):
     with patch("hermes_cli.banner.subprocess.run") as mock_run:
         mock_run.return_value = MagicMock(returncode=0, stdout="0\n")
         result = banner.check_for_updates()
+    assert result == 0
     # Should have fallen back to project root and run git commands
     assert mock_run.call_count >= 1
+
+
+def test_resolve_repo_dir_prefers_imported_checkout_over_home(tmp_path, monkeypatch):
+    """A stale HERMES_HOME checkout must not override the running imported checkout."""
+    import hermes_cli.banner as banner
+
+    active_root = tmp_path / "active" / "hermes-agent"
+    active_root.mkdir(parents=True)
+    (active_root / ".git").mkdir()
+    fake_banner = active_root / "hermes_cli" / "banner.py"
+    fake_banner.parent.mkdir(parents=True, exist_ok=True)
+    fake_banner.touch()
+
+    hermes_home = tmp_path / ".hermes"
+    stale_home_repo = hermes_home / "hermes-agent"
+    stale_home_repo.mkdir(parents=True)
+    (stale_home_repo / ".git").mkdir()
+
+    monkeypatch.setattr(banner, "__file__", str(fake_banner))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    assert banner._resolve_repo_dir() == active_root
+
+
+def test_check_for_updates_ignores_legacy_cache_when_no_repo(tmp_path, monkeypatch):
+    """Old repo-less cache entries must not produce fake update counts without a repo."""
+    import hermes_cli.banner as banner
+
+    fake_banner = tmp_path / "hermes_cli" / "banner.py"
+    fake_banner.parent.mkdir(parents=True, exist_ok=True)
+    fake_banner.touch()
+
+    cache_file = tmp_path / ".update_check"
+    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 4188, "rev": None}))
+
+    monkeypatch.setattr(banner, "__file__", str(fake_banner))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    with patch("hermes_cli.banner.subprocess.run") as mock_run:
+        result = banner.check_for_updates()
+
+    assert result is None
+    mock_run.assert_not_called()
+
+
+def test_check_for_updates_ignores_cache_for_different_repo(tmp_path, monkeypatch):
+    """Old repo-less cache entries are invalidated and rewritten for the active repo."""
+    import hermes_cli.banner as banner
+
+    active_root = tmp_path / "active" / "hermes-agent"
+    active_root.mkdir(parents=True)
+    (active_root / ".git").mkdir()
+    fake_banner = active_root / "hermes_cli" / "banner.py"
+    fake_banner.parent.mkdir(parents=True, exist_ok=True)
+    fake_banner.touch()
+
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    cache_file = hermes_home / ".update_check"
+    cache_file.write_text(json.dumps({"ts": time.time(), "behind": 4188, "rev": None}))
+
+    mock_results = [
+        MagicMock(returncode=0, stdout=""),
+        MagicMock(returncode=0, stdout="0\n"),
+    ]
+
+    monkeypatch.setattr(banner, "__file__", str(fake_banner))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    with patch("hermes_cli.banner.subprocess.run", side_effect=mock_results) as mock_run:
+        result = banner.check_for_updates()
+
+    assert result == 0
+    assert mock_run.call_count == 2
+    assert all(call.kwargs["cwd"] == str(active_root) for call in mock_run.call_args_list)
+
+    rewritten = json.loads(cache_file.read_text())
+    assert rewritten["behind"] == 0
+    assert rewritten["repo"] == str(active_root)
 
 
 def test_prefetch_non_blocking():

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1792,6 +1792,7 @@ class TestNormaliseThemeExtensions:
                     "bad prop!": "ignored",  # non-alnum prop rejected
                 },
                 "header": {"background": "linear-gradient(red, blue)"},
+                "terminal": {"backgroundColor": "#070a08", "color": "#ecfdf5"},
                 "rogueBucket": {"foo": "bar"},  # not a known bucket — rejected
             },
         })
@@ -1800,6 +1801,10 @@ class TestNormaliseThemeExtensions:
             "boxShadow": "inset 0 0 0 1px red",
         }
         assert r["componentStyles"]["header"]["background"].startswith("linear-gradient")
+        assert r["componentStyles"]["terminal"] == {
+            "backgroundColor": "#070a08",
+            "color": "#ecfdf5",
+        }
         assert "rogueBucket" not in r["componentStyles"]
 
     def test_component_styles_empty_buckets_dropped(self):

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -20,7 +20,7 @@ import { FitAddon } from "@xterm/addon-fit";
 import { Unicode11Addon } from "@xterm/addon-unicode11";
 import { WebLinksAddon } from "@xterm/addon-web-links";
 import { WebglAddon } from "@xterm/addon-webgl";
-import { Terminal } from "@xterm/xterm";
+import { Terminal, type ITheme } from "@xterm/xterm";
 import "@xterm/xterm/css/xterm.css";
 import { Button } from "@nous-research/ui/ui/components/button";
 import { Typography } from "@/components/NouiTypography";
@@ -35,6 +35,8 @@ import { usePageHeader } from "@/contexts/usePageHeader";
 import { useI18n } from "@/i18n";
 import { api } from "@/lib/api";
 import { PluginSlot } from "@/plugins";
+import { useTheme } from "@/themes";
+import type { DashboardTheme } from "@/themes/types";
 
 function buildWsUrl(
   token: string,
@@ -58,17 +60,40 @@ function generateChannelId(): string {
   return `chat-${Math.random().toString(36).slice(2)}-${Date.now().toString(36)}`;
 }
 
-// Colors for the terminal body.  Matches the dashboard's dark teal canvas
-// with cream foreground — we intentionally don't pick monokai or a loud
-// theme, because the TUI's skin engine already paints the content; the
-// terminal chrome just needs to sit quietly inside the dashboard.
-const TERMINAL_THEME = {
+// Fallback colors for the terminal body. Runtime values are derived from the
+// active dashboard theme so a custom dark/noir theme does not leave `/chat`
+// stuck on the built-in teal canvas.
+const FALLBACK_TERMINAL_THEME: ITheme = {
   background: "#0d2626",
   foreground: "#f0e6d2",
   cursor: "#f0e6d2",
   cursorAccent: "#0d2626",
   selectionBackground: "#f0e6d244",
 };
+
+function terminalThemeFromDashboardTheme(theme: DashboardTheme): ITheme {
+  const terminal = theme.componentStyles?.terminal ?? {};
+  const background =
+    terminal.backgroundColor ??
+    terminal.background ??
+    theme.palette.background.hex ??
+    FALLBACK_TERMINAL_THEME.background;
+  const foreground =
+    terminal.color ??
+    terminal.foreground ??
+    theme.palette.midground.hex ??
+    FALLBACK_TERMINAL_THEME.foreground;
+
+  return {
+    ...FALLBACK_TERMINAL_THEME,
+    background,
+    foreground,
+    cursor: terminal.cursor ?? foreground,
+    cursorAccent: terminal.cursorAccent ?? background,
+    selectionBackground:
+      terminal.selectionBackground ?? FALLBACK_TERMINAL_THEME.selectionBackground,
+  };
+}
 
 /**
  * CSS width for xterm font tiers.
@@ -134,6 +159,12 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   const mobilePanelOpen = isActive && mobilePanelOpenRaw;
   const { setEnd } = usePageHeader();
   const { t } = useI18n();
+  const { theme } = useTheme();
+  const terminalTheme = useMemo(
+    () => terminalThemeFromDashboardTheme(theme),
+    [theme],
+  );
+  const terminalThemeRef = useRef(terminalTheme);
   const closeMobilePanel = useCallback(() => setMobilePanelOpenRaw(false), []);
   const modelToolsLabel = useMemo(
     () => `${t.app.modelToolsSheetTitle} ${t.app.modelToolsSheetSubtitle}`,
@@ -155,7 +186,11 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   // treat the current resume target as part of the PTY identity and rebuild the
   // terminal session when it changes.
   const resumeParam = searchParams.get("resume");
-  const channel = useMemo(() => generateChannelId(), [resumeParam]);
+  const channel = useMemo(() => {
+    // Tie the PTY channel identity to the active resume target.
+    void resumeParam;
+    return generateChannelId();
+  }, [resumeParam]);
 
   useEffect(() => {
     if (!resumeParam) return;
@@ -290,7 +325,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       // let the inner Hermes TUI own transcript history/scroll behavior.
       // The outer browser xterm should act as a display/input bridge only.
       scrollback: 0,
-      theme: TERMINAL_THEME,
+      theme: terminalThemeRef.current,
     });
     termRef.current = term;
 
@@ -333,7 +368,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
           // original keydown event's activation. Log to aid debugging.
           console.warn("[dashboard clipboard] OSC 52 write failed:", err.message);
         });
-      } catch (e) {
+      } catch {
         console.warn("[dashboard clipboard] malformed OSC 52 payload");
       }
       return true;
@@ -659,6 +694,14 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     };
   }, [channel, resumeParam]);
 
+  useEffect(() => {
+    terminalThemeRef.current = terminalTheme;
+    const term = termRef.current;
+    if (!term) return;
+    term.options.theme = terminalTheme;
+    term.refresh(0, Math.max(0, term.rows - 1));
+  }, [terminalTheme]);
+
   // When the user returns to the chat tab (isActive: false → true), the
   // terminal host just transitioned from display:none to display:flex.
   // ResizeObserver won't fire on that kind of style-driven box change —
@@ -813,7 +856,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
             "p-2 sm:p-3",
           )}
           style={{
-            backgroundColor: TERMINAL_THEME.background,
+            backgroundColor: terminalTheme.background,
             boxShadow: "0 8px 32px rgba(0, 0, 0, 0.4)",
           }}
         >
@@ -836,7 +879,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
               "bottom-2 right-2 px-2 py-1 text-[0.65rem] sm:bottom-3 sm:right-3 sm:px-2.5 sm:py-1.5 sm:text-xs",
               "lg:bottom-4 lg:right-4",
             )}
-            style={{ color: TERMINAL_THEME.foreground }}
+            style={{ color: terminalTheme.foreground }}
           >
             <span className="inline-flex items-center gap-1.5">
               <Copy className="h-3 w-3 shrink-0" />

--- a/web/src/themes/context.tsx
+++ b/web/src/themes/context.tsx
@@ -137,7 +137,7 @@ const NAMED_ASSET_KEYS = ["bg", "hero", "logo", "crest", "sidebar", "header"] as
  *  Each bucket emits `--component-<bucket>-<kebab-prop>` CSS vars. */
 const COMPONENT_BUCKETS = [
   "card", "header", "footer", "sidebar", "tab",
-  "progress", "badge", "backdrop", "page",
+  "progress", "badge", "backdrop", "page", "terminal",
 ] as const;
 
 /** Camel → kebab (`clipPath` → `clip-path`). */

--- a/web/src/themes/types.ts
+++ b/web/src/themes/types.ts
@@ -117,6 +117,8 @@ export interface ThemeComponentStyles {
   badge?: Record<string, string>;
   backdrop?: Record<string, string>;
   page?: Record<string, string>;
+  /** Embedded xterm.js chat surface in `/chat`. */
+  terminal?: Record<string, string>;
 }
 
 /** Optional hex overrides keyed by shadcn-compat token name (without the


### PR DESCRIPTION
## Summary
- Keeps the CLI update check scoped to the active Hermes checkout instead of a stale profile clone
- Adds repo-aware update-check cache invalidation
- Carries the dashboard chat theme plumbing through the React web build

## Test Plan
- `scripts/run_tests.sh tests/hermes_cli/test_update_check.py tests/hermes_cli/test_web_server.py`
- `cd web && npm run build`
