### PR TITLE
feat(mcp): add codex preset for Codex CLI MCP server (salvage #22663)

### DIFF
--- a/hermes_cli/mcp_config.py
+++ b/hermes_cli/mcp_config.py
@@ -31,7 +31,12 @@ logger = logging.getLogger(__name__)
 _ENV_VAR_NAME_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
 
 
-_MCP_PRESETS: Dict[str, Dict[str, Any]] = {}
+_MCP_PRESETS: Dict[str, Dict[str, Any]] = {
+    "codex": {
+        "command": "codex",
+        "args": ["mcp-server"],
+    },
+}
 
 
 # ─── UI Helpers ───────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Salvage of #22663 — `hermes mcp add codex --preset codex` now works, wiring `codex mcp-server` (OpenAI Codex CLI's built-in MCP server) into Hermes as a stdio MCP server.

## Changes
- `hermes_cli/mcp_config.py`: add a `codex` entry to `_MCP_PRESETS` with `command: codex` and `args: ["mcp-server"]`. 6 lines.

## Validation
- Matches the existing `_MCP_PRESETS` schema (`_apply_mcp_preset` reads exactly the keys provided).
- `codex mcp-server` is the documented Codex CLI subcommand for stdio MCP.

Note: not a fix for #22655 itself — that issue tracks 6 separate codex-cli external-process-provider follow-ups (session persistence, setup wizard, gateway tuning, JSONL tool parsing, aux model, docs). This PR is a tangentially-related but standalone addition to the MCP preset registry. #22655 stays open.
