### PR TITLE
fix(gateway): dedupe WSL interop PATH entries

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2000,6 +2000,19 @@ def get_python_path() -> str:
 # Systemd (Linux)
 # =============================================================================
 
+def _normalize_path_entry_for_dedup(path: str) -> str:
+    """Return a stable PATH entry key/payload for generated service units.
+
+    WSL interop paths can appear both from the caller's PATH and from built-in
+    fallbacks, sometimes differing only by a trailing slash. Without normalizing
+    those variants, the generated gateway unit can oscillate between two
+    equivalent PATH strings and `hermes gateway status` reports a stale unit.
+    """
+    if not path:
+        return ""
+    return path.rstrip(os.sep) or os.sep
+
+
 def _build_user_local_paths(home: Path, path_entries: list[str]) -> list[str]:
     """Return user-local bin dirs that exist and aren't already in *path_entries*."""
     candidates = [
@@ -2043,11 +2056,14 @@ def _build_wsl_interop_paths(path_entries: list[str]) -> list[str]:
             candidates.append(entry)
 
     result: list[str] = []
-    seen = set(path_entries)
+    seen = {_normalize_path_entry_for_dedup(p) for p in path_entries}
     for entry in candidates:
-        if entry and entry not in seen:
-            seen.add(entry)
-            result.append(entry)
+        if not entry:
+            continue
+        normalized = _normalize_path_entry_for_dedup(entry)
+        if normalized and normalized not in seen:
+            seen.add(normalized)
+            result.append(normalized)
     return result
 
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -350,7 +350,26 @@ class TestGeneratedSystemdUnits:
         unit = gateway_cli.generate_systemd_unit(system=False)
 
         assert "/mnt/c/WINDOWS/system32" in unit
-        assert "/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0/" in unit
+        assert "/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0" in unit
+        assert "/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0/:" not in unit
+
+    def test_wsl_windows_interop_paths_are_stable_across_trailing_slash_variants(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "is_wsl", lambda: True)
+        monkeypatch.setenv(
+            "PATH",
+            "/usr/local/bin:/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0",
+        )
+        monkeypatch.setattr(
+            gateway_cli.shutil,
+            "which",
+            lambda cmd: "/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0/powershell.exe" if cmd == "powershell.exe" else None,
+        )
+
+        unit = gateway_cli.generate_systemd_unit(system=False)
+        path_line = next(line for line in unit.splitlines() if line.startswith('Environment="PATH='))
+
+        assert path_line.count("/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0") == 1
+        assert "/mnt/c/WINDOWS/System32/WindowsPowerShell/v1.0/:" not in path_line
 
     def test_user_unit_omits_windows_interop_paths_outside_wsl(self, monkeypatch):
         monkeypatch.setattr(gateway_cli, "is_wsl", lambda: False)


### PR DESCRIPTION
Normalize WSL Windows interop PATH candidates before deduping them so systemd unit generation stays stable when PATH and shutil.which disagree only by a trailing slash. This prevents hermes gateway status from reporting the installed service definition as outdated immediately after restart.

Adds a regression test for the WindowsPowerShell trailing-slash variant.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- hermes_cli/gateway.py
- tests/hermes_cli/test_gateway_service.py

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

- venv/bin/python -m pytest tests/hermes_cli/test_gateway_service.py -q --tb=short -o 'addopts='

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A