### PR TITLE
fix: use credential_pool for custom endpoint model listing probes (salvage #22810)

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -889,10 +889,9 @@ def switch_model(
             # "ollama-launch" that resolve_runtime_provider doesn't know), keep existing
             # credentials. Otherwise use the resolved values (picks up credential rotation,
             # base_url adjustments for OpenCode, etc.).
-            if runtime.get("provider") != "custom":
-                api_key = runtime.get("api_key", "")
-                base_url = runtime.get("base_url", "")
-                api_mode = runtime.get("api_mode", "")
+            api_key = runtime.get("api_key", "")
+            base_url = runtime.get("base_url", "")
+            api_mode = runtime.get("api_mode", "")
         except Exception:
             pass
 

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -492,6 +492,13 @@ def _resolve_named_custom_runtime(
     requested_norm = (requested_provider or "").strip().lower()
     if requested_norm == "custom" and explicit_base_url:
         base_url = explicit_base_url.strip().rstrip("/")
+        # Check credential pool first — mirrors the named-custom-provider path
+        # so bare `provider: custom` with a configured custom_providers entry
+        # also gets its api_key from the pool instead of env var fallbacks.
+        pool_result = _try_resolve_from_custom_pool(base_url, "custom", None)
+        if pool_result:
+            pool_result["source"] = "direct-alias"
+            return pool_result
         api_key_candidates = [
             (explicit_api_key or "").strip(),
             os.getenv("OPENAI_API_KEY", "").strip(),

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -66,6 +66,7 @@ AUTHOR_MAP = {
     "axmaiqiu@gmail.com": "qWaitCrypto",
     "44045911+kidonng@users.noreply.github.com": "kidonng",
     "daniellsmarta@gmail.com": "DanielLSM",
+    "264291321+v1b3coder@users.noreply.github.com": "v1b3coder",
     "maksesipov@gmail.com": "Qwinty",
     "denisamania@gmail.com": "CalmProton",
     "308068+mbac@users.noreply.github.com": "mbac",


### PR DESCRIPTION
## Summary
Salvage of #22810 — same-provider `/model` switches on a custom endpoint now consult the credential pool for listing probes and adopt freshly-resolved credentials instead of pinning the stale ones.

## Changes (contributor commit, re-authored from `agent@hermes.local` placeholder to v1b3coder's noreply)
- `hermes_cli/runtime_provider.py::_resolve_named_custom_runtime`: bare-custom + explicit_base_url path now calls `_try_resolve_from_custom_pool(base_url, "custom", None)` before falling back to env-var candidates. Mirrors the named-custom-provider branch already in place.
- `hermes_cli/model_switch.py::switch_model`: drops the `if runtime.get("provider") != "custom":` guard so same-provider switches DO adopt the freshly-resolved api_key/base_url/api_mode. The original guard (#15088) was added to preserve base_url across switches; that's now handled by `resolve_runtime_provider` reading `model_cfg.base_url`.

## Validation
- The bare-custom + explicit_base_url path bypassed the credential pool entirely; listing probes hit OPENAI/OPENROUTER env fallbacks even when a custom pool was configured.
- The same-provider guard pinned stale credentials, so a rotated pool key was never picked up on `/model` switches.

Refs #18681 (the gateway-side `current_api_key = model_cfg.get("api_key", "")` fix is separate and still needed), #16254, #12919.
