### PR TITLE
fix(cli): prevent RuntimeWarning in _prompt_text_input from background thread

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5859,6 +5859,7 @@ class HermesCLI:
 
     def _prompt_text_input(self, prompt_text: str) -> str | None:
         """Prompt for free-text input safely inside or outside prompt_toolkit."""
+        import threading
         result = [None]
 
         def _ask():
@@ -5867,7 +5868,13 @@ class HermesCLI:
             except (KeyboardInterrupt, EOFError):
                 pass
 
-        if self._app:
+        # run_in_terminal requires the prompt_toolkit asyncio event loop —
+        # only available on the main thread.  When called from a background
+        # thread (e.g. process_loop dispatching /new, /clear, /undo, or
+        # /reload-mcp mid-run), fall back to a blocking input() call.
+        in_main_thread = threading.current_thread() is threading.main_thread()
+
+        if self._app and in_main_thread:
             from prompt_toolkit.application import run_in_terminal
             was_visible = self._status_bar_visible
             self._status_bar_visible = False


### PR DESCRIPTION
## Summary

`_prompt_text_input()` called `run_in_terminal()` without checking whether it was on the main thread. When `/new`, `/clear`, `/undo`, or `/reload-mcp` were dispatched from `process_loop` (background thread), `run_in_terminal` returned a coroutine that was never awaited, producing:

```
RuntimeWarning: coroutine 'run_in_terminal.<locals>.run' was never awaited
```

## Root Cause

`_prompt_text_input()` (line 5870) checked `if self._app:` (does a prompt_toolkit app exist?) but never checked `threading.current_thread() is threading.main_thread()` (am I on the main event loop thread?). `run_in_terminal` requires the asyncio event loop, which only exists on the main thread.

The sibling method `_run_curses_picker()` (line 5830) already has this guard — it was added when curses integration was implemented — but `_prompt_text_input` was never updated to match.

## Fix

Add a `threading.main_thread()` check before calling `run_in_terminal`, falling back to a blocking `input()` call when not on the main thread — identical to the pattern in `_run_curses_picker()`.

## Affected Commands

- `/new` (and `/reset`)
- `/clear`
- `/undo`
- `/reload-mcp`

## How to Test

1. Start a multi-turn agent run (e.g. message that triggers tool calls)
2. While spinner is active, type `/new`
3. Confirm prompt should appear without RuntimeWarning
4. Repeat for `/clear`, `/undo`, `/reload-mcp`

## Platform Tested

- Linux (WSL2 on Windows 11)

Closes #22970