### PR TITLE
fix(error_classifier): classify generic-typed timeout messages as transient (carve-out of #22664)

### DIFF
--- a/agent/error_classifier.py
+++ b/agent/error_classifier.py
@@ -254,6 +254,20 @@ _THINKING_SIG_PATTERNS = [
     "signature",  # Combined with "thinking" check
 ]
 
+# Message-string patterns that indicate a provider-side timeout even when
+# the exception type is generic (e.g. RuntimeError from a local shim that
+# wraps a subprocess timeout).  Checked before the type-based transport
+# heuristics so custom-provider "timed out" errors don't fall through to
+# the unknown bucket and get misreported as empty responses.
+_TIMEOUT_MESSAGE_PATTERNS = [
+    "timed out",
+    "turn timed out",
+    "request timed out",
+    "deadline exceeded",
+    "operation timed out",
+    "upstream timed out",
+]
+
 # Transport error type names
 _TRANSPORT_ERROR_TYPES = frozenset({
     "ReadTimeout", "ConnectTimeout", "PoolTimeout",
@@ -962,6 +976,14 @@ def _classify_by_message(
             retryable=False,
             should_fallback=True,
         )
+
+    # Timeout message patterns — generic exception types (e.g. RuntimeError)
+    # raised by local shims or custom providers that internally wrap a
+    # subprocess/HTTP timeout.  Classified as transport timeout so the retry
+    # loop rebuilds the client instead of treating the turn as an empty
+    # model response.
+    if any(p in error_msg for p in _TIMEOUT_MESSAGE_PATTERNS):
+        return result_fn(FailoverReason.timeout, retryable=True)
 
     return None
 

--- a/tests/agent/test_error_classifier.py
+++ b/tests/agent/test_error_classifier.py
@@ -587,6 +587,28 @@ class TestClassifyApiError:
         result = classify_api_error(e)
         assert result.reason == FailoverReason.timeout
 
+    def test_runtime_error_cli_turn_timed_out_classifies_as_timeout(self):
+        # RuntimeError from a local claude-cli shim that wraps a subprocess
+        # timeout must classify as FailoverReason.timeout, not unknown, so
+        # the retry loop rebuilds the client instead of treating the turn as
+        # an empty model response (#22548).
+        e = RuntimeError("claude CLI turn timed out")
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.timeout
+        assert result.retryable is True
+
+    def test_runtime_error_request_timed_out_classifies_as_timeout(self):
+        e = RuntimeError("request timed out after 120s")
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.timeout
+        assert result.retryable is True
+
+    def test_runtime_error_deadline_exceeded_classifies_as_timeout(self):
+        e = RuntimeError("deadline exceeded")
+        result = classify_api_error(e)
+        assert result.reason == FailoverReason.timeout
+        assert result.retryable is True
+
     # ── Error code classification ──
 
     def test_error_code_resource_exhausted(self):


### PR DESCRIPTION
## Summary
Salvage of #22664's classifier portion — `_classify_by_message` now recognizes timeout-shaped messages on generic exception types (e.g. `RuntimeError("claude CLI turn timed out")` from a local OpenAI-compatible shim).

## Root cause
`agent/error_classifier.py::_classify_by_message` covered billing / rate_limit / auth / context_overflow / model_not_found patterns but had no timeout-message branch. The type-based check requires `isinstance(error, (TimeoutError, ConnectionError, OSError))`, so a plain `RuntimeError("…timed out")` didn't match. Result: timeouts from a local shim fell through to `FailoverReason.unknown`, surfaced as "Empty response from model", and burned 3 retry slots on the same dead endpoint.

## Changes (carve-out from #22664)
- `agent/error_classifier.py`: new `_TIMEOUT_MESSAGE_PATTERNS` list (`"timed out"`, `"deadline exceeded"`, `"request timed out"`, `"operation timed out"`, `"upstream timed out"`, `"turn timed out"`). `_classify_by_message` returns `FailoverReason.timeout` (retryable=True) when any pattern matches.
- 3 regression tests covering RuntimeError CLI-turn-timeout, request-timed-out, and deadline-exceeded.

## Carve-out rationale
The original PR #22664 also bundled:
- A fallback self-selection guard — already on main via #22780, redundant.
- A DeepSeek thinking-block extraction — already on main via #22643/#22798.
- session_search content_session_id routing (#22150) — separate concern.

This carve-out keeps just the title-described classifier work.

## Validation
- 13/13 timeout / timed_out tests pass on the salvage branch.

Follow-up to #22780 — fixes the still-broken classification of generic-typed provider-shim timeouts that #22780's dedup couldn't cover.
