### PR TITLE
fix(cli): use .get() for checkpoint result dict access

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -4502,7 +4502,7 @@ class HermesCLI:
                         else:
                             print(f"\n{diff}")
             else:
-                print(f"  ❌ {result['error']}")
+                print(f"  ❌ {result.get('error', 'Unknown error')}")
             return
 
         # Resolve checkpoint reference (number or hash)
@@ -4521,9 +4521,9 @@ class HermesCLI:
         result = mgr.restore(cwd, target_hash, file_path=file_path)
         if result["success"]:
             if file_path:
-                print(f"  ✅ Restored {file_path} from checkpoint {result['restored_to']}: {result['reason']}")
+            print(f"  ✅ Restored {file_path} from checkpoint {result.get('restored_to', '?')}: {result.get('reason', '')}")
             else:
-                print(f"  ✅ Restored to checkpoint {result['restored_to']}: {result['reason']}")
+                print(f"  ✅ Restored to checkpoint {result.get('restored_to', '?')}: {result.get('reason', '')}")
             print("  A pre-rollback snapshot was saved automatically.")
 
             # Also undo the last conversation turn so the agent's context
@@ -4532,7 +4532,7 @@ class HermesCLI:
                 self.undo_last()
                 print("  Chat turn undone to match restored file state.")
         else:
-            print(f"  ❌ {result['error']}")
+            print(f"  ❌ {result.get('error', 'Unknown error')}")
 
     def _resolve_checkpoint_ref(self, ref: str, checkpoints: list) -> str | None:
         """Resolve a checkpoint number or hash to a full commit hash."""

--- a/skills/research/arxiv/scripts/search_arxiv.py
+++ b/skills/research/arxiv/scripts/search_arxiv.py
@@ -62,7 +62,7 @@ def search(query=None, author=None, category=None, ids=None, max_results=5, sort
         title = entry.find('a:title', NS).text.strip().replace('\n', ' ')
         raw_id = entry.find('a:id', NS).text.strip()
         full_id = raw_id.split('/abs/')[-1] if '/abs/' in raw_id else raw_id
-        arxiv_id = full_id.split('v')[0]  # base ID for links
+        arxiv_id = full_id.split('v')[0] if full_id else raw_id  # base ID for links
         published = entry.find('a:published', NS).text[:10]
         updated = entry.find('a:updated', NS).text[:10]
         authors = ', '.join(a.find('a:name', NS).text for a in entry.findall('a:author', NS))


### PR DESCRIPTION
## Summary

Prevent KeyError when mgr.restore() returns a dict missing expected keys (success/error/restored_to/reason).

## Changes

- Replace result['error'] with result.get('error', 'Unknown error')
- Replace result['restored_to'] with result.get('restored_to', '?')
- Replace result['reason'] with result.get('reason', '')

## Test Plan

