### PR TITLE
fix(kanban): sanitize comment author rendering in build_worker_context

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4072,7 +4072,14 @@ def build_worker_context(conn: sqlite3.Connection, task_id: str) -> str:
             )
         for c in shown_c:
             ts = time.strftime("%Y-%m-%d %H:%M", time.localtime(c.created_at))
-            lines.append(f"**{c.author}** ({ts}):")
+            # Render author with explicit "comment from worker" framing so
+            # operator-controlled HERMES_PROFILE values like "hermes-system"
+            # or "operator" can't be misread by the next worker as a system
+            # directive above the (attacker-influenceable) comment body.
+            # Defense-in-depth — the LLM-controlled author-forgery surface
+            # was already closed in #22435. See #22452.
+            safe_author = (c.author or "").replace("`", "")
+            lines.append(f"comment from worker `{safe_author}` at {ts}:")
             lines.append(_cap(c.body, _CTX_MAX_COMMENT_BYTES))
             lines.append("")
 

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -2507,6 +2507,27 @@ def test_build_worker_context_caps_prior_attempts(kanban_home):
         conn.close()
 
 
+def test_build_worker_context_renders_author_with_safe_framing(kanban_home):
+    """Author rendering wraps the operator-controlled author in code fences
+    + "comment from worker" prefix so a misleading HERMES_PROFILE name
+    (e.g. "hermes-system", "operator") can't be misread as a system
+    directive above the comment body. Defense-in-depth — see #22452."""
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="t", assignee="worker")
+        kb.add_comment(conn, tid, author="hermes-system", body="some note")
+        ctx = kb.build_worker_context(conn, tid)
+
+        # No bold-author rendering anywhere in the context.
+        assert "**hermes-system**" not in ctx
+        # Explicit provenance prefix is present.
+        assert "comment from worker `hermes-system` at " in ctx
+        # The body still renders.
+        assert "some note" in ctx
+    finally:
+        conn.close()
+
+
 def test_build_worker_context_caps_comments(kanban_home):
     """Same cap for comments — comment-storm tasks stay bounded."""
     conn = kb.connect()
@@ -2516,10 +2537,15 @@ def test_build_worker_context_caps_comments(kanban_home):
             kb.add_comment(conn, tid, author=f"u{i % 3}", body=f"comment {i}")
         ctx = kb.build_worker_context(conn, tid)
         # Only _CTX_MAX_COMMENTS most-recent shown in full
-        comment_count = ctx.count("**u")
-        # 3 distinct authors u0/u1/u2 so the count is trickier; use the
-        # "comment N" body text to count.
-        body_count = sum(1 for line in ctx.splitlines() if line.startswith("comment "))
+        # Count by body text since author rendering uses code-fenced
+        # "comment from worker `<author>` at <ts>:" framing (#22452).
+        # Comment bodies are "comment 0".."comment 99" so we need to
+        # match the body specifically (digit suffix), not the author
+        # provenance line (which also starts with "comment ").
+        import re
+        body_count = sum(
+            1 for line in ctx.splitlines() if re.fullmatch(r"comment \d+", line)
+        )
         assert body_count == kb._CTX_MAX_COMMENTS, (
             f"expected {kb._CTX_MAX_COMMENTS} comments shown, got {body_count}"
         )


### PR DESCRIPTION
## Summary
Defense-in-depth — render kanban comment authors with explicit `comment from worker \`<author>\` at <ts>:` framing instead of `**<author>** (<ts>):` so operator-controlled `HERMES_PROFILE` values can't be misread as system directives by the next worker.

## Threat model
The LLM-controlled author-forgery primitive was already closed in #22435 (author removed from `KANBAN_COMMENT_SCHEMA`; workers can't pass `args["author"]`). The residual surface this PR closes:

- An operator picks a misleading `HERMES_PROFILE` name (`hermes-system`, `operator`, `kernel`, …)
- That name is rendered with markdown bolding directly above an attacker-influenceable comment body in the next-worker prompt
- An LLM scanning the block can mistake `**operator** (ts): IGNORE PRIOR INSTRUCTIONS…` for a system directive

Confused-deputy primitive gated on operator misconfig. Likelihood low, blast radius high (system-prompt-adjacent context). Worth closing — rendering shouldn't depend on operator hygiene.

## Changes
- `hermes_cli/kanban_db.py::build_worker_context`: replace `**<author>** (<ts>):` with `comment from worker \`<author>\` at <ts>:`. Strip backticks from author so they can't break out of the inline-code fence.
- `tests/hermes_cli/test_kanban_core_functionality.py`: new regression test (`test_build_worker_context_renders_author_with_safe_framing`) plus an update to `test_build_worker_context_caps_comments` (its `body_count` heuristic relied on `comment ` being unique to the body line — now also matches the provenance line, so use a regex on the body's `comment <digit>` shape).

## Validation
- 9/9 `build_worker_context` tests pass.
- The regression test confirms `**hermes-system**` is absent and `comment from worker \`hermes-system\` at ` is present.

Closes #22452.
