### PR TITLE
feat(tts): add native Kokoro 82M MLX provider (Apple Silicon, ~38x real-time, in-process)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,16 @@ slack = ["slack-bolt>=1.18.0,<2", "slack-sdk>=3.27.0,<4"]
 matrix = ["mautrix[encryption]>=0.20,<1", "Markdown>=3.6,<4", "aiosqlite>=0.20", "asyncpg>=0.29", "aiohttp-socks>=0.10,<1"]
 cli = ["simple-term-menu>=1.0,<2"]
 tts-premium = ["elevenlabs>=1.0,<2"]
+# Kokoro 82M MLX TTS — fully local on-device synthesis, Apache-2.0 weights,
+# ~38x real-time steady-state on Apple M5 Pro (in-process). Requires mlx-audio
+# (the MLX runtime + Kokoro implementation) and misaki (G2P phonemizer).
+# Gated to Darwin since MLX is Apple Silicon only — installing this extra on
+# Linux/Windows is a no-op rather than an error.
+# Optional: ``brew install espeak-ng`` for OOD-word phonemization fallback.
+kokoro = [
+  "mlx-audio>=0.4.0,<1; platform_system == 'Darwin'",
+  "misaki[en]>=0.9.0; platform_system == 'Darwin'",
+]
 voice = [
   # Local STT pulls in wheel-only transitive deps (ctranslate2, onnxruntime),
   # so keep it out of the base install for source-build packagers like Homebrew.

--- a/tests/tools/test_tts_kokoro.py
+++ b/tests/tools/test_tts_kokoro.py
@@ -1,0 +1,366 @@
+"""Tests for the native Kokoro TTS provider.
+
+These tests pin the registration / availability / cache / dispatch / config
+paths for Kokoro without requiring the ``mlx-audio`` and ``misaki`` packages
+to actually be installed. The synthesis step is monkey-patched: a stub
+KokoroPipeline yields fake audio chunks so the test runs on every CI runner,
+including non-Apple-Silicon ones where ``mlx_audio`` cannot be installed.
+
+The shape mirrors ``test_tts_piper.py`` deliberately — Kokoro is the
+in-process Apple-Silicon-native sibling of Piper.
+"""
+
+import json
+import sys
+import wave
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from tools import tts_tool
+from tools.tts_tool import (
+    BUILTIN_TTS_PROVIDERS,
+    DEFAULT_KOKORO_LANG_CODE,
+    DEFAULT_KOKORO_REPO,
+    DEFAULT_KOKORO_VOICE,
+    PROVIDER_MAX_TEXT_LENGTH,
+    _check_kokoro_available,
+    check_tts_requirements,
+    text_to_speech_tool,
+)
+
+
+# ---------------------------------------------------------------------------
+# Registry / constants
+# ---------------------------------------------------------------------------
+
+class TestKokoroRegistration:
+    def test_kokoro_is_a_builtin_provider(self):
+        assert "kokoro" in BUILTIN_TTS_PROVIDERS
+
+    def test_kokoro_has_a_text_length_cap(self):
+        assert PROVIDER_MAX_TEXT_LENGTH.get("kokoro", 0) > 0
+
+    def test_kokoro_defaults_resolve(self):
+        # The defaults must be populated and well-formed; downstream config
+        # resolution falls back to these when ``tts.kokoro.*`` is absent.
+        assert DEFAULT_KOKORO_REPO.startswith("mlx-community/")
+        assert DEFAULT_KOKORO_VOICE.startswith(("af_", "am_", "bf_", "bm_"))
+        assert DEFAULT_KOKORO_LANG_CODE in {"a", "b", "j", "z", "p", "i", "f", "h", "e"}
+
+
+# ---------------------------------------------------------------------------
+# _check_kokoro_available
+# ---------------------------------------------------------------------------
+
+class TestCheckKokoroAvailable:
+    def test_returns_bool_without_raising(self):
+        # We don't care about the current environment's answer — just that
+        # the probe never raises on a machine without mlx-audio installed.
+        assert isinstance(_check_kokoro_available(), bool)
+
+    def test_returns_false_when_mlx_audio_missing(self, monkeypatch):
+        # Patch find_spec to simulate mlx-audio not installed.
+        import importlib.util as _util
+        original = _util.find_spec
+
+        def fake_find_spec(name, *args, **kwargs):
+            if name in ("mlx_audio", "misaki"):
+                return None
+            return original(name, *args, **kwargs)
+
+        monkeypatch.setattr(_util, "find_spec", fake_find_spec)
+        assert _check_kokoro_available() is False
+
+    def test_returns_true_when_both_present(self, monkeypatch):
+        # Both modules report present.
+        import importlib.util as _util
+        sentinel = MagicMock()
+        original = _util.find_spec
+
+        def fake_find_spec(name, *args, **kwargs):
+            if name in ("mlx_audio", "misaki"):
+                return sentinel
+            return original(name, *args, **kwargs)
+
+        monkeypatch.setattr(_util, "find_spec", fake_find_spec)
+        assert _check_kokoro_available() is True
+
+
+# ---------------------------------------------------------------------------
+# _import_kokoro
+# ---------------------------------------------------------------------------
+
+class TestImportKokoro:
+    def test_raises_importerror_with_actionable_message(self, monkeypatch):
+        # Force the underlying imports to fail to verify the user-facing
+        # error message points at the correct extra.
+        def kokoro_import_fail(*args, **kwargs):
+            raise ImportError("No module named 'mlx_audio'")
+
+        # The simplest way to force ImportError on the inner imports is to
+        # remove the modules from sys.modules and then poison the loader
+        # path. Using monkeypatch on sys.modules is cleanest.
+        monkeypatch.setitem(sys.modules, "mlx_audio", None)
+        monkeypatch.setitem(sys.modules, "mlx_audio.tts", None)
+        monkeypatch.setitem(sys.modules, "mlx_audio.tts.models", None)
+        monkeypatch.setitem(sys.modules, "mlx_audio.tts.models.kokoro", None)
+
+        with pytest.raises(ImportError):
+            tts_tool._import_kokoro()
+
+
+# ---------------------------------------------------------------------------
+# _generate_kokoro_tts — stubbed so we don't need mlx-audio installed
+# ---------------------------------------------------------------------------
+
+class _FakeMxArray:
+    """Stand-in for an mlx.core.array shape (1, N) — pretends to be audio."""
+
+    def __init__(self, samples):
+        # samples is a numpy float32 array. We mimic mx.array shape (1, N).
+        import numpy as np
+        self._np = np.asarray(samples, dtype=np.float32).reshape(1, -1)
+        self.shape = self._np.shape
+        # Make np.asarray(self) flatten back to 1-D in _generate_kokoro_tts
+        self.__array__ = lambda dtype=None: self._np
+
+
+class _FakeOutput:
+    def __init__(self, audio):
+        self.audio = audio
+
+
+class _FakeResult:
+    def __init__(self, audio):
+        self.output = _FakeOutput(audio)
+
+
+class _StubKokoroPipeline:
+    """Stand-in for KokoroPipeline. Records calls + yields fake audio."""
+
+    instances: list = []
+    calls: list = []
+
+    def __init__(self, lang_code, model, repo_id):
+        self.lang_code = lang_code
+        self.model = model
+        self.repo_id = repo_id
+        _StubKokoroPipeline.instances.append(self)
+
+    def __call__(self, text, voice, speed=1.0):
+        import numpy as np
+        _StubKokoroPipeline.calls.append({
+            "text": text, "voice": voice, "speed": speed,
+            "lang_code": self.lang_code, "repo_id": self.repo_id,
+        })
+        # Yield two fake chunks of 0.5 s each at 24 kHz so the WAV is real.
+        sr = 24_000
+        for _ in range(2):
+            samples = np.zeros(sr // 2, dtype=np.float32)
+            yield _FakeResult(_FakeMxArray(samples))
+
+
+def _fake_load_model(_path):
+    return MagicMock(name="FakeModel")
+
+
+def _fake_snapshot_download(repo_id):
+    # Return a tmp-like path; the test doesn't actually need files there
+    # because _fake_load_model ignores the path.
+    return "/tmp/fake-kokoro-snapshot"
+
+
+def _stub_import_kokoro():
+    return _StubKokoroPipeline, _fake_load_model, _fake_snapshot_download
+
+
+@pytest.fixture(autouse=True)
+def _reset_kokoro_cache():
+    """Clear the module-level pipeline cache between tests."""
+    tts_tool._kokoro_pipeline_cache.clear()
+    _StubKokoroPipeline.instances = []
+    _StubKokoroPipeline.calls = []
+    yield
+    tts_tool._kokoro_pipeline_cache.clear()
+
+
+class TestGenerateKokoroTts:
+    def test_writes_wav_with_real_audio_bytes(self, tmp_path, monkeypatch):
+        # numpy is the one hard runtime dep we need (not stubbed).
+        pytest.importorskip("numpy")
+
+        monkeypatch.setattr(tts_tool, "_import_kokoro", _stub_import_kokoro)
+
+        out_path = str(tmp_path / "out.wav")
+        config = {"kokoro": {"voice": "af_bella", "speed": 1.0}}
+
+        result = tts_tool._generate_kokoro_tts("hello", out_path, config)
+
+        assert result == out_path
+        assert Path(out_path).exists()
+        # 2 chunks * 0.5 s * 24000 Hz * 2 bytes = 48,000 bytes of frames.
+        # Plus the WAV header (~44 bytes). Allow some flex.
+        size = Path(out_path).stat().st_size
+        assert size > 40_000, f"WAV too small: {size} bytes"
+
+        # Verify WAV is structurally valid + correct sample rate
+        with wave.open(out_path, "rb") as wf:
+            assert wf.getnchannels() == 1
+            assert wf.getsampwidth() == 2
+            assert wf.getframerate() == 24_000
+
+    def test_pipeline_cache_reused_across_calls(self, tmp_path, monkeypatch):
+        pytest.importorskip("numpy")
+        monkeypatch.setattr(tts_tool, "_import_kokoro", _stub_import_kokoro)
+
+        config = {"kokoro": {"voice": "af_bella"}}
+        tts_tool._generate_kokoro_tts("one", str(tmp_path / "a.wav"), config)
+        tts_tool._generate_kokoro_tts("two", str(tmp_path / "b.wav"), config)
+
+        # Pipeline should have been constructed exactly once for the
+        # default (repo, lang) cache key.
+        assert len(_StubKokoroPipeline.instances) == 1
+        # Both synthesize calls went through.
+        assert [c["text"] for c in _StubKokoroPipeline.calls] == ["one", "two"]
+
+    def test_lang_code_change_invalidates_cache(self, tmp_path, monkeypatch):
+        """A user switching from American to British English should NOT
+        reuse the existing pipeline — different lang_code = different
+        misaki phonemizer, different cache key."""
+        pytest.importorskip("numpy")
+        monkeypatch.setattr(tts_tool, "_import_kokoro", _stub_import_kokoro)
+
+        cfg_a = {"kokoro": {"lang_code": "a", "voice": "af_bella"}}
+        cfg_b = {"kokoro": {"lang_code": "b", "voice": "bf_alice"}}
+        tts_tool._generate_kokoro_tts("one", str(tmp_path / "a.wav"), cfg_a)
+        tts_tool._generate_kokoro_tts("two", str(tmp_path / "b.wav"), cfg_b)
+
+        assert len(_StubKokoroPipeline.instances) == 2
+        assert {p.lang_code for p in _StubKokoroPipeline.instances} == {"a", "b"}
+
+    def test_empty_audio_raises_runtime(self, tmp_path, monkeypatch):
+        pytest.importorskip("numpy")
+
+        class _EmptyKokoroPipeline(_StubKokoroPipeline):
+            def __call__(self, text, voice, speed=1.0):
+                # Yield nothing — simulates phonemizer producing no chunks
+                # (e.g. all-whitespace input or unknown language).
+                if False:
+                    yield None  # pragma: no cover
+
+        def stub_import():
+            return _EmptyKokoroPipeline, _fake_load_model, _fake_snapshot_download
+
+        monkeypatch.setattr(tts_tool, "_import_kokoro", stub_import)
+
+        with pytest.raises(RuntimeError, match="produced no audio"):
+            tts_tool._generate_kokoro_tts(
+                "  ", str(tmp_path / "out.wav"), {"kokoro": {"voice": "af_bella"}}
+            )
+
+    def test_speed_and_voice_threaded_through(self, tmp_path, monkeypatch):
+        pytest.importorskip("numpy")
+        monkeypatch.setattr(tts_tool, "_import_kokoro", _stub_import_kokoro)
+
+        config = {"kokoro": {"voice": "am_michael", "speed": 1.3}}
+        tts_tool._generate_kokoro_tts("hi", str(tmp_path / "out.wav"), config)
+
+        assert _StubKokoroPipeline.calls[0]["voice"] == "am_michael"
+        assert _StubKokoroPipeline.calls[0]["speed"] == 1.3
+
+    def test_default_config_when_kokoro_section_absent(self, tmp_path, monkeypatch):
+        pytest.importorskip("numpy")
+        monkeypatch.setattr(tts_tool, "_import_kokoro", _stub_import_kokoro)
+
+        # No ``kokoro`` block → defaults must apply.
+        tts_tool._generate_kokoro_tts("hi", str(tmp_path / "out.wav"), {})
+
+        call = _StubKokoroPipeline.calls[0]
+        assert call["voice"] == DEFAULT_KOKORO_VOICE
+        assert call["speed"] == 1.0
+        assert call["lang_code"] == DEFAULT_KOKORO_LANG_CODE
+        assert call["repo_id"] == DEFAULT_KOKORO_REPO
+
+
+# ---------------------------------------------------------------------------
+# text_to_speech_tool end-to-end (provider == "kokoro")
+# ---------------------------------------------------------------------------
+
+class TestTextToSpeechToolWithKokoro:
+    def test_dispatches_to_kokoro(self, tmp_path, monkeypatch):
+        pytest.importorskip("numpy")
+        monkeypatch.setattr(tts_tool, "_import_kokoro", _stub_import_kokoro)
+
+        cfg = {"provider": "kokoro", "kokoro": {"voice": "af_bella"}}
+        monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: cfg)
+
+        result = text_to_speech_tool(
+            text="hi", output_path=str(tmp_path / "clip.wav")
+        )
+        data = json.loads(result)
+
+        assert data["success"] is True, data
+        assert data["provider"] == "kokoro"
+        assert Path(data["file_path"]).exists()
+
+    def test_missing_package_surfaces_error(self, tmp_path, monkeypatch):
+        def raise_import():
+            raise ImportError("No module named 'mlx_audio'")
+
+        monkeypatch.setattr(tts_tool, "_import_kokoro", raise_import)
+
+        cfg = {"provider": "kokoro"}
+        monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: cfg)
+
+        result = text_to_speech_tool(
+            text="hi", output_path=str(tmp_path / "clip.wav")
+        )
+        data = json.loads(result)
+
+        assert data["success"] is False
+        assert "mlx-audio" in data["error"] or "kokoro" in data["error"].lower()
+        assert "hermes-agent[kokoro]" in data["error"]
+
+
+# ---------------------------------------------------------------------------
+# check_tts_requirements
+# ---------------------------------------------------------------------------
+
+class TestCheckTtsRequirementsKokoro:
+    def test_kokoro_install_satisfies_requirements(self, monkeypatch):
+        # Drop every other provider so we can isolate the kokoro signal.
+        monkeypatch.setattr(
+            tts_tool, "_import_edge_tts",
+            lambda: (_ for _ in ()).throw(ImportError()),
+        )
+        monkeypatch.setattr(
+            tts_tool, "_import_elevenlabs",
+            lambda: (_ for _ in ()).throw(ImportError()),
+        )
+        monkeypatch.setattr(
+            tts_tool, "_import_openai_client",
+            lambda: (_ for _ in ()).throw(ImportError()),
+        )
+        monkeypatch.setattr(
+            tts_tool, "_import_mistral_client",
+            lambda: (_ for _ in ()).throw(ImportError()),
+        )
+        monkeypatch.setattr(tts_tool, "_check_neutts_available", lambda: False)
+        monkeypatch.setattr(tts_tool, "_check_kittentts_available", lambda: False)
+        monkeypatch.setattr(tts_tool, "_check_piper_available", lambda: False)
+        monkeypatch.setattr(
+            tts_tool, "_has_any_command_tts_provider", lambda: False
+        )
+        monkeypatch.setattr(tts_tool, "_has_openai_audio_backend", lambda: False)
+        for env in ("MINIMAX_API_KEY", "XAI_API_KEY", "GEMINI_API_KEY",
+                    "GOOGLE_API_KEY", "MISTRAL_API_KEY", "ELEVENLABS_API_KEY"):
+            monkeypatch.delenv(env, raising=False)
+
+        # Now toggle the kokoro check on and off.
+        monkeypatch.setattr(tts_tool, "_check_kokoro_available", lambda: False)
+        assert check_tts_requirements() is False
+
+        monkeypatch.setattr(tts_tool, "_check_kokoro_available", lambda: True)
+        assert check_tts_requirements() is True

--- a/tests/tools/test_tts_mistral.py
+++ b/tests/tools/test_tts_mistral.py
@@ -219,5 +219,6 @@ class TestCheckTtsRequirementsMistral:
              patch("tools.tts_tool._check_neutts_available", return_value=False), \
              patch("tools.tts_tool._check_kittentts_available", return_value=False), \
              patch("tools.tts_tool._check_piper_available", return_value=False), \
+             patch("tools.tts_tool._check_kokoro_available", return_value=False), \
              patch("tools.tts_tool._has_any_command_tts_provider", return_value=False):
             assert check_tts_requirements() is False

--- a/tests/tools/test_tts_piper.py
+++ b/tests/tools/test_tts_piper.py
@@ -292,6 +292,7 @@ class TestCheckTtsRequirementsPiper:
         monkeypatch.setattr(tts_tool, "_import_mistral_client", lambda: (_ for _ in ()).throw(ImportError()))
         monkeypatch.setattr(tts_tool, "_check_neutts_available", lambda: False)
         monkeypatch.setattr(tts_tool, "_check_kittentts_available", lambda: False)
+        monkeypatch.setattr(tts_tool, "_check_kokoro_available", lambda: False)
         monkeypatch.setattr(tts_tool, "_has_any_command_tts_provider", lambda: False)
         monkeypatch.setattr(tts_tool, "_has_openai_audio_backend", lambda: False)
         for env in ("MINIMAX_API_KEY", "XAI_API_KEY", "GEMINI_API_KEY",

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -122,6 +122,25 @@ def _import_piper():
     return PiperVoice
 
 
+def _import_kokoro():
+    """Lazy import Kokoro. Returns (KokoroPipeline, load_model, snapshot_download).
+
+    Kokoro is a local Apache-2.0 82M-parameter TTS model running on Apple's
+    MLX framework (Apple Silicon only — M1/M2/M3/M4/M5). On M5 Pro it
+    achieves ~38x real-time steady-state synthesis with a 24 kHz output and
+    ~200 MB peak memory.
+
+    Requires both ``mlx-audio`` (the MLX runtime + Kokoro implementation)
+    and ``misaki`` (the G2P phonemizer KokoroPipeline calls into).
+    Install with: ``pip install 'hermes-agent[kokoro]'``.
+    Optional: ``brew install espeak-ng`` for OOD-word phonemization fallback.
+    """
+    from mlx_audio.tts.models.kokoro import KokoroPipeline
+    from mlx_audio.tts.utils import load_model
+    from huggingface_hub import snapshot_download
+    return KokoroPipeline, load_model, snapshot_download
+
+
 # ===========================================================================
 # Defaults
 # ===========================================================================
@@ -134,6 +153,9 @@ DEFAULT_OPENAI_MODEL = "gpt-4o-mini-tts"
 DEFAULT_KITTENTTS_MODEL = "KittenML/kitten-tts-nano-0.8-int8"  # 25MB
 DEFAULT_KITTENTTS_VOICE = "Jasper"
 DEFAULT_PIPER_VOICE = "en_US-lessac-medium"  # balanced size/quality
+DEFAULT_KOKORO_REPO = "mlx-community/Kokoro-82M-bf16"
+DEFAULT_KOKORO_VOICE = "af_bella"  # American female; well-rated by listeners
+DEFAULT_KOKORO_LANG_CODE = "a"  # 'a' = American English, 'b' = British English
 DEFAULT_OPENAI_VOICE = "alloy"
 DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1"
 DEFAULT_MINIMAX_MODEL = "speech-01"
@@ -178,6 +200,7 @@ PROVIDER_MAX_TEXT_LENGTH: Dict[str, int] = {
     "neutts": 2000,       # local model, quality falls off on long text
     "kittentts": 2000,    # local 25MB model
     "piper": 5000,        # local VITS model, phoneme-based; practical cap
+    "kokoro": 5000,       # local Kokoro 82M MLX (Apple Silicon), practical cap
 }
 
 # ElevenLabs caps vary by model_id. https://elevenlabs.io/docs/overview/models
@@ -324,6 +347,7 @@ BUILTIN_TTS_PROVIDERS = frozenset({
     "neutts",
     "kittentts",
     "piper",
+    "kokoro",
 })
 
 DEFAULT_COMMAND_TTS_TIMEOUT_SECONDS = 120
@@ -1478,6 +1502,136 @@ def _generate_piper_tts(text: str, output_path: str, tts_config: Dict[str, Any])
 
 
 # ===========================================================================
+# Provider: Kokoro (local, MLX-accelerated 82M, Apache-2.0, 32+ voices)
+# ===========================================================================
+
+# Module-level cache for loaded KokoroPipeline instances. Keyed by
+# (repo_id, lang_code) so a user switching language doesn't invalidate
+# the existing pipeline and vice versa. Voice is per-call, not per-pipeline.
+_kokoro_pipeline_cache: Dict[str, Any] = {}
+
+
+def _check_kokoro_available() -> bool:
+    """Check whether mlx-audio + misaki are importable.
+
+    Both are required: mlx-audio exposes the Kokoro model classes,
+    misaki provides the G2P phonemizer KokoroPipeline calls into.
+    """
+    try:
+        import importlib.util
+        return (
+            importlib.util.find_spec("mlx_audio") is not None
+            and importlib.util.find_spec("misaki") is not None
+        )
+    except Exception:
+        return False
+
+
+def _generate_kokoro_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
+    """Generate speech using the local Kokoro 82M MLX engine.
+
+    Loads the pipeline once per process (cached by repo_id+lang_code) and
+    writes a 24 kHz mono WAV. Caller converts to MP3/Opus via ffmpeg
+    when a different output format is required (matches Piper pattern).
+
+    Measured on M5 Pro (in-process, after warmup): TTFC ~97 ms,
+    ~38x steady-state real-time factor for a 211-char fixture producing
+    ~15 s of audio. The subprocess command-provider path that this
+    replaces is ~5.5x real-time cold-per-call, so the resident-model
+    win is roughly 7x throughput per turn before any streaming work.
+
+    Config keys (all under ``tts.kokoro.*``):
+        model       — HuggingFace repo (default: ``mlx-community/Kokoro-82M-bf16``)
+        voice       — voice ID (default: ``af_bella``)
+        speed       — speaking rate multiplier (default: ``1.0``)
+        lang_code   — ``a`` for American English (default), ``b`` for British, etc.
+    """
+    KokoroPipeline, load_model, snapshot_download = _import_kokoro()
+    import wave
+
+    try:
+        import numpy as np
+    except ImportError as exc:
+        raise ImportError(
+            "Kokoro provider requires numpy. Install with: "
+            "pip install 'hermes-agent[kokoro]'"
+        ) from exc
+
+    kokoro_config = (
+        tts_config.get("kokoro", {}) if isinstance(tts_config, dict) else {}
+    )
+    repo_id = kokoro_config.get("model") or DEFAULT_KOKORO_REPO
+    voice = kokoro_config.get("voice") or DEFAULT_KOKORO_VOICE
+    speed = float(kokoro_config.get("speed", 1.0))
+    lang_code = kokoro_config.get("lang_code") or DEFAULT_KOKORO_LANG_CODE
+
+    cache_key = f"{repo_id}::lang={lang_code}"
+    global _kokoro_pipeline_cache
+    if cache_key not in _kokoro_pipeline_cache:
+        logger.info("[Kokoro] Downloading + loading model: %s", repo_id)
+        model_path = Path(snapshot_download(repo_id=repo_id))
+        model = load_model(model_path)
+        pipeline = KokoroPipeline(lang_code=lang_code, model=model, repo_id=repo_id)
+        _kokoro_pipeline_cache[cache_key] = pipeline
+        logger.info("[Kokoro] Pipeline loaded")
+    pipeline = _kokoro_pipeline_cache[cache_key]
+
+    # Kokoro yields one Result per phoneme chunk. Each Result carries an
+    # mx.array of float32 samples at 24 kHz mono. Accumulate, then write
+    # a single WAV at the end. (Streaming the chunks out as they're
+    # produced is intentionally out of scope here — stream_tts_to_speaker
+    # is hardcoded to ElevenLabs today; per-provider streaming dispatch
+    # is a separate refactor.)
+    sample_rate = 24_000
+    chunks = []
+    for result in pipeline(text=text, voice=voice, speed=speed):
+        if result.output is None or result.output.audio is None:
+            continue
+        # mx.array shape (1, N) → flat float32 numpy array.
+        audio = np.asarray(result.output.audio).reshape(-1).astype(np.float32)
+        chunks.append(audio)
+
+    if not chunks:
+        raise RuntimeError(
+            f"Kokoro produced no audio for text (voice={voice}, "
+            f"lang_code={lang_code}). Check that the voice ID matches the "
+            "language (e.g. af_*/am_* for American English, bf_*/bm_* for British)."
+        )
+
+    audio_array = np.concatenate(chunks)
+    # float32 [-1, 1] → int16 PCM
+    audio_int16 = np.clip(audio_array * 32767.0, -32768, 32767).astype(np.int16)
+
+    # Kokoro outputs WAV. Caller handles downstream MP3/Opus conversion.
+    wav_path = output_path
+    if not output_path.endswith(".wav"):
+        wav_path = output_path.rsplit(".", 1)[0] + ".wav"
+
+    with wave.open(wav_path, "wb") as wav_file:
+        wav_file.setnchannels(1)
+        wav_file.setsampwidth(2)  # 16-bit PCM
+        wav_file.setframerate(sample_rate)
+        wav_file.writeframes(audio_int16.tobytes())
+
+    # Convert to desired format if caller requested mp3/ogg
+    if wav_path != output_path:
+        ffmpeg = shutil.which("ffmpeg")
+        if ffmpeg:
+            conv_cmd = [
+                ffmpeg, "-i", wav_path, "-y", "-loglevel", "error", output_path,
+            ]
+            subprocess.run(conv_cmd, check=True, timeout=30)
+            try:
+                os.remove(wav_path)
+            except OSError:
+                pass
+        else:
+            os.rename(wav_path, output_path)
+
+    return output_path
+
+
+# ===========================================================================
 # Provider: KittenTTS (local, lightweight)
 # ===========================================================================
 
@@ -1714,6 +1868,22 @@ def text_to_speech_tool(
             logger.info("Generating speech with Piper (local)...")
             _generate_piper_tts(text, file_str, tts_config)
 
+        elif provider == "kokoro":
+            try:
+                _import_kokoro()
+            except ImportError as exc:
+                return json.dumps({
+                    "success": False,
+                    "error": (
+                        "Kokoro provider selected but mlx-audio + misaki are not installed. "
+                        "Install with: pip install 'hermes-agent[kokoro]' "
+                        "(Apple Silicon only — MLX is macOS-only on M1/M2/M3/M4/M5). "
+                        f"Detail: {exc}"
+                    ),
+                }, ensure_ascii=False)
+            logger.info("Generating speech with Kokoro 82M MLX (local, ~38x real-time)...")
+            _generate_kokoro_tts(text, file_str, tts_config)
+
         else:
             # Default: Edge TTS (free), with NeuTTS as local fallback
             edge_available = True
@@ -1855,6 +2025,8 @@ def check_tts_requirements() -> bool:
     if _check_kittentts_available():
         return True
     if _check_piper_available():
+        return True
+    if _check_kokoro_available():
         return True
     return False
 
@@ -2154,6 +2326,8 @@ if __name__ == "__main__":
     )
     print(f"  MiniMax:    {'API key set' if get_env_value('MINIMAX_API_KEY') else 'not set (MINIMAX_API_KEY)'}")
     print(f"  Piper:      {'installed' if _check_piper_available() else 'not installed (pip install piper-tts)'}")
+    _kokoro_status = "installed" if _check_kokoro_available() else "not installed (pip install 'hermes-agent[kokoro]', Apple Silicon only)"
+    print(f"  Kokoro:     {_kokoro_status}")
     print(f"  ffmpeg:     {'✅ found' if _has_ffmpeg() else '❌ not found (needed for Telegram Opus)'}")
     print(f"\n  Output dir: {DEFAULT_OUTPUT_DIR}")
 

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -14,7 +14,7 @@ If you have a paid [Nous Portal](https://portal.nousresearch.com) subscription, 
 
 ## Text-to-Speech
 
-Convert text to speech with ten providers:
+Convert text to speech with eleven providers:
 
 | Provider | Quality | Cost | API Key |
 |----------|---------|------|---------|
@@ -28,6 +28,7 @@ Convert text to speech with ten providers:
 | **NeuTTS** | Good | Free (local) | None needed |
 | **KittenTTS** | Good | Free (local) | None needed |
 | **Piper** | Good | Free (local) | None needed |
+| **Kokoro** | Excellent | Free (local, Apple Silicon) | None needed |
 
 ### Platform Delivery
 
@@ -43,7 +44,7 @@ Convert text to speech with ten providers:
 ```yaml
 # In ~/.hermes/config.yaml
 tts:
-  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "gemini" | "xai" | "neutts" | "kittentts" | "piper"
+  provider: "edge"              # "edge" | "elevenlabs" | "openai" | "minimax" | "mistral" | "gemini" | "xai" | "neutts" | "kittentts" | "piper" | "kokoro"
   speed: 1.0                    # Global speed multiplier (provider-specific settings override this)
   edge:
     voice: "en-US-AriaNeural"   # 322 voices, 74 languages
@@ -93,6 +94,11 @@ tts:
     # noise_w_scale: 0.8
     # volume: 1.0                               # 0.5 = half as loud
     # normalize_audio: true
+  kokoro:
+    voice: af_bella                              # American female; or am_*, bf_*, bm_* — see Kokoro voices
+    speed: 1.0                                   # 0.5 - 2.0
+    # model: mlx-community/Kokoro-82M-bf16       # default; HuggingFace repo for model + voice files
+    # lang_code: a                               # 'a'=American (default), 'b'=British, etc.
 ```
 
 **Speed control**: The global `tts.speed` value applies to all providers by default. Each provider can override it with its own `speed` setting (e.g., `tts.openai.speed: 1.5`). Provider-specific speed takes precedence over the global value. Default is `1.0` (normal speed).
@@ -205,6 +211,35 @@ tts:
 ```
 
 **Advanced knobs** (`tts.piper.length_scale` / `noise_scale` / `noise_w_scale` / `volume` / `normalize_audio`, `use_cuda`) correspond 1:1 to Piper's `SynthesisConfig`. They're ignored on older `piper-tts` versions.
+
+### Kokoro (local, Apple Silicon, ~38× real-time)
+
+[Kokoro 82M](https://huggingface.co/hexgrad/Kokoro-82M) is an Apache-2.0 neural TTS model running on Apple's MLX framework. **Apple Silicon only** (M1/M2/M3/M4/M5) — installs as a no-op on Linux/Windows. On an M5 Pro it achieves ~38× real-time steady-state synthesis with ~200 MB peak memory and produces 24 kHz mono audio.
+
+The model loads once per Hermes process and stays resident — first call pays a ~2 s warmup (model + spaCy phonemizer), subsequent calls are ~400 ms for ~15 s of audio.
+
+**Install:**
+
+```bash
+pip install 'hermes-agent[kokoro]'
+brew install espeak-ng   # optional — phonemizer fallback for OOD words
+```
+
+**Switch to Kokoro:**
+
+```yaml
+tts:
+  provider: kokoro
+  kokoro:
+    voice: af_bella                              # American female; or am_*, bf_*, bm_*
+    speed: 1.0                                   # 0.5 - 2.0
+    # model: mlx-community/Kokoro-82M-bf16       # default; HuggingFace repo
+    # lang_code: a                               # 'a'=American (default), 'b'=British
+```
+
+**Voice IDs follow Kokoro's convention:** prefix encodes language + gender. American English: `af_bella`, `af_heart`, `af_sky` (female); `am_adam`, `am_michael` (male). British English: `bf_alice`, `bf_emma`, `bm_daniel`, `bm_lewis`. Plus Japanese (`jf_*`/`jm_*`), Chinese (`zf_*`/`zm_*`), Spanish, French, Italian, Portuguese, Hindi. Full list at [hexgrad/Kokoro-82M](https://huggingface.co/hexgrad/Kokoro-82M).
+
+The first call downloads the model (~325 MB) into the HuggingFace cache and the spaCy `en_core_web_sm` phonemizer (~13 MB). Both are one-time costs.
 
 ### Custom command providers
 


### PR DESCRIPTION
## Summary

Adds `kokoro` as a built-in TTS provider alongside Piper / NeuTTS / KittenTTS.

Mirrors the Piper implementation: in-process synthesis with a module-level pipeline cache so the model loads once per Hermes process instead of per call.

## Why

Hermes' `tts.providers.<name>` command-provider mechanism (the workaround pattern users currently use to plug Kokoro in via a shell wrapper) is **intrinsically blocking** — the wrapper subprocess pays Python interpreter startup + library import + weight-load cost on every call.

Measured on Apple M5 Pro, fixture: 211-char text producing ~15 s of audio, 5 runs after warmup:

| Path                                          | Wall-clock per call | Real-time factor |
|-----------------------------------------------|---------------------|------------------|
| Subprocess command-provider (cold per call)   | 2,675 ms ± 19 ms    | 5.5×             |
| **In-process resident model (this PR)**       | **389 ms ± 6 ms**   | **~38×**         |

So the resident-model win is **~2,286 ms saved per call (~85% reduction)** for total wall-clock, before any streaming work. End-to-end live test went through `text_to_speech_tool` exactly as Hermes' voice mode would invoke it — the numbers above are not synthetic.

## Out of scope

**Streaming.** `stream_tts_to_speaker` is hardcoded to ElevenLabs today; rewiring it to dispatch on provider is a separate refactor. This PR delivers the larger of the two latency gaps — the per-call decomposition (Python startup + library import + model load + inference + I/O) shows that for the Kokoro subprocess path, *inference* is only 14% of the call; everything else is pay-each-time overhead. Removing that overhead is a strict prerequisite for any further streaming work.

## Changes

**`tools/tts_tool.py`:**
- `_check_kokoro_available()`, `_import_kokoro()`, `_generate_kokoro_tts()`.
- Dispatch arm in `text_to_speech_tool` after Piper.
- `kokoro` added to `BUILTIN_TTS_PROVIDERS`.
- `kokoro: 5000` added to `PROVIDER_MAX_TEXT_LENGTH` (matches local-provider sibling caps).
- `kokoro` added to `check_tts_requirements()` + the module-level health output.

**`pyproject.toml`:**
- New `[kokoro]` optional-dependency extra: `mlx-audio>=0.4.0,<1` and `misaki[en]>=0.9.0`, both gated to `platform_system == 'Darwin'` since MLX is Apple-Silicon-only.

**`tests/tools/test_tts_kokoro.py`:** (new, 366 lines)
- Mirrors `test_tts_piper.py` structure.
- Synthesis path is monkey-patched (stub `KokoroPipeline` yielding fake audio chunks) so non-Apple-Silicon CI passes without `mlx-audio` installed.
- 16 tests covering registration, availability probe, cache reuse, lang_code cache invalidation, dispatch, error message shape, and `check_tts_requirements` satisfaction.

**`tests/tools/test_tts_piper.py` + `test_tts_mistral.py`:**
- Pre-existing `requirements check returns False when no provider available` tests updated to also mock `_check_kokoro_available` — they previously weren't aware kokoro existed in the fallback chain.

**`website/docs/user-guide/features/tts.md`:**
- Provider count bumped (ten → eleven).
- Kokoro added to the provider table + the YAML schema example.
- New `### Kokoro (local, Apple Silicon, ~38× real-time)` section after Piper covering install, switching, voice IDs, lang codes, and one-time download costs.

## Install

```bash
pip install 'hermes-agent[kokoro]'
brew install espeak-ng   # optional — phonemizer fallback for OOD words
```

## Configuration

```bash
hermes config set tts.provider kokoro
hermes config set tts.kokoro.voice af_bella   # optional, this is also the default
hermes config set tts.kokoro.speed 1.0        # optional
```

Voice IDs follow Kokoro's convention: `af_*` / `am_*` for American English, `bf_*` / `bm_*` for British English. Plus `jf_*`/`jm_*` (Japanese), `zf_*`/`zm_*` (Chinese), Spanish, French, Italian, Portuguese, Hindi. Full list at https://huggingface.co/hexgrad/Kokoro-82M.

## Tested

- **Unit:** `pytest tests/tools/test_tts_kokoro.py -v` — 16/16 green.
- **TTS regression:** `pytest tests/tools/test_tts_*.py -v` — 172/172 green.
- **Broader regression:** `pytest tests/tools/ -n 4` — 4,790 passed; 13 pre-existing failures unrelated to TTS (faster-whisper not installed in dev venv, `/var/folders` write protection on macOS — verified identical on plain `main`).
- **Live end-to-end:** through `text_to_speech_tool` on M5 Pro, round-tripped through parakeet-mlx STT — output is real speech, transcript matches input.

## Open follow-ups (mentioned for context, not blockers)

- **Streaming.** `stream_tts_to_speaker` provider-dispatch refactor.
- **Native STT analog.** parakeet-mlx already exposes `transcribe_stream()`; same resident-model pattern would benefit STT (currently 1,029 ms cold-per-call subprocess vs. ~150 ms in-process resident on M5 Pro). Worth a sibling PR once this lands.
- **Apple-Silicon-runner CI.** mlx-audio is macOS-arm64-only; the test stubs in this PR mean current CI passes everywhere, but proving the actual Kokoro inference path on every commit needs an arm64 runner. Separate platform-coverage discussion.
