### PR TITLE
fix(ollama-cloud): collapse tool-role messages for strict user/assistant alternation

### DIFF
--- a/plugins/model-providers/ollama-cloud/__init__.py
+++ b/plugins/model-providers/ollama-cloud/__init__.py
@@ -1,9 +1,93 @@
-"""Ollama Cloud provider profile."""
+"""Ollama Cloud provider profile.
+
+Ollama Cloud's API only supports strict user/assistant alternation — it
+does not accept ``tool``-role messages.  When Hermes makes a tool call,
+the resulting ``tool``-role messages cause HTTP 400:
+"Conversation roles must alternate user/assistant/user/assistant..."
+
+``OllamaCloudProfile.prepare_messages`` converts tool-role messages into
+plain ``user`` messages so the conversation stays within the alternation
+constraint that Ollama Cloud enforces.
+"""
+
+import copy
+from typing import Any
 
 from providers import register_provider
 from providers.base import ProviderProfile
 
-ollama_cloud = ProviderProfile(
+
+class OllamaCloudProfile(ProviderProfile):
+    """Ollama Cloud — collapse tool-role messages for strict alternation."""
+
+    def prepare_messages(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        """Convert tool-role messages to user-role messages.
+
+        Ollama Cloud only accepts user/assistant alternation.  We:
+        1. Strip ``tool_calls`` from assistant messages (the model won't
+           generate them anyway since we don't send ``tools``).
+        2. Convert ``tool``-role messages to ``user``-role with the tool
+           output embedded as readable text.
+        3. Merge consecutive user messages that result from the conversion.
+        """
+        prepared = copy.deepcopy(messages)
+        if not prepared:
+            return prepared
+
+        result: list[dict[str, Any]] = []
+        for msg in prepared:
+            if not isinstance(msg, dict):
+                result.append(msg)
+                continue
+
+            role = msg.get("role")
+
+            # Strip tool_calls from assistant messages — Ollama Cloud
+            # won't generate them and the field confuses strict parsers.
+            if role == "assistant":
+                msg.pop("tool_calls", None)
+                msg.pop("function_call", None)
+                result.append(msg)
+                continue
+
+            # Convert tool-role messages to user-role.
+            if role == "tool":
+                tool_name = msg.get("name", "tool")
+                content = msg.get("content", "")
+                if isinstance(content, list):
+                    # Multimodal tool result — extract text parts only.
+                    text_parts = [
+                        p.get("text", "") for p in content
+                        if isinstance(p, dict) and p.get("type") == "text"
+                    ]
+                    content = "\n".join(text_parts)
+                new_msg = {
+                    "role": "user",
+                    "content": f"[Tool result from `{tool_name}`]:\n{content}",
+                }
+                result.append(new_msg)
+                continue
+
+            result.append(msg)
+
+        # Merge consecutive same-role messages (happens when multiple
+        # tool results are converted to user-role in a row).
+        merged: list[dict[str, Any]] = []
+        for msg in result:
+            if (
+                merged
+                and merged[-1].get("role") == msg.get("role") == "user"
+                and isinstance(merged[-1].get("content"), str)
+                and isinstance(msg.get("content"), str)
+            ):
+                merged[-1]["content"] += "\n\n" + msg["content"]
+            else:
+                merged.append(msg)
+
+        return merged
+
+
+ollama_cloud = OllamaCloudProfile(
     name="ollama-cloud",
     aliases=("ollama_cloud",),
     default_aux_model="nemotron-3-nano:30b",

--- a/tests/providers/test_provider_profiles.py
+++ b/tests/providers/test_provider_profiles.py
@@ -272,6 +272,102 @@ class TestQwenProfile:
         assert "metadata" not in eb
 
 
+class TestOllamaCloudProfile:
+    """Ollama Cloud only accepts user/assistant alternation."""
+
+    def test_prepare_messages_strips_tool_calls_from_assistant(self):
+        p = get_provider_profile("ollama-cloud")
+        msgs = [
+            {"role": "user", "content": "search for X"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "tc1", "function": {"name": "web_search", "arguments": "{}"}}
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "tc1",
+                "name": "web_search",
+                "content": "Search results here",
+            },
+            {"role": "assistant", "content": "Here are the results"},
+        ]
+        result = p.prepare_messages(msgs)
+
+        # tool_calls stripped from assistant
+        assert "tool_calls" not in result[1]
+        # tool message converted to user
+        assert result[2]["role"] == "user"
+        assert "web_search" in result[2]["content"]
+        assert "Search results here" in result[2]["content"]
+        # final assistant unchanged
+        assert result[3]["role"] == "assistant"
+
+    def test_prepare_messages_merges_consecutive_user_messages(self):
+        p = get_provider_profile("ollama-cloud")
+        msgs = [
+            {"role": "user", "content": "do two things"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "tc1", "function": {"name": "tool_a", "arguments": "{}"}},
+                    {"id": "tc2", "function": {"name": "tool_b", "arguments": "{}"}},
+                ],
+            },
+            {"role": "tool", "tool_call_id": "tc1", "name": "tool_a", "content": "result A"},
+            {"role": "tool", "tool_call_id": "tc2", "name": "tool_b", "content": "result B"},
+            {"role": "assistant", "content": "Done"},
+        ]
+        result = p.prepare_messages(msgs)
+
+        # Two consecutive tool messages should be merged into one user message
+        user_msgs = [m for m in result if m.get("role") == "user"]
+        # Original user + merged tool results = 2 user messages
+        assert len(user_msgs) == 2
+        assert "result A" in user_msgs[1]["content"]
+        assert "result B" in user_msgs[1]["content"]
+
+    def test_prepare_messages_passes_through_clean_conversation(self):
+        p = get_provider_profile("ollama-cloud")
+        msgs = [
+            {"role": "user", "content": "hello"},
+            {"role": "assistant", "content": "hi there"},
+            {"role": "user", "content": "how are you?"},
+        ]
+        result = p.prepare_messages(msgs)
+        assert result == msgs
+
+    def test_prepare_messages_handles_multimodal_tool_result(self):
+        p = get_provider_profile("ollama-cloud")
+        msgs = [
+            {"role": "user", "content": "take a screenshot"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {"id": "tc1", "function": {"name": "browser_vision", "arguments": "{}"}}
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "tc1",
+                "name": "browser_vision",
+                "content": [
+                    {"type": "text", "text": "Screenshot shows a login page"},
+                    {"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}},
+                ],
+            },
+        ]
+        result = p.prepare_messages(msgs)
+        # Image parts should be stripped, text preserved
+        assert result[2]["role"] == "user"
+        assert "Screenshot shows a login page" in result[2]["content"]
+        assert "image" not in result[2]["content"].lower() or "data:" not in result[2]["content"]
+
+
 class TestBaseProfile:
     def test_prepare_messages_passthrough(self):
         p = ProviderProfile(name="test")


### PR DESCRIPTION
## Problem

When using Ollama Cloud as the provider, any session involving tool calls fails with HTTP 400:

> "Conversation roles must alternate user/assistant/user/assistant..."

Ollama Cloud's API only accepts strict user/assistant alternation — it does not support `tool`-role messages. When Hermes makes a tool call, the resulting `tool`-role messages in the conversation history cause this error on every subsequent turn, making tool-using sessions completely unusable on Ollama Cloud.

## Fix

Override `prepare_messages()` on the `OllamaCloudProfile` to transform the conversation before sending:

1. **Strip `tool_calls` from assistant messages** — the model won't generate them since Ollama Cloud doesn't support native tool calling.
2. **Convert `tool`-role messages to `user`-role** — embed the tool output as readable text: ``[Tool result from `tool_name`]:
output``.
3. **Merge consecutive `user` messages** — when multiple tool results are converted, they're merged into a single user message to avoid consecutive same-role messages.

This keeps the conversation within the strict alternation constraint that Ollama Cloud enforces, while preserving tool output as context for the model.

## Before vs After

| Scenario | Before | After |
|---|---|---|
| Tool call on Ollama Cloud | HTTP 400 on every turn | Works — tool output embedded in user messages |
| Clean conversation (no tools) | Works | Works — passthrough, no changes |
| Multimodal tool result | N/A (error before reaching this) | Text parts extracted, images stripped |

## Tests

4 new tests in `tests/providers/test_provider_profiles.py::TestOllamaCloudProfile`:
- `test_prepare_messages_strips_tool_calls_from_assistant` — verifies tool_calls field removed
- `test_prepare_messages_merges_consecutive_user_messages` — verifies multi-tool results merged
- `test_prepare_messages_passes_through_clean_conversation` — verifies no-op on clean messages
- `test_prepare_messages_handles_multimodal_tool_result` — verifies text extraction from multimodal

All tests pass.

---

Fixes #23024
