### PR TITLE
[security] fix(dashboard): require auth for plugin API routes

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -225,7 +225,7 @@ async def host_header_middleware(request: Request, call_next):
 async def auth_middleware(request: Request, call_next):
     """Require the session token on all /api/ routes except the public list."""
     path = request.url.path
-    if path.startswith("/api/") and path not in _PUBLIC_API_PATHS and not path.startswith("/api/plugins/"):
+    if path.startswith("/api/") and path not in _PUBLIC_API_PATHS:
         if not _has_valid_session_token(request):
             return JSONResponse(
                 status_code=401,

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -125,6 +125,21 @@ class TestWebServerEndpoints:
         assert "hermes_home" in data
         assert "active_sessions" in data
 
+    def test_plugin_api_routes_require_session_token(self):
+        from hermes_cli.web_server import _SESSION_HEADER_NAME
+
+        self.client.headers.pop(_SESSION_HEADER_NAME, None)
+
+        resp = self.client.get("/api/plugins/kanban/boards")
+
+        assert resp.status_code == 401
+
+    def test_plugin_api_routes_accept_valid_session_token(self):
+        resp = self.client.get("/api/plugins/kanban/boards")
+
+        assert resp.status_code == 200
+        assert "boards" in resp.json()
+
     def test_get_status_filters_unconfigured_gateway_platforms(self, monkeypatch):
         import gateway.config as gateway_config
         import hermes_cli.web_server as web_server


### PR DESCRIPTION
## Summary

This PR requires the dashboard session token for backend plugin API routes under `/api/plugins/*`.

Current dashboard auth protects most `/api/*` routes, but explicitly excludes `/api/plugins/*`. Dashboard plugins can mount backend FastAPI routers under that prefix; the bundled Kanban plugin exposes mutating task APIs and a dispatch endpoint there. When the dashboard is reachable by an untrusted client, that carve-out allows unauthenticated requests to create Kanban tasks and trigger dispatch into local Hermes worker execution.

This patch removes the plugin-route exemption and adds regression coverage for the Kanban plugin API path.

## Security issues covered

| Issue | Severity | Status |
| --- | --- | --- |
| Dashboard plugin API routes bypass the dashboard session-token check | Critical for exposed dashboards; otherwise local/dashboard hardening | Fixed |

## Before this PR

- `auth_middleware()` required the dashboard session token for most `/api/*` routes.
- The same middleware skipped any path starting with `/api/plugins/`.
- Plugin API routers mounted by `_mount_plugin_api_routes()` were therefore reachable without `X-Hermes-Session-Token`.
- The Kanban plugin exposed mutating routes such as task creation and dispatch below `/api/plugins/kanban/*`.

## After this PR

- All non-public `/api/*` routes, including `/api/plugins/*`, require the dashboard session token.
- Plugin static assets under `/dashboard-plugins/*` are unchanged.
- Regression tests verify that `/api/plugins/kanban/boards` returns `401` without a session token and still works with a valid token.

## Why this matters

Dashboard plugin APIs run in the Hermes dashboard backend and can expose sensitive operations. The bundled Kanban plugin can create tasks and call the dispatcher. If these routes are reachable without the dashboard token, an attacker with network access to the dashboard can cross from unauthenticated HTTP into local Hermes control-plane actions.

For deployments that bind or proxy the dashboard beyond loopback, this can become an unauthenticated remote path to starting local Hermes worker runs from attacker-controlled Kanban task content.

## How this differs from related issue/PR

This patch addresses the same trust boundary discussed in:

- #19533
- #19541
- #20618

It keeps the fix intentionally minimal: remove the `/api/plugins/` authentication exemption and add focused regression coverage for a bundled plugin API route. It does not change plugin discovery, plugin static asset serving, or the Kanban dispatcher behavior itself.

## Attack flow

1. The dashboard is reachable by an untrusted HTTP client.
2. The attacker calls a backend plugin API route under `/api/plugins/*` without `X-Hermes-Session-Token`.
3. The auth middleware skips the plugin route because of the `/api/plugins/` exemption.
4. For the Kanban plugin, the attacker can create or mutate Kanban tasks and call the dispatch endpoint.
5. The dispatcher can claim ready assigned tasks and start Hermes worker subprocesses for those tasks.

## Affected code

- `hermes_cli/web_server.py`
  - `auth_middleware()`
  - `_mount_plugin_api_routes()` mounts plugin routers under `/api/plugins/<name>`.
- `plugins/kanban/dashboard/plugin_api.py`
  - Bundled plugin API routes such as `/tasks`, `/dispatch`, and `/boards`.
- `hermes_cli/kanban_db.py`
  - Dispatcher and worker-spawn path reached by Kanban dispatch.

## Root cause

- The dashboard has a token boundary for `/api/*` routes.
- Plugin backend routes are mounted under that same API namespace.
- The middleware carved out `/api/plugins/*`, so dynamically mounted plugin backends did not inherit the dashboard token requirement.

## CVSS assessment

- Issue: Dashboard plugin API auth bypass reaching Kanban control-plane dispatch
- CVSS v3.1: 9.1 Critical
- Vector: `CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H`
- Rationale: for dashboards exposed to untrusted networks, exploitation is network-reachable, low complexity, requires no privileges or user interaction, and can allow unauthenticated control of backend plugin APIs that can start local Hermes worker activity. Impact is deployment-dependent; loopback-only deployments reduce exposure but do not remove the broken dashboard API auth boundary.

## Safe reproduction steps

A local FastAPI `TestClient` harness against the real dashboard app demonstrates the boundary without launching a real worker:

1. Request a protected non-plugin API route without the session token.
2. Observe `401`.
3. Request `/api/plugins/kanban/tasks` without the session token.
4. Observe that the vulnerable code accepts the request.
5. Request `/api/plugins/kanban/dispatch?max=1` without the session token.
6. Observe that dispatch reaches the worker-spawn path for the attacker-created task.

The regression test in this PR uses a safer read route, `/api/plugins/kanban/boards`, to assert the authentication boundary directly.

## Expected vulnerable behavior

On vulnerable code, plugin API routes under `/api/plugins/*` are reachable without `X-Hermes-Session-Token`, while ordinary protected dashboard API routes return `401` without the token.

## Changes in this PR

- Removes the `/api/plugins/` exemption from dashboard `auth_middleware()`.
- Adds a regression test that verifies a plugin API route requires the session token.
- Adds a companion regression test that verifies the same route still works with a valid session token.

## Files changed

| Category | Files | What changed |
| --- | --- | --- |
| Auth boundary | `hermes_cli/web_server.py` | Plugin API routes now use the same session-token check as other non-public `/api/*` routes |
| Tests | `tests/hermes_cli/test_web_server.py` | Added regression coverage for unauthenticated and authenticated plugin API access |

## Maintainer impact

- Users must access plugin backend API routes through the dashboard session-token flow, matching other protected dashboard API routes.
- Static dashboard plugin assets under `/dashboard-plugins/*` remain unaffected.
- Plugins that intentionally need public webhook-style routes should expose those through a separate explicitly public surface with their own authentication model, not by bypassing dashboard API auth globally.

## Fix rationale

Plugin backend APIs are dashboard API routes and should inherit the dashboard API authentication boundary by default. A global unauthenticated carve-out is unsafe because each plugin router can define arbitrary backend behavior.

## Type of change

- [x] Security fix
- [x] Bug fix
- [x] Tests
- [ ] Documentation-only change
- [ ] Breaking API change

## Test plan

Commands run locally:

- `python3 -m pytest tests/hermes_cli/test_web_server.py -q -k 'plugin_api_routes_require_session_token or plugin_api_routes_accept_valid_session_token'`
- `python3 -m py_compile hermes_cli/web_server.py tests/hermes_cli/test_web_server.py`
- `git diff --check`
- `python3 -m ruff check hermes_cli/web_server.py tests/hermes_cli/test_web_server.py`

Note: `python3 -m ruff format --check hermes_cli/web_server.py tests/hermes_cli/test_web_server.py` would reformat broad pre-existing sections in both files, so I did not include whole-file formatting churn in this security patch.

## Disclosure notes

This PR is scoped to the dashboard plugin API authentication boundary. It does not claim to redesign plugin installation, plugin discovery, Kanban dispatch semantics, or dashboard public-bind policy. Severity depends on dashboard reachability; the broken auth boundary is still real because `/api/plugins/*` routes bypass the same dashboard token required by other non-public `/api/*` endpoints.
