### PR TITLE
fix(gateway): pass max_total_size_mb and max_file_size_mb to CheckpointManager (salvage #22823)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9561,6 +9561,8 @@ class GatewayRunner:
         mgr = CheckpointManager(
             enabled=True,
             max_snapshots=cp_cfg.get("max_snapshots", 50),
+            max_total_size_mb=cp_cfg.get("max_total_size_mb", 500),
+            max_file_size_mb=cp_cfg.get("max_file_size_mb", 10),
         )
 
         cwd = os.getenv("TERMINAL_CWD", str(Path.home()))

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -65,6 +65,7 @@ AUTHOR_MAP = {
     "am@studio1.tailb672fe.ts.net": "subtract0",
     "axmaiqiu@gmail.com": "qWaitCrypto",
     "44045911+kidonng@users.noreply.github.com": "kidonng",
+    "daniellsmarta@gmail.com": "DanielLSM",
     "maksesipov@gmail.com": "Qwinty",
     "denisamania@gmail.com": "CalmProton",
     "308068+mbac@users.noreply.github.com": "mbac",


### PR DESCRIPTION
## Summary
Salvage of #22823 — gateway `/rollback` handler now forwards `max_total_size_mb` and `max_file_size_mb` from `config.yaml` `checkpoints:` to `CheckpointManager`, so user-configured size caps are actually honored.

## Root cause
`gateway/run.py::_handle_rollback_command` constructed `CheckpointManager(enabled=True, max_snapshots=...)` but omitted the two size kwargs. `CheckpointManager` has defaults for them (500 MB / 10 MB), so user-configured values in `config.yaml` were silently ignored on the gateway path. `run_agent.py::AIAgent.__init__` already forwards all four — gateway was the outlier.

## Changes (contributor commit)
- `gateway/run.py`: 2-line — pass `max_total_size_mb=cp_cfg.get("max_total_size_mb", 500)` and `max_file_size_mb=cp_cfg.get("max_file_size_mb", 10)` to `CheckpointManager(...)`.

Note: the original PR description claimed a `TypeError` reproduction, but the constructor has defaults so there's no actual TypeError on main — the real bug is just that user-configured caps weren't honored. Behavior is otherwise unchanged for users running with default sizes.

Refs #11409 and #18841 (which still need their own fixes — checkpoint snapshots not actually created on file mutations, and AIAgent not getting checkpoint config in gateway mode).
