### PR TITLE
fix(prompt_builder): guard _build_snapshot_entry against None platform entries

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -915,7 +915,7 @@ def _build_snapshot_entry(
         "category": category,
         "frontmatter_name": str(frontmatter.get("name", skill_name)),
         "description": description,
-        "platforms": [str(p).strip() for p in platforms if str(p).strip()],
+        "platforms": [str(p).strip() for p in platforms if p is not None and str(p).strip()],
         "conditions": extract_skill_conditions(frontmatter),
     }
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -15,6 +15,7 @@ from agent.prompt_builder import (
     _find_hermes_md,
     _find_git_root,
     _strip_yaml_frontmatter,
+    _build_snapshot_entry,
     build_skills_system_prompt,
     build_nous_subscription_prompt,
     build_context_files_prompt,
@@ -1003,6 +1004,33 @@ class TestSkillShouldShow:
         conditions = {"fallback_for_toolsets": [], "requires_toolsets": [],
                       "fallback_for_tools": [], "requires_tools": ["terminal"]}
         assert _skill_should_show(conditions, {"terminal"}, set()) is True
+
+
+class TestBuildSnapshotEntryNoneFilter:
+    """_build_snapshot_entry must drop None entries from the platforms list."""
+
+    def _make_entry(self, platforms):
+        from pathlib import Path
+        skills_dir = Path("/skills")
+        skill_file = skills_dir / "myplugin" / "myskill" / "SKILL.md"
+        frontmatter = {"platforms": platforms}
+        return _build_snapshot_entry(skill_file, skills_dir, frontmatter, "desc")
+
+    def test_none_entries_not_converted_to_string(self):
+        result = self._make_entry(["macos", None, "linux"])
+        assert "None" not in result["platforms"]
+
+    def test_none_entries_dropped(self):
+        result = self._make_entry(["macos", None, "linux"])
+        assert result["platforms"] == ["macos", "linux"]
+
+    def test_all_none_produces_empty_list(self):
+        result = self._make_entry([None, None])
+        assert result["platforms"] == []
+
+    def test_no_none_unchanged(self):
+        result = self._make_entry(["macos", "linux"])
+        assert result["platforms"] == ["macos", "linux"]
 
 
 class TestBuildSkillsSystemPromptConditional:


### PR DESCRIPTION
## What does this PR do?

`_build_snapshot_entry` in `agent/prompt_builder.py` builds serialisable metadata for each skill. When a skill's YAML frontmatter contains a `null` entry in the `platforms` list (e.g. `platforms: [macos, null, linux]`), the list comprehension converts `None` to the literal string `"None"` before testing truthiness, so the null entry is never filtered out:

## Root cause

`_build_snapshot_entry` in `agent/prompt_builder.py` builds serialisable metadata for each skill. When a skill's YAML frontmatter contains a `null` entry in the `platforms` list (e.g. `platforms: [macos, null, linux]`), the list comprehension converts `None` to the literal string `"None"` before testing truthiness, so the null entry is never filtered out:

```python
# Before (line 918):
"platforms": [str(p).strip() for p in platforms if str(p).strip()]
# str(None) == "None" → passes the truthiness check → "None" ends up in the list
```

This corrupts the platforms list used for skill platform-compatibility filtering, potentially including skills on platforms they don't support.

## Fix

Add an explicit `p is not None` pre-check before the `str()` conversion:

```python
# After:
"platforms": [str(p).strip() for p in platforms if p is not None and str(p).strip()]
```

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

N/A

<details>
<summary>Original body</summary>

## Summary

`_build_snapshot_entry` in `agent/prompt_builder.py` builds serialisable metadata for each skill. When a skill's YAML frontmatter contains a `null` entry in the `platforms` list (e.g. `platforms: [macos, null, linux]`), the list comprehension converts `None` to the literal string `"None"` before testing truthiness, so the null entry is never filtered out:

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Problem

`_build_snapshot_entry` in `agent/prompt_builder.py` builds serialisable metadata for each skill. When a skill's YAML frontmatter contains a `null` entry in the `platforms` list (e.g. `platforms: [macos, null, linux]`), the list comprehension converts `None` to the literal string `"None"` before testing truthiness, so the null entry is never filtered out:

```python
# Before (line 918):
"platforms": [str(p).strip() for p in platforms if str(p).strip()]
# str(None) == "None" → passes the truthiness check → "None" ends up in the list
```

This corrupts the platforms list used for skill platform-compatibility filtering, potentially including skills on platforms they don't support.

## Root cause

`str(None)` returns `"None"`, which is a non-empty string and therefore truthy. The guard `if str(p).strip()` never catches `None` entries.

## Fix

Add an explicit `p is not None` pre-check before the `str()` conversion:

```python
# After:
"platforms": [str(p).strip() for p in platforms if p is not None and str(p).strip()]
```

## Tests

Added `TestBuildSnapshotEntryNoneFilter` with 4 regression cases:
- `None` mixed with valid strings → `None` dropped, valid strings kept
- All-`None` list → empty result
- `None`-free list → unchanged
- Asserts `"None"` (the string) never appears in output

All 125 existing `test_prompt_builder.py` tests continue to pass.

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_