### PR TITLE
docs(google-meet): document gpt-realtime-2 support

### DIFF
--- a/plugins/google_meet/README.md
+++ b/plugins/google_meet/README.md
@@ -96,6 +96,36 @@ On macOS, hermes will **not** switch your system audio input automatically — t
 user has to do it. This is deliberate: switching default input on a whim would
 be a surprising side effect.
 
+### Configuring the OpenAI Realtime model
+
+Realtime mode accepts any model identifier through
+`HERMES_MEET_REALTIME_MODEL`. Hermes passes the value straight through to the
+OpenAI Realtime WebSocket URL.
+
+Related env vars:
+
+| Variable | Purpose |
+|---|---|
+| `HERMES_MEET_REALTIME_MODEL` | Realtime model identifier (default: `gpt-realtime`) |
+| `HERMES_MEET_REALTIME_VOICE` | Voice name for spoken replies |
+| `HERMES_MEET_REALTIME_KEY` | Dedicated Realtime API key (falls back to `OPENAI_API_KEY`) |
+| `HERMES_MEET_REALTIME_INSTRUCTIONS` | Optional system instructions for the voice session |
+
+Known-good identifiers:
+
+| Model | Notes |
+|---|---|
+| `gpt-realtime` | Default alias |
+| `gpt-realtime-2` | Recommended for new realtime agents |
+| `gpt-realtime-2025-08-28` | Snapshot-style pinned identifier |
+
+Example:
+
+```bash
+echo 'HERMES_MEET_REALTIME_MODEL=gpt-realtime-2' >> ~/.hermes/.env
+hermes meet join https://meet.google.com/abc-defg-hij --mode realtime
+```
+
 ## Remote node host
 
 On the node machine (e.g. user's Mac with a signed-in Chrome):

--- a/plugins/google_meet/SKILL.md
+++ b/plugins/google_meet/SKILL.md
@@ -30,6 +30,8 @@ The user says any of:
 | `realtime` | Same as transcribe PLUS speaks into the meeting via OpenAI Realtime. The agent calls `meet_say(text)` and the bot's voice comes out of the call. |
 
 Pick `realtime` only when the user actually wants the agent to speak. It costs real money (OpenAI Realtime is pay-per-audio-minute) and requires a virtual audio device set up on the machine running the bot.
+The realtime model defaults to `gpt-realtime`; set
+`HERMES_MEET_REALTIME_MODEL=gpt-realtime-2` when you want the newer alias.
 
 ## Two locations
 
@@ -64,6 +66,7 @@ pip install playwright websockets && python -m playwright install chromium
 #   macOS:  brew install blackhole-2ch ffmpeg
 #           → System Settings → Sound → Input → BlackHole 2ch
 #   Then set OPENAI_API_KEY or HERMES_MEET_REALTIME_KEY in ~/.hermes/.env
+#   Optional: HERMES_MEET_REALTIME_MODEL=gpt-realtime-2
 ```
 
 For a remote node:

--- a/tests/plugins/test_google_meet_realtime.py
+++ b/tests/plugins/test_google_meet_realtime.py
@@ -86,7 +86,8 @@ def _install_fake_websockets(monkeypatch, fake_ws):
 # ---------------------------------------------------------------------------
 
 
-def test_connect_sends_session_update_with_voice_and_instructions(monkeypatch):
+@pytest.mark.parametrize("model", ["gpt-realtime", "gpt-realtime-2"])
+def test_connect_sends_session_update_with_voice_and_instructions(monkeypatch, model):
     from plugins.google_meet.realtime.openai_client import RealtimeSession
 
     ws = _FakeWS(recv_frames=[])
@@ -94,7 +95,7 @@ def test_connect_sends_session_update_with_voice_and_instructions(monkeypatch):
 
     sess = RealtimeSession(
         api_key="sk-test",
-        model="gpt-realtime",
+        model=model,
         voice="verse",
         instructions="Be brief.",
     )
@@ -102,7 +103,7 @@ def test_connect_sends_session_update_with_voice_and_instructions(monkeypatch):
 
     # Auth + beta headers set.
     assert captured["url"].startswith("wss://api.openai.com/v1/realtime")
-    assert "model=gpt-realtime" in captured["url"]
+    assert f"model={model}" in captured["url"]
     headers = captured["headers"] or []
     hdict = dict(headers)
     assert hdict.get("Authorization") == "Bearer sk-test"

--- a/website/docs/user-guide/features/built-in-plugins.md
+++ b/website/docs/user-guide/features/built-in-plugins.md
@@ -206,6 +206,21 @@ Usage from chat:
 
 The agent kicks off the meeting join, streams the transcription back into its context as the call proceeds, and produces a structured summary when the meeting ends (or when you tell it to stop).
 
+**Realtime mode (optional):**
+
+| Variable | Purpose |
+|---|---|
+| `HERMES_MEET_REALTIME_MODEL` | Realtime model identifier (default: `gpt-realtime`) |
+| `HERMES_MEET_REALTIME_VOICE` | Voice name for spoken replies |
+| `HERMES_MEET_REALTIME_KEY` | Dedicated Realtime API key (falls back to `OPENAI_API_KEY`) |
+| `HERMES_MEET_REALTIME_INSTRUCTIONS` | Optional instructions sent to the Realtime session |
+
+Recommended identifiers:
+
+- `gpt-realtime` — default alias
+- `gpt-realtime-2` — recommended for new voice agents
+- `gpt-realtime-2025-08-28` — pinned snapshot identifier
+
 **When to use it:** recurring standups where you want a bot to transcribe + summarize for async attendees; deposition-style interviews where you want structured notes; any case where you'd otherwise need Fireflies / Otter / Grain. When you'd rather not have an AI listening in — don't enable it.
 
 **Disabling:** `hermes plugins disable google_meet`. Any cached transcripts and recordings stay in `~/.hermes/cache/google_meet/` until you remove them.


### PR DESCRIPTION
## What does this PR do?

Documents `gpt-realtime-2` as a supported Google Meet realtime model and extends the regression test to cover the alternate model id.

## Related Issue

Fixes #22699

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- add `gpt-realtime-2` guidance to the plugin README, skill doc, and built-in plugins guide
- parameterize the realtime transport test so both supported model ids are covered

## How to Test

1. Run `UV_PYTHON=3.11 uv run --frozen pytest -q -o addopts='' tests/plugins/test_google_meet_realtime.py`
2. Run `UV_PYTHON=3.11 uv run --frozen ruff check plugins/google_meet/realtime/openai_client.py tests/plugins/test_google_meet_realtime.py`
3. Run `env -i HOME="$HOME" PATH="/Library/Frameworks/Python.framework/Versions/3.10/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin" UV_PYTHON=3.11 /Library/Frameworks/Python.framework/Versions/3.10/bin/uv run --frozen pytest --collect-only -q -o addopts='' tests/plugins/test_google_meet_realtime.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
