### PR TITLE
fix(delegate): add do-not-use guidance to acp schema (carve-out of #22680)

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -2032,6 +2032,32 @@ class TestOrchestratorRoleSchema(unittest.TestCase):
         self.assertIn("role", task_props)
         self.assertEqual(task_props["role"]["enum"], ["leaf", "orchestrator"])
 
+    def test_acp_command_description_has_do_not_set_guidance(self):
+        # acp_command/acp_args descriptions must NOT bias the model toward
+        # assuming an ACP CLI (Claude, Copilot, etc.) is installed. They must
+        # carry explicit "do not set unless told" guidance so the model doesn't
+        # hallucinate ACP availability (#22013).
+        from tools.delegate_tool import DELEGATE_TASK_SCHEMA
+        props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+
+        top_acp_desc = props["acp_command"]["description"]
+        self.assertIn("Do NOT set", top_acp_desc)
+        self.assertIn("explicitly told you", top_acp_desc)
+
+        task_props = props["tasks"]["items"]["properties"]
+        per_task_acp_desc = task_props["acp_command"]["description"]
+        self.assertIn("Do NOT set", per_task_acp_desc)
+
+    def test_acp_command_description_has_no_claude_as_example(self):
+        # Descriptions must not list 'claude' as a canonical example value —
+        # that directly primes the model to attempt Claude ACP even when it is
+        # not installed (#22013).
+        from tools.delegate_tool import DELEGATE_TASK_SCHEMA
+        props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]
+        top_acp_desc = props["acp_command"]["description"].lower()
+        self.assertNotIn("e.g. 'claude'", top_acp_desc)
+        self.assertNotIn("e.g. \"claude\"", top_acp_desc)
+
 
 # Sentinel used to distinguish "role kwarg omitted" from "role=None".
 _SENTINEL = object()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -2681,12 +2681,16 @@ DELEGATE_TASK_SCHEMA = {
                         },
                         "acp_command": {
                             "type": "string",
-                            "description": "Per-task ACP command override (e.g. 'copilot'). Overrides the top-level acp_command for this task only.",
+                            "description": (
+                                "Per-task ACP command override (e.g. 'copilot'). "
+                                "Overrides the top-level acp_command for this task only. "
+                                "Do NOT set unless the user explicitly told you an ACP CLI is installed."
+                            ),
                         },
                         "acp_args": {
                             "type": "array",
                             "items": {"type": "string"},
-                            "description": "Per-task ACP args override.",
+                            "description": "Per-task ACP args override. Leave empty unless acp_command is set.",
                         },
                         "role": {
                             "type": "string",
@@ -2713,7 +2717,10 @@ DELEGATE_TASK_SCHEMA = {
                     "When set, children use ACP subprocess transport instead of inheriting "
                     "the parent's transport. Requires an ACP-compatible CLI "
                     "(currently GitHub Copilot CLI via 'copilot --acp --stdio'). "
-                    "See agent/copilot_acp_client.py for the implementation."
+                    "See agent/copilot_acp_client.py for the implementation. "
+                    "IMPORTANT: Do NOT set this unless the user has explicitly told you "
+                    "a specific ACP-compatible CLI is installed and configured. "
+                    "Leave empty to use the parent's default transport (Hermes subagents)."
                 ),
             },
             "acp_args": {
@@ -2721,7 +2728,8 @@ DELEGATE_TASK_SCHEMA = {
                 "items": {"type": "string"},
                 "description": (
                     "Arguments for the ACP command (default: ['--acp', '--stdio']). "
-                    "Only used when acp_command is set."
+                    "Only used when acp_command is set. "
+                    "Leave empty unless acp_command is explicitly provided."
                 ),
             },
         },


### PR DESCRIPTION
## Summary
Carve-out of #22680 — keeps just the `delegate_task` schema-text changes that target #22013, drops the unrelated bundled fixes for #22548 / #21944 / #22150.

## Root cause (for #22013)
`tools/delegate_tool.py` schema descriptions for `acp_command` / `acp_args` previously read like canonical examples (`"e.g. 'copilot'"` / `"Arguments for the ACP command (default: ['--acp', '--stdio'])"`) — priming the model to populate them even when no ACP CLI was installed on the user's box. Models with weaker schema-following discipline would set them; the spawn would then fail with confusing errors.

## Changes (contributor commit, re-authored to wesleysimplicio)
- `tools/delegate_tool.py`: add explicit `"IMPORTANT: Do NOT set this unless the user has explicitly told you a specific ACP-compatible CLI is installed"` at the top-level `acp_command` description. Same at the per-task override. Strengthen `acp_args` to mention it stays empty unless `acp_command` is set.
- `tests/tools/test_delegate.py`: 2 tests pinning the descriptions (no-Claude-as-example + presence of "Do NOT set" guidance).

## Note on scope
This is a cosmetic prompt-engineering fix — `acp_command` / `acp_args` remain exposed in the schema at all times. The fully-correct fix is gating them behind a config flag or runtime ACP-CLI detection so the schema only emits them when an ACP harness is actually available. Tracked as a follow-up.

## Salvage rationale
The original PR #22680 by @wesleysimplicio bundled this delegate-schema fix together with unrelated changes for #22548 (timeout classification + fallback self-skip), #21944 (DeepSeek thinking blocks), and #22150 (session_search content_session_id routing). #22548 and #21944 are already addressed on main (#22780 merged, #22798 in flight from a focused salvage of #22643). #22150 deserves its own review. Carving out just the delegate schema changes here so the title-described work lands cleanly.

Author credited as wesleysimplicio.

## Validation
- 9/9 schema/acp tests pass on the salvage branch.

Closes #22013 via salvage.
