### PR TITLE
feat: add Engram memory provider — local-first DAG knowledge graph

### DIFF
--- a/plugins/memory/engram/README.md
+++ b/plugins/memory/engram/README.md
@@ -1,0 +1,101 @@
+# Engram Memory Provider for Hermes Agent
+
+Plugs Engram's DAG-based knowledge graph into [Hermes Agent](https://github.com/nousresearch/hermes-agent) as a first-class memory provider.
+
+- **`prefetch()`** — BFS retrieval injects structured context (decisions, constraints, implementations) before each LLM call
+- **`sync_turn()`** — incremental fact extraction runs in the background after each turn; the graph grows automatically
+- **Tools** — exposes `engram_query` (semantic BFS search) and `engram_recall` (tag-based lookup) to the Hermes LLM
+
+## Why Engram vs other Hermes memory providers
+
+| | Engram | Mem0 | Hindsight | Honcho |
+|---|---|---|---|---|
+| Infrastructure | None (SQLite file) | Cloud API | Cloud API | Cloud API |
+| Graph structure | DAG + typed edges | Flat cards | Entity graph | Flat |
+| Supersession | Yes (structural) | No | Partial | No |
+| Temporal validity | Yes (`valid_to`, `occurred_at`) | No | No | No |
+| Air-gapped / offline | Yes | No | No | No |
+| Open source | Yes | Partial | No | No |
+
+## Installation
+
+### Option A — copy into a Hermes installation
+
+```bash
+cp -r hermes_plugin/ /path/to/hermes-agent/plugins/memory/engram/
+pip install engram
+```
+
+### Option B — install as a package (coming soon)
+
+```bash
+pip install engram-hermes
+```
+
+## Configuration
+
+### Via `hermes memory setup`
+
+Run `hermes memory setup` and select `engram`. You'll be prompted for:
+
+| Field | Description | Required |
+|---|---|---|
+| `project` | Engram project name (must already exist: `engram init <project>`) | Yes |
+| `db_path` | Explicit path to `context.db` (overrides project lookup) | No |
+| `config_path` | Path to Engram `config.yaml` | No |
+| `top_k` | Max nodes per retrieval (default: 10) | No |
+| `hops` | BFS traversal depth (default: 3) | No |
+| `auto_extract` | Extract facts from turns automatically (default: true) | No |
+
+### Via environment variables
+
+```bash
+export ENGRAM_PROJECT=my-project
+export ENGRAM_TOP_K=15
+export ENGRAM_HOPS=3
+export ENGRAM_EXTRACT=1   # set to "0" to disable auto-extraction
+```
+
+## Setup
+
+1. **Create an Engram project** (if you don't have one):
+   ```bash
+   engram init my-project
+   ```
+
+2. **Optionally seed it** with existing transcripts:
+   ```bash
+   engram extract my-project transcript.md --verify
+   ```
+
+3. **Start Hermes** with the Engram provider selected.
+
+The graph grows automatically as Hermes has conversations — each session's turns are buffered and extracted in the background.
+
+## How it works
+
+```
+Hermes LLM call
+     │
+     ▼ prefetch(query)                     ← BFS retrieval, sub-second
+EngramMemoryProvider
+     │ returns structured markdown context
+     ▼
+LLM call with context injected
+
+     │ after response
+     ▼ sync_turn(user, assistant)          ← buffer turn content (non-blocking)
+ExtractionBuffer
+     │ when buffer threshold reached (3 turns or 200 words)
+     ▼ background thread
+LLM extraction → new nodes merged into graph
+```
+
+The extraction LLM call happens in the background; Hermes never blocks waiting for it.
+
+## Contributing
+
+To submit this provider to the upstream Hermes repo:
+1. Fork `nousresearch/hermes-agent`
+2. Copy `hermes_plugin/` to `plugins/memory/engram/`
+3. Submit a PR

--- a/plugins/memory/engram/__init__.py
+++ b/plugins/memory/engram/__init__.py
@@ -1,0 +1,478 @@
+"""Engram memory provider plugin for Hermes Agent.
+
+Implements the Hermes MemoryProvider interface to provide structured,
+DAG-based long-term memory backed by an Engram knowledge graph.
+
+Installation (into a Hermes Agent installation):
+    cp -r hermes_plugin/ /path/to/hermes-agent/plugins/memory/engram/
+    pip install engram  # or pip install -e /path/to/engram
+
+Configuration (hermes memory setup, or set env vars):
+    ENGRAM_PROJECT   — project name (required)
+    ENGRAM_DB_PATH   — explicit path to context.db (optional; overrides project lookup)
+    ENGRAM_CONFIG    — path to Engram config.yaml (optional)
+    ENGRAM_TOP_K     — max nodes per retrieval (default: 10)
+    ENGRAM_HOPS      — BFS traversal depth (default: 3)
+    ENGRAM_EXTRACT   — set to "0" to disable auto-extraction on sync_turn (default: enabled)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import threading
+from pathlib import Path
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Lazy MemoryProvider base — import from hermes at runtime so the plugin file
+# is importable even outside a Hermes installation (e.g. during tests).
+# ---------------------------------------------------------------------------
+
+def _get_base():
+    try:
+        from agent.memory_provider import MemoryProvider
+        return MemoryProvider
+    except ImportError:
+        # Running outside Hermes (tests, standalone); use a no-op base class.
+        class _Stub:
+            pass
+        return _Stub
+
+
+# ---------------------------------------------------------------------------
+# EngramMemoryProvider
+# ---------------------------------------------------------------------------
+
+class EngramMemoryProvider(_get_base()):
+    """Hermes MemoryProvider backed by an Engram knowledge graph.
+
+    - prefetch(): BFS retrieval injects structured context before each LLM call
+    - sync_turn(): incremental extraction runs in background after each turn
+    - Tools: engram_query (semantic search), engram_recall (full node dump by tags)
+    """
+
+    @property
+    def name(self) -> str:
+        return "engram"
+
+    # ------------------------------------------------------------------
+    # Configuration
+    # ------------------------------------------------------------------
+
+    def _load_engram_config(self) -> dict:
+        """Load Engram config from file or fall back to defaults."""
+        from engram.config import load_config
+        config_path = os.environ.get("ENGRAM_CONFIG") or self._config.get("config_path")
+        return load_config(config_path)
+
+    def _resolve_db_path(self) -> Path:
+        """Resolve the SQLite DB path for the configured project."""
+        explicit = os.environ.get("ENGRAM_DB_PATH") or self._config.get("db_path")
+        if explicit:
+            return Path(explicit).expanduser()
+        from engram.config import get_db_path
+        return get_db_path(self._engram_config, self._project)
+
+    # ------------------------------------------------------------------
+    # Required abstract methods
+    # ------------------------------------------------------------------
+
+    def is_available(self) -> bool:
+        """Return True if the configured Engram project DB exists."""
+        try:
+            self._load_engram_config()
+        except Exception:
+            return False
+        project = os.environ.get("ENGRAM_PROJECT") or self._config.get("project", "")
+        if not project:
+            return False
+        try:
+            from engram.config import load_config, get_db_path
+            cfg = load_config(os.environ.get("ENGRAM_CONFIG") or self._config.get("config_path"))
+            db = get_db_path(cfg, project)
+            return db.exists()
+        except Exception:
+            return False
+
+    def initialize(self, session_id: str, **kwargs) -> None:
+        """Set up the provider for the session.
+
+        Called once at agent startup. Reads config, opens the GraphStore,
+        and initialises the extraction buffer and background thread machinery.
+        """
+        hermes_home = kwargs.get("hermes_home", str(Path.home() / ".hermes"))
+        self._hermes_home = Path(hermes_home)
+        self._session_id = session_id
+        self._platform = kwargs.get("platform", "cli")
+
+        # Load persisted config from $HERMES_HOME/engram.json (or env vars)
+        config_file = self._hermes_home / "engram.json"
+        self._config: dict = {}
+        if config_file.exists():
+            try:
+                self._config = json.loads(config_file.read_text())
+            except Exception as e:
+                log.warning("engram: failed to read %s: %s", config_file, e)
+
+        # Resolve project name
+        self._project = (
+            os.environ.get("ENGRAM_PROJECT")
+            or self._config.get("project")
+            or ""
+        )
+        if not self._project:
+            log.warning("engram: ENGRAM_PROJECT not set — provider disabled")
+            self._store = None
+            return
+
+        # Load Engram config and open store
+        try:
+            self._engram_config = self._load_engram_config()
+            db_path = self._resolve_db_path()
+            from engram.store import GraphStore
+            self._store = GraphStore(db_path)
+        except Exception as e:
+            log.error("engram: failed to open graph store: %s", e)
+            self._store = None
+            return
+
+        # Retrieval settings
+        self._top_k = int(
+            os.environ.get("ENGRAM_TOP_K")
+            or self._config.get("top_k")
+            or self._engram_config.get("defaults", {}).get("top_k", 10)
+        )
+        self._hops = int(
+            os.environ.get("ENGRAM_HOPS")
+            or self._config.get("hops")
+            or self._engram_config.get("defaults", {}).get("hops", 3)
+        )
+        self._auto_extract = (
+            os.environ.get("ENGRAM_EXTRACT", "1") != "0"
+            and self._config.get("auto_extract", True)
+        )
+
+        # Extraction buffer and threading
+        from engram.extractor import ExtractionBuffer
+        self._buffer = ExtractionBuffer(
+            min_turns=self._engram_config.get("incremental", {}).get("min_turns", 3),
+            min_words=self._engram_config.get("incremental", {}).get("min_words", 200),
+            max_turns=self._engram_config.get("incremental", {}).get("max_turns", 10),
+        )
+        self._buffer_lock = threading.Lock()
+        self._extract_thread: threading.Thread | None = None
+        self._shutdown_event = threading.Event()
+
+        # Last prefetch result (written by background thread, read on next turn)
+        self._prefetch_result: str = ""
+        self._prefetch_lock = threading.Lock()
+        self._prefetch_thread: threading.Thread | None = None
+
+        log.info(
+            "engram: initialised — project=%s top_k=%d hops=%d auto_extract=%s",
+            self._project, self._top_k, self._hops, self._auto_extract,
+        )
+
+    def get_tool_schemas(self) -> list[dict]:
+        """Return OpenAI-format tool definitions exposed to Hermes."""
+        return [
+            {
+                "name": "engram_query",
+                "description": (
+                    "Search the Engram knowledge graph for facts relevant to a task or question. "
+                    "Returns structured context: decisions, constraints, implementations, and more. "
+                    "Use this when you need to recall project-specific facts, past decisions, or "
+                    "architectural context."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "description": "Natural language description of what you want to recall.",
+                        },
+                        "top_k": {
+                            "type": "integer",
+                            "description": "Max nodes to return (default: provider default).",
+                        },
+                    },
+                    "required": ["query"],
+                },
+            },
+            {
+                "name": "engram_recall",
+                "description": (
+                    "Retrieve all active knowledge graph nodes matching one or more tags. "
+                    "Useful for 'show me everything about X' queries where BFS traversal "
+                    "isn't needed. Returns raw node list."
+                ),
+                "parameters": {
+                    "type": "object",
+                    "properties": {
+                        "tags": {
+                            "type": "array",
+                            "items": {"type": "string"},
+                            "description": "Tags to match (OR logic — any match returns the node).",
+                        },
+                    },
+                    "required": ["tags"],
+                },
+            },
+        ]
+
+    # ------------------------------------------------------------------
+    # Optional lifecycle hooks
+    # ------------------------------------------------------------------
+
+    def system_prompt_block(self) -> str:
+        """Inject a brief note into the system prompt about Engram."""
+        if not self._store:
+            return ""
+        try:
+            stats = self._store.get_stats()
+            return (
+                f"[Engram memory: {stats['node_count']} nodes, project '{self._project}'. "
+                f"Call engram_query to search project knowledge.]"
+            )
+        except Exception:
+            return "[Engram memory: active]"
+
+    def prefetch(self, query: str, session_id: str | None = None) -> str:
+        """Retrieve relevant context before the LLM call.
+
+        Returns formatted markdown. Called synchronously but must complete
+        within the Hermes 5-second deadline. BFS retrieval is sub-second.
+        """
+        if not self._store:
+            return ""
+        try:
+            from engram.retriever import retrieve
+            strategies = self._engram_config.get("strategies", {})
+            result = retrieve(
+                self._store,
+                query,
+                hops=self._hops,
+                top_k=self._top_k,
+                strategies=strategies,
+            )
+            return result or ""
+        except Exception as e:
+            log.warning("engram: prefetch failed: %s", e)
+            return ""
+
+    def queue_prefetch(self, query: str, session_id: str | None = None) -> None:
+        """Kick off a background prefetch for the next turn."""
+        if not self._store:
+            return
+
+        def _run():
+            result = self.prefetch(query, session_id)
+            with self._prefetch_lock:
+                self._prefetch_result = result
+
+        t = threading.Thread(target=_run, daemon=True)
+        t.start()
+        with self._prefetch_lock:
+            self._prefetch_thread = t
+
+    def sync_turn(
+        self,
+        user_content: str,
+        assistant_content: str,
+        session_id: str | None = None,
+    ) -> None:
+        """Persist a completed turn. MUST be non-blocking.
+
+        Buffers user + assistant content and triggers background extraction
+        when the buffer reaches the flush threshold.
+        """
+        if not self._store or not self._auto_extract:
+            return
+
+        turn_text = f"Human: {user_content}\n\nAssistant: {assistant_content}"
+
+        with self._buffer_lock:
+            should_flush = self._buffer.add(turn_text)
+            if should_flush:
+                text_to_extract = self._buffer.flush()
+            else:
+                text_to_extract = None
+
+        if text_to_extract:
+            self._spawn_extraction(text_to_extract)
+
+    def on_session_end(self, messages: list | None = None) -> None:
+        """Flush remaining buffered turns on session end."""
+        if not self._store or not self._auto_extract:
+            return
+        with self._buffer_lock:
+            text = self._buffer.flush_if_nonempty()
+        if text:
+            self._spawn_extraction(text)
+        # Wait briefly for any in-flight extraction to finish
+        if self._extract_thread and self._extract_thread.is_alive():
+            self._extract_thread.join(timeout=30)
+
+    def handle_tool_call(self, tool_name: str, args: dict, **kwargs) -> str:
+        """Dispatch Engram tool calls from the LLM.
+
+        Returns a JSON string (per Hermes contract).
+        """
+        try:
+            if tool_name == "engram_query":
+                return self._handle_query(args)
+            elif tool_name == "engram_recall":
+                return self._handle_recall(args)
+            else:
+                return json.dumps({"error": f"Unknown tool: {tool_name}"})
+        except Exception as e:
+            log.error("engram: tool call %s failed: %s", tool_name, e)
+            return json.dumps({"error": str(e)})
+
+    def shutdown(self) -> None:
+        """Clean shutdown: flush buffer and close store."""
+        self._shutdown_event.set()
+        # Flush remaining buffer
+        if self._store and self._auto_extract:
+            with self._buffer_lock:
+                text = self._buffer.flush_if_nonempty()
+            if text:
+                self._spawn_extraction(text)
+        # Wait for in-flight extraction
+        if self._extract_thread and self._extract_thread.is_alive():
+            self._extract_thread.join(timeout=15)
+        if self._store:
+            try:
+                self._store.close()
+            except Exception:
+                pass
+
+    def get_config_schema(self) -> list[dict]:
+        """Config fields for 'hermes memory setup'."""
+        return [
+            {
+                "key": "project",
+                "description": "Engram project name",
+                "required": True,
+                "secret": False,
+                "env_var": "ENGRAM_PROJECT",
+            },
+            {
+                "key": "db_path",
+                "description": "Explicit path to context.db (optional — overrides project lookup)",
+                "required": False,
+                "secret": False,
+                "env_var": "ENGRAM_DB_PATH",
+            },
+            {
+                "key": "config_path",
+                "description": "Path to Engram config.yaml (optional)",
+                "required": False,
+                "secret": False,
+                "env_var": "ENGRAM_CONFIG",
+            },
+            {
+                "key": "top_k",
+                "description": "Max nodes per retrieval query (default: 10)",
+                "required": False,
+                "secret": False,
+                "env_var": "ENGRAM_TOP_K",
+                "default": 10,
+            },
+            {
+                "key": "hops",
+                "description": "BFS traversal depth (default: 3)",
+                "required": False,
+                "secret": False,
+                "env_var": "ENGRAM_HOPS",
+                "default": 3,
+            },
+            {
+                "key": "auto_extract",
+                "description": "Extract facts from turns into the graph automatically (default: true)",
+                "required": False,
+                "secret": False,
+                "env_var": "ENGRAM_EXTRACT",
+                "default": True,
+            },
+        ]
+
+    def save_config(self, values: dict, hermes_home: str) -> None:
+        """Write provider config to $HERMES_HOME/engram.json."""
+        config_file = Path(hermes_home) / "engram.json"
+        config_file.write_text(json.dumps(values, indent=2))
+        log.info("engram: config saved to %s", config_file)
+
+    # ------------------------------------------------------------------
+    # Private helpers
+    # ------------------------------------------------------------------
+
+    def _handle_query(self, args: dict) -> str:
+        query = args.get("query", "")
+        top_k = int(args.get("top_k") or self._top_k)
+        from engram.retriever import retrieve
+        strategies = self._engram_config.get("strategies", {})
+        result = retrieve(self._store, query, hops=self._hops, top_k=top_k, strategies=strategies)
+        return json.dumps({"context": result or "(no results)", "project": self._project})
+
+    def _handle_recall(self, args: dict) -> str:
+        tags = args.get("tags", [])
+        if not tags:
+            return json.dumps({"error": "tags array is required"})
+        nodes = self._store.get_nodes_by_tags(tags)[: self._top_k * 3]
+        items = [
+            {"id": n["id"], "fact": n["fact"], "type": n.get("type"), "confidence": n.get("confidence")}
+            for n in nodes
+        ]
+        return json.dumps({"nodes": items, "count": len(items), "project": self._project})
+
+    def _spawn_extraction(self, text: str) -> None:
+        """Spawn a daemon thread to run LLM extraction on buffered text."""
+        def _run():
+            try:
+                loop = asyncio.new_event_loop()
+                asyncio.set_event_loop(loop)
+                try:
+                    loop.run_until_complete(self._do_extract(text))
+                finally:
+                    loop.close()
+            except Exception as e:
+                log.error("engram: background extraction failed: %s", e)
+
+        t = threading.Thread(target=_run, daemon=True, name="engram-extract")
+        t.start()
+        self._extract_thread = t
+
+    async def _do_extract(self, text: str) -> None:
+        """Run LLM extraction and merge results into the graph."""
+        from engram.extractor import extract
+        from engram.store import GraphStore
+
+        # Re-open store in this thread (SQLite is not thread-safe across threads)
+        db_path = self._resolve_db_path()
+        store = GraphStore(db_path)
+        try:
+            result = await extract(text, self._engram_config, store=store)
+            nodes = result.get("nodes", [])
+            edges = result.get("edges", [])
+            if nodes:
+                store.merge_extraction(nodes, edges)
+                log.info("engram: extracted %d nodes from turn buffer", len(nodes))
+        except Exception as e:
+            log.warning("engram: extraction error: %s", e)
+        finally:
+            store.close()
+
+
+# ---------------------------------------------------------------------------
+# Plugin registration entrypoint
+# ---------------------------------------------------------------------------
+
+def register(ctx) -> None:
+    """Called by Hermes plugin loader to register this provider."""
+    ctx.register_memory_provider(EngramMemoryProvider())

--- a/plugins/memory/engram/plugin.yaml
+++ b/plugins/memory/engram/plugin.yaml
@@ -1,0 +1,9 @@
+name: engram
+version: 0.1.0
+description: >
+  Engram — structured, DAG-based long-term memory for Hermes Agent.
+  Extracts facts from conversations into a typed knowledge graph (SQLite, zero infra)
+  and retrieves relevant subgraphs via BFS traversal. Supports confidence scoring,
+  temporal validity, supersession tracking, and fully offline / air-gapped operation.
+pip_dependencies:
+  - engram


### PR DESCRIPTION
## Summary

Adds Engram as a first-class Hermes memory provider — a local-first, DAG-based knowledge graph that extracts typed facts from conversations and retrieves relevant subgraphs via BFS traversal.

**Why Engram?**

| | Engram | Mem0 | Hindsight | Honcho |
|---|---|---|---|---|
| Infrastructure | None (SQLite file) | Cloud API | Cloud API | Cloud API |
| Graph structure | DAG + typed edges | Flat cards | Entity graph | Flat |
| Supersession tracking | Yes (structural) | No | Partial | No |
| Temporal validity | Yes (\`valid_to\`, \`occurred_at\`) | No | No | No |
| Air-gapped / offline | Yes | No | No | No |
| Open source | Yes | Partial | No | No |

## What it does

- **\`prefetch()\`** — BFS retrieval injects structured context (decisions, constraints, implementations, transitions) before each LLM call. Sub-second, synchronous, safe within the 5-second Hermes deadline.
- **\`sync_turn()\`** — Buffers user + assistant content after each turn; triggers background LLM extraction when the buffer threshold is reached. Non-blocking.
- **\`engram_query\` tool** — Semantic BFS search exposed to the Hermes LLM for explicit knowledge graph queries
- **\`engram_recall\` tool** — Tag-based node lookup for "show me everything about X" queries

## Setup

\`\`\`bash
# Install Engram
pip install engram

# Initialize a project
engram init my-project

# Configure via hermes memory setup, or set env vars:
export ENGRAM_PROJECT=my-project
\`\`\`

## Configuration

| Env var | Description | Default |
|---|---|---|
| \`ENGRAM_PROJECT\` | Project name (required) | — |
| \`ENGRAM_DB_PATH\` | Explicit path to context.db | auto |
| \`ENGRAM_TOP_K\` | Max nodes per retrieval | 10 |
| \`ENGRAM_HOPS\` | BFS traversal depth | 3 |
| \`ENGRAM_EXTRACT\` | Auto-extraction on/off | 1 |

## Testing

The plugin is importable and tested outside a Hermes installation. The \`register()\` entrypoint follows the established plugin pattern. Gracefully degrades if \`ENGRAM_PROJECT\` is unset.

Generated with [Claude Code](https://claude.ai/claude-code)