### PR TITLE
fix(tests): harden run_tests.sh (uv-aware bootstrap + scrub HERMES_CRON_SESSION)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,7 +54,7 @@ dependencies = [
 modal = ["modal>=1.0.0,<2"]
 daytona = ["daytona>=0.148.0,<1"]
 vercel = ["vercel>=0.5.7,<0.6.0"]
-dev = ["debugpy>=1.8.0,<2", "pytest>=9.0.2,<10", "pytest-asyncio>=1.3.0,<2", "pytest-xdist>=3.0,<4", "mcp>=1.2.0,<2", "ty>=0.0.1a29,<0.0.22", "ruff"]
+dev = ["debugpy>=1.8.0,<2", "pytest>=9.0.2,<10", "pytest-asyncio>=1.3.0,<2", "pytest-xdist>=3.0,<4", "pytest-split>=0.9,<1", "mcp>=1.2.0,<2", "ty>=0.0.1a29,<0.0.22", "ruff"]
 messaging = ["python-telegram-bot[webhooks]>=22.6,<23", "discord.py[voice]>=2.7.1,<3", "aiohttp>=3.13.3,<4", "slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4", "qrcode>=7.0,<8"]
 cron = []  # croniter is now a core dependency; this extra kept for back-compat
 slack = ["slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4"]

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -44,7 +44,15 @@ PYTHON="$VENV/bin/python"
 # ── Ensure pytest-split is installed (required for shard-equivalent runs) ──
 if ! "$PYTHON" -c "import pytest_split" 2>/dev/null; then
   echo "→ installing pytest-split into $VENV"
-  "$PYTHON" -m pip install --quiet "pytest-split>=0.9,<1"
+  if command -v uv >/dev/null 2>&1; then
+    uv pip install --python "$PYTHON" --quiet "pytest-split>=0.9,<1"
+  elif "$PYTHON" -m pip --version >/dev/null 2>&1; then
+    "$PYTHON" -m pip install --quiet "pytest-split>=0.9,<1"
+  else
+    echo "error: neither uv nor pip is available in $VENV — pytest-split is missing" >&2
+    echo "  fix: run  uv pip install -e \".[dev]\"  from $REPO_ROOT" >&2
+    exit 1
+  fi
 fi
 
 # ── Hermetic environment ────────────────────────────────────────────────────
@@ -67,6 +75,7 @@ unset HERMES_YOLO_MODE HERMES_INTERACTIVE HERMES_QUIET HERMES_TOOL_PROGRESS \
       HERMES_TOOL_PROGRESS_MODE HERMES_MAX_ITERATIONS HERMES_SESSION_PLATFORM \
       HERMES_SESSION_CHAT_ID HERMES_SESSION_CHAT_NAME HERMES_SESSION_THREAD_ID \
       HERMES_SESSION_SOURCE HERMES_SESSION_KEY HERMES_GATEWAY_SESSION \
+      HERMES_CRON_SESSION \
       HERMES_PLATFORM HERMES_INFERENCE_PROVIDER HERMES_MANAGED HERMES_DEV \
       HERMES_CONTAINER HERMES_EPHEMERAL_SYSTEM_PROMPT HERMES_TIMEZONE \
       HERMES_REDACT_SECRETS HERMES_BACKGROUND_NOTIFICATIONS HERMES_EXEC_ASK \


### PR DESCRIPTION
## Summary
Two co-located fixes to `scripts/run_tests.sh`:

1. **#22401**: pytest-split bootstrap fails in uv venvs (no pip). Add uv fallback + declare pytest-split in dev extras.
2. **#22400**: hermetic env scrub missed `HERMES_CRON_SESSION`, so cron-invoked test runs flipped approval gates and broke approval-isolation tests.

## Changes
- `scripts/run_tests.sh`: `uv pip install --python "$PYTHON"` first, fall back to `pip`, error out with `uv pip install -e ".[dev]"` guidance if neither is available. Also adds `HERMES_CRON_SESSION` to the unset list alongside `HERMES_GATEWAY_SESSION`.
- `pyproject.toml`: `pytest-split>=0.9,<1` added to `dev` extra so a normal `.[dev]` install provisions it without runtime bootstrap.

## Validation
- `bash -n scripts/run_tests.sh` clean.
- After fix, `HERMES_CRON_SESSION=1 scripts/run_tests.sh tests/acp/test_approval_isolation.py` should match the `env -u HERMES_CRON_SESSION` baseline (per #22400 repro).

Closes #22400.
Closes #22401.
