### PR TITLE
fix(acp): read Hermes version from package metadata on import failure

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -8,6 +8,7 @@ import contextvars
 import json
 import logging
 import os
+from importlib import metadata as importlib_metadata
 from collections import defaultdict, deque
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
@@ -79,7 +80,10 @@ logger = logging.getLogger(__name__)
 try:
     from hermes_cli import __version__ as HERMES_VERSION
 except Exception:
-    HERMES_VERSION = "0.0.0"
+    try:
+        HERMES_VERSION = importlib_metadata.version("hermes-agent")
+    except importlib_metadata.PackageNotFoundError:
+        HERMES_VERSION = "0.0.0"
 
 # Thread pool for running AIAgent (synchronous) in parallel.
 _executor = ThreadPoolExecutor(max_workers=4, thread_name_prefix="acp-agent")


### PR DESCRIPTION
## What does this PR do?

When `hermes_cli` cannot be imported, `acp_adapter.server` now falls back to installed package metadata for `HERMES_VERSION` instead of the hardcoded `0.0.0` placeholder. That keeps ACP version reporting aligned with the installed release.

## Changes Made

- `acp_adapter/server.py`
  - add an `importlib.metadata` fallback for `HERMES_VERSION`
  - keep the old `0.0.0` fallback only when package metadata is unavailable

## How to Test

- Forced `hermes_cli` import-failure validation with `uv run --extra acp python` printed `0.13.0` for `acp_adapter.server.HERMES_VERSION`
- `git diff --check`

## Notes

No production behavior changes when `hermes_cli` imports normally; this only improves the fallback path used when that import is unavailable.