### PR TITLE
fix(tui): sync history rewrites to session db and agent flush cursor

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1973,6 +1973,61 @@ def test_session_compress_syncs_session_key_after_rotation(monkeypatch):
         server._sessions.pop("sid", None)
 
 
+def test_session_compress_rewrites_db_history_and_syncs_agent_state(monkeypatch):
+    class _FakeDB:
+        def __init__(self):
+            self.rewrites = []
+
+        def replace_messages(self, target, messages):
+            self.rewrites.append((target, list(messages)))
+
+    db = _FakeDB()
+    compressed = [{"role": "assistant", "content": "compressed handoff"}]
+    agent = types.SimpleNamespace(
+        session_id="rotated-id",
+        _last_flushed_db_idx=99,
+        _session_messages=[{"role": "user", "content": "stale"}],
+    )
+    server._sessions["sid"] = _session(
+        agent=agent,
+        history=[
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+            {"role": "user", "content": "follow-up"},
+            {"role": "assistant", "content": "answer"},
+        ],
+        session_key="old-key",
+    )
+
+    def _fake_compress(session, focus_topic=None, **_kw):
+        with session["history_lock"]:
+            session["history"] = list(compressed)
+            session["history_version"] = int(session.get("history_version", 0)) + 1
+        return 3, {"total": 42}
+
+    monkeypatch.setattr(server, "_get_db", lambda: db)
+    monkeypatch.setattr(server, "_compress_session_history", _fake_compress)
+    monkeypatch.setattr(server, "_session_info", lambda _agent: {"model": "x"})
+    monkeypatch.setattr(server, "_restart_slash_worker", lambda _s: None)
+
+    try:
+        with patch("tui_gateway.server._emit"):
+            resp = server.handle_request(
+                {
+                    "id": "1",
+                    "method": "session.compress",
+                    "params": {"session_id": "sid"},
+                }
+            )
+
+        assert resp["result"]["removed"] == 3
+        assert db.rewrites == [("rotated-id", compressed)]
+        assert agent._last_flushed_db_idx == len(compressed)
+        assert agent._session_messages == compressed
+    finally:
+        server._sessions.pop("sid", None)
+
+
 def test_prompt_submit_sets_approval_session_key(monkeypatch):
     from tools.approval import get_current_session_key
 
@@ -2559,7 +2614,20 @@ def test_session_undo_rejects_while_running():
 
 def test_session_undo_allowed_when_idle():
     """Regression guard: when not running, /undo still works."""
+    class _FakeDB:
+        def __init__(self):
+            self.rewrites = []
+
+        def replace_messages(self, target, messages):
+            self.rewrites.append((target, list(messages)))
+
+    db = _FakeDB()
+    agent = types.SimpleNamespace(
+        _last_flushed_db_idx=99,
+        _session_messages=[{"role": "assistant", "content": "stale"}],
+    )
     server._sessions["sid"] = _session(
+        agent=agent,
         running=False,
         history=[
             {"role": "user", "content": "hi"},
@@ -2567,12 +2635,65 @@ def test_session_undo_allowed_when_idle():
         ],
     )
     try:
-        resp = server.handle_request(
-            {"id": "1", "method": "session.undo", "params": {"session_id": "sid"}}
-        )
+        with patch("tui_gateway.server._get_db", lambda: db):
+            resp = server.handle_request(
+                {"id": "1", "method": "session.undo", "params": {"session_id": "sid"}}
+            )
         assert resp.get("result"), f"got error: {resp.get('error')}"
         assert resp["result"]["removed"] == 2
         assert server._sessions["sid"]["history"] == []
+        assert db.rewrites == [("session-key", [])]
+        assert agent._last_flushed_db_idx == 0
+        assert agent._session_messages == []
+    finally:
+        server._sessions.pop("sid", None)
+
+
+def test_rollback_restore_rewrites_db_history_and_syncs_agent_state():
+    class _FakeDB:
+        def __init__(self):
+            self.rewrites = []
+
+        def replace_messages(self, target, messages):
+            self.rewrites.append((target, list(messages)))
+
+    class _Mgr:
+        enabled = True
+
+        def restore(self, cwd, target, file_path=None):
+            return {"success": True}
+
+    db = _FakeDB()
+    agent = types.SimpleNamespace(
+        _checkpoint_mgr=_Mgr(),
+        _last_flushed_db_idx=99,
+        _session_messages=[{"role": "assistant", "content": "stale"}],
+    )
+    server._sessions["sid"] = _session(
+        agent=agent,
+        history=[
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ],
+    )
+    try:
+        with patch("tui_gateway.server._get_db", lambda: db), patch(
+            "tui_gateway.server._resolve_checkpoint_hash",
+            lambda mgr, cwd, ref: "resolved-hash",
+        ):
+            resp = server.handle_request(
+                {
+                    "id": "1",
+                    "method": "rollback.restore",
+                    "params": {"session_id": "sid", "hash": "abc"},
+                }
+            )
+        assert resp["result"]["success"] is True
+        assert resp["result"]["history_removed"] == 2
+        assert server._sessions["sid"]["history"] == []
+        assert db.rewrites == [("session-key", [])]
+        assert agent._last_flushed_db_idx == 0
+        assert agent._session_messages == []
     finally:
         server._sessions.pop("sid", None)
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1272,6 +1272,34 @@ def _sync_session_key_after_compress(
             pass
 
 
+def _rewrite_session_history(session: dict, messages: list | None = None) -> None:
+    """Persist an in-memory history rewrite and realign agent transcript state."""
+
+    if messages is None:
+        with session["history_lock"]:
+            messages = list(session.get("history", []))
+    else:
+        messages = list(messages)
+
+    session_key = str(session.get("session_key", "") or "")
+    db = _get_db()
+    if db is not None and session_key:
+        try:
+            db.replace_messages(session_key, messages)
+        except Exception:
+            logger.debug(
+                "Failed to rewrite TUI transcript for %s", session_key, exc_info=True
+            )
+
+    agent = session.get("agent")
+    if agent is None:
+        return
+    if hasattr(agent, "_session_messages"):
+        agent._session_messages = list(messages)
+    if hasattr(agent, "_last_flushed_db_idx"):
+        agent._last_flushed_db_idx = len(messages)
+
+
 def _get_usage(agent) -> dict:
     g = lambda k, fb=None: getattr(agent, k, 0) or (getattr(agent, fb, 0) if fb else 0)
     usage = {
@@ -2503,6 +2531,11 @@ def _(rid, params: dict) -> dict:
             removed += 1
         if removed:
             session["history_version"] = int(session.get("history_version", 0)) + 1
+            rewritten = list(history)
+        else:
+            rewritten = None
+    if rewritten is not None:
+        _rewrite_session_history(session, rewritten)
     return _ok(rid, {"removed": removed})
 
 
@@ -2573,6 +2606,7 @@ def _(rid, params: dict) -> dict:
             )
             agent = session["agent"]
             _sync_session_key_after_compress(sid, session)
+            _rewrite_session_history(session, messages)
             summary = summarize_manual_compression(
                 before_messages, messages, before_tokens, after_tokens
             )
@@ -5879,6 +5913,11 @@ def _(rid, params: dict) -> dict:
                         session["history_version"] = (
                             int(session.get("history_version", 0)) + 1
                         )
+                        rewritten = list(history)
+                    else:
+                        rewritten = None
+                if rewritten is not None:
+                    _rewrite_session_history(session, rewritten)
                 result["history_removed"] = removed
             return result
 


### PR DESCRIPTION
## What does this PR do?

Fixes a TUI session persistence bug where history-mutating commands updated only the in-memory transcript and left the persisted SessionDB transcript stale.

Before this change:
- `session.undo` removed turns from `session["history"]`, but resumed sessions and `session.history` could still show the old DB transcript.
- Manual `session.compress` replaced the in-memory history, but the rewritten compressed transcript was not persisted to the active session row.
- Full-history `rollback.restore` trimmed the in-memory transcript, but did not rewrite the stored conversation.
- After any of those mutations, the agent's append-only DB cursor (`_last_flushed_db_idx`) could stay out of sync with the new transcript length.

This PR adds a small TUI-local rewrite helper that:
- rewrites the current session transcript via `SessionDB.replace_messages(...)`
- updates the agent's `_session_messages`
- re-aligns `_last_flushed_db_idx`

That helper is now called after:
- `session.undo`
- manual `session.compress`
- full-history `rollback.restore`

This keeps TUI session history, persisted transcript state, and future DB flushes consistent.

## Related Issue


## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Added `_rewrite_session_history(...)` in `tui_gateway/server.py`
- Persisted rewritten history after `session.undo`
- Persisted rewritten history after manual `session.compress`
- Persisted rewritten history after full-history `rollback.restore`
- Synced agent transcript state after those rewrites
- Added regression tests in `tests/test_tui_gateway_server.py` for:
  - undo DB rewrite + cursor sync
  - compress DB rewrite + cursor sync
  - rollback DB rewrite + cursor sync

## How to Test

1. Start a TUI session and generate a few turns.
2. Trigger one of the history-mutating paths:
   - `session.undo`
   - manual `session.compress`
   - full-history `rollback.restore`
3. Re-open the session or inspect `session.history`.
4. Confirm the persisted transcript matches the rewritten in-memory history.
5. Send another turn and confirm subsequent transcript writes continue normally.

Regression tests:


.\.venv\Scripts\python.exe -m pytest tests/test_tui_gateway_server.py -k "session_undo_allowed_when_idle or session_compress_rewrites_db_history_and_syncs_agent_state or rollback_restore_rewrites_db_history_and_syncs_agent_state"

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11, Python 3.11.15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the compatibility guide — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted regression tests passed:

- `test_session_undo_allowed_when_idle`
- `test_rollback_restore_rewrites_db_history_and_syncs_agent_state`
- `test_session_compress_rewrites_db_history_and_syncs_agent_state`
