### PR TITLE
fix(xai-image): send literal '1k'/'2k' resolution to API

### DIFF
--- a/plugins/image_gen/xai/__init__.py
+++ b/plugins/image_gen/xai/__init__.py
@@ -63,10 +63,7 @@ _XAI_ASPECT_RATIOS = {
 }
 
 # xAI resolutions
-_XAI_RESOLUTIONS = {
-    "1k": "1024",
-    "2k": "2048",
-}
+_XAI_RESOLUTIONS = {"1k", "2k"}
 
 DEFAULT_RESOLUTION = "1k"
 
@@ -177,7 +174,7 @@ class XAIImageGenProvider(ImageGenProvider):
         aspect = resolve_aspect_ratio(aspect_ratio)
         xai_ar = _XAI_ASPECT_RATIOS.get(aspect, "1:1")
         resolution = _resolve_resolution()
-        xai_res = _XAI_RESOLUTIONS.get(resolution, "1024")
+        xai_res = resolution if resolution in _XAI_RESOLUTIONS else DEFAULT_RESOLUTION
 
         payload: Dict[str, Any] = {
             "model": API_MODEL,

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -923,6 +923,7 @@ AUTHOR_MAP = {
     "agentsmithlaor@gmail.com": "oferlaor",  # PR #22356 salvage (cron origin sender identity)
     "jhin.lee@unity3d.com": "leehack",  # PR #22053 salvage (telegram DM topic reply fallback)
     # pander: empty email, salvaged via PR #19665 from #16126 by @ms-alan
+    "ayman.a.kamal@hotmail.com": "A-kamal",  # PR #18678 (xAI image resolution fix)
 }
 
 

--- a/tests/plugins/image_gen/test_xai_provider.py
+++ b/tests/plugins/image_gen/test_xai_provider.py
@@ -239,6 +239,28 @@ class TestGenerate:
         assert "Bearer test-key-12345" in headers["Authorization"]
         assert "Hermes-Agent" in headers["User-Agent"]
 
+    def test_payload_resolution_is_literal_1k_or_2k(self):
+        """Regression: xAI API rejects numeric resolutions ("1024"/"2048") with 422.
+
+        The endpoint expects the literal strings "1k" or "2k". Ensure the wire
+        payload carries that literal — not a numeric mapping. See PR #18678.
+        """
+        from plugins.image_gen.xai import XAIImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.raise_for_status = MagicMock()
+        mock_resp.json.return_value = {"data": [{"url": "https://xai.image/test.png"}]}
+
+        with patch("plugins.image_gen.xai.requests.post", return_value=mock_resp) as mock_post:
+            provider = XAIImageGenProvider()
+            provider.generate(prompt="test")
+
+        payload = mock_post.call_args.kwargs.get("json") or mock_post.call_args[1].get("json")
+        assert payload["resolution"] in {"1k", "2k"}, (
+            f"resolution must be the literal '1k' or '2k', got {payload['resolution']!r}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # Registration test


### PR DESCRIPTION
## Summary
xAI image generation now actually works. Every request to `grok-imagine-image` was returning 422 since the provider shipped (PR #14765) — the `resolution` param was being mapped to `"1024"`/`"2048"` but xAI's API expects the literal strings `"1k"`/`"2k"`.

## Changes
- `plugins/image_gen/xai/__init__.py`: send the literal `"1k"`/`"2k"` directly; collapse the dead numeric-mapping `dict` to a validation `set`.
- `tests/plugins/image_gen/test_xai_provider.py`: regression test asserting the wire payload's `resolution` field is one of `{"1k", "2k"}` — the missing coverage that let this ship.
- `scripts/release.py`: AUTHOR_MAP entry for @A-kamal.

## Validation
| | Before | After |
|---|---|---|
| `grok-imagine-image` requests | 422 Unprocessable Entity | 200 (live-tested by contributor) |
| `tests/plugins/image_gen/` | 61 passed | 62 passed |

Salvages #18678 by @A-kamal (submitted first, cleaner diff). Closes #22443 by @rickcursive (same fix, narrower diff). Both contributors credited.