### PR TITLE
fix(gateway): use portable ps scan for gateway PIDs

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -394,13 +394,30 @@ def _scan_gateway_pids(exclude_pids: set[int], all_profiles: bool = False) -> li
                             pass
                     current_cmd = ""
         else:
-            result = subprocess.run(
-                ["ps", "-A", "eww", "-o", "pid=,command="],
-                capture_output=True,
-                text=True,
-                timeout=10,
+            # Prefer a portable POSIX shape, and avoid Linux-specific ``eww``.
+            # macOS/BSD ps handles ``aux`` consistently but can silently return
+            # empty output for GNU-style flag mixtures; Linux keeps the
+            # structured ``pid=,command=`` form and falls back to ``aux`` for
+            # distros whose ps does not accept ``ww``.
+            ps_commands = (
+                [["ps", "aux"]]
+                if is_macos()
+                else [
+                    ["ps", "-A", "ww", "-o", "pid=,command="],
+                    ["ps", "aux"],
+                ]
             )
-            if result.returncode != 0:
+            result = None
+            for ps_command in ps_commands:
+                result = subprocess.run(
+                    ps_command,
+                    capture_output=True,
+                    text=True,
+                    timeout=10,
+                )
+                if result.returncode == 0 and (result.stdout or "").strip():
+                    break
+            else:
                 return []
             for line in result.stdout.split("\n"):
                 stripped = line.strip()

--- a/tests/hermes_cli/test_gateway.py
+++ b/tests/hermes_cli/test_gateway.py
@@ -342,10 +342,13 @@ def test_install_linux_gateway_from_setup_system_choice_as_root_installs(monkeyp
 def test_find_gateway_pids_falls_back_to_pid_file_when_process_scan_fails(monkeypatch):
     monkeypatch.setattr(gateway, "_get_service_pids", lambda: set())
     monkeypatch.setattr(gateway, "is_windows", lambda: False)
+    monkeypatch.setattr(gateway, "is_macos", lambda: False)
     monkeypatch.setattr("gateway.status.get_running_pid", lambda: 321)
 
     def fake_run(cmd, **kwargs):
-        if cmd[:4] == ["ps", "-A", "eww", "-o"]:
+        if cmd[:4] == ["ps", "-A", "ww", "-o"]:
+            return SimpleNamespace(returncode=1, stdout="", stderr="ps failed")
+        if cmd == ["ps", "aux"]:
             return SimpleNamespace(returncode=1, stdout="", stderr="ps failed")
         if cmd[:3] == ["ps", "-o", "ppid="]:
             # _get_ancestor_pids() walks up the tree; return "no parent" so
@@ -356,6 +359,67 @@ def test_find_gateway_pids_falls_back_to_pid_file_when_process_scan_fails(monkey
     monkeypatch.setattr(gateway.subprocess, "run", fake_run)
 
     assert gateway.find_gateway_pids() == [321]
+
+
+def test_scan_gateway_pids_uses_ps_aux_on_macos(monkeypatch):
+    calls = []
+    monkeypatch.setattr(gateway, "is_windows", lambda: False)
+    monkeypatch.setattr(gateway, "is_macos", lambda: True)
+    monkeypatch.setattr(gateway, "_get_ancestor_pids", lambda: set())
+    monkeypatch.setattr(gateway, "_get_service_pids", lambda: set())
+    monkeypatch.setattr(gateway, "get_hermes_home", lambda: SimpleNamespace(resolve=lambda: "/tmp/hermes"))
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd == ["ps", "aux"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout=(
+                    "USER PID %CPU %MEM VSZ RSS TTY STAT STARTED TIME COMMAND\n"
+                    "me 456 0.0 0.1 1 2 ?? S 12:00 0:00 "
+                    "python -m hermes_cli.main gateway run\n"
+                ),
+                stderr="",
+            )
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    monkeypatch.setattr(gateway.subprocess, "run", fake_run)
+
+    assert gateway.find_gateway_pids() == [456]
+    assert calls == [["ps", "aux"]]
+
+
+def test_scan_gateway_pids_falls_back_to_ps_aux_when_posix_ps_empty(monkeypatch):
+    calls = []
+    monkeypatch.setattr(gateway, "is_windows", lambda: False)
+    monkeypatch.setattr(gateway, "is_macos", lambda: False)
+    monkeypatch.setattr(gateway, "_get_ancestor_pids", lambda: set())
+    monkeypatch.setattr(gateway, "_get_service_pids", lambda: set())
+    monkeypatch.setattr(gateway, "get_hermes_home", lambda: SimpleNamespace(resolve=lambda: "/tmp/hermes"))
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd[:4] == ["ps", "-A", "ww", "-o"]:
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+        if cmd == ["ps", "aux"]:
+            return SimpleNamespace(
+                returncode=0,
+                stdout=(
+                    "USER PID %CPU %MEM VSZ RSS TTY STAT STARTED TIME COMMAND\n"
+                    "me 789 0.0 0.1 1 2 ? S 12:00 0:00 "
+                    "python -m hermes_cli.main gateway run\n"
+                ),
+                stderr="",
+            )
+        raise AssertionError(f"Unexpected command: {cmd}")
+
+    monkeypatch.setattr(gateway.subprocess, "run", fake_run)
+
+    assert gateway.find_gateway_pids() == [789]
+    assert calls == [
+        ["ps", "-A", "ww", "-o", "pid=,command="],
+        ["ps", "aux"],
+    ]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Summary:
- avoid Linux-specific `ps eww` flags when scanning gateway processes on non-Windows systems
- use `ps aux` directly on macOS, where the BSD `ps` output shape is stable for this scan
- keep structured `ps -A ww -o pid=,command=` on other POSIX systems and fall back to `ps aux` when that output is empty
- add regression coverage for macOS command selection and the POSIX fallback path

Why:
- `find_gateway_pids()` backs `hermes gateway status` and update/restart flows
- if the process-table scan returns empty on macOS, Hermes can report that a manual gateway is not running even when it is
- this keeps PID-file detection intact and only hardens the supplemental process scan

Tests:
- `python3 -m pytest tests/hermes_cli/test_gateway.py -q`
- `git diff --check`

Related:
- Follows the same macOS failure mode described in #10684; that PR was closed without merging and current main still contains the incompatible `ps -A eww` scan.
