### PR TITLE
Fix Discord channel directory session fallback and deduplication

### DIFF
--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -112,19 +112,25 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
 def _build_discord(adapter) -> List[Dict[str, str]]:
     """Enumerate all text channels and forum channels the Discord bot can see."""
     channels = []
+    seen_ids: set[str] = set()
+    session_entries = _build_from_sessions("discord")
     client = getattr(adapter, "_client", None)
     if not client:
-        return channels
+        return session_entries
 
     try:
         import discord as _discord  # noqa: F401 — SDK presence check
     except ImportError:
-        return channels
+        return session_entries
 
     for guild in client.guilds:
         for ch in guild.text_channels:
+            channel_id = str(ch.id)
+            if channel_id in seen_ids:
+                continue
+            seen_ids.add(channel_id)
             channels.append({
-                "id": str(ch.id),
+                "id": channel_id,
                 "name": ch.name,
                 "guild": guild.name,
                 "type": "channel",
@@ -132,8 +138,12 @@ def _build_discord(adapter) -> List[Dict[str, str]]:
         # Forum channels (type 15) — creating a message auto-spawns a thread post.
         forums = getattr(guild, "forum_channels", None) or []
         for ch in forums:
+            channel_id = str(ch.id)
+            if channel_id in seen_ids:
+                continue
+            seen_ids.add(channel_id)
             channels.append({
-                "id": str(ch.id),
+                "id": channel_id,
                 "name": ch.name,
                 "guild": guild.name,
                 "type": "forum",
@@ -141,8 +151,12 @@ def _build_discord(adapter) -> List[Dict[str, str]]:
         # Also include DM-capable users we've interacted with is not
         # feasible via guild enumeration; those come from sessions.
 
-    # Merge any DMs from session history
-    channels.extend(_build_from_sessions("discord"))
+    # Merge in DM/session-discovered entries without duplicating guild channels.
+    for entry in session_entries:
+        entry_id = entry.get("id")
+        if entry_id and entry_id not in seen_ids:
+            channels.append(entry)
+            seen_ids.add(entry_id)
     return channels
 
 

--- a/tests/gateway/test_channel_directory.py
+++ b/tests/gateway/test_channel_directory.py
@@ -3,11 +3,13 @@
 import asyncio
 import json
 import os
+import sys
 from pathlib import Path
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from gateway.channel_directory import (
+    _build_discord,
     build_channel_directory,
     lookup_channel_type,
     resolve_channel_name,
@@ -357,11 +359,52 @@ def _make_slack_adapter(team_clients):
     return SimpleNamespace(_team_clients=team_clients)
 
 
+def _make_discord_adapter(guilds=None):
+    """Build a stand-in for DiscordAdapter exposing only ``_client``."""
+    return SimpleNamespace(_client=SimpleNamespace(guilds=guilds or []))
+
+
 def _make_slack_client(pages):
     """Build an AsyncWebClient mock whose ``users_conversations`` returns pages."""
     client = MagicMock()
     client.users_conversations = AsyncMock(side_effect=pages)
     return client
+
+
+class TestBuildDiscord:
+    def test_no_client_falls_back_to_sessions(self, tmp_path):
+        sessions_path = tmp_path / "sessions" / "sessions.json"
+        sessions_path.parent.mkdir(parents=True)
+        sessions_path.write_text(json.dumps({
+            "s1": {"origin": {"platform": "discord", "chat_id": "D123", "chat_name": "Alice"}},
+        }))
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            entries = _build_discord(SimpleNamespace(_client=None))
+
+        assert len(entries) == 1
+        assert entries[0]["id"] == "D123"
+
+    def test_session_entries_dedup_api_channels_by_id(self, tmp_path):
+        sessions_path = tmp_path / "sessions" / "sessions.json"
+        sessions_path.parent.mkdir(parents=True)
+        sessions_path.write_text(json.dumps({
+            "dup": {"origin": {"platform": "discord", "chat_id": "123", "chat_name": "general"}},
+            "dm": {"origin": {"platform": "discord", "chat_id": "D456", "chat_name": "Alice"}},
+        }))
+        guild = SimpleNamespace(
+            name="MyServer",
+            text_channels=[SimpleNamespace(id=123, name="general")],
+            forum_channels=[],
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}), \
+             patch.dict(sys.modules, {"discord": SimpleNamespace()}):
+            entries = _build_discord(_make_discord_adapter([guild]))
+
+        ids = [entry["id"] for entry in entries]
+        assert ids.count("123") == 1
+        assert "D456" in ids
 
 
 class TestBuildSlack:


### PR DESCRIPTION
## Summary

Fix Discord channel directory construction so it:
- falls back to session-derived entries when the Discord client is unavailable
- avoids duplicate entries when a guild channel is also present in session history

## Problem

`_build_discord()` currently returns an empty list when the Discord client is missing or the Discord SDK is unavailable, even if Hermes already has Discord targets in session history.

It also appends session-derived Discord entries after enumerating guild channels without deduplicating by channel ID. This can produce duplicate directory entries for the same channel and degrade list/lookup behavior.

## Root cause

The Discord path did not mirror the safer merge pattern already used elsewhere:
- no session fallback on missing client/import
- no `id`-based dedup between API-enumerated channels and session-derived entries

## Fix

- Load Discord session entries up front
- Return session entries instead of `[]` when `_client` is absent or `discord` cannot be imported
- Track seen channel IDs while enumerating guild text/forum channels
- Merge session-derived entries only if their `id` has not already been seen

## Tests

Added regression coverage for:
- session fallback when no Discord client is present
- deduplication when a session entry matches a guild channel ID, while still preserving distinct DM/session-only entries

## Validation

Targeted test result:
- `pytest tests/gateway/test_channel_directory.py -q`
- `35 passed in 3.41s`

Notes:
- broader gateway suite failures observed locally were in unrelated Feishu / Google Chat / WhatsApp / runtime-footer areas and do not touch `channel_directory`
