### PR TITLE
fix(oneshot): hermes -z returns empty stdout; fix(cron): whatsapp delivery silently dropped

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -111,6 +111,7 @@ _HOME_TARGET_ENV_VARS = {
     "weixin": "WEIXIN_HOME_CHANNEL",
     "bluebubbles": "BLUEBUBBLES_HOME_CHANNEL",
     "qqbot": "QQBOT_HOME_CHANNEL",
+    "whatsapp": "WHATSAPP_HOME_CHANNEL",
 }
 
 # Legacy env var names kept for back-compat.  Each entry is the current

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -332,6 +332,10 @@ def _run_agent(
     agent.suppress_status_output = True
     agent.stream_delta_callback = None
     agent.tool_gen_callback = None
+    # Force non-streaming path.  Without this, _use_streaming stays True
+    # even with no stream consumers — the response content is emitted as
+    # deltas into the void and chat() returns "" (fixes #22975).
+    agent._disable_streaming = True
 
     return agent.chat(prompt) or ""
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -350,6 +350,23 @@ class TestResolveDeliveryTarget:
 
         assert _resolve_delivery_targets({"deliver": []}) == []
 
+    def test_whatsapp_deliver_resolves_home_channel(self, monkeypatch):
+        """deliver='whatsapp' must resolve via WHATSAPP_HOME_CHANNEL (#22997).
+
+        Prior to this fix, 'whatsapp' was absent from _HOME_TARGET_ENV_VARS so
+        _resolve_home_env_var returned '' and delivery was silently dropped.
+        """
+        from cron.scheduler import _resolve_delivery_targets
+
+        monkeypatch.setenv("WHATSAPP_HOME_CHANNEL", "15551234567@s.whatsapp.net")
+        job = {"id": "wa-test", "name": "wa-test", "deliver": "whatsapp"}
+
+        targets = _resolve_delivery_targets(job)
+
+        assert len(targets) == 1, f"expected 1 target, got {targets}"
+        assert targets[0]["platform"] == "whatsapp"
+        assert targets[0]["chat_id"] == "15551234567@s.whatsapp.net"
+
 
 class TestRoutingIntents:
     """``all`` routing intent expands at fire time."""

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -485,6 +485,75 @@ def test_oneshot_wires_session_db_for_recall(monkeypatch):
     assert captured["prompt"] == "recall this"
 
 
+def test_oneshot_disables_streaming_to_prevent_empty_stdout(monkeypatch):
+    """_run_agent must set _disable_streaming=True so chat() returns content.
+
+    Without this, _use_streaming stays True even with no stream consumers:
+    response content is emitted as stream deltas into the void and chat()
+    returns '' (fixes #22975).
+    """
+    from hermes_cli.oneshot import _run_agent
+
+    captured = {}
+
+    class FakeAgent:
+        def __init__(self, **kwargs):
+            captured.update(kwargs)
+            self.suppress_status_output = False
+            self.stream_delta_callback = object()
+            self.tool_gen_callback = object()
+
+        def chat(self, prompt):
+            # Verify _disable_streaming was set before chat() is called
+            captured["disable_streaming"] = getattr(self, "_disable_streaming", None)
+            return "hello from model"
+
+    def mod(name, **attrs):
+        module = types.ModuleType(name)
+        for key, value in attrs.items():
+            setattr(module, key, value)
+        return module
+
+    monkeypatch.setitem(sys.modules, "run_agent", mod("run_agent", AIAgent=FakeAgent))
+    monkeypatch.setitem(sys.modules, "hermes_state", mod("hermes_state", SessionDB=object))
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.config",
+        mod("hermes_cli.config", load_config=lambda: {"model": {"default": "m"}}),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.models",
+        mod("hermes_cli.models", detect_provider_for_model=lambda *_args, **_kwargs: None),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.runtime_provider",
+        mod(
+            "hermes_cli.runtime_provider",
+            resolve_runtime_provider=lambda **_kwargs: {
+                "api_key": "k",
+                "base_url": "u",
+                "provider": "p",
+                "api_mode": "chat_completions",
+                "credential_pool": None,
+            },
+        ),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "hermes_cli.tools_config",
+        mod("hermes_cli.tools_config", _get_platform_tools=lambda *_args, **_kwargs: set()),
+    )
+
+    result = _run_agent("say hello")
+    assert result == "hello from model"
+    assert captured["disable_streaming"] is True, (
+        "_disable_streaming must be True before chat() — otherwise streaming "
+        "path emits tokens into the void and chat() returns '' (issue #22975)"
+    )
+
+
 def test_launch_tui_exports_model_provider_and_toolsets(monkeypatch, main_mod):
     captured = {}
     active_path_during_call = None


### PR DESCRIPTION
Fixes #22975 and #22997.

## fix(oneshot): hermes -z returns empty stdout (#22975)

**Root cause:** In `_run_agent()`, `agent.stream_delta_callback = None` suppresses token callbacks but `_has_stream_consumers()` returns `False` — so `_use_streaming` stays `True`. The response is emitted as stream deltas into the void; `chat()` returns `""`.

**Fix:** Set `agent._disable_streaming = True` before calling `chat()`. This forces the non-streaming path which returns the full response object directly.

**Test:** `test_oneshot_disables_streaming_to_prevent_empty_stdout` — asserts `_disable_streaming` is `True` when `chat()` is invoked.

## fix(cron): whatsapp delivery silently dropped (#22997)

**Root cause:** `'whatsapp'` was absent from `_HOME_TARGET_ENV_VARS` in `cron/scheduler.py`. `_resolve_home_env_var('whatsapp')` returned `''`, `_resolve_delivery_targets()` returned `[]`, and the job was silently marked successful with no message sent.

**Fix:** One-line addition: `'whatsapp': 'WHATSAPP_HOME_CHANNEL'` in `_HOME_TARGET_ENV_VARS`.

**Test:** `test_whatsapp_deliver_resolves_home_channel` — verifies the resolver returns a valid target when `WHATSAPP_HOME_CHANNEL` is set.