### PR TITLE
feat: pre-budget pause with structured audit state capture

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2416,6 +2416,13 @@ class HermesCLI:
                 self.max_turns = 90
         else:
             self.max_turns = 90
+
+        # Pre-budget warning: emit audit dump when remaining <= N
+        self.prebudget_warn_at = (
+            CLI_CONFIG["agent"].get("prebudget_warn_at", 10)
+            if "prebudget_warn_at" in CLI_CONFIG.get("agent", {})
+            else 10
+        )
         
         # Parse and validate toolsets
         self.enabled_toolsets = toolsets
@@ -4030,6 +4037,7 @@ class HermesCLI:
                 acp_args=runtime.get("args"),
                 credential_pool=runtime.get("credential_pool"),
                 max_iterations=self.max_turns,
+                prebudget_warn_at=getattr(self, "prebudget_warn_at", 10),
                 enabled_toolsets=self.enabled_toolsets,
                 disabled_toolsets=self.disabled_toolsets,
                 verbose_logging=self.verbose,
@@ -7249,6 +7257,7 @@ class HermesCLI:
                     acp_command=turn_route["runtime"].get("command"),
                     acp_args=turn_route["runtime"].get("args"),
                     max_iterations=self.max_turns,
+                    prebudget_warn_at=getattr(self, "prebudget_warn_at", 10),
                     enabled_toolsets=self.enabled_toolsets,
                     quiet_mode=True,
                     verbose_logging=False,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -9658,12 +9658,14 @@ class GatewayRunner:
             self._reasoning_config = reasoning_config
             self._service_tier = self._load_service_tier()
             turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
+            max_iterations_cfg = agent_cfg.get("prebudget_warn_at", 10) if "prebudget_warn_at" in agent_cfg else 10
 
             def run_sync():
                 agent = AIAgent(
                     model=turn_route["model"],
                     **turn_route["runtime"],
                     max_iterations=max_iterations,
+                    prebudget_warn_at=max_iterations_cfg,
                     quiet_mode=True,
                     verbose_logging=False,
                     enabled_toolsets=enabled_toolsets,

--- a/run_agent.py
+++ b/run_agent.py
@@ -293,12 +293,20 @@ class IterationBudget:
 
     ``execute_code`` (programmatic tool calling) iterations are refunded via
     :meth:`refund` so they don't eat into the budget.
+
+    Pre-budget warning: when ``warn_at`` is set and remaining drops to
+    ``warn_at``, ``on_warn(used, max_total)`` is called exactly once per
+    budget cycle.  This enables structured audit state capture before the
+    hard budget limit is reached.
     """
 
-    def __init__(self, max_total: int):
+    def __init__(self, max_total: int, on_warn: callable = None, warn_at: int = 0):
         self.max_total = max_total
         self._used = 0
         self._lock = threading.Lock()
+        self._on_warn = on_warn  # callable(used: int, max_total: int) -> None
+        self._warn_at = warn_at
+        self._warned = False  # ensure on_warn fires exactly once
 
     def consume(self) -> bool:
         """Try to consume one iteration.  Returns True if allowed."""
@@ -306,6 +314,17 @@ class IterationBudget:
             if self._used >= self.max_total:
                 return False
             self._used += 1
+            # Fire warning callback exactly once when remaining drops to warn_at
+            if not self._warned and self._warn_at > 0:
+                remaining = self.max_total - self._used
+                if remaining <= self._warn_at:
+                    self._warned = True
+                    if self._on_warn is not None:
+                        try:
+                            self._on_warn(self._used, self.max_total)
+                        except Exception:
+                            # Never let callback failure crash the budget mechanism
+                            logger.debug("Budget on_warn callback failed", exc_info=True)
             return True
 
     def refund(self) -> None:
@@ -1060,6 +1079,7 @@ class AIAgent:
         args: list[str] | None = None,
         model: str = "",
         max_iterations: int = 90,  # Default tool-calling iterations (shared with subagents)
+        prebudget_warn_at: int = 10,  # Emit audit dump when remaining <= N
         tool_delay: float = 1.0,
         enabled_toolsets: List[str] = None,
         disabled_toolsets: List[str] = None,
@@ -1125,6 +1145,7 @@ class AIAgent:
             api_mode (str): API mode override: "chat_completions" or "codex_responses"
             model (str): Model name to use (default: "anthropic/claude-opus-4.6")
             max_iterations (int): Maximum number of tool calling iterations (default: 90)
+            prebudget_warn_at (int): Emit structured audit dump when remaining iterations <= N. Default: 10.
             tool_delay (float): Delay between tool calls in seconds (default: 1.0)
             enabled_toolsets (List[str]): Only enable tools from these toolsets (optional)
             disabled_toolsets (List[str]): Disable tools from these toolsets (optional)
@@ -1167,9 +1188,19 @@ class AIAgent:
 
         self.model = model
         self.max_iterations = max_iterations
+        # Pre-budget warning: fire an audit dump when remaining <= this value
+        self.prebudget_warn_at = prebudget_warn_at
         # Shared iteration budget — parent creates, children inherit.
         # Consumed by every LLM turn across parent + all subagents.
-        self.iteration_budget = iteration_budget or IterationBudget(max_iterations)
+        # Wire callback via lambda to avoid early-bound-method resolution.
+        budget = iteration_budget
+        if budget is None:
+            budget = IterationBudget(
+                max_iterations,
+                on_warn=lambda used, max_total: self._on_budget_warn(used, max_total),
+                warn_at=self.prebudget_warn_at,
+            )
+        self.iteration_budget = budget
         self.tool_delay = tool_delay
         self.save_trajectories = save_trajectories
         self.verbose_logging = verbose_logging
@@ -2801,6 +2832,156 @@ class AIAgent:
             except Exception:
                 logger.debug("status_callback error in _emit_status", exc_info=True)
 
+    def _on_budget_warn(self, used: int, max_total: int) -> None:
+        """Called by IterationBudget.consume() when remaining <= warn_at.
+
+        Emits a structured audit state dump to both CLI and gateway channels.
+        Also returns the dump text for callers that need to log it or inject it.
+        """
+        dump = self._build_audit_dump(used, max_total)
+        self._emit_status(dump)
+        logger.info("Pre-budget audit dump emitted (%d/%d iterations used)", used, max_total)
+
+    def _build_audit_dump(self, used: int, max_total: int) -> str:
+        """Build the full structured audit dump text.
+
+        Returns a multi-section markdown-style status report that captures
+        enough context to enable resumption in a new session.
+        """
+        from datetime import datetime, timezone
+
+        now = datetime.now(timezone.utc).strftime("%Y-%m-%d %H:%M:%S UTC")
+        model_info = f"{self.model} ({self.provider})" if self.provider else self.model
+        remaining = max_total - used
+
+        lines = []
+        lines.append(f"⚠️  Pre-Budget Pause -- Audit State")
+        lines.append("")
+        lines.append(f"**Session**: `{self.session_id or 'unknown'}`")
+        lines.append(f"**Model**: {model_info}")
+        lines.append(f"**Iterations**: {used} / {max_total} used, {remaining} remaining")
+        lines.append(f"**Time**: {now}")
+        lines.append("")
+
+        # --- Current Task ---
+        lines.append("### Current Task")
+        lines.append("")
+        # Extract the most recent user message (last user-role message in messages)
+        task_preview = "N/A"
+        last_assistant_text = ""
+        # We don't have direct access to `messages` here -- the budget callback
+        # fires from consume() which is called early in the loop.  We capture
+        # what we can from available state.  The hard-exhaustion path has full
+        # access to messages and will inject the richer dump there.
+        user_msg = getattr(self, "_pending_user_message", None)
+        if user_msg:
+            task_preview = str(user_msg)[:600]
+        else:
+            task_preview = "Session in progress"
+        lines.append(f"> {task_preview}")
+        lines.append("")
+
+        # --- Files Modified ---
+        lines.append("### Files Modified")
+        lines.append("")
+        file_changes = self._get_file_diff_summary()
+        if file_changes:
+            lines.append(file_changes)
+        else:
+            lines.append("No files changed in this turn.")
+        lines.append("")
+
+        # --- Decisions & Assumptions ---
+        lines.append("### Next Steps")
+        lines.append("")
+        lines.append("The agent was mid-task when the pre-budget warning fired. To resume:")
+        lines.append(f"1. `hermes --resume {self.session_id or 'latest'}`")
+        lines.append("2. The full conversation history is preserved in the session DB")
+        lines.append("3. Continue from where the agent left off")
+        lines.append("")
+
+        return "\n".join(lines)
+
+    def _get_file_diff_summary(self) -> str:
+        """Get a summary of modified files in the working directory.
+
+        Uses git diff --stat when available, falls back to git status.
+        Cap at 30 files to avoid bloating the dump.
+        """
+        # Try git diff --stat HEAD first
+        try:
+            import subprocess
+            result = subprocess.run(
+                ["git", "diff", "--stat", "HEAD"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                cwd=getattr(self, "_cwd", os.getcwd()),
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                # Format: " 3 files changed, 12 insertions(+), 4 deletions(-)"
+                # followed by " file | +/-" lines
+                stats = result.stdout.strip()
+                # Get changed file paths
+                lines_out = stats.split("\n")
+                if len(lines_out) > 1:
+                    # File list is all lines except the summary line
+                    file_list = [l for l in lines_out if "|" in l or "*" in l]
+                    if not file_list:
+                        file_list = [l for l in lines_out[:-1] if l.strip()]
+                    if file_list:
+                        return f"_Changed {stats.split(chr(10))[0].strip()}_\n\n" + "\n".join(
+                            f"- `{f.split('|')[0].strip()}`"
+                            for f in file_list[:30]
+                        )
+                return f"_{stats.split(chr(10))[0].strip()}_\n"
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            pass
+
+        # Fallback: git status --short
+        try:
+            result = subprocess.run(
+                ["git", "status", "--short", "--untracked-files=no"],
+                capture_output=True,
+                text=True,
+                timeout=10,
+                cwd=getattr(self, "_cwd", os.getcwd()),
+            )
+            if result.returncode == 0 and result.stdout.strip():
+                paths = []
+                for line in result.stdout.strip().split("\n")[:30]:
+                    parts = line.split("  ", 1)
+                    if len(parts) == 2:
+                        paths.append(f"- `{parts[1].strip()}`")
+                if paths:
+                    return "\n".join(paths)
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            pass
+
+        # Final fallback: list recently modified .py/.rs/.md files
+        try:
+            cwd = getattr(self, "_cwd", os.getcwd())
+            cutoff = time.time() - 3600  # last hour
+            recent = []
+            for root, _, files in os.walk(cwd):
+                if any(skip in root for skip in {".git", "__pycache__", "node_modules", ".venv", "venv", "build", "target"}):
+                    continue
+                for f in files:
+                    if f.endswith((".py", ".rs", ".md", ".yaml", ".yml", ".json", ".toml", ".sh", ".ts", ".tsx", ".js", ".jsx", ".css", ".html")):
+                        fp = os.path.join(root, f)
+                        try:
+                            if os.path.getmtime(fp) > cutoff:
+                                rel = os.path.relpath(fp, cwd)
+                                recent.append(f"- `{rel}`")
+                        except OSError:
+                            pass
+            if recent:
+                return "\n".join(recent[:30])
+        except Exception:
+            pass
+
+        return ""
+
     def _emit_warning(self, message: str) -> None:
         """Emit a user-visible warning through the same status plumbing.
 
@@ -2838,6 +3019,67 @@ class AIAgent:
             "api_key": getattr(self, "api_key", "") or "",
             "api_mode": getattr(self, "api_mode", "") or "",
         }
+
+    def _build_exhaustion_injection(self, messages: list, api_call_count: int) -> str:
+        """Build a compressed audit state string for injection into messages.
+
+        This is injected BEFORE the summary request when hard budget
+        exhaustion happens.  It gives the model accurate context so it can
+        summarise what was accomplished rather than hallucinating.
+
+        Unlike the pre-budget dump (which is for the user), this is designed
+        to be read by the model — compact, structured, tool-call aware.
+        """
+        # Gather last N assistant tool calls for "Recent Activity"
+        messages_list = list(messages)
+
+        recent_tools = []
+        for msg in reversed(messages_list[-60:]):
+            if msg.get("role") == "assistant" and msg.get("tool_calls"):
+                for tc in msg["tool_calls"]:
+                    if isinstance(tc, dict):
+                        name = tc.get("function", {}).get("name", "unknown")
+                        args = tc.get("function", {}).get("arguments", "{}")
+                        recent_tools.append((name, args[:200]))
+                    elif hasattr(tc, "function"):
+                        name = tc.function.name
+                        args = tc.function.arguments
+                        recent_tools.append((name, args[:200]))
+                if len(recent_tools) >= 5:
+                    break
+
+        # Extract last assistant reasoning content (for "Next Steps")
+        next_steps = "Continue the task where the agent left off."
+        for msg in reversed(messages_list[-20:]):
+            if msg.get("role") == "assistant" and msg.get("reasoning"):
+                reasoning = msg["reasoning"]
+                if reasoning:
+                    # Take last 300 chars of reasoning as "next steps"
+                    next_steps = reasoning[-300:].strip()
+                    break
+
+        # File diff summary
+        file_changes = self._get_file_diff_summary()
+        file_section = f"\nFiles changed: {file_changes}" if file_changes else ""
+
+        # Build compact injection text
+        lines = [
+            "[BUDGET EXHAUSTED -- INJECTED STATE]",
+            f"Iterations used: {api_call_count}/{self.max_iterations}",
+        ]
+
+        if recent_tools:
+            tool_summary = ", ".join(
+                f"{name}(args)" for name, args in recent_tools[-5:]
+            )
+            lines.append(f"Recent tools: {tool_summary}")
+
+        lines.append(f"Next: {next_steps}")
+        if file_section:
+            lines.append(f"Files{file_section}")
+
+        lines.append("[/BUDGET EXHAUSTED -- INJECTED STATE]")
+        return "\n".join(lines)
 
     def _check_compression_model_feasibility(self) -> None:
         """Warn at session start if the auxiliary compression model's context
@@ -11194,7 +11436,14 @@ class AIAgent:
         # NOTE: _turns_since_memory and _iters_since_skill are NOT reset here.
         # They are initialized in __init__ and must persist across run_conversation
         # calls so that nudge logic accumulates correctly in CLI mode.
-        self.iteration_budget = IterationBudget(self.max_iterations)
+        # Recreate the budget each turn with prebudget_warn_at so subagents
+        # don't carry over the parent's _warned flag and so a new turn gets
+        # its own fresh warning cycle.
+        self.iteration_budget = IterationBudget(
+            self.max_iterations,
+            on_warn=lambda used, max_total: self._on_budget_warn(used, max_total),
+            warn_at=self.prebudget_warn_at,
+        )
 
         # Log conversation turn start for debugging/observability
         _preview_text = _summarize_user_message_for_log(user_message)
@@ -14603,8 +14852,10 @@ class AIAgent:
             or self.iteration_budget.remaining <= 0
         ):
             # Budget exhausted — ask the model for a summary via one extra
-            # API call with tools stripped.  _handle_max_iterations injects a
-            # user message and makes a single toolless request.
+            # API call with tools stripped.  We inject the audit dump into
+            # the messages list so the model has accurate context rather than
+            # hallucinating what it was doing.  _handle_max_iterations then
+            # appends the summary request and makes a single toolless call.
             _turn_exit_reason = f"max_iterations_reached({api_call_count}/{self.max_iterations})"
             self._emit_status(
                 f"⚠️ Iteration budget exhausted ({api_call_count}/{self.max_iterations}) "
@@ -14615,6 +14866,12 @@ class AIAgent:
                     f"\n⚠️  Iteration budget exhausted ({api_call_count}/{self.max_iterations}) "
                     "— requesting summary..."
                 )
+
+            # Inject structured audit state so the model can summarise accurately
+            inject_dump = self._build_exhaustion_injection(messages, api_call_count)
+            if inject_dump:
+                messages.append({"role": "user", "content": inject_dump})
+
             final_response = self._handle_max_iterations(messages, api_call_count)
         
         # Determine if conversation completed successfully

--- a/tests/run_agent/test_iteration_budget_race.py
+++ b/tests/run_agent/test_iteration_budget_race.py
@@ -107,3 +107,271 @@ def test_iteration_budget_remaining():
     assert budget.remaining == 2
     budget.refund()
     assert budget.remaining == 3
+
+
+# ─── Pre-budget warning tests ───────────────────────────────────────────────
+
+
+def test_budget_warn_fires_exactly_once():
+    """on_warn callback must fire exactly once when remaining crosses warn_at."""
+    from run_agent import IterationBudget
+
+    fire_count = 0
+
+    def on_warn(used, max_total):
+        nonlocal fire_count
+        fire_count += 1
+
+    budget = IterationBudget(max_total=10, on_warn=on_warn, warn_at=3)
+
+    # Consume up to the threshold: used=7, remaining=3 → fires
+    budget.consume()  # used=1, remaining=9
+    budget.consume()  # used=2, remaining=8
+    budget.consume()  # used=3, remaining=7
+    budget.consume()  # used=4, remaining=6
+    budget.consume()  # used=5, remaining=5
+    budget.consume()  # used=6, remaining=4
+    budget.consume()  # used=7, remaining=3 → fires
+    assert fire_count == 1, f"Expected 1 fire, got {fire_count}"
+
+    # Consume more — should NOT fire again
+    budget.consume()  # used=8, remaining=2
+    budget.consume()  # used=9, remaining=1
+    budget.consume()  # used=10, remaining=0
+    assert fire_count == 1, f"Expected still 1 fire, got {fire_count}"
+
+
+def test_budget_warn_no_callback_set():
+    """consume() must not crash when on_warn is None."""
+    from run_agent import IterationBudget
+
+    budget = IterationBudget(max_total=10, on_warn=None, warn_at=3)
+
+    for _ in range(10):
+        budget.consume()
+
+    # Should not raise
+
+
+def test_budget_warn_zero_warn_at_disables_warning():
+    """warn_at=0 must suppress all warning calls."""
+    from run_agent import IterationBudget
+
+    fire_count = 0
+
+    def on_warn(used, max_total):
+        nonlocal fire_count
+        fire_count += 1
+
+    budget = IterationBudget(max_total=5, on_warn=on_warn, warn_at=0)
+
+    for _ in range(5):
+        budget.consume()
+
+    assert fire_count == 0, f"Expected 0 fires with warn_at=0, got {fire_count}"
+
+
+def test_budget_warn_fires_at_correct_threshold():
+    """on_warn must receive correct used/max_total values when fired."""
+    from run_agent import IterationBudget
+
+    received_values = []
+
+    def on_warn(used, max_total):
+        received_values.append((used, max_total))
+
+    budget = IterationBudget(max_total=10, on_warn=on_warn, warn_at=2)
+
+    # consume until remaining <= 2
+    for _ in range(8):
+        budget.consume()
+
+    # At used=8, remaining=2 → should fire
+    assert len(received_values) == 1
+    assert received_values[0] == (8, 10)
+
+
+def test_budget_warn_with_refund_still_fires_once():
+    """Even if refund reduces used count, on_warn fires only once."""
+    from run_agent import IterationBudget
+
+    fire_count = 0
+
+    def on_warn(used, max_total):
+        nonlocal fire_count
+        fire_count += 1
+
+    budget = IterationBudget(max_total=10, on_warn=on_warn, warn_at=5)
+
+    budget.consume()  # used=1, remaining=9
+    budget.consume()  # used=2, remaining=8
+    budget.consume()  # used=3, remaining=7
+    budget.consume()  # used=4, remaining=6
+    budget.consume()  # used=5, remaining=5 → fires
+    assert fire_count == 1
+
+    # Refund back to used=3, remaining=7
+    budget.refund()
+    budget.refund()
+    assert budget.used == 3
+    assert budget.remaining == 7
+
+    # Consume again — should NOT fire a second time
+    budget.consume()  # used=4, remaining=6
+    budget.consume()  # used=5, remaining=5
+    budget.consume()  # used=6, remaining=4
+    budget.consume()  # used=7, remaining=3
+    budget.consume()  # used=8, remaining=2
+    assert fire_count == 1, f"Expected still 1 fire after refund+reconsume, got {fire_count}"
+
+
+def test_budget_warn_in_callback_does_not_infinite_loop():
+    """on_warn callback must not be called from within consume() reentrantly."""
+    from run_agent import IterationBudget
+
+    # The callback fires from within the lock — if it calls consume(),
+    # the lock is NOT reentrant, so this could deadlock with a regular Lock.
+    # Since we use a non-reentrant Lock, this test verifies the callback
+    # does not hold the lock when calling user code (or that user code
+    # can safely not call consume).
+    budget = IterationBudget(max_total=5, warn_at=2)
+    # Just ensure consume doesn't deadlock even with a callback that
+    # tries to acquire the same lock (by checking remaining inside).
+    remaining_during_callback = []
+
+    def on_warn(used, max_total):
+        remaining_during_callback.append(max_total - used)
+
+    budget = IterationBudget(max_total=5, on_warn=on_warn, warn_at=2)
+
+    for _ in range(5):
+        budget.consume()
+
+    assert len(remaining_during_callback) == 1
+    assert remaining_during_callback[0] <= 2
+
+
+def test_audit_dump_structure():
+    """_build_audit_dump must return a multi-section structured dump."""
+    import unittest.mock as mock
+    from run_agent import AIAgent
+
+    # Mock provider resolution to avoid real API key lookup
+    with mock.patch("agent.auxiliary_client.resolve_provider_client", return_value=(None, None)):
+        agent = AIAgent(
+            model="anthropic/claude-sonnet-4-20250514",
+            provider="anthropic",
+            api_key="test-key",
+            max_iterations=10,
+            prebudget_warn_at=5,
+            quiet_mode=True,
+        )
+
+    dump = agent._build_audit_dump(5, 10)
+
+    # Must contain required sections
+    assert "Pre-Budget Pause" in dump
+    assert "Session" in dump
+    assert "Model" in dump
+    assert "Iterations" in dump
+    assert "5 / 10 used" in dump
+    assert "5 remaining" in dump
+    assert "Current Task" in dump
+    assert "Files Modified" in dump
+    assert "Next Steps" in dump
+
+
+def test_exhaustion_injection_structure():
+    """_build_exhaustion_injection must return a compact model-readable dump."""
+    import unittest.mock as mock
+    from run_agent import AIAgent
+
+    with mock.patch("agent.auxiliary_client.resolve_provider_client", return_value=(None, None)):
+        agent = AIAgent(
+            model="anthropic/claude-sonnet-4-20250514",
+            provider="anthropic",
+            api_key="test-key",
+            max_iterations=10,
+            quiet_mode=True,
+        )
+
+    messages = [
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi there", "tool_calls": [
+            {"function": {"name": "read_file", "arguments": '{"path": "test.py"}'}},
+        ]},
+        {"role": "tool", "content": "file contents"},
+        {"role": "assistant", "content": "I found the file", "tool_calls": [
+            {"function": {"name": "search_files", "arguments": '{"pattern": "foo"}'}},
+        ]},
+        {"role": "tool", "content": "3 matches found"},
+        {"role": "assistant", "content": "Found matches", "reasoning": "Now I will patch the file to fix the bug."},
+    ]
+
+    injection = agent._build_exhaustion_injection(messages, 8)
+
+    assert "[BUDGET EXHAUSTED" in injection
+    assert "[/BUDGET EXHAUSTED" in injection
+    assert "8/10" in injection
+    assert "read_file" in injection
+    assert "search_files" in injection
+    assert "patch the file" in injection
+
+
+def test_exhaustion_injection_empty_messages():
+    """_build_exhaustion_injection must handle empty messages gracefully."""
+    import unittest.mock as mock
+    from run_agent import AIAgent
+
+    with mock.patch("agent.auxiliary_client.resolve_provider_client", return_value=(None, None)):
+        agent = AIAgent(
+            model="anthropic/claude-sonnet-4-20250514",
+            provider="anthropic",
+            api_key="test-key",
+            max_iterations=10,
+            quiet_mode=True,
+        )
+
+    injection = agent._build_exhaustion_injection([], 0)
+
+    assert "[BUDGET EXHAUSTED" in injection
+    assert "[/BUDGET EXHAUSTED" in injection
+
+
+def test_exhaustion_injection_no_reasoning():
+    """_build_exhaustion_injection uses default next steps when no reasoning exists."""
+    import unittest.mock as mock
+    from run_agent import AIAgent
+
+    with mock.patch("agent.auxiliary_client.resolve_provider_client", return_value=(None, None)):
+        agent = AIAgent(
+            model="anthropic/claude-sonnet-4-20250514",
+            provider="anthropic",
+            api_key="test-key",
+            max_iterations=10,
+            quiet_mode=True,
+        )
+
+    messages = [
+        {"role": "user", "content": "Hello"},
+        {"role": "assistant", "content": "Hi there"},
+    ]
+
+    injection = agent._build_exhaustion_injection(messages, 1)
+
+    assert "Continue the task" in injection
+
+
+def test_iteration_budget_callback_exception_does_not_crash():
+    """If on_warn raises an exception, consume() must still return correctly."""
+    from run_agent import IterationBudget
+
+    def bad_callback(used, max_total):
+        raise ValueError("kaboom")
+
+    budget = IterationBudget(max_total=5, on_warn=bad_callback, warn_at=3)
+
+    # This should not raise — the exception is caught inside consume()
+    result = budget.consume()
+    assert result is True
+    assert budget.used == 1

--- a/website/docs/developer-guide/agent-loop.md
+++ b/website/docs/developer-guide/agent-loop.md
@@ -179,11 +179,29 @@ These tools modify agent state directly and return synthetic tool results withou
 
 ### Iteration Budget
 
-The agent tracks iterations via `IterationBudget`:
+The agent tracks iterations via `IterationBudget` (defined in `run_agent.py`):
 
 - Default: 90 iterations (configurable via `agent.max_turns`)
 - Each agent gets its own budget. Subagents get independent budgets capped at `delegation.max_iterations` (default 50) — total iterations across parent + subagents can exceed the parent's cap
-- At 100%, the agent stops and returns a summary of work done
+- Thread-safe via `threading.Lock` — `used`, `remaining`, `consume()`, `refund()` all acquire the lock
+- `consume()` returns `False` when the budget is exhausted
+- `refund()` gives back one iteration (used by `execute_code` tool)
+
+**Pre-budget warning:** `IterationBudget` supports an `on_warn` callback that fires exactly once when remaining drops to `warn_at` (configurable via `agent.prebudget_warn_at`, default 10). This enables structured audit state capture before the hard limit is hit. The callback signature is `on_warn(used: int, max_total: int) -> None` and errors in the callback are caught so they can't crash the budget mechanism.
+
+**Hard budget exhaustion:** When the budget is exhausted, the agent:
+1. Prints `⚠ Iteration budget exhausted (N/M iterations used)` to the user
+2. Injects a `[BUDGET EXHAUSTED -- INJECTED STATE]` block into the conversation context containing recent tool calls, last reasoning content, and file changes
+3. Calls `_handle_max_iterations()` which requests a final summary from the model via one extra toolless API call
+4. If the model doesn't produce a text response, a forced user message tells it to summarise
+
+**Config:**
+
+```yaml
+agent:
+  max_turns: 90           # Hard cap (default: 90)
+  prebudget_warn_at: 10   # Emit audit dump when remaining <= N (default: 10, 0 = off)
+```
 
 ### Fallback Model
 

--- a/website/docs/user-guide/configuration.md
+++ b/website/docs/user-guide/configuration.md
@@ -706,6 +706,20 @@ Budget pressure is enabled by default. The agent sees warnings naturally as part
 
 When the iteration budget is fully exhausted, the CLI shows a notification to the user: `⚠ Iteration budget reached (90/90) — response may be incomplete`. If the budget runs out during active work, the agent generates a summary of what was accomplished before stopping.
 
+### Pre-Budget Pause
+
+When the agent approaches the iteration limit, it can emit a structured audit state dump to give the user visibility and a resumption anchor. The dump includes session ID, model/provider, iteration count, task preview, files changed, and next-step instructions. When the hard limit is reached, the dump is also injected into the conversation context so the model's summary request has accurate state rather than hallucinating.
+
+```yaml
+agent:
+  max_turns: 90                # Max iterations per conversation turn (default: 90)
+  prebudget_warn_at: 10        # Emit audit dump when remaining <= N (default: 10, 0 = off)
+  api_max_retries: 3           # Retries per provider before fallback engages (default: 3)
+```
+
+- **`max_turns`** — Hard cap. When reached, the agent stops and attempts a final summary.
+- **`prebudget_warn_at`** — Warning threshold. When iterations remaining drops to or below this value, the agent emits a structured audit dump via CLI notification, gateway message, or log. This fires exactly once per budget cycle and does not interrupt the agent — it simply surfaces state for the user. Set to `0` to disable.
+
 `agent.api_max_retries` controls how many times Hermes retries a provider API call on transient errors (rate limits, connection drops, 5xx) **before** fallback-provider switching engages. The default is `3` — four attempts total. If you have [fallback providers](/docs/user-guide/features/fallback-providers) configured and want to fail over faster, drop this to `0` so the first transient error on your primary immediately hands off to the fallback instead of churning retries against the flaky endpoint.
 
 ### API Timeouts


### PR DESCRIPTION
# feat: pre-budget pause with structured audit state capture

## Problem

When Hermes reaches its iteration budget (`agent.max_turns`), the agent loop
abruptly terminates. The user is left with a truncated conversation and no
coherent record of what was being worked on, making recovery on a new session
lossy and frustrating.

## Solution

Add a configurable pre-budget warning that fires when iterations remaining
drops to a threshold (default 10), emitting a structured audit state dump.
Additionally, enhance the hard-exhaustion path with injected state so the
model's summary request has accurate context.

### What it does

1. **Pre-budget warning** (when `remaining <= prebudget_warn_at`):
   - Emits a structured audit dump via `_emit_status` to both CLI and gateway
   - Includes session ID, model/provider, iteration count, task preview,
     files changed, and next-step/resume instructions
   - Logs to `agent.log` for cron/background jobs
   - Fires exactly once per budget cycle, survives refunds
   - Agent continues normally — this is visibility, not a hard stop

2. **Hard-exhaustion enhancement** (at `max_turns`):
   - Injects a `[BUDGET EXHAUSTED -- INJECTED STATE]` block into the
     messages list before the summary request
   - Contains recent tool calls + last reasoning content + file changes
   - Gives the model accurate context for summarisation instead of
     hallucinating what it was doing

### Architecture

```
Agent loop iteration N
  ├─ iteration_budget.consume() → True (remaining was 10, now 9)
  │   → _warned was False, (max - used) <= warn_at → fire on_warn
  │   → _on_budget_warn() builds and emits audit dump
  │   → _warned = True (prevents re-fire)
  ├─ build api_messages, call LLM
  └─ loop continues...
       └─ iteration_budget.consume() → False (at limit)
          └─ Inject [BUDGET EXHAUSTED] state → _handle_max_iterations()
```

### Config

```yaml
agent:
  max_turns: 150
  prebudget_warn_at: 10  # default, optional. 0 = off
```

## Files changed

| File | Change |
|------|--------|
| `run_agent.py` | IterationBudget callback mechanism, audit dump builder, file diff summary, exhaustion injection, AIAgent.__init__ param |
| `cli.py` | prebudget_warn_at loaded from config, passed to foreground/background AIAgent instances |
| `gateway/run.py` | prebudget_warn_at passed to AIAgent |
| `tests/run_agent/test_iteration_budget_race.py` | 10 new tests: single-fire, refund idempotency, callback safety, dump structure, exhaustion injection |

## Testing

All 16 tests in `test_iteration_budget_race.py` pass (6 existing + 10 new):

- `test_iteration_budget_used_is_thread_safe` — concurrent read/write lock correctness
- `test_iteration_budget_consume_returns_false_when_exhausted` — hard limit enforcement
- `test_iteration_budget_refund_restores_consume` — refund roundtrip
- `test_iteration_budget_used_reflects_consume_and_refund` — counter accuracy
- `test_iteration_budget_remaining` — property math
- `test_budget_warn_fires_exactly_once` — single-fire guarantee
- `test_budget_warn_no_callback_set` — None-callback safety
- `test_budget_warn_zero_warn_at_disables_warning` — opt-out via 0
- `test_budget_warn_fires_at_correct_threshold` — right values in callback
- `test_budget_warn_with_refund_still_fires_once` — refund doesn't re-trigger
- `test_budget_warn_in_callback_does_not_infinite_loop` — no deadlock
- `test_audit_dump_structure` — all 4+ sections present in pre-budget dump
- `test_exhaustion_injection_structure` — correct markers, tool refs, reasoning in injected block
- `test_exhaustion_injection_empty_messages` — handles empty conversation
- `test_exhaustion_injection_no_reasoning` — fallback next-steps text
- `test_iteration_budget_callback_exception_does_not_crash` — user callback errors are caught

## Edge cases handled

- Callback exception safety — never crashes the budget mechanism
- No git installed — falls back to `git status` then file walk
- Empty messages — uses default "continue where left off" next steps
- No reasoning content — same default fallback
- warn_at >= max_turns — warns on first iteration (useful for debugging)
- warn_at = 0 — completely disabled
- Refund after warning — _warned flag prevents re-fire


## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. set iterations to something small say 20
2. set prebudget_warn_at: 10
3. On prebudget exhaustion the agent shoud stop and output a state audit, for use after starting a new session.

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

