### PR TITLE
fix: correct zsh _arguments syntax in shell completion generation

### DIFF
--- a/hermes_cli/completion.py
+++ b/hermes_cli/completion.py
@@ -216,9 +216,9 @@ _hermes() {{
     typeset -A opt_args
 
     _arguments -C \\
-        '(-h --help){{-h,--help}}[Show help and exit]' \\
-        '(-V --version){{-V,--version}}[Show version and exit]' \\
-        '(-p --profile){{-p,--profile}}[Profile name]:profile:_hermes_profiles' \\
+        '(-)'{{-h,--help}}'[Show help and exit]' \\
+        '(-)'{{-V,--version}}'[Show version and exit]' \\
+        '(-)'{{-p,--profile}}'[Profile name]:profile:_hermes_profiles' \\
         '1:command:->commands' \\
         '*::arg:->args'
 


### PR DESCRIPTION
## Summary

- Fixes invalid zsh `_arguments` syntax in the generated shell completion script that caused zsh to reject the script with `invalid argument` errors
- Replaces mutual-exclusion groups like `(-h --help)` with `(-)` (no exclusion), which is correct since short/long forms are aliases of the same option

## Why

The hardcoded exclusion groups in `generate_zsh()` contained spaces between short and long option forms (e.g. `(-h --help)`), which zsh's `_arguments` parser rejects. The fix uses `(-)` to indicate no mutual exclusion, following zsh's official completion syntax guidelines.

Closes #22686