### PR TITLE
docs(providers): clarify concrete model.default values

### DIFF
--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -46,6 +46,8 @@ For the official API-key path, see the dedicated [Google Gemini guide](/docs/gui
 
 :::tip Model key alias
 In the `model:` config section, you can use either `default:` or `model:` as the key name for your model ID. Both `model: { default: my-model }` and `model: { model: my-model }` work identically.
+
+`model.default` still needs to be a real provider model ID (or a provider-published alias such as `gemini-pro-latest`). Hermes does not implement generic pseudo-values like `latest` or `auto`, so those will just be passed through as literal model names.
 :::
 
 


### PR DESCRIPTION
## What does this PR do?

Clarifies that `model.default` must be set to a real provider model ID (or a provider-published alias), and that Hermes does not implement generic pseudo-values like `latest` or `auto`.

## Related Issue

Fixes #14963

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- clarified the `Model key alias` note in `website/docs/integrations/providers.md`
- documented that generic pseudo-values such as `latest` and `auto` are not Hermes features
- called out that provider-published aliases remain valid when the provider actually supports them

## How to Test

1. Open `website/docs/integrations/providers.md`
2. Find the `Model key alias` tip near the top of the page
3. Confirm it now distinguishes real model IDs/provider aliases from unsupported pseudo-values like `latest`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (docs-only verification)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable (docs-only change).
