### PR TITLE
feat(skills): 다나와 최저가 비교 스킬 추가

### DIFF
--- a/skills/korea/DESCRIPTION.md
+++ b/skills/korea/DESCRIPTION.md
@@ -1,0 +1,3 @@
+# Korea
+
+Korea-specific skills for Korean-language services, local commerce, public data, and everyday workflows.

--- a/skills/korea/danawa-price-search/SKILL.md
+++ b/skills/korea/danawa-price-search/SKILL.md
@@ -1,0 +1,170 @@
+---
+name: danawa-price-search
+description: Use when searching Danawa products, comparing Korean shopping mall offers, or answering 다나와 최저가/가격비교 questions. Performs read-only Danawa product search and offer comparison through public HTML/AJAX surfaces, including shipping, card discounts, and installment notes.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+metadata:
+  hermes:
+    tags: [korea, shopping, danawa, price-comparison, ecommerce]
+    related_skills: []
+---
+
+# Danawa Price Search
+
+## Overview
+
+Use this skill to perform read-only Danawa product search and lowest-price comparison through public web surfaces. It is designed for Korean shopping queries where the user wants a practical comparison rather than only the catalog headline price.
+
+The helper script fetches Danawa search results, resolves product `pcode`s, calls the public price-comparison AJAX fragment, and emits JSON suitable for a concise Markdown comparison table.
+
+## When to Use
+
+Use this skill when the user asks for:
+
+- 다나와 검색, 다나와 최저가, 가격비교
+- Korean product lowest-price lookup
+- Mall-by-mall comparison including shipping fee
+- Whether a Danawa offer has card-specific discounts or interest-free installments
+
+Do not use this skill for:
+
+- Actually purchasing products or logging into a mall account
+- High-volume monitoring without adding throttling/backoff
+- Non-Korean stores where Danawa does not have catalog coverage
+
+## Public Surfaces
+
+The current implementation uses these unauthenticated Danawa surfaces:
+
+- Product search page: `https://search.danawa.com/dsearch.php?query=...`
+- Product detail page: `https://prod.danawa.com/info/?pcode=...`
+- Price comparison AJAX: `https://prod.danawa.com/info/ajax/getAllPriceCompareMallList.ajax.php`
+
+The AJAX endpoint returns HTML fragments. Parse `.diff_item`, mall logo `alt`, `em.prc_c`/`em.prc_t`, shipping text, card line, installment layer, and Danawa bridge links.
+
+## Commands
+
+From this skill directory:
+
+```bash
+python scripts/danawa_search.py search "에어팟 프로 2세대" --limit 8
+python scripts/danawa_search.py offers 28208783 --limit 10
+python scripts/danawa_search.py compare "에어팟 프로 2세대" --limit 5 --offers 5
+```
+
+The helper prints JSON only. Convert the JSON to a user-facing Korean summary after inspecting the candidate titles and offers.
+
+## Output Shape
+
+### `search`
+
+`search` emits:
+
+```json
+{
+  "query": "...",
+  "source_url": "...",
+  "count": 0,
+  "items": []
+}
+```
+
+Each item includes:
+
+- `pcode`
+- `title`
+- `price`
+- `price_text`
+- `mall_text`
+- `url`
+- `image_url`
+- `spec`
+
+### `offers`
+
+`offers` emits:
+
+```json
+{
+  "pcode": "...",
+  "title": "...",
+  "source_url": "...",
+  "count": 0,
+  "offers": []
+}
+```
+
+Each offer includes:
+
+- `mall`
+- `price`, `price_text`
+- `shipping`
+- `is_free_shipping`
+- `shipping_fee`
+- `total_price`, `total_price_text`
+- `card_price`, `card_price_text`
+- `card_name`
+- `card_discount`, `card_discount_text`
+- `installment`
+- `installment_detail`
+- `url`
+
+Always summarize whether shipping is free, the shipping-fee-inclusive total, card-specific discounted price if present, and interest-free installment text.
+
+### `compare`
+
+`compare` runs `search` first, then enriches each search result with per-product `offers[]` on a best-effort basis.
+
+## User-Facing Format
+
+For Discord/Telegram/chat responses, prefer a compact Markdown table.
+
+```md
+| 순위 | 판매처 | 상품가 | 배송 | 실구매가 | 카드할인가 | 무이자 | 링크 |
+|---:|---|---:|---|---:|---:|---|---|
+| 1 | G마켓 | 217,950원 | 무료배송 | 217,950원 | - | 최대 24개월 | 보기 |
+| 2 | 옥션 | 305,722원 | 무료배송 | 305,722원 | 우리카드 303,720원 | 최대 24개월 | 보기 |
+```
+
+Sort primarily by `total_price`. If `card_price` exists and changes the winner, call out the lowest card-discounted option separately below the table.
+
+Suggested summary lines:
+
+```md
+최저 실구매가: G마켓 217,950원 / 무료배송
+카드 기준 최저가: 옥션 우리카드 303,720원
+무이자: G마켓·옥션 최대 24개월 표기
+```
+
+If Danawa does not expose a card discount row, write “카드 할인가 표기 없음” rather than assuming no discount exists at checkout.
+
+## Implementation Notes
+
+1. Search Danawa by keyword and collect candidate `pcode`s.
+2. For a selected `pcode`, fetch the detail page and extract category/maker/product globals from inline JavaScript.
+3. POST those fields plus `oPriceCompareSetting` defaults to `getAllPriceCompareMallList.ajax.php` with:
+   - `User-Agent: Mozilla/5.0...`
+   - `Accept-Language: ko-KR,ko;q=0.9`
+   - `Referer: https://prod.danawa.com/info/?pcode=<pcode>`
+   - `X-Requested-With: XMLHttpRequest`
+4. Parse HTML fragments and sort/filter as needed. The endpoint already returns min-price ordering when `sSortType=minPrice`.
+5. Keep all actions read-only. Use Danawa bridge links as user-facing purchase links; do not bypass tracking unless explicitly needed.
+
+## Common Pitfalls
+
+1. **Search ranking can surface adjacent products first.** Show 3-5 candidates and note exact title/pcode when the query is ambiguous.
+2. **Search result price and AJAX lowest offer can differ.** Danawa catalog min price may reflect card/affiliate/updated price while the AJAX fragment shows current offer rows.
+3. **Card discount rows are conditional.** Danawa exposes card discounts per offer when it renders `.card_line`, for example `우리카드 303,720원`. Missing markup does not prove the checkout has no card promo.
+4. **Installment text is 안내용.** `.btn_foi` / `.foi_layer` can expose installment details, but card/payment amount conditions may vary at checkout.
+5. **The surface is scrape-style.** Keep request volume low and add throttling/backoff before monitor or batch use.
+6. **Selectors may change.** If parsing returns zero rows, re-check Danawa markup before assuming no offers exist.
+
+## Verification Checklist
+
+- [ ] `python scripts/danawa_search.py search "갤럭시 s25 울트라 자급제" --limit 3` returns product candidates.
+- [ ] `python scripts/danawa_search.py offers <pcode> --limit 5` returns mall offers.
+- [ ] Offer rows include shipping text and `total_price_text`.
+- [ ] Card-discounted offers include `card_name`, `card_price_text`, and `card_discount_text` when Danawa exposes them.
+- [ ] Installment text is included when Danawa exposes it.
+- [ ] User-facing answer is a table sorted by shipping-fee-inclusive total.

--- a/skills/korea/danawa-price-search/scripts/danawa_search.py
+++ b/skills/korea/danawa-price-search/scripts/danawa_search.py
@@ -1,0 +1,278 @@
+#!/usr/bin/env python3
+"""Read-only Danawa search/price comparison helper for Hermes.
+
+Usage:
+  python scripts/danawa_search.py search "에어팟 프로 2세대" --limit 8
+  python scripts/danawa_search.py offers 28208783 --limit 10
+  python scripts/danawa_search.py compare "에어팟 프로 2세대" --limit 5 --offers 5
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import sys
+import time
+import urllib.parse
+import urllib.request
+from html import unescape
+from typing import Any, Dict, List, Optional
+
+try:
+    from bs4 import BeautifulSoup
+except ImportError as exc:  # pragma: no cover - environment guard
+    raise SystemExit("beautifulsoup4 is required: python -m pip install beautifulsoup4") from exc
+
+UA = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/121 Safari/537.36"
+
+
+def fetch(url: str, *, method: str = "GET", data: Optional[dict] = None, referer: Optional[str] = None) -> str:
+    headers = {
+        "User-Agent": UA,
+        "Accept-Language": "ko-KR,ko;q=0.9,en;q=0.8",
+    }
+    body = None
+    if data is not None:
+        body = urllib.parse.urlencode(data).encode("utf-8")
+        headers["Content-Type"] = "application/x-www-form-urlencoded; charset=UTF-8"
+        headers["X-Requested-With"] = "XMLHttpRequest"
+    if referer:
+        headers["Referer"] = referer
+    req = urllib.request.Request(url, data=body, headers=headers, method=method)
+    with urllib.request.urlopen(req, timeout=25) as resp:
+        return resp.read().decode("utf-8", "replace")
+
+
+def soup_for(html: str) -> BeautifulSoup:
+    return BeautifulSoup(html, "html.parser")
+
+
+def clean_text(s: Optional[str]) -> Optional[str]:
+    if s is None:
+        return None
+    return " ".join(unescape(s).split())
+
+
+def parse_int(s: Optional[str]) -> Optional[int]:
+    if not s:
+        return None
+    digits = re.sub(r"\D", "", s)
+    return int(digits) if digits else None
+
+
+def abs_url(url: Optional[str]) -> Optional[str]:
+    if not url:
+        return None
+    if url.startswith("//"):
+        return "https:" + url
+    if url.startswith("/"):
+        return "https://prod.danawa.com" + url
+    return url
+
+
+def search(query: str, limit: int = 10) -> Dict[str, Any]:
+    url = "https://search.danawa.com/dsearch.php?query=" + urllib.parse.quote(query)
+    html = fetch(url)
+    soup = soup_for(html)
+    items: List[Dict[str, Any]] = []
+    for li in soup.select("li.prod_item"):
+        pid = (li.get("id") or "").replace("productItem", "") or None
+        name_el = li.select_one(".prod_name a") or li.select_one("p.prod_name a") or li.select_one('a[name="productName"]')
+        if not name_el:
+            continue
+        name = clean_text(name_el.get_text(" ", strip=True))
+        link = abs_url(name_el.get("href"))
+        min_input = li.select_one(f"#min_price_{pid}") if pid else None
+        price = parse_int(min_input.get("value") if min_input else None)
+        if price is None:
+            price_el = li.select_one(".price_sect strong") or li.select_one(".prod_pricelist strong")
+            price = parse_int(price_el.get_text() if price_el else None)
+        img = li.select_one(".thumb_image img")
+        image = abs_url((img.get("data-original") or img.get("src")) if img else None)
+        mall_el = li.select_one(".prod_pricelist .memory_sect") or li.select_one(".meta_item")
+        spec = " / ".join(clean_text(e.get_text(" ", strip=True)) or "" for e in li.select(".spec_list a, .spec_list span")[:10])
+        items.append(
+            {
+                "pcode": pid,
+                "title": name,
+                "price": price,
+                "price_text": f"{price:,}원" if price else None,
+                "mall_text": clean_text(mall_el.get_text(" ", strip=True)) if mall_el else None,
+                "url": link,
+                "image_url": image,
+                "spec": spec[:300] if spec else None,
+            }
+        )
+        if len(items) >= limit:
+            break
+    return {"query": query, "source_url": url, "count": len(items), "items": items, "meta": {"extraction": "danawa-search-html", "ts": int(time.time())}}
+
+
+def js_value(html: str, key: str) -> str:
+    patterns = [
+        rf"{re.escape(key)}\s*:\s*\"([^\"]*)\"",
+        rf"{re.escape(key)}\s*:\s*'([^']*)'",
+        rf"{re.escape(key)}\s*:\s*([0-9]+)",
+    ]
+    for pat in patterns:
+        m = re.search(pat, html)
+        if m:
+            raw = m.group(1)
+            if "\\u" in raw or "\\/" in raw:
+                try:
+                    return json.loads('"' + raw.replace('"', '\\"') + '"')
+                except Exception:
+                    return raw.replace("\\/", "/")
+            return raw
+    return ""
+
+
+def product_meta(pcode: str) -> Dict[str, str]:
+    url = f"https://prod.danawa.com/info/?pcode={urllib.parse.quote(str(pcode))}"
+    html = fetch(url)
+    meta = {
+        "pcode": str(pcode),
+        "source_url": url,
+        "cate1": js_value(html, "nCategoryCode1"),
+        "cate2": js_value(html, "nCategoryCode2"),
+        "cate3": js_value(html, "nCategoryCode3"),
+        "cate4": js_value(html, "nCategoryCode4") or "0",
+        "UICategoryCode": js_value(html, "nCategoryCode"),
+        "powerLinkKeyword": js_value(html, "powerLinkKeyword"),
+        "minPrice": js_value(html, "nMinPrice"),
+        "keyword": js_value(html, "sKeyword"),
+        "NaPm": js_value(html, "sNaPm"),
+        "sProductFullName": js_value(html, "sProductName"),
+        "makerCode": js_value(html, "makerCode"),
+        "makerName": js_value(html, "makerName"),
+    }
+    title = soup_for(html).select_one(".prod_tit .title")
+    if title:
+        meta["sProductFullName"] = clean_text(title.get_text(" ", strip=True)) or meta["sProductFullName"]
+    return meta
+
+
+def offers(pcode: str, limit: int = 20, include_shipping: bool = False) -> Dict[str, Any]:
+    meta = product_meta(pcode)
+    post_price = "Y" if include_shipping else "N"
+    data = {
+        "pcode": meta["pcode"],
+        "cate1": meta.get("cate1", ""),
+        "cate2": meta.get("cate2", ""),
+        "cate3": meta.get("cate3", ""),
+        "cate4": meta.get("cate4", "0"),
+        "UICategoryCode": meta.get("UICategoryCode", "0"),
+        "powerLinkKeyword": meta.get("powerLinkKeyword", ""),
+        "minPrice": meta.get("minPrice", ""),
+        "keyword": meta.get("keyword", ""),
+        "NaPm": meta.get("NaPm", ""),
+        "bDeliveryLeftRightYN": "N",
+        "bQuickPostSortYN": "N",
+        "sSortType": "minPrice",
+        "sProductFullName": meta.get("sProductFullName", ""),
+        "bPostPriceYN": post_price,
+        "bBadgeDefaultYN": "N",
+        "bWarrantyDefaultYN": "N",
+        "nOpenMarketMoreCount": "30",
+        "nAffiliateMoreCount": "30",
+        "nOverseasShoppingMoreCount": "30",
+        "nGeneralAffiliateMoreCount": "3",
+        "sRelationMenuType": "",
+        "sRelationType": "",
+        "bCoupangSortYN": "N",
+        "makerCode": meta.get("makerCode", ""),
+        "makerName": meta.get("makerName", ""),
+    }
+    html = fetch("https://prod.danawa.com/info/ajax/getAllPriceCompareMallList.ajax.php", method="POST", data=data, referer=meta["source_url"])
+    soup = soup_for(html)
+    rows: List[Dict[str, Any]] = []
+    for div in soup.select(".diff_item"):
+        mall_img = div.select_one(".d_mall img")
+        mall = mall_img.get("alt") if mall_img else None
+        price_el = div.select_one("em.prc_c") or div.select_one("em.prc_t")
+        price = parse_int(price_el.get_text() if price_el else None)
+        if not mall or price is None:
+            continue
+        ship_el = div.select_one(".ship") or div.select_one(".stxt")
+        shipping = clean_text(ship_el.get_text(" ", strip=True)) if ship_el else None
+        shipping_fee = 0 if shipping and "무료" in shipping else parse_int(shipping)
+        card_line = div.select_one(".card_line")
+        card_price_el = card_line.select_one(".card_prc") if card_line else None
+        card_name_el = card_line.select_one(".txt") if card_line else None
+        card_price = parse_int(card_price_el.get_text() if card_price_el else None)
+        installment_el = div.select_one(".btn_foi .txt")
+        installment_detail_el = div.select_one(".foi_layer .ly_cont")
+        link = div.select_one("a.priceCompareBuyLink")
+        rows.append(
+            {
+                "mall": clean_text(mall),
+                "price": price,
+                "price_text": f"{price:,}원",
+                "shipping": shipping,
+                "is_free_shipping": bool(shipping and "무료" in shipping),
+                "shipping_fee": shipping_fee,
+                "total_price": price + (shipping_fee or 0),
+                "total_price_text": f"{price + (shipping_fee or 0):,}원",
+                "card_price": card_price,
+                "card_price_text": f"{card_price:,}원" if card_price else None,
+                "card_name": clean_text(card_name_el.get_text(" ", strip=True)) if card_name_el else None,
+                "card_discount": (price - card_price) if card_price else None,
+                "card_discount_text": f"{price - card_price:,}원" if card_price else None,
+                "installment": clean_text(installment_el.get_text(" ", strip=True)) if installment_el else None,
+                "installment_detail": clean_text(installment_detail_el.get_text(" ", strip=True)) if installment_detail_el else None,
+                "url": abs_url(link.get("href") if link else None),
+            }
+        )
+        if len(rows) >= limit:
+            break
+    return {"pcode": str(pcode), "title": meta.get("sProductFullName"), "source_url": meta["source_url"], "count": len(rows), "offers": rows, "meta": {"extraction": "danawa-price-ajax", "include_shipping": include_shipping, "ts": int(time.time())}}
+
+
+def compare(query: str, limit: int, offer_limit: int) -> Dict[str, Any]:
+    result = search(query, limit=limit)
+    enriched = []
+    for item in result["items"]:
+        row = dict(item)
+        if item.get("pcode"):
+            try:
+                off = offers(item["pcode"], limit=offer_limit)
+                row["offers"] = off.get("offers", [])
+            except Exception as exc:  # keep search result usable if a detail call fails
+                row["offers_error"] = f"{type(exc).__name__}: {exc}"
+        enriched.append(row)
+    result["items"] = enriched
+    result["meta"]["detail_extraction"] = "best-effort"
+    return result
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    sub = ap.add_subparsers(dest="cmd", required=True)
+    s = sub.add_parser("search")
+    s.add_argument("query")
+    s.add_argument("--limit", type=int, default=10)
+    o = sub.add_parser("offers")
+    o.add_argument("pcode")
+    o.add_argument("--limit", type=int, default=20)
+    o.add_argument("--include-shipping", action="store_true")
+    c = sub.add_parser("compare")
+    c.add_argument("query")
+    c.add_argument("--limit", type=int, default=5)
+    c.add_argument("--offers", type=int, default=5)
+    args = ap.parse_args()
+    try:
+        if args.cmd == "search":
+            out = search(args.query, args.limit)
+        elif args.cmd == "offers":
+            out = offers(args.pcode, args.limit, args.include_shipping)
+        else:
+            out = compare(args.query, args.limit, args.offers)
+        print(json.dumps(out, ensure_ascii=False, indent=2))
+        return 0
+    except Exception as exc:
+        print(json.dumps({"error": f"{type(exc).__name__}: {exc}"}, ensure_ascii=False), file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 요약

다나와 공개 검색/가격비교 표면을 사용하는 `danawa-price-search` 스킬을 추가했습니다. 상품 검색, 판매처별 최저가 비교, 배송비 포함 실구매가, 카드 할인가, 무이자 할부 안내까지 JSON으로 추출할 수 있습니다.

## 주요 내용

- `skills/korea` 카테고리 추가
- `danawa-price-search` 스킬 문서 추가
- 다나와 검색/오퍼 조회용 read-only helper script 추가
- 판매처별 비교 필드 포함
  - 상품가
  - 무료배송 여부
  - 배송비
  - 배송비 포함 실구매가
  - 카드 할인가/카드명/할인액
  - 무이자 할부 안내
- Discord/Telegram 응답용 Markdown 표 포맷 가이드 추가

## 검증

- [x] `SKILL.md` frontmatter 검증
- [x] `python3 -m py_compile skills/korea/danawa-price-search/scripts/danawa_search.py`
- [x] `python3 skills/korea/danawa-price-search/scripts/danawa_search.py search "갤럭시 s25 울트라 자급제" --limit 2`
- [x] `python3 skills/korea/danawa-price-search/scripts/danawa_search.py offers <pcode> --limit 3`

## 참고

- 로그인이나 구매 액션은 수행하지 않습니다.
- 다나와 공개 HTML/AJAX 표면 기반이라 selector 변경 시 유지보수가 필요할 수 있습니다.
- 판매처 링크는 다나와 bridge link를 그대로 제공합니다.
