### PR TITLE
feat(dashboard): expose missing display and Telegram per-platform settings in config UI

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -330,6 +330,43 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
         "description": "Reasoning effort for delegated subagents",
         "options": ["", "low", "medium", "high"],
     },
+    # ── Virtual display fields — read at runtime but not in DEFAULT_CONFIG ──
+    # Global display settings used by gateway platforms.
+    "display.tool_progress": {
+        "type": "select",
+        "description": "Global tool progress visibility in messaging platforms",
+        "options": ["all", "new", "verbose", "off"],
+        "category": "display",
+    },
+    "display.background_process_notifications": {
+        "type": "select",
+        "description": "Notification mode for background process completion",
+        "options": ["all", "result", "error", "off"],
+        "category": "display",
+    },
+    "display.cleanup_progress": {
+        "type": "boolean",
+        "description": "Auto-delete tool progress bubbles after final response",
+        "category": "display",
+    },
+    # ── Telegram per-platform display overrides ──────────────────────────
+    "display.platforms.telegram.notifications": {
+        "type": "select",
+        "description": "Push notification mode for Telegram messages",
+        "options": ["important", "all"],
+        "category": "discord",
+    },
+    "display.platforms.telegram.tool_progress": {
+        "type": "select",
+        "description": "Tool progress visibility in Telegram",
+        "options": ["all", "new", "verbose", "off"],
+        "category": "discord",
+    },
+    "display.platforms.telegram.cleanup_progress": {
+        "type": "boolean",
+        "description": "Auto-delete tool progress bubbles after final response on Telegram",
+        "category": "discord",
+    },
 }
 
 # Categories with fewer fields get merged into "general" to avoid tab sprawl.
@@ -418,14 +455,27 @@ def _build_schema_from_config(
 CONFIG_SCHEMA = _build_schema_from_config(DEFAULT_CONFIG)
 
 # Inject virtual fields that don't live in DEFAULT_CONFIG but are surfaced
-# by the normalize/denormalize cycle.  Insert model_context_length right after
-# the "model" key so it renders adjacent in the frontend.
+# by the normalize/denormalize cycle or used at runtime by platform adapters.
+# Insert model_context_length right after the "model" key so it renders
+# adjacent in the frontend.
 _mcl_entry = _SCHEMA_OVERRIDES["model_context_length"]
 _ordered_schema: Dict[str, Dict[str, Any]] = {}
 for _k, _v in CONFIG_SCHEMA.items():
     _ordered_schema[_k] = _v
     if _k == "model":
         _ordered_schema["model_context_length"] = _mcl_entry
+# Append Telegram per-platform display overrides (virtual fields gated at
+# runtime by the Telegram adapter — not in DEFAULT_CONFIG).
+for _vk in (
+    "display.tool_progress",
+    "display.background_process_notifications",
+    "display.cleanup_progress",
+    "display.platforms.telegram.notifications",
+    "display.platforms.telegram.tool_progress",
+    "display.platforms.telegram.cleanup_progress",
+):
+    if _vk in _SCHEMA_OVERRIDES:
+        _ordered_schema[_vk] = dict(_SCHEMA_OVERRIDES[_vk])
 CONFIG_SCHEMA = _ordered_schema
 
 


### PR DESCRIPTION
## Summary

Exposes 6 runtime display settings in the dashboard config page that were previously only configurable via manual `config.yaml` edits. These are settings the gateway reads at runtime but weren't surfaced in `DEFAULT_CONFIG`.

This follows up on #22772 which added `display.platforms.telegram.notifications` to the gateway but didn't expose it in the dashboard.

## What was missing

The dashboard schema is built from `DEFAULT_CONFIG`, but `display.platforms` is `{}` there and several global display keys don't exist as root-level entries:

| Setting | Tab | Type | Values |
|---------|-----|------|--------|
| `display.tool_progress` | Display | select | all, new, verbose, off |
| `display.background_process_notifications` | Display | select | all, result, error, off |
| `display.cleanup_progress` | Display | boolean | true/false |
| `display.platforms.telegram.notifications` | Discord | select | all, important |
| `display.platforms.telegram.tool_progress` | Discord | select | all, new, verbose, off |
| `display.platforms.telegram.cleanup_progress` | Discord | boolean | true/false |

## How it works

All 6 are injected as virtual fields following the existing `model_context_length` pattern — defined in `_SCHEMA_OVERRIDES` with explicit `category`, then appended to `CONFIG_SCHEMA` after the tree-walk from `DEFAULT_CONFIG`.

## Testing

- 8/8 `TestBuildSchemaFromConfig` tests pass (includes category-merge and no-single-field-category invariants)
- All 640+ web server tests pass
- Verified all 6 fields appear in the schema with correct types and categories
- No single-field categories introduced (verified via Counter)

Closes #22964