### PR TITLE
feat(transports/codex): pass reasoning.effort to xAI Responses API

### DIFF
--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -105,6 +105,7 @@ class ResponsesApiTransport(ProviderTransport):
 
         if reasoning_enabled and is_xai_responses:
             kwargs["include"] = ["reasoning.encrypted_content"]
+            kwargs["reasoning"] = {"effort": reasoning_effort}
         elif reasoning_enabled:
             if is_github_responses:
                 github_reasoning = params.get("github_reasoning_extra")

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -149,6 +149,37 @@ class TestCodexBuildKwargs:
         # "minimal" should be clamped to "low"
         assert kw.get("reasoning", {}).get("effort") == "low"
 
+    def test_xai_reasoning_effort_passed(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="grok-4.3", messages=messages, tools=[],
+            is_xai_responses=True,
+            reasoning_config={"effort": "high"},
+        )
+        # xAI Responses must receive both encrypted reasoning content and the effort
+        assert kw.get("reasoning") == {"effort": "high"}
+        assert "reasoning.encrypted_content" in kw.get("include", [])
+
+    def test_xai_reasoning_disabled_no_reasoning_key(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="grok-4.3", messages=messages, tools=[],
+            is_xai_responses=True,
+            reasoning_config={"enabled": False},
+        )
+        # When reasoning is disabled, do not send the reasoning key at all
+        assert "reasoning" not in kw
+
+    def test_xai_minimal_effort_clamped(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="grok-4.3", messages=messages, tools=[],
+            is_xai_responses=True,
+            reasoning_config={"effort": "minimal"},
+        )
+        # "minimal" should be clamped to "low" for xAI as well
+        assert kw.get("reasoning", {}).get("effort") == "low"
+
 
 class TestCodexValidateResponse:
 


### PR DESCRIPTION
## Summary
`agent.reasoning_effort` (and any caller-injected `reasoning_config.effort`) is now actually transmitted on the xAI Responses path. Previously the `is_xai_responses` branch in `build_kwargs()` only set `include=["reasoning.encrypted_content"]` and silently dropped the resolved effort, so users on grok-4.3 got xAI's server-side default regardless of config.

xAI's official docs ([model-capabilities/text/reasoning](https://docs.x.ai/developers/model-capabilities/text/reasoning)) document `reasoning={"effort": "..."}` as the exact wire format for grok-4.3 — same shape the non-xAI Responses branch already uses.

## Changes
- `agent/transports/codex.py` (+1): set `kwargs["reasoning"] = {"effort": reasoning_effort}` in the xAI branch. `summary: "auto"` is deliberately omitted — xAI docs don't list it as an input on `/responses`.
- `tests/agent/transports/test_codex_transport.py` (+31): three new tests cover effort passthrough, disabled case, and `minimal→low` clamp parity.

## Validation
| | Before | After |
|---|---|---|
| `reasoning_effort` reaching xAI | dropped | sent as `reasoning.effort` |
| `tests/agent/transports/` | 166 passed | 169 passed |
| Live grok-4.3 call (per @Julientalbot) | `reasoning_tokens=0` | `reasoning_tokens=153` (effort=low) |

Salvages #22055 by @Julientalbot. Authorship preserved via rebase-merge.