### PR TITLE
feat: add TinyFish free web search + URL extraction provider

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1916,6 +1916,14 @@ OPTIONAL_ENV_VARS = {
         "password": True,
         "category": "tool",
     },
+    "TINYFISH_API_KEY": {
+        "description": "TinyFish API key for free web search and URL extraction",
+        "prompt": "TinyFish API key",
+        "url": "https://agent.tinyfish.ai",
+        "tools": ["web_search", "web_extract"],
+        "password": True,
+        "category": "tool",
+    },
     "SEARXNG_URL": {
         "description": "URL of your SearXNG instance for free self-hosted web search",
         "prompt": "SearXNG URL (e.g. http://localhost:8080)",
@@ -4783,7 +4791,7 @@ def set_config_value(key: str, value: str):
         'OPENROUTER_API_KEY', 'OPENAI_API_KEY', 'ANTHROPIC_API_KEY', 'VOICE_TOOLS_OPENAI_KEY',
         'EXA_API_KEY', 'PARALLEL_API_KEY', 'FIRECRAWL_API_KEY', 'FIRECRAWL_API_URL',
         'FIRECRAWL_GATEWAY_URL', 'TOOL_GATEWAY_DOMAIN', 'TOOL_GATEWAY_SCHEME',
-        'TOOL_GATEWAY_USER_TOKEN', 'TAVILY_API_KEY',
+        'TOOL_GATEWAY_USER_TOKEN', 'TAVILY_API_KEY', 'TINYFISH_API_KEY',
         'BROWSERBASE_API_KEY', 'BROWSERBASE_PROJECT_ID', 'BROWSER_USE_API_KEY',
         'FAL_KEY', 'TELEGRAM_BOT_TOKEN', 'DISCORD_BOT_TOKEN',
         'TERMINAL_SSH_HOST', 'TERMINAL_SSH_USER', 'TERMINAL_SSH_KEY',

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -320,6 +320,15 @@ TOOL_CATEGORIES = {
                 ],
             },
             {
+                "name": "TinyFish",
+                "badge": "free · search + extract",
+                "tag": "Free real-browser search & URL extraction — no credit card (5 req/min search)",
+                "web_backend": "tinyfish",
+                "env_vars": [
+                    {"key": "TINYFISH_API_KEY", "prompt": "TinyFish API key", "url": "https://agent.tinyfish.ai"},
+                ],
+            },
+            {
                 "name": "DuckDuckGo (ddgs)",
                 "badge": "free · no key · search only",
                 "tag": "Search via the ddgs Python package — no API key (pair with any extract provider)",

--- a/tests/tools/test_web_providers_tinyfish.py
+++ b/tests/tools/test_web_providers_tinyfish.py
@@ -1,0 +1,484 @@
+"""Tests for the TinyFish web search and fetch provider.
+
+Covers:
+- TinyFishSearchProvider / TinyFishExtractProvider is_configured() env var gating
+- TinyFishSearchProvider.search() — happy path, HTTP error, rate limit, request error, bad JSON
+- TinyFishExtractProvider.extract() — happy path, HTTP error, rate limit, request error, bad JSON
+- Result normalization (title, url, description/content, position)
+- Limit truncation
+- _is_backend_available("tinyfish") integration
+- _get_backend() recognizes "tinyfish" as a valid configured backend
+- check_web_api_key() includes tinyfish in availability check
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+
+# ---------------------------------------------------------------------------
+# TinyFishSearchProvider unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestTinyFishSearchProviderIsConfigured:
+    def test_configured_when_key_set(self, monkeypatch):
+        monkeypatch.setenv("TINYFISH_API_KEY", "tf-key-123")
+        from tools.web_providers.tinyfish import TinyFishSearchProvider
+        assert TinyFishSearchProvider().is_configured() is True
+
+    def test_not_configured_when_key_missing(self, monkeypatch):
+        monkeypatch.delenv("TINYFISH_API_KEY", raising=False)
+        from tools.web_providers.tinyfish import TinyFishSearchProvider
+        assert TinyFishSearchProvider().is_configured() is False
+
+    def test_not_configured_when_key_whitespace(self, monkeypatch):
+        monkeypatch.setenv("TINYFISH_API_KEY", "   ")
+        from tools.web_providers.tinyfish import TinyFishSearchProvider
+        assert TinyFishSearchProvider().is_configured() is False
+
+    def test_provider_name(self):
+        from tools.web_providers.tinyfish import TinyFishSearchProvider
+        assert TinyFishSearchProvider().provider_name() == "tinyfish"
+
+    def test_implements_web_search_provider(self):
+        from tools.web_providers.base import WebSearchProvider
+        from tools.web_providers.tinyfish import TinyFishSearchProvider
+        assert issubclass(TinyFishSearchProvider, WebSearchProvider)
+
+
+class TestTinyFishSearchProviderSearch:
+    _SAMPLE_RESPONSE = {
+        "results": [
+            {"title": "A", "url": "https://a.example.com", "snippet": "desc A", "position": 1},
+            {"title": "B", "url": "https://b.example.com", "snippet": "desc B", "position": 2},
+            {"title": "C", "url": "https://c.example.com", "snippet": "desc C", "position": 3},
+        ],
+        "total_results": 3,
+    }
+
+    @staticmethod
+    def _mock_resp(json_data, status_code=200):
+        m = MagicMock()
+        m.status_code = status_code
+        m.json.return_value = json_data
+        m.raise_for_status = MagicMock()
+        return m
+
+    def test_happy_path_normalizes_results(self, monkeypatch):
+        monkeypatch.setenv("TINYFISH_API_KEY", "tf-key-123")
+        from tools.web_providers.tinyfish import TinyFishSearchProvider
+
+        with patch("httpx.get", return_value=self._mock_resp(self._SAMPLE_RESPONSE)):
+            result = TinyFishSearchProvider().search("test query", limit=5)
+
+        assert result["success"] is True
+        web = result["data"]["web"]
+        assert len(web) == 3
+        assert web[0]["title"] == "A"
+        assert web[0]["url"] == "https://a.example.com"
+        assert web[0]["description"] == "desc A"
+        assert web[0]["position"] == 1
+
+    def test_sends_api_key_header(self, monkeypatch):
+        monkeypatch.setenv("TINYFISH_API_KEY", "tf-key-123")
+        from tools.web_providers.tinyfish import TinyFishSearchProvider
+
+        captured = {}
+
+        def fake_get(url, **kwargs):
+            captured["url"] = url
+            captured["headers"] = kwargs.get("headers", {})
+            captured["params"] = kwargs.get("params", {})
+            return self._mock_resp({"results": [], "total_results": 0})
+
+        with patch("httpx.get", side_effect=fake_get):
+            TinyFishSearchProvider().search("q", limit=5)
+
+        assert captured["url"] == "https://api.search.tinyfish.ai"
+        assert captured["headers"].get("X-API-Key") == "tf-key-123"
+        assert captured["params"].get("query") == "q"
+
+    def test_limit_is_respected_client_side(self, monkeypatch):
+        monkeypatch.setenv("TINYFISH_API_KEY", "tf-key-123")
+        from tools.web_providers.tinyfish import TinyFishSearchProvider
+
+        with patch("httpx.get", return_value=self._mock_resp(self._SAMPLE_RESPONSE)):
+            result = TinyFishSearchProvider().search("q", limit=2)
+
+        assert result["success"] is True
+        assert len(result["data"]["web"]) == 2
+
+    def test_empty_results(self, monkeypatch):
+        monkeypatch.setenv("TINYFISH_API_KEY", "tf-key-123")
+        from tools.web_providers.tinyfish import TinyFishSearchProvider
+
+        with patch("httpx.get", return_value=self._mock_resp({"results": [], "total_results": 0})):
+            result = TinyFishSearchProvider().search("nothing", limit=5)
+
+        assert result["success"] is True
+        assert result["data"]["web"] == []
+
+    def test_missing_results_key_returns_empty(self, monkeypatch):
+        monkeypatch.setenv("TINYFISH_API_KEY", "tf-key-123")
+        from tools.web_providers.tinyfish import TinyFishSearchProvider
+
+        with patch("httpx.get", return_value=self._mock_resp({})):
+            result = TinyFishSearchProvider().search("q", limit=5)
+
+        assert result["success"] is True
+        assert result["data"]["web"] == []
+
+    def test_rate_limit_429_returns_failure(self, monkeypatch):
+        monkeypatch.setenv("TINYFISH_API_KEY", "tf-key-123")
+        from tools.web_providers.tinyfish import TinyFishSearchProvider
+
+        m = MagicMock()
+        m.status_code = 429
+
+        with patch("httpx.get", return_value=m):
+            result = TinyFishSearchProvider().search("q", limit=5)
+
+        assert result["success"] is False
+        assert "rate limit" in result["error"].lower()
+
+    def test_http_error_returns_failure(self, monkeypatch):
+        import httpx
+        monkeypatch.setenv("TINYFISH_API_KEY", "tf-key-123")
+        from tools.web_providers.tinyfish import TinyFishSearchProvider
+
+        bad = MagicMock()
+        bad.status_code = 500
+        err = httpx.HTTPStatusError("500", request=MagicMock(), response=bad)
+
+        with patch("httpx.get", side_effect=err):
+            result = TinyFishSearchProvider().search("q", limit=5)
+
+        assert result["success"] is False
+        assert "500" in result["error"]
+
+    def test_request_error_returns_failure(self, monkeypatch):
+        import httpx
+        monkeypatch.setenv("TINYFISH_API_KEY", "tf-key-123")
+        from tools.web_providers.tinyfish import TinyFishSearchProvider
+
+        with patch("httpx.get", side_effect=httpx.RequestError("boom")):
+            result = TinyFishSearchProvider().search("q", limit=5)
+
+        assert result["success"] is False
+        assert "boom" in result["error"] or "TinyFish" in result["error"]
+
+    def test_missing_key_returns_failure(self, monkeypatch):
+        monkeypatch.delenv("TINYFISH_API_KEY", raising=False)
+        from tools.web_providers.tinyfish import TinyFishSearchProvider
+
+        result = TinyFishSearchProvider().search("q", limit=5)
+        assert result["success"] is False
+        assert "TINYFISH_API_KEY" in result["error"]
+
+    def test_bad_json_returns_failure(self, monkeypatch):
+        monkeypatch.setenv("TINYFISH_API_KEY", "tf-key-123")
+        from tools.web_providers.tinyfish import TinyFishSearchProvider
+
+        m = MagicMock()
+        m.status_code = 200
+        m.raise_for_status = MagicMock()
+        m.json.side_effect = ValueError("bad json")
+
+        with patch("httpx.get", return_value=m):
+            result = TinyFishSearchProvider().search("q", limit=5)
+
+        assert result["success"] is False
+        assert "parse" in result["error"].lower()
+
+
+# ---------------------------------------------------------------------------
+# TinyFishExtractProvider unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestTinyFishExtractProviderIsConfigured:
+    def test_configured_when_key_set(self, monkeypatch):
+        monkeypatch.setenv("TINYFISH_API_KEY", "tf-key-123")
+        from tools.web_providers.tinyfish import TinyFishExtractProvider
+        assert TinyFishExtractProvider().is_configured() is True
+
+    def test_not_configured_when_key_missing(self, monkeypatch):
+        monkeypatch.delenv("TINYFISH_API_KEY", raising=False)
+        from tools.web_providers.tinyfish import TinyFishExtractProvider
+        assert TinyFishExtractProvider().is_configured() is False
+
+    def test_provider_name(self):
+        from tools.web_providers.tinyfish import TinyFishExtractProvider
+        assert TinyFishExtractProvider().provider_name() == "tinyfish"
+
+    def test_implements_web_extract_provider(self):
+        from tools.web_providers.base import WebExtractProvider
+        from tools.web_providers.tinyfish import TinyFishExtractProvider
+        assert issubclass(TinyFishExtractProvider, WebExtractProvider)
+
+
+class TestTinyFishExtractProviderExtract:
+    _SAMPLE_RESPONSE = {
+        "results": [
+            {
+                "url": "https://example.com/1",
+                "final_url": "https://example.com/1",
+                "title": "Page 1",
+                "text": "Content of page 1",
+                "description": "A page",
+                "language": "en",
+                "latency_ms": 150,
+            },
+            {
+                "url": "https://example.com/2",
+                "final_url": "https://example.com/2",
+                "title": "Page 2",
+                "text": "Content of page 2",
+                "description": "Another page",
+                "language": "en",
+                "latency_ms": 200,
+            },
+        ],
+    }
+
+    @staticmethod
+    def _mock_resp(json_data, status_code=200):
+        m = MagicMock()
+        m.status_code = status_code
+        m.json.return_value = json_data
+        m.raise_for_status = MagicMock()
+        return m
+
+    def test_happy_path_normalizes_results(self, monkeypatch):
+        monkeypatch.setenv("TINYFISH_API_KEY", "tf-key-123")
+        from tools.web_providers.tinyfish import TinyFishExtractProvider
+
+        with patch("httpx.post", return_value=self._mock_resp(self._SAMPLE_RESPONSE)):
+            result = TinyFishExtractProvider().extract(
+                ["https://example.com/1", "https://example.com/2"]
+            )
+
+        assert result["success"] is True
+        data = result["data"]
+        assert len(data) == 2
+        assert data[0]["url"] == "https://example.com/1"
+        assert data[0]["title"] == "Page 1"
+        assert data[0]["content"] == "Content of page 1"
+        assert data[0]["metadata"]["language"] == "en"
+
+    def test_sends_api_key_header_and_json_body(self, monkeypatch):
+        monkeypatch.setenv("TINYFISH_API_KEY", "tf-key-123")
+        from tools.web_providers.tinyfish import TinyFishExtractProvider
+
+        captured = {}
+
+        def fake_post(url, **kwargs):
+            captured["url"] = url
+            captured["headers"] = kwargs.get("headers", {})
+            captured["json"] = kwargs.get("json", {})
+            return self._mock_resp({"results": []})
+
+        with patch("httpx.post", side_effect=fake_post):
+            TinyFishExtractProvider().extract(["https://example.com"], format="markdown")
+
+        assert captured["url"] == "https://api.fetch.tinyfish.ai"
+        assert captured["headers"].get("X-API-Key") == "tf-key-123"
+        assert captured["json"]["urls"] == ["https://example.com"]
+        assert captured["json"]["format"] == "markdown"
+
+    def test_empty_urls_returns_empty(self, monkeypatch):
+        monkeypatch.setenv("TINYFISH_API_KEY", "tf-key-123")
+        from tools.web_providers.tinyfish import TinyFishExtractProvider
+
+        result = TinyFishExtractProvider().extract([])
+        assert result["success"] is True
+        assert result["data"] == []
+
+    def test_format_defaults_to_markdown(self, monkeypatch):
+        monkeypatch.setenv("TINYFISH_API_KEY", "tf-key-123")
+        from tools.web_providers.tinyfish import TinyFishExtractProvider
+
+        captured = {}
+
+        def fake_post(url, **kwargs):
+            captured["json"] = kwargs.get("json", {})
+            return self._mock_resp({"results": []})
+
+        with patch("httpx.post", side_effect=fake_post):
+            TinyFishExtractProvider().extract(["https://example.com"])
+
+        assert captured["json"]["format"] == "markdown"
+
+    def test_invalid_format_falls_back_to_markdown(self, monkeypatch):
+        monkeypatch.setenv("TINYFISH_API_KEY", "tf-key-123")
+        from tools.web_providers.tinyfish import TinyFishExtractProvider
+
+        captured = {}
+
+        def fake_post(url, **kwargs):
+            captured["json"] = kwargs.get("json", {})
+            return self._mock_resp({"results": []})
+
+        with patch("httpx.post", side_effect=fake_post):
+            TinyFishExtractProvider().extract(["https://example.com"], format="xml")
+
+        assert captured["json"]["format"] == "markdown"
+
+    def test_per_url_errors_reported(self, monkeypatch):
+        monkeypatch.setenv("TINYFISH_API_KEY", "tf-key-123")
+        from tools.web_providers.tinyfish import TinyFishExtractProvider
+
+        response = {
+            "results": [
+                {"url": "https://ok.example.com", "title": "OK", "text": "good"},
+            ],
+            "errors": [
+                {"url": "https://fail.example.com", "error": "timeout"},
+            ],
+        }
+
+        with patch("httpx.post", return_value=self._mock_resp(response)):
+            result = TinyFishExtractProvider().extract(
+                ["https://ok.example.com", "https://fail.example.com"]
+            )
+
+        assert result["success"] is True
+        data = result["data"]
+        assert len(data) == 2
+        # Error entry added for failed URL
+        error_entry = [d for d in data if d["url"] == "https://fail.example.com"][0]
+        assert "error" in error_entry
+        assert "timeout" in error_entry["error"]
+
+    def test_rate_limit_429_returns_failure(self, monkeypatch):
+        monkeypatch.setenv("TINYFISH_API_KEY", "tf-key-123")
+        from tools.web_providers.tinyfish import TinyFishExtractProvider
+
+        m = MagicMock()
+        m.status_code = 429
+
+        with patch("httpx.post", return_value=m):
+            result = TinyFishExtractProvider().extract(["https://example.com"])
+
+        assert result["success"] is False
+        assert "rate limit" in result["error"].lower()
+
+    def test_http_error_returns_failure(self, monkeypatch):
+        import httpx
+        monkeypatch.setenv("TINYFISH_API_KEY", "tf-key-123")
+        from tools.web_providers.tinyfish import TinyFishExtractProvider
+
+        bad = MagicMock()
+        bad.status_code = 500
+        err = httpx.HTTPStatusError("500", request=MagicMock(), response=bad)
+
+        with patch("httpx.post", side_effect=err):
+            result = TinyFishExtractProvider().extract(["https://example.com"])
+
+        assert result["success"] is False
+        assert "500" in result["error"]
+
+    def test_request_error_returns_failure(self, monkeypatch):
+        import httpx
+        monkeypatch.setenv("TINYFISH_API_KEY", "tf-key-123")
+        from tools.web_providers.tinyfish import TinyFishExtractProvider
+
+        with patch("httpx.post", side_effect=httpx.RequestError("boom")):
+            result = TinyFishExtractProvider().extract(["https://example.com"])
+
+        assert result["success"] is False
+        assert "boom" in result["error"] or "TinyFish" in result["error"]
+
+    def test_missing_key_returns_failure(self, monkeypatch):
+        monkeypatch.delenv("TINYFISH_API_KEY", raising=False)
+        from tools.web_providers.tinyfish import TinyFishExtractProvider
+
+        result = TinyFishExtractProvider().extract(["https://example.com"])
+        assert result["success"] is False
+        assert "TINYFISH_API_KEY" in result["error"]
+
+    def test_bad_json_returns_failure(self, monkeypatch):
+        monkeypatch.setenv("TINYFISH_API_KEY", "tf-key-123")
+        from tools.web_providers.tinyfish import TinyFishExtractProvider
+
+        m = MagicMock()
+        m.status_code = 200
+        m.raise_for_status = MagicMock()
+        m.json.side_effect = ValueError("bad json")
+
+        with patch("httpx.post", return_value=m):
+            result = TinyFishExtractProvider().extract(["https://example.com"])
+
+        assert result["success"] is False
+        assert "parse" in result["error"].lower()
+
+    def test_text_dict_converted_to_string(self, monkeypatch):
+        """When text field is a dict (e.g. json format), it should be converted to string."""
+        monkeypatch.setenv("TINYFISH_API_KEY", "tf-key-123")
+        from tools.web_providers.tinyfish import TinyFishExtractProvider
+
+        response = {
+            "results": [
+                {"url": "https://example.com", "title": "JSON", "text": {"key": "value"}},
+            ],
+        }
+
+        with patch("httpx.post", return_value=self._mock_resp(response)):
+            result = TinyFishExtractProvider().extract(["https://example.com"])
+
+        assert result["success"] is True
+        assert isinstance(result["data"][0]["content"], str)
+
+
+# ---------------------------------------------------------------------------
+# Integration: _is_backend_available / _get_backend / check_web_api_key
+# ---------------------------------------------------------------------------
+
+
+class TestTinyFishBackendWiring:
+    def test_is_backend_available_true_when_key_set(self, monkeypatch):
+        monkeypatch.setenv("TINYFISH_API_KEY", "tf-key-123")
+        from tools.web_tools import _is_backend_available
+        assert _is_backend_available("tinyfish") is True
+
+    def test_is_backend_available_false_when_key_missing(self, monkeypatch):
+        monkeypatch.delenv("TINYFISH_API_KEY", raising=False)
+        from tools.web_tools import _is_backend_available
+        assert _is_backend_available("tinyfish") is False
+
+    def test_configured_backend_accepted(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "tinyfish"})
+        monkeypatch.setenv("TINYFISH_API_KEY", "tf-key-123")
+        assert web_tools._get_backend() == "tinyfish"
+
+    def test_auto_detect_picks_tinyfish_when_only_key_set(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {})
+        for key in ("FIRECRAWL_API_KEY", "FIRECRAWL_API_URL", "PARALLEL_API_KEY",
+                    "TAVILY_API_KEY", "EXA_API_KEY", "SEARXNG_URL", "BRAVE_SEARCH_API_KEY"):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("TINYFISH_API_KEY", "tf-key-123")
+        monkeypatch.setattr(web_tools, "_is_tool_gateway_ready", lambda: False)
+        monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: False)
+        assert web_tools._get_backend() == "tinyfish"
+
+    def test_tinyfish_does_not_override_paid_provider(self, monkeypatch):
+        """Tavily (higher priority) should win in auto-detect."""
+        from tools import web_tools
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {})
+        for key in ("FIRECRAWL_API_KEY", "FIRECRAWL_API_URL", "PARALLEL_API_KEY",
+                    "EXA_API_KEY", "SEARXNG_URL", "BRAVE_SEARCH_API_KEY"):
+            monkeypatch.delenv(key, raising=False)
+        monkeypatch.setenv("TAVILY_API_KEY", "tvly")
+        monkeypatch.setenv("TINYFISH_API_KEY", "tf-key-123")
+        monkeypatch.setattr(web_tools, "_is_tool_gateway_ready", lambda: False)
+        monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: False)
+        assert web_tools._get_backend() == "tavily"
+
+    def test_check_web_api_key_true_when_tinyfish_configured(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {"backend": "tinyfish"})
+        monkeypatch.setenv("TINYFISH_API_KEY", "tf-key-123")
+        assert web_tools.check_web_api_key() is True

--- a/tools/web_providers/tinyfish.py
+++ b/tools/web_providers/tinyfish.py
@@ -1,0 +1,309 @@
+"""TinyFish web search and fetch provider.
+
+TinyFish offers free Search and Fetch APIs for all developers — no credit card
+required. See https://tinyfish.ai for details.
+
+This provider implements both ``WebSearchProvider`` (via the Search API) and
+``WebExtractProvider`` (via the Fetch API). Authentication is via the
+``X-API-Key`` header.
+
+Configuration::
+
+    # ~/.hermes/.env
+    TINYFISH_API_KEY=tf-your-key-here
+
+    # ~/.hermes/config.yaml
+    web:
+      search_backend: "tinyfish"
+      extract_backend: "tinyfish"
+
+Rate limits:
+    - Search: 5 requests per minute
+    - Fetch: 1 credit = 15 URL fetches (credit consumption varies by plan)
+
+See https://docs.tinyfish.ai/search-api/reference and
+https://docs.tinyfish.ai/fetch-api/reference for full API docs.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Dict, List
+
+from tools.web_providers.base import WebExtractProvider, WebSearchProvider
+
+logger = logging.getLogger(__name__)
+
+_TINYFISH_SEARCH_ENDPOINT = "https://api.search.tinyfish.ai"
+_TINYFISH_FETCH_ENDPOINT = "https://api.fetch.tinyfish.ai"
+
+_MAX_FETCH_URLS = 10  # Fetch API max URLs per request
+
+
+class TinyFishSearchProvider(WebSearchProvider):
+    """Search via the TinyFish Search API.
+
+    Requires ``TINYFISH_API_KEY`` to be set. The value is passed as the
+    ``X-API-Key`` header. Returns up to 10 results per query (fixed by the API).
+    """
+
+    def provider_name(self) -> str:
+        return "tinyfish"
+
+    def is_configured(self) -> bool:
+        """Return True when ``TINYFISH_API_KEY`` is set to a non-empty value."""
+        return bool(os.getenv("TINYFISH_API_KEY", "").strip())
+
+    def search(self, query: str, limit: int = 5) -> Dict[str, Any]:
+        """Execute a search against the TinyFish Search API.
+
+        Returns normalized results::
+
+            {
+                "success": True,
+                "data": {
+                    "web": [
+                        {
+                            "title": str,
+                            "url": str,
+                            "description": str,
+                            "position": int,
+                        },
+                        ...
+                    ]
+                }
+            }
+
+        On failure returns ``{"success": False, "error": str}``.
+        """
+        import httpx
+
+        api_key = os.getenv("TINYFISH_API_KEY", "").strip()
+        if not api_key:
+            return {"success": False, "error": "TINYFISH_API_KEY is not set"}
+
+        safe_limit = max(1, int(limit))
+
+        try:
+            resp = httpx.get(
+                _TINYFISH_SEARCH_ENDPOINT,
+                params={"query": query},
+                headers={
+                    "X-API-Key": api_key,
+                    "Accept": "application/json",
+                },
+                timeout=15,
+            )
+            # 429 rate limit gets special handling
+            if resp.status_code == 429:
+                logger.warning("TinyFish Search rate limited (429)")
+                return {
+                    "success": False,
+                    "error": (
+                        "TinyFish Search rate limit exceeded (5 req/min). "
+                        "Retry after 15s with exponential backoff."
+                    ),
+                }
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            logger.warning("TinyFish Search HTTP error: %s", exc)
+            status = exc.response.status_code
+            detail = _search_error_detail(status)
+            return {"success": False, "error": f"TinyFish Search returned HTTP {status}: {detail}"}
+        except httpx.RequestError as exc:
+            logger.warning("TinyFish Search request error: %s", exc)
+            return {"success": False, "error": f"Could not reach TinyFish Search: {exc}"}
+
+        try:
+            data = resp.json()
+        except Exception as exc:
+            logger.warning("TinyFish Search response parse error: %s", exc)
+            return {"success": False, "error": "Could not parse TinyFish Search response as JSON"}
+
+        raw_results = data.get("results", []) or []
+        truncated = raw_results[:safe_limit]
+
+        web_results = [
+            {
+                "title": str(r.get("title", "")),
+                "url": str(r.get("url", "")),
+                "description": str(r.get("snippet", "")),
+                "position": int(r.get("position", i + 1)),
+            }
+            for i, r in enumerate(truncated)
+        ]
+
+        logger.info(
+            "TinyFish Search '%s': %d results (limit %d, total %d)",
+            query,
+            len(web_results),
+            limit,
+            data.get("total_results", 0),
+        )
+        return {"success": True, "data": {"web": web_results}}
+
+
+class TinyFishExtractProvider(WebExtractProvider):
+    """Extract page content via the TinyFish Fetch API.
+
+    Requires ``TINYFISH_API_KEY`` to be set. Uses a real browser to render
+    JavaScript-heavy pages and returns clean extracted text. Up to 10 URLs
+    per request.
+
+    Supports ``format`` parameter in ``extract()`` kwargs (``"markdown"``,
+    ``"html"``, or ``"json"``). Defaults to ``"markdown"`` (best for LLMs).
+    """
+
+    def provider_name(self) -> str:
+        return "tinyfish"
+
+    def is_configured(self) -> bool:
+        """Return True when ``TINYFISH_API_KEY`` is set to a non-empty value."""
+        return bool(os.getenv("TINYFISH_API_KEY", "").strip())
+
+    def extract(self, urls: List[str], **kwargs) -> Dict[str, Any]:
+        """Extract content from the given URLs using the TinyFish Fetch API.
+
+        Returns normalized results::
+
+            {
+                "success": True,
+                "data": [
+                    {
+                        "url": str,
+                        "title": str,
+                        "content": str,
+                        "raw_content": str,
+                        "metadata": dict,
+                    },
+                    ...
+                ]
+            }
+
+        On failure returns ``{"success": False, "error": str}``.
+        """
+        import httpx
+
+        api_key = os.getenv("TINYFISH_API_KEY", "").strip()
+        if not api_key:
+            return {"success": False, "error": "TINYFISH_API_KEY is not set"}
+
+        if not urls:
+            return {"success": True, "data": []}
+
+        # Fetch API max: 10 URLs per request
+        fetch_urls = urls[: _MAX_FETCH_URLS]
+
+        format = kwargs.get("format", "markdown")
+        if format not in ("markdown", "html", "json"):
+            format = "markdown"
+
+        payload = {
+            "urls": fetch_urls,
+            "format": format,
+        }
+
+        try:
+            resp = httpx.post(
+                _TINYFISH_FETCH_ENDPOINT,
+                json=payload,
+                headers={
+                    "X-API-Key": api_key,
+                    "Content-Type": "application/json",
+                    "Accept": "application/json",
+                },
+                timeout=60,
+            )
+            if resp.status_code == 429:
+                logger.warning("TinyFish Fetch rate limited (429)")
+                return {
+                    "success": False,
+                    "error": "TinyFish Fetch rate limit exceeded. Retry with backoff.",
+                }
+            resp.raise_for_status()
+        except httpx.HTTPStatusError as exc:
+            logger.warning("TinyFish Fetch HTTP error: %s", exc)
+            return {
+                "success": False,
+                "error": f"TinyFish Fetch returned HTTP {exc.response.status_code}",
+            }
+        except httpx.RequestError as exc:
+            logger.warning("TinyFish Fetch request error: %s", exc)
+            return {"success": False, "error": f"Could not reach TinyFish Fetch: {exc}"}
+
+        try:
+            data = resp.json()
+        except Exception as exc:
+            logger.warning("TinyFish Fetch response parse error: %s", exc)
+            return {"success": False, "error": "Could not parse TinyFish Fetch response as JSON"}
+
+        results: List[Dict[str, Any]] = []
+        raw_results = data.get("results", []) or []
+        for item in raw_results:
+            url = str(item.get("url", ""))
+            final_url = str(item.get("final_url", url))
+            title = str(item.get("title") or "")
+            text = item.get("text", "")
+
+            # text can be string or object depending on format
+            if isinstance(text, dict):
+                content = str(text)
+            else:
+                content = str(text or "")
+
+            metadata = {
+                "final_url": final_url,
+                "description": str(item.get("description") or ""),
+                "language": str(item.get("language") or ""),
+                "author": str(item.get("author") or ""),
+                "published_date": str(item.get("published_date") or ""),
+                "latency_ms": item.get("latency_ms"),
+            }
+
+            results.append({
+                "url": url,
+                "title": title,
+                "content": content,
+                "raw_content": content,
+                "metadata": metadata,
+            })
+
+        # Report per-URL errors from the API
+        fetch_errors = data.get("errors", []) or []
+        for err in fetch_errors:
+            err_url = err.get("url", "unknown")
+            err_type = err.get("error", "unknown")
+            logger.info("TinyFish Fetch error for %s: %s", err_url, err_type)
+            # Add error entries for URLs that failed
+            if not any(r["url"] == err_url for r in results):
+                results.append({
+                    "url": err_url,
+                    "title": "",
+                    "content": "",
+                    "raw_content": "",
+                    "error": f"TinyFish Fetch failed: {err_type}",
+                    "metadata": {},
+                })
+
+        logger.info(
+            "TinyFish Fetch: %d/%d URLs extracted successfully",
+            len(raw_results),
+            len(fetch_urls),
+        )
+        return {"success": True, "data": results}
+
+
+def _search_error_detail(status: int) -> str:
+    """Return a human-readable detail message for known Search API HTTP status codes."""
+    details = {
+        400: "Missing or invalid query parameter",
+        401: "Missing or invalid API key",
+        402: "Active subscription or credits needed",
+        403: "Search API access not enabled for this account",
+        404: "Search API not available",
+        429: "Rate limit exceeded (5 req/min)",
+        500: "Internal server error",
+        503: "Search service unavailable — retry with backoff",
+    }
+    return details.get(status, "Unknown error")

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -126,7 +126,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in ("parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs"):
+    if configured in ("parallel", "firecrawl", "tavily", "exa", "searxng", "brave-free", "ddgs", "tinyfish"):
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -142,6 +142,7 @@ def _get_backend() -> str:
         ("searxng", _has_env("SEARXNG_URL")),
         ("brave-free", _has_env("BRAVE_SEARCH_API_KEY")),
         ("ddgs", _ddgs_package_importable()),
+        ("tinyfish", _has_env("TINYFISH_API_KEY")),
     )
     for backend, available in backend_candidates:
         if available:
@@ -204,6 +205,8 @@ def _is_backend_available(backend: str) -> bool:
         return _has_env("BRAVE_SEARCH_API_KEY")
     if backend == "ddgs":
         return _ddgs_package_importable()
+    if backend == "tinyfish":
+        return _has_env("TINYFISH_API_KEY")
     return False
 
 
@@ -305,6 +308,7 @@ def _web_requires_env() -> list[str]:
         "TOOL_GATEWAY_DOMAIN",
         "TOOL_GATEWAY_SCHEME",
         "TOOL_GATEWAY_USER_TOKEN",
+        "TINYFISH_API_KEY",
     ]
 
 
@@ -1247,6 +1251,16 @@ def web_search_tool(query: str, limit: int = 5) -> str:
             _debug.save()
             return result_json
 
+        if backend == "tinyfish":
+            from tools.web_providers.tinyfish import TinyFishSearchProvider
+            response_data = TinyFishSearchProvider().search(query, limit)
+            debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
+            result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
+            debug_call_data["final_response_size"] = len(result_json)
+            _debug.log_call("web_search_tool", debug_call_data)
+            _debug.save()
+            return result_json
+
         if backend == "tavily":
             logger.info("Tavily search: '%s' (limit: %d)", query, limit)
             raw = _tavily_request("search", {
@@ -1397,6 +1411,12 @@ async def web_extract_tool(
                     "include_images": False,
                 })
                 results = _normalize_tavily_documents(raw, fallback_url=safe_urls[0] if safe_urls else "")
+            elif backend == "tinyfish":
+                from tools.web_providers.tinyfish import TinyFishExtractProvider
+                extract_result = TinyFishExtractProvider().extract(safe_urls, format=format or "markdown")
+                if not extract_result.get("success"):
+                    return json.dumps(extract_result, ensure_ascii=False)
+                results = extract_result.get("data", [])
             elif backend in ("searxng", "brave-free", "ddgs"):
                 # These backends are search-only — they cannot extract URL content
                 _label = {"searxng": "SearXNG", "brave-free": "Brave Search (free tier)", "ddgs": "DuckDuckGo (ddgs)"}[backend]
@@ -2084,11 +2104,11 @@ def check_firecrawl_api_key() -> bool:
 def check_web_api_key() -> bool:
     """Check whether the configured web backend is available."""
     configured = _load_web_config().get("backend", "").lower().strip()
-    if configured in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs"):
+    if configured in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "tinyfish"):
         return _is_backend_available(configured)
     return any(
         _is_backend_available(backend)
-        for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs")
+        for backend in ("exa", "parallel", "firecrawl", "tavily", "searxng", "brave-free", "ddgs", "tinyfish")
     )
 
 


### PR DESCRIPTION
## Summary
Adds [TinyFish](https://tinyfish.ai) as a free web search and URL extraction provider for Hermes Agent. TinyFish offers:

- **Search API** — real-time web search (5 req/min free, no credit card)
- **Fetch API** — real browser rendering for JS-heavy pages with clean text/markdown extraction
- No dependency on Firecrawl/Exa/Tavily SDK — uses plain httpx

## Changes

### New files
- `tools/web_providers/tinyfish.py` — `TinyFishSearchProvider` + `TinyFishExtractProvider` implementing `WebSearchProvider` and `WebExtractProvider`
- `tests/tools/test_web_providers_tinyfish.py` — 35 tests (unit + backend wiring + integration)

### Modified files
- `tools/web_tools.py` — add tinyfish to `_get_backend()`, `backend_candidates`, `_is_backend_available()`, `_web_requires_env()`, `web_search_tool()` dispatch, `web_extract_tool()` dispatch, `check_web_api_key()`
- `hermes_cli/config.py` — add `TINYFISH_API_KEY` to `OPTIONAL_ENV_VARS` and `api_keys` list
- `hermes_cli/tools_config.py` — add TinyFish to web provider picker UI

## Testing
- `pytest tests/tools/test_web_providers_tinyfish.py -v` — all 35 tests pass
- Test coverage: happy path, HTTP error, rate limit (429), network error, bad JSON, missing key, empty results, limit truncation, per-URL error reporting, auto-detect priority, backend wiring

Closes #22723