### PR TITLE
fix(gateway): strip ANSI from process watcher notifications

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12477,6 +12477,7 @@ class GatewayRunner:
           - ``error``  — final message only when exit code != 0
           - ``off``    — no messages at all
         """
+        from tools.ansi_strip import strip_ansi
         from tools.process_registry import process_registry
 
         session_id = watcher["session_id"]
@@ -12521,7 +12522,6 @@ class GatewayRunner:
                 # Skip if the agent already consumed the result via wait/poll/log
                 from tools.process_registry import process_registry as _pr_check
                 if agent_notify and not _pr_check.is_completion_consumed(session_id):
-                    from tools.ansi_strip import strip_ansi
                     _out = strip_ansi(session.output_buffer[-2000:]) if session.output_buffer else ""
                     synth_text = (
                         f"[IMPORTANT: Background process {session_id} completed "
@@ -12577,7 +12577,7 @@ class GatewayRunner:
                     or (notify_mode == "error" and session.exit_code not in (0, None))
                 )
                 if should_notify:
-                    new_output = session.output_buffer[-1000:] if session.output_buffer else ""
+                    new_output = strip_ansi(session.output_buffer[-1000:]) if session.output_buffer else ""
                     message_text = (
                         f"[Background process {session_id} finished with exit code {session.exit_code}~ "
                         f"Here's the final output:\n{new_output}]"
@@ -12598,7 +12598,7 @@ class GatewayRunner:
             elif has_new_output and notify_mode == "all" and not agent_notify:
                 # New output available -- deliver status update (only in "all" mode)
                 # Skip periodic updates for agent_notify watchers (they only care about completion)
-                new_output = session.output_buffer[-500:] if session.output_buffer else ""
+                new_output = strip_ansi(session.output_buffer[-500:]) if session.output_buffer else ""
                 message_text = (
                     f"[Background process {session_id} is still running~ "
                     f"New output:\n{new_output}]"

--- a/tests/gateway/test_background_process_notifications.py
+++ b/tests/gateway/test_background_process_notifications.py
@@ -246,6 +246,64 @@ async def test_no_thread_id_sends_no_metadata(monkeypatch, tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_finished_notification_strips_ansi_output(monkeypatch, tmp_path):
+    """Final background-process chat notifications should not leak ANSI codes."""
+    import tools.process_registry as pr_module
+
+    sessions = [
+        SimpleNamespace(
+            output_buffer="\x1b[31mred failure\x1b[0m\n\x1b[2Kclean line\n",
+            exited=True,
+            exit_code=1,
+        )
+    ]
+    monkeypatch.setattr(pr_module, "process_registry", _FakeRegistry(sessions))
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runner = _build_runner(monkeypatch, tmp_path, "result")
+    adapter = runner.adapters[Platform.TELEGRAM]
+
+    await runner._run_process_watcher(_watcher_dict())
+
+    sent_message = adapter.send.await_args.args[1]
+    assert "red failure" in sent_message
+    assert "clean line" in sent_message
+    assert "\x1b[" not in sent_message
+
+
+@pytest.mark.asyncio
+async def test_running_notification_strips_ansi_output(monkeypatch, tmp_path):
+    """Incremental background-process chat updates should not leak ANSI codes."""
+    import tools.process_registry as pr_module
+
+    sessions = [
+        SimpleNamespace(
+            output_buffer="\x1b[32mbuilding\x1b[0m...\r\x1b[K\n",
+            exited=False,
+            exit_code=None,
+        ),
+        None,
+    ]
+    monkeypatch.setattr(pr_module, "process_registry", _FakeRegistry(sessions))
+
+    async def _instant_sleep(*_a, **_kw):
+        pass
+    monkeypatch.setattr(asyncio, "sleep", _instant_sleep)
+
+    runner = _build_runner(monkeypatch, tmp_path, "all")
+    adapter = runner.adapters[Platform.TELEGRAM]
+
+    await runner._run_process_watcher(_watcher_dict())
+
+    sent_message = adapter.send.await_args.args[1]
+    assert "building" in sent_message
+    assert "\x1b[" not in sent_message
+
+
+@pytest.mark.asyncio
 async def test_inject_watch_notification_routes_from_session_store_origin(monkeypatch, tmp_path):
     from gateway.session import SessionSource
 


### PR DESCRIPTION
## Summary
- strip ANSI escape sequences from normal background process watcher completion messages
- strip ANSI escape sequences from incremental running-output notifications
- add regression coverage for both notification paths

## Tests
- `python -m pytest tests/gateway/test_background_process_notifications.py -q`
