### PR TITLE
fix(hindsight): make hindsight_retain tool fire-and-forget

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1497,11 +1497,15 @@ class HindsightMemoryProvider(MemoryProvider):
                     context=context,
                     tags=args.get("tags"),
                 )
+                bank_id = retain_kwargs.pop("bank_id", self._bank_id)
+                retain_kwargs.pop("retain_async", None)
                 logger.debug("Tool hindsight_retain: bank=%s, content_len=%d, context=%s",
-                             self._bank_id, len(content), context)
-                self._run_hindsight_operation(lambda client: client.aretain(**retain_kwargs))
+                             bank_id, len(content), context)
+                self._run_hindsight_operation(
+                    lambda client: client.aretain_batch(bank_id=bank_id, items=[retain_kwargs], retain_async=True)
+                )
                 logger.debug("Tool hindsight_retain: success")
-                return json.dumps({"result": "Memory stored successfully."})
+                return json.dumps({"result": "Memory queued for storage."})
             except Exception as e:
                 logger.warning("hindsight_retain failed: %s", e, exc_info=True)
                 return tool_error(f"Failed to store memory: {e}")

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -443,17 +443,19 @@ class TestToolHandlers:
         result = json.loads(provider.handle_tool_call(
             "hindsight_retain", {"content": "user likes dark mode"}
         ))
-        assert result["result"] == "Memory stored successfully."
-        provider._client.aretain.assert_called_once()
-        call_kwargs = provider._client.aretain.call_args.kwargs
+        assert result["result"] == "Memory queued for storage."
+        provider._client.aretain_batch.assert_called_once()
+        call_kwargs = provider._client.aretain_batch.call_args.kwargs
         assert call_kwargs["bank_id"] == "test-bank"
-        assert call_kwargs["content"] == "user likes dark mode"
+        assert call_kwargs["retain_async"] is True
+        assert len(call_kwargs["items"]) == 1
+        assert call_kwargs["items"][0]["content"] == "user likes dark mode"
 
     def test_retain_with_tags(self, provider_with_config):
         p = provider_with_config(retain_tags=["pref", "ui"])
         p.handle_tool_call("hindsight_retain", {"content": "likes dark mode"})
-        call_kwargs = p._client.aretain.call_args.kwargs
-        assert call_kwargs["tags"] == ["pref", "ui"]
+        item = p._client.aretain_batch.call_args.kwargs["items"][0]
+        assert item["tags"] == ["pref", "ui"]
 
     def test_retain_merges_per_call_tags_with_config_tags(self, provider_with_config):
         p = provider_with_config(retain_tags=["pref", "ui"])
@@ -461,13 +463,13 @@ class TestToolHandlers:
             "hindsight_retain",
             {"content": "likes dark mode", "tags": ["client:x", "ui"]},
         )
-        call_kwargs = p._client.aretain.call_args.kwargs
-        assert call_kwargs["tags"] == ["pref", "ui", "client:x"]
+        item = p._client.aretain_batch.call_args.kwargs["items"][0]
+        assert item["tags"] == ["pref", "ui", "client:x"]
 
     def test_retain_without_tags(self, provider):
         provider.handle_tool_call("hindsight_retain", {"content": "hello"})
-        call_kwargs = provider._client.aretain.call_args.kwargs
-        assert "tags" not in call_kwargs
+        item = provider._client.aretain_batch.call_args.kwargs["items"][0]
+        assert "tags" not in item
 
     def test_retain_missing_content(self, provider):
         result = json.loads(provider.handle_tool_call(
@@ -533,7 +535,7 @@ class TestToolHandlers:
         assert "error" in result
 
     def test_retain_error_handling(self, provider):
-        provider._client.aretain.side_effect = RuntimeError("connection failed")
+        provider._client.aretain_batch.side_effect = RuntimeError("connection failed")
         result = json.loads(provider.handle_tool_call(
             "hindsight_retain", {"content": "test"}
         ))


### PR DESCRIPTION
## What does this PR do?

`hindsight_retain` was calling `client.aretain()`, a thin SDK wrapper that hardcodes
`retain_async=False`. The tool blocks until the server finishes LLM extraction. Under load,
extraction exceeds `_DEFAULT_TIMEOUT` (120 s); the SDK raises a bare `TimeoutError`; the tool
returns `{"error": "Failed to store memory: "}` with an empty exception string.

`_do_retain` (the auto-retain path) has used `aretain_batch(retain_async=True)` since
[a1b6d9e](https://github.com/NousResearch/hermes-agent/commit/a1b6d9e) — the tool just never
got the same treatment. This PR brings them in line: route `hindsight_retain` through
`aretain_batch(retain_async=True)`, eliminating the timeout coupling entirely. Extraction runs
server-side; results surface via `recall` once Reflect runs.

Success message changes from `"Memory stored successfully."` to `"Memory queued for storage."`
to reflect the queued semantics.

## Related Issue

Partially addresses #14950 — resolves the `retain` case by eliminating the timeout dependency.
The `reflect` timeout described in that issue is out of scope here.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/memory/hindsight/__init__.py`: replace `client.aretain(**retain_kwargs)` with
  `client.aretain_batch(bank_id=..., items=[retain_kwargs], retain_async=True)` in
  `handle_tool_call("hindsight_retain")`. Update success message.
- `tests/plugins/memory/test_hindsight_provider.py`: update five `TestToolHandlers` retain tests
  to assert `aretain_batch.call_args.kwargs` instead of `aretain.call_args.kwargs`.

## How to Test

1. `pytest tests/plugins/memory/test_hindsight_provider.py -q` — 96 passed.
2. `pytest tests/plugins/ -q` — 539 passed. (One pre-existing flake:
   `test_achievements_plugin.py::test_evaluate_all_stale_cache_serves_stale_and_refreshes_in_background`
   — timing race, reproducible on clean `main`, unrelated.)
3. Manual: against a slow extraction backend, `hindsight_retain` returns
   `{"result": "Memory queued for storage."}` immediately; the operation appears at
   `GET /v1/default/banks/<bank>/operations` within ~200 ms.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — no duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/plugins/ -q` — 539 passed
- [x] I've added/updated tests for my changes
- [x] I've tested on my platform: macOS 15 (Apple Silicon)

### Documentation & Housekeeping

- [x] Docs — N/A
- [x] `cli-config.yaml.example` — N/A
- [x] `CONTRIBUTING.md` / `AGENTS.md` — N/A
- [x] Cross-platform — pure Python async, no platform-specific paths
- [x] Tool schema (`content`, `context`, `tags`) unchanged; success string updated

## Screenshots / Logs

**Before:**
```
{"error": "Failed to store memory: "}
```
**After:**
```
{"result": "Memory queued for storage."}
```
