### PR TITLE
fix(gateway): validate telegram voice artifacts

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -3581,13 +3581,22 @@ class TelegramAdapter(BasePlatformAdapter):
         """Send audio as a native Telegram voice message or audio file."""
         if not self._bot:
             return SendResult(success=False, error="Not connected")
+        ext = os.path.splitext(audio_path)[1].lower()
         
         try:
             if not os.path.exists(audio_path):
                 return SendResult(success=False, error=self._missing_media_path_error("Audio", audio_path))
+
+            if ext in {".ogg", ".opus"}:
+                from tools.tts_tool import _is_telegram_voice_artifact
+
+                if not _is_telegram_voice_artifact(audio_path):
+                    return SendResult(
+                        success=False,
+                        error=f"Not a valid Telegram voice artifact: {audio_path}",
+                    )
             
             with open(audio_path, "rb") as audio_file:
-                ext = os.path.splitext(audio_path)[1].lower()
                 # .ogg / .opus files -> send as voice (round playable bubble)
                 if ext in {".ogg", ".opus"}:
                     _voice_thread = self._metadata_thread_id(metadata)
@@ -3652,6 +3661,14 @@ class TelegramAdapter(BasePlatformAdapter):
                     )
             return SendResult(success=True, message_id=str(msg.message_id))
         except Exception as e:
+            if ext in {".ogg", ".opus"}:
+                logger.error(
+                    "[%s] Failed to send Telegram voice/audio: %s",
+                    self.name,
+                    e,
+                    exc_info=True,
+                )
+                return SendResult(success=False, error=f"Telegram voice/audio upload failed: {e}")
             logger.error(
                 "[%s] Failed to send Telegram voice/audio, falling back to base adapter: %s",
                 self.name,

--- a/tests/gateway/test_telegram_voice_delivery.py
+++ b/tests/gateway/test_telegram_voice_delivery.py
@@ -1,0 +1,36 @@
+from unittest.mock import AsyncMock
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_invalid_ogg_voice_is_not_sent_as_document(monkeypatch, tmp_path):
+    from gateway.config import Platform
+    from gateway.platforms.telegram import TelegramAdapter
+
+    adapter = object.__new__(TelegramAdapter)
+    adapter.platform = Platform.TELEGRAM
+    adapter._bot = AsyncMock()
+    adapter._missing_media_path_error = lambda label, path: f"{label} file not found: {path}"
+    adapter._metadata_thread_id = lambda metadata: None
+    adapter._reply_to_message_id_for_send = lambda reply_to, metadata, reply_to_mode=None: None
+    adapter._thread_kwargs_for_send = lambda *args, **kwargs: {}
+    adapter._notification_kwargs = lambda metadata: {}
+    adapter._reply_to_mode = "auto"
+    adapter._send_with_dm_topic_reply_anchor_retry = AsyncMock()
+    adapter.send_document = AsyncMock()
+
+    path = tmp_path / "bad.ogg"
+    path.write_bytes(b"mp3-bytes")
+    monkeypatch.setattr(
+        "tools.tts_tool._is_telegram_voice_artifact",
+        lambda audio_path: False,
+        raising=False,
+    )
+
+    result = await adapter.send_voice(chat_id="123", audio_path=str(path))
+
+    assert result.success is False
+    assert "valid telegram voice" in result.error.lower()
+    adapter._send_with_dm_topic_reply_anchor_retry.assert_not_called()
+    adapter.send_document.assert_not_called()

--- a/tests/tools/test_tts_command_providers.py
+++ b/tests/tools/test_tts_command_providers.py
@@ -452,9 +452,8 @@ class TestTextToSpeechToolWithCommandProvider:
         assert data["voice_compatible"] is False
         assert Path(data["file_path"]).exists()
 
-    def test_voice_compatible_opt_in_toggles_flag(self, tmp_path):
-        """voice_compatible=true is reflected in the response when the
-        file is already .ogg (no ffmpeg needed)."""
+    def test_voice_compatible_opt_in_requires_valid_artifact(self, tmp_path):
+        """voice_compatible=true still requires validated OGG/Opus output."""
         cfg = {
             "provider": "py-copy-ogg",
             "providers": {
@@ -468,7 +467,32 @@ class TestTextToSpeechToolWithCommandProvider:
         }
         out = tmp_path / "clip.ogg"
 
-        with patch("tools.tts_tool._load_tts_config", return_value=cfg):
+        with patch("tools.tts_tool._load_tts_config", return_value=cfg), \
+             patch("tools.tts_tool._is_telegram_voice_artifact", return_value=False, create=True), \
+             patch("tools.tts_tool._convert_to_opus", return_value=None):
+            result = text_to_speech_tool(text="hi", output_path=str(out))
+        data = json.loads(result)
+        assert data["success"] is True
+        assert data["voice_compatible"] is False
+        assert not data["media_tag"].startswith("[[audio_as_voice]]")
+
+    def test_voice_compatible_opt_in_marks_valid_artifact(self, tmp_path):
+        """Validated command-provider OGG/Opus can be sent as voice."""
+        cfg = {
+            "provider": "py-copy-ogg",
+            "providers": {
+                "py-copy-ogg": {
+                    "type": "command",
+                    "command": _python_copy_command(),
+                    "output_format": "ogg",
+                    "voice_compatible": True,
+                },
+            },
+        }
+        out = tmp_path / "clip.ogg"
+
+        with patch("tools.tts_tool._load_tts_config", return_value=cfg), \
+             patch("tools.tts_tool._is_telegram_voice_artifact", return_value=True, create=True):
             result = text_to_speech_tool(text="hi", output_path=str(out))
         data = json.loads(result)
         assert data["success"] is True

--- a/tests/tools/test_tts_opus_routing.py
+++ b/tests/tools/test_tts_opus_routing.py
@@ -60,6 +60,11 @@ def test_edge_telegram_converts_to_opus_voice(tmp_path, monkeypatch):
     monkeypatch.setattr(tts_tool, "_import_edge_tts", lambda: object())
     monkeypatch.setattr(tts_tool, "_generate_edge_tts", _write_edge_output)
     monkeypatch.setattr(tts_tool, "_convert_to_opus", convert)
+    monkeypatch.setattr(
+        tts_tool,
+        "_is_telegram_voice_artifact",
+        lambda path: Path(path) == opus,
+    )
 
     result = json.loads(tts_tool.text_to_speech_tool("hello", output_path=str(out)))
 

--- a/tests/tools/test_tts_voice_artifacts.py
+++ b/tests/tools/test_tts_voice_artifacts.py
@@ -1,0 +1,132 @@
+import json
+import subprocess
+from pathlib import Path
+
+from tools import tts_tool
+
+
+def _completed(stdout: str):
+    return subprocess.CompletedProcess(
+        args=["ffprobe"],
+        returncode=0,
+        stdout=stdout,
+        stderr="",
+    )
+
+
+def test_mp3_payload_named_ogg_is_not_telegram_voice(monkeypatch, tmp_path):
+    path = tmp_path / "reply.ogg"
+    path.write_bytes(b"fake")
+
+    validator = getattr(tts_tool, "_is_telegram_voice_artifact", None)
+    assert callable(validator)
+
+    monkeypatch.setattr(
+        tts_tool.subprocess,
+        "run",
+        lambda *args, **kwargs: _completed(json.dumps({
+            "format": {"format_name": "mp3"},
+            "streams": [
+                {
+                    "codec_type": "audio",
+                    "codec_name": "mp3",
+                    "duration": "1.2",
+                }
+            ],
+        })),
+    )
+
+    assert validator(str(path)) is False
+
+
+def test_ogg_opus_payload_is_telegram_voice(monkeypatch, tmp_path):
+    path = tmp_path / "reply.ogg"
+    path.write_bytes(b"fake")
+
+    validator = getattr(tts_tool, "_is_telegram_voice_artifact", None)
+    assert callable(validator)
+
+    monkeypatch.setattr(
+        tts_tool.subprocess,
+        "run",
+        lambda *args, **kwargs: _completed(json.dumps({
+            "format": {"format_name": "ogg"},
+            "streams": [
+                {
+                    "codec_type": "audio",
+                    "codec_name": "opus",
+                    "duration": "1.2",
+                }
+            ],
+        })),
+    )
+
+    assert validator(str(path)) is True
+
+
+def test_edge_requested_ogg_generates_native_mp3_then_validated_voice(
+    monkeypatch,
+    tmp_path,
+):
+    requested = tmp_path / "reply.ogg"
+    generated_paths = []
+
+    async def fake_generate_edge(text, output_path, config):
+        generated_paths.append(Path(output_path))
+        Path(output_path).write_bytes(b"mp3-bytes")
+        return output_path
+
+    def fake_convert(path):
+        converted = tmp_path / "reply.voice.ogg"
+        converted.write_bytes(b"ogg-opus")
+        return str(converted)
+
+    monkeypatch.setenv("HERMES_SESSION_PLATFORM", "telegram")
+    monkeypatch.setattr(tts_tool, "_load_tts_config", lambda: {"provider": "edge"})
+    monkeypatch.setattr(tts_tool, "_import_edge_tts", lambda: object())
+    monkeypatch.setattr(tts_tool, "_generate_edge_tts", fake_generate_edge)
+    monkeypatch.setattr(tts_tool, "_convert_to_opus", fake_convert)
+    monkeypatch.setattr(
+        tts_tool,
+        "_is_telegram_voice_artifact",
+        lambda path: Path(path).name == "reply.voice.ogg",
+        raising=False,
+    )
+
+    data = json.loads(tts_tool.text_to_speech_tool(text="hello", output_path=str(requested)))
+
+    assert data["success"] is True
+    assert data["voice_compatible"] is True
+    assert data["file_path"] == str(tmp_path / "reply.voice.ogg")
+    assert data["media_tag"] == f"[[audio_as_voice]]\nMEDIA:{tmp_path / 'reply.voice.ogg'}"
+    assert generated_paths == [tmp_path / "reply.mp3"]
+
+
+def test_convert_to_opus_uses_distinct_validated_voice_artifact(monkeypatch, tmp_path):
+    source = tmp_path / "reply.ogg"
+    source.write_bytes(b"mp3-bytes")
+    captured = {}
+
+    def fake_run(args, *unused_args, **unused_kwargs):
+        target = Path(args[-2])
+        captured["source"] = args[2]
+        captured["target"] = str(target)
+        target.write_bytes(b"ogg-opus")
+        return subprocess.CompletedProcess(args=args, returncode=0, stdout=b"", stderr=b"")
+
+    monkeypatch.setattr(tts_tool, "_has_ffmpeg", lambda: True)
+    monkeypatch.setattr(tts_tool.subprocess, "run", fake_run)
+    monkeypatch.setattr(
+        tts_tool,
+        "_is_telegram_voice_artifact",
+        lambda path: Path(path).name == "reply.voice.ogg",
+        raising=False,
+    )
+
+    result = tts_tool._convert_to_opus(str(source))
+
+    assert result == str(tmp_path / "reply.voice.ogg")
+    assert captured == {
+        "source": str(source),
+        "target": str(tmp_path / "reply.voice.ogg"),
+    }

--- a/tools/tts_tool.py
+++ b/tools/tts_tool.py
@@ -850,12 +850,78 @@ def _has_ffmpeg() -> bool:
     return shutil.which("ffmpeg") is not None
 
 
-def _convert_to_opus(mp3_path: str) -> Optional[str]:
+def _inspect_audio_file(path: str) -> Dict[str, Any]:
+    """Inspect an audio file's real container/codec metadata with ffprobe."""
+    result = subprocess.run(
+        [
+            "ffprobe",
+            "-v", "error",
+            "-show_entries", "format=format_name:stream=codec_type,codec_name,duration",
+            "-of", "json",
+            path,
+        ],
+        capture_output=True,
+        text=True,
+        timeout=10,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(result.stderr.strip() or "ffprobe failed")
+
+    data = json.loads(result.stdout or "{}")
+    streams = data.get("streams") or []
+    audio_stream = next(
+        (stream for stream in streams if stream.get("codec_type") == "audio"),
+        {},
+    )
+    duration = audio_stream.get("duration")
+    return {
+        "container": str((data.get("format") or {}).get("format_name") or ""),
+        "codec": str(audio_stream.get("codec_name") or ""),
+        "duration": float(duration) if duration not in (None, "N/A", "") else 0.0,
+        "size": os.path.getsize(path) if os.path.exists(path) else 0,
+    }
+
+
+def _is_telegram_voice_artifact(path: str) -> bool:
+    """Return True only for validated OGG/Opus Telegram voice artifacts."""
+    try:
+        info = _inspect_audio_file(path)
+    except Exception as exc:
+        logger.warning("Failed to inspect audio artifact %s: %s", path, exc)
+        return False
+    return (
+        Path(path).suffix.lower() in {".ogg", ".opus"}
+        and "ogg" in str(info.get("container", "")).lower()
+        and str(info.get("codec", "")).lower() == "opus"
+        and int(info.get("size") or 0) > 0
+    )
+
+
+_PROVIDER_SOURCE_EXTENSIONS: Dict[str, str] = {
+    "edge": ".mp3",
+    "minimax": ".mp3",
+    "xai": ".mp3",
+    "neutts": ".wav",
+    "kittentts": ".wav",
+    "piper": ".wav",
+}
+
+
+def _provider_source_path(output_path: str, provider: str) -> str:
+    """Return a provider-native source path for requested Telegram voice output."""
+    requested = Path(output_path)
+    source_ext = _PROVIDER_SOURCE_EXTENSIONS.get((provider or "").lower())
+    if requested.suffix.lower() in {".ogg", ".opus"} and source_ext:
+        return str(requested.with_suffix(source_ext))
+    return output_path
+
+
+def _convert_to_opus(source_path: str) -> Optional[str]:
     """
-    Convert an MP3 file to OGG Opus format for Telegram voice bubbles.
+    Convert an audio file to OGG Opus format for Telegram voice bubbles.
 
     Args:
-        mp3_path: Path to the input MP3 file.
+        source_path: Path to the input audio file.
 
     Returns:
         Path to the .ogg file, or None if conversion fails.
@@ -863,10 +929,11 @@ def _convert_to_opus(mp3_path: str) -> Optional[str]:
     if not _has_ffmpeg():
         return None
 
-    ogg_path = mp3_path.rsplit(".", 1)[0] + ".ogg"
+    source = Path(source_path)
+    ogg_path = str(source.with_name(f"{source.stem}.voice.ogg"))
     try:
         result = subprocess.run(
-            ["ffmpeg", "-i", mp3_path, "-acodec", "libopus",
+            ["ffmpeg", "-i", source_path, "-acodec", "libopus",
              "-ac", "1", "-b:a", "64k", "-vbr", "off", ogg_path, "-y"],
             capture_output=True, timeout=30,
         )
@@ -875,6 +942,12 @@ def _convert_to_opus(mp3_path: str) -> Optional[str]:
                           result.returncode, result.stderr.decode('utf-8', errors='ignore')[:200])
             return None
         if os.path.exists(ogg_path) and os.path.getsize(ogg_path) > 0:
+            if not _is_telegram_voice_artifact(ogg_path):
+                logger.warning(
+                    "ffmpeg produced non-telegram voice artifact: %s",
+                    ogg_path,
+                )
+                return None
             return ogg_path
     except subprocess.TimeoutExpired:
         logger.warning("ffmpeg OGG conversion timed out after 30s")
@@ -1914,9 +1987,14 @@ def text_to_speech_tool(
         else:
             file_path = out_dir / f"tts_{timestamp}.mp3"
 
+    requested_voice_artifact = file_path.suffix.lower() in {".ogg", ".opus"}
+
     # Ensure parent directory exists
     file_path.parent.mkdir(parents=True, exist_ok=True)
     file_str = str(file_path)
+    if command_provider_config is None:
+        file_str = _provider_source_path(file_str, provider)
+        Path(file_str).parent.mkdir(parents=True, exist_ok=True)
 
     try:
         # Generate audio with the configured provider
@@ -2076,11 +2154,11 @@ def text_to_speech_tool(
             # delivery only kicks in when the user explicitly opts in
             # via ``voice_compatible: true`` in their provider config.
             if _is_command_tts_voice_compatible(command_provider_config):
-                if not file_str.endswith(".ogg"):
+                if not _is_telegram_voice_artifact(file_str):
                     opus_path = _convert_to_opus(file_str)
                     if opus_path:
                         file_str = opus_path
-                voice_compatible = file_str.endswith(".ogg")
+                voice_compatible = _is_telegram_voice_artifact(file_str)
         elif provider not in BUILTIN_TTS_PROVIDERS:
             # Plugin-registered provider (issue #30398). Voice-bubble
             # delivery opts in via ``TTSProvider.voice_compatible``
@@ -2088,22 +2166,22 @@ def text_to_speech_tool(
             # already write Opus skip the ffmpeg conversion.
             plugin_voice_compatible = _plugin_provider_is_voice_compatible(provider)
             if plugin_voice_compatible:
-                if not file_str.endswith(".ogg"):
+                if not _is_telegram_voice_artifact(file_str):
                     opus_path = _convert_to_opus(file_str)
                     if opus_path:
                         file_str = opus_path
-                voice_compatible = file_str.endswith(".ogg")
+                voice_compatible = _is_telegram_voice_artifact(file_str)
         elif (
-            want_opus
-            and provider in {"edge", "neutts", "minimax", "xai", "kittentts", "piper"}
-            and not file_str.endswith(".ogg")
+            provider in _PROVIDER_SOURCE_EXTENSIONS
+            and (want_opus or requested_voice_artifact)
+            and not _is_telegram_voice_artifact(file_str)
         ):
             opus_path = _convert_to_opus(file_str)
             if opus_path:
                 file_str = opus_path
-                voice_compatible = True
+            voice_compatible = _is_telegram_voice_artifact(file_str)
         elif provider in {"elevenlabs", "openai", "mistral", "gemini"}:
-            voice_compatible = want_opus and file_str.endswith(".ogg")
+            voice_compatible = want_opus and _is_telegram_voice_artifact(file_str)
 
         file_size = os.path.getsize(file_str)
         logger.info("TTS audio saved: %s (%s bytes, provider: %s)", file_str, f"{file_size:,}", provider)


### PR DESCRIPTION
## Problem

Hermes currently treats `.ogg` / `.opus` filenames as if they are guaranteed Telegram voice artifacts. That is not always true: a provider can write MP3 or WAV bytes to a caller-requested `.ogg` path. Telegram `sendVoice` needs a real Ogg container with Opus audio, so extension-only routing can mark or send invalid files as native voice notes.

## Summary

- Add `ffprobe` inspection and only consider audio Telegram voice-compatible when the artifact is actually Ogg/Opus.
- For built-in providers that produce MP3/WAV, generate a provider-native source file first when a voice artifact is requested, then convert to a distinct `.voice.ogg` file and validate it.
- Keep ordinary non-Telegram/default TTS output as regular native audio, preserving the current `main` behavior added after this PR was first opened.
- Require command and plugin TTS providers that opt into `voice_compatible` to produce or convert to a validated artifact before emitting `[[audio_as_voice]]`.
- Prevent invalid `.ogg` / `.opus` paths from being sent through Telegram `sendVoice` or silently falling back as a document.

## Validation

Focused regression suite:

```bash
scripts/run_tests.sh tests/tools/test_tts_voice_artifacts.py tests/tools/test_tts_opus_routing.py tests/tools/test_tts_command_providers.py tests/tools/test_tts_plugin_dispatch.py tests/gateway/test_telegram_voice_delivery.py tests/gateway/test_voice_command.py -- -o addopts='' -q
```

Result: `276 passed, 0 failed`.

Local note: the fallback Hermes venv on this machine lacks `pytest-timeout`, so I used `-o addopts=''` for this local run. The tests themselves are regular pytest tests and should run under the default CI environment with the repo's normal dependencies.