### PR TITLE
fix(completion): use valid zsh _arguments exclusion-group syntax (salvage #22727)

### DIFF
--- a/hermes_cli/completion.py
+++ b/hermes_cli/completion.py
@@ -216,9 +216,9 @@ _hermes() {{
     typeset -A opt_args
 
     _arguments -C \\
-        '(-h --help){{-h,--help}}[Show help and exit]' \\
-        '(-V --version){{-V,--version}}[Show version and exit]' \\
-        '(-p --profile){{-p,--profile}}[Profile name]:profile:_hermes_profiles' \\
+        '(-)'{{-h,--help}}'[Show help and exit]' \\
+        '(-)'{{-V,--version}}'[Show version and exit]' \\
+        '(-)'{{-p,--profile}}'[Profile name]:profile:_hermes_profiles' \\
         '1:command:->commands' \\
         '*::arg:->args'
 


### PR DESCRIPTION
## Summary
Salvage of #22727 — corrects the zsh completion script's `_arguments` exclusion-group syntax. Replaces three invalid `(-X --Y){-X,--Y}` patterns with the canonical `'(-)'{-X,--Y}` form so `compinit` no longer rejects `_hermes` with `_arguments:comparguments:319: invalid argument`.

## Changes (contributor commit)
- `hermes_cli/completion.py`: 3-line surgical fix on the `-h --help`, `-V --version`, and `-p --profile` option emitters. F-string `{{...}}` braces preserved so the generated script is valid Python AND valid zsh.

## Validation
- 26/26 completion tests pass on the salvage branch.

Picked from 6 competing PRs:
- **#22720 (Ninso112)**: byte-identical fix; credited.
- **#22728 (AnnasMazhar)**: technically valid but inconsistent (`(-p)` vs `(-)`).
- **#22713 (Ninso112)**: scope creep — bundled unrelated Telegram quote feature.
- **#22701 (Ninso112)**: had a duplicate test method definition (silent shadow).
- **#22690 (KhanCold)**: BROKEN — single-brace `{-h,--help}` inside an f-string would raise `NameError` at runtime.

Closes #22686 via salvage.
