### PR TITLE
fix(gateway): refresh runtime argv metadata on every status write (salvage #22579)

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -482,10 +482,12 @@ def write_runtime_status(
     """Persist gateway runtime health information for diagnostics/status."""
     path = _get_runtime_status_path()
     payload = _read_json_file(path) or _build_runtime_status_record()
+    current_record = _build_pid_record()
     payload.setdefault("platforms", {})
-    payload.setdefault("kind", _GATEWAY_KIND)
-    payload["pid"] = os.getpid()
-    payload["start_time"] = _get_process_start_time(os.getpid())
+    payload["kind"] = current_record["kind"]
+    payload["pid"] = current_record["pid"]
+    payload["argv"] = current_record["argv"]
+    payload["start_time"] = current_record["start_time"]
     payload["updated_at"] = _utc_now_iso()
 
     if gateway_state is not _UNSET:

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -287,6 +287,30 @@ class TestGatewayRuntimeStatus:
         assert payload["pid"] == os.getpid(), "PID should be overwritten, not preserved via setdefault"
         assert payload["start_time"] != 1000.0, "start_time should be overwritten on restart"
 
+    def test_write_runtime_status_overwrites_stale_argv_on_restart(self, tmp_path, monkeypatch):
+        """Regression: gateway_state.json must not keep the previous launch argv."""
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+
+        state_path = tmp_path / "gateway_state.json"
+        state_path.write_text(json.dumps({
+            "pid": 99999,
+            "start_time": 1000.0,
+            "kind": "hermes-gateway",
+            "argv": ["/old/path/hermes", "gateway", "run"],
+            "platforms": {},
+            "updated_at": "2025-01-01T00:00:00Z",
+        }))
+
+        monkeypatch.setattr(status.sys, "argv", ["/new/path/hermes", "gateway", "run"])
+        monkeypatch.setattr(status, "_get_process_start_time", lambda pid: 2000)
+
+        status.write_runtime_status(gateway_state="running")
+
+        payload = status.read_runtime_status()
+        assert payload["argv"] == ["/new/path/hermes", "gateway", "run"]
+        assert payload["pid"] == os.getpid()
+        assert payload["start_time"] == 2000
+
     def test_write_runtime_status_records_platform_failure(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 


### PR DESCRIPTION
## Summary
Salvage of #22579 — `gateway_state.json` now refreshes argv (and pid/start_time/kind) on every `write_runtime_status` call instead of inheriting stale values from the prior payload.

## Root cause
`write_runtime_status` merged into the existing payload, refreshing only `pid`/`start_time`/`updated_at`. After a binary path change (e.g. an `hermes update`), the file kept reporting the old argv even though the running process used the new path.

## Changes
- `gateway/status.py`: route argv/pid/kind/start_time through a single `_build_pid_record()` call so all four come from the live process atomically. Matches the pattern `acquire_scoped_lock` already uses.
- Regression test asserts argv, pid, AND start_time post-conditions.

Picked over #22630 (wesleysimplicio +34/-1) because consolidating through `_build_pid_record()` eliminates duplicate `os.getpid()`/`sys.argv` reads. Picked over #22589 (XieNBi +80/-8) for staying in scope — that PR bundled CI workflow changes, model-metadata edits, and gateway/run.py refactors. Both other authors credited.

Closes #22560 via salvage.
