### PR TITLE
feat(cron/logs): Change name truncation in job creation and normalization

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -119,7 +119,7 @@ def _normalize_job_record(job: Dict[str, Any]) -> Dict[str, Any]:
             or job_id
             or "cron job"
         )
-        name = label_source[:50].strip() or "cron job"
+        name = label_source.strip() or "cron job"
     normalized["name"] = name
     normalized["schedule_display"] = _schedule_display_for_job(normalized)
 
@@ -596,7 +596,7 @@ def create_job(
     label_source = (prompt_text or (normalized_skills[0] if normalized_skills else None) or (normalized_script if normalized_no_agent else None)) or "cron job"
     job = {
         "id": job_id,
-        "name": name or label_source[:50].strip(),
+        "name": name or label_source.strip(),
         "prompt": prompt_text,
         "skills": normalized_skills,
         "skill": normalized_skills[0] if normalized_skills else None,

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -254,6 +254,15 @@ class TestJobCRUD:
         job = create_job(prompt="Test", schedule="30m")
         assert job["deliver"] == "local"
 
+    def test_create_job_preserves_full_auto_generated_name(self, tmp_cron_dir):
+        prompt = "A" * 80
+
+        job = create_job(prompt=prompt, schedule="every 1h")
+
+        assert job["name"] == prompt
+        fetched = get_job(job["id"])
+        assert fetched["name"] == prompt
+
 
 class TestUpdateJob:
     def test_update_name(self, tmp_cron_dir):
@@ -359,6 +368,25 @@ class TestMarkJobRun:
         updated = get_job(job["id"])
         assert updated["last_status"] == "error"
         assert updated["last_error"] == "timeout"
+
+
+class TestJobNormalization:
+    def test_list_jobs_preserves_full_fallback_name_for_legacy_records(self, tmp_cron_dir):
+        prompt = "B" * 90
+        save_jobs([
+            {
+                "id": "longname123456",
+                "name": None,
+                "prompt": prompt,
+                "schedule_display": "every 60m",
+                "schedule": {"kind": "interval", "minutes": 60, "display": "every 60m"},
+                "enabled": True,
+            }
+        ])
+
+        jobs = list_jobs()
+
+        assert jobs[0]["name"] == prompt
 
     def test_delivery_error_tracked_separately(self, tmp_cron_dir):
         """Agent succeeds but delivery fails — both tracked independently."""


### PR DESCRIPTION
## Summary

Update the content inside log files generated by cron

## Changes

- Preserve full prompt text in job name when label source is long
- Ensure fallback name uses stripped label source instead of truncated version
- Verify full names are retained during job list retrieval

Previous truncation caused job names to be cut off at 50 chars, losing descriptive context. This change ensures names match the original input length when possible, improving visibility and debugging

## Local tests

#### Example of log title generated using feature branch:

```
# Cron Job: Make Hermes backup using output in "/Users/kandy/Google Drive/My Drive/Hermes Agent/Backup"

**Job ID:** f3bd25ddb2d8
**Run Time:** 2026-05-10 10:36:00
**Schedule:** once in 1m
```

#### Example of log title generated using upstream branch:

```
# Cron Job: Make Hermes backup using output equal to "/Users/k

**Job ID:** 5c211e116d86
**Run Time:** 2026-05-10 09:40:05
**Schedule:** once in 1m
```

Notice that the title is cut off there