### PR TITLE
Fix dashboard display role for vision_analyze pre-analysis

### DIFF
--- a/hermes_cli/web_routers/sessions.py
+++ b/hermes_cli/web_routers/sessions.py
@@ -14,6 +14,7 @@ the late-binding seam in :mod:`hermes_cli.web_deps` so tests that
 
 import asyncio  # noqa: F401 — used by handlers
 import logging
+import re
 import time  # noqa: F401
 from typing import Any, Dict, List, Optional  # noqa: F401
 
@@ -595,6 +596,74 @@ async def get_session_latest_descendant(
     }
 
 
+# One vision pre-analysis block emitted by `_enrich_with_attached_images`
+# (tui_gateway/server.py). Success form is
+#   [The user attached an image:\n{desc}]\n[You can examine it with vision_analyze using image_url: {p}]
+# and the failure form replaces the first line with
+#   [The user attached an image but analysis failed.]
+# The `]\n[You can examine it with vision_analyze using image_url:` boundary
+# anchors the (possibly multi-line) description so `.*?` can't overrun it.
+_VISION_PREANALYSIS_BLOCK = (
+    r"\[The user attached an image"
+    r"(?::\n.*?\]| but analysis failed\.\])"
+    r"\n\[You can examine it with vision_analyze using image_url: .*?\]"
+)
+# One or more blocks (multiple attachments are joined with a blank line), taken
+# from the start of the message; whatever follows is the user's own text.
+_VISION_PREANALYSIS_RE = re.compile(
+    rf"^{_VISION_PREANALYSIS_BLOCK}(?:\n\n{_VISION_PREANALYSIS_BLOCK})*",
+    re.DOTALL,
+)
+
+
+def _normalize_dashboard_message_roles(
+    messages: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Return dashboard-only message copies that split synthetic vision pre-analysis.
+
+    Gateway image *text-mode* routing (``_enrich_with_attached_images`` in
+    ``tui_gateway/server.py``) pre-analyzes each attachment with
+    ``vision_analyze`` and prepends the description — plus a
+    ``[You can examine it with vision_analyze ...]`` hint — to the next user
+    turn, then appends the user's own text. That whole blob is persisted as a
+    single ``user`` row so the model replays the context, but the Dashboard
+    should not attribute the vision model's output to the user.
+
+    Each matching user row is projected into two rows: a synthetic
+    ``vision_analyze`` *tool* result carrying only the pre-analysis block(s),
+    and — when the user actually typed something after it — a ``user`` row
+    carrying just that trailing text. Non-matching rows pass through as shallow
+    copies. SessionDB's stored rows are never mutated.
+    """
+    normalized: List[Dict[str, Any]] = []
+    for msg in messages:
+        content = msg.get("content")
+        match = (
+            _VISION_PREANALYSIS_RE.match(content)
+            if msg.get("role") == "user" and isinstance(content, str)
+            else None
+        )
+        if not match:
+            normalized.append(dict(msg))
+            continue
+
+        synthetic = content[: match.end()]
+        trailing = content[match.end() :].lstrip("\n")
+
+        tool_row = dict(msg)
+        tool_row["role"] = "tool"
+        tool_row["content"] = synthetic
+        if not tool_row.get("tool_name"):
+            tool_row["tool_name"] = "vision_analyze"
+        normalized.append(tool_row)
+
+        if trailing:
+            user_row = dict(msg)
+            user_row["content"] = trailing
+            normalized.append(user_row)
+    return normalized
+
+
 @manage_router.get("/api/sessions/{session_id}/messages")
 async def get_session_messages(
     session_id: str,
@@ -611,21 +680,25 @@ async def get_session_messages(
             sid = db.resolve_resume_session_id(sid)
             # Clamp limit to prevent abuse (max 500 per page)
             _limit = min(limit, 500) if limit is not None else None
-            return sid, _limit, db.get_messages(sid, limit=_limit, offset=offset)
+            rows = db.get_messages(sid, limit=_limit, offset=offset)
+            # Dashboard-only projection: splitting a vision pre-analysis row can
+            # emit more messages than were stored, so report the stored-row
+            # count for `returned` — that's what pagination cursors advance over.
+            return sid, _limit, len(rows), _normalize_dashboard_message_roles(rows)
         finally:
             db.close()
 
     result = await asyncio.to_thread(_read)
     if result is None:
         raise HTTPException(status_code=404, detail="Session not found")
-    sid, _limit, messages = result
+    sid, _limit, stored_count, messages = result
     return {
         "session_id": sid,
         "messages": messages,
         "pagination": {
             "limit": _limit,
             "offset": offset,
-            "returned": len(messages),
+            "returned": stored_count,
         },
     }
 

--- a/tests/cli/test_web_server_dashboard_messages.py
+++ b/tests/cli/test_web_server_dashboard_messages.py
@@ -1,0 +1,161 @@
+"""Dashboard-only projection of gateway vision pre-analysis rows.
+
+Text-mode image routing (`_enrich_with_attached_images` in
+`tui_gateway/server.py`) prepends a synthetic `vision_analyze` description to
+the next user turn and persists the whole thing as one `user` row. The
+dashboard endpoint re-projects those rows so the vision output shows up as a
+tool result while the user's own trailing text stays a user message. The
+stored rows are never touched.
+"""
+
+from fastapi.testclient import TestClient
+
+from hermes_cli import web_server
+from hermes_cli.web_routers.sessions import _normalize_dashboard_message_roles
+
+
+# Mirror the exact strings emitted by `_enrich_with_attached_images` so these
+# tests fail if the gateway wording drifts.
+def _hint(path: str) -> str:
+    return f"[You can examine it with vision_analyze using image_url: {path}]"
+
+
+def _success_block(desc: str, path: str) -> str:
+    return f"[The user attached an image:\n{desc}]\n{_hint(path)}"
+
+
+def _failure_block(path: str) -> str:
+    return f"[The user attached an image but analysis failed.]\n{_hint(path)}"
+
+
+def test_success_preamble_with_user_text_splits_into_tool_and_user():
+    block = _success_block("A cat asleep on a chair.", "/tmp/cat.png")
+    messages = [
+        {"role": "user", "content": f"{block}\n\nwhat breed is this?", "tool_name": None}
+    ]
+
+    out = _normalize_dashboard_message_roles(messages)
+
+    assert [m["role"] for m in out] == ["tool", "user"]
+    assert out[0]["tool_name"] == "vision_analyze"
+    assert out[0]["content"] == block
+    assert out[1]["content"] == "what breed is this?"
+    # Stored row is left untouched.
+    assert messages[0]["role"] == "user"
+    assert messages[0]["content"].endswith("what breed is this?")
+    assert messages[0]["tool_name"] is None
+
+
+def test_success_preamble_without_user_text_is_single_tool_row():
+    block = _success_block("A bar chart of Q3 revenue.", "/tmp/chart.png")
+    messages = [{"role": "user", "content": block}]
+
+    out = _normalize_dashboard_message_roles(messages)
+
+    assert len(out) == 1
+    assert out[0]["role"] == "tool"
+    assert out[0]["tool_name"] == "vision_analyze"
+    assert out[0]["content"] == block
+
+
+def test_failure_preamble_still_labeled_as_tool():
+    block = _failure_block("/tmp/broken.png")
+    messages = [{"role": "user", "content": f"{block}\n\ncan you read it?"}]
+
+    out = _normalize_dashboard_message_roles(messages)
+
+    assert [m["role"] for m in out] == ["tool", "user"]
+    assert out[0]["content"] == block
+    assert out[0]["tool_name"] == "vision_analyze"
+    assert out[1]["content"] == "can you read it?"
+
+
+def test_multiple_image_blocks_stay_in_one_tool_row():
+    b1 = _success_block("First: a diagram.", "/tmp/a.png")
+    b2 = _success_block("Second: some code.", "/tmp/b.png")
+    prefix = f"{b1}\n\n{b2}"
+    messages = [{"role": "user", "content": f"{prefix}\n\ncompare these"}]
+
+    out = _normalize_dashboard_message_roles(messages)
+
+    assert [m["role"] for m in out] == ["tool", "user"]
+    assert out[0]["content"] == prefix
+    assert out[1]["content"] == "compare these"
+
+
+def test_existing_tool_name_is_preserved():
+    block = _success_block("A screenshot.", "/tmp/s.png")
+    messages = [{"role": "user", "content": block, "tool_name": "custom_vision"}]
+
+    out = _normalize_dashboard_message_roles(messages)
+
+    assert out[0]["role"] == "tool"
+    assert out[0]["tool_name"] == "custom_vision"
+
+
+def test_plain_user_and_other_roles_pass_through_as_copies():
+    messages = [
+        {"role": "user", "content": "please describe this image"},
+        {"role": "assistant", "content": "[The user attached an image: not really]"},
+        {"role": "user", "content": None},
+    ]
+
+    out = _normalize_dashboard_message_roles(messages)
+
+    assert [m["role"] for m in out] == ["user", "assistant", "user"]
+    assert out[0]["content"] == "please describe this image"
+    # Copies, not the same dict objects.
+    for original, projected in zip(messages, out):
+        assert projected is not original
+
+
+class _FakeDB:
+    """Minimal stand-in for SessionDB covering the messages endpoint path."""
+
+    def __init__(self, rows):
+        self._rows = rows
+        self.closed = False
+
+    def resolve_session_id(self, session_id):
+        return session_id
+
+    def resolve_resume_session_id(self, session_id):
+        return session_id
+
+    def get_messages(self, session_id, limit=None, offset=0):
+        rows = self._rows[offset:]
+        return rows[:limit] if limit is not None else rows
+
+    def close(self):
+        self.closed = True
+
+
+def test_messages_endpoint_projects_and_counts_stored_rows(monkeypatch):
+    block = _success_block("A landscape photo.", "/tmp/land.png")
+    stored = [{"role": "user", "content": f"{block}\n\nwhere is this?", "tool_name": None}]
+    fake = _FakeDB(stored)
+    # The sessions router resolves this helper on web_server at call time
+    # (late-binding seam), so patching web_server still takes effect.
+    monkeypatch.setattr(
+        web_server,
+        "_open_session_db_for_profile",
+        lambda profile, read_only=True: fake,
+    )
+    monkeypatch.setattr(web_server.app.state, "auth_required", False, raising=False)
+
+    client = TestClient(web_server.app)
+    client.headers[web_server._SESSION_HEADER_NAME] = web_server._SESSION_TOKEN
+    resp = client.get("/api/sessions/sess-1/messages?limit=10")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    roles = [m["role"] for m in body["messages"]]
+    assert roles == ["tool", "user"]
+    assert body["messages"][0]["tool_name"] == "vision_analyze"
+    assert body["messages"][1]["content"] == "where is this?"
+    # One stored row → `returned` stays 1 even though projection emitted two.
+    assert body["pagination"]["returned"] == 1
+    assert body["pagination"]["limit"] == 10
+    # Endpoint left the stored row untouched.
+    assert stored[0]["role"] == "user"
+    assert fake.closed is True


### PR DESCRIPTION
## Summary
- Normalize dashboard session message presentation so synthetic image pre-analysis is shown as a `vision_analyze` tool result instead of a user message.
- Keep the underlying stored session rows unchanged; this only affects the dashboard API response.
- Add focused tests for the dashboard message-role normalization helper.

Fixes #22961.

## Tests
- `python -m pytest tests/cli/test_web_server_dashboard_messages.py`
- `python -m py_compile hermes_cli/web_server.py`
