### PR TITLE
fix(web): explain unsupported dashboard updates

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -36,9 +36,11 @@ from hermes_cli.config import (
     cfg_get,
     DEFAULT_CONFIG,
     OPTIONAL_ENV_VARS,
+    format_managed_message,
     get_config_path,
     get_env_path,
     get_hermes_home,
+    is_managed,
     load_config,
     load_env,
     save_config,
@@ -699,6 +701,22 @@ def _tail_lines(path: Path, n: int) -> List[str]:
     return lines[-n:] if n > 0 else lines
 
 
+def _dashboard_update_unavailable_reason() -> Optional[str]:
+    """Return a user-facing reason the dashboard should not spawn ``hermes update``."""
+    if is_managed():
+        return format_managed_message("update Hermes Agent")
+
+    git_dir = PROJECT_ROOT / ".git"
+    if sys.platform != "win32" and not git_dir.exists():
+        return (
+            "Cannot update Hermes from the dashboard: this installation is not a git checkout.\n"
+            "Install or update from a terminal instead:\n"
+            "  curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash"
+        )
+
+    return None
+
+
 @app.post("/api/gateway/restart")
 async def restart_gateway():
     """Kick off a ``hermes gateway restart`` in the background."""
@@ -717,6 +735,10 @@ async def restart_gateway():
 @app.post("/api/hermes/update")
 async def update_hermes():
     """Kick off ``hermes update`` in the background."""
+    unavailable_reason = _dashboard_update_unavailable_reason()
+    if unavailable_reason:
+        raise HTTPException(status_code=409, detail=unavailable_reason)
+
     try:
         proc = _spawn_hermes_action(["update"], "hermes-update")
     except Exception as exc:

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -191,6 +191,47 @@ class TestWebServerEndpoints:
         assert resp.json()["gateway_state"] == "startup_failed"
         assert resp.json()["gateway_platforms"] == {}
 
+    def test_update_hermes_rejects_managed_install_without_spawning(self, monkeypatch):
+        import hermes_cli.web_server as web_server
+
+        monkeypatch.setenv("HERMES_MANAGED", "homebrew")
+        spawned = []
+        monkeypatch.setattr(
+            web_server,
+            "_spawn_hermes_action",
+            lambda *args, **kwargs: spawned.append((args, kwargs)),
+        )
+
+        resp = self.client.post("/api/hermes/update")
+
+        assert resp.status_code == 409
+        detail = resp.json()["detail"]
+        assert "managed by Homebrew" in detail
+        assert "brew upgrade hermes-agent" in detail
+        assert spawned == []
+
+    def test_update_hermes_rejects_non_git_checkout_without_spawning(self, monkeypatch, tmp_path):
+        import hermes_cli.web_server as web_server
+
+        runtime_root = tmp_path / "hermes-runtime-copy"
+        runtime_root.mkdir()
+        monkeypatch.setattr(web_server, "PROJECT_ROOT", runtime_root)
+        monkeypatch.setattr(web_server.sys, "platform", "linux")
+        spawned = []
+        monkeypatch.setattr(
+            web_server,
+            "_spawn_hermes_action",
+            lambda *args, **kwargs: spawned.append((args, kwargs)),
+        )
+
+        resp = self.client.post("/api/hermes/update")
+
+        assert resp.status_code == 409
+        detail = resp.json()["detail"]
+        assert "not a git checkout" in detail
+        assert "install" in detail.lower()
+        assert spawned == []
+
     def test_get_config_schema(self):
         resp = self.client.get("/api/config/schema")
         assert resp.status_code == 200


### PR DESCRIPTION
## Summary
- add Dashboard update preflight for managed installs and non-git checkouts
- return a clear `409` detail instead of spawning an update process that must fail
- cover both unsupported install shapes with web server endpoint tests

## Tests
- `scripts/run_tests.sh tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_update_hermes_rejects_managed_install_without_spawning tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_update_hermes_rejects_non_git_checkout_without_spawning tests/hermes_cli/test_managed_installs.py -q` — 7 passed
- `scripts/run_tests.sh tests/hermes_cli/test_web_server.py tests/hermes_cli/test_managed_installs.py -q` — 144 passed
- `git diff HEAD --check` — passed

## Notes
- Git checkout and Windows update paths keep the existing spawn behavior.
- This intentionally does not add a separate frontend capability endpoint; the minimal fix prevents repeated known-bad update attempts from the existing button.
