### PR TITLE
fix(cli): preserve startup banner on terminal resize

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2647,9 +2647,27 @@ class HermesCLI:
             pass
 
     def _recover_after_resize(self, app, original_on_resize) -> None:
-        """Recover a resized classic CLI without desynchronizing cursor state."""
-        self._clear_prompt_toolkit_screen(app, rebuild_scrollback=True)
-        _replay_output_history()
+        """Recover a resized classic CLI without desynchronizing cursor state.
+
+        Unlike _force_full_redraw, we do NOT clear the physical screen or
+        scrollback here.  The startup banner and tool summary are printed
+        before prompt_toolkit owns the live chrome, so they live in normal
+        terminal scrollback.  Erasing the screen on SIGWINCH removes that
+        startup UI and ``_replay_output_history`` cannot reconstruct it
+        (the banner was never added to ``_OUTPUT_HISTORY``).
+
+        Instead we just reset prompt_toolkit's renderer cache so the next
+        incremental redraw starts from a clean slate, then let
+        ``original_on_resize`` recalculate layout for the new size.
+        """
+        try:
+            app.renderer.reset(leave_alternate_screen=False)
+        except Exception:
+            pass
+        try:
+            app.invalidate()
+        except Exception:
+            pass
         original_on_resize()
 
     def _schedule_resize_recovery(self, app, original_on_resize, delay: float = 0.12) -> None:

--- a/tests/cli/test_cli_force_redraw.py
+++ b/tests/cli/test_cli_force_redraw.py
@@ -71,32 +71,32 @@ class TestForceFullRedraw:
             "invalidate",
         ]
 
-    def test_resize_rebuilds_scrollback_before_prompt_toolkit_redraw(self, bare_cli, monkeypatch):
+    def test_resize_preserves_scrollback_and_resets_renderer(self, bare_cli, monkeypatch):
+        """Resize recovery must NOT erase screen or scrollback.
+
+        The startup banner lives in normal terminal scrollback (printed
+        before prompt_toolkit owns the chrome).  Clearing scrollback on
+        SIGWINCH removes it and ``_replay_output_history`` cannot
+        reconstruct it.  The fix is to only reset the renderer cache and
+        let ``original_on_resize`` recalculate layout.
+        """
         app = MagicMock()
-        out = app.renderer.output
         events = []
-        out.reset_attributes.side_effect = lambda: events.append("reset_attrs")
-        out.erase_screen.side_effect = lambda: events.append("erase")
-        out.write_raw.side_effect = lambda text: events.append(("raw", text))
-        out.cursor_goto.side_effect = lambda *_: events.append("home")
-        out.flush.side_effect = lambda: events.append("flush")
         app.renderer.reset.side_effect = lambda **_: events.append("renderer_reset")
-        monkeypatch.setattr(cli_mod, "_replay_output_history", lambda: events.append("replay"))
+        app.invalidate.side_effect = lambda: events.append("invalidate")
         original_on_resize = lambda: events.append("original_resize")
 
         bare_cli._recover_after_resize(app, original_on_resize)
 
         assert events == [
-            "reset_attrs",
-            "erase",
-            ("raw", "\x1b[3J"),
-            "home",
-            "flush",
             "renderer_reset",
-            "replay",
+            "invalidate",
             "original_resize",
         ]
-        app.invalidate.assert_not_called()
+        # Must NOT clear the screen or scrollback — those destroy the banner.
+        app.renderer.output.erase_screen.assert_not_called()
+        app.renderer.output.write_raw.assert_not_called()
+        app.renderer.output.cursor_goto.assert_not_called()
 
     def test_force_redraw_uses_full_screen_clear_without_scrollback_clear(self, bare_cli):
         app = MagicMock()


### PR DESCRIPTION
## Problem

After starting the classic CLI in a small terminal window and then maximizing/resizing, the startup banner and right-side tool summary disappear. Only the bottom input prompt area remains visible.

**Root cause:** `_recover_after_resize()` calls `_clear_prompt_toolkit_screen(app, rebuild_scrollback=True)` which sends `erase_screen()` + `[3J]` (clear scrollback). The startup banner was printed before prompt_toolkit owned the chrome, so it lives in normal terminal scrollback — clearing it removes the banner permanently. `_replay_output_history` cannot reconstruct it because the banner was never added to `_OUTPUT_HISTORY`.

## Fix

Replace the aggressive screen/scrollback clear with a minimal renderer reset:

- `app.renderer.reset(leave_alternate_screen=False)` — drops prompt_toolkit's cached screen + cursor state so the next redraw starts clean
- `app.invalidate()` — schedules a repaint
- `original_on_resize()` — recalculates layout for the new terminal size

This matches how bash/zsh/fish/vim/htop handle SIGWINCH — they never clear scrollback on resize.

## Before vs After

| Scenario | Before | After |
|---|---|---|
| Resize terminal | Banner disappears, only prompt visible | Banner preserved, layout adapts |
| `_force_full_redraw` (Ctrl+L) | Full clear + replay (unchanged) | Same — explicit redraw still clears |
| Exception safety | `_clear_prompt_toolkit_screen` wrapped in try/except | Same — both try/except blocks swallow errors |

## Tests

Updated `test_resize_rebuilds_scrollback_before_prompt_toolkit_redraw` → `test_resize_preserves_scrollback_and_resets_renderer` to verify:
- `renderer.reset()` + `invalidate()` + `original_on_resize()` called in order
- `erase_screen`, `write_raw`, `cursor_goto` NOT called (scrollback preserved)

All 9 tests in `tests/cli/test_cli_force_redraw.py` pass.

---

Fixes #22999
