### PR TITLE
fix(telegram): refresh skill command menu after reload

### DIFF
--- a/gateway/slash_commands.py
+++ b/gateway/slash_commands.py
@@ -4227,13 +4227,11 @@ class GatewaySlashCommandsMixin:
             total = result.get("total", 0)
 
             # Let each connected adapter refresh any platform-side state
-            # that cached the skill list at startup. Today that's the
-            # Discord /skill autocomplete (registered once per connect);
-            # without this call, new skills stay invisible in the
-            # dropdown and deleted skills error out when clicked. Other
-            # adapters that don't override refresh_skill_group (Telegram's
-            # BotCommand menu, Slack subcommand map, etc.) are silently
-            # skipped — the in-process reload above is enough for them.
+            # that cached the skill list at startup. Discord uses this for
+            # /skill autocomplete, and Telegram uses it for the native
+            # BotCommand menu. Adapters that don't override
+            # refresh_skill_group are silently skipped — the in-process
+            # reload above is enough for them.
             for adapter in list(self.adapters.values()):
                 refresh = getattr(adapter, "refresh_skill_group", None)
                 if not callable(refresh):

--- a/plugins/platforms/telegram/adapter.py
+++ b/plugins/platforms/telegram/adapter.py
@@ -2905,6 +2905,83 @@ class TelegramAdapter(BasePlatformAdapter):
                             self.name, topic_name, seed_err,
                         )
 
+    def _build_bot_commands(self):
+        """Build Telegram BotCommand payload using the current configurable menu cap."""
+        from telegram import BotCommand
+        from hermes_cli.commands import telegram_menu_commands, telegram_menu_max_commands
+
+        # Telegram allows up to 100 commands but has an undocumented payload
+        # size limit (~4KB total). Hermes defaults to 60 while allowing users
+        # to tune the cap via platforms.telegram.extra.command_menu.
+        max_commands = telegram_menu_max_commands()
+        menu_commands, hidden_count = telegram_menu_commands(max_commands=max_commands)
+        bot_commands = [BotCommand(name, desc) for name, desc in menu_commands]
+        return bot_commands, hidden_count, max_commands
+
+    async def _register_bot_commands(self, *, include_forum_chats: bool = False) -> tuple[int, int]:
+        """Register the current Telegram command menu."""
+        from telegram import (
+            BotCommandScopeAllGroupChats,
+            BotCommandScopeAllPrivateChats,
+            BotCommandScopeChat,
+            BotCommandScopeDefault,
+        )
+
+        if self._bot is None:
+            return 0, 0
+
+        bot_commands, hidden_count, max_commands = self._build_bot_commands()
+
+        # Register for the same global scopes as startup — Telegram picks the
+        # narrowest matching scope per chat type.
+        for scope_cls in (
+            BotCommandScopeDefault,
+            BotCommandScopeAllPrivateChats,
+            BotCommandScopeAllGroupChats,
+        ):
+            scope_name = getattr(scope_cls, "__name__", str(scope_cls))
+            try:
+                await self._bot.set_my_commands(bot_commands, scope=scope_cls())
+                logger.info(
+                    "[%s] set_my_commands OK for scope %s (%d cmds)",
+                    self.name, scope_name, len(bot_commands),
+                )
+            except Exception as scope_err:
+                logger.warning(
+                    "[%s] set_my_commands FAILED for scope %s: %s",
+                    self.name, scope_name, scope_err,
+                )
+
+        if include_forum_chats:
+            async with self._forum_lock:
+                forum_chat_ids = tuple(sorted(self._forum_command_registered))
+            for chat_id in forum_chat_ids:
+                try:
+                    await self._bot.set_my_commands(
+                        bot_commands,
+                        scope=BotCommandScopeChat(chat_id=chat_id),
+                    )
+                    logger.info(
+                        "[%s] set_my_commands OK for forum chat %s (%d cmds)",
+                        self.name, chat_id, len(bot_commands),
+                    )
+                except Exception as scope_err:
+                    logger.warning(
+                        "[%s] set_my_commands FAILED for forum chat %s: %s",
+                        self.name, chat_id, scope_err,
+                    )
+
+        if hidden_count:
+            logger.info(
+                "[%s] Telegram menu: %d commands registered, %d hidden (over %d limit). Use /commands for full list.",
+                self.name, len(bot_commands), hidden_count, max_commands,
+            )
+        return len(bot_commands), hidden_count
+
+    async def refresh_skill_group(self) -> tuple[int, int]:
+        """Refresh Telegram BotCommand menus after /reload-skills."""
+        return await self._register_bot_commands(include_forum_chats=True)
+
     def _start_post_connect_housekeeping(self) -> None:
         """Kick off deferred post-connect housekeeping in the background.
 
@@ -2927,42 +3004,7 @@ class TelegramAdapter(BasePlatformAdapter):
             # List is derived from the central COMMAND_REGISTRY — adding a new
             # gateway command there automatically adds it to the Telegram menu.
             try:
-                from telegram import (
-                    BotCommand,
-                    BotCommandScopeAllPrivateChats,
-                    BotCommandScopeAllGroupChats,
-                    BotCommandScopeDefault,
-                )
-                from hermes_cli.commands import telegram_menu_commands, telegram_menu_max_commands
-                if not self._bot:
-                    return
-                # Telegram allows up to 100 commands but has an undocumented
-                # payload size limit (~4KB total).  Hermes defaults to 60 to
-                # keep built-ins plus common skill commands visible while
-                # staying under the threshold; users can tune the cap via
-                # platforms.telegram.extra.command_menu.
-                max_commands = telegram_menu_max_commands()
-                menu_commands, hidden_count = telegram_menu_commands(max_commands=max_commands)
-                bot_commands = [BotCommand(name, desc) for name, desc in menu_commands]
-                # Register for all scopes independently — Telegram picks the
-                # narrowest matching scope per chat type (forum topics fall
-                # through to AllGroupChats or Default).
-                for scope_cls in (BotCommandScopeDefault, BotCommandScopeAllPrivateChats, BotCommandScopeAllGroupChats):
-                    scope_name = getattr(scope_cls, "__name__", str(scope_cls))
-                    try:
-                        await self._bot.set_my_commands(bot_commands, scope=scope_cls())
-                        logger.info("[%s] set_my_commands OK for scope %s (%d cmds)", self.name, scope_name, len(bot_commands))
-                    except Exception as scope_err:
-                        logger.warning("[%s] set_my_commands FAILED for scope %s: %s", self.name, scope_name, scope_err)
-                # Forum topics don't inherit AllGroupChats — Telegram resolves
-                # commands via BotCommandScopeChat(chat_id) for forum groups.
-                # Lazy registration happens in _ensure_forum_commands on first
-                # message from a forum topic (see _handle_text_message).
-                if hidden_count:
-                    logger.info(
-                        "[%s] Telegram menu: %d commands registered, %d hidden (over %d limit). Use /commands for full list.",
-                        self.name, len(menu_commands), hidden_count, max_commands,
-                    )
+                await self._register_bot_commands()
             except Exception as e:
                 logger.warning(
                     "[%s] Could not register Telegram command menu: %s",
@@ -7480,10 +7522,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 chat_id = int(chat.id)
                 if chat_id in self._forum_command_registered:
                     return
-                from telegram import BotCommand, BotCommandScopeChat
-                from hermes_cli.commands import telegram_menu_commands, telegram_menu_max_commands
-                menu_commands, _ = telegram_menu_commands(max_commands=telegram_menu_max_commands())
-                bot_commands = [BotCommand(name, desc) for name, desc in menu_commands]
+                from telegram import BotCommandScopeChat
+                bot_commands, _, _ = self._build_bot_commands()
                 await self._bot.set_my_commands(bot_commands, scope=BotCommandScopeChat(chat_id=chat_id))
                 self._forum_command_registered.add(chat_id)
                 logger.info("[%s] Lazy-registered %d commands for forum chat %s", self.name, len(bot_commands), chat_id)

--- a/tests/gateway/test_reload_skills_telegram_resync.py
+++ b/tests/gateway/test_reload_skills_telegram_resync.py
@@ -1,0 +1,219 @@
+"""Tests for `/reload-skills` refreshing the Telegram command menu."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from gateway.config import Platform
+from gateway.run import GatewayRunner, MessageEvent
+
+
+class DefaultScope:
+    pass
+
+
+class ChatScope:
+    def __init__(self, chat_id):
+        self.chat_id = chat_id
+
+
+class PrivateScope:
+    pass
+
+
+class GroupScope:
+    pass
+
+
+def _make_adapter():
+    """Construct a TelegramAdapter without __init__ side effects."""
+    from plugins.platforms.telegram.adapter import TelegramAdapter
+
+    adapter = object.__new__(TelegramAdapter)
+    adapter.platform = Platform.TELEGRAM
+    adapter._bot = SimpleNamespace(set_my_commands=AsyncMock())
+    adapter._forum_command_registered = set()
+    adapter._forum_lock = asyncio.Lock()
+    return adapter
+
+
+class TestTelegramReloadSkillsResync:
+    @pytest.mark.asyncio
+    async def test_refresh_skill_group_registers_current_menu_for_startup_scopes(self):
+        adapter = _make_adapter()
+
+        with patch(
+            "hermes_cli.commands.telegram_menu_max_commands",
+            return_value=60,
+        ), patch(
+            "hermes_cli.commands.telegram_menu_commands",
+            return_value=([("start", "Start"), ("example_skill", "Example skill")], 0),
+        ), patch(
+            "telegram.BotCommand",
+            side_effect=lambda command, description: (command, description),
+        ), patch(
+            "telegram.BotCommandScopeDefault",
+            new=DefaultScope,
+        ), patch(
+            "telegram.BotCommandScopeAllPrivateChats",
+            new=PrivateScope,
+        ), patch(
+            "telegram.BotCommandScopeAllGroupChats",
+            new=GroupScope,
+        ):
+            count, hidden = await adapter.refresh_skill_group()
+
+        assert (count, hidden) == (2, 0)
+        assert adapter._bot.set_my_commands.await_count == 3
+        for call in adapter._bot.set_my_commands.await_args_list:
+            assert call.args[0] == [
+                ("start", "Start"),
+                ("example_skill", "Example skill"),
+            ]
+        assert [type(call.kwargs["scope"]) for call in adapter._bot.set_my_commands.await_args_list] == [
+            DefaultScope,
+            PrivateScope,
+            GroupScope,
+        ]
+
+    @pytest.mark.asyncio
+    async def test_refresh_skill_group_rereads_current_menu_commands(self):
+        adapter = _make_adapter()
+
+        with patch(
+            "hermes_cli.commands.telegram_menu_max_commands",
+            return_value=60,
+        ), patch(
+            "hermes_cli.commands.telegram_menu_commands",
+            side_effect=[
+                ([("old_skill", "Old skill")], 0),
+                ([("new_skill", "New skill")], 0),
+            ],
+        ), patch(
+            "telegram.BotCommand",
+            side_effect=lambda command, description: (command, description),
+        ), patch(
+            "telegram.BotCommandScopeDefault",
+            new=DefaultScope,
+        ), patch(
+            "telegram.BotCommandScopeAllPrivateChats",
+            new=PrivateScope,
+        ), patch(
+            "telegram.BotCommandScopeAllGroupChats",
+            new=GroupScope,
+        ):
+            await adapter.refresh_skill_group()
+            await adapter.refresh_skill_group()
+
+        second_refresh_calls = adapter._bot.set_my_commands.await_args_list[3:6]
+        assert len(second_refresh_calls) == 3
+        for call in second_refresh_calls:
+            assert call.args[0] == [("new_skill", "New skill")]
+
+    @pytest.mark.asyncio
+    async def test_refresh_skill_group_refreshes_cached_forum_chat_scopes(self):
+        adapter = _make_adapter()
+        adapter._forum_command_registered = {111, 222}
+
+        with patch(
+            "hermes_cli.commands.telegram_menu_max_commands",
+            return_value=60,
+        ), patch(
+            "hermes_cli.commands.telegram_menu_commands",
+            return_value=([("example_skill", "Example skill")], 0),
+        ), patch(
+            "telegram.BotCommand",
+            side_effect=lambda command, description: (command, description),
+        ), patch(
+            "telegram.BotCommandScopeDefault",
+            new=DefaultScope,
+        ), patch(
+            "telegram.BotCommandScopeAllPrivateChats",
+            new=PrivateScope,
+        ), patch(
+            "telegram.BotCommandScopeAllGroupChats",
+            new=GroupScope,
+        ), patch(
+            "telegram.BotCommandScopeChat",
+            new=ChatScope,
+        ):
+            count, hidden = await adapter.refresh_skill_group()
+
+        assert (count, hidden) == (1, 0)
+        assert adapter._bot.set_my_commands.await_count == 5
+        forum_scopes = [
+            call.kwargs["scope"]
+            for call in adapter._bot.set_my_commands.await_args_list
+            if isinstance(call.kwargs["scope"], ChatScope)
+        ]
+        assert [scope.chat_id for scope in forum_scopes] == [111, 222]
+
+    @pytest.mark.asyncio
+    async def test_refresh_skill_group_uses_configurable_menu_cap(self):
+        adapter = _make_adapter()
+
+        with patch(
+            "hermes_cli.commands.telegram_menu_max_commands",
+            return_value=7,
+        ), patch(
+            "hermes_cli.commands.telegram_menu_commands",
+            return_value=([("example_skill", "Example skill")], 3),
+        ) as menu_commands, patch(
+            "telegram.BotCommand",
+            side_effect=lambda command, description: (command, description),
+        ), patch(
+            "telegram.BotCommandScopeDefault",
+            new=DefaultScope,
+        ), patch(
+            "telegram.BotCommandScopeAllPrivateChats",
+            new=PrivateScope,
+        ), patch(
+            "telegram.BotCommandScopeAllGroupChats",
+            new=GroupScope,
+        ):
+            count, hidden = await adapter.refresh_skill_group()
+
+        assert (count, hidden) == (1, 3)
+        menu_commands.assert_called_once_with(max_commands=7)
+
+    @pytest.mark.asyncio
+    async def test_reload_skills_handler_calls_telegram_refresh(self):
+        runner = object.__new__(GatewayRunner)
+
+        telegram_adapter = SimpleNamespace(
+            name="telegram",
+            refresh_skill_group=AsyncMock(return_value=(42, 0)),
+        )
+        passive_adapter = SimpleNamespace(name="passive")
+        runner.adapters = {
+            "telegram": telegram_adapter,
+            "passive": passive_adapter,
+        }
+
+        fake_result = {
+            "added": [{"name": "example-skill", "description": "Example skill"}],
+            "removed": [],
+            "total": 42,
+            "errors": [],
+        }
+        event = MessageEvent(
+            text="/reload-skills",
+            source=SimpleNamespace(
+                platform=Platform.TELEGRAM,
+                channel="chat-id",
+                user_id="user-id",
+                thread_id=None,
+            ),
+            raw_message={},
+        )
+        runner._session_key_for_source = lambda source: None
+        runner._pending_skills_reload_notes = {}
+
+        with patch("agent.skill_commands.reload_skills", return_value=fake_result):
+            result = await runner._handle_reload_skills_command(event)
+
+        telegram_adapter.refresh_skill_group.assert_awaited_once()
+        assert "Skills Reloaded" in result
+        assert "example-skill" in result


### PR DESCRIPTION
## Summary

Fixes `/reload-skills` not refreshing Telegram's native BotCommand menu.

`/reload-skills` already reloads Hermes' in-process skill registry, so directly typing a newly loaded skill command can work. Telegram's `/` menu and autocomplete still stay stale until reconnect because Telegram was not participating in the gateway's adapter refresh hook.

## Fix

- Factor Telegram BotCommand registration into `_register_bot_commands()`.
- Share the current configurable menu-building path between startup and refresh.
- Refresh cached forum-chat BotCommand scopes on reload.
- Add regression coverage for the Telegram refresh path.

## Verification

Verified with a live Telegram bot token: current `main` does not update BotCommand scopes after reload; this branch updates the same scopes as startup. Original BotCommand scopes were restored after the check.

```bash
python -m pytest \
  tests/gateway/test_reload_skills_telegram_resync.py \
  tests/gateway/test_reload_skills_discord_resync.py \
  tests/gateway/test_reload_skills_command.py \
  tests/gateway/test_telegram_forum_commands.py \
  -q -o 'addopts='
```

Result: `19 passed`.
