### PR TITLE
fix: prevent goal judge rate-limit loops

### DIFF
--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -287,37 +287,35 @@ def judge_goal(
         return "continue", "empty response (nothing to evaluate)"
 
     try:
-        from agent.auxiliary_client import get_text_auxiliary_client
+        from agent.auxiliary_client import call_llm, _is_connection_error, _is_rate_limit_error
     except Exception as exc:
         logger.debug("goal judge: auxiliary client import failed: %s", exc)
         return "continue", "auxiliary client unavailable"
-
-    try:
-        client, model = get_text_auxiliary_client("goal_judge")
-    except Exception as exc:
-        logger.debug("goal judge: get_text_auxiliary_client failed: %s", exc)
-        return "continue", "auxiliary client unavailable"
-
-    if client is None or not model:
-        return "continue", "no auxiliary client configured"
 
     prompt = JUDGE_USER_PROMPT_TEMPLATE.format(
         goal=_truncate(goal, 2000),
         response=_truncate(last_response, _JUDGE_RESPONSE_SNIPPET_CHARS),
     )
+    messages = [
+        {"role": "system", "content": JUDGE_SYSTEM_PROMPT},
+        {"role": "user", "content": prompt},
+    ]
 
     try:
-        resp = client.chat.completions.create(
-            model=model,
-            messages=[
-                {"role": "system", "content": JUDGE_SYSTEM_PROMPT},
-                {"role": "user", "content": prompt},
-            ],
+        resp = call_llm(
+            task="goal_judge",
+            messages=messages,
             temperature=0,
             max_tokens=200,
             timeout=timeout,
         )
     except Exception as exc:
+        if _is_rate_limit_error(exc):
+            logger.info("goal judge: rate-limited after fallback (%s) — pausing goal", exc)
+            return "skipped", f"judge unavailable: rate limit ({type(exc).__name__})"
+        if _is_connection_error(exc):
+            logger.info("goal judge: connection failure after fallback (%s) — pausing goal", exc)
+            return "skipped", f"judge unavailable: connection error ({type(exc).__name__})"
         logger.info("goal judge: API call failed (%s) — falling through to continue", exc)
         return "continue", f"judge error: {type(exc).__name__}"
 
@@ -487,6 +485,22 @@ class GoalManager:
                 "verdict": "done",
                 "reason": reason,
                 "message": f"✓ Goal achieved: {reason}",
+            }
+
+        if verdict == "skipped":
+            state.status = "paused"
+            state.paused_reason = f"judge unavailable: {reason}"
+            save_goal(self.session_id, state)
+            return {
+                "status": "paused",
+                "should_continue": False,
+                "continuation_prompt": None,
+                "verdict": "skipped",
+                "reason": reason,
+                "message": (
+                    f"⏸ Goal paused — judge unavailable ({reason}). "
+                    "Use /goal resume to keep going, or /goal clear to stop."
+                ),
             }
 
         if state.turns_used >= state.max_turns:

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -124,7 +124,7 @@ class TestJudgeGoal:
         assert verdict == "continue"
 
     def test_api_error_continues(self):
-        """Judge exception → fail-open continue (don't wedge progress on judge bugs)."""
+        """Generic judge exceptions still fail-open so judge bugs don't wedge progress."""
         from hermes_cli import goals
 
         fake_client = MagicMock()
@@ -137,11 +137,48 @@ class TestJudgeGoal:
         assert verdict == "continue"
         assert "judge error" in reason.lower()
 
+    def test_rate_limit_uses_auxiliary_fallback(self):
+        """Judge calls go through the central auxiliary caller, including fallback support."""
+        from hermes_cli import goals
+
+        fake_response = MagicMock(
+            choices=[
+                MagicMock(
+                    message=MagicMock(content='{"done": true, "reason": "fallback judged it"}')
+                )
+            ]
+        )
+        with patch(
+            "agent.auxiliary_client.call_llm",
+            return_value=fake_response,
+        ) as call_llm:
+            verdict, reason = goals.judge_goal("goal", "agent response")
+
+        assert verdict == "done"
+        assert reason == "fallback judged it"
+        call_llm.assert_called_once()
+        assert call_llm.call_args.kwargs["task"] == "goal_judge"
+
+    def test_rate_limit_after_fallback_is_skipped_not_continue(self):
+        """If the fallback-capable judge is still rate-limited, don't continue the loop."""
+        from hermes_cli import goals
+
+        class RateLimitError(Exception):
+            pass
+
+        with patch(
+            "agent.auxiliary_client.call_llm",
+            side_effect=RateLimitError("rate limit"),
+        ):
+            verdict, reason = goals.judge_goal("goal", "agent response")
+
+        assert verdict == "skipped"
+        assert "rate limit" in reason.lower()
+
     def test_judge_says_done(self):
         from hermes_cli import goals
 
-        fake_client = MagicMock()
-        fake_client.chat.completions.create.return_value = MagicMock(
+        fake_response = MagicMock(
             choices=[
                 MagicMock(
                     message=MagicMock(content='{"done": true, "reason": "achieved"}')
@@ -149,8 +186,8 @@ class TestJudgeGoal:
             ]
         )
         with patch(
-            "agent.auxiliary_client.get_text_auxiliary_client",
-            return_value=(fake_client, "judge-model"),
+            "agent.auxiliary_client.call_llm",
+            return_value=fake_response,
         ):
             verdict, reason = goals.judge_goal("goal", "agent response")
         assert verdict == "done"
@@ -159,8 +196,7 @@ class TestJudgeGoal:
     def test_judge_says_continue(self):
         from hermes_cli import goals
 
-        fake_client = MagicMock()
-        fake_client.chat.completions.create.return_value = MagicMock(
+        fake_response = MagicMock(
             choices=[
                 MagicMock(
                     message=MagicMock(content='{"done": false, "reason": "not yet"}')
@@ -168,8 +204,8 @@ class TestJudgeGoal:
             ]
         )
         with patch(
-            "agent.auxiliary_client.get_text_auxiliary_client",
-            return_value=(fake_client, "judge-model"),
+            "agent.auxiliary_client.call_llm",
+            return_value=fake_response,
         ):
             verdict, reason = goals.judge_goal("goal", "agent response")
         assert verdict == "continue"
@@ -306,6 +342,24 @@ class TestGoalManager:
             assert mgr.state.status == "paused"
             assert mgr.state.turns_used == 2
             assert "budget" in (mgr.state.paused_reason or "").lower()
+
+    def test_evaluate_after_turn_judge_skipped_pauses(self, hermes_home):
+        """Judge unavailability pauses instead of firing another continuation prompt."""
+        from hermes_cli import goals
+        from hermes_cli.goals import GoalManager
+
+        mgr = GoalManager(session_id="eval-sid-judge-skipped", default_max_turns=5)
+        mgr.set("hard goal")
+
+        with patch.object(goals, "judge_goal", return_value=("skipped", "judge rate limited")):
+            decision = mgr.evaluate_after_turn("step 1")
+
+        assert decision["verdict"] == "skipped"
+        assert decision["should_continue"] is False
+        assert decision["continuation_prompt"] is None
+        assert mgr.state.status == "paused"
+        assert mgr.state.turns_used == 1
+        assert "judge unavailable" in (mgr.state.paused_reason or "").lower()
 
     def test_evaluate_after_turn_inactive(self, hermes_home):
         """evaluate_after_turn is a no-op when goal isn't active."""


### PR DESCRIPTION
## Summary
- route standing-goal judge calls through the centralized auxiliary `call_llm` path so configured auxiliary fallback handling can rescue rate-limit/connection failures
- treat rate-limit or connection failures that remain after fallback as `skipped` instead of `continue`
- pause active standing goals when the judge is unavailable, preventing continuation loops
- add regression coverage for fallback routing, exhausted rate limits, and skipped-judge pause behavior

## Why
We hit a Telegram standing-goal loop where the goal judge returned `RateLimitError`. The old `judge_goal()` implementation called the selected auxiliary client directly and caught every API failure as `("continue", "judge error: ...")`. That meant a rate-limited judge was interpreted as "keep working," so Hermes repeatedly injected continuation prompts and produced repeated "goal is complete" style answers even though the work was already done.

Using the centralized auxiliary caller lets the judge benefit from existing provider/model fallback behavior. If fallback still cannot produce a verdict, pausing is the safer default than continuing: it preserves progress, tells the user why automation stopped, and avoids burning turns on repeated self-prompts.

## Test plan
- `./venv/bin/python -m pytest tests/hermes_cli/test_goals.py -q`
