### PR TITLE
fix(agent): skip post-tool empty nudge when reasoning_content is populated

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -14184,10 +14184,24 @@ class AIAgent:
                                 re.IGNORECASE,
                             )
                         )
+                        # Parsers like Ollama's qwen3.5 PARSER or DeepSeek's
+                        # reasoning channel split thinking out of content and
+                        # into a separate API field (reasoning_content /
+                        # reasoning / reasoning_details).  When that happens,
+                        # final_response is empty AND contains no <think> tag,
+                        # so the inline check misses it and the nudge fires.
+                        # Gate on the structured field too so the response
+                        # routes to the prefill branch instead. Fixes #21811.
+                        _has_separate_reasoning = bool(
+                            getattr(assistant_message, "reasoning_content", None)
+                            or getattr(assistant_message, "reasoning", None)
+                            or getattr(assistant_message, "reasoning_details", None)
+                        )
                         if (
                             _prior_was_tool
                             and not getattr(self, "_post_tool_empty_retried", False)
                             and not _has_inline_thinking  # thinking model still working — let prefill handle
+                            and not _has_separate_reasoning  # ditto for parser-split reasoning fields
                         ):
                             self._post_tool_empty_retried = True
                             # Clear stale narration so it doesn't resurface

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2671,6 +2671,44 @@ class TestRunConversation:
         assert result["final_response"] == "Here is the actual answer."
         assert result["api_calls"] == 2  # 1 original + 1 nudge retry
 
+    def test_reasoning_content_after_tool_skips_nudge_routes_to_prefill(self, agent):
+        """Regression for #21811: when the model returns empty content but populated
+        reasoning_content after a tool call, the post-tool empty nudge must NOT fire.
+        The response should route to the prefill branch instead."""
+        self._setup_agent(agent)
+        agent.base_url = "http://127.0.0.1:1234/v1"
+        tc = _mock_tool_call(name="memory_save", arguments="{}", call_id="c1")
+        # Turn 1: tool call from model
+        tool_resp = _mock_response(content="", finish_reason="tool_calls", tool_calls=[tc])
+        # Turn 2: parser-split reasoning (empty content, reasoning in separate field)
+        reasoning_resp = _mock_response(
+            content=None,
+            finish_reason="stop",
+            reasoning_content="Thought: The user wants me to save…",
+        )
+        # Turn 3: prefill continuation produces the real answer
+        answer_resp = _mock_response(content="Saved your preference.", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [tool_resp, reasoning_resp, answer_resp]
+
+        status_messages = []
+
+        with (
+            patch("run_agent.handle_function_call", return_value="Saved."),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(agent, "_emit_status", side_effect=status_messages.append),
+        ):
+            result = agent.run_conversation("Save my preference: concise responses")
+
+        assert result["completed"] is True
+        assert result["final_response"] == "Saved your preference."
+        # Nudge must not have fired: no "nudging to continue" status emitted
+        nudge_msgs = [m for m in status_messages if "nudging" in m.lower()]
+        assert not nudge_msgs, (
+            f"Post-tool empty nudge fired despite reasoning_content being populated: {nudge_msgs}"
+        )
+
     def test_empty_response_triggers_fallback_provider(self, agent):
         """After 3 empty retries, fallback provider is activated and produces content."""
         self._setup_agent(agent)


### PR DESCRIPTION
## Problem

When a model's parser (Ollama qwen3.5 PARSER, DeepSeek-R1, or any provider that splits thinking into a separate API field) returns an empty `content` with reasoning in `reasoning_content` / `reasoning` / `reasoning_details`, the post-tool empty nudge fires incorrectly.

Root cause: the existing guard at run_agent.py checks only `_has_inline_thinking` (looks for `<think>` tags in `final_response`). Parser-split reasoning produces empty `final_response` with no tags — so the check returns False and the nudge fires, wasting a retry round-trip after every tool call.

## Fix

Compute `_has_separate_reasoning` from the structured API fields and add it to the nudge gate alongside `_has_inline_thinking`. When either flag is True, the response routes to the existing prefill branch instead of triggering the nudge.

```python
_has_separate_reasoning = bool(
    getattr(assistant_message, "reasoning_content", None)
    or getattr(assistant_message, "reasoning", None)
    or getattr(assistant_message, "reasoning_details", None)
)
if (
    _prior_was_tool
    and not getattr(self, "_post_tool_empty_retried", False)
    and not _has_inline_thinking
    and not _has_separate_reasoning  # new
):
    # fires nudge ...
```

## Tests

Added `test_reasoning_content_after_tool_skips_nudge_routes_to_prefill` in `TestRunConversation`: tool call → parser-split empty response → verify nudge status NOT emitted, prefill branch runs, final answer delivered.

All 32 `TestRunConversation` tests pass.

Closes #21811