### PR TITLE
Preserve gateway and Codex routing fixes

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -478,11 +478,20 @@ def extract_skill_description(frontmatter: Dict[str, Any]) -> str:
 def iter_skill_index_files(skills_dir: Path, filename: str):
     """Walk skills_dir yielding sorted paths matching *filename*.
 
-    Excludes ``.git``, ``.github``, ``.hub``, ``.archive`` directories.
+    Excludes hidden/internal directories (``.git``, ``.github``, ``.hub``,
+    ``.archive``, and other dot-prefixed dirs).  Skill bundles sometimes carry
+    host-specific mirrors under dotdirs (for example ``gstack/.hermes`` and
+    ``gstack/.openclaw``); indexing those duplicates bloats every system prompt
+    without adding discoverability because the top-level skills are already
+    present.
     """
     matches = []
     for root, dirs, files in os.walk(skills_dir, followlinks=True):
-        dirs[:] = [d for d in dirs if d not in EXCLUDED_SKILL_DIRS]
+        dirs[:] = [
+            d
+            for d in dirs
+            if d not in EXCLUDED_SKILL_DIRS and not d.startswith(".")
+        ]
         if filename in files:
             matches.append(Path(root) / filename)
     for path in sorted(matches, key=lambda p: str(p.relative_to(skills_dir))):

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -855,6 +855,8 @@ class APIServerAdapter(BasePlatformAdapter):
             fallback_model=fallback_model,
             reasoning_config=reasoning_config,
             gateway_session_key=gateway_session_key,
+            skip_context_files=True,
+            load_soul_identity=True,
         )
         return agent
 

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -713,8 +713,13 @@ class DiscordAdapter(BasePlatformAdapter):
 
                 # Bot message filtering (DISCORD_ALLOW_BOTS):
                 #   "none"     — ignore all other bots (default)
+                #   "handoff"  — accept bot messages only when they @mention us
+                #                  AND include an explicit HANDOFF marker. Bot
+                #                  replies are ignored in this mode to prevent
+                #                  Discord reply-reference ping-pong loops.
                 #   "mentions" — accept bot messages only when they @mention us
-                #   "all"      — accept all bot messages
+                #                  (legacy; unsafe for multi-agent war rooms)
+                #   "all"      — accept all bot messages (unsafe)
                 # Must run BEFORE the user allowlist check so that bots
                 # permitted by DISCORD_ALLOW_BOTS are not rejected for
                 # not being in DISCORD_ALLOWED_USERS (fixes #4466).
@@ -722,6 +727,18 @@ class DiscordAdapter(BasePlatformAdapter):
                     allow_bots = os.getenv("DISCORD_ALLOW_BOTS", "none").lower().strip()
                     if allow_bots == "none":
                         return
+                    elif allow_bots == "handoff":
+                        if not self._client.user or self._client.user not in message.mentions:
+                            return
+                        # A bot reply can carry mention/reference context from
+                        # the previous bot response, which is exactly how two
+                        # agents can echo each other forever. Require handoffs
+                        # to be fresh top-level messages with an explicit marker.
+                        if message.type == discord.MessageType.reply:
+                            return
+                        _handoff_text = (message.content or "").lower()
+                        if not re.search(r"\b(agent[-_ ]handoff|handoff)\b", _handoff_text):
+                            return
                     elif allow_bots == "mentions":
                         if not self._client.user or self._client.user not in message.mentions:
                             return

--- a/gateway/platforms/feishu_comment.py
+++ b/gateway/platforms/feishu_comment.py
@@ -1080,6 +1080,7 @@ def _run_comment_agent(prompt: str, client: Any, session_key: str = "") -> str:
             credential_pool=runtime_kwargs.get("credential_pool"),
             quiet_mode=True,
             skip_context_files=True,
+            load_soul_identity=True,
             skip_memory=True,
             max_iterations=15,
             enabled_toolsets=["feishu_doc", "feishu_drive"],

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4977,6 +4977,10 @@ class GatewayRunner:
             Platform.YUANBAO: "YUANBAO_ALLOW_ALL_USERS",
         }
         # Bots admitted by {PLATFORM}_ALLOW_BOTS bypass the human allowlist (#4466).
+        # For Discord, adapter-level filtering already enforces the safe
+        # semantics for DISCORD_ALLOW_BOTS=handoff (explicit top-level
+        # HANDOFF marker + @mention, no bot replies). This shared auth layer
+        # should not reject a bot message that the adapter already admitted.
         platform_allow_bots_map = {
             Platform.DISCORD: "DISCORD_ALLOW_BOTS",
             Platform.FEISHU: "FEISHU_ALLOW_BOTS",
@@ -5002,7 +5006,10 @@ class GatewayRunner:
 
         if getattr(source, "is_bot", False):
             allow_bots_var = platform_allow_bots_map.get(source.platform)
-            if allow_bots_var and os.getenv(allow_bots_var, "none").lower().strip() in ("mentions", "all"):
+            allow_bots_mode = os.getenv(allow_bots_var, "none").lower().strip() if allow_bots_var else "none"
+            if source.platform == Platform.DISCORD and allow_bots_mode == "handoff":
+                return True
+            if allow_bots_mode in ("mentions", "all"):
                 return True
 
         # Discord role-based access (DISCORD_ALLOWED_ROLES): the adapter's
@@ -6849,6 +6856,8 @@ class GatewayRunner:
                                     model=_hyg_model,
                                     max_iterations=4,
                                     quiet_mode=True,
+                                    skip_context_files=True,
+                                    load_soul_identity=True,
                                     skip_memory=True,
                                     enabled_toolsets=["memory"],
                                     session_id=session_entry.session_id,
@@ -9701,6 +9710,8 @@ class GatewayRunner:
                     thread_id=source.thread_id,
                     session_db=self._session_db,
                     fallback_model=self._fallback_model,
+                    skip_context_files=True,
+                    load_soul_identity=True,
                 )
                 try:
                     return agent.run_conversation(
@@ -10163,6 +10174,8 @@ class GatewayRunner:
                 model=model,
                 max_iterations=4,
                 quiet_mode=True,
+                skip_context_files=True,
+                load_soul_identity=True,
                 skip_memory=True,
                 enabled_toolsets=["memory"],
                 session_id=session_entry.session_id,
@@ -14382,6 +14395,8 @@ class GatewayRunner:
                     gateway_session_key=session_key,
                     session_db=self._session_db,
                     fallback_model=self._fallback_model,
+                    skip_context_files=True,
+                    load_soul_identity=True,
                 )
                 if _cache_lock and _cache is not None:
                     with _cache_lock:

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -77,6 +77,11 @@ def _normalize_provider(provider: str) -> str:
     normalized = (provider or "").strip().lower()
     if normalized in {"or", "open-router"}:
         return "openrouter"
+    # Built-in providers must win over custom-provider aliases. Otherwise a
+    # custom provider named e.g. "openai-codex" shadows the real OAuth-capable
+    # provider and routes `hermes auth add openai-codex` to `custom:openai-codex`.
+    if normalized in PROVIDER_REGISTRY or normalized == "openrouter":
+        return normalized
     # Check if it matches a custom provider name
     custom_key = _resolve_custom_provider_input(normalized)
     if custom_key:


### PR DESCRIPTION
## Summary
- Preserve gateway context-loading guardrails and platform entrypoint fixes from the Link HQ live runtime stabilization pass.
- Preserve built-in provider precedence for `openai-codex` so GPT-5.5 Codex OAuth is not shadowed by custom provider aliases.

## Verification
- `python3 -m py_compile agent/skill_utils.py gateway/platforms/api_server.py gateway/platforms/discord.py gateway/platforms/feishu_comment.py gateway/run.py hermes_cli/auth_commands.py`
- `git diff --check origin/main..HEAD`
- Direct provider normalization smoke: `openai-codex -> openai-codex`, `open-router -> openrouter`, `provider-normalization-ok`
- Focused pytest slice: `47 passed in 2.26s` for `tests/hermes_cli/test_auth_commands.py` and `tests/gateway/test_auth_fallback.py`

## Note
`tests/hermes_cli/test_codex_models.py` was not included in the final focused slice because the current local invocation can shadow the real `hermes_cli` package via `tests/hermes_cli/__init__.py`; direct provider normalization covered the routing regression this change protects.
