### PR TITLE
fix(tool_result_storage): validate fallback heredoc marker against content

### DIFF
--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -78,6 +78,38 @@ class TestHeredocMarker:
         assert marker.startswith("HERMES_PERSIST_")
         assert marker not in content
 
+    def test_uuid_fallback_marker_also_checked_against_content(self):
+        """Fallback UUID marker must be absent from content — loop until safe.
+
+        Regression: original code returned the first random marker without
+        re-checking it against content. If content happened to contain the
+        generated marker, _write_to_sandbox produced a heredoc that terminated
+        early, silently truncating the stored output.
+        """
+        # Make the first UUID candidate also collide with content.
+        first_hex  = "aabbccdd" + "0" * 24   # uuid4().hex is 32 chars; [:8] → "aabbccdd"
+        second_hex = "11223344" + "0" * 24   # safe candidate
+
+        first_marker  = "HERMES_PERSIST_aabbccdd"
+        second_marker = "HERMES_PERSIST_11223344"
+
+        content = f"body {HEREDOC_MARKER} mid {first_marker} end"
+
+        call_count = 0
+        def controlled_uuid4():
+            nonlocal call_count
+            call_count += 1
+            m = MagicMock()
+            m.hex = first_hex if call_count == 1 else second_hex
+            return m
+
+        with patch("tools.tool_result_storage.uuid.uuid4", side_effect=controlled_uuid4):
+            marker = _heredoc_marker(content)
+
+        assert call_count >= 2, "must retry when first UUID also collides"
+        assert marker == second_marker
+        assert marker not in content
+
 
 # ── _write_to_sandbox ─────────────────────────────────────────────────
 

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -69,10 +69,18 @@ def generate_preview(content: str, max_chars: int = DEFAULT_PREVIEW_SIZE_CHARS) 
 
 
 def _heredoc_marker(content: str) -> str:
-    """Return a heredoc delimiter that doesn't collide with content."""
-    if HEREDOC_MARKER not in content:
-        return HEREDOC_MARKER
-    return f"HERMES_PERSIST_{uuid.uuid4().hex[:8]}"
+    """Return a heredoc delimiter that doesn't collide with content.
+
+    Loops until a marker absent from *content* is found.  The default
+    marker (``HERMES_PERSIST_EOF``) is tried first; on collision, a
+    random 8-hex suffix is generated and also checked before use.
+    This avoids premature heredoc termination when tool output happens
+    to contain the fallback marker string.
+    """
+    marker = HEREDOC_MARKER
+    while marker in content:
+        marker = f"HERMES_PERSIST_{uuid.uuid4().hex[:8]}"
+    return marker
 
 
 def _write_to_sandbox(content: str, remote_path: str, env) -> bool:


### PR DESCRIPTION
## What does this PR do?

`_heredoc_marker()` in `tools/tool_result_storage.py` returned the first randomly-generated fallback marker without checking whether it also appeared in the content. If a tool result happened to contain the generated `HERMES_PERSIST_<8hex>` string, `_write_to_sandbox()` produced a heredoc that terminated early at that string, silently truncating the stored output — the file would contain only a partial result with no error reported.

## Root cause

`_heredoc_marker()` in `tools/tool_result_storage.py` returned the first randomly-generated fallback marker without checking whether it also appeared in the content. If a tool result happened to contain the generated `HERMES_PERSIST_<8hex>` string, `_write_to_sandbox()` produced a heredoc that terminated early at that string, silently truncating the stored output — the file would contain only a partial result with no error reported.

## Fix

Replace with a `while` loop that retries UUID generation until the candidate marker is absent from `content`. The common case (no collision with the default marker) remains O(1) — the loop body never executes.

```python
marker = HEREDOC_MARKER
while marker in content:
    marker = f"HERMES_PERSIST_{uuid.uuid4().hex[:8]}"
return marker
```

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

N/A

<details>
<summary>Original body</summary>

## Summary

`_heredoc_marker()` in `tools/tool_result_storage.py` returned the first randomly-generated fallback marker without checking whether it also appeared in the content. If a tool result happened to contain the generated `HERMES_PERSIST_<8hex>` string, `_write_to_sandbox()` produced a heredoc that terminated early at that string, silently truncating the stored output — the file would contain only a partial result with no error reported.

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Problem

`_heredoc_marker()` in `tools/tool_result_storage.py` returned the first randomly-generated fallback marker without checking whether it also appeared in the content. If a tool result happened to contain the generated `HERMES_PERSIST_<8hex>` string, `_write_to_sandbox()` produced a heredoc that terminated early at that string, silently truncating the stored output — the file would contain only a partial result with no error reported.

## Root Cause

Original one-shot fallback:
```python
if HEREDOC_MARKER not in content:
    return HEREDOC_MARKER
return f"HERMES_PERSIST_{uuid.uuid4().hex[:8]}"  # ← not checked against content
```

## Fix

Replace with a `while` loop that retries UUID generation until the candidate marker is absent from `content`. The common case (no collision with the default marker) remains O(1) — the loop body never executes.

```python
marker = HEREDOC_MARKER
while marker in content:
    marker = f"HERMES_PERSIST_{uuid.uuid4().hex[:8]}"
return marker
```

## Tests

New test `test_uuid_fallback_marker_also_checked_against_content` in `TestHeredocMarker`:
- Patches `uuid4()` so the **first** candidate also collides with content
- Asserts `call_count >= 2` (retried past first collision)
- Asserts returned marker is absent from content
- **Fails on `main` without this fix, passes with it**

All 50 existing `test_tool_result_storage.py` tests pass.

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_