### PR TITLE
fix(config): preserve providers max_output_tokens in compatibility view

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2693,6 +2693,7 @@ def _normalize_custom_provider_entry(
         "apiKeyEnv": "key_env",  # alias — OpenClaw-compatible + docs variant
         "defaultModel": "default_model",
         "contextLength": "context_length",
+        "maxOutputTokens": "max_output_tokens",
         "rateLimitDelay": "rate_limit_delay",
     }
     # api_key_env is a documented snake_case alias for key_env (see
@@ -2703,7 +2704,7 @@ def _normalize_custom_provider_entry(
     _KNOWN_KEYS = {
         "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env",
         "api_mode", "transport", "model", "default_model", "models",
-        "context_length", "rate_limit_delay",
+        "context_length", "max_output_tokens", "rate_limit_delay",
         "request_timeout_seconds", "stale_timeout_seconds",
     }
     for camel, snake in _CAMEL_ALIASES.items():
@@ -2790,6 +2791,10 @@ def _normalize_custom_provider_entry(
     context_length = entry.get("context_length")
     if isinstance(context_length, int) and context_length > 0:
         normalized["context_length"] = context_length
+
+    max_output_tokens = entry.get("max_output_tokens")
+    if isinstance(max_output_tokens, int) and max_output_tokens > 0:
+        normalized["max_output_tokens"] = max_output_tokens
 
     rate_limit_delay = entry.get("rate_limit_delay")
     if isinstance(rate_limit_delay, (int, float)) and rate_limit_delay >= 0:

--- a/tests/hermes_cli/test_config.py
+++ b/tests/hermes_cli/test_config.py
@@ -519,6 +519,34 @@ class TestCustomProviderCompatibility:
         assert compatible[0]["provider_key"] == "openai-direct"
         assert compatible[0]["api_mode"] == "codex_responses"
 
+    def test_providers_dict_preserves_max_output_tokens(self, tmp_path):
+        """Compatibility view must carry providers.max_output_tokens through."""
+        config_path = tmp_path / "config.yaml"
+        config_path.write_text(
+            yaml.safe_dump(
+                {
+                    "_config_version": 17,
+                    "providers": {
+                        "openai-direct": {
+                            "api": "https://api.openai.com/v1",
+                            "api_key": "test-key",
+                            "default_model": "gpt-5-mini",
+                            "max_output_tokens": 16384,
+                            "name": "OpenAI Direct",
+                            "transport": "codex_responses",
+                        }
+                    },
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            compatible = get_compatible_custom_providers()
+
+        assert len(compatible) == 1
+        assert compatible[0]["max_output_tokens"] == 16384
+
     def test_compatible_custom_providers_prefers_base_url_then_url_then_api(self, tmp_path):
         """URL field precedence is base_url > url > api (PR #9332)."""
         config_path = tmp_path / "config.yaml"

--- a/tests/hermes_cli/test_provider_config_validation.py
+++ b/tests/hermes_cli/test_provider_config_validation.py
@@ -92,17 +92,29 @@ class TestNormalizeCustomProviderEntry:
         assert any("unknown config keys" in r.message.lower() for r in caplog.records)
 
     def test_timeout_keys_not_flagged_unknown(self, caplog):
-        """request_timeout_seconds and stale_timeout_seconds should not produce warnings."""
+        """Known provider tuning keys should not produce warnings."""
         entry = {
             "base_url": "https://api.example.com/v1",
             "api_key": "***",
             "request_timeout_seconds": 300,
             "stale_timeout_seconds": 900,
+            "max_output_tokens": 8192,
         }
         with caplog.at_level(logging.WARNING):
             result = _normalize_custom_provider_entry(entry, provider_key="test")
         assert result is not None
         assert not any("unknown config keys" in r.message.lower() for r in caplog.records)
+        assert result["max_output_tokens"] == 8192
+
+    def test_camel_case_max_output_tokens_mapped(self):
+        """camelCase maxOutputTokens should be auto-mapped to max_output_tokens."""
+        entry = {
+            "base_url": "https://api.example.com/v1",
+            "maxOutputTokens": 16384,
+        }
+        result = _normalize_custom_provider_entry(entry, provider_key="myhost")
+        assert result is not None
+        assert result["max_output_tokens"] == 16384
 
     def test_camel_case_warning_logged(self, caplog):
         """camelCase alias mapping should produce a warning."""


### PR DESCRIPTION
## Summary

This fixes a config compatibility bug where `providers.<name>.max_output_tokens`
was dropped when Hermes built the legacy `custom_providers`-shaped compatibility
view via `get_compatible_custom_providers()`.

The patch:
- preserves `max_output_tokens` in `_normalize_custom_provider_entry()`
- accepts the camelCase alias `maxOutputTokens`
- adds regression coverage for both direct normalization and the runtime
  compatibility view

## Problem

Hermes still routes several runtime and picker flows through the
`custom_providers` compatibility layer even when the on-disk config uses the
newer `providers:` schema.

Before this change, `_normalize_custom_provider_entry()` did not recognize or
carry `max_output_tokens`, so the value silently disappeared when converting
`providers:` entries into the compatibility list.

## Repro

A config like this:

**providers:**
  openai-direct:
    api: https://api.openai.com/v1
    name: OpenAI Direct
    default_model: gpt-5-mini
    max_output_tokens: 16384
    
would round-trip through get_compatible_custom_providers() without
max_output_tokens.


## Fix
add max_output_tokens to the recognized provider config keys
map camelCase maxOutputTokens to max_output_tokens
preserve the value in the normalized compatibility entry when it is a
positive integer

## Tests
**Passed:**

tests/hermes_cli/test_provider_config_validation.py::TestNormalizeCustomProviderEntry::test_camel_case_max_output_tokens_mapped
tests/hermes_cli/test_config.py::TestCustomProviderCompatibility::test_providers_dict_preserves_max_output_tokens