### PR TITLE
fix(doctor): skip pluggable provider profiles when a dedicated check exists (salvage #22529)

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -254,13 +254,21 @@ def _build_apikey_providers_list() -> list:
     try:
         from providers import list_providers
         from providers.base import ProviderProfile as _PP
+        try:
+            from hermes_cli.providers import normalize_provider as _normalize_provider
+        except Exception:  # pragma: no cover - normalization is best-effort
+            def _normalize_provider(_name: str) -> str:
+                return (_name or "").strip().lower()
         for _pp in list_providers():
             if not isinstance(_pp, _PP) or _pp.auth_type != "api_key" or not _pp.env_vars:
                 continue
             _label = _pp.display_name or _pp.name
             if _label in _known_names or _pp.name in _known_canonical:
                 continue
-            if any(_alias in _dedicated_canonical for _alias in (_pp.aliases or ())):
+            _candidates = {_normalize_provider(_pp.name)}
+            for _alias in (_pp.aliases or ()):
+                _candidates.add(_normalize_provider(_alias))
+            if _candidates & _dedicated_canonical:
                 continue
             # Separate API-key vars from base-URL override vars — the health-check
             # loop sends the first found value as Authorization: Bearer, so a URL

--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -245,6 +245,12 @@ def _build_apikey_providers_list() -> list:
     }
     for _label, _canonical in _name_to_canonical.items():
         _known_canonical.add(_canonical)
+    # Providers that already have a dedicated health check above the generic
+    # API-key loop (with custom headers/auth). Skip their pluggable profiles
+    # here so the generic Bearer-auth loop doesn't run a duplicate, broken
+    # check (e.g. Anthropic native API requires x-api-key, not Bearer).
+    _dedicated_canonical = {"anthropic", "openrouter", "bedrock"}
+    _known_canonical.update(_dedicated_canonical)
     try:
         from providers import list_providers
         from providers.base import ProviderProfile as _PP
@@ -253,6 +259,8 @@ def _build_apikey_providers_list() -> list:
                 continue
             _label = _pp.display_name or _pp.name
             if _label in _known_names or _pp.name in _known_canonical:
+                continue
+            if any(_alias in _dedicated_canonical for _alias in (_pp.aliases or ())):
                 continue
             # Separate API-key vars from base-URL override vars — the health-check
             # loop sends the first found value as Authorization: Bearer, so a URL

--- a/tests/hermes_cli/test_doctor_dedicated_provider_skip.py
+++ b/tests/hermes_cli/test_doctor_dedicated_provider_skip.py
@@ -1,0 +1,50 @@
+"""Regression: hermes doctor must not run a generic Bearer-auth health
+check for providers that already have a dedicated check (Anthropic,
+OpenRouter, Bedrock).
+
+Anthropic's native API requires `x-api-key` + `anthropic-version` headers;
+the generic loop sends `Authorization: Bearer ...` which Anthropic answers
+with HTTP 404. The dedicated check at hermes_cli/doctor.py already covers
+Anthropic with the right headers, so the pluggable profile must be
+skipped by `_build_apikey_providers_list()`.
+
+See: NousResearch/hermes-agent#22346
+"""
+
+from __future__ import annotations
+
+
+def test_build_apikey_providers_list_skips_dedicated_check_providers():
+    from hermes_cli import doctor
+
+    # Force a rebuild — the module caches the list on first call.
+    doctor._APIKEY_PROVIDERS_CACHE = None
+    entries = doctor._build_apikey_providers_list()
+
+    # Tuple shape: (display_name, env_vars, default_url, base_env, supports_health_check)
+    names = {entry[0].lower() for entry in entries}
+    assert not any("anthropic" in name for name in names), (
+        f"Anthropic provider profile leaked into generic Bearer-auth health "
+        f"check loop. Dedicated check above already covers it with "
+        f"x-api-key headers. Got entries: {sorted(names)}"
+    )
+    assert not any("openrouter" in name for name in names), (
+        f"OpenRouter has a dedicated check; generic loop must skip it. "
+        f"Got: {sorted(names)}"
+    )
+    assert not any("bedrock" in name for name in names), (
+        f"Bedrock uses AWS SDK creds, not Bearer auth; generic loop must skip. "
+        f"Got: {sorted(names)}"
+    )
+
+
+def test_build_apikey_providers_list_includes_non_dedicated_providers():
+    """Sanity guard: the skip-set must not strip every provider."""
+    from hermes_cli import doctor
+
+    doctor._APIKEY_PROVIDERS_CACHE = None
+    entries = doctor._build_apikey_providers_list()
+
+    names = {entry[0] for entry in entries}
+    assert "DeepSeek" in names
+    assert "Z.AI / GLM" in names


### PR DESCRIPTION
## Summary
Salvage of #22529 — `hermes doctor` no longer runs a duplicate `anthropic` (or `openrouter` / `bedrock`) check from the pluggable provider profile loop; the dedicated check is the only path used.

## Root cause
`hermes_cli/doctor.py::_build_apikey_providers_list` walked all pluggable provider profiles (Anthropic, OpenRouter, Bedrock) AND emitted them into the apikey-loop, which already had dedicated checks elsewhere. The duplicate apikey-loop entry tried to validate using the wrong auth header (api-key style vs. OAuth token), produced HTTP 404, and surfaced as a confusing failure in `hermes doctor` even when the dedicated check passed.

## Changes (contributor commits)
- `hermes_cli/doctor.py::_build_apikey_providers_list`: skip provider profiles whose canonical name is in `{"anthropic", "openrouter", "bedrock"}` so they aren't double-checked. Alias-aware via `normalize_provider` so `claude` / `claude-oauth` aliases that resolve to the same canonical also skip.
- 2 regression tests with descriptive comments tied to #22346.

Picked over competing PR #22512 (ly82505129) for: includes Bedrock (which #22512 missed), alias-aware via `normalize_provider` (catches `claude`/`claude-oauth` profiles a pure display-name match misses), filters at the build phase (cleaner), ships regression tests. ly82505129 credited.

## Validation
- 106/106 doctor / apikey / pluggable tests pass on the salvage branch.

Closes #22346 via salvage.
