### PR TITLE
docs(context-engine): add third-party install steps

### DIFF
--- a/website/docs/developer-guide/context-engine-plugin.md
+++ b/website/docs/developer-guide/context-engine-plugin.md
@@ -143,6 +143,37 @@ def register(ctx):
 
 Only one engine can be registered. A second plugin attempting to register is rejected with a warning.
 
+## Installing a third-party context engine
+
+The `plugins/context_engine/<name>/` path above is the in-repo layout Hermes uses for bundled engines. Third-party engines are usually installed as regular Hermes plugins, then registered with `ctx.register_context_engine(...)`.
+
+Typical install flow:
+
+1. Clone or unpack the plugin into one of Hermes' plugin discovery directories:
+
+```bash
+# Personal install
+git clone https://github.com/example/hermes-lcm \
+  ~/.hermes/plugins/hermes-lcm
+
+# Project-local install (shared with one repo)
+git clone https://github.com/example/hermes-lcm \
+  .hermes/plugins/hermes-lcm
+```
+
+2. Make sure the plugin's `register(ctx)` function calls `ctx.register_context_engine(...)`.
+
+3. Restart Hermes (or reopen the CLI / gateway process) so the plugin is discovered.
+
+4. Select the engine by its `name` property:
+
+```yaml
+context:
+  engine: lcm
+```
+
+The plugin directory name does not have to match the engine name, but the `context.engine` value must match the engine object's `name`.
+
 ## Lifecycle
 
 ```


### PR DESCRIPTION
## What does this PR do?

Adds the missing installation story for third-party context engines, so readers can tell the difference between the in-repo bundled engine layout and the normal user/project plugin install flow.

## Related Issue

Fixes #10805

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- added a new `Installing a third-party context engine` section to `website/docs/developer-guide/context-engine-plugin.md`
- documented user-level and project-local plugin install directories
- clarified that `context.engine` must match the engine object's `name`, not the plugin directory name

## How to Test

1. Open `website/docs/developer-guide/context-engine-plugin.md`
2. Scroll to the registration/install area
3. Confirm the page now explains where third-party engines should be cloned and how they are activated

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (docs-only verification)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable (docs-only change).
