### PR TITLE
fix(mcp): lock _last_poll_timestamps access in _poll_once

### DIFF
--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -329,6 +329,17 @@ class EventBridge:
                 self._queue.pop(0)
         self._new_event.set()
 
+    def _get_last_poll_timestamp(self, session_key: str) -> float:
+        """Read the per-session poll cursor under the bridge lock."""
+        with self._lock:
+            return self._last_poll_timestamps.get(session_key, 0.0)
+
+    def _set_last_poll_timestamp(self, session_key: str, latest: float) -> None:
+        """Advance the per-session poll cursor without regressing it."""
+        with self._lock:
+            if latest > self._last_poll_timestamps.get(session_key, 0.0):
+                self._last_poll_timestamps[session_key] = latest
+
     def _poll_loop(self):
         """Background loop: poll SessionDB for new messages."""
         db = _get_session_db()
@@ -383,7 +394,7 @@ class EventBridge:
             if not session_id:
                 continue
 
-            last_seen = self._last_poll_timestamps.get(session_key, 0.0)
+            last_seen = self._get_last_poll_timestamp(session_key)
 
             try:
                 messages = db.get_messages(session_id)
@@ -440,7 +451,7 @@ class EventBridge:
             if all_ts:
                 latest = max(all_ts)
                 if latest > last_seen:
-                    self._last_poll_timestamps[session_key] = latest
+                    self._set_last_poll_timestamp(session_key, latest)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -491,6 +491,17 @@ class TestEventBridge:
         r = EventBridge().respond_to_approval("nope", "deny")
         assert "error" in r
 
+    def test_last_poll_timestamp_updates_are_monotonic(self):
+        from mcp_serve import EventBridge
+
+        bridge = EventBridge()
+        session_key = "agent:main:telegram:dm:lock-test"
+
+        bridge._set_last_poll_timestamp(session_key, 10.0)
+        bridge._set_last_poll_timestamp(session_key, 5.0)
+
+        assert bridge._get_last_poll_timestamp(session_key) == 10.0
+
 
 # ---------------------------------------------------------------------------
 # 3. END-TO-END TESTS — call MCP tools through FastMCP server


### PR DESCRIPTION
## Summary
- add locked helpers for reading and updating `_last_poll_timestamps`
- keep timestamp updates monotonic so stale writes cannot move the cursor backwards
- cover the regression with a focused broker test

## Verification
- `UV_PYTHON=3.11 uv run --frozen pytest -q -o addopts= tests/test_mcp_serve.py`\n- `UV_PYTHON=3.11 uv run --frozen ruff check mcp_serve.py tests/test_mcp_serve.py`