### PR TITLE
fix(tui): remove chmod from build script for Windows compatibility

### DIFF
--- a/ui-tui/package.json
+++ b/ui-tui/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "npm run build --prefix packages/hermes-ink && tsx --watch src/entry.tsx",
     "start": "tsx src/entry.tsx",
-    "build": "npm run build --prefix packages/hermes-ink && tsc -p tsconfig.build.json && npm run build:compile && chmod +x dist/entry.js",
+    "build": "npm run build --prefix packages/hermes-ink && tsc -p tsconfig.build.json && npm run build:compile",
     "build:compile": "babel dist --out-dir dist --config-file ./babel.compiler.config.cjs --extensions .js --keep-file-extension",
     "type-check": "tsc --noEmit -p tsconfig.json",
     "lint": "eslint src/ packages/",

--- a/ui-tui/src/__tests__/buildScript.test.ts
+++ b/ui-tui/src/__tests__/buildScript.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from "vitest";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const packageJsonPath = path.join(__dirname, "../../package.json");
+
+describe("TUI build script", () => {
+  it("should not contain chmod in the build script (Windows compatibility)", () => {
+    const raw = fs.readFileSync(packageJsonPath, "utf-8");
+    const pkg = JSON.parse(raw);
+    const buildScript = pkg.scripts?.build ?? "";
+
+    expect(buildScript).not.toContain("chmod");
+  });
+
+  it("should still compile and bundle the entry point", () => {
+    const raw = fs.readFileSync(packageJsonPath, "utf-8");
+    const pkg = JSON.parse(raw);
+    const buildScript = pkg.scripts?.build ?? "";
+
+    expect(buildScript).toContain("tsc -p tsconfig.build.json");
+    expect(buildScript).toContain("npm run build:compile");
+  });
+});


### PR DESCRIPTION
## Summary

Removes `&& chmod +x dist/entry.js` from the npm build script in `ui-tui/package.json`. Windows does not have `chmod`, causing `hermes --tui` to fail with "TUI build failed" even when all actual compilation steps (esbuild, tsc, babel) succeeded.

## Rationale

The TUI launcher always invokes the entry point via `node dist/entry.js`, which works regardless of POSIX file permissions. The execute bit is a cosmetic convenience that breaks the build on Windows.

## Changes

- `ui-tui/package.json`: removed `chmod` from the `build` script
- Added regression test (`src/__tests__/buildScript.test.ts`) asserting the build script does not contain `chmod` and still includes the required compile steps

## Test plan

```
cd ui-tui && npx vitest run src/__tests__/buildScript.test.ts
```

Result: 2 passed ✓

Fixes #22957