### PR TITLE
feat: make model and provider list searchable

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -4361,8 +4361,7 @@ def _prompt_model_selection(
     menu_title = "Select default model:"
     if has_pricing:
         # Align the header with the model column.
-        # Each choice is "  {label}" (2 spaces) and simple_term_menu prepends
-        # a 3-char cursor region ("-> " or "   "), so content starts at col 5.
+        # Each curses choice has a small cursor/radio prefix before content.
         pad = " " * 5
         header = f"\n{pad}{'':>{name_col}} {'In':>{price_col}}  {'Out':>{price_col}}"
         if has_cache:
@@ -4373,55 +4372,41 @@ def _prompt_model_selection(
     _DIM = "\033[2m"
     _RESET = "\033[0m"
 
-    # Try arrow-key menu first, fall back to number input
-    try:
-        from simple_term_menu import TerminalMenu
+    choices = [_label(mid) for mid in ordered]
+    choices.append("Enter custom model name")
+    choices.append("Skip (keep current)")
 
-        choices = [f"  {_label(mid)}" for mid in ordered]
-        choices.append("  Enter custom model name")
-        choices.append("  Skip (keep current)")
+    if sys.stdin.isatty():
+        try:
+            from hermes_cli.curses_ui import curses_radiolist
 
-        # Print the unavailable block BEFORE the menu via regular print().
-        # simple_term_menu pads title lines to terminal width (causes wrapping),
-        # so we keep the title minimal and use stdout for the static block.
-        # clear_screen=False means our printed output stays visible above.
-        _upgrade_url = (portal_url or DEFAULT_NOUS_PORTAL_URL).rstrip("/")
-        if _unavailable:
-            print(menu_title)
-            print()
-            for mid in _unavailable:
-                print(f"{_DIM}     {_label(mid)}{_RESET}")
-            print()
-            print(f"{_DIM}  ── Upgrade at {_upgrade_url} for paid models ──{_RESET}")
-            print()
-            effective_title = "Available free models:"
-        else:
+            _upgrade_url = (portal_url or DEFAULT_NOUS_PORTAL_URL).rstrip("/")
+            description = None
             effective_title = menu_title
+            if _unavailable:
+                unavailable_lines = [_label(mid) for mid in _unavailable]
+                description = "\n".join(
+                    ["Unavailable models (requires paid tier):", *unavailable_lines, f"Upgrade: {_upgrade_url}"]
+                )
+                effective_title = "Available free models:"
 
-        menu = TerminalMenu(
-            choices,
-            cursor_index=default_idx,
-            menu_cursor="-> ",
-            menu_cursor_style=("fg_green", "bold"),
-            menu_highlight_style=("fg_green",),
-            cycle_cursor=True,
-            clear_screen=False,
-            title=effective_title,
-        )
-        idx = menu.show()
-        from hermes_cli.curses_ui import flush_stdin
-        flush_stdin()
-        if idx is None:
+            idx = curses_radiolist(
+                effective_title,
+                choices,
+                selected=default_idx,
+                cancel_returns=len(ordered) + 1,
+                description=description,
+                searchable=True,
+            )
+            print()
+            if idx < len(ordered):
+                return ordered[idx]
+            if idx == len(ordered):
+                custom = input("Enter model name: ").strip()
+                return custom if custom else None
             return None
-        print()
-        if idx < len(ordered):
-            return ordered[idx]
-        elif idx == len(ordered):
-            custom = input("Enter model name: ").strip()
-            return custom if custom else None
-        return None
-    except (ImportError, NotImplementedError, OSError, subprocess.SubprocessError):
-        pass
+        except (KeyboardInterrupt, OSError, subprocess.SubprocessError):
+            return None
 
     # Fallback: numbered list
     print(menu_title)

--- a/hermes_cli/curses_ui.py
+++ b/hermes_cli/curses_ui.py
@@ -4,10 +4,113 @@ Used by `hermes tools` and `hermes skills` for interactive checklists.
 Provides a curses multi-select with keyboard navigation, plus a
 text-based numbered fallback for terminals without curses support.
 """
+from dataclasses import dataclass
 import sys
 from typing import Callable, List, Optional, Set
 
 from hermes_cli.colors import Colors, color
+
+
+def _query_matches(label: str, query: str) -> bool:
+    """Return True when every query token is a case-insensitive subsequence."""
+    normalized = label.lower()
+    tokens = query.lower().split()
+
+    if not tokens:
+        return True
+
+    for token in tokens:
+        pos = 0
+
+        for ch in token:
+            pos = normalized.find(ch, pos)
+
+            if pos < 0:
+                return False
+
+            pos += 1
+
+    return True
+
+
+def _filter_indices(items: List[str], query: str) -> List[int]:
+    """Return original item indices matching *query*, preserving list order."""
+    q = query.strip()
+
+    if not q:
+        return list(range(len(items)))
+
+    return [i for i, label in enumerate(items) if _query_matches(label, q)]
+
+
+@dataclass
+class _SearchState:
+    """Mutable search state shared by curses picker loops."""
+
+    active: bool = False
+    query: str = ""
+
+
+def _reconcile_cursor(filtered: List[int], cursor: int) -> tuple[int, int]:
+    """Return ``(cursor, cursor_pos)`` inside the filtered index list."""
+    if not filtered:
+        return cursor, 0
+
+    if cursor not in filtered:
+        cursor = filtered[0]
+
+    return cursor, filtered.index(cursor)
+
+
+def _move_filtered_cursor(filtered: List[int], cursor: int, cursor_pos: int, delta: int) -> int:
+    """Move through the filtered index list, wrapping like the legacy menus."""
+    if not filtered:
+        return cursor
+
+    return filtered[(cursor_pos + delta) % len(filtered)]
+
+
+def _scroll_for_cursor(scroll_offset: int, cursor_pos: int, visible_rows: int, total_rows: int) -> int:
+    """Clamp scroll offset so the cursor remains visible."""
+    visible_rows = max(1, visible_rows)
+
+    if cursor_pos < scroll_offset:
+        scroll_offset = cursor_pos
+    elif cursor_pos >= scroll_offset + visible_rows:
+        scroll_offset = cursor_pos - visible_rows + 1
+
+    return max(0, min(scroll_offset, max(0, total_rows - visible_rows)))
+
+
+def _handle_active_search_key(curses_mod, key: int, search: _SearchState) -> tuple[bool, bool, bool]:
+    """Handle a key while the search prompt is active.
+
+    Returns ``(handled, confirm, changed)``. Active search consumes query
+    editing keys, but leaves navigation keys for the menu loop to handle.
+    """
+    if not search.active:
+        return False, False, False
+
+    if key == 27:
+        search.active = False
+        return True, False, False
+
+    if key in (curses_mod.KEY_BACKSPACE, 127, 8):
+        search.query = search.query[:-1]
+        return True, False, True
+
+    if key == 21:  # Ctrl+U
+        search.query = ""
+        return True, False, True
+
+    if key in (curses_mod.KEY_ENTER, 10, 13):
+        return True, True, False
+
+    if 0 <= key < 256 and chr(key).isprintable():
+        search.query += chr(key)
+        return True, False, True
+
+    return False, False, False
 
 
 def flush_stdin() -> None:
@@ -169,6 +272,7 @@ def curses_radiolist(
     *,
     cancel_returns: int | None = None,
     description: str | None = None,
+    searchable: bool = False,
 ) -> int:
     """Curses single-select radio list. Returns the selected index.
 
@@ -180,6 +284,8 @@ def curses_radiolist(
         description: Optional multi-line text shown between the title and
             the item list.  Useful for context that should survive the
             curses screen clear.
+        searchable: When true, "/" opens a filter prompt. The returned value
+            is always the original item index, not the filtered row position.
     """
     if cancel_returns is None:
         cancel_returns = selected
@@ -204,10 +310,13 @@ def curses_radiolist(
                 curses.init_pair(2, curses.COLOR_YELLOW, -1)
             cursor = selected
             scroll_offset = 0
+            search = _SearchState()
 
             while True:
                 stdscr.clear()
                 max_y, max_x = stdscr.getmaxyx()
+                filtered = _filter_indices(items, search.query) if searchable else list(range(len(items)))
+                cursor, cursor_pos = _reconcile_cursor(filtered, cursor)
 
                 row = 0
 
@@ -226,26 +335,30 @@ def curses_radiolist(
                         stdscr.addnstr(row, 0, dline, max_x - 1, curses.A_NORMAL)
                         row += 1
 
-                    stdscr.addnstr(
-                        row, 0,
-                        "  \u2191\u2193 navigate  ENTER/SPACE select  ESC cancel",
-                        max_x - 1, curses.A_DIM,
-                    )
+                    if searchable and search.active:
+                        help_text = f"  Search: {search.query}\u258e  BACKSPACE edit  Ctrl+U clear  ESC stop search"
+                    elif searchable:
+                        help_text = "  \u2191\u2193 navigate  ENTER/SPACE select  / search  ESC cancel"
+                    else:
+                        help_text = "  \u2191\u2193 navigate  ENTER/SPACE select  ESC cancel"
+                    stdscr.addnstr(row, 0, help_text, max_x - 1, curses.A_DIM)
                     row += 1
                 except curses.error:
                     pass
 
                 # Scrollable item list
                 items_start = row + 1
-                visible_rows = max_y - items_start - 1
-                if cursor < scroll_offset:
-                    scroll_offset = cursor
-                elif cursor >= scroll_offset + visible_rows:
-                    scroll_offset = cursor - visible_rows + 1
+                visible_rows = max(1, max_y - items_start - 1)
+                scroll_offset = _scroll_for_cursor(scroll_offset, cursor_pos, visible_rows, len(filtered))
 
-                for draw_i, i in enumerate(
-                    range(scroll_offset, min(len(items), scroll_offset + visible_rows))
-                ):
+                if searchable and search.query and not filtered:
+                    try:
+                        stdscr.addnstr(items_start, 0, "  No matches", max_x - 1, curses.A_DIM)
+                    except curses.error:
+                        pass
+
+                for draw_i, filtered_pos in enumerate(range(scroll_offset, min(len(filtered), scroll_offset + visible_rows))):
+                    i = filtered[filtered_pos]
                     y = draw_i + items_start
                     if y >= max_y - 1:
                         break
@@ -265,13 +378,26 @@ def curses_radiolist(
                 stdscr.refresh()
                 key = stdscr.getch()
 
+                if searchable:
+                    handled, confirm, changed = _handle_active_search_key(curses, key, search)
+                    if handled:
+                        if changed:
+                            scroll_offset = 0
+                        if confirm and filtered:
+                            result_holder[0] = cursor
+                            return
+                        continue
+
                 if key in (curses.KEY_UP, ord("k")):
-                    cursor = (cursor - 1) % len(items)
+                    cursor = _move_filtered_cursor(filtered, cursor, cursor_pos, -1)
                 elif key in (curses.KEY_DOWN, ord("j")):
-                    cursor = (cursor + 1) % len(items)
+                    cursor = _move_filtered_cursor(filtered, cursor, cursor_pos, 1)
                 elif key in (ord(" "), curses.KEY_ENTER, 10, 13):
-                    result_holder[0] = cursor
-                    return
+                    if filtered:
+                        result_holder[0] = cursor
+                        return
+                elif searchable and key == ord("/"):
+                    search.active = True
                 elif key in (27, ord("q")):
                     result_holder[0] = cancel_returns
                     return
@@ -318,11 +444,14 @@ def curses_single_select(
     default_index: int = 0,
     *,
     cancel_label: str = "Cancel",
+    searchable: bool = False,
 ) -> int | None:
     """Curses single-select menu. Returns selected index or None on cancel.
 
     Works inside prompt_toolkit because curses.wrapper() restores the terminal
-    safely, unlike simple_term_menu which conflicts with /dev/tty.
+    safely, unlike simple_term_menu which conflicts with /dev/tty. When
+    searchable=True, "/" opens a filter prompt and selection still returns
+    the original item index.
     """
     if not sys.stdin.isatty():
         return None
@@ -343,33 +472,40 @@ def curses_single_select(
                 curses.init_pair(2, curses.COLOR_YELLOW, -1)
             cursor = min(default_index, len(all_items) - 1)
             scroll_offset = 0
+            search = _SearchState()
 
             while True:
                 stdscr.clear()
                 max_y, max_x = stdscr.getmaxyx()
+                filtered = _filter_indices(all_items, search.query) if searchable else list(range(len(all_items)))
+                cursor, cursor_pos = _reconcile_cursor(filtered, cursor)
 
                 try:
                     hattr = curses.A_BOLD
                     if curses.has_colors():
                         hattr |= curses.color_pair(2)
                     stdscr.addnstr(0, 0, title, max_x - 1, hattr)
-                    stdscr.addnstr(
-                        1, 0,
-                        "  ↑↓ navigate  ENTER confirm  ESC/q cancel",
-                        max_x - 1, curses.A_DIM,
-                    )
+                    if searchable and search.active:
+                        help_text = f"  Search: {search.query}\u258e  BACKSPACE edit  Ctrl+U clear  ESC stop search"
+                    elif searchable:
+                        help_text = "  ↑↓ navigate  ENTER confirm  / search  ESC/q cancel"
+                    else:
+                        help_text = "  ↑↓ navigate  ENTER confirm  ESC/q cancel"
+                    stdscr.addnstr(1, 0, help_text, max_x - 1, curses.A_DIM)
                 except curses.error:
                     pass
 
-                visible_rows = max_y - 3
-                if cursor < scroll_offset:
-                    scroll_offset = cursor
-                elif cursor >= scroll_offset + visible_rows:
-                    scroll_offset = cursor - visible_rows + 1
+                visible_rows = max(1, max_y - 3)
+                scroll_offset = _scroll_for_cursor(scroll_offset, cursor_pos, visible_rows, len(filtered))
 
-                for draw_i, i in enumerate(
-                    range(scroll_offset, min(len(all_items), scroll_offset + visible_rows))
-                ):
+                if searchable and search.query and not filtered:
+                    try:
+                        stdscr.addnstr(3, 0, "  No matches", max_x - 1, curses.A_DIM)
+                    except curses.error:
+                        pass
+
+                for draw_i, filtered_pos in enumerate(range(scroll_offset, min(len(filtered), scroll_offset + visible_rows))):
+                    i = filtered[filtered_pos]
                     y = draw_i + 3
                     if y >= max_y - 1:
                         break
@@ -388,13 +524,26 @@ def curses_single_select(
                 stdscr.refresh()
                 key = stdscr.getch()
 
+                if searchable:
+                    handled, confirm, changed = _handle_active_search_key(curses, key, search)
+                    if handled:
+                        if changed:
+                            scroll_offset = 0
+                        if confirm and filtered:
+                            result_holder[0] = cursor
+                            return
+                        continue
+
                 if key in (curses.KEY_UP, ord("k")):
-                    cursor = (cursor - 1) % len(all_items)
+                    cursor = _move_filtered_cursor(filtered, cursor, cursor_pos, -1)
                 elif key in (curses.KEY_DOWN, ord("j")):
-                    cursor = (cursor + 1) % len(all_items)
+                    cursor = _move_filtered_cursor(filtered, cursor, cursor_pos, 1)
                 elif key in (curses.KEY_ENTER, 10, 13):
-                    result_holder[0] = cursor
-                    return
+                    if filtered:
+                        result_holder[0] = cursor
+                        return
+                elif searchable and key == ord("/"):
+                    search.active = True
                 elif key in (27, ord("q")):
                     result_holder[0] = None
                     return

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2437,9 +2437,15 @@ def _prompt_provider_choice(choices, *, default=0):
     if the user cancels.
     """
     try:
-        from hermes_cli.setup import _curses_prompt_choice
+        from hermes_cli.curses_ui import curses_radiolist
 
-        idx = _curses_prompt_choice("Select provider:", choices, default)
+        idx = curses_radiolist(
+            "Select provider:",
+            choices,
+            selected=default,
+            cancel_returns=-1,
+            searchable=True,
+        )
         if idx >= 0:
             print()
             return idx

--- a/tests/hermes_cli/test_curses_ui_search.py
+++ b/tests/hermes_cli/test_curses_ui_search.py
@@ -1,0 +1,68 @@
+from hermes_cli.curses_ui import (
+    _SearchState,
+    _filter_indices,
+    _handle_active_search_key,
+    _move_filtered_cursor,
+    _reconcile_cursor,
+)
+
+
+class _FakeCurses:
+    KEY_BACKSPACE = 263
+    KEY_DOWN = 258
+    KEY_ENTER = 343
+
+
+def test_filter_indices_keeps_all_items_for_blank_query():
+    assert _filter_indices(["Anthropic", "OpenAI"], "") == [0, 1]
+    assert _filter_indices(["Anthropic", "OpenAI"], "   ") == [0, 1]
+
+
+def test_filter_indices_matches_subsequences():
+    items = ["claude-opus-4-7", "gpt-5.4-codex", "deepseek-v4"]
+
+    assert _filter_indices(items, "co47") == [0]
+    assert _filter_indices(items, "gpt5") == [1]
+
+
+def test_filter_indices_requires_all_tokens():
+    items = ["OpenAI Codex", "OpenAI Chat Completions", "Anthropic Claude"]
+
+    assert _filter_indices(items, "open cod") == [0]
+
+
+def test_reconcile_cursor_moves_to_first_visible_match():
+    assert _reconcile_cursor([2, 4], 0) == (2, 0)
+    assert _reconcile_cursor([2, 4], 4) == (4, 1)
+
+
+def test_move_filtered_cursor_wraps_within_matches():
+    filtered = [2, 4, 7]
+
+    assert _move_filtered_cursor(filtered, 2, 0, -1) == 7
+    assert _move_filtered_cursor(filtered, 7, 2, 1) == 2
+
+
+def test_active_search_allows_navigation_keys_to_reach_menu_loop():
+    search = _SearchState(active=True, query="opus")
+
+    assert _handle_active_search_key(_FakeCurses, _FakeCurses.KEY_DOWN, search) == (
+        False,
+        False,
+        False,
+    )
+    assert search.active is True
+    assert search.query == "opus"
+
+
+def test_active_search_consumes_query_editing_and_confirm_keys():
+    search = _SearchState(active=True, query="op")
+
+    assert _handle_active_search_key(_FakeCurses, ord("u"), search) == (True, False, True)
+    assert search.query == "opu"
+
+    assert _handle_active_search_key(_FakeCurses, _FakeCurses.KEY_ENTER, search) == (
+        True,
+        True,
+        False,
+    )

--- a/tests/hermes_cli/test_terminal_menu_fallbacks.py
+++ b/tests/hermes_cli/test_terminal_menu_fallbacks.py
@@ -12,14 +12,10 @@ class _BrokenTerminalMenu:
         raise subprocess.CalledProcessError(2, ["tput", "clear"])
 
 
-def test_prompt_model_selection_falls_back_on_terminalmenu_runtime_error(monkeypatch):
+def test_prompt_model_selection_uses_numbered_fallback_without_tty(monkeypatch):
     from hermes_cli.auth import _prompt_model_selection
 
-    monkeypatch.setitem(
-        sys.modules,
-        "simple_term_menu",
-        types.SimpleNamespace(TerminalMenu=_BrokenTerminalMenu),
-    )
+    monkeypatch.setattr(sys.stdin, "isatty", lambda: False)
     responses = iter(["2"])
     monkeypatch.setattr("builtins.input", lambda _prompt="": next(responses))
 

--- a/ui-tui/src/components/agentsOverlay.tsx
+++ b/ui-tui/src/components/agentsOverlay.tsx
@@ -14,6 +14,7 @@ import { useTurnSelector } from '../app/turnStore.js'
 import type { GatewayClient } from '../gatewayClient.js'
 import type { DelegationPauseResponse, DelegationStatusResponse, SubagentInterruptResponse } from '../gatewayTypes.js'
 import { asRpcResult } from '../lib/rpc.js'
+import { handleSearchInput, useIndexedFuzzyList } from '../lib/searchableList.js'
 import {
   buildSubagentTree,
   descendantIds,
@@ -39,8 +40,21 @@ type SortMode = 'depth-first' | 'duration-desc' | 'status' | 'tools-desc'
 type FilterMode = 'all' | 'failed' | 'leaf' | 'running'
 type Status = SubagentProgress['status']
 
+interface AgentRowEntry {
+  goal: string
+  id: string
+  index: number
+  model: string
+  node: SubagentNode
+  notes: string
+  status: Status
+  summary: string
+  tools: string
+}
+
 const SORT_ORDER: readonly SortMode[] = ['depth-first', 'tools-desc', 'duration-desc', 'status']
 const FILTER_ORDER: readonly FilterMode[] = ['all', 'running', 'failed', 'leaf']
+const AGENT_ROW_SEARCH_KEYS = ['goal', 'id', 'model', 'notes', 'status', 'summary', 'tools'] as const
 
 const SORT_LABEL: Record<SortMode, string> = {
   'depth-first': 'spawn order',
@@ -698,6 +712,8 @@ export function AgentsOverlay({ gw, initialHistoryIndex = 0, onClose, t }: Agent
   const [cursor, setCursor] = useState(0)
   const [flash, setFlash] = useState<string>('')
   const [now, setNow] = useState(() => Date.now())
+  const [searchActive, setSearchActive] = useState(false)
+  const [searchQuery, setSearchQuery] = useState('')
   // cc-style view switching: list = full-width row picker, detail = full-width
   // scrollable pane.  Two panes side-by-side in Ink fought Yoga flex.
   const [mode, setMode] = useState<'detail' | 'list'>('list')
@@ -720,13 +736,36 @@ export function AgentsOverlay({ gw, initialHistoryIndex = 0, onClose, t }: Agent
   const widths = useMemo(() => widthByDepth(tree), [tree])
   const spark = useMemo(() => sparkline(widths), [widths])
   const peak = useMemo(() => peakHotness(tree), [tree])
-  const rows = useMemo(() => prepareRows(tree, sort, filter), [tree, sort, filter])
+  const baseRows = useMemo(() => prepareRows(tree, sort, filter), [tree, sort, filter])
 
-  const selected = rows[cursor] ?? null
+  const rowEntries = useMemo<AgentRowEntry[]>(() => baseRows.map((node, index) => ({
+    goal: node.item.goal,
+    id: node.item.id,
+    index,
+    model: node.item.model ?? '',
+    node,
+    notes: node.item.notes.join(' '),
+    status: node.item.status,
+    summary: node.item.summary ?? '',
+    tools: node.item.tools.join(' ')
+  })), [baseRows])
+
+  const { filtered: filteredRowEntries, selectedPosition: cursorPos } = useIndexedFuzzyList(
+    rowEntries,
+    searchQuery,
+    AGENT_ROW_SEARCH_KEYS,
+    cursor,
+    setCursor,
+    mode === 'list'
+  )
+
+  const rows = useMemo(() => filteredRowEntries.map(entry => entry.node), [filteredRowEntries])
+
+  const selected = rows[cursorPos] ?? null
 
   const cols = stdout?.columns ?? 80
   const rowsH = Math.max(8, (stdout?.rows ?? 24) - 10)
-  const listWindowStart = Math.max(0, cursor - Math.floor(rowsH / 2))
+  const listWindowStart = Math.max(0, cursorPos - Math.floor(rowsH / 2))
 
   // ── Effects ────────────────────────────────────────────────────────
 
@@ -773,10 +812,10 @@ export function AgentsOverlay({ gw, initialHistoryIndex = 0, onClose, t }: Agent
   }, [gw])
 
   useEffect(() => {
-    if (cursor >= rows.length) {
-      setCursor(Math.max(0, rows.length - 1))
+    if (cursor >= rowEntries.length) {
+      setCursor(Math.max(0, rowEntries.length - 1))
     }
-  }, [cursor, rows.length])
+  }, [cursor, rowEntries.length])
 
   // ── Actions ────────────────────────────────────────────────────────
 
@@ -842,6 +881,14 @@ export function AgentsOverlay({ gw, initialHistoryIndex = 0, onClose, t }: Agent
   const scrollDetail = (dy: number) => detailScrollRef.current?.scrollBy(dy)
 
   useInput((ch, key) => {
+    if (mode === 'list' && handleSearchInput(ch, key, {
+      active: searchActive,
+      setActive: setSearchActive,
+      setQuery: setSearchQuery
+    })) {
+      return
+    }
+
     if (ch === 'q') {
       return closeWithCleanup()
     }
@@ -917,19 +964,25 @@ export function AgentsOverlay({ gw, initialHistoryIndex = 0, onClose, t }: Agent
     }
 
     if (key.upArrow || ch === 'k' || key.wheelUp) {
-      return setCursor(c => Math.max(0, c - 1))
+      const entry = filteredRowEntries[Math.max(0, cursorPos - 1)]
+
+      return entry ? setCursor(entry.index) : undefined
     }
 
     if (key.downArrow || ch === 'j' || key.wheelDown) {
-      return setCursor(c => Math.min(Math.max(0, rows.length - 1), c + 1))
+      const entry = filteredRowEntries[Math.min(Math.max(0, rows.length - 1), cursorPos + 1)]
+
+      return entry ? setCursor(entry.index) : undefined
     }
 
     if (ch === 'g') {
-      return setCursor(0)
+      return filteredRowEntries[0] ? setCursor(filteredRowEntries[0].index) : undefined
     }
 
     if (ch === 'G') {
-      return setCursor(Math.max(0, rows.length - 1))
+      const entry = filteredRowEntries.at(-1)
+
+      return entry ? setCursor(entry.index) : undefined
     }
 
     if (ch === 's') {
@@ -995,18 +1048,22 @@ export function AgentsOverlay({ gw, initialHistoryIndex = 0, onClose, t }: Agent
         </Text>
       </Box>
 
-      {rows.length === 0 ? (
+      {baseRows.length === 0 ? (
         <Box flexDirection="column" flexGrow={1}>
           <Text color={t.color.muted}>No subagents this turn. Trigger delegate_task to populate the tree.</Text>
         </Box>
+      ) : rows.length === 0 ? (
+        <Box flexDirection="column" flexGrow={1}>
+          <Text color={t.color.muted}>No subagents match "{searchQuery}".</Text>
+        </Box>
       ) : mode === 'list' ? (
         <Box flexDirection="column" flexGrow={1} flexShrink={1} minHeight={0}>
-          <GanttStrip cols={cols} cursor={cursor} flatNodes={rows} maxRows={6} now={now} t={t} />
+          <GanttStrip cols={cols} cursor={cursorPos} flatNodes={rows} maxRows={6} now={now} t={t} />
 
           <Box flexDirection="column" flexGrow={0} flexShrink={0} overflow="hidden">
             {rows.slice(listWindowStart, listWindowStart + rowsH).map((node, i) => (
               <ListRow
-                active={listWindowStart + i === cursor}
+                active={listWindowStart + i === cursorPos}
                 index={listWindowStart + i}
                 key={node.item.id}
                 node={node}
@@ -1021,7 +1078,7 @@ export function AgentsOverlay({ gw, initialHistoryIndex = 0, onClose, t }: Agent
         <Box flexDirection="row" flexGrow={1} flexShrink={1} minHeight={0}>
           <ScrollBox flexDirection="column" flexGrow={1} flexShrink={1} ref={detailScrollRef}>
             <Box flexDirection="column" paddingBottom={4} paddingRight={1}>
-              {selected ? <Detail id={formatRowId(cursor).trim()} node={selected} t={t} /> : null}
+              {selected ? <Detail id={formatRowId(cursorPos).trim()} node={selected} t={t} /> : null}
             </Box>
           </ScrollBox>
 
@@ -1038,6 +1095,7 @@ export function AgentsOverlay({ gw, initialHistoryIndex = 0, onClose, t }: Agent
           <Text color={t.color.muted}>
             ↑↓/jk move · g/G top/bottom · Enter/→ open detail{controlsHint} · s sort:{SORT_LABEL[sort]} · f filter:
             {FILTER_LABEL[filter]}
+            {searchQuery || searchActive ? ` · search:${searchQuery}${searchActive ? '▎' : ''} (${rows.length}/${baseRows.length})` : ' · / search'}
             {history.length > 0 ? ` · [ / ] history ${historyIndex}/${history.length}` : ''}
             {' · q close'}
           </Text>

--- a/ui-tui/src/components/modelPicker.tsx
+++ b/ui-tui/src/components/modelPicker.tsx
@@ -6,6 +6,7 @@ import { TUI_SESSION_MODEL_FLAG } from '../domain/slash.js'
 import type { GatewayClient } from '../gatewayClient.js'
 import type { ModelOptionProvider, ModelOptionsResponse } from '../gatewayTypes.js'
 import { asRpcResult, rpcErrorMessage } from '../lib/rpc.js'
+import { handleSearchInput, useIndexedFuzzyList } from '../lib/searchableList.js'
 import type { Theme } from '../theme.js'
 
 import { OverlayHint, useOverlayKeys, windowItems } from './overlayControls.js'
@@ -13,8 +14,24 @@ import { OverlayHint, useOverlayKeys, windowItems } from './overlayControls.js'
 const VISIBLE = 12
 const MIN_WIDTH = 40
 const MAX_WIDTH = 90
+const EMPTY_MODELS: string[] = []
+const MODEL_SEARCH_KEYS = ['label'] as const
+const PROVIDER_SEARCH_KEYS = ['displayName', 'name', 'slug'] as const
 
 type Stage = 'provider' | 'key' | 'model' | 'disconnect'
+
+interface ModelEntry {
+  index: number
+  label: string
+}
+
+interface ProviderEntry {
+  displayName: string
+  index: number
+  label: string
+  name: string
+  slug: string
+}
 
 export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPickerProps) {
   const [providers, setProviders] = useState<ModelOptionProvider[]>([])
@@ -28,6 +45,9 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
   const [keyInput, setKeyInput] = useState('')
   const [keySaving, setKeySaving] = useState(false)
   const [keyError, setKeyError] = useState('')
+  const [providerQuery, setProviderQuery] = useState('')
+  const [modelQuery, setModelQuery] = useState('')
+  const [searchStage, setSearchStage] = useState<null | Stage>(null)
 
   const { stdout } = useStdout()
   // Pin the picker to a stable width so the FloatBox parent (which shrinks-
@@ -69,13 +89,59 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
   }, [gw, sessionId])
 
   const provider = providers[providerIdx]
-  const models = provider?.models ?? []
+  const models = provider?.models ?? EMPTY_MODELS
   const names = useMemo(() => providerDisplayNames(providers), [providers])
+
+  const providerEntries = useMemo<ProviderEntry[]>(() => providers.map(
+    (p, i) => {
+      const authMark = p.authenticated === false ? '○' : p.is_current ? '*' : '●'
+      const modelCount = p.total_models ?? p.models?.length ?? 0
+
+      const suffix = p.authenticated === false
+        ? (p.auth_type === 'api_key' ? '(no key)' : '(needs setup)')
+        : `${modelCount} models`
+
+      return {
+        displayName: names[i] ?? p.name,
+        index: i,
+        label: `${authMark} ${names[i]} · ${suffix}`,
+        name: p.name,
+        slug: p.slug
+      }
+    }
+  ), [names, providers])
+
+  const modelEntries = useMemo<ModelEntry[]>(
+    () => models.map((label, index) => ({ index, label })),
+    [models]
+  )
+
+  const searchActive = searchStage === stage
+
+  const { filtered: filteredProviders, selectedPosition: providerPos } = useIndexedFuzzyList(
+    providerEntries,
+    providerQuery,
+    PROVIDER_SEARCH_KEYS,
+    providerIdx,
+    setProviderIdx,
+    stage === 'provider'
+  )
+
+  const { filtered: filteredModels, selectedPosition: modelPos } = useIndexedFuzzyList(
+    modelEntries,
+    modelQuery,
+    MODEL_SEARCH_KEYS,
+    modelIdx,
+    setModelIdx,
+    stage === 'model'
+  )
 
   const back = () => {
     if (stage === 'model' || stage === 'key' || stage === 'disconnect') {
       setStage('provider')
       setModelIdx(0)
+      setModelQuery('')
+      setSearchStage(null)
       setKeyInput('')
       setKeyError('')
       setKeySaving(false)
@@ -86,7 +152,7 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
     onCancel()
   }
 
-  useOverlayKeys({ onBack: back, onClose: onCancel })
+  useOverlayKeys({ disabled: searchActive, onBack: back, onClose: onCancel })
 
   useInput((ch, key) => {
     // Key entry stage handles its own input
@@ -201,25 +267,37 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
       return
     }
 
-    const count = stage === 'provider' ? providers.length : models.length
-    const sel = stage === 'provider' ? providerIdx : modelIdx
+    if (stage === 'provider' || stage === 'model') {
+      const setQuery = stage === 'provider' ? setProviderQuery : setModelQuery
+
+      if (handleSearchInput(ch, key, {
+        active: searchActive,
+        setActive: active => setSearchStage(active ? stage : null),
+        setQuery
+      })) {
+        return
+      }
+    }
+
+    const entries = stage === 'provider' ? filteredProviders : filteredModels
+    const sel = stage === 'provider' ? providerPos : modelPos
     const setSel = stage === 'provider' ? setProviderIdx : setModelIdx
 
-    if (key.upArrow && sel > 0) {
-      setSel(v => v - 1)
+    if (key.upArrow && entries.length && sel > 0) {
+      setSel(entries[sel - 1]!.index)
 
       return
     }
 
-    if (key.downArrow && sel < count - 1) {
-      setSel(v => v + 1)
+    if (key.downArrow && entries.length && sel < entries.length - 1) {
+      setSel(entries[sel + 1]!.index)
 
       return
     }
 
     if (key.return) {
       if (stage === 'provider') {
-        if (!provider) {
+        if (!provider || !filteredProviders.length) {
           return
         }
 
@@ -237,13 +315,15 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
 
         setStage('model')
         setModelIdx(0)
+        setModelQuery('')
+        setSearchStage(null)
 
         return
       }
 
       const model = models[modelIdx]
 
-      if (provider && model) {
+      if (provider && model && filteredModels.length) {
         onSelect(`${model} --provider ${provider.slug}${persistGlobal ? ' --global' : ` ${TUI_SESSION_MODEL_FLAG}`}`)
       } else {
         setStage('provider')
@@ -362,19 +442,11 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
 
   // ── Provider selection stage ─────────────────────────────────────────
   if (stage === 'provider') {
-    const rows = providers.map(
-      (p, i) => {
-        const authMark = p.authenticated === false ? '○' : p.is_current ? '*' : '●'
-        const modelCount = p.total_models ?? p.models?.length ?? 0
-        const suffix = p.authenticated === false
-          ? (p.auth_type === 'api_key' ? '(no key)' : '(needs setup)')
-          : `${modelCount} models`
+    const { items, offset } = windowItems(filteredProviders, providerPos, VISIBLE)
 
-        return `${authMark} ${names[i]} · ${suffix}`
-      }
-    )
-
-    const { items, offset } = windowItems(rows, providerIdx, VISIBLE)
+    const searchLabel = providerQuery || searchActive
+      ? `Search: ${providerQuery}${searchActive ? '▎' : ''} (${filteredProviders.length}/${providers.length})`
+      : 'Search: / to filter providers'
 
     return (
       <Box flexDirection="column" width={width}>
@@ -392,17 +464,20 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
         <Text color={t.color.label} wrap="truncate-end">
           {provider?.warning ? `warning: ${provider.warning}` : ' '}
         </Text>
+        <Text color={searchActive ? t.color.accent : t.color.muted} wrap="truncate-end">
+          {searchLabel}
+        </Text>
         <Text color={t.color.muted} wrap="truncate-end">
           {offset > 0 ? ` ↑ ${offset} more` : ' '}
         </Text>
 
         {Array.from({ length: VISIBLE }, (_, i) => {
-          const row = items[i]
-          const idx = offset + i
+          const entry = items[i]
+          const idx = entry?.index ?? -1
           const p = providers[idx]
           const dimmed = p?.authenticated === false
 
-          return row ? (
+          return entry ? (
             <Text
               bold={providerIdx === idx}
               color={providerIdx === idx ? t.color.accent : dimmed ? t.color.label : t.color.muted}
@@ -411,7 +486,11 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
               wrap="truncate-end"
             >
               {providerIdx === idx ? '▸ ' : '  '}
-              {idx + 1}. {row}
+              {offset + i + 1}. {entry.label}
+            </Text>
+          ) : !filteredProviders.length && i === 0 ? (
+            <Text color={t.color.muted} key="empty-provider" wrap="truncate-end">
+              no providers match "{providerQuery}"
             </Text>
           ) : (
             <Text color={t.color.muted} key={`pad-${i}`} wrap="truncate-end">
@@ -421,19 +500,23 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
         })}
 
         <Text color={t.color.muted} wrap="truncate-end">
-          {offset + VISIBLE < rows.length ? ` ↓ ${rows.length - offset - VISIBLE} more` : ' '}
+          {offset + VISIBLE < filteredProviders.length ? ` ↓ ${filteredProviders.length - offset - VISIBLE} more` : ' '}
         </Text>
 
         <Text color={t.color.muted} wrap="truncate-end">
           persist: {persistGlobal ? 'global' : 'session'} · g toggle
         </Text>
-        <OverlayHint t={t}>↑/↓ select · Enter choose · d disconnect · Esc/q cancel</OverlayHint>
+        <OverlayHint t={t}>↑/↓ select · Enter choose · / search · d disconnect · Esc/q cancel</OverlayHint>
       </Box>
     )
   }
 
   // ── Model selection stage ────────────────────────────────────────────
-  const { items, offset } = windowItems(models, modelIdx, VISIBLE)
+  const { items, offset } = windowItems(filteredModels, modelPos, VISIBLE)
+
+  const searchLabel = modelQuery || searchActive
+    ? `Search: ${modelQuery}${searchActive ? '▎' : ''} (${filteredModels.length}/${models.length})`
+    : 'Search: / to filter models'
 
   return (
     <Box flexDirection="column" width={width}>
@@ -447,18 +530,26 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
       <Text color={t.color.label} wrap="truncate-end">
         {provider?.warning ? `warning: ${provider.warning}` : ' '}
       </Text>
+      <Text color={searchActive ? t.color.accent : t.color.muted} wrap="truncate-end">
+        {searchLabel}
+      </Text>
       <Text color={t.color.muted} wrap="truncate-end">
         {offset > 0 ? ` ↑ ${offset} more` : ' '}
       </Text>
 
       {Array.from({ length: VISIBLE }, (_, i) => {
-        const row = items[i]
-        const idx = offset + i
+        const entry = items[i]
+        const idx = entry?.index ?? -1
+        const row = entry?.label
 
         if (!row) {
           return !models.length && i === 0 ? (
             <Text color={t.color.muted} key="empty" wrap="truncate-end">
               no models listed for this provider
+            </Text>
+          ) : models.length && !filteredModels.length && i === 0 ? (
+            <Text color={t.color.muted} key="empty-search" wrap="truncate-end">
+              no models match "{modelQuery}"
             </Text>
           ) : (
             <Text color={t.color.muted} key={`pad-${i}`} wrap="truncate-end">
@@ -478,20 +569,20 @@ export function ModelPicker({ gw, onCancel, onSelect, sessionId, t }: ModelPicke
             wrap="truncate-end"
           >
             {prefix}
-            {idx + 1}. {row}
+            {offset + i + 1}. {row}
           </Text>
         )
       })}
 
       <Text color={t.color.muted} wrap="truncate-end">
-        {offset + VISIBLE < models.length ? ` ↓ ${models.length - offset - VISIBLE} more` : ' '}
+        {offset + VISIBLE < filteredModels.length ? ` ↓ ${filteredModels.length - offset - VISIBLE} more` : ' '}
       </Text>
 
       <Text color={t.color.muted} wrap="truncate-end">
         persist: {persistGlobal ? 'global' : 'session'} · g toggle
       </Text>
       <OverlayHint t={t}>
-        {models.length ? '↑/↓ select · Enter switch · Esc back · q close' : 'Enter/Esc back · q close'}
+        {models.length ? '↑/↓ select · Enter switch · / search · Esc back · q close' : 'Enter/Esc back · q close'}
       </OverlayHint>
     </Box>
   )

--- a/ui-tui/src/components/sessionPicker.tsx
+++ b/ui-tui/src/components/sessionPicker.tsx
@@ -1,9 +1,10 @@
 import { Box, Text, useInput, useStdout } from '@hermes/ink'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import type { GatewayClient } from '../gatewayClient.js'
 import type { SessionDeleteResponse, SessionListItem, SessionListResponse } from '../gatewayTypes.js'
 import { asRpcResult, rpcErrorMessage } from '../lib/rpc.js'
+import { handleSearchInput, useIndexedFuzzyList } from '../lib/searchableList.js'
 import type { Theme } from '../theme.js'
 
 import { OverlayHint, useOverlayKeys, windowOffset } from './overlayControls.js'
@@ -11,6 +12,15 @@ import { OverlayHint, useOverlayKeys, windowOffset } from './overlayControls.js'
 const VISIBLE = 15
 const MIN_WIDTH = 60
 const MAX_WIDTH = 120
+const SESSION_SEARCH_KEYS = ['id', 'preview', 'source', 'title'] as const
+
+interface SessionEntry {
+  id: string
+  index: number
+  preview: string
+  source: string
+  title: string
+}
 
 const age = (ts: number) => {
   const d = (Date.now() / 1000 - ts) / 86400
@@ -35,11 +45,13 @@ export function SessionPicker({ gw, onCancel, onSelect, t }: SessionPickerProps)
   // a second `d`/`D` to confirm deletion.  Any other key cancels the prompt.
   const [confirmDelete, setConfirmDelete] = useState<null | number>(null)
   const [deleting, setDeleting] = useState(false)
+  const [searchActive, setSearchActive] = useState(false)
+  const [query, setQuery] = useState('')
 
   const { stdout } = useStdout()
   const width = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, (stdout?.columns ?? 80) - 6))
 
-  useOverlayKeys({ onClose: onCancel })
+  useOverlayKeys({ disabled: searchActive, onClose: onCancel })
 
   useEffect(() => {
     gw.request<SessionListResponse>('session.list', { limit: 200 })
@@ -62,6 +74,22 @@ export function SessionPicker({ gw, onCancel, onSelect, t }: SessionPickerProps)
         setLoading(false)
       })
   }, [gw])
+
+  const entries = useMemo<SessionEntry[]>(() => items.map((s, index) => ({
+    id: s.id,
+    index,
+    preview: s.preview || '',
+    source: s.source || '',
+    title: s.title || ''
+  })), [items])
+
+  const { filtered, selectedPosition: selPos } = useIndexedFuzzyList(
+    entries,
+    query,
+    SESSION_SEARCH_KEYS,
+    sel,
+    setSel
+  )
 
   const performDelete = (index: number) => {
     const target = items[index]
@@ -114,15 +142,25 @@ export function SessionPicker({ gw, onCancel, onSelect, t }: SessionPickerProps)
       return
     }
 
-    if (key.upArrow && sel > 0) {
-      setSel(s => s - 1)
+    if (handleSearchInput(ch, key, {
+      active: searchActive,
+      setActive: setSearchActive,
+      setQuery: setQuery
+    })) {
+      setConfirmDelete(null)
+
+      return
     }
 
-    if (key.downArrow && sel < items.length - 1) {
-      setSel(s => s + 1)
+    if (key.upArrow && filtered.length && selPos > 0) {
+      setSel(filtered[selPos - 1]!.index)
     }
 
-    if (key.return && items[sel]) {
+    if (key.downArrow && filtered.length && selPos < filtered.length - 1) {
+      setSel(filtered[selPos + 1]!.index)
+    }
+
+    if (key.return && items[sel] && filtered.length) {
       onSelect(items[sel]!.id)
 
       return
@@ -136,8 +174,13 @@ export function SessionPicker({ gw, onCancel, onSelect, t }: SessionPickerProps)
 
     const n = parseInt(ch)
 
-    if (n >= 1 && n <= Math.min(9, items.length)) {
-      onSelect(items[n - 1]!.id)
+    if (n >= 1 && n <= Math.min(9, filtered.length)) {
+      const offset = windowOffset(filtered.length, selPos, VISIBLE)
+      const entry = filtered[offset + n - 1]
+
+      if (entry) {
+        onSelect(entry.id)
+      }
     }
   })
 
@@ -163,7 +206,11 @@ export function SessionPicker({ gw, onCancel, onSelect, t }: SessionPickerProps)
     )
   }
 
-  const offset = windowOffset(items.length, sel, VISIBLE)
+  const offset = windowOffset(filtered.length, selPos, VISIBLE)
+
+  const searchLabel = query || searchActive
+    ? `Search: ${query}${searchActive ? '▎' : ''} (${filtered.length}/${items.length})`
+    : 'Search: / to filter sessions'
 
   return (
     <Box flexDirection="column" width={width}>
@@ -171,10 +218,14 @@ export function SessionPicker({ gw, onCancel, onSelect, t }: SessionPickerProps)
         Resume Session
       </Text>
 
+      <Text color={searchActive ? t.color.accent : t.color.muted}>{searchLabel}</Text>
       {offset > 0 && <Text color={t.color.muted}>  ↑ {offset} more</Text>}
 
-      {items.slice(offset, offset + VISIBLE).map((s, vi) => {
-        const i = offset + vi
+      {!filtered.length && query ? <Text color={t.color.muted}>no sessions match "{query}"</Text> : null}
+
+      {filtered.slice(offset, offset + VISIBLE).map((entry, vi) => {
+        const i = entry.index
+        const s = items[i]!
         const selected = sel === i
         const pendingDelete = confirmDelete === i
 
@@ -186,7 +237,7 @@ export function SessionPicker({ gw, onCancel, onSelect, t }: SessionPickerProps)
 
             <Box width={30}>
               <Text bold={selected} color={selected ? t.color.accent : t.color.muted} inverse={selected}>
-                {String(i + 1).padStart(2)}. [{s.id}]
+                {String(offset + vi + 1).padStart(2)}. [{s.id}]
               </Text>
             </Box>
 
@@ -208,12 +259,12 @@ export function SessionPicker({ gw, onCancel, onSelect, t }: SessionPickerProps)
         )
       })}
 
-      {offset + VISIBLE < items.length && <Text color={t.color.muted}>  ↓ {items.length - offset - VISIBLE} more</Text>}
+      {offset + VISIBLE < filtered.length && <Text color={t.color.muted}>  ↓ {filtered.length - offset - VISIBLE} more</Text>}
       {err && <Text color={t.color.label}>error: {err}</Text>}
       {deleting ? (
         <OverlayHint t={t}>deleting…</OverlayHint>
       ) : (
-        <OverlayHint t={t}>↑/↓ select · Enter resume · 1-9 quick · d delete · Esc/q cancel</OverlayHint>
+        <OverlayHint t={t}>↑/↓ select · Enter resume · / search · 1-9 quick · d delete · Esc/q cancel</OverlayHint>
       )}
     </Box>
   )

--- a/ui-tui/src/components/skillsHub.tsx
+++ b/ui-tui/src/components/skillsHub.tsx
@@ -1,8 +1,9 @@
 import { Box, Text, useInput, useStdout } from '@hermes/ink'
-import { useEffect, useState } from 'react'
+import { useEffect, useMemo, useState } from 'react'
 
 import type { GatewayClient } from '../gatewayClient.js'
 import { rpcErrorMessage } from '../lib/rpc.js'
+import { handleSearchInput, useIndexedFuzzyList } from '../lib/searchableList.js'
 import type { Theme } from '../theme.js'
 
 import { OverlayHint, useOverlayKeys, windowItems, windowOffset } from './overlayControls.js'
@@ -10,6 +11,12 @@ import { OverlayHint, useOverlayKeys, windowItems, windowOffset } from './overla
 const VISIBLE = 12
 const MIN_WIDTH = 40
 const MAX_WIDTH = 90
+const LABEL_SEARCH_KEYS = ['label'] as const
+
+interface IndexedLabel {
+  index: number
+  label: string
+}
 
 export function SkillsHub({ gw, onClose, t }: SkillsHubProps) {
   const [skillsByCat, setSkillsByCat] = useState<Record<string, string[]>>({})
@@ -21,6 +28,9 @@ export function SkillsHub({ gw, onClose, t }: SkillsHubProps) {
   const [installing, setInstalling] = useState(false)
   const [err, setErr] = useState('')
   const [loading, setLoading] = useState(true)
+  const [catQuery, setCatQuery] = useState('')
+  const [skillQuery, setSkillQuery] = useState('')
+  const [searchStage, setSearchStage] = useState<null | 'category' | 'skill'>(null)
 
   const { stdout } = useStdout()
   const width = Math.max(MIN_WIDTH, Math.min(MAX_WIDTH, (stdout?.columns ?? 80) - 6))
@@ -38,9 +48,39 @@ export function SkillsHub({ gw, onClose, t }: SkillsHubProps) {
       })
   }, [gw])
 
-  const cats = Object.keys(skillsByCat).sort()
-  const skills = selectedCat ? (skillsByCat[selectedCat] ?? []) : []
+  const cats = useMemo(() => Object.keys(skillsByCat).sort(), [skillsByCat])
+  const skills = useMemo(() => (selectedCat ? (skillsByCat[selectedCat] ?? []) : []), [selectedCat, skillsByCat])
   const skillName = skills[skillIdx] ?? ''
+
+  const catEntries = useMemo<IndexedLabel[]>(
+    () => cats.map((label, index) => ({ index, label: `${label} · ${skillsByCat[label]?.length ?? 0} skills` })),
+    [cats, skillsByCat]
+  )
+
+  const skillEntries = useMemo<IndexedLabel[]>(
+    () => skills.map((label, index) => ({ index, label })),
+    [skills]
+  )
+
+  const searchActive = searchStage === stage
+
+  const { filtered: filteredCats, selectedPosition: catPos } = useIndexedFuzzyList(
+    catEntries,
+    catQuery,
+    LABEL_SEARCH_KEYS,
+    catIdx,
+    setCatIdx,
+    stage === 'category'
+  )
+
+  const { filtered: filteredSkills, selectedPosition: skillPos } = useIndexedFuzzyList(
+    skillEntries,
+    skillQuery,
+    LABEL_SEARCH_KEYS,
+    skillIdx,
+    setSkillIdx,
+    stage === 'skill'
+  )
 
   const back = () => {
     if (stage === 'actions') {
@@ -54,6 +94,8 @@ export function SkillsHub({ gw, onClose, t }: SkillsHubProps) {
     if (stage === 'skill') {
       setStage('category')
       setSkillIdx(0)
+      setSkillQuery('')
+      setSearchStage(null)
 
       return
     }
@@ -61,7 +103,7 @@ export function SkillsHub({ gw, onClose, t }: SkillsHubProps) {
     onClose()
   }
 
-  useOverlayKeys({ disabled: installing, onBack: back, onClose })
+  useOverlayKeys({ disabled: installing || searchActive, onBack: back, onClose })
 
   const inspect = (name: string) => {
     setInfo(null)
@@ -96,31 +138,44 @@ export function SkillsHub({ gw, onClose, t }: SkillsHubProps) {
         return
       }
 
-      if (ch.toLowerCase() === 'x' && skillName) {
+      if (ch?.toLowerCase() === 'x' && skillName) {
         install(skillName)
 
         return
       }
 
-      if (ch.toLowerCase() === 'i' && skillName) {
+      if (ch?.toLowerCase() === 'i' && skillName) {
         inspect(skillName)
       }
 
       return
     }
 
-    const count = stage === 'category' ? cats.length : skills.length
-    const sel = stage === 'category' ? catIdx : skillIdx
+    if (stage === 'category' || stage === 'skill') {
+      const setQuery = stage === 'category' ? setCatQuery : setSkillQuery
+
+      if (handleSearchInput(ch, key, {
+        active: searchActive,
+        setActive: active => setSearchStage(active ? stage : null),
+        setQuery
+      })) {
+        return
+      }
+    }
+
+    const entries = stage === 'category' ? filteredCats : filteredSkills
+    const count = entries.length
+    const sel = stage === 'category' ? catPos : skillPos
     const setSel = stage === 'category' ? setCatIdx : setSkillIdx
 
     if (key.upArrow && sel > 0) {
-      setSel(v => v - 1)
+      setSel(entries[sel - 1]!.index)
 
       return
     }
 
     if (key.downArrow && sel < count - 1) {
-      setSel(v => v + 1)
+      setSel(entries[sel + 1]!.index)
 
       return
     }
@@ -129,12 +184,14 @@ export function SkillsHub({ gw, onClose, t }: SkillsHubProps) {
       if (stage === 'category') {
         const cat = cats[catIdx]
 
-        if (!cat) {
+        if (!cat || !filteredCats.length) {
           return
         }
 
         setSelectedCat(cat)
         setSkillIdx(0)
+        setSkillQuery('')
+        setSearchStage(null)
         setStage('skill')
 
         return
@@ -142,7 +199,7 @@ export function SkillsHub({ gw, onClose, t }: SkillsHubProps) {
 
       const name = skills[skillIdx]
 
-      if (name) {
+      if (name && filteredSkills.length) {
         setStage('actions')
         inspect(name)
       }
@@ -154,24 +211,31 @@ export function SkillsHub({ gw, onClose, t }: SkillsHubProps) {
 
     if (!Number.isNaN(n) && n >= 1 && n <= Math.min(10, count)) {
       const next = windowOffset(count, sel, VISIBLE) + n - 1
+      const entry = entries[next]
+
+      if (!entry) {
+        return
+      }
 
       if (stage === 'category') {
-        const cat = cats[next]
+        const cat = cats[entry.index]
 
         if (cat) {
           setSelectedCat(cat)
-          setCatIdx(next)
+          setCatIdx(entry.index)
           setSkillIdx(0)
+          setSkillQuery('')
+          setSearchStage(null)
           setStage('skill')
         }
 
         return
       }
 
-      const name = skills[next]
+      const name = skills[entry.index]
 
       if (name) {
-        setSkillIdx(next)
+        setSkillIdx(entry.index)
         setStage('actions')
         inspect(name)
       }
@@ -201,8 +265,11 @@ export function SkillsHub({ gw, onClose, t }: SkillsHubProps) {
   }
 
   if (stage === 'category') {
-    const rows = cats.map(c => `${c} · ${skillsByCat[c]?.length ?? 0} skills`)
-    const { items, offset } = windowItems(rows, catIdx, VISIBLE)
+    const { items, offset } = windowItems(filteredCats, catPos, VISIBLE)
+
+    const searchLabel = catQuery || searchActive
+      ? `Search: ${catQuery}${searchActive ? '▎' : ''} (${filteredCats.length}/${cats.length})`
+      : 'Search: / to filter categories'
 
     return (
       <Box flexDirection="column" width={width}>
@@ -211,33 +278,41 @@ export function SkillsHub({ gw, onClose, t }: SkillsHubProps) {
         </Text>
 
         <Text color={t.color.muted}>select a category</Text>
+        <Text color={searchActive ? t.color.accent : t.color.muted}>{searchLabel}</Text>
         {offset > 0 && <Text color={t.color.muted}> ↑ {offset} more</Text>}
+        {!filteredCats.length && catQuery ? <Text color={t.color.muted}>no categories match "{catQuery}"</Text> : null}
 
-        {items.map((row, i) => {
-          const idx = offset + i
+        {items.map((entry, i) => {
+          const idx = entry.index
 
           return (
             <Text
               bold={catIdx === idx}
               color={catIdx === idx ? t.color.accent : t.color.muted}
               inverse={catIdx === idx}
-              key={row}
+              key={entry.label}
               wrap="truncate-end"
             >
               {catIdx === idx ? '▸ ' : '  '}
-              {i + 1}. {row}
+              {offset + i + 1}. {entry.label}
             </Text>
           )
         })}
 
-        {offset + VISIBLE < rows.length && <Text color={t.color.muted}> ↓ {rows.length - offset - VISIBLE} more</Text>}
-        <OverlayHint t={t}>↑/↓ select · Enter open · 1-9,0 quick · Esc/q cancel</OverlayHint>
+        {offset + VISIBLE < filteredCats.length && (
+          <Text color={t.color.muted}> ↓ {filteredCats.length - offset - VISIBLE} more</Text>
+        )}
+        <OverlayHint t={t}>↑/↓ select · Enter open · / search · 1-9,0 quick · Esc/q cancel</OverlayHint>
       </Box>
     )
   }
 
   if (stage === 'skill') {
-    const { items, offset } = windowItems(skills, skillIdx, VISIBLE)
+    const { items, offset } = windowItems(filteredSkills, skillPos, VISIBLE)
+
+    const searchLabel = skillQuery || searchActive
+      ? `Search: ${skillQuery}${searchActive ? '▎' : ''} (${filteredSkills.length}/${skills.length})`
+      : 'Search: / to filter skills'
 
     return (
       <Box flexDirection="column" width={width}>
@@ -246,31 +321,35 @@ export function SkillsHub({ gw, onClose, t }: SkillsHubProps) {
         </Text>
 
         <Text color={t.color.muted}>{skills.length} skill(s)</Text>
+        <Text color={searchActive ? t.color.accent : t.color.muted}>{searchLabel}</Text>
         {!skills.length ? <Text color={t.color.muted}>no skills in this category</Text> : null}
+        {skills.length && !filteredSkills.length && skillQuery ? (
+          <Text color={t.color.muted}>no skills match "{skillQuery}"</Text>
+        ) : null}
         {offset > 0 && <Text color={t.color.muted}> ↑ {offset} more</Text>}
 
-        {items.map((row, i) => {
-          const idx = offset + i
+        {items.map((entry, i) => {
+          const idx = entry.index
 
           return (
             <Text
               bold={skillIdx === idx}
               color={skillIdx === idx ? t.color.accent : t.color.muted}
               inverse={skillIdx === idx}
-              key={row}
+              key={entry.label}
               wrap="truncate-end"
             >
               {skillIdx === idx ? '▸ ' : '  '}
-              {i + 1}. {row}
+              {offset + i + 1}. {entry.label}
             </Text>
           )
         })}
 
-        {offset + VISIBLE < skills.length && (
-          <Text color={t.color.muted}> ↓ {skills.length - offset - VISIBLE} more</Text>
+        {offset + VISIBLE < filteredSkills.length && (
+          <Text color={t.color.muted}> ↓ {filteredSkills.length - offset - VISIBLE} more</Text>
         )}
         <OverlayHint t={t}>
-          {skills.length ? '↑/↓ select · Enter open · 1-9,0 quick · Esc back · q close' : 'Esc back · q close'}
+          {skills.length ? '↑/↓ select · Enter open · / search · 1-9,0 quick · Esc back · q close' : 'Esc back · q close'}
         </OverlayHint>
       </Box>
     )

--- a/ui-tui/src/lib/fuzzy.test.ts
+++ b/ui-tui/src/lib/fuzzy.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+
+import { createFuzzyFilter, fuzzyFilter, queryMatchesText } from './fuzzy.js'
+
+interface Item {
+  label: string
+  slug: string
+}
+
+const items: Item[] = [
+  { label: 'Anthropic', slug: 'anthropic' },
+  { label: 'Google Gemini', slug: 'gemini' },
+  { label: 'OpenAI Codex', slug: 'openai-codex' }
+]
+
+describe('fuzzyFilter', () => {
+  it('returns the original list for blank queries', () => {
+    expect(fuzzyFilter(items, '', ['label'])).toBe(items)
+    expect(fuzzyFilter(items, '   ', ['label'])).toBe(items)
+  })
+
+  it('filters using the same tokenized subsequence contract as the Python picker', () => {
+    expect(fuzzyFilter(items, 'gem', ['label']).map(item => item.slug)).toEqual(['gemini'])
+  })
+
+  it('searches across the configured keys', () => {
+    expect(fuzzyFilter(items, 'codex', ['label', 'slug']).map(item => item.slug)).toEqual(['openai-codex'])
+  })
+
+  it('matches model abbreviations users type in model pickers', () => {
+    const models = [
+      { label: 'claude-opus-4-7' },
+      { label: 'claude-sonnet-4-6' },
+      { label: 'claude-haiku-4-5' },
+      { label: 'gpt-5-codex' }
+    ]
+
+    expect(fuzzyFilter(models, 'co47', ['label']).map(item => item.label)).toEqual(['claude-opus-4-7'])
+    expect(fuzzyFilter(models, 'co 47', ['label']).map(item => item.label)).toEqual(['claude-opus-4-7'])
+    expect(fuzzyFilter(models, 'cl 4', ['label']).map(item => item.label)).toEqual([
+      'claude-opus-4-7',
+      'claude-sonnet-4-6',
+      'claude-haiku-4-5'
+    ])
+  })
+
+  it('can reuse a prepared matcher across queries', () => {
+    const search = createFuzzyFilter(items, ['label', 'slug'])
+
+    expect(search('gem').map(item => item.slug)).toEqual(['gemini'])
+    expect(search('codex').map(item => item.slug)).toEqual(['openai-codex'])
+  })
+
+  it('requires every query token to match as a subsequence', () => {
+    expect(queryMatchesText('OpenAI Codex', 'open cod')).toBe(true)
+    expect(queryMatchesText('OpenAI Chat Completions', 'open cod')).toBe(false)
+  })
+
+  it('does not assemble a single query token across separate fields', () => {
+    const providers = [
+      { name: 'Nous Portal', slug: 'nous' },
+      { name: 'OpenRouter', slug: 'openrouter', status: 'needs setup' },
+      { name: 'LM Studio', slug: 'lm-studio', status: 'needs setup' }
+    ]
+
+    expect(fuzzyFilter(providers, 'nous', ['name', 'slug', 'status']).map(item => item.name)).toEqual([
+      'Nous Portal'
+    ])
+  })
+})

--- a/ui-tui/src/lib/fuzzy.ts
+++ b/ui-tui/src/lib/fuzzy.ts
@@ -1,0 +1,54 @@
+const queryTokens = (query: string): string[] => query.trim().toLowerCase().split(/\s+/).filter(Boolean)
+
+function isSubsequence(haystack: string, needle: string): boolean {
+  let pos = 0
+
+  for (const ch of needle) {
+    pos = haystack.indexOf(ch, pos)
+
+    if (pos < 0) {
+      return false
+    }
+
+    pos += 1
+  }
+
+  return true
+}
+
+function searchableFields<T>(item: T, keys: readonly string[]): string[] {
+  const record = item as Record<string, unknown>
+
+  return keys.map(key => String(record[key] ?? '').toLowerCase()).filter(Boolean)
+}
+
+export function queryMatchesText(text: string, query: string): boolean {
+  const normalized = text.toLowerCase()
+  const tokens = queryTokens(query)
+
+  if (!tokens.length) {
+    return true
+  }
+
+  return tokens.every(token => isSubsequence(normalized, token))
+}
+
+export function createFuzzyFilter<T>(items: T[], keys: readonly string[]) {
+  return (query: string): T[] => {
+    const tokens = queryTokens(query)
+
+    if (!tokens.length) {
+      return items
+    }
+
+    return items.filter(item => {
+      const fields = searchableFields(item, keys)
+
+      return tokens.every(token => fields.some(field => isSubsequence(field, token)))
+    })
+  }
+}
+
+export function fuzzyFilter<T>(items: T[], query: string, keys: readonly string[]): T[] {
+  return createFuzzyFilter(items, keys)(query)
+}

--- a/ui-tui/src/lib/searchableList.test.ts
+++ b/ui-tui/src/lib/searchableList.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from 'vitest'
+
+import { handleSearchInput, reconcileIndexedSelection } from './searchableList.js'
+
+describe('handleSearchInput', () => {
+  it('activates search on slash', () => {
+    let active = false
+    let query = ''
+
+    const consumed = handleSearchInput('/', {}, {
+      active,
+      setActive: v => {
+        active = v
+      },
+      setQuery: v => {
+        query = typeof v === 'function' ? v(query) : v
+      }
+    })
+
+    expect(consumed).toBe(true)
+    expect(active).toBe(true)
+    expect(query).toBe('')
+  })
+
+  it('edits an active query and reports query changes', () => {
+    let active = true
+    let changes = 0
+    let query = 'cl'
+
+    const setQuery = (v: string | ((prev: string) => string)) => {
+      query = typeof v === 'function' ? v(query) : v
+    }
+
+    expect(handleSearchInput('a', {}, {
+      active,
+      onQueryChange: () => {
+        changes += 1
+      },
+      setActive: v => {
+        active = v
+      },
+      setQuery
+    })).toBe(true)
+    expect(query).toBe('cla')
+
+    expect(handleSearchInput(undefined, { backspace: true }, {
+      active,
+      onQueryChange: () => {
+        changes += 1
+      },
+      setActive: v => {
+        active = v
+      },
+      setQuery
+    })).toBe(true)
+    expect(query).toBe('cl')
+    expect(changes).toBe(2)
+  })
+
+  it('clears the query on Ctrl+U in Ink key shape', () => {
+    let active = true
+    let changes = 0
+    let query = 'opus'
+
+    const consumed = handleSearchInput('u', { ctrl: true }, {
+      active,
+      onQueryChange: () => {
+        changes += 1
+      },
+      setActive: v => {
+        active = v
+      },
+      setQuery: v => {
+        query = typeof v === 'function' ? v(query) : v
+      }
+    })
+
+    expect(consumed).toBe(true)
+    expect(active).toBe(true)
+    expect(query).toBe('')
+    expect(changes).toBe(1)
+  })
+
+  it('exits active search on escape without clearing the query', () => {
+    let active = true
+    let query = 'opus'
+
+    const consumed = handleSearchInput(undefined, { escape: true }, {
+      active,
+      setActive: v => {
+        active = v
+      },
+      setQuery: v => {
+        query = typeof v === 'function' ? v(query) : v
+      }
+    })
+
+    expect(consumed).toBe(true)
+    expect(active).toBe(false)
+    expect(query).toBe('opus')
+  })
+
+  it('lets navigation and selection keys pass through while search is active', () => {
+    let active = true
+    let query = 'opus'
+
+    const opts = {
+      active,
+      setActive: (v: boolean) => {
+        active = v
+      },
+      setQuery: (v: string | ((prev: string) => string)) => {
+        query = typeof v === 'function' ? v(query) : v
+      }
+    }
+
+    expect(handleSearchInput(undefined, { downArrow: true }, opts)).toBe(false)
+    expect(handleSearchInput(undefined, { return: true }, opts)).toBe(false)
+    expect(active).toBe(true)
+    expect(query).toBe('opus')
+  })
+
+  it('reports the first visible item when indexed selection is filtered out', () => {
+    const filtered = [{ index: 2 }, { index: 4 }]
+
+    expect(reconcileIndexedSelection(filtered, 4)).toBeNull()
+    expect(reconcileIndexedSelection(filtered, 0)).toBe(2)
+    expect(reconcileIndexedSelection([], 0)).toBeNull()
+  })
+})

--- a/ui-tui/src/lib/searchableList.ts
+++ b/ui-tui/src/lib/searchableList.ts
@@ -1,0 +1,111 @@
+import { type Dispatch, type SetStateAction, useEffect, useMemo } from 'react'
+
+import { createFuzzyFilter } from './fuzzy.js'
+
+export interface IndexedEntry {
+  index: number
+}
+
+interface InkKey {
+  backspace?: boolean
+  ctrl?: boolean
+  delete?: boolean
+  downArrow?: boolean
+  escape?: boolean
+  meta?: boolean
+  return?: boolean
+  upArrow?: boolean
+}
+
+interface SearchInputOptions {
+  active: boolean
+  onQueryChange?: () => void
+  setActive: (active: boolean) => void
+  setQuery: Dispatch<SetStateAction<string>>
+}
+
+const isClearQueryKey = (ch: string | undefined, key: InkKey): boolean =>
+  ch === '\u0015' || (key.ctrl === true && ch?.toLowerCase() === 'u')
+
+export function handleSearchInput(ch: string | undefined, key: InkKey, opts: SearchInputOptions): boolean {
+  if (opts.active) {
+    if (key.escape) {
+      opts.setActive(false)
+
+      return true
+    }
+
+    if (key.backspace || key.delete) {
+      opts.setQuery(q => q.slice(0, -1))
+      opts.onQueryChange?.()
+
+      return true
+    }
+
+    if (isClearQueryKey(ch, key)) {
+      opts.setQuery('')
+      opts.onQueryChange?.()
+
+      return true
+    }
+
+    if (ch && !key.ctrl && !key.meta && !key.return) {
+      opts.setQuery(q => q + ch)
+      opts.onQueryChange?.()
+
+      return true
+    }
+
+    return false
+  }
+
+  if (ch === '/') {
+    opts.setActive(true)
+
+    return true
+  }
+
+  if (isClearQueryKey(ch, key)) {
+    opts.setQuery('')
+    opts.onQueryChange?.()
+
+    return true
+  }
+
+  return false
+}
+
+export function reconcileIndexedSelection<T extends IndexedEntry>(filtered: T[], selectedIndex: number): number | null {
+  if (!filtered.length || filtered.some(entry => entry.index === selectedIndex)) {
+    return null
+  }
+
+  return filtered[0]!.index
+}
+
+export function useIndexedFuzzyList<T extends IndexedEntry>(
+  entries: T[],
+  query: string,
+  keys: readonly string[],
+  selectedIndex: number,
+  setSelectedIndex: Dispatch<SetStateAction<number>>,
+  enabled = true
+) {
+  const search = useMemo(() => createFuzzyFilter(entries, keys), [entries, keys])
+  const filtered = useMemo(() => search(query), [query, search])
+  const selectedPosition = Math.max(0, filtered.findIndex(entry => entry.index === selectedIndex))
+
+  useEffect(() => {
+    if (!enabled) {
+      return
+    }
+
+    const nextIndex = reconcileIndexedSelection(filtered, selectedIndex)
+
+    if (nextIndex !== null) {
+      setSelectedIndex(nextIndex)
+    }
+  }, [enabled, filtered, selectedIndex, setSelectedIndex])
+
+  return { filtered, selectedPosition }
+}


### PR DESCRIPTION
## Demo


https://github.com/user-attachments/assets/2a4b92da-0afe-48cd-8172-11fd01fe8a8b


https://github.com/user-attachments/assets/178769bd-264f-4cd9-a73a-f95e9cf86b77



## Rationale

Model and provider lists have grown large enough that arrow-only selection is slow and error-prone, especially for users switching among many hosted providers and model IDs. The TUI `/model` picker already had keyboard navigation, and `hermes model` had curses navigation, but neither offered a consistent way to filter the list. This adds searchable selection to those surfaces with the smallest maintainable shared helpers: a tokenized subsequence matcher for model-style abbreviations such as `co47`, shared Ink list/search handling, and opt-in curses filtering without introducing new `simple_term_menu` usage.

## Implementation

- Add searchable curses support to `curses_radiolist` / `curses_single_select`, including `/` search mode, Backspace, Ctrl+U clear, Enter select, Esc exit search, and filtered arrow navigation.
- Use that curses path for `hermes model` provider/model selection instead of adding new `simple_term_menu` usage.
- Add shared TUI helpers for tokenized subsequence filtering and indexed searchable lists.
- Apply the shared TUI search behavior to `/model`, session picker, skills hub, and agents overlay.
- Keep provider search focused on provider identity fields so status text like “needs setup” does not create noisy matches.

## Tests

- `uv run --extra dev pytest -o addopts= tests/hermes_cli/test_curses_ui_search.py tests/hermes_cli/test_terminal_menu_fallbacks.py tests/hermes_cli/test_model_picker_viewport.py tests/test_model_picker_scroll.py tests/hermes_cli/test_setup_model_provider.py -q`
- `npx eslint src/lib/fuzzy.ts src/lib/fuzzy.test.ts src/lib/searchableList.ts src/lib/searchableList.test.ts src/components/modelPicker.tsx src/components/sessionPicker.tsx src/components/skillsHub.tsx src/components/agentsOverlay.tsx`
- `npm run type-check`
- `npm test -- --run src/lib/fuzzy.test.ts src/lib/searchableList.test.ts`

All checks were run from a clean worktree based on `upstream/main` at `369cee018`.

## Risks

- Curses and Ink picker behavior is partly state-machine driven, so the regression coverage focuses on the shared filtering/key-handling helpers plus existing picker tests rather than full terminal E2E automation.
- Search is opt-in via `/`, preserving existing arrow-key selection as the default interaction.
