### PR TITLE
fix(terminal): bridge docker_env config to TERMINAL_DOCKER_ENV (salvage #22626)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -517,6 +517,7 @@ def load_cli_config() -> Dict[str, Any]:
         "container_disk": "TERMINAL_CONTAINER_DISK",
         "container_persistent": "TERMINAL_CONTAINER_PERSISTENT",
         "docker_volumes": "TERMINAL_DOCKER_VOLUMES",
+        "docker_env": "TERMINAL_DOCKER_ENV",
         "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
         "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
         "sandbox_dir": "TERMINAL_SANDBOX_DIR",
@@ -540,7 +541,7 @@ def load_cli_config() -> Dict[str, Any]:
                 continue
             if _file_has_terminal_config or env_var not in os.environ:
                 val = terminal_config[config_key]
-                if isinstance(val, list):
+                if isinstance(val, (list, dict)):
                     os.environ[env_var] = json.dumps(val)
                 else:
                     os.environ[env_var] = str(val)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -460,6 +460,7 @@ if _config_path.exists():
                 "container_disk": "TERMINAL_CONTAINER_DISK",
                 "container_persistent": "TERMINAL_CONTAINER_PERSISTENT",
                 "docker_volumes": "TERMINAL_DOCKER_VOLUMES",
+                "docker_env": "TERMINAL_DOCKER_ENV",
                 "docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
                 "docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
                 "sandbox_dir": "TERMINAL_SANDBOX_DIR",
@@ -478,7 +479,7 @@ if _config_path.exists():
                     # receives a literal "~/" which the kernel rejects.
                     if _cfg_key == "cwd" and isinstance(_val, str):
                         _val = os.path.expanduser(_val)
-                    if isinstance(_val, list):
+                    if isinstance(_val, (list, dict)):
                         os.environ[_env_var] = json.dumps(_val)
                     else:
                         os.environ[_env_var] = str(_val)

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -4843,6 +4843,7 @@ def set_config_value(key: str, value: str):
         "terminal.vercel_runtime": "TERMINAL_VERCEL_RUNTIME",
         "terminal.docker_mount_cwd_to_workspace": "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE",
         "terminal.docker_run_as_host_user": "TERMINAL_DOCKER_RUN_AS_HOST_USER",
+        "terminal.docker_env": "TERMINAL_DOCKER_ENV",
         # terminal.cwd intentionally excluded — CLI resolves at runtime,
         # gateway bridges it in gateway/run.py. Persisting to .env causes
         # stale values to poison child processes.

--- a/tests/tools/test_terminal_config_env_sync.py
+++ b/tests/tools/test_terminal_config_env_sync.py
@@ -208,3 +208,19 @@ def test_docker_mount_cwd_to_workspace_is_bridged_everywhere():
     assert "docker_mount_cwd_to_workspace" in _gateway_env_map_keys()
     assert "docker_mount_cwd_to_workspace" in _save_config_env_sync_keys()
     assert "TERMINAL_DOCKER_MOUNT_CWD_TO_WORKSPACE" in _terminal_tool_env_var_names()
+
+
+def test_docker_env_is_bridged_everywhere():
+    """Regression pin for docker_env config key being silently ignored.
+
+    ``terminal.docker_env`` in config.yaml specifies extra env vars to inject
+    into the Docker container at runtime.  The key was present in
+    _create_environment's container_config consumer (line ~1130) but never
+    bridged from config.yaml to TERMINAL_DOCKER_ENV, so the dict was always
+    empty regardless of what the user set.  Guard all four bridging points so
+    this cannot regress.
+    """
+    assert "docker_env" in _cli_env_map_keys()
+    assert "docker_env" in _gateway_env_map_keys()
+    assert "docker_env" in _save_config_env_sync_keys()
+    assert "TERMINAL_DOCKER_ENV" in _terminal_tool_env_var_names()

--- a/tools/terminal_tool.py
+++ b/tools/terminal_tool.py
@@ -1085,6 +1085,7 @@ def _get_env_config() -> Dict[str, Any]:
         "container_disk": _parse_env_var("TERMINAL_CONTAINER_DISK", "51200"),        # MB (default 50GB)
         "container_persistent": os.getenv("TERMINAL_CONTAINER_PERSISTENT", "true").lower() in ("true", "1", "yes"),
         "docker_volumes": _parse_env_var("TERMINAL_DOCKER_VOLUMES", "[]", json.loads, "valid JSON"),
+        "docker_env": _parse_env_var("TERMINAL_DOCKER_ENV", "{}", json.loads, "valid JSON"),
         "docker_run_as_host_user": os.getenv("TERMINAL_DOCKER_RUN_AS_HOST_USER", "false").lower() in ("true", "1", "yes"),
     }
 


### PR DESCRIPTION
## Summary
Salvage of #22626 — `terminal.docker_env` from `config.yaml` is now bridged to the `TERMINAL_DOCKER_ENV` env var that `terminal_tool.py` reads, so user-configured `-e KEY=VAL` env vars actually get passed into Docker containers.

## Root cause
Four-point bridging gap:
- `cli.py::env_mappings` (~L516): no `docker_env` key
- `gateway/run.py::_terminal_env_map` (~L388): same omission
- `hermes_cli/config.py::_config_to_env_sync` (~L4807): didn't persist to `.env`
- `tools/terminal_tool.py::_get_env_config` (~L1085): didn't read it back

`terminal_tool.py:1130` reads `cc["docker_env"]` and passes it to `_DockerEnvironment`, which iterates `self._env` into `-e KEY=VAL` args. The defect was purely in the bridging layer.

## Changes (contributor commit)
- All four bridges added with the right env-var name (`TERMINAL_DOCKER_ENV`) and parser (`json.loads`, default `"{}"`). Serialisation widened from `isinstance(val, list)` to `isinstance(val, (list, dict))` in cli.py and gateway/run.py.
- New regression test `test_docker_env_is_bridged_everywhere` pinning all four sites.

## Validation
- 5/5 tests pass on the salvage branch.

Closes #20537 via salvage.
