### PR TITLE
ci: harden Oflow local CI safety checks

### DIFF
--- a/.github/workflows/oflow-local-ci-safety.yml
+++ b/.github/workflows/oflow-local-ci-safety.yml
@@ -1,0 +1,92 @@
+name: Oflow Local CI Safety
+
+on:
+  workflow_dispatch:
+    inputs:
+      upstream:
+        description: "Read-only upstream ref used for changed-file discovery"
+        required: false
+        default: "origin/main"
+
+permissions:
+  contents: read
+
+defaults:
+  run:
+    shell: bash
+
+concurrency:
+  group: oflow-local-ci-safety-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  local-ci-safety:
+    name: Local-only safety validation
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5  # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Enforce non-main branch execution
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REF_NAME}" == "main" || "${GITHUB_REF_NAME}" == "master" ]]; then
+            echo "Oflow local CI is review-only and must not run as direct main mutation evidence." >&2
+            exit 1
+          fi
+
+      - name: Set up Python
+        uses: actions/setup-python@e797f83bcb11b83ae66e0230d6156d7c80228e7c  # v6
+        with:
+          python-version: "3.11"
+
+      - name: Prepare artifact directory
+        run: mkdir -p artifacts/oflow-local-ci
+
+      - name: Denylist safety check
+        run: |
+          set -o pipefail
+          python3 scripts/review/oflow_local_ci.py denylist --repo . --upstream "${{ inputs.upstream }}" \
+            | tee artifacts/oflow-local-ci/denylist.json
+
+      - name: Python compile check
+        run: |
+          set -o pipefail
+          python3 scripts/review/oflow_local_ci.py py-compile --repo . --upstream "${{ inputs.upstream }}" \
+            | tee artifacts/oflow-local-ci/py-compile.json
+
+      - name: Git whitespace diff check
+        run: python3 scripts/review/oflow_local_ci.py diff-check --repo . --upstream "${{ inputs.upstream }}"
+
+      - name: Workflow YAML validation
+        run: |
+          set -o pipefail
+          python3 scripts/review/oflow_local_ci.py workflow-yaml --repo . --upstream "${{ inputs.upstream }}" \
+            | tee artifacts/oflow-local-ci/workflow-yaml.json
+
+      - name: Focused fixture tests
+        run: python3 scripts/review/oflow_local_ci.py pytest-subset --repo . tests/review/test_oflow_local_ci.py
+
+      - name: Write CI summary artifact
+        if: always()
+        run: |
+          python3 scripts/review/oflow_local_ci.py summary --repo . --upstream "${{ inputs.upstream }}" \
+            --output artifacts/oflow-local-ci/summary.json
+
+      - name: Handoff gate
+        run: |
+          python3 scripts/review/oflow_tracked_file_handoff_check.py --repo . --upstream "${{ inputs.upstream }}" \
+            --summary artifacts/oflow-local-ci/summary.json \
+            | tee artifacts/oflow-local-ci/handoff-gate.json
+
+      - name: Upload artifact-only review outputs
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02  # v4
+        with:
+          name: oflow-local-ci-safety-${{ github.run_id }}
+          path: artifacts/oflow-local-ci/
+          if-no-files-found: error

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ mini-swe-agent/
 result
 website/static/api/skills-index.json
 models-dev-upstream/
+
+# Oflow local CI generated review artifacts
+artifacts/oflow-local-ci/

--- a/docs/oflow-local-ci-isolation.md
+++ b/docs/oflow-local-ci-isolation.md
@@ -1,0 +1,70 @@
+# Oflow local CI safety and isolation model
+
+This document describes the local CI pilot added for Oflow review branches. The
+workflow is intentionally narrow: it gives reviewers repeatable repository-side
+validation evidence without touching runtime systems, credentials, production
+services, providers, or databases.
+
+## Runner isolation posture
+
+- Manual-only trigger: `.github/workflows/oflow-local-ci-safety.yml` uses
+  `workflow_dispatch` only. It is not attached to `push`, `pull_request`,
+  schedules, deployments, or release events.
+- Read-only repository permission: workflow permissions are limited to
+  `contents: read`, and checkout uses `persist-credentials: false`.
+- Branch guard: the job exits on `main`/`master` so the workflow cannot be used
+  as evidence for direct main mutation.
+- Concurrency guard: only one run per ref stays active; newer manual reruns
+  cancel stale runs for the same branch.
+- Job bound: the validation job has an explicit timeout so a runner cannot hang
+  indefinitely.
+- Artifact-only outputs: review evidence is written under
+  `artifacts/oflow-local-ci/` and uploaded as a GitHub Actions artifact. The
+  workflow does not create comments, labels, commits, deployments, releases, or
+  status mutations beyond the Actions run itself.
+
+## Local-only checks
+
+The helper at `scripts/review/oflow_local_ci.py` provides reusable, read-only
+commands for:
+
+- denylist scanning of changed files;
+- Python `py_compile` over changed Python files;
+- `git diff --check` whitespace validation;
+- workflow YAML structure validation;
+- focused pytest subsets for local fixture tests;
+- CI summary artifact generation.
+
+The denylist treats the following as hard failures when they appear in changed
+operational files: `.env` access, deploy script invocation, service-manager
+restart commands such as `systemctl`, `docker compose up`/`docker compose down`,
+SSH, and sqlite/postgres mutation commands. Secret-bearing paths are reported
+without reading their contents.
+
+## Runtime and production hard stops
+
+This pilot is repository validation only. It must not:
+
+- merge;
+- deploy;
+- restart services;
+- inspect `.env` files;
+- inspect secrets or credentials;
+- monitor runtime systems;
+- probe production;
+- call model/provider or trading APIs;
+- SSH to any host;
+- access databases;
+- migrate, backfill, or mutate data;
+- affect trading/order flow.
+
+The summary artifact records these hard stops explicitly so PR handoffs can cite
+machine-readable evidence.
+
+## Future approval gates
+
+If Oflow later needs broader CI behavior, add a separate approval layer instead
+of widening this pilot in place. Future work should require an explicit human
+approval gate before any capability that can mutate runtime state, register or
+manage runners, use credentials, call providers, access databases, deploy,
+restart services, or probe production.

--- a/scripts/review/oflow_local_ci.py
+++ b/scripts/review/oflow_local_ci.py
@@ -1,0 +1,326 @@
+#!/usr/bin/env python3
+"""Safe, local-only CI helper for the Oflow pilot.
+
+The helper intentionally stays inside repository metadata and checked-in files.
+It never reads secret-bearing paths, opens database files, starts services,
+connects to remotes, deploys, or mutates runtime state.
+"""
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import json
+import os
+import py_compile
+import re
+import subprocess
+import sys
+from dataclasses import asdict, dataclass
+from pathlib import Path
+from typing import Iterable, Sequence
+
+try:
+    import yaml  # type: ignore
+except Exception:  # pragma: no cover - optional dependency in local shells
+    yaml = None
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEFAULT_UPSTREAM = "origin/main"
+
+SECRET_PATH_PATTERNS = (
+    ".env",
+    ".env.*",
+    "**/.env",
+    "**/.env.*",
+    "**/*secret*",
+    "**/*secrets*",
+    "**/*credential*",
+    "**/*credentials*",
+)
+
+RUNTIME_PATH_PATTERNS = (
+    "runtime/**",
+    "prod/**",
+    "production/**",
+    "deploy/**",
+    "deployments/**",
+    "scripts/deploy*",
+    "scripts/**/deploy*",
+    "migrations/**",
+    "backfills/**",
+)
+
+MUTATION_DB_PATH_PATTERNS = (
+    "migrations/**",
+    "backfills/**",
+    "**/*sqlite*",
+    "**/*postgres*",
+    "**/*psql*",
+    "**/*migration*",
+    "**/*backfill*",
+)
+
+# Checked against text content of changed, non-secret files. Keep patterns broad
+# and readable because this is a safety gate, not a style linter.
+DENYLIST_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (".env access", re.compile(r"(?<![A-Za-z0-9_-])(?:cat|grep|source|\.\s+|cp|less|more|tail|head)\s+[^\n;&|]*\.env(?:\b|[./_-])", re.I)),
+    ("deploy script invocation", re.compile(r"(?:^|[\s./])(?:deploy(?:\.sh|\.py)?|scripts/deploy[^\s;&|]*)\b", re.I)),
+    ("systemctl", re.compile(r"\bsystemctl\b", re.I)),
+    ("docker compose up/down", re.compile(r"\bdocker\s+compose\s+(?:up|down)\b|\bdocker-compose\s+(?:up|down)\b", re.I)),
+    ("ssh", re.compile(r"(?<![\w-])ssh\s+(?!-V\b)", re.I)),
+    ("sqlite mutation", re.compile(r"\bsqlite3?\b.*\b(?:insert|update|delete|drop|alter|create|replace|vacuum|reindex)\b", re.I | re.S)),
+    ("postgres mutation", re.compile(r"\b(?:psql|postgres)\b.*\b(?:insert|update|delete|drop|alter|create|replace|truncate|vacuum|reindex)\b", re.I | re.S)),
+)
+
+SUMMARY_RUNTIME_PATTERNS = RUNTIME_PATH_PATTERNS + (
+    ".github/workflows/**",
+    "scripts/review/**",
+)
+
+# These files intentionally contain denylist words as documentation, tests, or
+# the denylist implementation itself. They still get path-level checks; only
+# command-content scanning is skipped to avoid fixture/self-reference failures.
+CONTENT_SCAN_EXEMPT_PATHS = (
+    ".gitignore",
+    "docs/**",
+    "tests/**",
+    "scripts/review/oflow_local_ci.py",
+    "scripts/review/oflow_tracked_file_handoff_check.py",
+)
+
+
+@dataclass(frozen=True)
+class Violation:
+    file: str
+    check: str
+    line: int | None
+    detail: str
+
+
+def run_git(args: Sequence[str], repo: Path = REPO_ROOT, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=check,
+    )
+
+
+def normalize(path: Path | str) -> str:
+    return str(path).replace(os.sep, "/")
+
+
+def matches_any(path: str, patterns: Iterable[str]) -> bool:
+    return any(fnmatch.fnmatch(path, pattern) for pattern in patterns)
+
+
+def changed_files(upstream: str = DEFAULT_UPSTREAM, repo: Path = REPO_ROOT) -> list[str]:
+    merge_base = run_git(["merge-base", upstream, "HEAD"], repo=repo).stdout.strip()
+    committed = run_git(["diff", "--name-only", f"{merge_base}..HEAD"], repo=repo).stdout
+    unstaged = run_git(["diff", "--name-only"], repo=repo).stdout
+    staged = run_git(["diff", "--cached", "--name-only"], repo=repo).stdout
+    untracked = run_git(["ls-files", "--others", "--exclude-standard"], repo=repo).stdout
+    files = [line.strip() for line in (committed + "\n" + unstaged + "\n" + staged + "\n" + untracked).splitlines() if line.strip()]
+    return sorted(dict.fromkeys(files))
+
+
+def text_line_number(text: str, start: int) -> int:
+    return text.count("\n", 0, start) + 1
+
+
+def scan_file(path: str, repo: Path = REPO_ROOT) -> list[Violation]:
+    rel = normalize(path)
+    violations: list[Violation] = []
+
+    if matches_any(rel, SECRET_PATH_PATTERNS):
+        return [Violation(rel, "secret path", None, "secret-bearing paths are not read by this helper")]
+    if matches_any(rel, RUNTIME_PATH_PATTERNS):
+        violations.append(Violation(rel, "runtime path", None, "runtime/prod/deploy paths are out of scope for local CI"))
+    if matches_any(rel, MUTATION_DB_PATH_PATTERNS):
+        violations.append(Violation(rel, "database mutation path", None, "database migration/backfill/mutation paths are out of scope"))
+
+    if matches_any(rel, CONTENT_SCAN_EXEMPT_PATHS):
+        return violations
+
+    full_path = repo / rel
+    if not full_path.exists() or not full_path.is_file():
+        return violations
+
+    try:
+        data = full_path.read_bytes()
+    except OSError as exc:
+        violations.append(Violation(rel, "read error", None, str(exc)))
+        return violations
+
+    if b"\0" in data:
+        return violations
+
+    text = data.decode("utf-8", errors="ignore")
+    for label, pattern in DENYLIST_PATTERNS:
+        for match in pattern.finditer(text):
+            violations.append(
+                Violation(
+                    rel,
+                    label,
+                    text_line_number(text, match.start()),
+                    match.group(0).splitlines()[0][:160],
+                )
+            )
+    return violations
+
+
+def run_denylist(args: argparse.Namespace) -> int:
+    repo = Path(args.repo).resolve()
+    files = args.files or changed_files(args.upstream, repo=repo)
+    violations: list[Violation] = []
+    for file_name in files:
+        violations.extend(scan_file(file_name, repo=repo))
+
+    payload = {"passed": not violations, "violations": [asdict(v) for v in violations], "files_scanned": files}
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0 if not violations else 1
+
+
+def python_files_for_compile(repo: Path, files: Sequence[str]) -> list[str]:
+    if files:
+        candidates = files
+    else:
+        candidates = changed_files(DEFAULT_UPSTREAM, repo=repo)
+    return [f for f in candidates if f.endswith(".py") and (repo / f).is_file() and not matches_any(f, SECRET_PATH_PATTERNS)]
+
+
+def run_py_compile(args: argparse.Namespace) -> int:
+    repo = Path(args.repo).resolve()
+    files = python_files_for_compile(repo, args.files)
+    failures: list[dict[str, str]] = []
+    for rel in files:
+        try:
+            py_compile.compile(str(repo / rel), doraise=True)
+        except py_compile.PyCompileError as exc:
+            failures.append({"file": rel, "error": str(exc)})
+    print(json.dumps({"passed": not failures, "files": files, "failures": failures}, indent=2, sort_keys=True))
+    return 0 if not failures else 1
+
+
+def run_diff_check(args: argparse.Namespace) -> int:
+    repo = Path(args.repo).resolve()
+    proc = run_git(["diff", "--check", args.upstream, "HEAD"], repo=repo, check=False)
+    print(proc.stdout, end="")
+    print(proc.stderr, end="", file=sys.stderr)
+    return proc.returncode
+
+
+def run_workflow_yaml(args: argparse.Namespace) -> int:
+    repo = Path(args.repo).resolve()
+    workflows = sorted((repo / ".github" / "workflows").glob("*.y*ml"))
+    failures: list[dict[str, str]] = []
+    for workflow in workflows:
+        try:
+            text = workflow.read_text(encoding="utf-8")
+            if yaml is not None:
+                parsed = yaml.safe_load(text)
+                if not isinstance(parsed, dict) or "jobs" not in parsed:
+                    failures.append({"file": normalize(workflow.relative_to(repo)), "error": "workflow YAML has no jobs mapping"})
+            else:
+                # Minimal structural fallback when PyYAML is unavailable.
+                if not re.search(r"(?m)^jobs:\s*$", text):
+                    failures.append({"file": normalize(workflow.relative_to(repo)), "error": "workflow YAML has no jobs: key"})
+        except Exception as exc:
+            failures.append({"file": normalize(workflow.relative_to(repo)), "error": str(exc)})
+    print(json.dumps({"passed": not failures, "files_checked": [normalize(w.relative_to(repo)) for w in workflows], "failures": failures}, indent=2, sort_keys=True))
+    return 0 if not failures else 1
+
+
+def run_pytest_subset(args: argparse.Namespace) -> int:
+    repo = Path(args.repo).resolve()
+    targets = args.targets or ["tests/review/test_oflow_local_ci.py"]
+    cmd = [sys.executable, "-m", "pytest", *targets]
+    proc = subprocess.run(cmd, cwd=repo)
+    return proc.returncode
+
+
+def run_summary(args: argparse.Namespace) -> int:
+    repo = Path(args.repo).resolve()
+    files = changed_files(args.upstream, repo=repo)
+    touched_areas = sorted({
+        "workflow" if matches_any(f, (".github/workflows/**",)) else
+        "runtime" if matches_any(f, RUNTIME_PATH_PATTERNS) else
+        "review-helper" if matches_any(f, ("scripts/review/**",)) else
+        "docs" if matches_any(f, ("docs/**",)) else
+        "tests" if matches_any(f, ("tests/**",)) else
+        "other"
+        for f in files
+    })
+    payload = {
+        "passed": True,
+        "changed_files": files,
+        "touched_workflow_runtime_areas": touched_areas,
+        "hard_stops": {
+            "no_merge": True,
+            "no_deploy": True,
+            "no_restart": True,
+            "no_env_inspection": True,
+            "no_secret_inspection": True,
+            "no_runtime_monitoring": True,
+            "no_production_probes": True,
+            "no_provider_api_calls": True,
+            "no_ssh": True,
+            "no_db_access": True,
+            "no_trading_or_order_impact": True,
+        },
+    }
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    def add_common(p: argparse.ArgumentParser) -> None:
+        p.add_argument("--repo", default=str(REPO_ROOT), help="repository root")
+        p.add_argument("--upstream", default=DEFAULT_UPSTREAM, help="upstream ref for changed-file discovery")
+
+    deny = sub.add_parser("denylist", help="scan changed files for local-CI safety denylist patterns")
+    add_common(deny)
+    deny.add_argument("files", nargs="*", help="explicit repository-relative files to scan")
+    deny.set_defaults(func=run_denylist)
+
+    pyc = sub.add_parser("py-compile", help="compile changed Python files")
+    add_common(pyc)
+    pyc.add_argument("files", nargs="*", help="explicit repository-relative Python files")
+    pyc.set_defaults(func=run_py_compile)
+
+    diff = sub.add_parser("diff-check", help="run git diff --check")
+    add_common(diff)
+    diff.set_defaults(func=run_diff_check)
+
+    workflow = sub.add_parser("workflow-yaml", help="validate workflow YAML structure")
+    add_common(workflow)
+    workflow.set_defaults(func=run_workflow_yaml)
+
+    pytest_cmd = sub.add_parser("pytest-subset", help="run safe fixture/local pytest subsets")
+    pytest_cmd.add_argument("--repo", default=str(REPO_ROOT), help="repository root")
+    pytest_cmd.add_argument("targets", nargs="*", help="pytest targets")
+    pytest_cmd.set_defaults(func=run_pytest_subset)
+
+    summary = sub.add_parser("summary", help="write artifact-only CI summary")
+    add_common(summary)
+    summary.add_argument("--output", type=Path, default=Path("artifacts/oflow-local-ci-summary.json"))
+    summary.set_defaults(func=run_summary)
+
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/review/oflow_tracked_file_handoff_check.py
+++ b/scripts/review/oflow_tracked_file_handoff_check.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Oflow tracked-file handoff gate.
+
+This gate is intentionally read-only. It reports changed files and verifies that
+handoff evidence explicitly records the local-CI hard stops required before a PR
+is created or updated.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+from pathlib import Path
+from typing import Sequence
+
+REQUIRED_HARD_STOPS = (
+    "no_merge",
+    "no_deploy",
+    "no_restart",
+    "no_env_inspection",
+    "no_secret_inspection",
+    "no_runtime_monitoring",
+    "no_production_probes",
+    "no_provider_api_calls",
+    "no_ssh",
+    "no_db_access",
+    "no_trading_or_order_impact",
+)
+
+
+def run_git(repo: Path, args: Sequence[str]) -> str:
+    return subprocess.run(
+        ["git", *args],
+        cwd=repo,
+        text=True,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        check=True,
+    ).stdout
+
+
+def changed_files(repo: Path, upstream: str) -> list[str]:
+    merge_base = run_git(repo, ["merge-base", upstream, "HEAD"]).strip()
+    committed = run_git(repo, ["diff", "--name-only", f"{merge_base}..HEAD"])
+    unstaged = run_git(repo, ["diff", "--name-only"])
+    staged = run_git(repo, ["diff", "--cached", "--name-only"])
+    untracked = run_git(repo, ["ls-files", "--others", "--exclude-standard"])
+    files = [line for line in (committed + "\n" + unstaged + "\n" + staged + "\n" + untracked).splitlines() if line]
+    return sorted(dict.fromkeys(files))
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", type=Path, default=Path.cwd())
+    parser.add_argument("--upstream", default="origin/main")
+    parser.add_argument("--summary", type=Path, default=Path("artifacts/oflow-local-ci-summary.json"))
+    args = parser.parse_args(argv)
+
+    repo = args.repo.resolve()
+    files = changed_files(repo, args.upstream)
+    summary_path = args.summary if args.summary.is_absolute() else repo / args.summary
+
+    failures: list[str] = []
+    hard_stops: dict[str, bool] = {}
+    if not summary_path.exists():
+        failures.append(f"missing summary artifact: {summary_path.relative_to(repo)}")
+    else:
+        data = json.loads(summary_path.read_text(encoding="utf-8"))
+        hard_stops = data.get("hard_stops", {})
+        missing = [key for key in REQUIRED_HARD_STOPS if hard_stops.get(key) is not True]
+        if missing:
+            failures.append("hard-stop evidence missing or false: " + ", ".join(missing))
+
+    payload = {
+        "passed": not failures,
+        "changed_files": files,
+        "required_hard_stops": list(REQUIRED_HARD_STOPS),
+        "hard_stops": hard_stops,
+        "failures": failures,
+    }
+    print(json.dumps(payload, indent=2, sort_keys=True))
+    return 0 if not failures else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/review/test_oflow_local_ci.py
+++ b/tests/review/test_oflow_local_ci.py
@@ -1,0 +1,65 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from scripts.review import oflow_local_ci
+
+
+def write(path: Path, text: str) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(text, encoding="utf-8")
+
+
+def test_denylist_flags_service_and_remote_mutation_commands(tmp_path: Path) -> None:
+    write(
+        tmp_path / "scripts" / "unsafe.sh",
+        "systemctl restart hermes\n"
+        "docker compose up -d\n"
+        "ssh prod.example.com\n"
+        "sqlite3 app.db 'update orders set status=1'\n",
+    )
+
+    violations = oflow_local_ci.scan_file("scripts/unsafe.sh", repo=tmp_path)
+
+    checks = {violation.check for violation in violations}
+    assert "systemctl" in checks
+    assert "docker compose up/down" in checks
+    assert "ssh" in checks
+    assert "sqlite mutation" in checks
+
+
+def test_secret_paths_are_reported_without_reading_contents(tmp_path: Path) -> None:
+    env_path = tmp_path / ".env"
+    env_path.write_text("TOKEN=super-secret\n", encoding="utf-8")
+
+    violations = oflow_local_ci.scan_file(".env", repo=tmp_path)
+
+    assert violations == [
+        oflow_local_ci.Violation(
+            file=".env",
+            check="secret path",
+            line=None,
+            detail="secret-bearing paths are not read by this helper",
+        )
+    ]
+
+
+def test_safe_review_helper_passes_denylist(tmp_path: Path) -> None:
+    write(
+        tmp_path / "scripts" / "review" / "safe.py",
+        "from pathlib import Path\n"
+        "Path('artifacts/summary.json').write_text('{}')\n",
+    )
+
+    assert oflow_local_ci.scan_file("scripts/review/safe.py", repo=tmp_path) == []
+
+
+def test_runtime_and_database_paths_are_blocked_without_command_content(tmp_path: Path) -> None:
+    write(tmp_path / "runtime" / "README.md", "runtime docs\n")
+    write(tmp_path / "migrations" / "001.sql", "-- migration docs\n")
+
+    runtime_violations = oflow_local_ci.scan_file("runtime/README.md", repo=tmp_path)
+    migration_violations = oflow_local_ci.scan_file("migrations/001.sql", repo=tmp_path)
+
+    assert any(v.check == "runtime path" for v in runtime_violations)
+    assert any(v.check == "database mutation path" for v in migration_violations)


### PR DESCRIPTION
## Summary
- Adds manual-only Oflow local CI safety workflow with read-only permissions, branch guard, concurrency, job timeout, and artifact-only outputs.
- Adds reusable repo-local helper commands for denylist scanning, Python compile checks, pytest subsets, git diff whitespace checks, workflow YAML validation, and summary artifact generation.
- Documents the runner isolation model, local-only posture, runtime hard stops, and future approval gates.

## Validation
- `python3 scripts/review/oflow_local_ci.py denylist --repo . --upstream origin/main`
- `python3 scripts/review/oflow_local_ci.py py-compile --repo . --upstream origin/main`
- `python3 scripts/review/oflow_local_ci.py diff-check --repo . --upstream origin/main`
- `python3 scripts/review/oflow_local_ci.py workflow-yaml --repo . --upstream origin/main`
- `python3 scripts/review/oflow_local_ci.py pytest-subset --repo . tests/review/test_oflow_local_ci.py` (4 passed)
- `python3 scripts/review/oflow_local_ci.py summary --repo . --upstream origin/main --output artifacts/oflow-local-ci/summary.json`
- `python3 scripts/review/oflow_tracked_file_handoff_check.py --repo . --upstream origin/main --summary artifacts/oflow-local-ci/summary.json`

## Oflow hard-stop evidence
- no merge: true
- no deploy: true
- no restart: true
- no .env inspection: true
- no secret inspection: true
- no runtime monitoring: true
- no production probes: true
- no provider/API calls: true
- no SSH: true
- no DB access: true
- no trading/order impact: true

## Safety posture
- Workflow remains `workflow_dispatch` only.
- Checkout persists no credentials.
- Review output is uploaded only as an artifact under `artifacts/oflow-local-ci/`.
- Checks use repository-local changed files and fixtures only.
