### PR TITLE
fix(completion): use valid zsh _arguments exclusion-group syntax

### DIFF
--- a/hermes_cli/completion.py
+++ b/hermes_cli/completion.py
@@ -216,9 +216,9 @@ _hermes() {{
     typeset -A opt_args
 
     _arguments -C \\
-        '(-h --help){{-h,--help}}[Show help and exit]' \\
-        '(-V --version){{-V,--version}}[Show version and exit]' \\
-        '(-p --profile){{-p,--profile}}[Profile name]:profile:_hermes_profiles' \\
+        '(-)'{{-h,--help}}'[Show help and exit]' \\
+        '(-)'{{-V,--version}}'[Show version and exit]' \\
+        '(-)'{{-p,--profile}}'[Profile name]:profile:_hermes_profiles' \\
         '1:command:->commands' \\
         '*::arg:->args'
 


### PR DESCRIPTION
## Summary

Replaces the invalid `(-X --Y)` exclusion groups emitted in the zsh completion script with the canonical `(-)` form. Long options cannot appear inside `_arguments` exclusion groups, and the previous output caused zsh to reject the script with `_arguments:comparguments: invalid argument: (-h --help){-h,--help}[...]`, breaking tab completion entirely on zsh.

## Repro

```
source <(hermes completion zsh)
# _arguments:comparguments:327: invalid argument: (-h --help){-h,--help}[Show help and exit]
```

## Changes

- `hermes_cli/completion.py` (`generate_zsh`): emit `(-)` instead of `(-X --Y)` so each flag pair is rendered as `(-){-X,--Y}'[desc]'` (e.g. `(-)`{-h,--help}`[Show help and exit]`). Fixes the three top-level option specs (`-h/--help`, `-V/--version`, `-p/--profile`).

## Testing

- `git diff` shows a 3-line minimal change in the zsh emitter.
- Unit tests in `tests/hermes_cli/test_completion.py` (the completion-relevant ones) all pass.
- Manual repro with `expect`-driven interactive zsh:
  - **Before:** `_arguments:comparguments:327: invalid argument: (-h --help){-h,--help}[Show help and exit]` on first TAB.
  - **After:** completion runs cleanly, no `_arguments` errors.

Fixes #22686