### PR TITLE
fix(file-operations): verify write_file persisted content before reporting success

### DIFF
--- a/tests/tools/test_file_operations.py
+++ b/tests/tools/test_file_operations.py
@@ -579,3 +579,59 @@ class TestPatchReplacePostWriteVerification:
         result = ops.patch_replace("/tmp/test/a.py", "hello", "hi")
         assert result.error is not None
         assert "could not re-read" in result.error.lower()
+
+
+class TestWriteFilePostWriteVerification:
+    """Tests for the post-write verification added in write_file."""
+
+    def test_write_file_fails_when_file_not_persisted(self, mock_env):
+        """Silent persistence failures must not report write success."""
+        file_contents = {"/tmp/test/a.py": "old content\n"}
+
+        def side_effect(command, stdin_data=None, **kwargs):
+            if command.startswith("cat "):
+                for path in file_contents:
+                    if path in command:
+                        return {"output": file_contents[path], "returncode": 0}
+                return {"output": "", "returncode": 1}
+            if command.startswith("mkdir "):
+                return {"output": "", "returncode": 0}
+            if command.startswith("wc -c"):
+                for path in file_contents:
+                    if path in command:
+                        return {"output": str(len(file_contents[path].encode())), "returncode": 0}
+                return {"output": "0", "returncode": 0}
+            if command.startswith("cat >"):
+                return {"output": "", "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        result = ops.write_file("/tmp/test/a.py", "new content\n")
+        assert result.error is not None
+        assert "verification failed" in result.error.lower()
+        assert "did not persist" in result.error.lower()
+
+    def test_write_file_succeeds_when_file_persisted(self, mock_env):
+        """Normal success path: persisted bytes should still report success."""
+        state = {"content": "old content\n"}
+
+        def side_effect(command, stdin_data=None, **kwargs):
+            if command.startswith("cat >"):
+                if stdin_data is not None:
+                    state["content"] = stdin_data
+                return {"output": "", "returncode": 0}
+            if command.startswith("cat "):
+                return {"output": state["content"], "returncode": 0}
+            if command.startswith("mkdir "):
+                return {"output": "", "returncode": 0}
+            if command.startswith("wc -c"):
+                return {"output": str(len(state["content"].encode())), "returncode": 0}
+            return {"output": "", "returncode": 0}
+
+        mock_env.execute.side_effect = side_effect
+        ops = ShellFileOperations(mock_env)
+        result = ops.write_file("/tmp/test/a.py", "new content\n")
+        assert result.error is None, f"Unexpected error: {result.error}"
+        assert result.bytes_written == len("new content\n".encode())
+        assert state["content"] == "new content\n"

--- a/tools/file_operations.py
+++ b/tools/file_operations.py
@@ -885,6 +885,32 @@ class ShellFileOperations(FileOperations):
         if write_result.exit_code != 0:
             return WriteResult(error=f"Failed to write file: {write_result.stdout}")
 
+        # Post-write verification - re-read the file and confirm the bytes we
+        # intended to write actually landed. Catches silent persistence
+        # failures (backend FS oddities, race with another task, truncated
+        # pipe, etc.) that would otherwise report success while leaving the
+        # file unchanged on disk.
+        verify_cmd = f"cat {self._escape_shell_arg(path)} 2>/dev/null"
+        verify_result = self._exec(verify_cmd)
+        if verify_result.exit_code != 0:
+            return WriteResult(
+                error=f"Post-write verification failed: could not re-read {path}"
+            )
+        _verify_stdout_normalized = (
+            verify_result.stdout.replace("\r\n", "\n").replace("\r", "\n")
+        )
+        _content_normalized = content.replace("\r\n", "\n").replace("\r", "\n")
+        if _verify_stdout_normalized != _content_normalized:
+            return WriteResult(
+                error=(
+                    f"Post-write verification failed for {path}: on-disk content "
+                    f"differs from intended write "
+                    f"(wrote {len(_content_normalized)} chars, read back "
+                    f"{len(_verify_stdout_normalized)} chars after normalizing line endings). "
+                    "The write did not persist. Re-read the file and try again."
+                )
+            )
+
         # Get bytes written (wc -c is POSIX, works on Linux + macOS)
         stat_cmd = f"wc -c < {self._escape_shell_arg(path)} 2>/dev/null"
         stat_result = self._exec(stat_cmd)


### PR DESCRIPTION
## Summary

`ShellFileOperations.write_file()` could report success after `cat > file`
returned cleanly even if the target file was not actually updated on disk.

This change adds a post-write verification step that re-reads the file and
compares the normalized content against the intended write before returning a
successful `WriteResult`.

## What changed

- Added post-write verification to `ShellFileOperations.write_file()`
- Return a clear error when the verify-read fails
- Return a clear error when the re-read content does not match the intended write
- Added deterministic tests for:
  - silent persistence failure
  - normal persisted write success

## Why

`patch_replace()` already verifies persistence after writing, but `write_file()`
did not. That left a false-success path where a backend write could appear to
succeed while the on-disk file remained stale or truncated.

This aligns both write paths around the same invariant: do not report success
until the file content is actually present on disk.

## Tests


- `tests/tools/test_file_operations.py::TestWriteFilePostWriteVerification::test_write_file_fails_when_file_not_persisted`
- `tests/tools/test_file_operations.py::TestWriteFilePostWriteVerification::test_write_file_succeeds_when_file_persisted`
- `tests/tools/test_file_operations.py::TestPatchReplacePostWriteVerification::test_patch_replace_fails_when_file_not_persisted`
- `tests/tools/test_file_operations.py::TestPatchReplacePostWriteVerification::test_patch_replace_succeeds_when_file_persisted`
- `tests/tools/test_file_operations.py::TestPatchReplacePostWriteVerification::test_patch_replace_fails_when_verify_read_errors`

Result: `5 passed`
