### PR TITLE
fix(account_usage): guard float() against non-numeric API credit values

### DIFF
--- a/agent/account_usage.py
+++ b/agent/account_usage.py
@@ -259,8 +259,14 @@ def _fetch_openrouter_account_usage(base_url: Optional[str], api_key: Optional[s
             key_data = (key_resp.json() or {}).get("data") or {}
         except Exception:
             key_data = {}
-    total_credits = float(credits.get("total_credits") or 0.0)
-    total_usage = float(credits.get("total_usage") or 0.0)
+    try:
+        total_credits = float(credits.get("total_credits") or 0.0)
+    except (TypeError, ValueError):
+        total_credits = 0.0
+    try:
+        total_usage = float(credits.get("total_usage") or 0.0)
+    except (TypeError, ValueError):
+        total_usage = 0.0
     details = [f"Credits balance: ${max(0.0, total_credits - total_usage):.2f}"]
     windows: list[AccountUsageWindow] = []
     limit = key_data.get("limit")

--- a/tests/test_account_usage.py
+++ b/tests/test_account_usage.py
@@ -201,3 +201,39 @@ def test_fetch_account_usage_openrouter_omits_quota_window_when_key_has_no_limit
     assert snapshot.windows == ()
     assert "Credits balance: $74.50" in snapshot.details
     assert "API key usage: $25.50 total • $1.25 today • $4.50 this week • $18.00 this month" in snapshot.details
+
+
+def test_fetch_account_usage_openrouter_tolerates_non_numeric_credit_values(monkeypatch):
+    """Non-numeric total_credits / total_usage must not raise ValueError."""
+    monkeypatch.setattr(
+        "agent.account_usage.resolve_runtime_provider",
+        lambda requested, explicit_base_url=None, explicit_api_key=None: {
+            "provider": "openrouter",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "sk-test",
+        },
+    )
+    monkeypatch.setattr(
+        "agent.account_usage.httpx.Client",
+        lambda timeout=10.0: _RoutingClient(
+            {
+                "https://openrouter.ai/api/v1/credits": {
+                    # API returning strings instead of numbers (malformed response)
+                    "data": {"total_credits": "N/A", "total_usage": "unknown"}
+                },
+                "https://openrouter.ai/api/v1/key": {
+                    "data": {
+                        "limit": None,
+                        "limit_remaining": None,
+                        "usage": None,
+                    }
+                },
+            }
+        ),
+    )
+
+    # Before fix this raised ValueError; now returns a snapshot with zeroed credits.
+    snapshot = fetch_account_usage("openrouter")
+
+    assert snapshot is not None
+    assert "Credits balance: $0.00" in snapshot.details


### PR DESCRIPTION
## What does this PR do?

`fetch_openrouter_account_usage` calls `float()` unconditionally on the `total_credits` and `total_usage` fields from the OpenRouter credits endpoint:

## Root cause

`fetch_openrouter_account_usage` calls `float()` unconditionally on the `total_credits` and `total_usage` fields from the OpenRouter credits endpoint:

```python
total_credits = float(credits.get("total_credits") or 0.0)
total_usage   = float(credits.get("total_usage")   or 0.0)
```

When the API returns a malformed response with non-numeric strings (`"N/A"`, `"unknown"`, etc.), `float()` raises `ValueError`. This exception propagates up through `fetch_account_usage`'s bare `except Exception: return None` handler, silently turning every `/usage` invocation into a no-op instead of a graceful degraded result.

## Fix

Wrap each conversion in `try/except (TypeError, ValueError)` with a `0.0` fallback:

```python
try:
    total_credits = float(credits.get("total_credits") or 0.0)
except (TypeError, ValueError):
    total_credits = 0.0
try:
    total_usage = float(credits.get("total_usage") or 0.0)
except (TypeError, ValueError):
    total_usage = 0.0
```

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

N/A

<details>
<summary>Original body</summary>

## Summary

`fetch_openrouter_account_usage` calls `float()` unconditionally on the `total_credits` and `total_usage` fields from the OpenRouter credits endpoint:

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Problem

`fetch_openrouter_account_usage` calls `float()` unconditionally on the `total_credits` and `total_usage` fields from the OpenRouter credits endpoint:

```python
total_credits = float(credits.get("total_credits") or 0.0)
total_usage   = float(credits.get("total_usage")   or 0.0)
```

When the API returns a malformed response with non-numeric strings (`"N/A"`, `"unknown"`, etc.), `float()` raises `ValueError`. This exception propagates up through `fetch_account_usage`'s bare `except Exception: return None` handler, silently turning every `/usage` invocation into a no-op instead of a graceful degraded result.

## Root Cause

Missing `try/except` around the `float()` conversions. The identical issue is already solved for rate-limit headers in `rate_limit_tracker.py` via `_safe_float()`, but `account_usage.py` didn't follow the same pattern.

## Fix

Wrap each conversion in `try/except (TypeError, ValueError)` with a `0.0` fallback:

```python
try:
    total_credits = float(credits.get("total_credits") or 0.0)
except (TypeError, ValueError):
    total_credits = 0.0
try:
    total_usage = float(credits.get("total_usage") or 0.0)
except (TypeError, ValueError):
    total_usage = 0.0
```

## Tests

`test_fetch_account_usage_openrouter_tolerates_non_numeric_credit_values` — passes `"N/A"` / `"unknown"` as credit values. Without the fix `fetch_account_usage` returns `None` (ValueError swallowed by caller); with the fix it returns a valid snapshot with `"Credits balance: $0.00"`.

Stash-verified: test fails `(assert None is not None)` without the fix, passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_