### PR TITLE
ci: trigger web and python checks

### DIFF
--- a/.github/workflows/docs-site-checks.yml
+++ b/.github/workflows/docs-site-checks.yml
@@ -46,3 +46,5 @@ jobs:
       - name: Build Docusaurus
         run: npm run build
         working-directory: website
+
+# Temporary no-op touch to force Python + web checks on this PR.

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,7 @@
 name: Tests
 
 on:
+  workflow_dispatch:
   push:
     branches: [main]
     paths-ignore:
@@ -80,3 +81,5 @@ jobs:
           OPENROUTER_API_KEY: ""
           OPENAI_API_KEY: ""
           NOUS_API_KEY: ""
+
+# Temporary no-op touch to force Python + web checks on this PR.


### PR DESCRIPTION
Temporary CI trigger PR to force the Python Tests workflow and Docs Site Checks (web) workflow to run on this branch.\n\nNo production code changes; only workflow_dispatch/no-op comments in workflow YAMLs.