### PR TITLE
fix(memory): preserve existing file permissions on memory updates (#22889)

### DIFF
--- a/tests/tools/test_memory_permission_regression_22889.py
+++ b/tests/tools/test_memory_permission_regression_22889.py
@@ -1,0 +1,127 @@
+"""
+Regression tests for memory file permission preservation (issue #22889).
+
+Hermes' MemoryStore._write_file() previously used tempfile.mkstemp() which
+creates files with 0o600 permissions. After atomic_replace(), the target
+file inherited these restrictive permissions, breaking group-shared deployments.
+"""
+
+import os
+import stat
+import tempfile
+from pathlib import Path
+
+
+class TestMemoryPermissionPreservation:
+    """Tests that MemoryStore preserves existing file permissions."""
+
+    def test_write_file_preserves_group_permissions(self):
+        """Existing file with 0o660 should keep 0o660 after update."""
+        from tools.memory_tool import MemoryStore
+
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "MEMORY.md"
+            p.write_text("old content", encoding="utf-8")
+            os.chmod(p, 0o660)
+
+            before = stat.S_IMODE(p.stat().st_mode)
+            MemoryStore._write_file(p, ["new entry"])
+            after = stat.S_IMODE(p.stat().st_mode)
+
+            assert before == 0o660, f"Setup failed: before={oct(before)}"
+            assert after == 0o660, f"Permissions changed: {oct(before)} -> {oct(after)}"
+
+    def test_write_file_preserves_owner_only(self):
+        """Existing file with 0o600 should keep 0o600 after update."""
+        from tools.memory_tool import MemoryStore
+
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "MEMORY.md"
+            p.write_text("old content", encoding="utf-8")
+            os.chmod(p, 0o600)
+
+            before = stat.S_IMODE(p.stat().st_mode)
+            MemoryStore._write_file(p, ["new entry"])
+            after = stat.S_IMODE(p.stat().st_mode)
+
+            assert before == 0o600
+            assert after == 0o600
+
+    def test_write_file_preserves_world_readable(self):
+        """Existing file with 0o644 should keep 0o644 after update."""
+        from tools.memory_tool import MemoryStore
+
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "MEMORY.md"
+            p.write_text("old content", encoding="utf-8")
+            os.chmod(p, 0o644)
+
+            MemoryStore._write_file(p, ["new entry"])
+            after = stat.S_IMODE(p.stat().st_mode)
+
+            assert after == 0o644
+
+    def test_new_file_gets_default_permissions(self):
+        """New file (doesn't exist) should get default permissions from mkstemp."""
+        from tools.memory_tool import MemoryStore
+
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "NEW_MEMORY.md"
+            # File does not exist yet
+
+            MemoryStore._write_file(p, ["first entry"])
+            after = stat.S_IMODE(p.stat().st_mode)
+
+            # mkstemp creates with 0o600, and there's no original to preserve
+            assert after == 0o600
+
+    def test_write_file_content_is_correct(self):
+        """Permission preservation shouldn't affect content correctness."""
+        from tools.memory_tool import MemoryStore
+
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "MEMORY.md"
+            p.write_text("old", encoding="utf-8")
+            os.chmod(p, 0o660)
+
+            MemoryStore._write_file(p, ["entry 1", "entry 2"])
+            content = p.read_text(encoding="utf-8")
+
+            assert "entry 1" in content
+            assert "entry 2" in content
+            assert "§" in content  # delimiter present
+
+    def test_multiple_writes_preserve_permissions(self):
+        """Multiple consecutive writes should all preserve the original mode."""
+        from tools.memory_tool import MemoryStore
+
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "MEMORY.md"
+            p.write_text("initial", encoding="utf-8")
+            os.chmod(p, 0o664)
+
+            for i in range(3):
+                MemoryStore._write_file(p, [f"entry {i}"])
+                after = stat.S_IMODE(p.stat().st_mode)
+                assert after == 0o664, f"Write {i+1} changed permissions: {oct(after)}"
+
+
+if __name__ == "__main__":
+    import sys
+
+    test_class = TestMemoryPermissionPreservation()
+    methods = [m for m in dir(test_class) if m.startswith("test_")]
+    passed = 0
+    failed = 0
+
+    for method_name in methods:
+        try:
+            getattr(test_class, method_name)()
+            print(f"✓ {method_name}")
+            passed += 1
+        except Exception as e:
+            print(f"✗ {method_name}: {e}")
+            failed += 1
+
+    print(f"\n{passed} passed, {failed} failed")
+    sys.exit(0 if failed == 0 else 1)

--- a/tests/tools/test_memory_permission_regression_22889.py
+++ b/tests/tools/test_memory_permission_regression_22889.py
@@ -1,0 +1,136 @@
+"""
+Regression tests for memory file permission preservation (issue #22889).
+
+Hermes' MemoryStore._write_file() previously used tempfile.mkstemp() which
+creates files with 0o600 permissions. After atomic_replace(), the target
+file inherited these restrictive permissions, breaking group-shared deployments.
+"""
+
+import os
+import stat
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+class TestMemoryPermissionPreservation:
+    """Tests that MemoryStore preserves existing file permissions."""
+
+    def test_write_file_preserves_group_permissions(self):
+        """Existing file with 0o660 should keep 0o660 after update."""
+        from tools.memory_tool import MemoryStore
+
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "MEMORY.md"
+            p.write_text("old content", encoding="utf-8")
+            os.chmod(p, 0o660)
+
+            before = stat.S_IMODE(p.stat().st_mode)
+            MemoryStore._write_file(p, ["new entry"])
+            after = stat.S_IMODE(p.stat().st_mode)
+
+            assert before == 0o660, f"Setup failed: before={oct(before)}"
+            assert after == 0o660, f"Permissions changed: {oct(before)} -> {oct(after)}"
+
+    def test_write_file_preserves_owner_only(self):
+        """Existing file with 0o600 should keep 0o600 after update."""
+        from tools.memory_tool import MemoryStore
+
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "MEMORY.md"
+            p.write_text("old content", encoding="utf-8")
+            os.chmod(p, 0o600)
+
+            before = stat.S_IMODE(p.stat().st_mode)
+            MemoryStore._write_file(p, ["new entry"])
+            after = stat.S_IMODE(p.stat().st_mode)
+
+            assert before == 0o600
+            assert after == 0o600
+
+    def test_write_file_preserves_world_readable(self):
+        """Existing file with 0o644 should keep 0o644 after update."""
+        from tools.memory_tool import MemoryStore
+
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "MEMORY.md"
+            p.write_text("old content", encoding="utf-8")
+            os.chmod(p, 0o644)
+
+            MemoryStore._write_file(p, ["new entry"])
+            after = stat.S_IMODE(p.stat().st_mode)
+
+            assert after == 0o644
+
+    def test_new_file_gets_default_permissions(self):
+        """New file (doesn't exist) should get default permissions from mkstemp."""
+        from tools.memory_tool import MemoryStore
+
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "NEW_MEMORY.md"
+            # File does not exist yet
+
+            MemoryStore._write_file(p, ["first entry"])
+            after = stat.S_IMODE(p.stat().st_mode)
+
+            # mkstemp creates with 0o600, and there's no original to preserve
+            assert after == 0o600
+
+    def test_write_file_content_is_correct(self):
+        """Permission preservation shouldn't affect content correctness."""
+        from tools.memory_tool import MemoryStore
+
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "MEMORY.md"
+            p.write_text("old", encoding="utf-8")
+            os.chmod(p, 0o660)
+
+            MemoryStore._write_file(p, ["entry 1", "entry 2"])
+            content = p.read_text(encoding="utf-8")
+
+            assert "entry 1" in content
+            assert "entry 2" in content
+            assert "§" in content  # delimiter present
+
+    def test_multiple_writes_preserve_permissions(self):
+        """Multiple consecutive writes should all preserve the original mode."""
+        from tools.memory_tool import MemoryStore
+
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d) / "MEMORY.md"
+            p.write_text("initial", encoding="utf-8")
+            os.chmod(p, 0o664)
+
+            for i in range(3):
+                MemoryStore._write_file(p, [f"entry {i}"])
+                after = stat.S_IMODE(p.stat().st_mode)
+                assert after == 0o664, (
+                    f"Write {i + 1} changed permissions: {oct(after)}"
+                )
+
+    def test_write_file_restores_owner_on_real_symlink_target(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Symlinked files should restore uid/gid on the real target."""
+        if os.name != "posix":
+            pytest.skip("POSIX-only")
+
+        from tools.memory_tool import MemoryStore
+
+        real = tmp_path / "MEMORY.md"
+        link = tmp_path / "memory-link.md"
+        real.write_text("old content", encoding="utf-8")
+        link.symlink_to(real)
+
+        chown_calls: list[tuple[Path, int, int]] = []
+        monkeypatch.setattr("utils._preserve_file_owner", lambda _path: (123, 456))
+        monkeypatch.setattr(
+            "utils.os.chown",
+            lambda path, uid, gid: chown_calls.append((Path(path), uid, gid)),
+        )
+
+        MemoryStore._write_file(link, ["new entry"])
+
+        assert link.is_symlink()
+        assert chown_calls == [(real, 123, 456)]

--- a/tests/tools/test_memory_permission_regression_22889.py
+++ b/tests/tools/test_memory_permission_regression_22889.py
@@ -105,7 +105,9 @@ class TestMemoryPermissionPreservation:
             for i in range(3):
                 MemoryStore._write_file(p, [f"entry {i}"])
                 after = stat.S_IMODE(p.stat().st_mode)
-                assert after == 0o664, f"Write {i+1} changed permissions: {oct(after)}"
+                assert after == 0o664, (
+                    f"Write {i + 1} changed permissions: {oct(after)}"
+                )
 
     def test_write_file_restores_owner_on_real_symlink_target(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
@@ -132,24 +134,3 @@ class TestMemoryPermissionPreservation:
 
         assert link.is_symlink()
         assert chown_calls == [(real, 123, 456)]
-
-
-if __name__ == "__main__":
-    import sys
-
-    test_class = TestMemoryPermissionPreservation()
-    methods = [m for m in dir(test_class) if m.startswith("test_")]
-    passed = 0
-    failed = 0
-
-    for method_name in methods:
-        try:
-            getattr(test_class, method_name)()
-            print(f"✓ {method_name}")
-            passed += 1
-        except Exception as e:
-            print(f"✗ {method_name}: {e}")
-            failed += 1
-
-    print(f"\n{passed} passed, {failed} failed")
-    sys.exit(0 if failed == 0 else 1)

--- a/tests/tools/test_memory_permission_regression_22889.py
+++ b/tests/tools/test_memory_permission_regression_22889.py
@@ -11,6 +11,8 @@ import stat
 import tempfile
 from pathlib import Path
 
+import pytest
+
 
 class TestMemoryPermissionPreservation:
     """Tests that MemoryStore preserves existing file permissions."""
@@ -104,6 +106,32 @@ class TestMemoryPermissionPreservation:
                 MemoryStore._write_file(p, [f"entry {i}"])
                 after = stat.S_IMODE(p.stat().st_mode)
                 assert after == 0o664, f"Write {i+1} changed permissions: {oct(after)}"
+
+    def test_write_file_restores_owner_on_real_symlink_target(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Symlinked files should restore uid/gid on the real target."""
+        if os.name != "posix":
+            pytest.skip("POSIX-only")
+
+        from tools.memory_tool import MemoryStore
+
+        real = tmp_path / "MEMORY.md"
+        link = tmp_path / "memory-link.md"
+        real.write_text("old content", encoding="utf-8")
+        link.symlink_to(real)
+
+        chown_calls: list[tuple[Path, int, int]] = []
+        monkeypatch.setattr("utils._preserve_file_owner", lambda _path: (123, 456))
+        monkeypatch.setattr(
+            "utils.os.chown",
+            lambda path, uid, gid: chown_calls.append((Path(path), uid, gid)),
+        )
+
+        MemoryStore._write_file(link, ["new entry"])
+
+        assert link.is_symlink()
+        assert chown_calls == [(real, 123, 456)]
 
 
 if __name__ == "__main__":

--- a/tests/tools/test_memory_tool.py
+++ b/tests/tools/test_memory_tool.py
@@ -706,3 +706,30 @@ class TestBomToleranceInMemoryFiles:
         raw, read_ok = MemoryStore._read_raw_checked(path)
         assert read_ok is False
         assert raw == ""
+
+    def test_write_preserves_file_owner(self, store, tmp_path, monkeypatch):
+        """Memory updates must preserve POSIX owner across atomic replace.
+
+        Docker / NixOS support hit this when a root-run setup wizard rewrote a
+        user-owned memory file, leaving it root-owned. The test forces a
+        preserved uid/gid so it does not need root.
+        """
+        import os
+        if os.name != "posix":
+            pytest.skip("POSIX-only")
+
+        # Patch atomic_write_text helpers to capture owner restore
+        chown_calls = []
+        monkeypatch.setattr("utils._preserve_file_owner", lambda _path: (789, 321))
+        monkeypatch.setattr(
+            "utils.os.chown",
+            lambda path, uid, gid: chown_calls.append((Path(path), uid, gid)),
+        )
+
+        result = store.add("memory", "owner-test fact")
+        assert result["success"] is True
+
+        # The owner should have been restored on the real file path
+        assert len(chown_calls) >= 1
+        assert chown_calls[-1][1:] == (789, 321)
+

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -900,10 +900,14 @@ class MemoryStore:
         file *before* the lock is acquired, creating a race window where
         concurrent readers see an empty file. Atomic rename avoids this:
         readers always see either the old complete file or the new one.
+
+        Preserves existing file permissions and ownership so group-shared
+        deployments (e.g. NixOS, Docker volumes) don't lose access after
+        every memory update (#22889).
         """
         content = ENTRY_DELIMITER.join(entries) if entries else ""
         try:
-            atomic_write_text(path, content, tmp_prefix=".mem_")
+            atomic_write_text(path, content, tmp_prefix=".mem_", preserve_mode=True)
         except (OSError, IOError) as e:
             raise RuntimeError(f"Failed to write memory file {path}: {e}")
 
@@ -1388,7 +1392,4 @@ registry.register(
     emoji="🧠",
     dynamic_schema_overrides=_build_memory_schema_overrides,
 )
-
-
-
 

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -869,9 +869,9 @@ class MemoryStore:
         concurrent readers see an empty file. Atomic rename avoids this:
         readers always see either the old complete file or the new one.
 
-        Preserves existing file permissions so group-shared deployments
-        (e.g. NixOS, Docker volumes) don't lose their permission bits
-        after every memory update (#22889).
+        Preserves existing file permissions and ownership so group-shared
+        deployments (e.g. NixOS, Docker volumes) don't lose access after
+        every memory update (#22889).
         """
         content = ENTRY_DELIMITER.join(entries) if entries else ""
         try:

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -868,10 +868,16 @@ class MemoryStore:
         file *before* the lock is acquired, creating a race window where
         concurrent readers see an empty file. Atomic rename avoids this:
         readers always see either the old complete file or the new one.
+
+        Preserves existing file permissions so group-shared deployments
+        (e.g. NixOS, Docker volumes) don't lose their permission bits
+        after every memory update (#22889).
         """
         content = ENTRY_DELIMITER.join(entries) if entries else ""
         try:
-            atomic_write_text(path, content, tmp_prefix=".mem_")
+            atomic_write_text(
+                path, content, tmp_prefix=".mem_", preserve_mode=True
+            )
         except (OSError, IOError) as e:
             raise RuntimeError(f"Failed to write memory file {path}: {e}")
 
@@ -1234,7 +1240,5 @@ registry.register(
     check_fn=check_memory_requirements,
     emoji="🧠",
 )
-
-
 
 

--- a/tools/memory_tool.py
+++ b/tools/memory_tool.py
@@ -875,9 +875,7 @@ class MemoryStore:
         """
         content = ENTRY_DELIMITER.join(entries) if entries else ""
         try:
-            atomic_write_text(
-                path, content, tmp_prefix=".mem_", preserve_mode=True
-            )
+            atomic_write_text(path, content, tmp_prefix=".mem_", preserve_mode=True)
         except (OSError, IOError) as e:
             raise RuntimeError(f"Failed to write memory file {path}: {e}")
 
@@ -1240,5 +1238,4 @@ registry.register(
     check_fn=check_memory_requirements,
     emoji="🧠",
 )
-
 


### PR DESCRIPTION
## Bug Description

Hermes' built-in memory writer unintentionally changed the permissions of existing memory files when saving updates.

On NixOS and other group-shared deployments, memory files changed from `0660` to `0600` after Hermes updated them, removing group access.

## Root Cause

`MemoryStore._write_file()` used `tempfile.mkstemp()` which creates files with `0o600` permissions. After `atomic_replace()`, the target file inherited the temp file's restrictive permissions instead of keeping the original mode.

## Fix

Use the existing `_preserve_file_mode()` and `_restore_file_mode()` helpers from `utils.py` (already used by `atomic_json_write()` and `atomic_yaml_write()`):

1. Capture original permissions before atomic write
2. Restore permissions after `atomic_replace()` completes
3. New files (no original) still get `0o600` from `mkstemp`

## Tests

Added `tests/tools/test_memory_permission_regression_22889.py` with 6 tests:
- Preserves group permissions (`0o660`)
- Preserves owner-only (`0o600`)
- Preserves world-readable (`0o644`)
- New file gets default `0o600`
- Content correctness unaffected
- Multiple consecutive writes all preserve permissions

All tests pass.

Fixes #22889