### PR TITLE
fix(cron): include whatsapp in _HOME_TARGET_ENV_VARS

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -111,6 +111,7 @@ _HOME_TARGET_ENV_VARS = {
     "weixin": "WEIXIN_HOME_CHANNEL",
     "bluebubbles": "BLUEBUBBLES_HOME_CHANNEL",
     "qqbot": "QQBOT_HOME_CHANNEL",
+    "whatsapp": "WHATSAPP_HOME_CHANNEL",
 }
 
 # Legacy env var names kept for back-compat.  Each entry is the current


### PR DESCRIPTION
## Summary

Cron jobs configured with `deliver: whatsapp` were silently dropped — the agent ran, output was saved, `jobs.json` marked success, but no WhatsApp message was sent and no error was logged.

Root cause: `cron/scheduler.py` defines `_HOME_TARGET_ENV_VARS`, the dict the cron resolver uses to look up each platform's home-channel env var. Every messaging platform was in there *except* `whatsapp` (matrix, telegram, discord, slack, signal, mattermost, sms, email, dingtalk, feishu, wecom, weixin, bluebubbles, qqbot — but no whatsapp). So `_resolve_delivery_targets({"deliver": "whatsapp"})` returned `[]`, and the caller treats "no targets" as a no-op.

The gateway adapter and the `send_message` tool path both already honored `WHATSAPP_HOME_CHANNEL` correctly — direct sends worked fine. Only the cron path missed.

## Change

One-line addition to `_HOME_TARGET_ENV_VARS`:

```python
"whatsapp": "WHATSAPP_HOME_CHANNEL",
```

## Verification

Before the fix:

```python
from cron.scheduler import _resolve_delivery_targets
job = {"id": "x", "name": "x", "deliver": "whatsapp"}
_resolve_delivery_targets(job)  # []
```

After:

```python
_resolve_delivery_targets(job)  # [{'platform': 'whatsapp', 'chat_id': '...', 'thread_id': None}]
```

End-to-end: scheduled three successive `deliver: whatsapp` cron pings (1 minute each) — all landed in the WhatsApp self-chat after this patch was applied to a running gateway. Before the patch, none arrived.

Fixes #22997
