### PR TITLE
fix(models_dev): guard cost field float() against non-numeric API values

### DIFF
--- a/agent/models_dev.py
+++ b/agent/models_dev.py
@@ -512,6 +512,14 @@ def list_agentic_models(provider: str) -> List[str]:
 # Rich dataclass constructors — parse raw models.dev JSON into dataclasses
 # ---------------------------------------------------------------------------
 
+def _safe_cost_float(value: Any, default: float = 0.0) -> float:
+    """Convert a cost field to float, returning default on non-numeric values."""
+    try:
+        return float(value or 0)
+    except (TypeError, ValueError):
+        return default
+
+
 def _parse_model_info(model_id: str, raw: Dict[str, Any], provider_id: str) -> ModelInfo:
     """Convert a raw models.dev model entry dict into a ModelInfo dataclass."""
     limit = raw.get("limit") or {}
@@ -552,10 +560,10 @@ def _parse_model_info(model_id: str, raw: Dict[str, Any], provider_id: str) -> M
         context_window=ctx_int,
         max_output=out_int,
         max_input=inp_int,
-        cost_input=float(cost.get("input", 0) or 0),
-        cost_output=float(cost.get("output", 0) or 0),
-        cost_cache_read=float(cost["cache_read"]) if "cache_read" in cost and cost["cache_read"] is not None else None,
-        cost_cache_write=float(cost["cache_write"]) if "cache_write" in cost and cost["cache_write"] is not None else None,
+        cost_input=_safe_cost_float(cost.get("input", 0)),
+        cost_output=_safe_cost_float(cost.get("output", 0)),
+        cost_cache_read=_safe_cost_float(cost["cache_read"]) if "cache_read" in cost and cost["cache_read"] is not None else None,
+        cost_cache_write=_safe_cost_float(cost["cache_write"]) if "cache_write" in cost and cost["cache_write"] is not None else None,
         knowledge_cutoff=raw.get("knowledge", "") or "",
         release_date=raw.get("release_date", "") or "",
         status=raw.get("status", "") or "",

--- a/tests/agent/test_models_dev.py
+++ b/tests/agent/test_models_dev.py
@@ -299,3 +299,58 @@ class TestGetModelCapabilities:
         with patch("agent.models_dev.fetch_models_dev", return_value=CAPS_REGISTRY):
             caps = get_model_capabilities("anthropic", "nonexistent-model")
         assert caps is None
+
+# ---------------------------------------------------------------------------
+# _safe_cost_float / _parse_model_info — non-numeric cost field robustness
+# ---------------------------------------------------------------------------
+
+
+class TestSafeCostFloat:
+    def test_numeric_string_converted(self):
+        from agent.models_dev import _safe_cost_float
+        assert _safe_cost_float("0.5") == 0.5
+
+    def test_none_returns_zero(self):
+        from agent.models_dev import _safe_cost_float
+        assert _safe_cost_float(None) == 0.0
+
+    def test_non_numeric_string_returns_default(self):
+        from agent.models_dev import _safe_cost_float
+        # Before fix, float("variable") raised ValueError in _parse_model_info.
+        assert _safe_cost_float("variable") == 0.0
+
+    def test_non_numeric_string_custom_default(self):
+        from agent.models_dev import _safe_cost_float
+        assert _safe_cost_float("N/A", default=1.5) == 1.5
+
+
+class TestParseModelInfoNonNumericCost:
+    """get_model_info must not raise ValueError when cost fields are strings."""
+
+    @patch("agent.models_dev.fetch_models_dev")
+    def test_string_cost_fields_return_zero(self, mock_fetch):
+        from agent.models_dev import get_model_info
+
+        mock_fetch.return_value = {
+            "openai": {
+                "models": {
+                    "gpt-test": {
+                        "cost": {
+                            # API returning non-numeric strings (malformed response)
+                            "input": "variable",
+                            "output": "N/A",
+                            "cache_read": "unknown",
+                            "cache_write": "unknown",
+                        }
+                    }
+                }
+            }
+        }
+
+        # Before fix this raised ValueError; now returns ModelInfo with 0.0 costs.
+        info = get_model_info("openai", "gpt-test")
+        assert info is not None
+        assert info.cost_input == 0.0
+        assert info.cost_output == 0.0
+        assert info.cost_cache_read == 0.0
+        assert info.cost_cache_write == 0.0


### PR DESCRIPTION
## What does this PR do?

`_parse_model_info` called `float()` unconditionally on cost fields from the models.dev JSON payload:

## Root cause

`_parse_model_info` called `float()` unconditionally on cost fields from the models.dev JSON payload:

```python
cost_input=float(cost.get("input", 0) or 0),
cost_output=float(cost.get("output", 0) or 0),
cost_cache_read=float(cost["cache_read"]) if "cache_read" in cost and cost["cache_read"] is not None else None,
cost_cache_write=float(cost["cache_write"]) if "cache_write" in cost and cost["cache_write"] is not None else None,
```

If the registry returns a non-numeric string (`"variable"`, `"N/A"`, etc.) for any cost field, `float()` raises `ValueError` and crashes model info lookup for that provider/model. The adjacent `limit` fields (`ctx_int`, `out_int`, `inp_int`) already use…

## Fix

Add `_safe_cost_float(value, default=0.0)` helper that wraps `float()` in `try/except (TypeError, ValueError)`, matching the `_safe_float` pattern already used in `rate_limit_tracker.py`. Replace all four bare `float()` calls with it.

## Why this shape

This shape mirrors #29640 so reviewers can quickly compare scope, root cause, fix, tests, and related context without having to decode a custom PR description.

## Tests

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## Related PRs / issues

N/A

<details>
<summary>Original body</summary>

## Summary

`_parse_model_info` called `float()` unconditionally on cost fields from the models.dev JSON payload:

## What Changed

- Standardized this PR body to the current Hermes Turbo template.
- Preserved the original detailed description below for reference.

## Fluxo

A mudança continua seguindo o fluxo original descrito na seção preservada abaixo, sem ampliar o escopo funcional deste PR.

## Visão

A padronização melhora a revisão, reduz ruído e evita deriva de formatação entre PRs abertos.

## Test Plan

- Veja a descrição original preservada abaixo para detalhes de validação, testes e notas de verificação.

<details>
<summary>Original body</summary>

## What does this PR do?

## Problem

`_parse_model_info` called `float()` unconditionally on cost fields from the models.dev JSON payload:

```python
cost_input=float(cost.get("input", 0) or 0),
cost_output=float(cost.get("output", 0) or 0),
cost_cache_read=float(cost["cache_read"]) if "cache_read" in cost and cost["cache_read"] is not None else None,
cost_cache_write=float(cost["cache_write"]) if "cache_write" in cost and cost["cache_write"] is not None else None,
```

If the registry returns a non-numeric string (`"variable"`, `"N/A"`, etc.) for any cost field, `float()` raises `ValueError` and crashes model info lookup for that provider/model. The adjacent `limit` fields (`ctx_int`, `out_int`, `inp_int`) already use `isinstance` guards — cost fields were inconsistently left unguarded.

## Fix

Add `_safe_cost_float(value, default=0.0)` helper that wraps `float()` in `try/except (TypeError, ValueError)`, matching the `_safe_float` pattern already used in `rate_limit_tracker.py`. Replace all four bare `float()` calls with it.

## Tests

- `TestSafeCostFloat`: verifies the helper handles numeric strings, `None`, and non-numeric strings correctly.
- `TestParseModelInfoNonNumericCost.test_string_cost_fields_return_zero`: passes `"variable"`/`"N/A"`/`"unknown"` cost fields through `get_model_info`; before fix raises `ValueError`; after fix returns `ModelInfo` with `cost_input == 0.0` etc.

Stash-verified: 5 tests fail (`ImportError` on `_safe_cost_float` + `ValueError` in `_parse_model_info`) without the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Solution Sketch

- fix the root cause in the touched subsystem instead of layering a broad workaround around the symptom
- keep surrounding behavior stable and avoid unrelated refactors while the area is under review
- prove the change with focused checks on the exact path that regressed

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- preserved the existing technical rationale and validation notes inside the template body
- scoped this PR description to the implementation already present on the branch
- aligned the delivery format with `.github/PULL_REQUEST_TEMPLATE.md`

## How to Test

1. Review the existing validation notes preserved in this PR body.
2. Run the focused checks for the touched area.
3. Confirm the scoped change still behaves as described above.

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- N/A.

</details>

---

_Generated by Hermes Turbo_

</details>

---

_Generated by Hermes Turbo_