### PR TITLE
fix(tui): clear terminal on resize to prevent ghost separator lines

### DIFF
--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -423,6 +423,12 @@ export function useMainApp(gw: GatewayClient) {
       clearTimeout(timer)
       timer = setTimeout(() => {
         timer = undefined
+        // Fix for Issue #22976: clear the terminal before re-rendering on resize
+        // to prevent ghost separator lines from accumulating. Ink's VDOM diff
+        // does not invalidate old output when the canvas geometry changes.
+        if (stdout && typeof stdout.write === 'function') {
+          stdout.write('\x1b[2J\x1b[H')
+        }
         void rpc<TerminalResizeResponse>('terminal.resize', { cols: stdout.columns ?? 80, session_id: ui.sid })
       }, 100)
     }


### PR DESCRIPTION
## Problem
When the terminal is resized while the TUI is running, Ink's VDOM reconciliation does not handle geometry changes. Old separator lines (──────) accumulate on screen, creating visual garbage.

## Solution
Add a raw ANSI escape sequence (`\x1b[2J\x1b[H`) to the resize handler to clear the terminal before Ink re-renders. This is a targeted fix that does not affect normal rendering.

## Testing
- Resized terminal during active TUI session
- No ghost lines observed after fix

Fixes #22976