### PR TITLE
docs(delegation): document fire-and-forget dispatch

### DIFF
--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -182,7 +182,7 @@ Registered only when the agent is spawned by the kanban dispatcher (`HERMES_KANB
 | Tool | Description | Requires environment |
 |------|-------------|----------------------|
 | `process` | Manage background processes started with terminal(background=true). Actions: 'list' (show all), 'poll' (check status + new output), 'log' (full output with pagination), 'wait' (block until done or timeout), 'kill' (terminate), 'write' (sen… | — |
-| `terminal` | Execute shell commands on a Linux environment. Filesystem persists between calls. Set `background=true` for long-running servers. Set `notify_on_complete=true` (with `background=true`) to get an automatic notification when the process finishes — no polling needed. Do NOT use cat/head/tail — use read_file. Do NOT use grep/rg/find — use search_files. | — |
+| `terminal` | Execute shell commands on a Linux environment. Filesystem persists between calls. Set `background=true` for long-running servers or fire-and-forget child Hermes sessions. Set `notify_on_complete=true` (with `background=true`) to get an automatic notification when the process finishes — no polling needed. Do NOT use cat/head/tail — use read_file. Do NOT use grep/rg/find — use search_files. | — |
 
 ## `todo` toolset
 
@@ -258,5 +258,4 @@ Registered only on the `hermes-yuanbao` platform toolset. Yuanbao is Tencent's c
 | `yb_send_dm` | Send a private/direct message to a user in a group, with optional media files. | Yuanbao credentials |
 | `yb_search_sticker` | Search the built-in Yuanbao sticker (TIM face) catalogue by keyword. | Yuanbao credentials |
 | `yb_send_sticker` | Send a built-in sticker to the current Yuanbao chat. | Yuanbao credentials |
-
 

--- a/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md
+++ b/website/docs/user-guide/skills/bundled/autonomous-ai-agents/autonomous-ai-agents-hermes-agent.md
@@ -571,6 +571,31 @@ terminal(command="hermes chat -q 'Research GRPO papers and write summary to ~/re
 terminal(command="hermes chat -q 'Set up CI/CD for ~/myapp'", background=true)
 ```
 
+### Fire-and-Forget Dispatch Pattern
+
+If you want a sub-agent to keep running after the current turn returns, launch a
+fresh Hermes session in the background instead of waiting on `delegate_task`:
+
+```
+terminal(
+  command="hermes chat -q 'Search restaurants in Yangpu and save the shortlist to ~/tmp/yangpu.md' --quiet 2>&1",
+  background=true,
+  notify_on_complete=true,
+  timeout=120
+)
+```
+
+Why this works:
+
+- the main turn returns quickly with an acknowledgment
+- the child runs as a fully independent Hermes session
+- `notify_on_complete=true` injects completion output on the next turn without
+  manual polling
+- the background session survives even if the parent turn has already ended
+
+Use this when you want "fire-and-forget" behavior. Use `delegate_task` when the
+parent must block and consume the child summary before continuing.
+
 ### Interactive PTY Mode (via tmux)
 
 Hermes uses prompt_toolkit, which requires a real terminal. Use tmux for interactive spawning:
@@ -623,7 +648,7 @@ terminal(command="tmux new-session -d -s resumed 'hermes --resume 20260225_14305
 - **Prefer `delegate_task` for quick subtasks** — less overhead than spawning a full process
 - **Use `-w` (worktree mode)** when spawning agents that edit code — prevents git conflicts
 - **Set timeouts** for one-shot mode — complex tasks can take 5-10 minutes
-- **Use `hermes chat -q` for fire-and-forget** — no PTY needed
+- **Use `hermes chat -q` + `background=true` + `notify_on_complete=true` for fire-and-forget** — no PTY needed
 - **Use tmux for interactive sessions** — raw PTY mode has `\r` vs `\n` issues with prompt_toolkit
 - **For scheduled tasks**, use the `cronjob` tool instead of spawning — handles delivery and retry
 


### PR DESCRIPTION
## What does this PR do?

Documents a fire-and-forget dispatch pattern for spawning independent Hermes child sessions with `terminal(background=true, notify_on_complete=true)`.

## Related Issue

Fixes #23060

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- add a dedicated fire-and-forget pattern section to the autonomous agents guide
- update the tools reference to call out background child Hermes sessions explicitly

## How to Test

1. Run `UV_PYTHON=3.11 uv run --frozen pytest -q -o addopts='' tests/tools/test_notify_on_complete.py tests/tools/test_terminal_foreground_timeout_cap.py tests/tools/test_delegate_toolset_scope.py tests/run_agent/test_real_interrupt_subagent.py`
2. Run `UV_PYTHON=3.11 uv run --frozen ruff check tests/tools/test_notify_on_complete.py tests/tools/test_terminal_foreground_timeout_cap.py tests/tools/test_delegate_toolset_scope.py tests/run_agent/test_real_interrupt_subagent.py`
3. Run `env -i HOME="$HOME" PATH="/Library/Frameworks/Python.framework/Versions/3.10/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin" UV_PYTHON=3.11 /Library/Frameworks/Python.framework/Versions/3.10/bin/uv run --frozen pytest --collect-only -q -o addopts='' tests/tools/test_notify_on_complete.py tests/tools/test_terminal_foreground_timeout_cap.py tests/tools/test_delegate_toolset_scope.py tests/run_agent/test_real_interrupt_subagent.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
