### PR TITLE
fix(ci): restore shared acceptance lanes

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -131,27 +131,37 @@ jobs:
             const body = fs.readFileSync('.lint-reports/summary.md', 'utf8');
             const marker = '<!-- lint-diff-summary -->';
             const fullBody = marker + '\n' + body;
-
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo:  context.repo.repo,
-              issue_number: context.issue.number,
-            });
-            const existing = comments.find(c => c.body && c.body.includes(marker));
-            if (existing) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo:  context.repo.repo,
-                comment_id: existing.id,
-                body: fullBody,
-              });
-            } else {
-              await github.rest.issues.createComment({
+            try {
+              const { data: comments } = await github.rest.issues.listComments({
                 owner: context.repo.owner,
                 repo:  context.repo.repo,
                 issue_number: context.issue.number,
-                body: fullBody,
               });
+              const existing = comments.find(c => c.body && c.body.includes(marker));
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo:  context.repo.repo,
+                  comment_id: existing.id,
+                  body: fullBody,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo:  context.repo.repo,
+                  issue_number: context.issue.number,
+                  body: fullBody,
+                });
+              }
+            } catch (error) {
+              const message = String(error && error.message ? error.message : error);
+              if (error && error.status === 403 && message.includes('Resource not accessible by integration')) {
+                core.warning(
+                  'Skipping lint-diff PR comment update: token cannot comment on this pull_request context.'
+                );
+              } else {
+                throw error;
+              }
             }
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -485,6 +485,23 @@ def _reset_module_state():
     except Exception:
         pass
 
+    # --- agent.i18n / hermes_cli.config — cached config and catalog state ---
+    # Tests swap HERMES_HOME and sometimes monkeypatch the locale directory.
+    # Clear these caches so a previous worker-local test cannot leave a fake
+    # catalog/config visible to unrelated gateway or tool tests.
+    try:
+        from agent import i18n as _i18n_mod
+        _i18n_mod.reset_language_cache()
+    except Exception:
+        pass
+    try:
+        from hermes_cli import config as _config_mod
+        _config_mod._LOAD_CONFIG_CACHE.clear()
+        _config_mod._RAW_CONFIG_CACHE.clear()
+        _config_mod._LAST_EXPANDED_CONFIG_BY_PATH.clear()
+    except Exception:
+        pass
+
     # --- tools.file_tools — per-task read history + file-ops cache ---
     # _read_tracker accumulates per-task_id read history for loop detection,
     # capped by _READ_HISTORY_CAP. If entries from a prior test persist, the

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -14,6 +14,7 @@ import sys
 import uuid
 from datetime import datetime, timezone
 from types import SimpleNamespace
+from typing import Any, cast
 from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
@@ -215,6 +216,9 @@ def make_runner(platform: Platform, session_entry: SessionEntry = None) -> "Gate
     runner._show_reasoning = False
 
     runner._is_user_authorized = lambda _source: True
+    runner._read_user_config = lambda: {
+        "approvals": {"destructive_slash_confirm": False}
+    }
     runner._set_session_env = lambda _context: None
     runner._handle_message_with_agent = AsyncMock(return_value="agent-handled-default")
     runner._should_send_voice_reply = lambda *_a, **_kw: False
@@ -396,11 +400,11 @@ def _make_discord_adapter_wired(runner=None):
         adapter = DiscordAdapter(config)
 
     bot_user = make_fake_bot_user()
-    adapter._client = SimpleNamespace(
+    adapter._client = cast(Any, SimpleNamespace(
         user=bot_user,
         get_channel=lambda _id: None,
         fetch_channel=AsyncMock(),
-    )
+    ))
 
     adapter.send = AsyncMock(return_value=SendResult(success=True, message_id="e2e-resp-1"))
     adapter.send_typing = AsyncMock()

--- a/tests/gateway/test_tts_media_routing.py
+++ b/tests/gateway/test_tts_media_routing.py
@@ -14,6 +14,7 @@ import pytest
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.platforms.base import _reply_anchor_for_event, _thread_metadata_for_source
 from gateway.run import GatewayRunner
 from gateway.session import SessionSource, build_session_key
 
@@ -48,6 +49,23 @@ def _event(thread_id=None):
         source=source,
         message_id="msg-1",
     )
+
+
+def _delivery_runner():
+    return SimpleNamespace(
+        _reply_anchor_for_event=lambda event: _reply_anchor_for_event(event),
+        _thread_metadata_for_source=lambda source, reply_to_message_id=None: _thread_metadata_for_source(
+            source, reply_to_message_id
+        ),
+    )
+
+
+def _dm_topic_metadata():
+    return {
+        "thread_id": "topic-1",
+        "telegram_dm_topic_reply_fallback": True,
+        "telegram_reply_to_message_id": "msg-1",
+    }
 
 
 @pytest.mark.asyncio
@@ -121,7 +139,7 @@ async def test_streaming_delivery_routes_telegram_flac_media_tag_to_document_sen
     )
 
     await GatewayRunner._deliver_media_from_response(
-        object(),
+        _delivery_runner(),
         "MEDIA:/tmp/speech.flac",
         event,
         adapter,
@@ -130,7 +148,7 @@ async def test_streaming_delivery_routes_telegram_flac_media_tag_to_document_sen
     adapter.send_document.assert_awaited_once_with(
         chat_id="chat-1",
         file_path="/tmp/speech.flac",
-        metadata={"thread_id": "topic-1"},
+        metadata=_dm_topic_metadata(),
     )
     adapter.send_voice.assert_not_awaited()
 
@@ -150,7 +168,7 @@ async def test_streaming_delivery_routes_non_voice_telegram_ogg_media_tag_to_doc
     )
 
     await GatewayRunner._deliver_media_from_response(
-        object(),
+        _delivery_runner(),
         "MEDIA:/tmp/speech.ogg",
         event,
         adapter,
@@ -159,7 +177,7 @@ async def test_streaming_delivery_routes_non_voice_telegram_ogg_media_tag_to_doc
     adapter.send_document.assert_awaited_once_with(
         chat_id="chat-1",
         file_path="/tmp/speech.ogg",
-        metadata={"thread_id": "topic-1"},
+        metadata=_dm_topic_metadata(),
     )
     adapter.send_voice.assert_not_awaited()
 
@@ -181,7 +199,7 @@ async def test_streaming_delivery_routes_telegram_mp3_media_tag_to_voice_sender(
     )
 
     await GatewayRunner._deliver_media_from_response(
-        object(),
+        _delivery_runner(),
         "MEDIA:/tmp/speech.mp3",
         event,
         adapter,
@@ -190,6 +208,6 @@ async def test_streaming_delivery_routes_telegram_mp3_media_tag_to_voice_sender(
     adapter.send_voice.assert_awaited_once_with(
         chat_id="chat-1",
         audio_path="/tmp/speech.mp3",
-        metadata={"thread_id": "topic-1"},
+        metadata=_dm_topic_metadata(),
     )
     adapter.send_document.assert_not_awaited()

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -1068,6 +1068,12 @@ class TestFindGatewayPidsExclude:
 
     def test_excludes_specified_pids(self, monkeypatch):
         monkeypatch.setattr(gateway_cli, "is_windows", lambda: False)
+        real_isdir = gateway_cli.os.path.isdir
+        monkeypatch.setattr(
+            gateway_cli.os.path,
+            "isdir",
+            lambda path: False if path == "/proc" else real_isdir(path),
+        )
 
         def fake_run(cmd, **kwargs):
             return subprocess.CompletedProcess(
@@ -1088,6 +1094,12 @@ class TestFindGatewayPidsExclude:
 
     def test_no_exclude_returns_all(self, monkeypatch):
         monkeypatch.setattr(gateway_cli, "is_windows", lambda: False)
+        real_isdir = gateway_cli.os.path.isdir
+        monkeypatch.setattr(
+            gateway_cli.os.path,
+            "isdir",
+            lambda path: False if path == "/proc" else real_isdir(path),
+        )
 
         def fake_run(cmd, **kwargs):
             return subprocess.CompletedProcess(
@@ -1111,6 +1123,12 @@ class TestFindGatewayPidsExclude:
         profile_dir.mkdir(parents=True)
         monkeypatch.setattr(gateway_cli, "is_windows", lambda: False)
         monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
+        real_isdir = gateway_cli.os.path.isdir
+        monkeypatch.setattr(
+            gateway_cli.os.path,
+            "isdir",
+            lambda path: False if path == "/proc" else real_isdir(path),
+        )
 
         def fake_run(cmd, **kwargs):
             return subprocess.CompletedProcess(

--- a/tests/run_agent/test_async_httpx_del_neuter.py
+++ b/tests/run_agent/test_async_httpx_del_neuter.py
@@ -178,11 +178,12 @@ class TestClientCacheBoundedGrowth:
         """When the loop changes, the old entry should be replaced, not duplicated."""
         from agent.auxiliary_client import (
             _client_cache,
+            _client_cache_key,
             _client_cache_lock,
             _get_cached_client,
         )
 
-        key = ("test_replace", True, "", "", "", (), False)
+        key = _client_cache_key("test_replace", async_mode=True)
 
         # Simulate a stale entry from a closed loop
         old_loop = asyncio.new_event_loop()

--- a/tests/test_lint_config.py
+++ b/tests/test_lint_config.py
@@ -113,3 +113,10 @@ class TestLintWorkflow:
             pytest.fail(f"lint.yml is not valid YAML: {exc}")
         assert isinstance(parsed, dict)
         assert "jobs" in parsed
+
+    def test_pr_comment_step_handles_fork_permission_403(self):
+        """Fork PRs must not fail the advisory diff job just because the token cannot comment."""
+        content = self.WORKFLOW_PATH.read_text(encoding="utf-8")
+        assert "error.status === 403" in content
+        assert "Resource not accessible by integration" in content
+        assert "core.warning(" in content

--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -152,6 +152,13 @@ class TestHandleVisionAnalyzeFastPath:
         """Main model supports native vision → fast path returns multimodal."""
         img = tmp_path / "x.png"
         img.write_bytes(_TINY_PNG)
+        monkeypatch.setattr(
+            "hermes_cli.config.load_config",
+            lambda: {
+                "agent": {"image_input_mode": "auto"},
+                "auxiliary": {"vision": {"provider": "auto"}},
+            },
+        )
 
         # Set runtime override so the handler thinks we're on opus@openrouter
         from agent.auxiliary_client import set_runtime_main, clear_runtime_main

--- a/tests/tools/test_vision_native_fast_path.py
+++ b/tests/tools/test_vision_native_fast_path.py
@@ -159,6 +159,10 @@ class TestHandleVisionAnalyzeFastPath:
                 "auxiliary": {"vision": {"provider": "auto"}},
             },
         )
+        monkeypatch.setattr(
+            "agent.image_routing.decide_image_input_mode",
+            lambda provider, model, cfg: "native",
+        )
 
         # Set runtime override so the handler thinks we're on opus@openrouter
         from agent.auxiliary_client import set_runtime_main, clear_runtime_main

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -452,6 +452,26 @@ class ProcessRegistry:
             except (OSError, ProcessLookupError, PermissionError):
                 pass
 
+    @staticmethod
+    def _hard_kill_popen_tree(proc: subprocess.Popen) -> None:
+        """Best-effort hard-stop for a freshly spawned local subprocess tree."""
+        if _IS_WINDOWS:
+            proc.kill()
+            return
+
+        try:
+            import psutil
+
+            parent = psutil.Process(proc.pid)
+            for child in parent.children(recursive=True):
+                try:
+                    child.kill()
+                except psutil.NoSuchProcess:
+                    pass
+            parent.kill()
+        except Exception:
+            proc.kill()
+
     # ----- Spawn -----
 
     @staticmethod
@@ -583,13 +603,7 @@ class ProcessRegistry:
             # descendants spawned via setsid) before re-raising so they do not
             # leak as untracked background processes.
             try:
-                if not _IS_WINDOWS:
-                    try:
-                        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-                    except (ProcessLookupError, PermissionError, OSError):
-                        proc.kill()
-                else:
-                    proc.kill()
+                self._hard_kill_popen_tree(proc)
             except Exception:
                 pass
             try:


### PR DESCRIPTION
Addresses #23056.

## Summary

This PR restores the shared CI/test baseline that has been making unrelated fork PRs appear red.

- Replace the `os.killpg(..., signal.SIGKILL)` cleanup path in `tools/process_registry.py` with a Windows-safe hard-kill helper.
- Make the lint-diff PR comment step advisory when fork-token permissions cannot comment (`403 Resource not accessible by integration`).
- Disable destructive slash confirmation in the e2e harness so `/new` command assertions keep testing the immediate-reset path.
- Refresh stale shared lane fixtures around TTS media routing, gateway restart helpers, and async HTTP cleanup.
- Reset worker-local i18n/config caches between tests so one test cannot poison unrelated gateway/tool tests.
- Make the native vision fast-path test explicit about its config, so it is not affected by previous auxiliary vision settings.

## Verification

Focused local checks run on the current branch:

```bash
uv run --frozen python -m pytest tests/gateway/test_restart_drain.py::test_restart_command_while_busy_requests_drain_without_interrupt tests/tools/test_vision_native_fast_path.py::TestHandleVisionAnalyzeFastPath::test_vision_capable_main_model_uses_fast_path -q --tb=short -n auto
# 2 passed

uv run --frozen python -m pytest tests/agent/test_i18n.py tests/gateway/test_restart_drain.py tests/tools/test_vision_native_fast_path.py -q --tb=short -n auto
# 61 passed

uv run --frozen ruff check tests/conftest.py tests/tools/test_vision_native_fast_path.py
# All checks passed
```

Earlier targeted checks for the first repair commit also passed:

```bash
uv run --frozen python -m pytest \
  tests/ci/test_lint_diff_workflow.py \
  tests/e2e/test_agent_workflow.py::test_agent_workflow_new_command_resets_session \
  tests/e2e/test_platform_commands.py::test_platform_commands_new_resets_session \
  tests/tools/test_process_registry.py \
  -q --tb=short
```

## Attribution

The failures addressed here were shared CI/test-lane issues observed across unrelated PRs, not regressions in those individual PR bodies. See #23056 for the issue-level summary and affected examples.
