### PR TITLE
fix(tui): detect Ghostty hyperlinks via TERM=xterm-ghostty (#22895)

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/supports-hyperlinks.test.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/supports-hyperlinks.test.ts
@@ -1,0 +1,59 @@
+/**
+ * Regression tests for Ghostty OSC 8 hyperlink support (issue #22895).
+ *
+ * Ghostty sets TERM=xterm-ghostty (not TERM_PROGRAM=ghostty), so the
+ * supports-hyperlinks detector needs to check TERM in addition to
+ * TERM_PROGRAM.
+ */
+
+import { supportsHyperlinks, ADDITIONAL_HYPERLINK_TERMINALS } from './supports-hyperlinks'
+
+describe('supportsHyperlinks', () => {
+  it('detects ghostty via TERM=xterm-ghostty', () => {
+    const result = supportsHyperlinks({
+      env: { TERM: 'xterm-ghostty' },
+      stdoutSupported: false,
+    })
+    expect(result).toBe(true)
+  })
+
+  it('detects ghostty via TERM_PROGRAM=ghostty', () => {
+    const result = supportsHyperlinks({
+      env: { TERM_PROGRAM: 'ghostty' },
+      stdoutSupported: false,
+    })
+    expect(result).toBe(true)
+  })
+
+  it('detects kitty via TERM=xterm-kitty', () => {
+    const result = supportsHyperlinks({
+      env: { TERM: 'xterm-kitty' },
+      stdoutSupported: false,
+    })
+    expect(result).toBe(true)
+  })
+
+  it('does not detect generic xterm', () => {
+    const result = supportsHyperlinks({
+      env: { TERM: 'xterm-256color' },
+      stdoutSupported: false,
+    })
+    expect(result).toBe(false)
+  })
+
+  it('returns true when stdoutSupported is true regardless of env', () => {
+    const result = supportsHyperlinks({
+      env: {},
+      stdoutSupported: true,
+    })
+    expect(result).toBe(true)
+  })
+
+  it('detects iTerm via TERM_PROGRAM', () => {
+    const result = supportsHyperlinks({
+      env: { TERM_PROGRAM: 'iTerm.app' },
+      stdoutSupported: false,
+    })
+    expect(result).toBe(true)
+  })
+})

--- a/ui-tui/packages/hermes-ink/src/ink/supports-hyperlinks.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/supports-hyperlinks.ts
@@ -40,10 +40,14 @@ export function supportsHyperlinks(options?: SupportsHyperlinksOptions): boolean
     return true
   }
 
-  // Kitty sets TERM=xterm-kitty
+  // Kitty sets TERM=xterm-kitty; Ghostty sets TERM=xterm-ghostty
   const term = env['TERM']
 
   if (term?.includes('kitty')) {
+    return true
+  }
+
+  if (term?.includes('ghostty')) {
     return true
   }
 


### PR DESCRIPTION
## Bug Description

URLs output by Hermes in Ghostty terminal were not clickable via Cmd+Click. Ghostty's link detector (`link-url = true`) couldn't identify URLs when they were surrounded by ANSI escape sequences.

## Root Cause

Ghostty sets `TERM=xterm-ghostty` (not `TERM_PROGRAM=ghostty`). The `supports-hyperlinks.ts` detector only checked `TERM_PROGRAM` and `LC_TERMINAL` for `ghostty`, missing the `TERM` environment variable check.

## Fix

Add `TERM` variable check for `ghostty` (same pattern already used for Kitty's `xterm-kitty`):

```typescript
if (term?.includes('ghostty')) {
  return true
}
```

## Tests

Added `supports-hyperlinks.test.ts` with 6 tests:
- Detects Ghostty via `TERM=xterm-ghostty`
- Detects Ghostty via `TERM_PROGRAM=ghostty`
- Detects Kitty via `TERM=xterm-kitty`
- Does NOT detect generic `xterm-256color`
- Returns true when stdoutSupported is true
- Detects iTerm via `TERM_PROGRAM`

Fixes #22895