### PR TITLE
fix(cli): wire up /sessions and /indicator slash commands

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5300,6 +5300,34 @@ class HermesCLI:
         print()
         return True
 
+    def _handle_sessions_command(self):
+        """Handle /sessions — list recent sessions for browsing and resume."""
+        self._show_recent_sessions(reason="sessions", limit=20)
+
+    def _handle_indicator_command(self, cmd: str):
+        """Handle /indicator [kaomoji|emoji|unicode|ascii] — show or change
+        the TUI busy-indicator style."""
+        VALID_STYLES = ("kaomoji", "emoji", "unicode", "ascii")
+
+        parts = cmd.strip().split(maxsplit=1)
+        if len(parts) < 2 or not parts[1].strip():
+            # No argument — show current style
+            current = self.config.get("display", {}).get("tui_status_indicator", "kaomoji")
+            _cprint(f"  Busy indicator: {current}")
+            _cprint(f"  Usage: /indicator [{'|'.join(VALID_STYLES)}]")
+            return
+
+        style = parts[1].strip().lower()
+        if style not in VALID_STYLES:
+            _cprint(f"  {_DIM}Unknown style: {style}{_RST}")
+            _cprint(f"  {_DIM}Valid: {'|'.join(VALID_STYLES)}{_RST}")
+            return
+
+        if save_config_value("display.tui_status_indicator", style):
+            _cprint(f"  {_ACCENT}✓ Busy indicator → {style} (saved){_RST}")
+        else:
+            _cprint(f"  {_ACCENT}✓ Busy indicator → {style}{_RST}")
+
     def show_history(self):
         """Display conversation history."""
         if not self.conversation_history:
@@ -6987,6 +7015,8 @@ class HermesCLI:
             self._handle_paste_command()
         elif canonical == "image":
             self._handle_image_command(cmd_original)
+        elif canonical == "indicator":
+            self._handle_indicator_command(cmd_original)
         elif canonical == "reload":
             from hermes_cli.config import reload_env
             count = reload_env()
@@ -7071,6 +7101,8 @@ class HermesCLI:
                 _cprint(f"  No agent running; queued as next turn: {payload[:80]}{'...' if len(payload) > 80 else ''}")
         elif canonical == "goal":
             self._handle_goal_command(cmd_original)
+        elif canonical == "sessions":
+            self._handle_sessions_command()
         elif canonical == "skin":
             self._handle_skin_command(cmd_original)
         elif canonical == "voice":

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -108,8 +108,6 @@ COMMAND_REGISTRY: list[CommandDef] = [
                gateway_only=True, aliases=("set-home",)),
     CommandDef("resume", "Resume a previously-named session", "Session",
                args_hint="[name]"),
-
-    # Configuration
     CommandDef("sessions", "Browse and resume previous sessions", "Session"),
 
     # Configuration


### PR DESCRIPTION
## Summary

Two slash commands (`/sessions` and `/indicator`) were registered in `COMMAND_REGISTRY` but had no handler dispatch in `process_command()`, causing them to silently fail in non-TUI CLI mode.

## Changes

### cli.py
- **Add `_handle_sessions_command()`** — delegates to existing `_show_recent_sessions(reason='sessions', limit=20)` which already queries the session DB and renders a table
- **Add `_handle_indicator_command()`** — validates style argument (kaomoji/emoji/unicode/ascii), saves to `display.tui_status_indicator` via `save_config_value()`, prints confirmation
- **Add dispatch branches** — `elif canonical == "sessions":` and `elif canonical == "indicator":` in `process_command()`

### hermes_cli/commands.py
- Remove stray blank line and misplaced `# Configuration` comment between `resume` and `sessions` CommandDef entries

## How to Test

1. Run `hermes` (without `--tui`)
2. Type `/sessions` — should list recent sessions with titles, previews, timestamps, and IDs
3. Type `/indicator` — should show current style and usage
4. Type `/indicator emoji` — should print "✓ Busy indicator → emoji (saved)"
5. Type `/indicator sparkle` — should reject with "Unknown style"

## Platform Tested

- Linux (WSL2 on Windows 11)

Closes #22960