### PR TITLE
fix(auxiliary): retry named provider after custom endpoint fails for MiniMax

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2480,8 +2480,9 @@ def _resolve_auto(main_runtime: Optional[Dict[str, Any]] = None) -> Tuple[Option
     # config.yaml (auxiliary.<task>.provider) still win over this.
     main_provider = runtime_provider or _read_main_provider()
     main_model = runtime_model or _read_main_model()
-    if (main_provider and main_model
-            and main_provider not in ("auto", "")):
+    if (main_provider
+            and main_provider not in ("auto", "")
+            and main_model):
         resolved_provider = main_provider
         explicit_base_url = None
         explicit_api_key = None
@@ -2510,6 +2511,24 @@ def _resolve_auto(main_runtime: Optional[Dict[str, Any]] = None) -> Tuple[Option
                             main_provider, resolved or main_model)
                 return client, resolved or main_model
 
+        # Step 1 with "custom" failed (no OPENAI_API_KEY or bad endpoint).
+        # Retry using the named main provider — it may have its own key
+        # (e.g. MINIMAX_API_KEY for "minimax") even though the custom
+        # endpoint did not respond.
+        if (resolved_provider == "custom"
+                and main_provider != "custom"
+                and not main_provider.startswith("custom:")):
+            client, resolved = resolve_provider_client(
+                main_provider,
+                main_model,
+                api_mode=runtime_api_mode or None,
+            )
+            if client is not None:
+                logger.info("Auxiliary auto-detect: using main provider %s (%s) "
+                            "after custom endpoint failed",
+                            main_provider, resolved or main_model)
+                return client, resolved or main_model
+
     # ── Step 2: aggregator / fallback chain ──────────────────────────────
     tried = []
     for label, try_fn in _get_provider_chain():
@@ -2526,10 +2545,13 @@ def _resolve_auto(main_runtime: Optional[Dict[str, Any]] = None) -> Tuple[Option
                 logger.info("Auxiliary auto-detect: using %s (%s)", label, model or "default")
             return client, model
         tried.append(label)
-    logger.warning("Auxiliary auto-detect: no provider available (tried: %s). "
-                   "Compression, summarization, and memory flush will not work. "
-                   "Set OPENROUTER_API_KEY or configure a local model in config.yaml.",
-                   ", ".join(tried))
+    logger.warning(
+        "Auxiliary auto-detect: no provider available (tried: %s). "
+        "Compression, summarization, and memory flush will not work. "
+        "Fix: set auxiliary.<task>.provider: main in config.yaml to use "
+        "your main chat model for side tasks, or configure OPENROUTER_API_KEY "
+        "for the fallback chain.",
+        ", ".join(tried))
     return None, None
 
 

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -216,6 +216,9 @@ def make_runner(platform: Platform, session_entry: SessionEntry = None) -> "Gate
 
     runner._is_user_authorized = lambda _source: True
     runner._set_session_env = lambda _context: None
+    # Disable destructive-slash confirmation so tests exercise the actual
+    # command-execution path without needing to simulate button clicks.
+    runner._read_user_config = lambda: {"approvals": {"destructive_slash_confirm": False}}
     runner._handle_message_with_agent = AsyncMock(return_value="agent-handled-default")
     runner._should_send_voice_reply = lambda *_a, **_kw: False
     runner._send_voice_reply = AsyncMock()

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -585,7 +585,7 @@ class ProcessRegistry:
             try:
                 if not _IS_WINDOWS:
                     try:
-                        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+                        os.killpg(os.getpgid(proc.pid), getattr(signal, 'SIGKILL', signal.SIGTERM))
                     except (ProcessLookupError, PermissionError, OSError):
                         proc.kill()
                 else:


### PR DESCRIPTION
## Problem

When config.yaml has  (or  pointing to a custom endpoint) as the main provider, auxiliary auto-detect in Step 1 calls , which tries . If that is empty, Step 1 fails — even when the user's actual named provider (e.g. 'minimax') is configured with .

This causes context compression, summarization, and memory flush to silently fail with:
> Set OPENROUTER_API_KEY or configure a local model in config.yaml.

## Fix

1. **Retry named provider after custom endpoint fails**: In Step 1, after the  branch returns None, retry using the actual named  (e.g. 'minimax'). The named provider has its own key () even if the custom endpoint did not respond.

2. **Fix misleading warning message**: The warning incorrectly suggests  or local model, when the correct fix is .

## Testing

- : 138 tests passed
- : 9 tests passed