### PR TITLE
fix(tui): respect show_reasoning for thinking segments

### DIFF
--- a/ui-tui/src/__tests__/turnController.test.ts
+++ b/ui-tui/src/__tests__/turnController.test.ts
@@ -1,0 +1,128 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+
+import { turnController } from '../app/turnController.js'
+import { getTurnState, resetTurnState } from '../app/turnStore.js'
+import { patchUiState, resetUiState } from '../app/uiStore.js'
+
+describe('turnController reasoning visibility (#22894)', () => {
+  beforeEach(() => {
+    resetUiState()
+    resetTurnState()
+    turnController.fullReset()
+  })
+
+  describe('display.show_reasoning = false', () => {
+    beforeEach(() => {
+      patchUiState({ showReasoning: false, streaming: true })
+    })
+
+    it('does not store streamed <think> content into turn state on flush', () => {
+      turnController.startMessage()
+      turnController.recordMessageDelta({ text: '<think>secret plan</think>visible reply' })
+      turnController.flushStreamingSegment()
+
+      expect(getTurnState().reasoning).toBe('')
+      expect(getTurnState().reasoningTokens).toBe(0)
+      expect(turnController.reasoningText).toBe('')
+    })
+
+    it('does not attach thinking when payload.text carries <think> tags', () => {
+      turnController.startMessage()
+      const result = turnController.recordMessageComplete({ text: '<think>secret plan</think>visible reply' })
+
+      expect(result.finalText).toBe('visible reply')
+      expect(result.finalMessages).toHaveLength(1)
+      expect(result.finalMessages[0]).toMatchObject({ role: 'assistant', text: 'visible reply' })
+      expect(result.finalMessages[0]?.thinking).toBeUndefined()
+      expect(result.finalMessages[0]?.thinkingTokens).toBeUndefined()
+    })
+
+    it('drops payload.reasoning on message.complete', () => {
+      turnController.startMessage()
+
+      const result = turnController.recordMessageComplete({
+        reasoning: 'gateway sent reasoning anyway',
+        text: 'visible reply'
+      })
+
+      expect(result.finalMessages[0]).toMatchObject({ role: 'assistant', text: 'visible reply' })
+      expect(result.finalMessages[0]?.thinking).toBeUndefined()
+    })
+
+    it('does not attach thinking when payload.rendered carries <think> tags', () => {
+      turnController.startMessage()
+      const result = turnController.recordMessageComplete({ rendered: '<think>secret plan</think>visible reply' })
+
+      expect(result.finalText).toBe('visible reply')
+      expect(result.finalMessages[0]).toMatchObject({ role: 'assistant', text: 'visible reply' })
+      expect(result.finalMessages[0]?.thinking).toBeUndefined()
+      expect(result.finalMessages[0]?.thinkingTokens).toBeUndefined()
+    })
+
+    it('drops reasoning captured before reasoning display is toggled off', () => {
+      turnController.startMessage()
+      patchUiState({ showReasoning: true })
+      turnController.recordMessageDelta({ text: '<think>earlier visible reasoning</think>partial reply' })
+      turnController.flushStreamingSegment()
+
+      patchUiState({ showReasoning: false })
+      const result = turnController.recordMessageComplete({ text: 'final visible reply' })
+
+      expect(result.finalMessages.map(msg => msg.text)).toEqual(['partial reply', 'final visible reply'])
+      expect(result.finalMessages.every(msg => msg.thinking === undefined)).toBe(true)
+      expect(result.finalMessages.every(msg => msg.thinkingTokens === undefined)).toBe(true)
+    })
+
+    it('preserves visible response text untouched', () => {
+      turnController.startMessage()
+      turnController.recordMessageDelta({ text: '<think>x</think>plain answer' })
+      turnController.flushStreamingSegment()
+
+      expect(getTurnState().streamSegments[0]).toMatchObject({ role: 'assistant', text: 'plain answer' })
+      expect(getTurnState().streamSegments[0]?.thinking).toBeUndefined()
+    })
+  })
+
+  describe('display.show_reasoning = true', () => {
+    beforeEach(() => {
+      patchUiState({ showReasoning: true, streaming: true })
+    })
+
+    it('stores streamed <think> content into turn state on flush', () => {
+      turnController.startMessage()
+      turnController.recordMessageDelta({ text: '<think>secret plan</think>visible reply' })
+      turnController.flushStreamingSegment()
+
+      expect(getTurnState().reasoning).toBe('secret plan')
+      expect(turnController.reasoningText).toBe('secret plan')
+    })
+
+    it('attaches thinking when payload.text carries <think> tags', () => {
+      turnController.startMessage()
+      const result = turnController.recordMessageComplete({ text: '<think>secret plan</think>visible reply' })
+
+      expect(result.finalMessages).toHaveLength(1)
+      expect(result.finalMessages[0]).toMatchObject({
+        role: 'assistant',
+        text: 'visible reply',
+        thinking: 'secret plan'
+      })
+      expect(result.finalMessages[0]?.thinkingTokens).toBeGreaterThan(0)
+    })
+
+    it('preserves payload.reasoning on message.complete', () => {
+      turnController.startMessage()
+
+      const result = turnController.recordMessageComplete({
+        reasoning: 'thought process',
+        text: 'visible reply'
+      })
+
+      expect(result.finalMessages[0]).toMatchObject({
+        role: 'assistant',
+        text: 'visible reply',
+        thinking: 'thought process'
+      })
+    })
+  })
+})

--- a/ui-tui/src/__tests__/turnController.test.ts
+++ b/ui-tui/src/__tests__/turnController.test.ts
@@ -26,7 +26,7 @@ describe('turnController reasoning visibility (#22894)', () => {
       expect(turnController.reasoningText).toBe('')
     })
 
-    it('does not attach thinking when payload.text carries <think> tags', () => {
+    it('does not emit thinking when payload.text carries <think> tags', () => {
       turnController.startMessage()
       const result = turnController.recordMessageComplete({ text: '<think>secret plan</think>visible reply' })
 
@@ -45,21 +45,23 @@ describe('turnController reasoning visibility (#22894)', () => {
         text: 'visible reply'
       })
 
+      expect(result.finalMessages).toHaveLength(1)
       expect(result.finalMessages[0]).toMatchObject({ role: 'assistant', text: 'visible reply' })
       expect(result.finalMessages[0]?.thinking).toBeUndefined()
     })
 
-    it('does not attach thinking when payload.rendered carries <think> tags', () => {
+    it('does not emit thinking when payload.rendered carries <think> tags', () => {
       turnController.startMessage()
       const result = turnController.recordMessageComplete({ rendered: '<think>secret plan</think>visible reply' })
 
       expect(result.finalText).toBe('visible reply')
+      expect(result.finalMessages).toHaveLength(1)
       expect(result.finalMessages[0]).toMatchObject({ role: 'assistant', text: 'visible reply' })
       expect(result.finalMessages[0]?.thinking).toBeUndefined()
       expect(result.finalMessages[0]?.thinkingTokens).toBeUndefined()
     })
 
-    it('drops reasoning captured before reasoning display is toggled off', () => {
+    it('redacts reasoning trail segments committed before reasoning display is toggled off', () => {
       turnController.startMessage()
       patchUiState({ showReasoning: true })
       turnController.recordMessageDelta({ text: '<think>earlier visible reasoning</think>partial reply' })
@@ -71,6 +73,44 @@ describe('turnController reasoning visibility (#22894)', () => {
       expect(result.finalMessages.map(msg => msg.text)).toEqual(['partial reply', 'final visible reply'])
       expect(result.finalMessages.every(msg => msg.thinking === undefined)).toBe(true)
       expect(result.finalMessages.every(msg => msg.thinkingTokens === undefined)).toBe(true)
+    })
+
+    it('keeps interim dedupe aligned after a redacted segment is dropped', () => {
+      turnController.startMessage()
+      patchUiState({ showReasoning: true })
+      turnController.recordReasoningDelta('live reasoning')
+
+      turnController.recordMessageDelta({ text: 'interim reply' })
+      turnController.recordInterimMessage('interim reply')
+
+      turnController.recordMessageDelta({ text: 'post interim chunk' })
+      turnController.flushStreamingSegment()
+
+      patchUiState({ showReasoning: false })
+      const result = turnController.recordMessageComplete({ text: 'post interim chunk\n\nfinal answer' })
+
+      // The reasoning-only segment is dropped, so the interim boundary has to
+      // shift with it — otherwise the post-interim segment escapes dedupe and
+      // its text renders twice.
+      expect(result.finalText).toBe('final answer')
+      expect(result.finalMessages.map(msg => msg.text)).toEqual(['interim reply', 'post interim chunk', 'final answer'])
+      expect(result.finalMessages.every(msg => msg.thinking === undefined)).toBe(true)
+    })
+
+    it('keeps MoA reference segments when reasoning is toggled off mid-turn', () => {
+      turnController.startMessage()
+      patchUiState({ showReasoning: true })
+      turnController.recordReasoningDelta('live reasoning')
+      turnController.recordMoaReference('model-a', 'reference output')
+
+      patchUiState({ showReasoning: false })
+      const result = turnController.recordMessageComplete({ text: 'final reply' })
+
+      const thinkingSegments = result.finalMessages.filter(msg => msg.thinking)
+
+      expect(thinkingSegments).toHaveLength(1)
+      expect(thinkingSegments[0]?.thinking).toContain('Reference — model-a')
+      expect(thinkingSegments[0]?.thinking).not.toContain('live reasoning')
     })
 
     it('preserves visible response text untouched', () => {
@@ -97,20 +137,23 @@ describe('turnController reasoning visibility (#22894)', () => {
       expect(turnController.reasoningText).toBe('secret plan')
     })
 
-    it('attaches thinking when payload.text carries <think> tags', () => {
+    it('emits thinking as a system trail message when payload.text carries <think> tags', () => {
       turnController.startMessage()
       const result = turnController.recordMessageComplete({ text: '<think>secret plan</think>visible reply' })
 
-      expect(result.finalMessages).toHaveLength(1)
+      expect(result.finalText).toBe('visible reply')
+      expect(result.finalMessages).toHaveLength(2)
       expect(result.finalMessages[0]).toMatchObject({
-        role: 'assistant',
-        text: 'visible reply',
+        kind: 'trail',
+        role: 'system',
         thinking: 'secret plan'
       })
       expect(result.finalMessages[0]?.thinkingTokens).toBeGreaterThan(0)
+      expect(result.finalMessages[1]).toMatchObject({ role: 'assistant', text: 'visible reply' })
+      expect(result.finalMessages[1]?.thinking).toBeUndefined()
     })
 
-    it('preserves payload.reasoning on message.complete', () => {
+    it('preserves payload.reasoning as a system trail message on message.complete', () => {
       turnController.startMessage()
 
       const result = turnController.recordMessageComplete({
@@ -118,10 +161,27 @@ describe('turnController reasoning visibility (#22894)', () => {
         text: 'visible reply'
       })
 
+      expect(result.finalMessages).toHaveLength(2)
       expect(result.finalMessages[0]).toMatchObject({
-        role: 'assistant',
-        text: 'visible reply',
+        kind: 'trail',
+        role: 'system',
         thinking: 'thought process'
+      })
+      expect(result.finalMessages[1]).toMatchObject({ role: 'assistant', text: 'visible reply' })
+    })
+
+    it('keeps the streamed reasoning trail segment in final messages', () => {
+      turnController.startMessage()
+      turnController.recordMessageDelta({ text: '<think>earlier visible reasoning</think>partial reply' })
+      turnController.flushStreamingSegment()
+
+      const result = turnController.recordMessageComplete({ text: 'final visible reply' })
+
+      expect(result.finalMessages.map(msg => msg.text)).toEqual(['', 'partial reply', 'final visible reply'])
+      expect(result.finalMessages[0]).toMatchObject({
+        kind: 'trail',
+        role: 'system',
+        thinking: 'earlier visible reasoning'
       })
     })
   })

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -127,6 +127,7 @@ class TurnController {
   private activeReasoningText = ''
   private reasoningSegmentIndex: null | number = null
   private interimBoundaryIndex: null | number = null
+  private reasoningSegmentIndices = new Set<number>()
   private activityId = 0
   private reasoningStreamingTimer: Timer = null
   private reasoningTimer: Timer = null
@@ -276,6 +277,7 @@ class TurnController {
     this.bufRef = ''
     this.pendingSegmentTools = []
     this.segmentMessages = []
+    this.reasoningSegmentIndices.clear()
 
     patchTurnState({
       streamPendingTools: [],
@@ -377,6 +379,7 @@ class TurnController {
 
     if (this.reasoningSegmentIndex === null) {
       this.reasoningSegmentIndex = this.segmentMessages.length
+      this.reasoningSegmentIndices.add(this.reasoningSegmentIndex)
       this.segmentMessages = [...this.segmentMessages, msg]
     } else {
       this.segmentMessages = this.segmentMessages.map((item, i) => (i === this.reasoningSegmentIndex ? msg : item))
@@ -551,6 +554,7 @@ class TurnController {
     this.clearStatusTimer()
     this.pendingSegmentTools = []
     this.segmentMessages = []
+    this.reasoningSegmentIndices.clear()
     this.turnTools = []
     this.persistedToolLabels.clear()
 
@@ -565,6 +569,47 @@ class TurnController {
     text?: string
   }) {
     this.closeReasoningSegment()
+
+    // When display.show_reasoning is off, drop any saved/streamed/payload
+    // reasoning so finalized assistant messages don't render `thinking`. The
+    // visible text is still split out of `<think>` tags below. See #22894.
+    const showReasoning = getUiState().showReasoning
+
+    // Reasoning captured while show_reasoning was still on lives in committed
+    // trail segments (closed/synced just above). Honour the setting at
+    // completion time: strip `thinking` from those segments and drop any that
+    // end up empty. MoA reference segments are not reasoning and stay put.
+    if (!showReasoning && this.reasoningSegmentIndices.size) {
+      // Dropping segments renumbers the array, so the interim boundary — the
+      // index message.complete slices from to skip sealed interims — has to
+      // shift by however many pre-boundary segments the filter removes.
+      const boundary = this.interimBoundaryIndex
+      let droppedBeforeBoundary = 0
+
+      this.segmentMessages = this.segmentMessages
+        .map((msg, i) => {
+          if (!this.reasoningSegmentIndices.has(i)) {
+            return msg
+          }
+
+          const { thinking, thinkingTokens, ...redacted } = msg
+
+          return redacted
+        })
+        .filter((msg, i) => {
+          const keep = Boolean(msg.text) || hasDetails(msg)
+
+          if (!keep && boundary !== null && i < boundary) {
+            droppedBeforeBoundary += 1
+          }
+
+          return keep
+        })
+
+      if (boundary !== null && droppedBeforeBoundary) {
+        this.interimBoundaryIndex = boundary - droppedBeforeBoundary
+      }
+    }
 
     // Ink renders markdown via <Md>; the gateway's Rich-rendered ANSI
     // (`payload.rendered`) is for terminals that can't.  Prioritising
@@ -583,14 +628,8 @@ class TurnController {
     // review: duplicate-message blocker)
     const dedupeStart = payload.response_previewed ? 0 : (this.interimBoundaryIndex ?? 0)
     const finalText = finalTail(split.text, this.segmentMessages.slice(dedupeStart))
-    // When display.show_reasoning is off, drop any saved/streamed/payload
-    // reasoning so finalized assistant messages don't render `thinking`. The
-    // visible text is still split out of `<think>` tags above. See #22894.
-    const showReasoning = getUiState().showReasoning
 
-    const existingReasoning = showReasoning
-      ? this.reasoningText.trim() || String(payload.reasoning ?? '').trim()
-      : ''
+    const existingReasoning = showReasoning ? this.reasoningText.trim() || String(payload.reasoning ?? '').trim() : ''
 
     const savedReasoning = showReasoning
       ? [existingReasoning, existingReasoning ? '' : split.reasoning].filter(Boolean).join('\n\n')
@@ -942,6 +981,7 @@ class TurnController {
     this.reasoningSegmentIndex = null
     this.interimBoundaryIndex = null
     this.segmentMessages = []
+    this.reasoningSegmentIndices.clear()
     this.turnTools = []
     this.toolTokenAcc = 0
     this.persistedToolLabels.clear()

--- a/ui-tui/src/app/turnController.ts
+++ b/ui-tui/src/app/turnController.ts
@@ -404,7 +404,10 @@ class TurnController {
         : { reasoning: '', text: raw }
       : { reasoning: '', text: '' }
 
-    if (split.reasoning && !this.reasoningText.trim()) {
+    // Drop split reasoning when display.show_reasoning is off — without this
+    // gate, embedded <think>…</think> chunks leak from streamed text into
+    // turn state and the finalized assistant Msg's `thinking` field. See #22894.
+    if (split.reasoning && !this.reasoningText.trim() && getUiState().showReasoning) {
       this.reasoningText = split.reasoning
       this.activeReasoningText = split.reasoning
       patchTurnState({ reasoning: this.reasoningText, reasoningTokens: estimateTokensRough(this.reasoningText) })
@@ -580,8 +583,19 @@ class TurnController {
     // review: duplicate-message blocker)
     const dedupeStart = payload.response_previewed ? 0 : (this.interimBoundaryIndex ?? 0)
     const finalText = finalTail(split.text, this.segmentMessages.slice(dedupeStart))
-    const existingReasoning = this.reasoningText.trim() || String(payload.reasoning ?? '').trim()
-    const savedReasoning = [existingReasoning, existingReasoning ? '' : split.reasoning].filter(Boolean).join('\n\n')
+    // When display.show_reasoning is off, drop any saved/streamed/payload
+    // reasoning so finalized assistant messages don't render `thinking`. The
+    // visible text is still split out of `<think>` tags above. See #22894.
+    const showReasoning = getUiState().showReasoning
+
+    const existingReasoning = showReasoning
+      ? this.reasoningText.trim() || String(payload.reasoning ?? '').trim()
+      : ''
+
+    const savedReasoning = showReasoning
+      ? [existingReasoning, existingReasoning ? '' : split.reasoning].filter(Boolean).join('\n\n')
+      : ''
+
     const savedToolTokens = this.toolTokenAcc
     let tools = this.pendingSegmentTools
     const last = this.segmentMessages[this.segmentMessages.length - 1]


### PR DESCRIPTION
## Summary

- Prevent TUI reasoning/thinking content from being stored or emitted when `display.show_reasoning` is disabled
- Ensure final assistant messages do not include `thinking` / `thinkingTokens` when reasoning display is off
- Add regression coverage for streaming, rendered payloads, and mid-turn `showReasoning` toggles

Fixes #22894

Note: I noticed #22946 also targets #22894. This PR keeps the fix scoped only to the TUI reasoning leak and related regression tests.

## Type of Change

- Bug fix
- Tests

## Test Plan

Tested on macOS.

- `npm run type-check`
- `npm run lint`
- `npm test -- src/__tests__/turnController.test.ts src/__tests__/createGatewayEventHandler.test.ts src/__tests__/reasoning.test.ts`
- `npm test`

Python pytest was not run because this PR only changes the TypeScript TUI package.
