### PR TITLE
fix(web): sync dashboard chat URL after TUI session changes

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -79,6 +79,109 @@ def test_dispatch_rejects_non_object_params():
     }
 
 
+def test_session_create_exposes_durable_resume_id_for_dashboard_url_sync(monkeypatch):
+    """Dashboard /chat must learn the durable session key created by /new.
+
+    The short gateway sid is only useful for JSON-RPC routing. Browser resume
+    links need the durable ``session_key`` so a PTY-side ``/new`` can passively
+    update ``/chat?resume=<session_key>`` without rebuilding the live PTY.
+    """
+
+    emitted = []
+
+    class _NoopTimer:
+        daemon = False
+
+        def __init__(self, _interval, _target):
+            pass
+
+        def start(self):
+            return None
+
+    monkeypatch.setattr(server, "_new_session_key", lambda: "durable-session-key")
+    monkeypatch.setattr(server, "_resolve_model", lambda: "test/model")
+    monkeypatch.setattr(server, "_enable_gateway_prompts", lambda: None)
+    monkeypatch.setattr(server, "_load_show_reasoning", lambda: False)
+    monkeypatch.setattr(server, "_load_tool_progress_mode", lambda: "all")
+    monkeypatch.setattr(server.threading, "Timer", _NoopTimer)
+    monkeypatch.setattr(server, "_emit", lambda *args: emitted.append(args))
+
+    try:
+        resp = server.handle_request(
+            {"id": "1", "method": "session.create", "params": {"cols": 100}}
+        )
+
+        result = resp["result"]
+        assert result["session_id"] != "durable-session-key"
+        assert result["session_key"] == "durable-session-key"
+        expected_lazy_info = {
+            "model": "test/model",
+            "tools": {},
+            "skills": {},
+            "cwd": os.getenv("TERMINAL_CWD", os.getcwd()),
+            "lazy": True,
+            "session_key": "durable-session-key",
+            "resume_session_id": "durable-session-key",
+        }
+        assert result["info"] == expected_lazy_info
+        assert emitted == [
+            (
+                "session.info",
+                result["session_id"],
+                expected_lazy_info,
+            )
+        ]
+    finally:
+        server._sessions.clear()
+
+
+def test_init_session_info_event_includes_durable_resume_id(monkeypatch):
+    emitted = []
+
+    class _FakeWorker:
+        def __init__(self, key, model):
+            self.key = key
+
+        def close(self):
+            return None
+
+    monkeypatch.setattr(server, "_SlashWorker", _FakeWorker)
+    monkeypatch.setattr(server, "_wire_callbacks", lambda _sid: None)
+    monkeypatch.setattr(server, "_notify_session_boundary", lambda *_args: None)
+    monkeypatch.setattr(server, "_load_show_reasoning", lambda: False)
+    monkeypatch.setattr(server, "_load_tool_progress_mode", lambda: "all")
+    monkeypatch.setattr(server, "_session_info", lambda _agent: {"model": "test/model"})
+    monkeypatch.setattr(server, "_emit", lambda *args: emitted.append(args))
+
+    import tools.approval as _approval
+
+    monkeypatch.setattr(_approval, "register_gateway_notify", lambda _key, _cb: None)
+    monkeypatch.setattr(_approval, "load_permanent_allowlist", lambda: None)
+
+    try:
+        server._init_session(
+            "gateway-sid",
+            "durable-session-key",
+            types.SimpleNamespace(model="test/model"),
+            history=[],
+            cols=80,
+        )
+
+        assert emitted == [
+            (
+                "session.info",
+                "gateway-sid",
+                {
+                    "model": "test/model",
+                    "session_key": "durable-session-key",
+                    "resume_session_id": "durable-session-key",
+                },
+            )
+        ]
+    finally:
+        server._sessions.pop("gateway-sid", None)
+
+
 def test_voice_toggle_returns_configured_record_key(monkeypatch):
     monkeypatch.setattr(
         server,
@@ -1895,7 +1998,11 @@ def test_config_set_personality_preserves_history_and_returns_info(monkeypatch):
     )
 
     assert resp["result"]["history_reset"] is False
-    assert resp["result"]["info"] == {"model": "?"}
+    assert resp["result"]["info"] == {
+        "model": "?",
+        "session_key": "session-key",
+        "resume_session_id": "session-key",
+    }
     # History is preserved with a pivot marker appended
     assert len(session["history"]) == 2
     assert session["history"][0] == {"role": "user", "text": "hi"}
@@ -1906,7 +2013,15 @@ def test_config_set_personality_preserves_history_and_returns_info(monkeypatch):
     # Agent's system prompt was updated in-place; cached prompt untouched
     assert agent.ephemeral_system_prompt == "You are helpful."
     assert agent._cached_system_prompt == "old"
-    assert ("session.info", "sid", {"model": "?"}) in emits
+    assert (
+        "session.info",
+        "sid",
+        {
+            "model": "?",
+            "session_key": "session-key",
+            "resume_session_id": "session-key",
+        },
+    ) in emits
 
 
 def test_session_compress_uses_compress_helper(monkeypatch):
@@ -1927,7 +2042,15 @@ def test_session_compress_uses_compress_helper(monkeypatch):
 
     assert resp["result"]["removed"] == 2
     assert resp["result"]["usage"]["total"] == 42
-    emit.assert_any_call("session.info", "sid", {"model": "x"})
+    emit.assert_any_call(
+        "session.info",
+        "sid",
+        {
+            "model": "x",
+            "session_key": "session-key",
+            "resume_session_id": "session-key",
+        },
+    )
     # Final status.update clears the pinned "compressing" indicator so the
     # status bar can revert to the neutral state when compaction finishes.
     emit.assert_any_call("status.update", "sid", {"kind": "status", "text": "ready"})
@@ -3009,7 +3132,15 @@ def test_mirror_slash_compress_does_not_prelock_history(monkeypatch):
     assert warning == ""
     assert seen["compress"]
     assert seen["sync"]
-    assert ("session.info", "sid", {"model": "x"}) in emitted
+    assert (
+        "session.info",
+        "sid",
+        {
+            "model": "x",
+            "session_key": "session-key",
+            "resume_session_id": "session-key",
+        },
+    ) in emitted
 
 
 # ---------------------------------------------------------------------------

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -581,7 +581,7 @@ def _start_agent_build(sid: str, session: dict) -> None:
             _wire_callbacks(sid)
             _notify_session_boundary("on_session_reset", key)
 
-            info = _session_info(agent)
+            info = _with_resume_session_info(_session_info(agent), key)
             warn = _probe_credentials(agent)
             if warn:
                 info["credential_warning"] = warn
@@ -1121,7 +1121,11 @@ def _apply_model_switch(sid: str, session: dict, raw_input: str) -> dict:
             api_mode=result.api_mode,
         )
         _restart_slash_worker(session)
-        _emit("session.info", sid, _session_info(agent))
+        _emit(
+            "session.info",
+            sid,
+            _with_resume_session_info(_session_info(agent), session["session_key"]),
+        )
 
     os.environ["HERMES_MODEL"] = result.new_model
     os.environ["HERMES_INFERENCE_MODEL"] = result.new_model
@@ -1360,6 +1364,18 @@ def _probe_config_health(cfg: dict) -> str:
                 "personality overlay will be skipped."
             )
     return " ".join(warnings).strip()
+
+
+def _with_resume_session_info(info: dict | None, session_key: str) -> dict:
+    """Attach the durable session id used by Dashboard resume links.
+
+    ``session_id`` in gateway responses is the short JSON-RPC sid. Browser
+    ``/chat?resume=...`` links need the durable session database key instead.
+    """
+    enriched = dict(info or {})
+    enriched["session_key"] = session_key
+    enriched["resume_session_id"] = session_key
+    return enriched
 
 
 def _session_info(agent) -> dict:
@@ -1762,7 +1778,7 @@ def _apply_personality_to_session(
         with session["history_lock"]:
             session["history"].append({"role": "user", "content": marker})
             session["history_version"] = int(session.get("history_version", 0)) + 1
-        info = _session_info(agent)
+        info = _with_resume_session_info(_session_info(agent), session["session_key"])
         _emit("session.info", sid, info)
         return False, info
     return False, None
@@ -1848,7 +1864,7 @@ def _reset_session_agent(sid: str, session: dict) -> dict:
     with session["history_lock"]:
         session["history"] = []
         session["history_version"] = int(session.get("history_version", 0)) + 1
-    info = _session_info(new_agent)
+    info = _with_resume_session_info(_session_info(new_agent), session["session_key"])
     _emit("session.info", sid, info)
     _restart_slash_worker(session)
     return info
@@ -1956,7 +1972,7 @@ def _init_session(sid: str, key: str, agent, history: list, cols: int = 80):
         pass
     _wire_callbacks(sid)
     _notify_session_boundary("on_session_reset", key)
-    _emit("session.info", sid, _session_info(agent))
+    _emit("session.info", sid, _with_resume_session_info(_session_info(agent), key))
 
 
 def _new_session_key() -> str:
@@ -2130,17 +2146,25 @@ def _(rid, params: dict) -> dict:
     build_timer.daemon = True
     build_timer.start()
 
+    lazy_info = _with_resume_session_info(
+        {
+            "model": _resolve_model(),
+            "tools": {},
+            "skills": {},
+            "cwd": os.getenv("TERMINAL_CWD", os.getcwd()),
+            "lazy": True,
+        },
+        key,
+    )
+    _emit("session.info", sid, lazy_info)
+
     return _ok(
         rid,
         {
             "session_id": sid,
-            "info": {
-                "model": _resolve_model(),
-                "tools": {},
-                "skills": {},
-                "cwd": os.getenv("TERMINAL_CWD", os.getcwd()),
-                "lazy": True,
-            },
+            "session_key": key,
+            "resume_session_id": key,
+            "info": lazy_info,
         },
     )
 
@@ -2274,7 +2298,7 @@ def _(rid, params: dict) -> dict:
             "resumed": target,
             "message_count": len(messages),
             "messages": messages,
-            "info": _session_info(agent),
+            "info": _with_resume_session_info(_session_info(agent), target),
         },
     )
 
@@ -2577,7 +2601,7 @@ def _(rid, params: dict) -> dict:
             summary = summarize_manual_compression(
                 before_messages, messages, before_tokens, after_tokens
             )
-            info = _session_info(agent)
+            info = _with_resume_session_info(_session_info(agent), session["session_key"])
             _emit("session.info", sid, info)
             return _ok(
                 rid,
@@ -2706,7 +2730,16 @@ def _(rid, params: dict) -> dict:
         )
     except Exception as e:
         return _err(rid, 5000, f"agent init failed on branch: {e}")
-    return _ok(rid, {"session_id": new_sid, "title": title, "parent": old_key})
+    return _ok(
+        rid,
+        {
+            "session_id": new_sid,
+            "session_key": new_key,
+            "resume_session_id": new_key,
+            "title": title,
+            "parent": old_key,
+        },
+    )
 
 
 @method("session.interrupt")
@@ -4198,7 +4231,11 @@ def _(rid, params: dict) -> dict:
             agent = session["agent"]
             if hasattr(agent, "refresh_tools"):
                 agent.refresh_tools()
-            _emit("session.info", params.get("session_id", ""), _session_info(agent))
+            _emit(
+                "session.info",
+                params.get("session_id", ""),
+                _with_resume_session_info(_session_info(agent), session["session_key"]),
+            )
 
         # Honor `always=true` by persisting the opt-out to config.
         if bool(params.get("always", False)):
@@ -5423,14 +5460,22 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
         elif name == "compress" and agent:
             _compress_session_history(session, arg)
             _sync_session_key_after_compress(sid, session)
-            _emit("session.info", sid, _session_info(agent))
+            _emit(
+                "session.info",
+                sid,
+                _with_resume_session_info(_session_info(agent), session["session_key"]),
+            )
         elif name == "fast" and agent:
             mode = arg.lower()
             if mode in {"fast", "on"}:
                 agent.service_tier = "priority"
             elif mode in {"normal", "off"}:
                 agent.service_tier = None
-            _emit("session.info", sid, _session_info(agent))
+            _emit(
+                "session.info",
+                sid,
+                _with_resume_session_info(_session_info(agent), session["session_key"]),
+            )
         elif name == "reload-mcp" and agent and hasattr(agent, "reload_mcp_tools"):
             agent.reload_mcp_tools()
         elif name == "stop":

--- a/ui-tui/src/__tests__/branding.test.ts
+++ b/ui-tui/src/__tests__/branding.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+
+import { normalizeSessionPanelCatalogs } from '../components/branding.js'
+
+describe('normalizeSessionPanelCatalogs', () => {
+  it('keeps existing skills and tools catalogs', () => {
+    expect(
+      normalizeSessionPanelCatalogs({
+        skills: { writing: ['plan'] },
+        tools: { terminal: ['terminal'] }
+      })
+    ).toEqual({
+      skills: { writing: ['plan'] },
+      tools: { terminal: ['terminal'] }
+    })
+  })
+
+  it('treats missing or null catalogs as empty objects', () => {
+    expect(normalizeSessionPanelCatalogs({ skills: null, tools: null })).toEqual({
+      skills: {},
+      tools: {}
+    })
+    expect(normalizeSessionPanelCatalogs({})).toEqual({ skills: {}, tools: {} })
+  })
+})

--- a/ui-tui/src/components/branding.tsx
+++ b/ui-tui/src/components/branding.tsx
@@ -96,6 +96,18 @@ function CollapseToggle({
 const SKILLS_MAX = 8
 const TOOLSETS_MAX = 8
 
+type SessionCatalog = Record<string, string[]>
+
+export function normalizeSessionPanelCatalogs(info: {
+  skills?: null | SessionCatalog
+  tools?: null | SessionCatalog
+}): { skills: SessionCatalog; tools: SessionCatalog } {
+  return {
+    skills: info.skills ?? {},
+    tools: info.tools ?? {}
+  }
+}
+
 export function SessionPanel({ info, sid, t }: SessionPanelProps) {
   const cols = useStdout().stdout?.columns ?? 100
   const heroLines = caduceus(t.color, t.bannerHero || undefined)
@@ -103,6 +115,7 @@ export function SessionPanel({ info, sid, t }: SessionPanelProps) {
   const wide = cols >= 90 && leftW + 40 < cols
   const w = Math.max(20, wide ? cols - leftW - 14 : cols - 12)
   const lineBudget = Math.max(12, w - 2)
+  const { skills, tools } = normalizeSessionPanelCatalogs(info)
   const strip = (s: string) => (s.endsWith('_tools') ? s.slice(0, -6) : s)
 
   // ── Local collapse state for each section ──
@@ -130,8 +143,8 @@ export function SessionPanel({ info, sid, t }: SessionPanelProps) {
   }
 
   // ── Collapsible skills section ──
-  const skillEntries = Object.entries(info.skills).sort()
-  const skillsTotal = flat(info.skills).length
+  const skillEntries = Object.entries(skills).sort()
+  const skillsTotal = flat(skills).length
   const skillsCatCount = skillEntries.length
 
   const skillsBody = () => {
@@ -158,8 +171,8 @@ export function SessionPanel({ info, sid, t }: SessionPanelProps) {
   }
 
   // ── Collapsible tools section ──
-  const toolEntries = Object.entries(info.tools).sort()
-  const toolsTotal = flat(info.tools).length
+  const toolEntries = Object.entries(tools).sort()
+  const toolsTotal = flat(tools).length
 
   const toolsBody = () => {
     const shown = toolEntries.slice(0, TOOLSETS_MAX)

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -111,7 +111,9 @@ export interface SetupStatusResponse {
 
 export interface SessionCreateResponse {
   info?: SessionInfo & { config_warning?: string; credential_warning?: string }
+  resume_session_id?: string
   session_id: string
+  session_key?: string
 }
 
 export interface SessionResumeResponse {

--- a/ui-tui/src/types.ts
+++ b/ui-tui/src/types.ts
@@ -148,7 +148,9 @@ export interface SessionInfo {
   model: string
   reasoning_effort?: string
   release_date?: string
+  resume_session_id?: string
   service_tier?: string
+  session_key?: string
   skills: Record<string, string[]>
   system_prompt?: string
   tools: Record<string, string[]>

--- a/web/src/pages/ChatPage.tsx
+++ b/web/src/pages/ChatPage.tsx
@@ -58,6 +58,46 @@ function generateChannelId(): string {
   return `chat-${Math.random().toString(36).slice(2)}-${Date.now().toString(36)}`;
 }
 
+interface RpcEnvelope {
+  method?: string;
+  params?: { payload?: unknown; type?: string };
+}
+
+function dashboardResumeIdFromPayload(payload: unknown): string | null {
+  if (!payload || typeof payload !== "object") {
+    return null;
+  }
+
+  const p = payload as { resume_session_id?: unknown; session_key?: unknown };
+  const candidate =
+    typeof p.resume_session_id === "string"
+      ? p.resume_session_id
+      : typeof p.session_key === "string"
+        ? p.session_key
+        : "";
+  const sessionId = candidate.trim();
+  return sessionId || null;
+}
+
+function replaceChatResumeParam(sessionId: string): void {
+  if (typeof window === "undefined") {
+    return;
+  }
+
+  const url = new URL(window.location.href);
+
+  if (!url.pathname.endsWith("/chat") || url.searchParams.get("resume") === sessionId) {
+    return;
+  }
+
+  url.searchParams.set("resume", sessionId);
+  window.history.replaceState(
+    window.history.state,
+    "",
+    `${url.pathname}${url.search}${url.hash}`,
+  );
+}
+
 // Colors for the terminal body.  Matches the dashboard's dark teal canvas
 // with cream foreground — we intentionally don't pick monokai or a loud
 // theme, because the TUI's skin engine already paints the content; the
@@ -181,6 +221,44 @@ export default function ChatPage({ isActive = true }: { isActive?: boolean }) {
       cancelled = true;
     };
   }, [resumeParam, searchParams, setSearchParams]);
+
+  useEffect(() => {
+    if (!isActive) return;
+
+    const token = window.__HERMES_SESSION_TOKEN__;
+
+    if (!token || !channel) {
+      return;
+    }
+
+    const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
+    const qs = new URLSearchParams({ token, channel });
+    const ws = new WebSocket(
+      `${proto}//${window.location.host}/api/events?${qs.toString()}`,
+    );
+
+    ws.addEventListener("message", (ev) => {
+      let frame: RpcEnvelope;
+
+      try {
+        frame = JSON.parse(ev.data) as RpcEnvelope;
+      } catch {
+        return;
+      }
+
+      if (frame.method !== "event" || frame.params?.type !== "session.info") {
+        return;
+      }
+
+      const nextResume = dashboardResumeIdFromPayload(frame.params.payload);
+
+      if (nextResume) {
+        replaceChatResumeParam(nextResume);
+      }
+    });
+
+    return () => ws.close(1000);
+  }, [channel, isActive]);
 
   useEffect(() => {
     const mql = window.matchMedia("(max-width: 1023px)");


### PR DESCRIPTION
## Summary
- expose the durable TUI session key in session lifecycle info
- keep lazy session info shaped like the normal intro-panel payload (`model`, empty `tools`/`skills`, and `cwd`)
- passively update Dashboard `/chat?resume=` when the embedded TUI creates or switches sessions
- defensively render the TUI session panel when `tools` or `skills` are missing/null
- avoid React Router search-param updates so the active PTY is not rebuilt during URL correction

## Tests
- `scripts/run_tests.sh tests/test_tui_gateway_server.py::test_session_create_exposes_durable_resume_id_for_dashboard_url_sync tests/test_tui_gateway_server.py::test_init_session_info_event_includes_durable_resume_id tests/tui_gateway/test_protocol.py -q` — 55 passed
- `scripts/run_tests.sh tests/test_tui_gateway_server.py tests/tui_gateway/test_protocol.py -q` — 229 passed
- `npm --prefix web run build` — passed (Vite chunk-size warning only)
- `npm --prefix ui-tui test -- src/__tests__/branding.test.ts` — 2 passed
- `npm --prefix ui-tui run type-check` — passed
- `npm --prefix ui-tui run build` — passed
- `git diff HEAD --check` — passed

## Notes
- This fixes the PTY/TUI → URL direction; existing resume PRs focus on the URL → PTY direction.
- Manual browser validation is still recommended before marking ready.
