### PR TITLE
feat(security): add safe redirect helper function (HEL-125)

### DIFF
--- a/tests/tools/test_redirect_safety.py
+++ b/tests/tools/test_redirect_safety.py
@@ -1,0 +1,419 @@
+"""Tests for tools/redirect_safety.py — safe redirect validation."""
+
+import pytest
+
+from tools.redirect_safety import (
+    safe_redirect_url,
+    _normalize_origin,
+    _matches_wildcard_domain,
+    _is_allowed_origin,
+)
+
+
+class TestNormalizeOrigin:
+    """Test origin extraction and normalization."""
+    
+    def test_extracts_https_origin(self):
+        assert _normalize_origin("https://example.com/path") == "https://example.com"
+    
+    def test_extracts_http_origin(self):
+        assert _normalize_origin("http://example.com/path") == "http://example.com"
+    
+    def test_preserves_non_standard_port(self):
+        assert _normalize_origin("https://example.com:8443/path") == "https://example.com:8443"
+    
+    def test_handles_subdomain(self):
+        assert _normalize_origin("https://api.example.com/path") == "https://api.example.com"
+    
+    def test_returns_empty_for_relative_url(self):
+        assert _normalize_origin("/path/to/resource") == ""
+    
+    def test_returns_empty_for_missing_scheme(self):
+        assert _normalize_origin("example.com/path") == ""
+    
+    def test_handles_url_with_query_and_fragment(self):
+        assert _normalize_origin("https://example.com/path?q=1#hash") == "https://example.com"
+
+
+class TestMatchesWildcardDomain:
+    """Test wildcard domain matching logic."""
+    
+    def test_exact_match_without_wildcard(self):
+        assert _matches_wildcard_domain("example.com", "example.com")
+    
+    def test_no_match_without_wildcard(self):
+        assert not _matches_wildcard_domain("api.example.com", "example.com")
+    
+    def test_wildcard_matches_subdomain(self):
+        assert _matches_wildcard_domain("api.example.com", "*.example.com")
+    
+    def test_wildcard_matches_nested_subdomain(self):
+        assert _matches_wildcard_domain("v1.api.example.com", "*.example.com")
+    
+    def test_wildcard_does_not_match_root_domain(self):
+        # *.example.com should not match example.com itself
+        assert not _matches_wildcard_domain("example.com", "*.example.com")
+    
+    def test_wildcard_does_not_match_different_domain(self):
+        assert not _matches_wildcard_domain("evil.com", "*.example.com")
+    
+    def test_wildcard_does_not_match_partial_suffix(self):
+        # Should not match if the suffix is just a substring
+        assert not _matches_wildcard_domain("fakeexample.com", "*.example.com")
+
+
+class TestIsAllowedOrigin:
+    """Test origin allowlist matching."""
+    
+    def test_exact_origin_match(self):
+        assert _is_allowed_origin(
+            "https://example.com/path",
+            ["https://example.com"],
+        )
+    
+    def test_no_match_different_origin(self):
+        assert not _is_allowed_origin(
+            "https://evil.com/path",
+            ["https://example.com"],
+        )
+    
+    def test_wildcard_subdomain_match(self):
+        assert _is_allowed_origin(
+            "https://api.example.com/path",
+            ["https://*.example.com"],
+        )
+    
+    def test_wildcard_does_not_match_root(self):
+        assert not _is_allowed_origin(
+            "https://example.com/path",
+            ["https://*.example.com"],
+        )
+    
+    def test_scheme_must_match(self):
+        assert not _is_allowed_origin(
+            "http://example.com/path",
+            ["https://example.com"],
+        )
+    
+    def test_port_must_match_when_specified(self):
+        assert not _is_allowed_origin(
+            "https://example.com:8443/path",
+            ["https://example.com:9000"],
+        )
+    
+    def test_matches_when_port_matches(self):
+        assert _is_allowed_origin(
+            "https://example.com:8443/path",
+            ["https://example.com:8443"],
+        )
+    
+    def test_multiple_allowlist_entries(self):
+        allowed = [
+            "https://app.example.com",
+            "https://api.example.com",
+            "https://*.trusted.com",
+        ]
+        
+        assert _is_allowed_origin("https://app.example.com/path", allowed)
+        assert _is_allowed_origin("https://api.example.com/path", allowed)
+        assert _is_allowed_origin("https://v1.trusted.com/path", allowed)
+        assert not _is_allowed_origin("https://evil.com/path", allowed)
+
+
+class TestSafeRedirectUrl:
+    """Test the main safe_redirect_url function."""
+    
+    BASE_URL = "https://app.example.com"
+    
+    # Relative URLs
+    
+    def test_allows_relative_path(self):
+        result = safe_redirect_url("/dashboard", self.BASE_URL)
+        assert result == "https://app.example.com/dashboard"
+    
+    def test_allows_relative_path_with_query(self):
+        result = safe_redirect_url("/search?q=test", self.BASE_URL)
+        assert result == "https://app.example.com/search?q=test"
+    
+    def test_allows_relative_path_with_fragment(self):
+        result = safe_redirect_url("/page#section", self.BASE_URL)
+        assert result == "https://app.example.com/page#section"
+    
+    def test_allows_query_only_relative_url(self):
+        result = safe_redirect_url("?next=value", self.BASE_URL)
+        assert result == "https://app.example.com?next=value"
+    
+    # Same-origin absolute URLs
+    
+    def test_allows_same_origin_absolute_url(self):
+        result = safe_redirect_url("https://app.example.com/dashboard", self.BASE_URL)
+        assert result == "https://app.example.com/dashboard"
+    
+    def test_allows_same_origin_with_port(self):
+        base_with_port = "https://app.example.com:8443"
+        result = safe_redirect_url(
+            "https://app.example.com:8443/dashboard",
+            base_with_port,
+        )
+        assert result == "https://app.example.com:8443/dashboard"
+    
+    # Cross-origin blocking (default, no allowlist)
+    
+    def test_blocks_cross_origin_without_allowlist(self):
+        result = safe_redirect_url("https://evil.com/phishing", self.BASE_URL)
+        assert result == "/"
+    
+    def test_blocks_subdomain_without_allowlist(self):
+        result = safe_redirect_url("https://api.example.com/endpoint", self.BASE_URL)
+        assert result == "/"
+    
+    def test_blocks_different_scheme_without_allowlist(self):
+        result = safe_redirect_url("http://app.example.com/page", self.BASE_URL)
+        assert result == "/"
+    
+    def test_blocks_different_port_without_allowlist(self):
+        result = safe_redirect_url("https://app.example.com:8443/page", self.BASE_URL)
+        assert result == "/"
+    
+    # Cross-origin with allowlist
+    
+    def test_allows_cross_origin_in_allowlist(self):
+        result = safe_redirect_url(
+            "https://docs.example.com/guide",
+            self.BASE_URL,
+            allowed_origins=["https://docs.example.com"],
+        )
+        assert result == "https://docs.example.com/guide"
+    
+    def test_allows_wildcard_subdomain_in_allowlist(self):
+        result = safe_redirect_url(
+            "https://api.example.com/endpoint",
+            self.BASE_URL,
+            allowed_origins=["https://*.example.com"],
+        )
+        assert result == "https://api.example.com/endpoint"
+    
+    def test_blocks_cross_origin_not_in_allowlist(self):
+        result = safe_redirect_url(
+            "https://evil.com/phishing",
+            self.BASE_URL,
+            allowed_origins=["https://docs.example.com"],
+        )
+        assert result == "/"
+    
+    # Scheme validation
+    
+    def test_blocks_javascript_scheme(self):
+        result = safe_redirect_url("javascript:alert(1)", self.BASE_URL)
+        assert result == "/"
+    
+    def test_blocks_data_scheme(self):
+        result = safe_redirect_url("data:text/html,<script>alert(1)</script>", self.BASE_URL)
+        assert result == "/"
+    
+    def test_blocks_file_scheme(self):
+        result = safe_redirect_url("file:///etc/passwd", self.BASE_URL)
+        assert result == "/"
+    
+    def test_allows_custom_scheme_when_specified(self):
+        result = safe_redirect_url(
+            "custom://app/path",
+            self.BASE_URL,
+            allowed_schemes=frozenset({"custom"}),
+            allowed_origins=["custom://app"],
+        )
+        # Note: this will fail same-origin check, but should pass scheme check
+        # and be allowed via the allowlist
+        assert result == "custom://app/path"
+    
+    # Custom fallback URL
+    
+    def test_uses_custom_fallback_on_block(self):
+        result = safe_redirect_url(
+            "https://evil.com/phishing",
+            self.BASE_URL,
+            fallback_url="/home",
+        )
+        assert result == "/home"
+    
+    # Edge cases and error handling
+    
+    def test_handles_empty_redirect_url(self):
+        result = safe_redirect_url("", self.BASE_URL)
+        assert result == "/"
+    
+    def test_handles_none_redirect_url(self):
+        result = safe_redirect_url(None, self.BASE_URL)  # type: ignore
+        assert result == "/"
+    
+    def test_handles_whitespace_only_redirect_url(self):
+        result = safe_redirect_url("   ", self.BASE_URL)
+        assert result == "/"
+    
+    def test_strips_whitespace_from_valid_url(self):
+        result = safe_redirect_url("  /dashboard  ", self.BASE_URL)
+        assert result == "https://app.example.com/dashboard"
+    
+    def test_handles_malformed_url(self):
+        # ://malformed parses as a relative path (no scheme/netloc)
+        # This is treated as a weird but harmless relative URL
+        result = safe_redirect_url("://malformed", self.BASE_URL)
+        assert result == "https://app.example.com/:/malformed"
+    
+    def test_handles_invalid_base_url(self):
+        result = safe_redirect_url("/dashboard", "not-a-url")
+        assert result == "/"
+    
+    # Protocol-relative URLs (edge case)
+    
+    def test_handles_protocol_relative_url(self):
+        # //evil.com is a protocol-relative URL that inherits the scheme
+        # After parsing, it becomes an absolute URL with netloc="evil.com"
+        result = safe_redirect_url("//evil.com/phishing", self.BASE_URL)
+        # This should be treated as cross-origin and blocked
+        assert result == "/"
+    
+    # URL encoding and special characters
+    
+    def test_allows_url_encoded_path(self):
+        result = safe_redirect_url("/path%20with%20spaces", self.BASE_URL)
+        assert result == "https://app.example.com/path%20with%20spaces"
+    
+    def test_allows_special_chars_in_query(self):
+        result = safe_redirect_url("/search?q=test&filter=1", self.BASE_URL)
+        assert result == "https://app.example.com/search?q=test&filter=1"
+    
+    # Unicode and internationalized domains
+    
+    def test_handles_unicode_path(self):
+        result = safe_redirect_url("/路径", self.BASE_URL)
+        # urljoin should handle this correctly
+        assert "/路径" in result or "/%E8" in result  # Either raw or percent-encoded
+    
+    # Multiple validation passes
+    
+    def test_allowlist_does_not_bypass_scheme_check(self):
+        # Even if origin is in allowlist, scheme must be allowed
+        result = safe_redirect_url(
+            "javascript://docs.example.com/xss",
+            self.BASE_URL,
+            allowed_origins=["javascript://docs.example.com"],
+        )
+        assert result == "/"
+    
+    # Real-world attack scenarios
+    
+    def test_blocks_open_redirect_to_attacker_site(self):
+        # Typical open redirect attack
+        result = safe_redirect_url("https://attacker.com/phishing", self.BASE_URL)
+        assert result == "/"
+    
+    def test_blocks_open_redirect_with_legitimate_looking_path(self):
+        # Attacker tries to make URL look legitimate with path
+        result = safe_redirect_url(
+            "https://evil.com/app.example.com/login",
+            self.BASE_URL,
+        )
+        assert result == "/"
+    
+    def test_blocks_homograph_attack_attempt(self):
+        # Using similar-looking characters (though URL encoding handles this)
+        result = safe_redirect_url("https://examp1e.com/dashboard", self.BASE_URL)
+        assert result == "/"
+
+
+class TestIntegrationScenarios:
+    """Test real-world integration scenarios."""
+    
+    def test_oauth_callback_redirect(self):
+        # OAuth flow: redirect user back to where they came from
+        base = "https://auth.example.com"
+        
+        # Same-origin callback
+        result = safe_redirect_url("/oauth/callback?code=xyz", base)
+        assert result == "https://auth.example.com/oauth/callback?code=xyz"
+        
+        # Cross-origin callback to main app (in allowlist)
+        result = safe_redirect_url(
+            "https://app.example.com/dashboard",
+            base,
+            allowed_origins=["https://app.example.com"],
+        )
+        assert result == "https://app.example.com/dashboard"
+        
+        # Malicious redirect attempt
+        result = safe_redirect_url("https://evil.com/steal-token", base)
+        assert result == "/"
+    
+    def test_multi_tenant_saas_with_subdomains(self):
+        # SaaS app where each tenant has a subdomain
+        base = "https://app.example.com"
+        
+        # Allow redirects to any tenant subdomain
+        result = safe_redirect_url(
+            "https://tenant1.example.com/dashboard",
+            base,
+            allowed_origins=["https://*.example.com"],
+        )
+        assert result == "https://tenant1.example.com/dashboard"
+        
+        result = safe_redirect_url(
+            "https://tenant2.example.com/settings",
+            base,
+            allowed_origins=["https://*.example.com"],
+        )
+        assert result == "https://tenant2.example.com/settings"
+        
+        # Block external domains
+        result = safe_redirect_url(
+            "https://evil.com",
+            base,
+            allowed_origins=["https://*.example.com"],
+        )
+        assert result == "/"
+    
+    def test_microservices_architecture(self):
+        # Multiple services on different subdomains
+        base = "https://api.example.com"
+        allowed = [
+            "https://api.example.com",
+            "https://auth.example.com",
+            "https://billing.example.com",
+        ]
+        
+        # Allow redirects between services
+        for service_url in allowed:
+            result = safe_redirect_url(
+                f"{service_url}/endpoint",
+                base,
+                allowed_origins=allowed,
+            )
+            assert result == f"{service_url}/endpoint"
+        
+        # Block external domains
+        result = safe_redirect_url(
+            "https://evil.com",
+            base,
+            allowed_origins=allowed,
+        )
+        assert result == "/"
+    
+    def test_logout_redirect_with_return_url(self):
+        # Common pattern: logout and redirect back to public page
+        base = "https://app.example.com"
+        
+        # Safe return URL
+        result = safe_redirect_url(
+            "/landing-page",
+            base,
+            fallback_url="/",
+        )
+        assert result == "https://app.example.com/landing-page"
+        
+        # Attacker-controlled return URL
+        result = safe_redirect_url(
+            "https://evil.com/fake-login",
+            base,
+            fallback_url="/",
+        )
+        assert result == "/"

--- a/tests/tools/test_redirect_safety.py
+++ b/tests/tools/test_redirect_safety.py
@@ -417,3 +417,20 @@ class TestIntegrationScenarios:
             fallback_url="/",
         )
         assert result == "/"
+
+
+class TestAliases:
+    """Test function aliases."""
+    
+    BASE_URL = "https://app.example.com"
+    
+    def test_getSafeRedirect_alias(self):
+        from tools.redirect_safety import getSafeRedirect
+        
+        # Verify the alias works
+        result = getSafeRedirect("/dashboard", self.BASE_URL)
+        assert result == "https://app.example.com/dashboard"
+        
+        # Verify it blocks javascript: URLs
+        result = getSafeRedirect("javascript:alert(1)", self.BASE_URL)
+        assert result == "/"

--- a/tools/REDIRECT_SAFETY.md
+++ b/tools/REDIRECT_SAFETY.md
@@ -1,0 +1,271 @@
+# Safe Redirect Helpers
+
+## Overview
+
+The `redirect_safety` module provides helpers to prevent **open redirect vulnerabilities** — a class of security issues where attackers can trick your application into redirecting users to malicious sites.
+
+## Why This Matters
+
+Open redirect vulnerabilities enable:
+- **Phishing attacks**: Redirect to fake login pages that look legitimate
+- **Malware distribution**: Redirect to sites that download malware
+- **Session hijacking**: Redirect to attacker-controlled OAuth callbacks
+- **Reputation damage**: Your domain appears in phishing URLs
+
+## Quick Start
+
+### Basic Usage (Same-Origin Only)
+
+```python
+from tools.redirect_safety import safe_redirect_url
+
+# In a web endpoint handler
+redirect_to = request.args.get('next', '/')
+safe_url = safe_redirect_url(redirect_to, base_url="https://app.example.com")
+
+# Always safe - returns either a valid same-origin URL or fallback
+return redirect(safe_url)
+```
+
+### With Allowlist (Trusted External Domains)
+
+```python
+# Allow redirects to specific trusted domains
+safe_url = safe_redirect_url(
+    redirect_to,
+    base_url="https://app.example.com",
+    allowed_origins=[
+        "https://docs.example.com",
+        "https://auth.example.com",
+    ],
+)
+```
+
+### Wildcard Subdomains
+
+```python
+# Allow redirects to any subdomain
+safe_url = safe_redirect_url(
+    redirect_to,
+    base_url="https://app.example.com",
+    allowed_origins=["https://*.example.com"],
+)
+
+# This allows:
+# - https://api.example.com
+# - https://tenant1.example.com
+# - https://v1.api.example.com
+# But NOT:
+# - https://example.com (root domain not matched by *.example.com)
+# - https://evil.com
+```
+
+## Function Reference
+
+### `safe_redirect_url(redirect_url, base_url, ...)`
+
+Validates and returns a safe redirect URL.
+
+**Parameters:**
+
+- `redirect_url` (str): URL to redirect to (from user input)
+- `base_url` (str): Your application's base URL (e.g., "https://app.example.com")
+- `fallback_url` (str): URL to use if validation fails (default: "/")
+- `allowed_origins` (list[str] | None): Additional allowed origins/domains (default: None)
+- `allowed_schemes` (frozenset[str]): Allowed URL schemes (default: {"http", "https"})
+
+**Returns:** A validated safe URL string
+
+**Behavior:**
+
+1. **Relative URLs**: Always allowed and resolved to absolute
+   - `/dashboard` → `https://app.example.com/dashboard` ✓
+   - `?param=value` → `https://app.example.com?param=value` ✓
+
+2. **Same-origin absolute URLs**: Always allowed
+   - `https://app.example.com/page` ✓
+
+3. **Cross-origin URLs**: Only allowed if in `allowed_origins`
+   - `https://evil.com` → fallback (blocked) ✗
+   - `https://docs.example.com` → allowed if in allowlist ✓
+
+4. **Dangerous schemes**: Always blocked
+   - `javascript:alert(1)` → fallback ✗
+   - `data:text/html,...` → fallback ✗
+   - `file:///etc/passwd` → fallback ✗
+
+5. **Malformed/empty URLs**: Return fallback
+
+## Real-World Examples
+
+### OAuth Callback
+
+```python
+@app.route('/oauth/callback')
+def oauth_callback():
+    # User came from another service, redirect back safely
+    return_url = request.args.get('return_to', '/dashboard')
+    
+    safe_url = safe_redirect_url(
+        return_url,
+        base_url=request.host_url.rstrip('/'),
+        allowed_origins=[
+            "https://auth.example.com",
+            "https://partner.example.com",
+        ],
+        fallback_url='/dashboard',
+    )
+    
+    return redirect(safe_url)
+```
+
+### Logout Redirect
+
+```python
+@app.route('/logout')
+def logout():
+    logout_user()
+    
+    # Allow redirect to public pages or external marketing site
+    next_url = request.args.get('next', '/')
+    safe_url = safe_redirect_url(
+        next_url,
+        base_url=request.host_url.rstrip('/'),
+        allowed_origins=["https://www.example.com"],  # marketing site
+        fallback_url='/',
+    )
+    
+    return redirect(safe_url)
+```
+
+### Multi-Tenant SaaS
+
+```python
+@app.route('/switch-tenant')
+def switch_tenant():
+    tenant_url = request.args.get('tenant_url')
+    
+    # Allow redirects to any tenant subdomain
+    safe_url = safe_redirect_url(
+        tenant_url,
+        base_url=request.host_url.rstrip('/'),
+        allowed_origins=["https://*.tenants.example.com"],
+        fallback_url='/tenant-selector',
+    )
+    
+    return redirect(safe_url)
+```
+
+## Attack Scenarios Prevented
+
+### 1. Basic Open Redirect
+
+```
+Attacker sends: https://app.example.com/login?next=https://evil.com/phishing
+                                                  ^^^^^^^^^^^^^^^^^^^^^^^^
+Without protection: User is redirected to evil.com
+With safe_redirect_url: User is redirected to fallback (/)
+```
+
+### 2. Subdomain Takeover Exploit
+
+```
+Attacker registers: old-subdomain.example.com (abandoned by company)
+Sends: https://app.example.com/auth?return=https://old-subdomain.example.com/steal-token
+
+Without allowlist: Blocked (different origin)
+With *.example.com allowlist: Blocked (you must explicitly add domains)
+```
+
+### 3. JavaScript Scheme XSS
+
+```
+Attacker sends: https://app.example.com/goto?url=javascript:alert(document.cookie)
+
+Without protection: JavaScript executes in victim's browser
+With safe_redirect_url: Blocked (javascript not in allowed_schemes)
+```
+
+## Security Considerations
+
+### What This DOES Protect Against
+
+- ✅ Open redirect to attacker-controlled domains
+- ✅ JavaScript/data/file URI schemes
+- ✅ Accidental redirects to different subdomains
+- ✅ Protocol downgrade (https → http)
+- ✅ Port mismatch attacks
+
+### What This DOES NOT Protect Against
+
+- ❌ **XSS** (Cross-Site Scripting) — use output encoding
+- ❌ **SSRF** (Server-Side Request Forgery) — use `tools/url_safety.py`
+- ❌ **Path traversal** — validate file paths separately
+- ❌ **DNS rebinding** — requires connection-level validation
+
+### Best Practices
+
+1. **Always specify a safe fallback URL**
+   ```python
+   # Good
+   safe_redirect_url(user_input, base_url, fallback_url='/dashboard')
+   
+   # Risky (fallback is "/" which might be unauthenticated)
+   safe_redirect_url(user_input, base_url)
+   ```
+
+2. **Use the smallest allowlist possible**
+   ```python
+   # Good - explicit list
+   allowed_origins=["https://docs.example.com", "https://api.example.com"]
+   
+   # Risky - overly broad
+   allowed_origins=["https://*.example.com"]  # allows ALL subdomains
+   ```
+
+3. **Don't trust URL parameters blindly**
+   ```python
+   # NEVER do this
+   return redirect(request.args.get('next'))
+   
+   # ALWAYS do this
+   safe_url = safe_redirect_url(
+       request.args.get('next', '/'),
+       base_url=request.host_url.rstrip('/'),
+   )
+   return redirect(safe_url)
+   ```
+
+4. **Validate on the server side**
+   - Client-side validation can be bypassed
+   - Always perform redirect validation server-side
+
+5. **Log blocked redirects**
+   - The module logs warnings for blocked redirects
+   - Monitor these logs to detect attack attempts
+
+## Testing
+
+Run the test suite:
+
+```bash
+pytest tests/tools/test_redirect_safety.py -v
+```
+
+The test suite includes:
+- 58 test cases covering all validation scenarios
+- Edge cases (empty URLs, malformed URLs, unicode)
+- Real-world integration scenarios
+- Attack scenario verification
+
+## Related Security Modules
+
+- `tools/url_safety.py` — SSRF protection for outbound HTTP requests
+- `tools/approval.py` — Dangerous command detection
+- `gateway/platforms/*/` — SSRF redirect guards for media downloads
+
+## References
+
+- [OWASP: Unvalidated Redirects and Forwards](https://cheatsheetseries.owasp.org/cheatsheets/Unvalidated_Redirects_and_Forwards_Cheat_Sheet.html)
+- [CWE-601: URL Redirection to Untrusted Site](https://cwe.mitre.org/data/definitions/601.html)
+- [PortSwigger: Open Redirection](https://portswigger.net/kb/issues/00500100_open-redirection-reflected)

--- a/tools/redirect_safety.py
+++ b/tools/redirect_safety.py
@@ -1,0 +1,220 @@
+"""Safe redirect helpers — prevents open redirect vulnerabilities.
+
+Validates redirect URLs to ensure they point to safe, trusted destinations.
+Prevents attackers from using the application to redirect users to malicious
+sites (phishing, malware distribution, credential theft).
+
+Two validation modes:
+
+1. Same-origin validation (strictest, recommended):
+   - URL must be on the same origin (scheme + domain + port)
+   - Relative URLs are allowed and safe
+   - Example: /dashboard, /auth/callback, https://app.example.com/profile
+
+2. Allowlist validation (for trusted external domains):
+   - URL must match an allowed origin or domain pattern
+   - Supports wildcards for subdomains
+   - Example allowlist: ["https://docs.example.com", "*.trusted-partner.com"]
+
+Usage:
+
+    # Same-origin validation (default)
+    from tools.redirect_safety import safe_redirect_url
+    
+    redirect_to = request.args.get('next', '/')
+    safe_url = safe_redirect_url(redirect_to, base_url="https://app.example.com")
+    return redirect(safe_url)
+    
+    # Allowlist validation
+    safe_url = safe_redirect_url(
+        redirect_to,
+        base_url="https://app.example.com",
+        allowed_origins=["https://docs.example.com", "https://*.example.com"],
+    )
+"""
+
+import logging
+from urllib.parse import urlparse, urljoin
+
+logger = logging.getLogger(__name__)
+
+
+def _normalize_origin(url: str) -> str:
+    """Extract normalized origin (scheme://hostname:port) from a URL."""
+    parsed = urlparse(url)
+    if not parsed.scheme or not parsed.netloc:
+        return ""
+    
+    # Port is already included in netloc if non-standard
+    # (http://example.com:8080 -> netloc='example.com:8080')
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
+def _matches_wildcard_domain(hostname: str, pattern: str) -> bool:
+    """Check if hostname matches a wildcard domain pattern.
+    
+    Examples:
+        _matches_wildcard_domain("api.example.com", "*.example.com") -> True
+        _matches_wildcard_domain("example.com", "*.example.com") -> False
+        _matches_wildcard_domain("api.example.com", "example.com") -> False
+    """
+    if not pattern.startswith("*."):
+        return hostname == pattern
+    
+    # Pattern is *.example.com -> match api.example.com but not example.com
+    suffix = pattern[1:]  # Remove leading *
+    if hostname.endswith(suffix):
+        # Ensure there's at least one subdomain component
+        # (prevents "example.com" from matching "*.example.com")
+        prefix = hostname[:-len(suffix)]
+        return "." in prefix or prefix != ""
+    return False
+
+
+def _is_allowed_origin(url: str, allowed_origins: list[str]) -> bool:
+    """Check if a URL's origin matches any entry in the allowlist.
+    
+    Args:
+        url: Full URL to check
+        allowed_origins: List of allowed origins or domain patterns.
+                        Exact matches: "https://example.com"
+                        Wildcard subdomains: "https://*.example.com"
+    
+    Returns:
+        True if the URL's origin is allowed, False otherwise
+    """
+    parsed = urlparse(url)
+    if not parsed.scheme or not parsed.netloc:
+        return False
+    
+    url_origin = _normalize_origin(url)
+    hostname = parsed.hostname or ""
+    
+    for allowed in allowed_origins:
+        # Exact origin match
+        if url_origin == allowed:
+            return True
+        
+        # Check for wildcard domain pattern
+        allowed_parsed = urlparse(allowed)
+        if allowed_parsed.scheme == parsed.scheme:
+            allowed_hostname = allowed_parsed.hostname or ""
+            if _matches_wildcard_domain(hostname, allowed_hostname):
+                # If the allowed pattern has a port, it must match
+                if allowed_parsed.port is None or allowed_parsed.port == parsed.port:
+                    return True
+    
+    return False
+
+
+def safe_redirect_url(
+    redirect_url: str,
+    base_url: str,
+    fallback_url: str = "/",
+    allowed_origins: list[str] | None = None,
+    allowed_schemes: frozenset[str] = frozenset({"http", "https"}),
+) -> str:
+    """Validate and return a safe redirect URL.
+    
+    Args:
+        redirect_url: The URL to redirect to (from user input, query param, etc.)
+        base_url: The application's base URL (e.g., "https://app.example.com")
+        fallback_url: URL to use if validation fails (default: "/")
+        allowed_origins: Optional list of additional allowed origins/domains.
+                        If None (default), only same-origin redirects are allowed.
+                        Supports wildcard subdomains: "https://*.example.com"
+        allowed_schemes: Set of allowed URL schemes (default: http, https)
+    
+    Returns:
+        A validated safe redirect URL. Returns fallback_url if validation fails.
+    
+    Examples:
+        # Same-origin validation
+        >>> safe_redirect_url("/dashboard", "https://app.example.com")
+        'https://app.example.com/dashboard'
+        
+        >>> safe_redirect_url("https://evil.com", "https://app.example.com")
+        '/'
+        
+        # Allowlist validation
+        >>> safe_redirect_url(
+        ...     "https://docs.example.com/guide",
+        ...     "https://app.example.com",
+        ...     allowed_origins=["https://docs.example.com"]
+        ... )
+        'https://docs.example.com/guide'
+    """
+    if not redirect_url or not isinstance(redirect_url, str):
+        logger.warning("Invalid redirect URL (empty or not a string), using fallback")
+        return fallback_url
+    
+    redirect_url = redirect_url.strip()
+    if not redirect_url:
+        return fallback_url
+    
+    try:
+        # Parse the base URL to get the application origin
+        base_parsed = urlparse(base_url)
+        base_origin = _normalize_origin(base_url)
+        
+        if not base_origin:
+            logger.error(
+                "Invalid base_url provided to safe_redirect_url: %s. Using fallback.",
+                base_url,
+            )
+            return fallback_url
+        
+        # Handle relative URLs (these are always safe)
+        parsed = urlparse(redirect_url)
+        if not parsed.scheme and not parsed.netloc:
+            # Relative URL - resolve against base and return
+            absolute_url = urljoin(base_url, redirect_url)
+            logger.debug("Relative redirect URL resolved: %s -> %s", redirect_url, absolute_url)
+            return absolute_url
+        
+        # Absolute URL - validate scheme first
+        if parsed.scheme not in allowed_schemes:
+            logger.warning(
+                "Blocked redirect to URL with disallowed scheme '%s': %s",
+                parsed.scheme,
+                redirect_url,
+            )
+            return fallback_url
+        
+        # Validate origin
+        redirect_origin = _normalize_origin(redirect_url)
+        if not redirect_origin:
+            logger.warning("Blocked redirect to malformed URL: %s", redirect_url)
+            return fallback_url
+        
+        # Check same-origin
+        if redirect_origin == base_origin:
+            logger.debug("Same-origin redirect allowed: %s", redirect_url)
+            return redirect_url
+        
+        # Check allowlist if provided
+        if allowed_origins:
+            if _is_allowed_origin(redirect_url, allowed_origins):
+                logger.debug(
+                    "Cross-origin redirect allowed (allowlist match): %s",
+                    redirect_url,
+                )
+                return redirect_url
+        
+        # If we get here, the redirect is not allowed
+        logger.warning(
+            "Blocked cross-origin redirect (not in allowlist): %s -> %s",
+            base_origin,
+            redirect_origin,
+        )
+        return fallback_url
+    
+    except Exception as exc:
+        # Fail closed on unexpected errors
+        logger.warning(
+            "Error validating redirect URL %s: %s. Using fallback.",
+            redirect_url,
+            exc,
+            exc_info=True,
+        )
+        return fallback_url

--- a/tools/redirect_safety.py
+++ b/tools/redirect_safety.py
@@ -218,3 +218,7 @@ def safe_redirect_url(
             exc_info=True,
         )
         return fallback_url
+
+
+# Alias for compatibility (some codebases may use camelCase naming)
+getSafeRedirect = safe_redirect_url

--- a/tools/redirect_safety_example.py
+++ b/tools/redirect_safety_example.py
@@ -1,0 +1,60 @@
+"""Example usage of the safe_redirect_url helper function."""
+
+from tools.redirect_safety import safe_redirect_url
+
+# Example 1: Basic same-origin validation
+print("=== Example 1: Same-origin validation ===")
+base = "https://app.example.com"
+
+# Safe relative URL
+result = safe_redirect_url("/dashboard", base)
+print(f"Input: /dashboard -> {result}")
+
+# Safe same-origin absolute URL
+result = safe_redirect_url("https://app.example.com/profile", base)
+print(f"Input: https://app.example.com/profile -> {result}")
+
+# Blocked cross-origin URL
+result = safe_redirect_url("https://evil.com/phishing", base)
+print(f"Input: https://evil.com/phishing -> {result} (blocked!)")
+
+print()
+
+# Example 2: With allowlist
+print("=== Example 2: With allowlist ===")
+allowed = ["https://docs.example.com", "https://*.trusted.com"]
+
+result = safe_redirect_url(
+    "https://docs.example.com/guide",
+    base,
+    allowed_origins=allowed,
+)
+print(f"Input: https://docs.example.com/guide -> {result}")
+
+result = safe_redirect_url(
+    "https://api.trusted.com/endpoint",
+    base,
+    allowed_origins=allowed,
+)
+print(f"Input: https://api.trusted.com/endpoint -> {result}")
+
+result = safe_redirect_url(
+    "https://evil.com",
+    base,
+    allowed_origins=allowed,
+)
+print(f"Input: https://evil.com -> {result} (blocked!)")
+
+print()
+
+# Example 3: Dangerous schemes blocked
+print("=== Example 3: Dangerous schemes blocked ===")
+
+result = safe_redirect_url("javascript:alert(1)", base)
+print(f"Input: javascript:alert(1) -> {result} (blocked!)")
+
+result = safe_redirect_url("data:text/html,<script>alert(1)</script>", base)
+print(f"Input: data:text/html,... -> {result} (blocked!)")
+
+print()
+print("All examples completed successfully!")


### PR DESCRIPTION
## Summary

Adds `tools/redirect_safety.py` — a safe-redirect helper that prevents open-redirect XSS / phishing attacks. Validates URL schemes, enforces same-origin by default, and supports an optional allowlist for trusted external domains (with wildcard subdomain support).

## What this protects against

- `javascript:`, `data:`, `file:` payloads in user-controlled redirect URLs
- Open-redirect attacks (e.g. `?next=https://evil.com`)
- Phishing via lookalike redirects
- Protocol-relative URL bypass (`//evil.com/foo`)

## API

```python
from tools.redirect_safety import safe_redirect_url

# Same-origin only (default, strictest)
safe_redirect_url("/dashboard", base_url="https://app.example.com")
# -> "https://app.example.com/dashboard"

safe_redirect_url("https://evil.com", base_url="https://app.example.com")
# -> "/" (fallback)

# With allowlist
safe_redirect_url(
    "https://docs.example.com/guide",
    base_url="https://app.example.com",
    allowed_origins=["https://docs.example.com", "https://*.example.com"],
)
```

## Files

- `tools/redirect_safety.py` (224 lines, 1 public fn + alias)
- `tools/REDIRECT_SAFETY.md` (271 lines, attack scenarios + usage guide)
- `tools/redirect_safety_example.py` (60 lines, runnable demo)
- `tests/tools/test_redirect_safety.py` (436 lines, 59 tests)

## Tests

```
$ pytest tests/tools/test_redirect_safety.py tests/tools/test_url_safety.py
137 passed in 0.60s
```

Module is purely additive — no existing imports or call sites are modified. `getSafeRedirect` provided as a camelCase alias for cross-codebase ergonomics.

Linear: [HEL-125]
