### PR TITLE
fix(agent): notify context engine on commit_memory_session

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5067,12 +5067,25 @@ class AIAgent:
         Called when session_id rotates (e.g. /new, context compression);
         providers keep their state and continue running under the old
         session_id — they just flush pending extraction now."""
-        if not self._memory_manager:
-            return
-        try:
-            self._memory_manager.on_session_end(messages or [])
-        except Exception:
-            pass
+        if self._memory_manager:
+            try:
+                self._memory_manager.on_session_end(messages or [])
+            except Exception:
+                pass
+        # Notify context engine of session end too — same lifecycle moment as
+        # the memory manager's on_session_end. Without this, engines that
+        # accumulate per-session state (DAGs, summaries) leak that state from
+        # the rotated-out session into whatever comes next under the same
+        # compressor instance. Mirrors the call in shutdown_memory_provider().
+        # See issue #22394.
+        if hasattr(self, "context_compressor") and self.context_compressor:
+            try:
+                self.context_compressor.on_session_end(
+                    self.session_id or "",
+                    messages or [],
+                )
+            except Exception:
+                pass
 
     def _sync_external_memory_for_turn(
         self,

--- a/tests/run_agent/test_commit_memory_session_context_engine.py
+++ b/tests/run_agent/test_commit_memory_session_context_engine.py
@@ -1,0 +1,102 @@
+"""Regression tests for AIAgent.commit_memory_session.
+
+Issue #22394: commit_memory_session was calling MemoryManager.on_session_end
+but never ContextEngine.on_session_end. Context engines that accumulate
+per-session state (LCM-style DAGs, summary stores) leaked that state from a
+rotated-out session into whatever continued under the same compressor
+instance.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+
+def _make_minimal_agent(memory_manager, context_compressor, session_id="abc"):
+    """Build an object with just enough surface for commit_memory_session to run.
+
+    AIAgent.__init__ is too heavy for a focused unit test — bind the method
+    to a SimpleNamespace-style object that has the attributes the method
+    actually touches.
+    """
+    from run_agent import AIAgent
+
+    obj = SimpleNamespace(
+        _memory_manager=memory_manager,
+        context_compressor=context_compressor,
+        session_id=session_id,
+    )
+    obj.commit_memory_session = AIAgent.commit_memory_session.__get__(obj)
+    return obj
+
+
+def test_commit_memory_session_notifies_context_engine():
+    """Both the memory manager AND the context engine receive on_session_end."""
+    mm = MagicMock()
+    ctx = MagicMock()
+    agent = _make_minimal_agent(mm, ctx, session_id="sess-42")
+
+    msgs = [{"role": "user", "content": "hi"}, {"role": "assistant", "content": "yo"}]
+    agent.commit_memory_session(msgs)
+
+    mm.on_session_end.assert_called_once_with(msgs)
+    ctx.on_session_end.assert_called_once_with("sess-42", msgs)
+
+
+def test_commit_memory_session_with_no_messages_passes_empty_list():
+    """Empty/None messages must still fire both hooks with an empty list."""
+    mm = MagicMock()
+    ctx = MagicMock()
+    agent = _make_minimal_agent(mm, ctx, session_id="sess-7")
+
+    agent.commit_memory_session(None)
+
+    mm.on_session_end.assert_called_once_with([])
+    ctx.on_session_end.assert_called_once_with("sess-7", [])
+
+
+def test_commit_memory_session_no_memory_manager_still_notifies_context_engine():
+    """If only the context engine is configured, it still gets the hook."""
+    ctx = MagicMock()
+    agent = _make_minimal_agent(None, ctx, session_id="sess-9")
+
+    agent.commit_memory_session([{"role": "user", "content": "x"}])
+
+    ctx.on_session_end.assert_called_once_with("sess-9", [{"role": "user", "content": "x"}])
+
+
+def test_commit_memory_session_no_context_engine_still_notifies_memory_manager():
+    """If only the memory manager is configured, it still gets the hook."""
+    mm = MagicMock()
+    agent = _make_minimal_agent(mm, None, session_id="sess-3")
+
+    agent.commit_memory_session([{"role": "user", "content": "x"}])
+
+    mm.on_session_end.assert_called_once_with([{"role": "user", "content": "x"}])
+
+
+def test_commit_memory_session_tolerates_memory_manager_failure():
+    """A raising memory manager must not block the context engine notification."""
+    mm = MagicMock()
+    mm.on_session_end.side_effect = RuntimeError("boom")
+    ctx = MagicMock()
+    agent = _make_minimal_agent(mm, ctx, session_id="sess-X")
+
+    # Must not raise
+    agent.commit_memory_session([{"role": "user", "content": "x"}])
+
+    ctx.on_session_end.assert_called_once_with("sess-X", [{"role": "user", "content": "x"}])
+
+
+def test_commit_memory_session_tolerates_context_engine_failure():
+    """A raising context engine must not surface the exception."""
+    mm = MagicMock()
+    ctx = MagicMock()
+    ctx.on_session_end.side_effect = RuntimeError("boom")
+    agent = _make_minimal_agent(mm, ctx, session_id="sess-Y")
+
+    # Must not raise
+    agent.commit_memory_session([{"role": "user", "content": "x"}])
+
+    mm.on_session_end.assert_called_once()


### PR DESCRIPTION
## Summary
`commit_memory_session` now notifies the context engine alongside the memory manager when session_id rotates, fixing leak of per-session state into rotated-out sessions.

## Root cause
`run_agent.py::commit_memory_session` (called when session_id rotates — `/new`, context compression — without tearing providers down) calls `MemoryManager.on_session_end` but skips `ContextEngine.on_session_end`. Engines that accumulate per-session state (LCM-style DAGs, summary stores) carry that state from the rotated-out session into whatever continues under the same compressor instance.

The asymmetry is right there in the file: `shutdown_memory_provider` (~L5038) calls both hooks; `commit_memory_session` (~L5065) called only the memory manager.

## Changes
- `run_agent.py::commit_memory_session`: also call `context_compressor.on_session_end(session_id, messages)` after the memory manager hook. Same `try/except`-tolerant pattern `shutdown_memory_provider` uses.
- `tests/run_agent/test_commit_memory_session_context_engine.py`: 6 regression tests covering both-hooks-fire, no-memory-manager, no-context-engine, memory-manager-raises, context-engine-raises.

## Why this is `on_session_end` not `on_session_reset`
The ContextEngine base class distinguishes:
- `on_session_end` — "real session boundaries (CLI exit, `/reset`, gateway expiry). Use this to flush state, close DB connections."
- `on_session_reset` — "Called on `/new` or `/reset`. Reset per-session state."

`commit_memory_session` runs BEFORE the session_id rotates — the old session is ENDING for the engine's purposes (its DAG/store keyed on that session_id is being archived). `on_session_reset` is invoked separately by `cli.py::_notify_session_boundary` for the plugin-level reset. The two hooks aren't redundant — `on_session_end` flushes; `on_session_reset` zeroes counters.

## Validation
- 6/6 new tests pass on the fix branch.
- 4/6 fail on `origin/main` (the two that don't fail are the no-context-engine paths, which the fix doesn't change).
- 78/78 pass across `tests/agent/test_memory_provider.py`, `tests/cli/test_cli_new_session.py`, `tests/cli/test_cli_shutdown_memory_messages.py`, plus the new file.

Closes #22394.

## Note on the auto-paired PR (#22576)
PR #22576 was titled `fix(agent): capture on_pre_compress return value...` and auto-linked to this issue but addresses a different bug (#7192 — `on_pre_compress` return value plumbing). Issue #22394 is about `on_session_end`. Different functions, different lifecycle hooks. #22576 should be evaluated on #7192's merits separately.
