### PR TITLE
fix(agent): skip post-tool empty nudge when reasoning_content is populated (salvage #22685)

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -14245,10 +14245,24 @@ class AIAgent:
                                 re.IGNORECASE,
                             )
                         )
+                        # Parsers like Ollama's qwen3.5 PARSER or DeepSeek's
+                        # reasoning channel split thinking out of content and
+                        # into a separate API field (reasoning_content /
+                        # reasoning / reasoning_details).  When that happens,
+                        # final_response is empty AND contains no <think> tag,
+                        # so the inline check misses it and the nudge fires.
+                        # Gate on the structured field too so the response
+                        # routes to the prefill branch instead. Fixes #21811.
+                        _has_separate_reasoning = bool(
+                            getattr(assistant_message, "reasoning_content", None)
+                            or getattr(assistant_message, "reasoning", None)
+                            or getattr(assistant_message, "reasoning_details", None)
+                        )
                         if (
                             _prior_was_tool
                             and not getattr(self, "_post_tool_empty_retried", False)
                             and not _has_inline_thinking  # thinking model still working — let prefill handle
+                            and not _has_separate_reasoning  # ditto for parser-split reasoning fields
                         ):
                             self._post_tool_empty_retried = True
                             # Clear stale narration so it doesn't resurface

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2671,6 +2671,44 @@ class TestRunConversation:
         assert result["final_response"] == "Here is the actual answer."
         assert result["api_calls"] == 2  # 1 original + 1 nudge retry
 
+    def test_reasoning_content_after_tool_skips_nudge_routes_to_prefill(self, agent):
+        """Regression for #21811: when the model returns empty content but populated
+        reasoning_content after a tool call, the post-tool empty nudge must NOT fire.
+        The response should route to the prefill branch instead."""
+        self._setup_agent(agent)
+        agent.base_url = "http://127.0.0.1:1234/v1"
+        tc = _mock_tool_call(name="memory_save", arguments="{}", call_id="c1")
+        # Turn 1: tool call from model
+        tool_resp = _mock_response(content="", finish_reason="tool_calls", tool_calls=[tc])
+        # Turn 2: parser-split reasoning (empty content, reasoning in separate field)
+        reasoning_resp = _mock_response(
+            content=None,
+            finish_reason="stop",
+            reasoning_content="Thought: The user wants me to save…",
+        )
+        # Turn 3: prefill continuation produces the real answer
+        answer_resp = _mock_response(content="Saved your preference.", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [tool_resp, reasoning_resp, answer_resp]
+
+        status_messages = []
+
+        with (
+            patch("run_agent.handle_function_call", return_value="Saved."),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(agent, "_emit_status", side_effect=status_messages.append),
+        ):
+            result = agent.run_conversation("Save my preference: concise responses")
+
+        assert result["completed"] is True
+        assert result["final_response"] == "Saved your preference."
+        # Nudge must not have fired: no "nudging to continue" status emitted
+        nudge_msgs = [m for m in status_messages if "nudging" in m.lower()]
+        assert not nudge_msgs, (
+            f"Post-tool empty nudge fired despite reasoning_content being populated: {nudge_msgs}"
+        )
+
     def test_empty_response_triggers_fallback_provider(self, agent):
         """After 3 empty retries, fallback provider is activated and produces content."""
         self._setup_agent(agent)


### PR DESCRIPTION
## Summary
Salvage of #22685 — the post-tool empty-content nudge no longer fires when the model produces split reasoning (Ollama qwen3.5 / DeepSeek-R1 / any reasoning model that emits `reasoning_content` while leaving `content=""`). The next message routes to the existing prefill branch instead of a spurious "please continue" retry.

## Root cause
`run_agent.py` post-tool empty-content nudge gate only checked `_has_inline_thinking` (regex for `<think>` tags in `final_response`). When parser-split reasoning models stripped tags into `reasoning_content` / `reasoning` / `reasoning_details`, the regex matched nothing, the nudge fired, the user saw a spurious warning, and a wasted round-trip happened. Ironically the very next branch already computed `_has_structured` from the same fields — but the nudge `continue`'d before that branch could run.

## Changes (contributor commit)
- `run_agent.py`: add `_has_separate_reasoning` (mirrors the `_has_structured` field set: `reasoning_content` / `reasoning` / `reasoning_details`) to the gate. When populated, skip the nudge so the prefill branch handles the turn.
- `tests/run_agent/test_run_agent.py`: regression test asserting no nudge status is emitted and the prefill path produces the final answer when `reasoning_content` is set.

## Validation
- 7/7 reasoning_content / empty_nudge / skip_nudge tests pass.

Closes #21811 via salvage.
