### PR TITLE
feat: add HermesShare MCP server

### DIFF
--- a/hermes_share_mcp/__init__.py
+++ b/hermes_share_mcp/__init__.py
@@ -1,0 +1,11 @@
+"""Restricted MCP server for a local HermesShare/SMB share root."""
+
+__all__ = ["ShareConfig", "ShareMCPService"]
+
+
+def __getattr__(name: str):
+    if name in __all__:
+        from .server import ShareConfig, ShareMCPService
+
+        return {"ShareConfig": ShareConfig, "ShareMCPService": ShareMCPService}[name]
+    raise AttributeError(name)

--- a/hermes_share_mcp/server.py
+++ b/hermes_share_mcp/server.py
@@ -1,0 +1,439 @@
+"""Restricted Local Files / SMB Share MCP server for HermesShare.
+
+The server intentionally exposes only a compact document-oriented API rooted at a
+single share directory.  It never accepts absolute paths, resolves symlinks, and
+rejects any path whose real location is outside the configured root.
+"""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import mimetypes
+import os
+import stat
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Iterable
+
+DEFAULT_SHARE_ROOT = Path("/home/hermes/HermesShare")
+DEFAULT_MAX_READ_BYTES = 256_000
+DEFAULT_MAX_SEARCH_BYTES = 1_000_000
+DEFAULT_MAX_WRITE_BYTES = 256_000
+TEXT_EXTENSIONS = {
+    ".txt",
+    ".md",
+    ".markdown",
+    ".rst",
+    ".csv",
+    ".tsv",
+    ".json",
+    ".jsonl",
+    ".yaml",
+    ".yml",
+    ".toml",
+    ".ini",
+    ".log",
+    ".py",
+    ".js",
+    ".jsx",
+    ".ts",
+    ".tsx",
+    ".css",
+    ".html",
+    ".xml",
+}
+DOC_EXTENSIONS = TEXT_EXTENSIONS | {".pdf", ".doc", ".docx", ".odt", ".rtf", ".xlsx", ".xls"}
+WRITE_EXTENSIONS = TEXT_EXTENSIONS - {".log"}
+
+
+class SharePathError(ValueError):
+    """Raised when a requested path is unsafe or outside the share root."""
+
+
+@dataclass(frozen=True)
+class ShareConfig:
+    root: Path = DEFAULT_SHARE_ROOT
+    allow_write: bool = True
+    include_hidden: bool = False
+    max_read_bytes: int = DEFAULT_MAX_READ_BYTES
+    max_search_bytes: int = DEFAULT_MAX_SEARCH_BYTES
+    max_write_bytes: int = DEFAULT_MAX_WRITE_BYTES
+
+    @classmethod
+    def from_env(cls) -> "ShareConfig":
+        root = Path(os.environ.get("HERMES_SHARE_MCP_ROOT", str(DEFAULT_SHARE_ROOT))).expanduser()
+        allow_write = _env_bool("HERMES_SHARE_MCP_ALLOW_WRITE", True)
+        include_hidden = _env_bool("HERMES_SHARE_MCP_INCLUDE_HIDDEN", False)
+        max_read_bytes = _env_int("HERMES_SHARE_MCP_MAX_READ_BYTES", DEFAULT_MAX_READ_BYTES)
+        max_search_bytes = _env_int("HERMES_SHARE_MCP_MAX_SEARCH_BYTES", DEFAULT_MAX_SEARCH_BYTES)
+        max_write_bytes = _env_int("HERMES_SHARE_MCP_MAX_WRITE_BYTES", DEFAULT_MAX_WRITE_BYTES)
+        return cls(
+            root=root,
+            allow_write=allow_write,
+            include_hidden=include_hidden,
+            max_read_bytes=max_read_bytes,
+            max_search_bytes=max_search_bytes,
+            max_write_bytes=max_write_bytes,
+        )
+
+    @property
+    def resolved_root(self) -> Path:
+        return self.root.expanduser().resolve(strict=False)
+
+
+def _env_bool(name: str, default: bool) -> bool:
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _env_int(name: str, default: int) -> int:
+    value = os.environ.get(name)
+    if not value:
+        return default
+    try:
+        parsed = int(value)
+    except ValueError:
+        return default
+    return parsed if parsed > 0 else default
+
+
+def _utc_iso(ts: float) -> str:
+    return datetime.fromtimestamp(ts, tz=timezone.utc).isoformat()
+
+
+def _is_relative_to(path: Path, root: Path) -> bool:
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+def _is_hidden(path: Path, root: Path) -> bool:
+    try:
+        rel_parts = path.relative_to(root).parts
+    except ValueError:
+        return True
+    return any(part.startswith(".") for part in rel_parts if part not in {".", ".."})
+
+
+def _looks_text(path: Path) -> bool:
+    if path.suffix.lower() in TEXT_EXTENSIONS:
+        return True
+    guessed, _ = mimetypes.guess_type(path.name)
+    return bool(guessed and guessed.startswith("text/"))
+
+
+def _compact_error(code: str, message: str) -> dict[str, Any]:
+    return {"ok": False, "error": {"code": code, "message": message}}
+
+
+class ShareMCPService:
+    """Document-oriented operations rooted at one local share directory."""
+
+    def __init__(self, config: ShareConfig | None = None):
+        self.config = config or ShareConfig.from_env()
+        self.root = self.config.resolved_root
+
+    def _resolve(self, relative_path: str | None = "", *, for_write: bool = False) -> Path:
+        raw = (relative_path or "").strip()
+        if raw in {"", "."}:
+            candidate = self.root
+        else:
+            requested = Path(raw)
+            if requested.is_absolute():
+                raise SharePathError("absolute paths are not allowed; use a path relative to the share root")
+            if any(part in {"..", ""} for part in requested.parts):
+                raise SharePathError("path traversal segments are not allowed")
+            candidate = (self.root / requested).resolve(strict=False)
+        if not _is_relative_to(candidate, self.root):
+            raise SharePathError("resolved path is outside the configured share root")
+        if not self.config.include_hidden and _is_hidden(candidate, self.root):
+            raise SharePathError("hidden files and directories are not exposed")
+        if for_write and candidate.suffix.lower() not in WRITE_EXTENSIONS:
+            raise SharePathError(f"writes are limited to text document extensions: {', '.join(sorted(WRITE_EXTENSIONS))}")
+        return candidate
+
+    def _relative(self, path: Path) -> str:
+        return path.relative_to(self.root).as_posix() or "."
+
+    def _entry(self, path: Path) -> dict[str, Any]:
+        st = path.stat()
+        return {
+            "path": self._relative(path),
+            "name": path.name,
+            "type": "directory" if path.is_dir() else "file",
+            "size": st.st_size if path.is_file() else None,
+            "modified": _utc_iso(st.st_mtime),
+            "extension": path.suffix.lower() if path.is_file() else None,
+        }
+
+    def _safe_walk(self, base: Path) -> Iterable[Path]:
+        for current, dirs, files in os.walk(base):
+            current_path = Path(current).resolve(strict=False)
+            if not _is_relative_to(current_path, self.root):
+                dirs[:] = []
+                continue
+            if not self.config.include_hidden:
+                dirs[:] = [d for d in dirs if not d.startswith(".")]
+                files = [f for f in files if not f.startswith(".")]
+            for name in dirs + files:
+                path = (current_path / name).resolve(strict=False)
+                if _is_relative_to(path, self.root):
+                    yield path
+
+    def list_share_files(
+        self,
+        path: str = "",
+        pattern: str = "*",
+        recursive: bool = False,
+        limit: int = 100,
+        include_dirs: bool = True,
+    ) -> dict[str, Any]:
+        try:
+            base = self._resolve(path)
+            if not base.exists():
+                return _compact_error("not_found", "path does not exist")
+            if not base.is_dir():
+                return _compact_error("not_directory", "path is not a directory")
+            limit = max(1, min(int(limit or 100), 500))
+            candidates = self._safe_walk(base) if recursive else ((base / child.name).resolve(strict=False) for child in base.iterdir())
+            entries: list[dict[str, Any]] = []
+            for item in candidates:
+                if not _is_relative_to(item, self.root):
+                    continue
+                if not self.config.include_hidden and _is_hidden(item, self.root):
+                    continue
+                if item.is_dir() and not include_dirs:
+                    continue
+                rel = self._relative(item)
+                if not fnmatch.fnmatch(item.name, pattern) and not fnmatch.fnmatch(rel, pattern):
+                    continue
+                entries.append(self._entry(item))
+                if len(entries) >= limit:
+                    break
+            entries.sort(key=lambda e: (e["type"] != "directory", e["path"].lower()))
+            return {"ok": True, "root": str(self.root), "path": self._relative(base), "entries": entries, "truncated": len(entries) >= limit}
+        except SharePathError as exc:
+            return _compact_error("unsafe_path", str(exc))
+        except OSError as exc:
+            return _compact_error("io_error", str(exc))
+
+    def read_shared_doc(self, path: str, max_bytes: int | None = None) -> dict[str, Any]:
+        try:
+            target = self._resolve(path)
+            if not target.exists():
+                return _compact_error("not_found", "file does not exist")
+            if not target.is_file():
+                return _compact_error("not_file", "path is not a file")
+            if not _looks_text(target):
+                return _compact_error("unsupported_type", "only text-like documents can be read inline")
+            max_len = max(1, min(int(max_bytes or self.config.max_read_bytes), self.config.max_read_bytes))
+            data = target.read_bytes()
+            truncated = len(data) > max_len
+            text = data[:max_len].decode("utf-8", errors="replace")
+            return {"ok": True, "path": self._relative(target), "bytes": len(data), "truncated": truncated, "content": text}
+        except SharePathError as exc:
+            return _compact_error("unsafe_path", str(exc))
+        except OSError as exc:
+            return _compact_error("io_error", str(exc))
+
+    def write_shared_doc(self, path: str, content: str, overwrite: bool = False) -> dict[str, Any]:
+        try:
+            if not self.config.allow_write:
+                return _compact_error("write_disabled", "writes are disabled for this server")
+            target = self._resolve(path, for_write=True)
+            encoded = content.encode("utf-8")
+            if len(encoded) > self.config.max_write_bytes:
+                return _compact_error("too_large", f"content exceeds max_write_bytes ({self.config.max_write_bytes})")
+            if target.exists() and not overwrite:
+                return _compact_error("exists", "file exists; pass overwrite=true to replace it")
+            target.parent.mkdir(parents=True, exist_ok=True)
+            parent = target.parent.resolve(strict=False)
+            if not _is_relative_to(parent, self.root):
+                return _compact_error("unsafe_path", "parent path escapes share root")
+            target.write_text(content, encoding="utf-8")
+            return {"ok": True, "path": self._relative(target), "bytes_written": len(encoded), "overwritten": overwrite}
+        except SharePathError as exc:
+            return _compact_error("unsafe_path", str(exc))
+        except OSError as exc:
+            return _compact_error("io_error", str(exc))
+
+    def search_share(
+        self,
+        query: str,
+        path: str = "",
+        glob: str = "*",
+        limit: int = 50,
+        max_file_bytes: int | None = None,
+    ) -> dict[str, Any]:
+        try:
+            if not query:
+                return _compact_error("invalid_query", "query is required")
+            base = self._resolve(path)
+            if not base.exists():
+                return _compact_error("not_found", "path does not exist")
+            limit = max(1, min(int(limit or 50), 200))
+            max_len = max(1, min(int(max_file_bytes or self.config.max_search_bytes), self.config.max_search_bytes))
+            needle = query.lower()
+            results: list[dict[str, Any]] = []
+            files = [base] if base.is_file() else [p for p in self._safe_walk(base) if p.is_file()]
+            for file_path in files:
+                rel = self._relative(file_path)
+                if not fnmatch.fnmatch(file_path.name, glob) and not fnmatch.fnmatch(rel, glob):
+                    continue
+                if not _looks_text(file_path) or file_path.stat().st_size > max_len:
+                    continue
+                text = file_path.read_text(encoding="utf-8", errors="replace")
+                for line_no, line in enumerate(text.splitlines(), start=1):
+                    idx = line.lower().find(needle)
+                    if idx < 0:
+                        continue
+                    start = max(0, idx - 80)
+                    end = min(len(line), idx + len(query) + 80)
+                    results.append({"path": rel, "line": line_no, "snippet": line[start:end]})
+                    if len(results) >= limit:
+                        return {"ok": True, "query": query, "matches": results, "truncated": True}
+            return {"ok": True, "query": query, "matches": results, "truncated": False}
+        except SharePathError as exc:
+            return _compact_error("unsafe_path", str(exc))
+        except (OSError, UnicodeError) as exc:
+            return _compact_error("io_error", str(exc))
+
+    def get_recent_files(self, path: str = "", limit: int = 25, extensions: list[str] | None = None) -> dict[str, Any]:
+        try:
+            base = self._resolve(path)
+            if not base.exists():
+                return _compact_error("not_found", "path does not exist")
+            limit = max(1, min(int(limit or 25), 100))
+            allowed = {e.lower() if e.startswith(".") else f".{e.lower()}" for e in extensions or []}
+            files = [base] if base.is_file() else [p for p in self._safe_walk(base) if p.is_file()]
+            entries = [self._entry(p) for p in files if (not allowed or p.suffix.lower() in allowed)]
+            entries.sort(key=lambda e: e["modified"], reverse=True)
+            return {"ok": True, "files": entries[:limit], "truncated": len(entries) > limit}
+        except SharePathError as exc:
+            return _compact_error("unsafe_path", str(exc))
+        except OSError as exc:
+            return _compact_error("io_error", str(exc))
+
+    def sync_status(self) -> dict[str, Any]:
+        try:
+            exists = self.root.exists()
+            writable = bool(exists and os.access(self.root, os.W_OK))
+            readable = bool(exists and os.access(self.root, os.R_OK))
+            file_count = 0
+            newest: str | None = None
+            if exists and readable:
+                mtimes: list[float] = []
+                for path in self._safe_walk(self.root):
+                    if path.is_file():
+                        file_count += 1
+                        mtimes.append(path.stat().st_mtime)
+                        if file_count >= 10_000:
+                            break
+                if mtimes:
+                    newest = _utc_iso(max(mtimes))
+            mode = self.root.stat().st_mode if exists else 0
+            return {
+                "ok": True,
+                "root": str(self.root),
+                "exists": exists,
+                "readable": readable,
+                "writable": writable and self.config.allow_write,
+                "write_configured": self.config.allow_write,
+                "file_count_sample": file_count,
+                "newest_file_modified": newest,
+                "root_mode": stat.filemode(mode) if exists else None,
+            }
+        except OSError as exc:
+            return _compact_error("io_error", str(exc))
+
+
+def _register_tools(service: ShareMCPService):
+    try:
+        from mcp.server.fastmcp import FastMCP
+    except Exception as exc:  # pragma: no cover - exercised only without optional dep
+        raise SystemExit("The 'mcp' package is required. Install with: pip install 'hermes-agent[mcp]'") from exc
+
+    mcp = FastMCP("HermesShare Local Files")
+
+    @mcp.tool()
+    def list_share_files(path: str = "", pattern: str = "*", recursive: bool = False, limit: int = 100, include_dirs: bool = True) -> dict[str, Any]:
+        """List files/directories under the configured share root with path safety."""
+        return service.list_share_files(path, pattern, recursive, limit, include_dirs)
+
+    @mcp.tool()
+    def search_share(query: str, path: str = "", glob: str = "*", limit: int = 50, max_file_bytes: int | None = None) -> dict[str, Any]:
+        """Search text-like files in the share and return compact line snippets."""
+        return service.search_share(query, path, glob, limit, max_file_bytes)
+
+    @mcp.tool()
+    def read_shared_doc(path: str, max_bytes: int | None = None) -> dict[str, Any]:
+        """Read a UTF-8 text-like document from the share root."""
+        return service.read_shared_doc(path, max_bytes)
+
+    @mcp.tool()
+    def write_shared_doc(path: str, content: str, overwrite: bool = False) -> dict[str, Any]:
+        """Write a UTF-8 text document inside the share root if writes are enabled."""
+        return service.write_shared_doc(path, content, overwrite)
+
+    @mcp.tool()
+    def get_recent_files(path: str = "", limit: int = 25, extensions: list[str] | None = None) -> dict[str, Any]:
+        """Return recently modified files under the share root."""
+        return service.get_recent_files(path, limit, extensions)
+
+    @mcp.tool()
+    def sync_status() -> dict[str, Any]:
+        """Report share root readability/writability and a compact freshness sample."""
+        return service.sync_status()
+
+    return mcp
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Restricted MCP stdio server for HermesShare / SMB share files.")
+    parser.add_argument("--root", default=os.environ.get("HERMES_SHARE_MCP_ROOT", str(DEFAULT_SHARE_ROOT)), help="Share root to expose (default: /home/hermes/HermesShare)")
+    parser.add_argument("--read-only", action="store_true", help="Disable write_shared_doc")
+    parser.add_argument("--include-hidden", action="store_true", help="Expose dotfiles/dot directories inside the root")
+    parser.add_argument("--max-read-bytes", type=int, default=DEFAULT_MAX_READ_BYTES)
+    parser.add_argument("--max-search-bytes", type=int, default=DEFAULT_MAX_SEARCH_BYTES)
+    parser.add_argument("--max-write-bytes", type=int, default=DEFAULT_MAX_WRITE_BYTES)
+    parser.add_argument("--print-config-snippet", action="store_true", help="Print a Hermes mcp_servers config snippet and exit")
+    return parser
+
+
+def config_snippet(root: str = str(DEFAULT_SHARE_ROOT), read_only: bool = False) -> str:
+    args = ["hermes-share-mcp", "--root", root]
+    if read_only:
+        args.append("--read-only")
+    return "mcp_servers:\n  hermesshare:\n    command: \"{}\"\n    args: {}\n    timeout: 30\n    connect_timeout: 30\n".format(args[0], json.dumps(args[1:]))
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    if args.print_config_snippet:
+        print(config_snippet(args.root, args.read_only))
+        return
+    service = ShareMCPService(
+        ShareConfig(
+            root=Path(args.root),
+            allow_write=not args.read_only and _env_bool("HERMES_SHARE_MCP_ALLOW_WRITE", True),
+            include_hidden=args.include_hidden or _env_bool("HERMES_SHARE_MCP_INCLUDE_HIDDEN", False),
+            max_read_bytes=args.max_read_bytes,
+            max_search_bytes=args.max_search_bytes,
+            max_write_bytes=args.max_write_bytes,
+        )
+    )
+    mcp = _register_tools(service)
+    mcp.run()
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main(sys.argv[1:])

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,7 @@ all = [
 hermes = "hermes_cli.main:main"
 hermes-agent = "run_agent:main"
 hermes-acp = "acp_adapter.entry:main"
+hermes-share-mcp = "hermes_share_mcp.server:main"
 
 [tool.setuptools]
 py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajectory_compressor", "toolset_distributions", "cli", "hermes_bootstrap", "hermes_constants", "hermes_state", "hermes_time", "hermes_logging", "rl_cli", "utils"]
@@ -178,7 +179,7 @@ hermes_cli = ["web_dist/**/*"]
 gateway = ["assets/**/*"]
 
 [tool.setuptools.packages.find]
-include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]
+include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*", "hermes_share_mcp"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]

--- a/tests/test_hermes_share_mcp.py
+++ b/tests/test_hermes_share_mcp.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from hermes_share_mcp.server import ShareConfig, ShareMCPService, config_snippet
+
+
+def _service(tmp_path: Path, **kwargs) -> ShareMCPService:
+    return ShareMCPService(ShareConfig(root=tmp_path, **kwargs))
+
+
+def test_read_rejects_path_traversal(tmp_path: Path):
+    outside = tmp_path.parent / "secret.txt"
+    outside.write_text("secret", encoding="utf-8")
+    service = _service(tmp_path)
+
+    result = service.read_shared_doc("../secret.txt")
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "unsafe_path"
+
+
+def test_read_rejects_absolute_path_even_inside_root(tmp_path: Path):
+    target = tmp_path / "note.md"
+    target.write_text("hello", encoding="utf-8")
+    service = _service(tmp_path)
+
+    result = service.read_shared_doc(str(target))
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "unsafe_path"
+
+
+def test_symlink_escape_is_rejected(tmp_path: Path):
+    outside = tmp_path.parent / "outside.md"
+    outside.write_text("outside", encoding="utf-8")
+    (tmp_path / "link.md").symlink_to(outside)
+    service = _service(tmp_path)
+
+    result = service.read_shared_doc("link.md")
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "unsafe_path"
+
+
+def test_list_filters_hidden_and_patterns(tmp_path: Path):
+    (tmp_path / "visible.md").write_text("shown", encoding="utf-8")
+    (tmp_path / "visible.txt").write_text("shown", encoding="utf-8")
+    (tmp_path / ".hidden.md").write_text("hidden", encoding="utf-8")
+    service = _service(tmp_path)
+
+    result = service.list_share_files(pattern="*.md")
+
+    assert result["ok"] is True
+    assert [entry["path"] for entry in result["entries"]] == ["visible.md"]
+
+
+def test_read_shared_doc_returns_compact_text_and_truncation(tmp_path: Path):
+    (tmp_path / "doc.md").write_text("abcdef", encoding="utf-8")
+    service = _service(tmp_path, max_read_bytes=4)
+
+    result = service.read_shared_doc("doc.md")
+
+    assert result["ok"] is True
+    assert result["content"] == "abcd"
+    assert result["truncated"] is True
+    assert result["bytes"] == 6
+
+
+def test_read_rejects_binary_file(tmp_path: Path):
+    (tmp_path / "image.png").write_bytes(b"\x89PNG\r\n\x1a\n")
+    service = _service(tmp_path)
+
+    result = service.read_shared_doc("image.png")
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "unsupported_type"
+
+
+def test_write_shared_doc_respects_read_only(tmp_path: Path):
+    service = _service(tmp_path, allow_write=False)
+
+    result = service.write_shared_doc("note.md", "content")
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "write_disabled"
+    assert not (tmp_path / "note.md").exists()
+
+
+def test_write_shared_doc_creates_text_file_and_requires_overwrite(tmp_path: Path):
+    service = _service(tmp_path)
+
+    first = service.write_shared_doc("folder/note.md", "first")
+    second = service.write_shared_doc("folder/note.md", "second")
+    third = service.write_shared_doc("folder/note.md", "third", overwrite=True)
+
+    assert first["ok"] is True
+    assert second["ok"] is False
+    assert second["error"]["code"] == "exists"
+    assert third["ok"] is True
+    assert (tmp_path / "folder" / "note.md").read_text(encoding="utf-8") == "third"
+
+
+def test_write_rejects_non_text_extension(tmp_path: Path):
+    service = _service(tmp_path)
+
+    result = service.write_shared_doc("payload.bin", "not allowed")
+
+    assert result["ok"] is False
+    assert result["error"]["code"] == "unsafe_path"
+
+
+def test_search_share_returns_line_snippets(tmp_path: Path):
+    (tmp_path / "a.md").write_text("alpha\nneedle here\n", encoding="utf-8")
+    (tmp_path / "b.md").write_text("nothing\n", encoding="utf-8")
+    service = _service(tmp_path)
+
+    result = service.search_share("needle")
+
+    assert result["ok"] is True
+    assert result["matches"] == [{"path": "a.md", "line": 2, "snippet": "needle here"}]
+
+
+def test_get_recent_files_can_filter_extensions(tmp_path: Path):
+    (tmp_path / "a.md").write_text("a", encoding="utf-8")
+    (tmp_path / "b.txt").write_text("b", encoding="utf-8")
+    service = _service(tmp_path)
+
+    result = service.get_recent_files(extensions=["md"])
+
+    assert result["ok"] is True
+    assert [entry["path"] for entry in result["files"]] == ["a.md"]
+
+
+def test_sync_status_reports_root_state(tmp_path: Path):
+    (tmp_path / "a.md").write_text("a", encoding="utf-8")
+    service = _service(tmp_path)
+
+    result = service.sync_status()
+
+    assert result["ok"] is True
+    assert result["exists"] is True
+    assert result["readable"] is True
+    assert result["file_count_sample"] == 1
+
+
+def test_config_snippet_uses_mcp_servers_key():
+    snippet = config_snippet("/home/hermes/HermesShare", read_only=True)
+
+    assert "mcp_servers:" in snippet
+    assert "hermesshare:" in snippet
+    assert "hermes-share-mcp" in snippet
+    assert "--read-only" in snippet
+
+
+def test_fastmcp_registration_when_dependency_available(tmp_path: Path):
+    pytest.importorskip("mcp.server.fastmcp")
+    from hermes_share_mcp.server import _register_tools
+
+    server = _register_tools(_service(tmp_path))
+
+    assert type(server).__name__ == "FastMCP"
+
+
+def test_env_config_defaults_to_hermesshare(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("HERMES_SHARE_MCP_ROOT", raising=False)
+
+    config = ShareConfig.from_env()
+
+    assert config.root == Path("/home/hermes/HermesShare")
+
+
+def test_env_config_can_override_root(monkeypatch: pytest.MonkeyPatch, tmp_path: Path):
+    monkeypatch.setenv("HERMES_SHARE_MCP_ROOT", os.fspath(tmp_path))
+    monkeypatch.setenv("HERMES_SHARE_MCP_ALLOW_WRITE", "false")
+
+    config = ShareConfig.from_env()
+
+    assert config.root == tmp_path
+    assert config.allow_write is False

--- a/website/docs/guides/hermesshare-mcp-server.md
+++ b/website/docs/guides/hermesshare-mcp-server.md
@@ -1,0 +1,72 @@
+---
+sidebar_position: 7
+title: "HermesShare MCP Server"
+description: "Configure the restricted Local Files / SMB Share MCP server for HermesShare"
+---
+
+# HermesShare Local Files / SMB Share MCP Server
+
+Hermes ships a restricted MCP stdio server for exposing a single local fileshare, such as Brandon's `/home/hermes/HermesShare`, to Hermes sessions as MCP tools. It is intentionally narrower than a general filesystem MCP server: every request is resolved under one configured root, absolute paths are rejected, `..` traversal is rejected, symlink escapes are rejected, and hidden files are excluded by default.
+
+## Tools
+
+When configured as the `hermesshare` MCP server, Hermes discovers tools with the usual `mcp_` prefix:
+
+- `mcp_hermesshare_list_share_files` — list files/directories below the share root.
+- `mcp_hermesshare_search_share` — search text-like files and return compact snippets.
+- `mcp_hermesshare_read_shared_doc` — read UTF-8 text-like documents with byte limits.
+- `mcp_hermesshare_write_shared_doc` — write UTF-8 text documents when writes are enabled.
+- `mcp_hermesshare_get_recent_files` — return recently modified files.
+- `mcp_hermesshare_sync_status` — report root readability/writability and a compact freshness sample.
+
+## Hermes config snippet
+
+Add this to `~/.hermes/config.yaml` and restart Hermes:
+
+```yaml
+mcp_servers:
+  hermesshare:
+    command: "hermes-share-mcp"
+    args: ["--root", "/home/hermes/HermesShare"]
+    timeout: 30
+    connect_timeout: 30
+```
+
+For read-only use:
+
+```yaml
+mcp_servers:
+  hermesshare:
+    command: "hermes-share-mcp"
+    args: ["--root", "/home/hermes/HermesShare", "--read-only"]
+    timeout: 30
+    connect_timeout: 30
+```
+
+Environment overrides are also supported for service managers:
+
+- `HERMES_SHARE_MCP_ROOT` — defaults to `/home/hermes/HermesShare`.
+- `HERMES_SHARE_MCP_ALLOW_WRITE` — defaults to `true`; set `false` to disable writes.
+- `HERMES_SHARE_MCP_INCLUDE_HIDDEN` — defaults to `false`.
+- `HERMES_SHARE_MCP_MAX_READ_BYTES`, `HERMES_SHARE_MCP_MAX_SEARCH_BYTES`, `HERMES_SHARE_MCP_MAX_WRITE_BYTES` — positive integer byte caps.
+
+## Verification
+
+1. Confirm the package includes the entry point:
+
+   ```bash
+   hermes-share-mcp --print-config-snippet
+   ```
+
+2. Add the config snippet, then restart Hermes or run `/reload-mcp` from an existing session.
+
+3. Confirm discovery:
+
+   ```bash
+   hermes mcp list
+   hermes mcp test hermesshare
+   ```
+
+4. Ask Hermes to call `mcp_hermesshare_sync_status`, then list or search a known file under `/home/hermes/HermesShare`.
+
+5. Safety smoke checks: attempts to read `/etc/passwd`, `../outside.md`, a hidden file such as `.secret.md`, or a symlink pointing outside the share root should return `ok: false` with `unsafe_path`.

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -172,6 +172,7 @@ const sidebars: SidebarsConfig = {
         'guides/team-telegram-assistant',
         'guides/python-library',
         'guides/use-mcp-with-hermes',
+        'guides/hermesshare-mcp-server',
         'guides/use-soul-with-hermes',
         'guides/use-voice-mode-with-hermes',
         'guides/build-a-hermes-plugin',


### PR DESCRIPTION
## Summary
- Add a restricted `hermes-share-mcp` stdio MCP server rooted at `/home/hermes/HermesShare` by default.
- Expose compact local-share tools: `list_share_files`, `search_share`, `read_shared_doc`, `write_shared_doc`, `get_recent_files`, and `sync_status`.
- Add root-confinement/path-safety protections, hidden-file filtering, read-only mode, byte caps, docs, and a Hermes config snippet.

## Test Plan
- `python -m pytest tests/test_hermes_share_mcp.py -q -o 'addopts='`
- `python -m ruff check hermes_share_mcp tests/test_hermes_share_mcp.py`
- `python -m hermes_share_mcp.server --print-config-snippet`

## Notes
- Intended for private/local HermesShare access; users can explicitly override the share root in MCP server environment variables.
