### PR TITLE
fix(api-server): emit length/error finish_reason in SSE chat-completions stream

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1381,6 +1381,7 @@ class APIServerAdapter(BasePlatformAdapter):
                 last_activity = await _emit(delta)
 
             # Get usage from completed agent
+            result = {}
             usage = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
             try:
                 result, agent_usage = await agent_task
@@ -1388,11 +1389,22 @@ class APIServerAdapter(BasePlatformAdapter):
             except Exception as exc:
                 logger.warning("Agent task %s failed, usage data lost: %s", completion_id, exc)
 
+            # Mirror _handle_chat_completions finish_reason logic: report
+            # "length" for truncation and "error" for failures so streaming
+            # clients get the same signal as non-streaming ones (PR #22775).
+            err_msg = result.get("error")
+            if result.get("partial") and err_msg and "truncat" in err_msg.lower():
+                finish_reason = "length"
+            elif result.get("failed") or (not result.get("completed", True) and err_msg):
+                finish_reason = "error"
+            else:
+                finish_reason = "stop"
+
             # Finish chunk
             finish_chunk = {
                 "id": completion_id, "object": "chat.completion.chunk",
                 "created": created, "model": model,
-                "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                "choices": [{"index": 0, "delta": {}, "finish_reason": finish_reason}],
                 "usage": {
                     "prompt_tokens": usage.get("input_tokens", 0),
                     "completion_tokens": usage.get("output_tokens", 0),

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -2521,6 +2521,113 @@ class TestChatCompletionsAgentIncomplete:
             assert "X-Hermes-Completed" not in resp.headers
 
 
+class TestChatCompletionsStreamingFinishReason:
+    """Streaming endpoint must emit the same finish_reason semantics as the
+    non-streaming endpoint (fixed by PR #22775).  Regression for the parity
+    gap where _write_sse_chat_completion always sent finish_reason='stop'."""
+
+    def _parse_sse_finish_reason(self, body: str) -> str:
+        """Return the finish_reason from the last non-[DONE] data chunk."""
+        import json as _json
+        reason = None
+        for line in body.splitlines():
+            if not line.startswith("data: ") or line == "data: [DONE]":
+                continue
+            try:
+                chunk = _json.loads(line[6:])
+                fr = chunk.get("choices", [{}])[0].get("finish_reason")
+                if fr is not None:
+                    reason = fr
+            except Exception:
+                pass
+        return reason
+
+    @pytest.mark.asyncio
+    async def test_stream_truncation_emits_length_finish_reason(self, adapter):
+        """Truncated run with partial=True must emit finish_reason='length'."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                cb = kwargs.get("stream_delta_callback")
+                if cb:
+                    cb("Partial answer")
+                    cb(None)
+                return (
+                    {
+                        "final_response": "Partial answer",
+                        "completed": False,
+                        "partial": True,
+                        "error": "Response truncated due to output length limit",
+                        "messages": [],
+                        "api_calls": 1,
+                    },
+                    {"input_tokens": 5, "output_tokens": 3, "total_tokens": 8},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={"model": "test", "messages": [{"role": "user", "content": "hi"}], "stream": True},
+                )
+            assert resp.status == 200
+            body = await resp.text()
+            assert self._parse_sse_finish_reason(body) == "length"
+
+    @pytest.mark.asyncio
+    async def test_stream_failed_run_emits_error_finish_reason(self, adapter):
+        """Failed run must emit finish_reason='error', not 'stop'."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                cb = kwargs.get("stream_delta_callback")
+                if cb:
+                    cb(None)
+                return (
+                    {
+                        "final_response": "",
+                        "completed": False,
+                        "failed": True,
+                        "error": "Agent encountered an unrecoverable error",
+                        "messages": [],
+                        "api_calls": 1,
+                    },
+                    {"input_tokens": 5, "output_tokens": 0, "total_tokens": 5},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={"model": "test", "messages": [{"role": "user", "content": "hi"}], "stream": True},
+                )
+            assert resp.status == 200
+            body = await resp.text()
+            assert self._parse_sse_finish_reason(body) == "error"
+
+    @pytest.mark.asyncio
+    async def test_stream_normal_completion_still_emits_stop(self, adapter):
+        """Happy path must still emit finish_reason='stop'."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                cb = kwargs.get("stream_delta_callback")
+                if cb:
+                    cb("Done!")
+                    cb(None)
+                return (
+                    {"final_response": "Done!", "completed": True, "messages": [], "api_calls": 1},
+                    {"input_tokens": 5, "output_tokens": 2, "total_tokens": 7},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={"model": "test", "messages": [{"role": "user", "content": "hi"}], "stream": True},
+                )
+            assert resp.status == 200
+            body = await resp.text()
+            assert self._parse_sse_finish_reason(body) == "stop"
+
+
 # ---------------------------------------------------------------------------
 # CORS
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

`_write_sse_chat_completion()` always emitted `finish_reason: "stop"` in the
final SSE chunk, even when the agent run was truncated (`partial=True`) or
failed (`failed=True`).

`_handle_chat_completions()` (non-streaming) was fixed by PR #22775 to report
`"length"` for truncation and `"error"` for failures. The streaming sibling
was missed.

**Root cause:** The finish chunk was built with a hardcoded `"stop"` and `result`
from `agent_task` was never inspected:

```python
# Before
finish_chunk = {
    ...
    "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],  # always stop
}
```

**Fix:** Initialise `result = {}` before the `agent_task` try-block, then
derive `finish_reason` with the same three-branch logic that
`_handle_chat_completions` uses (lines 1218–1223). When `agent_task` raises
(usage-data-lost path), `result` stays `{}` and falls through to `"stop"`,
preserving existing exception-path behaviour.

```python
# After — symmetric with _handle_chat_completions lines 1218-1223
result = {}
try:
    result, agent_usage = await agent_task
    ...
except Exception as exc:
    logger.warning(...)

err_msg = result.get("error")
if result.get("partial") and err_msg and "truncat" in err_msg.lower():
    finish_reason = "length"
elif result.get("failed") or (not result.get("completed", True) and err_msg):
    finish_reason = "error"
else:
    finish_reason = "stop"
```

## Related Issue

Fixes #22496 (streaming leg — non-streaming leg closed by #22775).

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `gateway/platforms/api_server.py`: initialise `result = {}`, add 10-line
  `finish_reason` derivation block before the finish chunk (lines 1384–1401)
- `tests/gateway/test_api_server.py`: add `TestChatCompletionsStreamingFinishReason`
  with 3 regression tests (truncation → `length`, failed → `error`, normal → `stop`)

## How to Test

```bash
python -m pytest tests/gateway/test_api_server.py::TestChatCompletionsStreamingFinishReason -v
```

Or the full module:
```bash
scripts/run_tests.sh tests/gateway/test_api_server.py
```

## Checklist

### Code
- [x] Contributing Guide read
- [x] Conventional Commits
- [x] No duplicate PR
- [x] Fix scoped to this bug only
- [x] Tests added
- [x] Symmetric with `_handle_chat_completions` lines 1218–1223

### Documentation & Housekeeping
- [x] Docs — N/A
- [x] cli-config.yaml.example — N/A
- [x] Cross-platform impact — N/A (gateway-only, no OS-specific code)