### PR TITLE
fix(osv-check): filter @latest from scoped npm package versions

### DIFF
--- a/tests/tools/test_osv_check.py
+++ b/tests/tools/test_osv_check.py
@@ -50,6 +50,20 @@ class TestParseNpmPackage:
     def test_latest_ignored(self):
         assert _parse_npm_package("react@latest") == ("react", None)
 
+    def test_scoped_latest_ignored(self):
+        """Scoped packages with @latest should return version=None.
+
+        Regression: prior behaviour returned ("@scope/pkg", "latest") for
+        scoped tokens because the @latest filter in the unscoped branch was
+        not applied in the scoped (regex) branch.  Passing "latest" as a
+        version to the OSV API yields zero matches, silently missing malware
+        advisories that affect the package at all versions.
+        """
+        assert _parse_npm_package("@modelcontextprotocol/server@latest") == (
+            "@modelcontextprotocol/server", None
+        )
+        assert _parse_npm_package("@scope/pkg@latest") == ("@scope/pkg", None)
+
 
 class TestParsePypiPackage:
     def test_simple(self):

--- a/tools/osv_check.py
+++ b/tools/osv_check.py
@@ -108,7 +108,9 @@ def _parse_npm_package(token: str) -> Tuple[Optional[str], Optional[str]]:
         # Scoped: @scope/name@version
         match = re.match(r"^(@[^/]+/[^@]+)(?:@(.+))?$", token)
         if match:
-            return match.group(1), match.group(2)
+            raw_version = match.group(2)
+            version = raw_version if raw_version and raw_version != "latest" else None
+            return match.group(1), version
         return token, None
     # Unscoped: name@version
     if "@" in token:


### PR DESCRIPTION
## Problem

`_parse_npm_package` applied the `@latest → None` filter only in the unscoped branch. Scoped tokens like `@scope/pkg@latest` matched the regex branch and returned `("@scope/pkg", "latest")` instead of `("@scope/pkg", None)`.

## Impact

Passing `version="latest"` to the OSV API yields zero vulnerability matches — the OSV database has no version labelled `"latest"`. Any `npx` call using a scoped package with `@latest` (e.g. `npx -y @modelcontextprotocol/server-filesystem@latest`) would bypass the malware check entirely.

## Fix

Extract `raw_version` from `match.group(2)` and apply the same guard (`raw_version and raw_version != "latest"`) used in the unscoped branch before returning.

## Tests

Added `test_scoped_latest_ignored` to `TestParseNpmPackage` covering:
- `@modelcontextprotocol/server@latest` → `("@modelcontextprotocol/server", None)`
- `@scope/pkg@latest` → `("@scope/pkg", None)`

Full `tests/tools/test_osv_check.py` suite: 25/25 passed.