### PR TITLE
fix(gateway): clean up Discord typing tasks on teardown

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -870,6 +870,8 @@ class DiscordAdapter(BasePlatformAdapter):
 
     async def disconnect(self) -> None:
         """Disconnect from Discord."""
+        await self._cancel_typing_tasks(reason="disconnect")
+
         # Clean up all active voice connections before closing the client
         for guild_id in list(self._voice_clients.keys()):
             try:
@@ -898,6 +900,43 @@ class DiscordAdapter(BasePlatformAdapter):
         self._release_platform_lock()
 
         logger.info("[%s] Disconnected", self.name)
+
+    async def cancel_background_tasks(self) -> None:
+        """Cancel Discord-specific background loops plus base tasks."""
+        await self._cancel_typing_tasks(reason="shutdown")
+        await super().cancel_background_tasks()
+
+    async def _cancel_typing_tasks(self, reason: str = "cleanup") -> None:
+        """Cancel all persistent typing loops owned by this adapter.
+
+        Discord keeps typing indicators alive with per-channel background tasks.
+        Those tasks are not part of BasePlatformAdapter's message-processing
+        task registry, so shutdown/restart must drain them explicitly.
+        """
+        tasks = [(chat_id, task) for chat_id, task in self._typing_tasks.items()]
+        if not tasks:
+            return
+
+        self._typing_tasks.clear()
+        live_tasks = [task for _, task in tasks if not task.done()]
+        for task in live_tasks:
+            task.cancel()
+
+        if live_tasks:
+            try:
+                await asyncio.wait_for(
+                    asyncio.gather(*live_tasks, return_exceptions=True),
+                    timeout=2.0,
+                )
+            except asyncio.TimeoutError:
+                logger.warning(
+                    "[%s] %d Discord typing task(s) did not exit within 2s during %s",
+                    self.name,
+                    len([task for task in live_tasks if not task.done()]),
+                    reason,
+                )
+
+        logger.debug("[%s] Cleared %d Discord typing task(s) during %s", self.name, len(tasks), reason)
 
     def _command_sync_state_path(self) -> _Path:
         from hermes_constants import get_hermes_home


### PR DESCRIPTION
## Summary

Fixes a Discord gateway teardown leak where typing indicator background tasks could survive `disconnect()` / `cancel_background_tasks()`, interfering with clean shutdown during gateway restarts or profile switches.

## Changes

- Track and clear Discord typing indicator tasks during adapter teardown.
- Ensure `disconnect()` cancels typing tasks before shutting down.
- Ensure `cancel_background_tasks()` clears Discord typing tasks before delegating to the base cleanup path.

## Validation

- `python -m py_compile gateway/platforms/discord.py`
- Local full test run was checked; unrelated pre-existing failures remain outside this PR scope.

## Notes

This PR is intentionally scoped to `gateway/platforms/discord.py` only.
