### PR TITLE
fix(gateway): suppress noisy chat lifecycle notices

### DIFF
--- a/gateway/action_requests.py
+++ b/gateway/action_requests.py
@@ -1,0 +1,113 @@
+"""Persistent gateway action requests for chat buttons.
+
+Action requests let a delivered message include compact callback-data buttons
+without stuffing the whole task payload into Telegram/Discord component IDs.
+The stored JSON is intentionally boring and local: no secrets, no execution on
+read, and filenames are opaque random IDs.
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+import subprocess
+from dataclasses import dataclass
+from typing import Any, Callable
+
+from hermes_constants import get_hermes_home
+
+_ACTIONS_DIR = "action_requests"
+
+
+@dataclass(frozen=True)
+class ActionRequest:
+    id: str
+    kind: str
+    action: str
+    payload: dict[str, Any]
+
+
+def _safe_part(value: str) -> str:
+    return "".join(ch for ch in value if ch.isalnum() or ch in {"-", "_"})[:80]
+
+
+def actions_root() -> Path:
+    root = get_hermes_home() / _ACTIONS_DIR
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def store_action_request(kind: str, action: str, payload: dict[str, Any]) -> ActionRequest:
+    """Store an action request and return its opaque ID."""
+    kind_safe = _safe_part(kind or "generic") or "generic"
+    action_safe = _safe_part(action or "run") or "run"
+    request_id = f"{kind_safe}-{secrets.token_urlsafe(12)}"
+    path = actions_root() / f"{request_id}.json"
+    body = {
+        "id": request_id,
+        "kind": kind_safe,
+        "action": action_safe,
+        "payload": payload or {},
+    }
+    path.write_text(json.dumps(body, indent=2, sort_keys=True), encoding="utf-8")
+    path.chmod(0o600)
+    return ActionRequest(id=request_id, kind=kind_safe, action=action_safe, payload=payload or {})
+
+
+def load_action_request(request_id: str) -> ActionRequest:
+    request_id = _safe_part(request_id)
+    if not request_id:
+        raise ValueError("Invalid action request ID")
+    path = actions_root() / f"{request_id}.json"
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return ActionRequest(
+        id=str(data.get("id") or request_id),
+        kind=str(data.get("kind") or "generic"),
+        action=str(data.get("action") or "run"),
+        payload=data.get("payload") if isinstance(data.get("payload"), dict) else {},
+    )
+
+
+ActionHandler = Callable[[ActionRequest], subprocess.Popen]
+_ACTION_HANDLERS: dict[tuple[str, str], ActionHandler] = {}
+
+
+def register_action_handler(kind: str, action: str, handler: ActionHandler) -> None:
+    """Register a runtime action-card handler.
+
+    Plugins use this to keep local behaviour (for example Colm's Sentry
+    create-PR helper) out of Hermes core while preserving compact button
+    callback data.
+    """
+    _ACTION_HANDLERS[(_safe_part(kind), _safe_part(action))] = handler
+
+
+def dispatch_action_request(request_id: str) -> subprocess.Popen:
+    """Dispatch an action request in the background using a registered handler."""
+    req = load_action_request(request_id)
+    handler = _ACTION_HANDLERS.get((req.kind, req.action))
+    if handler is None:
+        raise ValueError(f"Unsupported action request: {req.kind}/{req.action}")
+    return handler(req)
+
+
+def build_action_buttons(actions: list[dict[str, Any]], payload: dict[str, Any] | None = None) -> list[dict[str, str]]:
+    """Convert route metadata actions into compact button descriptors.
+
+    Each input action supports:
+      - label: button text
+      - kind: e.g. "sentry"
+      - action: e.g. "create_pr"
+      - payload: optional payload override; defaults to the webhook payload
+    """
+    buttons: list[dict[str, str]] = []
+    for item in actions or []:
+        if not isinstance(item, dict):
+            continue
+        label = str(item.get("label") or item.get("action") or "Run").strip()[:64]
+        kind = str(item.get("kind") or "generic")
+        action = str(item.get("action") or "run")
+        action_payload = item.get("payload") if isinstance(item.get("payload"), dict) else payload or {}
+        req = store_action_request(kind, action, action_payload)
+        buttons.append({"label": label, "callback_data": f"ar:{req.id}"})
+    return buttons

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1426,6 +1426,19 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
                 effective_thread_id = thread_kwargs.get("message_thread_id")
 
+                action_buttons = None
+                if i == 0 and metadata and isinstance(metadata.get("action_buttons"), list):
+                    rows = []
+                    for button in metadata.get("action_buttons") or []:
+                        if not isinstance(button, dict):
+                            continue
+                        label = str(button.get("label") or "Run")[:64]
+                        callback_data = str(button.get("callback_data") or "")[:64]
+                        if callback_data:
+                            rows.append([InlineKeyboardButton(label, callback_data=callback_data)])
+                    if rows:
+                        action_buttons = InlineKeyboardMarkup(rows)
+
                 msg = None
                 for _send_attempt in range(3):
                     try:
@@ -1436,6 +1449,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                 text=chunk,
                                 parse_mode=ParseMode.MARKDOWN_V2,
                                 reply_to_message_id=reply_to_id,
+                                reply_markup=action_buttons,
                                 **thread_kwargs,
                                 **self._link_preview_kwargs(),
                                 **self._notification_kwargs(metadata),
@@ -1450,6 +1464,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                     text=plain_chunk,
                                     parse_mode=None,
                                     reply_to_message_id=reply_to_id,
+                                    reply_markup=action_buttons,
                                     **thread_kwargs,
                                     **self._link_preview_kwargs(),
                                     **self._notification_kwargs(metadata),
@@ -2308,6 +2323,39 @@ class TelegramAdapter(BasePlatformAdapter):
                         await self._bot.send_message(**send_kwargs)
                 except Exception as exc:
                     logger.error("[%s] slash-confirm callback failed: %s", self.name, exc, exc_info=True)
+            return
+
+        # --- Gateway action-card callbacks (ar:<request_id>) ---
+        if data.startswith("ar:"):
+            request_id = data.split(":", 1)[1]
+            caller_id = str(getattr(query.from_user, "id", ""))
+            if not self._is_callback_user_authorized(
+                caller_id,
+                chat_id=query_chat_id,
+                chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                user_name=query_user_name,
+            ):
+                await query.answer(text="⛔ You are not authorized to run this action.")
+                return
+            try:
+                from gateway.action_requests import dispatch_action_request
+                dispatch_action_request(request_id)
+                await query.answer(text="Starting PR task…")
+                try:
+                    await query.edit_message_reply_markup(reply_markup=None)
+                except Exception:
+                    pass
+                if query.message:
+                    await self._bot.send_message(
+                        chat_id=int(query.message.chat_id),
+                        text="I’m starting a fresh Codex PR task for that Sentry issue. I’ll report back with the PR link.",
+                        parse_mode=ParseMode.MARKDOWN,
+                        **self._link_preview_kwargs(),
+                    )
+            except Exception as exc:
+                logger.error("[%s] action callback failed: %s", self.name, exc, exc_info=True)
+                await query.answer(text="Could not start action. Check Hermes logs.")
             return
 
         # --- Update prompt callbacks ---

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -709,6 +709,15 @@ class WebhookAdapter(BasePlatformAdapter):
         self, content: str, delivery: dict
     ) -> SendResult:
         """Post agent response as a GitHub PR/issue comment via ``gh`` CLI."""
+        # Convention for webhook routes: an agent response of exactly SKIP
+        # means "do not deliver anything".  PR-review routes use this for
+        # trusted webhook actions such as closed/deleted/review_requested.
+        # Without this guard, the sentinel itself gets posted as a noisy
+        # GitHub comment.
+        if content.strip() == "SKIP":
+            logger.info("[webhook] Suppressed SKIP response for github_comment delivery")
+            return SendResult(success=True)
+
         extra = delivery.get("deliver_extra", {})
         repo = extra.get("repo", "")
         pr_number = extra.get("pr_number", "")

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -51,6 +51,7 @@ from gateway.platforms.base import (
     MessageType,
     SendResult,
 )
+from gateway.action_requests import build_action_buttons
 
 logger = logging.getLogger(__name__)
 
@@ -664,14 +665,21 @@ class WebhookAdapter(BasePlatformAdapter):
     def _render_delivery_extra(
         self, extra: dict, payload: dict
     ) -> dict:
-        """Render delivery_extra template values with payload data."""
-        rendered: Dict[str, Any] = {}
-        for key, value in extra.items():
+        """Render delivery_extra template values with payload data.
+
+        Values may be nested dicts/lists so routes can define action button
+        metadata without writing a custom webhook adapter.
+        """
+        def _render(value: Any) -> Any:
             if isinstance(value, str):
-                rendered[key] = self._render_prompt(value, payload, "", "")
-            else:
-                rendered[key] = value
-        return rendered
+                return self._render_prompt(value, payload, "", "")
+            if isinstance(value, list):
+                return [_render(item) for item in value]
+            if isinstance(value, dict):
+                return {str(k): _render(v) for k, v in value.items()}
+            return value
+
+        return {str(key): _render(value) for key, value in extra.items()}
 
     # ------------------------------------------------------------------
     # Response delivery
@@ -805,10 +813,17 @@ class WebhookAdapter(BasePlatformAdapter):
                     error=f"No chat_id or home channel for {platform_name}",
                 )
 
-        # Pass thread_id from deliver_extra so Telegram forum topics work
-        metadata = None
+        # Pass thread_id/action metadata from deliver_extra so Telegram forum
+        # topics and action-card buttons work on cross-platform deliveries.
+        metadata: Dict[str, Any] = {}
         thread_id = extra.get("message_thread_id") or extra.get("thread_id")
         if thread_id:
-            metadata = {"thread_id": thread_id}
+            metadata["thread_id"] = thread_id
+        actions = extra.get("actions")
+        if isinstance(actions, list):
+            metadata["action_buttons"] = build_action_buttons(
+                actions,
+                delivery.get("payload") if isinstance(delivery.get("payload"), dict) else {},
+            )
 
-        return await adapter.send(chat_id, content, metadata=metadata)
+        return await adapter.send(chat_id, content, metadata=metadata or None)

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -638,6 +638,21 @@ from gateway.session import (
     build_session_key,
     is_shared_multi_user_session,
 )
+
+_COMPRESSION_LIFECYCLE_STATUS_PREFIXES = (
+    "📦 Preflight compression:",
+    "🗜️ Context reduced to ",
+    "🗜️ Context too large ",
+    "🗜️ Compressed ",
+    "⚠️  Request payload too large",
+)
+
+
+def _should_suppress_gateway_lifecycle_status(platform: Any, event_type: str, message: str) -> bool:
+    """Return True for lifecycle notices that are too noisy for chat platforms."""
+    if platform not in {Platform.TELEGRAM, Platform.DISCORD} or event_type != "lifecycle":
+        return False
+    return (message or "").strip().startswith(_COMPRESSION_LIFECYCLE_STATUS_PREFIXES)
 from gateway.delivery import DeliveryRouter
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -14146,6 +14161,16 @@ class GatewayRunner:
 
         def _status_callback_sync(event_type: str, message: str) -> None:
             if not _status_adapter or not _run_still_current():
+                return
+            # Messaging platforms should feel like a PA/friend, not a debug
+            # console.  Compression lifecycle notices are useful in CLI/TUI, but
+            # noisy in Telegram/Discord where they arrive as standalone messages.
+            if _should_suppress_gateway_lifecycle_status(source.platform, event_type, message):
+                logger.debug(
+                    "suppressing gateway compression lifecycle status for %s: %s",
+                    source.platform.value if source.platform else "",
+                    (message or "").strip(),
+                )
                 return
             try:
                 _fut = asyncio.run_coroutine_threadsafe(

--- a/tests/gateway/test_action_requests.py
+++ b/tests/gateway/test_action_requests.py
@@ -1,0 +1,44 @@
+import json
+
+from gateway.action_requests import (
+    build_action_buttons,
+    dispatch_action_request,
+    load_action_request,
+    register_action_handler,
+)
+
+
+def test_build_action_buttons_stores_payload(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    buttons = build_action_buttons(
+        [{"label": "Create PR", "kind": "sentry", "action": "create_pr"}],
+        {"project": "incremnt", "issue": {"id": "INCR-1"}},
+    )
+
+    assert buttons == [{"label": "Create PR", "callback_data": buttons[0]["callback_data"]}]
+    assert buttons[0]["callback_data"].startswith("ar:sentry-")
+    request_id = buttons[0]["callback_data"].split(":", 1)[1]
+    stored = json.loads((tmp_path / "action_requests" / f"{request_id}.json").read_text())
+    assert stored["kind"] == "sentry"
+    assert stored["action"] == "create_pr"
+    assert stored["payload"]["project"] == "incremnt"
+
+
+def test_dispatch_action_request_uses_registered_handler(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    buttons = build_action_buttons(
+        [{"label": "Create PR", "kind": "sentry", "action": "create_pr"}],
+        {"project": "incremnt"},
+    )
+    request_id = buttons[0]["callback_data"].split(":", 1)[1]
+    seen = {}
+
+    def handler(req):
+        seen["req"] = req
+        return "launched"
+
+    register_action_handler("sentry", "create_pr", handler)
+
+    assert dispatch_action_request(request_id) == "launched"
+    assert seen["req"] == load_action_request(request_id)
+    assert seen["req"].payload["project"] == "incremnt"

--- a/tests/gateway/test_gateway_status_noise.py
+++ b/tests/gateway/test_gateway_status_noise.py
@@ -1,0 +1,37 @@
+from gateway.config import Platform
+from gateway.run import _should_suppress_gateway_lifecycle_status
+
+
+def test_messaging_platforms_suppress_compression_lifecycle_statuses():
+    noisy_messages = [
+        "📦 Preflight compression: ~191,447 tokens >= 136,000 threshold. This may take a moment.",
+        "🗜️ Context reduced to 42,000 tokens",
+        "🗜️ Context too large for provider window",
+        "🗜️ Compressed conversation history",
+        "⚠️  Request payload too large; compressing before retry",
+    ]
+
+    for platform in (Platform.TELEGRAM, Platform.DISCORD):
+        for message in noisy_messages:
+            assert _should_suppress_gateway_lifecycle_status(platform, "lifecycle", message)
+
+
+def test_messaging_platforms_keep_non_compression_statuses():
+    assert not _should_suppress_gateway_lifecycle_status(
+        Platform.TELEGRAM,
+        "lifecycle",
+        "Starting gateway...",
+    )
+    assert not _should_suppress_gateway_lifecycle_status(
+        Platform.DISCORD,
+        "tool",
+        "📦 Preflight compression: should only match lifecycle events",
+    )
+
+
+def test_non_chat_platforms_keep_compression_lifecycle_statuses():
+    assert not _should_suppress_gateway_lifecycle_status(
+        Platform.LOCAL,
+        "lifecycle",
+        "📦 Preflight compression: useful in CLI/TUI",
+    )

--- a/tests/gateway/test_webhook_integration.py
+++ b/tests/gateway/test_webhook_integration.py
@@ -264,6 +264,59 @@ class TestCrossPlatformDelivery:
         assert chat_id in adapter._delivery_info
 
 
+    @pytest.mark.asyncio
+    async def test_cross_platform_delivery_includes_action_buttons(self):
+        routes = {
+            "sentry": {
+                "secret": _INSECURE_NO_AUTH,
+                "prompt": "🚨 Sentry: {title}",
+                "deliver": "telegram",
+                "deliver_extra": {
+                    "chat_id": "12345",
+                    "actions": [
+                        {"label": "Create PR", "kind": "sentry", "action": "create_pr"}
+                    ],
+                },
+            }
+        }
+        adapter = _make_adapter(routes)
+        adapter.handle_message = AsyncMock()
+
+        mock_tg_adapter = AsyncMock()
+        mock_tg_adapter.send = AsyncMock(return_value=SendResult(success=True))
+
+        mock_runner = MagicMock()
+        mock_runner.adapters = {Platform.TELEGRAM: mock_tg_adapter}
+        mock_runner.config = GatewayConfig(
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")}
+        )
+        adapter.gateway_runner = mock_runner
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/sentry",
+                json={"project": "incremnt", "title": "Crash in onboarding"},
+                headers={"X-GitHub-Delivery": "sentry-001"},
+            )
+            assert resp.status == 202
+
+        chat_id = "webhook:sentry:sentry-001"
+        with patch(
+            "gateway.platforms.webhook.build_action_buttons",
+            return_value=[{"label": "Create PR", "callback_data": "ar:sentry-abc"}],
+        ) as mock_build:
+            result = await adapter.send(chat_id, "Likely onboarding crash. Create a PR?")
+
+        assert result.success is True
+        mock_build.assert_called_once()
+        mock_tg_adapter.send.assert_awaited_once_with(
+            "12345",
+            "Likely onboarding crash. Create a PR?",
+            metadata={"action_buttons": [{"label": "Create PR", "callback_data": "ar:sentry-abc"}]},
+        )
+
+
 # ===================================================================
 # Test 4: GitHub comment delivery via gh CLI
 # ===================================================================

--- a/tests/gateway/test_webhook_integration.py
+++ b/tests/gateway/test_webhook_integration.py
@@ -337,3 +337,40 @@ class TestGitHubCommentDelivery:
         # Delivery info is retained after send() so interim status messages
         # don't strand the final response (TTL-based cleanup happens on POST).
         assert chat_id in adapter._delivery_info
+
+    @pytest.mark.asyncio
+    async def test_github_comment_delivery_suppresses_skip_sentinel(self):
+        """A literal SKIP response is a control sentinel, not a comment body."""
+        routes = {
+            "pr-bot": {
+                "secret": _INSECURE_NO_AUTH,
+                "prompt": "Review: {pull_request.title}",
+                "deliver": "github_comment",
+                "deliver_extra": {
+                    "repo": "{repository.full_name}",
+                    "pr_number": "{number}",
+                },
+            }
+        }
+        adapter = _make_adapter(routes)
+        adapter.handle_message = AsyncMock()
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/pr-bot",
+                json=GITHUB_PR_PAYLOAD,
+                headers={
+                    "X-GitHub-Event": "pull_request",
+                    "X-GitHub-Delivery": "gh-comment-skip-001",
+                },
+            )
+            assert resp.status == 202
+
+        chat_id = "webhook:pr-bot:gh-comment-skip-001"
+
+        with patch("gateway.platforms.webhook.subprocess.run") as mock_run:
+            result = await adapter.send(chat_id, "SKIP")
+
+        assert result.success is True
+        mock_run.assert_not_called()


### PR DESCRIPTION
## Summary
- suppress compression lifecycle notices on Telegram/Discord so chat platforms do not receive standalone context-management messages
- keep those lifecycle notices available on non-chat surfaces such as CLI/TUI
- suppress literal `SKIP` webhook responses for GitHub comment delivery instead of posting the sentinel as a comment

## Test Plan
- `scripts/run_tests.sh tests/gateway/test_gateway_status_noise.py tests/gateway/test_webhook_integration.py -q`