### PR TITLE
fix: write Honcho peer cards with observer target

### DIFF
--- a/plugins/memory/honcho/session.py
+++ b/plugins/memory/honcho/session.py
@@ -1164,13 +1164,18 @@ class HonchoSessionManager:
         if not session:
             return None
         try:
-            peer_id = self._resolve_peer_id(session, peer)
-            if peer_id is None:
+            observer_peer_id, target_peer_id = self._resolve_observer_target(session, peer)
+            if observer_peer_id is None:
                 logger.warning("Could not resolve peer '%s' for set_peer_card in session '%s'", peer, session_key)
                 return None
-            peer_obj = self._get_or_create_peer(peer_id)
-            result = peer_obj.set_card(card)
-            logger.info("Updated peer card for %s (%d facts)", peer_id, len(card))
+            peer_obj = self._get_or_create_peer(observer_peer_id)
+            result = peer_obj.set_card(card, target=target_peer_id) if target_peer_id is not None else peer_obj.set_card(card)
+            logger.info(
+                "Updated peer card for observer=%s target=%s (%d facts)",
+                observer_peer_id,
+                target_peer_id or observer_peer_id,
+                len(card),
+            )
             return result
         except Exception as e:
             logger.error("Failed to set peer card: %s", e)

--- a/tests/honcho_plugin/test_session.py
+++ b/tests/honcho_plugin/test_session.py
@@ -230,6 +230,21 @@ class TestPeerLookupHelpers:
             search_query="neuralancer",
         )
 
+    def test_set_peer_card_uses_same_observer_target_as_get_peer_card(self):
+        mgr, session = self._make_cached_manager()
+        assistant_peer = MagicMock()
+        assistant_peer.set_card.return_value = ["Role: DevOps"]
+        mgr._get_or_create_peer = MagicMock(return_value=assistant_peer)
+
+        result = mgr.set_peer_card(session.key, ["Role: DevOps"], peer="user")
+
+        assert result == ["Role: DevOps"]
+        mgr._get_or_create_peer.assert_called_once_with(session.assistant_peer_id)
+        assistant_peer.set_card.assert_called_once_with(
+            ["Role: DevOps"],
+            target=session.user_peer_id,
+        )
+
     def test_search_context_unified_mode_uses_user_self_context(self):
         mgr, session = self._make_cached_manager()
         mgr._ai_observe_others = False


### PR DESCRIPTION
Title: fix: write Honcho peer cards with observer target

## Summary
- Fixes `HonchoSessionManager.set_peer_card()` so it writes peer cards through the same observer/target relationship used by `get_peer_card()`.
- Adds a regression test proving `set_peer_card(..., peer="user")` calls `assistant_peer.set_card(card, target=user_peer_id)` when AI-observes-user mode is enabled.

## Bug
In AI-observes-user mode, peer-card reads use the assistant observer with a user target, e.g.:

```python
assistant_peer.get_card(target=session.user_peer_id)
```

Before this patch, peer-card writes resolved only the target peer and called:

```python
user_peer.set_card(card)
```

That made `honcho_profile(card=[...], peer="user")` report success while a subsequent `honcho_profile(peer="user")` could still return an empty card, because the read and write paths addressed different Honcho card scopes.

## Fix
`set_peer_card()` now uses `_resolve_observer_target()` and writes to the observer peer with the resolved target:

```python
observer_peer.set_card(card, target=target_peer_id)
```

It falls back to bare `set_card(card)` only when there is no separate target, matching the existing read-side behavior.

## Verification
Ran:

```bash
python -m pytest tests/honcho_plugin/test_session.py -q -o 'addopts='
python -m pytest tests/honcho_plugin -q -o 'addopts='
```

Results:

```text
116 passed in 1.97s
267 passed in 2.91s
```

## Local reproduction observed
A one-time Honcho backfill created conclusions successfully, and `honcho_search` / `honcho_reasoning` could see them. But `honcho_profile(peer="user")` returned an empty profile even after `honcho_profile(card=[...], peer="user")` returned success. After this patch and a fresh Hermes process, `honcho_profile(peer="user")` returned the seeded facts correctly.
