### PR TITLE
fix(context_references): guard json.loads in _default_url_fetcher against non-JSON responses

### DIFF
--- a/agent/context_references.py
+++ b/agent/context_references.py
@@ -318,7 +318,10 @@ async def _default_url_fetcher(url: str) -> str:
     from tools.web_tools import web_extract_tool
 
     raw = await web_extract_tool([url], format="markdown", use_llm_processing=True)
-    payload = json.loads(raw)
+    try:
+        payload = json.loads(raw)
+    except (json.JSONDecodeError, TypeError):
+        return str(raw or "").strip()
     docs = payload.get("data", {}).get("documents", [])
     if not docs:
         return ""

--- a/tests/agent/test_context_references.py
+++ b/tests/agent/test_context_references.py
@@ -334,3 +334,62 @@ async def test_blocks_sensitive_home_and_hermes_paths(tmp_path: Path, monkeypatc
     assert "API_KEY=super-secret" not in result.message
     assert "PRIVATE-KEY" not in result.message
     assert any("sensitive credential" in warning for warning in result.warnings)
+
+
+# ---------------------------------------------------------------------------
+# _default_url_fetcher — JSON decode robustness
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_default_url_fetcher_returns_raw_on_json_decode_error():
+    """web_extract_tool returning plain text must not raise JSONDecodeError."""
+    from agent.context_references import _default_url_fetcher
+
+    with patch(
+        "agent.context_references._default_url_fetcher",
+        wraps=_default_url_fetcher,
+    ):
+        with patch(
+            "tools.web_tools.web_extract_tool",
+            return_value="plain text, not JSON",
+        ):
+            # Before fix this raised json.JSONDecodeError; now returns raw text.
+            result = await _default_url_fetcher("https://example.com")
+    assert result == "plain text, not JSON"
+
+
+@pytest.mark.asyncio
+async def test_default_url_fetcher_returns_empty_on_none_response():
+    """web_extract_tool returning None must not raise TypeError."""
+    from agent.context_references import _default_url_fetcher
+
+    with patch(
+        "tools.web_tools.web_extract_tool",
+        return_value=None,
+    ):
+        result = await _default_url_fetcher("https://example.com")
+    assert result == ""
+
+
+@pytest.mark.asyncio
+async def test_default_url_fetcher_returns_content_on_valid_json():
+    """Valid JSON envelope still extracts document content correctly."""
+    import json as _json
+
+    from agent.context_references import _default_url_fetcher
+
+    payload = _json.dumps({
+        "data": {
+            "documents": [
+                {"content": "extracted markdown", "raw_content": "raw"}
+            ]
+        }
+    })
+
+    with patch(
+        "tools.web_tools.web_extract_tool",
+        return_value=payload,
+    ):
+        result = await _default_url_fetcher("https://example.com")
+    assert result == "extracted markdown"


### PR DESCRIPTION
## Problem

`_default_url_fetcher` called `json.loads(raw)` unconditionally on the return value of `web_extract_tool`. That function is an external I/O call — it can return plain text, an empty string, or `None`. Any non-JSON response caused an unhandled exception that crashed the entire URL reference expansion:

- Plain text → `json.JSONDecodeError: Expecting value`
- `None` → `TypeError: the JSON object must be str, bytes or bytearray, not NoneType`

## Root Cause

Missing `try/except` around `json.loads` in `_default_url_fetcher` (`agent/context_references.py` line 321).

## Fix

Wrap `json.loads` in `try/except (json.JSONDecodeError, TypeError)`. On parse failure, fall back to `str(raw or "").strip()` so plain-text responses are returned as-is rather than crashing the caller.

```python
try:
    payload = json.loads(raw)
except (json.JSONDecodeError, TypeError):
    return str(raw or "").strip()
```

## Tests

Three new tests in `tests/agent/test_context_references.py`:

| Test | Covers |
|------|--------|
| `test_default_url_fetcher_returns_raw_on_json_decode_error` | Plain-text response → return raw string, no exception |
| `test_default_url_fetcher_returns_empty_on_none_response` | `None` response → return `""`, no exception |
| `test_default_url_fetcher_returns_content_on_valid_json` | Valid JSON envelope → still extracts `content` field correctly |

Stash-verified: first two tests fail (`JSONDecodeError`, `TypeError`) without the fix; all three pass after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)