### PR TITLE
fix(cli): wire classic sessions command

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5597,6 +5597,32 @@ class HermesCLI:
         else:
             _cprint(f"  ↻ Resumed session {target_id}{title_part} — no messages, starting fresh.")
 
+    def _handle_sessions_command(self) -> None:
+        """Handle /sessions by browsing prior sessions and relaunching into the selection."""
+        if not self._session_db:
+            from hermes_state import format_session_db_unavailable
+            _cprint(f"  {format_session_db_unavailable()}")
+            return
+
+        sessions = self._session_db.list_sessions_rich(
+            source=None, exclude_sources=["tool"], limit=500
+        )
+        if not sessions:
+            print("No sessions found.")
+            return
+
+        from hermes_cli.main import _session_browse_picker
+
+        selected_id = _session_browse_picker(sessions)
+        if not selected_id:
+            print("Cancelled.")
+            return
+
+        print(f"Resuming session: {selected_id}")
+        from hermes_cli.relaunch import relaunch
+
+        relaunch(["--resume", selected_id])
+
     def _handle_branch_command(self, cmd_original: str) -> None:
         """Handle /branch [name] — fork the current session into a new independent copy.
 
@@ -6922,6 +6948,8 @@ class HermesCLI:
             self.new_session(title=title)
         elif canonical == "resume":
             self._handle_resume_command(cmd_original)
+        elif canonical == "sessions":
+            self._handle_sessions_command()
         elif canonical == "model":
             self._handle_model_switch(cmd_original)
         elif canonical == "gquota":

--- a/cli.py
+++ b/cli.py
@@ -5605,7 +5605,7 @@ class HermesCLI:
             return
 
         sessions = self._session_db.list_sessions_rich(
-            source=None, exclude_sources=["tool"], limit=500
+            exclude_sources=["tool"], limit=500
         )
         if not sessions:
             print("No sessions found.")
@@ -8223,8 +8223,9 @@ class HermesCLI:
         compressions = compressor.compression_count
 
         msg_count = len(self.conversation_history)
+        model_name = agent.model if isinstance(agent.model, str) else ""
         cost_result = estimate_usage_cost(
-            agent.model,
+            model_name,
             CanonicalUsage(
                 input_tokens=input_tokens,
                 output_tokens=output_tokens,

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -486,3 +486,46 @@ class TestProviderResolution:
         cli = _make_cli()
         assert isinstance(cli.model, str)
         assert isinstance(cli.model, str) and '/' in cli.model
+
+
+class TestSessionsCommand:
+    def test_sessions_command_relaunches_selected_session(self, capsys):
+        cli = _make_cli()
+        cli._session_db = MagicMock()
+        cli._session_db.list_sessions_rich.return_value = [{"id": "session-abc"}]
+
+        with patch("hermes_cli.main._session_browse_picker", return_value="session-abc") as mock_picker, \
+             patch("hermes_cli.relaunch.relaunch") as mock_relaunch:
+            assert cli.process_command("/sessions") is True
+
+        cli._session_db.list_sessions_rich.assert_called_once_with(
+            source=None,
+            exclude_sources=["tool"],
+            limit=500,
+        )
+        mock_picker.assert_called_once_with([{"id": "session-abc"}])
+        mock_relaunch.assert_called_once_with(["--resume", "session-abc"])
+        assert "Resuming session: session-abc" in capsys.readouterr().out
+
+    def test_sessions_command_cancel_does_not_relaunch(self, capsys):
+        cli = _make_cli()
+        cli._session_db = MagicMock()
+        cli._session_db.list_sessions_rich.return_value = [{"id": "session-abc"}]
+
+        with patch("hermes_cli.main._session_browse_picker", return_value=None), \
+             patch("hermes_cli.relaunch.relaunch") as mock_relaunch:
+            assert cli.process_command("/sessions") is True
+
+        mock_relaunch.assert_not_called()
+        assert "Cancelled." in capsys.readouterr().out
+
+    def test_sessions_command_prints_when_no_sessions_exist(self, capsys):
+        cli = _make_cli()
+        cli._session_db = MagicMock()
+        cli._session_db.list_sessions_rich.return_value = []
+
+        with patch("hermes_cli.main._session_browse_picker") as mock_picker:
+            assert cli.process_command("/sessions") is True
+
+        mock_picker.assert_not_called()
+        assert "No sessions found." in capsys.readouterr().out

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -499,7 +499,6 @@ class TestSessionsCommand:
             assert cli.process_command("/sessions") is True
 
         cli._session_db.list_sessions_rich.assert_called_once_with(
-            source=None,
             exclude_sources=["tool"],
             limit=500,
         )


### PR DESCRIPTION
## Summary
- add a classic CLI `/sessions` handler that reuses the shared session browser
- relaunch into the selected session instead of falling through to unknown command
- add regression tests for select, cancel, and empty-session flows

## Testing
- ./.venv/bin/python -m pytest -q -o addopts= tests/cli/test_cli_init.py
- ./.venv/bin/ruff check .
- env -i PATH="/Library/Frameworks/Python.framework/Versions/3.10/bin:/usr/bin:/bin:/usr/sbin:/sbin" HOME="$HOME" TERM="${TERM:-xterm-256color}" TZ=UTC LANG=C.UTF-8 LC_ALL=C.UTF-8 PYTHONHASHSEED=0 ./.venv/bin/python -m pytest -o addopts= --collect-only --ignore=tests/integration --ignore=tests/e2e -m 'not integration'