### PR TITLE
feat(gateway): auto-name Telegram sessions

### DIFF
--- a/agent/session_title_defaults.py
+++ b/agent/session_title_defaults.py
@@ -1,0 +1,63 @@
+"""Deterministic fallback titles for sessions that need an immediate name."""
+
+from __future__ import annotations
+
+import re
+from datetime import datetime
+from typing import Optional
+
+_TELEGRAM_FALLBACK_RE = re.compile(
+    r"^Telegram [A-Z][a-z]{2} \d{1,2} \d{2}:\d{2} [0-9a-f]{4,8}$"
+)
+_SESSION_ID_TS_RE = re.compile(r"^(\d{8})_(\d{6})_")
+_SESSION_SUFFIX_RE = re.compile(r"[A-Za-z0-9]+")
+_MONTH_ABBR = (
+    "Jan", "Feb", "Mar", "Apr", "May", "Jun",
+    "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
+)
+
+
+def _timestamp_from_session_id(session_id: str) -> Optional[datetime]:
+    match = _SESSION_ID_TS_RE.match(session_id or "")
+    if not match:
+        return None
+    try:
+        return datetime.strptime("".join(match.groups()), "%Y%m%d%H%M%S")
+    except ValueError:
+        return None
+
+
+def _session_suffix(session_id: str, length: int = 8) -> str:
+    tail = (session_id or "").rsplit("_", 1)[-1]
+    cleaned = "".join(_SESSION_SUFFIX_RE.findall(tail)).lower()
+    if cleaned:
+        return cleaned[:length]
+    return "session"
+
+
+def telegram_fallback_title(session_id: str, created_at: Optional[datetime] = None) -> str:
+    """Return a short deterministic title for a Telegram gateway session.
+
+    The title is immediately useful in `/resume` and unique in normal Hermes
+    session IDs because it includes the short random suffix.
+    """
+    dt = created_at or _timestamp_from_session_id(session_id) or datetime.now()
+    month = _MONTH_ABBR[dt.month - 1]
+    return f"Telegram {month} {dt.day} {dt:%H:%M} {_session_suffix(session_id)}"
+
+
+def fallback_title_for_gateway_session(
+    platform: object,
+    session_id: str,
+    created_at: Optional[datetime] = None,
+) -> Optional[str]:
+    """Return an immediate fallback title for platforms that need one."""
+    value = getattr(platform, "value", platform)
+    if str(value or "").lower() == "telegram":
+        return telegram_fallback_title(session_id, created_at=created_at)
+    return None
+
+
+def is_generated_fallback_title(title: Optional[str]) -> bool:
+    """Whether a title is one of Hermes' deterministic fallback names."""
+    return bool(title and _TELEGRAM_FALLBACK_RE.match(title.strip()))

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -9,6 +9,7 @@ import threading
 from typing import Callable, Optional
 
 from agent.auxiliary_client import call_llm
+from agent.session_title_defaults import is_generated_fallback_title
 
 logger = logging.getLogger(__name__)
 
@@ -104,10 +105,12 @@ def auto_title_session(
     if not session_db or not session_id:
         return
 
-    # Check if title already exists (user may have set one via /title before first response)
+    # Check if title already exists.  User-set titles are authoritative, but
+    # deterministic Telegram fallback titles are placeholders that content-based
+    # auto-title is allowed to replace after the first successful exchange.
     try:
         existing = session_db.get_session_title(session_id)
-        if existing:
+        if existing and not is_generated_fallback_title(existing):
             return
     except Exception:
         return

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -10500,7 +10500,7 @@ class GatewayRunner:
             "  /topic             Enable topic mode, or show status if already on\n"
             "  /topic help        Show this message\n"
             "  /topic off         Disable topic mode and clear topic bindings\n"
-            "  /topic <id>        Inside a topic: restore a previous session by ID\n"
+            "  /topic <id-or-title> Inside a topic: restore a previous session by ID or title\n"
             "\n"
             "How it works:\n"
             "1. Run /topic once in this DM — Hermes checks BotFather Threads\n"
@@ -10585,7 +10585,7 @@ class GatewayRunner:
             if not source.thread_id:
                 return (
                     "To restore a session, first create or open a Telegram topic, "
-                    "then send /topic <session-id> inside that topic. To create a "
+                    "then send /topic <session-id-or-title> inside that topic. To create a "
                     "new topic, open All Messages and send any message there."
                 )
             return await self._restore_telegram_topic_session(event, args)
@@ -10697,7 +10697,7 @@ class GatewayRunner:
                 "",
                 "To restore one:",
                 "1. Create or open a topic. To create a new one, open All Messages and send any message there.",
-                "2. Send /topic <session-id> inside that topic.",
+                "2. Send /topic <session-id-or-title> inside that topic.",
                 f"Example: Send /topic {sessions[0].get('id')} inside a topic.",
             ])
         else:
@@ -10706,20 +10706,26 @@ class GatewayRunner:
                 "",
                 "To restore a previous session later:",
                 "1. Create or open a topic. To create a new one, open All Messages and send any message there.",
-                "2. Send /topic <session-id> inside that topic.",
+                "2. Send /topic <session-id-or-title> inside that topic.",
             ])
         return "\n".join(lines)
 
     async def _restore_telegram_topic_session(self, event: MessageEvent, raw_session_id: str) -> str:
         """Restore an existing Telegram-owned Hermes session into this topic."""
         source = event.source
-        session_id = self._session_db.resolve_session_id(raw_session_id.strip())
+        raw = raw_session_id.strip()
+        session_id = self._session_db.resolve_session_id(raw)
         if not session_id:
-            return f"Session not found: {raw_session_id.strip()}"
+            try:
+                session_id = self._session_db.resolve_session_by_title(raw)
+            except Exception:
+                session_id = None
+        if not session_id:
+            return f"Session not found: {raw}"
 
         session = self._session_db.get_session(session_id)
         if not session:
-            return f"Session not found: {raw_session_id.strip()}"
+            return f"Session not found: {raw}"
         if str(session.get("source") or "") != "telegram":
             return "That session is not a Telegram session and cannot be restored into this topic."
         if str(session.get("user_id") or "") != str(source.user_id):
@@ -10863,6 +10869,27 @@ class GatewayRunner:
         except Exception as e:
             logger.debug("Failed to resolve resume continuation for %s: %s", target_id, e)
 
+        # A Telegram topic can only own one session binding at a time, and a
+        # session can only be linked to one topic. Check before switching the
+        # in-memory SessionStore so an already-linked target doesn't leave the
+        # current topic half-switched.
+        if self._is_telegram_topic_lane(source):
+            try:
+                current_binding = self._session_db.get_telegram_topic_binding(
+                    chat_id=str(source.chat_id),
+                    thread_id=str(source.thread_id),
+                )
+                target_linked = self._session_db.is_telegram_session_linked_to_topic(
+                    session_id=target_id,
+                )
+                if target_linked and (
+                    not current_binding
+                    or str(current_binding.get("session_id") or "") != str(target_id)
+                ):
+                    return "That session is already linked to another Telegram topic."
+            except Exception:
+                logger.debug("Failed to preflight Telegram topic resume binding", exc_info=True)
+
         # Check if already on that session
         current_entry = self.session_store.get_or_create_session(source)
         if current_entry.session_id == target_id:
@@ -10886,6 +10913,20 @@ class GatewayRunner:
 
         # Get the title for confirmation
         title = self._session_db.get_session_title(target_id) or name
+
+        # Telegram topic lanes are pinned by an explicit topic -> session_id
+        # binding. Keep it in sync with /resume so the next message doesn't
+        # snap back to the previously-bound session.
+        if self._is_telegram_topic_lane(source):
+            try:
+                self._record_telegram_topic_binding(source, new_entry)
+                self._schedule_telegram_topic_title_rename(source, target_id, title)
+            except ValueError as exc:
+                if "already linked" in str(exc):
+                    return "That session is already linked to another Telegram topic."
+                raise
+            except Exception:
+                logger.debug("Failed to rebind Telegram topic after /resume", exc_info=True)
 
         # Count messages for context
         history = self.session_store.load_transcript(target_id)

--- a/gateway/session.py
+++ b/gateway/session.py
@@ -742,6 +742,24 @@ class SessionStore:
             group_sessions_per_user=getattr(self.config, "group_sessions_per_user", True),
             thread_sessions_per_user=getattr(self.config, "thread_sessions_per_user", False),
         )
+
+    def _assign_generated_fallback_title(self, source: SessionSource, entry: SessionEntry) -> None:
+        """Give newly-created sessions an immediate platform fallback title."""
+        if self._db is None:
+            return
+        try:
+            from agent.session_title_defaults import fallback_title_for_gateway_session
+
+            title = fallback_title_for_gateway_session(
+                source.platform,
+                entry.session_id,
+                created_at=entry.created_at,
+            )
+            if not title:
+                return
+            self._db.set_session_title(entry.session_id, title)
+        except Exception as exc:
+            logger.debug("Failed to assign generated session fallback title: %s", exc)
     
     def _is_session_expired(self, entry: SessionEntry) -> bool:
         """Check if a session has expired based on its reset policy.
@@ -943,6 +961,7 @@ class SessionStore:
         if self._db and db_create_kwargs:
             try:
                 self._db.create_session(**db_create_kwargs)
+                self._assign_generated_fallback_title(source, entry)
             except Exception as e:
                 print(f"[gateway] Warning: Failed to create SQLite session: {e}")
 
@@ -1168,6 +1187,8 @@ class SessionStore:
         if self._db and db_create_kwargs:
             try:
                 self._db.create_session(**db_create_kwargs)
+                if new_entry.origin is not None:
+                    self._assign_generated_fallback_title(new_entry.origin, new_entry)
             except Exception as e:
                 logger.debug("Session DB operation failed: %s", e)
 

--- a/tests/agent/test_session_title_defaults.py
+++ b/tests/agent/test_session_title_defaults.py
@@ -1,0 +1,23 @@
+"""Tests for deterministic gateway fallback session titles."""
+
+from datetime import datetime
+
+from agent.session_title_defaults import (
+    is_generated_fallback_title,
+    telegram_fallback_title,
+)
+
+
+def test_telegram_fallback_title_is_locale_independent_and_short():
+    title = telegram_fallback_title(
+        "20260203_040506_DEADBEEF",
+        created_at=datetime(2026, 2, 3, 4, 5, 6),
+    )
+
+    assert title == "Telegram Feb 3 04:05 deadbeef"
+    assert is_generated_fallback_title(title)
+
+
+def test_non_generated_titles_are_not_placeholders():
+    assert not is_generated_fallback_title("Telegram Research Session")
+    assert not is_generated_fallback_title("Existing User Title")

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -128,6 +128,15 @@ class TestAutoTitleSession:
             auto_title_session(db, "sess-1", "hi", "hello")
             gen.assert_not_called()
 
+    def test_replaces_generated_telegram_fallback_title(self):
+        db = MagicMock()
+        db.get_session_title.return_value = "Telegram May 10 12:38 deadbe"
+
+        with patch("agent.title_generator.generate_title", return_value="DeFi Liquidation Searcher"):
+            auto_title_session(db, "sess-1", "hi", "hello")
+
+        db.set_session_title.assert_called_once_with("sess-1", "DeFi Liquidation Searcher")
+
     def test_generates_and_sets_title(self):
         db = MagicMock()
         db.get_session_title.return_value = None

--- a/tests/gateway/test_session.py
+++ b/tests/gateway/test_session.py
@@ -167,6 +167,41 @@ class TestLocalCliFactory:
         assert source.chat_name == "CLI terminal"
 
 
+class TestTelegramGeneratedSessionTitles:
+    def _store_with_db(self, tmp_path):
+        from hermes_state import SessionDB
+
+        db = SessionDB(db_path=tmp_path / "state.db")
+        store = SessionStore(tmp_path / "sessions", GatewayConfig())
+        store._db = db
+        return store, db
+
+    def test_new_telegram_session_gets_fallback_title_immediately(self, tmp_path):
+        store, db = self._store_with_db(tmp_path)
+        source = SessionSource(
+            platform=Platform.TELEGRAM,
+            chat_id="12345",
+            chat_type="dm",
+            user_id="42",
+            user_name="stevan",
+        )
+
+        entry = store.get_or_create_session(source)
+
+        title = db.get_session_title(entry.session_id)
+        assert title is not None
+        assert title.startswith("Telegram ")
+        assert entry.session_id.rsplit("_", 1)[-1][:6] in title
+
+    def test_new_local_session_stays_untitled(self, tmp_path):
+        store, db = self._store_with_db(tmp_path)
+        source = SessionSource(platform=Platform.LOCAL, chat_id="cli")
+
+        entry = store.get_or_create_session(source)
+
+        assert db.get_session_title(entry.session_id) is None
+
+
 class TestBuildSessionContextPrompt:
     def test_telegram_prompt_contains_platform_and_chat(self):
         config = GatewayConfig(
@@ -491,7 +526,7 @@ class TestLoadTranscriptCorruptLines:
         session_id = "corrupt_test"
         transcript_path = store.get_transcript_path(session_id)
         transcript_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(transcript_path, "w") as f:
+        with open(transcript_path, "w", encoding="utf-8") as f:
             f.write('{"role": "user", "content": "hello"}\n')
             f.write('{"role": "assistant", "content": "hi th')  # truncated
             f.write("\n")
@@ -506,7 +541,7 @@ class TestLoadTranscriptCorruptLines:
         session_id = "all_corrupt"
         transcript_path = store.get_transcript_path(session_id)
         transcript_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(transcript_path, "w") as f:
+        with open(transcript_path, "w", encoding="utf-8") as f:
             f.write("not json at all\n")
             f.write("{truncated\n")
 

--- a/tests/gateway/test_telegram_session_titles.py
+++ b/tests/gateway/test_telegram_session_titles.py
@@ -1,0 +1,96 @@
+"""Telegram session title/resume behavior."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform
+from gateway.session import SessionSource, SessionStore
+
+
+@pytest.mark.asyncio
+async def test_restore_telegram_topic_accepts_generated_session_title(tmp_path):
+    from gateway.run import GatewayRunner
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    target_session_id = "20260510_123000_deadbeef"
+    target_title = "Telegram May 10 12:30 deadbe"
+    db.create_session(target_session_id, "telegram", user_id="42")
+    db.set_session_title(target_session_id, target_title)
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._session_db = db
+    runner.config = GatewayConfig()
+    runner.session_store = SessionStore(tmp_path / "sessions", runner.config)
+    runner.session_store._db = db
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        user_id="42",
+        thread_id="99",
+    )
+    event = MagicMock()
+    event.source = source
+
+    response = await runner._restore_telegram_topic_session(event, target_title)
+
+    assert response.startswith(f"Session restored: {target_title}")
+    binding = db.get_telegram_topic_binding(chat_id="12345", thread_id="99")
+    assert binding is not None
+    assert binding["session_id"] == target_session_id
+
+
+@pytest.mark.asyncio
+async def test_resume_by_title_inside_telegram_topic_rebinds_topic(tmp_path):
+    from gateway.run import GatewayRunner
+    from hermes_state import SessionDB
+
+    db = SessionDB(db_path=tmp_path / "state.db")
+    config = GatewayConfig()
+    store = SessionStore(tmp_path / "sessions", config)
+    store._db = db
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="12345",
+        chat_type="dm",
+        user_id="42",
+        thread_id="99",
+    )
+    db.enable_telegram_topic_mode(chat_id="12345", user_id="42")
+    current_entry = store.get_or_create_session(source)
+    db.bind_telegram_topic(
+        chat_id="12345",
+        thread_id="99",
+        user_id="42",
+        session_key=current_entry.session_key,
+        session_id=current_entry.session_id,
+    )
+
+    target_session_id = "20260510_123000_deadbeef"
+    target_title = "Telegram May 10 12:30 deadbe"
+    db.create_session(target_session_id, "telegram", user_id="42")
+    db.set_session_title(target_session_id, target_title)
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner._session_db = db
+    runner.config = config
+    runner.session_store = store
+    runner._running_agents = {}
+    runner._running_agents_ts = {}
+    runner._busy_ack_ts = {}
+
+    event = MagicMock()
+    event.source = source
+    event.get_command_args.return_value = target_title
+
+    response = await runner._handle_resume_command(event)
+
+    assert "Resumed session" in response
+    assert target_title in response
+    binding = db.get_telegram_topic_binding(chat_id="12345", thread_id="99")
+    assert binding is not None
+    assert binding["session_id"] == target_session_id


### PR DESCRIPTION
## Summary
- Add deterministic fallback titles for newly created Telegram gateway sessions so they are immediately discoverable/resumable.
- Allow LLM auto-title generation to replace those generated placeholders while preserving user-set titles.
- Support Telegram Topic Mode restore/resume by generated title and rebind topics when `/resume` switches sessions.

## How to test
- Start the Telegram gateway and send a message in a new Telegram session; the session should immediately have a short `Telegram <Mon> <day> <HH:MM> <suffix>` title visible to `/resume`.
- Use `/resume <generated title>` to switch back to the session.
- In Telegram Topic Mode, use `/topic <generated title>` inside a topic to restore an unlinked Telegram session.

## Automated test plan
- `git diff --check origin/main...HEAD`
- `python scripts/check-windows-footguns.py --diff origin/main`
- Manual smoke via Python gateway classes: create a Telegram `SessionStore` session and verify the generated title is persisted.
- `scripts/run_tests.sh tests/agent/test_session_title_defaults.py tests/agent/test_title_generator.py -q`
- `scripts/run_tests.sh tests/gateway/test_session.py tests/gateway/test_telegram_session_titles.py -q`
- `scripts/run_tests.sh tests/gateway/test_telegram_topic_mode.py tests/gateway/test_telegram_session_titles.py tests/gateway/test_session.py::TestTelegramGeneratedSessionTitles tests/agent/test_title_generator.py tests/agent/test_session_title_defaults.py -q`

## Platforms tested
- Linux / Ubuntu dev environment with Python 3.11 via `scripts/run_tests.sh` hermetic wrapper.

## Related issues
- None.

## Notes
- Broader `scripts/run_tests.sh tests/gateway/ -q` was also run locally. It currently reports 8 failures in config/CORS/TTS media-routing tests.
- Verified the same 8 failing tests fail on `origin/main`/`44cdf555a`, so they are pre-existing baseline failures unrelated to this PR.
