### PR TITLE
fix(agent): mark turn as completed when iteration-limit summary succeeds

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -4401,9 +4401,16 @@ def run_conversation(
                 )
 
     # Determine if conversation completed successfully
+    # When max_iterations is reached but _handle_max_iterations successfully
+    # returns a summary, the conversation should still be considered completed
+    # so the summary is properly displayed to the user instead of appearing
+    # as if the agent "paused" or got stuck.
     completed = (
         final_response is not None
-        and api_call_count < agent.max_iterations
+        and (
+            api_call_count < agent.max_iterations
+            or _turn_exit_reason.startswith("max_iterations_reached")
+        )
         and not failed
     )
 


### PR DESCRIPTION
## Bug Description

When the agent reaches `max_iterations` (default 90), it shows:
```
⚠️ Iteration budget exhausted (90/90) — asking model to summarise
```

Then `_handle_max_iterations()` makes a final toolless API call to request a summary. However, the `completed` flag was set to **False** because `api_call_count >= max_iterations`, causing the CLI/gateway to treat the turn as incomplete. This made the summary invisible to users — the agent appeared to "pause" or get stuck after showing the budget-exhausted message.

## Root Cause

In `run_agent.py` line 14498:
```python
completed = final_response is not None and api_call_count < self.max_iterations
```

When `api_call_count == max_iterations` (e.g., 90/90), `completed` is always `False`, even when `_handle_max_iterations()` successfully returns a summary.

## Fix

Treat turns that exited via `max_iterations_reached` as completed when `final_response` is present (i.e., the summary call succeeded):

```python
completed = final_response is not None and (
    api_call_count < self.max_iterations
    or _turn_exit_reason.startswith("max_iterations_reached")
)
```

## Verification

- Scenario 1: Normal completion (50/90 iterations) → `completed=True` ✓
- Scenario 2: Budget exhausted, summary succeeds (90/90) → `completed=True` (was `False`) ✓
- Scenario 3: Budget exhausted, summary fails → `completed=True` (has final_response) ✓
- Scenario 4: Budget exhausted, final_response=None → `completed=False` ✓
- Scenario 5: Error near max iterations (89/90) → `completed=True` ✓
