### PR TITLE
docs(contributing): polish contributor quick start

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,12 +66,21 @@ If your skill is specialized, community-contributed, or niche, it's better suite
 git clone --recurse-submodules https://github.com/NousResearch/hermes-agent.git
 cd hermes-agent
 
+# Fast path: installer script (prefers uv.lock when present)
+./setup-hermes.sh
+./hermes
+```
+
+If you want the manual path instead:
+
+```bash
+
 # Create venv with Python 3.11
 uv venv venv --python 3.11
 export VIRTUAL_ENV="$(pwd)/venv"
 
 # Install with all extras (messaging, cron, CLI menus, dev tools)
-uv pip install -e ".[all,dev]"
+uv sync --all-extras
 
 # Optional: RL training submodule
 # git submodule update --init tinker-atropos && uv pip install -e "./tinker-atropos"
@@ -102,6 +111,15 @@ ln -sf "$(pwd)/venv/bin/hermes" ~/.local/bin/hermes
 hermes doctor
 hermes chat -q "Hello"
 ```
+
+### Contributor notes for Windows / WSL2
+
+- For repository development, prefer WSL2 over native Windows terminals. The
+  main guide is: `website/docs/user-guide/windows-wsl-quickstart.md`.
+- Keep the repo on the Linux side (`~/code/...`), not under `/mnt/c/...`, to
+  avoid slow file I/O and flaky file watchers.
+- If `hermes` is still not on PATH after setup, open a new shell or run
+  `source ~/.bashrc`.
 
 ### Run tests
 

--- a/README.md
+++ b/README.md
@@ -159,10 +159,10 @@ We welcome contributions! See the [Contributing Guide](https://hermes-agent.nous
 Quick start for contributors — clone and go with `setup-hermes.sh`:
 
 ```bash
-git clone https://github.com/NousResearch/hermes-agent.git
+git clone --recurse-submodules https://github.com/NousResearch/hermes-agent.git
 cd hermes-agent
-./setup-hermes.sh     # installs uv, creates venv, installs .[all], symlinks ~/.local/bin/hermes
-./hermes              # auto-detects the venv, no need to `source` first
+./setup-hermes.sh     # installs uv if needed, creates venv, prefers uv.lock, links ~/.local/bin/hermes
+./hermes              # runs from the repo venv directly, no `source` required
 ```
 
 Manual path (equivalent to the above):
@@ -171,9 +171,17 @@ Manual path (equivalent to the above):
 curl -LsSf https://astral.sh/uv/install.sh | sh
 uv venv .venv --python 3.11
 source .venv/bin/activate
-uv pip install -e ".[all,dev]"
+uv sync --all-extras
 scripts/run_tests.sh
 ```
+
+Windows contributors: prefer the [Windows (WSL2) guide](https://hermes-agent.nousresearch.com/docs/user-guide/windows-wsl-quickstart) for repo work. Native Windows is supported, but WSL2 is the path that matches Linux/macOS contributor workflows most closely.
+
+Common setup gotchas:
+
+- `hermes: command not found` after setup -> open a new shell or run `source ~/.bashrc`
+- slow `git status` / dev servers on Windows -> keep the repo inside WSL (`~/code/...`), not `/mnt/c/...`
+- missing optional tooling after clone -> rerun `git submodule update --init --recursive`
 
 > **RL Training (optional):** The RL/Atropos integration (`environments/`) — see [`CONTRIBUTING.md`](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#development-setup) for the full setup.
 


### PR DESCRIPTION
## What does this PR do?

Polishes the contributor quick-start so the recommended setup path matches the current repo workflow more closely, especially for fresh clones and WSL users.

## Related Issue

Fixes #22731

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- switch the quick-start toward `--recurse-submodules` and `uv sync --all-extras`
- add Windows / WSL contributor notes and common gotchas

## How to Test

1. Run `bash -n setup-hermes.sh`
2. Run `UV_PYTHON=3.11 uv run --frozen pytest -q -o addopts='' tests/hermes_cli/test_plugins_cmd.py`
3. Run `UV_PYTHON=3.11 uv run --frozen ruff check hermes_cli/setup.py tests/hermes_cli/test_plugins_cmd.py`
4. Run `env -i HOME="$HOME" PATH="/Library/Frameworks/Python.framework/Versions/3.10/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin" UV_PYTHON=3.11 /Library/Frameworks/Python.framework/Versions/3.10/bin/uv run --frozen pytest --collect-only -q -o addopts='' tests/hermes_cli/test_plugins_cmd.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
