### PR TITLE
fix(skills): resolve skills directory from active profile per-call

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -943,3 +943,29 @@ class TestPinnedGuard:
                        side_effect=RuntimeError("sidecar broken")):
                 result = _delete_skill("my-skill")
         assert result["success"] is True
+
+
+class TestActiveSkillsDir:
+    """Tests for skill_manager_tool._active_skills_dir() profile-aware resolution."""
+
+    def test_follows_hermes_home(self, tmp_path, monkeypatch):
+        """_active_skills_dir() resolves from get_hermes_home(), not the
+        module constant, when SKILLS_DIR has not been monkeypatched."""
+        import tools.skill_manager_tool as smt
+        profile_home = tmp_path / "profiles" / "test"
+        profile_skills = profile_home / "skills"
+        profile_skills.mkdir(parents=True)
+        monkeypatch.setattr(
+            "hermes_constants.get_hermes_home", lambda: profile_home
+        )
+        assert smt._active_skills_dir() == profile_skills
+
+    def test_honours_monkeypatched_skills_dir(self, tmp_path, monkeypatch):
+        """When SKILLS_DIR is patched (existing test pattern), the patched
+        value takes precedence over dynamic resolution."""
+        import tools.skill_manager_tool as smt
+        patched_dir = tmp_path / "patched_skills"
+        patched_dir.mkdir()
+        monkeypatch.setattr(smt, "SKILLS_DIR", patched_dir)
+        assert smt._active_skills_dir() == patched_dir
+        

--- a/tests/tools/test_skills_tool.py
+++ b/tests/tools/test_skills_tool.py
@@ -1076,3 +1076,27 @@ Do the legacy thing.
         assert result["setup_needed"] is False
         assert result["missing_required_environment_variables"] == []
         assert result["readiness_status"] == "available"
+
+
+class TestActiveSkillsDir:
+    """Tests for _active_skills_dir() profile-aware resolution."""
+
+    def test_follows_hermes_home(self, tmp_path, monkeypatch):
+        """_active_skills_dir() resolves from get_hermes_home(), not the
+        module constant, when SKILLS_DIR has not been monkeypatched."""
+        profile_home = tmp_path / "profiles" / "test"
+        profile_skills = profile_home / "skills"
+        profile_skills.mkdir(parents=True)
+        monkeypatch.setattr(
+            "hermes_constants.get_hermes_home", lambda: profile_home
+        )
+        assert skills_tool_module._active_skills_dir() == profile_skills
+
+    def test_honours_monkeypatched_skills_dir(self, tmp_path, monkeypatch):
+        """When SKILLS_DIR is patched (existing test pattern), the patched
+        value takes precedence over dynamic resolution."""
+        patched_dir = tmp_path / "patched_skills"
+        patched_dir.mkdir()
+        monkeypatch.setattr(skills_tool_module, "SKILLS_DIR", patched_dir)
+        assert skills_tool_module._active_skills_dir() == patched_dir
+        

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -107,6 +107,20 @@ import yaml
 # All skills live in ~/.hermes/skills/ (single source of truth)
 HERMES_HOME = get_hermes_home()
 SKILLS_DIR = HERMES_HOME / "skills"
+_ORIGINAL_SKILLS_DIR = SKILLS_DIR
+
+
+def _active_skills_dir() -> Path:
+    """Return skills directory for the currently active profile.
+
+    See tools/skills_tool.py::_active_skills_dir for full rationale.
+    When SKILLS_DIR has been monkeypatched (e.g. by tests), the patched
+    value is honoured.
+    """
+    if SKILLS_DIR != _ORIGINAL_SKILLS_DIR:
+        return SKILLS_DIR
+    return get_hermes_home() / "skills"
+
 
 MAX_NAME_LENGTH = 64
 MAX_DESCRIPTION_LENGTH = 1024
@@ -131,7 +145,7 @@ def _containing_skills_root(skill_path: Path) -> Path:
             return root
         except (ValueError, OSError):
             continue
-    return SKILLS_DIR
+    return _active_skills_dir()
 
 
 def _pinned_guard(name: str) -> Optional[str]:
@@ -270,9 +284,10 @@ def _validate_content_size(content: str, label: str = "SKILL.md") -> Optional[st
 
 def _resolve_skill_dir(name: str, category: str = None) -> Path:
     """Build the directory path for a new skill, optionally under a category."""
+    _sd = _active_skills_dir()
     if category:
-        return SKILLS_DIR / category / name
-    return SKILLS_DIR / name
+        return _sd / category / name
+    return _sd / name
 
 
 def _find_skill(name: str) -> Optional[Dict[str, Any]]:
@@ -415,7 +430,7 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
     result = {
         "success": True,
         "message": f"Skill '{name}' created.",
-        "path": str(skill_dir.relative_to(SKILLS_DIR)),
+        "path": str(skill_dir.relative_to(_active_skills_dir())),
         "skill_md": str(skill_md),
     }
     if category:

--- a/tools/skills_tool.py
+++ b/tools/skills_tool.py
@@ -87,6 +87,26 @@ logger = logging.getLogger(__name__)
 # skills all coexist here without polluting the git repo.
 HERMES_HOME = get_hermes_home()
 SKILLS_DIR = HERMES_HOME / "skills"
+_ORIGINAL_SKILLS_DIR = SKILLS_DIR
+
+
+def _active_skills_dir() -> Path:
+    """Return skills directory for the currently active profile.
+
+    In WebUI deployments, per-client profile switches use
+    switch_profile(process_wide=False) which does not update os.environ or
+    module-level constants. This function resolves the correct directory
+    per-call from get_hermes_home(), which respects the active_profile file
+    and thread-local context.
+
+    When SKILLS_DIR has been monkeypatched (e.g. by tests), the patched
+    value is honoured so existing test fixtures continue to work without
+    modification.
+    """
+    if SKILLS_DIR != _ORIGINAL_SKILLS_DIR:
+        return SKILLS_DIR
+    return get_hermes_home() / "skills"
+
 
 # Anthropic-recommended limits for progressive disclosure efficiency
 MAX_NAME_LENGTH = 64
@@ -452,7 +472,7 @@ def _get_category_from_path(skill_path: Path) -> Optional[str]:
     """
     # Try the module-level SKILLS_DIR first (respects monkeypatching in tests),
     # then fall back to external dirs from config.
-    dirs_to_check = [SKILLS_DIR]
+    dirs_to_check = [_active_skills_dir()]
     try:
         from agent.skill_utils import get_external_skills_dirs
         dirs_to_check.extend(get_external_skills_dirs())
@@ -567,8 +587,9 @@ def _find_all_skills(*, skip_disabled: bool = False) -> List[Dict[str, Any]]:
 
     # Scan local dir first, then external dirs (local takes precedence)
     dirs_to_scan = []
-    if SKILLS_DIR.exists():
-        dirs_to_scan.append(SKILLS_DIR)
+    _sd = _active_skills_dir()
+    if _sd.exists():
+        dirs_to_scan.append(_sd)
     dirs_to_scan.extend(get_external_skills_dirs())
 
     for scan_dir in dirs_to_scan:
@@ -686,8 +707,9 @@ def skills_list(category: str = None, task_id: str = None) -> str:
         JSON string with minimal skill info: name, description, category
     """
     try:
-        if not SKILLS_DIR.exists():
-            SKILLS_DIR.mkdir(parents=True, exist_ok=True)
+        _sd = _active_skills_dir()
+        if not _sd.exists():
+            _sd.mkdir(parents=True, exist_ok=True)
             return json.dumps(
                 {
                     "success": True,
@@ -940,8 +962,9 @@ def skill_view(
 
         # Build list of all skill directories to search
         all_dirs = []
-        if SKILLS_DIR.exists():
-            all_dirs.append(SKILLS_DIR)
+        _sd = _active_skills_dir()
+        if _sd.exists():
+            all_dirs.append(_sd)
         all_dirs.extend(get_external_skills_dirs())
 
         if not all_dirs:
@@ -1027,7 +1050,7 @@ def skill_view(
         # Security: warn if skill is loaded from outside trusted directories
         # (local skills dir + configured external_dirs are all trusted)
         _outside_skills_dir = True
-        _trusted_dirs = [SKILLS_DIR.resolve()]
+        _trusted_dirs = [_active_skills_dir().resolve()]
         try:
             _trusted_dirs.extend(d.resolve() for d in all_dirs[1:])
         except Exception:
@@ -1256,7 +1279,7 @@ def skill_view(
             linked_files["scripts"] = script_files
 
         try:
-            rel_path = str(skill_md.relative_to(SKILLS_DIR))
+            rel_path = str(skill_md.relative_to(_active_skills_dir()))
         except ValueError:
             # External skill — use path relative to the skill's own parent dir
             rel_path = str(skill_md.relative_to(skill_md.parent.parent)) if skill_md.parent.parent else skill_md.name


### PR DESCRIPTION
## What does this PR do?

In WebUI multi-profile deployments, `tools/skills_tool.py` and `tools/skill_manager_tool.py` always resolve skills from the root profile's directory regardless of which profile is active in the browser session.

Both files set `SKILLS_DIR` as a module-level constant at import time:

\`\`\`python
HERMES_HOME = get_hermes_home()
SKILLS_DIR = HERMES_HOME / "skills"   # never updated after this
\`\`\`

WebUI per-client profile switches call `switch_profile(process_wide=False)`, which intentionally avoids mutating `os.environ` or module-level constants (introduced in #1700 to allow switching while a stream is active). `SKILLS_DIR` therefore always points at the root profile's skills directory for the lifetime of the process.

### Current behaviour

- Agent in non-root profile: `skills_list()` returns root profile skills
- `skill_view(<profile-specific-skill>)` returns "not found"
- `skill_manage(action='create')` writes to root profile directory

### Fix

Add `_active_skills_dir()` helper to both files that calls `get_hermes_home()` per-invocation rather than reading the cached constant. Replace all `SKILLS_DIR` usages in skill functions with it.

A sentinel value (`_ORIGINAL_SKILLS_DIR`) preserves backward compatibility:
when `SKILLS_DIR` has been monkeypatched (the pattern used by 49+ existing tests), the patched value is honoured. In production, where `SKILLS_DIR` is never patched, the function resolves dynamically from the active profile.

This mirrors the pattern already used in `nesquena/hermes-webui` after PR #1917, which fixed the display half of this issue by deriving the skills directory from `get_active_hermes_home()` per-request in `api/routes.py`.

## Related Issue

WebUI display half: nesquena/hermes-webui#1917

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- `tools/skills_tool.py` — 7 edits: add `_active_skills_dir()` with
  `_ORIGINAL_SKILLS_DIR` sentinel, replace all `SKILLS_DIR` reads in
  `_get_category_from_path`, `_find_all_skills`, `skills_list`, `skill_view`
- `tools/skill_manager_tool.py` — 4 edits: add `_active_skills_dir()` with
  same sentinel pattern, replace `SKILLS_DIR` in `_containing_skills_root`,
  `_resolve_skill_dir`, and create-result path
- `tests/tools/test_skills_tool.py` — 2 new tests: verify dynamic resolution
  follows `get_hermes_home()`, verify monkeypatched `SKILLS_DIR` is honoured
- `tests/tools/test_skill_manager_tool.py` — 2 new tests: same coverage for
  the `skill_manager_tool` copy of `_active_skills_dir()`

## How to Test

1. Create a non-root profile and add skills to its skills directory
2. Switch to that profile in the WebUI
3. Confirm `skills_list()` returns the profile's skills
4. Confirm `skill_view(<name>)` resolves correctly
5. Create a skill via `skill_manage(action='create')` — confirm it lands
   in the active profile's skills directory
6. Switch back to root profile and verify its skills are unaffected
7. Run `pytest tests/tools/test_skills_tool.py tests/tools/test_skill_manager_tool.py -q`
   — all existing tests pass

## Checklist

- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes
- [x] I've tested on my platform: Unraid 7.2.x (Docker, two-container compose)