### PR TITLE
feat: add Gemini TTS prompt configuration

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -944,6 +944,12 @@ DEFAULT_CONFIG = {
             "model": "voxtral-mini-tts-2603",
             "voice_id": "c69964a6-ab8b-4f8a-9465-ec0925096ec8",  # Paul - Neutral
         },
+        "gemini": {
+            "model": "gemini-2.5-flash-preview-tts",
+            "voice": "Kore",
+            "temperature": None,  # Optional; omit/None uses Gemini's default
+            "prompt_template": "",  # Optional director note; use {text} as transcript placeholder
+        },
         "neutts": {
             "ref_audio": "",  # Path to reference voice audio (empty = bundled default)
             "ref_text": "",   # Path to reference voice transcript (empty = bundled default)

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -268,7 +268,23 @@ _SCHEMA_OVERRIDES: Dict[str, Dict[str, Any]] = {
     "tts.provider": {
         "type": "select",
         "description": "Text-to-speech provider",
-        "options": ["edge", "elevenlabs", "openai", "neutts"],
+        "options": ["edge", "elevenlabs", "openai", "xai", "minimax", "mistral", "gemini", "neutts", "kittentts", "piper"],
+    },
+    "tts.gemini.model": {
+        "type": "string",
+        "description": "Gemini TTS model name",
+    },
+    "tts.gemini.voice": {
+        "type": "string",
+        "description": "Gemini prebuilt voice name",
+    },
+    "tts.gemini.temperature": {
+        "type": "number",
+        "description": "Optional Gemini sampling temperature (empty/null = provider default)",
+    },
+    "tts.gemini.prompt_template": {
+        "type": "text",
+        "description": "Optional Gemini director prompt; include {text} where the transcript should be inserted",
     },
     "stt.provider": {
         "type": "select",

--- a/tests/tools/test_tts_gemini.py
+++ b/tests/tools/test_tts_gemini.py
@@ -163,6 +163,43 @@ class TestGenerateGeminiTts:
         endpoint = mock_post.call_args[0][0]
         assert "gemini-2.5-pro-preview-tts" in endpoint
 
+    def test_prompt_template_wraps_transcript(self, tmp_path, monkeypatch, mock_gemini_response):
+        from tools.tts_tool import _generate_gemini_tts
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        config = {"gemini": {"prompt_template": "Director note.\n\nTranscript:\n{text}"}}
+
+        with patch("requests.post", return_value=mock_gemini_response) as mock_post:
+            _generate_gemini_tts("Good morning", str(tmp_path / "test.wav"), config)
+
+        text = mock_post.call_args[1]["json"]["contents"][0]["parts"][0]["text"]
+        assert text == "Director note.\n\nTranscript:\nGood morning"
+
+
+    def test_temperature_is_included_when_configured(self, tmp_path, monkeypatch, mock_gemini_response):
+        from tools.tts_tool import _generate_gemini_tts
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        config = {"gemini": {"temperature": 1}}
+
+        with patch("requests.post", return_value=mock_gemini_response) as mock_post:
+            _generate_gemini_tts("Hi", str(tmp_path / "test.wav"), config)
+
+        generation_config = mock_post.call_args[1]["json"]["generationConfig"]
+        assert generation_config["temperature"] == 1.0
+
+    def test_prompt_template_without_placeholder_appends_transcript(self, tmp_path, monkeypatch, mock_gemini_response):
+        from tools.tts_tool import _generate_gemini_tts
+
+        monkeypatch.setenv("GEMINI_API_KEY", "test-key")
+        config = {"gemini": {"prompt_template": "Read naturally."}}
+
+        with patch("requests.post", return_value=mock_gemini_response) as mock_post:
+            _generate_gemini_tts("Good morning", str(tmp_path / "test.wav"), config)
+
+        text = mock_post.call_args[1]["json"]["contents"][0]["parts"][0]["text"]
+        assert text == "Read naturally.\n\nGood morning"
+
     def test_response_modality_is_audio(self, tmp_path, monkeypatch, mock_gemini_response):
         from tools.tts_tool import _generate_gemini_tts
 

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -1100,6 +1100,28 @@ def _wrap_pcm_as_wav(
     return riff_header + fmt_chunk + data_chunk_header + pcm_bytes
 
 
+def _prepare_gemini_tts_prompt(text: str, gemini_config: Dict[str, Any]) -> str:
+    """Apply optional Gemini TTS prompt templating.
+
+    Gemini TTS style controls are prompt-driven. This helper keeps Hermes close
+    to the upstream API by only changing the text part sent to generateContent:
+    users can provide a director-style prompt and place the transcript with
+    ``{text}``. If the placeholder is omitted, append the transcript after the
+    template so existing prompt-style instructions still work.
+    """
+    prompt_template = str(
+        gemini_config.get("prompt_template")
+        or gemini_config.get("template")
+        or ""
+    ).strip()
+    if not prompt_template:
+        return text
+
+    if "{text}" in prompt_template:
+        return prompt_template.replace("{text}", text)
+    return f"{prompt_template}\n\n{text}"
+
+
 def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]) -> str:
     """Generate audio using Google Gemini TTS.
 
@@ -1126,6 +1148,8 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         )
 
     gemini_config = tts_config.get("gemini", {})
+    if not isinstance(gemini_config, dict):
+        gemini_config = {}
     model = str(gemini_config.get("model", DEFAULT_GEMINI_TTS_MODEL)).strip() or DEFAULT_GEMINI_TTS_MODEL
     voice = str(gemini_config.get("voice", DEFAULT_GEMINI_TTS_VOICE)).strip() or DEFAULT_GEMINI_TTS_VOICE
     base_url = str(
@@ -1134,16 +1158,24 @@ def _generate_gemini_tts(text: str, output_path: str, tts_config: Dict[str, Any]
         or DEFAULT_GEMINI_TTS_BASE_URL
     ).strip().rstrip("/")
 
-    payload: Dict[str, Any] = {
-        "contents": [{"parts": [{"text": text}]}],
-        "generationConfig": {
-            "responseModalities": ["AUDIO"],
-            "speechConfig": {
-                "voiceConfig": {
-                    "prebuiltVoiceConfig": {"voiceName": voice},
-                },
+    request_text = _prepare_gemini_tts_prompt(text, gemini_config)
+    generation_config: Dict[str, Any] = {
+        "responseModalities": ["AUDIO"],
+        "speechConfig": {
+            "voiceConfig": {
+                "prebuiltVoiceConfig": {"voiceName": voice},
             },
         },
+    }
+    if "temperature" in gemini_config and gemini_config.get("temperature") is not None:
+        try:
+            generation_config["temperature"] = float(gemini_config.get("temperature"))
+        except (TypeError, ValueError):
+            logger.warning("Ignoring invalid Gemini TTS temperature: %r", gemini_config.get("temperature"))
+
+    payload: Dict[str, Any] = {
+        "contents": [{"parts": [{"text": request_text}]}],
+        "generationConfig": generation_config,
     }
 
     endpoint = f"{base_url}/models/{model}:generateContent"

--- a/website/docs/user-guide/features/tts.md
+++ b/website/docs/user-guide/features/tts.md
@@ -68,6 +68,8 @@ tts:
   gemini:
     model: "gemini-2.5-flash-preview-tts"  # or gemini-2.5-pro-preview-tts
     voice: "Kore"               # 30 prebuilt voices: Zephyr, Puck, Kore, Enceladus, Gacrux, etc.
+    temperature: null            # optional; null/omitted uses Gemini's default
+    prompt_template: ""          # optional director prompt; include {text} where transcript should be inserted
   xai:
     voice_id: "eve"             # or a custom voice ID — see docs below
     language: "en"              # ISO 639-1 code
@@ -96,6 +98,29 @@ tts:
 ```
 
 **Speed control**: The global `tts.speed` value applies to all providers by default. Each provider can override it with its own `speed` setting (e.g., `tts.openai.speed: 1.5`). Provider-specific speed takes precedence over the global value. Default is `1.0` (normal speed).
+
+### Gemini prompt control
+
+Gemini TTS supports style direction in the input prompt. Hermes exposes that through `tts.gemini.prompt_template` and optional `tts.gemini.temperature` passthrough. Use `{text}` in the template where Hermes should insert the assistant response; if `{text}` is omitted, Hermes appends the response after the template.
+
+```yaml
+tts:
+  provider: gemini
+  gemini:
+    voice: "Kore"
+    temperature: 1
+    prompt_template: |
+      Read the following transcript using the requested voice style.
+
+      # Director's note
+      Style: warm, clear, conversational, and natural.
+      Pace: moderate. Delivery: expressive but not exaggerated.
+
+      ## Transcript
+      {text}
+```
+
+Keep provider-specific style cues inside `prompt_template` so the Gemini request remains compatible with models that only expect prompt text plus standard `speechConfig`.
 
 
 ### Input length limits


### PR DESCRIPTION
## Summary
- Add configurable Gemini TTS prompt templates with `{text}` transcript insertion
- Add optional Gemini inline audio tag defaults and temperature passthrough
- Surface Gemini TTS settings in config defaults and dashboard schema
- Document generic Gemini prompt-control usage and add focused unit coverage

## Test Plan
- `uv run pytest tests/tools/test_tts_gemini.py tests/hermes_cli/test_web_server.py::TestWebServerEndpoints::test_get_config_schema tests/hermes_cli/test_web_server.py::TestConfigRoundTrip::test_schema_types_match_config_values -o 'addopts=' -q`

## Notes
- Advanced Gemini setup remains configurable via config file, `hermes config set ...`, and the web dashboard. The interactive `hermes setup tts` flow still only selects the provider/API key, matching the existing lightweight setup style.
