### PR TITLE
fix(openrouter): add x-grok-conv-id header for Grok models (carve-out of #22708)

### DIFF
--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -448,6 +448,7 @@ class ChatCompletionsTransport(ProviderTransport):
                 qwen_session_metadata=params.get("qwen_session_metadata"),
                 model=model,
                 ollama_num_ctx=params.get("ollama_num_ctx"),
+                session_id=params.get("session_id"),
             )
         )
         api_kwargs.update(top_level_from_profile)

--- a/plugins/model-providers/openrouter/__init__.py
+++ b/plugins/model-providers/openrouter/__init__.py
@@ -53,16 +53,28 @@ class OpenRouterProfile(ProviderProfile):
         *,
         reasoning_config: dict | None = None,
         supports_reasoning: bool = False,
+        model: str | None = None,
+        session_id: str | None = None,
         **context: Any,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
-        """OpenRouter passes the full reasoning_config dict as extra_body.reasoning."""
+        """OpenRouter passes the full reasoning_config dict as extra_body.reasoning.
+
+        For xAI Grok models routed through OpenRouter, attach the
+        ``x-grok-conv-id`` header so that xAI's prompt cache stays pinned to
+        the same backend server across turns.
+        """
         extra_body: dict[str, Any] = {}
         if supports_reasoning:
             if reasoning_config is not None:
                 extra_body["reasoning"] = dict(reasoning_config)
             else:
                 extra_body["reasoning"] = {"enabled": True, "effort": "medium"}
-        return extra_body, {}
+
+        extra_headers: dict[str, Any] = {}
+        if session_id and model and model.startswith(("x-ai/grok-", "xai/grok-")):
+            extra_headers["x-grok-conv-id"] = session_id
+
+        return extra_body, {"extra_headers": extra_headers} if extra_headers else {}
 
 
 openrouter = OpenRouterProfile(

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -67,6 +67,7 @@ AUTHOR_MAP = {
     "maksesipov@gmail.com": "Qwinty",
     "denisamania@gmail.com": "CalmProton",
     "308068+mbac@users.noreply.github.com": "mbac",
+    "ninso112@proton.me": "Ninso112",
     "wesleysimplicio@live.com": "wesleysimplicio",
     "matthew.dean.cater@gmail.com": "SiliconID",
     "xieniu@proton.me": "xieNniu",

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -121,6 +121,52 @@ class TestOpenRouterProfile:
         eb, _ = p.build_api_kwargs_extras(supports_reasoning=True)
         assert eb["reasoning"] == {"enabled": True, "effort": "medium"}
 
+    def test_grok_session_id_sets_cache_affinity_header(self):
+        """OpenRouter + Grok model + session_id => x-grok-conv-id header."""
+        p = get_provider_profile("openrouter")
+        _, tl = p.build_api_kwargs_extras(
+            model="x-ai/grok-4",
+            session_id="sess-abc123",
+        )
+        assert tl["extra_headers"]["x-grok-conv-id"] == "sess-abc123"
+
+    def test_grok_xai_prefix_also_supported(self):
+        """xai/ prefix (without dash) should also get the header."""
+        p = get_provider_profile("openrouter")
+        _, tl = p.build_api_kwargs_extras(
+            model="xai/grok-3",
+            session_id="sess-xyz",
+        )
+        assert tl["extra_headers"]["x-grok-conv-id"] == "sess-xyz"
+
+    def test_non_grok_model_no_affinity_header(self):
+        """OpenRouter + non-Grok model => no x-grok-conv-id header."""
+        p = get_provider_profile("openrouter")
+        _, tl = p.build_api_kwargs_extras(
+            model="anthropic/claude-sonnet-4.6",
+            session_id="sess-abc123",
+        )
+        assert "extra_headers" not in tl
+        assert "x-grok-conv-id" not in tl
+
+    def test_grok_without_session_id_no_header(self):
+        """Grok model but no session_id => no header (nothing to pin)."""
+        p = get_provider_profile("openrouter")
+        _, tl = p.build_api_kwargs_extras(model="x-ai/grok-4")
+        assert "extra_headers" not in tl
+
+    def test_grok_reasoning_and_header_together(self):
+        """Reasoning extra_body and Grok header should coexist."""
+        p = get_provider_profile("openrouter")
+        eb, tl = p.build_api_kwargs_extras(
+            model="x-ai/grok-4",
+            session_id="sess-123",
+            supports_reasoning=True,
+            reasoning_config={"enabled": True, "effort": "high"},
+        )
+        assert eb["reasoning"] == {"enabled": True, "effort": "high"}
+        assert tl["extra_headers"]["x-grok-conv-id"] == "sess-123"
+
 
 class TestNousProfile:
     def test_tags(self):


### PR DESCRIPTION
## Summary
Carve-out of #22708 — keeps only the Grok-cache-affinity header work.

## Root cause (for #22705)
`agent/transports/chat_completions.py` called `profile.build_api_kwargs_extras(...)` without passing `session_id`. The OpenRouter profile therefore had no way to attach the `x-grok-conv-id: <session-id>` header that xAI's prompt cache requires for server affinity. Result: Grok prompt-cache hit rates dropped dramatically on multi-turn sessions because every request landed on a fresh xAI backend.

## Changes (contributor commit, re-authored to Ninso112)
- `agent/transports/chat_completions.py`: thread `session_id` through `_build_kwargs_from_profile`.
- `plugins/model-providers/openrouter/__init__.py`: gate the `x-grok-conv-id` header on `model.startswith(("x-ai/grok-", "xai/grok-"))` AND `session_id` being set. Preserves existing reasoning/extra_body behavior.
- `tests/providers/test_provider_profiles.py`: 5 unit tests (positive, prefix variant, negative, missing session_id no-op, coexistence with reasoning).

## Salvage rationale
The original PR #22708 by @Ninso112 bundled this Grok fix together with three unrelated changes that don't belong in a "fix(openrouter)" PR:
- A new `/diff` slash command in `cli.py` + `hermes_cli/commands.py` (~40 LOC) — separate feature.
- A zsh completion syntax fix in `hermes_cli/completion.py` — already on main via PR #22802 (focused single-fix winner among 6 competing PRs for #22686).
- Holographic memory store null-guards (162-line test file) — separate concurrency hardening.

Plus a duplicated test method in `test_completion.py` that Python silently shadows. Carving out just the Grok header work to land cleanly. Author preserved as Ninso112; the dropped pieces remain available on the original PR if they want to re-submit them as separate PRs.

## Validation
- 5/5 grok / x_grok / xai header tests pass on the salvage branch.

Closes #22705 via salvage.

Note: the issue also flags a SECOND bug — `request_overrides.extra_headers` overwriting provider `extra_headers` last-write-wins. Not addressed by this PR (was also not addressed by original #22708). Worth a follow-up if it bites users in practice.
