### PR TITLE
fix(cron): fall back to home channel when cli origin TUI session is dead

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -17,6 +17,7 @@ import os
 import shutil
 import subprocess
 import sys
+import psutil
 
 # fcntl is Unix-only; on Windows use msvcrt for file locking
 try:
@@ -255,6 +256,26 @@ def _iter_home_target_platforms():
         pass
 
 
+def _has_active_tui_session() -> bool:
+    """Return True if a TUI process (ui-tui/dist/entry.js) is currently running.
+
+    Uses psutil for cross-platform process enumeration. Returns True on any
+    error so that delivery behaviour degrades gracefully rather than
+    incorrectly dropping cli-origin jobs.
+    """
+    try:
+        for proc in psutil.process_iter(["cmdline"]):
+            try:
+                cmdline = proc.info.get("cmdline") or []
+                if any("ui-tui/dist/entry.js" in arg for arg in cmdline):
+                    return True
+            except (psutil.NoSuchProcess, psutil.AccessDenied):
+                pass
+        return False
+    except Exception:
+        return True
+
+
 def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[dict]:
     """Resolve one concrete auto-delivery target for a cron job."""
 
@@ -265,18 +286,26 @@ def _resolve_single_delivery_target(job: dict, deliver_value: str) -> Optional[d
 
     if deliver_value == "origin":
         if origin:
-            return {
-                "platform": origin["platform"],
-                "chat_id": str(origin["chat_id"]),
-                "thread_id": origin.get("thread_id"),
-            }
-        # Origin missing (e.g. job created via API/script) — try each
-        # platform's home channel as a fallback instead of silently dropping.
+            if origin.get("platform") == "cli" and not _has_active_tui_session():
+                # TUI session is dead — fall through to home-channel fallback
+                logger.info(
+                    "Job '%s' has deliver=origin with cli platform but no active TUI session;"
+                    " falling back to home channel",
+                    job.get("name", job.get("id", "?")),
+                )
+            else:
+                return {
+                    "platform": origin["platform"],
+                    "chat_id": str(origin["chat_id"]),
+                    "thread_id": origin.get("thread_id"),
+                }
+        # Origin missing or cli origin with dead TUI — try each platform's
+        # home channel as a fallback instead of silently dropping.
         for platform_name in _iter_home_target_platforms():
             chat_id = _get_home_target_chat_id(platform_name)
             if chat_id:
                 logger.info(
-                    "Job '%s' has deliver=origin but no origin; falling back to %s home channel",
+                    "Job '%s' has deliver=origin but no reachable origin; falling back to %s home channel",
                     job.get("name", job.get("id", "?")),
                     platform_name,
                 )

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -7,7 +7,17 @@ from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
 
-from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt
+from cron.scheduler import (
+    _resolve_origin,
+    _resolve_delivery_target,
+    _resolve_single_delivery_target,
+    _has_active_tui_session,
+    _deliver_result,
+    _send_media_via_adapter,
+    run_job,
+    SILENT_MARKER,
+    _build_job_prompt,
+)
 from tools.env_passthrough import clear_env_passthrough
 from tools.credential_files import clear_credential_files
 
@@ -2386,3 +2396,85 @@ class TestSendMediaTimeoutCancelsFuture:
         # 2. Second file still got dispatched — one timeout doesn't abort the batch
         adapter.send_video.assert_called_once()
         assert adapter.send_video.call_args[1]["video_path"] == "/tmp/fast.mp4"
+
+
+class TestCliOriginTuiLivenessFallback:
+    """Tests for deliver=origin with cli platform and TUI liveness check."""
+
+    def test_has_active_tui_session_returns_bool(self):
+        """_has_active_tui_session() must always return a bool."""
+        result = _has_active_tui_session()
+        assert isinstance(result, bool)
+
+    def test_has_active_tui_session_true_when_tui_process_running(self):
+        """Returns True when a process with ui-tui/dist/entry.js in cmdline exists."""
+        fake_proc = MagicMock()
+        fake_proc.info = {"cmdline": ["node", "/home/user/ui-tui/dist/entry.js", "--port", "3000"]}
+        with patch("psutil.process_iter", return_value=[fake_proc]):
+            assert _has_active_tui_session() is True
+
+    def test_has_active_tui_session_false_when_no_tui_process(self):
+        """Returns False when no process with ui-tui/dist/entry.js in cmdline exists."""
+        fake_proc = MagicMock()
+        fake_proc.info = {"cmdline": ["node", "/home/user/other-app/dist/entry.js"]}
+        with patch("psutil.process_iter", return_value=[fake_proc]):
+            assert _has_active_tui_session() is False
+
+    def test_cli_origin_used_when_tui_alive(self):
+        """When TUI is alive, cli origin is returned as-is."""
+        job = {
+            "deliver": "origin",
+            "origin": {"platform": "cli", "chat_id": "local"},
+        }
+        with patch("cron.scheduler._has_active_tui_session", return_value=True):
+            result = _resolve_single_delivery_target(job, "origin")
+        assert result == {"platform": "cli", "chat_id": "local", "thread_id": None}
+
+    def test_cli_origin_falls_back_to_home_channel_when_tui_dead(self, monkeypatch):
+        """When TUI is dead, cli origin is skipped and home channel is used."""
+        job = {
+            "deliver": "origin",
+            "origin": {"platform": "cli", "chat_id": "local"},
+        }
+        for env_var in (
+            "MATRIX_HOME_ROOM", "MATRIX_HOME_CHANNEL", "TELEGRAM_HOME_CHANNEL",
+            "DISCORD_HOME_CHANNEL", "SLACK_HOME_CHANNEL", "SIGNAL_HOME_CHANNEL",
+            "MATTERMOST_HOME_CHANNEL", "SMS_HOME_CHANNEL", "EMAIL_HOME_ADDRESS",
+            "DINGTALK_HOME_CHANNEL", "BLUEBUBBLES_HOME_CHANNEL", "FEISHU_HOME_CHANNEL",
+            "WECOM_HOME_CHANNEL", "WEIXIN_HOME_CHANNEL", "QQ_HOME_CHANNEL",
+        ):
+            monkeypatch.delenv(env_var, raising=False)
+        monkeypatch.setenv("TELEGRAM_HOME_CHANNEL", "987654")
+        with patch("cron.scheduler._has_active_tui_session", return_value=False):
+            result = _resolve_single_delivery_target(job, "origin")
+        assert result == {"platform": "telegram", "chat_id": "987654", "thread_id": None}
+
+    def test_cli_origin_falls_back_to_none_when_tui_dead_and_no_home_channels(
+        self, monkeypatch
+    ):
+        """When TUI is dead and no home channels configured, returns None."""
+        job = {
+            "deliver": "origin",
+            "origin": {"platform": "cli", "chat_id": "local"},
+        }
+        for env_var in (
+            "MATRIX_HOME_ROOM", "MATRIX_HOME_CHANNEL", "TELEGRAM_HOME_CHANNEL",
+            "DISCORD_HOME_CHANNEL", "SLACK_HOME_CHANNEL", "SIGNAL_HOME_CHANNEL",
+            "MATTERMOST_HOME_CHANNEL", "SMS_HOME_CHANNEL", "EMAIL_HOME_ADDRESS",
+            "DINGTALK_HOME_CHANNEL", "BLUEBUBBLES_HOME_CHANNEL", "FEISHU_HOME_CHANNEL",
+            "WECOM_HOME_CHANNEL", "WEIXIN_HOME_CHANNEL", "QQ_HOME_CHANNEL",
+        ):
+            monkeypatch.delenv(env_var, raising=False)
+        with patch("cron.scheduler._has_active_tui_session", return_value=False):
+            result = _resolve_single_delivery_target(job, "origin")
+        assert result is None
+
+    def test_non_cli_origin_not_affected_by_tui_check(self):
+        """TUI liveness check only applies to cli platform; telegram origin is unaffected."""
+        job = {
+            "deliver": "origin",
+            "origin": {"platform": "telegram", "chat_id": "111222"},
+        }
+        with patch("cron.scheduler._has_active_tui_session", return_value=False):
+            result = _resolve_single_delivery_target(job, "origin")
+        assert result == {"platform": "telegram", "chat_id": "111222", "thread_id": None}


### PR DESCRIPTION
## Summary

- When a cron job has `deliver=origin` with `origin.platform=cli` but no active TUI session is running, the output is no longer silently dropped. Instead, it falls back to the configured home channel.
- Uses `psutil` (existing dependency) for cross-platform process detection — no POSIX-only `pgrep`/`ps` commands.

Fixes #22795

## Changes

- `cron/scheduler.py` — add `_has_active_tui_session()` helper using `psutil.process_iter`; update `_resolve_single_delivery_target` to check TUI liveness for `cli` origin and fall through to home-channel fallback when dead
- `tests/cron/test_scheduler.py` — add 7 tests in `TestCliOriginTuiLivenessFallback` covering: bool return type, psutil detection logic, cli origin alive/dead fallback, no-home-channel edge case, non-cli platform unaffected

## Test Plan

- [x] All 128 tests in `tests/cron/test_scheduler.py` pass
- [x] 7 new `TestCliOriginTuiLivenessFallback` tests pass
- [x] Windows footgun linter passes cleanly (`scripts/check-windows-footguns.py cron/scheduler.py`)