### PR TITLE
docs(google-chat): document relay format 3 envelope

### DIFF
--- a/website/docs/user-guide/messaging/google_chat.md
+++ b/website/docs/user-guide/messaging/google_chat.md
@@ -189,6 +189,60 @@ tombstones.
 
 ---
 
+## Cloud Run relay / "Format 3" envelope (optional)
+
+The Pub/Sub setup above is the default path. Some operators instead run a Cloud
+Run relay that receives Google Chat events and republishes a flattened envelope
+into the Hermes topic. Hermes supports that relay shape too.
+
+### Relay envelope contract
+
+For relay-forwarded events, Hermes expects a flat payload with these fields:
+
+| Field | Required | Notes |
+|---|---|---|
+| `event_type` | Yes | Usually `MESSAGE`, `ADDED_TO_SPACE`, or another Chat event type. |
+| `sender_email` | Yes | Used for allowlist checks and session identity. |
+| `sender_type` | Yes | Must be `"HUMAN"` or `"BOT"` for correct self-filtering. |
+| `space_name` | Yes | Chat space resource name, e.g. `spaces/AAAA...`. |
+| `message_name` | Yes | Chat message resource name. |
+| `text` | Yes | Flattened message text delivered to Hermes. |
+| `thread_name` | No | Include when the upstream message belongs to a thread. |
+
+Minimal example:
+
+```json
+{
+  "event_type": "MESSAGE",
+  "sender_email": "alice@example.com",
+  "sender_type": "HUMAN",
+  "space_name": "spaces/AAAA123",
+  "message_name": "spaces/AAAA123/messages/msg-42",
+  "thread_name": "spaces/AAAA123/threads/thread-7",
+  "text": "summarize the last action items"
+}
+```
+
+### `sender_type` is the critical field
+
+Your relay must forward the upstream Google Chat `sender.type` into
+`sender_type`.
+
+- `sender_type: "BOT"` -> Hermes drops the event as a bot-originated reply.
+- `sender_type: "HUMAN"` -> Hermes passes it into the agent loop normally.
+
+If the field is missing, Hermes falls back to `HUMAN` for backward
+compatibility. That keeps old relays working, but it also disables the bot-loop
+guard for that event. In practice, a misconfigured relay can echo the bot's own
+messages back into Hermes as if they came from a real user.
+
+### Trust boundary
+
+The relay is trusted infrastructure. Anyone who can publish arbitrary envelopes
+to the topic can spoof `sender_email`, `sender_type`, or message text. Format 3
+support solves compatibility and self-filtering; it is not a signed-envelope
+security layer.
+
 ## Formatting and capabilities
 
 Google Chat renders a limited markdown subset:


### PR DESCRIPTION
## What does this PR do?

Documents the optional Cloud Run / Format 3 relay envelope for Google Chat so relay users know the expected payload and sender filtering behavior.

## Related Issue

Fixes #22451

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- add a dedicated section for the optional relay envelope format
- explain `sender_type`, fallback behavior, and trust-boundary expectations

## How to Test

1. Run `UV_PYTHON=3.11 uv run --frozen pytest -q -o addopts='' tests/gateway/test_google_chat.py`
2. Run `UV_PYTHON=3.11 uv run --frozen ruff check plugins/platforms/google_chat/adapter.py tests/gateway/test_google_chat.py`
3. Run `env -i HOME="$HOME" PATH="/Library/Frameworks/Python.framework/Versions/3.10/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin" UV_PYTHON=3.11 /Library/Frameworks/Python.framework/Versions/3.10/bin/uv run --frozen pytest --collect-only -q -o addopts='' tests/gateway/test_google_chat.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
