### PR TITLE
tests: add Windows skip guards for UNIX-only stdlib imports (salvage #22567)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -67,6 +67,7 @@ AUTHOR_MAP = {
     "wesleysimplicio@live.com": "wesleysimplicio",
     "matthew.dean.cater@gmail.com": "SiliconID",
     "xieniu@proton.me": "xieNniu",
+    "rw8143a@american.edu": "wali-reheman",
     "egitimviscara@gmail.com": "uzunkuyruk",
     "zhekinmaksim@gmail.com": "Zhekinmaksim",
     "obafemiferanmi1999@gmail.com": "KvnGz",

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1,7 +1,7 @@
 """Tests for gateway service management helpers."""
 
 import os
-import pwd
+pwd = pytest.importorskip("pwd")
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
@@ -1284,7 +1284,7 @@ class TestSystemServiceIdentityRootHandling:
 
     def test_auto_detected_root_is_rejected(self, monkeypatch):
         """When root is auto-detected (not explicitly requested), raise."""
-        import pwd
+        pwd = pytest.importorskip("pwd")
         import grp
 
         monkeypatch.delenv("SUDO_USER", raising=False)
@@ -1297,7 +1297,7 @@ class TestSystemServiceIdentityRootHandling:
 
     def test_explicit_root_is_allowed(self, monkeypatch):
         """When root is explicitly passed via --run-as-user root, allow it."""
-        import pwd
+        pwd = pytest.importorskip("pwd")
         import grp
 
         root_info = pwd.getpwnam("root")
@@ -1309,7 +1309,7 @@ class TestSystemServiceIdentityRootHandling:
 
     def test_non_root_user_passes_through(self, monkeypatch):
         """Normal non-root user works as before."""
-        import pwd
+        pwd = pytest.importorskip("pwd")
         import grp
 
         monkeypatch.delenv("SUDO_USER", raising=False)

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -1,12 +1,13 @@
 """Tests for gateway service management helpers."""
 
 import os
-pwd = pytest.importorskip("pwd")
 import subprocess
 from pathlib import Path
 from types import SimpleNamespace
 
 import pytest
+
+pwd = pytest.importorskip("pwd")
 
 import hermes_cli.gateway as gateway_cli
 from gateway import status
@@ -1284,20 +1285,17 @@ class TestSystemServiceIdentityRootHandling:
 
     def test_auto_detected_root_is_rejected(self, monkeypatch):
         """When root is auto-detected (not explicitly requested), raise."""
-        pwd = pytest.importorskip("pwd")
         import grp
 
         monkeypatch.delenv("SUDO_USER", raising=False)
         monkeypatch.setenv("USER", "root")
         monkeypatch.setenv("LOGNAME", "root")
 
-        import pytest
         with pytest.raises(ValueError, match="pass --run-as-user root to override"):
             gateway_cli._system_service_identity(run_as_user=None)
 
     def test_explicit_root_is_allowed(self, monkeypatch):
         """When root is explicitly passed via --run-as-user root, allow it."""
-        pwd = pytest.importorskip("pwd")
         import grp
 
         root_info = pwd.getpwnam("root")
@@ -1309,7 +1307,6 @@ class TestSystemServiceIdentityRootHandling:
 
     def test_non_root_user_passes_through(self, monkeypatch):
         """Normal non-root user works as before."""
-        pwd = pytest.importorskip("pwd")
         import grp
 
         monkeypatch.delenv("SUDO_USER", raising=False)

--- a/tests/tools/test_file_sync_back.py
+++ b/tests/tools/test_file_sync_back.py
@@ -1,6 +1,6 @@
 """Tests for FileSyncManager.sync_back() — pull remote changes to host."""
 
-import fcntl
+fcntl = pytest.importorskip("fcntl")
 import io
 import logging
 import os

--- a/tests/tools/test_file_sync_back.py
+++ b/tests/tools/test_file_sync_back.py
@@ -1,6 +1,5 @@
 """Tests for FileSyncManager.sync_back() — pull remote changes to host."""
 
-fcntl = pytest.importorskip("fcntl")
 import io
 import logging
 import os
@@ -11,6 +10,8 @@ from pathlib import Path
 from unittest.mock import MagicMock, call, patch
 
 import pytest
+
+fcntl = pytest.importorskip("fcntl")
 
 from tools.environments.file_sync import (
     FileSyncManager,


### PR DESCRIPTION
## Summary
Salvage of #22567 — `pytest` collection on Windows no longer hard-fails on `tests/hermes_cli/test_gateway_service.py` (UNIX-only `pwd`) and `tests/tools/test_file_sync_back.py` (UNIX-only `fcntl`).

## Root cause
Both test modules unconditionally imported a UNIX-only stdlib module at the top, so on Windows `pytest --collect-only` aborted with `ModuleNotFoundError` before any test ran. Downstream staged-update gates that pytest-collect a candidate build were marking everything `verified=false` purely on collection failure.

## Changes (contributor commits)
- `tests/hermes_cli/test_gateway_service.py`: `pwd = pytest.importorskip("pwd")` at module level.
- `tests/tools/test_file_sync_back.py`: same pattern for `fcntl`.

## Salvage improvements (added on top)
The original PR was broken on every platform — `pytest.importorskip("pwd")` ran on line 4 but `import pytest` was on line 9, raising `NameError` at module load. Three in-function `pwd = pytest.importorskip("pwd")` rewrites in `TestSystemServiceIdentityRootHandling` also confused Python's scope analysis (a later `import pytest` made `pytest` local for the whole function) and surfaced as `UnboundLocalError`.

Fixup commit:
- Move `import pytest` ABOVE the `importorskip` line in both files.
- Drop the now-redundant in-function `pwd = pytest.importorskip` calls — the module-level guard handles them.

## Validation
- 149/149 tests across both files pass on the salvage branch.
- Without the fixup, collection still failed on Linux (`NameError: name 'pytest' is not defined`).

Note: scope deliberately matches the original issue (pwd/fcntl). Two follow-up clusters mentioned in the issue thread (`is_container()`/`is_wsl()` skip guards, audio/voice runtime probes) are real but require `pytest.mark.skipif` instead of `importorskip` and should be filed as separate issues.

Closes #22420 via salvage.
