### PR TITLE
fix(computer-use): skip follow-up capture when action failed (ok=False)

### DIFF
--- a/tests/tools/test_computer_use.py
+++ b/tests/tools/test_computer_use.py
@@ -155,6 +155,40 @@ class TestDispatch:
         click_kw = next(c[1] for c in noop_backend.calls if c[0] == "click")
         assert click_kw["button"] == "right"
 
+    def test_capture_after_skipped_when_action_failed(self, noop_backend):
+        """capture_after must not fire when res.ok=False (regression guard).
+
+        A follow-up screenshot after a failed action shows the screen in a
+        normal state, misleading the model into thinking the action succeeded.
+        """
+        from unittest.mock import patch
+        from tools.computer_use.backend import ActionResult
+        from tools.computer_use.tool import handle_computer_use
+
+        # Make click() return a failure.
+        with patch.object(noop_backend, "click",
+                          return_value=ActionResult(ok=False, action="click",
+                                                    message="element not found")):
+            out = handle_computer_use({"action": "click", "element": 99,
+                                       "capture_after": True})
+
+        parsed = json.loads(out)
+        # Should return the error, not a multimodal capture.
+        assert parsed.get("ok") is False
+        assert parsed.get("action") == "click"
+        # No follow-up capture should have been issued.
+        capture_calls = [c for c in noop_backend.calls if c[0] == "capture"]
+        assert len(capture_calls) == 0, "capture must not be called after a failed action"
+
+    def test_capture_after_fires_when_action_succeeds(self, noop_backend):
+        """capture_after must trigger for successful actions."""
+        from tools.computer_use.tool import handle_computer_use
+        out = handle_computer_use({"action": "click", "element": 1,
+                                   "capture_after": True})
+        # Noop backend returns ok=True, so capture should have been called.
+        capture_calls = [c for c in noop_backend.calls if c[0] == "capture"]
+        assert len(capture_calls) == 1
+
 
 # ---------------------------------------------------------------------------
 # Safety guards (type / key block lists)

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -456,6 +456,11 @@ def _maybe_follow_capture(
 ) -> Any:
     if not do_capture:
         return _text_response(res)
+    # Skip the follow-up capture when the action itself failed: showing a
+    # normal-looking screenshot after a failure misleads the model into thinking
+    # the action succeeded. Return the error text instead.
+    if not res.ok:
+        return _text_response(res)
     try:
         cap = backend.capture(mode="som")
     except Exception as e:


### PR DESCRIPTION
## Problem

`_maybe_follow_capture()` in `tool.py` always performs a follow-up screenshot after an action, even when `res.ok = False`. This is misleading: the model receives a normal-looking screenshot that suggests the action succeeded, making it harder to detect and recover from failures.

## Fix

Added an early-return guard in `_maybe_follow_capture` immediately after the `do_capture` check:

```python
if not res.ok:
    return _text_response(res)
```

When the action fails, the function now returns the plain error text — no screenshot is taken. This preserves the error signal so the model can reason about what went wrong.

## Tests

Two new test cases in `tests/tools/test_computer_use.py`:
- `test_capture_after_skipped_when_action_failed` — verifies no screenshot is taken on failure.
- `test_capture_after_fires_when_action_succeeds` — verifies the screenshot still fires on success (no regression).

All 46 tests pass.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)