### PR TITLE
fix(kanban): tolerate concurrent DB migrations

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -963,18 +963,45 @@ def init_db(
     return path
 
 
+def _add_column_if_missing(
+    conn: sqlite3.Connection,
+    table: str,
+    known_cols: set[str],
+    column: str,
+    column_sql: str,
+) -> bool:
+    """Idempotently add a column to a SQLite table.
+
+    ``known_cols`` is a point-in-time PRAGMA snapshot. Another Hermes process
+    may migrate the same DB between that snapshot and our ALTER TABLE, so treat
+    SQLite's duplicate-column error as success and update the snapshot.
+    """
+    if column in known_cols:
+        return False
+    try:
+        conn.execute(f"ALTER TABLE {table} ADD COLUMN {column_sql}")
+    except sqlite3.OperationalError as exc:
+        if "duplicate column name" not in str(exc).lower():
+            raise
+        known_cols.add(column)
+        return False
+    known_cols.add(column)
+    return True
+
+
 def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     """Add columns that were introduced after v1 release to legacy DBs.
 
     Called by ``init_db`` so opening an old DB is always safe.
     """
     cols = {row["name"] for row in conn.execute("PRAGMA table_info(tasks)")}
-    if "tenant" not in cols:
-        conn.execute("ALTER TABLE tasks ADD COLUMN tenant TEXT")
-    if "result" not in cols:
-        conn.execute("ALTER TABLE tasks ADD COLUMN result TEXT")
-    if "idempotency_key" not in cols:
-        conn.execute("ALTER TABLE tasks ADD COLUMN idempotency_key TEXT")
+    if _add_column_if_missing(conn, "tasks", cols, "tenant", "tenant TEXT"):
+        pass
+    if _add_column_if_missing(conn, "tasks", cols, "result", "result TEXT"):
+        pass
+    if _add_column_if_missing(
+        conn, "tasks", cols, "idempotency_key", "idempotency_key TEXT"
+    ):
         conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_tasks_idempotency "
             "ON tasks(idempotency_key)"
@@ -992,56 +1019,66 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
     # ADD-first-then-copy is tolerant of both shapes and preserves
     # historical counter values when the legacy columns do exist.
     #
-    # NOTE: ``cols`` reflects the schema at entry to this function and is
-    # not refreshed between ALTER TABLE calls.  Every guard below checks
-    # the *original* snapshot; this is intentional and safe as long as
-    # no step depends on a column added by a previous step in the same call.
-    if "consecutive_failures" not in cols:
-        conn.execute(
-            "ALTER TABLE tasks ADD COLUMN consecutive_failures "
-            "INTEGER NOT NULL DEFAULT 0"
-        )
+    # NOTE: ``cols`` reflects the schema at entry to this function, and
+    # ``_add_column_if_missing`` updates it as local ALTER TABLE calls
+    # succeed.  If another Hermes process wins the same migration race, the
+    # helper treats SQLite's duplicate-column error as a no-op.
+    if _add_column_if_missing(
+        conn,
+        "tasks",
+        cols,
+        "consecutive_failures",
+        "consecutive_failures INTEGER NOT NULL DEFAULT 0",
+    ):
         if "spawn_failures" in cols:
             conn.execute(
                 "UPDATE tasks SET consecutive_failures = COALESCE(spawn_failures, 0)"
             )
-    if "worker_pid" not in cols:
-        conn.execute("ALTER TABLE tasks ADD COLUMN worker_pid INTEGER")
-    if "last_failure_error" not in cols:
-        conn.execute("ALTER TABLE tasks ADD COLUMN last_failure_error TEXT")
+    _add_column_if_missing(conn, "tasks", cols, "worker_pid", "worker_pid INTEGER")
+    if _add_column_if_missing(
+        conn, "tasks", cols, "last_failure_error", "last_failure_error TEXT"
+    ):
         if "last_spawn_error" in cols:
             conn.execute(
                 "UPDATE tasks SET last_failure_error = last_spawn_error"
             )
-    if "max_runtime_seconds" not in cols:
-        conn.execute("ALTER TABLE tasks ADD COLUMN max_runtime_seconds INTEGER")
-    if "last_heartbeat_at" not in cols:
-        conn.execute("ALTER TABLE tasks ADD COLUMN last_heartbeat_at INTEGER")
-    if "current_run_id" not in cols:
-        conn.execute("ALTER TABLE tasks ADD COLUMN current_run_id INTEGER")
-    if "workflow_template_id" not in cols:
-        conn.execute("ALTER TABLE tasks ADD COLUMN workflow_template_id TEXT")
-    if "current_step_key" not in cols:
-        conn.execute("ALTER TABLE tasks ADD COLUMN current_step_key TEXT")
-    if "skills" not in cols:
+    _add_column_if_missing(
+        conn, "tasks", cols, "max_runtime_seconds", "max_runtime_seconds INTEGER"
+    )
+    _add_column_if_missing(
+        conn, "tasks", cols, "last_heartbeat_at", "last_heartbeat_at INTEGER"
+    )
+    _add_column_if_missing(
+        conn, "tasks", cols, "current_run_id", "current_run_id INTEGER"
+    )
+    _add_column_if_missing(
+        conn, "tasks", cols, "workflow_template_id", "workflow_template_id TEXT"
+    )
+    _add_column_if_missing(
+        conn, "tasks", cols, "current_step_key", "current_step_key TEXT"
+    )
+    if _add_column_if_missing(conn, "tasks", cols, "skills", "skills TEXT"):
         # JSON array of skill names the dispatcher force-loads into the
         # worker (additive to the built-in `kanban-worker`). NULL is fine
         # for existing rows.
-        conn.execute("ALTER TABLE tasks ADD COLUMN skills TEXT")
+        pass
 
-    if "max_retries" not in cols:
+    if _add_column_if_missing(
+        conn, "tasks", cols, "max_retries", "max_retries INTEGER"
+    ):
         # Per-task override for the consecutive-failure circuit breaker.
         # NULL = fall through to the dispatcher-level ``kanban.failure_limit``
         # config, then ``DEFAULT_FAILURE_LIMIT``. Existing rows get NULL,
         # which is the correct default (they keep the global behaviour
         # they were getting before the column existed).
-        conn.execute("ALTER TABLE tasks ADD COLUMN max_retries INTEGER")
+        pass
 
     # task_events gained a run_id column; back-fill it as NULL for
     # historical events (they predate runs and can't be attributed).
     ev_cols = {row["name"] for row in conn.execute("PRAGMA table_info(task_events)")}
-    if "run_id" not in ev_cols:
-        conn.execute("ALTER TABLE task_events ADD COLUMN run_id INTEGER")
+    if _add_column_if_missing(
+        conn, "task_events", ev_cols, "run_id", "run_id INTEGER"
+    ):
         conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_events_run "
             "ON task_events(run_id, id)"

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -3030,6 +3030,18 @@ def test_legacy_migration_both_columns_already_present(tmp_path):
     assert "last_failure_error" in cols_after
     assert "spawn_failures" in cols_after  # legacy preserved
 
+    # Simulate a race where the PRAGMA snapshot is stale but another process
+    # already added the column before our ALTER TABLE.  The duplicate-column
+    # OperationalError must be swallowed as a no-op, not crash gateway startup.
+    stale_cols = set(cols_after) - {"consecutive_failures"}
+    assert kb._add_column_if_missing(
+        conn,
+        "tasks",
+        stale_cols,
+        "consecutive_failures",
+        "consecutive_failures INTEGER NOT NULL DEFAULT 0",
+    ) is False
+
     # Idempotent second run must not modify values or raise.
     kb._migrate_add_optional_columns(conn)
     row_again = conn.execute("SELECT * FROM tasks WHERE id = 't2'").fetchone()


### PR DESCRIPTION
## Summary
- add an idempotent helper for optional SQLite migration columns
- treat duplicate-column races from concurrent Hermes processes as no-ops
- cover stale PRAGMA snapshot behavior in kanban migration tests

## Test Plan
- `venv/bin/python -m pytest tests/hermes_cli/test_kanban_core_functionality.py -k 'legacy_migration_both_columns_already_present'`\n\nNote: `scripts/run_tests.sh ...` could not run because the configured venv python has no `pip` module for installing pytest-split.