### PR TITLE
fix: remove chmod from TUI build script to fix Windows compatibility

### DIFF
--- a/ui-tui/package.json
+++ b/ui-tui/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "npm run build --prefix packages/hermes-ink && tsx --watch src/entry.tsx",
     "start": "tsx src/entry.tsx",
-    "build": "npm run build --prefix packages/hermes-ink && tsc -p tsconfig.build.json && npm run build:compile && chmod +x dist/entry.js",
+    "build": "npm run build --prefix packages/hermes-ink && tsc -p tsconfig.build.json && npm run build:compile",
     "build:compile": "babel dist --out-dir dist --config-file ./babel.compiler.config.cjs --extensions .js --keep-file-extension",
     "type-check": "tsc --noEmit -p tsconfig.json",
     "lint": "eslint src/ packages/",


### PR DESCRIPTION
## Summary

The npm build script in `ui-tui/package.json` ended with `&& chmod +x dist/entry.js`, which fails on Windows because `chmod` is not a valid command there. This caused `hermes --tui` to print "TUI build failed" and exit — even though all actual compilation steps (esbuild, tsc, babel) succeeded.

## Changes

- Removed `&& chmod +x dist/entry.js` from the `build` script in `ui-tui/package.json`

## Rationale

The execute bit is a cosmetic POSIX convenience. The TUI launcher always invokes the entry point via `node dist/entry.js`, which works regardless of file permissions. No functional behavior is lost on any platform.

## Testing

- Verified `package.json` is valid JSON after the change
- Confirmed `chmod` is no longer referenced in the build pipeline
- Build steps (hermes-ink, tsc, babel) remain unchanged

Closes #22952
