### PR TITLE
fix(feishu): handle quote field for quoted reply messages

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2930,14 +2930,29 @@ class FeishuAdapter(BasePlatformAdapter):
             if hint:
                 text = f"{hint}\n\n{text}" if text else hint
 
-        thread_id = getattr(message, "thread_id", None) or getattr(message, "root_id", None) or None
+        # Note: root_id is the root message ID of a thread, NOT a thread identifier.
+        # Using root_id as thread_id fallback causes quoted replies in P2P to be
+        # routed to a new "thread" session incorrectly. Only thread_id is used for
+        # session routing. root_id is only used as reply_to_message_id fallback.
+        thread_id = getattr(message, "thread_id", None) or None
+        # Extract quote (reply-to) context from Feishu message
+        quote = getattr(message, "quote", None) or {}
+        quote_id = quote.get("id") or quote.get("message_id") or None
+        quote_text = quote.get("text") or None
+        reply_to_text = None
+
         reply_to_message_id = (
             getattr(message, "parent_id", None)
             or getattr(message, "upper_message_id", None)
             or getattr(message, "root_id", None)
+            or quote_id
             or None
         )
-        reply_to_text = await self._fetch_message_text(reply_to_message_id) if reply_to_message_id else None
+
+        # Use quote_text as fallback when parent_id/upper_message_id/root_id are empty
+        if not reply_to_text:
+            reply_to_text = quote_text
+        reply_to_text = await self._fetch_message_text(reply_to_message_id) if reply_to_message_id else (reply_to_text or None)
 
         sender_primary = (
             getattr(sender_id, "open_id", None)


### PR DESCRIPTION
## Summary

Extract `reply_to_message_id` and `reply_to_text` from the Feishu `quote` field in message events, similar to how Signal adapter handles it.

Previously only `parent_id`, `upper_message_id`, and `root_id` were checked, which are empty for quoted replies outside of threads.

## Changes

In `gateway/platforms/feishu.py`:

1. Extract quote field from message: `quote = getattr(message, "quote", None) or {}`
2. Get `quote_id` and `quote_text` from the quote field
3. Use `quote_id` as fallback when `parent_id`/`upper_message_id`/`root_id` are empty
4. Use `quote_text` as fallback for `reply_to_text`

## Fixes

Fixes #22934