### PR TITLE
feat(image-gen): add Gemini provider

### DIFF
--- a/agent/curator.py
+++ b/agent/curator.py
@@ -21,6 +21,7 @@ Strict invariants:
 
 from __future__ import annotations
 
+import contextlib
 import json
 import logging
 import os
@@ -57,6 +58,37 @@ DEFAULT_INTERVAL_HOURS = 24 * 7  # 7 days
 DEFAULT_MIN_IDLE_HOURS = 2
 DEFAULT_STALE_AFTER_DAYS = 30
 DEFAULT_ARCHIVE_AFTER_DAYS = 90
+
+_KANBAN_WORKER_ENV_KEYS = (
+    "HERMES_KANBAN_TASK",
+    "HERMES_KANBAN_WORKSPACE",
+    "HERMES_TENANT",
+)
+
+
+@contextlib.contextmanager
+def _without_kanban_worker_context():
+    """Temporarily hide dispatcher env from auxiliary curator agents.
+
+    Curator reviews can be launched from inside a Kanban worker via
+    ``hermes curator run --sync --dry-run``. In that subprocess the worker's
+    ``HERMES_KANBAN_TASK`` env would otherwise make the forked review AIAgent
+    look like the worker itself: kanban tools enter the schema, Kanban worker
+    guidance enters the prompt, and omitted tool task_id args default to the
+    parent task. The curator is an auxiliary maintenance agent, not a worker,
+    so scrub that context only while constructing/running the fork.
+    """
+    saved = {key: os.environ.get(key) for key in _KANBAN_WORKER_ENV_KEYS}
+    try:
+        for key in _KANBAN_WORKER_ENV_KEYS:
+            os.environ.pop(key, None)
+        yield
+    finally:
+        for key, value in saved.items():
+            if value is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = value
 
 
 # ---------------------------------------------------------------------------
@@ -1525,7 +1557,6 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
 
     Never raises; callers get a structured failure instead.
     """
-    import contextlib
     result_meta: Dict[str, Any] = {
         "final": "",
         "summary": "",
@@ -1581,36 +1612,41 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
 
     review_agent = None
     try:
-        review_agent = AIAgent(
-            model=_model_name,
-            provider=_resolved_provider,
-            api_key=_api_key,
-            base_url=_base_url,
-            api_mode=_api_mode,
-            # Umbrella-building over a large skill collection is worth a
-            # high iteration ceiling — the pass typically takes 50-100
-            # API calls against hundreds of candidate skills. The
-            # single-session review path caps itself at a much smaller
-            # number because it's not doing a curation sweep.
-            max_iterations=9999,
-            quiet_mode=True,
-            platform="curator",
-            skip_context_files=True,
-            skip_memory=True,
-        )
-        # Disable recursive nudges — the curator must never spawn its own review.
-        review_agent._memory_nudge_interval = 0
-        review_agent._skill_nudge_interval = 0
+        with _without_kanban_worker_context():
+            review_agent = AIAgent(
+                model=_model_name,
+                provider=_resolved_provider,
+                api_key=_api_key,
+                base_url=_base_url,
+                api_mode=_api_mode,
+                # Umbrella-building over a large skill collection is worth a
+                # high iteration ceiling — the pass typically takes 50-100
+                # API calls against hundreds of candidate skills. The
+                # single-session review path caps itself at a much smaller
+                # number because it's not doing a curation sweep.
+                max_iterations=9999,
+                quiet_mode=True,
+                platform="curator",
+                # Defense in depth: even if the process env or the quiet-mode
+                # tool-definition cache says "kanban worker", the curator
+                # fork must not receive kanban tools or worker prompt guidance.
+                disabled_toolsets=["kanban"],
+                skip_context_files=True,
+                skip_memory=True,
+            )
+            # Disable recursive nudges — the curator must never spawn its own review.
+            review_agent._memory_nudge_interval = 0
+            review_agent._skill_nudge_interval = 0
 
-        # Redirect the forked agent's stdout/stderr to /dev/null while it
-        # runs so its tool-call chatter doesn't pollute the foreground
-        # terminal. The background-thread runner also hides it; this
-        # belt-and-suspenders path matters when a caller invokes
-        # run_curator_review(synchronous=True) from the CLI.
-        with open(os.devnull, "w", encoding="utf-8") as _devnull, \
-             contextlib.redirect_stdout(_devnull), \
-             contextlib.redirect_stderr(_devnull):
-            conv_result = review_agent.run_conversation(user_message=prompt)
+            # Redirect the forked agent's stdout/stderr to /dev/null while it
+            # runs so its tool-call chatter doesn't pollute the foreground
+            # terminal. The background-thread runner also hides it; this
+            # belt-and-suspenders path matters when a caller invokes
+            # run_curator_review(synchronous=True) from the CLI.
+            with open(os.devnull, "w", encoding="utf-8") as _devnull, \
+                 contextlib.redirect_stdout(_devnull), \
+                 contextlib.redirect_stderr(_devnull):
+                conv_result = review_agent.run_conversation(user_message=prompt)
 
         final = ""
         if isinstance(conv_result, dict):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6064,6 +6064,11 @@ class GatewayRunner:
         self._running_agents[_quick_key] = _AGENT_PENDING_SENTINEL
         self._running_agents_ts[_quick_key] = time.time()
         _run_generation = self._begin_session_run_generation(_quick_key)
+        # Keep gateway_state.json honest while a turn is actually in flight.
+        # Without this, external diagnostics can report active_agents=0 for a
+        # live long-running Discord turn, which makes slow work look like stale
+        # UI/session state.
+        self._update_runtime_status()
 
         try:
             _agent_result = await self._handle_message_with_agent(event, source, _quick_key, _run_generation)
@@ -12897,6 +12902,7 @@ class GatewayRunner:
         self._running_agents_ts.pop(session_key, None)
         if hasattr(self, "_busy_ack_ts"):
             self._busy_ack_ts.pop(session_key, None)
+        self._update_runtime_status()
         return True
 
     def _clear_session_boundary_security_state(self, session_key: str) -> None:

--- a/plugins/image_gen/gemini/README.md
+++ b/plugins/image_gen/gemini/README.md
@@ -1,0 +1,51 @@
+# Gemini / Nano Banana image generation backend
+
+This backend gives Hermes `image_generate` a direct Google Gemini path, separate from Nous/FAL.
+
+## Credentials
+
+The backend looks for the first non-empty key in this order:
+
+1. `GEMINI_API_KEY`
+2. `GOOGLE_API_KEY`
+3. `NANO_BANANA_API_KEY`
+
+`NANO_BANANA_API_KEY` is supported as a Palmer-local alias so the existing credential can be reused without copying or printing its value.
+
+If you want the conventional Google env name too, run this in a shell that has Palmer's env loaded:
+
+```bash
+export GEMINI_API_KEY="$NANO_BANANA_API_KEY"
+```
+
+Do not paste the key into chat or logs.
+
+## Config
+
+Palmer profile config:
+
+```yaml
+image_gen:
+  provider: gemini
+  model: gemini-2.5-flash-image
+  use_gateway: false
+  gemini:
+    image_size: 1K
+```
+
+Supported model IDs:
+
+- `gemini-2.5-flash-image` — Nano Banana, fastest/safest default
+- `gemini-3.1-flash-image-preview` — Nano Banana 2
+- `gemini-3-pro-image-preview` — Nano Banana Pro
+
+Optional env overrides:
+
+- `GEMINI_IMAGE_MODEL`
+- `GEMINI_IMAGE_SIZE` (`512`, `1K`, `2K`, `4K`)
+
+## Usage
+
+Once the `image_gen` toolset is enabled and the profile/gateway has been restarted, ask Palmer to generate an image. The backend saves inline Gemini image data under:
+
+`$HERMES_HOME/cache/images/`

--- a/plugins/image_gen/gemini/__init__.py
+++ b/plugins/image_gen/gemini/__init__.py
@@ -1,0 +1,374 @@
+"""Google Gemini / Nano Banana image generation backend.
+
+Implements Hermes' :class:`ImageGenProvider` interface using the Gemini
+GenerateContent REST API directly. This avoids adding google-genai/Pillow as
+runtime dependencies while still supporting Gemini's native image models.
+
+Key selection precedence:
+1. ``GEMINI_API_KEY``
+2. ``GOOGLE_API_KEY``
+3. ``NANO_BANANA_API_KEY`` (Palmer-local alias; value is never logged)
+
+Model selection precedence:
+1. ``GEMINI_IMAGE_MODEL`` env var
+2. ``image_gen.gemini.model`` in ``config.yaml``
+3. ``image_gen.model`` in ``config.yaml`` when it is one of this backend's IDs
+4. ``gemini-2.5-flash-image``
+"""
+
+from __future__ import annotations
+
+import logging
+import mimetypes
+import os
+from typing import Any, Dict, List, Optional, Tuple
+
+import requests
+
+from agent.image_gen_provider import (
+    DEFAULT_ASPECT_RATIO,
+    ImageGenProvider,
+    error_response,
+    resolve_aspect_ratio,
+    save_b64_image,
+    success_response,
+)
+
+logger = logging.getLogger(__name__)
+
+API_BASE_URL = "https://generativelanguage.googleapis.com/v1beta"
+DEFAULT_MODEL = "gemini-2.5-flash-image"
+DEFAULT_IMAGE_SIZE = "1K"
+_KEY_ENV_VARS = ("GEMINI_API_KEY", "GOOGLE_API_KEY", "NANO_BANANA_API_KEY")
+
+_MODELS: Dict[str, Dict[str, Any]] = {
+    "gemini-2.5-flash-image": {
+        "display": "Gemini 2.5 Flash Image (Nano Banana)",
+        "speed": "fast",
+        "strengths": "Speed/efficiency for routine image generation",
+        "price": "Google Gemini API pricing",
+    },
+    "gemini-3.1-flash-image-preview": {
+        "display": "Gemini 3.1 Flash Image Preview (Nano Banana 2)",
+        "speed": "fast",
+        "strengths": "High-efficiency Gemini 3 image generation",
+        "price": "Google Gemini API pricing",
+    },
+    "gemini-3-pro-image-preview": {
+        "display": "Gemini 3 Pro Image Preview (Nano Banana Pro)",
+        "speed": "slower",
+        "strengths": "Professional/high-fidelity assets and text rendering",
+        "price": "Google Gemini API pricing",
+    },
+}
+
+_ASPECT_RATIOS = {
+    "landscape": "16:9",
+    "square": "1:1",
+    "portrait": "9:16",
+}
+
+_IMAGE_SIZES = {"512", "1K", "2K", "4K"}
+
+
+def _load_image_gen_config() -> Dict[str, Any]:
+    """Read ``image_gen`` config, returning {} on any failure."""
+    try:
+        from hermes_cli.config import load_config
+
+        cfg = load_config()
+        section = cfg.get("image_gen") if isinstance(cfg, dict) else None
+        return section if isinstance(section, dict) else {}
+    except Exception as exc:
+        logger.debug("Could not load image_gen config: %s", exc)
+        return {}
+
+
+def _resolve_api_key() -> Tuple[str, str]:
+    """Return ``(api_key, env_var_name)`` without logging or exposing the key."""
+    for name in _KEY_ENV_VARS:
+        value = os.getenv(name, "").strip()
+        if value:
+            return value, name
+    return "", ""
+
+
+def _resolve_model() -> Tuple[str, Dict[str, Any]]:
+    env_override = os.getenv("GEMINI_IMAGE_MODEL", "").strip()
+    if env_override in _MODELS:
+        return env_override, _MODELS[env_override]
+
+    cfg = _load_image_gen_config()
+    gemini_cfg = cfg.get("gemini") if isinstance(cfg.get("gemini"), dict) else {}
+    candidate: Optional[str] = None
+    if isinstance(gemini_cfg, dict):
+        value = gemini_cfg.get("model")
+        if isinstance(value, str) and value.strip() in _MODELS:
+            candidate = value.strip()
+
+    if candidate is None:
+        value = cfg.get("model")
+        if isinstance(value, str) and value.strip() in _MODELS:
+            candidate = value.strip()
+
+    if candidate is not None:
+        return candidate, _MODELS[candidate]
+    return DEFAULT_MODEL, _MODELS[DEFAULT_MODEL]
+
+
+def _resolve_image_size() -> str:
+    env_size = os.getenv("GEMINI_IMAGE_SIZE", "").strip().upper()
+    if env_size in _IMAGE_SIZES:
+        return env_size
+
+    cfg = _load_image_gen_config()
+    gemini_cfg = cfg.get("gemini") if isinstance(cfg.get("gemini"), dict) else {}
+    if isinstance(gemini_cfg, dict):
+        value = gemini_cfg.get("image_size")
+        if isinstance(value, str) and value.strip().upper() in _IMAGE_SIZES:
+            return value.strip().upper()
+    return DEFAULT_IMAGE_SIZE
+
+
+def _extension_for_mime(mime_type: str) -> str:
+    if not mime_type:
+        return "png"
+    if mime_type == "image/jpeg":
+        return "jpg"
+    ext = mimetypes.guess_extension(mime_type.split(";", 1)[0].strip())
+    return (ext or ".png").lstrip(".")
+
+
+def _extract_error_message(response: requests.Response) -> str:
+    """Return a bounded provider error message without leaking request headers."""
+    try:
+        payload = response.json()
+        err = payload.get("error") if isinstance(payload, dict) else None
+        if isinstance(err, dict):
+            msg = err.get("message")
+            if isinstance(msg, str) and msg.strip():
+                return msg.strip()[:500]
+    except Exception:
+        pass
+    return (response.text or response.reason or "unknown error")[:500]
+
+
+class GeminiImageGenProvider(ImageGenProvider):
+    """Google Gemini native image generation backend."""
+
+    @property
+    def name(self) -> str:
+        return "gemini"
+
+    @property
+    def display_name(self) -> str:
+        return "Gemini / Nano Banana"
+
+    def is_available(self) -> bool:
+        api_key, _ = _resolve_api_key()
+        return bool(api_key)
+
+    def list_models(self) -> List[Dict[str, Any]]:
+        return [
+            {
+                "id": model_id,
+                "display": meta.get("display", model_id),
+                "speed": meta.get("speed", ""),
+                "strengths": meta.get("strengths", ""),
+                "price": meta.get("price", ""),
+            }
+            for model_id, meta in _MODELS.items()
+        ]
+
+    def default_model(self) -> Optional[str]:
+        return DEFAULT_MODEL
+
+    def get_setup_schema(self) -> Dict[str, Any]:
+        return {
+            "name": "Gemini / Nano Banana",
+            "badge": "paid",
+            "tag": "Native Google Gemini image generation; accepts GEMINI_API_KEY, GOOGLE_API_KEY, or Palmer's NANO_BANANA_API_KEY alias",
+            "env_vars": [
+                {
+                    "key": "GEMINI_API_KEY",
+                    "prompt": "Google Gemini API key",
+                    "url": "https://aistudio.google.com/app/apikey",
+                }
+            ],
+        }
+
+    def generate(
+        self,
+        prompt: str,
+        aspect_ratio: str = DEFAULT_ASPECT_RATIO,
+        **kwargs: Any,
+    ) -> Dict[str, Any]:
+        prompt = (prompt or "").strip()
+        aspect = resolve_aspect_ratio(aspect_ratio)
+        if not prompt:
+            return error_response(
+                error="Prompt is required and must be a non-empty string",
+                error_type="invalid_argument",
+                provider="gemini",
+                aspect_ratio=aspect,
+            )
+
+        api_key, key_name = _resolve_api_key()
+        if not api_key:
+            return error_response(
+                error=(
+                    "No Gemini API key configured. Set GEMINI_API_KEY or GOOGLE_API_KEY; "
+                    "Palmer also accepts NANO_BANANA_API_KEY as a local alias."
+                ),
+                error_type="auth_required",
+                provider="gemini",
+                aspect_ratio=aspect,
+                prompt=prompt,
+            )
+
+        model_id, _meta = _resolve_model()
+        image_size = _resolve_image_size()
+        payload: Dict[str, Any] = {
+            "contents": [
+                {
+                    "role": "user",
+                    "parts": [{"text": prompt}],
+                }
+            ],
+            "generationConfig": {
+                "responseModalities": ["TEXT", "IMAGE"],
+                "imageConfig": {
+                    "aspectRatio": _ASPECT_RATIOS.get(aspect, "16:9"),
+                    "imageSize": image_size,
+                },
+            },
+        }
+        url = f"{API_BASE_URL}/models/{model_id}:generateContent"
+        headers = {
+            "Content-Type": "application/json",
+            "x-goog-api-key": api_key,
+            "User-Agent": "Hermes-Agent-Gemini-ImageGen/1.0",
+        }
+
+        try:
+            response = requests.post(url, headers=headers, json=payload, timeout=180)
+        except requests.Timeout:
+            return error_response(
+                error="Gemini image generation timed out (180s)",
+                error_type="timeout",
+                provider="gemini",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+        except requests.ConnectionError as exc:
+            return error_response(
+                error=f"Gemini connection error: {exc}",
+                error_type="connection_error",
+                provider="gemini",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+        except Exception as exc:
+            return error_response(
+                error=f"Gemini request setup failed: {type(exc).__name__}: {exc}",
+                error_type="request_error",
+                provider="gemini",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        if response.status_code >= 400:
+            return error_response(
+                error=(
+                    f"Gemini image generation failed ({response.status_code}) using {key_name}: "
+                    f"{_extract_error_message(response)}"
+                ),
+                error_type="api_error",
+                provider="gemini",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        try:
+            result = response.json()
+        except Exception as exc:
+            return error_response(
+                error=f"Gemini returned invalid JSON: {exc}",
+                error_type="invalid_response",
+                provider="gemini",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        text_parts: List[str] = []
+        image_parts: List[Tuple[str, str]] = []
+        for candidate in result.get("candidates", []) if isinstance(result, dict) else []:
+            content = candidate.get("content", {}) if isinstance(candidate, dict) else {}
+            parts = content.get("parts", []) if isinstance(content, dict) else []
+            for part in parts:
+                if not isinstance(part, dict):
+                    continue
+                text = part.get("text")
+                if isinstance(text, str) and text.strip():
+                    text_parts.append(text.strip())
+                inline = part.get("inlineData") or part.get("inline_data")
+                if isinstance(inline, dict):
+                    data = inline.get("data")
+                    mime_type = inline.get("mimeType") or inline.get("mime_type") or "image/png"
+                    if isinstance(data, str) and data.strip():
+                        image_parts.append((data.strip(), str(mime_type)))
+
+        if not image_parts:
+            finish_reasons = []
+            for candidate in result.get("candidates", []) if isinstance(result, dict) else []:
+                if isinstance(candidate, dict) and candidate.get("finishReason"):
+                    finish_reasons.append(str(candidate.get("finishReason")))
+            suffix = f" Finish reason: {', '.join(finish_reasons)}." if finish_reasons else ""
+            return error_response(
+                error=f"Gemini returned no inline image data.{suffix}",
+                error_type="empty_response",
+                provider="gemini",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        b64_data, mime_type = image_parts[0]
+        try:
+            saved_path = save_b64_image(
+                b64_data,
+                prefix=f"gemini_{model_id.replace('/', '_')}",
+                extension=_extension_for_mime(mime_type),
+            )
+        except Exception as exc:
+            return error_response(
+                error=f"Could not save Gemini image to cache: {exc}",
+                error_type="io_error",
+                provider="gemini",
+                model=model_id,
+                prompt=prompt,
+                aspect_ratio=aspect,
+            )
+
+        return success_response(
+            image=str(saved_path),
+            model=model_id,
+            prompt=prompt,
+            aspect_ratio=aspect,
+            provider="gemini",
+            extra={
+                "text": "\n".join(text_parts),
+                "mime_type": mime_type,
+                "image_size": image_size,
+            },
+        )
+
+
+def register(ctx):
+    """Plugin entry point — wire ``GeminiImageGenProvider`` into Hermes."""
+    ctx.register_image_gen_provider(GeminiImageGenProvider())

--- a/plugins/image_gen/gemini/plugin.yaml
+++ b/plugins/image_gen/gemini/plugin.yaml
@@ -1,0 +1,9 @@
+name: gemini
+version: 1.0.0
+description: "Google Gemini / Nano Banana image generation backend. Uses GEMINI_API_KEY, GOOGLE_API_KEY, or NANO_BANANA_API_KEY."
+author: Palmer
+kind: backend
+requires_env:
+  - GEMINI_API_KEY
+  - GOOGLE_API_KEY
+  - NANO_BANANA_API_KEY

--- a/tests/agent/test_curator.py
+++ b/tests/agent/test_curator.py
@@ -812,6 +812,88 @@ def test_review_model_legacy_curator_auxiliary_still_works(curator_env, caplog):
     ), "expected deprecation warning when legacy curator.auxiliary is used"
 
 
+def test_llm_review_scrubs_kanban_worker_context_from_curator_fork(
+    curator_env, monkeypatch
+):
+    """A curator fork launched inside a Kanban worker must not inherit the
+    worker task's tools, prompt guidance, or HERMES_KANBAN_* env defaults.
+    """
+    import importlib
+    import os
+    import sys
+    import types
+
+    # The fixture stubs _run_llm_review for most tests; this regression test
+    # needs the real implementation.
+    curator = importlib.reload(curator_env["curator"])
+    monkeypatch.setenv("HERMES_KANBAN_TASK", "t_parent")
+    monkeypatch.setenv("HERMES_KANBAN_WORKSPACE", "/tmp/parent-workspace")
+    monkeypatch.setenv("HERMES_TENANT", "tenant-a")
+
+    captured = {}
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            captured["init_kwargs"] = kwargs
+            captured["init_env"] = {
+                key: os.environ.get(key)
+                for key in ("HERMES_KANBAN_TASK", "HERMES_KANBAN_WORKSPACE", "HERMES_TENANT")
+            }
+            self._session_messages = []
+
+        def run_conversation(self, **kwargs):
+            captured["run_kwargs"] = kwargs
+            captured["run_env"] = {
+                key: os.environ.get(key)
+                for key in ("HERMES_KANBAN_TASK", "HERMES_KANBAN_WORKSPACE", "HERMES_TENANT")
+            }
+            return {"final_response": "curator done"}
+
+        def close(self):
+            captured["closed"] = True
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = FakeAgent
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+
+    import hermes_cli.config as config_mod
+    import hermes_cli.runtime_provider as runtime_provider_mod
+
+    monkeypatch.setattr(
+        config_mod,
+        "load_config",
+        lambda: {"model": {"provider": "openrouter", "default": "openai/gpt-5.5"}},
+    )
+    monkeypatch.setattr(
+        runtime_provider_mod,
+        "resolve_runtime_provider",
+        lambda requested, target_model: {
+            "provider": requested,
+            "api_key": "test-key",
+            "base_url": "https://example.test/v1",
+            "api_mode": "chat_completions",
+        },
+    )
+
+    meta = curator._run_llm_review("review prompt")
+
+    assert meta["final"] == "curator done"
+    assert captured["closed"] is True
+    assert captured["init_kwargs"]["platform"] == "curator"
+    assert "kanban" in captured["init_kwargs"].get("disabled_toolsets", [])
+    assert captured["run_kwargs"] == {"user_message": "review prompt"}
+    assert captured["init_env"] == {
+        "HERMES_KANBAN_TASK": None,
+        "HERMES_KANBAN_WORKSPACE": None,
+        "HERMES_TENANT": None,
+    }
+    assert captured["run_env"] == captured["init_env"]
+    # The parent process env is restored after the curator pass.
+    assert os.environ["HERMES_KANBAN_TASK"] == "t_parent"
+    assert os.environ["HERMES_KANBAN_WORKSPACE"] == "/tmp/parent-workspace"
+    assert os.environ["HERMES_TENANT"] == "tenant-a"
+
+
 def test_review_model_new_slot_wins_over_legacy(curator_env):
     """When BOTH new and legacy are set, the canonical slot wins."""
     curator = curator_env["curator"]

--- a/tests/plugins/image_gen/test_gemini_provider.py
+++ b/tests/plugins/image_gen/test_gemini_provider.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Tests for Gemini / Nano Banana image generation provider."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _fake_api_key(monkeypatch):
+    for key in ("GEMINI_API_KEY", "GOOGLE_API_KEY", "NANO_BANANA_API_KEY"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("NANO_BANANA_API_KEY", "test-gemini-key")
+
+
+class TestGeminiImageGenProvider:
+    def test_name_and_display(self):
+        from plugins.image_gen.gemini import GeminiImageGenProvider
+
+        provider = GeminiImageGenProvider()
+        assert provider.name == "gemini"
+        assert provider.display_name == "Gemini / Nano Banana"
+
+    def test_is_available_with_alias_key(self):
+        from plugins.image_gen.gemini import GeminiImageGenProvider
+
+        assert GeminiImageGenProvider().is_available() is True
+
+    def test_is_available_without_any_key(self, monkeypatch):
+        for key in ("GEMINI_API_KEY", "GOOGLE_API_KEY", "NANO_BANANA_API_KEY"):
+            monkeypatch.delenv(key, raising=False)
+        from plugins.image_gen.gemini import GeminiImageGenProvider
+
+        assert GeminiImageGenProvider().is_available() is False
+
+    def test_list_models(self):
+        from plugins.image_gen.gemini import GeminiImageGenProvider
+
+        models = GeminiImageGenProvider().list_models()
+        ids = {m["id"] for m in models}
+        assert "gemini-2.5-flash-image" in ids
+        assert "gemini-3-pro-image-preview" in ids
+
+    def test_default_model(self):
+        from plugins.image_gen.gemini import GeminiImageGenProvider
+
+        assert GeminiImageGenProvider().default_model() == "gemini-2.5-flash-image"
+
+    def test_get_setup_schema_uses_conventional_google_key(self):
+        from plugins.image_gen.gemini import GeminiImageGenProvider
+
+        schema = GeminiImageGenProvider().get_setup_schema()
+        assert schema["name"] == "Gemini / Nano Banana"
+        assert schema["env_vars"][0]["key"] == "GEMINI_API_KEY"
+
+
+class TestGeminiConfig:
+    def test_resolve_api_key_prefers_gemini(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_API_KEY", "gemini")
+        monkeypatch.setenv("GOOGLE_API_KEY", "google")
+        monkeypatch.setenv("NANO_BANANA_API_KEY", "banana")
+        from plugins.image_gen.gemini import _resolve_api_key
+
+        value, name = _resolve_api_key()
+        assert value == "gemini"
+        assert name == "GEMINI_API_KEY"
+
+    def test_resolve_api_key_accepts_nano_banana_alias(self, monkeypatch):
+        monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+        monkeypatch.delenv("GOOGLE_API_KEY", raising=False)
+        monkeypatch.setenv("NANO_BANANA_API_KEY", "banana")
+        from plugins.image_gen.gemini import _resolve_api_key
+
+        value, name = _resolve_api_key()
+        assert value == "banana"
+        assert name == "NANO_BANANA_API_KEY"
+
+    def test_env_model_override(self, monkeypatch):
+        monkeypatch.setenv("GEMINI_IMAGE_MODEL", "gemini-3-pro-image-preview")
+        from plugins.image_gen.gemini import _resolve_model
+
+        model_id, _ = _resolve_model()
+        assert model_id == "gemini-3-pro-image-preview"
+
+
+class TestGeminiGenerate:
+    def test_missing_api_key(self, monkeypatch):
+        for key in ("GEMINI_API_KEY", "GOOGLE_API_KEY", "NANO_BANANA_API_KEY"):
+            monkeypatch.delenv(key, raising=False)
+        from plugins.image_gen.gemini import GeminiImageGenProvider
+
+        result = GeminiImageGenProvider().generate(prompt="test")
+        assert result["success"] is False
+        assert result["error_type"] == "auth_required"
+        assert "NANO_BANANA_API_KEY" in result["error"]
+
+    def test_successful_generation_saves_inline_data(self):
+        from plugins.image_gen.gemini import GeminiImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {
+            "candidates": [
+                {
+                    "content": {
+                        "parts": [
+                            {"text": "done"},
+                            {"inlineData": {"mimeType": "image/png", "data": "dGVzdA=="}},
+                        ]
+                    }
+                }
+            ]
+        }
+
+        with patch("plugins.image_gen.gemini.requests.post", return_value=mock_resp) as mock_post:
+            with patch("plugins.image_gen.gemini.save_b64_image", return_value="/tmp/gemini.png"):
+                result = GeminiImageGenProvider().generate(prompt="A tiny blue banana", aspect_ratio="square")
+
+        assert result["success"] is True
+        assert result["image"] == "/tmp/gemini.png"
+        assert result["provider"] == "gemini"
+        assert result["model"] == "gemini-2.5-flash-image"
+        assert result["text"] == "done"
+
+        _, kwargs = mock_post.call_args
+        assert "key=" not in kwargs["url"] if "url" in kwargs else "key=" not in mock_post.call_args.args[0]
+        assert kwargs["headers"]["x-goog-api-key"] == "test-gemini-key"
+        assert kwargs["json"]["generationConfig"]["imageConfig"]["aspectRatio"] == "1:1"
+
+    def test_api_error_does_not_include_key(self):
+        from plugins.image_gen.gemini import GeminiImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 401
+        mock_resp.json.return_value = {"error": {"message": "API key not valid"}}
+        mock_resp.text = "API key not valid"
+
+        with patch("plugins.image_gen.gemini.requests.post", return_value=mock_resp):
+            result = GeminiImageGenProvider().generate(prompt="test")
+
+        assert result["success"] is False
+        assert result["error_type"] == "api_error"
+        assert "test-gemini-key" not in result["error"]
+
+    def test_empty_response(self):
+        from plugins.image_gen.gemini import GeminiImageGenProvider
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.json.return_value = {"candidates": [{"finishReason": "STOP", "content": {"parts": []}}]}
+
+        with patch("plugins.image_gen.gemini.requests.post", return_value=mock_resp):
+            result = GeminiImageGenProvider().generate(prompt="test")
+
+        assert result["success"] is False
+        assert result["error_type"] == "empty_response"
+
+    def test_register_calls_context(self):
+        from plugins.image_gen.gemini import GeminiImageGenProvider, register
+
+        class Ctx:
+            def __init__(self):
+                self.provider = None
+
+            def register_image_gen_provider(self, provider):
+                self.provider = provider
+
+        ctx = Ctx()
+        register(ctx)
+        assert isinstance(ctx.provider, GeminiImageGenProvider)


### PR DESCRIPTION
## Summary
- Add a Gemini / Nano Banana image generation backend for `image_generate`, with `GEMINI_API_KEY`, `GOOGLE_API_KEY`, and `NANO_BANANA_API_KEY` key resolution.
- Support Gemini image model selection and image size overrides through env/config, with generated inline image data saved through the existing image cache helper.
- Prevent curator review agents launched inside Kanban workers from inheriting worker task context or Kanban tools.
- Keep gateway runtime status current while Discord/gateway turns are actively in flight.

## Test Plan
- [x] `python -m pytest tests/plugins/image_gen/test_gemini_provider.py tests/agent/test_curator.py -q -o 'addopts='`
- [x] `python -m pytest tests/gateway/test_session_race_guard.py tests/gateway/test_session_split_brain_11016.py tests/gateway/test_status.py -q -o 'addopts='`
- [x] After rebasing onto `origin/main`: `python -m pytest tests/plugins/image_gen/test_gemini_provider.py tests/agent/test_curator.py tests/gateway/test_session_race_guard.py tests/gateway/test_session_split_brain_11016.py tests/gateway/test_status.py -q -o 'addopts='`