### PR TITLE
feat(discord): per-guild/per-server configuration overrides

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -772,6 +772,18 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["group_allow_from"] = platform_cfg["group_allow_from"]
                 if plat in (Platform.DISCORD, Platform.SLACK) and "channel_skill_bindings" in platform_cfg:
                     bridged["channel_skill_bindings"] = platform_cfg["channel_skill_bindings"]
+                # Per-guild overrides for Discord (nested mapping: guild_id → settings dict)
+                if plat == Platform.DISCORD and "guilds" in platform_cfg:
+                    guilds_raw = platform_cfg["guilds"]
+                    if isinstance(guilds_raw, dict):
+                        # Normalize guild ID keys to strings (YAML parses
+                        # bare numbers as int; guild IDs can overflow 64-bit)
+                        bridged["guilds"] = {str(k): v for k, v in guilds_raw.items()}
+                    else:
+                        logger.warning(
+                            "discord.guilds must be a mapping, got %s — ignoring",
+                            type(guilds_raw).__name__,
+                        )
                 if "channel_prompts" in platform_cfg:
                     channel_prompts = platform_cfg["channel_prompts"]
                     if isinstance(channel_prompts, dict):

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -2279,6 +2279,10 @@ class DiscordAdapter(BasePlatformAdapter):
         chan_obj = getattr(interaction, "channel", None)
         in_dm = isinstance(chan_obj, discord.DMChannel) if chan_obj is not None else False
 
+        # Resolve guild ID for per-guild config.
+        _int_guild = getattr(interaction, "guild", None)
+        _int_guild_id = str(_int_guild.id) if _int_guild else None
+
         # ── Channel scope (mirrors on_message lines 3374-3388) ──
         # DMs aren't channel-gated — DMs follow on_message's DM lockdown
         # path which has its own user-allowlist enforcement.
@@ -2296,9 +2300,9 @@ class DiscordAdapter(BasePlatformAdapter):
                     if parent_id:
                         channel_ids.add(str(parent_id))
 
-            allowed_raw = os.getenv("DISCORD_ALLOWED_CHANNELS", "")
+            allowed_raw = self._resolve_discord_setting(_int_guild_id, "allowed_channels")
             if allowed_raw:
-                allowed = {c.strip() for c in allowed_raw.split(",") if c.strip()}
+                allowed = self._coerce_channel_set(allowed_raw)
                 if "*" not in allowed:
                     if not channel_ids:
                         # Channel policy is configured but the interaction
@@ -2313,9 +2317,9 @@ class DiscordAdapter(BasePlatformAdapter):
             # Ignored beats allowed: even when a thread's parent channel
             # is on the allowlist, an explicit DISCORD_IGNORED_CHANNELS
             # entry on the thread or its parent rejects the interaction.
-            ignored_raw = os.getenv("DISCORD_IGNORED_CHANNELS", "")
+            ignored_raw = self._resolve_discord_setting(_int_guild_id, "ignored_channels")
             if ignored_raw and channel_ids:
-                ignored = {c.strip() for c in ignored_raw.split(",") if c.strip()}
+                ignored = self._coerce_channel_set(ignored_raw)
                 if "*" in ignored or (channel_ids & ignored):
                     return (False, "channel in DISCORD_IGNORED_CHANNELS")
 
@@ -3519,25 +3523,95 @@ class DiscordAdapter(BasePlatformAdapter):
         from gateway.platforms.base import resolve_channel_prompt
         return resolve_channel_prompt(self.config.extra, channel_id, parent_id)
 
-    def _discord_require_mention(self) -> bool:
-        """Return whether Discord channel messages require a bot mention."""
-        configured = self.config.extra.get("require_mention")
-        if configured is not None:
-            if isinstance(configured, str):
-                return configured.lower() not in ("false", "0", "no", "off")
-            return bool(configured)
-        return os.getenv("DISCORD_REQUIRE_MENTION", "true").lower() not in ("false", "0", "no", "off")
+    # ------------------------------------------------------------------
+    # Per-guild configuration resolution
+    # ------------------------------------------------------------------
 
-    def _discord_free_response_channels(self) -> set:
+    def _discord_guild_config(self, guild_id: str | None) -> dict:
+        """Return the per-guild override dict for the given guild, or empty."""
+        if guild_id is None:
+            return {}
+        config = getattr(self, "config", None)
+        if config is None:
+            return {}
+        guilds = config.extra.get("guilds")
+        if not isinstance(guilds, dict):
+            return {}
+        entry = guilds.get(guild_id)
+        if isinstance(entry, dict):
+            return entry
+        return {}
+
+    def _resolve_discord_setting(
+        self, guild_id: str | None, key: str, default: Any = None,
+    ) -> Any:
+        """Resolve a Discord setting, checking per-guild → global config → env → default.
+
+        This is the single source of truth for settings that support per-guild
+        overrides (``require_mention``, ``auto_thread``, ``allowed_channels``,
+        ``ignored_channels``, ``free_response_channels``, ``no_thread_channels``).
+
+        Callers must pass the guild ID so per-guild entries are honored; pass
+        ``None`` for DMs or when guild context is unavailable.
+        """
+        guild_cfg = self._discord_guild_config(guild_id)
+
+        # 1. Per-guild override
+        if key in guild_cfg:
+            return guild_cfg[key]
+
+        # 2. Global config (extra)
+        config = getattr(self, "config", None)
+        if config is not None and key in config.extra:
+            return config.extra[key]
+
+        # 3. Environment variable fallback
+        env_map = {
+            "require_mention": "DISCORD_REQUIRE_MENTION",
+            "auto_thread": "DISCORD_AUTO_THREAD",
+            "allowed_channels": "DISCORD_ALLOWED_CHANNELS",
+            "ignored_channels": "DISCORD_IGNORED_CHANNELS",
+            "free_response_channels": "DISCORD_FREE_RESPONSE_CHANNELS",
+            "no_thread_channels": "DISCORD_NO_THREAD_CHANNELS",
+        }
+        env_key = env_map.get(key)
+        if env_key:
+            val = os.getenv(env_key)
+            if val is not None:
+                return val
+
+        return default
+
+    def _discord_require_mention(self, guild_id: str | None = None) -> bool:
+        """Return whether Discord channel messages require a bot mention."""
+        raw = self._resolve_discord_setting(guild_id, "require_mention", default="true")
+        if isinstance(raw, str):
+            return raw.lower() not in ("false", "0", "no", "off")
+        return bool(raw)
+
+    def _coerce_channel_set(self, raw: Any) -> set:
+        """Normalize a raw channel config value (list/str/set) into a set of stripped strings."""
+        if raw is None:
+            return set()
+        if isinstance(raw, set):
+            return raw
+        if isinstance(raw, list):
+            return {str(part).strip() for part in raw if str(part).strip()}
+        s = str(raw).strip()
+        if s:
+            return {part.strip() for part in s.split(",") if part.strip()}
+        return set()
+
+    def _discord_free_response_channels(self, guild_id: str | None = None) -> set:
         """Return Discord channel IDs where no bot mention is required.
 
         A single ``"*"`` entry (either from a list or a comma-separated
         string) is preserved in the returned set so callers can short-circuit
         on wildcard membership, consistent with ``allowed_channels``.
         """
-        raw = self.config.extra.get("free_response_channels")
+        raw = self._resolve_discord_setting(guild_id, "free_response_channels")
         if raw is None:
-            raw = os.getenv("DISCORD_FREE_RESPONSE_CHANNELS", "")
+            return set()
         if isinstance(raw, list):
             return {str(part).strip() for part in raw if str(part).strip()}
         # Coerce non-list scalars (str/int/float) to str before splitting.
@@ -3546,7 +3620,7 @@ class DiscordAdapter(BasePlatformAdapter):
         # previously falling through the isinstance(str) branch and silently
         # returning an empty set.  str() here accepts whatever scalar the YAML
         # loader hands us without changing existing string/CSV semantics.
-        s = str(raw).strip() if raw is not None else ""
+        s = str(raw).strip()
         if s:
             return {part.strip() for part in s.split(",") if part.strip()}
         return set()
@@ -4073,26 +4147,31 @@ class DiscordAdapter(BasePlatformAdapter):
             if parent_channel_id:
                 channel_ids.add(parent_channel_id)
 
+            # Resolve guild ID for per-guild config lookups.
+            _msg_guild = getattr(message, "guild", None)
+            _guild_id = str(_msg_guild.id) if _msg_guild else None
+
             # Check allowed channels - if set, only respond in these channels
-            allowed_channels_raw = os.getenv("DISCORD_ALLOWED_CHANNELS", "")
-            if allowed_channels_raw:
-                allowed_channels = {ch.strip() for ch in allowed_channels_raw.split(",") if ch.strip()}
+            allowed_raw = self._resolve_discord_setting(_guild_id, "allowed_channels")
+            if allowed_raw:
+                allowed_channels = self._coerce_channel_set(allowed_raw)
                 if "*" not in allowed_channels and not (channel_ids & allowed_channels):
                     logger.debug("[%s] Ignoring message in non-allowed channel: %s", self.name, channel_ids)
                     return
 
             # Check ignored channels - never respond even when mentioned
-            ignored_channels_raw = os.getenv("DISCORD_IGNORED_CHANNELS", "")
-            ignored_channels = {ch.strip() for ch in ignored_channels_raw.split(",") if ch.strip()}
-            if "*" in ignored_channels or (channel_ids & ignored_channels):
-                logger.debug("[%s] Ignoring message in ignored channel: %s", self.name, channel_ids)
-                return
+            ignored_raw = self._resolve_discord_setting(_guild_id, "ignored_channels")
+            if ignored_raw:
+                ignored_channels = self._coerce_channel_set(ignored_raw)
+                if "*" in ignored_channels or (channel_ids & ignored_channels):
+                    logger.debug("[%s] Ignoring message in ignored channel: %s", self.name, channel_ids)
+                    return
 
-            free_channels = self._discord_free_response_channels()
+            free_channels = self._discord_free_response_channels(_guild_id)
             if parent_channel_id:
                 channel_ids.add(parent_channel_id)
 
-            require_mention = self._discord_require_mention()
+            require_mention = self._discord_require_mention(_guild_id)
             # Voice-linked text channels act as free-response while voice is active.
             # Only the exact bound channel gets the exemption, not sibling threads.
             voice_linked_ids = {str(ch_id) for ch_id in self._voice_text_channels.values()}
@@ -4117,10 +4196,14 @@ class DiscordAdapter(BasePlatformAdapter):
         # no_thread_channels: channels where bot responds directly without thread.
         auto_threaded_channel = None
         if not is_thread and not isinstance(message.channel, discord.DMChannel):
-            no_thread_channels_raw = os.getenv("DISCORD_NO_THREAD_CHANNELS", "")
-            no_thread_channels = {ch.strip() for ch in no_thread_channels_raw.split(",") if ch.strip()}
+            no_thread_raw = self._resolve_discord_setting(_guild_id, "no_thread_channels")
+            no_thread_channels = self._coerce_channel_set(no_thread_raw) if no_thread_raw else set()
             skip_thread = bool(channel_ids & no_thread_channels)
-            auto_thread = os.getenv("DISCORD_AUTO_THREAD", "true").lower() in ("true", "1", "yes")
+            auto_thread = self._resolve_discord_setting(_guild_id, "auto_thread", default="true")
+            if isinstance(auto_thread, str):
+                auto_thread = auto_thread.lower() in ("true", "1", "yes")
+            elif not isinstance(auto_thread, bool):
+                auto_thread = bool(auto_thread)
             is_reply_message = getattr(message, "type", None) == discord.MessageType.reply
             if auto_thread and not skip_thread and not is_voice_linked_channel and not is_reply_message:
                 thread = await self._auto_create_thread(message)

--- a/tests/gateway/test_discord_per_guild_config.py
+++ b/tests/gateway/test_discord_per_guild_config.py
@@ -1,0 +1,438 @@
+"""Tests for per-guild/per-server Discord configuration overrides.
+
+Guild-scoped config under ``discord.guilds:<guild_id>:`` allows different
+mention rules, channel lists, and threading behavior per Discord server.
+Resolution priority: per-guild → global config → env var → default.
+"""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+import sys
+
+import pytest
+
+from gateway.config import PlatformConfig
+
+
+def _ensure_discord_mock():
+    """Install a mock discord module when discord.py isn't available."""
+    if "discord" in sys.modules and hasattr(sys.modules["discord"], "__file__"):
+        return
+
+    discord_mod = MagicMock()
+    discord_mod.Intents.default.return_value = MagicMock()
+    discord_mod.Client = MagicMock
+    discord_mod.File = MagicMock
+    discord_mod.DMChannel = type("DMChannel", (), {})
+    discord_mod.Thread = type("Thread", (), {})
+    discord_mod.ForumChannel = type("ForumChannel", (), {})
+    discord_mod.ui = SimpleNamespace(View=object, button=lambda *a, **k: (lambda fn: fn), Button=object)
+    discord_mod.ButtonStyle = SimpleNamespace(success=1, primary=2, secondary=2, danger=3, green=1, grey=2, blurple=2, red=3)
+    discord_mod.Color = SimpleNamespace(orange=lambda: 1, green=lambda: 2, blue=lambda: 3, red=lambda: 4, purple=lambda: 5)
+    discord_mod.Interaction = object
+    discord_mod.Embed = MagicMock
+    discord_mod.app_commands = SimpleNamespace(
+        describe=lambda **kwargs: (lambda fn: fn),
+        choices=lambda **kwargs: (lambda fn: fn),
+        Choice=lambda **kwargs: SimpleNamespace(**kwargs),
+    )
+
+    ext_mod = MagicMock()
+    commands_mod = MagicMock()
+    commands_mod.Bot = MagicMock
+    ext_mod.commands = commands_mod
+
+    sys.modules.setdefault("discord", discord_mod)
+    sys.modules.setdefault("discord.ext", ext_mod)
+    sys.modules.setdefault("discord.ext.commands", commands_mod)
+
+
+_ensure_discord_mock()
+
+import gateway.platforms.discord as discord_platform  # noqa: E402
+from gateway.platforms.discord import DiscordAdapter  # noqa: E402
+
+
+class FakeDMChannel:
+    def __init__(self, channel_id: int = 1, name: str = "dm"):
+        self.id = channel_id
+        self.name = name
+
+
+class FakeGuild:
+    def __init__(self, guild_id: int = 100, name: str = "Guild 100"):
+        self.id = guild_id
+        self.name = name
+
+
+class FakeTextChannel:
+    def __init__(self, channel_id: int = 1, name: str = "general", guild_name: str = "Hermes Server", guild_id: int = 100):
+        self.id = channel_id
+        self.name = name
+        self.guild = FakeGuild(guild_id=guild_id, name=guild_name)
+        self.topic = None
+
+
+class FakeForumChannel:
+    def __init__(self, channel_id: int = 1, name: str = "support-forum", guild_name: str = "Hermes Server", guild_id: int = 100):
+        self.id = channel_id
+        self.name = name
+        self.guild = FakeGuild(guild_id=guild_id, name=guild_name)
+        self.type = 15
+        self.topic = None
+
+
+class FakeThread:
+    def __init__(self, channel_id: int = 1, name: str = "thread", parent=None, guild_name: str = "Hermes Server", guild_id: int = 100):
+        self.id = channel_id
+        self.name = name
+        self.parent = parent
+        self.parent_id = getattr(parent, "id", None)
+        self.guild = getattr(parent, "guild", None) or FakeGuild(guild_id=guild_id, name=guild_name)
+        self.topic = None
+
+
+@pytest.fixture
+def adapter(monkeypatch):
+    monkeypatch.setattr(discord_platform.discord, "DMChannel", FakeDMChannel, raising=False)
+    monkeypatch.setattr(discord_platform.discord, "Thread", FakeThread, raising=False)
+    monkeypatch.setattr(discord_platform.discord, "ForumChannel", FakeForumChannel, raising=False)
+
+    config = PlatformConfig(enabled=True, token="fake-token")
+    adapter = DiscordAdapter(config)
+    adapter._client = SimpleNamespace(user=SimpleNamespace(id=999))
+    adapter._text_batch_delay_seconds = 0  # disable batching for tests
+    adapter.handle_message = AsyncMock()
+    return adapter
+
+
+def make_message(*, channel, content: str, mentions=None, msg_type=None):
+    author = SimpleNamespace(id=42, display_name="Jezza", name="Jezza")
+    guild = getattr(channel, "guild", None)
+    return SimpleNamespace(
+        id=123,
+        content=content,
+        mentions=list(mentions or []),
+        attachments=[],
+        reference=None,
+        created_at=datetime.now(timezone.utc),
+        channel=channel,
+        author=author,
+        guild=guild,
+        type=msg_type if msg_type is not None else discord_platform.discord.MessageType.default,
+    )
+
+
+# ---------------------------------------------------------------------------
+# _discord_guild_config
+# ---------------------------------------------------------------------------
+
+def test_guild_config_returns_entry(adapter):
+    adapter.config.extra["guilds"] = {
+        "100": {"require_mention": False},
+    }
+    assert adapter._discord_guild_config("100") == {"require_mention": False}
+
+
+def test_guild_config_returns_empty_for_unknown(adapter):
+    adapter.config.extra["guilds"] = {"100": {"require_mention": False}}
+    assert adapter._discord_guild_config("999") == {}
+
+
+def test_guild_config_returns_empty_for_none(adapter):
+    adapter.config.extra["guilds"] = None
+    assert adapter._discord_guild_config("100") == {}
+
+
+def test_guild_config_returns_empty_for_missing_key(adapter):
+    assert adapter._discord_guild_config("100") == {}
+
+
+def test_guild_config_returns_empty_for_dm(adapter):
+    adapter.config.extra["guilds"] = {"100": {"require_mention": False}}
+    assert adapter._discord_guild_config(None) == {}
+
+
+# ---------------------------------------------------------------------------
+# _resolve_discord_setting – priority chain
+# ---------------------------------------------------------------------------
+
+def test_resolve_setting_per_guild_wins(adapter):
+    adapter.config.extra["guilds"] = {"100": {"require_mention": False}}
+    adapter.config.extra["require_mention"] = True  # global
+    assert adapter._resolve_discord_setting("100", "require_mention") is False
+
+
+def test_resolve_setting_falls_back_to_global(adapter):
+    adapter.config.extra["require_mention"] = False
+    assert adapter._resolve_discord_setting("100", "require_mention") is False
+
+
+def test_resolve_setting_falls_back_to_env(adapter, monkeypatch):
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    adapter.config.extra["guilds"] = {}
+    adapter.config.extra.pop("free_response_channels", None)
+    monkeypatch.setenv("DISCORD_FREE_RESPONSE_CHANNELS", "111,222")
+    result = adapter._resolve_discord_setting("100", "free_response_channels")
+    assert result == "111,222"
+
+
+def test_resolve_setting_returns_default(adapter, monkeypatch):
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+    adapter.config.extra.pop("auto_thread", None)
+    adapter.config.extra["guilds"] = {}
+    result = adapter._resolve_discord_setting("100", "auto_thread", default="true")
+    assert result == "true"
+
+
+# ---------------------------------------------------------------------------
+# Per-guild require_mention
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_per_guild_requirement_false_allows_unmentioned(adapter, monkeypatch):
+    """Guild A has require_mention: false → messages pass without @mention."""
+    monkeypatch.delenv("DISCORD_REQUIRE_MENTION", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    adapter.config.extra["require_mention"] = True  # global: require mention
+    adapter.config.extra["guilds"] = {
+        "100": {"require_mention": False},  # Guild 100: no mention needed
+    }
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=1, guild_id=100),
+        content="hello without mention",
+    )
+    await adapter._handle_message(message)
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_per_guild_requirement_true_blocks_unmentioned(adapter, monkeypatch):
+    """Guild B has require_mention: true → messages without mention are ignored."""
+    monkeypatch.delenv("DISCORD_REQUIRE_MENTION", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    adapter.config.extra.pop("require_mention", None)  # no global
+    adapter.config.extra["guilds"] = {
+        "200": {"require_mention": True},  # Guild 200: must mention
+    }
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=1, guild_id=200),
+        content="ignored without mention",
+    )
+    await adapter._handle_message(message)
+    adapter.handle_message.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Per-guild free_response_channels
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_per_guild_free_response_allows_unmentioned(adapter, monkeypatch):
+    """Guild A lists a channel in free_response_channels → mention not required."""
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_REQUIRE_MENTION", raising=False)
+    adapter.config.extra["require_mention"] = True  # global
+    adapter.config.extra["guilds"] = {
+        "100": {"free_response_channels": [42]},  # channel 42 is free in Guild 100
+    }
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=42, guild_id=100),
+        content="free response without mention",
+    )
+    await adapter._handle_message(message)
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_per_guild_free_response_wildcard(adapter, monkeypatch):
+    """Guild A with free_response_channels: '*' → every channel is free."""
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    adapter.config.extra["require_mention"] = True
+    adapter.config.extra["guilds"] = {
+        "100": {"free_response_channels": "*"},
+    }
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=9999, guild_id=100),
+        content="any channel is free",
+    )
+    await adapter._handle_message(message)
+    adapter.handle_message.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Per-guild allowed_channels
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_per_guild_allowed_channels_allows(adapter, monkeypatch):
+    """Guild A has its own allowed_channels whitelist."""
+    monkeypatch.delenv("DISCORD_ALLOWED_CHANNELS", raising=False)
+    adapter.config.extra.pop("allowed_channels", None)
+    adapter.config.extra["guilds"] = {
+        "100": {"allowed_channels": [1]},
+    }
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=1, guild_id=100),
+        content="in allowed channel",
+    )
+    # Need to also pass mention check — set require_mention to False
+    adapter.config.extra["require_mention"] = False
+    await adapter._handle_message(message)
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_per_guild_allowed_channels_blocks(adapter, monkeypatch):
+    """Guild A's allowed_channels blocks a channel not in the list."""
+    monkeypatch.delenv("DISCORD_ALLOWED_CHANNELS", raising=False)
+    adapter.config.extra.pop("allowed_channels", None)
+    adapter.config.extra["guilds"] = {
+        "100": {"allowed_channels": [1]},
+    }
+    adapter.config.extra["require_mention"] = False
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=99, guild_id=100),
+        content="in blocked channel",
+    )
+    await adapter._handle_message(message)
+    adapter.handle_message.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Per-guild ignored_channels
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_per_guild_ignored_channels(adapter, monkeypatch):
+    """Guild A has its own ignored_channels list."""
+    monkeypatch.delenv("DISCORD_IGNORED_CHANNELS", raising=False)
+    adapter.config.extra.pop("ignored_channels", None)
+    adapter.config.extra["guilds"] = {
+        "100": {"ignored_channels": [666]},
+    }
+    adapter.config.extra["require_mention"] = False
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=666, guild_id=100),
+        content="in ignored channel",
+    )
+    await adapter._handle_message(message)
+    adapter.handle_message.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Per-guild auto_thread
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_per_guild_auto_thread_disabled(adapter, monkeypatch):
+    """Guild A has auto_thread: false → no thread creation."""
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+    adapter.config.extra.pop("auto_thread", None)
+    adapter.config.extra["require_mention"] = False
+    adapter.config.extra["guilds"] = {
+        "100": {"auto_thread": False},
+    }
+    adapter._auto_create_thread = AsyncMock()
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=1, guild_id=100),
+        content="no auto thread here",
+    )
+    await adapter._handle_message(message)
+    adapter._auto_create_thread.assert_not_awaited()
+    adapter.handle_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_per_guild_auto_thread_enabled(adapter, monkeypatch):
+    """Guild A has auto_thread: true → thread is created."""
+    monkeypatch.delenv("DISCORD_AUTO_THREAD", raising=False)
+    adapter.config.extra.pop("auto_thread", None)
+    adapter.config.extra["require_mention"] = False
+    adapter.config.extra["guilds"] = {
+        "100": {"auto_thread": True},
+    }
+    fake_thread = FakeThread(channel_id=777, guild_id=100)
+    adapter._auto_create_thread = AsyncMock(return_value=fake_thread)
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=1, guild_id=100),
+        content="create thread please",
+    )
+    await adapter._handle_message(message)
+    adapter._auto_create_thread.assert_awaited_once()
+
+
+# ---------------------------------------------------------------------------
+# Per-guild no_thread_channels
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_per_guild_no_thread_channels(adapter, monkeypatch):
+    """Guild A has its own no_thread_channels list."""
+    monkeypatch.delenv("DISCORD_NO_THREAD_CHANNELS", raising=False)
+    adapter.config.extra.pop("no_thread_channels", None)
+    adapter.config.extra["require_mention"] = False
+    adapter.config.extra["guilds"] = {
+        "100": {"no_thread_channels": [42]},
+    }
+    adapter._auto_create_thread = AsyncMock()
+
+    message = make_message(
+        channel=FakeTextChannel(channel_id=42, guild_id=100),
+        content="no thread here",
+    )
+    await adapter._handle_message(message)
+    adapter._auto_create_thread.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# Cross-guild isolation
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_cross_guild_isolation(adapter, monkeypatch):
+    """Guild A has free_response, Guild B does not — settings don't leak."""
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.delenv("DISCORD_REQUIRE_MENTION", raising=False)
+    adapter.config.extra["require_mention"] = True  # global: require mention
+    adapter.config.extra["guilds"] = {
+        "100": {"free_response_channels": [1]},  # channel 1 is free in Guild 100
+    }
+
+    # Same channel id, but different guild — Guild 200 has no free_response override
+    message = make_message(
+        channel=FakeTextChannel(channel_id=1, guild_id=200),
+        content="not free in guild 200",
+    )
+    await adapter._handle_message(message)
+    adapter.handle_message.assert_not_awaited()
+
+
+# ---------------------------------------------------------------------------
+# _coerce_channel_set helper
+# ---------------------------------------------------------------------------
+
+def test_coerce_channel_set_from_list(adapter):
+    assert adapter._coerce_channel_set([1, 2, 3]) == {"1", "2", "3"}
+
+
+def test_coerce_channel_set_from_str(adapter):
+    assert adapter._coerce_channel_set("1, 2, 3") == {"1", "2", "3"}
+
+
+def test_coerce_channel_set_from_set(adapter):
+    assert adapter._coerce_channel_set({"a", "b"}) == {"a", "b"}
+
+
+def test_coerce_channel_set_from_none(adapter):
+    assert adapter._coerce_channel_set(None) == set()

--- a/website/docs/user-guide/messaging/discord.md
+++ b/website/docs/user-guide/messaging/discord.md
@@ -421,6 +421,46 @@ Behavior:
 - If a message arrives inside a thread or forum post and that thread has no explicit entry, Hermes falls back to the parent channel/forum ID.
 - Prompts are applied ephemerally at runtime, so changing them affects future turns immediately without rewriting past session history.
 
+#### Per-guild configuration (`discord.guilds`)
+
+When the bot is deployed to multiple Discord servers, you can override settings per-guild so each server behaves differently. Settings defined at the guild level take priority over the global `discord.*` values, which in turn take priority over the equivalent `DISCORD_*` environment variable.
+
+```yaml
+discord:
+  require_mention: true           # Global default: require mention everywhere
+  auto_thread: true               # Global default: auto-thread on mention
+
+  guilds:
+    "123456789012345678":         # Server A (guild ID)
+      require_mention: false      # No mention needed — free chat mode
+      auto_thread: false          # Reply inline, no threads
+      free_response_channels: "*" # All channels are free-response
+
+    "987654321098765432":         # Server B (guild ID)
+      require_mention: true       # Must mention the bot
+      allowed_channels:           # Only respond in these channels
+        - 111111111111111111
+        - 222222222222222222
+      no_thread_channels:
+        - 333333333333333333       # Bot replies inline in this channel
+```
+
+**Supported per-guild overrides:**
+
+| Setting | Description |
+|---------|-------------|
+| `require_mention` | Whether @mention is required in server channels |
+| `allowed_channels` | Whitelist of channels where the bot responds |
+| `ignored_channels` | Channels where the bot never responds |
+| `free_response_channels` | Channels where mention is not required |
+| `no_thread_channels` | Channels where bot replies inline (no auto-thread) |
+| `auto_thread` | Whether to auto-create threads on @mention |
+
+**Notes:**
+- Guild IDs must be quoted strings in YAML. Bare numbers can overflow 64-bit integers and get mangled by the YAML parser.
+- Any setting **not** specified in a guild block falls back to the global `discord.*` value, then to the env var. This means you can override just one setting per guild and leave the rest at their defaults.
+- Settings only apply to server channels (not DMs).
+
 #### `group_sessions_per_user`
 
 **Type:** boolean — **Default:** `true`


### PR DESCRIPTION
## Summary

- Per-guild/per-server configuration support for the Discord adapter.
- `require_mention`, `allowed_channels`, `ignored_channels`, `free_response_channels`, `auto_thread`, and `no_thread_channels` can now be configured differently per Discord server.

Fixes #23051

## Changes

- `gateway/config.py` — parse `discord.guilds` into `extra["guilds"]`, normalizing guild ID keys to strings
- `gateway/platforms/discord.py` — add `_resolve_discord_setting` resolver with priority: per-guild → global config → env var → default; rewire all setting read sites including `_handle_message` and `_evaluate_slash_authorization`
- `tests/gateway/test_discord_per_guild_config.py` — 24 tests covering per-guild isolation, priority chain, all six supported settings, and `_coerce_channel_set` helper
- `website/docs/user-guide/messaging/discord.md` — add per-guild config section with YAML examples

## Test Plan

- [x] 339 Discord gateway tests pass (including 24 new)
- [x] 43 config tests pass
- [x] 0 regressions vs existing tests