### PR TITLE
fix(file): count unterminated final line in read_file

### DIFF
--- a/tests/tools/test_file_tools_live.py
+++ b/tests/tools/test_file_tools_live.py
@@ -229,6 +229,34 @@ class TestReadFile:
         assert result.error is None
         _assert_clean(result.content)
 
+    def test_total_lines_counts_file_without_trailing_newline(self, ops, tmp_path):
+        f = tmp_path / "no_trailing_newline.txt"
+        f.write_text("line1\nline2\nline3", encoding="utf-8")
+        result = ops.read_file(str(f))
+        assert result.error is None
+        assert result.total_lines == 3
+        assert "     3|line3" in result.content
+        _assert_clean(result.content)
+
+    def test_total_lines_counts_single_line_without_trailing_newline(self, ops, tmp_path):
+        f = tmp_path / "single_line.txt"
+        f.write_text("solo", encoding="utf-8")
+        result = ops.read_file(str(f))
+        assert result.error is None
+        assert result.total_lines == 1
+        assert result.content == "     1|solo"
+        _assert_clean(result.content)
+
+    def test_pagination_hint_uses_correct_total_lines_without_trailing_newline(self, ops, tmp_path):
+        f = tmp_path / "paginated_no_newline.txt"
+        f.write_text("line1\nline2\nline3", encoding="utf-8")
+        result = ops.read_file(str(f), offset=1, limit=2)
+        assert result.error is None
+        assert result.total_lines == 3
+        assert result.truncated is True
+        assert result.hint == "Use offset=3 to continue reading (showing 1-2 of 3 lines)"
+        _assert_clean(result.content)
+
 
 # ── write_file ───────────────────────────────────────────────────────────
 

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -521,6 +521,13 @@ class ShellFileOperations(FileOperations):
             result = self._exec(f"command -v {cmd} >/dev/null 2>&1 && echo 'yes'")
             self._command_cache[cmd] = result.stdout.strip() == 'yes'
         return self._command_cache[cmd]
+
+    def _ends_with_newline(self, path: str) -> bool:
+        """Return True when the file's final byte is a newline."""
+        result = self._exec(f"tail -c 1 {self._escape_shell_arg(path)} 2>/dev/null")
+        if result.exit_code != 0:
+            return False
+        return _strip_terminal_fence_leaks(result.stdout) == "\n"
     
     def _is_likely_binary(self, path: str, content_sample: str = None) -> bool:
         """
@@ -692,6 +699,10 @@ class ShellFileOperations(FileOperations):
             total_lines = int(wc_output.strip())
         except ValueError:
             total_lines = 0
+        if file_size > 0 and not self._ends_with_newline(path):
+            # wc -l counts newline bytes, so a non-empty file without a
+            # trailing newline still has one more logical line.
+            total_lines += 1
         
         # Check if truncated
         truncated = total_lines > end_line


### PR DESCRIPTION
## Summary
- correct `read_file()` line counting for non-empty files that do not end with a trailing newline
- keep the existing `wc -l` fast path, then compensate when the final byte is not `\n`
- add live regression coverage for multi-line, single-line, and paginated reads without trailing newlines

## Testing
- `git diff --check`
- `uv sync --frozen --extra all`
- `./.venv/bin/python -m pytest -q -o addopts= tests/tools/test_file_tools_live.py tests/tools/test_file_operations.py`
- `./.venv/bin/ruff check .`
- clean `env -i` pytest `--collect-only`
- base-vs-head `ruff`/`ty` lint-diff against `origin/main` (touched files: 0 new diagnostics)

Closes #3907.
