### PR TITLE
fix(fallback): skip chain entries matching current provider/model/base_url

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -8042,6 +8042,32 @@ class AIAgent:
         if not fb_provider or not fb_model:
             return self._try_activate_fallback()  # skip invalid, try next
 
+        # Skip entries that resolve to the current (provider, model) — falling
+        # back to the same backend that just failed loops the failure. Compare
+        # base_url too so two distinct custom_providers entries pointing at the
+        # same shim/proxy URL also dedup. See issue #22548.
+        current_provider = (getattr(self, "provider", "") or "").strip().lower()
+        current_model = (getattr(self, "model", "") or "").strip()
+        current_base_url = str(getattr(self, "base_url", "") or "").rstrip("/").lower()
+        fb_base_url_for_dedup = (fb.get("base_url") or "").strip().rstrip("/").lower()
+        if fb_provider == current_provider and fb_model == current_model:
+            logging.warning(
+                "Fallback skip: chain entry %s/%s matches current provider/model",
+                fb_provider, fb_model,
+            )
+            return self._try_activate_fallback()
+        if (
+            fb_base_url_for_dedup
+            and current_base_url
+            and fb_base_url_for_dedup == current_base_url
+            and fb_model == current_model
+        ):
+            logging.warning(
+                "Fallback skip: chain entry base_url %s matches current backend",
+                fb_base_url_for_dedup,
+            )
+            return self._try_activate_fallback()
+
         # Use centralized router for client construction.
         # raw_codex=True because the main agent needs direct responses.stream()
         # access for Codex providers.

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -220,3 +220,88 @@ class TestPoolRotationRoom:
 
     def test_many_credentials_available_returns_true(self):
         assert _pool_may_recover_from_rate_limit(_pool(10)) is True
+
+
+# ── Skip-self dedup (#22548) ───────────────────────────────────────────────
+
+
+class TestFallbackChainDedup:
+    """A fallback chain entry that resolves to the current provider/model
+    (or the same custom-provider base_url) must be skipped, not retried.
+    Otherwise a misconfigured chain or two custom_providers entries pointing
+    at the same shim loop the same failure. See issue #22548."""
+
+    def test_skips_entry_matching_current_provider_and_model(self):
+        """Chain has [same-as-current, real-fallback]; activate must skip
+        the first and use the second."""
+        fbs = [
+            # First entry == current state. Should be skipped.
+            {"provider": "openrouter", "model": "z-ai/glm-4.7"},
+            # Second entry: real fallback.
+            {"provider": "zai", "model": "glm-4.7"},
+        ]
+        agent = _make_agent(fallback_model=fbs)
+        agent.provider = "openrouter"
+        agent.model = "z-ai/glm-4.7"
+        agent.base_url = "https://openrouter.ai/api/v1"
+
+        # Stub out resolve_provider_client so we can assert which entry was
+        # actually used — return a MagicMock client tagged with the provider.
+        called = []
+        def _resolve(provider, model=None, raw_codex=False, **kwargs):
+            called.append((provider, model))
+            return _mock_client(), model
+        with patch("agent.auxiliary_client.resolve_provider_client", side_effect=_resolve):
+            with patch("hermes_cli.model_normalize.normalize_model_for_provider", side_effect=lambda m, p: m):
+                ok = agent._try_activate_fallback()
+
+        assert ok is True
+        # The first entry was skipped — only the second reached resolve.
+        assert called == [("zai", "glm-4.7")], (
+            f"expected fallback to skip same-state entry, got call order: {called}"
+        )
+
+    def test_skips_entry_matching_current_base_url_and_model(self):
+        """Two custom_providers entries pointing at the same shim URL
+        with the same model should dedup even if their provider names differ."""
+        fbs = [
+            # Different provider name but same shim URL + model — same backend.
+            {"provider": "claude-cli-alt", "model": "claude-opus-4.7",
+             "base_url": "http://127.0.0.1:7891/v1"},
+            # Real different fallback.
+            {"provider": "openrouter", "model": "anthropic/claude-opus-4.7"},
+        ]
+        agent = _make_agent(fallback_model=fbs)
+        agent.provider = "claude-cli"
+        agent.model = "claude-opus-4.7"
+        agent.base_url = "http://127.0.0.1:7891/v1"
+
+        called = []
+        def _resolve(provider, model=None, raw_codex=False, **kwargs):
+            called.append((provider, model))
+            return _mock_client(), model
+        with patch("agent.auxiliary_client.resolve_provider_client", side_effect=_resolve):
+            with patch("hermes_cli.model_normalize.normalize_model_for_provider", side_effect=lambda m, p: m):
+                ok = agent._try_activate_fallback()
+
+        assert ok is True
+        # Same shim/base_url+model entry skipped, second one used.
+        assert called == [("openrouter", "anthropic/claude-opus-4.7")], (
+            f"expected base_url-aware dedup, got call order: {called}"
+        )
+
+    def test_returns_false_when_only_self_matching_entries(self):
+        """A chain with only self-matching entries exhausts to False."""
+        fbs = [
+            {"provider": "openrouter", "model": "z-ai/glm-4.7"},
+        ]
+        agent = _make_agent(fallback_model=fbs)
+        agent.provider = "openrouter"
+        agent.model = "z-ai/glm-4.7"
+        agent.base_url = "https://openrouter.ai/api/v1"
+
+        with patch("agent.auxiliary_client.resolve_provider_client") as mock_resolve:
+            ok = agent._try_activate_fallback()
+
+        assert ok is False
+        mock_resolve.assert_not_called()


### PR DESCRIPTION
## Summary
Provider fallback chain no longer loops back to the failing backend. `_try_activate_fallback()` skips chain entries that resolve to the current `(provider, model)` or the current `(base_url, model)` and advances to the next real fallback.

## Root cause
`run_agent.py::_try_activate_fallback` walked `self._fallback_chain[self._fallback_index]` without comparing the candidate against the currently-failing backend. Two real-world misconfigurations cause the chain to land back on the same broken backend:

1. A chain that lists the same `(provider, model)` as the primary (config drift, hand-edit, etc.). Hermes happily "fell back" to itself.
2. Two `custom_providers` entries with different names pointing at the same `base_url` (e.g. `claude-cli` and `claude-cli-alt` both → `http://127.0.0.1:7891/v1`). They look distinct by `provider` name but resolve to the same backend; the chain walked them both.

The user-visible symptom in #22548 was an empty-response retry loop hitting the same downstream shim three times before any fallback could engage — magnified by the shim returning an empty body on transport timeout.

## Changes
- `run_agent.py::_try_activate_fallback`: after parsing `fb_provider`/`fb_model`, before calling `resolve_provider_client`, compare against `self.provider`/`self.model`/`self.base_url`. If `(fb_provider, fb_model) == (self.provider, self.model)` OR `(fb_base_url, fb_model) == (self.base_url, self.model)`, log + recurse to the next entry.
- `tests/run_agent/test_provider_fallback.py`: 3 regression tests — same-provider-same-model skip, base_url-aware dedup, all-self-matching-returns-False exhaustion path.

## Validation
- 107/107 fallback-related tests pass on the fix branch (104 existing + 3 new).
- The dedup tests all FAIL on `origin/main` (the chain reaches `resolve_provider_client` for the self-matching entry, breaking the call-order assertion).

## Note on the downstream timeout
The 120 s `SUBPROCESS_TIMEOUT` in `wherewolf87`'s downstream `claude_shim.py` is not Hermes code — that's a deployment-side wrapper around the `claude` CLI. The right fix there is the env-var knob they describe (raise to 300 s for cold-spawn first turn). This PR addresses the Hermes-side bug that magnified the symptom: the loop-back-to-same-provider behavior triggered by their misconfigured chain.

Closes #22548 (Hermes-side).
