### PR TITLE
fix(cli): schedule prompt_toolkit terminal awaitables

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1510,7 +1510,13 @@ def _cprint(text: str):
     # fails we fall back to a direct print so the line isn't lost.
     def _schedule():
         try:
-            run_in_terminal(lambda: _pt_print(_PT_ANSI(text)))
+            result = run_in_terminal(lambda: _pt_print(_PT_ANSI(text)))
+            try:
+                import inspect as _inspect
+                if _inspect.isawaitable(result):
+                    loop.create_task(result)
+            except Exception:
+                pass
         except Exception:
             try:
                 _pt_print(_PT_ANSI(text))
@@ -5793,9 +5799,71 @@ class HermesCLI:
         remaining = len(self.conversation_history)
         print(f"  {remaining} message(s) remaining in history.")
     
+    def _run_terminal_callable_sync(self, func, *, render_cli_done: bool = False, in_executor: bool = False):
+        """Run a synchronous callable through prompt_toolkit's terminal bridge.
+
+        ``prompt_toolkit.application.run_in_terminal`` returns an awaitable in
+        current prompt_toolkit releases.  Slash-command handlers usually run in
+        ``process_loop`` (a background thread), so simply calling it creates an
+        unawaited coroutine and the command is dropped.  When the prompt app is
+        active, schedule the awaitable on the app loop and block this caller for
+        the result; otherwise fall back to calling ``func`` directly.
+        """
+        if not self._app:
+            return func()
+
+        try:
+            from prompt_toolkit.application import run_in_terminal
+        except Exception:
+            return func()
+
+        import asyncio as _asyncio
+        import inspect as _inspect
+
+        loop = getattr(self._app, "loop", None)
+        if loop is not None:
+            try:
+                loop_running = loop.is_running()
+            except Exception:
+                loop_running = False
+            try:
+                current_loop = _asyncio.get_running_loop()
+            except RuntimeError:
+                current_loop = None
+            except Exception:
+                current_loop = None
+
+            if loop_running and current_loop is not loop:
+                async def _run_on_app_loop():
+                    result = run_in_terminal(
+                        func,
+                        render_cli_done=render_cli_done,
+                        in_executor=in_executor,
+                    )
+                    if _inspect.isawaitable(result):
+                        return await result
+                    return result
+
+                return _asyncio.run_coroutine_threadsafe(_run_on_app_loop(), loop).result()
+
+        result = run_in_terminal(
+            func,
+            render_cli_done=render_cli_done,
+            in_executor=in_executor,
+        )
+        if not _inspect.isawaitable(result):
+            return result
+
+        # No usable running app loop.  Close the coroutine before falling back
+        # so Python does not emit "coroutine was never awaited" warnings.
+        try:
+            result.close()
+        except Exception:
+            pass
+        return func()
+
     def _run_curses_picker(self, title: str, items: list[str], default_index: int = 0) -> int | None:
         """Run curses_single_select via run_in_terminal so prompt_toolkit handles terminal ownership cleanly."""
-        import threading
         from hermes_cli.curses_ui import curses_single_select
 
         result = [None]
@@ -5803,18 +5871,12 @@ class HermesCLI:
         def _pick():
             result[0] = curses_single_select(title, items, default_index=default_index)
 
-        # run_in_terminal requires an asyncio event loop — only exists in the
-        # main prompt_toolkit thread.  If we're in a background thread (e.g.
-        # process_loop), fall back to direct curses call.
-        in_main_thread = threading.current_thread() is threading.main_thread()
-
-        if self._app and in_main_thread:
-            from prompt_toolkit.application import run_in_terminal
+        if self._app:
             was_visible = self._status_bar_visible
             self._status_bar_visible = False
             self._app.invalidate()
             try:
-                run_in_terminal(_pick)
+                self._run_terminal_callable_sync(_pick)
             finally:
                 self._status_bar_visible = was_visible
                 self._app.invalidate()
@@ -5834,12 +5896,11 @@ class HermesCLI:
                 pass
 
         if self._app:
-            from prompt_toolkit.application import run_in_terminal
             was_visible = self._status_bar_visible
             self._status_bar_visible = False
             self._app.invalidate()
             try:
-                run_in_terminal(_ask)
+                self._run_terminal_callable_sync(_ask)
             finally:
                 self._status_bar_visible = was_visible
                 self._app.invalidate()
@@ -11268,7 +11329,13 @@ class HermesCLI:
             def _suspend():
                 os.write(1, msg.encode())
                 os.kill(0, _sig.SIGTSTP)
-            run_in_terminal(_suspend)
+            result = run_in_terminal(_suspend)
+            try:
+                import inspect as _inspect
+                if _inspect.isawaitable(result):
+                    event.app.create_background_task(result)
+            except Exception:
+                pass
 
         # Voice push-to-talk key: configurable via config.yaml (voice.record_key)
         # Default: Ctrl+B (avoids conflict with Ctrl+R readline reverse-search).

--- a/tests/cli/test_cprint_bg_thread.py
+++ b/tests/cli/test_cprint_bg_thread.py
@@ -12,8 +12,12 @@ These tests verify the routing logic without spinning up a real PT app.
 
 from __future__ import annotations
 
+import asyncio
+import builtins
 import sys
+import threading
 import types
+import warnings
 from types import SimpleNamespace
 
 import pytest
@@ -213,6 +217,74 @@ def test_cprint_swallows_prompt_toolkit_import_error(monkeypatch):
         sys.meta_path.remove(blocker)
 
     assert direct_prints == ["fallback2"]
+
+
+def test_prompt_text_input_schedules_awaitable_run_in_terminal_from_bg_thread(monkeypatch):
+    """Regression: /new confirmation prompts run from process_loop.
+
+    prompt_toolkit 3.x returns an awaitable from run_in_terminal().  The CLI
+    must schedule that awaitable on the active Application loop when a slash
+    command asks for text input from a background thread; merely calling it
+    drops the prompt and emits "coroutine was never awaited".
+    """
+    loop = asyncio.new_event_loop()
+    ready = threading.Event()
+    loop_thread_id = []
+
+    def _run_loop():
+        asyncio.set_event_loop(loop)
+        loop_thread_id.append(threading.get_ident())
+        ready.set()
+        loop.run_forever()
+
+    loop_thread = threading.Thread(target=_run_loop, daemon=True)
+    loop_thread.start()
+    ready.wait(timeout=2)
+
+    async def _fake_run_in_terminal(func, **_kwargs):
+        assert threading.get_ident() == loop_thread_id[0]
+        return func()
+
+    fake_pt_app = types.ModuleType("prompt_toolkit.application")
+    fake_pt_app.run_in_terminal = _fake_run_in_terminal
+    monkeypatch.setitem(sys.modules, "prompt_toolkit.application", fake_pt_app)
+    monkeypatch.setattr(builtins, "input", lambda _prompt: "1")
+
+    app = SimpleNamespace(loop=loop, invalidate=lambda: None)
+    hermes_cli = cli.HermesCLI.__new__(cli.HermesCLI)
+    hermes_cli._app = app
+    hermes_cli._status_bar_visible = True
+
+    result = []
+    errors = []
+    caught = []
+
+    def _call_from_process_loop_thread():
+        try:
+            with warnings.catch_warnings(record=True) as warning_records:
+                warnings.simplefilter("always")
+                result.append(hermes_cli._prompt_text_input("Choice [1/2/3]: "))
+                caught.extend(warning_records)
+        except BaseException as exc:  # pragma: no cover - assertion aid
+            errors.append(exc)
+
+    caller_thread = threading.Thread(target=_call_from_process_loop_thread)
+    try:
+        caller_thread.start()
+        caller_thread.join(timeout=2)
+    finally:
+        loop.call_soon_threadsafe(loop.stop)
+        loop_thread.join(timeout=2)
+        loop.close()
+
+    assert not caller_thread.is_alive()
+    assert not errors
+    assert result == ["1"]
+    assert hermes_cli._status_bar_visible is True
+    assert not [
+        warning for warning in caught
+        if "coroutine" in str(warning.message) and "never awaited" in str(warning.message)
+    ]
 
 
 def test_output_history_strips_ansi_and_keeps_recent_lines():


### PR DESCRIPTION
## Summary
- Schedule `prompt_toolkit.application.run_in_terminal(...)` on the active prompt_toolkit app loop before calling it from background slash-command threads.
- Fix destructive slash command confirmation prompts such as `/new`, `/reset`, `/clear`, and `/undo` when prompt_toolkit returns an awaitable.
- Apply the same awaitable handling to related terminal-bridged call sites for curses picker, background `_cprint`, and Ctrl+Z suspend.
- Add a regression test covering `_prompt_text_input` from a process-loop-like background thread while `run_in_terminal` executes on the app-loop thread.

## Related issues / PRs
- Related to #22958: destructive slash-command confirmation prompts in TUI mode.
- Addresses the `run_in_terminal(...)` awaitable root cause of #22970 and duplicate report #23009: `RuntimeWarning: coroutine 'run_in_terminal.<locals>.run' was never awaited`.
- Overlaps with #22989, which changes the prompt implementation itself (`input()` -> prompt_toolkit prompt). This PR focuses on safely scheduling/awaiting `run_in_terminal(...)` from background-thread call sites and includes a regression test for that path.

## Why
`/new` and other destructive slash commands run their confirmation flow from the CLI `process_loop` background thread while prompt_toolkit owns the terminal on its application event loop. In prompt_toolkit 3.x, `run_in_terminal(...)` returns/schedules an awaitable and must be called from the app loop. Calling it directly from the background thread can drop the prompt and emit:

```text
RuntimeWarning: coroutine 'run_in_terminal.<locals>.run' was never awaited
```

## How to test
Reproduction before this fix:
1. Start interactive Hermes CLI.
2. Enter `/new`.
3. Observe the destructive-command confirmation fail with the unawaited coroutine warning.

After this fix:
1. Start interactive Hermes CLI.
2. Enter `/new`.
3. The confirmation prompt appears.
4. Enter `3` to cancel.
5. Hermes reports `/new cancelled` without the coroutine warning.

## Platforms tested
- macOS
- Python 3.11
- prompt_toolkit 3.0.52

## Test Plan
Verified in a fresh clone following the CONTRIBUTING setup instructions on commit `3bc8df818`.

Passed:
- `venv/bin/python -m py_compile cli.py tests/cli/test_cprint_bg_thread.py`
- `venv/bin/python scripts/check-windows-footguns.py cli.py tests/cli/test_cprint_bg_thread.py`
- `scripts/run_tests.sh tests/cli/test_cprint_bg_thread.py tests/hermes_cli/test_destructive_slash_confirm_gate.py`
  - `17 passed`

Manual verification:
- Started Hermes with an isolated temporary home directory, ran `/new`, selected `3` to cancel, and verified the confirmation prompt worked without the unawaited coroutine warning.

Full-suite note:
- Attempted `scripts/run_tests.sh tests` in a fresh clone. It did not complete green (`16333 passed, 75 skipped, 33 failed, 5057 errors`), with broad unrelated-looking failures across plugin/skill/TUI/website tests. A representative reported failing test passed when rerun in isolation, so I did not treat this as related to this CLI fix.
- `scripts/run_tests.sh` with no args currently fails locally with `ARGS[@]: unbound variable`; `scripts/run_tests.sh tests` was used for the full-suite attempt.
