### PR TITLE
fix(tui): add mac multiline LF fallback

### DIFF
--- a/ui-tui/src/__tests__/textInputReturnAction.test.ts
+++ b/ui-tui/src/__tests__/textInputReturnAction.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const originalPlatform = process.platform
+
+async function importTextInput(platform: NodeJS.Platform) {
+  vi.resetModules()
+  Object.defineProperty(process, 'platform', { value: platform })
+
+  return import('../components/textInput.js')
+}
+
+afterEach(() => {
+  Object.defineProperty(process, 'platform', { value: originalPlatform })
+  vi.resetModules()
+})
+
+const key = (overrides: Record<string, unknown> = {}) =>
+  ({ ctrl: false, meta: false, return: true, shift: false, super: false, ...overrides }) as any
+
+describe('shouldInsertNewlineOnReturn', () => {
+  it('keeps plain Enter as submit on macOS', async () => {
+    const { shouldInsertNewlineOnReturn } = await importTextInput('darwin')
+
+    expect(shouldInsertNewlineOnReturn(key(), '\r')).toBe(false)
+  })
+
+  it('accepts bare LF as a macOS multiline fallback', async () => {
+    const { shouldInsertNewlineOnReturn } = await importTextInput('darwin')
+
+    expect(shouldInsertNewlineOnReturn(key(), '\n')).toBe(true)
+  })
+
+  it('still inserts newlines for explicit modified Enter chords', async () => {
+    const { shouldInsertNewlineOnReturn } = await importTextInput('darwin')
+
+    expect(shouldInsertNewlineOnReturn(key({ ctrl: true }), '\r')).toBe(true)
+    expect(shouldInsertNewlineOnReturn(key({ shift: true }), '\r')).toBe(true)
+    expect(shouldInsertNewlineOnReturn(key({ super: true }), '\r')).toBe(true)
+  })
+
+  it('does not treat bare LF as multiline on non-macOS', async () => {
+    const { shouldInsertNewlineOnReturn } = await importTextInput('linux')
+
+    expect(shouldInsertNewlineOnReturn(key(), '\n')).toBe(false)
+  })
+})

--- a/ui-tui/src/components/textInput.tsx
+++ b/ui-tui/src/components/textInput.tsx
@@ -179,6 +179,29 @@ export function lineNav(s: string, p: number, dir: -1 | 1): null | number {
 
 export { offsetFromPosition }
 
+type ReturnDecisionKey = {
+  ctrl: boolean
+  meta: boolean
+  return?: boolean
+  shift?: boolean
+  super?: boolean
+}
+
+export function shouldInsertNewlineOnReturn(key: ReturnDecisionKey, sequence = ''): boolean {
+  if (!key.return) {
+    return false
+  }
+
+  if (key.shift || key.ctrl || (isMac ? isActionMod(key) : key.meta)) {
+    return true
+  }
+
+  // Some macOS terminals collapse Ctrl+J / modified Enter into a bare LF.
+  // Preserve Enter submit on CR while still giving TUI a reliable multiline
+  // fallback when the terminal strips the modifier on the wire.
+  return isMac && sequence === '\n'
+}
+
 function renderWithCursor(value: string, cursor: number) {
   const pos = Math.max(0, Math.min(cursor, value.length))
 
@@ -762,7 +785,9 @@ export function TextInput({
       }
 
       if (k.return) {
-        if (k.shift || k.ctrl || (isMac ? isActionMod(k) : k.meta)) {
+        const eventSequence = (event.keypress as { sequence?: string }).sequence ?? eventRaw ?? ''
+
+        if (shouldInsertNewlineOnReturn(k, eventSequence)) {
           flushParentChange()
           commit(ins(vRef.current, curRef.current, '\n'), curRef.current + 1)
         } else {


### PR DESCRIPTION
## Summary
- treat a bare LF as a multiline fallback in the TUI composer on macOS while keeping CR as submit
- keep the existing modified-Enter behavior and cover the return/newline decision with focused tests

## Testing
- cd ui-tui && ./node_modules/.bin/vitest run src/__tests__/textInputReturnAction.test.ts packages/hermes-ink/src/ink/events/cmd-shortcuts.test.ts && ./node_modules/.bin/tsc --noEmit -p tsconfig.json
- uv sync --frozen --extra all
- uv run --frozen ruff check .
- env -i PATH="$PATH" HOME="$HOME" TERM="${TERM:-xterm-256color}" TZ=UTC LANG=C.UTF-8 LC_ALL=C.UTF-8 PYTHONHASHSEED=0 ./.venv/bin/python -m pytest -o addopts= --collect-only --ignore=tests/integration --ignore=tests/e2e -m 'not integration'\n\nCloses #22909