### PR TITLE
fix: correct zsh completion _arguments exclusion syntax

### DIFF
--- a/hermes_cli/completion.py
+++ b/hermes_cli/completion.py
@@ -216,9 +216,9 @@ _hermes() {{
     typeset -A opt_args
 
     _arguments -C \\
-        '(-h --help){{-h,--help}}[Show help and exit]' \\
-        '(-V --version){{-V,--version}}[Show version and exit]' \\
-        '(-p --profile){{-p,--profile}}[Profile name]:profile:_hermes_profiles' \\
+        '(-)'{{-h,--help}}'[Show help and exit]' \\
+        '(-)'{{-V,--version}}'[Show version and exit]' \\
+        '(-p)'{{-p,--profile}}'[Profile name]:profile:_hermes_profiles' \\
         '1:command:->commands' \\
         '*::arg:->args'
 


### PR DESCRIPTION
## Description

Fixes #22686

The generated `hermes completion zsh` script used invalid `_arguments` syntax:
```zsh
'(-h --help){-h,--help}[Show help and exit]'
```

zsh only accepts single-letter options (or `-`) inside the `()` mutual exclusion group — long options like `--help` cause a parse error.

## Fix

- Removed long options from `()` exclusion specs
- Using `(-)` for help/version (no mutual exclusion needed)
- Using `(-p)` for `--profile` (`-p` is a single char, valid)
- Kept brace groups `{-h,--help}` for option aliases

## Testing
- Regenerated completion output with live parser
- Verified with `zsh -n` — zero errors

Changed file: `hermes_cli/completion.py`