### PR TITLE
feat(kanban): push notification when a task transitions to blocked

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3644,6 +3644,12 @@ class GatewayRunner:
         # so human-in-the-loop workflows hear back without polling.
         asyncio.create_task(self._kanban_notifier_watcher())
 
+        # Start background kanban global block-notifier — delivers `blocked`
+        # / `gave_up` events to a configured channel (or all home channels)
+        # without requiring per-task subscriptions. Gated by
+        # `kanban.notify_on_block`; no-op when disabled.
+        asyncio.create_task(self._kanban_global_block_watcher())
+
         # Start background kanban dispatcher — spawns workers for ready
         # tasks. Gated by `kanban.dispatch_in_gateway` (default True).
         # When false, users run `hermes kanban daemon` externally or
@@ -4089,6 +4095,249 @@ class GatewayRunner:
             )
         finally:
             conn.close()
+
+    async def _kanban_global_block_watcher(self, interval: float = 5.0) -> None:
+        """Fan-out ``blocked`` / ``gave_up`` events to a global channel.
+
+        Companion to ``_kanban_notifier_watcher``. Where that watcher
+        delivers terminal events to **per-task** subscribers registered
+        via ``hermes kanban notify-subscribe``, this watcher delivers a
+        single notification per block to a **global** target — typically
+        the user's home channel — so unattended workflows surface a stall
+        without requiring a subscription on every task.
+
+        Gated by ``kanban.notify_on_block`` (default false). When the flag
+        is off the loop exits immediately; flipping it on requires a
+        gateway restart, matching the dispatcher/notifier pattern.
+
+        Channel resolution (``kanban.notify_on_block_channel``):
+
+        * empty (default) — broadcasts to every connected platform's
+          home channel, mirroring ``_send_home_channel_startup_notifications``.
+        * ``"<platform>:<chat_id>[:<thread_id>]"`` — single explicit
+          target. ``thread_id`` may itself contain ``:`` (matrix room ids)
+          so the split caps at three pieces.
+
+        Cursor: persisted per board in ``kanban_kv`` so the watcher
+        survives gateway restarts without re-delivering. On first enable
+        the cursor is seeded to ``MAX(task_events.id)`` per board, so a
+        long-running install doesn't flood the home channel with weeks
+        of historical block events the moment the flag flips to true.
+        """
+        from gateway.config import Platform as _Platform
+        try:
+            from hermes_cli.config import load_config as _load_config
+        except Exception:
+            logger.warning(
+                "kanban block-notifier: config loader unavailable; disabled"
+            )
+            return
+        try:
+            from hermes_cli import kanban_db as _kb
+        except Exception:
+            logger.warning(
+                "kanban block-notifier: kanban_db not importable; disabled"
+            )
+            return
+
+        try:
+            cfg = _load_config()
+        except Exception as exc:
+            logger.warning(
+                "kanban block-notifier: cannot load config (%s); disabled", exc,
+            )
+            return
+        kanban_cfg = cfg.get("kanban", {}) if isinstance(cfg, dict) else {}
+        if not kanban_cfg.get("notify_on_block", False):
+            return  # feature off — silent no-op
+
+        raw_target = str(kanban_cfg.get("notify_on_block_channel") or "").strip()
+        explicit_target: Optional[tuple[str, str, Optional[str]]] = None
+        if raw_target:
+            # Three-piece split keeps thread_ids that contain ':' intact
+            # (e.g. matrix room aliases). Anything malformed disables the
+            # watcher loudly — silent misconfig would hide the feature.
+            parts = raw_target.split(":", 2)
+            if len(parts) < 2 or not parts[0] or not parts[1]:
+                logger.warning(
+                    "kanban block-notifier: invalid kanban.notify_on_block_channel=%r "
+                    "(expected 'platform:chat_id[:thread_id]'); disabled",
+                    raw_target,
+                )
+                return
+            plat_str = parts[0].strip().lower()
+            try:
+                _Platform(plat_str)
+            except ValueError:
+                logger.warning(
+                    "kanban block-notifier: unknown platform %r in "
+                    "kanban.notify_on_block_channel; disabled", plat_str,
+                )
+                return
+            chat_id = parts[1].strip()
+            thread_id = parts[2].strip() if len(parts) == 3 and parts[2].strip() else None
+            explicit_target = (plat_str, chat_id, thread_id)
+            logger.info(
+                "kanban block-notifier: enabled (target=%s)", raw_target,
+            )
+        else:
+            logger.info(
+                "kanban block-notifier: enabled (broadcast to all home channels)"
+            )
+
+        # Initial delay so the gateway can finish wiring adapters.
+        await asyncio.sleep(5)
+
+        while self._running:
+            try:
+                def _collect() -> list[dict]:
+                    """Per-board: seed cursor on first run, then pull new events.
+
+                    Runs in a worker thread via ``asyncio.to_thread`` so the
+                    SQLite WAL lock never blocks the event loop. Returns one
+                    dict per board with ``events`` (possibly empty) and the
+                    ``new_cursor`` to persist after delivery.
+                    """
+                    out: list[dict] = []
+                    try:
+                        boards = _kb.list_boards(include_archived=False)
+                    except Exception:
+                        boards = [_kb.read_board_metadata(_kb.DEFAULT_BOARD)]
+                    for board_meta in boards:
+                        slug = board_meta.get("slug") or _kb.DEFAULT_BOARD
+                        try:
+                            conn = _kb.connect(board=slug)
+                        except Exception:
+                            continue
+                        try:
+                            cursor = _kb.get_block_notify_cursor(conn)
+                            if cursor is None:
+                                # First time the watcher sees this board:
+                                # seed at MAX(id) so historical events
+                                # don't flood the channel.
+                                seed = _kb.max_event_id(conn)
+                                _kb.set_block_notify_cursor(conn, seed)
+                                cursor = seed
+                            events = _kb.unseen_block_events(
+                                conn, after_id=cursor, limit=50,
+                            )
+                            if not events:
+                                continue
+                            tasks_by_id: dict[str, Any] = {}
+                            for ev in events:
+                                if ev.task_id in tasks_by_id:
+                                    continue
+                                tasks_by_id[ev.task_id] = _kb.get_task(
+                                    conn, ev.task_id,
+                                )
+                            out.append({
+                                "board": slug,
+                                "events": events,
+                                "tasks": tasks_by_id,
+                                "new_cursor": max(ev.id for ev in events),
+                            })
+                        finally:
+                            conn.close()
+                    return out
+
+                def _persist(slug: str, cursor: int) -> None:
+                    conn = _kb.connect(board=slug)
+                    try:
+                        _kb.set_block_notify_cursor(conn, cursor)
+                    finally:
+                        conn.close()
+
+                batches = await asyncio.to_thread(_collect)
+                for batch in batches:
+                    slug = batch["board"]
+                    events = batch["events"]
+                    tasks = batch["tasks"]
+                    delivered_all = True
+                    for ev in events:
+                        task = tasks.get(ev.task_id)
+                        title = (
+                            (task.title if task else ev.task_id)[:120]
+                        )
+                        who = (task.assignee if task and task.assignee else None)
+                        tag = f"@{who} " if who else ""
+                        if ev.kind == "blocked":
+                            reason = ""
+                            if ev.payload and ev.payload.get("reason"):
+                                reason = f": {str(ev.payload['reason'])[:160]}"
+                            msg = (
+                                f"⏸ {tag}Kanban {ev.task_id} blocked"
+                                f" — {title}{reason}"
+                            )
+                        else:  # gave_up — auto-block on repeated failures
+                            err = ""
+                            if ev.payload and ev.payload.get("error"):
+                                err = f"\n{str(ev.payload['error'])[:200]}"
+                            limit = ""
+                            if ev.payload and ev.payload.get("effective_limit"):
+                                limit = (
+                                    f" (after {ev.payload['effective_limit']} "
+                                    f"failures)"
+                                )
+                            msg = (
+                                f"✖ {tag}Kanban {ev.task_id} blocked"
+                                f"{limit} — {title}{err}"
+                            )
+                        # Resolve targets: explicit override, or every
+                        # connected platform's home channel.
+                        targets: list[tuple[str, str, Optional[str]]] = []
+                        if explicit_target is not None:
+                            targets.append(explicit_target)
+                        else:
+                            for platform, _adapter in self.adapters.items():
+                                home = self.config.get_home_channel(platform)
+                                if not home or not home.chat_id:
+                                    continue
+                                targets.append((
+                                    platform.value,
+                                    str(home.chat_id),
+                                    str(home.thread_id) if home.thread_id else None,
+                                ))
+                        any_send_failed = False
+                        for plat_str, chat_id, thread_id in targets:
+                            try:
+                                plat = _Platform(plat_str)
+                            except ValueError:
+                                continue
+                            adapter = self.adapters.get(plat)
+                            if adapter is None:
+                                # Platform not currently connected. Treat as
+                                # delivered for this target — we don't want
+                                # to block the cursor forever waiting for an
+                                # offline platform; the next block event will
+                                # be delivered when it reconnects.
+                                continue
+                            metadata: dict[str, Any] = {}
+                            if thread_id:
+                                metadata["thread_id"] = thread_id
+                            try:
+                                await adapter.send(chat_id, msg, metadata=metadata)
+                            except Exception as exc:
+                                any_send_failed = True
+                                logger.warning(
+                                    "kanban block-notifier: send failed for "
+                                    "%s on %s: %s",
+                                    ev.task_id, plat_str, exc,
+                                )
+                        if any_send_failed:
+                            # Stop the batch and retry next tick. Cursor
+                            # advances only past events we fully delivered.
+                            delivered_all = False
+                            break
+                    if delivered_all:
+                        await asyncio.to_thread(
+                            _persist, slug, batch["new_cursor"],
+                        )
+            except Exception as exc:
+                logger.warning("kanban block-notifier tick failed: %s", exc)
+            for _ in range(int(max(1, interval))):
+                if not self._running:
+                    return
+                await asyncio.sleep(1)
 
     async def _kanban_dispatcher_watcher(self) -> None:
         """Embedded kanban dispatcher — one tick every `dispatch_interval_seconds`.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -1314,6 +1314,22 @@ DEFAULT_CONFIG = {
         # same task/profile (spawn_failed, timed_out, or crashed). Reassignment
         # resets the streak for the new profile.
         "failure_limit": 2,
+        # Push a notification to the user when a kanban task transitions to
+        # `blocked` (whether via manual `kanban block` or auto-block on
+        # repeated failure). Off by default for backward compatibility — the
+        # existing `notify-subscribe` flow continues to work unchanged.
+        # Useful for unattended/multi-agent workflows where downstream tasks
+        # would otherwise stall silently.
+        "notify_on_block": False,
+        # Override the delivery target for `notify_on_block`. Empty string
+        # (the default) broadcasts to every connected platform's home
+        # channel — same fan-out as the gateway-restart notification. Set
+        # to `<platform>:<chat_id>[:<thread_id>]` to deliver to a single
+        # channel instead. Examples:
+        #     notify_on_block_channel: ""                       # all home channels
+        #     notify_on_block_channel: "telegram:123456789"     # one DM
+        #     notify_on_block_channel: "discord:9876:54321"     # thread
+        "notify_on_block_channel": "",
     },
 
     # execute_code settings — controls the tool used for programmatic tool calls.

--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -1731,6 +1731,8 @@ def _cmd_daemon(args: argparse.Namespace) -> int:
             "      dispatch_in_gateway: true      # default\n"
             "      dispatch_interval_seconds: 60\n"
             "      failure_limit: 2              # consecutive non-success attempts before auto-block\n"
+            "      notify_on_block: false        # push notification when a task transitions to blocked\n"
+            "      notify_on_block_channel: \"\"   # empty=all home channels; or platform:chat_id[:thread]\n"
             "\n"
             "Running both the gateway AND this standalone daemon will\n"
             "race for claims. If you truly need the old standalone\n"

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -875,6 +875,16 @@ CREATE INDEX IF NOT EXISTS idx_events_run            ON task_events(run_id, id);
 CREATE INDEX IF NOT EXISTS idx_runs_task             ON task_runs(task_id, started_at);
 CREATE INDEX IF NOT EXISTS idx_runs_status           ON task_runs(status);
 CREATE INDEX IF NOT EXISTS idx_notify_task           ON kanban_notify_subs(task_id);
+
+-- Tiny per-board key/value store. Used by background watchers (e.g. the
+-- gateway's global block-notifier) that need a durable cursor outside
+-- of any per-task subscription. Keys are namespaced by the writer
+-- (e.g. ``notify_on_block.last_event_id``); values are opaque strings.
+CREATE TABLE IF NOT EXISTS kanban_kv (
+    key        TEXT PRIMARY KEY,
+    value      TEXT,
+    updated_at INTEGER NOT NULL
+);
 """
 
 
@@ -4299,6 +4309,115 @@ def advance_notify_cursor(
             "WHERE task_id = ? AND platform = ? AND chat_id = ? AND thread_id = ?",
             (int(new_cursor), task_id, platform, chat_id, thread_id or ""),
         )
+
+
+# ---------------------------------------------------------------------------
+# Per-board key/value store (kanban_kv)
+# ---------------------------------------------------------------------------
+#
+# Tiny KV used by background watchers that need a durable cursor outside
+# of any per-task subscription — e.g. the gateway's global block-notifier
+# which fans out ``blocked``/``gave_up`` events to home channels and must
+# persist its last delivered event id across gateway restarts.
+
+def get_kv(conn: sqlite3.Connection, key: str) -> Optional[str]:
+    """Return the stored value for ``key`` or ``None`` when unset."""
+    row = conn.execute(
+        "SELECT value FROM kanban_kv WHERE key = ?", (key,),
+    ).fetchone()
+    if row is None:
+        return None
+    val = row["value"]
+    return None if val is None else str(val)
+
+
+def set_kv(conn: sqlite3.Connection, key: str, value: Optional[str]) -> None:
+    """Upsert ``key`` → ``value``. ``None`` deletes the row."""
+    now = int(time.time())
+    with write_txn(conn):
+        if value is None:
+            conn.execute("DELETE FROM kanban_kv WHERE key = ?", (key,))
+        else:
+            conn.execute(
+                "INSERT INTO kanban_kv (key, value, updated_at) VALUES (?, ?, ?) "
+                "ON CONFLICT(key) DO UPDATE SET "
+                "    value = excluded.value, updated_at = excluded.updated_at",
+                (key, str(value), now),
+            )
+
+
+# ---------------------------------------------------------------------------
+# Global block-event stream (used by the gateway's notify_on_block watcher)
+# ---------------------------------------------------------------------------
+
+# Persisted under ``kanban_kv`` so the watcher's cursor survives gateway
+# restarts. Format: integer event id, stored as TEXT.
+_NOTIFY_ON_BLOCK_CURSOR_KEY = "notify_on_block.last_event_id"
+
+# Event kinds that represent "task is now blocked from the user's POV":
+#   * ``blocked``  — explicit ``kanban block`` (or workflow guard).
+#   * ``gave_up``  — circuit breaker tripped after ``failure_limit`` hits.
+# Both flip ``tasks.status`` to ``blocked``; the user cares about both.
+NOTIFY_ON_BLOCK_KINDS = ("blocked", "gave_up")
+
+
+def max_event_id(conn: sqlite3.Connection) -> int:
+    """Return the largest ``task_events.id`` on this board, or 0 if empty.
+
+    Used to seed the global block-notifier cursor on first enable so a
+    busy board doesn't flood the home channel with historical events.
+    """
+    row = conn.execute("SELECT MAX(id) AS m FROM task_events").fetchone()
+    if row is None or row["m"] is None:
+        return 0
+    return int(row["m"])
+
+
+def get_block_notify_cursor(conn: sqlite3.Connection) -> Optional[int]:
+    """Return the persisted block-notifier cursor for this board, or None."""
+    raw = get_kv(conn, _NOTIFY_ON_BLOCK_CURSOR_KEY)
+    if raw is None:
+        return None
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return None
+
+
+def set_block_notify_cursor(conn: sqlite3.Connection, cursor: int) -> None:
+    """Persist the block-notifier cursor for this board."""
+    set_kv(conn, _NOTIFY_ON_BLOCK_CURSOR_KEY, str(int(cursor)))
+
+
+def unseen_block_events(
+    conn: sqlite3.Connection, *, after_id: int, limit: int = 100,
+) -> list[Event]:
+    """Return block events (``blocked`` / ``gave_up``) with ``id > after_id``.
+
+    Ordered by id ASC so the caller can advance the cursor monotonically.
+    ``limit`` caps a single tick's fan-out so a sudden burst of blocks
+    can't pin the watcher's event loop.
+    """
+    placeholders = ",".join("?" * len(NOTIFY_ON_BLOCK_KINDS))
+    q = (
+        f"SELECT * FROM task_events "
+        f"WHERE id > ? AND kind IN ({placeholders}) "
+        f"ORDER BY id ASC LIMIT ?"
+    )
+    params: list[Any] = [int(after_id), *NOTIFY_ON_BLOCK_KINDS, int(limit)]
+    rows = conn.execute(q, params).fetchall()
+    out: list[Event] = []
+    for r in rows:
+        try:
+            payload = json.loads(r["payload"]) if r["payload"] else None
+        except Exception:
+            payload = None
+        out.append(Event(
+            id=r["id"], task_id=r["task_id"], kind=r["kind"],
+            payload=payload, created_at=r["created_at"],
+            run_id=(int(r["run_id"]) if "run_id" in r.keys() and r["run_id"] is not None else None),
+        ))
+    return out
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -569,6 +569,90 @@ def test_notify_cursor_advances(kanban_home):
 
 
 # ---------------------------------------------------------------------------
+# Per-board KV + global block-notifier cursor
+# ---------------------------------------------------------------------------
+
+def test_kv_set_get_roundtrip_and_delete(kanban_home):
+    conn = kb.connect()
+    try:
+        assert kb.get_kv(conn, "absent") is None
+        kb.set_kv(conn, "answer", "42")
+        assert kb.get_kv(conn, "answer") == "42"
+        # Upsert overwrites.
+        kb.set_kv(conn, "answer", "43")
+        assert kb.get_kv(conn, "answer") == "43"
+        # None deletes.
+        kb.set_kv(conn, "answer", None)
+        assert kb.get_kv(conn, "answer") is None
+    finally:
+        conn.close()
+
+
+def test_max_event_id_empty_and_populated(kanban_home):
+    conn = kb.connect()
+    try:
+        # Fresh board with no tasks → no events → 0.
+        assert kb.max_event_id(conn) == 0
+        tid = kb.create_task(conn, title="x")
+        # `created` event exists now.
+        assert kb.max_event_id(conn) > 0
+    finally:
+        conn.close()
+
+
+def test_block_notify_cursor_persists(kanban_home):
+    conn = kb.connect()
+    try:
+        assert kb.get_block_notify_cursor(conn) is None
+        kb.set_block_notify_cursor(conn, 17)
+        assert kb.get_block_notify_cursor(conn) == 17
+        kb.set_block_notify_cursor(conn, 99)
+        assert kb.get_block_notify_cursor(conn) == 99
+    finally:
+        conn.close()
+
+
+def test_unseen_block_events_filters_kind_and_cursor(kanban_home, all_assignees_spawnable):
+    """`unseen_block_events` returns only blocked/gave_up beyond cursor."""
+    conn = kb.connect()
+    try:
+        tid_a = kb.create_task(conn, title="a", assignee="w")
+        tid_b = kb.create_task(conn, title="b", assignee="w")
+
+        # Manual block on A → emits kind="blocked".
+        kb.block_task(conn, tid_a, reason="halt")
+
+        # Auto-block on B via failure_limit=1 spawn failure → kind="gave_up".
+        def _bad_spawn(task, ws):
+            raise RuntimeError("boom")
+        res = kb.dispatch_once(
+            conn, spawn_fn=_bad_spawn, failure_limit=1,
+        )
+        assert tid_b in res.auto_blocked
+
+        # No cursor yet: both block events are unseen.
+        events = kb.unseen_block_events(conn, after_id=0)
+        kinds = sorted(e.kind for e in events)
+        assert kinds == ["blocked", "gave_up"]
+        assert {e.task_id for e in events} == {tid_a, tid_b}
+
+        # `created` / `assigned` / `claimed` etc. are NOT returned.
+        assert all(e.kind in ("blocked", "gave_up") for e in events)
+
+        # Advance cursor past the first event; only the later one remains.
+        first_id = events[0].id
+        remaining = kb.unseen_block_events(conn, after_id=first_id)
+        assert len(remaining) == 1
+        assert remaining[0].id > first_id
+
+        # Beyond the last id: empty.
+        last_id = events[-1].id
+        assert kb.unseen_block_events(conn, after_id=last_id) == []
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
 # GC + retention
 # ---------------------------------------------------------------------------
 

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -301,3 +301,290 @@ def test_dispatcher_tick_does_not_call_init_db(kanban_home, monkeypatch):
         "_kanban_notifier_watcher must not call _kb.init_db(board=slug) — "
         "see issue #21378."
     )
+
+
+# ---------------------------------------------------------------------------
+# Global block-notifier (kanban.notify_on_block)
+# ---------------------------------------------------------------------------
+#
+# Companion to the per-task notifier above. These tests exercise
+# `_kanban_global_block_watcher`: the gateway watcher that fans out
+# `blocked` / `gave_up` events to a configured channel (or all home
+# channels) without requiring per-task subscriptions.
+
+def _make_runner_with_adapter(platform):
+    """Construct a GatewayRunner stub with a single mocked adapter."""
+    from gateway.run import GatewayRunner
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    fake_adapter = MagicMock()
+    delivered: list[tuple[str, str, dict]] = []
+
+    async def _capture(chat_id, msg, metadata=None):
+        delivered.append((chat_id, msg, metadata or {}))
+
+    fake_adapter.send = AsyncMock(side_effect=_capture)
+    runner.adapters = {platform: fake_adapter}
+    return runner, fake_adapter, delivered
+
+
+def _stop_after(runner, ticks=3):
+    """Return a fast-sleep coroutine that stops the watcher after N ticks."""
+    counter = {"n": 0}
+    _orig = asyncio.sleep
+
+    async def _fast(_):
+        counter["n"] += 1
+        if counter["n"] >= ticks:
+            runner._running = False
+        await _orig(0)
+    return _fast
+
+
+@pytest.mark.asyncio
+async def test_global_block_watcher_disabled_by_default(kanban_home):
+    """When kanban.notify_on_block is unset/false, the watcher exits quietly."""
+    from gateway.run import GatewayRunner
+    from gateway.config import Platform
+
+    runner, fake_adapter, _delivered = _make_runner_with_adapter(Platform.TELEGRAM)
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="ignored", assignee="w")
+        kb.block_task(conn, tid, reason="x")
+    finally:
+        conn.close()
+
+    # `load_config` returning an empty kanban section keeps the flag false.
+    with patch(
+        "hermes_cli.config.load_config",
+        return_value={"kanban": {}},
+    ):
+        await asyncio.wait_for(
+            runner._kanban_global_block_watcher(interval=1),
+            timeout=5.0,
+        )
+    fake_adapter.send.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_global_block_watcher_seeds_cursor_then_delivers_new_block(kanban_home):
+    """First enable seeds cursor at MAX(id); only NEW block events fire."""
+    from gateway.run import GatewayRunner
+    from gateway.config import Platform, HomeChannel
+
+    runner, fake_adapter, delivered = _make_runner_with_adapter(Platform.TELEGRAM)
+
+    # Provide a home channel for the runner's config.
+    runner.config = MagicMock()
+    runner.config.get_home_channel = MagicMock(
+        return_value=HomeChannel(
+            platform=Platform.TELEGRAM, chat_id="home-chat", name="home",
+        )
+    )
+
+    # Pre-existing block (must NOT fire — it predates the cursor seed).
+    conn = kb.connect()
+    try:
+        old_tid = kb.create_task(conn, title="old", assignee="w")
+        kb.block_task(conn, old_tid, reason="historical")
+    finally:
+        conn.close()
+
+    cfg = {"kanban": {"notify_on_block": True, "notify_on_block_channel": ""}}
+
+    # Tick #1 should seed the cursor and find no NEW events. Then we
+    # inject a fresh block and a follow-up tick delivers it. The
+    # fast-sleep helper stops the watcher after a few ticks.
+    new_tid_holder: dict[str, str] = {}
+
+    real_sleep = asyncio.sleep
+    tick = {"n": 0}
+
+    async def _fast(_):
+        tick["n"] += 1
+        # tick 1 = initial 5s delay; tick 2 = first inter-iteration sleep
+        # AFTER the cursor-seeding pass. Insert at tick 2 so the seed
+        # pins the cursor at the historical event and the fresh block
+        # is seen as new on the next iteration.
+        if tick["n"] == 2:
+            conn2 = kb.connect()
+            try:
+                tid = kb.create_task(conn2, title="fresh", assignee="w")
+                kb.block_task(conn2, tid, reason="halt")
+                new_tid_holder["tid"] = tid
+            finally:
+                conn2.close()
+        if tick["n"] >= 5:
+            runner._running = False
+        await real_sleep(0)
+
+    with patch("hermes_cli.config.load_config", return_value=cfg), \
+         patch("gateway.run.asyncio.sleep", side_effect=_fast):
+        await asyncio.wait_for(
+            runner._kanban_global_block_watcher(interval=1),
+            timeout=10.0,
+        )
+
+    assert "tid" in new_tid_holder
+    # Exactly one delivery, and it references the fresh block (not the
+    # historical one that predated the cursor seed).
+    assert fake_adapter.send.called
+    msgs = [m for (_chat, m, _meta) in delivered]
+    assert any(new_tid_holder["tid"] in m for m in msgs), (
+        f"expected delivery to mention fresh task {new_tid_holder['tid']}, got {msgs}"
+    )
+    assert not any("historical" in m for m in msgs), (
+        f"historical block must NOT be delivered, got {msgs}"
+    )
+
+    # Cursor was persisted past the new event id.
+    conn = kb.connect()
+    try:
+        cursor = kb.get_block_notify_cursor(conn)
+    finally:
+        conn.close()
+    assert cursor is not None and cursor > 0
+
+
+@pytest.mark.asyncio
+async def test_global_block_watcher_delivers_gave_up_with_failure_count(kanban_home):
+    """Auto-block via failure_limit emits `gave_up` and the watcher delivers it."""
+    from gateway.run import GatewayRunner
+    from gateway.config import Platform, HomeChannel
+
+    runner, fake_adapter, delivered = _make_runner_with_adapter(Platform.TELEGRAM)
+    runner.config = MagicMock()
+    runner.config.get_home_channel = MagicMock(
+        return_value=HomeChannel(
+            platform=Platform.TELEGRAM, chat_id="ops", name="ops",
+        )
+    )
+
+    cfg = {"kanban": {"notify_on_block": True, "notify_on_block_channel": ""}}
+
+    # Seed the cursor first so the historical task creation events
+    # don't get re-attributed as block events. (They aren't `blocked`
+    # or `gave_up`, so they wouldn't fire anyway, but we want the
+    # cursor seeded before we induce the auto-block to mirror real life.)
+    real_sleep = asyncio.sleep
+    tick = {"n": 0}
+    induced = {"done": False}
+
+    async def _fast(_):
+        tick["n"] += 1
+        # Insert at tick 2 (after cursor seeding) so the gave_up event
+        # registers as new. See the seed-cursor test above. We emit
+        # `gave_up` directly with a payload that matches what
+        # `_record_task_failure` writes — simpler than driving a real
+        # auto-block through the dispatcher (which is already covered
+        # in test_kanban_core_functionality.py).
+        if tick["n"] == 2 and not induced["done"]:
+            conn2 = kb.connect()
+            try:
+                tid = kb.create_task(conn2, title="will-fail", assignee="w")
+                kb._append_event(
+                    conn2, tid, "gave_up",
+                    {
+                        "failures": 2,
+                        "effective_limit": 2,
+                        "limit_source": "dispatcher",
+                        "error": "boom",
+                        "trigger_outcome": "spawn_failed",
+                    },
+                )
+                induced["done"] = True
+                induced["tid"] = tid
+            finally:
+                conn2.close()
+        if tick["n"] >= 5:
+            runner._running = False
+        await real_sleep(0)
+
+    with patch("hermes_cli.config.load_config", return_value=cfg), \
+         patch("gateway.run.asyncio.sleep", side_effect=_fast):
+        await asyncio.wait_for(
+            runner._kanban_global_block_watcher(interval=1),
+            timeout=10.0,
+        )
+
+    msgs = [m for (_chat, m, _meta) in delivered]
+    assert any(induced["tid"] in m and "blocked" in m for m in msgs), (
+        f"expected gave_up delivery for {induced.get('tid')!r}, got {msgs}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_global_block_watcher_explicit_channel_override(kanban_home):
+    """Explicit notify_on_block_channel overrides the home-channel fan-out."""
+    from gateway.run import GatewayRunner
+    from gateway.config import Platform, HomeChannel
+
+    runner, fake_adapter, delivered = _make_runner_with_adapter(Platform.TELEGRAM)
+    # Set a DIFFERENT home channel so we can verify the explicit override
+    # routes elsewhere (specifically: chat_id="ops-chat", thread "42").
+    runner.config = MagicMock()
+    runner.config.get_home_channel = MagicMock(
+        return_value=HomeChannel(
+            platform=Platform.TELEGRAM, chat_id="home-default", name="home",
+        )
+    )
+
+    cfg = {"kanban": {
+        "notify_on_block": True,
+        "notify_on_block_channel": "telegram:ops-chat:42",
+    }}
+
+    real_sleep = asyncio.sleep
+    tick = {"n": 0}
+    induced = {"tid": None}
+
+    async def _fast(_):
+        tick["n"] += 1
+        if tick["n"] == 2:
+            conn2 = kb.connect()
+            try:
+                tid = kb.create_task(conn2, title="halt-me", assignee="w")
+                kb.block_task(conn2, tid, reason="manual halt")
+                induced["tid"] = tid
+            finally:
+                conn2.close()
+        if tick["n"] >= 5:
+            runner._running = False
+        await real_sleep(0)
+
+    with patch("hermes_cli.config.load_config", return_value=cfg), \
+         patch("gateway.run.asyncio.sleep", side_effect=_fast):
+        await asyncio.wait_for(
+            runner._kanban_global_block_watcher(interval=1),
+            timeout=10.0,
+        )
+
+    # Routed to the explicit chat, not the home default; thread metadata set.
+    assert fake_adapter.send.called
+    chat_ids = {chat for (chat, _msg, _meta) in delivered}
+    assert "ops-chat" in chat_ids
+    assert "home-default" not in chat_ids
+    metas = [meta for (_chat, _msg, meta) in delivered]
+    assert any(meta.get("thread_id") == "42" for meta in metas)
+
+
+@pytest.mark.asyncio
+async def test_global_block_watcher_rejects_malformed_channel(kanban_home):
+    """Misconfigured channel disables the watcher loudly (no sends, no crash)."""
+    from gateway.run import GatewayRunner
+    from gateway.config import Platform
+
+    runner, fake_adapter, _delivered = _make_runner_with_adapter(Platform.TELEGRAM)
+
+    cfg = {"kanban": {
+        "notify_on_block": True,
+        "notify_on_block_channel": "this-is-not-valid",
+    }}
+    with patch("hermes_cli.config.load_config", return_value=cfg):
+        await asyncio.wait_for(
+            runner._kanban_global_block_watcher(interval=1),
+            timeout=5.0,
+        )
+    fake_adapter.send.assert_not_called()


### PR DESCRIPTION
## Summary

Closes #22995.

Adds a global block-notifier so unattended kanban workflows surface a
stall without requiring a per-task `notify-subscribe`. Off by default
for backward compatibility.

New config keys (`hermes_cli/config.py`, default config block):

```yaml
kanban:
  notify_on_block: false           # push when a task transitions to blocked
  notify_on_block_channel: ""      # empty = broadcast to all home channels;
                                   # or "<platform>:<chat_id>[:<thread_id>]"
```

When `notify_on_block` is true, a new gateway watcher
(`_kanban_global_block_watcher`) tails `task_events` for kinds
`blocked` (manual `kanban block`) and `gave_up` (auto-block on
`failure_limit`) across every board and delivers one message per event
to either every connected platform's home channel (default) or a single
explicit `platform:chat_id[:thread_id]` target.

The watcher persists its cursor in a new tiny `kanban_kv` table so it
survives gateway restarts. On first enable the cursor is seeded to
`MAX(task_events.id)` per board so a long-running install doesn't flood
the home channel with historical block events the moment the flag flips
on.

The watcher mirrors the existing `_kanban_notifier_watcher` pattern:

* All SQLite work runs via `asyncio.to_thread` so the event loop never
  blocks on the WAL lock.
* Failed sends do not advance the cursor — the next tick retries.
* Malformed `notify_on_block_channel` disables the watcher with a clear
  warning log line rather than silently swallowing events.
* Cross-board fan-out reuses the same `list_boards` iteration as the
  per-task notifier.

## Why this is independent of the existing notifier

`_kanban_notifier_watcher` already delivers terminal events, but only
to chats in `kanban_notify_subs` — i.e. the user must run
`kanban notify-subscribe` for **every** task. The issue points out
this scales poorly for fleet/multi-agent workflows where a single
blocked task can stall every downstream task. The new watcher is the
zero-subscription, zero-token-cost path the issue asks for.

## Files

| File | Change |
|---|---|
| `hermes_cli/config.py` | Two new keys in the default `kanban` block |
| `hermes_cli/kanban.py` | Updated `kanban daemon --force` config snippet |
| `hermes_cli/kanban_db.py` | New `kanban_kv` table; `get_kv`/`set_kv` helpers; `max_event_id`, `get/set_block_notify_cursor`, `unseen_block_events` |
| `gateway/run.py` | New `_kanban_global_block_watcher` + `asyncio.create_task` registration |
| `tests/hermes_cli/test_kanban_core_functionality.py` | KV + cursor + event-filter tests |
| `tests/hermes_cli/test_kanban_notify.py` | 5 watcher tests (disabled default, cursor seeding, gave_up, channel override, malformed config) |

The new schema is added via `CREATE TABLE IF NOT EXISTS` so existing
DBs migrate transparently on the next `connect()` — same pattern as
the existing `kanban_notify_subs` table.

## Test plan

- [x] `pytest tests/hermes_cli/test_kanban_core_functionality.py -k "kv or block_notify or max_event_id or unseen_block_events"` — 4 new passing
- [x] `pytest tests/hermes_cli/test_kanban_notify.py` — 12 passing (5 new + 7 existing, no regressions)
- [x] `python3 -m py_compile` clean on all modified files
- [x] Manual: end-to-end smoke run; confirm watcher exits silently when flag is off
- [ ] Reviewer: run `scripts/run_tests.sh` against the full suite (my local minimal venv doesn't include FastAPI/dashboard plugin deps; the only failures I saw were the pre-existing `plugins/kanban/dashboard` tests that require those)

Tested on macOS (darwin 25.3.0, Python 3.11.14). No OS-specific syscalls touched — all changes are SQLite + asyncio so cross-platform behavior is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)