### PR TITLE
fix(prompt_builder): stop parent .hermes.md discovery outside git repos

### DIFF
--- a/agent/prompt_builder.py
+++ b/agent/prompt_builder.py
@@ -99,6 +99,15 @@ def _find_hermes_md(cwd: Path) -> Optional[Path]:
     stop_at = _find_git_root(cwd)
     current = cwd.resolve()
 
+    # Without a repository root, walking all the way to the filesystem root
+    # leaks unrelated parent worktree rules into ad-hoc directories.
+    if stop_at is None:
+        for name in _HERMES_MD_NAMES:
+            candidate = current / name
+            if candidate.is_file():
+                return candidate
+        return None
+
     for directory in [current, *current.parents]:
         for name in _HERMES_MD_NAMES:
             candidate = directory / name

--- a/tests/agent/test_prompt_builder.py
+++ b/tests/agent/test_prompt_builder.py
@@ -727,6 +727,22 @@ class TestFindHermesMd:
         (repo / ".git").mkdir()
         assert _find_hermes_md(repo) is None
 
+    def test_does_not_walk_to_parent_without_git_root(self, tmp_path):
+        """Ad-hoc workdirs must not inherit unrelated parent .hermes.md files."""
+        (tmp_path / ".hermes.md").write_text("outside")
+        workdir = tmp_path / "work" / "proj"
+        workdir.mkdir(parents=True)
+        assert _find_hermes_md(workdir) is None
+
+    def test_build_context_prompt_ignores_parent_without_git_root(self, tmp_path):
+        (tmp_path / ".hermes.md").write_text("outside parent rules")
+        workdir = tmp_path / "scratch" / "task"
+        workdir.mkdir(parents=True)
+
+        result = build_context_files_prompt(cwd=str(workdir))
+
+        assert "outside parent rules" not in result
+
 
 class TestFindGitRoot:
     def test_finds_git_dir(self, tmp_path):


### PR DESCRIPTION
## Summary

Prevent `.hermes.md` / `HERMES.md` discovery from walking into unrelated parent directories when the current workdir is not inside a git repository.

Before this change, `_find_hermes_md()` could walk all the way to the filesystem root when no `.git` directory was present, which allowed parent-level Hermes rules from outside the working directory to leak into the prompt context.

## What changed

- Limit `.hermes.md` discovery to the current directory when no git root is found
- Preserve the existing parent-walk behavior when a git root exists
- Add regression coverage for:
  - no-git workdirs not inheriting parent `.hermes.md`
  - `build_context_files_prompt()` not injecting parent rules in that case
  - existing git-root discovery behavior still working

## Why this matters

This fixes a small but real context-boundary bug:
ad-hoc directories and scratch worktrees should not inherit unrelated parent prompt rules unless they are part of the same git-scoped project.

## Tests

Ran:

- `tests/agent/test_prompt_builder.py`

Relevant regression checks:

- `TestFindHermesMd::test_does_not_walk_to_parent_without_git_root`
- `TestFindHermesMd::test_build_context_prompt_ignores_parent_without_git_root`
- `TestFindHermesMd::test_walks_to_git_root`

Result:

- `123 passed, 1 skipped`
