### PR TITLE
fix(scripts): declare pytest-split in dev deps and unset HERMES_CRON_SESSION

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
 modal = ["modal>=1.0.0,<2"]
 daytona = ["daytona>=0.148.0,<1"]
 vercel = ["vercel>=0.5.7,<0.6.0"]
-dev = ["debugpy>=1.8.0,<2", "pytest>=9.0.2,<10", "pytest-asyncio>=1.3.0,<2", "pytest-xdist>=3.0,<4", "mcp>=1.2.0,<2", "ty>=0.0.1a29,<0.0.22", "ruff"]
+dev = ["debugpy>=1.8.0,<2", "pytest>=9.0.2,<10", "pytest-asyncio>=1.3.0,<2", "pytest-xdist>=3.0,<4", "pytest-split>=0.9,<1", "mcp>=1.2.0,<2", "ty>=0.0.1a29,<0.0.22", "ruff"]
 messaging = ["python-telegram-bot[webhooks]>=22.6,<23", "discord.py[voice]>=2.7.1,<3", "aiohttp>=3.13.3,<4", "slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4", "qrcode>=7.0,<8"]
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
 slack = ["slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4"]

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -42,9 +42,17 @@ fi
 PYTHON="$VENV/bin/python"
 
 # ── Ensure pytest-split is installed (required for shard-equivalent runs) ──
+# pytest-split is declared in pyproject.toml [dev], so `uv sync --extra dev`
+# installs it automatically. The fallback handles legacy venvs created before
+# the dep was declared; it prefers `uv pip install` because uv-created venvs
+# may not include pip.
 if ! "$PYTHON" -c "import pytest_split" 2>/dev/null; then
   echo "→ installing pytest-split into $VENV"
-  "$PYTHON" -m pip install --quiet "pytest-split>=0.9,<1"
+  if command -v uv >/dev/null 2>&1; then
+    uv pip install --quiet --python "$PYTHON" "pytest-split>=0.9,<1"
+  else
+    "$PYTHON" -m pip install --quiet "pytest-split>=0.9,<1"
+  fi
 fi
 
 # ── Hermetic environment ────────────────────────────────────────────────────
@@ -70,7 +78,7 @@ unset HERMES_YOLO_MODE HERMES_INTERACTIVE HERMES_QUIET HERMES_TOOL_PROGRESS \
       HERMES_PLATFORM HERMES_INFERENCE_PROVIDER HERMES_MANAGED HERMES_DEV \
       HERMES_CONTAINER HERMES_EPHEMERAL_SYSTEM_PROMPT HERMES_TIMEZONE \
       HERMES_REDACT_SECRETS HERMES_BACKGROUND_NOTIFICATIONS HERMES_EXEC_ASK \
-      HERMES_HOME_MODE 2>/dev/null || true
+      HERMES_HOME_MODE HERMES_CRON_SESSION 2>/dev/null || true
 
 # Pin deterministic runtime.
 export TZ=UTC

--- a/tests/test_lint_config.py
+++ b/tests/test_lint_config.py
@@ -113,3 +113,61 @@ class TestLintWorkflow:
             pytest.fail(f"lint.yml is not valid YAML: {exc}")
         assert isinstance(parsed, dict)
         assert "jobs" in parsed
+
+
+class TestDevDependencies:
+    """Guard against dev-dependency omissions that break the canonical test runner.
+
+    pytest-split was missing from the dev extra, causing scripts/run_tests.sh
+    to attempt a runtime `pip install` that fails in uv-created venvs without
+    pip (issue #22401).
+    """
+
+    def test_pytest_split_declared_in_dev_extra(self):
+        """pytest-split must appear in [project.optional-dependencies].dev."""
+        cfg = _load_pyproject()
+        dev_deps = (
+            cfg.get("project", {})
+            .get("optional-dependencies", {})
+            .get("dev", [])
+        )
+        assert any("pytest-split" in dep for dep in dev_deps), (
+            "pytest-split is missing from [project.optional-dependencies].dev. "
+            "scripts/run_tests.sh requires it; without the declaration a fresh "
+            "`uv sync --extra dev` will not install it and the runtime bootstrap "
+            "in the script will attempt `pip install` which fails in uv-managed "
+            "venvs that do not include pip (issue #22401)."
+        )
+
+
+class TestRunTestsShScript:
+    """Guard against environment contamination in scripts/run_tests.sh.
+
+    HERMES_CRON_SESSION was not being unset, causing approval tests to see
+    cron-deny behavior when the test runner was invoked from a cron job
+    (issue #22400).
+    """
+
+    SCRIPT_PATH = REPO_ROOT / "scripts" / "run_tests.sh"
+
+    def test_hermes_cron_session_is_unset(self):
+        """HERMES_CRON_SESSION must appear in the unset list so cron-invoked
+        runs do not contaminate approval-gate tests."""
+        content = self.SCRIPT_PATH.read_text(encoding="utf-8")
+        assert "HERMES_CRON_SESSION" in content, (
+            "HERMES_CRON_SESSION is not unset in scripts/run_tests.sh. "
+            "When the test runner is invoked from a Hermes cron job this var "
+            "leaks into pytest and switches approval logic to cron-deny mode, "
+            "making approval tests fail (issue #22400)."
+        )
+
+    def test_bootstrap_supports_uv_pip(self):
+        """The pytest-split bootstrap must try `uv pip install` before falling
+        back to `python -m pip` so that uv-created venvs without pip work."""
+        content = self.SCRIPT_PATH.read_text(encoding="utf-8")
+        assert "uv pip install" in content, (
+            "scripts/run_tests.sh pytest-split bootstrap does not attempt "
+            "`uv pip install`. In uv-created venvs without pip the fallback "
+            "`python -m pip install` fails immediately (issue #22401). "
+            "Add a `uv pip install` path guarded by `command -v uv`."
+        )


### PR DESCRIPTION
## Summary

Two hermetic test-runner bugs fixed together (both in `scripts/run_tests.sh` / `pyproject.toml`).

Closes #22401  
Closes #22400

---

### Problem 1 — missing `pytest-split` dev dep (#22401)

`scripts/run_tests.sh` requires `pytest-split` but it was not declared in `pyproject.toml [project.optional-dependencies].dev`. A fresh `uv sync --extra dev` would not install it. The runtime bootstrap fell back to `python -m pip install`, which fails immediately in uv-created venvs that do not ship pip, exiting the test runner before pytest starts.

### Problem 2 — `HERMES_CRON_SESSION` env leak (#22400)

`scripts/run_tests.sh` unsets many `HERMES_*` behavioral vars but omitted `HERMES_CRON_SESSION`. When the canonical test runner is invoked from a Hermes cron job, that variable leaks into pytest and switches approval logic to cron-deny mode, making approval-gate tests fail only under scheduled/cron runs.

---

## Fix

- **`pyproject.toml`**: add `"pytest-split>=0.9,<1"` to the `dev` extra so `uv sync --extra dev` installs it automatically.
- **`scripts/run_tests.sh` (bootstrap)**: prefer `uv pip install` (guarded by `command -v uv`) over `python -m pip install` for the legacy fallback path; pip is optional in uv-created venvs.
- **`scripts/run_tests.sh` (scrub list)**: add `HERMES_CRON_SESSION` to the `unset` list so cron-invoked runs are fully hermeticized.

## Tests

Three new regression tests in `tests/test_lint_config.py`:

- `TestDevDependencies.test_pytest_split_declared_in_dev_extra` — asserts `pytest-split` present in `[project.optional-dependencies].dev`
- `TestRunTestsShScript.test_hermes_cron_session_is_unset` — asserts `HERMES_CRON_SESSION` appears in the unset list
- `TestRunTestsShScript.test_bootstrap_supports_uv_pip` — asserts `uv pip install` path exists in bootstrap

All three stash-verified (fail without fix, pass with it).