### PR TITLE
fix(cli): add goal_judge to auxiliary model dashboards and remove hardcoded model suggestion

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -831,6 +831,14 @@ DEFAULT_CONFIG = {
             "timeout": 120,
             "extra_body": {},
         },
+        "goal_judge": {
+            "provider": "auto",
+            "model": "",           # cheap/fast model recommended (e.g. gemini-flash); must produce valid JSON
+            "base_url": "",
+            "api_key": "",
+            "timeout": 30,
+            "extra_body": {},
+        },
         # Curator — skill-usage review fork. Timeout is generous because the
         # review pass can take several minutes on reasoning models (umbrella
         # building over hundreds of candidate skills). "auto" = use main chat

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -520,9 +520,8 @@ class GoalManager:
         # Auto-pause when the judge model can't produce the expected JSON
         # verdict N turns in a row. Points the user at the goal_judge config
         # so they can route this side task to a model that follows the
-        # contract (e.g. google/gemini-3-flash-preview). Without this guard,
-        # weak judge models burn the entire turn budget returning prose or
-        # empty strings.
+        # JSON contract. Without this guard, weak judge models burn the
+        # entire turn budget returning prose or empty strings.
         if state.consecutive_parse_failures >= DEFAULT_MAX_CONSECUTIVE_PARSE_FAILURES:
             state.status = "paused"
             state.paused_reason = (
@@ -537,13 +536,10 @@ class GoalManager:
                 "reason": reason,
                 "message": (
                     f"⏸ Goal paused — the judge model ({state.consecutive_parse_failures} turns) "
-                    "isn't returning the required JSON verdict. Route the judge to a stricter "
-                    "model in ~/.hermes/config.yaml:\n"
-                    "  auxiliary:\n"
-                    "    goal_judge:\n"
-                    "      provider: openrouter\n"
-                    "      model: google/gemini-3-flash-preview\n"
-                    "Then /goal resume to continue."
+                    "isn't returning the required JSON verdict. Route the goal judge to a stricter "
+                    "model via the dashboard Models page (http://127.0.0.1:9119/models) or in "
+                    "~/.hermes/config.yaml under auxiliary.goal_judge to use a strict "
+                    "JSON-capable model. Then /goal resume to continue."
                 ),
             }
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -2102,6 +2102,7 @@ _AUX_TASKS: list[tuple[str, str, str]] = [
     ("mcp", "MCP", "MCP tool reasoning"),
     ("title_generation", "Title generation", "session titles"),
     ("skills_hub", "Skills hub", "skills search/install"),
+    ("goal_judge", "Goal judge", "goal completion evaluation"),
     ("curator", "Curator", "skill-usage review pass"),
 ]
 

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -966,6 +966,7 @@ _AUX_TASK_SLOTS: Tuple[str, ...] = (
     "approval",
     "mcp",
     "title_generation",
+    "goal_judge",
     "curator",
 )
 


### PR DESCRIPTION
## Summary

- Adds `goal_judge` to both the web dashboard Models page and the CLI `hermes model` wizard so users can configure the goal judge model through the UI
- Adds `goal_judge` default entry to `DEFAULT_CONFIG` with `"auto"` (inherits main model)
- Replaces the hardcoded `google/gemini-3-flash-preview` suggestion in the auto-pause error message with a generic reference to the dashboard and config file

## Fixes

Closes #22936

## Changes

| File | Change |
|------|--------|
| `hermes_cli/web_server.py` | Added `"goal_judge"` to `_AUX_TASK_SLOTS` |
| `hermes_cli/main.py` | Added `"goal_judge"` to `_AUX_TASKS` |
| `hermes_cli/config.py` | Added `"goal_judge"` entry to `DEFAULT_CONFIG["auxiliary"]` |
| `hermes_cli/goals.py` | Replaced hardcoded model suggestion with generic dashboard+config reference |

## Testing

- All 35 goal-related tests pass
- No new test failures introduced
- Existing test assertions on the error message (`"auxiliary"`, `"goal_judge"`, `"config.yaml"` in message) remain satisfied