### PR TITLE
fix(kanban): add heartbeat grace window to prevent reclaiming slow workers (#23025)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1979,12 +1979,21 @@ def release_stale_claims(
     """
     now = int(time.time())
     reclaimed = 0
+    # Grace window: if the worker heartbeated within the last 5 minutes,
+    # the claim is still considered alive even if claim_expires has passed.
+    # This prevents reclaiming slow-model workers (e.g. kimi-k2.6) that are
+    # actively processing but whose claim TTL expired between heartbeats.
+    HEARTBEAT_GRACE_SECONDS = 5 * 60
     stale = conn.execute(
-        "SELECT id, claim_lock, worker_pid FROM tasks "
+        "SELECT id, claim_lock, worker_pid, last_heartbeat_at FROM tasks "
         "WHERE status = 'running' AND claim_expires IS NOT NULL AND claim_expires < ?",
         (now,),
     ).fetchall()
     for row in stale:
+        # Skip if worker heartbeated recently — it's alive, just slow.
+        last_hb = row["last_heartbeat_at"] or 0
+        if now - last_hb < HEARTBEAT_GRACE_SECONDS:
+            continue
         termination = _terminate_reclaimed_worker(
             row["worker_pid"], row["claim_lock"], signal_fn=signal_fn,
         )

--- a/tests/hermes_cli/test_kanban_stale_claim_grace_regression_23025.py
+++ b/tests/hermes_cli/test_kanban_stale_claim_grace_regression_23025.py
@@ -1,0 +1,230 @@
+"""
+Regression tests for kanban stale claim grace window (issue #23025).
+
+release_stale_claims() previously reclaimed any running task whose
+claim_expires had passed, even if the worker had heartbeated recently.
+This caused slow-model workers (e.g. kimi-k2.6) to be repeatedly
+reclaimed while actively processing.
+"""
+
+import sqlite3
+import time
+from unittest.mock import patch, MagicMock
+
+
+class TestReleaseStaleClaimsGraceWindow:
+    """Tests that release_stale_claims respects recent heartbeats."""
+
+    def test_does_not_reclaim_when_heartbeated_recently(self):
+        """Worker that heartbeated 2 min ago should NOT be reclaimed."""
+        from hermes_cli.kanban_db import release_stale_claims, claim_task, heartbeat_worker
+
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        # Setup minimal schema
+        conn.executescript("""
+            CREATE TABLE tasks (
+                id TEXT PRIMARY KEY,
+                status TEXT,
+                claim_lock TEXT,
+                claim_expires INTEGER,
+                worker_pid INTEGER,
+                last_heartbeat_at INTEGER,
+                current_run_id INTEGER,
+                title TEXT,
+                assignee TEXT,
+                body TEXT,
+                board TEXT,
+                tenant TEXT,
+                priority INTEGER DEFAULT 0,
+                workspace_kind TEXT DEFAULT 'scratch',
+                triage INTEGER DEFAULT 0,
+                created_by TEXT
+            );
+            CREATE TABLE task_runs (
+                id INTEGER PRIMARY KEY,
+                task_id TEXT,
+                status TEXT,
+                outcome TEXT,
+                started_at INTEGER,
+                claim_expires INTEGER,
+                last_heartbeat_at INTEGER
+            );
+            CREATE TABLE task_events (
+                id INTEGER PRIMARY KEY,
+                task_id TEXT,
+                event_type TEXT,
+                payload TEXT,
+                run_id INTEGER,
+                created_at INTEGER
+            );
+        """)
+
+        now = int(time.time())
+        # Insert a running task with expired claim but recent heartbeat
+        conn.execute(
+            "INSERT INTO tasks (id, status, claim_lock, claim_expires, worker_pid, last_heartbeat_at, title, assignee) "
+            "VALUES (?, 'running', ?, ?, ?, ?, ?, ?)",
+            ("t_123", "lock-abc", now - 60, 12345, now - 120, "Test", "worker"),
+        )
+        conn.execute(
+            "INSERT INTO task_runs (id, task_id, status, started_at, claim_expires, last_heartbeat_at) "
+            "VALUES (?, ?, 'running', ?, ?, ?)",
+            (1, "t_123", now - 300, now - 60, now - 120),
+        )
+        conn.commit()
+
+        with patch("hermes_cli.kanban_db._terminate_reclaimed_worker") as mock_term:
+            reclaimed = release_stale_claims(conn)
+
+        assert reclaimed == 0, "Should NOT reclaim worker with recent heartbeat"
+        mock_term.assert_not_called()
+
+    def test_reclaims_when_no_recent_heartbeat(self):
+        """Worker that hasn't heartbeated for 10 min SHOULD be reclaimed."""
+        from hermes_cli.kanban_db import release_stale_claims
+
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.executescript("""
+            CREATE TABLE tasks (
+                id TEXT PRIMARY KEY,
+                status TEXT,
+                claim_lock TEXT,
+                claim_expires INTEGER,
+                worker_pid INTEGER,
+                last_heartbeat_at INTEGER,
+                current_run_id INTEGER,
+                title TEXT,
+                assignee TEXT,
+                body TEXT,
+                board TEXT,
+                tenant TEXT,
+                priority INTEGER DEFAULT 0,
+                workspace_kind TEXT DEFAULT 'scratch',
+                triage INTEGER DEFAULT 0,
+                created_by TEXT
+            );
+            CREATE TABLE task_runs (
+                id INTEGER PRIMARY KEY,
+                task_id TEXT,
+                status TEXT,
+                outcome TEXT,
+                started_at INTEGER,
+                claim_expires INTEGER,
+                last_heartbeat_at INTEGER
+            );
+            CREATE TABLE task_events (
+                id INTEGER PRIMARY KEY,
+                task_id TEXT,
+                event_type TEXT,
+                payload TEXT,
+                run_id INTEGER,
+                created_at INTEGER
+            );
+        """)
+
+        now = int(time.time())
+        # Insert a running task with expired claim and OLD heartbeat (10 min ago)
+        conn.execute(
+            "INSERT INTO tasks (id, status, claim_lock, claim_expires, worker_pid, last_heartbeat_at, title, assignee) "
+            "VALUES (?, 'running', ?, ?, ?, ?, ?, ?)",
+            ("t_456", "lock-def", now - 60, 12345, now - 600, "Test", "worker"),
+        )
+        conn.execute(
+            "INSERT INTO task_runs (id, task_id, status, started_at, claim_expires, last_heartbeat_at) "
+            "VALUES (?, ?, 'running', ?, ?, ?)",
+            (1, "t_456", now - 300, now - 60, now - 600),
+        )
+        conn.commit()
+
+        with patch("hermes_cli.kanban_db._terminate_reclaimed_worker", return_value={}) as mock_term:
+            reclaimed = release_stale_claims(conn)
+
+        assert reclaimed == 1, "Should reclaim worker with old heartbeat"
+        mock_term.assert_called_once()
+
+    def test_reclaims_when_no_heartbeat_at_all(self):
+        """Worker that never heartbeated SHOULD be reclaimed."""
+        from hermes_cli.kanban_db import release_stale_claims
+
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        conn.executescript("""
+            CREATE TABLE tasks (
+                id TEXT PRIMARY KEY,
+                status TEXT,
+                claim_lock TEXT,
+                claim_expires INTEGER,
+                worker_pid INTEGER,
+                last_heartbeat_at INTEGER,
+                current_run_id INTEGER,
+                title TEXT,
+                assignee TEXT,
+                body TEXT,
+                board TEXT,
+                tenant TEXT,
+                priority INTEGER DEFAULT 0,
+                workspace_kind TEXT DEFAULT 'scratch',
+                triage INTEGER DEFAULT 0,
+                created_by TEXT
+            );
+            CREATE TABLE task_runs (
+                id INTEGER PRIMARY KEY,
+                task_id TEXT,
+                status TEXT,
+                outcome TEXT,
+                started_at INTEGER,
+                claim_expires INTEGER,
+                last_heartbeat_at INTEGER
+            );
+            CREATE TABLE task_events (
+                id INTEGER PRIMARY KEY,
+                task_id TEXT,
+                event_type TEXT,
+                payload TEXT,
+                run_id INTEGER,
+                created_at INTEGER
+            );
+        """)
+
+        now = int(time.time())
+        # Insert a running task with expired claim and NULL heartbeat
+        conn.execute(
+            "INSERT INTO tasks (id, status, claim_lock, claim_expires, worker_pid, last_heartbeat_at, title, assignee) "
+            "VALUES (?, 'running', ?, ?, ?, NULL, ?, ?)",
+            ("t_789", "lock-ghi", now - 60, 12345, "Test", "worker"),
+        )
+        conn.execute(
+            "INSERT INTO task_runs (id, task_id, status, started_at, claim_expires, last_heartbeat_at) "
+            "VALUES (?, ?, 'running', ?, ?, NULL)",
+            (1, "t_789", now - 300, now - 60),
+        )
+        conn.commit()
+
+        with patch("hermes_cli.kanban_db._terminate_reclaimed_worker", return_value={}) as mock_term:
+            reclaimed = release_stale_claims(conn)
+
+        assert reclaimed == 1, "Should reclaim worker that never heartbeated"
+        mock_term.assert_called_once()
+
+
+if __name__ == "__main__":
+    import sys
+
+    test_class = TestReleaseStaleClaimsGraceWindow()
+    methods = [m for m in dir(test_class) if m.startswith("test_")]
+    passed = 0
+    failed = 0
+
+    for method_name in methods:
+        try:
+            getattr(test_class, method_name)()
+            print(f"✓ {method_name}")
+            passed += 1
+        except Exception as e:
+            print(f"✗ {method_name}: {e}")
+            failed += 1
+
+    print(f"\n{passed} passed, {failed} failed")
+    sys.exit(0 if failed == 0 else 1)


### PR DESCRIPTION
## Bug Description

Kanban workers on the default board repeatedly entered a stall loop:
1. Worker spawns (status: running)
2. Worker produces no output
3. Worker is reclaimed after ~15 min (status: reclaimed, error: stale_lock)
4. Dispatcher immediately respawns a new worker
5. New worker immediately hits the same pattern

This was particularly bad for slow models like kimi-k2.6.

## Root Cause

`release_stale_claims()` reclaimed any running task whose `claim_expires` had passed, regardless of whether the worker had heartbeated recently. The default claim TTL is 15 minutes, but slow models can take longer between heartbeats.

## Fix

Add a 5-minute heartbeat grace window to `release_stale_claims()`:
- If a worker heartbeated within the last 5 minutes, skip reclaim even if `claim_expires` has passed
- Workers that are truly stuck (no heartbeat for >5 min) are still reclaimed
- This gives slow-model workers extra time while still catching dead workers

## Tests

Added `tests/hermes_cli/test_kanban_stale_claim_grace_regression_23025.py` with 3 tests:
- Does NOT reclaim when worker heartbeated 2 minutes ago
- DOES reclaim when worker last heartbeated 10 minutes ago
- DOES reclaim when worker never heartbeated

All tests pass.

Fixes #23025