### PR TITLE
chore(packaging): publish project URLs metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dependencies = [
 ]
 
 [project.urls]
-Homepage = "https://hermes-agent.nousresearch.com/docs/"
+Homepage = "https://hermes-agent.nousresearch.com/"
 Documentation = "https://hermes-agent.nousresearch.com/docs/"
 Repository = "https://github.com/NousResearch/hermes-agent"
 Issues = "https://github.com/NousResearch/hermes-agent/issues"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,12 @@ dependencies = [
   "psutil==7.2.2",
 ]
 
+[project.urls]
+Homepage = "https://hermes-agent.nousresearch.com/docs/"
+Documentation = "https://hermes-agent.nousresearch.com/docs/"
+Repository = "https://github.com/NousResearch/hermes-agent"
+Issues = "https://github.com/NousResearch/hermes-agent/issues"
+
 [project.optional-dependencies]
 # Native Anthropic provider — only needed when provider=anthropic (not via
 # OpenRouter or other aggregators).

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -131,7 +131,7 @@ def test_project_urls_publish_user_support_links():
     project = _load_project_metadata()
 
     assert project["urls"] == {
-        "Homepage": "https://hermes-agent.nousresearch.com/docs/",
+        "Homepage": "https://hermes-agent.nousresearch.com/",
         "Documentation": "https://hermes-agent.nousresearch.com/docs/",
         "Repository": "https://github.com/NousResearch/hermes-agent",
         "Issues": "https://github.com/NousResearch/hermes-agent/issues",

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -4,11 +4,14 @@ from pathlib import Path
 import tomllib
 
 
-def _load_optional_dependencies():
+def _load_project_metadata():
     pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
     with pyproject_path.open("rb") as handle:
-        project = tomllib.load(handle)["project"]
-    return project["optional-dependencies"]
+        return tomllib.load(handle)["project"]
+
+
+def _load_optional_dependencies():
+    return _load_project_metadata()["optional-dependencies"]
 
 
 def _load_package_data():
@@ -122,3 +125,14 @@ def test_dashboard_plugin_manifests_and_assets_are_packaged():
     assert "*/dashboard/manifest.json" in plugin_data
     assert "*/dashboard/dist/*" in plugin_data
     assert "*/dashboard/dist/**/*" in plugin_data
+
+
+def test_project_urls_publish_user_support_links():
+    project = _load_project_metadata()
+
+    assert project["urls"] == {
+        "Homepage": "https://hermes-agent.nousresearch.com/docs/",
+        "Documentation": "https://hermes-agent.nousresearch.com/docs/",
+        "Repository": "https://github.com/NousResearch/hermes-agent",
+        "Issues": "https://github.com/NousResearch/hermes-agent/issues",
+    }


### PR DESCRIPTION
## Summary
- Add PyPI metadata links for homepage, documentation, repository, and issue tracker in `pyproject.toml`.
- Reuse the project metadata test helper so URL metadata is parsed from the same TOML source.
- Add a regression test that keeps the published project URLs aligned with the current README/docs links.

## Real behavior proof
- `python3 -m pytest tests/test_project_metadata.py -q`
  - Result: `5 passed in 3.84s`
- `git diff --check`
  - Result: passed

## Notes
This is metadata-only: it does not change runtime behavior, dependencies, or optional extras.
