### PR TITLE
[security] fix(termux): contain psutil sdist extraction

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -131,7 +131,8 @@ import argparse
 import json
 import shutil
 import subprocess
-from pathlib import Path
+import tarfile
+from pathlib import Path, PureWindowsPath
 from typing import Optional
 
 
@@ -7999,6 +8000,50 @@ def _is_android_python() -> bool:
     return sys.platform == "android"
 
 
+def _safe_extract_psutil_sdist(tar: "tarfile.TarFile", dest: Path) -> None:
+    """Safely extract the pinned psutil sdist into ``dest``.
+
+    The Android compatibility path downloads a source archive before running
+    pip against the extracted tree. Treat the archive as untrusted at the
+    filesystem boundary: reject absolute paths, ``..`` traversal, symlinks,
+    hardlinks, device files, and other special members before anything is
+    written outside the temporary build directory.
+    """
+    dest_resolved = dest.resolve()
+    validated_members = []
+    for member in tar.getmembers():
+        if Path(member.name).is_absolute() or PureWindowsPath(member.name).is_absolute():
+            raise RuntimeError(
+                f"Refusing to extract psutil sdist member with absolute path: {member.name!r}"
+            )
+
+        target = (dest / member.name).resolve()
+        try:
+            target.relative_to(dest_resolved)
+        except ValueError as exc:
+            raise RuntimeError(
+                f"Refusing to extract psutil sdist member outside temp dir: {member.name!r}"
+            ) from exc
+
+        if not (member.isdir() or member.isfile()):
+            raise RuntimeError(
+                f"Refusing to extract unsupported psutil sdist member: {member.name!r}"
+            )
+        validated_members.append((member, target))
+
+    for member, target in validated_members:
+        if member.isdir():
+            target.mkdir(parents=True, exist_ok=True)
+            continue
+
+        target.parent.mkdir(parents=True, exist_ok=True)
+        source = tar.extractfile(member)
+        if source is None:
+            raise RuntimeError(f"Could not read psutil sdist member: {member.name!r}")
+        with source, target.open("wb") as fh:
+            shutil.copyfileobj(source, fh)
+
+
 def _install_psutil_android_compat(
     install_cmd_prefix: list[str],
     *,
@@ -8035,7 +8080,7 @@ def _install_psutil_android_compat(
         archive = tmp_path / "psutil.tar.gz"
         urllib.request.urlretrieve(psutil_url, archive)
         with tarfile.open(archive) as tar:
-            tar.extractall(tmp_path)
+            _safe_extract_psutil_sdist(tar, tmp_path)
 
         src_root = next(
             p for p in tmp_path.iterdir() if p.is_dir() and p.name.startswith("psutil-")

--- a/scripts/install_psutil_android.py
+++ b/scripts/install_psutil_android.py
@@ -30,7 +30,7 @@ import sys
 import tarfile
 import tempfile
 import urllib.request
-from pathlib import Path
+from pathlib import Path, PureWindowsPath
 
 # Pin a version we know patches cleanly. Update when a newer psutil
 # changes the marker line shape and we need to follow upstream.
@@ -42,6 +42,52 @@ PSUTIL_URL = (
 
 MARKER = 'LINUX = sys.platform.startswith("linux")'
 REPLACEMENT = 'LINUX = sys.platform.startswith(("linux", "android"))'
+
+
+def _safe_extract_psutil_sdist(tar: tarfile.TarFile, dest: Path) -> None:
+    """Safely extract the pinned psutil sdist into ``dest``.
+
+    Treat the downloaded archive as untrusted at the filesystem boundary:
+    reject absolute paths, ``..`` traversal, symlinks, hardlinks, device files,
+    and other special members before anything is written outside the temporary
+    build directory.
+    """
+    dest_resolved = dest.resolve()
+    validated_members: list[tuple[tarfile.TarInfo, Path]] = []
+    for member in tar.getmembers():
+        if (
+            Path(member.name).is_absolute()
+            or PureWindowsPath(member.name).is_absolute()
+        ):
+            raise RuntimeError(
+                f"Refusing to extract psutil sdist member with absolute path: {member.name!r}"
+            )
+
+        target = (dest / member.name).resolve()
+        try:
+            target.relative_to(dest_resolved)
+        except ValueError as exc:
+            raise RuntimeError(
+                f"Refusing to extract psutil sdist member outside temp dir: {member.name!r}"
+            ) from exc
+
+        if not (member.isdir() or member.isfile()):
+            raise RuntimeError(
+                f"Refusing to extract unsupported psutil sdist member: {member.name!r}"
+            )
+        validated_members.append((member, target))
+
+    for member, target in validated_members:
+        if member.isdir():
+            target.mkdir(parents=True, exist_ok=True)
+            continue
+
+        target.parent.mkdir(parents=True, exist_ok=True)
+        source = tar.extractfile(member)
+        if source is None:
+            raise RuntimeError(f"Could not read psutil sdist member: {member.name!r}")
+        with source, target.open("wb") as fh:
+            shutil.copyfileobj(source, fh)
 
 
 def _resolve_install_cmd(pip_arg: str | None, prefer_uv: bool) -> list[str]:
@@ -83,11 +129,12 @@ def main() -> int:
         archive = tmp_path / "psutil.tar.gz"
         urllib.request.urlretrieve(PSUTIL_URL, archive)
         with tarfile.open(archive) as tar:
-            tar.extractall(tmp_path)
+            _safe_extract_psutil_sdist(tar, tmp_path)
 
         try:
             src_root = next(
-                p for p in tmp_path.iterdir()
+                p
+                for p in tmp_path.iterdir()
                 if p.is_dir() and p.name.startswith("psutil-")
             )
         except StopIteration:

--- a/tests/hermes_cli/test_android_psutil_safe_extract.py
+++ b/tests/hermes_cli/test_android_psutil_safe_extract.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import io
+import importlib.util
+import tarfile
+from pathlib import Path
+
+from hermes_cli.main import _safe_extract_psutil_sdist as main_safe_extract
+
+
+SCRIPT_PATH = (
+    Path(__file__).resolve().parents[2] / "scripts" / "install_psutil_android.py"
+)
+
+
+def _load_install_script_module():
+    spec = importlib.util.spec_from_file_location("install_psutil_android", SCRIPT_PATH)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+EXTRACTORS = (
+    main_safe_extract,
+    _load_install_script_module()._safe_extract_psutil_sdist,
+)
+
+
+def _tar_with_members(*members: tuple[str, bytes, str]) -> io.BytesIO:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+        for name, body, kind in members:
+            info = tarfile.TarInfo(name)
+            if kind == "dir":
+                info.type = tarfile.DIRTYPE
+                tar.addfile(info)
+            elif kind == "symlink":
+                info.type = tarfile.SYMTYPE
+                info.linkname = "target"
+                tar.addfile(info)
+            elif kind == "hardlink":
+                info.type = tarfile.LNKTYPE
+                info.linkname = "target"
+                tar.addfile(info)
+            else:
+                info.size = len(body)
+                tar.addfile(info, io.BytesIO(body))
+    buf.seek(0)
+    return buf
+
+
+def _run_extract(extractor, archive: io.BytesIO, dest: Path) -> None:
+    with tarfile.open(fileobj=archive, mode="r:gz") as tar:
+        extractor(tar, dest)
+
+
+def _assert_extract_rejected(
+    extractor, archive: io.BytesIO, dest: Path, match: str
+) -> None:
+    try:
+        _run_extract(extractor, archive, dest)
+    except RuntimeError as exc:
+        assert match in str(exc)
+    else:  # pragma: no cover - failure branch for clearer assertion output
+        raise AssertionError("expected unsafe psutil sdist member to be rejected")
+
+
+def test_psutil_sdist_safe_extract_allows_regular_files(tmp_path):
+    for extractor in EXTRACTORS:
+        dest = tmp_path / extractor.__module__.replace(".", "_")
+        archive = _tar_with_members(
+            ("psutil-7.2.2", b"", "dir"),
+            (
+                "psutil-7.2.2/psutil/_common.py",
+                b'LINUX = sys.platform.startswith("linux")\n',
+                "file",
+            ),
+        )
+
+        _run_extract(extractor, archive, dest)
+
+        extracted = dest / "psutil-7.2.2" / "psutil" / "_common.py"
+        assert extracted.read_text() == 'LINUX = sys.platform.startswith("linux")\n'
+
+
+def test_psutil_sdist_safe_extract_rejects_path_traversal(tmp_path):
+    for extractor in EXTRACTORS:
+        dest = tmp_path / extractor.__module__.replace(".", "_")
+        outside = dest.parent / f"outside-owned-{dest.name}.txt"
+        archive = _tar_with_members(("../outside-owned.txt", b"owned", "file"))
+
+        _assert_extract_rejected(extractor, archive, dest, "outside temp dir")
+
+        assert not outside.exists()
+
+
+def test_psutil_sdist_safe_extract_rejects_absolute_paths(tmp_path):
+    for extractor in EXTRACTORS:
+        dest = tmp_path / extractor.__module__.replace(".", "_")
+        outside = dest.parent / f"absolute-owned-{dest.name}.txt"
+        archive = _tar_with_members((str(outside), b"owned", "file"))
+
+        _assert_extract_rejected(extractor, archive, dest, "absolute path")
+
+        assert not outside.exists()
+
+
+def test_psutil_sdist_safe_extract_rejects_windows_absolute_paths(tmp_path):
+    for extractor in EXTRACTORS:
+        dest = tmp_path / extractor.__module__.replace(".", "_")
+        archive = _tar_with_members(("C:/Users/attacker/owned.txt", b"owned", "file"))
+
+        _assert_extract_rejected(extractor, archive, dest, "absolute path")
+
+        assert not (dest / "C:" / "Users" / "attacker" / "owned.txt").exists()
+
+
+def test_psutil_sdist_safe_extract_rejects_links(tmp_path):
+    for extractor in EXTRACTORS:
+        for kind in ("symlink", "hardlink"):
+            dest = tmp_path / extractor.__module__.replace(".", "_") / kind
+            archive = _tar_with_members(("psutil-7.2.2/link", b"", kind))
+
+            _assert_extract_rejected(
+                extractor,
+                archive,
+                dest,
+                "unsupported psutil sdist member",
+            )
+
+            assert not (dest / "psutil-7.2.2" / "link").exists()


### PR DESCRIPTION
## Summary

This PR hardens the Android/Termux psutil compatibility installer so a downloaded psutil source distribution cannot write outside the temporary build directory during extraction.

It replaces the two unsafe `tar.extractall()` calls with a small safe extraction helper that:
- rejects POSIX and Windows absolute member paths before extraction;
- rejects `..` traversal after path resolution;
- rejects symlinks, hardlinks, device files, FIFOs, and other non-regular members;
- pre-validates the full archive before writing files; and
- adds regression tests for both Android psutil installer paths.

## Security issues covered

| Issue | Impact | Severity |
|-------|--------|----------|
| Unsafe psutil sdist tar extraction in the Android/Termux install/update path | A malicious or compromised psutil sdist can write files outside the temporary extraction directory as the Hermes user during install/update | High |

## Before this PR

- `hermes_cli/main.py::_install_psutil_android_compat()` downloaded `psutil-7.2.2.tar.gz` and extracted it with `tar.extractall(tmp_path)`.
- `scripts/install_psutil_android.py` repeated the same extraction pattern for fresh Termux installs.
- Tar members with absolute paths, `../` traversal, symlinks, or hardlinks were not rejected before extraction.
- There were no regression tests covering malicious tar members in this installer path.

## After this PR

- Both Android psutil installer paths use `_safe_extract_psutil_sdist()` instead of `tar.extractall()`.
- Archive members are validated before anything is written to disk.
- Only directories and regular files that resolve under the temporary build directory are extracted.
- Traversal, POSIX absolute paths, Windows absolute paths, symlinks, and hardlinks are covered by tests for both helper copies.

## Why this matters

The Android/Termux psutil compatibility path is an install/update path that handles a remote source archive and then runs `pip install --no-build-isolation` against the extracted tree. That makes the extraction boundary security-sensitive: a malicious archive should not be able to modify files outside the temporary build directory before the installer even reaches the package build step.

A compromised package download path could otherwise overwrite user-writable files such as Hermes configuration, scripts, shell startup files, or other state accessible to the Hermes user.

## How this differs from #22901

PR #22901 introduced the Android/Termux psutil compatibility flow so fresh installs and updates could build psutil on Android by patching the upstream sdist. This PR keeps that compatibility behavior intact, but hardens the archive extraction step that #22901 added.

The distinction is:
- #22901 fixed Termux compatibility by downloading, patching, and installing the psutil sdist.
- This PR fixes the filesystem containment boundary for that downloaded sdist before it is patched or installed.

## Attack flow

```text
Compromised or malicious psutil sdist
    -> Android/Termux Hermes install or update path
        -> tar.extractall(tmp_path) on untrusted archive members
            -> absolute/traversal/link member writes outside tmp_path
                -> arbitrary file write as the Hermes user
```

## Affected code

| Issue | Files |
|-------|-------|
| Unsafe psutil sdist tar extraction | `hermes_cli/main.py`, `scripts/install_psutil_android.py` |

## Root cause

Unsafe psutil sdist tar extraction:
- The install/update helpers trusted archive member names and used `tar.extractall()` directly.
- The extraction boundary did not verify that every member resolved under the intended temporary build directory.
- Link and special-file members were not rejected before extraction.

## CVSS assessment

| Issue | CVSS v3.1 | Vector |
|-------|-----------|--------|
| Unsafe psutil sdist tar extraction | 7.5 High | `CVSS:3.1/AV:N/AC:H/PR:N/UI:R/S:U/C:H/I:H/A:H` |

Rationale:
- Network attack vector reflects compromise/control of the remote package download path.
- Attack complexity is high because the attacker must influence the pinned sdist download or equivalent package transport path.
- User interaction is required because the vulnerable path runs during Android/Termux install or update.
- Successful exploitation can write arbitrary files as the Hermes user and can affect confidentiality, integrity, and availability of user-writable Hermes or shell state.

## Safe reproduction steps

1. Build a test tarball containing:
   - a valid-looking `psutil-7.2.2/psutil/_common.py`; and
   - a malicious member such as `../outside-owned.txt`, an absolute path, a symlink, or a hardlink.
2. Pass the tarball through the Android psutil extraction helper.
3. On vulnerable code, `tar.extractall(tmp_path)` accepts the member and may write outside `tmp_path`.
4. With this PR, `_safe_extract_psutil_sdist()` raises before extraction for the malicious member and the outside marker is not created.

## Expected vulnerable behavior

Before this PR, the installer used `tar.extractall(tmp_path)` directly. A crafted tar member could escape the extraction directory or introduce link-based filesystem effects before the psutil tree was patched and installed.

## Changes in this PR

- Adds `_safe_extract_psutil_sdist()` to the CLI update path.
- Adds the same standalone helper to `scripts/install_psutil_android.py` so fresh Termux installs receive the same protection.
- Replaces both `tar.extractall(tmp_path)` calls with the safe helper.
- Adds tests for:
  - valid regular psutil files;
  - `../` traversal members;
  - POSIX absolute paths;
  - Windows absolute paths;
  - symlink members; and
  - hardlink members.

## Files changed

| Category | Files | What changed |
|----------|-------|--------------|
| Installer hardening | `hermes_cli/main.py` | Adds safe psutil sdist extraction and uses it in the Android update compatibility path |
| Fresh-install hardening | `scripts/install_psutil_android.py` | Adds the same standalone extraction guard for Termux fresh installs |
| Regression tests | `tests/hermes_cli/test_android_psutil_safe_extract.py` | Covers valid extraction and malicious member rejection for both helper copies |

## Maintainer impact

- The existing Termux/Android psutil compatibility behavior is preserved.
- The patch is limited to the psutil compatibility installer paths and focused tests.
- No normal psutil sdist files are rejected: directories and regular files under the extraction root still extract normally.
- The standalone script remains self-contained for `scripts/install.sh` use.

## Fix rationale

The safest boundary is the archive extraction point, before any package patching or installation happens. Validating member paths and member types there prevents filesystem effects from malicious archive metadata and keeps later installer logic working on a contained build tree.

Pre-validating all members before writing also avoids partially extracting a malicious archive when a later member is rejected.

## Type of change

- [x] Security fix
- [x] Tests
- [ ] Documentation update
- [ ] Refactor with no behavior change

## Test plan

- [x] Focused regression and adjacent update tests passed.
- [x] Touched files compile.
- [x] Ruff check passed for touched Python files.
- [x] Ruff format check passed for the new/standalone touched files.
- [x] Git whitespace check passed.
- [x] Independent reviewer subagent inspected the staged diff and found no blocking issues.

Executed with:
- `scripts/run_tests.sh tests/hermes_cli/test_android_psutil_safe_extract.py tests/hermes_cli/test_cmd_update.py tests/hermes_cli/test_update_autostash.py`
- `python3 -m py_compile scripts/install_psutil_android.py hermes_cli/main.py tests/hermes_cli/test_android_psutil_safe_extract.py`
- `python3 -m ruff check hermes_cli/main.py scripts/install_psutil_android.py tests/hermes_cli/test_android_psutil_safe_extract.py`
- `python3 -m ruff format --check scripts/install_psutil_android.py tests/hermes_cli/test_android_psutil_safe_extract.py`
- `git diff --cached --check`

## Disclosure notes

This PR is intentionally bounded to the Android/Termux psutil compatibility installer path. It does not claim a default unauthenticated remote RCE against a running Hermes service; exploitation requires control or compromise of the package archive download path, or an equivalent package-transport/supply-chain condition during install or update.

No unrelated files are changed.
