### PR TITLE
fix(extract_pymupdf): guard and validate --pages argument [REPLACED]

### DIFF
--- a/skills/productivity/ocr-and-documents/scripts/extract_pymupdf.py
+++ b/skills/productivity/ocr-and-documents/scripts/extract_pymupdf.py
@@ -79,8 +79,13 @@ if __name__ == "__main__":
         idx = args.index("--pages")
         p = args[idx + 1]
         if "-" in p:
-            start, end = p.split("-")
-            pages = list(range(int(start), int(end) + 1))
+            parts = p.split("-")
+            if len(parts) == 2:
+                start, end = parts
+                pages = list(range(int(start), int(end) + 1))
+            else:
+                print(f"ERROR: Invalid page range format: {p}", file=sys.stderr)
+                sys.exit(1)
         else:
             pages = [int(p)]
 

--- a/skills/productivity/ocr-and-documents/scripts/extract_pymupdf.py
+++ b/skills/productivity/ocr-and-documents/scripts/extract_pymupdf.py
@@ -66,6 +66,29 @@ def show_metadata(path):
         "format": doc.metadata.get("format", ""),
     }, indent=2))
 
+def parse_pages(args):
+    if "--pages" not in args:
+        return None
+
+    idx = args.index("--pages")
+    if idx + 1 >= len(args):
+        raise ValueError("--pages requires a value")
+
+    value = args[idx + 1]
+    try:
+        if "-" not in value:
+            return [int(value)]
+
+        parts = value.split("-")
+        if len(parts) != 2 or not all(parts):
+            raise ValueError
+        start, end = map(int, parts)
+        return list(range(start, end + 1))
+    except ValueError:
+        raise ValueError(
+            f"invalid --pages value {value!r}; expected N or START-END"
+        ) from None
+
 if __name__ == "__main__":
     args = sys.argv[1:]
     if not args or args[0] in {"-h", "--help"}:
@@ -73,21 +96,11 @@ if __name__ == "__main__":
         sys.exit(0)
 
     path = args[0]
-    pages = None
-
-    if "--pages" in args:
-        idx = args.index("--pages")
-        p = args[idx + 1]
-        if "-" in p:
-            parts = p.split("-")
-            if len(parts) == 2:
-                start, end = parts
-                pages = list(range(int(start), int(end) + 1))
-            else:
-                print(f"ERROR: Invalid page range format: {p}", file=sys.stderr)
-                sys.exit(1)
-        else:
-            pages = [int(p)]
+    try:
+        pages = parse_pages(args)
+    except ValueError as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        sys.exit(1)
 
     if "--metadata" in args:
         show_metadata(path)

--- a/tests/test_extract_pymupdf_defensive.py
+++ b/tests/test_extract_pymupdf_defensive.py
@@ -1,34 +1,48 @@
-"""防御性测试：extract_pymupdf 的 --pages 参数校验"""
+import importlib.util
+import runpy
 import sys
 from pathlib import Path
 
-script = Path(__file__).resolve().parents[3] / "skills/productivity/ocr-and-documents/scripts/extract_pymupdf.py"
-sys.path.insert(0, str(script.parent))
+import pytest
 
-def test_page_split_defensive():
-    """验证带有多个 '-' 的 page range 会被拒绝而不是 unpack ValueError"""
-    p = "1-2-3"
-    parts = p.split("-")
-    assert len(parts) == 3
-    # 原始代码的 start, end = p.split("-") 会在这里 ValueError
-    # 修复后的代码先检查 len(parts) == 2
-    if len(parts) != 2:
-        accepted = False
-    else:
-        accepted = True
-    assert not accepted
-    print("test_page_split_defensive passed")
 
-def test_valid_page_range_accepted():
-    """验证正常 page range 仍被接受"""
-    p = "1-5"
-    parts = p.split("-")
-    assert len(parts) == 2
-    start, end = parts
-    assert int(start) == 1
-    assert int(end) == 5
-    print("test_valid_page_range_accepted passed")
+SCRIPT = (
+    Path(__file__).resolve().parents[1]
+    / "skills/productivity/ocr-and-documents/scripts/extract_pymupdf.py"
+)
+SPEC = importlib.util.spec_from_file_location("extract_pymupdf", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+extract_pymupdf = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(extract_pymupdf)
 
-if __name__ == "__main__":
-    test_page_split_defensive()
-    test_valid_page_range_accepted()
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        ("3", [3]),
+        ("1-5", [1, 2, 3, 4, 5]),
+    ],
+)
+def test_parse_pages_accepts_valid_values(value, expected):
+    assert extract_pymupdf.parse_pages(["document.pdf", "--pages", value]) == expected
+
+
+@pytest.mark.parametrize(
+    "page_args",
+    [
+        ["--pages"],
+        ["--pages", "1-2-3"],
+        ["--pages", "abc"],
+        ["--pages", "1-x"],
+    ],
+)
+def test_invalid_pages_exit_cleanly(page_args, monkeypatch, capsys):
+    monkeypatch.setattr(sys, "argv", [str(SCRIPT), "document.pdf", *page_args])
+
+    with pytest.raises(SystemExit) as exc_info:
+        runpy.run_path(str(SCRIPT), run_name="__main__")
+
+    captured = capsys.readouterr()
+    assert exc_info.value.code == 1
+    assert "ERROR:" in captured.err
+    assert "Traceback" not in captured.err

--- a/tests/test_extract_pymupdf_defensive.py
+++ b/tests/test_extract_pymupdf_defensive.py
@@ -1,0 +1,34 @@
+"""防御性测试：extract_pymupdf 的 --pages 参数校验"""
+import sys
+from pathlib import Path
+
+script = Path(__file__).resolve().parents[3] / "skills/productivity/ocr-and-documents/scripts/extract_pymupdf.py"
+sys.path.insert(0, str(script.parent))
+
+def test_page_split_defensive():
+    """验证带有多个 '-' 的 page range 会被拒绝而不是 unpack ValueError"""
+    p = "1-2-3"
+    parts = p.split("-")
+    assert len(parts) == 3
+    # 原始代码的 start, end = p.split("-") 会在这里 ValueError
+    # 修复后的代码先检查 len(parts) == 2
+    if len(parts) != 2:
+        accepted = False
+    else:
+        accepted = True
+    assert not accepted
+    print("test_page_split_defensive passed")
+
+def test_valid_page_range_accepted():
+    """验证正常 page range 仍被接受"""
+    p = "1-5"
+    parts = p.split("-")
+    assert len(parts) == 2
+    start, end = parts
+    assert int(start) == 1
+    assert int(end) == 5
+    print("test_valid_page_range_accepted passed")
+
+if __name__ == "__main__":
+    test_page_split_defensive()
+    test_valid_page_range_accepted()


### PR DESCRIPTION
## Summary

Fixes crashes when `--pages` is missing a value or contains a malformed page number or range.

## Changes

- Centralized `--pages` parsing in the production script
- Reports malformed values through stderr and exits with status 1
- Covers missing, non-numeric, and multi-hyphen values
- Replaced the locally reimplemented split test with tests that exercise the production parser and script

## Test Plan

- `python -m pytest -q tests/test_extract_pymupdf_defensive.py` — 6 passed
- `python -m py_compile skills/productivity/ocr-and-documents/scripts/extract_pymupdf.py tests/test_extract_pymupdf_defensive.py`
