### PR TITLE
fix(dashboard): preserve recent chat sessions

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3026,6 +3026,114 @@ def _ws_client_is_allowed(ws: "WebSocket") -> bool:
 # drops AND the publisher has disconnected.
 _event_channels: dict[str, set] = {}
 _event_lock = asyncio.Lock()
+_DASHBOARD_CHAT_REUSABLE_EMPTY_MAX_AGE_SECONDS = 3600
+
+
+def _dashboard_chat_auto_resume_enabled() -> bool:
+    """Whether bare Dashboard /chat should resume a recent TUI session.
+
+    Kept behind ``display.tui_auto_resume_recent`` so existing installations
+    retain the historical "bare /chat creates a new session" behavior unless
+    the user opts in.
+    """
+    try:
+        cfg = load_config()
+    except Exception:
+        _log.exception("Failed to load config for dashboard chat auto-resume")
+        return False
+
+    display = cfg.get("display") if isinstance(cfg, dict) else None
+    return bool((display or {}).get("tui_auto_resume_recent", False))
+
+
+def _session_message_count(session: Dict[str, Any]) -> int:
+    try:
+        return int(session.get("message_count") or 0)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _session_last_activity(session: Dict[str, Any]) -> float:
+    value = session.get("last_active", session.get("started_at", 0))
+    try:
+        return float(value or 0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
+def _select_dashboard_chat_auto_resume_session_id(
+    sessions: List[Dict[str, Any]],
+    *,
+    now: Optional[float] = None,
+    reusable_empty_max_age_seconds: int = _DASHBOARD_CHAT_REUSABLE_EMPTY_MAX_AGE_SECONDS,
+) -> Optional[str]:
+    """Pick the TUI session a bare Dashboard /chat should resume.
+
+    The policy is intentionally conversation-preserving: prefer the most
+    recently active non-empty TUI session, including raw compression
+    continuation children.  Only when there is no non-empty TUI conversation
+    at all do we reuse a recent empty TUI session to prevent blank refresh
+    loops from creating many empty rows.  Non-TUI sessions are ignored so
+    dashboard Chat does not jump into cron, gateway, or plain CLI
+    conversations.
+    """
+    tui_sessions = [
+        s
+        for s in sessions
+        if s.get("source") == "tui" and str(s.get("id") or "").strip()
+    ]
+    if not tui_sessions:
+        return None
+
+    def sort_key(session: Dict[str, Any]) -> tuple[float, float]:
+        try:
+            started = float(session.get("started_at") or 0)
+        except (TypeError, ValueError):
+            started = 0.0
+        return (_session_last_activity(session), started)
+
+    ordered = sorted(tui_sessions, key=sort_key, reverse=True)
+
+    for session in ordered:
+        if _session_message_count(session) > 0:
+            return str(session["id"])
+
+    current_time = time.time() if now is None else now
+    for session in ordered:
+        age = current_time - _session_last_activity(session)
+        if 0 <= age <= reusable_empty_max_age_seconds:
+            return str(session["id"])
+
+    return str(ordered[0]["id"])
+
+
+def _dashboard_chat_auto_resume_session_id() -> Optional[str]:
+    """Return the recent TUI session id to resume, or None to start fresh."""
+    try:
+        from hermes_state import SessionDB
+
+        db = SessionDB()
+        try:
+            sessions = db.list_sessions_rich(
+                source="tui",
+                limit=100,
+                include_children=True,
+                project_compression_tips=False,
+                order_by_last_active=True,
+            )
+        finally:
+            close = getattr(db, "close", None)
+            if callable(close):
+                close()
+    except Exception:
+        _log.exception("Failed to select dashboard chat auto-resume session")
+        return None
+
+    return _select_dashboard_chat_auto_resume_session_id(sessions)
+
+
+def _truthy_query_param(value: Optional[str]) -> bool:
+    return (value or "").strip().lower() in {"1", "true", "yes", "on"}
 
 
 def _resolve_chat_argv(
@@ -3140,6 +3248,13 @@ async def pty_ws(ws: WebSocket) -> None:
 
     # --- spawn PTY ------------------------------------------------------
     resume = ws.query_params.get("resume") or None
+    if (
+        resume is None
+        and not _truthy_query_param(ws.query_params.get("new"))
+        and _dashboard_chat_auto_resume_enabled()
+    ):
+        resume = _dashboard_chat_auto_resume_session_id()
+
     channel = _channel_or_close_code(ws)
     sidecar_url = _build_sidecar_url(channel) if channel else None
 

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -1949,6 +1949,179 @@ class TestDashboardPluginManifestExtensions:
 # monkeypatch that hook.
 # ---------------------------------------------------------------------------
 
+class TestDashboardChatAutoResume:
+    def test_prefers_latest_nonempty_tui_session_over_recent_empty(self):
+        import hermes_cli.web_server as ws
+
+        sessions = [
+            {
+                "id": "recent-empty",
+                "source": "tui",
+                "message_count": 0,
+                "started_at": 990.0,
+                "last_active": 990.0,
+            },
+            {
+                "id": "older-nonempty",
+                "source": "tui",
+                "message_count": 8,
+                "started_at": 900.0,
+                "last_active": 950.0,
+            },
+        ]
+
+        assert (
+            ws._select_dashboard_chat_auto_resume_session_id(sessions, now=1000.0)
+            == "older-nonempty"
+        )
+
+    def test_reuses_recent_empty_tui_session_when_no_nonempty_exists(self):
+        import hermes_cli.web_server as ws
+
+        sessions = [
+            {
+                "id": "recent-empty",
+                "source": "tui",
+                "message_count": 0,
+                "started_at": 990.0,
+                "last_active": 990.0,
+            },
+            {
+                "id": "older-empty",
+                "source": "tui",
+                "message_count": 0,
+                "started_at": 900.0,
+                "last_active": 900.0,
+            },
+        ]
+
+        assert (
+            ws._select_dashboard_chat_auto_resume_session_id(sessions, now=1000.0)
+            == "recent-empty"
+        )
+
+    def test_selects_latest_nonempty_by_activity_not_input_order(self):
+        import hermes_cli.web_server as ws
+
+        sessions = [
+            {
+                "id": "old-compression-root",
+                "source": "tui",
+                "message_count": 170,
+                "started_at": 100.0,
+                "last_active": 200.0,
+            },
+            {
+                "id": "latest-continuation",
+                "source": "tui",
+                "message_count": 184,
+                "started_at": 300.0,
+                "last_active": 400.0,
+            },
+            {
+                "id": "newer-empty-continuation",
+                "source": "tui",
+                "message_count": 0,
+                "started_at": 500.0,
+                "last_active": 500.0,
+            },
+        ]
+
+        assert (
+            ws._select_dashboard_chat_auto_resume_session_id(sessions, now=1000.0)
+            == "latest-continuation"
+        )
+
+    def test_skips_stale_empty_tui_session_for_latest_nonempty(self):
+        import hermes_cli.web_server as ws
+
+        sessions = [
+            {
+                "id": "stale-empty",
+                "source": "tui",
+                "message_count": 0,
+                "started_at": 100.0,
+                "last_active": 100.0,
+            },
+            {
+                "id": "latest-nonempty",
+                "source": "tui",
+                "message_count": 4,
+                "started_at": 90.0,
+                "last_active": 120.0,
+            },
+        ]
+
+        assert (
+            ws._select_dashboard_chat_auto_resume_session_id(
+                sessions,
+                now=10_000.0,
+                reusable_empty_max_age_seconds=3600,
+            )
+            == "latest-nonempty"
+        )
+
+    def test_ignores_non_tui_sessions(self):
+        import hermes_cli.web_server as ws
+
+        sessions = [
+            {
+                "id": "cli-session",
+                "source": "cli",
+                "message_count": 99,
+                "started_at": 950.0,
+                "last_active": 950.0,
+            },
+            {
+                "id": "tui-session",
+                "source": "tui",
+                "message_count": 1,
+                "started_at": 900.0,
+                "last_active": 900.0,
+            },
+        ]
+
+        assert (
+            ws._select_dashboard_chat_auto_resume_session_id(sessions, now=1000.0)
+            == "tui-session"
+        )
+
+    def test_auto_resume_reads_raw_tui_sessions_including_compression_children(
+        self, monkeypatch
+    ):
+        import hermes_cli.web_server as ws
+        import hermes_state
+
+        calls: dict = {}
+
+        class FakeSessionDB:
+            def list_sessions_rich(self, **kwargs):
+                calls.update(kwargs)
+                return [
+                    {
+                        "id": "compression-root",
+                        "source": "tui",
+                        "message_count": 120,
+                        "started_at": 100.0,
+                        "last_active": 150.0,
+                    },
+                    {
+                        "id": "compression-child",
+                        "source": "tui",
+                        "message_count": 12,
+                        "started_at": 200.0,
+                        "last_active": 300.0,
+                    },
+                ]
+
+        monkeypatch.setattr(hermes_state, "SessionDB", FakeSessionDB)
+
+        assert ws._dashboard_chat_auto_resume_session_id() == "compression-child"
+        assert calls["source"] == "tui"
+        assert calls["include_children"] is True
+        assert calls["project_compression_tips"] is False
+
+
 import sys
 
 
@@ -2140,6 +2313,89 @@ class TestPtyWebSocket:
             except Exception:
                 pass
         assert captured.get("resume") == "sess-42"
+
+    def test_auto_resume_recent_session_is_forwarded_when_config_enabled(
+        self, monkeypatch
+    ):
+        captured: dict = {}
+
+        def fake_resolve(resume=None, sidecar_url=None):
+            captured["resume"] = resume
+            return (["/bin/sh", "-c", "printf auto-resume-ok"], None, None)
+
+        monkeypatch.setattr(
+            self.ws_module, "_dashboard_chat_auto_resume_enabled", lambda: True
+        )
+        monkeypatch.setattr(
+            self.ws_module,
+            "_dashboard_chat_auto_resume_session_id",
+            lambda: "auto-session",
+        )
+        monkeypatch.setattr(self.ws_module, "_resolve_chat_argv", fake_resolve)
+
+        with self.client.websocket_connect(self._url()) as conn:
+            try:
+                conn.receive_bytes()
+            except Exception:
+                pass
+
+        assert captured.get("resume") == "auto-session"
+
+    def test_explicit_resume_overrides_auto_resume(self, monkeypatch):
+        captured: dict = {}
+
+        def fake_resolve(resume=None, sidecar_url=None):
+            captured["resume"] = resume
+            return (["/bin/sh", "-c", "printf explicit-resume-ok"], None, None)
+
+        def should_not_auto_resume():
+            raise AssertionError("auto resume should not run for explicit resume")
+
+        monkeypatch.setattr(
+            self.ws_module, "_dashboard_chat_auto_resume_enabled", lambda: True
+        )
+        monkeypatch.setattr(
+            self.ws_module,
+            "_dashboard_chat_auto_resume_session_id",
+            should_not_auto_resume,
+        )
+        monkeypatch.setattr(self.ws_module, "_resolve_chat_argv", fake_resolve)
+
+        with self.client.websocket_connect(self._url(resume="explicit-session")) as conn:
+            try:
+                conn.receive_bytes()
+            except Exception:
+                pass
+
+        assert captured.get("resume") == "explicit-session"
+
+    def test_new_param_disables_auto_resume(self, monkeypatch):
+        captured: dict = {}
+
+        def fake_resolve(resume=None, sidecar_url=None):
+            captured["resume"] = resume
+            return (["/bin/sh", "-c", "printf new-chat-ok"], None, None)
+
+        def should_not_auto_resume():
+            raise AssertionError("auto resume should not run when new=1")
+
+        monkeypatch.setattr(
+            self.ws_module, "_dashboard_chat_auto_resume_enabled", lambda: True
+        )
+        monkeypatch.setattr(
+            self.ws_module,
+            "_dashboard_chat_auto_resume_session_id",
+            should_not_auto_resume,
+        )
+        monkeypatch.setattr(self.ws_module, "_resolve_chat_argv", fake_resolve)
+
+        with self.client.websocket_connect(self._url(new="1")) as conn:
+            try:
+                conn.receive_bytes()
+            except Exception:
+                pass
+
+        assert captured.get("resume") is None
 
     def test_channel_param_propagates_sidecar_url(self, monkeypatch):
         """When /api/pty is opened with ?channel=, the PTY child gets a

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -3012,6 +3012,68 @@ def test_mirror_slash_compress_does_not_prelock_history(monkeypatch):
     assert ("session.info", "sid", {"model": "x"}) in emitted
 
 
+def test_session_create_with_persist_false_skips_session_db(monkeypatch):
+    """Dashboard sidecars need a runtime sid without creating blank history rows."""
+    created_sessions: list[tuple[tuple, dict]] = []
+    make_agent_calls: list[dict] = []
+
+    class _FakeWorker:
+        def __init__(self, key, model):
+            self.key = key
+
+        def close(self):
+            return None
+
+    class _FakeAgent:
+        def __init__(self):
+            self.model = "x"
+            self.provider = "openrouter"
+            self.base_url = ""
+            self.api_key = ""
+
+    def _make_agent(sid, key, *, persist_to_db=True):
+        make_agent_calls.append({"sid": sid, "key": key, "persist_to_db": persist_to_db})
+        return _FakeAgent()
+
+    monkeypatch.setattr(server, "_make_agent", _make_agent)
+    monkeypatch.setattr(server, "_SlashWorker", _FakeWorker)
+    monkeypatch.setattr(
+        server,
+        "_get_db",
+        lambda: types.SimpleNamespace(
+            create_session=lambda *a, **kw: created_sessions.append((a, kw))
+        ),
+    )
+    monkeypatch.setattr(server, "_session_info", lambda _a: {"model": "x"})
+    monkeypatch.setattr(server, "_probe_credentials", lambda _a: None)
+    monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
+    monkeypatch.setattr(server, "_emit", lambda *a, **kw: None)
+
+    import tools.approval as _approval
+
+    monkeypatch.setattr(_approval, "register_gateway_notify", lambda key, cb: None)
+    monkeypatch.setattr(_approval, "unregister_gateway_notify", lambda key: None)
+    monkeypatch.setattr(_approval, "load_permanent_allowlist", lambda: None)
+
+    resp = server.handle_request(
+        {
+            "id": "1",
+            "method": "session.create",
+            "params": {"cols": 80, "persist": False},
+        }
+    )
+    sid = resp["result"]["session_id"]
+    session = server._sessions[sid]
+    session["agent_ready"].wait(timeout=2.0)
+
+    assert make_agent_calls == [
+        {"sid": sid, "key": session["session_key"], "persist_to_db": False}
+    ]
+    assert created_sessions == []
+
+    server._sessions.pop(sid, None)
+
+
 # ---------------------------------------------------------------------------
 # session.create / session.close race: fast /new churn must not orphan the
 # slash_worker subprocess or the global approval-notify registration.

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -550,7 +550,10 @@ def _start_agent_build(sid: str, session: dict) -> None:
         try:
             tokens = _set_session_context(key)
             try:
-                agent = _make_agent(sid, key)
+                if current.get("persist_to_db", True):
+                    agent = _make_agent(sid, key)
+                else:
+                    agent = _make_agent(sid, key, persist_to_db=False)
             finally:
                 _clear_session_context(tokens)
 
@@ -1854,7 +1857,13 @@ def _reset_session_agent(sid: str, session: dict) -> dict:
     return info
 
 
-def _make_agent(sid: str, key: str, session_id: str | None = None):
+def _make_agent(
+    sid: str,
+    key: str,
+    session_id: str | None = None,
+    *,
+    persist_to_db: bool = True,
+):
     from run_agent import AIAgent
     from hermes_cli.runtime_provider import resolve_runtime_provider
 
@@ -1897,7 +1906,7 @@ def _make_agent(sid: str, key: str, session_id: str | None = None):
         enabled_toolsets=_load_enabled_toolsets(),
         platform="tui",
         session_id=session_id or key,
-        session_db=_get_db(),
+        session_db=_get_db() if persist_to_db else None,
         ephemeral_system_prompt=system_prompt or None,
         checkpoints_enabled=is_truthy_value(os.environ.get("HERMES_TUI_CHECKPOINTS")),
         pass_session_id=is_truthy_value(os.environ.get("HERMES_TUI_PASS_SESSION_ID")),
@@ -2092,6 +2101,7 @@ def _(rid, params: dict) -> dict:
     sid = uuid.uuid4().hex[:8]
     key = _new_session_key()
     cols = int(params.get("cols", 80))
+    persist_to_db = params.get("persist", True) is not False
     _enable_gateway_prompts()
 
     ready = threading.Event()
@@ -2108,6 +2118,7 @@ def _(rid, params: dict) -> dict:
         "history_version": 0,
         "image_counter": 0,
         "pending_title": None,
+        "persist_to_db": persist_to_db,
         "running": False,
         "session_key": key,
         "show_reasoning": _load_show_reasoning(),

--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -119,7 +119,9 @@ export function ChatSidebar({ channel, className }: ChatSidebarProps) {
         if (cancelled) {
           return;
         }
-        return gw.request<{ session_id: string }>("session.create", {});
+        return gw.request<{ session_id: string }>("session.create", {
+          persist: false,
+        });
       })
       .then((created) => {
         if (cancelled || !created?.session_id) {

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -39,11 +39,13 @@ import { PluginSlot } from "@/plugins";
 function buildWsUrl(
   token: string,
   resume: string | null,
+  newChat: string | null,
   channel: string,
 ): string {
   const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
   const qs = new URLSearchParams({ token, channel });
   if (resume) qs.set("resume", resume);
+  if (newChat) qs.set("new", newChat);
   return `${proto}//${window.location.host}/api/pty?${qs.toString()}`;
 }
 
@@ -153,9 +155,11 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
   // param changes do NOT remount the component. Resume-in-chat from the
   // Sessions page relies on `/chat?resume=<id>` changing at runtime, so we must
   // treat the current resume target as part of the PTY identity and rebuild the
-  // terminal session when it changes.
+  // terminal session when it changes. Explicit `/chat?new=1` must also rebuild
+  // and propagate to the backend so it bypasses Dashboard auto-resume.
   const resumeParam = searchParams.get("resume");
-  const channel = useMemo(() => generateChannelId(), [resumeParam]);
+  const newChatParam = searchParams.get("new");
+  const channel = useMemo(() => generateChannelId(), [resumeParam, newChatParam]);
 
   useEffect(() => {
     if (!resumeParam) return;
@@ -552,7 +556,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
     });
 
     // WebSocket
-    const url = buildWsUrl(token, resumeParam, channel);
+    const url = buildWsUrl(token, resumeParam, newChatParam, channel);
     const ws = new WebSocket(url);
     ws.binaryType = "arraybuffer";
     wsRef.current = ws;
@@ -657,7 +661,7 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
         copyResetRef.current = null;
       }
     };
-  }, [channel, resumeParam]);
+  }, [channel, resumeParam, newChatParam]);
 
   // When the user returns to the chat tab (isActive: false → true), the
   // terminal host just transitioned from display:none to display:flex.


### PR DESCRIPTION
## Summary
- keep Dashboard Chat sidecar sessions out of the durable session DB by requesting `session.create` with `persist: false`
- add opt-in bare `/chat` auto-resume for `display.tui_auto_resume_recent`
- prefer the latest non-empty TUI conversation, including compression continuation children, and only reuse a recent empty TUI session when no non-empty TUI session exists
- pass `/chat?new=1` through to the PTY websocket so users can explicitly bypass auto-resume and start fresh

## Tests
- `scripts/run_tests.sh tests/test_tui_gateway_server.py::test_session_create_with_persist_false_skips_session_db tests/hermes_cli/test_web_server.py::TestDashboardChatAutoResume tests/hermes_cli/test_web_server.py::TestPtyWebSocket -q` — 21 passed
- `scripts/run_tests.sh tests/hermes_cli/test_web_server.py tests/test_tui_gateway_server.py -q` — 321 passed
- `npm --prefix web run build` — passed (Vite chunk-size warning only)
- `git diff HEAD --check` — passed

## Notes
- This keeps the behavior behind the existing `display.tui_auto_resume_recent` opt-in.
- Manual browser validation was done previously on the local Dashboard runtime; this PR branch only rebuilds/tests the generalized upstream patch.
