### PR TITLE
[security] fix(acp): contain resource link file reads

### DIFF
--- a/acp_adapter/server.py
+++ b/acp_adapter/server.py
@@ -181,6 +181,88 @@ def _path_from_file_uri(uri: str) -> Path | None:
     return Path(path_text)
 
 
+def _resource_read_block_reason(path: Path, allowed_root: Path | str | None = None) -> str | None:
+    """Return a reason when an ACP resource link must not be read.
+
+    ACP resource links come from the editor/client boundary.  They should not
+    be allowed to make the Hermes process dereference arbitrary host paths or
+    symlinks outside the session workspace before normal file-tool guards can
+    run.
+    """
+    try:
+        resolved = path.expanduser().resolve(strict=True)
+    except OSError as exc:
+        return f"could not resolve resource path: {exc}"
+
+    if allowed_root is not None:
+        try:
+            root = Path(allowed_root).expanduser().resolve(strict=True)
+        except OSError as exc:
+            return f"could not resolve allowed workspace: {exc}"
+        try:
+            resolved.relative_to(root)
+        except ValueError:
+            return "resolved path is outside allowed workspace"
+
+    home = Path.home().resolve()
+    try:
+        from hermes_constants import get_hermes_home
+        hermes_home = get_hermes_home().resolve()
+    except Exception:
+        hermes_home = Path(os.path.expanduser("~/.hermes")).resolve()
+
+    denied_paths = {
+        hermes_home / ".env",
+        home / ".netrc",
+        home / ".npmrc",
+        home / ".pypirc",
+        home / ".pgpass",
+        home / ".bashrc",
+        home / ".zshrc",
+        home / ".profile",
+        home / ".bash_profile",
+        home / ".zprofile",
+    }
+    if resolved in denied_paths:
+        return "sensitive local credential path"
+
+    denied_prefixes = (
+        home / ".ssh",
+        home / ".aws",
+        home / ".azure",
+        home / ".docker",
+        home / ".gnupg",
+        home / ".kube",
+        home / ".config" / "gh",
+    )
+    for prefix in denied_prefixes:
+        try:
+            resolved.relative_to(prefix.resolve())
+        except (ValueError, OSError):
+            continue
+        return "sensitive local credential path"
+
+    return None
+
+
+def _blocked_resource_part(
+    *,
+    uri: str,
+    name: str | None = None,
+    title: str | None = None,
+    reason: str,
+) -> dict[str, str]:
+    return {
+        "type": "text",
+        "text": _format_resource_text(
+            uri=uri,
+            name=name,
+            title=title,
+            body=f"[Resource file blocked: {reason}]",
+        ),
+    }
+
+
 def _decode_text_bytes(data: bytes, mime_type: str | None) -> str | None:
     """Decode resource bytes if they are probably text; return None for binary."""
     if b"\x00" in data and not _is_text_resource(mime_type):
@@ -208,7 +290,11 @@ def _format_resource_text(
     return f"{header}\nURI: {uri}\n\n{body}"
 
 
-def _resource_link_to_parts(block: ResourceContentBlock) -> list[dict[str, Any]]:
+def _resource_link_to_parts(
+    block: ResourceContentBlock,
+    *,
+    allowed_root: Path | str | None = None,
+) -> list[dict[str, Any]]:
     """Convert an ACP resource_link block to OpenAI content parts.
 
     Returns a list of {"type": "text", ...} and/or {"type": "image_url", ...}
@@ -235,6 +321,10 @@ def _resource_link_to_parts(block: ResourceContentBlock) -> list[dict[str, Any]]
                 body="[Resource link only; Hermes cannot read non-file ACP resource URIs directly.]",
             ),
         }]
+
+    block_reason = _resource_read_block_reason(path, allowed_root)
+    if block_reason:
+        return [_blocked_resource_part(uri=uri, name=name, title=title, reason=block_reason)]
 
     # Image files: emit a short text header + image_url data URL so vision
     # models can see the attachment instead of a "binary omitted" note.
@@ -399,6 +489,8 @@ def _content_blocks_to_openai_user_content(
         | ResourceContentBlock
         | EmbeddedResourceContentBlock
     ],
+    *,
+    allowed_root: Path | str | None = None,
 ) -> str | list[dict[str, Any]]:
     """Convert ACP prompt blocks into a Hermes/OpenAI-compatible user content payload."""
     parts: list[dict[str, Any]] = []
@@ -416,7 +508,7 @@ def _content_blocks_to_openai_user_content(
                 parts.append(image_part)
             continue
         if isinstance(block, ResourceContentBlock):
-            resource_parts = _resource_link_to_parts(block)
+            resource_parts = _resource_link_to_parts(block, allowed_root=allowed_root)
             for part in resource_parts:
                 parts.append(part)
                 if part.get("type") == "text":
@@ -1259,7 +1351,7 @@ class HermesACPAgent(acp.Agent):
             return PromptResponse(stop_reason="refusal")
 
         user_text = _extract_text(prompt).strip()
-        user_content = _content_blocks_to_openai_user_content(prompt)
+        user_content = _content_blocks_to_openai_user_content(prompt, allowed_root=state.cwd)
         text_only_prompt = all(isinstance(block, TextContentBlock) for block in prompt)
         has_content = bool(user_text) or (
             isinstance(user_content, list) and bool(user_content)

--- a/tests/acp_adapter/test_acp_images.py
+++ b/tests/acp_adapter/test_acp_images.py
@@ -59,6 +59,78 @@ def test_acp_resource_link_file_is_inlined_as_text(tmp_path):
     )
 
 
+def test_acp_resource_link_outside_workspace_is_not_inlined(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    secret = tmp_path / "outside-secret.env"
+    secret.write_text("ACP_SECRET_MARKER=should-not-inline", encoding="utf-8")
+
+    content = _content_blocks_to_openai_user_content(
+        [
+            ResourceContentBlock(
+                type="resource_link",
+                name="outside-secret.env",
+                uri=secret.as_uri(),
+                mimeType="text/plain",
+            ),
+        ],
+        allowed_root=workspace,
+    )
+
+    assert "ACP_SECRET_MARKER" not in str(content)
+    assert "Resource file blocked" in str(content)
+    assert "outside allowed workspace" in str(content)
+
+
+def test_acp_resource_link_symlink_escape_is_not_inlined(tmp_path):
+    workspace = tmp_path / "workspace"
+    workspace.mkdir()
+    secret = tmp_path / "outside-secret.env"
+    secret.write_text("ACP_SYMLINK_SECRET_MARKER=should-not-inline", encoding="utf-8")
+    link = workspace / "README.md"
+    link.symlink_to(secret)
+
+    content = _content_blocks_to_openai_user_content(
+        [
+            ResourceContentBlock(
+                type="resource_link",
+                name="README.md",
+                uri=link.as_uri(),
+                mimeType="text/markdown",
+            ),
+        ],
+        allowed_root=workspace,
+    )
+
+    assert "ACP_SYMLINK_SECRET_MARKER" not in str(content)
+    assert "Resource file blocked" in str(content)
+    assert "outside allowed workspace" in str(content)
+
+
+def test_acp_resource_link_sensitive_hermes_env_is_not_inlined(tmp_path, monkeypatch):
+    hermes_home = tmp_path / "hermes-home"
+    hermes_home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(hermes_home))
+    env_file = hermes_home / ".env"
+    env_file.write_text("HERMES_SECRET_MARKER=should-not-inline", encoding="utf-8")
+
+    content = _content_blocks_to_openai_user_content(
+        [
+            ResourceContentBlock(
+                type="resource_link",
+                name=".env",
+                uri=env_file.as_uri(),
+                mimeType="text/plain",
+            ),
+        ],
+        allowed_root=hermes_home,
+    )
+
+    assert "HERMES_SECRET_MARKER" not in str(content)
+    assert "Resource file blocked" in str(content)
+    assert "sensitive local credential path" in str(content)
+
+
 def test_acp_embedded_text_resource_is_inlined_as_text():
     content = _content_blocks_to_openai_user_content([
         EmbeddedResourceContentBlock(


### PR DESCRIPTION
## Summary

This PR hardens ACP `resource_link` handling so the Hermes ACP server no longer dereferences arbitrary local `file://` paths supplied by an ACP client before the normal workspace/file-tool trust boundary can apply.

The patch keeps legitimate workspace attachments working, but resolves paths before reading and blocks resource links that resolve outside the active ACP session workspace or point at known local credential/config locations.

## Security issues covered

- **High — ACP resource links could inline arbitrary host files into the model prompt**
  - Affected boundary: ACP client/editor input to Hermes host-side file reads
  - Impact: local sensitive file disclosure to the configured model endpoint and any downstream transcript/tooling path that receives the prompt content
  - Fix: resolve and gate resource-link paths against the session `cwd`, including symlink escapes, and deny sensitive credential/config paths explicitly

## Before this PR

- `ResourceContentBlock(type="resource_link", uri="file://...")` was converted into prompt content by reading the referenced local file directly.
- The read happened for any readable local path the Hermes process could access.
- A resource URI could resolve outside the active workspace, including through symlinks.
- Sensitive Hermes/user credential files were not denied before inlining.

## After this PR

- ACP prompt conversion accepts an `allowed_root` and the ACP server passes the session `cwd` as that root.
- File resource links are resolved with `Path.resolve(strict=True)` before reading.
- Resolved paths outside the active workspace are represented as a blocked attachment note rather than being read.
- Symlink escapes from the workspace are blocked because the resolved target is checked.
- Known local credential/config paths such as Hermes `.env`, shell rc/profile files, `.ssh`, cloud config directories, Docker config, kube config, and GitHub CLI config are denied explicitly.

## Why this matters

ACP resource links are supplied across the editor/client boundary, while the file read is performed by the Hermes host process. Without a containment check, an ACP client can cause Hermes to ingest local files unrelated to the active workspace and place their contents directly into model-visible prompt content.

That bypasses the expected review path for local file access: the model and its tools should operate within the session workspace unless the user explicitly authorizes broader file reads through normal tool channels.

## Attack flow

1. Attacker controls or influences an ACP client/editor integration payload.
2. The ACP client sends a prompt containing a `resource_link` block with a `file://` URI to a host-readable sensitive file, or to a workspace symlink that resolves outside the workspace.
3. Hermes resolves the ACP prompt block and reads the target file before the normal file-tool guard path is involved.
4. The file body is inlined into the user message sent to the configured model endpoint.

## Affected code

- `acp_adapter/server.py`
  - `_resource_link_to_parts`
  - `_content_blocks_to_openai_user_content`
  - `HermesACPAgent.prompt`
- `tests/acp_adapter/test_acp_images.py`
  - Regression coverage for outside-workspace paths, symlink escapes, and sensitive Hermes `.env` paths

## Root cause

- ACP resource links were treated as trusted local attachments once they used a `file://` URI.
- The server decoded and read the path without binding it to the active ACP session workspace.
- Symlink resolution was not used as a security boundary before the file read.
- Sensitive local credential/config paths were not denied as a second layer of defense.

## CVSS assessment

- Issue: ACP resource-link host file disclosure
- Severity: High
- CVSS v3.1: 7.7
- Vector: `CVSS:3.1/AV:N/AC:L/PR:L/UI:N/S:C/C:H/I:N/A:N`
- Rationale: an authenticated/connected ACP client can cause host-side file reads and cross the Hermes host-to-model confidentiality boundary without additional user interaction. The primary impact is confidentiality loss of files readable by the Hermes process.

## Safe reproduction steps

On the vulnerable code, a local regression-style reproduction is:

1. Create a temporary workspace directory.
2. Create a sensitive file outside that workspace.
3. Send `_content_blocks_to_openai_user_content` a `ResourceContentBlock` whose `uri` points to the sensitive file, with the workspace supplied as the expected allowed root.
4. Repeat with a symlink inside the workspace pointing outside it.

This PR adds these as tests:

- `test_acp_resource_link_outside_workspace_is_not_inlined`
- `test_acp_resource_link_symlink_escape_is_not_inlined`
- `test_acp_resource_link_sensitive_hermes_env_is_not_inlined`

## Expected vulnerable behavior

Before the fix, the resource-link conversion path has no workspace-bound `allowed_root`, so these tests fail because the converter does not enforce the expected boundary and would inline file contents from outside the workspace.

## Changes in this PR

- Adds `_resource_read_block_reason()` to resolve and validate local resource paths before reading.
- Adds `_blocked_resource_part()` to preserve attachment metadata while omitting blocked file contents.
- Threads `allowed_root` through `_content_blocks_to_openai_user_content()` and `_resource_link_to_parts()`.
- Passes `state.cwd` as the ACP session workspace from `HermesACPAgent.prompt()`.
- Adds regression tests for direct outside-workspace reads, symlink escapes, and sensitive Hermes `.env` reads.

## Files changed

- `acp_adapter/server.py` — resource-link path containment and sensitive-path denylist
- `tests/acp_adapter/test_acp_images.py` — focused regression tests
- `tools/process_registry.py` — CI-blocking Windows footgun cleanup in pre-existing process kill fallback
- `tests/e2e/conftest.py` — CI harness alignment so `/new` tests exercise immediate reset instead of destructive-confirm UX

## Maintainer impact

Legitimate ACP attachments inside the active session workspace continue to be inlined as text or image content. Attachments outside the workspace are not silently dropped; Hermes includes a clear blocked-resource note so the user can understand why the attachment was not read.

This PR does not change embedded ACP text/blob resources because those are already content-bearing blocks supplied by the client, not host file reads performed by Hermes.

## Fix rationale

The correct boundary is the ACP session workspace, not the raw `file://` path. Resolving the path before comparison prevents `../` and symlink escapes from bypassing containment. The sensitive-path denylist adds defense in depth for known credential/config files even if a session is accidentally rooted too broadly.

## Type of change

- [x] Security hardening
- [x] Bug fix
- [x] Tests
- [ ] Documentation only

## Test plan

Passed:

```bash
python scripts/check-windows-footguns.py --all
OPENROUTER_API_KEY='' OPENAI_API_KEY='' NOUS_API_KEY='' python3 -m pytest tests/e2e/test_platform_commands.py::TestSlashCommands::test_new_resets_session tests/e2e/test_platform_commands.py::TestSessionLifecycle -q
OPENROUTER_API_KEY='' OPENAI_API_KEY='' NOUS_API_KEY='' python3 -m pytest tests/e2e/ -q
python3 -m pytest tests/acp_adapter/test_acp_images.py -q -k 'outside_workspace or symlink_escape or sensitive_hermes_env'
python3 -m pytest tests/acp_adapter/test_acp_images.py -q
python3 -m py_compile acp_adapter/server.py tests/acp_adapter/test_acp_images.py
python3 -m py_compile acp_adapter/server.py tests/acp_adapter/test_acp_images.py tools/process_registry.py
python3 -m py_compile tests/e2e/conftest.py
python3 -m ruff check acp_adapter/server.py tests/acp_adapter/test_acp_images.py
python3 -m ruff check acp_adapter/server.py tests/acp_adapter/test_acp_images.py tools/process_registry.py
python3 -m ruff check tests/e2e/conftest.py
git diff --check
python3 -m pytest tests/acp_adapter -q
```

Additional broader check run:

```bash
python3 -m pytest tests/acp -q
```

Result: 207 passed, 1 failed. The failure is in `tests/acp/test_approval_isolation.py::TestAcpExecAskGate::test_interactive_env_var_routes_to_callback`, where the approval guard returned `approved=False` for a dangerous `rm -rf` command. That path is outside the ACP resource-link conversion code touched here; the focused ACP adapter tests passed.

## Disclosure notes

This PR is intentionally limited to ACP resource-link file dereferencing. It does not claim to solve every possible untrusted-editor or prompt-injection issue in ACP clients; it closes the host-side local-file read primitive introduced by trusting `file://` resource links without workspace containment.
