### PR TITLE
  fix(banner): invalidate cached update check when local HEAD changes

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -190,22 +190,9 @@ def check_for_updates() -> Optional[int]:
     cache_file = hermes_home / ".update_check"
     embedded_rev = os.environ.get("HERMES_REVISION") or None
 
-    # Read cache — invalidate if the embedded rev has changed since last check
-    now = time.time()
-    try:
-        if cache_file.exists():
-            cached = json.loads(cache_file.read_text())
-            if (
-                now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
-                and cached.get("rev") == embedded_rev
-            ):
-                return cached.get("behind")
-    except Exception:
-        pass
-
-    if embedded_rev:
-        behind = _check_via_rev(embedded_rev)
-    else:
+    repo_dir: Optional[Path] = None
+    cache_rev = embedded_rev
+    if not embedded_rev:
         # Prefer the running code's location over the profile-scoped path.
         # $HERMES_HOME/hermes-agent/ may be a stale copy from --clone-all;
         # Path(__file__) always resolves to the actual installed checkout.
@@ -214,10 +201,30 @@ def check_for_updates() -> Optional[int]:
             repo_dir = hermes_home / "hermes-agent"
         if not (repo_dir / ".git").exists():
             return None
+        # Include the active local HEAD in the cache key so a successful
+        # ``git pull`` invalidates any stale "behind" result immediately.
+        cache_rev = _git_short_hash(repo_dir, "HEAD")
+
+    # Read cache — invalidate if the revision identity has changed since last check.
+    now = time.time()
+    try:
+        if cache_file.exists():
+            cached = json.loads(cache_file.read_text())
+            if (
+                now - cached.get("ts", 0) < _UPDATE_CHECK_CACHE_SECONDS
+                and cached.get("rev") == cache_rev
+            ):
+                return cached.get("behind")
+    except Exception:
+        pass
+
+    if embedded_rev:
+        behind = _check_via_rev(embedded_rev)
+    else:
         behind = _check_via_local_git(repo_dir)
 
     try:
-        cache_file.write_text(json.dumps({"ts": now, "behind": behind, "rev": embedded_rev}))
+        cache_file.write_text(json.dumps({"ts": now, "behind": behind, "rev": cache_rev}))
     except Exception:
         pass
 

--- a/tests/hermes_cli/test_banner.py
+++ b/tests/hermes_cli/test_banner.py
@@ -1,5 +1,7 @@
 """Tests for banner toolset name normalization and skin color usage."""
 
+import json
+
 from unittest.mock import patch
 
 from rich.console import Console
@@ -133,3 +135,43 @@ def test_build_welcome_banner_title_falls_back_when_no_tag():
     raw = buf.getvalue()
     assert "Hermes Agent v" in raw, "Version label missing from title"
     assert "\x1b]8;" not in raw, "OSC-8 hyperlink should not be emitted without a tag"
+
+
+def test_check_for_updates_uses_cached_result_when_local_head_matches(tmp_path, monkeypatch):
+    import hermes_cli.banner as _banner
+
+    monkeypatch.delenv("HERMES_REVISION", raising=False)
+    monkeypatch.setattr(_banner, "get_hermes_home", lambda: tmp_path)
+    (tmp_path / ".update_check").write_text(json.dumps({"ts": 1000, "behind": 764, "rev": "head1234"}))
+
+    with (
+        patch.object(_banner.time, "time", return_value=1001),
+        patch.object(_banner, "_git_short_hash", return_value="head1234"),
+        patch.object(_banner, "_check_via_local_git") as check_local,
+    ):
+        behind = _banner.check_for_updates()
+
+    assert behind == 764
+    check_local.assert_not_called()
+
+
+def test_check_for_updates_invalidates_cache_when_local_head_changes(tmp_path, monkeypatch):
+    import hermes_cli.banner as _banner
+
+    monkeypatch.delenv("HERMES_REVISION", raising=False)
+    monkeypatch.setattr(_banner, "get_hermes_home", lambda: tmp_path)
+    cache_file = tmp_path / ".update_check"
+    cache_file.write_text(json.dumps({"ts": 1000, "behind": 764, "rev": "oldhead"}))
+
+    with (
+        patch.object(_banner.time, "time", return_value=1001),
+        patch.object(_banner, "_git_short_hash", return_value="newhead"),
+        patch.object(_banner, "_check_via_local_git", return_value=0) as check_local,
+    ):
+        behind = _banner.check_for_updates()
+
+    assert behind == 0
+    check_local.assert_called_once()
+    cached = json.loads(cache_file.read_text())
+    assert cached["behind"] == 0
+    assert cached["rev"] == "newhead"


### PR DESCRIPTION
Summary

  This fixes stale banner update-check results when the local `HEAD` changes.

  Previously, cached update-check state could survive across local branch/commit
  changes, which made the banner show outdated information. This change invalidates
  the cache when the local `HEAD` no longer matches the cached revision and adds
  test coverage for that behavior.

  ## Changes

  - invalidate cached banner update-check results on local `HEAD` change
  - keep existing cache behavior when the local revision is unchanged
  - add tests covering cache invalidation and related banner behavior

  ## Testing

  - `python -m pytest tests/hermes_cli/test_banner.py -q`

  ## Notes

  This PR only changes banner/update-check behavior and does not change webhook or
  gateway runtime behavior.


## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

