### PR TITLE
fix(signal): pass group messages from linked devices to agent (#23064)

### DIFF
--- a/gateway/platforms/signal.py
+++ b/gateway/platforms/signal.py
@@ -437,8 +437,10 @@ class SignalAdapter(BasePlatformAdapter):
         envelope_data = envelope.get("envelope", envelope)
 
         # Handle syncMessage: extract "Note to Self" messages (sent to own account)
-        # while still filtering other sync events (read receipts, typing, etc.)
+        # AND group messages from linked devices.  All other sync events (read
+        # receipts, typing indicators, etc.) are still filtered out.
         is_note_to_self = False
+        is_linked_device_group_msg = False
         if "syncMessage" in envelope_data:
             sync_msg = envelope_data.get("syncMessage")
             if sync_msg and isinstance(sync_msg, dict):
@@ -446,6 +448,7 @@ class SignalAdapter(BasePlatformAdapter):
                 if sent_msg and isinstance(sent_msg, dict):
                     dest = sent_msg.get("destinationNumber") or sent_msg.get("destination")
                     sent_ts = sent_msg.get("timestamp")
+                    sent_group_id = (sent_msg.get("groupInfo") or {}).get("groupId")
                     if dest == self._account_normalized:
                         # Check if this is an echo of our own outbound reply
                         if sent_ts and sent_ts in self._recent_sent_timestamps:
@@ -454,7 +457,18 @@ class SignalAdapter(BasePlatformAdapter):
                         # Genuine user Note to Self — promote to dataMessage
                         is_note_to_self = True
                         envelope_data = {**envelope_data, "dataMessage": sent_msg}
-            if not is_note_to_self:
+                    elif sent_group_id:
+                        # Group message from a linked device (fixes #23064).
+                        # The sourceNumber is the bot's own number (the linked
+                        # device that sent it), but the message originated from
+                        # the user — promote to dataMessage and bypass the
+                        # self-loop filter below with is_linked_device_group_msg.
+                        if sent_ts and sent_ts in self._recent_sent_timestamps:
+                            self._recent_sent_timestamps.discard(sent_ts)
+                            return
+                        is_linked_device_group_msg = True
+                        envelope_data = {**envelope_data, "dataMessage": sent_msg}
+            if not is_note_to_self and not is_linked_device_group_msg:
                 return
 
         # Extract sender info
@@ -471,8 +485,9 @@ class SignalAdapter(BasePlatformAdapter):
             logger.debug("Signal: ignoring envelope with no sender")
             return
 
-        # Self-message filtering — prevent reply loops (but allow Note to Self)
-        if self._account_normalized and sender == self._account_normalized and not is_note_to_self:
+        # Self-message filtering — prevent reply loops (but allow Note to Self
+        # and group messages forwarded from linked devices).
+        if self._account_normalized and sender == self._account_normalized and not is_note_to_self and not is_linked_device_group_msg:
             return
 
         # Filter stories

--- a/tests/gateway/test_signal.py
+++ b/tests/gateway/test_signal.py
@@ -1794,3 +1794,70 @@ class TestSignalContentlessEnvelope:
 
         assert "event" in captured, "Normal message should NOT be skipped"
         assert captured["event"].text == "hello world"
+
+
+class TestSignalSyncGroupMessages:
+    """Group messages from linked devices via syncMessage must not be silently dropped (#23064)."""
+
+    @pytest.mark.asyncio
+    async def test_sync_group_message_from_linked_device_is_delivered(self, monkeypatch):
+        """A syncMessage.sentMessage with groupInfo.groupId must reach handle_message."""
+        # Use group_allowed='*' so the group-authorization gate doesn't filter first.
+        # account must match sourceNumber so the self-loop guard is what we're testing.
+        adapter = _make_signal_adapter(monkeypatch, account="+15551234567", group_allowed="*")
+        captured = {}
+
+        async def fake_handle(event):
+            captured["event"] = event
+
+        adapter.handle_message = fake_handle
+
+        await adapter._handle_envelope({
+            "envelope": {
+                # Linked-device sync: sourceNumber is the bot's own number.
+                "sourceNumber": "+15551234567",
+                "sourceUuid": "aaaaaaaa-0000-0000-0000-000000000001",
+                "sourceName": "My Linked Phone",
+                "timestamp": 1777600696000,
+                "syncMessage": {
+                    "sentMessage": {
+                        "timestamp": 1777600696000,
+                        "message": "hello from group via linked device",
+                        "groupInfo": {
+                            "groupId": "abc123groupId==",
+                            "type": "DELIVER",
+                        },
+                    }
+                },
+            }
+        })
+
+        assert "event" in captured, (
+            "Group message from linked device was silently dropped — "
+            "syncMessage.sentMessage with groupInfo must reach handle_message (fix #23064)"
+        )
+        assert captured["event"].text == "hello from group via linked device"
+
+    @pytest.mark.asyncio
+    async def test_sync_non_group_non_note_to_self_is_still_filtered(self, monkeypatch):
+        """A syncMessage with no sentMessage (e.g. read receipt) must still be dropped."""
+        adapter = _make_signal_adapter(monkeypatch)
+        captured = {}
+
+        async def fake_handle(event):
+            captured["event"] = event
+
+        adapter.handle_message = fake_handle
+
+        await adapter._handle_envelope({
+            "envelope": {
+                "sourceNumber": "+15550000000",
+                "sourceUuid": "aaaaaaaa-0000-0000-0000-000000000001",
+                "timestamp": 1777600696000,
+                "syncMessage": {
+                    "readMessages": [{"sender": "+15551111111", "timestamp": 1777600000000}],
+                },
+            }
+        })
+
+        assert "event" not in captured, "Read receipts and non-sentMessage syncs must still be filtered"


### PR DESCRIPTION
Fixes #23064.

## Root cause

`_handle_envelope()`'s syncMessage handler only promoted Note-to-Self messages (where `destinationNumber == bot's own account`). Group messages from linked devices have a `groupInfo.groupId` instead of a matching `destinationNumber`, so they hit the `if not is_note_to_self: return` guard and were silently dropped. No error, no log — they just vanished.

## Fix

Added `is_linked_device_group_msg` flag alongside `is_note_to_self`:

- When `sentMessage` has `groupInfo.groupId`, promote it to `dataMessage` and set `is_linked_device_group_msg = True`
- Bypass the self-loop filter for these messages (`sourceNumber` equals the bot account by design — it's the linked device that forwarded the message)
- The sync-message return guard now reads: `if not is_note_to_self and not is_linked_device_group_msg: return`

Read receipts and other `syncMessage` events without `sentMessage` (or without `groupInfo`) are still filtered correctly.

## Tests

- `test_sync_group_message_from_linked_device_is_delivered` — group sync message reaches `handle_message`
- `test_sync_non_group_non_note_to_self_is_still_filtered` — read receipts are still dropped