### PR TITLE
fix(tui): replace chmod with cross-platform node call in build script (#22952)

### DIFF
--- a/ui-tui/package.json
+++ b/ui-tui/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "dev": "npm run build --prefix packages/hermes-ink && tsx --watch src/entry.tsx",
     "start": "tsx src/entry.tsx",
-    "build": "npm run build --prefix packages/hermes-ink && tsc -p tsconfig.build.json && npm run build:compile && chmod +x dist/entry.js",
+    "build": "npm run build --prefix packages/hermes-ink && tsc -p tsconfig.build.json && npm run build:compile && node -e \"process.platform!=='win32'&&require('fs').chmodSync('dist/entry.js',0o755)\"",
     "build:compile": "babel dist --out-dir dist --config-file ./babel.compiler.config.cjs --extensions .js --keep-file-extension",
     "type-check": "tsc --noEmit -p tsconfig.json",
     "lint": "eslint src/ packages/",


### PR DESCRIPTION
Fixes #22952.

`chmod` does not exist on Windows, causing `hermes --tui` to fail with 'TUI build failed'.

Replace with an inline node one-liner that skips the chmod on `win32` and applies it on all other platforms:
```
node -e "process.platform!=='win32'&&require('fs').chmodSync('dist/entry.js',0o755)"
```
No test needed — the fix is a one-line JSON string change in package.json.