### PR TITLE
fix(cron): protect CRUD operations with _jobs_file_lock to prevent concurrent corruption

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -629,9 +629,10 @@ def create_job(
         "workdir": normalized_workdir,
     }
 
-    jobs = load_jobs()
-    jobs.append(job)
-    save_jobs(jobs)
+    with _jobs_file_lock:
+        jobs = load_jobs()
+        jobs.append(job)
+        save_jobs(jobs)
 
     return job
 
@@ -655,49 +656,50 @@ def list_jobs(include_disabled: bool = False) -> List[Dict[str, Any]]:
 
 def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """Update a job by ID, refreshing derived schedule fields when needed."""
-    jobs = load_jobs()
-    for i, job in enumerate(jobs):
-        if job["id"] != job_id:
-            continue
+    with _jobs_file_lock:
+        jobs = load_jobs()
+        for i, job in enumerate(jobs):
+            if job["id"] != job_id:
+                continue
 
-        # Validate / normalize workdir if present in updates.  Empty string or
-        # None both mean "clear the field" (restore old behaviour).
-        if "workdir" in updates:
-            _wd = updates["workdir"]
-            if _wd in (None, "", False):
-                updates["workdir"] = None
-            else:
-                updates["workdir"] = _normalize_workdir(_wd)
+            # Validate / normalize workdir if present in updates.  Empty string or
+            # None both mean "clear the field" (restore old behaviour).
+            if "workdir" in updates:
+                _wd = updates["workdir"]
+                if _wd in (None, "", False):
+                    updates["workdir"] = None
+                else:
+                    updates["workdir"] = _normalize_workdir(_wd)
 
-        updated = _apply_skill_fields({**job, **updates})
-        schedule_changed = "schedule" in updates
+            updated = _apply_skill_fields({**job, **updates})
+            schedule_changed = "schedule" in updates
 
-        if "skills" in updates or "skill" in updates:
-            normalized_skills = _normalize_skill_list(updated.get("skill"), updated.get("skills"))
-            updated["skills"] = normalized_skills
-            updated["skill"] = normalized_skills[0] if normalized_skills else None
+            if "skills" in updates or "skill" in updates:
+                normalized_skills = _normalize_skill_list(updated.get("skill"), updated.get("skills"))
+                updated["skills"] = normalized_skills
+                updated["skill"] = normalized_skills[0] if normalized_skills else None
 
-        if schedule_changed:
-            updated_schedule = updated["schedule"]
-            # The API may pass schedule as a raw string (e.g. "every 10m")
-            # instead of a pre-parsed dict.  Normalize it the same way
-            # create_job() does so downstream code can call .get() safely.
-            if isinstance(updated_schedule, str):
-                updated_schedule = parse_schedule(updated_schedule)
-                updated["schedule"] = updated_schedule
-            updated["schedule_display"] = updates.get(
-                "schedule_display",
-                updated_schedule.get("display", updated.get("schedule_display")),
-            )
-            if updated.get("state") != "paused":
-                updated["next_run_at"] = compute_next_run(updated_schedule)
+            if schedule_changed:
+                updated_schedule = updated["schedule"]
+                # The API may pass schedule as a raw string (e.g. "every 10m")
+                # instead of a pre-parsed dict.  Normalize it the same way
+                # create_job() does so downstream code can call .get() safely.
+                if isinstance(updated_schedule, str):
+                    updated_schedule = parse_schedule(updated_schedule)
+                    updated["schedule"] = updated_schedule
+                updated["schedule_display"] = updates.get(
+                    "schedule_display",
+                    updated_schedule.get("display", updated.get("schedule_display")),
+                )
+                if updated.get("state") != "paused":
+                    updated["next_run_at"] = compute_next_run(updated_schedule)
 
-        if updated.get("enabled", True) and updated.get("state") != "paused" and not updated.get("next_run_at"):
-            updated["next_run_at"] = compute_next_run(updated["schedule"])
+            if updated.get("enabled", True) and updated.get("state") != "paused" and not updated.get("next_run_at"):
+                updated["next_run_at"] = compute_next_run(updated["schedule"])
 
-        jobs[i] = updated
-        save_jobs(jobs)
-        return _normalize_job_record(jobs[i])
+            jobs[i] = updated
+            save_jobs(jobs)
+            return _normalize_job_record(jobs[i])
     return None
 
 
@@ -752,16 +754,17 @@ def trigger_job(job_id: str) -> Optional[Dict[str, Any]]:
 
 def remove_job(job_id: str) -> bool:
     """Remove a job by ID."""
-    jobs = load_jobs()
-    original_len = len(jobs)
-    jobs = [j for j in jobs if j["id"] != job_id]
-    if len(jobs) < original_len:
-        save_jobs(jobs)
-        # Clean up output directory to prevent orphaned dirs accumulating
-        job_output_dir = OUTPUT_DIR / job_id
-        if job_output_dir.exists():
-            shutil.rmtree(job_output_dir)
-        return True
+    with _jobs_file_lock:
+        jobs = load_jobs()
+        original_len = len(jobs)
+        jobs = [j for j in jobs if j["id"] != job_id]
+        if len(jobs) < original_len:
+            save_jobs(jobs)
+            # Clean up output directory to prevent orphaned dirs accumulating
+            job_output_dir = OUTPUT_DIR / job_id
+            if job_output_dir.exists():
+                shutil.rmtree(job_output_dir)
+            return True
     return False
 
 

--- a/tests/cron/test_cron_job_concurrency.py
+++ b/tests/cron/test_cron_job_concurrency.py
@@ -1,0 +1,261 @@
+"""Tests for concurrent access safety in cron job CRUD operations.
+
+Regression test for #22761: mass cron job model/provider field corruption
+during rapid updates. The fix adds _jobs_file_lock to update_job(),
+create_job(), and remove_job() so they serialize with the scheduler's
+mark_job_run() / advance_next_run() / get_due_jobs() calls.
+"""
+
+from __future__ import annotations
+
+import threading
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture()
+def tmp_cron_dir(tmp_path, monkeypatch):
+    """Isolate cron job storage into a temp dir so tests don't stomp on real jobs."""
+    monkeypatch.setattr("cron.jobs.CRON_DIR", tmp_path / "cron")
+    monkeypatch.setattr("cron.jobs.JOBS_FILE", tmp_path / "cron" / "jobs.json")
+    monkeypatch.setattr("cron.jobs.OUTPUT_DIR", tmp_path / "cron" / "output")
+    return tmp_path
+
+
+def _create_test_job(tmp_cron_dir, job_id="test-job-1", model="gpt-5.5", provider="openai-codex"):
+    """Helper: create a job with known model/provider fields."""
+    from cron.jobs import create_job
+    job = create_job(
+        prompt="test prompt",
+        schedule="every 10m",
+        name="test job",
+        model=model,
+        provider=provider,
+    )
+    return job
+
+
+class TestConcurrentUpdateSafety:
+    """Verify that concurrent update_job() calls don't corrupt other jobs."""
+
+    def test_rapid_updates_preserve_model_provider(self, tmp_cron_dir):
+        """Multiple rapid sequential updates to one job must not null out
+        model/provider on that job or any other job in the store."""
+        from cron.jobs import create_job, get_job, update_job
+
+        # Create 5 jobs with distinct model/provider values
+        job_ids = []
+        for i in range(5):
+            job = create_job(
+                prompt=f"job {i} prompt",
+                schedule="every 10m",
+                name=f"job-{i}",
+                model=f"model-{i}",
+                provider=f"provider-{i}",
+            )
+            job_ids.append(job["id"])
+
+        # Rapid sequential updates to job 0 — different field combos,
+        # never touching model/provider
+        for field_update in [
+            {"skills": ["skill-a"]},
+            {"enabled_toolsets": ["terminal", "file"]},
+            {"prompt": "updated prompt"},
+            {"skills": ["skill-b"], "enabled_toolsets": ["terminal"]},
+        ]:
+            update_job(job_ids[0], field_update)
+
+        # Verify all jobs retain their original model/provider
+        for i, jid in enumerate(job_ids):
+            job = get_job(jid)
+            assert job is not None, f"Job {jid} disappeared"
+            assert job["model"] == f"model-{i}", (
+                f"Job {jid} model corrupted: expected 'model-{i}', got '{job['model']}'"
+            )
+            assert job["provider"] == f"provider-{i}", (
+                f"Job {jid} provider corrupted: expected 'provider-{i}', got '{job['provider']}'"
+            )
+
+    def test_concurrent_thread_updates_no_corruption(self, tmp_cron_dir):
+        """Concurrent threads updating different jobs must not corrupt each other."""
+        from cron.jobs import create_job, get_job, update_job
+
+        # Create 10 jobs
+        job_ids = []
+        for i in range(10):
+            job = create_job(
+                prompt=f"job {i}",
+                schedule="every 10m",
+                name=f"job-{i}",
+                model=f"model-{i}",
+                provider=f"provider-{i}",
+            )
+            job_ids.append(job["id"])
+
+        errors = []
+
+        def update_job_thread(idx):
+            try:
+                for _ in range(5):
+                    update_job(job_ids[idx], {"prompt": f"updated-{idx}"})
+            except Exception as e:
+                errors.append(e)
+
+        # Launch concurrent updaters
+        threads = [threading.Thread(target=update_job_thread, args=(i,)) for i in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+
+        assert not errors, f"Concurrent updates raised errors: {errors}"
+
+        # Verify no corruption
+        for i, jid in enumerate(job_ids):
+            job = get_job(jid)
+            assert job is not None, f"Job {jid} disappeared after concurrent updates"
+            assert job["model"] == f"model-{i}", (
+                f"Job {jid} model corrupted: expected 'model-{i}', got '{job['model']}'"
+            )
+            assert job["provider"] == f"provider-{i}", (
+                f"Job {jid} provider corrupted: expected 'provider-{i}', got '{job['provider']}'"
+            )
+
+    def test_concurrent_create_and_update_no_corruption(self, tmp_cron_dir):
+        """Concurrent create and update operations must not corrupt existing jobs."""
+        from cron.jobs import create_job, get_job, update_job
+
+        # Pre-create some jobs
+        existing_ids = []
+        for i in range(5):
+            job = create_job(
+                prompt=f"existing-{i}",
+                schedule="every 10m",
+                name=f"existing-{i}",
+                model=f"model-{i}",
+                provider=f"provider-{i}",
+            )
+            existing_ids.append(job["id"])
+
+        errors = []
+        new_ids = []
+
+        def creator():
+            try:
+                for i in range(5):
+                    job = create_job(
+                        prompt=f"new-{i}",
+                        schedule="every 10m",
+                        name=f"new-{i}",
+                        model=f"new-model-{i}",
+                        provider=f"new-provider-{i}",
+                    )
+                    new_ids.append(job["id"])
+            except Exception as e:
+                errors.append(e)
+
+        def updater():
+            try:
+                for jid in existing_ids:
+                    update_job(jid, {"prompt": "concurrently-updated"})
+            except Exception as e:
+                errors.append(e)
+
+        t1 = threading.Thread(target=creator)
+        t2 = threading.Thread(target=updater)
+        t1.start()
+        t2.start()
+        t1.join(timeout=30)
+        t2.join(timeout=30)
+
+        assert not errors, f"Concurrent operations raised errors: {errors}"
+
+        # Verify existing jobs are intact
+        for i, jid in enumerate(existing_ids):
+            job = get_job(jid)
+            assert job is not None, f"Existing job {jid} disappeared"
+            assert job["model"] == f"model-{i}", (
+                f"Existing job {jid} model corrupted: expected 'model-{i}', got '{job['model']}'"
+            )
+            assert job["provider"] == f"provider-{i}", (
+                f"Existing job {jid} provider corrupted: expected 'provider-{i}', got '{job['provider']}'"
+            )
+
+
+class TestCreateJobLocking:
+    """Verify create_job() is safe under concurrent access."""
+
+    def test_create_job_serialized(self, tmp_cron_dir):
+        """Concurrent create_job() calls must not corrupt the job list."""
+        from cron.jobs import create_job, list_jobs
+
+        errors = []
+        created = []
+
+        def creator(idx):
+            try:
+                for i in range(3):
+                    job = create_job(
+                        prompt=f"concurrent-{idx}-{i}",
+                        schedule="every 10m",
+                        name=f"job-{idx}-{i}",
+                        model=f"model-{idx}-{i}",
+                        provider=f"provider-{idx}-{i}",
+                    )
+                    created.append(job["id"])
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=creator, args=(i,)) for i in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+
+        assert not errors, f"Concurrent create_job raised errors: {errors}"
+        assert len(created) == 15, f"Expected 15 jobs created, got {len(created)}"
+
+        # All jobs must be present and have correct fields
+        all_jobs = list_jobs(include_disabled=True)
+        assert len(all_jobs) == 15, f"Expected 15 jobs in store, got {len(all_jobs)}"
+        for job in all_jobs:
+            assert job["model"] is not None, f"Job {job['id']} has null model"
+            assert job["provider"] is not None, f"Job {job['id']} has null provider"
+
+
+class TestRemoveJobLocking:
+    """Verify remove_job() is safe under concurrent access."""
+
+    def test_remove_job_serialized(self, tmp_cron_dir):
+        """Concurrent remove_job() calls must not corrupt the job list."""
+        from cron.jobs import create_job, list_jobs, remove_job
+
+        # Create 10 jobs
+        job_ids = []
+        for i in range(10):
+            job = create_job(
+                prompt=f"to-remove-{i}",
+                schedule="every 10m",
+                name=f"remove-{i}",
+            )
+            job_ids.append(job["id"])
+
+        errors = []
+
+        def remover(jid):
+            try:
+                remove_job(jid)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=remover, args=(jid,)) for jid in job_ids]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+
+        assert not errors, f"Concurrent remove_job raised errors: {errors}"
+
+        all_jobs = list_jobs(include_disabled=True)
+        assert len(all_jobs) == 0, f"Expected 0 jobs after removing all, got {len(all_jobs)}"


### PR DESCRIPTION
## What does this PR do?

Protects `create_job()`, `update_job()`, and `remove_job()` with the existing `_jobs_file_lock` threading lock to prevent concurrent corruption of `jobs.json`.


### Root Cause

The scheduler's internal operations (`mark_job_run()`, `advance_next_run()`, `get_due_jobs()`) correctly acquire `_jobs_file_lock` before performing load-modify-save cycles on `jobs.json`. However, the CRUD operations called by the `cronjob` tool did **not** acquire this lock.

When the LLM agent performs rapid consecutive `cronjob(action='update')` calls — or when a cron tool update overlaps with a scheduler tick — concurrent load-modify-save cycles can corrupt the jobs file. The scheduler writes to `jobs.json` on every tick (updating `last_run_at`, `next_run_at`), and if a CRUD operation reads the file mid-write or overwrites a scheduler save, fields can be silently nulled.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A