### PR TITLE
fix(dingtalk): clarify webhook media behavior (salvage #22593)

### DIFF
--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -886,6 +886,65 @@ class DingTalkAdapter(BasePlatformAdapter):
         """DingTalk does not support typing indicators."""
         pass
 
+    async def send_image(
+        self,
+        chat_id: str,
+        image_url: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send an image via DingTalk markdown.
+
+        DingTalk's session webhook only supports text/markdown payloads, not
+        native image/file attachments. For remote image URLs, render the image
+        inline with markdown so the user still sees the image. Local files need
+        OpenAPI media upload and are handled separately.
+        """
+        image_block = f"![image]({image_url})"
+        content = f"{caption}\n\n{image_block}" if caption else image_block
+        return await self.send(
+            chat_id=chat_id,
+            content=content,
+            reply_to=reply_to,
+            metadata=metadata,
+        )
+
+    async def send_image_file(
+        self,
+        chat_id: str,
+        image_path: str,
+        caption: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs,
+    ) -> SendResult:
+        """DingTalk webhook replies cannot send local image files directly."""
+        return SendResult(
+            success=False,
+            error=(
+                "DingTalk session webhook replies do not support local image uploads. "
+                "Only markdown/text replies are supported without OpenAPI media upload."
+            ),
+        )
+
+    async def send_document(
+        self,
+        chat_id: str,
+        file_path: str,
+        caption: Optional[str] = None,
+        file_name: Optional[str] = None,
+        reply_to: Optional[str] = None,
+        **kwargs,
+    ) -> SendResult:
+        """DingTalk webhook replies cannot send local file attachments directly."""
+        return SendResult(
+            success=False,
+            error=(
+                "DingTalk session webhook replies do not support local file attachments. "
+                "Only markdown/text replies are supported without OpenAPI message send."
+            ),
+        )
+
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
         """Return basic info about a DingTalk conversation."""
         return {

--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -916,6 +916,7 @@ class DingTalkAdapter(BasePlatformAdapter):
         image_path: str,
         caption: Optional[str] = None,
         reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
         """DingTalk webhook replies cannot send local image files directly."""
@@ -934,6 +935,7 @@ class DingTalkAdapter(BasePlatformAdapter):
         caption: Optional[str] = None,
         file_name: Optional[str] = None,
         reply_to: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
         """DingTalk webhook replies cannot send local file attachments directly."""

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -256,7 +256,7 @@ class TestSend:
         result = await adapter.send_image_file("chat-123", "/tmp/demo.png")
 
         assert result.success is False
-        assert "do not support local image uploads" in result.error
+        assert result.error and "do not support local image uploads" in result.error
 
     @pytest.mark.asyncio
     async def test_send_document_returns_explicit_unsupported_error(self):
@@ -266,7 +266,7 @@ class TestSend:
         result = await adapter.send_document("chat-123", "/tmp/demo.pdf")
 
         assert result.success is False
-        assert "do not support local file attachments" in result.error
+        assert result.error and "do not support local file attachments" in result.error
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -223,6 +223,51 @@ class TestSend:
         assert result.success is False
         assert "400" in result.error
 
+    @pytest.mark.asyncio
+    async def test_send_image_renders_markdown_image(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.text = "OK"
+
+        mock_client = AsyncMock()
+        mock_client.post = AsyncMock(return_value=mock_response)
+        adapter._http_client = mock_client
+
+        result = await adapter.send_image(
+            "chat-123",
+            "https://example.com/demo.png",
+            caption="Screenshot",
+            metadata={"session_webhook": "https://dingtalk.example/webhook"},
+        )
+
+        assert result.success is True
+        payload = mock_client.post.call_args.kwargs["json"]
+        assert payload["msgtype"] == "markdown"
+        assert payload["markdown"]["text"] == "Screenshot\n\n![image](https://example.com/demo.png)"
+
+    @pytest.mark.asyncio
+    async def test_send_image_file_returns_explicit_unsupported_error(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+
+        result = await adapter.send_image_file("chat-123", "/tmp/demo.png")
+
+        assert result.success is False
+        assert "do not support local image uploads" in result.error
+
+    @pytest.mark.asyncio
+    async def test_send_document_returns_explicit_unsupported_error(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+
+        result = await adapter.send_document("chat-123", "/tmp/demo.pdf")
+
+        assert result.success is False
+        assert "do not support local file attachments" in result.error
+
 
 # ---------------------------------------------------------------------------
 # Connect / disconnect


### PR DESCRIPTION
## Summary
Salvage of #22593 — DingTalk gateway no longer silently degrades local image/file sends to fake-attachment text (`📎 File: /path`). Remote image URLs render as markdown images; local-file sends now return an explicit `success=False` error.

## Root cause
`gateway/platforms/base.py` falls back to `📎 File: ...` / `🖼️ Image: ...` text when an adapter doesn't override the media send method. DingTalk hadn't overridden them, so users sending images locally got a broken UX that looked successful.

## Changes
- `gateway/platforms/dingtalk.py`: override `send_image` (URL → DingTalk markdown image), `send_image_file`, `send_document` (local → explicit unsupported error).
- 3 regression tests covering the three send paths.

## Salvage improvements
Added a small fixup commit on top of the contributor's work:
- Aligned `send_image_file` and `send_document` signatures with the base class (added `metadata: Optional[Dict[str, Any]] = None`) so `ty` no longer flags `invalid-method-override`.
- Guarded the test asserts with `result.error and ...` since `SendResult.error` is `Optional[str]`.

## Validation
- 7/7 `TestSend` tests pass on the salvage branch.

Note: this is a partial fix. Native local-media via DingTalk OpenAPI is a separate follow-up — issue #22487 stays open with that scope. Caller-visible UX strictly improves (`success=False` with a clear error instead of silent fake send).

Related to #22487. (Issue stays open for OpenAPI media follow-up.)
