### PR TITLE
feat(api_server): forward tool result fields in hermes.tool.progress …

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -254,6 +254,11 @@ _FILE_PART_TYPES = frozenset({"file", "input_file"})
 # Only success=true JSON results are unpacked.  Non-JSON results, failures,
 # and tools not in the whitelist emit the base {tool, toolCallId, status}
 # payload unchanged.
+#
+# Note: forwarded field values are sent verbatim in every SSE event.  Do
+# not whitelist fields that can carry large payloads (base64 blobs, long
+# text).  Keep forwarded values to identifier-sized data (URLs, IDs, short
+# tags).
 _TOOL_RESULT_FIELDS: dict[str, frozenset[str]] = {
     "image_generate": frozenset({"image"}),
 }
@@ -2782,6 +2787,8 @@ class APIServerAdapter(BasePlatformAdapter):
                         parsed = None
                     if isinstance(parsed, dict) and parsed.get("success") is True:
                         for key in fields:
+                            if key in {"tool", "toolCallId", "status"}:
+                                continue  # never overwrite base payload keys
                             value = parsed.get(key)
                             if value is not None:
                                 payload[key] = value

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -237,6 +237,28 @@ _IMAGE_PART_TYPES = frozenset({"image_url", "input_image"})
 _FILE_PART_TYPES = frozenset({"file", "input_file"})
 
 
+# ── Tool result forwarding ──────────────────────────────────────────────
+# When a whitelisted tool completes with ``success: true``, selected fields
+# from the tool's result JSON are forwarded in the ``hermes.tool.progress``
+# (status=completed) SSE event so consumers (bridges, frontends,
+# observability) can act on tool output without scraping assistant prose.
+#
+# To add a new tool:
+#   1. Add an entry to _TOOL_RESULT_FIELDS below mapping the tool name to
+#      a frozenset of field names to forward.
+#   2. Add a test in test_api_server.py covering:
+#      - Field forwarding on success
+#      - Skipping on failure (success=false)
+#      - Skipping for non-whitelisted tools with colliding field names
+#
+# Only success=true JSON results are unpacked.  Non-JSON results, failures,
+# and tools not in the whitelist emit the base {tool, toolCallId, status}
+# payload unchanged.
+_TOOL_RESULT_FIELDS: dict[str, frozenset[str]] = {
+    "image_generate": frozenset({"image"}),
+}
+
+
 def _normalize_multimodal_content(content: Any) -> Any:
     """Validate and normalize multimodal content for the API server.
 
@@ -2736,15 +2758,35 @@ class APIServerAdapter(BasePlatformAdapter):
                 Dropped if the start was filtered (internal tool, missing
                 id, or never seen) so clients never get an orphaned
                 ``completed`` they can't correlate to a prior ``running``.
+
+                When *function_name* is in ``_TOOL_RESULT_FIELDS`` and the
+                result is a JSON object with ``"success": true``, the
+                configured fields are forwarded so SSE consumers can act on
+                tool output without scraping assistant prose.
                 """
                 if not tool_call_id or tool_call_id not in _started_tool_call_ids:
                     return
                 _started_tool_call_ids.discard(tool_call_id)
-                _stream_q.put(("__tool_progress__", {
+
+                payload: dict = {
                     "tool": function_name,
                     "toolCallId": tool_call_id,
                     "status": "completed",
-                }))
+                }
+
+                fields = _TOOL_RESULT_FIELDS.get(function_name)
+                if fields and isinstance(function_result, str):
+                    try:
+                        parsed = json.loads(function_result)
+                    except (json.JSONDecodeError, TypeError):
+                        parsed = None
+                    if isinstance(parsed, dict) and parsed.get("success") is True:
+                        for key in fields:
+                            value = parsed.get(key)
+                            if value is not None:
+                                payload[key] = value
+
+                _stream_q.put(("__tool_progress__", payload))
 
             # Start agent in background.  agent_ref is a mutable container
             # so the SSE writer can interrupt the agent on client disconnect.

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1621,6 +1621,236 @@ class TestChatCompletionsEndpoint:
             assert '"status": "completed"' not in body
 
     @pytest.mark.asyncio
+    async def test_tool_complete_forwards_image_url(self, adapter):
+        """image_generate completed events carry the ``image`` field when success=true."""
+        import asyncio
+        import json as _json
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                ts_cb = kwargs.get("tool_start_callback")
+                tc_cb = kwargs.get("tool_complete_callback")
+                cb = kwargs.get("stream_delta_callback")
+                if ts_cb:
+                    ts_cb("call_img_1", "image_generate",
+                          {"prompt": "a cat"})
+                if tc_cb:
+                    tc_cb("call_img_1", "image_generate",
+                          {"prompt": "a cat"},
+                          _json.dumps({
+                              "success": True,
+                              "image": "https://fal.media/cat.png",
+                          }))
+                if cb:
+                    cb("Here you go.")
+                return (
+                    {"final_response": "Here you go.", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "draw"}],
+                        "stream": True,
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+            found = None
+            for i, line in enumerate(body.splitlines()):
+                if "event: hermes.tool.progress" not in line:
+                    continue
+                for follow in body.splitlines()[i + 1: i + 4]:
+                    if follow.startswith("data: "):
+                        data = _json.loads(follow[len("data: "):])
+                        if data.get("status") == "completed" and data.get("tool") == "image_generate":
+                            found = data
+                            break
+                if found:
+                    break
+
+            assert found is not None, "no completed event for image_generate"
+            assert found.get("image") == "https://fal.media/cat.png"
+            assert found.get("toolCallId") == "call_img_1"
+
+    @pytest.mark.asyncio
+    async def test_tool_complete_skips_result_on_failure(self, adapter):
+        """Failed tool results are not forwarded."""
+        import asyncio
+        import json as _json
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                ts_cb = kwargs.get("tool_start_callback")
+                tc_cb = kwargs.get("tool_complete_callback")
+                cb = kwargs.get("stream_delta_callback")
+                if ts_cb:
+                    ts_cb("call_img_1", "image_generate",
+                          {"prompt": "a cat"})
+                if tc_cb:
+                    tc_cb("call_img_1", "image_generate",
+                          {"prompt": "a cat"},
+                          _json.dumps({
+                              "success": False,
+                              "error": "FAL_KEY not set",
+                          }))
+                if cb:
+                    cb("Couldn't generate.")
+                return (
+                    {"final_response": "Couldn't generate.", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "draw"}],
+                        "stream": True,
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+            found = None
+            for i, line in enumerate(body.splitlines()):
+                if "event: hermes.tool.progress" not in line:
+                    continue
+                for follow in body.splitlines()[i + 1: i + 4]:
+                    if follow.startswith("data: "):
+                        data = _json.loads(follow[len("data: "):])
+                        if data.get("status") == "completed" and data.get("tool") == "image_generate":
+                            found = data
+                            break
+                if found:
+                    break
+
+            assert found is not None, "no completed event"
+            assert "image" not in found, "failed result leaked image field"
+
+    @pytest.mark.asyncio
+    async def test_tool_complete_skips_non_json_results(self, adapter):
+        """Non-JSON tool results don't crash the completed event."""
+        import asyncio
+        import json as _json
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                ts_cb = kwargs.get("tool_start_callback")
+                tc_cb = kwargs.get("tool_complete_callback")
+                cb = kwargs.get("stream_delta_callback")
+                if ts_cb:
+                    ts_cb("call_term_1", "terminal", {"command": "echo hi"})
+                if tc_cb:
+                    tc_cb("call_term_1", "terminal",
+                          {"command": "echo hi"}, "hi\n")
+                if cb:
+                    cb("done.")
+                return (
+                    {"final_response": "done.", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "stream": True,
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+            # Verify completed events for non-whitelisted tools carry only
+            # the base fields — no stray result data leaking through.
+            seen_terminal_completed = False
+            for i, line in enumerate(body.splitlines()):
+                if "event: hermes.tool.progress" not in line:
+                    continue
+                for follow in body.splitlines()[i + 1: i + 4]:
+                    if follow.startswith("data: "):
+                        data = _json.loads(follow[len("data: "):])
+                        if data.get("status") == "completed" and data.get("tool") == "terminal":
+                            seen_terminal_completed = True
+                            assert set(data.keys()) == {"tool", "toolCallId", "status"}, (
+                                f"non-whitelisted tool must not leak result data; "
+                                f"got keys: {set(data.keys())}"
+                            )
+                            break
+
+            assert seen_terminal_completed, "expected a completed event for terminal"
+
+    @pytest.mark.asyncio
+    async def test_tool_complete_does_not_forward_for_non_whitelisted_tools(self, adapter):
+        """Tools not in _TOOL_RESULT_FIELDS never forward result data, even
+        when the result JSON happens to contain whitelisted field names."""
+        import asyncio
+        import json as _json
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                ts_cb = kwargs.get("tool_start_callback")
+                tc_cb = kwargs.get("tool_complete_callback")
+                cb = kwargs.get("stream_delta_callback")
+                if ts_cb:
+                    ts_cb("call_web_1", "web_search", {"query": "cats"})
+                if tc_cb:
+                    tc_cb("call_web_1", "web_search",
+                          {"query": "cats"},
+                          _json.dumps({
+                              "success": True,
+                              "image": "https://evil.com/exfil.png",
+                          }))
+                if cb:
+                    cb("found results.")
+                return (
+                    {"final_response": "found results.", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "search"}],
+                        "stream": True,
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+            found = None
+            for i, line in enumerate(body.splitlines()):
+                if "event: hermes.tool.progress" not in line:
+                    continue
+                for follow in body.splitlines()[i + 1: i + 4]:
+                    if follow.startswith("data: "):
+                        data = _json.loads(follow[len("data: "):])
+                        if data.get("status") == "completed" and data.get("tool") == "web_search":
+                            found = data
+                            break
+                if found:
+                    break
+
+            assert found is not None, "no completed event for web_search"
+            assert "image" not in found, (
+                "non-whitelisted tool must not forward result fields even when "
+                "the result JSON contains them"
+            )
+
+    @pytest.mark.asyncio
     async def test_no_user_message_returns_400(self, adapter):
         app = _create_app(adapter)
         async with TestClient(TestServer(app)) as cli:

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -1623,7 +1623,6 @@ class TestChatCompletionsEndpoint:
     @pytest.mark.asyncio
     async def test_tool_complete_forwards_image_url(self, adapter):
         """image_generate completed events carry the ``image`` field when success=true."""
-        import asyncio
         import json as _json
 
         app = _create_app(adapter)
@@ -1681,7 +1680,6 @@ class TestChatCompletionsEndpoint:
     @pytest.mark.asyncio
     async def test_tool_complete_skips_result_on_failure(self, adapter):
         """Failed tool results are not forwarded."""
-        import asyncio
         import json as _json
 
         app = _create_app(adapter)
@@ -1738,7 +1736,6 @@ class TestChatCompletionsEndpoint:
     @pytest.mark.asyncio
     async def test_tool_complete_skips_non_json_results(self, adapter):
         """Non-JSON tool results don't crash the completed event."""
-        import asyncio
         import json as _json
 
         app = _create_app(adapter)
@@ -1794,7 +1791,6 @@ class TestChatCompletionsEndpoint:
     async def test_tool_complete_does_not_forward_for_non_whitelisted_tools(self, adapter):
         """Tools not in _TOOL_RESULT_FIELDS never forward result data, even
         when the result JSON happens to contain whitelisted field names."""
-        import asyncio
         import json as _json
 
         app = _create_app(adapter)
@@ -1848,6 +1844,117 @@ class TestChatCompletionsEndpoint:
             assert "image" not in found, (
                 "non-whitelisted tool must not forward result fields even when "
                 "the result JSON contains them"
+            )
+
+    @pytest.mark.asyncio
+    async def test_tool_complete_skips_json_null_literal(self, adapter):
+        """JSON `null` literal (json.dumps(None) → "null") is not a dict,
+        so no fields are forwarded."""
+        import json as _json
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                ts_cb = kwargs.get("tool_start_callback")
+                tc_cb = kwargs.get("tool_complete_callback")
+                cb = kwargs.get("stream_delta_callback")
+                if ts_cb:
+                    ts_cb("call_img_1", "image_generate",
+                          {"prompt": "a cat"})
+                if tc_cb:
+                    tc_cb("call_img_1", "image_generate",
+                          {"prompt": "a cat"},
+                          _json.dumps(None))
+                if cb:
+                    cb("done.")
+                return (
+                    {"final_response": "done.", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "stream": True,
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+            found = None
+            for i, line in enumerate(body.splitlines()):
+                if "event: hermes.tool.progress" not in line:
+                    continue
+                for follow in body.splitlines()[i + 1: i + 4]:
+                    if follow.startswith("data: "):
+                        data = _json.loads(follow[len("data: "):])
+                        if (data.get("status") == "completed"
+                                and data.get("tool") == "image_generate"):
+                            found = data
+                            break
+
+            assert found is not None, "no completed event"
+            assert set(found.keys()) == {"tool", "toolCallId", "status"}, (
+                f"null result must not produce forwarded fields; "
+                f"got keys: {set(found.keys())}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_tool_complete_skips_missing_whitelisted_field(self, adapter):
+        """When a whitelisted tool returns success=true but the field is absent,
+        the completed event carries only base keys."""
+        import json as _json
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                ts_cb = kwargs.get("tool_start_callback")
+                tc_cb = kwargs.get("tool_complete_callback")
+                cb = kwargs.get("stream_delta_callback")
+                if ts_cb:
+                    ts_cb("call_img_1", "image_generate",
+                          {"prompt": "a cat"})
+                if tc_cb:
+                    tc_cb("call_img_1", "image_generate",
+                          {"prompt": "a cat"},
+                          _json.dumps({"success": True}))
+                if cb:
+                    cb("done.")
+                return (
+                    {"final_response": "done.", "messages": [], "api_calls": 1},
+                    {"input_tokens": 1, "output_tokens": 1, "total_tokens": 2},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "hi"}],
+                        "stream": True,
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+
+            found = None
+            for i, line in enumerate(body.splitlines()):
+                if "event: hermes.tool.progress" not in line:
+                    continue
+                for follow in body.splitlines()[i + 1: i + 4]:
+                    if follow.startswith("data: "):
+                        data = _json.loads(follow[len("data: "):])
+                        if (data.get("status") == "completed"
+                                and data.get("tool") == "image_generate"):
+                            found = data
+                            break
+
+            assert found is not None, "no completed event"
+            assert "image" not in found, (
+                "missing whitelisted field must not appear in payload"
             )
 
     @pytest.mark.asyncio

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -106,10 +106,19 @@ Standard OpenAI Chat Completions format. Stateless — the full conversation is 
 
 Uploaded files (`file` / `input_file` / `file_id`) and non-image `data:` URLs return `400 unsupported_content_type`.
 
-**Streaming** (`"stream": true`): Returns Server-Sent Events (SSE) with token-by-token response chunks. For **Chat Completions**, the stream uses standard `chat.completion.chunk` events plus Hermes' custom `hermes.tool.progress` event for tool-start UX. For **Responses**, the stream uses OpenAI Responses event types such as `response.created`, `response.output_text.delta`, `response.output_item.added`, `response.output_item.done`, and `response.completed`.
+**Streaming** (`"stream": true`): Returns Server-Sent Events (SSE) with token-by-token response chunks. For **Chat Completions**, the stream uses standard `chat.completion.chunk` events plus Hermes' custom `hermes.tool.progress` event. For **Responses**, the stream uses OpenAI Responses event types such as `response.created`, `response.output_text.delta`, `response.output_item.added`, `response.output_item.done`, and `response.completed`.
 
 **Tool progress in streams**:
-- **Chat Completions**: Hermes emits `event: hermes.tool.progress` for tool-start visibility without polluting persisted assistant text.
+- **Chat Completions**: Hermes emits `event: hermes.tool.progress` for tool lifecycle visibility. Each event carries:
+  - `status`: `"running"` when a tool starts, `"completed"` when it finishes
+  - `tool`: the tool name (e.g. `"web_search"`, `"image_generate"`)
+  - `toolCallId`: stable identifier for correlating running/completed pairs
+  - `label` / `emoji`: UI hints (running events only, pre-existing fields)
+
+  For completed events, select tools forward additional result fields when the tool returns `"success": true`. Currently:
+  - `image_generate` → `"image"` (the generated image URL)
+
+  The forwarding whitelist is extensible — new tools can be added with a one-line change to `_TOOL_RESULT_FIELDS` in `api_server.py`.
 - **Responses**: Hermes emits spec-native `function_call` and `function_call_output` output items during the SSE stream, so clients can render structured tool UI in real time.
 
 ### POST /v1/responses


### PR DESCRIPTION
## What does this PR do?

Adds an extensible whitelist pattern to `/v1/chat/completions` streaming: when a whitelisted tool completes with `"success": true` JSON, selected fields from the result are forwarded in the `hermes.tool.progress` completed event payload.

SSE consumers (bridges, frontends, observability) currently must scrape assistant prose to find tool output like generated image URLs. The agent's prose format is inconsistent — sometimes `<image_url>https://...</image_url>`, sometimes `![alt](https://...)`, sometimes bare URLs. Structured events let consumers extract data reliably without parsing natural language.

Initial whitelist: `image_generate` → `"image"` (the generated URL). New tools are added with a one-line entry in `_TOOL_RESULT_FIELDS`.

## Related Issue

N/A

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)
- [x] 📝 Documentation update

## Changes Made

- `gateway/platforms/api_server.py`: Added module-level `_TOOL_RESULT_FIELDS` whitelist dict. Revised `_on_tool_complete` closure to forward whitelisted result fields when tool completes with `success: true` JSON.
- `tests/gateway/test_api_server.py`: Four new tests — happy path (image URL forwarded), failure path (skipped), non-JSON safety (caught), whitelist boundary (non-whitelisted tool with colliding field name not forwarded).
- `website/docs/user-guide/features/api-server.md`: Documented completed event fields and forwarding behavior.

## How to Test

1. `pytest tests/gateway/test_api_server.py -v` — 142 passed, 4 new tests green
2. `python -c "import ast; ast.parse(open('gateway/platforms/api_server.py').read())"` — syntax clean
3. Verify `image_generate` tool completion in SSE stream now includes `"image"` field

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/gateway/test_api_server.py -v` (targeted scope) — 142 passed. Full suite `pytest tests/ -q` shows 21365 passed, 91 failed, 81 skipped; failures are pre-existing in unrelated subsystems (discord, dm topics, tencent, code execution, TTS provider) and none are in `test_api_server.py`.
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 (ARM64 / aarch64)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — docs updated
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (pure Python logic, no OS-specific paths)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A
