### PR TITLE
fix(auxiliary): enumerate custom_providers[] in auto fallback chain

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -9,10 +9,12 @@ Resolution order for text tasks (auto mode):
      aggregators, direct API-key providers, native Anthropic, Codex, etc.)
   2. OpenRouter  (OPENROUTER_API_KEY)
   3. Nous Portal (~/.hermes/auth.json active provider)
-  4. Custom endpoint (config.yaml model.base_url + OPENAI_API_KEY)
-  5. Native Anthropic
-  6. Direct API-key providers (z.ai/GLM, Kimi/Moonshot, MiniMax, MiniMax-CN)
-  7. None
+  4. Named custom providers (config.yaml ``custom_providers:`` list — each
+     entry tried in declaration order)
+  5. Custom endpoint (config.yaml model.base_url + OPENAI_API_KEY)
+  6. Native Anthropic
+  7. Direct API-key providers (z.ai/GLM, Kimi/Moonshot, MiniMax, MiniMax-CN)
+  8. None
 
 Resolution order for vision/multimodal tasks (auto mode):
   1. Selected main provider, if it is one of the supported vision backends below
@@ -1777,6 +1779,7 @@ def _try_anthropic(explicit_api_key: str = None) -> Tuple[Optional[Any], Optiona
 _AUTO_PROVIDER_LABELS = {
     "_try_openrouter": "openrouter",
     "_try_nous": "nous",
+    "_try_named_custom_providers": "named-custom",
     "_try_custom_endpoint": "local/custom",
     "_resolve_api_key_provider": "api-key",
 }
@@ -1799,6 +1802,68 @@ def _normalize_main_runtime(main_runtime: Optional[Dict[str, Any]]) -> Dict[str,
     return normalized
 
 
+def _try_named_custom_providers() -> Tuple[Optional[Any], Optional[str]]:
+    """Enumerate ``custom_providers[]`` entries from config.yaml as a fallback.
+
+    The legacy ``_try_custom_endpoint`` only looks at the single-slot
+    ``model.base_url`` (or ``OPENAI_BASE_URL`` env), so users who declare
+    their endpoint exclusively as a named entry under ``custom_providers:``
+    were unreachable from the auto chain.  This step iterates each named
+    custom provider and tries it via the same router used by explicit
+    ``provider: custom:<name>`` configs.
+
+    Returns the first working ``(client, model)`` pair, or ``(None, None)``
+    when no entry yields one.  Per-entry failures are logged at debug only.
+    """
+    try:
+        from hermes_cli.config import get_compatible_custom_providers, load_config
+    except ImportError:
+        return None, None
+
+    try:
+        config = load_config()
+    except Exception as exc:
+        logger.debug("Auxiliary named-custom: load_config failed: %s", exc)
+        return None, None
+
+    entries = get_compatible_custom_providers(config) if config else []
+    if not entries:
+        return None, None
+
+    # Skip the entry already attempted as the main provider in Step 1 of
+    # _resolve_auto, so we don't waste a second roundtrip on the same
+    # endpoint that just failed.  Match by normalized name only — it's the
+    # cheap, reliable signal.
+    main_provider = (_read_main_provider() or "").strip().lower()
+    main_named = ""
+    if main_provider.startswith("custom:"):
+        main_named = main_provider.split(":", 1)[1].strip()
+
+    for entry in entries:
+        if not isinstance(entry, dict):
+            continue
+        name = (entry.get("name") or "").strip()
+        if not name:
+            continue
+        if main_named and name.lower() == main_named.lower():
+            continue
+        try:
+            client, model = resolve_provider_client(f"custom:{name}", model=None)
+        except Exception as exc:  # pragma: no cover — defensive
+            logger.debug(
+                "Auxiliary named-custom: resolve_provider_client(custom:%s) raised %s",
+                name, exc,
+            )
+            continue
+        if client is not None:
+            logger.debug(
+                "Auxiliary named-custom: using custom_providers[name=%s] (%s)",
+                name, model or "default",
+            )
+            return client, model
+    return None, None
+
+
 def _get_provider_chain() -> List[tuple]:
     """Return the ordered provider detection chain.
 
@@ -1815,6 +1880,7 @@ def _get_provider_chain() -> List[tuple]:
     return [
         ("openrouter", _try_openrouter),
         ("nous", _try_nous),
+        ("named-custom", _try_named_custom_providers),
         ("local/custom", _try_custom_endpoint),
         ("api-key", _resolve_api_key_provider),
     ]

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -913,11 +913,11 @@ class TestIsRateLimitError:
 class TestGetProviderChain:
     """_get_provider_chain() resolves functions at call time (testable)."""
 
-    def test_returns_four_entries(self):
+    def test_returns_expected_entries(self):
         chain = _get_provider_chain()
-        assert len(chain) == 4
+        assert len(chain) == 5
         labels = [label for label, _ in chain]
-        assert labels == ["openrouter", "nous", "local/custom", "api-key"]
+        assert labels == ["openrouter", "nous", "named-custom", "local/custom", "api-key"]
         # Codex is deliberately NOT in this chain — see _get_provider_chain
         # docstring. ChatGPT-account Codex has a shifting model allow-list;
         # guessing a model to fall back on breaks more often than it helps.

--- a/tests/agent/test_auxiliary_named_custom_chain.py
+++ b/tests/agent/test_auxiliary_named_custom_chain.py
@@ -1,0 +1,235 @@
+"""Regression tests for ``custom_providers[]`` enumeration in the auto chain.
+
+Before this change, ``_resolve_auto``'s fallback chain only checked the
+single-slot legacy custom endpoint (``model.base_url + OPENAI_API_KEY``).
+Users who declared their endpoint exclusively as a named entry under
+``custom_providers:`` saw the misleading "No auxiliary LLM provider
+configured" warning even though a working entry was right there in the
+config — they had to point each ``auxiliary.<task>.provider`` at the named
+custom provider explicitly to wire it up.
+
+The fix adds a ``_try_named_custom_providers`` step between Nous and the
+legacy ``local/custom`` step, enumerating each ``custom_providers[]`` entry
+and trying it via the same ``custom:<name>`` router used by explicit config.
+
+Related: gh-13762, gh-22317.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _isolate(tmp_path, monkeypatch):
+    """Redirect HERMES_HOME and clear known env vars that would short-circuit."""
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    # Strip env vars that would let earlier chain steps (OpenRouter / custom
+    # endpoint) succeed and mask the named-custom step under test.
+    for var in ("OPENROUTER_API_KEY", "OPENAI_BASE_URL", "OPENAI_API_KEY"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _write_config(tmp_path, config_dict):
+    """Write a config.yaml to the test HERMES_HOME."""
+    import yaml
+    config_path = tmp_path / ".hermes" / "config.yaml"
+    config_path.write_text(yaml.dump(config_dict))
+
+
+# ── Provider-chain composition ──────────────────────────────────────────────
+
+
+class TestChainShape:
+    """The chain ordering must remain stable for callers that rely on it."""
+
+    def test_named_custom_step_present(self):
+        from agent.auxiliary_client import _get_provider_chain
+        labels = [label for label, _ in _get_provider_chain()]
+        assert "named-custom" in labels
+
+    def test_named_custom_runs_before_legacy_custom(self):
+        from agent.auxiliary_client import _get_provider_chain
+        labels = [label for label, _ in _get_provider_chain()]
+        assert labels.index("named-custom") < labels.index("local/custom")
+
+    def test_named_custom_runs_after_aggregators(self):
+        """Aggregators (OpenRouter / Nous) keep their priority — they're the
+        common case and a named custom provider should only be tried when
+        those have no credentials."""
+        from agent.auxiliary_client import _get_provider_chain
+        labels = [label for label, _ in _get_provider_chain()]
+        assert labels.index("openrouter") < labels.index("named-custom")
+        assert labels.index("nous") < labels.index("named-custom")
+
+
+# ── _try_named_custom_providers behavior ───────────────────────────────────
+
+
+class TestTryNamedCustomProviders:
+    """The new step iterates ``custom_providers[]`` and returns the first hit."""
+
+    def test_returns_none_when_no_custom_providers(self, tmp_path):
+        _write_config(tmp_path, {"model": {"default": "claude-opus-4-7", "provider": "anthropic"}})
+        from agent.auxiliary_client import _try_named_custom_providers
+        client, model = _try_named_custom_providers()
+        assert client is None
+        assert model is None
+
+    def test_returns_first_working_entry(self, tmp_path):
+        _write_config(tmp_path, {
+            "model": {"default": "claude-opus-4-7", "provider": "anthropic"},
+            "custom_providers": [
+                {"name": "azure-tunnel", "base_url": "http://localhost:8787/v1",
+                 "api_key": "dummy", "model": "gpt-5.4"},
+            ],
+        })
+        mock_client = MagicMock()
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, "gpt-5.4"),
+        ) as mock_resolve:
+            from agent.auxiliary_client import _try_named_custom_providers
+            client, model = _try_named_custom_providers()
+
+        assert client is mock_client
+        assert model == "gpt-5.4"
+        # Verify the router was called with the custom:<name> form
+        called_provider = mock_resolve.call_args.args[0]
+        assert called_provider == "custom:azure-tunnel"
+
+    def test_skips_main_provider_to_avoid_double_attempt(self, tmp_path):
+        """If the main provider is custom:foo, we already tried it in Step 1;
+        re-trying it in the chain is wasted work."""
+        _write_config(tmp_path, {
+            "model": {"default": "gpt-5.4", "provider": "custom:azure-tunnel"},
+            "custom_providers": [
+                {"name": "azure-tunnel", "base_url": "http://localhost:8787/v1",
+                 "api_key": "dummy", "model": "gpt-5.4"},
+                {"name": "other-tunnel", "base_url": "http://localhost:9999/v1",
+                 "api_key": "dummy", "model": "other-model"},
+            ],
+        })
+        mock_client = MagicMock()
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, "other-model"),
+        ) as mock_resolve:
+            from agent.auxiliary_client import _try_named_custom_providers
+            client, model = _try_named_custom_providers()
+
+        # Only "other-tunnel" should have been attempted
+        assert client is mock_client
+        called_providers = [c.args[0] for c in mock_resolve.call_args_list]
+        assert called_providers == ["custom:other-tunnel"]
+
+    def test_falls_through_when_entry_returns_no_client(self, tmp_path):
+        _write_config(tmp_path, {
+            "model": {"default": "claude-opus-4-7", "provider": "anthropic"},
+            "custom_providers": [
+                {"name": "broken", "base_url": "http://localhost:1/v1"},
+                {"name": "working", "base_url": "http://localhost:8787/v1",
+                 "api_key": "dummy", "model": "gpt-5.4"},
+            ],
+        })
+        mock_client = MagicMock()
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            side_effect=[(None, None), (mock_client, "gpt-5.4")],
+        ) as mock_resolve:
+            from agent.auxiliary_client import _try_named_custom_providers
+            client, model = _try_named_custom_providers()
+
+        assert client is mock_client
+        assert model == "gpt-5.4"
+        assert mock_resolve.call_count == 2
+
+    def test_skips_malformed_entries(self, tmp_path):
+        """Non-dict / nameless entries are silently skipped."""
+        _write_config(tmp_path, {
+            "model": {"default": "claude-opus-4-7", "provider": "anthropic"},
+            "custom_providers": [
+                "bogus-string-entry",          # not a dict
+                {"base_url": "http://x"},      # missing name
+                {"name": "real", "base_url": "http://localhost:8787/v1",
+                 "api_key": "dummy", "model": "gpt-5.4"},
+            ],
+        })
+        mock_client = MagicMock()
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(mock_client, "gpt-5.4"),
+        ) as mock_resolve:
+            from agent.auxiliary_client import _try_named_custom_providers
+            client, model = _try_named_custom_providers()
+
+        assert client is mock_client
+        assert mock_resolve.call_count == 1
+        assert mock_resolve.call_args.args[0] == "custom:real"
+
+
+# ── End-to-end: _resolve_auto picks up the named-custom entry ──────────────
+
+
+class TestResolveAutoUsesNamedCustom:
+    """The bug from the issue: main provider has no aux-usable client and the
+    only configured endpoint is in custom_providers[]. The chain must reach it."""
+
+    def test_anthropic_oauth_main_with_named_custom_fallback(self, tmp_path):
+        """Reproduces the original report: main=anthropic (OAuth-only on Claude
+        Code, no API key), custom_providers has a working tunnel — auto must
+        find it instead of warning 'No auxiliary LLM provider configured'."""
+        _write_config(tmp_path, {
+            "model": {"default": "claude-opus-4-7", "provider": "anthropic"},
+            "custom_providers": [
+                {"name": "azure-tunnel", "base_url": "http://localhost:8787/v1",
+                 "api_key": "dummy", "model": "gpt-5.4"},
+            ],
+        })
+        named_client = MagicMock()
+
+        def fake_resolve(provider, model=None, **kwargs):
+            if provider == "custom:azure-tunnel":
+                return named_client, "gpt-5.4"
+            # Step 1 (main provider) returns no client — Anthropic OAuth-only
+            return None, None
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            side_effect=fake_resolve,
+        ):
+            from agent.auxiliary_client import _resolve_auto
+            client, model = _resolve_auto()
+
+        assert client is named_client
+        assert model == "gpt-5.4"
+
+    def test_main_model_still_wins_when_resolvable(self, tmp_path):
+        """Step 1 (main provider) must keep priority over the chain when its
+        client is available — the chain is a fallback only."""
+        _write_config(tmp_path, {
+            "model": {"default": "deepseek-chat", "provider": "deepseek"},
+            "custom_providers": [
+                {"name": "azure-tunnel", "base_url": "http://localhost:8787/v1",
+                 "api_key": "dummy", "model": "gpt-5.4"},
+            ],
+        })
+        main_client = MagicMock()
+
+        def fake_resolve(provider, model=None, **kwargs):
+            if provider == "deepseek":
+                return main_client, "deepseek-chat"
+            return None, None  # would be hit if the test fails
+
+        with patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            side_effect=fake_resolve,
+        ):
+            from agent.auxiliary_client import _resolve_auto
+            client, model = _resolve_auto()
+
+        assert client is main_client
+        assert model == "deepseek-chat"


### PR DESCRIPTION
## What does this PR do?

Fixes the auxiliary LLM `auto` resolution chain so it actually finds endpoints declared **exclusively** under `custom_providers:` in `config.yaml`.

## Root cause

The `auto` resolution order in `agent/auxiliary_client.py` (see top-of-file docstring) for text aux tasks was:

```
1. Main provider + main model
2. OpenRouter
3. Nous Portal
4. Custom endpoint (model.base_url + OPENAI_API_KEY)   ← legacy single-slot only
5. Native Anthropic
6. Direct API-key providers
7. None
```

Step 4 (`_try_custom_endpoint`) only consults the **legacy single-slot** custom endpoint — `config.yaml → model.base_url` plus `OPENAI_API_KEY`. The newer **`custom_providers:` list** (named providers, referenced as `provider: custom:<name>`) was never enumerated by the chain.

## Symptom

A user whose only working aux backend is a named custom provider — e.g. a self-hosted Azure tunnel:

```yaml
model:
  default: claude-opus-4-7
  provider: anthropic            # OAuth (Claude Code) — gated to api.anthropic.com/v1/code,
                                 # cannot be reused for arbitrary aux completions
custom_providers:
  - name: azure-tunnel
    base_url: http://localhost:8787/openai/v1
    api_key: dummy
    api_mode: chat_completions
```

…sees this on session start and every compression attempt:

> ⚠ No auxiliary LLM provider configured — context compression will drop middle turns without a summary. Run `hermes setup` or set `OPENROUTER_API_KEY`.

…even though `custom:azure-tunnel` works fine when wired up explicitly under each `auxiliary.<task>.provider`. The chain just never reaches it.

The workaround until now is to manually duplicate `provider: custom:<name>` and `model: <model>` under every aux task in `auxiliary:` (`compression`, `title_generation`, `session_search`, `skills_hub`, `approval`, `mcp`, `web_extract`). That's brittle and not discoverable.

## Fix

Insert a new step `_try_named_custom_providers` between Nous and the legacy custom-endpoint step. It:

1. Loads `custom_providers` from config via the existing `get_compatible_custom_providers(load_config())` helper.
2. Iterates entries in declaration order.
3. Skips the entry already attempted as the main provider in Step 1 (matches by normalized name) — avoids a guaranteed-failing second roundtrip on the same endpoint.
4. Calls `resolve_provider_client(f"custom:{name}")` per entry — the same router used by explicit `provider: custom:<name>` configs, so all the existing auth / `api_mode` / `default_headers` / credential-pool logic is reused.
5. Returns the first `(client, model)` pair where the client is non-None.
6. Per-entry failures are `logger.debug` only, so one misconfigured entry doesn't block subsequent ones.

New text-task chain:

```
1. Main provider + main model
2. OpenRouter
3. Nous Portal
4. Named custom providers (custom_providers[])         ← NEW
5. Custom endpoint (model.base_url + OPENAI_API_KEY)
6. Native Anthropic
7. Direct API-key providers
8. None
```

Vision chain is unchanged — vision has its own provider-allow-list resolution and a different fallback ordering.

## Why between Nous and `local/custom`?

- Aggregators (OpenRouter / Nous) keep priority because they're the common case and have model selection latitude. A user with both a Nous portal session AND a tiny local tunnel almost always wants the Nous-routed model for aux summaries.
- Named custom providers are tried *before* the legacy `local/custom` step because `custom_providers[]` is the modern way to declare a custom endpoint; the legacy slot is increasingly only used by env-driven setups.
- API-key providers stay last — z.ai, Kimi, MiniMax all carry credentials a user might forget about and shouldn't silently win over an explicitly declared local tunnel.

## Test plan

```bash
$ pytest tests/agent/ -k "auxiliary or aux_" -q
268 passed in 3.44s
```

10 new regression tests in `tests/agent/test_auxiliary_named_custom_chain.py`:

**`TestChainShape`** — chain composition is stable for callers that depend on ordering:
- `named-custom` step is present
- `named-custom` runs before `local/custom`
- `named-custom` runs after `openrouter` and `nous`

**`TestTryNamedCustomProviders`** — the new step's behavior in isolation:
- Returns `(None, None)` when no `custom_providers` are configured
- Returns the first working entry, calling `resolve_provider_client("custom:<name>")`
- Skips the entry already used as `main_provider` (no double-attempt)
- Falls through to the next entry when one returns `(None, None)`
- Skips malformed entries (non-dict, missing `name`)

**`TestResolveAutoUsesNamedCustom`** — end-to-end scenarios reproducing the bug:
- `anthropic` main + named custom fallback → `_resolve_auto` finds the named custom provider (the original bug from this PR's repro).
- Main model still wins when its own provider client resolves — the chain remains a pure fallback, no priority regression.

Existing test `tests/agent/test_auxiliary_client.py::TestGetProviderChain::test_returns_four_entries` was updated to expect 5 entries and renamed `test_returns_expected_entries`.

## Related

- #13762 — `custom_providers` not working with auxiliary tasks (about explicit `auxiliary.<task>.provider: custom:<name>` resolution; this PR is the auto-chain sibling)
- #22317 — Auxiliary auto-detect ignores named custom providers (about Step 1 model selection when main IS a named custom provider; this PR is the orthogonal Step-N enumeration fix)

Both of those bugs and this one share the underlying theme that the `custom_providers:` list isn't a full peer of the legacy single-slot in every aux code path. This PR closes the auto-chain gap specifically.

## Platform tested on

macOS 26.3, Python 3.11.15.
