### PR TITLE
Implement controlled Discord agent2agent relays

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -125,6 +125,54 @@ def _build_allowed_mentions():
     )
 
 
+_DISCORD_USER_MENTION_RE = re.compile(r"<@!?\d+>")
+
+
+def _discord_split_mention_prefix_and_body(content: str) -> Tuple[str, str]:
+    """Move the first raw Discord user mention into a split prefix.
+
+    Hermes splits long Discord messages before sending. In bot-to-bot
+    ``DISCORD_ALLOW_BOTS=mentions`` mode, only the first split chunk would
+    contain the target mention unless we repeat it. Agents sometimes write a
+    short preface before the raw mention, so use the first explicit user
+    mention in the outgoing text and place it at the start of every chunk.
+    """
+    content = content or ""
+    match = _DISCORD_USER_MENTION_RE.search(content)
+    if not match:
+        return "", content
+
+    body = f"{content[:match.start()]}{content[match.end():]}".strip()
+    return f"{match.group(0)}\n", body
+
+
+def _message_explicitly_mentions_user(message, user) -> bool:
+    """Return True only for mentions typed into message content.
+
+    Discord reply references can populate ``message.mentions`` via replied-user
+    pings. Bot-to-bot admission must not treat that implicit reply ping as a
+    handoff, or two agents can bounce replies forever.
+    """
+    if not user:
+        return False
+
+    user_id = getattr(user, "id", None)
+    if user_id is None:
+        return False
+
+    user_id_str = str(user_id)
+    raw_mentions = getattr(message, "raw_mentions", None)
+    if raw_mentions is not None:
+        try:
+            if any(str(mention_id) == user_id_str for mention_id in raw_mentions):
+                return True
+        except TypeError:
+            pass
+
+    content = getattr(message, "content", "") or ""
+    return f"<@{user_id_str}>" in content or f"<@!{user_id_str}>" in content
+
+
 class VoiceReceiver:
     """Captures and decodes voice audio from a Discord voice channel.
 
@@ -539,6 +587,7 @@ class DiscordAdapter(BasePlatformAdapter):
         # Text batching: merge rapid successive messages (Telegram-style)
         self._text_batch_delay_seconds = float(os.getenv("HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS", "0.6"))
         self._text_batch_split_delay_seconds = float(os.getenv("HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0"))
+        self._text_batch_bot_delay_seconds = float(os.getenv("HERMES_DISCORD_BOT_TEXT_BATCH_DELAY_SECONDS", "2.5"))
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
         self._voice_text_channels: Dict[int, int] = {}  # guild_id -> text_channel_id
@@ -565,6 +614,27 @@ class DiscordAdapter(BasePlatformAdapter):
         # chunk only, default), "all" (reply-reference on every chunk).
         self._reply_to_mode: str = getattr(config, 'reply_to_mode', 'first') or 'first'
         self._slash_commands: bool = self.config.extra.get("slash_commands", True)
+
+    def _split_text_for_send(self, formatted: str, max_length: Optional[int] = None) -> List[str]:
+        """Split outgoing text, preserving bot-to-bot mentions on chunks."""
+        repeat_raw = os.getenv(
+            "DISCORD_REPEAT_MENTIONS_ON_SPLIT",
+            os.getenv("DISCORD_REPEAT_LEADING_MENTIONS_ON_SPLIT", "true"),
+        )
+        repeat = repeat_raw.lower().strip() in ("true", "1", "yes", "on")
+
+        max_length = max_length or self.MAX_MESSAGE_LENGTH
+        if not repeat or len(formatted) <= max_length:
+            return self.truncate_message(formatted, max_length)
+
+        mention_prefix, body = _discord_split_mention_prefix_and_body(formatted)
+        if not mention_prefix or len(mention_prefix) >= max_length:
+            return self.truncate_message(formatted, max_length)
+
+        split_length = max_length - len(mention_prefix)
+        chunks = self.truncate_message(body, split_length)
+
+        return [f"{mention_prefix}{chunk.lstrip()}" for chunk in chunks]
 
     async def connect(self) -> bool:
         """Connect to Discord and start receiving events."""
@@ -723,7 +793,7 @@ class DiscordAdapter(BasePlatformAdapter):
                     if allow_bots == "none":
                         return
                     elif allow_bots == "mentions":
-                        if not self._client.user or self._client.user not in message.mentions:
+                        if not _message_explicitly_mentions_user(message, self._client.user):
                             return
                     # "all" falls through; bot is permitted — skip the
                     # human-user allowlist below (bots aren't in it).
@@ -1384,7 +1454,7 @@ class DiscordAdapter(BasePlatformAdapter):
 
             # Format and split message if needed
             formatted = self.format_message(content)
-            chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+            chunks = self._split_text_for_send(formatted)
 
             message_ids = []
             reference = None
@@ -1457,7 +1527,7 @@ class DiscordAdapter(BasePlatformAdapter):
         from tools.send_message_tool import _derive_forum_thread_name
 
         formatted = self.format_message(content)
-        chunks = self.truncate_message(formatted, self.MAX_MESSAGE_LENGTH)
+        chunks = self._split_text_for_send(formatted)
 
         thread_name = _derive_forum_thread_name(content)
 
@@ -4383,6 +4453,8 @@ class DiscordAdapter(BasePlatformAdapter):
                 delay = self._text_batch_split_delay_seconds
             else:
                 delay = self._text_batch_delay_seconds
+            if pending and getattr(getattr(pending, "source", None), "is_bot", False):
+                delay = max(delay, self._text_batch_bot_delay_seconds)
             await asyncio.sleep(delay)
             event = self._pending_text_batches.pop(key, None)
             if not event:

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 import queue
 import re
 import time
@@ -24,6 +25,7 @@ from dataclasses import dataclass
 from typing import Any, Optional
 
 logger = logging.getLogger("gateway.stream_consumer")
+_DISCORD_USER_MENTION_RE = re.compile(r"<@!?\d+>")
 
 # Sentinel to signal the stream is complete
 _DONE = object()
@@ -131,6 +133,7 @@ class GatewayStreamConsumer:
         self._adapter_requires_finalize: bool = (
             getattr(adapter, "REQUIRES_EDIT_FINALIZE", False) is True
         )
+        self._discord_stream_mention_prefix = ""
 
         # Think-block filter state (mirrors CLI's _stream_delta tag suppression)
         self._in_think_block = False
@@ -174,6 +177,41 @@ class GatewayStreamConsumer:
         self._last_sent_text = ""
         self._fallback_final_send = False
         self._fallback_prefix = ""
+        self._discord_stream_mention_prefix = ""
+
+    def _is_discord_stream_mention_repeat_enabled(self) -> bool:
+        platform = getattr(self.adapter, "platform", None)
+        platform_value = getattr(platform, "value", platform)
+        if str(platform_value).lower() != "discord":
+            return False
+        repeat_raw = os.getenv(
+            "DISCORD_REPEAT_MENTIONS_ON_SPLIT",
+            os.getenv("DISCORD_REPEAT_LEADING_MENTIONS_ON_SPLIT", "true"),
+        )
+        return repeat_raw.lower().strip() in ("true", "1", "yes", "on")
+
+    def _apply_discord_stream_mention_prefix(self, text: str) -> str:
+        if not text or not self._is_discord_stream_mention_repeat_enabled():
+            return text
+
+        match = _DISCORD_USER_MENTION_RE.search(text)
+        if match:
+            self._discord_stream_mention_prefix = f"{match.group(0)}\n"
+            body = f"{text[:match.start()]}{text[match.end():]}".strip()
+            return f"{self._discord_stream_mention_prefix}{body}".rstrip()
+
+        if self._discord_stream_mention_prefix and text.strip():
+            return f"{self._discord_stream_mention_prefix}{text.lstrip()}"
+        return text
+
+    def _split_text_chunks_for_platform(self, text: str, limit: int) -> list[str]:
+        splitter = getattr(self.adapter, "_split_text_for_send", None)
+        if callable(splitter):
+            try:
+                return splitter(text, max_length=limit)
+            except TypeError:
+                return splitter(text)
+        return self.adapter.truncate_message(text, limit)
 
     def on_delta(self, text: str) -> None:
         """Thread-safe callback — called from the agent's worker thread.
@@ -359,7 +397,7 @@ class GatewayStreamConsumer:
                         # helper the non-streaming path uses — to split with
                         # proper word/code-fence boundaries and chunk
                         # indicators like "(1/2)".
-                        chunks = self.adapter.truncate_message(
+                        chunks = self._split_text_chunks_for_platform(
                             self._accumulated, _safe_limit
                         )
                         for chunk in chunks:
@@ -534,6 +572,7 @@ class GatewayStreamConsumer:
         Returns the message_id so callers can thread subsequent chunks.
         """
         text = self._clean_for_display(text)
+        text = self._apply_discord_stream_mention_prefix(text)
         if not text.strip():
             return reply_to_id
         try:
@@ -649,7 +688,7 @@ class GatewayStreamConsumer:
             for attempt in range(2):
                 result = await self.adapter.send(
                     chat_id=self.chat_id,
-                    content=chunk,
+                    content=self._apply_discord_stream_mention_prefix(chunk),
                     metadata=self.metadata,
                 )
                 if result.success:
@@ -724,7 +763,7 @@ class GatewayStreamConsumer:
         try:
             result = await self.adapter.send(
                 chat_id=self.chat_id,
-                content=tail,
+                content=self._apply_discord_stream_mention_prefix(tail),
                 metadata=self.metadata,
             )
             if result.success:
@@ -868,6 +907,15 @@ class GatewayStreamConsumer:
         # Media files are delivered as native attachments after the stream
         # finishes (via _deliver_media_from_response in gateway/run.py).
         text = self._clean_for_display(text)
+        last_sent_had_discord_mention = bool(_DISCORD_USER_MENTION_RE.search(self._last_sent_text or ""))
+        text = self._apply_discord_stream_mention_prefix(text)
+        if (
+            self._discord_stream_mention_prefix
+            and self._message_id is not None
+            and not last_sent_had_discord_mention
+        ):
+            self._message_id = None
+            self._message_created_ts = None
         # A bare streaming cursor is not meaningful user-visible content and
         # can render as a stray tofu/white-box message on some clients.
         visible_without_cursor = text

--- a/skills/autonomous-ai-agents/discord-agent2agent-relay/SKILL.md
+++ b/skills/autonomous-ai-agents/discord-agent2agent-relay/SKILL.md
@@ -1,0 +1,203 @@
+---
+name: discord-agent2agent-relay
+description: Use when coordinating multiple Hermes agents through Discord. Provides a controlled agent2agent relay protocol using explicit bot mentions, long-message handoff rules, and loop prevention.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [discord, gateway, agent2agent, relay, multi-agent, mentions]
+    related_skills: [hermes-agent]
+---
+
+# Discord Agent2Agent Relay
+
+## Overview
+
+Use this skill when multiple Hermes agents share a Discord server or thread and need to communicate through visible Discord messages.
+
+The safe pattern is a controlled relay: a human asks one agent to contact another agent, the first agent explicitly mentions the target agent, the target replies back to the requesting agent, and the requesting agent summarizes to the human. Agents should not freely respond to every bot message in a shared channel.
+
+This skill assumes the Discord gateway is configured so bot messages are admitted only when they explicitly mention the receiving bot, for example with `DISCORD_ALLOW_BOTS=mentions`.
+
+## Core Rule
+
+Only treat a bot-authored Discord message as agent2agent input when the message contains your explicit raw bot mention, such as `<@1234567890>` or `<@!1234567890>`.
+
+Do not treat reply pings, thread context, channel presence, or a bot message merely appearing nearby as permission to respond.
+
+## Relay Protocol
+
+### Human to Agent A
+
+The human starts the workflow by mentioning Agent A and asking it to contact Agent B.
+
+Example:
+
+```text
+@AgentA ask @AgentB for their take on this plan, then summarize it back to me.
+```
+
+Agent A should:
+
+- decide whether Agent B actually needs to be contacted
+- send a clear handoff to Agent B using Agent B's raw mention
+- tell Agent B whether it should reply back to Agent A
+- wait for Agent B's answer before summarizing to the human
+
+### Agent A to Agent B
+
+Every visible handoff message to Agent B must include Agent B's raw mention.
+
+Good:
+
+```text
+<@AGENT_B_ID>
+The human asked for your perspective on this plan. Please answer with your view and mention <@AGENT_A_ID> so I can summarize it back to them.
+```
+
+Bad:
+
+```text
+The human asked for your perspective on this plan. What do you think?
+```
+
+The bad version may be ignored by Agent B because it lacks an explicit target mention.
+
+### Agent B to Agent A
+
+If Agent B wants Agent A to read the answer, Agent B must mention Agent A explicitly.
+
+Good:
+
+```text
+<@AGENT_A_ID>
+My view: the plan is workable, but the risk is unclear ownership. I would tighten the next action and success metric.
+```
+
+Bad:
+
+```text
+My view: the plan is workable, but the risk is unclear ownership.
+```
+
+The bad version may be visible in Discord but should not start Agent A unless Agent A is explicitly mentioned.
+
+### Agent A to Human
+
+When Agent A summarizes back to the human, Agent A should not mention Agent B again unless the human explicitly asks for another round.
+
+Good:
+
+```text
+Here is the summary from Agent B: the plan is workable, but ownership and the success metric need to be sharper.
+```
+
+Bad:
+
+```text
+@AgentB summary for the human: ...
+```
+
+The bad version may start a new relay cycle.
+
+## Long Messages
+
+Discord may split long outputs. When a handoff to another agent spans multiple visible messages, every message must repeat the target agent's raw mention.
+
+Good:
+
+```text
+<@AGENT_B_ID>
+Part 1/2: context...
+```
+
+```text
+<@AGENT_B_ID>
+Part 2/2: more context...
+```
+
+Bad:
+
+```text
+<@AGENT_B_ID>
+Part 1/2: context...
+```
+
+```text
+Part 2/2: more context...
+```
+
+The bad version can cause Agent B to receive only the first part.
+
+## Streaming Outputs
+
+When composing a streamed handoff, put the target mention as early as possible. If the message starts with a preface and later turns into a handoff, the handoff portion must still include the target mention.
+
+Good:
+
+```text
+<@AGENT_B_ID>
+I need your review on this specific question: ...
+```
+
+Acceptable:
+
+```text
+I will ask Agent B.
+
+<@AGENT_B_ID>
+Please review this specific question: ...
+```
+
+Avoid streaming long handoffs where only an early chunk contains the target mention.
+
+## Loop Prevention
+
+- Do not reply to a bot unless it explicitly mentions you.
+- Do not mention the peer agent in the final human-facing summary unless another relay round is intended.
+- Do not keep asking open-ended follow-ups between agents without human instruction.
+- Do not rely on Discord reply metadata as a relay signal.
+- Prefer one request, one answer, one summary.
+
+## Configuration Hints
+
+For Hermes Discord gateways that support these options, this protocol works best with:
+
+```env
+DISCORD_REQUIRE_MENTION=true
+DISCORD_IGNORE_NO_MENTION=true
+DISCORD_ALLOW_BOTS=mentions
+DISCORD_ALLOW_MENTION_REPLIED_USER=false
+DISCORD_REPEAT_MENTIONS_ON_SPLIT=true
+HERMES_DISCORD_BOT_TEXT_BATCH_DELAY_SECONDS=2.5
+```
+
+Use direct bot user mentions for relay routing. Role mentions may notify humans or groups, but they are not a reliable substitute for a receiving bot's raw user mention unless the gateway explicitly supports role-based bot admission.
+
+## Quick Template
+
+Agent A handoff to Agent B:
+
+```text
+<@AGENT_B_ID>
+The human asked me to get your perspective on: [question].
+
+Please answer with your concise view and mention <@AGENT_A_ID> so I can summarize it back to the human.
+```
+
+Agent B reply to Agent A:
+
+```text
+<@AGENT_A_ID>
+My answer: [answer].
+
+Key point for the human: [summary-ready takeaway].
+```
+
+Agent A summary to human:
+
+```text
+Here is the summary from the other agent: [summary].
+```

--- a/tests/gateway/test_discord_bot_filter.py
+++ b/tests/gateway/test_discord_bot_filter.py
@@ -5,7 +5,6 @@ import os
 import unittest
 from unittest.mock import AsyncMock, MagicMock, patch
 
-
 def _make_author(*, bot: bool = False, is_self: bool = False):
     """Create a mock Discord author."""
     author = MagicMock()
@@ -23,6 +22,7 @@ def _make_message(*, author=None, content="hello", mentions=None, is_dm=False):
     msg.content = content
     msg.attachments = []
     msg.mentions = mentions or []
+    msg.raw_mentions = [getattr(m, "id", m) for m in msg.mentions]
     if is_dm:
         import discord
         msg.channel = MagicMock(spec=discord.DMChannel)
@@ -52,7 +52,18 @@ class TestDiscordBotFilter(unittest.TestCase):
             if allow == "none":
                 return False
             elif allow == "mentions":
-                if not client_user or client_user not in message.mentions:
+                user_id = getattr(client_user, "id", None)
+                raw_mentions = getattr(message, "raw_mentions", None)
+                explicit = bool(
+                    client_user
+                    and user_id is not None
+                    and (
+                        any(str(mid) == str(user_id) for mid in raw_mentions or [])
+                        or f"<@{user_id}>" in getattr(message, "content", "")
+                        or f"<@!{user_id}>" in getattr(message, "content", "")
+                    )
+                )
+                if not explicit:
                     return False
             # "all" falls through
         
@@ -95,8 +106,16 @@ class TestDiscordBotFilter(unittest.TestCase):
         """With allow_bots=mentions, bot messages with @mention are accepted."""
         our_user = _make_author(is_self=True)
         bot = _make_author(bot=True)
-        msg = _make_message(author=bot, mentions=[our_user])
+        msg = _make_message(author=bot, content=f"<@{our_user.id}> please handle this", mentions=[our_user])
         self.assertTrue(self._run_filter(msg, "mentions", our_user))
+
+    def test_allow_bots_mentions_rejects_reply_ping_only(self):
+        """Implicit reply pings must not count as bot-to-bot handoffs."""
+        our_user = _make_author(is_self=True)
+        bot = _make_author(bot=True)
+        msg = _make_message(author=bot, content="replying to you", mentions=[our_user])
+        msg.raw_mentions = []
+        self.assertFalse(self._run_filter(msg, "mentions", our_user))
 
     def test_default_is_none(self):
         """Default behavior (no env var) should be 'none'."""

--- a/tests/gateway/test_discord_send.py
+++ b/tests/gateway/test_discord_send.py
@@ -122,6 +122,81 @@ async def test_send_retries_without_reference_when_reply_target_is_deleted():
 
 
 @pytest.mark.asyncio
+async def test_send_repeats_leading_mention_on_split_continuations(monkeypatch):
+    """Bot-to-bot relay chunks must all keep the target mention."""
+    monkeypatch.setenv("DISCORD_REPEAT_MENTIONS_ON_SPLIT", "true")
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter.MAX_MESSAGE_LENGTH = 40
+
+    send_calls = []
+
+    async def fake_send(*, content, reference=None):
+        send_calls.append({"content": content, "reference": reference})
+        return SimpleNamespace(id=2000 + len(send_calls))
+
+    channel = SimpleNamespace(send=AsyncMock(side_effect=fake_send))
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.send("555", "<@999> " + ("alpha " * 20))
+
+    assert result.success is True
+    assert len(send_calls) > 1
+    assert all(
+        call["content"].startswith("<@999>\n")
+        for call in send_calls
+    )
+    assert all(
+        call["content"].count("<@999>") == 1
+        for call in send_calls
+    )
+    assert all(
+        len(call["content"]) <= adapter.MAX_MESSAGE_LENGTH
+        for call in send_calls
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_moves_in_body_mention_to_each_split_chunk(monkeypatch):
+    """A preface before the target mention must not strand later chunks."""
+    monkeypatch.setenv("DISCORD_REPEAT_MENTIONS_ON_SPLIT", "true")
+    adapter = DiscordAdapter(PlatformConfig(enabled=True, token="***"))
+    adapter.MAX_MESSAGE_LENGTH = 40
+
+    send_calls = []
+
+    async def fake_send(*, content, reference=None):
+        send_calls.append({"content": content, "reference": reference})
+        return SimpleNamespace(id=3000 + len(send_calls))
+
+    channel = SimpleNamespace(send=AsyncMock(side_effect=fake_send))
+    adapter._client = SimpleNamespace(
+        get_channel=lambda _chat_id: channel,
+        fetch_channel=AsyncMock(),
+    )
+
+    result = await adapter.send("555", "oke aku tanyain ya <@999> " + ("beta " * 20))
+
+    assert result.success is True
+    assert len(send_calls) > 1
+    assert all(
+        call["content"].startswith("<@999>\n")
+        for call in send_calls
+    )
+    assert "oke aku tanyain ya" in "\n".join(call["content"] for call in send_calls)
+    assert all(
+        call["content"].count("<@999>") == 1
+        for call in send_calls
+    )
+    assert all(
+        len(call["content"]) <= adapter.MAX_MESSAGE_LENGTH
+        for call in send_calls
+    )
+
+
+@pytest.mark.asyncio
 async def test_send_does_not_retry_on_unrelated_errors():
     """Regression guard: errors unrelated to the reply reference (e.g. 50013
     Missing Permissions) must NOT trigger the no-reference retry path — they

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -956,6 +956,55 @@ class TestCancelledConsumerSetsFlags:
 # ── Think-block filtering unit tests ─────────────────────────────────────
 
 
+class TestDiscordMentionStreaming:
+    """Discord bot-to-bot mentions must survive streaming chunking."""
+
+    def _adapter(self):
+        adapter = MagicMock()
+        adapter.platform = SimpleNamespace(value="discord")
+        adapter.MAX_MESSAGE_LENGTH = 4096
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="msg_1"))
+        adapter.edit_message = AsyncMock(return_value=SimpleNamespace(success=True, message_id="msg_1"))
+        return adapter
+
+    @pytest.mark.asyncio
+    async def test_mention_after_preface_starts_fresh_message(self, monkeypatch):
+        monkeypatch.setenv("DISCORD_REPEAT_MENTIONS_ON_SPLIT", "true")
+        adapter = self._adapter()
+        adapter.send.side_effect = [
+            SimpleNamespace(success=True, message_id="msg_1"),
+            SimpleNamespace(success=True, message_id="msg_2"),
+        ]
+        consumer = GatewayStreamConsumer(adapter, "chat_123", StreamConsumerConfig(cursor=""))
+
+        await consumer._send_or_edit("oke aku siap")
+        await consumer._send_or_edit("oke aku tanyain ya <@999> beta beta")
+
+        assert adapter.send.await_count == 2
+        adapter.edit_message.assert_not_called()
+        second_content = adapter.send.await_args_list[1].kwargs["content"]
+        assert second_content.startswith("<@999>\n")
+        assert "oke aku tanyain ya" in second_content
+
+    @pytest.mark.asyncio
+    async def test_followup_stream_chunk_reuses_detected_mention(self, monkeypatch):
+        monkeypatch.setenv("DISCORD_REPEAT_MENTIONS_ON_SPLIT", "true")
+        adapter = self._adapter()
+        adapter.send.side_effect = [
+            SimpleNamespace(success=True, message_id="msg_1"),
+            SimpleNamespace(success=True, message_id="msg_2"),
+        ]
+        consumer = GatewayStreamConsumer(adapter, "chat_123", StreamConsumerConfig(cursor=""))
+
+        await consumer._send_new_chunk("<@999> first chunk", None)
+        await consumer._send_new_chunk("second chunk", "msg_1")
+
+        assert adapter.send.await_count == 2
+        assert adapter.send.await_args_list[0].kwargs["content"].startswith("<@999>\n")
+        assert adapter.send.await_args_list[1].kwargs["content"].startswith("<@999>\n")
+        assert adapter.send.await_args_list[1].kwargs["content"].count("<@999>") == 1
+
+
 def _make_consumer() -> GatewayStreamConsumer:
     """Create a bare consumer for unit-testing the filter (no adapter needed)."""
     adapter = MagicMock()

--- a/tests/gateway/test_text_batching.py
+++ b/tests/gateway/test_text_batching.py
@@ -27,11 +27,17 @@ def _make_event(
     platform: Platform,
     chat_id: str = "12345",
     msg_type: MessageType = MessageType.TEXT,
+    is_bot: bool = False,
 ) -> MessageEvent:
     return MessageEvent(
         text=text,
         message_type=msg_type,
-        source=SessionSource(platform=platform, chat_id=chat_id, chat_type="dm"),
+        source=SessionSource(
+            platform=platform,
+            chat_id=chat_id,
+            chat_type="dm",
+            is_bot=is_bot,
+        ),
     )
 
 
@@ -111,6 +117,27 @@ class TestDiscordTextBatching:
         assert "chunk 1" in text
         assert "chunk 2" in text
         assert "chunk 3" in text
+
+    @pytest.mark.asyncio
+    async def test_bot_messages_use_longer_batch_delay(self):
+        """Bot-to-bot relay chunks get extra time to arrive before dispatch."""
+        adapter = _make_discord_adapter()
+        adapter._text_batch_bot_delay_seconds = 0.3
+
+        adapter._enqueue_text_event(_make_event("<@1> part one", Platform.DISCORD, is_bot=True))
+        await asyncio.sleep(0.15)
+        adapter.handle_message.assert_not_called()
+
+        adapter._enqueue_text_event(_make_event("<@1> part two", Platform.DISCORD, is_bot=True))
+        await asyncio.sleep(0.15)
+        adapter.handle_message.assert_not_called()
+
+        await asyncio.sleep(0.25)
+        adapter.handle_message.assert_called_once()
+        text = adapter.handle_message.call_args[0][0].text
+        assert "part one" in text
+        assert "part two" in text
+
 
     @pytest.mark.asyncio
     async def test_different_chats_not_merged(self):


### PR DESCRIPTION
## Summary
- implement controlled Discord agent2agent relay semantics on top of the existing `DISCORD_ALLOW_BOTS=mentions` mode
- require an explicit raw target mention before a bot-authored Discord message can trigger another bot, so reply pings do not create relay loops
- preserve relay intent across long Discord outputs by repeating the target mention on every split send chunk
- preserve relay intent during streaming by carrying the detected target mention into streamed continuation chunks
- start a fresh Discord message when a streamed response first emits non-mentioned preface text and later emits the actual target mention
- add a bot-specific Discord text batching delay so multi-message bot relay input is merged before dispatch instead of interrupting the target agent mid-handoff
- add a universal built-in `discord-agent2agent-relay` skill documenting the controlled relay protocol agents should follow in Discord

## Why
Discord already had a primitive bot mention mode, but it was not enough for reliable agent2agent workflows. A controlled relay flow needs the human to intentionally ask one agent to mention another agent, the target agent to reply back to the requesting agent, and the requester to summarize back to the human without accidentally pinging the peer again.

Before this change, that flow could break in several ways:
- Discord reply pings could populate `message.mentions`, making a bot message look like an intentional handoff even when no raw mention was present
- long relay messages split by Discord could mention the target only in the first chunk, so later context never reached the target agent
- streamed outputs could lose the target mention on continuation chunks
- split bot output could arrive as multiple independent tasks instead of one coherent relay input
- agents had no bundled universal guidance for how to structure Discord agent2agent handoffs without re-triggering each other

## Implementation Notes
- Adds explicit raw mention detection for Discord bot admission using `raw_mentions` / raw `<@id>` content checks instead of trusting reply-populated `message.mentions`.
- Adds Discord send splitting that moves the first raw user mention into a per-chunk prefix when `DISCORD_REPEAT_MENTIONS_ON_SPLIT` is enabled.
- Keeps backwards compatibility with `DISCORD_REPEAT_LEADING_MENTIONS_ON_SPLIT` as a fallback env name.
- Adds Discord streaming mention prefix tracking in `GatewayStreamConsumer` so streamed relay chunks keep the same target mention.
- Adds `HERMES_DISCORD_BOT_TEXT_BATCH_DELAY_SECONDS` so bot-originated split messages get a longer merge window than normal human messages.
- Adds `skills/autonomous-ai-agents/discord-agent2agent-relay/SKILL.md` with universal relay rules, long-message guidance, loop prevention, config hints, and templates.
- Leaves non-Discord platform streaming behavior unchanged.

## Tests
- `/home/galyarder/.hermes/hermes-agent/venv/bin/python -m py_compile gateway/platforms/discord.py gateway/stream_consumer.py`
- `/home/galyarder/.hermes/hermes-agent/venv/bin/python -m pytest -n 0 tests/gateway/test_text_batching.py tests/gateway/test_stream_consumer.py tests/gateway/test_discord_send.py tests/gateway/test_discord_bot_filter.py -q`
- `python -c frontmatter validation for skills/autonomous-ai-agents/discord-agent2agent-relay/SKILL.md`
- `git diff --check`

## Test Result
- `133 passed, 7 warnings`
