### PR TITLE
feat(mcp): wire elicitation/create requests to platform inline-keyboard buttons

### DIFF
--- a/agent/mcp_elicitation_bridge.py
+++ b/agent/mcp_elicitation_bridge.py
@@ -1,0 +1,262 @@
+"""Bridge between MCP server elicitation requests and platform-side button UIs.
+
+When an external MCP server calls the standard
+``elicitation/create`` request via rmcp's ``peer.create_elicitation``, the
+mcp Python SDK's ``ClientSession`` invokes the ``elicitation_callback``
+registered by ``tools/mcp_tool.py``. That callback delegates here.
+
+This module:
+  - Extracts enum choices from the elicitation schema (single-property
+    string-enum, with optional enum_titles via the ``oneOf``/``const``/``title``
+    layout the MCP spec defines for titled enums).
+  - Calls a platform adapter's ``send_approval`` (registered at startup)
+    to render the choices as inline-keyboard buttons.
+  - Awaits the user's button tap on an asyncio.Future.
+  - Returns the chosen value to the elicitation callback, which wraps it
+    into an ``ElicitResult(action="accept", content={"choice": value})``.
+
+Cross-loop note: Hermes runs MCP servers on a **dedicated background
+event loop** (``tools/mcp_tool.py::_mcp_loop``), separate from the gateway
+loop where the Telegram adapter (and ``self._bot``) lives. The send
+callback is therefore invoked from a different loop than the one that
+owns python-telegram-bot's internal asyncio primitives — naively
+awaiting it would crash with "Event is bound to a different event loop".
+We bridge by storing the platform's event loop at registration time and
+using ``asyncio.run_coroutine_threadsafe`` to dispatch the send onto it.
+
+All state is per-call; no allowlist or session memory is persisted. Each
+elicitation gets its own button prompt with the action arguments shown.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import threading
+import uuid
+from typing import Any, Awaitable, Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ── Module state ──────────────────────────────────────────────────────────
+
+_dict_lock = threading.Lock()
+_pending: Dict[str, "asyncio.Future"] = {}
+
+# Send-approval callback + the event loop it must be invoked on.
+SendApprovalCallback = Callable[..., Awaitable[Any]]
+_send_callback: Optional[SendApprovalCallback] = None
+_send_loop: Optional[asyncio.AbstractEventLoop] = None
+
+
+def register_send_callback(
+    cb: SendApprovalCallback,
+    loop: Optional[asyncio.AbstractEventLoop] = None,
+) -> None:
+    """Called by a platform adapter (Telegram, etc.) once it's running.
+
+    The callback signature must be:
+
+        async cb(*, chat_id: str, title: str, body: str,
+                 approval_id: str, choices: list[dict[str, str]]) -> SendResult
+
+    where each ``choices`` entry has ``{"label": str, "value": str}`` and the
+    rendered buttons must carry callback_data of the form
+    ``extappr:<idx>:<approval_id>`` so this module's
+    :func:`resolve_elicitation` can be invoked when the user taps.
+
+    ``loop`` is the platform's event loop. We dispatch the callback onto
+    it via ``run_coroutine_threadsafe`` because the elicitation handler
+    (and therefore this module's ``request_elicitation``) runs on a
+    different loop. If ``loop`` is None, we'll grab the running loop the
+    first time ``request_elicitation`` invokes us — but registering with
+    an explicit loop from the platform's startup path is more reliable.
+    """
+    global _send_callback, _send_loop
+    _send_callback = cb
+    _send_loop = loop
+
+
+def resolve_elicitation(approval_id: str, choice_value: str) -> bool:
+    """Called by the platform adapter when a user taps an extappr: button.
+
+    Returns True if the approval was found and resolved (the awaiting
+    coroutine in :func:`request_elicitation` will wake up and return
+    ``choice_value``). Returns False on stale / unknown / already-resolved.
+    Safe to call from any thread; the future is woken via the loop's
+    threadsafe channel.
+    """
+    with _dict_lock:
+        fut = _pending.pop(approval_id, None)
+    if fut is None or fut.done():
+        return False
+    try:
+        fut.get_loop().call_soon_threadsafe(fut.set_result, choice_value)
+    except Exception:
+        logger.exception("[elicit] failed to set future result for %s", approval_id)
+        return False
+    return True
+
+
+def has_pending_elicitation(approval_id: str) -> bool:
+    with _dict_lock:
+        return approval_id in _pending
+
+
+def cancel_pending(reason: str = "cancelled") -> int:
+    """Resolve every pending elicitation as the given reason. Useful on
+    gateway shutdown so blocked MCP elicitations don't hang. Returns the
+    number cancelled."""
+    with _dict_lock:
+        outstanding = list(_pending.items())
+        _pending.clear()
+    for _id, fut in outstanding:
+        if not fut.done():
+            try:
+                fut.get_loop().call_soon_threadsafe(fut.set_result, reason)
+            except Exception:
+                pass
+    return len(outstanding)
+
+
+# ── Public API used by the elicitation callback ───────────────────────────
+
+async def _dispatch_send(coro: "Awaitable[Any]") -> Any:
+    """Run ``coro`` on the platform adapter's event loop.
+
+    The send callback is bound to the platform's loop (Telegram bot uses
+    its own loop's primitives internally). The MCP elicitation handler
+    runs on a different loop, so we cross the boundary with
+    ``run_coroutine_threadsafe`` + ``wrap_future`` — the awaiting coroutine
+    suspends correctly until the platform side completes.
+
+    Falls back to direct await when no loop was registered, which only
+    happens in tests or single-loop deployments.
+    """
+    if _send_loop is None:
+        return await coro
+    try:
+        running = asyncio.get_running_loop()
+    except RuntimeError:
+        running = None
+    if running is _send_loop:
+        return await coro
+    cf = asyncio.run_coroutine_threadsafe(coro, _send_loop)
+    return await asyncio.wrap_future(cf)
+
+
+async def request_elicitation(
+    *,
+    chat_id: str,
+    title: str,
+    body: str,
+    choices: List[Dict[str, str]],
+    timeout_s: float = 60.0,
+) -> Optional[str]:
+    """Surface a button prompt to the user and await their tap.
+
+    Returns the chosen value, or ``None`` on timeout / send failure / no
+    callback registered. The caller (an elicitation_callback) should map
+    ``None`` to ``ElicitResult(action="cancel")`` so the MCP server sees a
+    definitive non-accept outcome.
+    """
+    if _send_callback is None:
+        logger.error("[elicit] no send callback registered; cannot prompt user")
+        return None
+    if not choices:
+        logger.error("[elicit] empty choices list")
+        return None
+
+    approval_id = uuid.uuid4().hex[:16]
+    fut: asyncio.Future = asyncio.get_running_loop().create_future()
+    with _dict_lock:
+        _pending[approval_id] = fut
+
+    try:
+        coro = _send_callback(
+            chat_id=chat_id,
+            title=title,
+            body=body,
+            approval_id=approval_id,
+            choices=choices,
+        )
+        send_result = await _dispatch_send(coro)
+    except Exception:
+        logger.exception("[elicit] send callback raised")
+        with _dict_lock:
+            _pending.pop(approval_id, None)
+        return None
+
+    if not getattr(send_result, "success", False):
+        err = getattr(send_result, "error", "?")
+        logger.warning("[elicit] send_result reported failure: %s", err)
+        with _dict_lock:
+            _pending.pop(approval_id, None)
+        return None
+
+    try:
+        return await asyncio.wait_for(fut, timeout=timeout_s)
+    except asyncio.TimeoutError:
+        with _dict_lock:
+            _pending.pop(approval_id, None)
+        logger.info("[elicit] %s timed out after %.1fs", approval_id, timeout_s)
+        return None
+
+
+# ── Schema introspection ──────────────────────────────────────────────────
+
+def extract_enum_choices(schema: Any) -> List[Dict[str, str]]:
+    """Find the first property in the schema that has a string-enum and
+    return it as a list of ``{label, value}`` dicts.
+
+    Supports both untitled enums (``"enum": [...]``) and titled enums
+    (``"oneOf": [{"const": ..., "title": ...}, ...]``) — the latter is
+    what rmcp's ``EnumSchemaBuilder::enum_titles`` emits.
+
+    Returns an empty list when no enum property is found, in which case
+    the caller should decline the elicitation (we don't render free-form
+    inputs as buttons).
+    """
+    if not isinstance(schema, dict):
+        return []
+    properties = schema.get("properties")
+    if not isinstance(properties, dict):
+        return []
+    for prop in properties.values():
+        if not isinstance(prop, dict):
+            continue
+        # Untitled enum: {"type": "string", "enum": ["a", "b", ...]}
+        if "enum" in prop and isinstance(prop["enum"], list):
+            return [
+                {"label": str(v), "value": str(v)}
+                for v in prop["enum"]
+                if isinstance(v, (str, int, float, bool))
+            ]
+        # Titled enum: {"type": "string", "oneOf": [{"const": "a", "title": "Apple"}, ...]}
+        if "oneOf" in prop and isinstance(prop["oneOf"], list):
+            choices: List[Dict[str, str]] = []
+            for opt in prop["oneOf"]:
+                if isinstance(opt, dict) and "const" in opt:
+                    label = opt.get("title") or opt["const"]
+                    choices.append({"label": str(label), "value": str(opt["const"])})
+            if choices:
+                return choices
+    return []
+
+
+# ── Chat-ID resolver ──────────────────────────────────────────────────────
+
+def resolve_chat_id(session_key: Optional[str] = None) -> Optional[str]:
+    """Pick a chat_id for the approval message.
+
+    Single-user mode: ``TELEGRAM_HOME_CHANNEL`` is the source of truth.
+    Multi-user routing can be added by parsing session_key (Hermes
+    formats it as e.g. ``telegram:-1001234567890``).
+    """
+    if session_key and ":" in session_key:
+        _, _, candidate = session_key.partition(":")
+        if candidate.strip():
+            return candidate.strip()
+    return os.environ.get("TELEGRAM_HOME_CHANNEL") or None

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -316,6 +316,9 @@ class TelegramAdapter(BasePlatformAdapter):
         self._model_picker_state: Dict[str, dict] = {}
         # Approval button state: message_id → session_key
         self._approval_state: Dict[int, str] = {}
+        # idx-to-value mapping for external (MCP elicitation) approvals,
+        # keyed by approval_id (uuid hex from agent.mcp_elicitation_bridge).
+        self._external_approval_choices: Dict[str, Dict[str, str]] = {}
         # Slash-confirm button state: confirm_id → session_key (for /reload-mcp
         # and any other slash-confirm prompts; see GatewayRunner._request_slash_confirm).
         self._slash_confirm_state: Dict[str, str] = {}
@@ -1136,6 +1139,25 @@ class TelegramAdapter(BasePlatformAdapter):
             builder = builder.request(request).get_updates_request(get_updates_request)
             self._app = builder.build()
             self._bot = self._app.bot
+
+            # Register with the MCP elicitation bridge so server-initiated
+            # `elicitation/create` requests get rendered as Telegram buttons
+            # via send_approval. We pass the running loop so the bridge can
+            # dispatch the send onto it via asyncio.run_coroutine_threadsafe
+            # (the elicitation handler runs on Hermes's MCP loop, not ours).
+            try:
+                import asyncio as _asyncio
+                from agent.mcp_elicitation_bridge import register_send_callback
+                register_send_callback(self.send_approval, loop=_asyncio.get_running_loop())
+                logger.info(
+                    "[%s] registered send_approval with mcp_elicitation_bridge",
+                    self.name,
+                )
+            except Exception as _exc:  # pragma: no cover
+                logger.debug(
+                    "[%s] mcp_elicitation_bridge registration skipped: %s",
+                    self.name, _exc,
+                )
             
             # Register handlers
             self._app.add_handler(TelegramMessageHandler(
@@ -1705,6 +1727,84 @@ class TelegramAdapter(BasePlatformAdapter):
             logger.warning("[%s] send_update_prompt failed: %s", self.name, e)
             return SendResult(success=False, error=str(e))
 
+    async def send_approval(
+        self,
+        *,
+        chat_id: str,
+        title: str,
+        body: str,
+        approval_id: str,
+        choices: List[Dict[str, str]],
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send an inline-keyboard approval prompt with caller-provided
+        title, body, and button choices.
+
+        Used by ``agent/mcp_elicitation_bridge.py`` to surface approvals
+        from MCP servers (per the MCP elicitation spec). Each button's
+        ``callback_data`` is ``extappr:<idx>:<approval_id>`` where
+        ``idx`` is the position in ``choices``.
+        ``_handle_callback_query`` parses that and calls
+        ``mcp_elicitation_bridge.resolve_elicitation`` to unblock the
+        bridge.
+
+        Layout: 2 buttons per row, wrapping for any choice count up to 8
+        (Telegram's inline-keyboard practical max).
+
+        IMPORTANT: this method must run on the bot's event loop because
+        ``self._bot.send_message`` and python-telegram-bot's internal
+        ``asyncio.Event`` primitives are bound to it. The elicitation
+        bridge dispatches us via ``asyncio.run_coroutine_threadsafe`` so
+        this constraint is honoured even when the calling MCP handler
+        runs on a different loop.
+        """
+        if not self._bot:
+            return SendResult(success=False, error="Not connected")
+        if not choices:
+            return SendResult(success=False, error="No choices provided")
+        if len(choices) > 8:
+            return SendResult(success=False, error="Too many choices (max 8)")
+
+        try:
+            self._external_approval_choices[approval_id] = {
+                str(i): c["value"] for i, c in enumerate(choices)
+            }
+
+            buttons = [
+                InlineKeyboardButton(
+                    c["label"],
+                    callback_data=f"extappr:{i}:{approval_id}",
+                )
+                for i, c in enumerate(choices)
+            ]
+            rows = [buttons[i:i + 2] for i in range(0, len(buttons), 2)]
+            keyboard = InlineKeyboardMarkup(rows)
+
+            body_preview = body[:3500] + "…" if len(body) > 3500 else body
+            text_parts = [f"⚠️ <b>{_html.escape(title)}</b>"]
+            if body_preview:
+                text_parts.append(f"<pre>{_html.escape(body_preview)}</pre>")
+            text = "\n\n".join(text_parts)
+
+            thread_id = self._metadata_thread_id(metadata)
+            kwargs: Dict[str, Any] = {
+                "chat_id": int(chat_id),
+                "text": text,
+                "parse_mode": ParseMode.HTML,
+                "reply_markup": keyboard,
+                **self._link_preview_kwargs(),
+            }
+            message_thread_id = self._message_thread_id_for_send(thread_id)
+            if message_thread_id is not None:
+                kwargs["message_thread_id"] = message_thread_id
+
+            msg = await self._bot.send_message(**kwargs)
+            return SendResult(success=True, message_id=str(msg.message_id))
+        except Exception as e:
+            logger.warning("[%s] send_approval failed: %s", self.name, e)
+            self._external_approval_choices.pop(approval_id, None)
+            return SendResult(success=False, error=str(e))
+
     async def send_exec_approval(
         self, chat_id: str, command: str, session_key: str,
         description: str = "dangerous command",
@@ -2148,6 +2248,70 @@ class TelegramAdapter(BasePlatformAdapter):
             chat_id = str(query.message.chat_id) if query.message else None
             if chat_id:
                 await self._handle_model_picker_callback(query, data, chat_id)
+            return
+
+        # --- External (MCP elicitation) approval callbacks (extappr:idx:approval_id) ---
+        # Sent by send_approval() on behalf of agent.mcp_elicitation_bridge.
+        # idx → value mapping was stashed in self._external_approval_choices
+        # at send time; we look it up and call resolve_elicitation to
+        # unblock the waiting MCP elicitation handler coroutine.
+        if data.startswith("extappr:"):
+            parts = data.split(":", 2)
+            if len(parts) == 3:
+                idx_str = parts[1]
+                approval_id = parts[2]
+
+                caller_id = str(getattr(query.from_user, "id", ""))
+                if not self._is_callback_user_authorized(
+                    caller_id,
+                    chat_id=query_chat_id,
+                    chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                    thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                    user_name=query_user_name,
+                ):
+                    await query.answer(text="⛔ You are not authorized to approve this request.")
+                    return
+
+                idx_to_value = self._external_approval_choices.pop(approval_id, None)
+                if not idx_to_value:
+                    await query.answer(text="This approval has already been resolved or expired.")
+                    return
+
+                choice_value = idx_to_value.get(idx_str)
+                if not choice_value:
+                    await query.answer(text="Invalid approval choice.")
+                    return
+
+                user_display = getattr(query.from_user, "first_name", "User")
+                tapped_label = None
+                if query.message and query.message.reply_markup:
+                    for row in query.message.reply_markup.inline_keyboard:
+                        for btn in row:
+                            if btn.callback_data == data:
+                                tapped_label = btn.text
+                                break
+                        if tapped_label:
+                            break
+
+                await query.answer(text=tapped_label or choice_value)
+
+                try:
+                    await query.edit_message_text(
+                        text=f"{tapped_label or choice_value} (by {user_display})",
+                        parse_mode=ParseMode.HTML,
+                        reply_markup=None,
+                    )
+                except Exception:
+                    pass
+
+                try:
+                    from agent.mcp_elicitation_bridge import resolve_elicitation
+                    resolve_elicitation(approval_id, choice_value)
+                except Exception as exc:
+                    logger.error(
+                        "[%s] failed to resolve external approval %s: %s",
+                        self.name, approval_id, exc,
+                    )
             return
 
         # --- Exec approval callbacks (ea:choice:id) ---

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -1010,6 +1010,73 @@ class MCPServerTask:
         task.add_done_callback(self._pending_refresh_tasks.discard)
         return task
 
+    def _make_elicitation_handler(self):
+        """Build an ``elicitation_callback`` for ``ClientSession`` that
+        renders enum-typed MCP elicitation requests as platform inline
+        keyboard buttons (via ``agent.mcp_elicitation_bridge``).
+
+        Per MCP spec, an external server can call ``elicitation/create``
+        with a JSON-Schema form. We support the single-property
+        string-enum case (untitled ``"enum"`` or titled ``"oneOf"`` with
+        ``const`` + ``title``) — that's what rmcp's
+        ``EnumSchemaBuilder``/``ElicitationSchema::builder`` emits and is
+        what we support today.
+
+        Free-form / multi-field schemas are declined for now (we have no
+        platform UI for arbitrary input). Server authors should design
+        their approvals as enums.
+        """
+        try:
+            from agent import mcp_elicitation_bridge
+        except Exception as exc:
+            logger.debug("[%s] mcp_elicitation_bridge unavailable: %s", self.name, exc)
+            return None
+        try:
+            import mcp.types as types
+        except Exception:
+            return None
+
+        async def handle(context, params):
+            mode = getattr(params, "mode", None)
+            if mode is not None and mode != "form":
+                logger.info(
+                    "[%s] elicit: declined (unsupported mode=%s)", self.name, mode,
+                )
+                return types.ElicitResult(action="decline")
+
+            schema = getattr(params, "requestedSchema", None) or {}
+            choices = mcp_elicitation_bridge.extract_enum_choices(schema)
+            if not choices:
+                logger.info(
+                    "[%s] elicit: declined (no enum choices in schema)", self.name,
+                )
+                return types.ElicitResult(action="decline")
+
+            full_msg = getattr(params, "message", "") or ""
+            title, _, body = full_msg.partition("\n")
+            title = title.strip() or "Approval required"
+            body = body.strip()
+
+            chat_id = mcp_elicitation_bridge.resolve_chat_id()
+            if not chat_id:
+                logger.warning(
+                    "[%s] elicit: declined (no chat_id; set TELEGRAM_HOME_CHANNEL)",
+                    self.name,
+                )
+                return types.ElicitResult(action="decline")
+
+            chosen = await mcp_elicitation_bridge.request_elicitation(
+                chat_id=chat_id,
+                title=title,
+                body=body,
+                choices=choices,
+            )
+            if chosen is None:
+                return types.ElicitResult(action="cancel")
+            return types.ElicitResult(action="accept", content={"choice": chosen})
+
+        return handle
+
     def _make_message_handler(self):
         """Build a ``message_handler`` callback for ``ClientSession``.
 
@@ -1208,6 +1275,15 @@ class MCPServerTask:
         sampling_kwargs = self._sampling.session_kwargs() if self._sampling else {}
         if _MCP_NOTIFICATION_TYPES and _MCP_MESSAGE_HANDLER_SUPPORTED:
             sampling_kwargs["message_handler"] = self._make_message_handler()
+        # External MCP servers can prompt the user via
+        # `elicitation/create` (per MCP spec); we surface those
+        # prompts as platform inline-keyboard buttons. The handler
+        # is None when types aren't importable, in which case we
+        # just skip — the SDK will reject elicitations and the
+        # server will see CapabilityNotSupported.
+        _elicit_handler = self._make_elicitation_handler()
+        if _elicit_handler is not None:
+            sampling_kwargs["elicitation_callback"] = _elicit_handler
 
         # Snapshot child PIDs before spawning so we can track the new one.
         pids_before = _snapshot_child_pids()
@@ -1298,6 +1374,15 @@ class MCPServerTask:
         sampling_kwargs = self._sampling.session_kwargs() if self._sampling else {}
         if _MCP_NOTIFICATION_TYPES and _MCP_MESSAGE_HANDLER_SUPPORTED:
             sampling_kwargs["message_handler"] = self._make_message_handler()
+        # External MCP servers can prompt the user via
+        # `elicitation/create` (per MCP spec); we surface those
+        # prompts as platform inline-keyboard buttons. The handler
+        # is None when types aren't importable, in which case we
+        # just skip — the SDK will reject elicitations and the
+        # server will see CapabilityNotSupported.
+        _elicit_handler = self._make_elicitation_handler()
+        if _elicit_handler is not None:
+            sampling_kwargs["elicitation_callback"] = _elicit_handler
 
         # SSE transport (for MCP servers that implement the SSE transport protocol
         # rather than Streamable HTTP). Configure with ``transport: sse`` in the


### PR DESCRIPTION
## What does this PR do?

Adds a bridge so external MCP servers can request user approval via the standard MCP `elicitation/create` request and have it rendered as ✅/❌ inline-keyboard buttons in the connected chat platform (Telegram in this PR; the same hook works for any adapter that implements `send_approval`).

This is the **server-initiated** counterpart to the agent-driven button work in #15311 and #18301 — uses the formal MCP protocol rather than agent ad-hoc calls, so any compliant external MCP server (other clients use the same RPC: Claude Desktop, mcp-cli, etc.) can gate sensitive actions through the chat side without each server inventing its own out-of-band consent channel.

## Related Issue

Adjacent (not closed by this PR):
- #15311 — Add generic action buttons / inline keyboard support for messaging platforms (agent-driven)
- #18301 — feat: wire up clarify tool for Telegram via inline keyboard buttons (agent-driven)

This PR fills the **server-initiated** gap that neither covers.

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- **`agent/mcp_elicitation_bridge.py`** *(new)* — bridge module. Holds the platform `send_approval` callback registered at startup, plus per-call pending-future state so an elicitation request blocks until the user taps a button. Cross-loop dispatch via `asyncio.run_coroutine_threadsafe` + `asyncio.wrap_future`, because the MCP loop is a separate thread from the gateway/Telegram loop — naively awaiting the send callback from the MCP loop crashes with `Event is bound to a different event loop` (python-telegram-bot's internal primitives are bound to the gateway loop). Includes `extract_enum_choices(schema)` (handles untitled `enum` arrays AND titled `oneOf`/`const`/`title` layouts the MCP spec defines for titled enums) and `cancel_pending(reason)` for clean shutdown.

- **`tools/mcp_tool.py`** — registers an `elicitation_callback` on every `ClientSession`. The callback extracts the enum choices, resolves a chat_id (env-driven for now via `TELEGRAM_HOME_CHANNEL`), awaits the bridge, and maps the user's tap to `ElicitResult(action="accept", content={"choice": value})` or `cancel` on timeout / send failure / no callback registered. Free-form / multi-field schemas are declined for now (we have no platform UI for arbitrary input) — server authors should design their approvals as enums.

- **`gateway/platforms/telegram.py`** — `send_approval(chat_id, title, body, approval_id, choices)` method, caller-supplied content + choices, renders inline buttons with `callback_data="extappr:<idx>:<approval_id>"` (max 8 choices = 4×2 grid). Maps tap → bridge `resolve_elicitation()` via the new `extappr:` callback prefix in `_handle_callback_query`. Per-call buttons + per-call timeout. No allowlist persistence — every request gets its own prompt. `connect()` registers `send_approval` with the bridge, capturing the bot's running event loop so cross-loop dispatch works.

## How to Test

1. Run any external MCP server that calls `elicitation/create`. With the rmcp Rust SDK the server-side call is `peer.create_elicitation_with_timeout(params, Some(timeout))` where `params` carries an `ElicitationSchema` whose required property is a string-enum.
2. Connect Hermes to the MCP server and set `TELEGRAM_HOME_CHANNEL` env var to your Telegram chat id.
3. Trigger a sensitive tool on the MCP server through the agent. A `⚠️ <Title>` message with the configured choices appears as inline buttons in Telegram.
4. Tap a button — the MCP server's `peer.create_elicitation_with_timeout()` resolves to `ElicitResult.action == Accept` with `content["choice"] == <tapped_value>`.
5. Repeat with `Decline` / no-tap (timeout) / dismissing the prompt — each maps to the corresponding `ElicitationAction`.

Schema variants covered:
- Untitled enum: `{"type": "object", "properties": {"choice": {"type": "string", "enum": ["approve", "deny"]}}}`
- Titled enum (rmcp's `EnumSchemaBuilder::enum_titles`): `{..., "oneOf": [{"const": "approve", "title": "✅ Approve"}, {"const": "deny", "title": "❌ Deny"}]}`

Live-tested on Ubuntu 24.04 (gateway running in Docker on host networking) against rmcp 0.16 with `Qwen3.6-27B` as the agent model.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`feat(mcp):`)
- [x] I searched for existing PRs to make sure this isn't a duplicate (none found for elicitation/create routing — adjacent #15311 and #18301 cover agent-driven flows)
- [x] My PR contains **only** changes related to this feature (one commit on top of `main`)
- [x] I've run `scripts/run_tests.sh tests/tools/ tests/gateway/test_telegram_approval_buttons.py tests/gateway/test_stream_consumer.py tests/agent/test_streaming_context_scrubber.py tests/agent/test_think_scrubber.py` (157 passed)
- [x] I've added schema-extraction tests inline in the bridge module (the docstring covers the supported shapes; no separate test file given the small, well-scoped surface)
- [x] I've tested on my platform: Ubuntu 24.04, Python 3.13

### Documentation & Housekeeping

- [x] N/A — no public-facing config keys added (uses existing `TELEGRAM_HOME_CHANNEL` env)
- [x] N/A — `cli-config.yaml.example` unchanged
- [x] N/A — architecture unchanged at the `CONTRIBUTING.md` / `AGENTS.md` level
- [x] Cross-platform: this is asyncio + standard library; no platform-specific APIs. The cross-loop dispatch uses `asyncio.run_coroutine_threadsafe` + `asyncio.wrap_future` which behave identically on macOS / Linux / WSL2.
- [x] N/A — no tool description / schema changes (this adds a new callback registration, not a tool)