### PR TITLE
fix(api-server): require a terminal user turn for chat and responses requests

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -256,6 +256,24 @@ def _normalize_multimodal_content(content: Any) -> Any:
     return normalized_parts
 
 
+def _extract_terminal_user_turn(
+    messages: List[Dict[str, Any]],
+) -> tuple[List[Dict[str, Any]], Any]:
+    """Split a request message list into history and the terminal user turn.
+
+    OpenAI-style request/response APIs expect the last actionable turn to come
+    from the user. Earlier user/assistant messages become conversation history;
+    a trailing assistant turn is invalid and must not be forwarded as the next
+    prompt to the agent.
+    """
+    if not messages:
+        return [], ""
+    last = messages[-1]
+    if str(last.get("role", "")).strip().lower() != "user":
+        return [], None
+    return messages[:-1], last.get("content", "")
+
+
 def _content_has_visible_payload(content: Any) -> bool:
     """True when content has any text or image attachment.  Used to reject empty turns."""
     if isinstance(content, str):
@@ -1010,12 +1028,7 @@ class APIServerAdapter(BasePlatformAdapter):
                     return _multimodal_validation_error(exc, param=f"messages[{idx}].content")
                 conversation_messages.append({"role": role, "content": content})
 
-        # Extract the last user message as the primary input
-        user_message: Any = ""
-        history = []
-        if conversation_messages:
-            user_message = conversation_messages[-1].get("content", "")
-            history = conversation_messages[:-1]
+        history, user_message = _extract_terminal_user_turn(conversation_messages)
 
         if not _content_has_visible_payload(user_message):
             return web.json_response(
@@ -2126,12 +2139,8 @@ class APIServerAdapter(BasePlatformAdapter):
             if instructions is None:
                 instructions = stored.get("instructions")
 
-        # Append new input messages to history (all but the last become history)
-        for msg in input_messages[:-1]:
-            conversation_history.append(msg)
-
-        # Last input message is the user_message
-        user_message: Any = input_messages[-1].get("content", "") if input_messages else ""
+        input_history, user_message = _extract_terminal_user_turn(input_messages)
+        conversation_history.extend(input_history)
         if not _content_has_visible_payload(user_message):
             return web.json_response(_openai_error("No user message found in input"), status=400)
 

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -649,6 +649,28 @@ class TestChatCompletionsEndpoint:
             assert resp.status == 400
 
     @pytest.mark.asyncio
+    async def test_trailing_assistant_message_returns_400(self, adapter):
+        """The terminal chat/completions turn must come from the user."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [
+                            {"role": "user", "content": "1+1=?"},
+                            {"role": "assistant", "content": "2"},
+                        ],
+                    },
+                )
+
+            assert resp.status == 400
+            data = await resp.json()
+            assert "No user message found" in data["error"]["message"]
+            mock_run.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_stream_true_returns_sse(self, adapter):
         """stream=true returns SSE format with the full response."""
         app = _create_app(adapter)
@@ -1316,6 +1338,28 @@ class TestResponsesEndpoint:
             assert resp.status == 200
             call_kwargs = mock_run.call_args.kwargs
             assert call_kwargs["ephemeral_system_prompt"] == "Talk like a pirate."
+
+    @pytest.mark.asyncio
+    async def test_input_with_trailing_assistant_message_returns_400(self, adapter):
+        """The terminal responses input item must come from the user."""
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": [
+                            {"role": "user", "content": "1+1=?"},
+                            {"role": "assistant", "content": "2"},
+                        ],
+                    },
+                )
+
+            assert resp.status == 400
+            data = await resp.json()
+            assert "No user message found" in data["error"]["message"]
+            mock_run.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_previous_response_id_chaining(self, adapter):


### PR DESCRIPTION
This PR fixes a request parsing bug in the API server’s OpenAI-compatible endpoints.

Previously, both `POST /v1/chat/completions` and `POST /v1/responses` assumed that the last actionable message in the request was always the next user prompt. In practice, that meant a payload ending in an `assistant` message could be forwarded to the agent as if it were a new user input.

This change adds a small shared helper in `gateway/platforms/api_server.py` to split parsed messages into:
- prior conversation history
- the terminal user turn

If the final actionable turn is not a `user` message, the request is now rejected with a 400 instead of misrouting assistant content into the next agent run.

Scope of the fix:
- `chat/completions`: validate that the terminal parsed message is a user turn before building `user_message`
- `responses`: apply the same validation to normalized `input` messages before extending `conversation_history`

Tests added:
- `TestChatCompletionsEndpoint::test_trailing_assistant_message_returns_400`
- `TestResponsesEndpoint::test_input_with_trailing_assistant_message_returns_400`

Regression checks also passed:
- `TestChatCompletionsEndpoint::test_conversation_history_passed`
- `TestResponsesEndpoint::test_instructions_as_ephemeral_prompt`

Result:
Invalid assistant-terminal payloads are now rejected cleanly, while valid multi-turn history handling remains unchanged.
