### PR TITLE
fix(time,logging): narrow broad except Exception to specific types

### DIFF
--- a/hermes_logging.py
+++ b/hermes_logging.py
@@ -373,6 +373,9 @@ def _read_logging_config():
     """
     try:
         import yaml
+    except ImportError:
+        return (None, None, None)
+    try:
         config_path = get_config_path()
         if config_path.exists():
             with open(config_path, "r", encoding="utf-8") as f:
@@ -384,6 +387,6 @@ def _read_logging_config():
                     log_cfg.get("max_size_mb"),
                     log_cfg.get("backup_count"),
                 )
-    except Exception:
+    except (OSError, yaml.YAMLError):
         pass
     return (None, None, None)

--- a/hermes_time.py
+++ b/hermes_time.py
@@ -48,6 +48,9 @@ def _resolve_timezone_name() -> str:
     # 2. config.yaml ``timezone`` key
     try:
         import yaml
+    except ImportError:
+        return ""
+    try:
         config_path = get_config_path()
         if config_path.exists():
             with open(config_path, encoding="utf-8") as f:
@@ -55,7 +58,7 @@ def _resolve_timezone_name() -> str:
             tz_cfg = cfg.get("timezone", "")
             if isinstance(tz_cfg, str) and tz_cfg.strip():
                 return tz_cfg.strip()
-    except Exception:
+    except (OSError, yaml.YAMLError):
         pass
 
     return ""
@@ -67,7 +70,7 @@ def _get_zoneinfo(name: str) -> Optional[ZoneInfo]:
         return None
     try:
         return ZoneInfo(name)
-    except (KeyError, Exception) as exc:
+    except KeyError as exc:
         logger.warning(
             "Invalid timezone '%s': %s. Falling back to server local time.",
             name, exc,

--- a/tests/test_hermes_logging.py
+++ b/tests/test_hermes_logging.py
@@ -771,3 +771,35 @@ class TestReadLoggingConfig:
 
         level, max_size, backup = hermes_logging._read_logging_config()
         assert level is None
+
+
+class TestReadLoggingConfigExceptionSpecificity:
+    """Regression tests: _read_logging_config except Exception narrowed to specific types."""
+
+    def test_returns_nones_on_os_error(self, hermes_home):
+        """OSError opening config.yaml returns (None, None, None)."""
+        from unittest.mock import patch
+        (hermes_home / "config.yaml").write_text("logging:\n  level: DEBUG\n")
+        with patch("builtins.open", side_effect=OSError("disk error")):
+            result = hermes_logging._read_logging_config()
+        assert result == (None, None, None)
+
+    def test_returns_nones_on_malformed_yaml(self, hermes_home):
+        """yaml.YAMLError from malformed config.yaml returns (None, None, None)."""
+        (hermes_home / "config.yaml").write_text("{ bad yaml [[[")
+        result = hermes_logging._read_logging_config()
+        assert result == (None, None, None)
+
+    def test_propagates_runtime_error(self, hermes_home):
+        """RuntimeError from yaml.safe_load must propagate, not be swallowed.
+
+        Stash-verify anchor: fails under old ``except Exception`` (RuntimeError
+        swallowed, returns (None, None, None)), passes after narrowing to
+        ``except (OSError, yaml.YAMLError)``.
+        """
+        import yaml
+        from unittest.mock import patch
+        (hermes_home / "config.yaml").write_text("logging:\n  level: DEBUG\n")
+        with patch.object(yaml, "safe_load", side_effect=RuntimeError("unexpected")):
+            with pytest.raises(RuntimeError):
+                hermes_logging._read_logging_config()

--- a/tests/test_timezone.py
+++ b/tests/test_timezone.py
@@ -383,3 +383,58 @@ class TestCronTimezone:
 
         next_run = datetime.fromisoformat(job["next_run_at"])
         assert next_run.tzinfo is not None
+
+
+class TestExceptionSpecificity:
+    """Regression tests: hermes_time.py except Exception narrowed to specific types."""
+
+    def test_resolve_timezone_name_returns_empty_on_os_error(self, monkeypatch, tmp_path):
+        """OSError reading config.yaml returns empty string, not an exception."""
+        from unittest.mock import patch
+        import hermes_time
+        monkeypatch.delenv("HERMES_TIMEZONE", raising=False)
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("timezone: UTC")
+        monkeypatch.setattr("hermes_time.get_config_path", lambda: cfg)
+        with patch("builtins.open", side_effect=OSError("disk error")):
+            result = hermes_time._resolve_timezone_name()
+        assert result == ""
+
+    def test_resolve_timezone_name_returns_empty_on_yaml_error(self, monkeypatch, tmp_path):
+        """yaml.YAMLError from safe_load returns empty string, not an exception."""
+        import hermes_time
+        monkeypatch.delenv("HERMES_TIMEZONE", raising=False)
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("{ bad yaml [[[")
+        monkeypatch.setattr("hermes_time.get_config_path", lambda: cfg)
+        result = hermes_time._resolve_timezone_name()
+        assert result == ""
+
+    def test_resolve_timezone_name_propagates_runtime_error(self, monkeypatch, tmp_path):
+        """RuntimeError from yaml.safe_load must propagate, not be swallowed.
+
+        Stash-verify anchor: fails under old ``except Exception`` (RuntimeError
+        swallowed, returns ""), passes after narrowing to ``except (OSError, yaml.YAMLError)``.
+        """
+        import yaml
+        import hermes_time
+        from unittest.mock import patch
+        monkeypatch.delenv("HERMES_TIMEZONE", raising=False)
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("timezone: UTC")
+        monkeypatch.setattr("hermes_time.get_config_path", lambda: cfg)
+        with patch.object(yaml, "safe_load", side_effect=RuntimeError("unexpected")):
+            with pytest.raises(RuntimeError):
+                hermes_time._resolve_timezone_name()
+
+    def test_get_zoneinfo_propagates_non_key_error(self):
+        """Non-KeyError from ZoneInfo must propagate, not be swallowed.
+
+        Stash-verify anchor: fails under old ``except (KeyError, Exception)``
+        (all exceptions swallowed), passes after narrowing to ``except KeyError``.
+        """
+        from unittest.mock import patch
+        import hermes_time
+        with patch("hermes_time.ZoneInfo", side_effect=RuntimeError("unexpected")):
+            with pytest.raises(RuntimeError):
+                hermes_time._get_zoneinfo("America/Sao_Paulo")


### PR DESCRIPTION
## What does this PR do?

Three `except Exception` handlers across `hermes_time.py` and `hermes_logging.py` silently swallowed any exception. Each is narrowed to the specific expected failure modes:

## Root cause

The detailed rationale from the original PR body is preserved below. This template update keeps the review structure consistent with #29640.

## Fix

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

N/A

<details>
<summary>Original body</summary>

## Summary

Three `except Exception` handlers across `hermes_time.py` and `hermes_logging.py` silently swallowed any exception. Each is narrowed to the specific expected failure modes:

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Summary

Three `except Exception` handlers across `hermes_time.py` and `hermes_logging.py` silently swallowed any exception. Each is narrowed to the specific expected failure modes:

| File | Function | Old | New |
|---|---|---|---|
| `hermes_time.py` | `_resolve_timezone_name` | `except Exception` | `except (OSError, yaml.YAMLError)` + split `except ImportError` |
| `hermes_time.py` | `_get_zoneinfo` | `except (KeyError, Exception)` | `except KeyError` |
| `hermes_logging.py` | `_read_logging_config` | `except Exception` | `except (OSError, yaml.YAMLError)` + split `except ImportError` |

**`_resolve_timezone_name` / `_read_logging_config`:** both read `config.yaml` using `yaml.safe_load`. The only expected failures are `OSError` (missing/unreadable file) and `yaml.YAMLError` (malformed YAML). The `import yaml` is now guarded separately with `except ImportError` so the outer try can use `yaml.YAMLError` safely.

**`_get_zoneinfo`:** `ZoneInfoNotFoundError` is already a `KeyError` subclass — listing `Exception` after it made `KeyError` redundant and swallowed unrelated errors like `RuntimeError`.

## Tests

- `TestExceptionSpecificity` in `tests/test_timezone.py` (4 tests)
- `TestReadLoggingConfigExceptionSpecificity` in `tests/test_hermes_logging.py` (3 tests)

Stash-verify anchors:
- `test_resolve_timezone_name_propagates_runtime_error` — patches `yaml.safe_load` → `RuntimeError`; confirms propagation
- `test_get_zoneinfo_propagates_non_key_error` — patches `ZoneInfo` → `RuntimeError`; confirms propagation
- `test_propagates_runtime_error` (logging) — patches `yaml.safe_load` → `RuntimeError`; confirms propagation

All 7 tests pass.

## Related

Part of a series narrowing broad exception handlers across hermes-agent (#22659, #22666, #22695, #22735).

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_