### PR TITLE
fix(models): keep NVIDIA NIM curated models visible

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1079,7 +1079,7 @@ def list_authenticated_providers(
     from hermes_cli.auth import PROVIDER_REGISTRY
     from hermes_cli.models import (
         OPENROUTER_MODELS, _PROVIDER_MODELS,
-        _MODELS_DEV_PREFERRED, _merge_with_models_dev, provider_model_ids,
+        _MODELS_DEV_PREFERRED, _merge_models_dev_for_provider, provider_model_ids,
     )
 
     results: List[dict] = []
@@ -1242,7 +1242,7 @@ def list_authenticated_providers(
         # show up in the picker without requiring a Hermes release.
         model_ids = curated.get(hermes_id, [])
         if hermes_id in _MODELS_DEV_PREFERRED:
-            model_ids = _merge_with_models_dev(hermes_id, model_ids)
+            model_ids = _merge_models_dev_for_provider(hermes_id, model_ids)
         total = len(model_ids)
         top = model_ids[:max_models]
 
@@ -1359,7 +1359,7 @@ def list_authenticated_providers(
             model_ids = curated.get(hermes_slug, []) or curated.get(pid, [])
             # Merge with models.dev for preferred providers (same rationale as above).
             if hermes_slug in _MODELS_DEV_PREFERRED:
-                model_ids = _merge_with_models_dev(hermes_slug, model_ids)
+                model_ids = _merge_models_dev_for_provider(hermes_slug, model_ids)
         total = len(model_ids)
         top = model_ids[:max_models]
 

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -254,8 +254,10 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "nvidia/nemotron-3-nano-30b-a3b",
         "nvidia/llama-3.3-nemotron-super-49b-v1.5",
         # Third-party agentic models hosted on build.nvidia.com
-        # (map to OpenRouter defaults — users get familiar picks on NIM)
+        # (group by vendor — users get familiar picks on NIM)
         "qwen/qwen3.5-397b-a17b",
+        "deepseek-ai/deepseek-v4-pro",
+        "deepseek-ai/deepseek-v4-flash",
         "deepseek-ai/deepseek-v3.2",
         "moonshotai/kimi-k2.6",
         "minimaxai/minimax-m2.5",
@@ -1902,6 +1904,14 @@ _MODELS_DEV_PREFERRED: frozenset[str] = frozenset({
 })
 
 
+_MODELS_DEV_CURATED_FIRST: frozenset[str] = frozenset({
+    # NVIDIA's public models.dev catalog contains many broad NIM/VLM entries.
+    # Keep Hermes' hand-picked agentic NIM models visible in short pickers and
+    # append live-discovered extras after them.
+    "nvidia",
+})
+
+
 def _merge_with_models_dev(provider: str, curated: list[str]) -> list[str]:
     """Merge curated list with fresh models.dev entries for a preferred provider.
 
@@ -1937,6 +1947,40 @@ def _merge_with_models_dev(provider: str, curated: list[str]) -> list[str]:
         seen_lower.add(key)
         merged.append(mid)
     return merged
+
+
+def _merge_model_id_lists(*model_lists: list[str] | tuple[str, ...] | None) -> list[str]:
+    """Merge model ID lists in order with case-insensitive deduplication."""
+    seen_lower: set[str] = set()
+    merged: list[str] = []
+    for model_list in model_lists:
+        if not model_list:
+            continue
+        for mid in model_list:
+            if not isinstance(mid, str) or not mid.strip():
+                continue
+            key = mid.lower()
+            if key in seen_lower:
+                continue
+            seen_lower.add(key)
+            merged.append(mid)
+    return merged
+
+
+def _merge_models_dev_for_provider(provider: str, curated: list[str]) -> list[str]:
+    """Merge models.dev with curated IDs using provider-specific ordering."""
+    if provider not in _MODELS_DEV_CURATED_FIRST:
+        return _merge_with_models_dev(provider, curated)
+
+    try:
+        from agent.models_dev import list_agentic_models
+        mdev = list_agentic_models(provider)
+    except Exception:
+        mdev = []
+
+    if not mdev:
+        return list(curated)
+    return _merge_model_id_lists(curated, mdev)
 
 
 def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) -> list[str]:
@@ -2082,15 +2126,25 @@ def provider_model_ids(provider: Optional[str], *, force_refresh: bool = False) 
                 live = _p.fetch_models(api_key=api_key)
                 if live:
                     return live
-            # Use profile's fallback_models if defined
+            # Use profile fallbacks without letting stale plugin-level lists
+            # shadow the curated catalog in this module. The generic profile
+            # path is reached by providers such as NVIDIA and DeepSeek, whose
+            # fast-moving model lists are also maintained in _PROVIDER_MODELS
+            # and refreshed through models.dev. Returning _p.fallback_models
+            # directly would hide newer curated IDs when the live /models
+            # endpoint is unreachable or rate-limited.
             if _p.fallback_models:
-                return list(_p.fallback_models)
+                curated_static = list(_PROVIDER_MODELS.get(normalized, []))
+                fallback = _merge_model_id_lists(curated_static, _p.fallback_models)
+                if normalized in _MODELS_DEV_PREFERRED:
+                    return _merge_models_dev_for_provider(normalized, fallback)
+                return fallback
     except Exception:
         pass
 
     curated_static = list(_PROVIDER_MODELS.get(normalized, []))
     if normalized in _MODELS_DEV_PREFERRED:
-        return _merge_with_models_dev(normalized, curated_static)
+        return _merge_models_dev_for_provider(normalized, curated_static)
     return curated_static
 
 

--- a/tests/hermes_cli/test_list_picker_providers.py
+++ b/tests/hermes_cli/test_list_picker_providers.py
@@ -223,6 +223,33 @@ def test_passthrough_kwargs_to_base(monkeypatch):
     assert captured["max_models"] == 12
 
 
+def test_nvidia_picker_keeps_curated_models_visible(monkeypatch):
+    """NVIDIA's broad models.dev catalog must not bury curated NIM picks."""
+    monkeypatch.setenv("NVIDIA_API_KEY", "test-key")
+    monkeypatch.setattr(
+        "agent.models_dev.fetch_models_dev",
+        lambda: {"nvidia": {"env": ["NVIDIA_API_KEY"]}},
+    )
+    monkeypatch.setattr(
+        "agent.models_dev.list_agentic_models",
+        lambda provider: [f"vendor/extra-{i}" for i in range(20)],
+    )
+    monkeypatch.setattr(
+        "hermes_cli.models.fetch_openrouter_models",
+        lambda *a, **kw: [],
+    )
+
+    result = model_switch.list_picker_providers(max_models=8)
+
+    nvidia = next(row for row in result if row["slug"] == "nvidia")
+    assert "deepseek-ai/deepseek-v4-pro" in nvidia["models"]
+    assert "deepseek-ai/deepseek-v4-flash" in nvidia["models"]
+    assert "moonshotai/kimi-k2.6" in nvidia["models"]
+    assert nvidia["models"].index("deepseek-ai/deepseek-v4-pro") < nvidia["models"].index(
+        "deepseek-ai/deepseek-v4-flash"
+    )
+
+
 def test_current_custom_endpoint_passthrough_marks_current_row(monkeypatch):
     """Interactive picker should preserve current custom endpoint semantics."""
     monkeypatch.setattr("agent.models_dev.fetch_models_dev", lambda: {})
@@ -230,6 +257,8 @@ def test_current_custom_endpoint_passthrough_marks_current_row(monkeypatch):
     monkeypatch.setattr("hermes_cli.providers.HERMES_OVERLAYS", {})
     monkeypatch.setattr("hermes_cli.models.fetch_openrouter_models",
                         lambda *a, **kw: [])
+    monkeypatch.setattr("hermes_cli.models.fetch_api_models",
+                        lambda *a, **kw: None)
 
     result = model_switch.list_picker_providers(
         current_provider="custom:ollama",

--- a/tests/hermes_cli/test_models_dev_preferred_merge.py
+++ b/tests/hermes_cli/test_models_dev_preferred_merge.py
@@ -23,6 +23,7 @@ from unittest.mock import patch
 import pytest
 
 from hermes_cli.models import (
+    _MODELS_DEV_CURATED_FIRST,
     _MODELS_DEV_PREFERRED,
     _merge_with_models_dev,
     provider_model_ids,
@@ -97,6 +98,57 @@ class TestProviderModelIdsPreferred:
             out = provider_model_ids("opencode-zen")
         assert "claude-opus-4-7" in out
         assert "kimi-k2.6" in out
+
+    def test_nvidia_profile_fallback_does_not_hide_curated_models(self):
+        """Offline NVIDIA profile fallback must still include curated NIM models."""
+        with patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            return_value={"api_key": "", "base_url": ""},
+        ), patch("agent.models_dev.list_agentic_models", return_value=[]):
+            out = provider_model_ids("nvidia")
+
+        assert "moonshotai/kimi-k2.6" in out
+        assert "deepseek-ai/deepseek-v4-pro" in out
+        assert "deepseek-ai/deepseek-v4-flash" in out
+        assert "nvidia/nemotron-3-super-120b-a12b" in out
+        # Keep legacy provider-profile fallback entries too.
+        assert "nvidia/llama-3.1-nemotron-70b-instruct" in out
+
+    def test_nvidia_keeps_curated_models_before_models_dev_extras(self):
+        """Short model pickers must show curated NVIDIA agentic models first."""
+        assert "nvidia" in _MODELS_DEV_CURATED_FIRST
+        with patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            return_value={"api_key": "", "base_url": ""},
+        ), patch(
+            "agent.models_dev.list_agentic_models",
+            return_value=["vendor/extra-a", "vendor/extra-b"],
+        ):
+            out = provider_model_ids("nvidia")
+
+        assert out.index("moonshotai/kimi-k2.6") < out.index("vendor/extra-a")
+        assert out.index("deepseek-ai/deepseek-v4-pro") < out.index("vendor/extra-a")
+        assert out.index("deepseek-ai/deepseek-v4-flash") < out.index("vendor/extra-a")
+        assert out.index("deepseek-ai/deepseek-v4-pro") < out.index(
+            "deepseek-ai/deepseek-v4-flash"
+        )
+        assert out.index("deepseek-ai/deepseek-v4-flash") < out.index(
+            "deepseek-ai/deepseek-v3.2"
+        )
+
+    def test_deepseek_profile_fallback_does_not_hide_v4_models(self):
+        """Offline DeepSeek profile fallback must still include V4 models."""
+        with patch(
+            "hermes_cli.auth.resolve_api_key_provider_credentials",
+            return_value={"api_key": "", "base_url": ""},
+        ), patch("agent.models_dev.list_agentic_models", return_value=[]):
+            out = provider_model_ids("deepseek")
+
+        assert "deepseek-v4-pro" in out
+        assert "deepseek-v4-flash" in out
+        # Keep legacy aliases too.
+        assert "deepseek-chat" in out
+        assert "deepseek-reasoner" in out
 
 
 class TestOpenRouterAndNousUnchanged:


### PR DESCRIPTION
## Summary
- add recent NVIDIA NIM model IDs for Kimi K2.6 and DeepSeek V4 Pro/Flash to the curated NVIDIA catalog
- keep NVIDIA curated agentic models before broad models.dev extras so short `/models` pickers do not hide them
- merge stale provider-profile fallbacks with Hermes curated catalogs instead of returning the stale plugin list directly

## Context
NVIDIA docs list `deepseek-ai/deepseek-v4-flash` and `deepseek-ai/deepseek-v4-pro` as LLM chat completion endpoints, and the Kimi K2.6 NVIDIA reference page exposes `moonshotai/kimi-k2.6` as an available endpoint:
- https://docs.api.nvidia.com/nim/reference/llm-apis
- https://docs.api.nvidia.com/nim/reference/deepseek-ai-deepseek-v4-pro
- https://docs.api.nvidia.com/nim/reference/moonshotai-kimi-k2-6

## Tests
- `venv/bin/python -m pytest -q tests/hermes_cli/test_models_dev_preferred_merge.py tests/hermes_cli/test_list_picker_providers.py tests/hermes_cli/test_model_validation.py::TestProviderModelIds::test_zai_returns_glm_models tests/hermes_cli/test_gmi_provider.py::TestGmiModelCatalog`