### PR TITLE
docs(memory): fix broken developer guide link

### DIFF
--- a/website/docs/user-guide/features/memory-providers.md
+++ b/website/docs/user-guide/features/memory-providers.md
@@ -546,4 +546,4 @@ Each provider's data is isolated per [profile](/docs/user-guide/profiles):
 
 ## Building a Memory Provider
 
-See the [Developer Guide: Memory Provider Plugins](/docs/developer-guide/memory-provider-plugin) for how to create your own.
+See the [Developer Guide: Memory Provider Plugins](../../developer-guide/memory-provider-plugin.md) for how to create your own.


### PR DESCRIPTION
## Summary
- replace the broken absolute memory provider guide link with a repo-relative docs link
- keep the user guide page navigable from both the docs site and GitHub source view

## Verification
- `UV_PYTHON=3.11 uv run --frozen pytest -q -o addopts= tests/hermes_cli/test_plugins_cmd.py -k memory`\n- `UV_PYTHON=3.11 uv run --frozen ruff check tests/hermes_cli/test_plugins_cmd.py`