### PR TITLE
perf(spotify): defer httpx import to first SpotifyClient.request() call

### DIFF
--- a/plugins/spotify/client.py
+++ b/plugins/spotify/client.py
@@ -6,7 +6,13 @@ import json
 from typing import Any, Dict, Iterable, Optional
 from urllib.parse import urlparse
 
-import httpx
+# httpx is imported lazily inside SpotifyClient.request() — the only method
+# that actually constructs an HTTP call. The top-level import pulled in the
+# entire httpx + httpcore stack on every process that triggered plugin
+# discovery, even ones that never instantiate SpotifyClient.
+# ``from __future__ import annotations`` above keeps the ``httpx.Response``
+# parameter annotations valid as strings at runtime; nothing in the codebase
+# calls ``typing.get_type_hints()`` on these signatures.
 
 from hermes_cli.auth import (
     AuthError,
@@ -71,6 +77,7 @@ class SpotifyClient:
         allow_retry_on_401: bool = True,
         empty_response: Optional[Dict[str, Any]] = None,
     ) -> Any:
+        import httpx  # lazy — see module-level note
         url = f"{self.base_url}{path}"
         response = httpx.request(
             method,

--- a/tests/tools/test_spotify_client.py
+++ b/tests/tools/test_spotify_client.py
@@ -55,7 +55,7 @@ def test_spotify_client_retries_once_after_401(monkeypatch: pytest.MonkeyPatch) 
             return _FakeResponse(401, {"error": {"message": "expired token"}})
         return _FakeResponse(200, {"devices": [{"id": "dev-1"}]})
 
-    monkeypatch.setattr(spotify_mod.httpx, "request", fake_request)
+    monkeypatch.setattr("httpx.request", fake_request)
 
     client = spotify_mod.SpotifyClient()
     payload = client.get_devices()
@@ -114,7 +114,7 @@ def test_spotify_client_formats_friendly_api_errors(
     def fake_request(method, url, headers=None, params=None, json=None, timeout=None):
         return _FakeResponse(status_code, payload, headers={"content-type": "application/json", "Retry-After": "7"})
 
-    monkeypatch.setattr(spotify_mod.httpx, "request", fake_request)
+    monkeypatch.setattr("httpx.request", fake_request)
 
     client = spotify_mod.SpotifyClient()
     with pytest.raises(spotify_mod.SpotifyAPIError) as exc:
@@ -136,7 +136,7 @@ def test_get_currently_playing_returns_explanatory_empty_payload(monkeypatch: py
     def fake_request(method, url, headers=None, params=None, json=None, timeout=None):
         return _FakeResponse(204, None, text="", headers={"content-type": "application/json"})
 
-    monkeypatch.setattr(spotify_mod.httpx, "request", fake_request)
+    monkeypatch.setattr("httpx.request", fake_request)
 
     client = spotify_mod.SpotifyClient()
     payload = client.get_currently_playing()
@@ -186,7 +186,7 @@ def test_library_contains_uses_generic_library_endpoint(monkeypatch: pytest.Monk
         seen.append((method, url, params))
         return _FakeResponse(200, [True])
 
-    monkeypatch.setattr(spotify_mod.httpx, "request", fake_request)
+    monkeypatch.setattr("httpx.request", fake_request)
 
     client = spotify_mod.SpotifyClient()
     payload = client.library_contains(uris=["spotify:album:abc", "spotify:track:def"])
@@ -230,7 +230,7 @@ def test_library_remove_uses_generic_library_endpoint(
         seen.append((method, url, params))
         return _FakeResponse(200, {})
 
-    monkeypatch.setattr(spotify_mod.httpx, "request", fake_request)
+    monkeypatch.setattr("httpx.request", fake_request)
 
     client = spotify_mod.SpotifyClient()
     getattr(client, method_name)(**{item_key: item_value})


### PR DESCRIPTION
## What does this PR do?

`plugins/spotify/client.py` had a top-level `import httpx` that loaded the
entire httpx + httpcore stack on every process that triggered plugin
discovery — even ones that never invoke a Spotify tool.

The bundled Spotify plugin is auto-loaded as a `kind: backend` plugin, so
plugin discovery runs on every `hermes` CLI invocation. The top-level
import was unnecessary for the vast majority of those processes.

**Root cause:** same pattern fixed in PR #22831 (Teams adapter). The only
call site for `httpx` in `client.py` is `httpx.request()` inside
`SpotifyClient.request()`. Moving `import httpx` there makes it lazy.

**Why the annotations are safe:** `from __future__ import annotations` was
already present at the top of `client.py`, so the `httpx.Response` type
annotations on `_raise_api_error()` and `_extract_spotify_error_detail()`
are already treated as strings at runtime. No resolver ever needs to
materialise the `httpx.Response` symbol.

**Test update:** tests previously patched via `spotify_mod.httpx` (the
module-level name). Updated to `monkeypatch.setattr("httpx.request", …)`,
which patches the same attribute on the `httpx` module object in
`sys.modules`. This is fully compatible with the lazy in-function import:
`monkeypatch.setattr` imports `httpx` first, then the `import httpx` inside
`SpotifyClient.request()` retrieves the same module object from
`sys.modules` — so the patch is already in place.

## Related

Symmetric with PR #22831 (`perf(teams): defer httpx import to first webhook call`).

## Type of Change

- [x] ♻️ Refactor / performance (no behaviour change)

## Changes Made

- `plugins/spotify/client.py`: remove top-level `import httpx`; add
  `import httpx` inside `SpotifyClient.request()` (+7 lines comment, +1 line import, -1 line)
- `tests/tools/test_spotify_client.py`: replace 5× `monkeypatch.setattr(spotify_mod.httpx, …)`
  with `monkeypatch.setattr("httpx.request", …)`

## How to Test

```bash
scripts/run_tests.sh tests/tools/test_spotify_client.py
```

## Checklist

### Code
- [x] Contributing Guide read
- [x] Conventional Commits
- [x] No duplicate PR
- [x] Fix scoped to this change only
- [x] Tests updated and passing
- [x] Symmetric with PR #22831 pattern

### Documentation & Housekeeping
- [x] Docs — N/A
- [x] Cross-platform impact — N/A (pure Python import change)