### PR TITLE
fix(cli): guard split()[0] against empty/whitespace strings

### DIFF
--- a/tests/hermes_cli/test_split_guard.py
+++ b/tests/hermes_cli/test_split_guard.py
@@ -12,9 +12,7 @@ class TestSplitGuard(unittest.TestCase):
 
     def test_split_zero_guard_exists(self):
         """cli.py must contain guards against empty split results."""
-        cli_path = REPO_ROOT / "cli.py"
-        with open(cli_path) as f:
-            source = f.read()
+        source = (REPO_ROOT / "cli.py").read_text()
         # Check for the guard pattern we added
         guards = [
             "text.split()[0] if text.strip() else",

--- a/tests/hermes_cli/test_split_guard.py
+++ b/tests/hermes_cli/test_split_guard.py
@@ -1,0 +1,27 @@
+"""Regression tests for split() guard fixes."""
+
+import unittest
+from pathlib import Path
+
+
+class TestSplitGuard(unittest.TestCase):
+    """Verify split()[0] guards exist in cli.py for empty/whitespace strings."""
+
+    def test_split_zero_guard_exists(self):
+        """cli.py must contain guards against empty split results."""
+        repo_root = Path(__file__).resolve().parents[2]
+        cli_path = repo_root / "cli.py"
+        with open(cli_path) as f:
+            source = f.read()
+        # Check for the guard pattern we added
+        guards = [
+            "text.split()[0] if text.strip() else",
+            "cmd_lower.split()[0].lstrip(\"/\") if cmd_lower.strip() else",
+            "cmd_lower.split()[0] if cmd_lower.strip() else",
+        ]
+        for guard in guards:
+            self.assertIn(guard, source, f"Missing guard: {guard}")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/hermes_cli/test_split_guard.py
+++ b/tests/hermes_cli/test_split_guard.py
@@ -4,13 +4,15 @@ import unittest
 from pathlib import Path
 
 
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
 class TestSplitGuard(unittest.TestCase):
     """Verify split()[0] guards exist in cli.py for empty/whitespace strings."""
 
     def test_split_zero_guard_exists(self):
         """cli.py must contain guards against empty split results."""
-        repo_root = Path(__file__).resolve().parents[2]
-        cli_path = repo_root / "cli.py"
+        cli_path = REPO_ROOT / "cli.py"
         with open(cli_path) as f:
             source = f.read()
         # Check for the guard pattern we added


### PR DESCRIPTION
## Summary

Prevent IndexError when text/cmd_lower contains only whitespace.

## Changes

- Added guards for three split()[0] accesses in cli.py

## Test Plan

