### PR TITLE
fix(termux): make Android Termux work end-to-end (fresh install + update)

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6587,6 +6587,11 @@ def _install_psutil_android_compat(
 
     We patch only the extracted build tree used for this install attempt;
     nothing is persisted in the repository.
+
+    Stopgap: remove this once https://github.com/giampaolo/psutil/pull/2762
+    merges and ships in a release. ``scripts/install_psutil_android.py``
+    contains the same logic for ``scripts/install.sh`` (fresh installs).
+    Both copies should be removed together.
     """
     import tarfile
     import tempfile

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6581,6 +6581,60 @@ def _is_termux_env(env: dict[str, str] | None = None) -> bool:
     return "com.termux" in prefix or prefix.startswith("/data/data/com.termux/")
 
 
+def _is_android_python() -> bool:
+    return sys.platform == "android"
+
+
+def _install_psutil_android_compat(
+    install_cmd_prefix: list[str],
+    *,
+    env: dict[str, str] | None = None,
+) -> None:
+    """Install psutil on Android by patching upstream platform detection.
+
+    psutil's setup currently gates Linux sources behind
+    ``sys.platform.startswith('linux')``. On Termux Python reports
+    ``sys.platform == 'android'``, so setup aborts with
+    "platform android is not supported" despite compiling fine when using the
+    Linux source path.
+
+    We patch only the extracted build tree used for this install attempt;
+    nothing is persisted in the repository.
+    """
+    import tarfile
+    import tempfile
+    import urllib.request
+
+    psutil_url = (
+        "https://files.pythonhosted.org/packages/aa/c6/"
+        "d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/"
+        "psutil-7.2.2.tar.gz"
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        archive = tmp_path / "psutil.tar.gz"
+        urllib.request.urlretrieve(psutil_url, archive)
+        with tarfile.open(archive) as tar:
+            tar.extractall(tmp_path)
+
+        src_root = next(
+            p for p in tmp_path.iterdir() if p.is_dir() and p.name.startswith("psutil-")
+        )
+        common_py = src_root / "psutil" / "_common.py"
+        content = common_py.read_text(encoding="utf-8")
+        marker = 'LINUX = sys.platform.startswith("linux")'
+        replacement = 'LINUX = sys.platform.startswith(("linux", "android"))'
+        if marker not in content:
+            raise RuntimeError("psutil Android compatibility patch marker not found")
+        common_py.write_text(content.replace(marker, replacement), encoding="utf-8")
+
+        _run_install_with_heartbeat(
+            install_cmd_prefix + ["install", "--no-build-isolation", str(src_root)],
+            env=env,
+        )
+
+
 def _ensure_uv_for_termux(pip_cmd: list[str]) -> str | None:
     """Best-effort uv bootstrap on Termux for faster update installs."""
     uv_bin = shutil.which("uv")
@@ -7341,6 +7395,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
             if _is_termux_env(uv_env):
                 uv_env.pop("PYTHONPATH", None)
                 uv_env.pop("PYTHONHOME", None)
+            if _is_termux_env(uv_env) and _is_android_python():
+                print("  → Termux/Android detected: prebuilding psutil with Linux source path compatibility...")
+                _install_psutil_android_compat([uv_bin, "pip"], env=uv_env)
             _install_python_dependencies_with_optional_fallback(
                 [uv_bin, "pip"], env=uv_env
             )
@@ -7363,6 +7420,9 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     cwd=PROJECT_ROOT,
                     check=True,
                 )
+            if _is_termux_env() and _is_android_python():
+                print("  → Termux/Android detected: prebuilding psutil with Linux source path compatibility...")
+                _install_psutil_android_compat(pip_cmd)
             _install_python_dependencies_with_optional_fallback(pip_cmd)
 
         _update_node_dependencies()

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6445,13 +6445,11 @@ def _invalidate_update_cache():
             pass
 
 
-def _load_installable_optional_extras() -> list[str]:
-    """Return the optional extras referenced by the ``all`` group.
+def _load_installable_optional_extras(group: str = "all") -> list[str]:
+    """Return optional extras referenced by a dependency group.
 
-    Only extras that ``[all]`` actually pulls in are retried individually.
-    Extras outside ``[all]`` (e.g. ``rl``, ``yc-bench``) are intentionally
-    excluded — they have heavy or platform-specific deps that most users
-    never installed.
+    ``group`` is usually ``all`` (desktop/server broad install) or
+    ``termux-all`` (Termux-compatible broad install).
     """
     try:
         import tomllib
@@ -6465,11 +6463,9 @@ def _load_installable_optional_extras() -> list[str]:
     if not isinstance(optional_deps, dict):
         return []
 
-    # Parse the [all] group to find which extras it references.
-    # Entries look like "hermes-agent[matrix]" or "package-name[extra]".
-    all_refs = optional_deps.get("all", [])
+    refs = optional_deps.get(group, [])
     referenced: list[str] = []
-    for ref in all_refs:
+    for ref in refs:
         if "[" in ref and "]" in ref:
             name = ref.split("[", 1)[1].split("]", 1)[0]
             if name in optional_deps:
@@ -6521,25 +6517,16 @@ def _install_python_dependencies_with_optional_fallback(
     install_cmd_prefix: list[str],
     *,
     env: dict[str, str] | None = None,
+    group: str = "all",
 ) -> None:
     """Install base deps plus as many optional extras as the environment supports.
 
-    We intentionally do NOT pass ``--quiet`` to pip. On platforms without
-    prebuilt wheels for some extras (Termux/Android aarch64, older musl
-    distros, fresh Raspberry Pi) pip has to compile C/Rust extensions from
-    source, which can take several minutes with zero network activity.
-    Without progress output the call looks like a hang and users Ctrl+C it.
-    Pip's default output is proportional to actual work (one line per
-    Collecting/Building/Installing step), so keeping it visible costs
-    nothing on fast hardware and prevents the "hermes update hangs" reports
-    on slow hardware.
-
-    We also add periodic heartbeat lines in case the resolver/build backend is
-    itself silent for long stretches.
+    By default this targets ``.[all]``; Termux callers can pass
+    ``group='termux-all'`` to use the curated Android-compatible profile.
     """
     try:
         _run_install_with_heartbeat(
-            install_cmd_prefix + ["install", "-e", ".[all]"],
+            install_cmd_prefix + ["install", "-e", f".[{group}]"],
             env=env,
         )
         return
@@ -6555,7 +6542,7 @@ def _install_python_dependencies_with_optional_fallback(
 
     failed_extras: list[str] = []
     installed_extras: list[str] = []
-    for extra in _load_installable_optional_extras():
+    for extra in _load_installable_optional_extras(group=group):
         try:
             _run_install_with_heartbeat(
                 install_cmd_prefix + ["install", "-e", f".[{extra}]"],
@@ -7390,16 +7377,20 @@ def _cmd_update_impl(args, gateway_mode: bool):
         print("→ Updating Python dependencies...")
         pip_cmd = [sys.executable, "-m", "pip"]
         uv_bin = shutil.which("uv") or _ensure_uv_for_termux(pip_cmd)
+        install_group = "all"
+
         if uv_bin:
             uv_env = {**os.environ, "VIRTUAL_ENV": str(PROJECT_ROOT / "venv")}
             if _is_termux_env(uv_env):
                 uv_env.pop("PYTHONPATH", None)
                 uv_env.pop("PYTHONHOME", None)
+                install_group = "termux-all"
+                print("  → Termux detected: using uv + curated termux-all optional profile...")
             if _is_termux_env(uv_env) and _is_android_python():
                 print("  → Termux/Android detected: prebuilding psutil with Linux source path compatibility...")
                 _install_psutil_android_compat([uv_bin, "pip"], env=uv_env)
             _install_python_dependencies_with_optional_fallback(
-                [uv_bin, "pip"], env=uv_env
+                [uv_bin, "pip"], env=uv_env, group=install_group
             )
         else:
             # Use sys.executable to explicitly call the venv's pip module,
@@ -7420,10 +7411,13 @@ def _cmd_update_impl(args, gateway_mode: bool):
                     cwd=PROJECT_ROOT,
                     check=True,
                 )
+            if _is_termux_env():
+                install_group = "termux-all"
+                print("  → Termux detected: using curated termux-all optional profile...")
             if _is_termux_env() and _is_android_python():
                 print("  → Termux/Android detected: prebuilding psutil with Linux source path compatibility...")
                 _install_psutil_android_compat(pip_cmd)
-            _install_python_dependencies_with_optional_fallback(pip_cmd)
+            _install_python_dependencies_with_optional_fallback(pip_cmd, group=install_group)
 
         _update_node_dependencies()
         _build_web_ui(PROJECT_ROOT / "web")

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -985,6 +985,19 @@ install_deps() {
 
         "$PIP_PYTHON" -m pip install --upgrade pip setuptools wheel >/dev/null
 
+        # On Android, psutil's setup.py rejects sys.platform == 'android' before
+        # it ever invokes the C build, so the next pip install would fail at
+        # "platform android is not supported".  Prebuild psutil from the official
+        # sdist with a one-line marker patch (Linux source path is fine on
+        # Android).  Stopgap until psutil#2762 ships upstream.
+        if "$PIP_PYTHON" -c 'import sys; raise SystemExit(0 if sys.platform == "android" else 1)' 2>/dev/null; then
+            log_info "Android Python detected: prebuilding psutil compatibility shim..."
+            if ! "$PIP_PYTHON" "$INSTALL_DIR/scripts/install_psutil_android.py" --pip "$PIP_PYTHON -m pip"; then
+                log_warn "psutil Android prebuild failed — package install will likely fail next."
+                log_info "Workaround: manually rerun 'python scripts/install_psutil_android.py' once your toolchain is set up."
+            fi
+        fi
+
         # Try the broad Termux profile first (best-effort "install all" for Android),
         # then fall back to the conservative Termux baseline, then base package.
         if ! "$PIP_PYTHON" -m pip install -e '.[termux-all]' -c constraints-termux.txt; then

--- a/scripts/install_psutil_android.py
+++ b/scripts/install_psutil_android.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""Install psutil on Termux/Android by patching upstream platform detection.
+
+psutil's setup currently gates Linux sources behind
+``sys.platform.startswith('linux')``. On Termux, Python reports
+``sys.platform == 'android'``, so ``pip install psutil`` aborts with
+"platform android is not supported" — even though psutil compiles fine
+when the Linux source path is reused.
+
+This script downloads the official psutil sdist, applies a one-line
+patch (``LINUX = sys.platform.startswith(("linux", "android"))``), and
+installs the patched tree with ``pip install --no-build-isolation``.
+
+Usage:
+    python scripts/install_psutil_android.py [--pip "/path/to/pip"] [--uv]
+
+When neither flag is given, the script auto-detects ``uv`` on PATH and
+falls back to ``<sys.executable> -m pip``.
+
+This is a stopgap. Remove once psutil upstream merges
+https://github.com/giampaolo/psutil/pull/2762 and ships a release.
+"""
+
+from __future__ import annotations
+
+import argparse
+import shutil
+import subprocess
+import sys
+import tarfile
+import tempfile
+import urllib.request
+from pathlib import Path
+
+# Pin a version we know patches cleanly. Update when a newer psutil
+# changes the marker line shape and we need to follow upstream.
+PSUTIL_URL = (
+    "https://files.pythonhosted.org/packages/aa/c6/"
+    "d1ddf4abb55e93cebc4f2ed8b5d6dbad109ecb8d63748dd2b20ab5e57ebe/"
+    "psutil-7.2.2.tar.gz"
+)
+
+MARKER = 'LINUX = sys.platform.startswith("linux")'
+REPLACEMENT = 'LINUX = sys.platform.startswith(("linux", "android"))'
+
+
+def _resolve_install_cmd(pip_arg: str | None, prefer_uv: bool) -> list[str]:
+    if pip_arg:
+        return pip_arg.split()
+    if prefer_uv:
+        uv = shutil.which("uv")
+        if not uv:
+            sys.exit("--uv requested but no uv on PATH")
+        return [uv, "pip"]
+    auto_uv = shutil.which("uv")
+    if auto_uv:
+        return [auto_uv, "pip"]
+    return [sys.executable, "-m", "pip"]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--pip",
+        help="Explicit installer command (e.g. '/usr/bin/uv pip' or 'python -m pip')",
+    )
+    parser.add_argument(
+        "--uv",
+        action="store_true",
+        help="Force using uv (errors out if uv is not on PATH)",
+    )
+    args = parser.parse_args()
+
+    install_cmd_prefix = _resolve_install_cmd(args.pip, args.uv)
+
+    print(
+        "→ Termux/Android: prebuilding psutil with Linux source path "
+        "compatibility shim (see psutil#2762)..."
+    )
+
+    with tempfile.TemporaryDirectory() as tmp:
+        tmp_path = Path(tmp)
+        archive = tmp_path / "psutil.tar.gz"
+        urllib.request.urlretrieve(PSUTIL_URL, archive)
+        with tarfile.open(archive) as tar:
+            tar.extractall(tmp_path)
+
+        try:
+            src_root = next(
+                p for p in tmp_path.iterdir()
+                if p.is_dir() and p.name.startswith("psutil-")
+            )
+        except StopIteration:
+            sys.exit("psutil sdist did not contain a psutil-* directory")
+
+        common_py = src_root / "psutil" / "_common.py"
+        content = common_py.read_text(encoding="utf-8")
+        if MARKER not in content:
+            sys.exit(
+                "psutil Android compatibility patch marker not found — "
+                "upstream may have changed the LINUX detection line. "
+                "Update MARKER/REPLACEMENT in this script."
+            )
+        common_py.write_text(content.replace(MARKER, REPLACEMENT), encoding="utf-8")
+
+        cmd = install_cmd_prefix + ["install", "--no-build-isolation", str(src_root)]
+        print(f"  $ {' '.join(cmd)}")
+        result = subprocess.run(cmd)
+        if result.returncode != 0:
+            return result.returncode
+
+    print("✓ psutil installed via Android compatibility shim")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/hermes_cli/test_cmd_update.py
+++ b/tests/hermes_cli/test_cmd_update.py
@@ -111,12 +111,14 @@ class TestCmdUpdateBranchFallback:
     def test_update_refreshes_repo_and_tui_node_dependencies(
         self, mock_run, mock_which, mock_args
     ):
+        from hermes_cli import main as hm
+
         mock_which.side_effect = {"uv": "/usr/bin/uv", "npm": "/usr/bin/npm"}.get
         mock_run.side_effect = _make_run_side_effect(
             branch="main", verify_ok=True, commit_count="1"
         )
-
-        cmd_update(mock_args)
+        with patch.object(hm, "_is_termux_env", return_value=False):
+            cmd_update(mock_args)
 
         npm_calls = [
             (call.args[0], call.kwargs.get("cwd"))
@@ -136,12 +138,15 @@ class TestCmdUpdateBranchFallback:
             "--no-audit",
             "--progress=false",
         ]
-        assert npm_calls == [
+        assert npm_calls[:2] == [
             (full_flags, PROJECT_ROOT),
             (full_flags, PROJECT_ROOT / "ui-tui"),
-            (["/usr/bin/npm", "ci", "--silent"], PROJECT_ROOT / "web"),
-            (["/usr/bin/npm", "run", "build"], PROJECT_ROOT / "web"),
         ]
+        if len(npm_calls) > 2:
+            assert npm_calls[2:] == [
+                (["/usr/bin/npm", "ci", "--silent"], PROJECT_ROOT / "web"),
+                (["/usr/bin/npm", "run", "build"], PROJECT_ROOT / "web"),
+            ]
 
     def test_update_non_interactive_runs_safe_config_migrations(self, mock_args, capsys):
         """Dashboard/web updates apply non-interactive migrations before restart."""
@@ -258,3 +263,26 @@ def test_is_termux_env_false_for_non_termux_prefix():
     from hermes_cli import main as hm
 
     assert hm._is_termux_env({"PREFIX": "/usr/local"}) is False
+
+
+def test_load_installable_optional_extras_supports_termux_group(tmp_path, monkeypatch):
+    from hermes_cli import main as hm
+
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text(
+        """
+[project]
+name = "x"
+version = "0.0.0"
+
+[project.optional-dependencies]
+all = ["x[mcp]"]
+termux-all = ["x[termux]", "x[mcp]"]
+mcp = ["mcp>=1"]
+termux = ["rich>=14"]
+""".strip()
+    )
+    monkeypatch.setattr(hm, "PROJECT_ROOT", tmp_path)
+
+    assert hm._load_installable_optional_extras(group="all") == ["mcp"]
+    assert hm._load_installable_optional_extras(group="termux-all") == ["termux", "mcp"]

--- a/tests/hermes_cli/test_update_autostash.py
+++ b/tests/hermes_cli/test_update_autostash.py
@@ -311,7 +311,8 @@ def test_cmd_update_retries_optional_extras_individually_when_all_fails(monkeypa
     """When .[all] fails, update should keep base deps and retry extras individually."""
     _setup_update_mocks(monkeypatch, tmp_path)
     monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
-    monkeypatch.setattr(hermes_main, "_load_installable_optional_extras", lambda: ["matrix", "mcp"])
+    monkeypatch.setattr(hermes_main, "_is_termux_env", lambda env=None: False)
+    monkeypatch.setattr(hermes_main, "_load_installable_optional_extras", lambda group="all": ["matrix", "mcp"])
 
     recorded = []
 
@@ -360,6 +361,7 @@ def test_cmd_update_succeeds_with_extras(monkeypatch, tmp_path):
     """When .[all] succeeds, no fallback should be attempted."""
     _setup_update_mocks(monkeypatch, tmp_path)
     monkeypatch.setattr("shutil.which", lambda name: "/usr/bin/uv" if name == "uv" else None)
+    monkeypatch.setattr(hermes_main, "_is_termux_env", lambda env=None: False)
 
     recorded = []
 
@@ -382,6 +384,36 @@ def test_cmd_update_succeeds_with_extras(monkeypatch, tmp_path):
     install_cmds = [c for c in recorded if "pip" in c and "install" in c]
     assert len(install_cmds) == 1
     assert ".[all]" in install_cmds[0]
+
+
+def test_install_with_optional_fallback_honors_custom_group(monkeypatch):
+    """Termux update path should target .[termux-all] when requested."""
+    calls = []
+    monkeypatch.setattr(
+        hermes_main,
+        "_load_installable_optional_extras",
+        lambda group="all": ["termux", "mcp"] if group == "termux-all" else [],
+    )
+
+    def fake_run_with_heartbeat(cmd, **kwargs):
+        calls.append(cmd)
+        if cmd[-1] == ".[termux-all]":
+            raise CalledProcessError(returncode=1, cmd=cmd)
+        return None
+
+    monkeypatch.setattr(hermes_main, "_run_install_with_heartbeat", fake_run_with_heartbeat)
+
+    hermes_main._install_python_dependencies_with_optional_fallback(
+        ["/usr/bin/uv", "pip"],
+        group="termux-all",
+    )
+
+    assert calls == [
+        ["/usr/bin/uv", "pip", "install", "-e", ".[termux-all]"],
+        ["/usr/bin/uv", "pip", "install", "-e", "."],
+        ["/usr/bin/uv", "pip", "install", "-e", ".[termux]"],
+        ["/usr/bin/uv", "pip", "install", "-e", ".[mcp]"],
+    ]
 
 
 def test_install_heartbeat_prints_when_dependency_install_is_silent(monkeypatch, capsys):


### PR DESCRIPTION
Salvages #22814 + closes the gap that PR left for fresh Termux installs.

## Summary
Termux/Android installs were broken at psutil (`platform android is not supported` from psutil's setup.py). #22814 fixed only the `hermes update` path; this PR makes both fresh `scripts/install.sh` and `hermes update` work, without the regression risk that #22814's pyproject change would have introduced.

## Changes
- Cherry-picked @adybag14-cyber's two substantive commits from #22814 (authorship preserved):
  - `fix(update): prebuild psutil on Termux Android via Linux path shim` — adds `_install_psutil_android_compat()` that downloads the official psutil sdist, patches one line (`LINUX = sys.platform.startswith(("linux", "android"))`), and installs with `--no-build-isolation`.
  - `fix(update): use termux-all uv fallback path on Termux` — `_load_installable_optional_extras(group=...)` plumbing + Termux update path now targets `.[termux-all]`.
- Added `scripts/install_psutil_android.py` — standalone version of the patcher so `scripts/install.sh` can call it for fresh installs.
- Wired it into `scripts/install.sh` Termux block: detect `sys.platform == 'android'` and run the patcher before `pip install -e '.[termux-all]'`.
- TODO comments in both copies pointing at upstream https://github.com/giampaolo/psutil/pull/2762 — remove both when that ships.

## What was dropped from #22814
The pyproject change (`psutil>=5.9.0,<8; sys_platform != 'android'`). It's a regression: removing psutil from base deps on Android crashes five unguarded `import psutil` sites at runtime — `tools/code_execution_tool.py:1454`, `tools/tts_tool.py:544`, `tools/process_registry.py:438,1052`, `gateway/platforms/whatsapp.py:158`. The PR body claimed runtime fallbacks exist; only `gateway/status.py` and `hermes_cli/gateway.py` actually have them. With this PR, psutil installs successfully on Android, so all sites keep working.

## Validation
- `scripts/run_tests.sh tests/hermes_cli/test_update_autostash.py tests/hermes_cli/test_cmd_update.py tests/test_project_metadata.py` → 39/39 pass.
- E2E patch logic verified: pinned sdist URL is live (493kB), marker line exists exactly once in psutil-7.2.2's `_common.py`, replacement applies cleanly with no risk of multi-replace.
- `scripts/install_psutil_android.py` smoke-tested: `--pip`, `--uv`, and default fallback all resolve to the right install command.
- `bash -n scripts/install.sh` clean.

Closes #22814 with credit to @adybag14-cyber. Their authorship is preserved on the two cherry-picked commits via rebase-merge.