### PR TITLE
feat(kanban): add failure rollups and dispatcher caps

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4057,6 +4057,23 @@ class GatewayRunner:
         if max_spawn is not None:
             logger.info(f"kanban dispatcher: max_spawn={max_spawn}")
 
+        raw_max_spawn_by_assignee = kanban_cfg.get("max_spawn_by_assignee", None)
+        try:
+            max_spawn_by_assignee = _kb._normalize_max_spawn_by_assignee(
+                raw_max_spawn_by_assignee
+            )
+        except ValueError:
+            logger.warning(
+                "kanban dispatcher: invalid kanban.max_spawn_by_assignee=%r; ignoring per-assignee caps",
+                raw_max_spawn_by_assignee,
+            )
+            max_spawn_by_assignee = {}
+        if max_spawn_by_assignee:
+            logger.info(
+                "kanban dispatcher: max_spawn_by_assignee=%s",
+                max_spawn_by_assignee,
+            )
+
         raw_failure_limit = kanban_cfg.get("failure_limit", _kb.DEFAULT_FAILURE_LIMIT)
         try:
             failure_limit = int(raw_failure_limit)
@@ -4107,6 +4124,7 @@ class GatewayRunner:
                     conn,
                     board=slug,
                     max_spawn=max_spawn,
+                    max_spawn_by_assignee=max_spawn_by_assignee,
                     failure_limit=failure_limit,
                 )
             except Exception:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1281,6 +1281,14 @@ DEFAULT_CONFIG = {
         # Seconds between dispatcher ticks (idle or not). Lower = snappier
         # pickup of newly-ready tasks; higher = less SQL pressure.
         "dispatch_interval_seconds": 60,
+        # Global cap on workers spawned per dispatcher tick. Omit / leave
+        # unset for no global cap.
+        "max_spawn": None,
+        # Optional per-assignee caps. Example:
+        #   {"ship-planner": 1, "ship-coder": 2}
+        # Counts currently-running tasks plus workers already spawned in the
+        # same tick before dispatching more work to that assignee.
+        "max_spawn_by_assignee": {},
         # Auto-block after this many consecutive non-success attempts for the
         # same task/profile (spawn_failed, timed_out, or crashed). Reassignment
         # resets the streak for the new profile.

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -46,6 +46,35 @@ def _fmt_ts(ts: Optional[int]) -> str:
     return time.strftime("%Y-%m-%d %H:%M", time.localtime(ts))
 
 
+def _parse_max_assignee_overrides(raw_items: Optional[list[str]]) -> dict[str, int]:
+    """Parse repeated ``--max-assignee profile=N`` CLI args."""
+    if not raw_items:
+        return {}
+    parsed: dict[str, int] = {}
+    for item in raw_items:
+        text = str(item or "").strip()
+        if not text or "=" not in text:
+            raise ValueError(
+                "--max-assignee expects PROFILE=N (example: ship-planner=1)"
+            )
+        assignee, limit = text.split("=", 1)
+        key = assignee.strip()
+        if not key:
+            raise ValueError("--max-assignee requires a non-empty assignee name")
+        try:
+            count = int(limit)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"--max-assignee {item!r} has invalid limit {limit!r}; expected positive int"
+            ) from exc
+        if count < 1:
+            raise ValueError(
+                f"--max-assignee {item!r} must be >= 1"
+            )
+        parsed[key] = count
+    return parsed
+
+
 def _fmt_task_line(t: kb.Task) -> str:
     icon = _STATUS_ICONS.get(t.status, "?")
     assignee = t.assignee or "(unassigned)"
@@ -451,6 +480,12 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                         help="Don't actually spawn processes; just print what would happen")
     p_disp.add_argument("--max", type=int, default=None,
                         help="Cap number of spawns this pass")
+    p_disp.add_argument(
+        "--max-assignee",
+        action="append",
+        default=None,
+        help="Per-assignee cap override, repeatable as PROFILE=N (example: ship-planner=1)",
+    )
     p_disp.add_argument("--failure-limit", type=int,
                         default=kb.DEFAULT_SPAWN_FAILURE_LIMIT,
                         help=f"Auto-block a task after this many consecutive non-success attempts "
@@ -466,6 +501,12 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                           help="Seconds between dispatch ticks (default: 60)")
     p_daemon.add_argument("--max", type=int, default=None,
                           help="Cap number of spawns per tick")
+    p_daemon.add_argument(
+        "--max-assignee",
+        action="append",
+        default=None,
+        help=argparse.SUPPRESS,
+    )
     p_daemon.add_argument("--failure-limit", type=int,
                           default=kb.DEFAULT_SPAWN_FAILURE_LIMIT)
     p_daemon.add_argument("--pidfile", default=None,
@@ -1209,7 +1250,9 @@ def _cmd_show(args: argparse.Namespace) -> int:
         sev_marker = {"warning": "⚠", "error": "!!", "critical": "!!!"}
         print(f"\n  Diagnostics ({len(diags)}):")
         for d in diags:
-            print(f"    {sev_marker.get(d.severity, '?')} [{d.severity}] {d.title}")
+            primary_class = (d.classification or {}).get("primary")
+            class_tag = f" [{primary_class}]" if primary_class else ""
+            print(f"    {sev_marker.get(d.severity, '?')} [{d.severity}]{class_tag} {d.title}")
             if d.data:
                 bits = []
                 for k, v in d.data.items():
@@ -1430,7 +1473,9 @@ def _cmd_diagnostics(args: argparse.Namespace) -> int:
         assignee = m.get("assignee") or "(unassigned)"
         print(f"  {tid}  {status:8s}  @{assignee:18s}  {title}")
         for d in dl:
-            print(f"    {sev_marker.get(d.severity, '?')} [{d.severity}] {d.kind}: {d.title}")
+            primary_class = (d.classification or {}).get("primary")
+            class_tag = f" [{primary_class}]" if primary_class else ""
+            print(f"    {sev_marker.get(d.severity, '?')} [{d.severity}]{class_tag} {d.kind}: {d.title}")
             if d.data:
                 # Compact key:value pairs on one line.
                 bits = []
@@ -1655,11 +1700,15 @@ def _cmd_tail(args: argparse.Namespace) -> int:
 
 
 def _cmd_dispatch(args: argparse.Namespace) -> int:
+    max_spawn_by_assignee = kb._normalize_max_spawn_by_assignee(
+        _parse_max_assignee_overrides(getattr(args, "max_assignee", None))
+    )
     with kb.connect() as conn:
         res = kb.dispatch_once(
             conn,
             dry_run=args.dry_run,
             max_spawn=args.max,
+            max_spawn_by_assignee=max_spawn_by_assignee,
             failure_limit=getattr(args, "failure_limit", kb.DEFAULT_SPAWN_FAILURE_LIMIT),
         )
     if getattr(args, "json", False):
@@ -1827,9 +1876,13 @@ def _cmd_daemon(args: argparse.Namespace) -> int:
             return False
 
     try:
+        max_spawn_by_assignee = kb._normalize_max_spawn_by_assignee(
+            _parse_max_assignee_overrides(getattr(args, "max_assignee", None))
+        )
         kb.run_daemon(
             interval=args.interval,
             max_spawn=args.max,
+            max_spawn_by_assignee=max_spawn_by_assignee,
             failure_limit=getattr(args, "failure_limit", kb.DEFAULT_SPAWN_FAILURE_LIMIT),
             on_tick=_on_tick,
         )

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3527,6 +3527,34 @@ def has_spawnable_ready(conn: sqlite3.Connection) -> bool:
     return False
 
 
+def _normalize_max_spawn_by_assignee(
+    raw: Optional[dict[str, Any]],
+) -> dict[str, int]:
+    """Validate + normalize per-assignee dispatcher caps."""
+    if not raw:
+        return {}
+    if not isinstance(raw, dict):
+        raise ValueError("max_spawn_by_assignee must be a mapping of assignee -> positive int")
+
+    normalized: dict[str, int] = {}
+    for assignee, limit in raw.items():
+        key = str(assignee or "").strip()
+        if not key:
+            raise ValueError("max_spawn_by_assignee keys must be non-empty assignee names")
+        try:
+            count = int(limit)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"max_spawn_by_assignee[{key!r}] must be a positive int"
+            ) from exc
+        if count < 1:
+            raise ValueError(
+                f"max_spawn_by_assignee[{key!r}] must be >= 1"
+            )
+        normalized[key] = count
+    return normalized
+
+
 def dispatch_once(
     conn: sqlite3.Connection,
     *,
@@ -3534,6 +3562,7 @@ def dispatch_once(
     ttl_seconds: int = DEFAULT_CLAIM_TTL_SECONDS,
     dry_run: bool = False,
     max_spawn: Optional[int] = None,
+    max_spawn_by_assignee: Optional[dict[str, Any]] = None,
     failure_limit: int = DEFAULT_SPAWN_FAILURE_LIMIT,
     board: Optional[str] = None,
 ) -> DispatchResult:
@@ -3603,6 +3632,21 @@ def dispatch_once(
     result.timed_out = enforce_max_runtime(conn)
     result.promoted = recompute_ready(conn)
 
+    per_assignee_caps = _normalize_max_spawn_by_assignee(max_spawn_by_assignee)
+    running_by_assignee: dict[str, int] = {}
+    if per_assignee_caps:
+        running_rows = conn.execute(
+            "SELECT assignee, COUNT(*) AS n FROM tasks "
+            "WHERE status = 'running' AND assignee IS NOT NULL "
+            "GROUP BY assignee"
+        ).fetchall()
+        running_by_assignee = {
+            str(row["assignee"]): int(row["n"])
+            for row in running_rows
+            if row["assignee"]
+        }
+    spawned_this_tick_by_assignee: dict[str, int] = {}
+
     ready_rows = conn.execute(
         "SELECT id, assignee FROM tasks "
         "WHERE status = 'ready' AND claim_lock IS NULL "
@@ -3615,6 +3659,15 @@ def dispatch_once(
         if not row["assignee"]:
             result.skipped_unassigned.append(row["id"])
             continue
+        assignee = str(row["assignee"])
+        assignee_cap = per_assignee_caps.get(assignee)
+        if assignee_cap is not None:
+            in_flight = (
+                running_by_assignee.get(assignee, 0)
+                + spawned_this_tick_by_assignee.get(assignee, 0)
+            )
+            if in_flight >= assignee_cap:
+                continue
         # Skip ready tasks whose assignee is not a real Hermes profile.
         # `_default_spawn` invokes ``hermes -p <assignee>`` which fails
         # with "Profile 'X' does not exist" when the assignee names a
@@ -3640,6 +3693,10 @@ def dispatch_once(
             continue
         if dry_run:
             result.spawned.append((row["id"], row["assignee"], ""))
+            spawned += 1
+            spawned_this_tick_by_assignee[assignee] = (
+                spawned_this_tick_by_assignee.get(assignee, 0) + 1
+            )
             continue
         claimed = claim_task(conn, row["id"], ttl_seconds=ttl_seconds)
         if claimed is None:
@@ -3680,6 +3737,10 @@ def dispatch_once(
             # counter is cleared only on successful completion (see
             # complete_task).
             result.spawned.append((claimed.id, claimed.assignee or "", str(workspace)))
+            if claimed.assignee:
+                spawned_this_tick_by_assignee[claimed.assignee] = (
+                    spawned_this_tick_by_assignee.get(claimed.assignee, 0) + 1
+                )
             spawned += 1
         except Exception as exc:
             auto = _record_spawn_failure(
@@ -3840,6 +3901,7 @@ def run_daemon(
     *,
     interval: float = 60.0,
     max_spawn: Optional[int] = None,
+    max_spawn_by_assignee: Optional[dict[str, Any]] = None,
     failure_limit: int = DEFAULT_SPAWN_FAILURE_LIMIT,
     stop_event=None,
     on_tick=None,
@@ -3877,6 +3939,7 @@ def run_daemon(
                 res = dispatch_once(
                     conn,
                     max_spawn=max_spawn,
+                    max_spawn_by_assignee=max_spawn_by_assignee,
                     failure_limit=failure_limit,
                 )
             if on_tick is not None:

--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -41,6 +41,182 @@ import time
 SEVERITY_ORDER = ("warning", "error", "critical")
 
 
+# First-class failure-class taxonomy for Kanban diagnostics. This is
+# intentionally narrower than diagnostic ``kind``: kinds describe the
+# concrete signal (hallucinated cards, repeated crashes, stale worker),
+# while classes answer "what operational bucket does this failure belong
+# to?" so dashboards and APIs can roll up actionably across many tasks.
+FAILURE_CLASSIFICATION_TAXONOMY: dict[str, dict[str, str]] = {
+    "readiness": {
+        "label": "Readiness",
+        "description": (
+            "Worker/profile/repo is not ready to execute the task cleanly "
+            "(missing profile, dependency, worktree, or other preflight setup)."
+        ),
+    },
+    "linear_writeback": {
+        "label": "Linear writeback",
+        "description": (
+            "The task failed while writing status or metadata back to Linear."
+        ),
+    },
+    "vault_persistence": {
+        "label": "Vault persistence",
+        "description": (
+            "The task failed while persisting durable notes/artifacts to the vault."
+        ),
+    },
+    "credentials": {
+        "label": "Credentials",
+        "description": (
+            "The task failed because required credentials, API keys, or OAuth "
+            "state were missing or invalid."
+        ),
+    },
+    "stale_worker": {
+        "label": "Stale worker",
+        "description": (
+            "A worker claim or heartbeat went stale and operator intervention is needed."
+        ),
+    },
+    "repo_tests": {
+        "label": "Repo tests",
+        "description": (
+            "The task failed because repository tests or verification steps failed."
+        ),
+    },
+}
+
+FAILURE_CLASSIFICATION_ORDER = tuple(FAILURE_CLASSIFICATION_TAXONOMY.keys())
+
+
+def _empty_failure_classification() -> dict:
+    return {"primary": None, "matches": [], "confidence": "none"}
+
+
+def _failure_classification(
+    primary: Optional[str],
+    matches: Optional[Iterable[str]] = None,
+    *,
+    confidence: str = "high",
+) -> dict:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for slug in FAILURE_CLASSIFICATION_ORDER:
+        if slug == primary and slug not in seen:
+            seen.add(slug)
+            ordered.append(slug)
+    for slug in matches or []:
+        if slug in FAILURE_CLASSIFICATION_TAXONOMY and slug not in seen:
+            seen.add(slug)
+            ordered.append(slug)
+    return {
+        "primary": primary if primary in FAILURE_CLASSIFICATION_TAXONOMY else None,
+        "matches": ordered,
+        "confidence": confidence if ordered else "none",
+    }
+
+
+def _pick_primary_failure_class(matches: Iterable[str]) -> Optional[str]:
+    seen = set(matches)
+    for slug in FAILURE_CLASSIFICATION_ORDER:
+        if slug in seen:
+            return slug
+    return None
+
+
+def _contains_any(text: str, needles: Iterable[str]) -> bool:
+    return any(n in text for n in needles)
+
+
+def _classify_failure_signal(*, error_text: Optional[str], outcome: Optional[str] = None) -> dict:
+    """Conservatively classify a failure signal into taxonomy buckets.
+
+    Only emits a class when the text clearly points at that operational bucket.
+    Ambiguous failures stay unclassified rather than producing false positives.
+    """
+    text = (error_text or "").strip().lower()
+    matches: list[str] = []
+    if not text and outcome != "spawn_failed":
+        return _empty_failure_classification()
+
+    if _contains_any(text, (
+        "vault-sync",
+        "vault frontmatter",
+        "obsidian vault",
+        "/vault/",
+        " vault/",
+        "vault persistence",
+    )):
+        matches.append("vault_persistence")
+    if _contains_any(text, (
+        "linear writeback",
+        "linear graphql",
+        "api.linear.app",
+        "linear api",
+        "commentcreate",
+        "issueupdate",
+        "issue label",
+        "label inventory",
+    )):
+        matches.append("linear_writeback")
+    if _contains_any(text, (
+        "credential",
+        "credentials",
+        "api key",
+        "oauth",
+        "access token",
+        "refresh token",
+        "auth token",
+        "login required",
+        "not logged in",
+        "no provider credentials",
+        "missing credentials",
+        "invalid api key",
+        "expired token",
+    )):
+        matches.append("credentials")
+    if _contains_any(text, (
+        "pytest",
+        "tests failed",
+        "test failed",
+        "failing tests",
+        "assertionerror",
+        "repo tests",
+        "unit test",
+        "integration test",
+    )):
+        matches.append("repo_tests")
+    if _contains_any(text, (
+        "stale worker",
+        "stale claim",
+        "claim expired",
+        "heartbeat",
+    )):
+        matches.append("stale_worker")
+    if outcome == "spawn_failed" and _contains_any(text, (
+        "profile",
+        "doctor",
+        "does not exist",
+        "command not found",
+        "module not found",
+        "no such file or directory",
+        "not installed",
+        "venv",
+        "virtualenv",
+        "workspace",
+        "worktree",
+        "dependency",
+        "importerror",
+        "modulenotfounderror",
+    )):
+        matches.append("readiness")
+
+    primary = _pick_primary_failure_class(matches)
+    confidence = "high" if len(matches) <= 1 else "medium"
+    return _failure_classification(primary, matches, confidence=confidence)
+
+
 @dataclass
 class DiagnosticAction:
     """A single recovery action attached to a diagnostic.
@@ -92,6 +268,8 @@ class Diagnostic:
     run_id: Optional[int] = None
     # Optional structured payload for the UI (phantom ids, failure count).
     data: dict = field(default_factory=dict)
+    # Optional machine-readable failure classification taxonomy.
+    classification: dict = field(default_factory=_empty_failure_classification)
 
     def to_dict(self) -> dict:
         return {
@@ -105,6 +283,7 @@ class Diagnostic:
             "count": self.count,
             "run_id": self.run_id,
             "data": self.data,
+            "classification": self.classification,
         }
 
 
@@ -219,6 +398,18 @@ def _generic_recovery_actions(task: Any, *, running: bool) -> list[DiagnosticAct
     return out
 
 
+def _running_task_log_hint(task: Any) -> list[DiagnosticAction]:
+    task_id = _task_field(task, "id")
+    if not task_id:
+        return []
+    return [DiagnosticAction(
+        kind="cli_hint",
+        label=f"Check logs: hermes kanban log {task_id}",
+        payload={"command": f"hermes kanban log {task_id}"},
+        suggested=True,
+    )]
+
+
 # ---------------------------------------------------------------------------
 # Rule implementations
 # ---------------------------------------------------------------------------
@@ -275,6 +466,7 @@ def _rule_hallucinated_cards(task, events, runs, now, cfg) -> list[Diagnostic]:
         last_seen_at=last,
         count=len(hits),
         data={"phantom_ids": phantom_ids},
+        classification=_empty_failure_classification(),
     )]
 
 
@@ -309,6 +501,7 @@ def _rule_prose_phantom_refs(task, events, runs, now, cfg) -> list[Diagnostic]:
         last_seen_at=_event_ts(hits[-1]),
         count=len(hits),
         data={"phantom_refs": phantom_refs},
+        classification=_empty_failure_classification(),
     )]
 
 
@@ -377,14 +570,7 @@ def _rule_repeated_failures(task, events, runs, now, cfg) -> list[Diagnostic]:
     elif most_recent_outcome in ("timed_out", "crashed"):
         # Worker got off the ground but died. Logs are the right place
         # to diagnose; reclaim/reassign are the recovery levers.
-        task_id = _task_field(task, "id")
-        if task_id:
-            actions.append(DiagnosticAction(
-                kind="cli_hint",
-                label=f"Check logs: hermes kanban log {task_id}",
-                payload={"command": f"hermes kanban log {task_id}"},
-                suggested=True,
-            ))
+        actions.extend(_running_task_log_hint(task))
     actions.extend(_generic_recovery_actions(
         task, running=_task_field(task, "status") == "running",
     ))
@@ -429,6 +615,10 @@ def _rule_repeated_failures(task, events, runs, now, cfg) -> list[Diagnostic]:
             "most_recent_outcome": most_recent_outcome,
             "last_error": last_err,
         },
+        classification=_classify_failure_signal(
+            error_text=last_err,
+            outcome=most_recent_outcome,
+        ),
     )]
 
 
@@ -477,15 +667,8 @@ def _rule_repeated_crashes(task, events, runs, now, cfg) -> list[Diagnostic]:
             continue
     if consecutive < threshold:
         return []
-    task_id = _task_field(task, "id")
     actions: list[DiagnosticAction] = []
-    if task_id:
-        actions.append(DiagnosticAction(
-            kind="cli_hint",
-            label=f"Check logs: hermes kanban log {task_id}",
-            payload={"command": f"hermes kanban log {task_id}"},
-            suggested=True,
-        ))
+    actions.extend(_running_task_log_hint(task))
     running = _task_field(task, "status") == "running"
     actions.extend(_generic_recovery_actions(task, running=running))
     severity = "critical" if consecutive >= threshold * 2 else "error"
@@ -516,6 +699,52 @@ def _rule_repeated_crashes(task, events, runs, now, cfg) -> list[Diagnostic]:
         last_seen_at=now,
         count=consecutive,
         data={"consecutive_crashes": consecutive, "last_error": last_err},
+        classification=_classify_failure_signal(error_text=last_err, outcome="crashed"),
+    )]
+
+
+def _rule_stale_worker(task, events, runs, now, cfg) -> list[Diagnostic]:
+    """A running task whose claim has already expired is almost certainly wedged.
+
+    This is intentionally conservative: we only fire once the active claim is
+    already stale (plus a small grace window), not merely when a task has been
+    running for a long time.
+    """
+    if _task_field(task, "status") != "running":
+        return []
+    claim_expires = _task_field(task, "claim_expires")
+    if not claim_expires:
+        return []
+    grace_seconds = int(cfg.get("stale_worker_grace_seconds", 60))
+    stale_seconds = now - int(claim_expires)
+    if stale_seconds <= grace_seconds:
+        return []
+    heartbeat_at = _task_field(task, "last_heartbeat_at")
+    data = {
+        "claim_expires": int(claim_expires),
+        "stale_seconds": stale_seconds,
+    }
+    if heartbeat_at:
+        data["last_heartbeat_at"] = int(heartbeat_at)
+        data["heartbeat_age_seconds"] = max(0, now - int(heartbeat_at))
+    actions: list[DiagnosticAction] = []
+    actions.extend(_running_task_log_hint(task))
+    actions.extend(_generic_recovery_actions(task, running=True))
+    return [Diagnostic(
+        kind="stale_worker",
+        severity="error",
+        title=f"Worker claim expired {stale_seconds}s ago",
+        detail=(
+            "This task is still marked running, but its claim TTL has already "
+            "expired. That usually means the worker wedged, died without a clean "
+            "handoff, or stopped heartbeating. Reclaim the task after checking the log."
+        ),
+        actions=actions,
+        first_seen_at=int(claim_expires),
+        last_seen_at=now,
+        count=1,
+        data=data,
+        classification=_failure_classification("stale_worker", ["stale_worker"]),
     )]
 
 
@@ -567,6 +796,7 @@ def _rule_stuck_in_blocked(task, events, runs, now, cfg) -> list[Diagnostic]:
         last_seen_at=last_blocked_ts,
         count=1,
         data={"blocked_at": last_blocked_ts, "age_hours": round(age_hours, 1)},
+        classification=_empty_failure_classification(),
     )]
 
 
@@ -575,6 +805,7 @@ def _rule_stuck_in_blocked(task, events, runs, now, cfg) -> list[Diagnostic]:
 _RULES: list[RuleFn] = [
     _rule_hallucinated_cards,
     _rule_prose_phantom_refs,
+    _rule_stale_worker,
     _rule_repeated_failures,
     _rule_repeated_crashes,
     _rule_stuck_in_blocked,
@@ -586,6 +817,7 @@ _RULES: list[RuleFn] = [
 DIAGNOSTIC_KINDS = (
     "hallucinated_cards",
     "prose_phantom_refs",
+    "stale_worker",
     "repeated_failures",
     "repeated_crashes",
     "stuck_in_blocked",
@@ -598,6 +830,7 @@ DEFAULT_CONFIG = {
     "spawn_failure_threshold": 3,
     "crash_threshold": 2,
     "blocked_stale_hours": 24,
+    "stale_worker_grace_seconds": 60,
 }
 
 

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -267,18 +267,18 @@ def _compute_task_diagnostics(
 def _warnings_summary_from_diagnostics(
     diagnostics: list[dict],
 ) -> Optional[dict]:
-    """Compact summary for cards: {count, highest_severity, kinds,
-    latest_at}. Replaces the old hallucination-only ``warnings`` object
-    — same shape additions plus ``highest_severity`` so the UI can color
-    badges per diagnostic severity.
+    """Compact per-task summary for card badges and attention strips.
 
+    Includes severity and failure-class rollups so the UI can distinguish
+    "credentials" vs "stale worker" without hydrating the full drawer.
     Returns None when ``diagnostics`` is empty.
     """
     if not diagnostics:
         return None
-    from hermes_cli.kanban_diagnostics import SEVERITY_ORDER
+    from hermes_cli.kanban_diagnostics import SEVERITY_ORDER, FAILURE_CLASSIFICATION_ORDER
 
     kinds: dict[str, int] = {}
+    classification_counts: dict[str, int] = {}
     latest = 0
     highest_idx = -1
     highest_sev: Optional[str] = None
@@ -295,11 +295,63 @@ def _warnings_summary_from_diagnostics(
             if idx > highest_idx:
                 highest_idx = idx
                 highest_sev = sev
+        primary = ((d.get("classification") or {}).get("primary"))
+        if primary:
+            classification_counts[primary] = classification_counts.get(primary, 0) + 1
+    primary_classification = None
+    for slug in FAILURE_CLASSIFICATION_ORDER:
+        if classification_counts.get(slug):
+            primary_classification = slug
+            break
     return {
         "count": count,
         "kinds": kinds,
         "latest_at": latest,
         "highest_severity": highest_sev,
+        "classification_counts": classification_counts,
+        "primary_classification": primary_classification,
+    }
+
+
+def _diagnostic_rollup(diags_by_task: dict[str, list[dict]]) -> dict:
+    """Aggregate board-level/API-level diagnostic rollup."""
+    from hermes_cli.kanban_diagnostics import (
+        FAILURE_CLASSIFICATION_ORDER,
+        FAILURE_CLASSIFICATION_TAXONOMY,
+        SEVERITY_ORDER,
+    )
+
+    severity_counts = {sev: 0 for sev in SEVERITY_ORDER}
+    classification_counts = {slug: 0 for slug in FAILURE_CLASSIFICATION_ORDER}
+    highest_idx = -1
+    highest_severity = None
+    diagnostic_count = 0
+    unclassified_count = 0
+
+    for dl in diags_by_task.values():
+        for d in dl:
+            diagnostic_count += 1
+            sev = d.get("severity")
+            if sev in severity_counts:
+                severity_counts[sev] += 1
+                idx = SEVERITY_ORDER.index(sev)
+                if idx > highest_idx:
+                    highest_idx = idx
+                    highest_severity = sev
+            primary = ((d.get("classification") or {}).get("primary"))
+            if primary in classification_counts:
+                classification_counts[primary] += 1
+            else:
+                unclassified_count += 1
+
+    return {
+        "task_count": len(diags_by_task),
+        "diagnostic_count": diagnostic_count,
+        "highest_severity": highest_severity,
+        "severity_counts": severity_counts,
+        "classification_counts": classification_counts,
+        "unclassified_count": unclassified_count,
+        "taxonomy": FAILURE_CLASSIFICATION_TAXONOMY,
     }
 
 
@@ -444,6 +496,7 @@ def get_board(
             ],
             "tenants": tenants,
             "assignees": assignees,
+            "diagnostic_rollup": _diagnostic_rollup(diagnostics_per_task),
             "latest_event_id": int(latest_event_id),
             "now": int(time.time()),
         }
@@ -920,7 +973,7 @@ def list_diagnostics(
     try:
         diags_by_task = _compute_task_diagnostics(conn, task_ids=None)
         if not diags_by_task:
-            return {"diagnostics": [], "count": 0}
+            return {"diagnostics": [], "count": 0, "diagnostic_rollup": _diagnostic_rollup({})}
 
         # Narrow by severity if asked.
         if severity:
@@ -931,7 +984,7 @@ def list_diagnostics(
                     filtered[tid] = keep
             diags_by_task = filtered
             if not diags_by_task:
-                return {"diagnostics": [], "count": 0}
+                return {"diagnostics": [], "count": 0, "diagnostic_rollup": _diagnostic_rollup({})}
 
         # Pull the task rows we need in one query so we can include
         # titles/statuses without a per-task lookup.
@@ -966,9 +1019,11 @@ def list_diagnostics(
             )
         out.sort(key=_sort_key)
 
+        filtered_by_task = {row["task_id"]: row["diagnostics"] for row in out}
         return {
             "diagnostics": out,
             "count": sum(len(d["diagnostics"]) for d in out),
+            "diagnostic_rollup": _diagnostic_rollup(filtered_by_task),
         }
     finally:
         conn.close()

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -3082,6 +3082,9 @@ def test_config_default_dispatch_in_gateway_is_true():
     assert isinstance(interval, (int, float)) and interval >= 1, (
         f"dispatch_interval_seconds must be a positive number, got {interval!r}"
     )
+    assert kanban.get("max_spawn_by_assignee") == {}, (
+        "kanban.max_spawn_by_assignee default should be an empty mapping"
+    )
 
 
 def test_check_dispatcher_presence_silent_when_gateway_running(monkeypatch):
@@ -3252,6 +3255,33 @@ def test_cli_daemon_help_marks_deprecated():
     )
 
 
+def test_kanban_dispatch_parser_accepts_per_assignee_caps():
+    """CLI surface exposes repeatable --max-assignee PROFILE=N overrides."""
+    import argparse as _ap
+    from hermes_cli import kanban as kb_cli
+
+    parser = _ap.ArgumentParser()
+    kb_cli.build_parser(parser.add_subparsers(dest="command"))
+
+    args = parser.parse_args(
+        [
+            "kanban",
+            "dispatch",
+            "--dry-run",
+            "--max-assignee",
+            "ship-planner=1",
+            "--max-assignee",
+            "ship-coder=2",
+        ]
+    )
+
+    assert args.max_assignee == ["ship-planner=1", "ship-coder=2"]
+    assert kb_cli._parse_max_assignee_overrides(args.max_assignee) == {
+        "ship-planner": 1,
+        "ship-coder": 2,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Gateway embedded dispatcher watcher
 # ---------------------------------------------------------------------------
@@ -3317,6 +3347,72 @@ def test_gateway_dispatcher_watcher_env_truthy_uses_config(monkeypatch):
             timeout=3.0,
         )
     )
+
+
+def test_gateway_dispatcher_watcher_passes_per_assignee_caps(monkeypatch):
+    """Embedded dispatcher should parse kanban.max_spawn_by_assignee and
+    forward the normalized mapping into dispatch_once."""
+    import asyncio
+    from types import SimpleNamespace
+    from gateway.run import GatewayRunner
+    import hermes_cli.config as _cfg_mod
+    from hermes_cli import kanban_db as _kb
+
+    calls = []
+
+    class _FakeConn:
+        def close(self):
+            return None
+
+    monkeypatch.setattr(
+        _cfg_mod,
+        "load_config",
+        lambda: {
+            "kanban": {
+                "dispatch_in_gateway": True,
+                "dispatch_interval_seconds": 1,
+                "max_spawn": 5,
+                "max_spawn_by_assignee": {"ship-planner": 1, "ship-coder": 2},
+                "failure_limit": 2,
+            }
+        },
+    )
+    _real_sleep = asyncio.sleep
+
+    async def _fast_sleep(*_args, **_kwargs):
+        await _real_sleep(0)
+
+    monkeypatch.setattr(asyncio, "sleep", _fast_sleep)
+    monkeypatch.setattr(_kb, "connect", lambda board=None: _FakeConn())
+    monkeypatch.setattr(_kb, "init_db", lambda board=None: None)
+    monkeypatch.setattr(
+        _kb,
+        "list_boards",
+        lambda include_archived=False: [{"slug": _kb.DEFAULT_BOARD}],
+    )
+    monkeypatch.setattr(_kb, "has_spawnable_ready", lambda conn: False)
+
+    def _fake_dispatch_once(conn, **kwargs):
+        calls.append(kwargs)
+        runner._running = False
+        return SimpleNamespace(
+            spawned=[], reclaimed=0, crashed=[], timed_out=[], promoted=0, auto_blocked=[]
+        )
+
+    monkeypatch.setattr(_kb, "dispatch_once", _fake_dispatch_once)
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    asyncio.run(
+        asyncio.wait_for(
+            runner._kanban_dispatcher_watcher(),
+            timeout=3.0,
+        )
+    )
+
+    assert calls, "dispatch_once was not called"
+    assert calls[0]["max_spawn"] == 5
+    assert calls[0]["max_spawn_by_assignee"] == {"ship-planner": 1, "ship-coder": 2}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -516,6 +516,76 @@ def test_dispatch_dry_run_does_not_claim(kanban_home, all_assignees_spawnable):
         assert kb.get_task(conn, t2).status == "ready"
 
 
+def test_dispatch_dry_run_respects_global_max_spawn(
+    kanban_home, all_assignees_spawnable
+):
+    with kb.connect() as conn:
+        t1 = kb.create_task(conn, title="a", assignee="alice")
+        t2 = kb.create_task(conn, title="b", assignee="bob")
+        kb.create_task(conn, title="c", assignee="carol")
+        res = kb.dispatch_once(conn, dry_run=True, max_spawn=2)
+
+    assert [task_id for task_id, _, _ in res.spawned] == [t1, t2]
+    with kb.connect() as conn:
+        assert kb.get_task(conn, t1).status == "ready"
+        assert kb.get_task(conn, t2).status == "ready"
+
+
+def test_dispatch_respects_per_assignee_caps_against_running_and_current_tick(
+    kanban_home, all_assignees_spawnable
+):
+    spawns = []
+
+    def fake_spawn(task, workspace):
+        spawns.append((task.id, task.assignee, workspace))
+
+    with kb.connect() as conn:
+        running = kb.create_task(conn, title="already running", assignee="alice")
+        queued_1 = kb.create_task(conn, title="queued 1", assignee="alice")
+        queued_2 = kb.create_task(conn, title="queued 2", assignee="alice")
+        bob = kb.create_task(conn, title="bob queued", assignee="bob")
+        kb.claim_task(conn, running)
+
+        res = kb.dispatch_once(
+            conn,
+            spawn_fn=fake_spawn,
+            max_spawn_by_assignee={"alice": 2, "bob": 1},
+        )
+
+        assert [task_id for task_id, _, _ in res.spawned] == [queued_1, bob]
+        assert [task_id for task_id, _, _ in spawns] == [queued_1, bob]
+        assert kb.get_task(conn, queued_1).status == "running"
+        assert kb.get_task(conn, queued_2).status == "ready"
+        assert kb.get_task(conn, bob).status == "running"
+
+
+def test_dispatch_dry_run_counts_same_tick_spawns_toward_assignee_cap(
+    kanban_home, all_assignees_spawnable
+):
+    with kb.connect() as conn:
+        t1 = kb.create_task(conn, title="a1", assignee="alice")
+        t2 = kb.create_task(conn, title="a2", assignee="alice")
+        t3 = kb.create_task(conn, title="b1", assignee="bob")
+        res = kb.dispatch_once(
+            conn,
+            dry_run=True,
+            max_spawn_by_assignee={"alice": 1, "bob": 1},
+        )
+
+    assert [task_id for task_id, _, _ in res.spawned] == [t1, t3]
+    with kb.connect() as conn:
+        assert kb.get_task(conn, t1).status == "ready"
+        assert kb.get_task(conn, t2).status == "ready"
+        assert kb.get_task(conn, t3).status == "ready"
+
+
+def test_dispatch_rejects_invalid_per_assignee_caps(kanban_home):
+    with kb.connect() as conn:
+        kb.create_task(conn, title="a", assignee="alice")
+        with pytest.raises(ValueError, match="max_spawn_by_assignee"):
+            kb.dispatch_once(conn, dry_run=True, max_spawn_by_assignee={"alice": 0})
+
+
 def test_dispatch_skips_unassigned(kanban_home):
     with kb.connect() as conn:
         t = kb.create_task(conn, title="floater")

--- a/tests/hermes_cli/test_kanban_diagnostics.py
+++ b/tests/hermes_cli/test_kanban_diagnostics.py
@@ -243,6 +243,23 @@ def test_stuck_in_blocked_silent_when_not_blocked():
     assert kd.compute_task_diagnostics(task, events, [], now=9999999) == []
 
 
+def test_stale_worker_fires_when_running_claim_has_expired():
+    now = int(time.time())
+    task = _task(
+        status="running",
+        claim_expires=now - 600,
+        last_heartbeat_at=now - 900,
+    )
+    diags = kd.compute_task_diagnostics(task, [], [], now=now)
+    assert len(diags) == 1
+    d = diags[0]
+    assert d.kind == "stale_worker"
+    assert d.classification["primary"] == "stale_worker"
+    assert d.data["stale_seconds"] >= 600
+    suggested = [a.label for a in d.actions if a.suggested]
+    assert any("log" in s.lower() for s in suggested)
+
+
 def test_repeated_crashes_surfaces_actual_error_in_title():
     """The title should lead with the actual error text so operators
     see WHAT broke (e.g. rate-limit, auth, OOM) without opening logs.
@@ -279,6 +296,28 @@ def test_repeated_failures_surfaces_actual_error_in_title():
     d = diags[0]
     assert "insufficient_quota" in d.title or "billing limit" in d.title
     assert "insufficient_quota" in d.detail
+
+
+@pytest.mark.parametrize(
+    ("outcome", "error_text", "expected_primary"),
+    [
+        ("spawn_failed", "Profile 'debugger' does not exist", "readiness"),
+        ("spawn_failed", "missing credentials for provider openai", "credentials"),
+        ("crashed", "Linear GraphQL writeback failed", "linear_writeback"),
+        ("crashed", "vault-sync failed: frontmatter lint error", "vault_persistence"),
+        ("crashed", "pytest failed: 2 tests failed", "repo_tests"),
+    ],
+)
+def test_failure_signal_classifier_maps_known_hardening_taxonomy(
+    outcome, error_text, expected_primary,
+):
+    classification = kd._classify_failure_signal(
+        error_text=error_text,
+        outcome=outcome,
+    )
+    assert classification["primary"] == expected_primary
+    assert expected_primary in classification["matches"]
+    assert classification["confidence"] in {"high", "medium"}
 
 
 def test_repeated_crashes_truncates_huge_tracebacks():

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -1498,6 +1498,7 @@ def test_diagnostics_endpoint_empty_for_clean_board(client):
     data = r.json()
     assert data["count"] == 0
     assert data["diagnostics"] == []
+    assert data["diagnostic_rollup"]["diagnostic_count"] == 0
 
 
 def test_diagnostics_endpoint_surfaces_blocked_hallucination(client):
@@ -1522,7 +1523,10 @@ def test_diagnostics_endpoint_surfaces_blocked_hallucination(client):
     assert row["task_id"] == parent
     assert row["diagnostics"][0]["kind"] == "hallucinated_cards"
     assert row["diagnostics"][0]["severity"] == "error"
+    assert row["diagnostics"][0]["classification"]["primary"] is None
     assert "t_ffff00001234" in row["diagnostics"][0]["data"]["phantom_ids"]
+    assert data["diagnostic_rollup"]["diagnostic_count"] == 1
+    assert data["diagnostic_rollup"]["unclassified_count"] == 1
 
 
 def test_diagnostics_endpoint_severity_filter(client):
@@ -1556,20 +1560,20 @@ def test_diagnostics_endpoint_severity_filter(client):
     assert data["diagnostics"][0]["task_id"] == p2
 
 
-def test_board_exposes_diagnostics_list_and_summary(client):
-    """/board should attach both the full diagnostics list AND the
-    compact warnings summary (with highest_severity) on each task
-    that has any diagnostic.
+def test_board_exposes_diagnostics_list_summary_and_rollup(client):
+    """/board should attach the full diagnostics list, per-task warning summary,
+    and a board-level rollup with failure classifications.
     """
     conn = kb.connect()
     try:
         t = kb.create_task(conn, title="crashy", assignee="worker")
-        # Simulate 2 consecutive crashes -> repeated_crashes error diag
+        # Simulate 2 consecutive crashes -> repeated_crashes error diag.
+        # Error text intentionally mentions pytest so the classification is repo_tests.
         for i in range(2):
             conn.execute(
                 "INSERT INTO task_runs (task_id, status, outcome, started_at, "
                 "ended_at, error) VALUES (?, 'crashed', 'crashed', ?, ?, ?)",
-                (t, int(time.time()) - 100, int(time.time()) - 50, "OOM"),
+                (t, int(time.time()) - 100, int(time.time()) - 50, "pytest failed: 2 tests failed"),
             )
         conn.commit()
     finally:
@@ -1581,7 +1585,39 @@ def test_board_exposes_diagnostics_list_and_summary(client):
     task_dict = next(x for x in tasks if x["title"] == "crashy")
     assert task_dict["warnings"] is not None
     assert task_dict["warnings"]["highest_severity"] == "error"
+    assert task_dict["warnings"]["primary_classification"] == "repo_tests"
+    assert task_dict["warnings"]["classification_counts"]["repo_tests"] == 1
     assert task_dict["diagnostics"][0]["kind"] == "repeated_crashes"
+    assert task_dict["diagnostics"][0]["classification"]["primary"] == "repo_tests"
+    assert data["diagnostic_rollup"]["diagnostic_count"] == 1
+    assert data["diagnostic_rollup"]["classification_counts"]["repo_tests"] == 1
+    assert "repo_tests" in data["diagnostic_rollup"]["taxonomy"]
+
+
+
+
+def test_diagnostics_endpoint_rolls_up_stale_worker_classification(client):
+    now = int(time.time())
+    conn = kb.connect()
+    try:
+        task_id = kb.create_task(conn, title="wedged", assignee="worker")
+        conn.execute(
+            "UPDATE tasks SET status='running', claim_lock=?, claim_expires=?, last_heartbeat_at=? WHERE id=?",
+            ("lock123", now - 600, now - 900, task_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    r = client.get("/api/plugins/kanban/diagnostics")
+    assert r.status_code == 200
+    data = r.json()
+    row = next(x for x in data["diagnostics"] if x["task_id"] == task_id)
+    diag = row["diagnostics"][0]
+    assert diag["kind"] == "stale_worker"
+    assert diag["classification"]["primary"] == "stale_worker"
+    assert data["diagnostic_rollup"]["classification_counts"]["stale_worker"] == 1
+    assert data["diagnostic_rollup"]["highest_severity"] == "error"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- add machine-readable Kanban failure classification taxonomy and expose rollups through CLI/API/dashboard data
- add conservative stale-worker diagnostic classification and tests
- add per-assignee Kanban dispatcher caps via config and CLI overrides while preserving global `max_spawn`
- plumb per-assignee caps through the gateway embedded dispatcher

## Test Plan
- `env -u HERMES_KANBAN_DB -u HERMES_KANBAN_HOME -u HERMES_KANBAN_WORKSPACES_ROOT -u HERMES_KANBAN_BOARD -u HERMES_KANBAN_TASK -u HERMES_KANBAN_RUN_ID python -m pytest tests/hermes_cli/test_kanban_diagnostics.py tests/plugins/test_kanban_dashboard_plugin.py tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py -q -o addopts=''`
- Result after latest rebase: 323 passed, 1 skipped

## Review Notes
- Independent review passed with no blocking security or logic findings.
- Addressed reviewer suggestions by tightening broad classifier substrings and making dry-run respect global `max_spawn`.