### PR TITLE
fix(gateway): Telegram unsupported doc type notifies user directly; cache failure bails early (#23045)

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -4383,13 +4383,22 @@ class TelegramAdapter(BasePlatformAdapter):
 
                 # Check if supported
                 if ext not in SUPPORTED_DOCUMENT_TYPES:
+                    # Bug fix (#23045): reply directly to the user instead of injecting
+                    # the gateway error string into event.text and routing it through
+                    # handle_message.  The old path caused the agent to receive a fake
+                    # user message like "Unsupported document type '.epub'..." with no
+                    # indication it was gateway-generated, leading to confused loops.
                     supported_list = ", ".join(sorted(SUPPORTED_DOCUMENT_TYPES.keys()))
-                    event.text = (
-                        f"Unsupported document type '{ext or 'unknown'}'. "
-                        f"Supported types: {supported_list}"
+                    file_label = original_filename or f"document{ext or ''}"
+                    reply_text = (
+                        f"\u274c Unsupported file type: {file_label!r}\n"
+                        f"Supported document types: {supported_list}"
                     )
-                    logger.info("[Telegram] Unsupported document type: %s", ext or "unknown")
-                    await self.handle_message(event)
+                    logger.info("[Telegram] Unsupported document type: %s — notifying user directly", ext or "unknown")
+                    try:
+                        await msg.reply_text(reply_text)
+                    except Exception as reply_err:
+                        logger.warning("[Telegram] Could not send unsupported-type reply: %s", reply_err)
                     return
 
                 # Download and cache
@@ -4421,7 +4430,19 @@ class TelegramAdapter(BasePlatformAdapter):
                         )
 
             except Exception as e:
+                # Bug fix (#23045): cache failures were silently swallowed, leaving
+                # event.media_urls/media_types empty and delivering a broken event
+                # to the agent.  Notify the user directly and bail so the agent
+                # never receives a partial/empty attachment event.
                 logger.warning("[Telegram] Failed to cache document: %s", e, exc_info=True)
+                try:
+                    await msg.reply_text(
+                        "\u274c Failed to process the attached document.  "
+                        "Please try sending it again or use a different format."
+                    )
+                except Exception as reply_err:
+                    logger.warning("[Telegram] Could not send cache-failure reply: %s", reply_err)
+                return
 
         media_group_id = getattr(msg, "media_group_id", None)
         if media_group_id:

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -108,6 +108,8 @@ def _make_message(document=None, caption=None, media_group_id=None, photo=None):
     msg.from_user.id = 1
     msg.from_user.full_name = "Test User"
     msg.message_thread_id = None
+    # reply_text must be an AsyncMock so the fixed code path can await it
+    msg.reply_text = AsyncMock()
     return msg
 
 
@@ -333,14 +335,31 @@ class TestDocumentDownloadBlock:
         assert event.media_types == ["application/pdf"]
 
     @pytest.mark.asyncio
+    async def test_unsupported_type_notifies_user_not_agent(self, adapter):
+        """Bug fix #23045: unsupported types must reply to user, not inject into agent pipeline."""
+        doc = _make_document(file_name="book.epub", mime_type="application/epub+zip", file_size=100)
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+        # Agent pipeline must NOT receive a fake user message
+        adapter.handle_message.assert_not_called()
+        # User must receive the error reply directly
+        msg.reply_text.assert_awaited_once()
+        reply = msg.reply_text.call_args.args[0]
+        assert "book.epub" in reply or "Unsupported" in reply
+
+    @pytest.mark.asyncio
     async def test_missing_filename_and_mime_rejected(self, adapter):
         doc = _make_document(file_name=None, mime_type=None, file_size=100)
         msg = _make_message(document=doc)
         update = _make_update(msg)
 
         await adapter._handle_media_message(update, MagicMock())
-        event = adapter.handle_message.call_args[0][0]
-        assert "Unsupported" in event.text
+        # Agent pipeline must NOT receive the error string as a user message
+        adapter.handle_message.assert_not_called()
+        # User gets the error notification
+        msg.reply_text.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_unicode_decode_error_handled(self, adapter):
@@ -382,8 +401,8 @@ class TestDocumentDownloadBlock:
         assert "[Content of" not in (event.text or "")
 
     @pytest.mark.asyncio
-    async def test_download_exception_handled(self, adapter):
-        """If get_file() raises, the handler logs the error without crashing."""
+    async def test_download_exception_notifies_user_not_agent(self, adapter):
+        """Bug fix #23045: cache failures must notify user and NOT deliver a broken event to the agent."""
         doc = _make_document(file_name="crash.pdf", file_size=100)
         doc.get_file = AsyncMock(side_effect=RuntimeError("Telegram API down"))
         msg = _make_message(document=doc)
@@ -391,8 +410,12 @@ class TestDocumentDownloadBlock:
 
         # Should not raise
         await adapter._handle_media_message(update, MagicMock())
-        # handle_message should still be called (the handler catches the exception)
-        adapter.handle_message.assert_called_once()
+        # Agent must NOT receive a partial/empty event
+        adapter.handle_message.assert_not_called()
+        # User must get a friendly error message
+        msg.reply_text.assert_awaited_once()
+        reply = msg.reply_text.call_args.args[0]
+        assert "Failed" in reply or "failed" in reply or "process" in reply
 
 
 class TestVideoDownloadBlock:


### PR DESCRIPTION
## Summary

Fixes two bugs reported in #23045 in `gateway/platforms/telegram.py`.

---

### Bug 1: Unsupported document types injected into agent pipeline as fake user messages

**Root cause** — When a user sends an unsupported file (e.g. `.epub`), the handler set `event.text` to a gateway-generated error string and called `handle_message(event)`. The agent received a turn that looked exactly like the user had typed `"Unsupported document type '.epub'..."` — with no metadata indicating it was gateway-generated, not user content.

**Impact** — The agent couldn't tell an attachment attempt had occurred, went in circles asking "where is the file?", and produced confused responses as documented in the issue.

**Fix** — Use `msg.reply_text()` to send the error notice back to the user directly, then `return` without touching the agent pipeline. The file label (original filename) is included in the reply so the user knows which attachment was rejected.

---

### Bug 2: Cache failures silently swallowed; broken event delivered to agent

**Root cause** — The `except Exception` block only logged the error, then let execution fall through to the `handle_message` call below. The agent received a `MessageEvent` with empty `media_urls`/`media_types`, with no signal that the document was never actually cached.

**Fix** — After notifying the user via `reply_text`, `return` immediately so no partial event ever reaches the agent.

---

### Tests

- Updated `test_missing_filename_and_mime_rejected` — old version asserted the old (buggy) error-string-in-agent behaviour; now asserts `handle_message` is NOT called and `reply_text` IS called.  
- Updated `test_download_exception_handled` → renamed `test_download_exception_notifies_user_not_agent` — old version asserted `handle_message` was still called after a download failure; now asserts the opposite.  
- Added `test_unsupported_type_notifies_user_not_agent` — explicit .epub test confirming the pipeline is never entered.

All 42 tests in `test_telegram_documents.py` pass.