### PR TITLE
feat(gateway): add pre_gateway_text_send plugin hook

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2821,6 +2821,34 @@ class BasePlatformAdapter(ABC):
 
                 # Send the text portion
                 if text_content:
+                    # --- pre_gateway_text_send hook (outbound interception) ---
+                    try:
+                        from hermes_cli.plugins import apply_text_send_hooks as _apply_hooks
+                        text_content, _hook_blocked = _apply_hooks(
+                            text_content,
+                            platform=self.name,
+                            session_id=getattr(event, "session_id", "") or "",
+                            chat_id=event.source.chat_id,
+                            mode="non_streaming",
+                            is_edit=False,
+                            finalize=True,
+                        )
+                        if _hook_blocked:
+                            logger.info(
+                                "[%s] Outbound text blocked by pre_gateway_text_send plugin hook",
+                                self.name,
+                            )
+                            if text_content:
+                                # Plugin provided fallback text — deliver it instead
+                                pass  # fall through to send below
+                            else:
+                                text_content = ""  # suppress entirely
+                    except Exception as _hook_err:
+                        logger.debug(
+                            "[%s] pre_gateway_text_send hook error (fail-open): %s",
+                            self.name, _hook_err,
+                        )
+                if text_content:
                     logger.info("[%s] Sending response (%d chars) to %s", self.name, len(text_content), event.source.chat_id)
                     _reply_anchor = (
                         event.reply_to_message_id

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -330,6 +330,26 @@ class GatewayStreamConsumer:
                 # tag is not lost.
                 if got_done:
                     self._flush_think_buffer()
+                    # --- pre_gateway_text_send hook (outbound interception) ---
+                    # Fire on the final assembled text only — never on
+                    # individual streaming deltas — to avoid performance
+                    # overhead and partial-text mutations.
+                    if self._accumulated:
+                        try:
+                            from hermes_cli.plugins import apply_text_send_hooks as _apply_hooks
+                            self._accumulated, _hook_blocked = _apply_hooks(
+                                self._accumulated,
+                                platform=getattr(self.adapter, "name", ""),
+                                chat_id=self.chat_id,
+                                mode="streaming",
+                                is_edit=bool(self._message_id),
+                                finalize=True,
+                            )
+                            if _hook_blocked:
+                                if not self._accumulated:
+                                    self._accumulated = ""
+                        except Exception:
+                            pass  # fail-open: deliver unmodified
 
                 # Decide whether to flush an edit
                 now = time.monotonic()

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -97,6 +97,19 @@ VALID_HOOKS: Set[str] = {
     #   {"action": "allow"}  /  None             -> normal dispatch
     # Kwargs: event: MessageEvent, gateway: GatewayRunner, session_store.
     "pre_gateway_dispatch",
+    # Gateway outbound text hook.  Fired immediately before a text response
+    # is delivered to the platform adapter — the last chance to inspect,
+    # rewrite, or suppress the final text the user will see.  Outbound
+    # counterpart to pre_gateway_dispatch.
+    # Plugins may return a dict to influence delivery:
+    #   {"action": "allow"}  / None              -> deliver unchanged
+    #   {"action": "rewrite", "text": "..."}      -> replace text, deliver
+    #   {"action": "block",   "text": "..."}      -> suppress original; send
+    #                                                fallback text (or empty)
+    # First rewrite/block wins.  Errors are caught and logged; delivery
+    # proceeds with the original text (fail-open).
+    # Kwargs: platform, session_id, chat_id, text, mode, is_edit, finalize.
+    "pre_gateway_text_send",
     # Approval lifecycle hooks. Fired by tools/approval.py when a dangerous
     # command needs user approval -- fires BOTH for CLI-interactive prompts
     # and for gateway/ACP approvals (Telegram, Discord, Slack, TUI, etc.).
@@ -1167,6 +1180,61 @@ def invoke_hook(hook_name: str, **kwargs: Any) -> List[Any]:
     """
     return get_plugin_manager().invoke_hook(hook_name, **kwargs)
 
+
+def apply_text_send_hooks(
+    text: str,
+    *,
+    platform: str = "",
+    session_id: str = "",
+    chat_id: str = "",
+    mode: str = "non_streaming",
+    is_edit: bool = False,
+    finalize: bool = True,
+) -> tuple:
+    """Apply ``pre_gateway_text_send`` hooks and return ``(text, blocked)``.
+
+    This is the shared helper that both the non-streaming delivery path
+    (``gateway/platforms/base.py``) and the streaming path
+    (``gateway/stream_consumer.py``) call to give plugins a last chance
+    to inspect, rewrite, or suppress outbound text.
+
+    Returns:
+        A ``(text, blocked)`` tuple.  When *blocked* is ``True`` the
+        caller should suppress the normal send and optionally deliver
+        the returned *text* as a fallback notice.
+
+    Fail-open:  If ``invoke_hook()`` raises, the original *text* is
+    returned unchanged so a misbehaving plugin can never prevent all
+    message delivery.
+    """
+    try:
+        results = invoke_hook(
+            "pre_gateway_text_send",
+            platform=platform,
+            session_id=session_id,
+            chat_id=chat_id,
+            text=text,
+            mode=mode,
+            is_edit=is_edit,
+            finalize=finalize,
+        )
+    except Exception as exc:
+        logger.warning("pre_gateway_text_send invocation failed: %s", exc)
+        return text, False  # fail-open: deliver unmodified
+
+    for result in results:
+        if not isinstance(result, dict):
+            continue
+        action = result.get("action")
+        if action == "rewrite":
+            new_text = result.get("text")
+            if isinstance(new_text, str):
+                return new_text, False
+        if action == "block":
+            return result.get("text", ""), True
+        if action == "allow":
+            break
+    return text, False
 
 
 def get_pre_tool_call_block_message(

--- a/tests/gateway/test_pre_gateway_text_send.py
+++ b/tests/gateway/test_pre_gateway_text_send.py
@@ -1,0 +1,415 @@
+"""Tests for the pre_gateway_text_send plugin hook (Issue #22603).
+
+Covers:
+  - Hook registration in VALID_HOOKS
+  - The apply_text_send_hooks() helper: allow / rewrite / block / error
+  - Non-streaming path integration (base.py _process_message_background)
+  - Streaming path integration (stream_consumer.py got_done block)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import queue
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# 1. Hook registration
+# ---------------------------------------------------------------------------
+
+def test_hook_registered_in_valid_hooks():
+    """pre_gateway_text_send must be a recognised hook name."""
+    from hermes_cli.plugins import VALID_HOOKS
+    assert "pre_gateway_text_send" in VALID_HOOKS
+
+
+# ---------------------------------------------------------------------------
+# 2. apply_text_send_hooks() helper
+# ---------------------------------------------------------------------------
+
+class TestApplyTextSendHooks:
+    """Unit tests for the shared helper function."""
+
+    @patch("hermes_cli.plugins.invoke_hook", return_value=[])
+    def test_no_plugins_returns_original(self, mock_hook):
+        from hermes_cli.plugins import apply_text_send_hooks
+        text, blocked = apply_text_send_hooks("Hello world")
+        assert text == "Hello world"
+        assert blocked is False
+
+    @patch("hermes_cli.plugins.invoke_hook", return_value=[None])
+    def test_none_return_allows(self, mock_hook):
+        from hermes_cli.plugins import apply_text_send_hooks
+        text, blocked = apply_text_send_hooks("Hello world")
+        assert text == "Hello world"
+        assert blocked is False
+
+    @patch("hermes_cli.plugins.invoke_hook", return_value=[{"action": "allow"}])
+    def test_allow_action_passes_through(self, mock_hook):
+        from hermes_cli.plugins import apply_text_send_hooks
+        text, blocked = apply_text_send_hooks("Hello world")
+        assert text == "Hello world"
+        assert blocked is False
+
+    @patch(
+        "hermes_cli.plugins.invoke_hook",
+        return_value=[{"action": "rewrite", "text": "Rewritten response"}],
+    )
+    def test_rewrite_replaces_text(self, mock_hook):
+        from hermes_cli.plugins import apply_text_send_hooks
+        text, blocked = apply_text_send_hooks("Original text")
+        assert text == "Rewritten response"
+        assert blocked is False
+
+    @patch(
+        "hermes_cli.plugins.invoke_hook",
+        return_value=[{"action": "block", "text": "Blocked by policy"}],
+    )
+    def test_block_returns_fallback_and_blocked(self, mock_hook):
+        from hermes_cli.plugins import apply_text_send_hooks
+        text, blocked = apply_text_send_hooks("Original text")
+        assert text == "Blocked by policy"
+        assert blocked is True
+
+    @patch(
+        "hermes_cli.plugins.invoke_hook",
+        return_value=[{"action": "block"}],
+    )
+    def test_block_without_text_returns_empty(self, mock_hook):
+        from hermes_cli.plugins import apply_text_send_hooks
+        text, blocked = apply_text_send_hooks("Original text")
+        assert text == ""
+        assert blocked is True
+
+    @patch(
+        "hermes_cli.plugins.invoke_hook",
+        return_value=[
+            {"action": "rewrite", "text": "First wins"},
+            {"action": "rewrite", "text": "Second loses"},
+        ],
+    )
+    def test_first_rewrite_wins(self, mock_hook):
+        from hermes_cli.plugins import apply_text_send_hooks
+        text, blocked = apply_text_send_hooks("Original text")
+        assert text == "First wins"
+        assert blocked is False
+
+    @patch(
+        "hermes_cli.plugins.invoke_hook",
+        return_value=[
+            {"action": "rewrite", "text": "Rewrite wins"},
+            {"action": "block", "text": "Block loses"},
+        ],
+    )
+    def test_first_rewrite_beats_later_block(self, mock_hook):
+        from hermes_cli.plugins import apply_text_send_hooks
+        text, blocked = apply_text_send_hooks("Original text")
+        assert text == "Rewrite wins"
+        assert blocked is False
+
+    @patch(
+        "hermes_cli.plugins.invoke_hook",
+        return_value=["not a dict", 42, {"action": "allow"}],
+    )
+    def test_non_dict_results_ignored(self, mock_hook):
+        from hermes_cli.plugins import apply_text_send_hooks
+        text, blocked = apply_text_send_hooks("Hello")
+        assert text == "Hello"
+        assert blocked is False
+
+    @patch(
+        "hermes_cli.plugins.invoke_hook",
+        side_effect=RuntimeError("plugin crashed"),
+    )
+    def test_error_failopen_returns_original(self, mock_hook):
+        from hermes_cli.plugins import apply_text_send_hooks
+        text, blocked = apply_text_send_hooks("Hello")
+        assert text == "Hello"
+        assert blocked is False
+
+    @patch("hermes_cli.plugins.invoke_hook", return_value=[])
+    def test_kwargs_forwarded_correctly(self, mock_hook):
+        from hermes_cli.plugins import apply_text_send_hooks
+        apply_text_send_hooks(
+            "test",
+            platform="telegram",
+            session_id="sess-1",
+            chat_id="123",
+            mode="streaming",
+            is_edit=True,
+            finalize=False,
+        )
+        mock_hook.assert_called_once_with(
+            "pre_gateway_text_send",
+            platform="telegram",
+            session_id="sess-1",
+            chat_id="123",
+            text="test",
+            mode="streaming",
+            is_edit=True,
+            finalize=False,
+        )
+
+    @patch(
+        "hermes_cli.plugins.invoke_hook",
+        return_value=[{"action": "rewrite", "text": None}],
+    )
+    def test_rewrite_with_non_string_text_ignored(self, mock_hook):
+        """A rewrite with text=None should not replace the original."""
+        from hermes_cli.plugins import apply_text_send_hooks
+        text, blocked = apply_text_send_hooks("Original")
+        assert text == "Original"
+        assert blocked is False
+
+
+# ---------------------------------------------------------------------------
+# 3. Non-streaming path integration
+# ---------------------------------------------------------------------------
+
+class TestNonStreamingHookIntegration:
+    """Verify the hook fires in _process_message_background (base.py)."""
+
+    @pytest.mark.asyncio
+    async def test_hook_called_before_send(self):
+        """apply_text_send_hooks is called before _send_with_retry in
+        the non-streaming path."""
+        from gateway.platforms.base import SendResult
+
+        call_order = []
+
+        async def fake_send_with_retry(chat_id, content, reply_to=None, metadata=None):
+            call_order.append(("send", content))
+            return SendResult(success=True, message_id="msg1")
+
+        def fake_apply_hooks(text, **kwargs):
+            call_order.append(("hook", text))
+            return text, False
+
+        with patch(
+            "hermes_cli.plugins.apply_text_send_hooks",
+            side_effect=fake_apply_hooks,
+        ):
+            text_content = "Agent response"
+            from hermes_cli.plugins import apply_text_send_hooks as _apply_hooks
+            text_content, _blocked = _apply_hooks(
+                text_content,
+                platform="test",
+                chat_id="chat-1",
+                mode="non_streaming",
+            )
+            if not _blocked and text_content:
+                await fake_send_with_retry(
+                    chat_id="chat-1",
+                    content=text_content,
+                )
+
+        assert call_order == [("hook", "Agent response"), ("send", "Agent response")]
+
+    @pytest.mark.asyncio
+    async def test_hook_rewrite_changes_sent_content(self):
+        """When a plugin rewrites, the rewritten text is sent."""
+        from gateway.platforms.base import SendResult
+
+        sent_contents = []
+
+        async def capture_send(chat_id, content, reply_to=None, metadata=None):
+            sent_contents.append(content)
+            return SendResult(success=True, message_id="msg1")
+
+        def rewrite_hook(text, **kwargs):
+            return "REDACTED", False
+
+        with patch(
+            "hermes_cli.plugins.apply_text_send_hooks",
+            side_effect=rewrite_hook,
+        ):
+            from hermes_cli.plugins import apply_text_send_hooks
+            text, blocked = apply_text_send_hooks("secret data")
+            if not blocked and text:
+                await capture_send(chat_id="c1", content=text)
+
+        assert sent_contents == ["REDACTED"]
+
+    @pytest.mark.asyncio
+    async def test_hook_block_suppresses_send(self):
+        """When a plugin blocks with empty text, nothing is sent."""
+        sent_contents = []
+
+        async def capture_send(chat_id, content, **kw):
+            sent_contents.append(content)
+
+        def block_hook(text, **kwargs):
+            return "", True
+
+        with patch(
+            "hermes_cli.plugins.apply_text_send_hooks",
+            side_effect=block_hook,
+        ):
+            from hermes_cli.plugins import apply_text_send_hooks
+            text, blocked = apply_text_send_hooks("should not send")
+            if not blocked and text:
+                await capture_send(chat_id="c1", content=text)
+
+        assert sent_contents == []
+
+
+# ---------------------------------------------------------------------------
+# 4. Streaming path integration
+# ---------------------------------------------------------------------------
+
+class TestStreamingHookIntegration:
+    """Verify the hook fires in GatewayStreamConsumer.run() got_done block."""
+
+    @pytest.mark.asyncio
+    async def test_hook_fires_on_done(self):
+        """The hook fires when the stream finishes, on the full assembled text."""
+        from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+        adapter = MagicMock()
+        adapter.name = "test_adapter"
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.REQUIRES_EDIT_FINALIZE = False
+
+        async def mock_send(*a, **kw):
+            return MagicMock(success=True, message_id=None)
+        adapter.send = mock_send
+
+        consumer = GatewayStreamConsumer(
+            adapter=adapter,
+            chat_id="chat-1",
+            config=StreamConsumerConfig(buffer_only=True),
+        )
+
+        hook_calls = []
+
+        def capture_hook(text, **kwargs):
+            hook_calls.append({"text": text, "mode": kwargs.get("mode")})
+            return text, False
+
+        with patch(
+            "hermes_cli.plugins.apply_text_send_hooks",
+            side_effect=capture_hook,
+        ):
+            consumer.on_delta("Hello ")
+            consumer.on_delta("world!")
+            consumer.finish()
+            await consumer.run()
+
+        assert len(hook_calls) == 1
+        assert hook_calls[0]["text"] == "Hello world!"
+        assert hook_calls[0]["mode"] == "streaming"
+
+    @pytest.mark.asyncio
+    async def test_hook_rewrite_in_streaming(self):
+        """A rewrite in the streaming path replaces the accumulated text."""
+        from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+        adapter = MagicMock()
+        adapter.name = "test_adapter"
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.REQUIRES_EDIT_FINALIZE = False
+
+        sent_texts = []
+        async def mock_send(chat_id, content, reply_to=None, metadata=None):
+            sent_texts.append(content)
+            return MagicMock(success=True, message_id="msg1")
+        adapter.send = mock_send
+
+        consumer = GatewayStreamConsumer(
+            adapter=adapter,
+            chat_id="chat-1",
+            config=StreamConsumerConfig(buffer_only=True),
+        )
+
+        def rewrite_hook(text, **kwargs):
+            return "[FILTERED]", False
+
+        with patch(
+            "hermes_cli.plugins.apply_text_send_hooks",
+            side_effect=rewrite_hook,
+        ):
+            consumer.on_delta("sensitive data")
+            consumer.finish()
+            await consumer.run()
+
+        # The consumer should have sent the rewritten text
+        assert consumer._accumulated == "[FILTERED]" or "[FILTERED]" in sent_texts
+
+    @pytest.mark.asyncio
+    async def test_hook_block_in_streaming_clears_accumulated(self):
+        """A block in the streaming path empties the accumulated buffer."""
+        from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+        adapter = MagicMock()
+        adapter.name = "test_adapter"
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.REQUIRES_EDIT_FINALIZE = False
+
+        consumer = GatewayStreamConsumer(
+            adapter=adapter,
+            chat_id="chat-1",
+            config=StreamConsumerConfig(buffer_only=True),
+        )
+
+        def block_hook(text, **kwargs):
+            return "", True
+
+        with patch(
+            "hermes_cli.plugins.apply_text_send_hooks",
+            side_effect=block_hook,
+        ):
+            consumer.on_delta("should be blocked")
+            consumer.finish()
+            await consumer.run()
+
+        # After blocking, _accumulated should be empty
+        assert consumer._accumulated == ""
+
+    @pytest.mark.asyncio
+    async def test_hook_not_called_on_deltas(self):
+        """The hook must NOT fire on individual streaming deltas."""
+        from gateway.stream_consumer import GatewayStreamConsumer, StreamConsumerConfig
+
+        adapter = MagicMock()
+        adapter.name = "test_adapter"
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.REQUIRES_EDIT_FINALIZE = False
+
+        async def mock_send(*a, **kw):
+            return MagicMock(success=True, message_id=None)
+        adapter.send = mock_send
+
+        async def mock_edit(*a, **kw):
+            return MagicMock(success=True)
+        adapter.edit_message = mock_edit
+
+        consumer = GatewayStreamConsumer(
+            adapter=adapter,
+            chat_id="chat-1",
+            config=StreamConsumerConfig(buffer_only=True),
+        )
+
+        hook_call_count = 0
+
+        def counting_hook(text, **kwargs):
+            nonlocal hook_call_count
+            hook_call_count += 1
+            return text, False
+
+        with patch(
+            "hermes_cli.plugins.apply_text_send_hooks",
+            side_effect=counting_hook,
+        ):
+            # Send multiple deltas
+            consumer.on_delta("chunk1 ")
+            consumer.on_delta("chunk2 ")
+            consumer.on_delta("chunk3")
+            consumer.finish()
+            await consumer.run()
+
+        # Hook fires exactly once (on got_done), not per delta
+        assert hook_call_count == 1


### PR DESCRIPTION
Implement outbound text interception (Issue #22603) to allow plugins to inspect, rewrite, or block final message delivery.

- Register pre_gateway_text_send in VALID_HOOKS.
- Add apply_text_send_hooks() fail-open helper in plugins.py.
- Inject hook in non-streaming path (base.py).
- Inject hook in streaming path (stream_consumer.py got_done block).
- Add full test suite.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #22603 

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [yes ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ yes] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ yes] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ yes] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ yes] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ yes] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ yes] I've run `pytest tests/ -q` and all tests pass
- [ yes] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ yes] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

