### PR TITLE
fix(process_registry): kill orphaned Popen on post-spawn setup failure (salvage #22628)

### DIFF
--- a/tests/tools/test_process_registry.py
+++ b/tests/tools/test_process_registry.py
@@ -531,6 +531,96 @@ class TestSpawnEnvSanitization:
 
 
 # =========================================================================
+# Popen leak prevention
+# =========================================================================
+
+class TestPopenLeakOnSetupFailure:
+    """Regression for issue #2749: subprocess orphaned when post-Popen setup raises."""
+
+    def test_popen_killed_when_thread_creation_fails(self, registry):
+        """If Thread() raises after Popen, proc must be killed — not orphaned."""
+        killed = []
+
+        proc = MagicMock()
+        proc.pid = 9999
+        proc.stdout = iter([])
+        proc.stdin = MagicMock()
+        proc.poll.return_value = None
+
+        def fake_kill():
+            killed.append(True)
+
+        proc.kill = fake_kill
+        proc.wait = MagicMock()
+
+        def boom(*args, **kwargs):
+            raise RuntimeError("Thread creation failed")
+
+        with patch("tools.process_registry._find_shell", return_value="/bin/bash"), \
+             patch("subprocess.Popen", return_value=proc), \
+             patch("threading.Thread", side_effect=boom), \
+             patch.object(registry, "_write_checkpoint"):
+            with pytest.raises(RuntimeError, match="Thread creation failed"):
+                registry.spawn_local("echo hello", cwd="/tmp")
+
+        assert killed, "proc.kill() must be called when post-Popen setup raises"
+
+    def test_popen_killed_when_write_checkpoint_fails(self, registry):
+        """If _write_checkpoint raises after Popen, proc must still be killed."""
+        killed = []
+
+        proc = MagicMock()
+        proc.pid = 8888
+        proc.stdout = iter([])
+        proc.stdin = MagicMock()
+        proc.poll.return_value = None
+
+        def fake_kill():
+            killed.append(True)
+
+        proc.kill = fake_kill
+        proc.wait = MagicMock()
+
+        fake_thread = MagicMock()
+
+        with patch("tools.process_registry._find_shell", return_value="/bin/bash"), \
+             patch("subprocess.Popen", return_value=proc), \
+             patch("threading.Thread", return_value=fake_thread), \
+             patch.object(registry, "_write_checkpoint", side_effect=OSError("disk full")):
+            with pytest.raises(OSError, match="disk full"):
+                registry.spawn_local("echo hello", cwd="/tmp")
+
+        assert killed, "proc.kill() must be called when _write_checkpoint raises"
+
+    def test_popen_not_killed_on_success(self, registry):
+        """Successful spawn must NOT kill the process."""
+        killed = []
+
+        proc = MagicMock()
+        proc.pid = 7777
+        proc.stdout = iter([])
+        proc.stdin = MagicMock()
+        proc.poll.return_value = None
+
+        def fake_kill():
+            killed.append(True)
+
+        proc.kill = fake_kill
+        proc.wait = MagicMock()
+
+        fake_thread = MagicMock()
+
+        with patch("tools.process_registry._find_shell", return_value="/bin/bash"), \
+             patch("subprocess.Popen", return_value=proc), \
+             patch("threading.Thread", return_value=fake_thread), \
+             patch.object(registry, "_write_checkpoint"):
+            session = registry.spawn_local("echo hello", cwd="/tmp")
+
+        assert not killed, "proc.kill() must NOT be called on successful spawn"
+        assert session.pid == 7777
+
+
+# =========================================================================
 # Checkpoint
 # =========================================================================
 

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -562,21 +562,42 @@ class ProcessRegistry:
         session.process = proc
         session.pid = proc.pid
 
-        # Start output reader thread
-        reader = threading.Thread(
-            target=self._reader_loop,
-            args=(session,),
-            daemon=True,
-            name=f"proc-reader-{session.id}",
-        )
-        session._reader_thread = reader
-        reader.start()
+        try:
+            # Start output reader thread
+            reader = threading.Thread(
+                target=self._reader_loop,
+                args=(session,),
+                daemon=True,
+                name=f"proc-reader-{session.id}",
+            )
+            session._reader_thread = reader
+            reader.start()
 
-        with self._lock:
-            self._prune_if_needed()
-            self._running[session.id] = session
+            with self._lock:
+                self._prune_if_needed()
+                self._running[session.id] = session
 
-        self._write_checkpoint()
+            self._write_checkpoint()
+        except Exception:
+            # Post-Popen setup failed — kill the orphaned subprocess (and any
+            # descendants spawned via setsid) before re-raising so they do not
+            # leak as untracked background processes.
+            try:
+                if not _IS_WINDOWS:
+                    try:
+                        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+                    except (ProcessLookupError, PermissionError, OSError):
+                        proc.kill()
+                else:
+                    proc.kill()
+            except Exception:
+                pass
+            try:
+                proc.wait(timeout=5)
+            except Exception:
+                pass
+            raise
+
         return session
 
     def spawn_via_env(


### PR DESCRIPTION
## Summary
Salvage of #22628 — `process_registry.spawn_local()` no longer leaks the child process when post-spawn setup (Thread construction, registry insert, checkpoint write) raises.

## Root cause
After Popen succeeded with `os.setsid` (detached process group), 5 things happened with no try/except: Thread construction, reader.start(), lock acquisition, prune_if_needed + registry insert, checkpoint write. If any raised, the Popen object went unregistered, GC'd silently, and the detached process group leaked indefinitely. Realistic triggers: disk full, fd/thread limits.

## Changes (squashed contributor commits, re-authored)
- `tools/process_registry.py::spawn_local`: wrap post-Popen block in try/except. On failure: `os.killpg(getpgid(pid), SIGKILL)` takes down the entire process group (not just the shell — important because the `-lic` shell wrapper may have spawned children), with `proc.kill()` fallback for ProcessLookupError/PermissionError/OSError, then `proc.wait(timeout=5)` to reap, then `raise` to preserve the original traceback. Nested try/except around cleanup so a secondary failure can't mask the original.
- 3 regression tests (Thread failure, checkpoint failure, happy path).

## Salvage notes
- Two commits in the original PR: an initial orphan-kill fix (9dcdf249f) and a follow-up that extended it to descendant-kill + bounded wait (c1f887cc9). The follow-up supersedes the first; squashed both into a single commit during salvage since the first commit's narrower form is dead history once the second lands.
- Resolved a conflict against current main where the surrounding code structure had refactored.

## Validation
- 8/8 leak/orphan/setup tests pass on the salvage branch.

Closes #2749 via salvage.
