### PR TITLE
fix(plugins): resolve git via absolute path fallbacks when PATH is minimal

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -27,6 +27,24 @@ class PluginOperationError(Exception):
     """Recoverable plugin install/update failure (CLI exits; HTTP maps to 4xx)."""
 
 
+def _find_git() -> str:
+    """Return the absolute path to the git executable.
+
+    Resolves via shutil.which() first, then falls back to common absolute
+    paths for runtime environments (dashboard, systemd) where PATH may be
+    minimal.  Returns the bare string "git" as a last resort so the
+    downstream FileNotFoundError still surfaces the original error message.
+    See issue #22583.
+    """
+    found = shutil.which("git")
+    if found:
+        return found
+    for candidate in ("/usr/bin/git", "/usr/local/bin/git", "/bin/git"):
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    return "git"
+
+
 # Minimum manifest version this installer understands.
 # Plugins may declare ``manifest_version: 1`` in plugin.yaml;
 # future breaking changes to the manifest schema bump this.
@@ -326,7 +344,7 @@ def _install_plugin_core(identifier: str, *, force: bool) -> tuple[Path, dict, s
 
         try:
             result = subprocess.run(
-                ["git", "clone", "--depth", "1", git_url, str(tmp_target)],
+                [_find_git(), "clone", "--depth", "1", git_url, str(tmp_target)],
                 capture_output=True,
                 text=True,
                 timeout=60,
@@ -1474,7 +1492,7 @@ def dashboard_update_user_plugin(name: str) -> dict[str, Any]:
 def _git_pull_plugin_dir(target: Path) -> tuple[bool, str]:
     try:
         result = subprocess.run(
-            ["git", "pull", "--ff-only"],
+            [_find_git(), "pull", "--ff-only"],
             capture_output=True,
             text=True,
             timeout=60,

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -597,6 +597,43 @@ class TestProviderDiscovery:
 # ── Auto-activation fix ──────────────────────────────────────────────────
 
 
+class TestFindGit:
+    """Regression tests for _find_git() (issue #22583).
+
+    Dashboard/systemd runtimes may run with a minimal PATH so shutil.which("git")
+    returns None even when git exists at an absolute path.  _find_git() must fall
+    back to known absolute locations before giving up.
+    """
+
+    def test_find_git_uses_which_when_available(self, monkeypatch):
+        """shutil.which result is returned directly."""
+        import shutil as _shutil
+        from hermes_cli.plugins_cmd import _find_git
+        monkeypatch.setattr(_shutil, "which", lambda _: "/usr/local/bin/git")
+        assert _find_git() == "/usr/local/bin/git"
+
+    def test_find_git_falls_back_to_absolute_path_when_which_fails(self, monkeypatch):
+        """When shutil.which returns None, the first accessible absolute path wins."""
+        import shutil as _shutil
+        import os as _os
+        from hermes_cli.plugins_cmd import _find_git
+        monkeypatch.setattr(_shutil, "which", lambda _: None)
+        monkeypatch.setattr(_os.path, "isfile", lambda p: p in ("/usr/local/bin/git",))
+        monkeypatch.setattr(_os, "access", lambda p, _m: p in ("/usr/local/bin/git",))
+        assert _find_git() == "/usr/local/bin/git"
+
+    def test_find_git_returns_bare_git_when_not_found_anywhere(self, monkeypatch):
+        """When git is nowhere to be found, return bare 'git' so FileNotFoundError
+        message is preserved downstream."""
+        import shutil as _shutil
+        import os as _os
+        from hermes_cli.plugins_cmd import _find_git
+        monkeypatch.setattr(_shutil, "which", lambda _: None)
+        monkeypatch.setattr(_os.path, "isfile", lambda _p: False)
+        monkeypatch.setattr(_os, "access", lambda _p, _m: False)
+        assert _find_git() == "git"
+
+
 class TestNoAutoActivation:
     """Verify that plugin engines don't auto-activate when config says 'compressor'."""
 


### PR DESCRIPTION
## Problem

Installing or updating a plugin from the Dashboard/API (or any non-interactive runtime launched by systemd) can fail with:

```
git is not installed or not in PATH.
```

…even when `git` exists at `/usr/bin/git` and works in a normal shell. Runtime PATH in these environments is often stripped to the bare minimum, so `subprocess.run(["git", ...])` raises `FileNotFoundError`.

## Root cause

Both `_install_plugin_core()` and `_git_pull_plugin_dir()` pass the bare string `"git"` to subprocess. `shutil.which()` is not consulted; if PATH doesn't contain the directory holding `git`, the OS raises `FileNotFoundError` and the call is reported as "git not installed."

## Fix

Add `_find_git()` helper:

```python
def _find_git() -> str:
    found = shutil.which("git")
    if found:
        return found
    for candidate in ("/usr/bin/git", "/usr/local/bin/git", "/bin/git"):
        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
            return candidate
    return "git"  # last resort — preserves downstream FileNotFoundError message
```

Used in both `_install_plugin_core()` and `_git_pull_plugin_dir()`.

## Tests

New `TestFindGit` class in `tests/hermes_cli/test_plugins_cmd.py`:

| Test | Scenario |
|------|----------|
| `test_find_git_uses_which_when_available` | `shutil.which` result returned directly |
| `test_find_git_falls_back_to_absolute_path_when_which_fails` | First accessible absolute path wins when `which` returns `None` |
| `test_find_git_returns_bare_git_when_not_found_anywhere` | Bare `"git"` returned when nothing found |

**Stash-verified:** fallback test raises `ImportError` without `_find_git`, passes with it. **3/3** tests green.

Closes #22583.