### PR TITLE
fix(telegram): use native quote text for partial reply context

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -4031,7 +4031,12 @@ class TelegramAdapter(BasePlatformAdapter):
         reply_to_text = None
         if message.reply_to_message:
             reply_to_id = str(message.reply_to_message.message_id)
-            reply_to_text = message.reply_to_message.text or message.reply_to_message.caption or None
+            # Use native partial quote text if available (Telegram's quote/reply feature),
+            # otherwise fall back to the full replied-to message text/caption.
+            if getattr(message, "quote", None):
+                reply_to_text = message.quote.text
+            else:
+                reply_to_text = message.reply_to_message.text or message.reply_to_message.caption or None
 
         # Per-channel/topic ephemeral prompt
         from gateway.platforms.base import resolve_channel_prompt

--- a/tests/gateway/test_dm_topics.py
+++ b/tests/gateway/test_dm_topics.py
@@ -738,3 +738,79 @@ def test_build_message_event_dm_from_user_present_uses_user():
     # Normal case — from_user is used directly
     assert event.source.user_id == "99999"
     assert event.source.user_name == "Bob"
+
+
+# ── _build_message_event: native Telegram quote (partial reply) ──
+
+
+def _make_mock_message_with_reply(chat_id=111, chat_type="private", text="reply text",
+                                   user_id=42, user_name="Test User",
+                                   reply_to_id=500, reply_to_text="original full message",
+                                   quote_text=None):
+    """Create a mock Telegram Message with a reply-to message, optionally with a native quote."""
+    chat = SimpleNamespace(id=chat_id, type=chat_type, title=None)
+    chat.full_name = user_name
+    user = SimpleNamespace(id=user_id, full_name=user_name)
+    reply_to_msg = SimpleNamespace(
+        message_id=reply_to_id,
+        text=reply_to_text,
+        caption=None,
+    )
+    msg = SimpleNamespace(
+        chat=chat,
+        from_user=user,
+        text=text,
+        message_thread_id=None,
+        message_id=1001,
+        reply_to_message=reply_to_msg,
+        date=None,
+        forum_topic_created=None,
+    )
+    if quote_text is not None:
+        msg.quote = SimpleNamespace(text=quote_text)
+    return msg
+
+
+def test_build_message_event_uses_native_quote_text_when_available():
+    """When message.quote exists (Telegram partial quote), reply_to_text should use quote.text."""
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter()
+    msg = _make_mock_message_with_reply(
+        reply_to_text="original full message with multiple sections",
+        quote_text="only the selected quoted part",
+    )
+
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.reply_to_message_id == "500"
+    assert event.reply_to_text == "only the selected quoted part"
+
+
+def test_build_message_event_falls_back_to_full_text_without_quote():
+    """When no native quote exists, reply_to_text should fall back to reply_to_message.text."""
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter()
+    msg = _make_mock_message_with_reply(
+        reply_to_text="original full message",
+        quote_text=None,
+    )
+
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.reply_to_message_id == "500"
+    assert event.reply_to_text == "original full message"
+
+
+def test_build_message_event_no_reply_context():
+    """Messages without reply_to_message should have None reply_to fields."""
+    from gateway.platforms.base import MessageType
+
+    adapter = _make_adapter()
+    msg = _make_mock_message(chat_id=111, text="standalone message")
+
+    event = adapter._build_message_event(msg, MessageType.TEXT)
+
+    assert event.reply_to_message_id is None
+    assert event.reply_to_text is None


### PR DESCRIPTION
## Summary

- Fixes a bug where Telegram's native partial quote feature was ignored, causing the agent to receive the entire replied-to message instead of just the user-selected quoted text
- When `message.quote` (TextQuote) is available, the adapter now uses `quote.text` as `reply_to_text`, falling back to the full `reply_to_message.text` only when no native quote exists
- Adds 3 tests covering: native quote usage, fallback to full text, and no-reply-context messages

## Why

When a user replies using Telegram's native quote feature to select only part of a previous message, the adapter was ignoring `message.quote` and injecting the entire replied-to message as `reply_to_text`. This could materially change the user's intent — for example, if Hermes sent a multi-item briefing and the user quoted just one item with "mark this done", the agent would see the entire briefing and might act on the wrong item.

The fix uses `python-telegram-bot`'s existing `Message.quote` / `TextQuote` API (documented since v22.7) to respect the user's selected quote text.

Closes #22619