### PR TITLE
fix(model-metadata): align hy3-preview static fallback + delete change-detector test (salvage #22574)

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -210,8 +210,10 @@ DEFAULT_CONTEXT_LENGTHS = {
     "grok": 131072,             # catch-all (grok-beta, unknown grok-*)
     # Kimi
     "kimi": 262144,
-    # Tencent — Hy3 Preview (Hunyuan) with 256K context window
-    "hy3-preview": 256000,
+    # Tencent — Hy3 Preview (Hunyuan) with 256K context window.
+    # OpenRouter live metadata reports 262144 (256 × 1024); align the
+    # static fallback so cache and offline both agree (issue #22268).
+    "hy3-preview": 262144,
     # Nemotron — NVIDIA's open-weights series (128K context across all sizes)
     "nemotron": 131072,
     # Arcee

--- a/tests/hermes_cli/test_tencent_tokenhub_provider.py
+++ b/tests/hermes_cli/test_tencent_tokenhub_provider.py
@@ -304,12 +304,20 @@ class TestTencentTokenhubURLMapping:
 
 
 class TestTencentTokenhubContextLength:
-    """hy3-preview context length is registered."""
+    """hy3-preview has a context-length entry registered.
 
-    def test_hy3_preview_context_length(self):
+    Asserting the relationship (registered + ≥ 4096) instead of a
+    specific value, per AGENTS.md "Don't write change-detector tests".
+    The previous version of this class pinned an exact integer that
+    broke whenever Tencent / OpenRouter bumped the published context
+    window (#22268).
+    """
+
+    def test_hy3_preview_has_registered_context_length(self):
         from agent.model_metadata import get_model_context_length
         ctx = get_model_context_length("hy3-preview")
-        assert ctx == 256000
+        assert isinstance(ctx, int)
+        assert ctx >= 4096, f"hy3-preview context length looks unset/wrong: {ctx}"
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
Two co-located fixes:

1. **`agent/model_metadata.py`**: bump `hy3-preview` static fallback from `256000` to `262144` (256 × 1024) to match OpenRouter live metadata. Cache and offline both now agree.
2. **`tests/hermes_cli/test_tencent_tokenhub_provider.py`**: delete the exact-value change-detector and replace with an invariant assertion (registered + `>= 4096`). Per `AGENTS.md` "Don't write change-detector tests": pinning the upstream-controlled context length is exactly the test class the rule forbids — every time the provider publishes a bump, the test breaks with zero behavioral coverage gained.

## Why this is salvage-with-redirect of #22574
The original PR by @wesleysimplicio bumped the integer (good) AND added a SECOND change-detector pinning `DEFAULT_CONTEXT_LENGTHS["hy3-preview"] == 262144` (bad — same anti-pattern). That would re-break on the next published bump. Author credited; we kept the right hunk and replaced the test direction.

## Validation
- 1/1 invariant test passes.

Closes #22268 via salvage.
