### PR TITLE
fix(xai): skip reasoning effort for grok 4.1 responses

### DIFF
--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -11,6 +11,18 @@ from agent.transports.base import ProviderTransport
 from agent.transports.types import NormalizedResponse, ToolCall
 
 
+def _xai_supports_reasoning_effort(model: str) -> bool:
+    """Return whether xAI Responses should receive a reasoning effort payload.
+
+    Grok 4.1 variants currently reject ``reasoningEffort`` with HTTP 400, even
+    though newer xAI reasoning models accept it. Keep the gate narrow so small
+    fixes to older Grok routes do not hard-fail on every turn.
+    """
+    normalized = str(model or "").strip().lower().replace("_", "-")
+    normalized = normalized.replace("xai/", "").replace("x-ai/", "")
+    return not normalized.startswith(("grok-4-1", "grok-4.1"))
+
+
 class ResponsesApiTransport(ProviderTransport):
     """Transport for api_mode='codex_responses'.
 
@@ -105,7 +117,8 @@ class ResponsesApiTransport(ProviderTransport):
 
         if reasoning_enabled and is_xai_responses:
             kwargs["include"] = ["reasoning.encrypted_content"]
-            kwargs["reasoning"] = {"effort": reasoning_effort}
+            if _xai_supports_reasoning_effort(model):
+                kwargs["reasoning"] = {"effort": reasoning_effort}
         elif reasoning_enabled:
             if is_github_responses:
                 github_reasoning = params.get("github_reasoning_extra")

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -160,6 +160,25 @@ class TestCodexBuildKwargs:
         assert kw.get("reasoning") == {"effort": "high"}
         assert "reasoning.encrypted_content" in kw.get("include", [])
 
+    def test_xai_grok_4_1_fast_skips_reasoning_effort(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="grok-4-1-fast", messages=messages, tools=[],
+            is_xai_responses=True,
+            reasoning_config={"effort": "high"},
+        )
+        assert "reasoning" not in kw
+        assert "reasoning.encrypted_content" in kw.get("include", [])
+
+    def test_xai_prefixed_grok_4_1_skips_reasoning_effort(self, transport):
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="x-ai/grok-4.1-fast", messages=messages, tools=[],
+            is_xai_responses=True,
+            reasoning_config={"effort": "high"},
+        )
+        assert "reasoning" not in kw
+
     def test_xai_reasoning_disabled_no_reasoning_key(self, transport):
         messages = [{"role": "user", "content": "Hi"}]
         kw = transport.build_kwargs(


### PR DESCRIPTION
## Summary
- avoid sending xAI reasoning effort for `grok-4-1` response models that hard-fail with HTTP 400
- keep encrypted reasoning includes intact for the xAI responses path
- add focused transport coverage for supported and unsupported Grok variants

## Verification
- `UV_PYTHON=3.11 uv run --frozen pytest -q -o addopts= tests/agent/transports/test_codex_transport.py`\n- `UV_PYTHON=3.11 uv run --frozen ruff check agent/transports/codex.py tests/agent/transports/test_codex_transport.py`