### PR TITLE
feat(cron): log runtime telemetry events

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -11,12 +11,16 @@ runs at a time if multiple processes overlap.
 import asyncio
 import concurrent.futures
 import contextvars
+import hashlib
 import json
 import logging
 import os
 import shutil
 import subprocess
 import sys
+import threading
+import time
+from datetime import datetime, timezone
 
 # fcntl is Unix-only; on Windows use msvcrt for file locking
 try:
@@ -40,6 +44,84 @@ from hermes_cli.config import load_config, _expand_env_vars
 from hermes_time import now as _hermes_now
 
 logger = logging.getLogger(__name__)
+
+_CRON_RUNTIME_EVENT_LOCK = threading.Lock()
+
+
+def _cron_runtime_failure_kind(status: str, resolution: Optional[str]) -> str:
+    """Normalize cron runtime outcomes for the Phase 5.75 telemetry schema."""
+    if status in {"completed", "silent"}:
+        return "none"
+    normalized = str(resolution or "").strip().lower()
+    if normalized in {"timeout", "inactivity_timeout"}:
+        return "timeout"
+    if normalized in {"prompt_injection_blocked", "blocked"}:
+        return "safety_block"
+    if normalized in {"script_failed", "script_missing"}:
+        return "script_error"
+    return "error"
+
+
+def _write_cron_runtime_event(
+    *,
+    job: dict,
+    status: str,
+    resolution: str,
+    session_id: Optional[str] = None,
+    provider: Optional[str] = None,
+    model: Optional[str] = None,
+    latency_seconds: Optional[float] = None,
+    error: Optional[str] = None,
+    safety_trip: bool = False,
+) -> None:
+    """Append cron lifecycle metadata to the unified runtime telemetry log.
+
+    The event intentionally excludes prompts, script stdout, final responses,
+    delivery targets, raw commands, and provider payloads. Error text is stored
+    only as a short hash plus a coarse error type so operator dashboards can
+    count failures without leaking job contents.
+    """
+    try:
+        logs_dir = _get_hermes_home() / "logs"
+        logs_dir.mkdir(parents=True, exist_ok=True)
+        event = {
+            "ts": datetime.now(timezone.utc).isoformat(timespec="milliseconds"),
+            "event_type": "cron.runtime",
+            "platform": "cron",
+            "role": "cron",
+            "job_id": str(job.get("id") or "unknown"),
+            "job_name": str(job.get("name") or "(unnamed)")[:120],
+            "status": status,
+            "provider": provider or "unknown",
+            "model": model or "unknown",
+            "failure_kind": _cron_runtime_failure_kind(status, resolution),
+            "resolution": resolution,
+            "accepted": False,
+            "safety_trip": bool(safety_trip),
+        }
+        if session_id:
+            event["session_id"] = str(session_id)
+        if latency_seconds is not None:
+            event["latency_seconds"] = round(float(latency_seconds), 3)
+            event["duration_seconds"] = round(float(latency_seconds), 3)
+        if error:
+            error_text = str(error)
+            raw_type = error_text.split(":", 1)[0].strip()
+            if (
+                raw_type.replace("_", "").isalnum()
+                and " " not in raw_type
+                and len(raw_type) <= 80
+                and raw_type.endswith(("Error", "Exception", "Timeout"))
+            ):
+                event["error_type"] = raw_type
+            else:
+                event["error_type"] = "Error"
+            event["error_hash"] = hashlib.sha256(error_text.encode("utf-8", "ignore")).hexdigest()[:16]
+        with _CRON_RUNTIME_EVENT_LOCK:
+            with (logs_dir / "provider-failover-events.jsonl").open("a", encoding="utf-8") as fh:
+                fh.write(json.dumps(event, sort_keys=True) + "\n")
+    except Exception as exc:
+        logger.debug("cron runtime event log failed: %s", exc)
 
 
 class CronPromptInjectionBlocked(Exception):
@@ -1018,6 +1100,7 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
     """
     job_id = job["id"]
     job_name = str(job.get("name") or job.get("prompt") or job_id or "cron job")
+    _job_started_at = time.monotonic()
 
     # ---------------------------------------------------------------
     # no_agent short-circuit — the script IS the job, no LLM involvement.
@@ -1042,6 +1125,13 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
         if not script_path:
             err = "no_agent=True but no script is set for this job"
             logger.error("Job '%s': %s", job_id, err)
+            _write_cron_runtime_event(
+                job=job,
+                status="failed",
+                resolution="script_missing",
+                latency_seconds=time.monotonic() - _job_started_at,
+                error=err,
+            )
             return False, "", "", err
 
         # Apply workdir if configured — lets scripts use predictable relative
@@ -1084,6 +1174,13 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 f"**Status:** script failed\n\n"
                 f"{output}\n"
             )
+            _write_cron_runtime_event(
+                job=job,
+                status="failed",
+                resolution="script_failed",
+                latency_seconds=time.monotonic() - _job_started_at,
+                error=output,
+            )
             return False, doc, alert, output
 
         # Honour the wakeAgent gate as a silent signal — `wakeAgent: false`
@@ -1099,6 +1196,12 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 f"**Mode:** no_agent (script)\n"
                 f"**Status:** silent (wakeAgent=false)\n"
             )
+            _write_cron_runtime_event(
+                job=job,
+                status="silent",
+                resolution="wake_agent_false",
+                latency_seconds=time.monotonic() - _job_started_at,
+            )
             return True, silent_doc, SILENT_MARKER, None
 
         if not output.strip():
@@ -1110,6 +1213,12 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 f"**Mode:** no_agent (script)\n"
                 f"**Status:** silent (empty output)\n"
             )
+            _write_cron_runtime_event(
+                job=job,
+                status="silent",
+                resolution="empty_output",
+                latency_seconds=time.monotonic() - _job_started_at,
+            )
             return True, silent_doc, SILENT_MARKER, None
 
         doc = (
@@ -1119,6 +1228,12 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             f"**Mode:** no_agent (script)\n\n"
             f"---\n\n"
             f"{output}\n"
+        )
+        _write_cron_runtime_event(
+            job=job,
+            status="completed",
+            resolution="script_completed",
+            latency_seconds=time.monotonic() - _job_started_at,
         )
         return True, doc, output, None
 
@@ -1159,6 +1274,12 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
                 f"**Run Time:** {_hermes_now().strftime('%Y-%m-%d %H:%M:%S')}\n\n"
                 "Script gate returned `wakeAgent=false` — agent skipped.\n"
             )
+            _write_cron_runtime_event(
+                job=job,
+                status="silent",
+                resolution="wake_agent_false",
+                latency_seconds=time.monotonic() - _job_started_at,
+            )
             return True, silent_doc, SILENT_MARKER, None
 
     try:
@@ -1185,9 +1306,23 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             "and the match is a false positive, rephrase the content to avoid "
             "the threat pattern (`tools/cronjob_tools.py::_CRON_THREAT_PATTERNS`)."
         )
+        _write_cron_runtime_event(
+            job=job,
+            status="failed",
+            resolution="prompt_injection_blocked",
+            latency_seconds=time.monotonic() - _job_started_at,
+            error=str(block_exc),
+            safety_trip=True,
+        )
         return False, blocked_doc, "", str(block_exc)
     if prompt is None:
         logger.info("Job '%s': script produced no output, skipping AI call.", job_name)
+        _write_cron_runtime_event(
+            job=job,
+            status="silent",
+            resolution="script_empty_output",
+            latency_seconds=time.monotonic() - _job_started_at,
+        )
         return True, "", SILENT_MARKER, None
     origin = _resolve_origin(job)
     _cron_session_id = f"cron_{job_id}_{_hermes_now().strftime('%Y%m%d_%H%M%S')}"
@@ -1588,6 +1723,15 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
 """
         
         logger.info("Job '%s' completed successfully", job_name)
+        _write_cron_runtime_event(
+            job=job,
+            status="silent" if not final_response.strip() else "completed",
+            resolution="no_response" if not final_response.strip() else "agent_completed",
+            session_id=_cron_session_id,
+            provider=runtime.get("provider") if isinstance(runtime, dict) else None,
+            model=model,
+            latency_seconds=time.monotonic() - _job_started_at,
+        )
         return True, output, final_response, None
         
     except Exception as e:
@@ -1610,6 +1754,22 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
 {error_msg}
 ```
 """
+        _runtime_for_event = locals().get("runtime")
+        _model_for_event = locals().get("model")
+        _write_cron_runtime_event(
+            job=job,
+            status="failed",
+            resolution="inactivity_timeout" if isinstance(e, TimeoutError) else "agent_failed",
+            session_id=locals().get("_cron_session_id"),
+            provider=(
+                _runtime_for_event.get("provider")
+                if isinstance(_runtime_for_event, dict)
+                else None
+            ),
+            model=_model_for_event if isinstance(_model_for_event, str) else None,
+            latency_seconds=time.monotonic() - _job_started_at,
+            error=error_msg,
+        )
         return False, output, "", error_msg
 
     finally:

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -18,6 +18,13 @@ from unittest.mock import patch
 import pytest
 
 
+def _read_runtime_events(hermes_home: Path) -> list[dict]:
+    path = hermes_home / "logs" / "provider-failover-events.jsonl"
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
 @pytest.fixture
 def hermes_env(tmp_path, monkeypatch):
     """Isolate HERMES_HOME for each test so jobs/scripts don't leak."""
@@ -210,6 +217,19 @@ def test_run_job_no_agent_success_returns_script_stdout(hermes_env):
     assert "RAM 92% on host" in final_response
     assert "RAM 92% on host" in doc
 
+    events = _read_runtime_events(hermes_env)
+    assert len(events) == 1
+    event = events[0]
+    assert event["event_type"] == "cron.runtime"
+    assert event["platform"] == "cron"
+    assert event["role"] == "cron"
+    assert event["job_id"] == job["id"]
+    assert event["status"] == "completed"
+    assert event["resolution"] == "script_completed"
+    assert event["failure_kind"] == "none"
+    assert isinstance(event["latency_seconds"], float)
+    assert "RAM 92%" not in json.dumps(event)
+
 
 def test_run_job_no_agent_empty_output_is_silent(hermes_env):
     """Empty stdout → SILENT_MARKER, which suppresses delivery downstream."""
@@ -227,6 +247,11 @@ def test_run_job_no_agent_empty_output_is_silent(hermes_env):
     assert error is None
     assert final_response == SILENT_MARKER
 
+    events = _read_runtime_events(hermes_env)
+    assert events[-1]["status"] == "silent"
+    assert events[-1]["resolution"] == "empty_output"
+    assert events[-1]["failure_kind"] == "none"
+
 
 def test_run_job_no_agent_wake_gate_is_silent(hermes_env):
     """wakeAgent=false gate in stdout triggers a silent run."""
@@ -242,6 +267,12 @@ def test_run_job_no_agent_wake_gate_is_silent(hermes_env):
     success, doc, final_response, error = run_job(job)
     assert success is True
     assert final_response == SILENT_MARKER
+
+    events = _read_runtime_events(hermes_env)
+    assert events[-1]["status"] == "silent"
+    assert events[-1]["resolution"] == "wake_agent_false"
+    assert events[-1]["failure_kind"] == "none"
+    assert events[-1]["safety_trip"] is False
 
 
 def test_run_job_no_agent_script_failure_delivers_error(hermes_env):
@@ -261,6 +292,14 @@ def test_run_job_no_agent_script_failure_delivers_error(hermes_env):
     assert "oops" in final_response or "exited with code 3" in final_response
     assert "Cron watchdog" in final_response  # alert header
 
+    events = _read_runtime_events(hermes_env)
+    assert events[-1]["status"] == "failed"
+    assert events[-1]["resolution"] == "script_failed"
+    assert events[-1]["failure_kind"] == "script_error"
+    assert events[-1]["error_type"]
+    assert events[-1]["error_hash"]
+    assert "oops" not in json.dumps(events[-1])
+
 
 def test_run_job_no_agent_never_invokes_aiagent(hermes_env):
     """no_agent jobs must NOT import/construct the AIAgent."""
@@ -279,6 +318,33 @@ def test_run_job_no_agent_never_invokes_aiagent(hermes_env):
         run_job(job)
 
     ai_mock.assert_not_called()
+
+
+def test_run_job_prompt_injection_block_writes_safety_telemetry(hermes_env):
+    """LLM cron prompt-injection blocks should emit redacted safety telemetry."""
+    from cron.jobs import create_job
+    from cron.scheduler import CronPromptInjectionBlocked, run_job
+
+    job = create_job(prompt="run", schedule="every 5m", deliver="local")
+
+    with patch("cron.scheduler._build_job_prompt") as build_prompt:
+        build_prompt.side_effect = CronPromptInjectionBlocked("secret payload blocked")
+        success, doc, final_response, error = run_job(job)
+
+    assert success is False
+    assert final_response == ""
+    assert "BLOCKED" in doc
+    assert "secret payload blocked" in error
+
+    events = _read_runtime_events(hermes_env)
+    event = events[-1]
+    assert event["event_type"] == "cron.runtime"
+    assert event["status"] == "failed"
+    assert event["resolution"] == "prompt_injection_blocked"
+    assert event["failure_kind"] == "safety_block"
+    assert event["safety_trip"] is True
+    assert event["error_hash"]
+    assert "secret payload blocked" not in json.dumps(event)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add privacy-safe `cron.runtime` JSONL telemetry events for cron job execution paths.
- Record coarse status, provider/model lineage, latency/duration, safety trip state, and normalized failure kind without logging prompts, script stdout, final responses, delivery targets, raw commands, provider payloads, or raw error text.
- Add focused regression coverage for runtime event writing and failure-kind normalization.

## Verification
- `py_compile cron/scheduler.py tests/cron/test_cron_no_agent.py`
- `PYTHONPATH=/private/tmp/hermes-cron-runtime-telemetry-pr-current ~/.hermes/hermes-agent/.venv/bin/python -m pytest tests/cron/test_cron_no_agent.py -q` — 19 passed
- `git diff --check origin/main..HEAD`
- privacy/secret scan on the outgoing commit diff — 0 hits

## Notes
- Clean branch rebuilt from current `origin/main`; excludes unrelated local Hermes commits and fallback-summary changes.
- Previous full local cron-suite caveat remains unrelated: this shared venv lacks `croniter`, which causes one existing cron jobs test to fail outside this telemetry slice.
