### PR TITLE
fix(terminal): reject foreground sleep > 30s to prevent agent blockage

### DIFF
--- a/tests/tools/test_sleep_intercept.py
+++ b/tests/tools/test_sleep_intercept.py
@@ -1,0 +1,61 @@
+"""Tests for long-sleep intercept in terminal_tool.
+
+Foreground `sleep N` with N > 30 must be rejected immediately so the agent
+cannot be blocked for minutes at a time.
+
+See: NousResearch/hermes-agent#8612
+"""
+
+import json
+
+from tools.terminal_tool import terminal_tool
+
+
+class TestSleepIntercept:
+    """Long foreground sleep commands must be rejected with a helpful message."""
+
+    def test_sleep_31_foreground_rejected(self):
+        result = json.loads(terminal_tool("sleep 31"))
+        assert result["exit_code"] == -1
+        assert "rejected" in result["error"].lower()
+        assert "31" in result["error"]
+
+    def test_sleep_300_foreground_rejected(self):
+        result = json.loads(terminal_tool("sleep 300"))
+        assert result["exit_code"] == -1
+        assert "background" in result["error"].lower()
+
+    def test_sleep_30_foreground_allowed(self):
+        """Threshold is >30, so exactly 30 must NOT be rejected by this guard."""
+        result = json.loads(terminal_tool("sleep 30"))
+        # Guard did not fire — exit_code is 0 (sleep ran) or not a guard rejection
+        assert result.get("exit_code") != -1 or "rejected" not in result.get("error") or ""
+
+    def test_sleep_1_foreground_allowed(self):
+        result = json.loads(terminal_tool("sleep 1"))
+        assert result.get("exit_code") != -1 or "rejected" not in result.get("error") or ""
+
+    def test_sleep_31_background_allowed(self):
+        """background=True bypasses the guard — long sleeps are fine in background."""
+        result = json.loads(terminal_tool("sleep 31", background=True))
+        error = result.get("error") or ""
+        assert "rejected" not in error.lower() or "sleep" not in error.lower()
+
+    def test_sleep_with_leading_whitespace_rejected(self):
+        result = json.loads(terminal_tool("  sleep 60"))
+        assert result["exit_code"] == -1
+        assert "rejected" in result["error"].lower()
+
+    def test_non_sleep_command_unaffected(self):
+        """Regular commands must not be caught by the sleep guard."""
+        result = json.loads(terminal_tool("echo hello"))
+        assert result.get("exit_code") == 0
+        assert "rejected" not in (result.get("error") or "").lower()
+
+    def test_error_message_suggests_background(self):
+        result = json.loads(terminal_tool("sleep 120"))
+        assert "background" in result["error"].lower()
+
+    def test_error_message_mentions_poll(self):
+        result = json.loads(terminal_tool("sleep 120"))
+        assert "poll" in result["error"].lower()

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1886,6 +1886,24 @@ def terminal_tool(
                 "EOF."
             )
 
+        # Intercept long sleep commands that block the agent and prevent
+        # user interaction. The interrupt flag is checked between tool calls,
+        # not during subprocess execution, so a 6-minute sleep cannot be interrupted.
+        _sleep_match = re.match(r"^\s*sleep\s+(\d+)", command)
+        if _sleep_match and int(_sleep_match.group(1)) > 30 and not background:
+            _sleep_secs = int(_sleep_match.group(1))
+            return json.dumps({
+                "output": "",
+                "exit_code": -1,
+                "error": (
+                    f"Rejected: 'sleep {_sleep_secs}' would block the agent for "
+                    f"{_sleep_secs}s, preventing user interaction. "
+                    "Instead: run your long process with background=true, then "
+                    "use process(action='poll', session_id=...) to check progress. "
+                    "For short waits, use sleep values <= 30."
+                ),
+            }, ensure_ascii=False)
+
         if background:
             # Spawn a tracked background process via the process registry.
             # For local backends: uses subprocess.Popen with output buffering.


### PR DESCRIPTION
## What does this PR do?

- Long foreground `sleep N` commands (N > 30) lock the agent for the full duration — the interrupt flag is only checked between tool calls, not during subprocess execution - Add a guard that intercepts `sleep N` (N > 30) before the subprocess is spawned, returns `exit_code: -1` with a clear error message suggesting `background=true` + `process(action='poll')` - `sleep N` with N ≤ 30 is unaffected; `background=True` bypasses the guard

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

N/A

<details>
<summary>Original body</summary>

## Summary

- Long foreground `sleep N` commands (N > 30) lock the agent for the full duration — the interrupt flag is only checked between tool calls, not during subprocess execution - Add a guard that intercepts `sleep N` (N > 30) before the subprocess is spawned, returns `exit_code: -1` with a clear error message suggesting `background=true` + `process(action='poll')` - `sleep N` with N ≤ 30 is unaffected; `background=True` bypasses the guard

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Summary

- Long foreground `sleep N` commands (N > 30) lock the agent for the full duration — the interrupt flag is only checked between tool calls, not during subprocess execution
- Add a guard that intercepts `sleep N` (N > 30) before the subprocess is spawned, returns `exit_code: -1` with a clear error message suggesting `background=true` + `process(action='poll')`
- `sleep N` with N ≤ 30 is unaffected; `background=True` bypasses the guard

Salvage of #8612.

## Test plan

- [ ] `pytest tests/tools/test_sleep_intercept.py` — 9 tests pass
- [ ] `sleep 31` foreground → rejected, error contains "31" and "background"
- [ ] `sleep 300` foreground → rejected, error mentions "poll"
- [ ] `sleep 30` foreground → NOT rejected (at threshold)
- [ ] `sleep 31` with `background=True` → NOT rejected
- [ ] `  sleep 60` (leading whitespace) → rejected
- [ ] `echo hello` → unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_