### PR TITLE
fix(compression): use extract_content_or_reasoning for thinking models (supersedes #19007)

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -23,7 +23,7 @@ import re
 import time
 from typing import Any, Dict, List, Optional
 
-from agent.auxiliary_client import call_llm, _is_connection_error
+from agent.auxiliary_client import call_llm, _is_connection_error, extract_content_or_reasoning
 from agent.context_engine import ContextEngine
 from agent.model_metadata import (
     MINIMUM_CONTEXT_LENGTH,
@@ -949,7 +949,7 @@ The user has requested that this compaction PRIORITISE preserving all informatio
             if self.summary_model:
                 call_kwargs["model"] = self.summary_model
             response = call_llm(**call_kwargs)
-            content = response.choices[0].message.content
+            content = extract_content_or_reasoning(response)
             # Handle cases where content is not a string (e.g., dict from llama.cpp)
             if not isinstance(content, str):
                 content = str(content) if content else ""


### PR DESCRIPTION
This PR supersedes #19007 which had fallen behind origin/main and showed `DIRTY` merge state.

## What changed

The original fix in #19007 changed `agent/context_compressor.py` line 871 from:
```python
content = response.choices[0].message.content
```
to:
```python
content = extract_content_or_reasoning(response)
```

### Conflicts resolved

- **Import merge** (`<<<<<<< HEAD ... >>>>>>>` in line 26): origin/main had added `_is_connection_error` to the same import line that the PR added `extract_content_or_reasoning`. Resolved by keeping both imports:
  ```python
  from agent.auxiliary_client import call_llm, _is_connection_error, extract_content_or_reasoning
  ```

## Original change description

> When code reads an LLM response's text content, using `response.choices[0].message.content` silently returns empty string for thinking/reasoning models that put output in `reasoning`/`reasoning_content` fields. The fix uses the existing `extract_content_or_reasoning()` helper.

No other logic was changed.

Closes #19007 (supersedes)
