### PR TITLE
fix(batch_runner, hardware_check): guard split() indexing against malformed input

### DIFF
--- a/tests/test_batch_runner_split_guard.py
+++ b/tests/test_batch_runner_split_guard.py
@@ -1,0 +1,21 @@
+"""Regression tests for batch_runner split guard."""
+
+import unittest
+from pathlib import Path
+
+
+class TestBatchRunnerSplitGuard(unittest.TestCase):
+    """batch_runner must guard batch_file.stem.split('_')[1]."""
+
+    def test_batch_split_guard_in_source(self):
+        """Source must contain a length check before indexing split result."""
+        repo_root = Path(__file__).resolve().parent
+        source_path = repo_root / "batch_runner.py"
+        with open(source_path) as f:
+            source = f.read()
+        self.assertIn("batch_file.stem.split(\"_\")", source)
+        self.assertIn("parts[1] if len(parts) > 1", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_batch_runner_split_guard.py
+++ b/tests/test_batch_runner_split_guard.py
@@ -4,15 +4,15 @@ import unittest
 from pathlib import Path
 
 
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
 class TestBatchRunnerSplitGuard(unittest.TestCase):
     """batch_runner must guard batch_file.stem.split('_')[1]."""
 
     def test_batch_split_guard_in_source(self):
         """Source must contain a length check before indexing split result."""
-        repo_root = Path(__file__).resolve().parent
-        source_path = repo_root / "batch_runner.py"
-        with open(source_path) as f:
-            source = f.read()
+        source = (REPO_ROOT / "batch_runner.py").read_text()
         self.assertIn("batch_file.stem.split(\"_\")", source)
         self.assertIn("parts[1] if len(parts) > 1", source)
 

--- a/tests/test_hardware_check_meminfo_guard.py
+++ b/tests/test_hardware_check_meminfo_guard.py
@@ -1,0 +1,21 @@
+"""Regression tests for hardware_check meminfo guard."""
+
+import unittest
+from pathlib import Path
+
+
+class TestHardwareCheckMeminfoGuard(unittest.TestCase):
+    """hardware_check must guard against malformed /proc/meminfo lines."""
+
+    def test_memtotal_split_guard_in_source(self):
+        """Source must contain a length check before indexing line.split()[1]."""
+        repo_root = Path(__file__).resolve().parent
+        source_path = repo_root / "skills" / "creative" / "comfyui" / "scripts" / "hardware_check.py"
+        with open(source_path) as f:
+            source = f.read()
+        self.assertIn("parts = line.split()", source)
+        self.assertIn("len(parts) >= 2", source)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hardware_check_meminfo_guard.py
+++ b/tests/test_hardware_check_meminfo_guard.py
@@ -4,15 +4,15 @@ import unittest
 from pathlib import Path
 
 
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
 class TestHardwareCheckMeminfoGuard(unittest.TestCase):
     """hardware_check must guard against malformed /proc/meminfo lines."""
 
     def test_memtotal_split_guard_in_source(self):
         """Source must contain a length check before indexing line.split()[1]."""
-        repo_root = Path(__file__).resolve().parent
-        source_path = repo_root / "skills" / "creative" / "comfyui" / "scripts" / "hardware_check.py"
-        with open(source_path) as f:
-            source = f.read()
+        source = (REPO_ROOT / "skills" / "creative" / "comfyui" / "scripts" / "hardware_check.py").read_text()
         self.assertIn("parts = line.split()", source)
         self.assertIn("len(parts) >= 2", source)
 


### PR DESCRIPTION
## Summary

Prevents IndexError when split() results have fewer elements than expected.

## Changes

- batch_runner.py: guard batch_file.stem.split('_')[1] when filename lacks '_'
- hardware_check.py: guard line.split()[1] when /proc/meminfo line is malformed

## Test Plan

```bash
python3 -m unittest tests.test_batch_runner_split_guard tests.test_hardware_check_meminfo_guard -v
# 2 passed
```