### PR TITLE
fix(cron): guard load_jobs against malformed jobs.json shapes

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -407,12 +407,27 @@ def load_jobs() -> List[Dict[str, Any]]:
     try:
         with open(JOBS_FILE, 'r', encoding='utf-8') as f:
             data = json.load(f)
+            # Guard against malformed shapes (bare list, null, scalar, string)
+            if not isinstance(data, dict):
+                if isinstance(data, list):
+                    logger.warning("jobs.json is a bare list — auto-migrating to dict shape")
+                    save_jobs(data)
+                    return data
+                logger.error("Malformed jobs.json: expected dict, got %s", type(data).__name__)
+                return []
             return data.get("jobs", [])
     except json.JSONDecodeError:
         # Retry with strict=False to handle bare control chars in string values
         try:
             with open(JOBS_FILE, 'r', encoding='utf-8') as f:
                 data = json.loads(f.read(), strict=False)
+                if not isinstance(data, dict):
+                    if isinstance(data, list):
+                        logger.warning("jobs.json is a bare list — auto-migrating to dict shape")
+                        save_jobs(data)
+                        return data
+                    logger.error("Malformed jobs.json: expected dict, got %s", type(data).__name__)
+                    return []
                 jobs = data.get("jobs", [])
                 if jobs:
                     # Auto-repair: rewrite with proper escaping

--- a/tests/cron/test_cron_load_jobs_malformed.py
+++ b/tests/cron/test_cron_load_jobs_malformed.py
@@ -1,0 +1,77 @@
+"""Regression tests for #22569 — guard load_jobs against malformed jobs.json shapes."""
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+# cron/jobs.py uses a module-level JOBS_FILE path.
+# We patch it to a temp file for isolation.
+
+
+class TestLoadJobsMalformedShapes(unittest.TestCase):
+    """load_jobs must not crash when jobs.json is not a dict."""
+
+    def setUp(self):
+        self.tmp_dir = tempfile.TemporaryDirectory()
+        self.jobs_file = Path(self.tmp_dir.name) / "jobs.json"
+
+    def tearDown(self):
+        self.tmp_dir.cleanup()
+
+    def _write_json(self, obj):
+        self.jobs_file.write_text(json.dumps(obj), encoding="utf-8")
+
+    def _load(self):
+        # Import inside test so JOBS_FILE can be patched
+        import importlib
+        import cron.jobs as jobs_mod
+        with patch.object(jobs_mod, "JOBS_FILE", self.jobs_file):
+            # ensure_dirs writes to the parent, already exists via tmp_dir
+            return jobs_mod.load_jobs()
+
+    def test_bare_list(self):
+        """Legacy bare-list format should be auto-migrated."""
+        self._write_json([{"id": "j1", "name": "test"}])
+        result = self._load()
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["id"], "j1")
+        # After migration, file should be rewritten as dict shape
+        data = json.loads(self.jobs_file.read_text(encoding="utf-8"))
+        self.assertIn("jobs", data)
+
+    def test_null(self):
+        """null root should return empty list, not crash."""
+        self._write_json(None)
+        result = self._load()
+        self.assertEqual(result, [])
+
+    def test_scalar_string(self):
+        """String root should return empty list, not crash."""
+        self._write_json("corrupted")
+        result = self._load()
+        self.assertEqual(result, [])
+
+    def test_scalar_number(self):
+        """Number root should return empty list, not crash."""
+        self._write_json(42)
+        result = self._load()
+        self.assertEqual(result, [])
+
+    def test_normal_dict(self):
+        """Normal dict shape should work as before."""
+        self._write_json({"jobs": [{"id": "j1"}], "updated_at": "2026-01-01T00:00:00"})
+        result = self._load()
+        self.assertEqual(len(result), 1)
+        self.assertEqual(result[0]["id"], "j1")
+
+    def test_empty_dict(self):
+        """Empty dict should return empty list."""
+        self._write_json({})
+        result = self._load()
+        self.assertEqual(result, [])
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes #22569.

`cron.jobs.load_jobs` called `data.get("jobs", [])` immediately after `json.load()`, assuming the parsed root is always a `dict`. If `jobs.json` is hand-edited or written by a legacy release in any non-dict shape — a bare list (`[{"id": "x"}]`), `null`, a scalar, or a string — the call crashes with `AttributeError`.

## Changes

- Guard both `json.load()` and `json.loads(strict=False)` fallback paths with `isinstance(data, dict)` checks.
- If `data` is a bare list (legacy format), auto-migrate by calling `save_jobs()` and return the list.
- If `data` is any other non-dict shape, log an error and return `[]` instead of crashing.

## Test Plan

Added regression tests in `tests/cron/test_cron_load_jobs_malformed.py` covering:
1. Bare list auto-migration
2. `null` root → empty list
3. String root → empty list
4. Number root → empty list
5. Normal dict shape → works as before
6. Empty dict → empty list

```bash
python3 -m unittest tests.cron.test_cron_load_jobs_malformed -v
# 6 passed
```