### PR TITLE
fix(gateway): finalize final stream edit on done (salvage #22755)

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -411,7 +411,7 @@ class GatewayStreamConsumer:
                     # path below so we don't finalize here for it.
                     current_update_visible = await self._send_or_edit(
                         display_text,
-                        finalize=got_segment_break,
+                        finalize=(got_done or got_segment_break),
                     )
                     self._last_edit_time = time.monotonic()
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -64,6 +64,7 @@ AUTHOR_MAP = {
     "ytchen0719@gmail.com": "liquidchen",
     "am@studio1.tailb672fe.ts.net": "subtract0",
     "axmaiqiu@gmail.com": "qWaitCrypto",
+    "44045911+kidonng@users.noreply.github.com": "kidonng",
     "maksesipov@gmail.com": "Qwinty",
     "denisamania@gmail.com": "CalmProton",
     "308068+mbac@users.noreply.github.com": "mbac",


### PR DESCRIPTION
## Summary
Salvage of #22755 — Telegram streaming-edit `got_done` ticks now finalize with markdown formatting instead of leaving the final message as plain text.

## Root cause
`gateway/stream_consumer.py` (line ~412) sent the final mid-stream edit with `finalize=False` for adapters that don't set `REQUIRES_EDIT_FINALIZE=True`. Telegram is one such adapter — its `edit_message` only applies `MARKDOWN_V2` when `finalize=True`. The "finalize path below" branch then hit the early-exit case (`current_update_visible and not _adapter_requires_finalize`) and set `_final_response_sent=True` without re-editing, so the formatting was never applied.

## Changes (contributor commit)
- `gateway/stream_consumer.py`: 1-line — use `finalize=(got_done or got_segment_break)` for the mid-stream edit, so the final tick applies markdown formatting on Telegram.

## Validation
- 1-line surgical change at the right call site. Adapters that DO require explicit finalize (e.g. DingTalk) still get their explicit finalize edit through the existing branch below.

Closes #22518 via salvage.
