### PR TITLE
fix(kanban-dashboard): age running tasks from active run, not first run

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -4161,12 +4161,31 @@ def board_stats(conn: sqlite3.Connection) -> dict:
     }
 
 
-def task_age(task: Task) -> dict:
-    """Return age metrics for a single task. All values are seconds or None."""
+def task_age(
+    task: Task,
+    *,
+    active_run_started_at: Optional[int] = None,
+) -> dict:
+    """Return age metrics for a single task. All values are seconds or None.
+
+    ``active_run_started_at`` overrides ``task.started_at`` for the
+    ``started_age_seconds`` value when the task is currently running.
+    The task-level ``started_at`` records the FIRST run's start; once a
+    task is reclaimed (stale-lock recovery, crash recovery, manual
+    requeue) the first-run timestamp is no longer meaningful for "how
+    long has the current attempt been going". Passing the active run's
+    ``started_at`` produces an age that resets at each reclaim, which
+    is what the dashboard's stale-card colouring actually wants.
+    """
     now = int(time.time())
     age_since_created = now - int(task.created_at) if task.created_at else None
+    started_ref = (
+        active_run_started_at
+        if (task.status == "running" and active_run_started_at is not None)
+        else task.started_at
+    )
     age_since_started = (
-        now - int(task.started_at) if task.started_at else None
+        now - int(started_ref) if started_ref else None
     )
     time_to_complete = (
         int(task.completed_at) - int(task.started_at or task.created_at)
@@ -4177,6 +4196,34 @@ def task_age(task: Task) -> dict:
         "started_age_seconds": age_since_started,
         "time_to_complete_seconds": time_to_complete,
     }
+
+
+def active_run_starts(
+    conn: sqlite3.Connection, task_ids: Iterable[str]
+) -> dict[str, int]:
+    """Batch-fetch ``started_at`` of the currently-open run per task.
+
+    Returns a dict mapping ``task_id`` → ``started_at`` for every task
+    that has an open (``ended_at IS NULL``) run row. Tasks with no open
+    run are omitted. Used by the dashboard to compute per-attempt age
+    for ``running`` cards in a single query (avoids N+1 ``active_run``
+    calls on boards with many in-flight tasks).
+    """
+    ids = list(task_ids)
+    if not ids:
+        return {}
+    placeholders = ",".join("?" for _ in ids)
+    rows = conn.execute(
+        f"""
+        SELECT task_id, MAX(started_at) AS started_at
+          FROM task_runs
+         WHERE task_id IN ({placeholders})
+           AND ended_at IS NULL
+         GROUP BY task_id
+        """,
+        ids,
+    ).fetchall()
+    return {r["task_id"]: int(r["started_at"]) for r in rows if r["started_at"] is not None}
 
 
 # ---------------------------------------------------------------------------

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -132,11 +132,18 @@ def _task_dict(
     task: kanban_db.Task,
     *,
     latest_summary: Optional[str] = None,
+    active_run_started_at: Optional[int] = None,
 ) -> dict[str, Any]:
     d = asdict(task)
     # Add derived age metrics so the UI can colour stale cards without
-    # computing deltas client-side.
-    d["age"] = kanban_db.task_age(task)
+    # computing deltas client-side. For ``running`` tasks the age is
+    # measured from the CURRENT run's start (passed in by the caller),
+    # not the task-level ``started_at`` which records the first run —
+    # otherwise reclaimed tasks glow stale on the dashboard immediately
+    # after a fresh attempt begins.
+    d["age"] = kanban_db.task_age(
+        task, active_run_started_at=active_run_started_at
+    )
     # Surface the latest non-null run summary so dashboards don't show
     # blank cards/drawers for tasks where the worker handed off via
     # ``task_runs.summary`` (the kanban-worker pattern) instead of
@@ -399,13 +406,22 @@ def get_board(
         # for boards with hundreds of tasks). Truncated to a card-size
         # preview here — the full text is available via /tasks/:id.
         summary_map = kanban_db.latest_summaries(conn, [t.id for t in tasks])
+        # For ``running`` tasks, fetch the current run's start so card
+        # age reflects the active attempt (post-reclaim) rather than
+        # the task's first-run timestamp.
+        running_ids = [t.id for t in tasks if t.status == "running"]
+        active_starts = kanban_db.active_run_starts(conn, running_ids)
 
         for t in tasks:
             full = summary_map.get(t.id)
             preview = (
                 full[:_CARD_SUMMARY_PREVIEW_CHARS] if full else None
             )
-            d = _task_dict(t, latest_summary=preview)
+            d = _task_dict(
+                t,
+                latest_summary=preview,
+                active_run_started_at=active_starts.get(t.id),
+            )
             d["link_counts"] = link_counts.get(t.id, {"parents": 0, "children": 0})
             d["comment_count"] = comment_counts.get(t.id, 0)
             d["progress"] = progress.get(t.id)  # None when the task has no children
@@ -467,7 +483,16 @@ def get_task(task_id: str, board: Optional[str] = Query(None)):
         # operators can read the complete worker handoff without making
         # a second round-trip. Cards on /board carry a 200-char preview.
         full_summary = kanban_db.latest_summary(conn, task_id)
-        task_d = _task_dict(task, latest_summary=full_summary)
+        active_started: Optional[int] = None
+        if task.status == "running":
+            run = kanban_db.active_run(conn, task_id)
+            if run is not None:
+                active_started = run.started_at
+        task_d = _task_dict(
+            task,
+            latest_summary=full_summary,
+            active_run_started_at=active_started,
+        )
         # Attach diagnostics so the drawer's Diagnostics section can
         # render recovery actions without a second round-trip.
         diags = _compute_task_diagnostics(conn, task_ids=[task_id])

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -500,6 +500,107 @@ def test_task_age_helper(kanban_home):
         conn.close()
 
 
+def test_task_age_running_uses_active_run_start(kanban_home):
+    """For ``running`` tasks, ``started_age_seconds`` measures the
+    CURRENT run's start (after reclaim), not the task's first-run start.
+
+    Regression: dashboard glowed red on freshly-reclaimed tasks because
+    age was computed off ``tasks.started_at`` (first run) instead of
+    the active run row's ``started_at``.
+    """
+    import time as _time
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="x", assignee="a")
+        # Simulate a task that started long ago (first run) and was
+        # reclaimed onto a fresh active run that just began.
+        first_run_start = int(_time.time()) - 7200  # 2h ago
+        active_run_start = int(_time.time()) - 60   # 1m ago
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status='running', started_at=? WHERE id=?",
+                (first_run_start, tid),
+            )
+        task = kb.get_task(conn, tid)
+
+        # Without override → uses task.started_at (the stale first run)
+        stale = kb.task_age(task)
+        assert stale["started_age_seconds"] >= 7200 - 5
+
+        # With override → uses active run start
+        fresh = kb.task_age(task, active_run_started_at=active_run_start)
+        assert fresh["started_age_seconds"] < 120
+        # created age unchanged
+        assert fresh["created_age_seconds"] == stale["created_age_seconds"]
+    finally:
+        conn.close()
+
+
+def test_task_age_override_ignored_when_not_running(kanban_home):
+    """The active-run override only applies to ``running`` tasks; for
+    any other status the task-level ``started_at`` wins (so completed
+    tasks keep their historical age, etc.)."""
+    import time as _time
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="x", assignee="a")
+        first_run_start = int(_time.time()) - 3600
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status='ready', started_at=? WHERE id=?",
+                (first_run_start, tid),
+            )
+        task = kb.get_task(conn, tid)
+        # Override should be ignored — status is 'ready', not 'running'.
+        result = kb.task_age(task, active_run_started_at=int(_time.time()))
+        assert result["started_age_seconds"] >= 3600 - 5
+    finally:
+        conn.close()
+
+
+def test_active_run_starts_batch(kanban_home):
+    import time as _time
+    conn = kb.connect()
+    try:
+        t1 = kb.create_task(conn, title="a", assignee="x")
+        t2 = kb.create_task(conn, title="b", assignee="x")
+        t3 = kb.create_task(conn, title="c", assignee="x")
+        now = int(_time.time())
+        # t1: closed run + open run (open should win, latest started_at)
+        with kb.write_txn(conn):
+            conn.execute(
+                "INSERT INTO task_runs (task_id, profile, status, started_at, ended_at) "
+                "VALUES (?, 'p', 'crashed', ?, ?)",
+                (t1, now - 7200, now - 3600),
+            )
+            conn.execute(
+                "INSERT INTO task_runs (task_id, profile, status, started_at) "
+                "VALUES (?, 'p', 'running', ?)",
+                (t1, now - 60),
+            )
+            # t2: open run only
+            conn.execute(
+                "INSERT INTO task_runs (task_id, profile, status, started_at) "
+                "VALUES (?, 'p', 'running', ?)",
+                (t2, now - 30),
+            )
+            # t3: only closed runs → omitted
+            conn.execute(
+                "INSERT INTO task_runs (task_id, profile, status, started_at, ended_at) "
+                "VALUES (?, 'p', 'completed', ?, ?)",
+                (t3, now - 1000, now - 500),
+            )
+
+        result = kb.active_run_starts(conn, [t1, t2, t3])
+        assert result[t1] == now - 60
+        assert result[t2] == now - 30
+        assert t3 not in result
+        # Empty input is a no-op.
+        assert kb.active_run_starts(conn, []) == {}
+    finally:
+        conn.close()
+
+
 # ---------------------------------------------------------------------------
 # Notify subscriptions
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
[redacted]