### PR TITLE
fix(context): prevent ## Active Task corruption on iterative re-compression

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1504,28 +1504,54 @@ The user has requested that this compaction PRIORITISE preserving all informatio
 
         last_head_role = messages[compress_start - 1].get("role", "user") if compress_start > 0 else "user"
         first_tail_role = messages[compress_end].get("role", "user") if compress_end < n_messages else "user"
-        # Always pick a role that creates alternation with both neighbors.
-        # When head and tail have the same role, flip to the opposite.
-        # When they differ, use the head role — this always creates alternation.
-        # Drop-in replacement for the previous 3-way logic (flip-or-merge) that
-        # could silently merge into the tail message in the assistant|user case,
-        # causing the model to misinterpret the summary as user input.
-        if last_head_role == first_tail_role:
-            summary_role = "assistant" if last_head_role == "user" else "user"
+        # Pick a role that avoids consecutive same-role with both neighbors.
+        # Priority: pick based on head, then flip if collides with tail.
+        # Only use merge-into-tail as last resort when even flipping collides.
+        _merge_summary_into_tail = False
+        if last_head_role in {"assistant", "tool"}:
+            summary_role = "user"
         else:
-            summary_role = last_head_role
+            summary_role = "assistant"
+        # If the chosen role collides with the tail AND flipping wouldn't
+        # collide with the head, flip it.
+        if summary_role == first_tail_role:
+            flipped = "assistant" if summary_role == "user" else "user"
+            if flipped != last_head_role:
+                summary_role = flipped
+            else:
+                # Both roles would create consecutive same-role messages
+                # (e.g. head=assistant, tail=user). Merge into tail instead.
+                _merge_summary_into_tail = True
 
-        # Append an explicit end-of-summary marker so weak models do not
-        # interpret the ## Active Task quote as fresh user input (#11475, #14521).
-        summary = (
-            summary
-            + "\n\n--- END OF CONTEXT SUMMARY — "
-            "respond to the message below, not the summary above ---"
-        )
-        compressed.append({"role": summary_role, "content": summary})
+        # When the summary lands as a standalone role="user" message,
+        # weak models read the verbatim "## Active Task" quote of a past
+        # user request as fresh input (#11475, #14521). Append the explicit
+        # end marker — the same one used in the merge-into-tail path — so
+        # the model has a clear "summary above, not new input" signal.
+        if not _merge_summary_into_tail and summary_role == "user":
+            summary = (
+                summary
+                + "\n\n--- END OF CONTEXT SUMMARY — "
+                "respond to the message below, not the summary above ---"
+            )
+
+        if not _merge_summary_into_tail:
+            compressed.append({"role": summary_role, "content": summary})
 
         for i in range(compress_end, n_messages):
             msg = messages[i].copy()
+            if _merge_summary_into_tail and i == compress_end:
+                merged_prefix = (
+                    summary
+                    + "\n\n--- END OF CONTEXT SUMMARY — "
+                    "respond to the message below, not the summary above ---\n\n"
+                )
+                msg["content"] = _append_text_to_content(
+                    msg.get("content"),
+                    merged_prefix,
+                    prepend=True,
+                )
+                _merge_summary_into_tail = False
             compressed.append(msg)
 
         self.compression_count += 1

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -25,6 +25,8 @@ from typing import Any, Dict, List, Optional
 
 from agent.auxiliary_client import call_llm, _is_connection_error
 from agent.context_engine import ContextEngine
+from agent.safe_truncate import safe_truncate as _safe_truncate
+from agent.entity_state_tracker import EntityStateTracker
 from agent.model_metadata import (
     MINIMUM_CONTEXT_LENGTH,
     get_model_context_length,
@@ -461,6 +463,10 @@ class ContextCompressor(ContextEngine):
             )
         self._context_probed = False  # True after a step-down from context error
 
+        # Entity state tracker for detecting conflicts after compression
+        self._entity_tracker = EntityStateTracker()
+        self._pre_compression_snapshotted = False
+
         self.last_prompt_tokens = 0
         self.last_completion_tokens = 0
 
@@ -727,15 +733,15 @@ class ContextCompressor(ContextEngine):
             # Tool results: keep enough content for the summarizer
             if role == "tool":
                 tool_id = msg.get("tool_call_id", "")
-                if len(content) > self._CONTENT_MAX:
-                    content = content[:self._CONTENT_HEAD] + "\n...[truncated]...\n" + content[-self._CONTENT_TAIL:]
+                content, _ = _safe_truncate(content, max_length=self._CONTENT_MAX,
+                                                head=self._CONTENT_HEAD, tail=self._CONTENT_TAIL)
                 parts.append(f"[TOOL RESULT {tool_id}]: {content}")
                 continue
 
             # Assistant messages: include tool call names AND arguments
             if role == "assistant":
-                if len(content) > self._CONTENT_MAX:
-                    content = content[:self._CONTENT_HEAD] + "\n...[truncated]...\n" + content[-self._CONTENT_TAIL:]
+                content, _ = _safe_truncate(content, max_length=self._CONTENT_MAX,
+                                                head=self._CONTENT_HEAD, tail=self._CONTENT_TAIL)
                 tool_calls = msg.get("tool_calls", [])
                 if tool_calls:
                     tc_parts = []
@@ -757,8 +763,8 @@ class ContextCompressor(ContextEngine):
                 continue
 
             # User and other roles
-            if len(content) > self._CONTENT_MAX:
-                content = content[:self._CONTENT_HEAD] + "\n...[truncated]...\n" + content[-self._CONTENT_TAIL:]
+            content, _ = _safe_truncate(content, max_length=self._CONTENT_MAX,
+                                            head=self._CONTENT_HEAD, tail=self._CONTENT_TAIL)
             parts.append(f"[{role.upper()}]: {content}")
 
         return "\n\n".join(parts)
@@ -1462,6 +1468,8 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             )
 
         # Phase 3: Generate structured summary
+        # Snapshot entity state before compression for conflict detection
+        self._entity_tracker.snapshot_all()
         summary = self._generate_summary(turns_to_summarize, focus_topic=focus_topic)
 
         # Phase 4: Assemble compressed message list
@@ -1544,5 +1552,12 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                 savings_pct,
             )
             logger.info("Compression #%d complete", self.compression_count)
+
+        # Check for entity state conflicts after compression
+        conflicts = self._entity_tracker.check_conflicts()
+        if conflicts and not self.quiet_mode:
+            warnings = self._entity_tracker.get_warnings()
+            for warning in warnings:
+                logger.warning("Entity state conflict detected: %s", warning)
 
         return compressed

--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -1494,57 +1494,30 @@ The user has requested that this compaction PRIORITISE preserving all informatio
                 f"recent messages below and the current state of any files or resources."
             )
 
-        _merge_summary_into_tail = False
         last_head_role = messages[compress_start - 1].get("role", "user") if compress_start > 0 else "user"
         first_tail_role = messages[compress_end].get("role", "user") if compress_end < n_messages else "user"
-        # Pick a role that avoids consecutive same-role with both neighbors.
-        # Priority: avoid colliding with head (already committed), then tail.
-        if last_head_role in {"assistant", "tool"}:
-            summary_role = "user"
+        # Always pick a role that creates alternation with both neighbors.
+        # When head and tail have the same role, flip to the opposite.
+        # When they differ, use the head role — this always creates alternation.
+        # Drop-in replacement for the previous 3-way logic (flip-or-merge) that
+        # could silently merge into the tail message in the assistant|user case,
+        # causing the model to misinterpret the summary as user input.
+        if last_head_role == first_tail_role:
+            summary_role = "assistant" if last_head_role == "user" else "user"
         else:
-            summary_role = "assistant"
-        # If the chosen role collides with the tail AND flipping wouldn't
-        # collide with the head, flip it.
-        if summary_role == first_tail_role:
-            flipped = "assistant" if summary_role == "user" else "user"
-            if flipped != last_head_role:
-                summary_role = flipped
-            else:
-                # Both roles would create consecutive same-role messages
-                # (e.g. head=assistant, tail=user — neither role works).
-                # Merge the summary into the first tail message instead
-                # of inserting a standalone message that breaks alternation.
-                _merge_summary_into_tail = True
+            summary_role = last_head_role
 
-        # When the summary lands as a standalone role="user" message,
-        # weak models read the verbatim "## Active Task" quote of a past
-        # user request as fresh input (#11475, #14521). Append the explicit
-        # end marker — the same one used in the merge-into-tail path — so
-        # the model has a clear "summary above, not new input" signal.
-        if not _merge_summary_into_tail and summary_role == "user":
-            summary = (
-                summary
-                + "\n\n--- END OF CONTEXT SUMMARY — "
-                "respond to the message below, not the summary above ---"
-            )
-
-        if not _merge_summary_into_tail:
-            compressed.append({"role": summary_role, "content": summary})
+        # Append an explicit end-of-summary marker so weak models do not
+        # interpret the ## Active Task quote as fresh user input (#11475, #14521).
+        summary = (
+            summary
+            + "\n\n--- END OF CONTEXT SUMMARY — "
+            "respond to the message below, not the summary above ---"
+        )
+        compressed.append({"role": summary_role, "content": summary})
 
         for i in range(compress_end, n_messages):
             msg = messages[i].copy()
-            if _merge_summary_into_tail and i == compress_end:
-                merged_prefix = (
-                    summary
-                    + "\n\n--- END OF CONTEXT SUMMARY — "
-                    "respond to the message below, not the summary above ---\n\n"
-                )
-                msg["content"] = _append_text_to_content(
-                    msg.get("content"),
-                    merged_prefix,
-                    prepend=True,
-                )
-                _merge_summary_into_tail = False
             compressed.append(msg)
 
         self.compression_count += 1

--- a/agent/entity_state_tracker.py
+++ b/agent/entity_state_tracker.py
@@ -1,0 +1,152 @@
+"""
+Entity State Tracker: tracks entity state changes and detects conflicts
+after context compression.
+
+Use cases:
+- Variable assignments that get truncated/lost
+- File paths/config items modified mid-execution
+- Key事实陈述被压缩
+"""
+
+from __future__ import annotations
+
+import copy
+import dataclasses
+from typing import Any
+
+
+@dataclasses.dataclass
+class StateSnapshot:
+    """A snapshot of an entity's state at a point in time."""
+    entity_key: str
+    value: Any
+    timestamp: float
+
+
+@dataclasses.dataclass
+class ConflictRecord:
+    """Records a detected conflict after compression."""
+    entity_key: str
+    pre_compression_value: Any
+    post_compression_value: Any
+    warning: str
+
+
+class EntityStateTracker:
+    """
+    Tracks entity states before/after context compression.
+
+    Example:
+        tracker = EntityStateTracker()
+        tracker.record("variable_x", 42)
+        tracker.record("file_path", "/tmp/output.txt")
+
+        # Before compression - snapshot all tracked entities
+        tracker.snapshot_all()
+
+        # ... compression happens, values may change ...
+
+        # After compression - check for conflicts
+        conflicts = tracker.check_conflicts()
+        if conflicts:
+            tracker.inject_warnings_into_summary()
+    """
+
+    def __init__(self):
+        self._entity_state: dict[str, Any] = {}
+        self._entity_history: list[StateSnapshot] = []
+        self._pre_compression_snapshot: dict[str, Any] = {}
+        self._conflict_log: list[ConflictRecord] = []
+
+    def record(self, entity_key: str, value: Any) -> None:
+        """Record the current state of an entity."""
+        self._entity_state[entity_key] = copy.deepcopy(value)
+        self._entity_history.append(StateSnapshot(
+            entity_key=entity_key,
+            value=copy.deepcopy(value),
+            timestamp=_now(),
+        ))
+
+    def snapshot_all(self) -> None:
+        """Snapshot all tracked entity states before compression."""
+        self._pre_compression_snapshot = copy.deepcopy(self._entity_state)
+
+    def check_conflicts(self) -> list[ConflictRecord]:
+        """
+        Compare pre/post compression states and detect conflicts.
+        Returns list of conflicts found.
+        """
+        conflicts = []
+        for key, pre_value in self._pre_compression_snapshot.items():
+            post_value = self._entity_state.get(key)
+            if not self._values_equal(pre_value, post_value):
+                conflict = ConflictRecord(
+                    entity_key=key,
+                    pre_compression_value=copy.deepcopy(pre_value),
+                    post_compression_value=copy.deepcopy(post_value),
+                    warning=self._build_warning(key, pre_value, post_value),
+                )
+                conflicts.append(conflict)
+                self._conflict_log.append(conflict)
+        return conflicts
+
+    def has_conflicts(self) -> bool:
+        """Quick check if any conflicts were detected."""
+        return len(self._conflict_log) > 0
+
+    def get_warnings(self) -> list[str]:
+        """Get human-readable warnings for all detected conflicts."""
+        return [c.warning for c in self._conflict_log]
+
+    def inject_warnings_into_summary(self) -> str:
+        """Generate a summary string with all conflict warnings."""
+        if not self._conflict_log:
+            return ""
+        lines = ["[Entity State Conflict Detected]"]
+        for c in self._conflict_log:
+            lines.append(f"  - {c.warning}")
+        return "\n".join(lines)
+
+    def get_history(self, entity_key: str | None = None) -> list[StateSnapshot]:
+        """Get history for all entities or a specific one."""
+        if entity_key is None:
+            return list(self._entity_history)
+        return [s for s in self._entity_history if s.entity_key == entity_key]
+
+    def get_current_state(self, entity_key: str) -> Any:
+        """Get current state of a tracked entity."""
+        return copy.deepcopy(self._entity_state.get(entity_key))
+
+    def clear(self) -> None:
+        """Reset all tracked state."""
+        self._entity_state.clear()
+        self._entity_history.clear()
+        self._pre_compression_snapshot.clear()
+        self._conflict_log.clear()
+
+    # --- private helpers ---
+
+    def _values_equal(self, a: Any, b: Any) -> bool:
+        try:
+            return a == b
+        except Exception:
+            return False
+
+    def _build_warning(self, key: str, pre: Any, post: Any) -> str:
+        pre_repr = _truncate(repr(pre), 50)
+        post_repr = _truncate(repr(post), 50)
+        return (
+            f"Entity '{key}' changed after compression: "
+            f"{pre_repr} -> {post_repr}"
+        )
+
+
+def _now() -> float:
+    import time
+    return time.time()
+
+
+def _truncate(s: str, max_len: int) -> str:
+    if len(s) <= max_len:
+        return s
+    return s[:max_len - 3] + "..."

--- a/agent/safe_truncate.py
+++ b/agent/safe_truncate.py
@@ -1,0 +1,304 @@
+"""
+Safe Truncation Module — preserves important identifiers when truncating context.
+
+When context is truncated via head+tail, important symbols (file paths, URLs,
+variable names, etc.) are extracted from the middle and preserved.
+"""
+
+import re
+from typing import List, Tuple
+
+# ── Identifier Patterns ──────────────────────────────────────────────────────
+
+_IDENTIFIER_PATTERNS: List[Tuple[str, str]] = [
+    # File paths: /home/user/project/file.py, ./config.yml, ~/dotfiles/.zshrc
+    (r'(?:/[a-zA-Z0-9_.~-]+)+/[a-zA-Z0-9_.~-]+', 'file_path'),
+    # URLs: https://example.com/path, http://api.service:8080/v2
+    (r'https?://[a-zA-Z0-9._~:/\-?#\[\]@!$&\'()*+,;=%]+', 'url'),
+    # Variable names: $VAR, ${VAR}, $HOME, $USER_ID
+    (r'\$[a-zA-Z_][a-zA-Z0-9_]*|\$\{[a-zA-Z_][a-zA-Z0-9_]*\}', 'env_var'),
+    # Python/Filesystem identifiers with dots: module.submodule, obj.attr
+    (r'\b[a-zA-Z_][a-zA-Z0-9_]*(?:\.[a-zA-Z_][a-zA-Z0-9_]*)+\b', 'qualified_name'),
+    # Function definitions: def function_name(
+    (r'def\s+[a-zA-Z_][a-zA-Z0-9_]*\s*\(', 'function_def'),
+    # Class definitions: class ClassName
+    (r'class\s+[a-zA-Z_][a-zA-Z0-9_]*\s*[\(:]', 'class_def'),
+    # Import statements: from module import name, import module
+    (r'(?:from\s+[a-zA-Z_][a-zA-Z0-9_.]+\s+)?import\s+[a-zA-Z_][a-zA-Z0-9_,\s]+', 'import_statement'),
+    # API endpoints: /api/v2/users, /v1/resource/{id}
+    (r'/[a-zA-Z0-9_/{}~-]+(?:/[a-zA-Z0-9_~./{}-]*[a-zA-Z0-9_}~-]?)?', 'api_path'),
+    # Hash/Commit refs: abc1234, 0x1a2b3c
+    (r'\b[0-9a-f]{6,40}\b', 'hash_ref'),
+]
+
+# Compile patterns for performance
+_COMPILED_PATTERNS: List[Tuple[re.Pattern, str]] = [
+    (re.compile(pattern, re.IGNORECASE), label) for pattern, label in _IDENTIFIER_PATTERNS
+]
+
+
+# ── Core Functions ───────────────────────────────────────────────────────────
+
+def _extract_identifiers(text: str) -> List[str]:
+    """
+    Extract all important identifiers from text.
+
+    Returns a deduplicated list of identifiers found, preserving order of first
+    appearance. Filters out very short matches that are likely noise.
+    """
+    seen = set()
+    identifiers = []
+
+    for pattern, label in _COMPILED_PATTERNS:
+        for match in pattern.finditer(text):
+            identifier = match.group()
+            # Filter: skip very short matches (likely false positives)
+            if len(identifier) < 3:
+                continue
+            # Deduplicate by value
+            if identifier not in seen:
+                seen.add(identifier)
+                identifiers.append(identifier)
+
+    return identifiers
+
+
+def safe_truncate(
+    text: str,
+    max_length: int,
+    head: int = None,
+    tail: int = None,
+    head_ratio: float = 0.4,
+    tail_ratio: float = 0.4,
+) -> Tuple[str, List[str]]:
+    """
+    Truncate text while preserving important identifiers from the middle.
+
+    Strategy:
+    - Keep `head_ratio` of available space from the start (default 40%)
+    - Keep `tail_ratio` of available space from the end (default 40%)
+    - If middle content is removed, extract and append identifiers from middle
+
+    Args:
+        text: Text to truncate
+        max_length: Maximum allowed length
+        head: Explicit head size (overrides head_ratio if set)
+        tail: Explicit tail size (overrides tail_ratio if set)
+        head_ratio: Fraction of available space for head when head not explicit
+        tail_ratio: Fraction of available space for tail when tail not explicit
+
+    Returns:
+        Tuple of (truncated_text, list_of_preserved_identifiers)
+    """
+    if len(text) <= max_length:
+        return text, []
+
+    marker = "[Identifiers preserved from middle]"
+
+    # Extract identifiers from the middle BEFORE we decide head/tail sizes
+    # Middle = everything between head and tail regions
+    middle = text  # will recompute after we know head/tail
+    identifiers = []
+
+    head_size = head if head is not None else int(max_length * head_ratio)
+    tail_size = tail if tail is not None else int(max_length * tail_ratio)
+
+    # Enforce invariants
+    head_size = min(head_size, max_length // 2)
+    tail_size = min(tail_size, max_length // 2)
+
+    # Middle = text between head and tail (what would be removed)
+    middle = text[head_size:-tail_size] if tail_size > 0 else text[head_size:]
+
+    identifiers = _extract_identifiers(middle)
+    preserved_line = ""
+
+    if identifiers:
+        # Strategy: head and tail go at the edges; marker+ids fill the gap between them.
+        # Compute how much space is left after reserving head and tail.
+        # We want:  head_part + marker_line + tail_part  <= max_length
+
+        head_part = text[:head_size]
+        tail_part = text[-tail_size:] if tail_size > 0 else ""
+
+        marker = "[Identifiers preserved from middle]"
+        marker_label = f"\n{marker}: "
+
+        # Start with all identifiers and shrink until everything fits
+        id_list = list(identifiers)
+        while id_list:
+            preserved_line = marker_label + ", ".join(id_list)
+            if len(head_part) + len(preserved_line) + len(tail_part) <= max_length:
+                break
+            id_list.pop()
+
+        if not id_list:
+            # Even a single identifier is too long — truncate it
+            max_chars = max(0, max_length - len(head_part) - len(tail_part) - len(marker_label) - 4)
+            if max_chars > 0:
+                id_str = ", ".join(identifiers)
+                preserved_line = marker_label + id_str[:max_chars] + "..."
+            else:
+                # No room for any identifiers at all
+                preserved_line = ""
+
+        # If still over budget, shrink head and tail to fit
+        while len(head_part) + len(preserved_line) + len(tail_part) > max_length:
+            if len(tail_part) > len(head_part) and len(tail_part) > 0:
+                tail_part = tail_part[:-1]
+            elif len(head_part) > 0:
+                head_part = head_part[:-1]
+            else:
+                # Nothing left to shrink — truncate preserved_line
+                max_avail = max(0, max_length - 1)
+                preserved_line = preserved_line[:max_avail]
+                break
+
+        result = head_part + preserved_line + tail_part
+    else:
+        # No identifiers — simple head + tail, both must fit in max_length
+        head_part = text[:head_size]
+        tail_part = text[-tail_size:] if tail_size > 0 else ""
+
+        while len(head_part) + len(tail_part) > max_length and (len(head_part) > 0 or len(tail_part) > 0):
+            if len(head_part) > len(tail_part):
+                head_part = head_part[:-1]
+            else:
+                tail_part = tail_part[1:] if tail_part else ""
+
+        result = head_part + tail_part
+
+    return result, identifiers
+
+
+def truncate_context(
+    text: str,
+    max_length: int,
+    head: int = None,
+    tail: int = None,
+) -> str:
+    """
+    Convenience wrapper — returns just the truncated text.
+    Drop-in replacement for simple head+tail truncation.
+    """
+    result, _ = safe_truncate(text, max_length, head=head, tail=tail)
+    return result
+
+
+# ── Tests ───────────────────────────────────────────────────────────────────
+
+if __name__ == "__main__":
+    import sys
+
+    def test_file_paths():
+        text = (
+            "File: /home/user/project/src/main.py contains the application entry point. "
+            "Configuration loaded from /etc/app/config.yaml. "
+            "Logs written to /var/log/app/application.log. "
+            "User data stored in /home/user/.config/app/data.json"
+        )
+        result, ids = safe_truncate(text, max_length=120)
+        print("=== File Paths Test ===")
+        print(f"Original length: {len(text)}")
+        print(f"Truncated:\n{result}")
+        print(f"Preserved identifiers: {ids}")
+        assert len(result) <= 120, f"Result too long: {len(result)}"
+        # main.py and /home/user/project are in the head — check result contains them
+        assert "main.py" in result, "main.py (head) should be in result"
+        # Middle identifiers from the preserved middle section
+        assert any("/etc/app/config" in id or "config.yaml" in id for id in ids), \
+            "Middle identifiers (config.yaml, /etc/app/config) should be preserved"
+        print("PASS\n")
+
+    def test_urls():
+        text = (
+            "API available at https://api.example.com/v2/users endpoint. "
+            "Documentation at http://docs.example.com/guide/quickstart.html. "
+            "Callback URL: https://example.com/callback?token=abc123&redirect=/home. "
+            "Health check: http://localhost:8080/health"
+        )
+        result, ids = safe_truncate(text, max_length=150)
+        print("=== URLs Test ===")
+        print(f"Original length: {len(text)}")
+        print(f"Truncated:\n{result}")
+        print(f"Preserved identifiers: {ids}")
+        assert len(result) <= 150, f"Result too long: {len(result)}"
+        assert any("https://" in id or "http://" in id for id in ids), "URLs should be preserved"
+        print("PASS\n")
+
+    def test_variable_names():
+        text = (
+            "Environment variables: $HOME=/home/user, $PROJECT_ROOT=/home/user/project. "
+            "Access via os.environ.get('HOME'), config.get('PROJECT_ROOT'). "
+            "User ID: $USER_ID, Session: $SESSION_TOKEN. "
+            "Python vars: sys.path, os.environ, json.dumps()"
+        )
+        result, ids = safe_truncate(text, max_length=140)
+        print("=== Variable Names Test ===")
+        print(f"Original length: {len(text)}")
+        print(f"Truncated:\n{result}")
+        print(f"Preserved identifiers: {ids}")
+        assert len(result) <= 140, f"Result too long: {len(result)}"
+        assert any("$HOME" in id or "$USER" in id for id in ids), "Env vars should be preserved"
+        print("PASS\n")
+
+    def test_no_truncation_needed():
+        short = "This is a short text."
+        result, ids = safe_truncate(short, max_length=1000)
+        assert result == short, "Short text should be unchanged"
+        assert ids == [], "No identifiers for short text"
+        print("=== No Truncation Test ===")
+        print("PASS\n")
+
+    def test_mixed_content():
+        text = (
+            "def process_user_data(user_id: int, config_path: str) -> dict:\n"
+            "    import os\n"
+            "    from src.utils.helpers import parse_config\n"
+            "    # Load config from /etc/app/config.yaml\n"
+            "    url = 'https://api.example.com/users/' + str(user_id)\n"
+            "    return {'status': 'ok', 'user_id': user_id}\n"
+            "    # Log file: /var/log/app/users.log\n"
+            "    # Commit: a1b2c3d4e5f6"
+        )
+        result, ids = safe_truncate(text, max_length=200)
+        print("=== Mixed Content Test ===")
+        print(f"Original length: {len(text)}")
+        print(f"Truncated:\n{result}")
+        print(f"Preserved identifiers: {ids}")
+        assert len(result) <= 200, f"Result too long: {len(result)}"
+        print("PASS\n")
+
+    def test_truncate_context_convenience():
+        text = "A" * 500 + " important_value " + "B" * 500
+        result = truncate_context(text, max_length=100)
+        print("=== truncate_context() wrapper test ===")
+        print(f"Original length: {len(text)}")
+        print(f"Truncated length: {len(result)}")
+        assert len(result) <= 100, f"Result too long: {len(result)}"
+        print("PASS\n")
+
+    tests = [
+        test_file_paths,
+        test_urls,
+        test_variable_names,
+        test_no_truncation_needed,
+        test_mixed_content,
+        test_truncate_context_convenience,
+    ]
+
+    passed = 0
+    failed = 0
+    for test in tests:
+        try:
+            test()
+            passed += 1
+        except AssertionError as e:
+            print(f"FAIL: {e}\n")
+            failed += 1
+        except Exception as e:
+            print(f"ERROR: {e}\n")
+            failed += 1
+
+    print(f"Ran {passed + failed} tests, {passed} passed, {failed} failed")
+    sys.exit(0 if failed == 0 else 1)


### PR DESCRIPTION
## Summary

Context re-compression could corrupt the `## Active Task` field in two ways, causing the agent to forget its current task across compression cycles.

## Root Causes

### Bug 1 — Iterative prompt leaks `[N/A]` placeholder
The iterative update prompt referenced `{_template_sections}`, which contained a literal `[N/A]` placeholder. The LLM was free to output `[N/A]` as the `## Active Task` value, overwriting the correctly-injected task string.

### Bug 2 — Summarizer cannot see the latest user message
`## Active Task` should reflect the user's most recent request. However, during iterative re-compression, the latest user message lives in the protected tail (never sent to the summarizer). Asking the summarizer to "update ## Active Task" produced stale or hallucinated values.

## Changes

### 1. Iterative prompt — PRESERVE guidance (context_compressor.py)
- Replaced `{_template_sections}` with explicit per-section `PRESERVE AS-IS` instructions for all 14 summary sections.
- Marked `## Active Task` explicitly: `PRESERVE AS-IS — this field is set by code, not by the summarizer. Do not modify.`

### 2. First-compaction template — clarify `[N/A]` meaning
- Replaced verbose instructions with: `[N/A — this field is set by code, not by the summarizer. Do not fill in.]`

### 3. New `_inject_active_task()` method
- Extracts the verbatim last user message from the protected tail.
- Overwrites `## Active Task` directly in the summary text after summarization.
- Called after `_generate_summary()` in `compress()`.

### 4. Complete missing PRESERVE sections in iterative prompt
- The iterative prompt was missing `## Constraints & Preferences`, `## Blocked`, `## Pending User Asks`, `## Relevant Files`, `## Remaining Work`, and `## Critical Context`.
- All 14 sections now have explicit PRESERVE instructions.

## Related fixes (included in this PR)

- **gateway/run.py**: Exclude the restart caller from drain to prevent 60s hang (`exclude_key` param added to `_drain_active_agents` and `_interrupt_running_agents`).
- **auxiliary/gateway_shim.py**: Pass original `base_url` to `_maybe_wrap_anthropic` in the compression path (fixes anthropic API errors during compression).

## Testing

- `tests/agent/test_context_compressor.py` — all 76 tests pass
- `tests/agent/test_context_compressor_entity_state_tracker.py` — all 8 tests pass
- `tests/agent/test_context_compressor_identifier_policy.py` — all 22 tests pass
- `tests/agent/test_context_compressor_summary_continuity.py` — all 2 tests pass
- **Total: 108 tests pass**

Note: 3 pre-existing test failures in unrelated modules (`acp`, `cli`, `gateway`) are present in `upstream/main` and are not introduced by this PR.

## Files Changed

| File | Change |
|------|--------|
| `agent/context_compressor.py` | PRESERVE guidance, `_inject_active_task()`, `_safe_truncate()`, Entity State Tracker |
| `gateway/run.py` | `exclude_key` param for drain/interrupt |
| `auxiliary/gateway_shim.py` | Pass `base_url` in compression path |
| `tests/agent/test_context_compressor*.py` | New and updated tests |
