### PR TITLE
fix(discord): add thread_require_mention config option to gate in-thr…

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -823,6 +823,8 @@ def load_gateway_config() -> GatewayConfig:
             if isinstance(discord_cfg, dict):
                 if "require_mention" in discord_cfg and not os.getenv("DISCORD_REQUIRE_MENTION"):
                     os.environ["DISCORD_REQUIRE_MENTION"] = str(discord_cfg["require_mention"]).lower()
+                if "thread_require_mention" in discord_cfg and not os.getenv("DISCORD_THREAD_REQUIRE_MENTION"):
+                    os.environ["DISCORD_THREAD_REQUIRE_MENTION"] = str(discord_cfg["thread_require_mention"]).lower()
                 frc = discord_cfg.get("free_response_channels")
                 if frc is not None and not os.getenv("DISCORD_FREE_RESPONSE_CHANNELS"):
                     if isinstance(frc, list):

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3528,6 +3528,15 @@ class DiscordAdapter(BasePlatformAdapter):
             return bool(configured)
         return os.getenv("DISCORD_REQUIRE_MENTION", "true").lower() not in ("false", "0", "no", "off")
 
+    def _discord_thread_require_mention(self) -> bool:
+        """Return whether threads where the bot participated require a mention."""
+        configured = self.config.extra.get("thread_require_mention")
+        if configured is not None:
+            if isinstance(configured, str):
+                return configured.lower() not in ("false", "0", "no", "off")
+            return bool(configured)
+        return os.getenv("DISCORD_THREAD_REQUIRE_MENTION", "false").lower() not in ("false", "0", "no", "off")
+
     def _discord_free_response_channels(self) -> set:
         """Return Discord channel IDs where no bot mention is required.
 
@@ -4107,8 +4116,9 @@ class DiscordAdapter(BasePlatformAdapter):
             # Skip the mention check if the message is in a thread where
             # the bot has previously participated (auto-created or replied in).
             in_bot_thread = is_thread and thread_id in self._threads
+            thread_require_mention = self._discord_thread_require_mention()
 
-            if require_mention and not is_free_channel and not in_bot_thread:
+            if require_mention and not is_free_channel and not (in_bot_thread and not thread_require_mention):
                 if self._client.user not in message.mentions and not mention_prefix:
                     return
         # Auto-thread: when enabled, automatically create a thread for every

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -422,6 +422,37 @@ async def test_discord_thread_participation_tracked_on_dispatch(adapter, monkeyp
     assert "777" in adapter._threads
 
 
+def test_thread_require_mention_defaults_to_false(adapter):
+    """thread_require_mention should default to False (existing behavior)."""
+    result = adapter._discord_thread_require_mention()
+    assert result is False
+
+
+def test_thread_require_mention_is_true_via_env(adapter, monkeypatch):
+    """thread_require_mention should return True when env var is set."""
+    monkeypatch.setenv("DISCORD_THREAD_REQUIRE_MENTION", "true")
+    result = adapter._discord_thread_require_mention()
+    assert result is True
+
+
+@pytest.mark.asyncio
+async def test_discord_bot_thread_with_thread_require_mention_respects_mention(adapter, monkeypatch):
+    """When thread_require_mention=true, messages in bot threads require @mention."""
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_THREAD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+
+    adapter._threads.mark("456")
+
+    thread = FakeThread(channel_id=456, name="existing thread")
+    message = make_message(channel=thread, content="follow-up without mention")
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+
+
 @pytest.mark.asyncio
 async def test_discord_voice_linked_channel_skips_mention_requirement_and_auto_thread(adapter, monkeypatch):
     """Active voice-linked text channels should behave like free-response channels."""


### PR DESCRIPTION
fix(discord): add thread_require_mention config to gate in-thread responses

Add `discord.thread_require_mention` config option. When set to `true`,
the bot requires @mention to respond even in threads where it previously
participated. Defaults to `false` (existing behavior unchanged).

Closes #23084
