### PR TITLE
fix(agent): fallback to reasoning_content when content is null

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -14562,12 +14562,12 @@ class AIAgent:
                     # No tool calls - this is the final response
                     # Fix for Issue #22949: Kimi K2-6 returns content:null with reasoning_content
                     # when chat_template_kwargs.thinking is enabled. Fall back to reasoning content
-                    # when the primary content field is empty.
-                    final_response = assistant_message.content or ""
-                    if not final_response:
+                    # only when content is explicitly None (not empty string, which is a valid response).
+                    if assistant_message.content is None:
                         reasoning = self._extract_reasoning(assistant_message)
-                        if reasoning:
-                            final_response = reasoning
+                        final_response = reasoning if reasoning else ""
+                    else:
+                        final_response = assistant_message.content
                     
                     # Fix: unmute output when entering the no-tool-call branch
                     # so the user can see empty-response warnings and recovery

--- a/run_agent.py
+++ b/run_agent.py
@@ -14560,7 +14560,14 @@ class AIAgent:
                 
                 else:
                     # No tool calls - this is the final response
+                    # Fix for Issue #22949: Kimi K2-6 returns content:null with reasoning_content
+                    # when chat_template_kwargs.thinking is enabled. Fall back to reasoning content
+                    # when the primary content field is empty.
                     final_response = assistant_message.content or ""
+                    if not final_response:
+                        reasoning = self._extract_reasoning(assistant_message)
+                        if reasoning:
+                            final_response = reasoning
                     
                     # Fix: unmute output when entering the no-tool-call branch
                     # so the user can see empty-response warnings and recovery


### PR DESCRIPTION
## Problem
When using Kimi K2-6 with `chat_template_kwargs.thinking: true`, the model returns `content: null` but `reasoning_content` contains the actual response text. The current code at line 14563 does:

```python
final_response = assistant_message.content or ""
```

This results in an empty `final_response`, losing the model output entirely.

## Solution
After the initial `content` check, add a fallback to `self._extract_reasoning(assistant_message)` which already handles `reasoning_content`, `reasoning`, and `reasoning_details` fields across multiple providers.

## Changes
- Line 14563: Added fallback chain: `content` → `_extract_reasoning()` → empty string
- No changes to `_extract_reasoning()` itself (already supports all provider formats)

## Testing
- Verified with Kimi K2-6 `thinking` mode
- Response correctly falls back to `reasoning_content`

Fixes #22949