### PR TITLE
feat(skills): add read-only Privy wallet skill

### DIFF
--- a/optional-skills/blockchain/privy/SKILL.md
+++ b/optional-skills/blockchain/privy/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: privy-wallet
+description: "Read-only Privy app user and wallet inspection."
+version: 0.1.0
+author: Patrick (@leprincep35700), Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+required_environment_variables:
+  - name: PRIVY_APP_ID
+    prompt: "Privy application ID"
+    help: "Available in the Privy dashboard; credentials may authorize write operations elsewhere"
+  - name: PRIVY_APP_SECRET
+    prompt: "Privy application secret"
+    help: "Privileged server credential; may authorize write operations elsewhere; never expose it"
+metadata:
+  hermes:
+    tags: [Privy, Wallet, Web3, Blockchain, Embedded Wallets, Read-only]
+    category: blockchain
+    related_skills: [evm, solana]
+    requires_toolsets: [terminal]
+---
+
+# Privy Wallet Skill
+
+Read-only Privy application user and wallet inspection for Hermes. This skill
+helps an administrator understand which wallets are linked to a Privy user without exposing
+private keys, raw identity data, or transaction-signing capabilities.
+
+This skill is intentionally **read-only**. It **does not sign** messages,
+prepare transactions, send transactions, export keys, or bypass Privy's user
+approval flows. Any future signing or transaction capability should be built as
+a separate, human-approved flow with simulation, policy limits, and explicit
+confirmation.
+
+"Read-only" describes this helper's deliberately limited command surface. The
+Privy credentials themselves are not read-only and may authorize privileged
+application operations elsewhere. Store them as server secrets, never expose
+them to prompts or client-side code, and rotate them if disclosure is suspected.
+
+---
+
+## When to Use
+
+- User asks which wallet(s) are linked to a Privy account.
+- User wants to inspect embedded or external wallet addresses for a Privy user.
+- User wants a safe identity-to-wallet bridge before using EVM/Solana skills.
+- User is designing a wallet-aware Hermes workflow and needs read-only context.
+
+Do **not** use this skill to sign messages, approve transactions, or move funds.
+
+---
+
+## Prerequisites
+
+The helper script uses only Python standard library modules.
+
+Privy server credentials are required:
+
+```bash
+export PRIVY_APP_ID="your-privy-app-id"
+export PRIVY_APP_SECRET="your-privy-app-secret"
+```
+
+Keep `PRIVY_APP_SECRET` out of prompts, chat transcripts, and committed files.
+
+---
+
+## How to Run
+
+Use the `terminal` tool for every command. The helper performs only read-only
+Privy API requests and prints PII-minimized JSON.
+
+### Quick Reference
+
+Helper script path after installation:
+
+```text
+~/.hermes/skills/blockchain/privy/scripts/privy_client.py
+```
+
+Commands:
+
+```bash
+python3 privy_client.py user    <did:privy:...>
+python3 privy_client.py wallets <did:privy:...>
+python3 privy_client.py users   [--limit N] [--cursor CURSOR] [--email EMAIL]
+```
+
+Output is JSON and intentionally PII-minimized. Email addresses and phone
+numbers are not included in summaries; linked-account types and wallet metadata
+are retained.
+
+---
+
+## Procedure
+
+### 1. Check setup
+
+```bash
+python3 ~/.hermes/skills/blockchain/privy/scripts/privy_client.py users --limit 1
+```
+
+If credentials are missing, the helper exits with a clear message naming
+`PRIVY_APP_ID` and/or `PRIVY_APP_SECRET`.
+
+### 2. Inspect a Privy user safely
+
+```bash
+python3 ~/.hermes/skills/blockchain/privy/scripts/privy_client.py \
+  user did:privy:example
+```
+
+The result includes:
+
+- Privy user id
+- creation timestamp if returned by Privy
+- linked account types, e.g. `email`, `wallet`, `phone`
+- wallet linked accounts with address, chain type, wallet client type,
+  connector type, and verification timestamp
+
+It does not include raw email addresses or phone numbers.
+
+### 3. List wallets only
+
+```bash
+python3 ~/.hermes/skills/blockchain/privy/scripts/privy_client.py \
+  wallets did:privy:example
+```
+
+Use the resulting EVM or Solana addresses with the `evm` or `solana` optional
+skills for chain-specific portfolio, token, or transaction inspection.
+
+### 4. Search/list users
+
+```bash
+python3 ~/.hermes/skills/blockchain/privy/scripts/privy_client.py users --limit 20
+python3 ~/.hermes/skills/blockchain/privy/scripts/privy_client.py users --email alice@example.com
+```
+
+The `--email` filter uses Privy's documented `POST /v1/users/email/address`
+endpoint with an `{"address": "..."}` JSON body. Returned summaries stay
+redacted, and the address never appears in a request URL or error output.
+
+---
+
+## Safety Model
+
+This skill is safe by default because it only performs server-side read calls.
+For any future write/signing extension, require all of the following before
+implementation:
+
+1. human-approved confirmation in the active platform;
+2. transaction or message simulation/preview;
+3. explicit chain and contract allowlists;
+4. amount/value limits;
+5. no private-key or app-secret exposure to the LLM prompt;
+6. audit-friendly logs that redact tokens and personal data.
+
+Recommended future shape: keep write operations in a separate MCP server or
+separate toolset so deployments can enable read-only Privy inspection without
+enabling signing.
+
+---
+
+## Pitfalls
+
+- **Server credentials are sensitive** — `PRIVY_APP_SECRET` is an app-level
+  secret. Store it in environment/config secret storage only.
+- **Wallet ownership can change** — always fetch fresh data before using a
+  wallet address for authorization decisions.
+- **Read-only is not authorization** — seeing a wallet linked to a user does
+  not by itself grant permission to spend or act on behalf of that wallet.
+- **Privy API shapes can evolve** — the helper preserves a small stable summary
+  instead of passing raw API payloads into the agent transcript.
+- **No signing path** — this skill deliberately avoids signing and transactions.
+  Add those only with human-approved policy controls.
+
+---
+
+## Verification
+
+Run the targeted tests from the Hermes repo root:
+
+```bash
+python -m pytest tests/skills/test_privy_wallet_skill.py -q -o addopts=''
+```

--- a/optional-skills/blockchain/privy/scripts/privy_client.py
+++ b/optional-skills/blockchain/privy/scripts/privy_client.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""Read-only Privy helper for Hermes optional skill usage.
+
+The helper intentionally supports only user and wallet inspection. It does not
+prepare, sign, or broadcast transactions.
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import os
+import urllib.parse
+import urllib.request
+from typing import Any, cast
+
+DEFAULT_API_BASE = "https://api.privy.io"
+
+
+class NoRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Refuse every HTTP redirect before urllib can rebuild the request."""
+
+    def redirect_request(
+        self,
+        req: urllib.request.Request,
+        fp: Any,
+        code: int,
+        msg: str,
+        headers: Any,
+        newurl: str,
+    ) -> None:
+        return None
+
+
+def build_basic_auth_header(app_id: str, app_secret: str) -> str:
+    token = f"{app_id}:{app_secret}".encode("utf-8")
+    return "Basic " + base64.b64encode(token).decode("ascii")
+
+
+def load_credentials() -> tuple[str, str]:
+    app_id = os.getenv("PRIVY_APP_ID")
+    app_secret = os.getenv("PRIVY_APP_SECRET")
+    missing = [
+        name
+        for name, value in (("PRIVY_APP_ID", app_id), ("PRIVY_APP_SECRET", app_secret))
+        if not value
+    ]
+    if missing:
+        raise SystemExit("Missing required Privy credentials: " + ", ".join(missing))
+    return app_id or "", app_secret or ""
+
+
+def build_users_query(*, limit: int = 20, cursor: str | None = None) -> str:
+    if not 1 <= limit <= 100:
+        raise ValueError("Privy user list limit must be between 1 and 100")
+    params: dict[str, str | int] = {"limit": limit}
+    if cursor:
+        params["cursor"] = cursor
+    return "/v1/users?" + urllib.parse.urlencode(params)
+
+
+def bounded_limit(value: str) -> int:
+    limit = int(value)
+    if not 1 <= limit <= 100:
+        raise argparse.ArgumentTypeError("limit must be between 1 and 100")
+    return limit
+
+
+def request_json(
+    path: str,
+    *,
+    safe_route: str,
+    method: str = "GET",
+    body: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    app_id, app_secret = load_credentials()
+    url = DEFAULT_API_BASE + path
+    headers = {
+        "Authorization": build_basic_auth_header(app_id, app_secret),
+        "privy-app-id": app_id,
+        "Accept": "application/json",
+    }
+    request_body = None
+    if body is not None:
+        headers["Content-Type"] = "application/json"
+        request_body = json.dumps(body).encode("utf-8")
+    request = urllib.request.Request(
+        url,
+        data=request_body,
+        headers=headers,
+        method=method,
+    )
+    try:
+        opener = urllib.request.build_opener(NoRedirectHandler())
+        with opener.open(request, timeout=30) as response:
+            payload = response.read().decode("utf-8")
+        return json.loads(payload)
+    except Exception:  # pragma: no cover - exact failures vary by network/runtime
+        raise SystemExit(f"Privy API {method.upper()} {safe_route} failed") from None
+
+
+def extract_wallets(user: dict[str, Any]) -> list[dict[str, Any]]:
+    wallets: list[dict[str, Any]] = []
+    for account in user.get("linked_accounts") or []:
+        if account.get("type") != "wallet":
+            continue
+        wallets.append({
+            "address": account.get("address"),
+            "chain_type": account.get("chain_type"),
+            "wallet_client_type": account.get("wallet_client_type"),
+            "connector_type": account.get("connector_type"),
+            "verified_at": account.get("verified_at"),
+        })
+    return wallets
+
+
+def summarize_user(user: dict[str, Any]) -> dict[str, Any]:
+    """Return a PII-minimized user summary suitable for an agent transcript."""
+    linked_accounts = user.get("linked_accounts") or []
+    return {
+        "id": user.get("id") or user.get("user_id") or user.get("did"),
+        "created_at": user.get("created_at"),
+        "linked_account_types": [
+            account.get("type") for account in linked_accounts if account.get("type")
+        ],
+        "wallets": extract_wallets(user),
+    }
+
+
+def extract_user_payload(data: dict[str, Any]) -> dict[str, Any]:
+    user = data.get("user")
+    if isinstance(user, dict):
+        return cast(dict[str, Any], user)
+    return data
+
+
+def cmd_user(args: argparse.Namespace) -> dict[str, Any]:
+    data = request_json(
+        f"/v1/users/{urllib.parse.quote(args.user_id, safe='')}",
+        safe_route="/v1/users/{user_id}",
+    )
+    user = extract_user_payload(data)
+    return summarize_user(user)
+
+
+def cmd_wallets(args: argparse.Namespace) -> dict[str, Any]:
+    data = request_json(
+        f"/v1/users/{urllib.parse.quote(args.user_id, safe='')}",
+        safe_route="/v1/users/{user_id}",
+    )
+    user = extract_user_payload(data)
+    return {"user_id": user.get("id") or args.user_id, "wallets": extract_wallets(user)}
+
+
+def cmd_users(args: argparse.Namespace) -> dict[str, Any]:
+    if args.email:
+        data = request_json(
+            "/v1/users/email/address",
+            safe_route="/v1/users/email/address",
+            method="POST",
+            body={"address": args.email},
+        )
+        raw_users = [extract_user_payload(data)]
+        next_cursor = None
+    else:
+        data = request_json(
+            build_users_query(limit=args.limit, cursor=args.cursor),
+            safe_route="/v1/users",
+        )
+        raw_users = data.get("users") or data.get("data") or []
+        next_cursor = data.get("next_cursor") or data.get("cursor")
+    return {
+        "users": [summarize_user(user) for user in raw_users],
+        "next_cursor": next_cursor,
+    }
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Read-only Privy user and wallet inspection helper. No signing or transactions."
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_user = sub.add_parser("user", help="Fetch a PII-minimized Privy user summary")
+    p_user.add_argument("user_id", help="Privy DID/user id, for example did:privy:...")
+    p_user.set_defaults(func=cmd_user)
+
+    p_wallets = sub.add_parser(
+        "wallets", help="List wallet linked accounts for a Privy user"
+    )
+    p_wallets.add_argument(
+        "user_id", help="Privy DID/user id, for example did:privy:..."
+    )
+    p_wallets.set_defaults(func=cmd_wallets)
+
+    p_users = sub.add_parser("users", help="List Privy users with PII-minimized output")
+    p_users.add_argument("--limit", type=bounded_limit, default=20)
+    p_users.add_argument("--cursor")
+    p_users.add_argument(
+        "--email", help="Optional server-side email filter; output remains redacted"
+    )
+    p_users.set_defaults(func=cmd_users)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    print(json.dumps(args.func(args), indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/tests/skills/test_privy_wallet_skill.py
+++ b/tests/skills/test_privy_wallet_skill.py
@@ -1,0 +1,317 @@
+"""Tests for optional-skills/blockchain/privy/scripts/privy_client.py."""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+import urllib.error
+import urllib.request
+
+import pytest  # ty: ignore[unresolved-import]
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2]
+    / "optional-skills"
+    / "blockchain"
+    / "privy"
+    / "scripts"
+    / "privy_client.py"
+)
+SKILL_PATH = SCRIPT_PATH.parents[1] / "SKILL.md"
+
+
+@pytest.fixture(scope="module")
+def privy_client():
+    spec = importlib.util.spec_from_file_location("privy_client", SCRIPT_PATH)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_skill_is_read_only_and_warns_against_signing():
+    text = SKILL_PATH.read_text(encoding="utf-8")
+    frontmatter = text.split("---", 2)[1]
+    description = next(
+        line.split(":", 1)[1].strip().strip('"')
+        for line in frontmatter.splitlines()
+        if line.startswith("description:")
+    )
+    author = next(
+        line.split(":", 1)[1].strip()
+        for line in frontmatter.splitlines()
+        if line.startswith("author:")
+    )
+
+    assert "read-only" in text.lower()
+    assert "does not sign" in text.lower()
+    assert "human-approved" in text.lower()
+    assert "PRIVY_APP_ID" in text
+    assert "PRIVY_APP_SECRET" in text
+    assert len(description) <= 60
+    assert author.startswith("Patrick (@leprincep35700)")
+    assert "## How to Run" in text
+    assert "related_skills: [evm, solana]" in text
+    assert "requires_toolsets: [terminal]" in text
+    assert "required_environment_variables:" in frontmatter
+    assert "name: PRIVY_APP_ID" in frontmatter
+    assert "name: PRIVY_APP_SECRET" in frontmatter
+    assert "credentials themselves are not read-only" in text.lower()
+    assert "may authorize write operations elsewhere" in frontmatter.lower()
+    assert "PRIVY_API_BASE" not in text
+    assert "`base`" not in text.lower()
+    assert "base/solana" not in text.lower()
+
+
+def test_build_basic_auth_header_uses_app_id_and_secret(privy_client):
+    assert (
+        privy_client.build_basic_auth_header("app_123", "secret_456")
+        == "Basic YXBwXzEyMzpzZWNyZXRfNDU2"
+    )
+
+
+def test_load_credentials_requires_app_id_and_secret(privy_client, monkeypatch):
+    monkeypatch.delenv("PRIVY_APP_ID", raising=False)
+    monkeypatch.delenv("PRIVY_APP_SECRET", raising=False)
+
+    with pytest.raises(SystemExit) as exc:
+        privy_client.load_credentials()
+
+    assert "PRIVY_APP_ID" in str(exc.value)
+    assert "PRIVY_APP_SECRET" in str(exc.value)
+
+
+def test_extract_wallets_returns_only_wallet_linked_accounts(privy_client):
+    user = {
+        "id": "did:privy:abc",
+        "linked_accounts": [
+            {"type": "email", "address": "alice@example.com"},
+            {
+                "type": "wallet",
+                "address": "0x1234567890abcdef1234567890abcdef12345678",
+                "chain_type": "ethereum",
+                "wallet_client_type": "privy",
+                "connector_type": "embedded",
+                "verified_at": 1710000000,
+            },
+            {
+                "type": "wallet",
+                "address": "So11111111111111111111111111111111111111112",
+                "chain_type": "solana",
+            },
+        ],
+    }
+
+    assert privy_client.extract_wallets(user) == [
+        {
+            "address": "0x1234567890abcdef1234567890abcdef12345678",
+            "chain_type": "ethereum",
+            "wallet_client_type": "privy",
+            "connector_type": "embedded",
+            "verified_at": 1710000000,
+        },
+        {
+            "address": "So11111111111111111111111111111111111111112",
+            "chain_type": "solana",
+            "wallet_client_type": None,
+            "connector_type": None,
+            "verified_at": None,
+        },
+    ]
+
+
+def test_summarize_user_redacts_pii_but_keeps_wallets(privy_client):
+    user = {
+        "id": "did:privy:abc",
+        "created_at": 1710000000,
+        "linked_accounts": [
+            {"type": "email", "address": "alice@example.com"},
+            {"type": "phone", "phoneNumber": "+15551234567"},
+            {
+                "type": "wallet",
+                "address": "0x1234567890abcdef1234567890abcdef12345678",
+                "chain_type": "ethereum",
+            },
+        ],
+    }
+
+    summary = privy_client.summarize_user(user)
+
+    assert summary["id"] == "did:privy:abc"
+    assert summary["created_at"] == 1710000000
+    assert summary["linked_account_types"] == ["email", "phone", "wallet"]
+    assert summary["wallets"] == [
+        {
+            "address": "0x1234567890abcdef1234567890abcdef12345678",
+            "chain_type": "ethereum",
+            "wallet_client_type": None,
+            "connector_type": None,
+            "verified_at": None,
+        }
+    ]
+    assert "alice@example.com" not in json.dumps(summary)
+    assert "+15551234567" not in json.dumps(summary)
+
+
+def test_build_users_query_encodes_listing_filters(privy_client):
+    path = privy_client.build_users_query(limit=10, cursor="next cursor")
+    assert path == "/v1/users?limit=10&cursor=next+cursor"
+
+
+@pytest.mark.parametrize("limit", [0, 101])
+def test_user_list_limit_is_bounded(privy_client, limit):
+    with pytest.raises(ValueError, match="between 1 and 100"):
+        privy_client.build_users_query(limit=limit)
+
+    with pytest.raises(SystemExit):
+        privy_client.build_parser().parse_args(["users", "--limit", str(limit)])
+
+
+def test_arbitrary_api_base_environment_is_ignored(privy_client, monkeypatch):
+    captured = {}
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            return b'{"users":[]}'
+
+    class Opener:
+        def open(self, request, timeout):
+            captured["request"] = request
+            return Response()
+
+    def fake_build_opener(*handlers):
+        captured["handlers"] = handlers
+        return Opener()
+
+    monkeypatch.setenv("PRIVY_APP_ID", "app_123")
+    monkeypatch.setenv("PRIVY_APP_SECRET", "secret_456")
+    monkeypatch.setenv("PRIVY_API_BASE", "https://attacker.example")
+    monkeypatch.setattr(privy_client.urllib.request, "build_opener", fake_build_opener)
+
+    privy_client.request_json("/v1/users?limit=20", safe_route="/v1/users")
+
+    assert captured["request"].full_url == "https://api.privy.io/v1/users?limit=20"
+    assert any(
+        isinstance(handler, privy_client.NoRedirectHandler)
+        for handler in captured["handlers"]
+    )
+
+
+@pytest.mark.parametrize("status", [301, 302, 303, 307, 308])
+def test_authenticated_redirects_are_never_followed_or_rebuilt(privy_client, status):
+    request = urllib.request.Request(
+        "https://api.privy.io/v1/users",
+        headers={
+            "Authorization": "Basic secret",
+            "privy-app-id": "app_123",
+        },
+    )
+
+    redirected = privy_client.NoRedirectHandler().redirect_request(
+        request,
+        None,
+        status,
+        "redirect",
+        {},
+        "https://attacker.example/collect",
+    )
+
+    assert redirected is None
+
+
+def test_email_lookup_uses_documented_post_endpoint(privy_client, monkeypatch):
+    captured = {}
+
+    class Response:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return False
+
+        def read(self):
+            return b'{"id":"did:privy:abc","linked_accounts":[]}'
+
+    class Opener:
+        def open(self, request, timeout):
+            captured["request"] = request
+            captured["timeout"] = timeout
+            return Response()
+
+    monkeypatch.setenv("PRIVY_APP_ID", "app_123")
+    monkeypatch.setenv("PRIVY_APP_SECRET", "secret_456")
+    monkeypatch.setattr(
+        privy_client.urllib.request,
+        "build_opener",
+        lambda *_handlers: Opener(),
+    )
+    args = privy_client.build_parser().parse_args([
+        "users",
+        "--email",
+        "alice@example.com",
+    ])
+
+    result = privy_client.cmd_users(args)
+
+    request = captured["request"]
+    assert request.get_method() == "POST"
+    assert request.full_url == "https://api.privy.io/v1/users/email/address"
+    assert json.loads(request.data) == {"address": "alice@example.com"}
+    assert request.headers["Content-type"] == "application/json"
+    assert result["users"][0]["id"] == "did:privy:abc"
+
+
+@pytest.mark.parametrize(
+    ("argv", "expected_error", "sensitive_values"),
+    [
+        (
+            ["user", "did:privy:private-user"],
+            "Privy API GET /v1/users/{user_id} failed",
+            ["did:privy:private-user", "socket-secret"],
+        ),
+        (
+            ["users", "--cursor", "private-cursor"],
+            "Privy API GET /v1/users failed",
+            ["private-cursor", "limit=20", "socket-secret"],
+        ),
+        (
+            ["users", "--email", "private.person@example.com"],
+            "Privy API POST /v1/users/email/address failed",
+            ["private.person@example.com", "socket-secret"],
+        ),
+    ],
+)
+def test_request_failures_only_report_method_and_static_route(
+    privy_client,
+    monkeypatch,
+    argv,
+    expected_error,
+    sensitive_values,
+):
+    monkeypatch.setenv("PRIVY_APP_ID", "app_123")
+    monkeypatch.setenv("PRIVY_APP_SECRET", "secret_456")
+
+    class FailingOpener:
+        def open(self, *_args, **_kwargs):
+            raise urllib.error.URLError("socket-secret")
+
+    monkeypatch.setattr(
+        privy_client.urllib.request,
+        "build_opener",
+        lambda *_handlers: FailingOpener(),
+    )
+    args = privy_client.build_parser().parse_args(argv)
+
+    with pytest.raises(SystemExit) as exc:
+        args.func(args)
+
+    assert str(exc.value) == expected_error
+    for value in sensitive_values:
+        assert value not in str(exc.value)

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -43,6 +43,7 @@ hermes skills uninstall <skill-name>
 |-------|-------------|
 | [**evm**](/docs/user-guide/skills/optional/blockchain/blockchain-evm) | Read-only EVM client: wallets, tokens, gas across 8 chains. |
 | [**hyperliquid**](/docs/user-guide/skills/optional/blockchain/blockchain-hyperliquid) | Hyperliquid market data, account history, trade review. |
+| [**privy-wallet**](/docs/user-guide/skills/optional/blockchain/blockchain-privy) | Read-only Privy app user and wallet inspection. |
 | [**solana**](/docs/user-guide/skills/optional/blockchain/blockchain-solana) | Query Solana blockchain data with USD pricing — wallet balances, token portfolios with values, transaction details, NFTs, whale detection, and live network stats. Uses Solana RPC + CoinGecko. No API key required. |
 
 ## communication

--- a/website/docs/user-guide/skills/optional/blockchain/blockchain-privy.md
+++ b/website/docs/user-guide/skills/optional/blockchain/blockchain-privy.md
@@ -1,0 +1,195 @@
+---
+title: "Privy Wallet — Read-only Privy app user and wallet inspection"
+sidebar_label: "Privy Wallet"
+description: "Read-only Privy app user and wallet inspection"
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Privy Wallet
+
+Read-only Privy app user and wallet inspection.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/blockchain/privy` |
+| Path | `optional-skills/blockchain/privy` |
+| Version | `0.1.0` |
+| Author | Patrick (@leprincep35700), Hermes Agent |
+| License | MIT |
+| Platforms | linux, macos, windows |
+| Tags | `Privy`, `Wallet`, `Web3`, `Blockchain`, `Embedded Wallets`, `Read-only` |
+| Related skills | [`evm`](/docs/user-guide/skills/optional/blockchain/blockchain-evm), [`solana`](/docs/user-guide/skills/optional/blockchain/blockchain-solana) |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Privy Wallet Skill
+
+Read-only Privy application user and wallet inspection for Hermes. This skill
+helps an administrator understand which wallets are linked to a Privy user without exposing
+private keys, raw identity data, or transaction-signing capabilities.
+
+This skill is intentionally **read-only**. It **does not sign** messages,
+prepare transactions, send transactions, export keys, or bypass Privy's user
+approval flows. Any future signing or transaction capability should be built as
+a separate, human-approved flow with simulation, policy limits, and explicit
+confirmation.
+
+"Read-only" describes this helper's deliberately limited command surface. The
+Privy credentials themselves are not read-only and may authorize privileged
+application operations elsewhere. Store them as server secrets, never expose
+them to prompts or client-side code, and rotate them if disclosure is suspected.
+
+---
+
+## When to Use
+
+- User asks which wallet(s) are linked to a Privy account.
+- User wants to inspect embedded or external wallet addresses for a Privy user.
+- User wants a safe identity-to-wallet bridge before using EVM/Solana skills.
+- User is designing a wallet-aware Hermes workflow and needs read-only context.
+
+Do **not** use this skill to sign messages, approve transactions, or move funds.
+
+---
+
+## Prerequisites
+
+The helper script uses only Python standard library modules.
+
+Privy server credentials are required:
+
+```bash
+export PRIVY_APP_ID="your-privy-app-id"
+export PRIVY_APP_SECRET="your-privy-app-secret"
+```
+
+Keep `PRIVY_APP_SECRET` out of prompts, chat transcripts, and committed files.
+
+---
+
+## How to Run
+
+Use the `terminal` tool for every command. The helper performs only read-only
+Privy API requests and prints PII-minimized JSON.
+
+### Quick Reference
+
+Helper script path after installation:
+
+```text
+~/.hermes/skills/blockchain/privy/scripts/privy_client.py
+```
+
+Commands:
+
+```bash
+python3 privy_client.py user    <did:privy:...>
+python3 privy_client.py wallets <did:privy:...>
+python3 privy_client.py users   [--limit N] [--cursor CURSOR] [--email EMAIL]
+```
+
+Output is JSON and intentionally PII-minimized. Email addresses and phone
+numbers are not included in summaries; linked-account types and wallet metadata
+are retained.
+
+---
+
+## Procedure
+
+### 1. Check setup
+
+```bash
+python3 ~/.hermes/skills/blockchain/privy/scripts/privy_client.py users --limit 1
+```
+
+If credentials are missing, the helper exits with a clear message naming
+`PRIVY_APP_ID` and/or `PRIVY_APP_SECRET`.
+
+### 2. Inspect a Privy user safely
+
+```bash
+python3 ~/.hermes/skills/blockchain/privy/scripts/privy_client.py \
+  user did:privy:example
+```
+
+The result includes:
+
+- Privy user id
+- creation timestamp if returned by Privy
+- linked account types, e.g. `email`, `wallet`, `phone`
+- wallet linked accounts with address, chain type, wallet client type,
+  connector type, and verification timestamp
+
+It does not include raw email addresses or phone numbers.
+
+### 3. List wallets only
+
+```bash
+python3 ~/.hermes/skills/blockchain/privy/scripts/privy_client.py \
+  wallets did:privy:example
+```
+
+Use the resulting EVM or Solana addresses with the `evm` or `solana` optional
+skills for chain-specific portfolio, token, or transaction inspection.
+
+### 4. Search/list users
+
+```bash
+python3 ~/.hermes/skills/blockchain/privy/scripts/privy_client.py users --limit 20
+python3 ~/.hermes/skills/blockchain/privy/scripts/privy_client.py users --email alice@example.com
+```
+
+The `--email` filter uses Privy's documented `POST /v1/users/email/address`
+endpoint with an `{"address": "..."}` JSON body. Returned summaries stay
+redacted, and the address never appears in a request URL or error output.
+
+---
+
+## Safety Model
+
+This skill is safe by default because it only performs server-side read calls.
+For any future write/signing extension, require all of the following before
+implementation:
+
+1. human-approved confirmation in the active platform;
+2. transaction or message simulation/preview;
+3. explicit chain and contract allowlists;
+4. amount/value limits;
+5. no private-key or app-secret exposure to the LLM prompt;
+6. audit-friendly logs that redact tokens and personal data.
+
+Recommended future shape: keep write operations in a separate MCP server or
+separate toolset so deployments can enable read-only Privy inspection without
+enabling signing.
+
+---
+
+## Pitfalls
+
+- **Server credentials are sensitive** — `PRIVY_APP_SECRET` is an app-level
+  secret. Store it in environment/config secret storage only.
+- **Wallet ownership can change** — always fetch fresh data before using a
+  wallet address for authorization decisions.
+- **Read-only is not authorization** — seeing a wallet linked to a user does
+  not by itself grant permission to spend or act on behalf of that wallet.
+- **Privy API shapes can evolve** — the helper preserves a small stable summary
+  instead of passing raw API payloads into the agent transcript.
+- **No signing path** — this skill deliberately avoids signing and transactions.
+  Add those only with human-approved policy controls.
+
+---
+
+## Verification
+
+Run the targeted tests from the Hermes repo root:
+
+```bash
+python -m pytest tests/skills/test_privy_wallet_skill.py -q -o addopts=''
+```

--- a/website/sidebars.ts
+++ b/website/sidebars.ts
@@ -362,6 +362,7 @@ const sidebars: SidebarsConfig = {
                   items: [
                     'user-guide/skills/optional/blockchain/blockchain-evm',
                     'user-guide/skills/optional/blockchain/blockchain-hyperliquid',
+                    'user-guide/skills/optional/blockchain/blockchain-privy',
                     'user-guide/skills/optional/blockchain/blockchain-solana',
                   ],
                 },


### PR DESCRIPTION
## Summary

I added a read-only Privy application user/wallet inspection skill. It gives Hermes PII-minimized user and linked-wallet context without exposing signing, transaction, or key-export commands.

## What changed

- Added `optional-skills/blockchain/privy/SKILL.md` with human-first attribution, required credential metadata, terminal toolset metadata, and explicit operational safety guidance.
- Added a standard-library `privy_client.py` helper for user lookup, wallet extraction, and paginated PII-minimized application-user inspection.
- Email lookup uses Privy’s documented `POST /v1/users/email/address` endpoint with an `{"address": "..."}` JSON body; the address is not placed in request URLs or failure output.
- Authenticated requests are pinned to `https://api.privy.io`; arbitrary `PRIVY_API_BASE` overrides are ignored so application credentials cannot be redirected to another origin.
- User-list limits are constrained to 1..100.
- Generated skill documentation, catalog entry, and sidebar navigation are synchronized.

## Security model

“Read-only” describes this helper’s deliberately limited command surface. The `PRIVY_APP_ID` / `PRIVY_APP_SECRET` credentials themselves are privileged and may authorize write operations elsewhere; they must remain server-side secrets and must not be pasted into prompts, committed, or exposed to clients.

The helper returns only whitelisted user metadata, linked-account types, and wallet fields. It does not return raw email addresses or phone numbers, sign messages, prepare/send transactions, or export keys.

## Validation

Fresh validation on rebased head `4f3a98df94b3` (`main` base `c44de9985`):

```text
Broad skills/docs suite: 325 passed
Post-review focused suite: 31 passed
Ruff: passed
py_compile: passed
Windows footgun scan: 757 files, no findings
git diff --check: passed
```

Regression tests cover the documented POST method/path/body, PII-free failures, fixed API origin despite an attacker-controlled environment override, pagination bounds, redacted summaries, frontmatter requirements, and the read-only credential warning.

## Status

Ready for maintainer review on `4f3a98df94b3`. GitHub checks are green: 24 success, 6 skipped, 1 neutral, no failures or pending checks.
