### PR TITLE
fix(arxiv): guard full_id.split('v')[0] against empty string

### DIFF
--- a/skills/research/arxiv/scripts/search_arxiv.py
+++ b/skills/research/arxiv/scripts/search_arxiv.py
@@ -62,7 +62,7 @@ def search(query=None, author=None, category=None, ids=None, max_results=5, sort
         title = entry.find('a:title', NS).text.strip().replace('\n', ' ')
         raw_id = entry.find('a:id', NS).text.strip()
         full_id = raw_id.split('/abs/')[-1] if '/abs/' in raw_id else raw_id
-        arxiv_id = full_id.split('v')[0]  # base ID for links
+        arxiv_id = full_id.split('v')[0] if full_id else raw_id  # base ID for links
         published = entry.find('a:published', NS).text[:10]
         updated = entry.find('a:updated', NS).text[:10]
         authors = ', '.join(a.find('a:name', NS).text for a in entry.findall('a:author', NS))


### PR DESCRIPTION
## Summary

Prevent IndexError when full_id is an empty string during arxiv ID parsing.

## Changes

- Add conditional: full_id.split('v')[0] only when full_id is truthy

## Test Plan

