### PR TITLE
docs(runtime): document fallback_providers precedence

### DIFF
--- a/website/docs/developer-guide/provider-runtime.md
+++ b/website/docs/developer-guide/provider-runtime.md
@@ -165,11 +165,11 @@ When an auxiliary task is configured with provider `main`, Hermes resolves that 
 
 ## Fallback models
 
-Hermes supports a configured fallback provider chain — a list of `(provider, model)` entries tried in order when the primary model encounters errors. The legacy single-pair `fallback_model` dict is still accepted for back-compat (and migrated on first write).
+Hermes supports a configured fallback provider chain — a top-level `fallback_providers:` list of `(provider, model)` entries tried in order when the primary model encounters errors. The legacy single-pair `fallback_model` dict is still accepted for back-compat.
 
 ### How it works internally
 
-1. **Storage**: `AIAgent.__init__` stores the `fallback_model` dict and sets `_fallback_activated = False`.
+1. **Storage**: `AIAgent.__init__` normalizes the incoming config into `_fallback_chain`, stores the first entry in `_fallback_model` for compatibility, and sets `_fallback_activated = False`.
 
 2. **Trigger points**: `_try_activate_fallback()` is called from three places in the main retry loop in `run_agent.py`:
    - After max retries on invalid API responses (None choices, missing content)
@@ -187,9 +187,9 @@ Hermes supports a configured fallback provider chain — a list of `(provider, m
    - Resets retry count to 0 and continues the loop
 
 4. **Config flow**:
-   - CLI: `cli.py` reads `CLI_CONFIG["fallback_model"]` → passes to `AIAgent(fallback_model=...)`
-   - Gateway: `gateway/run.py._load_fallback_model()` reads `config.yaml` → passes to `AIAgent`
-   - Validation: both `provider` and `model` keys must be non-empty, or fallback is disabled
+   - CLI: `cli.py` reads `CLI_CONFIG["fallback_providers"]` first, then falls back to `CLI_CONFIG["fallback_model"]`
+   - Gateway: `gateway/run.py._load_fallback_model()` reads `fallback_providers` first and falls back to the legacy key
+   - Validation: each fallback entry must have non-empty `provider` and `model` keys, or that entry is ignored
 
 ### What does NOT support fallback
 


### PR DESCRIPTION
## What does this PR do?

Updates the runtime guide so its fallback storage and precedence notes match the current CLI and gateway resolution flow.

## Related Issue

Fixes #19691

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- updated `website/docs/developer-guide/provider-runtime.md`
- aligned the docs with current Hermes behavior for this specific issue
- kept the change isolated to a single documentation concern

## How to Test

1. Review `website/docs/developer-guide/provider-runtime.md` and confirm the wording matches the current behavior described in the issue.
2. Run `git diff --check`.
3. Run the local proof gate used for this branch:
   - `UV_PYTHON=3.11 /Library/Frameworks/Python.framework/Versions/3.10/bin/uv run --frozen pytest -q -o addopts='' tests/hermes_cli/test_plugins_cmd.py`
   - `UV_PYTHON=3.11 /Library/Frameworks/Python.framework/Versions/3.10/bin/uv run --frozen ruff check tests/hermes_cli/test_plugins_cmd.py`
   - `env -i HOME="$HOME" PATH="/Library/Frameworks/Python.framework/Versions/3.10/bin:/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin" UV_PYTHON=3.11 /Library/Frameworks/Python.framework/Versions/3.10/bin/uv run --frozen pytest --collect-only -q -o addopts='' tests/hermes_cli/test_plugins_cmd.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

N/A
