### PR TITLE
fix(tui): remove chmod from npm build script to fix Windows build

### DIFF
--- a/ui-tui/package.json
+++ b/ui-tui/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "npm run build --prefix packages/hermes-ink && tsx --watch src/entry.tsx",
     "start": "tsx src/entry.tsx",
-    "build": "npm run build --prefix packages/hermes-ink && tsc -p tsconfig.build.json && npm run build:compile && chmod +x dist/entry.js",
+    "build": "npm run build --prefix packages/hermes-ink && tsc -p tsconfig.build.json && npm run build:compile",
     "build:compile": "babel dist --out-dir dist --config-file ./babel.compiler.config.cjs --extensions .js --keep-file-extension",
     "type-check": "tsc --noEmit -p tsconfig.json",
     "lint": "eslint src/ packages/",


### PR DESCRIPTION
Closing as duplicate. Duplicate of #22957 — same fix (remove chmod from TUI build script for Windows compatibility).

Should have checked `is:pr is:open` before submitting — lesson learned.