### PR TITLE
docs(datagen): generalize checkout path examples

### DIFF
--- a/datagen-config-examples/run_browser_tasks.sh
+++ b/datagen-config-examples/run_browser_tasks.sh
@@ -15,7 +15,7 @@
 #   - A dataset JSONL file with one {"prompt": "..."} per line
 #
 # Usage:
-#   cd ~/.hermes/hermes-agent
+#   cd /path/to/hermes-agent
 #   bash datagen-config-examples/run_browser_tasks.sh
 #
 # Output: data/browser_tasks_example/trajectories.jsonl

--- a/optional-skills/mlops/hermes-atropos-environments/references/usage-patterns.md
+++ b/optional-skills/mlops/hermes-atropos-environments/references/usage-patterns.md
@@ -11,7 +11,7 @@ training server.
 ### Step 1: Run 1 trajectory
 
 ```bash
-cd ~/.hermes/hermes-agent
+cd /path/to/hermes-agent
 source venv/bin/activate
 
 python environments/your_env.py process \


### PR DESCRIPTION
## What does this PR do?

Generalizes hardcoded checkout path examples in data-generation and Atropos environment docs.

## Related Issue

Part of #6237

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- updated `datagen-config-examples/run_browser_tasks.sh`
- updated `optional-skills/mlops/hermes-atropos-environments/references/usage-patterns.md`

## How to Test

1. Open the changed example files
2. Find the checkout commands in the usage comments/examples
3. Confirm they now use a generic Hermes checkout path instead of assuming `~/.hermes/hermes-agent`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 (docs-only verification)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Not applicable (docs-only change).
