### PR TITLE
fix: keep telegram document failures out of agent input

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -4366,15 +4366,25 @@ class TelegramAdapter(BasePlatformAdapter):
                     await self.handle_message(event)
                     return
 
-                # Check if supported
+                # Check if supported. Unsupported attachments are a gateway
+                # notice, not user-authored text — reply in Telegram and stop
+                # instead of routing the error string into the agent pipeline.
                 if ext not in SUPPORTED_DOCUMENT_TYPES:
                     supported_list = ", ".join(sorted(SUPPORTED_DOCUMENT_TYPES.keys()))
-                    event.text = (
-                        f"Unsupported document type '{ext or 'unknown'}'. "
+                    display_name = original_filename or ext or "unknown document"
+                    notice = (
+                        f"Unsupported document type '{ext or 'unknown'}' for {display_name}. "
                         f"Supported types: {supported_list}"
                     )
                     logger.info("[Telegram] Unsupported document type: %s", ext or "unknown")
-                    await self.handle_message(event)
+                    try:
+                        await msg.reply_text(notice)
+                    except Exception as reply_err:
+                        logger.warning(
+                            "[Telegram] Failed to notify user about unsupported document type: %s",
+                            reply_err,
+                            exc_info=True,
+                        )
                     return
 
                 # Download and cache
@@ -4407,6 +4417,19 @@ class TelegramAdapter(BasePlatformAdapter):
 
             except Exception as e:
                 logger.warning("[Telegram] Failed to cache document: %s", e, exc_info=True)
+                display_name = original_filename or getattr(doc, "file_name", None) or "attachment"
+                try:
+                    await msg.reply_text(
+                        "⚠️ Couldn't download your attachment "
+                        f"({display_name}; {e.__class__.__name__}). Please retry."
+                    )
+                except Exception as reply_err:
+                    logger.warning(
+                        "[Telegram] Failed to notify user about document cache failure: %s",
+                        reply_err,
+                        exc_info=True,
+                    )
+                return
 
         media_group_id = getattr(msg, "media_group_id", None)
         if media_group_id:

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -108,6 +108,7 @@ def _make_message(document=None, caption=None, media_group_id=None, photo=None):
     msg.from_user.id = 1
     msg.from_user.full_name = "Test User"
     msg.message_thread_id = None
+    msg.reply_text = AsyncMock()
     return msg
 
 
@@ -339,8 +340,44 @@ class TestDocumentDownloadBlock:
         update = _make_update(msg)
 
         await adapter._handle_media_message(update, MagicMock())
-        event = adapter.handle_message.call_args[0][0]
-        assert "Unsupported" in event.text
+
+        adapter.handle_message.assert_not_called()
+        msg.reply_text.assert_awaited_once()
+        notice = msg.reply_text.await_args.args[0]
+        assert "Unsupported document type" in notice
+        assert "Supported types" in notice
+
+    @pytest.mark.asyncio
+    async def test_unsupported_document_type_replies_without_agent_event(self, adapter):
+        """Gateway-generated unsupported-type text must not be forged as user text."""
+        doc = _make_document(file_name="book.epub", mime_type="application/epub+zip", file_size=100)
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+
+        adapter.handle_message.assert_not_called()
+        msg.reply_text.assert_awaited_once()
+        notice = msg.reply_text.await_args.args[0]
+        assert "Unsupported document type '.epub'" in notice
+        assert "book.epub" in notice
+
+    @pytest.mark.asyncio
+    async def test_cache_failure_replies_without_empty_agent_event(self, adapter):
+        """Download/cache failures should be visible to Telegram and not sent as empty events."""
+        doc = _make_document(file_name="notes.md", mime_type="text/markdown", file_size=100)
+        doc.get_file = AsyncMock(side_effect=RuntimeError("Telegram CDN down"))
+        msg = _make_message(document=doc)
+        update = _make_update(msg)
+
+        await adapter._handle_media_message(update, MagicMock())
+
+        adapter.handle_message.assert_not_called()
+        msg.reply_text.assert_awaited_once()
+        notice = msg.reply_text.await_args.args[0]
+        assert "Couldn't download your attachment" in notice
+        assert "notes.md" in notice
+        assert "RuntimeError" in notice
 
     @pytest.mark.asyncio
     async def test_unicode_decode_error_handled(self, adapter):
@@ -383,16 +420,17 @@ class TestDocumentDownloadBlock:
 
     @pytest.mark.asyncio
     async def test_download_exception_handled(self, adapter):
-        """If get_file() raises, the handler logs the error without crashing."""
+        """If get_file() raises, the handler replies and does not send an empty event."""
         doc = _make_document(file_name="crash.pdf", file_size=100)
         doc.get_file = AsyncMock(side_effect=RuntimeError("Telegram API down"))
         msg = _make_message(document=doc)
         update = _make_update(msg)
 
-        # Should not raise
         await adapter._handle_media_message(update, MagicMock())
-        # handle_message should still be called (the handler catches the exception)
-        adapter.handle_message.assert_called_once()
+
+        adapter.handle_message.assert_not_called()
+        msg.reply_text.assert_awaited_once()
+        assert "Couldn't download your attachment" in msg.reply_text.await_args.args[0]
 
 
 class TestVideoDownloadBlock:


### PR DESCRIPTION
## Summary
- Reply in Telegram for unsupported document types instead of forging gateway error text as agent input.
- Reply in Telegram when document download/cache fails, then stop instead of forwarding an empty/broken event.
- Add regressions for unsupported document rejection and cache/download failure visibility.

Closes #23045

## Test Plan
- `scripts/run_tests.sh tests/gateway/test_telegram_documents.py -q`
- `scripts/run_tests.sh tests/gateway/test_telegram_documents.py tests/gateway/test_telegram_photo_interrupts.py tests/gateway/test_telegram_group_gating.py -q`
