### PR TITLE
fix(auth): preserve titled Codex OAuth credentials

### DIFF
--- a/agent/credential_pool.py
+++ b/agent/credential_pool.py
@@ -56,6 +56,12 @@ AUTH_TYPE_API_KEY = "api_key"
 
 SOURCE_MANUAL = "manual"
 
+
+def _is_device_code_source(source: str) -> bool:
+    normalized = (source or "").strip().lower()
+    return normalized == "device_code" or normalized == f"{SOURCE_MANUAL}:device_code"
+
+
 STRATEGY_FILL_FIRST = "fill_first"
 STRATEGY_ROUND_ROBIN = "round_robin"
 STRATEGY_RANDOM = "random"
@@ -492,7 +498,7 @@ class CredentialPool:
         device_code-sourced entries; env/API-key-sourced entries have no
         auth.json shadow to sync from.
         """
-        if self.provider != "openai-codex" or entry.source != "device_code":
+        if self.provider != "openai-codex" or not _is_device_code_source(entry.source):
             return entry
         try:
             with _auth_store_lock():
@@ -606,7 +612,7 @@ class CredentialPool:
         Applies to any OAuth provider whose singleton lives in auth.json
         (currently Nous and OpenAI Codex).
         """
-        if entry.source != "device_code":
+        if not _is_device_code_source(entry.source):
             return
         try:
             with _auth_store_lock():
@@ -877,7 +883,7 @@ class CredentialPool:
             # frozen behind last_error_reset_at (can be hours in the
             # future for ChatGPT weekly windows).
             if (self.provider == "openai-codex"
-                    and entry.source == "device_code"
+                    and _is_device_code_source(entry.source)
                     and entry.last_status == STATUS_EXHAUSTED):
                 synced = self._sync_codex_entry_from_auth_store(entry)
                 if synced is not entry:
@@ -1379,6 +1385,8 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
         # via `hermes auth openai-codex`.
         if isinstance(tokens, dict) and tokens.get("access_token"):
             active_sources.add("device_code")
+            if any(_is_device_code_source(entry.source) for entry in entries):
+                return changed, active_sources
             changed |= _upsert_entry(
                 entries,
                 provider,
@@ -1390,7 +1398,8 @@ def _seed_from_singletons(provider: str, entries: List[PooledCredential]) -> Tup
                     "refresh_token": tokens.get("refresh_token"),
                     "base_url": "https://chatgpt.com/backend-api/codex",
                     "last_refresh": state.get("last_refresh"),
-                    "label": label_from_token(tokens.get("access_token", ""), "device_code"),
+                    "label": str(state.get("label") or "").strip()
+                    or label_from_token(tokens.get("access_token", ""), "device_code"),
                 },
             )
 

--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2425,19 +2425,39 @@ def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
     else:
         auth_store = _load_auth_store()
     state = _load_provider_state(auth_store, "openai-codex")
-    if not state:
+    tokens = state.get("tokens") if isinstance(state, dict) else None
+
+    # Compatibility for credentials written by `hermes auth add openai-codex
+    # --label ...` before the singleton mirror was updated.  Those entries
+    # live only in credential_pool.openai-codex, so the runtime resolver must
+    # still be able to use them instead of reporting "missing tokens".
+    if not isinstance(tokens, dict):
+        pool_entries = auth_store.get("credential_pool", {}).get("openai-codex", [])
+        if isinstance(pool_entries, list):
+            for entry in pool_entries:
+                if not isinstance(entry, dict):
+                    continue
+                if entry.get("auth_type") != "oauth":
+                    continue
+                if entry.get("source") not in {"device_code", "manual:device_code"}:
+                    continue
+                access = entry.get("access_token")
+                refresh = entry.get("refresh_token")
+                if isinstance(access, str) and access.strip() and isinstance(refresh, str) and refresh.strip():
+                    tokens = {"access_token": access, "refresh_token": refresh}
+                    state = {
+                        "tokens": tokens,
+                        "last_refresh": entry.get("last_refresh"),
+                        "auth_mode": "chatgpt",
+                        "label": entry.get("label"),
+                    }
+                    break
+
+    if not isinstance(tokens, dict):
         raise AuthError(
             "No Codex credentials stored. Run `hermes auth` to authenticate.",
             provider="openai-codex",
             code="codex_auth_missing",
-            relogin_required=True,
-        )
-    tokens = state.get("tokens")
-    if not isinstance(tokens, dict):
-        raise AuthError(
-            "Codex auth state is missing tokens. Run `hermes auth` to re-authenticate.",
-            provider="openai-codex",
-            code="codex_auth_invalid_shape",
             relogin_required=True,
         )
     access_token = tokens.get("access_token")
@@ -2462,7 +2482,7 @@ def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
     }
 
 
-def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None) -> None:
+def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None, label: str | None = None) -> None:
     """Save Codex OAuth tokens to Hermes auth store (~/.hermes/auth.json)."""
     if last_refresh is None:
         last_refresh = datetime.now(timezone.utc).isoformat().replace("+00:00", "Z")
@@ -2472,6 +2492,8 @@ def _save_codex_tokens(tokens: Dict[str, str], last_refresh: str = None) -> None
         state["tokens"] = tokens
         state["last_refresh"] = last_refresh
         state["auth_mode"] = "chatgpt"
+        if label:
+            state["label"] = label
         _save_provider_state(auth_store, "openai-codex", state)
         _save_auth_store(auth_store)
 

--- a/hermes_cli/auth_commands.py
+++ b/hermes_cli/auth_commands.py
@@ -317,6 +317,11 @@ def auth_add_command(args) -> None:
             creds["tokens"]["access_token"],
             _oauth_default_label(provider, len(pool.entries()) + 1),
         )
+        auth_mod._save_codex_tokens(
+            creds["tokens"],
+            creds.get("last_refresh"),
+            label=label,
+        )
         entry = PooledCredential(
             provider=provider,
             id=uuid.uuid4().hex[:6],

--- a/tests/hermes_cli/test_auth_commands.py
+++ b/tests/hermes_cli/test_auth_commands.py
@@ -264,6 +264,189 @@ def test_auth_add_codex_oauth_persists_pool_entry(tmp_path, monkeypatch):
     assert entry["source"] == "manual:device_code"
     assert entry["refresh_token"] == "refresh-token"
     assert entry["base_url"] == "https://chatgpt.com/backend-api/codex"
+    singleton = payload["providers"]["openai-codex"]
+    assert singleton["tokens"]["access_token"] == token
+    assert singleton["tokens"]["refresh_token"] == "refresh-token"
+    assert singleton["label"] == "codex@example.com"
+
+
+def test_auth_add_codex_oauth_honors_custom_label_and_runtime(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    _write_auth_store(tmp_path, {"version": 1, "providers": {}})
+    token = _jwt_with_email("codex@example.com")
+    monkeypatch.setattr(
+        "hermes_cli.auth._codex_device_code_login",
+        lambda: {
+            "tokens": {
+                "access_token": token,
+                "refresh_token": "refresh-token",
+            },
+            "base_url": "https://chatgpt.com/backend-api/codex",
+            "last_refresh": "2026-03-23T10:00:00Z",
+        },
+    )
+
+    from hermes_cli.auth import resolve_codex_runtime_credentials
+    from hermes_cli.auth_commands import auth_add_command
+
+    class _Args:
+        provider = "openai-codex"
+        auth_type = "oauth"
+        api_key = None
+        label = "work-codex"
+
+    auth_add_command(_Args())
+
+    payload = json.loads((tmp_path / "hermes" / "auth.json").read_text())
+    entries = payload["credential_pool"]["openai-codex"]
+    entry = next(item for item in entries if item["source"] == "manual:device_code")
+    assert entry["label"] == "work-codex"
+    assert payload["providers"]["openai-codex"]["label"] == "work-codex"
+    assert resolve_codex_runtime_credentials()["api_key"] == token
+
+
+def test_codex_runtime_reads_legacy_titled_pool_entry(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    token = _jwt_with_email("codex@example.com")
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "providers": {},
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "cred-1",
+                        "label": "work-codex",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "manual:device_code",
+                        "access_token": token,
+                        "refresh_token": "refresh-token",
+                        "last_refresh": "2026-03-23T10:00:00Z",
+                    }
+                ]
+            },
+        },
+    )
+
+    from hermes_cli.auth import resolve_codex_runtime_credentials
+
+    creds = resolve_codex_runtime_credentials()
+    assert creds["api_key"] == token
+    assert creds["last_refresh"] == "2026-03-23T10:00:00Z"
+
+
+def test_codex_titled_entries_round_robin_without_singleton_duplication(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    work_token = _jwt_with_email("work@example.com")
+    personal_token = _jwt_with_email("personal@example.com")
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": personal_token,
+                        "refresh_token": "personal-refresh",
+                    },
+                    "last_refresh": "2026-03-23T10:00:00Z",
+                    "auth_mode": "chatgpt",
+                    "label": "personal-codex",
+                },
+            },
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "cred-1",
+                        "label": "work-codex",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "manual:device_code",
+                        "access_token": work_token,
+                        "refresh_token": "work-refresh",
+                    },
+                    {
+                        "id": "cred-2",
+                        "label": "personal-codex",
+                        "auth_type": "oauth",
+                        "priority": 1,
+                        "source": "manual:device_code",
+                        "access_token": personal_token,
+                        "refresh_token": "personal-refresh",
+                    },
+                ],
+            },
+        },
+    )
+
+    import agent.credential_pool as credential_pool
+
+    monkeypatch.setattr(
+        credential_pool,
+        "_load_config_safe",
+        lambda: {"credential_pool_strategies": {"openai-codex": "round_robin"}},
+    )
+
+    pool = credential_pool.load_pool("openai-codex")
+    entries = pool.entries()
+    assert [entry.label for entry in entries] == ["work-codex", "personal-codex"]
+    assert not any(entry.source == "device_code" for entry in entries)
+
+    assert pool.select().label == "work-codex"
+    assert pool.select().label == "personal-codex"
+    assert pool.select().label == "work-codex"
+
+
+def test_codex_manual_device_entry_resyncs_after_exhaustion(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes"))
+    old_token = _jwt_with_email("old@example.com")
+    new_token = _jwt_with_email("new@example.com")
+    _write_auth_store(
+        tmp_path,
+        {
+            "version": 1,
+            "providers": {
+                "openai-codex": {
+                    "tokens": {
+                        "access_token": new_token,
+                        "refresh_token": "new-refresh",
+                    },
+                    "last_refresh": "2026-03-23T10:00:00Z",
+                    "auth_mode": "chatgpt",
+                    "label": "work-codex",
+                },
+            },
+            "credential_pool": {
+                "openai-codex": [
+                    {
+                        "id": "cred-1",
+                        "label": "work-codex",
+                        "auth_type": "oauth",
+                        "priority": 0,
+                        "source": "manual:device_code",
+                        "access_token": old_token,
+                        "refresh_token": "old-refresh",
+                        "last_status": "exhausted",
+                        "last_status_at": 1711188000.0,
+                        "last_error_code": 401,
+                        "last_error_reset_at": 1893456000.0,
+                    }
+                ]
+            },
+        },
+    )
+
+    from agent.credential_pool import load_pool
+
+    pool = load_pool("openai-codex")
+    entry = pool.select()
+    assert entry is not None
+    assert entry.label == "work-codex"
+    assert entry.access_token == new_token
+    assert entry.refresh_token == "new-refresh"
+    assert entry.last_status is None
 
 
 def test_auth_remove_reindexes_priorities(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
- Mirror `hermes auth add openai-codex --label ...` credentials into `providers.openai-codex`
- Preserve titled Codex OAuth entries as manual pool entries so multiple titled accounts can rotate
- Prevent singleton re-seeding from duplicating or overwriting titled pool entries when rotation strategies are enabled
- Teach Codex exhaustion/refresh sync paths to treat both `device_code` and `manual:device_code` as device-code credentials
- Add a compatibility fallback for legacy titled entries that only exist in the credential pool

## Test Plan
- `venv/bin/python -m pytest tests/hermes_cli/test_auth_commands.py tests/hermes_cli/test_auth_codex_provider.py -q -o 'addopts='`
- `venv/bin/python -m ruff check agent/credential_pool.py hermes_cli/auth.py hermes_cli/auth_commands.py tests/hermes_cli/test_auth_commands.py`
- `git diff --check`
