### PR TITLE
chore(tests): register ssh pytest marker to fix PytestUnknownMarkWarning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -228,6 +228,7 @@ include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "gateway", "gat
 testpaths = ["tests"]
 markers = [
     "integration: marks tests requiring external services (API keys, Modal, etc.)",
+    "ssh: tests requiring SSH access to a remote host",
 ]
 addopts = "-m 'not integration' -n auto"
 


### PR DESCRIPTION
## Summary

`test_file_sync_perf.py` uses `@pytest.mark.ssh` (line 82) but the `ssh` marker was never registered in `pyproject.toml` `[tool.pytest.ini_options] markers`. This causes a **PytestUnknownMarkWarning** on every test collection:

```
tests/tools/test_file_sync_perf.py:82: PytestUnknownMarkWarning:
  Unknown pytest.mark.ssh - is this a typo?
```

## Fix

Add `"ssh: tests requiring SSH access to a remote host"` to the registered markers list.

## Verification

- ✅ Warning eliminated (`pytest --co` produces zero warnings)
- ✅ All existing tests pass (33/33 memory tests, full suite unchanged)
- ✅ Additive-only change — no behavior modification
- ✅ 1 file, +1 line