### PR TITLE
fix(tool-result-storage): persist via stdin to bypass 128 KB exec-arg cap

### DIFF
--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -90,8 +90,11 @@ class TestWriteToSandbox:
         env.execute.assert_called_once()
         cmd = env.execute.call_args[0][0]
         assert "mkdir -p" in cmd
-        assert "hello world" in cmd
-        assert HEREDOC_MARKER in cmd
+        # Content travels through stdin, NOT inside the command string —
+        # otherwise large content would hit Linux's 128 KB MAX_ARG_STRLEN
+        # ceiling on `bash -c <cmd>` (#22906).
+        assert "hello world" not in cmd
+        assert env.execute.call_args[1]["stdin_data"] == "hello world"
 
     def test_failure_returns_false(self):
         env = MagicMock()
@@ -99,16 +102,16 @@ class TestWriteToSandbox:
         result = _write_to_sandbox("content", "/tmp/hermes-results/abc.txt", env)
         assert result is False
 
-    def test_heredoc_collision_uses_uuid_marker(self):
+    def test_large_content_via_stdin(self):
+        """Regression: 200 KB content exceeds Linux MAX_ARG_STRLEN (128 KB).
+        It must travel via stdin, never inside the command string."""
         env = MagicMock()
         env.execute.return_value = {"output": "", "returncode": 0}
-        content = f"text with {HEREDOC_MARKER} inside"
-        _write_to_sandbox(content, "/tmp/hermes-results/abc.txt", env)
+        big = "x" * 200_000
+        _write_to_sandbox(big, "/tmp/hermes-results/big.txt", env)
         cmd = env.execute.call_args[0][0]
-        # The default marker should NOT be used as the delimiter
-        lines = cmd.split("\n")
-        # The first and last lines contain the actual delimiter
-        assert HEREDOC_MARKER not in lines[0].split("<<")[1]
+        assert len(cmd) < 1_000  # cmd is just `mkdir -p X && cat > Y`
+        assert env.execute.call_args[1]["stdin_data"] == big
 
     def test_timeout_passed(self):
         env = MagicMock()
@@ -247,9 +250,9 @@ class TestMaybePersistToolResult:
             threshold=30_000,
         )
         assert PERSISTED_OUTPUT_TAG in result
-        # The heredoc written to sandbox should contain the full JSON blob
-        cmd = env.execute.call_args[0][0]
-        assert '"exit_code"' in cmd
+        # Content is delivered through stdin (no longer embedded in the
+        # command string — see test_large_content_via_stdin for why).
+        assert env.execute.call_args[1]["stdin_data"] == content
 
     def test_above_threshold_no_env_truncates_inline(self):
         content = "x" * 60_000

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -76,15 +76,21 @@ def _heredoc_marker(content: str) -> str:
 
 
 def _write_to_sandbox(content: str, remote_path: str, env) -> bool:
-    """Write content into the sandbox via env.execute(). Returns True on success."""
-    marker = _heredoc_marker(content)
+    """Write content into the sandbox via env.execute(). Returns True on success.
+
+    Pushes ``content`` through stdin rather than embedding it in the command
+    string. Linux's ``MAX_ARG_STRLEN`` caps any single argv element at 128 KB
+    (32 * PAGE_SIZE), so the previous heredoc-in-the-command-string approach
+    silently failed with ``OSError: [Errno 7] Argument list too long`` for any
+    tool result over ~128 KB — exactly the case persistence exists to handle.
+    Routing through stdin removes that ceiling on local + ssh (``_stdin_mode
+    == "pipe"``); remote backends with ``_stdin_mode == "heredoc"`` keep their
+    existing API-body sized limit, which is orders of magnitude larger than
+    the exec-arg ceiling.
+    """
     storage_dir = os.path.dirname(remote_path)
-    cmd = (
-        f"mkdir -p {shlex.quote(storage_dir)} && cat > {shlex.quote(remote_path)} << '{marker}'\n"
-        f"{content}\n"
-        f"{marker}"
-    )
-    result = env.execute(cmd, timeout=30)
+    cmd = f"mkdir -p {shlex.quote(storage_dir)} && cat > {shlex.quote(remote_path)}"
+    result = env.execute(cmd, timeout=30, stdin_data=content)
     return result.get("returncode", 1) == 0
 
 


### PR DESCRIPTION
## Summary
Tool results over ~128 KB now persist correctly to the sandbox instead of being silently truncated to a 1.5 KB preview.

Linux caps any single argv element at 128 KB (`MAX_ARG_STRLEN = 32 * PAGE_SIZE`). The previous `_write_to_sandbox` built a heredoc-in-a-bash-c-string and called `bash -c <cmd_with_full_content>`. Any result over ~128 KB raised `OSError [Errno 7] 'Argument list too long'` before the heredoc ever ran. The caller logged a `Sandbox write failed` warning, but `quiet_mode` (CLI default) sets `tools.*` to ERROR so the warning never reached `agent.log` either — falling through to inline truncation with the message `Full output could not be saved to sandbox`. Hits `delegate_task` routinely once 3+ subagents return.

## Changes
- `tools/tool_result_storage.py` — `_write_to_sandbox` now passes content via `env.execute(stdin_data=content)`. Command is now just `mkdir -p X && cat > Y` (sub-1KB), payload travels through stdin where no argv-element limit applies. `BaseEnvironment.execute` already supports `stdin_data` for every backend (local + ssh use a real pipe; vercel/daytona/modal heredoc-encode for their remote API but those bodies are orders of magnitude larger than 128 KB).
- `tests/tools/test_tool_result_storage.py` — updated three tests that asserted on the heredoc-encoded `cmd`. The deleted `test_heredoc_collision_uses_uuid_marker` is replaced with `test_large_content_via_stdin`, which is the actual regression: 200 KB content must round-trip without OSError.

## Validation
| | Before | After |
|---|---|---|
| 144,778-char `delegate_task` envelope (the user's failure) | `OSError: Argument list too long`, falls through to 1.5 KB `Truncated` preview, three task summaries lost | Round-trips cleanly to `/tmp/hermes-results/<id>.txt`, 144,778 bytes verbatim, JSON re-parses with all three task results intact |
| 200,000-char synthetic content | Same OSError | `<persisted-output>` block returned, file on disk matches byte-for-byte, both head/tail markers preserved |
| `tests/tools/test_tool_result_storage.py` | n/a | 49 passed |

## Notes
The companion logging-visibility issue (`tools.*` quiet_mode swallows the `Sandbox write failed` warning so this kind of failure is invisible in `agent.log`) is a separate, smaller change — saved for a follow-up PR rather than mixing concerns. The fix here removes the actual failure mode; the logging tweak just helps catch the next class of sandbox-write bug if one shows up.