### PR TITLE
fix(completion): correct zsh _arguments syntax for options with short and long forms

### DIFF
--- a/hermes_cli/completion.py
+++ b/hermes_cli/completion.py
@@ -216,9 +216,9 @@ _hermes() {{
     typeset -A opt_args
 
     _arguments -C \\
-        '(-h --help){{-h,--help}}[Show help and exit]' \\
-        '(-V --version){{-V,--version}}[Show version and exit]' \\
-        '(-p --profile){{-p,--profile}}[Profile name]:profile:_hermes_profiles' \\
+        '(-)'{{-h,--help}}'[Show help and exit]' \\
+        '(-)'{{-V,--version}}'[Show version and exit]' \\
+        '(-)'{{-p,--profile}}'[Profile name]:profile:_hermes_profiles' \\
         '1:command:->commands' \\
         '*::arg:->args'
 

--- a/tests/hermes_cli/test_completion.py
+++ b/tests/hermes_cli/test_completion.py
@@ -140,6 +140,38 @@ class TestGenerateZsh:
         # gateway has subcommands so a _cmds array must be generated
         assert "gateway_cmds" in out
 
+    def test_valid_zsh_arguments_syntax(self):
+        """_arguments entries must use valid zsh syntax.
+
+        The pattern '(-X --Y){-X,--Y}[...]' is invalid because () groups
+        cannot contain long options with spaces.  Correct form:
+        '(-)'{-h,--help}'[...]'
+        """
+        out = generate_zsh(_make_parser())
+        # Reject the broken pattern: a () group containing a long option
+        bad = re.findall(r"\('\([^)]*--\w+", out)
+        assert not bad, f"Invalid _arguments syntax found: {bad}"
+        # Verify the correct pattern is present for top-level options
+        assert "'(-)'{-h,--help}'" in out
+        assert "'(-)'{-V,--version}'" in out
+        assert "'(-)'{-p,--profile}'" in out
+
+    def test_valid_zsh_arguments_syntax(self):
+        """_arguments entries must use valid zsh syntax.
+
+        The pattern '(-X --Y){-X,--Y}[...]' is invalid because () groups
+        cannot contain long options with spaces.  Correct form:
+        '(-)'{-h,--help}'[...]'
+        """
+        out = generate_zsh(_make_parser())
+        # Reject the broken pattern: a () group containing a long option
+        bad = re.findall(r"\('\([^)]*--\w+", out)
+        assert not bad, f"Invalid _arguments syntax found: {bad}"
+        # Verify the correct pattern is present for top-level options
+        assert "'(-)'{-h,--help}'" in out
+        assert "'(-)'{-V,--version}'" in out
+        assert "'(-)'{-p,--profile}'" in out
+
 
 # ---------------------------------------------------------------------------
 # 4. Fish output


### PR DESCRIPTION
## Summary

- Fix invalid `_arguments` syntax in generated zsh completion script
- The pattern `(-h --help){-h,--help}[...]` is rejected by zsh because `()` groups cannot contain long options with spaces
- Changed to `(-)'{-h,--help}'[...]` which is the standard zsh completion convention
- Added regression test to prevent future breakage

Closes #22686