### PR TITLE
Add stable plugin inventory JSON contract

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -38,6 +38,7 @@ import importlib.metadata
 import importlib.util
 import inspect
 import logging
+import math
 import os
 import sys
 import threading
@@ -268,6 +269,39 @@ def _get_enabled_plugins() -> Optional[set]:
         return set(enabled)
     except Exception:
         return None
+
+
+PLUGIN_INVENTORY_SCHEMA_VERSION = 1
+
+
+def _as_manifest_list(value: Any) -> List[Any]:
+    """Normalize manifest fields that may be absent, scalar, tuple, or list."""
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    return [value]
+
+
+def _append_inventory_warning(
+    warnings: Optional[List[Dict[str, Any]]],
+    *,
+    code: str,
+    message: str,
+    key: str = "",
+    path: str = "",
+) -> None:
+    """Append a structured inventory warning when a collector is present."""
+    if warnings is None:
+        return
+    entry: Dict[str, Any] = {"code": code, "message": message}
+    if key:
+        entry["key"] = key
+    if path:
+        entry["path"] = path
+    warnings.append(entry)
 
 
 # ---------------------------------------------------------------------------
@@ -1566,6 +1600,7 @@ class PluginManager:
         plugin_dir: Path,
         source: str,
         prefix: str,
+        warnings: Optional[List[Dict[str, Any]]] = None,
     ) -> Optional[PluginManifest]:
         """Parse a single ``plugin.yaml`` into a :class:`PluginManifest`.
 
@@ -1585,9 +1620,18 @@ class PluginManager:
                 raw_kind = "standalone"
             kind = raw_kind.strip().lower()
             if kind not in _VALID_PLUGIN_KINDS:
-                logger.warning(
-                    "Plugin %s: unknown kind '%s' (valid: %s); treating as 'standalone'",
-                    key, raw_kind, ", ".join(sorted(_VALID_PLUGIN_KINDS)),
+                message = (
+                    f"Plugin {key}: unknown kind '{raw_kind}' "
+                    f"(valid: {', '.join(sorted(_VALID_PLUGIN_KINDS))}); "
+                    "treating as 'standalone'"
+                )
+                logger.warning(message)
+                _append_inventory_warning(
+                    warnings,
+                    code="unknown_kind",
+                    message=message,
+                    key=key,
+                    path=str(manifest_file),
                 )
                 kind = "standalone"
 
@@ -1637,17 +1681,26 @@ class PluginManager:
                 version=str(data.get("version", "")),
                 description=data.get("description", ""),
                 author=data.get("author", ""),
-                requires_env=data.get("requires_env", []),
-                provides_tools=data.get("provides_tools", []),
-                provides_hooks=data.get("provides_hooks", []),
+                requires_env=_as_manifest_list(data.get("requires_env")),
+                provides_tools=_as_manifest_list(data.get("provides_tools")),
+                provides_hooks=_as_manifest_list(
+                    data.get("provides_hooks", data.get("hooks"))
+                ),
                 source=source,
                 path=str(plugin_dir),
                 kind=kind,
                 key=key,
             )
         except Exception as exc:
+            message = f"Failed to parse {manifest_file}: {exc}"
             logger.warning(
-                "Failed to parse %s: %s", manifest_file, exc, exc_info=_PLUGINS_DEBUG,
+                message, exc_info=_PLUGINS_DEBUG,
+            )
+            _append_inventory_warning(
+                warnings,
+                code="manifest_parse_failed",
+                message=message,
+                path=str(manifest_file),
             )
             return None
 
@@ -2020,6 +2073,446 @@ class PluginManager:
     def remove_plugin_skill(self, qualified_name: str) -> None:
         """Remove a stale registry entry (silently ignores missing keys)."""
         self._plugin_skills.pop(qualified_name, None)
+
+
+# ---------------------------------------------------------------------------
+# Read-only inventory contract
+# ---------------------------------------------------------------------------
+
+
+def _inventory_manifest_file(plugin_dir: Path) -> Optional[Path]:
+    yaml_file = plugin_dir / "plugin.yaml"
+    if yaml_file.exists():
+        return yaml_file
+    yml_file = plugin_dir / "plugin.yml"
+    if yml_file.exists():
+        return yml_file
+    return None
+
+
+def _scan_inventory_directory(
+    manager: PluginManager,
+    root: Path,
+    *,
+    source: str,
+    warnings: List[Dict[str, Any]],
+    skip_names: Optional[Set[str]] = None,
+) -> List[PluginManifest]:
+    """Scan manifests for inventory without importing plugin modules."""
+    manifests: List[PluginManifest] = []
+    try:
+        root_is_dir = root.is_dir()
+    except OSError as exc:
+        _append_inventory_warning(
+            warnings,
+            code="scan_error",
+            message=f"{exc.__class__.__name__}: {exc}",
+            path=str(root),
+        )
+        return manifests
+    if not root_is_dir:
+        return manifests
+
+    def visit(path: Path, *, prefix: str, depth: int) -> None:
+        if depth > 1:
+            return
+        try:
+            children = sorted(path.iterdir())
+        except OSError as exc:
+            _append_inventory_warning(
+                warnings,
+                code="scan_error",
+                message=f"{exc.__class__.__name__}: {exc}",
+                path=str(path),
+            )
+            return
+        for child in children:
+            try:
+                child_is_dir = child.is_dir()
+            except OSError as exc:
+                _append_inventory_warning(
+                    warnings,
+                    code="scan_error",
+                    message=f"{exc.__class__.__name__}: {exc}",
+                    path=str(child),
+                )
+                continue
+            if not child_is_dir:
+                continue
+            if depth == 0 and skip_names and child.name in skip_names:
+                continue
+            try:
+                manifest_file = _inventory_manifest_file(child)
+            except OSError as exc:
+                _append_inventory_warning(
+                    warnings,
+                    code="scan_error",
+                    message=f"{exc.__class__.__name__}: {exc}",
+                    path=str(child),
+                )
+                continue
+            if manifest_file is not None:
+                manifest = manager._parse_manifest(
+                    manifest_file,
+                    child,
+                    source,
+                    prefix,
+                    warnings,
+                )
+                if manifest is not None:
+                    manifests.append(manifest)
+                continue
+            if depth < 1:
+                sub_prefix = f"{prefix}/{child.name}" if prefix else child.name
+                visit(child, prefix=sub_prefix, depth=depth + 1)
+
+    visit(root, prefix="", depth=0)
+    return manifests
+
+
+def _scan_inventory_entry_points() -> List[PluginManifest]:
+    """Return entry-point plugin metadata without calling EntryPoint.load()."""
+    manifests: List[PluginManifest] = []
+    try:
+        eps = importlib.metadata.entry_points()
+        if hasattr(eps, "select"):
+            group_eps = eps.select(group=ENTRY_POINTS_GROUP)
+        elif isinstance(eps, dict):
+            group_eps = eps.get(ENTRY_POINTS_GROUP, [])
+        else:
+            group_eps = [ep for ep in eps if ep.group == ENTRY_POINTS_GROUP]
+        for ep in group_eps:
+            manifests.append(
+                PluginManifest(
+                    name=ep.name,
+                    source="entrypoint",
+                    path=getattr(ep, "value", ""),
+                    kind="standalone",
+                    key=ep.name,
+                )
+            )
+    except Exception as exc:
+        logger.debug("Entry-point inventory scan failed: %s", exc)
+    return manifests
+
+
+def _runtime_config_aliases(manifest: PluginManifest) -> Set[str]:
+    """Aliases runtime PluginManager honors for plugins.enabled/disabled."""
+    return {
+        alias
+        for alias in {
+            _inventory_str(manifest.key or manifest.name),
+            _inventory_str(manifest.name),
+        }
+        if alias
+    }
+
+
+def _provider_selection_aliases(manifest: PluginManifest) -> Set[str]:
+    key = _inventory_str(manifest.key or manifest.name)
+    aliases = _runtime_config_aliases(manifest)
+    if key:
+        aliases.add(key.split("/")[-1])
+    if manifest.path:
+        aliases.add(Path(_inventory_str(manifest.path)).name)
+    name = _inventory_str(manifest.name)
+    if name.endswith("-provider"):
+        aliases.add(name[: -len("-provider")])
+    return {alias for alias in aliases if alias}
+
+
+def _selected_provider_for_manifest(manifest: PluginManifest, config: Dict[str, Any]) -> str:
+    key = _inventory_str(manifest.key or manifest.name)
+    category = key.split("/", 1)[0] if "/" in key else ""
+    if category == "memory" or manifest.kind == "exclusive":
+        provider = cfg_get(config, "memory", "provider", default="") or ""
+        return str(provider)
+    if category == "context_engine":
+        provider = cfg_get(config, "context", "engine", default="compressor") or "compressor"
+        return str(provider)
+    if manifest.kind == "model-provider" or category == "model-providers":
+        provider = cfg_get(config, "model", "provider", default="") or ""
+        return str(provider)
+    return ""
+
+
+def _inventory_status(
+    manifest: PluginManifest,
+    *,
+    enabled: Optional[Set[str]],
+    disabled: Set[str],
+    config: Dict[str, Any],
+) -> Dict[str, Any]:
+    key = manifest.key or manifest.name
+    config_aliases = _runtime_config_aliases(manifest)
+    provider_aliases = _provider_selection_aliases(manifest)
+    disabled_match = sorted(config_aliases & disabled)
+
+    selected_provider = _selected_provider_for_manifest(manifest, config)
+    if manifest.kind == "exclusive":
+        if selected_provider and selected_provider in provider_aliases:
+            return {
+                "enabled": True,
+                "config_status": "provider_selected",
+                "effective_status": "provider_selected",
+                "activation_hint": "selected by provider config",
+                "selected_provider": selected_provider,
+            }
+        return {
+            "enabled": False,
+            "config_status": "provider_not_selected",
+            "effective_status": "inactive",
+            "activation_hint": "select via provider config",
+            "selected_provider": selected_provider,
+        }
+
+    if manifest.kind == "model-provider":
+        if selected_provider and selected_provider in provider_aliases:
+            effective_status = "provider_selected"
+            config_status = "provider_selected"
+            hint = "selected by model.provider"
+        else:
+            effective_status = "provider_managed"
+            config_status = "provider_managed"
+            hint = "managed by model provider discovery"
+        return {
+            "enabled": True,
+            "config_status": config_status,
+            "effective_status": effective_status,
+            "activation_hint": hint,
+            "selected_provider": selected_provider,
+        }
+
+    if disabled_match:
+        return {
+            "enabled": False,
+            "config_status": "disabled",
+            "effective_status": "disabled",
+            "activation_hint": "disabled via plugins.disabled",
+            "matched_config_key": disabled_match[0],
+        }
+
+    if manifest.source == "bundled" and manifest.kind in {"backend", "platform"}:
+        return {
+            "enabled": True,
+            "config_status": "auto_active",
+            "effective_status": "auto_active",
+            "activation_hint": "bundled backend/platform auto-loads",
+        }
+
+    enabled_match = sorted(config_aliases & enabled) if enabled is not None else []
+    if enabled_match:
+        return {
+            "enabled": True,
+            "config_status": "explicitly_enabled",
+            "effective_status": "active",
+            "activation_hint": "enabled via plugins.enabled",
+            "matched_config_key": enabled_match[0],
+        }
+
+    return {
+        "enabled": False,
+        "config_status": "not_enabled",
+        "effective_status": "inactive",
+        "activation_hint": f"run `hermes plugins enable {key}` to activate",
+    }
+
+
+def _inventory_str(value: Any) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return str(value)
+
+
+def _inventory_json_safe(value: Any) -> Any:
+    """Coerce manifest data to JSON-safe primitive values for schema v1."""
+    if isinstance(value, float) and not math.isfinite(value):
+        return str(value)
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, (list, tuple, set)):
+        return [_inventory_json_safe(item) for item in value]
+    if isinstance(value, dict):
+        return {
+            _inventory_str(key): _inventory_json_safe(item)
+            for key, item in value.items()
+        }
+    return str(value)
+
+
+def _inventory_list(value: Any) -> List[Any]:
+    if not isinstance(value, list):
+        return []
+    return [_inventory_json_safe(item) for item in value]
+
+
+def _inventory_entry(manifest: PluginManifest, status: Dict[str, Any]) -> Dict[str, Any]:
+    path = _inventory_str(manifest.path)
+    source = _inventory_str(manifest.source)
+    entrypoint = path if source == "entrypoint" else ""
+    entry: Dict[str, Any] = {
+        "key": _inventory_str(manifest.key or manifest.name),
+        "name": _inventory_str(manifest.name),
+        "version": _inventory_str(manifest.version),
+        "description": _inventory_str(manifest.description),
+        "author": _inventory_str(manifest.author),
+        "kind": _inventory_str(manifest.kind),
+        "source": source,
+        "path": path,
+        "entrypoint": entrypoint,
+        "requires_env": _inventory_list(manifest.requires_env),
+        "provides_tools": _inventory_list(manifest.provides_tools),
+        "provides_hooks": _inventory_list(manifest.provides_hooks),
+        "enabled": bool(status.get("enabled")),
+        "config_status": _inventory_str(status.get("config_status", "not_enabled")),
+        "effective_status": _inventory_str(status.get("effective_status", "inactive")),
+        "activation_hint": _inventory_str(status.get("activation_hint", "")),
+        "error": _inventory_json_safe(status.get("error")),
+    }
+    for optional_key in ("matched_config_key", "selected_provider"):
+        if optional_key in status:
+            entry[optional_key] = _inventory_json_safe(status[optional_key])
+    return entry
+
+
+def list_plugin_inventory(
+    *,
+    include_project: Optional[bool] = None,
+    schema_version: int = PLUGIN_INVENTORY_SCHEMA_VERSION,
+) -> Dict[str, Any]:
+    """Return a stable, read-only plugin manifest inventory.
+
+    This public contract is intended for non-Python consumers such as Hermes Web
+    UI. It scans plugin manifests and entry-point metadata only; it never imports
+    directory plugin modules or calls plugin ``register()`` functions.
+    """
+    if schema_version != PLUGIN_INVENTORY_SCHEMA_VERSION:
+        raise ValueError(
+            f"unsupported plugin inventory schema version: {schema_version}"
+        )
+
+    warnings: List[Dict[str, Any]] = []
+    manager = PluginManager()
+    manifests: List[PluginManifest] = []
+
+    bundled_dir = get_bundled_plugins_dir()
+    user_dir = get_hermes_home() / "plugins"
+    project_enabled = (
+        _env_enabled("HERMES_ENABLE_PROJECT_PLUGINS")
+        if include_project is None
+        else bool(include_project)
+    )
+
+    manifests.extend(
+        _scan_inventory_directory(
+            manager,
+            bundled_dir,
+            source="bundled",
+            warnings=warnings,
+            skip_names={"platforms"},
+        )
+    )
+    manifests.extend(
+        _scan_inventory_directory(
+            manager,
+            bundled_dir / "platforms",
+            source="bundled",
+            warnings=warnings,
+        )
+    )
+    manifests.extend(
+        _scan_inventory_directory(manager, user_dir, source="user", warnings=warnings)
+    )
+    if project_enabled:
+        manifests.extend(
+            _scan_inventory_directory(
+                manager,
+                Path.cwd() / ".hermes" / "plugins",
+                source="project",
+                warnings=warnings,
+            )
+        )
+    manifests.extend(_scan_inventory_entry_points())
+
+    # Later general sources override earlier ones by key, matching the general
+    # plugin manager. Inventory keeps only the effective manifest per key.
+    winners: Dict[str, PluginManifest] = {}
+    for manifest in manifests:
+        winners[_inventory_str(manifest.key or manifest.name)] = manifest
+
+    # Memory-provider runtime discovery gives bundled providers precedence by
+    # provider directory name. Their inventory keys are namespaced
+    # (``memory/<name>``), while user providers use ``<name>``; plain key
+    # deduplication therefore cannot model that precedence on its own.
+    bundled_memory_manifests = {
+        Path(_inventory_str(manifest.path)).name: manifest
+        for manifest in manifests
+        if manifest.source == "bundled"
+        and _inventory_str(manifest.key or manifest.name).startswith("memory/")
+    }
+    for provider_name, bundled_manifest in bundled_memory_manifests.items():
+        for key, manifest in list(winners.items()):
+            manifest_key = _inventory_str(manifest.key or manifest.name)
+            if (
+                manifest.source != "bundled"
+                and Path(_inventory_str(manifest.path)).name == provider_name
+                and (manifest.kind == "exclusive" or manifest_key.startswith("memory/"))
+            ):
+                del winners[key]
+        bundled_key = _inventory_str(bundled_manifest.key or bundled_manifest.name)
+        winners[bundled_key] = bundled_manifest
+
+    try:
+        from hermes_cli.config import load_config
+        config = load_config()
+        if not isinstance(config, dict):
+            config = {}
+    except Exception:
+        config = {}
+
+    disabled = _get_disabled_plugins()
+    enabled = _get_enabled_plugins()
+    plugins: List[Dict[str, Any]] = []
+    for manifest in sorted(
+        winners.values(), key=lambda item: _inventory_str(item.key or item.name)
+    ):
+        status = _inventory_status(
+            manifest,
+            enabled=enabled,
+            disabled=disabled,
+            config=config,
+        )
+        plugins.append(_inventory_entry(manifest, status))
+
+    summary = {
+        "total": len(plugins),
+        "enabled": sum(1 for plugin in plugins if plugin["enabled"]),
+        "disabled": sum(1 for plugin in plugins if plugin["effective_status"] == "disabled"),
+        "inactive": sum(1 for plugin in plugins if plugin["effective_status"] == "inactive"),
+        "auto_active": sum(1 for plugin in plugins if plugin["effective_status"] == "auto_active"),
+        "provider_managed": sum(
+            1
+            for plugin in plugins
+            if plugin["effective_status"] in {"provider_managed", "provider_selected"}
+        ),
+        "warnings": len(warnings),
+    }
+
+    return {
+        "schema_version": PLUGIN_INVENTORY_SCHEMA_VERSION,
+        "metadata": {
+            "bundled_plugins_dir": str(bundled_dir),
+            "user_plugins_dir": str(user_dir),
+            "cwd": str(Path.cwd()),
+            "project_plugins_enabled": project_enabled,
+            "entry_points_group": ENTRY_POINTS_GROUP,
+        },
+        "summary": summary,
+        "plugins": plugins,
+        "warnings": _inventory_json_safe(warnings),
+    }
 
 
 # ---------------------------------------------------------------------------

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -1095,8 +1095,33 @@ def _filter_plugin_entries(entries: list, args: Any, enabled: set, disabled: set
     return filtered
 
 
+def _print_legacy_plugins_json(entries: list, enabled: set, disabled: set) -> None:
+    """Emit the backwards-compatible ``hermes plugins list --json`` payload."""
+    payload = [
+        {
+            "name": name,
+            "status": _plugin_status(name, enabled, disabled, key=key),
+            "version": str(version),
+            "description": description,
+            "source": source,
+        }
+        for name, version, description, source, _dir, key in entries
+    ]
+    print(json.dumps(payload, indent=2))
+
+
 def cmd_list(args: Any | None = None) -> None:
-    """List all plugins (bundled + user) with enabled/disabled state."""
+    """List all plugins.
+
+    ``--inventory-json`` emits the stable schema-v1 contract. The legacy
+    ``--json`` flag keeps its existing shallow array payload for scripts.
+    """
+    if getattr(args, "inventory_json", False) is True:
+        from hermes_cli.plugins import list_plugin_inventory
+
+        print(json.dumps(list_plugin_inventory(), indent=2))
+        return
+
     from rich.console import Console
     from rich.table import Table
 
@@ -1112,17 +1137,7 @@ def cmd_list(args: Any | None = None) -> None:
     entries = _filter_plugin_entries(entries, args, enabled, disabled)
 
     if getattr(args, "json", False):
-        payload = [
-            {
-                "name": name,
-                "status": _plugin_status(name, enabled, disabled, key=key),
-                "version": str(version),
-                "description": description,
-                "source": source,
-            }
-            for name, version, description, source, _dir, key in entries
-        ]
-        print(json.dumps(payload, indent=2))
+        _print_legacy_plugins_json(entries, enabled, disabled)
         return
 
     if getattr(args, "plain", False):

--- a/hermes_cli/subcommands/plugins.py
+++ b/hermes_cli/subcommands/plugins.py
@@ -79,7 +79,12 @@ def build_plugins_parser(subparsers, *, cmd_plugins: Callable) -> None:
     plugins_list.add_argument(
         "--json",
         action="store_true",
-        help="Print machine-readable JSON",
+        help="Emit backwards-compatible plugin list JSON",
+    )
+    plugins_list.add_argument(
+        "--inventory-json",
+        action="store_true",
+        help="Emit stable schema-v1 plugin inventory JSON",
     )
 
     plugins_enable = plugins_subparsers.add_parser(

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -503,7 +503,12 @@ async def _plugin_api_runtime_gate(request: Request, call_next):
     the enabled/disabled check for a request that auth already let through.
     """
     path = request.url.path
-    if path.startswith("/api/plugins/"):
+    # ``inventory`` is a core Hermes endpoint, not a plugin-owned router.
+    # Keep only this authenticated route outside the runtime plugin-name gate.
+    if path.startswith("/api/plugins/") and path not in {
+        "/api/plugins/inventory",
+        "/api/plugins/inventory/",
+    }:
         # Only gate authenticated requests. Unauthenticated ones fall
         # through so auth_middleware / the OAuth gate return 401 first and
         # this route can't be used as a plugin-name oracle.
@@ -16528,6 +16533,19 @@ def _merged_plugins_hub() -> Dict[str, Any]:
             "context_options": context_engines,
         },
     }
+
+
+@app.get("/api/plugins/inventory")
+async def get_plugin_inventory(request: Request):
+    """Stable read-only agent plugin inventory contract (session protected)."""
+    _require_token(request)
+    from hermes_cli.plugins import list_plugin_inventory
+
+    try:
+        return list_plugin_inventory()
+    except Exception as exc:
+        _log.warning("plugins/inventory failed: %s", exc)
+        raise HTTPException(status_code=500, detail="Failed to build plugin inventory.") from exc
 
 
 @app.get("/api/dashboard/plugins/hub")

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import argparse
+import json
 import logging
 import os
 import shutil
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -842,6 +845,400 @@ class TestNoAutoActivation:
         # The fix removes this. Verify it's gone.
         assert "Even with default config, check if a plugin registered one" not in source
 
+
+# ── plugin inventory contract ───────────────────────────────────────────────
+
+def _write_inventory_plugin(
+    root: Path,
+    relative: str,
+    manifest: dict,
+    init_body: str = "raise RuntimeError('plugin code executed')\n",
+) -> Path:
+    plugin_dir = root.joinpath(*relative.split("/"))
+    plugin_dir.mkdir(parents=True, exist_ok=True)
+    (plugin_dir / "plugin.yaml").write_text(yaml.safe_dump(manifest))
+    (plugin_dir / "__init__.py").write_text(init_body)
+    return plugin_dir
+
+
+def test_plugin_inventory_scans_manifests_without_executing_code(tmp_path, monkeypatch):
+    from hermes_cli.plugins import list_plugin_inventory
+
+    bundled = tmp_path / "bundled"
+    hermes_home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_BUNDLED_PLUGINS", str(bundled))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({"plugins": {"enabled": ["user-tool"]}})
+    )
+
+    _write_inventory_plugin(
+        bundled,
+        "image_gen/openai",
+        {
+            "name": "openai",
+            "version": "1.2.3",
+            "kind": "backend",
+            "hooks": ["pre_tool_call"],
+            "provides_tools": ["image_generate"],
+        },
+    )
+    _write_inventory_plugin(
+        hermes_home / "plugins",
+        "user-tool",
+        {"name": "user-tool", "version": "0.1.0", "kind": "standalone"},
+    )
+
+    inventory = list_plugin_inventory(include_project=False, schema_version=1)
+    with pytest.raises(ValueError):
+        list_plugin_inventory(schema_version=2)
+    plugins = {plugin["key"]: plugin for plugin in inventory["plugins"]}
+
+    assert plugins["image_gen/openai"]["effective_status"] == "auto_active"
+    assert plugins["image_gen/openai"]["provides_hooks"] == ["pre_tool_call"]
+    assert plugins["image_gen/openai"]["provides_tools"] == ["image_generate"]
+    assert plugins["user-tool"]["config_status"] == "explicitly_enabled"
+
+
+def test_plugin_inventory_status_aliases_and_project_opt_in(tmp_path, monkeypatch):
+    from hermes_cli.plugins import list_plugin_inventory
+
+    bundled = tmp_path / "bundled"
+    hermes_home = tmp_path / "home"
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.chdir(project)
+    monkeypatch.setenv("HERMES_BUNDLED_PLUGINS", str(bundled))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump(
+            {
+                "plugins": {"disabled": ["openai", "honcho", "openrouter-provider"]},
+                "memory": {"provider": "honcho"},
+                "model": {"provider": "openrouter"},
+            }
+        )
+    )
+
+    _write_inventory_plugin(bundled, "image_gen/openai", {"name": "openai", "kind": "backend"})
+    _write_inventory_plugin(bundled, "memory/honcho", {"name": "honcho", "kind": "exclusive"})
+    _write_inventory_plugin(
+        bundled,
+        "model-providers/openrouter",
+        {"name": "openrouter-provider", "kind": "model-provider"},
+    )
+    _write_inventory_plugin(project / ".hermes" / "plugins", "proj", {"name": "proj"})
+
+    inventory = list_plugin_inventory(include_project=True)
+    plugins = {plugin["key"]: plugin for plugin in inventory["plugins"]}
+
+    assert plugins["image_gen/openai"]["effective_status"] == "disabled"
+    assert plugins["image_gen/openai"]["matched_config_key"] == "openai"
+    assert plugins["memory/honcho"]["effective_status"] == "provider_selected"
+    assert "matched_config_key" not in plugins["memory/honcho"]
+    assert plugins["model-providers/openrouter"]["effective_status"] == "provider_selected"
+    assert "matched_config_key" not in plugins["model-providers/openrouter"]
+    assert plugins["proj"]["source"] == "project"
+
+
+def test_plugin_inventory_matches_bundled_memory_provider_precedence(
+    tmp_path, monkeypatch
+):
+    from hermes_cli.plugins import list_plugin_inventory
+
+    bundled = tmp_path / "bundled"
+    hermes_home = tmp_path / "home"
+    project = tmp_path / "project"
+    project.mkdir()
+    monkeypatch.chdir(project)
+    monkeypatch.setenv("HERMES_BUNDLED_PLUGINS", str(bundled))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    hermes_home.mkdir(parents=True)
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({"memory": {"provider": "dup"}})
+    )
+
+    _write_inventory_plugin(
+        bundled,
+        "memory/dup",
+        {"name": "dup", "kind": "exclusive"},
+    )
+    _write_inventory_plugin(
+        hermes_home / "plugins",
+        "dup",
+        {"name": "dup", "kind": "exclusive"},
+    )
+    _write_inventory_plugin(
+        project / ".hermes" / "plugins",
+        "memory/dup",
+        {"name": "dup", "kind": "exclusive"},
+    )
+
+    inventory = list_plugin_inventory(include_project=True)
+    duplicates = [plugin for plugin in inventory["plugins"] if plugin["name"] == "dup"]
+
+    assert [
+        (plugin["key"], plugin["source"], plugin["effective_status"])
+        for plugin in duplicates
+    ] == [("memory/dup", "bundled", "provider_selected")]
+    assert inventory["summary"]["provider_managed"] == 1
+
+
+def test_plugin_inventory_warns_and_continues_when_subdirectory_is_unreadable(
+    tmp_path, monkeypatch
+):
+    from hermes_cli.plugins import list_plugin_inventory
+
+    bundled = tmp_path / "bundled"
+    hermes_home = tmp_path / "home"
+    user_plugins = hermes_home / "plugins"
+    blocked = user_plugins / "blocked"
+    blocked.mkdir(parents=True)
+    _write_inventory_plugin(user_plugins, "good", {"name": "good"})
+    monkeypatch.setenv("HERMES_BUNDLED_PLUGINS", str(bundled))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+
+    original_iterdir = Path.iterdir
+
+    def _iterdir(path):
+        if path == blocked:
+            raise PermissionError("simulated unreadable plugin directory")
+        return original_iterdir(path)
+
+    monkeypatch.setattr(Path, "iterdir", _iterdir)
+
+    inventory = list_plugin_inventory(include_project=False)
+    plugins = {plugin["key"]: plugin for plugin in inventory["plugins"]}
+
+    assert "good" in plugins
+    assert inventory["summary"]["warnings"] == 1
+    assert inventory["warnings"] == [
+        {
+            "code": "scan_error",
+            "message": "PermissionError: simulated unreadable plugin directory",
+            "path": str(blocked),
+        }
+    ]
+
+
+def test_plugin_inventory_uses_runtime_platform_keys(tmp_path, monkeypatch):
+    from hermes_cli.plugins import PluginManager, list_plugin_inventory
+
+    bundled = tmp_path / "bundled"
+    hermes_home = tmp_path / "home"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_BUNDLED_PLUGINS", str(bundled))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({"plugins": {"disabled": ["irc-platform"]}})
+    )
+    _write_inventory_plugin(
+        bundled,
+        "platforms/irc",
+        {"name": "irc-platform", "kind": "platform", "version": "1.0.0"},
+    )
+
+    runtime_platform_keys = {
+        manifest.key
+        for manifest in PluginManager()._scan_directory(
+            bundled / "platforms", source="bundled"
+        )
+    }
+    inventory = list_plugin_inventory(include_project=False)
+    plugins = {plugin["key"]: plugin for plugin in inventory["plugins"]}
+
+    assert runtime_platform_keys == {"irc-platform"}
+    assert "irc-platform" in plugins
+    assert "platforms/irc" not in plugins
+    assert plugins["irc-platform"]["effective_status"] == "disabled"
+
+
+def test_plugin_inventory_disabled_matching_matches_runtime_aliases(tmp_path, monkeypatch):
+    from hermes_cli.plugins import list_plugin_inventory
+
+    bundled = tmp_path / "bundled"
+    hermes_home = tmp_path / "home"
+    hermes_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_BUNDLED_PLUGINS", str(bundled))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    (hermes_home / "config.yaml").write_text(
+        yaml.safe_dump({"plugins": {"disabled": ["irc"]}})
+    )
+    _write_inventory_plugin(
+        bundled,
+        "platforms/irc",
+        {"name": "irc-platform", "kind": "platform", "version": "1.0.0"},
+    )
+
+    plugins = {
+        plugin["key"]: plugin
+        for plugin in list_plugin_inventory(include_project=False)["plugins"]
+    }
+
+    assert plugins["irc-platform"]["effective_status"] == "auto_active"
+
+
+def test_plugin_inventory_reports_unknown_kind_warning(tmp_path, monkeypatch):
+    from hermes_cli.plugins import list_plugin_inventory
+
+    bundled = tmp_path / "bundled"
+    hermes_home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_BUNDLED_PLUGINS", str(bundled))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    _write_inventory_plugin(hermes_home / "plugins", "odd", {"name": "odd", "kind": "general"})
+
+    inventory = list_plugin_inventory(include_project=False)
+    odd = next(plugin for plugin in inventory["plugins"] if plugin["key"] == "odd")
+
+    assert odd["kind"] == "standalone"
+    assert any(warning["code"] == "unknown_kind" for warning in inventory["warnings"])
+
+
+def test_plugin_inventory_coerces_manifest_scalars_to_json_safe_values(tmp_path, monkeypatch):
+    from hermes_cli.plugins import list_plugin_inventory
+
+    bundled = tmp_path / "bundled"
+    hermes_home = tmp_path / "home"
+    monkeypatch.setenv("HERMES_BUNDLED_PLUGINS", str(bundled))
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    hermes_home.mkdir(parents=True, exist_ok=True)
+
+    numeric = bundled / "numeric"
+    numeric.mkdir(parents=True)
+    (numeric / "plugin.yaml").write_text(
+        "name: 123\n"
+        "description: 2024-01-01\n"
+        "requires_env:\n"
+        "  - name: TOKEN\n"
+        "    default: .nan\n"
+        "provides_tools:\n"
+        "  - .inf\n"
+    )
+    (numeric / "__init__.py").write_text("raise RuntimeError('plugin code executed')\n")
+    _write_inventory_plugin(bundled, "alpha", {"name": "alpha"})
+
+    inventory = list_plugin_inventory(include_project=False)
+    json.dumps(inventory, allow_nan=False)
+    plugins = {plugin["key"]: plugin for plugin in inventory["plugins"]}
+
+    assert "123" in plugins
+    assert plugins["123"]["name"] == "123"
+    assert plugins["123"]["description"] == "2024-01-01"
+    assert plugins["123"]["requires_env"] == [
+        {"name": "TOKEN", "default": "nan"}
+    ]
+    assert plugins["123"]["provides_tools"] == ["inf"]
+
+
+def test_plugin_inventory_entry_points_do_not_load(monkeypatch, tmp_path):
+    from hermes_cli.plugins import ENTRY_POINTS_GROUP, list_plugin_inventory
+
+    monkeypatch.setenv("HERMES_BUNDLED_PLUGINS", str(tmp_path / "bundled"))
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "home"))
+    fake_ep = MagicMock()
+    fake_ep.name = "ep-plugin"
+    fake_ep.value = "ep_mod:register"
+    fake_ep.group = ENTRY_POINTS_GROUP
+    fake_ep.load.side_effect = AssertionError("entry point loaded")
+
+    class EntryPoints:
+        def select(self, *, group):
+            assert group == ENTRY_POINTS_GROUP
+            return [fake_ep]
+
+    monkeypatch.setattr("importlib.metadata.entry_points", lambda: EntryPoints())
+
+    inventory = list_plugin_inventory(include_project=False)
+    ep_plugin = next(plugin for plugin in inventory["plugins"] if plugin["key"] == "ep-plugin")
+
+    assert ep_plugin["source"] == "entrypoint"
+    assert ep_plugin["entrypoint"] == "ep_mod:register"
+    fake_ep.load.assert_not_called()
+
+
+def test_cmd_list_inventory_json_outputs_schema_v1(monkeypatch, capsys):
+    from hermes_cli.plugins_cmd import cmd_list
+
+    monkeypatch.setattr(
+        "hermes_cli.plugins.list_plugin_inventory",
+        lambda: {
+            "schema_version": 1,
+            "metadata": {},
+            "summary": {"total": 0},
+            "plugins": [],
+            "warnings": [],
+        },
+    )
+
+    cmd_list(SimpleNamespace(inventory_json=True))
+    output = capsys.readouterr().out
+
+    assert json.loads(output)["schema_version"] == 1
+
+
+def test_cmd_list_legacy_json_keeps_shallow_array(monkeypatch, capsys):
+    from hermes_cli import plugins_cmd
+
+    monkeypatch.setattr(
+        plugins_cmd,
+        "_discover_all_plugins",
+        lambda: [("alpha", "1.2.3", "Alpha plugin", "bundled", None, "alpha")],
+    )
+    monkeypatch.setattr(plugins_cmd, "_get_enabled_set", lambda: {"alpha"})
+    monkeypatch.setattr(plugins_cmd, "_get_disabled_set", lambda: set())
+
+    # Existing internal callers use a loose MagicMock with only legacy flags;
+    # an absent inventory_json attribute must not select the new contract.
+    args = MagicMock()
+    args.json = True
+    args.no_bundled = False
+    args.user = False
+    args.enabled = False
+    args.plain = False
+    plugins_cmd.cmd_list(args)
+
+    assert json.loads(capsys.readouterr().out) == [
+        {
+            "description": "Alpha plugin",
+            "name": "alpha",
+            "source": "bundled",
+            "status": "enabled",
+            "version": "1.2.3",
+        }
+    ]
+
+
+def test_cmd_list_legacy_json_empty_preserves_current_main_diagnostics(
+    monkeypatch, capsys
+):
+    from hermes_cli import plugins_cmd
+
+    monkeypatch.setattr(plugins_cmd, "_discover_all_plugins", lambda: [])
+
+    plugins_cmd.cmd_list(SimpleNamespace(inventory_json=False, json=True))
+    output = capsys.readouterr().out
+
+    assert "No plugins installed." in output
+    assert "Install with: hermes plugins install owner/repo" in output
+    assert output.strip() != "[]"
+
+
+def test_plugins_list_parser_exposes_inventory_json_separately():
+    from hermes_cli.subcommands.plugins import build_plugins_parser
+
+    parser = argparse.ArgumentParser()
+    subparsers = parser.add_subparsers(dest="command")
+    build_plugins_parser(subparsers, cmd_plugins=lambda args: None)
+
+    inventory_args = parser.parse_args(["plugins", "list", "--inventory-json"])
+    legacy_args = parser.parse_args(["plugins", "list", "--json"])
+
+    assert inventory_args.inventory_json is True
+    assert inventory_args.json is False
+    assert legacy_args.json is True
+    assert legacy_args.inventory_json is False
 
 # ── End-to-end subdirectory install ──────────────────────────────────────────
 

--- a/tests/hermes_cli/test_plugins_inventory_api.py
+++ b/tests/hermes_cli/test_plugins_inventory_api.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from fastapi.testclient import TestClient
+
+
+def test_plugins_inventory_api_requires_session_token(monkeypatch):
+    from hermes_cli import web_server
+
+    monkeypatch.setattr(
+        "hermes_cli.plugins.list_plugin_inventory",
+        lambda: {
+            "schema_version": 1,
+            "metadata": {},
+            "summary": {"total": 0},
+            "plugins": [],
+            "warnings": [],
+        },
+    )
+
+    client = TestClient(web_server.app)
+
+    unauthorized = client.get("/api/plugins/inventory")
+    assert unauthorized.status_code == 401
+
+    authorized = client.get(
+        "/api/plugins/inventory",
+        headers={web_server._SESSION_HEADER_NAME: web_server._SESSION_TOKEN},
+    )
+    assert authorized.status_code == 200
+    assert authorized.json()["schema_version"] == 1
+    assert authorized.json()["plugins"] == []


### PR DESCRIPTION
## Summary

Adds a stable read-only plugin inventory contract for Hermes Agent:

- `list_plugin_inventory(schema_version=1)` Python API for manifest-only plugin inventory
- `hermes plugins list --json` / `hermes plugins ls --json` for machine-readable CLI output
- session-protected `GET /api/plugins/inventory` endpoint
- schema v1 entries with plugin key/name/version/kind/source/path/capabilities/status metadata

The inventory scan is read-only: it parses plugin manifests and entry-point metadata without importing directory plugin modules, calling `register()`, or invoking `EntryPoint.load()`.

## Contract notes

- `schema_version: 1` is enforced and unsupported versions raise `ValueError`.
- Bundled, user, project, and entry-point sources are included.
- Bundled `memory/*` and `model-providers/*` provider manifests are included.
- `platforms/*` is scanned separately so runtime platform keys remain canonical, e.g. `irc-platform` rather than `platforms/irc`.
- `plugins.enabled` / `plugins.disabled` matching follows runtime aliases only.
- Provider-managed plugins report provider-managed/selected state and are not overridden by `plugins.disabled`, matching runtime provider selection semantics.
- Manifest scalar/list/dict values are coerced to JSON-safe schema values so malformed YAML scalars do not break `--json` output.

## Verification

- `git diff --cached --check`
- `python -m py_compile hermes_cli/plugins.py hermes_cli/plugins_cmd.py hermes_cli/main.py hermes_cli/web_server.py tests/hermes_cli/test_plugins_cmd.py tests/hermes_cli/test_plugins_inventory_api.py`
- `scripts/run_tests.sh tests/hermes_cli/test_plugins.py tests/hermes_cli/test_plugins_cmd.py tests/hermes_cli/test_plugins_inventory_api.py -q` → `133 passed`
- `python -m hermes_cli.main plugins list --json` parsed successfully
- Independent review: PASS; no blockers found
