### PR TITLE
fix(dashboard): yield event loop after WebSocket accept in pty_ws handler

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3125,6 +3125,7 @@ async def pty_ws(ws: WebSocket) -> None:
         return
 
     await ws.accept()
+    await asyncio.sleep(0)  # yield once so uvicorn flushes the HTTP 101 upgrade before PTY spawn blocks the loop
 
     # On native Windows, the POSIX PTY bridge can't be imported.  Tell the
     # client and close cleanly rather than pretending the feature works.

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -2016,6 +2016,54 @@ class TestPtyWebSocket:
                 pass
         assert exc.value.code == 4401
 
+    def test_pty_ws_yields_to_event_loop_before_spawn(self, monkeypatch):
+        """Regression for #22864: pty_ws must ``await asyncio.sleep(0)``
+        after ``ws.accept()`` so uvicorn flushes the HTTP 101 upgrade
+        before the synchronous ``PtyBridge.spawn`` blocks the event loop.
+        """
+        import asyncio
+        import sys
+        from unittest.mock import MagicMock
+
+        call_log: list[str] = []
+        real_sleep = asyncio.sleep
+
+        async def recording_sleep(delay, *args, **kwargs):
+            # Only record sleep(0) calls coming from pty_ws itself, so
+            # asyncio/starlette internals don't pollute the order log.
+            if delay == 0 and sys._getframe(1).f_code.co_name == "pty_ws":
+                call_log.append("sleep_zero")
+            return await real_sleep(delay, *args, **kwargs)
+
+        fake_bridge = MagicMock()
+        fake_bridge.read.return_value = None  # EOF — reader exits cleanly
+
+        def recording_spawn(cls, *args, **kwargs):
+            call_log.append("spawn")
+            return fake_bridge
+
+        monkeypatch.setattr(asyncio, "sleep", recording_sleep)
+        monkeypatch.setattr(
+            self.ws_module.PtyBridge,
+            "spawn",
+            classmethod(recording_spawn),
+        )
+        monkeypatch.setattr(
+            self.ws_module,
+            "_resolve_chat_argv",
+            lambda resume=None, sidecar_url=None: (["/bin/true"], None, None),
+        )
+
+        with self.client.websocket_connect(self._url()):
+            # Disconnect immediately; the handler runs accept → sleep(0)
+            # → spawn between two awaits, so all three happen before
+            # the writer loop processes the disconnect.
+            pass
+
+        assert call_log == ["sleep_zero", "spawn"], (
+            f"expected ['sleep_zero', 'spawn'], got: {call_log}"
+        )
+
     def test_streams_child_stdout_to_client(self, monkeypatch):
         monkeypatch.setattr(
             self.ws_module,


### PR DESCRIPTION
Fixes #19914
Refs #22864, #21948

## Summary

The /api/pty WebSocket handler runs synchronous PTY/TUI startup (_resolve_chat_argv, PtyBridge.spawn) immediately after `await ws.accept()`. On slower hosts this blocks the event loop long enough that uvicorn never flushes the HTTP 101 Switching Protocols response before the client times out:

    InvalidMessage: did not receive a valid HTTP response

Adding `await asyncio.sleep(0)` right after `accept()` yields once so uvicorn drains the handshake before the synchronous PTY spawn re-takes the loop.

## Why this approach

Aware of the prior attempts in this area:

- **#19938** (open, unreviewed since 2026-05-04) diagnoses the issue as a FastAPI 0.136 close-before-accept regression and reorders accept() above close() in early-return paths. That doesn't address the success-path race — the spawn after a successful accept still blocks the loop.
- **#19943** (closed by the author via automation, deferring to #19938 — never reviewed) had the correct diagnosis ("running them inline starved uvicorn's websockets task so the HTTP 101 upgrade was never flushed") and wrapped `_resolve_chat_argv` and `PtyBridge.spawn` in `loop.run_in_executor(...)`.

The executor approach in #19943 works but is heavier than necessary: it moves blocking work off the loop entirely. The simpler shape is to keep the work on the loop and just yield once so uvicorn can flush the upgrade response — which is exactly what the issue submitter in #22864 verified locally.

This PR implements that one-line yield. Out of scope for this PR but worth a separate look: two other accept() call sites in the same file (lines ~3283 and ~3312) have a similar shape but their post-accept work is async, so they're not affected by this race.

## Tests

Adds `test_pty_ws_yields_to_event_loop_before_spawn` to `TestPtyWebSocket` in `tests/hermes_cli/test_web_server.py`. The test monkeypatches `asyncio.sleep` and `PtyBridge.spawn` to record calls into a shared list (filtered to the pty_ws frame to avoid capturing internal asyncio yields), connects via TestClient, and asserts the call ordering is exactly `["sleep_zero", "spawn"]`.

The test is skipped on Windows along with the rest of the `TestPtyWebSocket` class (PtyBridge is POSIX-only). Local verification on POSIX wasn't available; the test was reasoned through against the existing class conventions and will be verified on the Linux CI runner.

## How to test

Run the new test:

    pytest tests/hermes_cli/test_web_server.py::TestPtyWebSocket::test_pty_ws_yields_to_event_loop_before_spawn -v

Manual repro from #22864:

    hermes dashboard --host 127.0.0.1 --port 9119 --no-open --tui

Then connect a WebSocket client to /api/pty with the session token. Without the fix on a slow-spawn host, the handshake times out with `InvalidMessage: did not receive a valid HTTP response`. With the fix, the upgrade completes and PTY bytes start streaming.