### PR TITLE
feat(hooks): honor enabled field in HOOK.yaml to disable hooks

### DIFF
--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -44,6 +44,7 @@ from typing import Any, Callable, Dict, List, Optional
 import yaml
 
 from hermes_cli.config import get_hermes_home
+from utils import is_truthy_value
 
 
 HOOKS_DIR = get_hermes_home() / "hooks"
@@ -110,6 +111,13 @@ class HookRegistry:
                     continue
 
                 hook_name = manifest.get("name", hook_dir.name)
+                # Optional 'enabled' field (defaults to true).
+                # Uses is_truthy_value to handle YAML booleans, quoted
+                # strings ("false", "no"), and numeric 0.
+                if not is_truthy_value(manifest.get("enabled"), default=True):
+                    print(f"[hooks] Skipping {hook_name}: disabled by manifest", flush=True)
+                    continue
+
                 events = manifest.get("events", [])
                 if not events:
                     print(f"[hooks] Skipping {hook_name}: no events declared", flush=True)

--- a/tests/gateway/test_hooks.py
+++ b/tests/gateway/test_hooks.py
@@ -1,5 +1,6 @@
 """Tests for gateway/hooks.py — event hook system."""
 
+import sys
 from unittest.mock import patch
 
 import pytest
@@ -97,6 +98,28 @@ class TestDiscoverAndLoad:
             reg.discover_and_load()
 
         assert len(reg.loaded_hooks) == 0
+
+    def test_skips_disabled_hook(self, tmp_path):
+        hook_dir = tmp_path / "disabled-hook"
+        hook_dir.mkdir()
+        (hook_dir / "HOOK.yaml").write_text(
+            "name: disabled-hook\n"
+            "description: This hook is disabled\n"
+            "events:\n"
+            "  - agent:start\n"
+            "enabled: false\n"
+        )
+        (hook_dir / "handler.py").write_text(
+            "def handle(event_type, context):\n    pass\n"
+        )
+
+        reg = HookRegistry()
+        with patch("gateway.hooks.HOOKS_DIR", tmp_path), _patch_no_builtins(reg):
+            reg.discover_and_load()
+
+        assert len(reg.loaded_hooks) == 0
+        assert "agent:start" not in reg._handlers
+        assert "hermes_hook_disabled-hook" not in sys.modules
 
     def test_multiple_hooks(self, tmp_path):
         _create_hook(tmp_path, "hook-a", '["agent:start"]',

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -40,9 +40,12 @@ events:
   - agent:start
   - agent:end
   - agent:step
+enabled: true  # optional, defaults to true
 ```
 
 The `events` list determines which events trigger your handler. You can subscribe to any combination of events, including wildcards like `command:*`.
+
+The optional `enabled` field controls whether the hook is loaded on gateway startup. It defaults to `true`; setting it to `false` skips handler loading entirely — the hook will not appear in `loaded_hooks` and its handler will not be registered for any events.
 
 #### handler.py
 


### PR DESCRIPTION
## Summary
Adds support for `enabled: false` in `HOOK.yaml` manifest. When set, the hook registry skips loading that hook entirely.

## Changes
- `gateway/hooks.py`: Added check for `manifest.get('enabled', True)` before loading hook handlers
- Disabled hooks are logged as `[hooks] Skipping {hook_name}: disabled in HOOK.yaml`

## Test
1. Set `enabled: false` in any hook's HOOK.yaml
2. Restart gateway
3. Verify hook is not loaded