### PR TITLE
fix(gateway): handle Discord error 30032 gracefully on reconnect

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1023,6 +1023,16 @@ class DiscordAdapter(BasePlatformAdapter):
             return True
         return False
 
+    @staticmethod
+    def _is_discord_max_commands_error(exc: BaseException) -> bool:
+        """True when Discord returns error code 30032 (max application commands reached).
+
+        This is a configuration issue, not a transient failure.  The sync
+        should be skipped on subsequent reconnects rather than spamming
+        the logs with a full stack trace every time."""
+        text = str(exc).lower()
+        return "30032" in text or "maximum number of application commands" in text
+
     def _command_sync_mutation_interval_seconds(self) -> float:
         return _DISCORD_COMMAND_SYNC_MUTATION_INTERVAL_SECONDS
 
@@ -1105,7 +1115,15 @@ class DiscordAdapter(BasePlatformAdapter):
         except asyncio.CancelledError:
             raise
         except Exception as e:  # pragma: no cover - defensive logging
-            logger.warning("[%s] Slash command sync failed: %s", self.name, e, exc_info=True)
+            if self._is_discord_max_commands_error(e):
+                logger.warning(
+                    "[%s] Slash command sync skipped: Discord application has reached "
+                    "the maximum of 100 commands. Remove unused commands from the "
+                    "Discord Developer Portal or consolidate with subcommands.",
+                    self.name,
+                )
+            else:
+                logger.warning("[%s] Slash command sync failed: %s", self.name, e, exc_info=True)
 
     def _get_discord_command_sync_policy(self) -> str:
         raw = str(os.getenv("DISCORD_COMMAND_SYNC_POLICY", "safe") or "").strip().lower()


### PR DESCRIPTION
When Discord returns error 30032 (max application commands reached), skip the verbose stack trace on every reconnect.  This is a configuration issue, not a transient failure.

Instead of logging a full traceback each time the gateway reconnects, emit a single concise warning suggesting the user consolidate commands.

## What does this PR do?

This PR fixes excessive log noise during Discord gateway reconnections.

When a Discord application reaches the hard limit of 100 slash commands, the gateway attempts to sync commands on every reconnect and receives error code 30032 ("Maximum number of application commands reached").

Previously, this triggered a full warning log with a stack trace on every single reconnection, cluttering logs and potentially masking real issues. This PR detects error 30032 specifically and replaces the verbose stack trace with a single, concise warning message advising the user to consolidate their commands.

## Related Issue

N/A

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (improves logging behavior and robustness)

## Changes Made

- **gateway/platforms/discord.py**:
  - Added _is_discord_max_commands_error() static method to identify error code 30032.
  - Updated _run_post_connect_initialization exception handling to suppress stack traces for this specific error.

## How to Test

1. Ensure your Discord app has 100+ slash commands registered (or trigger the error manually if possible).
2. Restart the gateway or force a reconnection.
3. Verify that errors.log does not contain a traceback for error 30032.
4. Verify that agent.log contains a concise warning: "Slash command sync skipped: Discord application has reached the maximum of 100 commands..."

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (fix(gateway): handle Discord error 30032 gracefully on reconnect`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run 'pytest tests/gateway/ -k discord' and all relevant tests pass
- [ ] I've added tests for my changes (logic is defensive logging; difficult to mock specific HTTPException behavior in integration without extensive setup)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] N/A (No documentation changes required)
- [x] N/A (No config keys changed)
- [x] N/A (Architecture unchanged)
- [x] I've considered cross-platform impact — No platform-specific code changed.
- [x] N/A (No tool behavior changed)
