### PR TITLE
fix computer use cua reconnect handling

### DIFF
--- a/tools/computer_use/cua_backend.py
+++ b/tools/computer_use/cua_backend.py
@@ -244,6 +244,9 @@ class _CuaDriverSession:
         self._exit_stack = None
         self._session = None
 
+    def _is_closed(self) -> bool:
+        return self._exit_stack is None or self._session is None
+
     def start(self) -> None:
         with self._lock:
             if self._started:
@@ -267,7 +270,24 @@ class _CuaDriverSession:
 
     def call_tool(self, name: str, args: Dict[str, Any], timeout: float = 30.0) -> Dict[str, Any]:
         self._require_started()
-        return self._bridge.run(self._call_tool_async(name, args), timeout=timeout)
+        import anyio
+        try:
+            return self._bridge.run(self._call_tool_async(name, args), timeout=timeout)
+        except (anyio.ClosedResourceError, OSError, RuntimeError) as exc:
+            logger.warning("cua-driver connection lost (%s: %s). Reconnecting...",
+                           type(exc).__name__, exc)
+            # Full teardown: close session, then bridge (kills event loop).
+            try:
+                self._bridge.run(self._aexit(), timeout=5.0)
+            except Exception as e2:
+                logger.debug("aexit during reconnect: %s", e2)
+            self._bridge.stop()
+            self._started = False
+            # Re-init: new bridge thread + new MCP session.
+            self._bridge.start()
+            self._bridge.run(self._aenter(), timeout=15.0)
+            self._started = True
+            return self._bridge.run(self._call_tool_async(name, args), timeout=timeout)
 
 
 def _extract_tool_result(mcp_result: Any) -> Dict[str, Any]:
@@ -524,21 +544,28 @@ class CuaDriverBackend(ComputerUseBackend):
         return self._action("scroll", args)
 
     # ── Keyboard ───────────────────────────────────────────────────
-    def type_text(self, text: str) -> ActionResult:
-        pid = self._active_pid
+    def type_text(self, text: str, app: Optional[str] = None) -> ActionResult:
+        pid = self._resolve_pid(app)
         if pid is None:
+            err = "No active window — call capture() first."
+            if app:
+                err = f"Could not resolve PID for app '{app}'. Call focus_app or capture first."
             return ActionResult(ok=False, action="type_text",
-                                message="No active window — call capture() first.")
+                                message=err)
         # Safari WebKit AXTextField does not accept AX attribute writes (type_text),
-        # so use type_text_chars which synthesises individual key events instead.
+        # so use type_text which synthesises individual key events instead.
         # This works universally across all macOS apps in background mode.
-        return self._action("type_text_chars", {"pid": pid, "text": text})
+        # Note: cua-driver v0.1.5 calls this tool "type_text", not "type_text_chars".
+        return self._action("type_text", {"pid": pid, "text": text})
 
-    def key(self, keys: str) -> ActionResult:
-        pid = self._active_pid
+    def key(self, keys: str, app: Optional[str] = None) -> ActionResult:
+        pid = self._resolve_pid(app)
         if pid is None:
+            err = "No active window — call capture() first."
+            if app:
+                err = f"Could not resolve PID for app '{app}'. Call focus_app or capture first."
             return ActionResult(ok=False, action="key",
-                                message="No active window — call capture() first.")
+                                message=err)
 
         key_name, modifiers = _parse_key_combo(keys)
         if not key_name:
@@ -633,13 +660,46 @@ class CuaDriverBackend(ComputerUseBackend):
         return ActionResult(ok=False, action="focus_app",
                             message=f"No on-screen window found for app '{app}'.")
 
+    def _resolve_pid(self, app: Optional[str] = None) -> Optional[int]:
+        """Resolve a PID from _active_pid, or look up via list_apps as fallback."""
+        if self._active_pid is not None:
+            return self._active_pid
+        if not app:
+            return None
+        apps = self.list_apps()
+        app_lower = app.lower()
+        for a in apps:
+            name = a.get("name", "")
+            if app_lower in name.lower():
+                pid = a.get("pid")
+                if pid and pid > 0:
+                    self._active_pid = pid
+                    return pid
+        return None
+
     # ── Internal ───────────────────────────────────────────────────
+    _TOOL_ALIASES = {
+        "type_text_chars": "type_text",
+    }
+
     def _action(self, name: str, args: Dict[str, Any]) -> ActionResult:
         try:
             out = self._session.call_tool(name, args)
         except Exception as e:
-            logger.exception("cua-driver %s call failed", name)
-            return ActionResult(ok=False, action=name, message=f"cua-driver error: {e}")
+            err_str = str(e)
+            # Auto-retry with alias if the tool name doesn't exist on this version
+            if "Unknown tool" in err_str and name in self._TOOL_ALIASES:
+                alias = self._TOOL_ALIASES[name]
+                logger.warning("Tool '%s' not found, retrying as '%s'", name, alias)
+                try:
+                    out = self._session.call_tool(alias, args)
+                    name = alias  # use the working name for reporting
+                except Exception as e2:
+                    return ActionResult(ok=False, action=name,
+                                        message=f"cua-driver error: {e2}")
+            else:
+                logger.exception("cua-driver %s call failed", name)
+                return ActionResult(ok=False, action=name, message=f"cua-driver error: {e}")
         ok = not out["isError"]
         message = ""
         data = out["data"]

--- a/tools/computer_use/tool.py
+++ b/tools/computer_use/tool.py
@@ -254,6 +254,20 @@ def handle_computer_use(args: Dict[str, Any], **kwargs) -> Any:
         return _dispatch(backend, action, args)
     except Exception as e:
         logger.exception("computer_use %s failed", action)
+        # Attempt automatic reconnect on connection-level errors
+        err_str = str(e)
+        if any(x in err_str for x in ("ClosedResource", "Resource closed", "BrokenPipe")):
+            import anyio
+            logger.warning("Attempting auto-reconnect after: %s", err_str)
+            try:
+                backend.stop()
+            except Exception:
+                pass
+            with _backend_lock:
+                _backend = None
+            backend = _get_backend()
+            logger.info("Auto-reconnect succeeded, retrying %s", action)
+            return _dispatch(backend, action, args)
         return json.dumps({"error": f"{action} failed: {e}"})
 
 
@@ -380,11 +394,17 @@ def _dispatch(backend: ComputerUseBackend, action: str, args: Dict[str, Any]) ->
         return _maybe_follow_capture(backend, res, capture_after)
 
     if action == "type":
-        res = backend.type_text(args.get("text", ""))
+        app = args.get("app")
+        if app:
+            backend.focus_app(app)
+        res = backend.type_text(args.get("text", ""), app=app)
         return _maybe_follow_capture(backend, res, capture_after)
 
     if action == "key":
-        res = backend.key(args.get("keys", ""))
+        app = args.get("app")
+        if app:
+            backend.focus_app(app)
+        res = backend.key(args.get("keys", ""), app=app)
         return _maybe_follow_capture(backend, res, capture_after)
 
     if action == "set_value":


### PR DESCRIPTION
  ## What does this PR do?

  Fixes reliability issues in the CUA computer-use backend when the underlying
  `cua-driver` MCP connection is closed or interrupted.

  This change adds automatic reconnect and retry behavior for connection-level
  failures, updates text input to use the current `cua-driver` `type_text` tool
  name, and lets `type` / `key` actions resolve or focus a target app before
  dispatching. This prevents common failures after the CUA session goes stale and
  improves background typing/key handling on macOS apps.

  ## Related Issue

  Fixes #

  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [ ] ✨ New feature (non-breaking change that adds functionality)
  - [ ] 🔒 Security fix
  - [ ] 📝 Documentation update
  - [ ] ✅ Tests (adding or improving test coverage)
  - [ ] ♻️ Refactor (no behavior change)
  - [ ] 🎯 New skill (bundled or hub)

  ## Changes Made

  - Updated `tools/computer_use/cua_backend.py`
    - Added CUA driver session reconnect handling when the MCP connection is
  closed or lost.
    - Added retry behavior after reconnecting the bridge/session.
    - Changed text input dispatch from the old `type_text_chars` tool name to the
  current `type_text` tool name.
    - Added fallback alias handling for older/newer CUA driver tool-name
  differences.
    - Added app-aware PID resolution for `type_text` and `key` actions.
    - Improved error messages when an app PID cannot be resolved.

  - Updated `tools/computer_use/tool.py`
    - Added automatic backend reset/retry for connection-level failures such as
  closed resources or broken pipes.
    - Updated `type` and `key` actions to optionally focus/resolve the requested
  app before dispatching.

  ## How to Test

  1. Start Hermes with computer-use / CUA enabled on macOS.
  2. Run a computer-use action that captures or focuses an app, then use `type`
  or `key` with an `app` argument.
  3. Restart or interrupt the underlying CUA driver session, then run another
  `type`, `key`, or capture-related action and verify Hermes reconnects and
  retries instead of failing with a closed-resource error.

  ## Checklist

  ### Code

  - [ ] I've read the [Contributing Guide](https://github.com/NousResearch/
  hermes-agent/blob/main/CONTRIBUTING.md)
  - [ ] My commit messages follow [Conventional Commits](https://
  www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
  - [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-
  agent/pulls) to make sure this isn't a duplicate
  - [x] My PR contains **only** changes related to this fix/feature (no unrelated
  commits)
  - [ ] I've run `pytest tests/ -q` and all tests pass
  - [ ] I've added tests for my changes (required for bug fixes, strongly
  encouraged for features)
  - [x] I've tested on my platform: macOS

  ### Documentation & Housekeeping

  - [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/
  A
  - [x] I've updated `cli-config.yaml.example` if I added/changed config keys —
  or N/A
  - [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture
  or workflows — or N/A
  - [x] I've considered cross-platform impact (Windows, macOS) per the
  [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/
  CONTRIBUTING.md#cross-platform-compatibility) — or N/A
  - [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/
  A

  ## Screenshots / Logs

  N/A