### PR TITLE
fix(cron): action='run' now executes job immediately instead of just scheduling (#21867)

### DIFF
--- a/tests/tools/test_cronjob_run_regression_21867.py
+++ b/tests/tools/test_cronjob_run_regression_21867.py
@@ -1,0 +1,191 @@
+"""
+Regression tests for cronjob action='run' immediate execution (issue #21867).
+
+The cronjob tool's action='run' previously only set next_run_at to the current
+time, but did not actually execute the job. Users expected immediate execution.
+"""
+
+import json
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from tools.cronjob_tools import cronjob
+
+
+class TestCronjobRunImmediateExecution:
+    """Tests that action='run' executes the job immediately."""
+
+    @patch("tools.cronjob_tools.trigger_job")
+    @patch("tools.cronjob_tools.get_job")
+    @patch("tools.cronjob_tools._run_cron_job")
+    @patch("tools.cronjob_tools._save_cron_output")
+    @patch("tools.cronjob_tools.mark_job_run")
+    def test_run_executes_job_immediately(
+        self,
+        mock_mark_run,
+        mock_save_output,
+        mock_run_job,
+        mock_get_job,
+        mock_trigger,
+    ):
+        """action='run' should call run_job() immediately, not just trigger."""
+        # Setup mocks
+        mock_trigger.return_value = {
+            "id": "test-job-123",
+            "name": "Test Job",
+            "state": "scheduled",
+        }
+        mock_get_job.return_value = {
+            "id": "test-job-123",
+            "name": "Test Job",
+            "prompt": "test prompt",
+        }
+        mock_run_job.return_value = (True, "output doc", "final response", None)
+
+        result = cronjob(action="run", job_id="test-job-123")
+        data = json.loads(result)
+
+        # Should trigger the job first
+        mock_trigger.assert_called_once_with("test-job-123")
+        # Should get the job details
+        mock_get_job.assert_called_once_with("test-job-123")
+        # Should run the job immediately
+        mock_run_job.assert_called_once()
+        # Should save output
+        mock_save_output.assert_called_once_with("test-job-123", "output doc")
+        # Should mark the run
+        mock_mark_run.assert_called_once_with("test-job-123", True, None)
+        # Result should include output
+        assert data["success"] is True
+        assert data["output"] == "final response"
+        assert data["error"] is None
+
+    @patch("tools.cronjob_tools.trigger_job")
+    @patch("tools.cronjob_tools.get_job")
+    @patch("tools.cronjob_tools._run_cron_job")
+    @patch("tools.cronjob_tools._save_cron_output")
+    @patch("tools.cronjob_tools.mark_job_run")
+    def test_run_now_executes_job_immediately(
+        self,
+        mock_mark_run,
+        mock_save_output,
+        mock_run_job,
+        mock_get_job,
+        mock_trigger,
+    ):
+        """action='run_now' should also execute immediately."""
+        mock_trigger.return_value = {
+            "id": "test-job-123",
+            "name": "Test Job",
+            "state": "scheduled",
+        }
+        mock_get_job.return_value = {
+            "id": "test-job-123",
+            "name": "Test Job",
+            "prompt": "test prompt",
+        }
+        mock_run_job.return_value = (True, "output", "response", None)
+
+        result = cronjob(action="run_now", job_id="test-job-123")
+        data = json.loads(result)
+
+        mock_run_job.assert_called_once()
+        assert data["success"] is True
+        assert data["output"] == "response"
+
+    @patch("tools.cronjob_tools.trigger_job")
+    @patch("tools.cronjob_tools.get_job")
+    @patch("tools.cronjob_tools._run_cron_job")
+    def test_trigger_does_not_execute(
+        self,
+        mock_run_job,
+        mock_get_job,
+        mock_trigger,
+    ):
+        """action='trigger' should only schedule, not execute (backward compat)."""
+        mock_trigger.return_value = {
+            "id": "test-job-123",
+            "name": "Test Job",
+            "state": "scheduled",
+        }
+
+        result = cronjob(action="trigger", job_id="test-job-123")
+        data = json.loads(result)
+
+        mock_run_job.assert_not_called()
+        mock_get_job.assert_not_called()
+        assert data["success"] is True
+        assert "output" not in data
+
+    @patch("tools.cronjob_tools.trigger_job")
+    @patch("tools.cronjob_tools.get_job")
+    @patch("tools.cronjob_tools._run_cron_job")
+    @patch("tools.cronjob_tools._save_cron_output")
+    @patch("tools.cronjob_tools.mark_job_run")
+    def test_run_with_job_failure(
+        self,
+        mock_mark_run,
+        mock_save_output,
+        mock_run_job,
+        mock_get_job,
+        mock_trigger,
+    ):
+        """action='run' should report failure when job execution fails."""
+        mock_trigger.return_value = {
+            "id": "test-job-123",
+            "name": "Test Job",
+            "state": "scheduled",
+        }
+        mock_get_job.return_value = {
+            "id": "test-job-123",
+            "name": "Test Job",
+            "prompt": "test prompt",
+        }
+        mock_run_job.return_value = (False, "", "", "API error")
+
+        result = cronjob(action="run", job_id="test-job-123")
+        data = json.loads(result)
+
+        assert data["success"] is False
+        assert data["error"] == "API error"
+        mock_mark_run.assert_called_once_with("test-job-123", False, "API error")
+
+    @patch("tools.cronjob_tools.trigger_job")
+    @patch("tools.cronjob_tools.get_job")
+    @patch("tools.cronjob_tools._run_cron_job")
+    def test_run_with_exception(
+        self,
+        mock_run_job,
+        mock_get_job,
+        mock_trigger,
+    ):
+        """action='run' should gracefully handle exceptions during execution."""
+        mock_trigger.return_value = {
+            "id": "test-job-123",
+            "name": "Test Job",
+            "state": "scheduled",
+        }
+        mock_get_job.return_value = {
+            "id": "test-job-123",
+            "name": "Test Job",
+            "prompt": "test prompt",
+        }
+        mock_run_job.side_effect = RuntimeError("Scheduler crashed")
+
+        result = cronjob(action="run", job_id="test-job-123")
+        data = json.loads(result)
+
+        assert data["success"] is False
+        assert "Scheduler crashed" in data["error"]
+
+    @patch("tools.cronjob_tools.trigger_job")
+    def test_run_job_not_found(self, mock_trigger):
+        """action='run' should error if trigger_job returns None (job not found)."""
+        mock_trigger.return_value = None
+
+        result = cronjob(action="run", job_id="missing-job")
+        data = json.loads(result)
+
+        assert data["success"] is False
+        assert "Failed to trigger" in data["error"]

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -31,6 +31,7 @@ from cron.jobs import (
     trigger_job,
     update_job,
 )
+from cron.scheduler import run_job as _run_cron_job, save_job_output as _save_cron_output
 
 
 # ---------------------------------------------------------------------------
@@ -583,6 +584,39 @@ def cronjob(
 
         if normalized in {"run", "run_now", "trigger"}:
             updated = trigger_job(job_id)
+            if not updated:
+                return tool_error(f"Failed to trigger job '{job_id}'", success=False)
+
+            # For explicit "run" / "run_now", execute the job immediately
+            # instead of waiting for the next scheduler tick (#21867).
+            if normalized in {"run", "run_now"}:
+                try:
+                    job = get_job(job_id)
+                    if job:
+                        success, output, final_response, error = _run_cron_job(job)
+                        _save_cron_output(job_id, output)
+                        from cron.jobs import mark_job_run
+                        mark_job_run(job_id, success, error)
+                        return json.dumps(
+                            {
+                                "success": success,
+                                "job": _format_job(updated),
+                                "output": final_response,
+                                "error": error,
+                            },
+                            indent=2,
+                        )
+                except Exception as exc:
+                    logger.exception("Cron immediate run failed for job %s", job_id)
+                    return json.dumps(
+                        {
+                            "success": False,
+                            "job": _format_job(updated),
+                            "error": str(exc),
+                        },
+                        indent=2,
+                    )
+
             return json.dumps({"success": True, "job": _format_job(updated)}, indent=2)
 
         if normalized == "update":


### PR DESCRIPTION
## Bug Description

The `cronjob` tool's `action='run'` parameter did not trigger immediate execution of a scheduled cron job. It only set `next_run_at` to the current time and waited for the scheduler's next tick (typically 60 seconds later).

## Root Cause

`action='run'` called `trigger_job()` which only updated the job's `next_run_at` field. The actual execution required the scheduler's `tick()` to be called, which happens on a timer.

## Fix

For `action='run'` and `action='run_now'`:
1. Still call `trigger_job()` to update the job state
2. Immediately execute the job via `run_job()`
3. Save the output via `save_job_output()`
4. Mark the run via `mark_job_run()`
5. Return the output/error in the response

`action='trigger'` retains the old behavior (schedule-only, no execution) for backward compatibility.

## Tests

Added `tests/tools/test_cronjob_run_regression_21867.py` with 6 tests:
- `run` executes job immediately
- `run_now` executes job immediately
- `trigger` does NOT execute (backward compat)
- Job failure is reported correctly
- Exceptions during execution are handled gracefully
- Missing job returns proper error

Fixes #21867