### PR TITLE
fix(kanban): request default board explicitly (salvage #22106)

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -385,7 +385,7 @@
 
     // --- load config once ---------------------------------------------------
     useEffect(function () {
-      SDK.fetchJSON(`${API}/config`)
+      SDK.fetchJSON(withBoard(`${API}/config`, board))
         .then(function (c) {
           setConfig(c);
           if (!configApplied) {
@@ -418,7 +418,7 @@
 
     // --- load list of boards for the switcher ------------------------------
     const loadBoardList = useCallback(function () {
-      return SDK.fetchJSON(`${API}/boards`)
+      return SDK.fetchJSON(withBoard(`${API}/boards`, board))
         .then(function (data) {
           const boards = (data && data.boards) || [];
           setBoardList(boards);
@@ -640,7 +640,7 @@
         if (slug && payload.switch) switchBoard(slug);
         return res;
       });
-    }, [loadBoardList, switchBoard]);
+    }, [loadBoardList, switchBoard, board]);
 
     const deleteBoard = useCallback(function (slug) {
       if (!slug || slug === "default") return Promise.resolve();

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -1683,3 +1683,43 @@ def test_specify_no_aux_client_surfaces_reason(client, monkeypatch):
     # Task must stay in triage — nothing was touched.
     detail = client.get(f"/api/plugins/kanban/tasks/{t['id']}").json()["task"]
     assert detail["status"] == "triage"
+
+
+def test_board_endpoint_accepts_explicit_board_default_param(client):
+    """GET /board?board=default must not fall through to env/current-file resolution.
+
+    The dashboard always sends ``?board=<slug>`` (including ``board=default``)
+    so that the server-side ``current`` file can never override the dashboard's
+    selected board.  This test asserts the endpoint accepts the parameter and
+    returns the default board without falling back to environment variable or
+    current-file resolution.
+    Regression: #21819.
+    """
+    # Create a task on the default board.
+    t = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "on-default-board"},
+    ).json()["task"]
+    assert t["status"] == "ready"
+
+    # Request with explicit board=default — must succeed and include the task.
+    r = client.get("/api/plugins/kanban/board?board=default")
+    assert r.status_code == 200
+    data = r.json()
+    ready = next((c for c in data["columns"] if c["name"] == "ready"), None)
+    assert ready is not None, "no 'ready' column in default board response"
+    task_ids = [task["id"] for task in ready["tasks"]]
+    assert t["id"] in task_ids, (
+        f"task {t['id']} not found in ready column of default board "
+        f"(got tasks: {task_ids}). The board=default param was likely ignored."
+    )
+
+
+def test_dashboard_requests_default_board_explicitly():
+    """Dashboard REST calls must include board=default instead of relying on server current board."""
+    repo_root = Path(__file__).resolve().parents[2]
+    dist = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text()
+
+    assert "SDK.fetchJSON(withBoard(`${API}/config`, board))" in dist
+    assert "SDK.fetchJSON(withBoard(`${API}/boards`, board))" in dist
+    assert "}, [loadBoardList, switchBoard, board]);" in dist


### PR DESCRIPTION
## Summary
Stops the dashboard "Default" board from rendering whichever board the server most recently used. The dashboard now sends `board=<slug>` (including `board=default`) on every config/boards REST call so the server-side `current` file can never override the dashboard's selection.

## Changes
- `plugins/kanban/dashboard/dist/index.js`: wrap `${API}/config` and `${API}/boards` in `withBoard(...)` so the slug rides on every request; add `board` to the deps of the loadBoardList callback.
- `tests/plugins/test_kanban_dashboard_plugin.py`: regression test that `GET /board?board=default` returns the default board's tasks (not env/current-file fallback), plus a contract test asserting the dashboard ships those `withBoard` wrappings in its compiled bundle.

## Validation
| | Before | After |
|---|---|---|
| `tests/plugins/test_kanban_dashboard_plugin.py -k "default_board or board_endpoint"` | n/a | 2/2 pass |

Closes #21819 via salvage. Salvage of #22106; original commit by @Tranquil-Flow preserved via cherry-pick.
