### PR TITLE
fix(tools): read managed gateway auth JSON as UTF-8

### DIFF
--- a/tests/tools/test_managed_tool_gateway.py
+++ b/tests/tools/test_managed_tool_gateway.py
@@ -97,3 +97,24 @@ def test_read_nous_access_token_refreshes_expiring_cached_token(tmp_path, monkey
     )
 
     assert managed_tool_gateway.read_nous_access_token() == "fresh-token"
+
+
+def test_read_nous_provider_state_reads_auth_json_as_utf8(monkeypatch):
+    class Utf8OnlyAuthPath:
+        def is_file(self):
+            return True
+
+        def read_text(self, *, encoding):
+            assert encoding == "utf-8"
+            return json.dumps({
+                "providers": {
+                    "nous": {
+                        "access_token": "cached-token",
+                        "expires_at": "2999-01-01T00:00:00Z",
+                    }
+                }
+            })
+
+    monkeypatch.setattr(managed_tool_gateway, "auth_json_path", lambda: Utf8OnlyAuthPath())
+
+    assert managed_tool_gateway.read_nous_access_token() == "cached-token"

--- a/tools/managed_tool_gateway.py
+++ b/tools/managed_tool_gateway.py
@@ -37,7 +37,7 @@ def _read_nous_provider_state() -> Optional[dict]:
         path = auth_json_path()
         if not path.is_file():
             return None
-        data = json.loads(path.read_text())
+        data = json.loads(path.read_text(encoding="utf-8"))
         providers = data.get("providers", {})
         if not isinstance(providers, dict):
             return None


### PR DESCRIPTION
## What does this PR do?

Reads the managed tool gateway auth store with an explicit UTF-8 encoding. This avoids relying on the platform default text encoding when loading `auth.json`, which is especially important on Windows.

## Related Issue

N/A

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Security fix
- [ ] Documentation update
- [x] Tests (adding or improving test coverage)
- [ ] Refactor (no behavior change)
- [ ] New skill (bundled or hub)

## Changes Made

- Updated `tools/managed_tool_gateway.py` to read `auth.json` with `encoding="utf-8"`
- Added regression coverage in `tests/tools/test_managed_tool_gateway.py`

## How to Test

1. `python -m pytest tests/tools/test_managed_tool_gateway.py -q -o addopts=''`
2. `python -m py_compile tools/managed_tool_gateway.py tests/tools/test_managed_tool_gateway.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / Python 3.13.7

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) -- N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys -- N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows -- N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
- [x] I've updated tool descriptions/schemas if I changed tool behavior -- N/A

## For New Skills

N/A

## Screenshots / Logs

```text
python -m pytest tests/tools/test_managed_tool_gateway.py -q -o addopts=''
......                                                                   [100%]
6 passed in 1.18s
```

```text
python -m py_compile tools/managed_tool_gateway.py tests/tools/test_managed_tool_gateway.py
# exit code 0
```
