### PR TITLE
fix(model-picker): use live Copilot catalog in /model

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1235,13 +1235,20 @@ def list_authenticated_providers(
         if not has_creds:
             continue
 
-        # Use curated list, falling back to models.dev if no curated list.
-        # For preferred providers, merge models.dev entries into the curated
-        # catalog so newly released models (e.g. mimo-v2.5-pro on opencode-go)
-        # show up in the picker without requiring a Hermes release.
-        model_ids = curated.get(hermes_id, [])
-        if hermes_id in _MODELS_DEV_PREFERRED:
-            model_ids = _merge_with_models_dev(hermes_id, model_ids)
+        # GitHub-backed providers need the live catalog here as well.
+        # Otherwise section 1 consumes the provider first and section 2 never
+        # gets a chance to replace the static curated list with the live one.
+        if hermes_id in {"copilot", "copilot-acp"}:
+            model_ids = provider_model_ids(hermes_id)
+        else:
+            # Use curated list, falling back to models.dev if no curated list.
+            # For preferred providers, merge models.dev entries into the
+            # curated catalog so newly released models (e.g. mimo-v2.5-pro on
+            # opencode-go) show up in the picker without requiring a Hermes
+            # release.
+            model_ids = curated.get(hermes_id, [])
+            if hermes_id in _MODELS_DEV_PREFERRED:
+                model_ids = _merge_with_models_dev(hermes_id, model_ids)
         total = len(model_ids)
         top = model_ids[:max_models]
 


### PR DESCRIPTION
## What does this PR do?

Fixes the `/model` provider picker so GitHub Copilot entries use the live catalog when credentials are available, instead of getting stuck on the static curated list during `list_authenticated_providers()`.

The root cause is that section 1 of `list_authenticated_providers()` consumes `copilot` / `copilot-acp` before section 2 can replace the curated models with `provider_model_ids(...)`. This change applies the live-catalog path in section 1 as well, while still preserving the existing fallback behavior inside `provider_model_ids()`.

## Related Issue

Fixes #22990

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `hermes_cli/model_switch.py` so `copilot` and `copilot-acp` use `provider_model_ids(...)` in section 1 of `list_authenticated_providers()`.
- Kept the existing curated fallback behavior by relying on `provider_model_ids(...)` to fall back when the live GitHub catalog is unavailable.
- Verified the existing Copilot picker regression tests now pass against this path.

## How to Test

1. Run `uv run --frozen pytest -q -o addopts='' tests/hermes_cli/test_copilot_in_model_list.py`
2. Run `uv run --frozen ruff check hermes_cli/model_switch.py tests/hermes_cli/test_copilot_in_model_list.py`
3. With GitHub Copilot credentials available, open the `/model` picker and confirm the Copilot entry reflects the live catalog instead of only the static curated list.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `uv run --frozen pytest -q -o addopts='' tests/hermes_cli/test_copilot_in_model_list.py` -> `2 passed`
- `env -i ... UV_PYTHON=3.11 uv run --frozen --extra all pytest tests/ --collect-only -q -o addopts=''` -> `21827 tests collected`
