### PR TITLE
refactor(agent): remove skip_soul context loading path

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -1296,9 +1296,7 @@ def _truncate_content(content: str, filename: str, max_chars: int = CONTEXT_FILE
 def load_soul_md() -> Optional[str]:
     """Load SOUL.md from HERMES_HOME and return its content, or None.
 
-    Used as the agent identity (slot #1 in the system prompt).  When this
-    returns content, ``build_context_files_prompt`` should be called with
-    ``skip_soul=True`` so SOUL.md isn't injected twice.
+    Used as the agent identity (slot #1 in the system prompt).
     """
     try:
         from hermes_cli.config import ensure_hermes_home
@@ -1406,7 +1404,7 @@ def _load_cursorrules(cwd_path: Path) -> str:
     return _truncate_content(cursorrules_content, ".cursorrules")
 
 
-def build_context_files_prompt(cwd: Optional[str] = None, skip_soul: bool = False) -> str:
+def build_context_files_prompt(cwd: Optional[str] = None) -> str:
     """Discover and load context files for the system prompt.
 
     Priority (first found wins — only ONE project context type is loaded):
@@ -1415,11 +1413,8 @@ def build_context_files_prompt(cwd: Optional[str] = None, skip_soul: bool = Fals
       3. CLAUDE.md / claude.md   (cwd only)
       4. .cursorrules / .cursor/rules/*.mdc  (cwd only)
 
-    SOUL.md from HERMES_HOME is independent and always included when present.
+    SOUL.md is loaded separately via ``load_soul_md()`` for the identity slot.
     Each context source is capped at 20,000 chars.
-
-    When *skip_soul* is True, SOUL.md is not included here (it was already
-    loaded via ``load_soul_md()`` for the identity slot).
     """
     if cwd is None:
         cwd = os.getcwd()
@@ -1436,12 +1431,6 @@ def build_context_files_prompt(cwd: Optional[str] = None, skip_soul: bool = Fals
     )
     if project_context:
         sections.append(project_context)
-
-    # SOUL.md from HERMES_HOME only — skip when already loaded as identity
-    if not skip_soul:
-        soul_content = load_soul_md()
-        if soul_content:
-            sections.append(soul_content)
 
     if not sections:
         return ""

--- a/run_agent.py
+++ b/run_agent.py
@@ -5754,8 +5754,7 @@ class AIAgent:
             # dir, so os.getcwd() would pick up the repo's AGENTS.md and
             # other dev files — inflating token usage by ~10k for no benefit.
             _context_cwd = os.getenv("TERMINAL_CWD") or None
-            context_files_prompt = build_context_files_prompt(
-                cwd=_context_cwd, skip_soul=_soul_loaded)
+            context_files_prompt = build_context_files_prompt(cwd=_context_cwd)
             if context_files_prompt:
                 prompt_parts.append(context_files_prompt)
 

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -19,6 +19,7 @@ from agent.prompt_builder import (
     build_nous_subscription_prompt,
     build_context_files_prompt,
     build_environment_hints,
+    load_soul_md,
     CONTEXT_FILE_MAX_CHARS,
     DEFAULT_AGENT_IDENTITY,
     TOOL_USE_ENFORCEMENT_GUIDANCE,
@@ -491,15 +492,9 @@ class TestBuildNousSubscriptionPrompt:
 
 
 class TestBuildContextFilesPrompt:
-    def test_empty_dir_loads_seeded_global_soul(self, tmp_path):
-        from unittest.mock import patch
-
-        fake_home = tmp_path / "fake_home"
-        fake_home.mkdir()
-        with patch("pathlib.Path.home", return_value=fake_home):
-            result = build_context_files_prompt(cwd=str(tmp_path))
-        assert "Project Context" in result
-        assert "Hermes Agent" in result
+    def test_empty_dir_returns_empty(self, tmp_path):
+        result = build_context_files_prompt(cwd=str(tmp_path))
+        assert result == ""
 
     def test_loads_agents_md(self, tmp_path):
         (tmp_path / "AGENTS.md").write_text("Use Ruff for linting.")
@@ -512,13 +507,22 @@ class TestBuildContextFilesPrompt:
         result = build_context_files_prompt(cwd=str(tmp_path))
         assert "type hints" in result
 
-    def test_loads_soul_md_from_hermes_home_only(self, tmp_path, monkeypatch):
+    def test_does_not_load_soul_md(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
         hermes_home = tmp_path / "hermes_home"
         hermes_home.mkdir()
         (hermes_home / "SOUL.md").write_text("Be concise and friendly.", encoding="utf-8")
         (tmp_path / "SOUL.md").write_text("cwd soul should be ignored", encoding="utf-8")
         result = build_context_files_prompt(cwd=str(tmp_path))
+        assert result == ""
+
+    def test_loads_soul_md_from_hermes_home_only(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_home"))
+        hermes_home = tmp_path / "hermes_home"
+        hermes_home.mkdir()
+        (hermes_home / "SOUL.md").write_text("Be concise and friendly.", encoding="utf-8")
+        (tmp_path / "SOUL.md").write_text("cwd soul should be ignored", encoding="utf-8")
+        result = load_soul_md()
         assert "Be concise and friendly." in result
         assert "cwd soul should be ignored" not in result
 
@@ -527,7 +531,7 @@ class TestBuildContextFilesPrompt:
         hermes_home = tmp_path / "hermes_home"
         hermes_home.mkdir()
         (hermes_home / "SOUL.md").write_text("Be concise and friendly.", encoding="utf-8")
-        result = build_context_files_prompt(cwd=str(tmp_path))
+        result = load_soul_md()
         assert "Be concise and friendly." in result
         assert "If SOUL.md is present" not in result
         assert "## SOUL.md" not in result
@@ -537,8 +541,8 @@ class TestBuildContextFilesPrompt:
         hermes_home = tmp_path / "hermes_home"
         hermes_home.mkdir()
         (hermes_home / "SOUL.md").write_text("\n\n", encoding="utf-8")
-        result = build_context_files_prompt(cwd=str(tmp_path))
-        assert result == ""
+        result = load_soul_md()
+        assert result is None
 
     def test_blocks_injection_in_agents_md(self, tmp_path):
         (tmp_path / "AGENTS.md").write_text(
@@ -1186,6 +1190,5 @@ class TestOpenAIModelExecutionGuidance:
 # =========================================================================
 # Budget warning history stripping
 # =========================================================================
-
 
 

--- a/website/docs/developer-guide/prompt-assembly.md
+++ b/website/docs/developer-guide/prompt-assembly.md
@@ -132,7 +132,7 @@ def load_soul_md() -> Optional[str]:
     return content
 ```
 
-When `load_soul_md()` returns content, it replaces the hardcoded `DEFAULT_AGENT_IDENTITY`. The `build_context_files_prompt()` function is then called with `skip_soul=True` to prevent SOUL.md from appearing twice (once as identity, once as a context file).
+When `load_soul_md()` returns content, it replaces the hardcoded `DEFAULT_AGENT_IDENTITY`. `SOUL.md` is not loaded by `build_context_files_prompt()`, so it appears only once in the assembled prompt.
 
 If `SOUL.md` doesn't exist, the system falls back to:
 
@@ -152,7 +152,7 @@ Be targeted and efficient in your exploration and investigations.
 
 ```python
 # From agent/prompt_builder.py (simplified)
-def build_context_files_prompt(cwd=None, skip_soul=False):
+def build_context_files_prompt(cwd=None):
     cwd_path = Path(cwd).resolve()
 
     # Priority: first match wins — only ONE project context loaded
@@ -166,12 +166,6 @@ def build_context_files_prompt(cwd=None, skip_soul=False):
     sections = []
     if project_context:
         sections.append(project_context)
-
-    # SOUL.md from HERMES_HOME (independent of project context)
-    if not skip_soul:
-        soul_content = load_soul_md()
-        if soul_content:
-            sections.append(soul_content)
 
     if not sections:
         return ""
@@ -222,7 +216,7 @@ Local memory and user profile data are injected as frozen snapshots at session s
 3. `CLAUDE.md` (CWD only)
 4. `.cursorrules` / `.cursor/rules/*.mdc` (CWD only)
 
-`SOUL.md` is loaded separately via `load_soul_md()` for the identity slot. When it loads successfully, `build_context_files_prompt(skip_soul=True)` prevents it from appearing twice.
+`SOUL.md` is loaded separately via `load_soul_md()` for the identity slot and is not part of the project context block.
 
 Long files are truncated before injection.
 

--- a/website/docs/user-guide/features/context-files.md
+++ b/website/docs/user-guide/features/context-files.md
@@ -1,12 +1,12 @@
 ---
 sidebar_position: 8
 title: "Context Files"
-description: "Project context files — .hermes.md, AGENTS.md, CLAUDE.md, global SOUL.md, and .cursorrules — automatically injected into every conversation"
+description: "Project context files — .hermes.md, AGENTS.md, CLAUDE.md, and .cursorrules — automatically injected into every conversation"
 ---
 
 # Context Files
 
-Hermes Agent automatically discovers and loads context files that shape how it behaves. Some are project-local and discovered from your working directory. `SOUL.md` is now global to the Hermes instance and is loaded from `HERMES_HOME` only.
+Hermes Agent automatically discovers and loads context files that shape how it behaves. Project context files are discovered from your working directory. `SOUL.md` is global to the Hermes instance, loaded from `HERMES_HOME` only, and used as the primary identity.
 
 ## Supported Context Files
 
@@ -15,7 +15,6 @@ Hermes Agent automatically discovers and loads context files that shape how it b
 | **.hermes.md** / **HERMES.md** | Project instructions (highest priority) | Walks to git root |
 | **AGENTS.md** | Project instructions, conventions, architecture | CWD at startup + subdirectories progressively |
 | **CLAUDE.md** | Claude Code context files (also detected) | CWD at startup + subdirectories progressively |
-| **SOUL.md** | Global personality and tone customization for this Hermes instance | `HERMES_HOME/SOUL.md` only |
 | **.cursorrules** | Cursor IDE coding conventions | CWD only |
 | **.cursor/rules/*.mdc** | Cursor IDE rule modules | CWD only |
 
@@ -79,7 +78,7 @@ This is a Next.js 14 web application with a Python FastAPI backend.
 
 ## SOUL.md
 
-`SOUL.md` controls the agent's personality, tone, and communication style. See the [Personality](/docs/user-guide/features/personality) page for full details.
+`SOUL.md` controls the agent's personality, tone, and communication style. It is loaded separately as the first system prompt layer, not inside the `# Project Context` block. See the [Personality](/docs/user-guide/features/personality) page for full details.
 
 **Location:**
 
@@ -92,7 +91,7 @@ Important details:
 - Hermes loads `SOUL.md` only from `HERMES_HOME`
 - Hermes does not probe the working directory for `SOUL.md`
 - If the file is empty, nothing from `SOUL.md` is added to the prompt
-- If the file has content, the content is injected verbatim after scanning and truncation
+- If the file has content, the content is injected verbatim as the agent identity after scanning and truncation
 
 ## .cursorrules
 
@@ -134,15 +133,9 @@ The following project context files have been loaded and should be followed:
 ## AGENTS.md
 
 [Your AGENTS.md content here]
-
-## .cursorrules
-
-[Your .cursorrules content here]
-
-[Your SOUL.md content here]
 ```
 
-Notice that SOUL content is inserted directly, without extra wrapper text.
+`SOUL.md` appears earlier in the system prompt as the identity layer, so it is not repeated here.
 
 ## Security: Prompt Injection Protection
 


### PR DESCRIPTION
## Summary
- Remove the `skip_soul` parameter from `build_context_files_prompt()`.
- Keep `SOUL.md` loading exclusively in `load_soul_md()` as the identity layer.
- Update tests and docs so project context assembly no longer suggests a second SOUL.md injection path.

## Why
`skip_soul` was added when SOUL.md moved from the project context block to the primary identity slot in #1922. The main prompt assembly now has `load_soul_identity` for the real cron use case from #17509, so the helper-level fallback path preserves old mixed context behavior and makes the prompt order harder to understand.

## How to test
- `.venv/bin/python -m pytest -o addopts='' tests/agent/test_prompt_builder.py::TestBuildContextFilesPrompt tests/run_agent/test_run_agent.py::TestBuildSystemPrompt tests/cron/test_cron_workdir.py::TestRunJobTerminalCwd -q`
- `.venv/bin/python - <<'PY' ... PY` smoke test covering `load_soul_md()` plus `build_context_files_prompt()`
- `git diff --check`

## Platforms tested
- macOS 26.4, CPython 3.14.3 via uv-created `.venv`

## Related
- Follow-up cleanup to #1922 and #17509. No separate issue was opened for this refactor.

## Cross-platform impact
This is prompt assembly cleanup only. It removes duplicate SOUL.md loading from the context helper and does not add platform-specific behavior.