### PR TITLE
fix(web): handle malformed Brave Search response shapes without crashing

### DIFF
--- a/tests/tools/test_web_providers_brave_free.py
+++ b/tests/tools/test_web_providers_brave_free.py
@@ -147,6 +147,86 @@ class TestBraveFreeProviderSearch:
         assert result["success"] is True
         assert result["data"]["web"] == []
 
+    def test_non_dict_web_value_returns_empty_not_crash(self, monkeypatch):
+        """A 200 body shaped like ``{"web": <non-dict>}`` must not AttributeError.
+
+        Regression for ``(data.get("web") or {}).get("results", [])`` —
+        if ``data["web"]`` is a non-dict truthy value (e.g. an error
+        envelope coerced to a string by a permissive proxy, or an HTML
+        snippet a tolerant JSON decoder reduced to a literal), the legacy
+        code raised ``AttributeError`` and aborted the tool with no
+        graceful failure. The provider must instead surface an empty
+        result set so the caller can fall back.
+        """
+        monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "BSAkey123")
+        from tools.web_providers.brave_free import BraveFreeSearchProvider
+
+        for malformed in ({"web": "rate-limited"}, {"web": 0xdead}, {"web": ["a", "b"]}):
+            with patch("httpx.get", return_value=self._mock_resp(malformed)):
+                result = BraveFreeSearchProvider().search("q", limit=5)
+            assert result["success"] is True, f"crashed on {malformed!r}: {result}"
+            assert result["data"]["web"] == [], f"non-empty for {malformed!r}: {result}"
+
+    def test_non_dict_results_items_are_skipped(self, monkeypatch):
+        """``data["web"]["results"]`` items that aren't dicts must be skipped, not crash.
+
+        Same defensive concern as
+        ``test_non_dict_web_value_returns_empty_not_crash`` but one level
+        down: if Brave (or a proxy) returns a list mixing dict and
+        non-dict items, the per-item ``r.get(...)`` calls crash. The
+        provider should drop the bad items and keep the good ones.
+        """
+        monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "BSAkey123")
+        from tools.web_providers.brave_free import BraveFreeSearchProvider
+
+        body = {
+            "web": {
+                "results": [
+                    {"title": "Real", "url": "https://real.example.com", "description": "ok"},
+                    "https://stringified-url.example.com",  # non-dict, must be skipped
+                    None,                                    # non-dict, must be skipped
+                    {"title": "Also real", "url": "https://other.example.com", "description": "ok"},
+                ]
+            }
+        }
+        with patch("httpx.get", return_value=self._mock_resp(body)):
+            result = BraveFreeSearchProvider().search("q", limit=5)
+
+        assert result["success"] is True
+        web = result["data"]["web"]
+        assert len(web) == 2
+        assert [r["title"] for r in web] == ["Real", "Also real"]
+        # Position must reflect post-filter index, not original list index.
+        assert web[0]["position"] == 1
+        assert web[1]["position"] == 2
+
+    def test_non_list_results_value_returns_empty(self, monkeypatch):
+        """``data["web"]["results"]`` that isn't a list must produce an empty
+        result set instead of raising ``TypeError`` on the slice.
+        """
+        monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "BSAkey123")
+        from tools.web_providers.brave_free import BraveFreeSearchProvider
+
+        with patch("httpx.get", return_value=self._mock_resp({"web": {"results": "not-a-list"}})):
+            result = BraveFreeSearchProvider().search("q", limit=5)
+
+        assert result["success"] is True
+        assert result["data"]["web"] == []
+
+    def test_top_level_non_dict_response_returns_empty(self, monkeypatch):
+        """A ``resp.json()`` that returns something that isn't a dict at all
+        (e.g. ``[]`` or ``"string"``) must not AttributeError on
+        ``data.get(...)``.
+        """
+        monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "BSAkey123")
+        from tools.web_providers.brave_free import BraveFreeSearchProvider
+
+        for malformed in ([], "plain-string", 42, None):
+            with patch("httpx.get", return_value=self._mock_resp(malformed)):
+                result = BraveFreeSearchProvider().search("q", limit=5)
+            assert result["success"] is True, f"crashed on {malformed!r}: {result}"
+            assert result["data"]["web"] == [], f"non-empty for {malformed!r}: {result}"
+
     def test_http_error_returns_failure(self, monkeypatch):
         import httpx
         monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "BSAkey123")

--- a/tools/web_providers/brave_free.py
+++ b/tools/web_providers/brave_free.py
@@ -106,8 +106,20 @@ class BraveFreeSearchProvider(WebSearchProvider):
             logger.warning("Brave Search response parse error: %s", exc)
             return {"success": False, "error": "Could not parse Brave Search response as JSON"}
 
-        raw_results = (data.get("web") or {}).get("results", []) or []
-        truncated = raw_results[:limit]
+        # Brave's documented happy path is ``{"web": {"results": [...]}}``,
+        # but a non-2xx body that slips past raise_for_status (e.g. an
+        # error envelope, an HTML error page parsed by a permissive JSON
+        # decoder, or a corporate proxy injecting plaintext) can put a
+        # non-dict value at ``web`` or non-dict items in ``results`` —
+        # both would AttributeError on ``.get(...)`` and abort the tool
+        # with no graceful failure. Coerce defensively.
+        web_block = data.get("web") if isinstance(data, dict) else None
+        if not isinstance(web_block, dict):
+            web_block = {}
+        raw_results = web_block.get("results")
+        if not isinstance(raw_results, list):
+            raw_results = []
+        truncated = [r for r in raw_results[:limit] if isinstance(r, dict)]
 
         web_results = [
             {


### PR DESCRIPTION
## Summary

`BraveFreeSearchProvider.search` parsed the response with:

```python
raw_results = (data.get(\"web\") or {}).get(\"results\", []) or []
```

This assumes `data[\"web\"]` is a dict-or-falsy. If the Brave API returns a 200 with a non-dict truthy value at `web` — e.g. an error envelope coerced to a string by a permissive proxy, an HTML snippet that a tolerant JSON decoder reduced to a literal, or a corporate proxy injecting plaintext — the `.get(\"results\", [])` call raises `AttributeError` and aborts the tool with no graceful failure (the outer try/except only catches HTTP and JSON-decode errors).

The same shape assumption applies one level down: items inside `data[\"web\"][\"results\"]` were iterated with `r.get(...)`, so non-dict items in that list (a stringified URL, `None`, etc.) crash the comprehension.

Coerce defensively at every level: skip the top-level dict probe if `data` itself isn't a dict, fall back to `{}` if `data[\"web\"]` isn't a dict, fall back to `[]` if `results` isn't a list, and filter the per-item iteration to dict items only. The position index now reflects the post-filter index so callers don't see gaps.

Brave Search free tier (added in 04193cf7) is the new entry point users will hit when web extracts misbehave under quota/throttle, so the failure mode here is realistic, not hypothetical.

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- `tools/web_providers/brave_free.py`: Replace the chained `.get(...)` with explicit `isinstance(..., dict)` and `isinstance(..., list)` checks at three levels (top-level `data`, `web` block, `results` list). Filter `truncated` to dict items so the per-item `r.get(...)` loop is safe regardless of upstream response shape.
- `tests/tools/test_web_providers_brave_free.py`: Add four regression tests:
  - `test_non_dict_web_value_returns_empty_not_crash` — `{\"web\": <str|int|list>}` → empty result, not AttributeError
  - `test_non_dict_results_items_are_skipped` — mixed dict + non-dict items in `results` → non-dicts dropped, dicts kept with consecutive position numbers
  - `test_non_list_results_value_returns_empty` — `{\"web\": {\"results\": \"not-a-list\"}}` → empty
  - `test_top_level_non_dict_response_returns_empty` — `resp.json()` returns `[]`/`\"string\"`/`42`/`None` → empty

## How to Test

1. `pytest -q tests/tools/test_web_providers_brave_free.py`
2. Confirm all four new tests pass.
3. Confirm pre-existing happy-path / empty / missing-key / HTTP-error / request-error tests still pass.

To reproduce the original crash without this fix, against the legacy code:

```python
from unittest.mock import MagicMock, patch
from tools.web_providers.brave_free import BraveFreeSearchProvider
import os; os.environ[\"BRAVE_SEARCH_API_KEY\"] = \"x\"
m = MagicMock(); m.json.return_value = {\"web\": \"rate-limited\"}; m.raise_for_status = MagicMock()
with patch(\"httpx.get\", return_value=m):
    BraveFreeSearchProvider().search(\"q\")  # AttributeError: 'str' object has no attribute 'get'
```

## Validation

- `pytest -q tests/tools/test_web_providers_brave_free.py` -> `26 passed`
- Tested on macOS 25.4 / Python 3.14.4.