### PR TITLE
fix(cli): drop ChatGPT-account-rejected models from openai-codex picker

### DIFF
--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -29,9 +29,15 @@ DEFAULT_CODEX_MODELS: List[str] = [
     # curated fallback so Pro users still see Spark in `/model` when live
     # discovery is unavailable (offline first run, transient API failure).
     "gpt-5.3-codex-spark",
-    "gpt-5.2-codex",
-    "gpt-5.1-codex-max",
-    "gpt-5.1-codex-mini",
+    # gpt-5.2-codex, gpt-5.1-codex-max, and gpt-5.1-codex-mini are
+    # intentionally NOT listed here. The openai-codex provider always
+    # authenticates via the ChatGPT-account OAuth backend
+    # (chatgpt.com/backend-api/codex; resolve_codex_runtime_credentials
+    # always sets auth_mode="chatgpt"), and that backend rejects those
+    # older slugs with HTTP 400: "The '<model>' model is not supported
+    # when using Codex with a ChatGPT account." Issue #23097. They remain
+    # in _PROVIDER_MODELS["openai"] / opencode-zen because those backends
+    # still accept them; this fallback is openai-codex-only.
 ]
 
 _FORWARD_COMPAT_TEMPLATE_MODELS: List[tuple[str, tuple[str, ...]]] = [

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -57,6 +57,28 @@ def test_get_codex_model_ids_falls_back_to_curated_defaults(tmp_path, monkeypatc
     assert "gpt-5.3-codex-spark" in models
 
 
+def test_default_codex_models_excludes_chatgpt_account_unsupported():
+    """Regression for #23097: the openai-codex picker fallback must not
+    surface slugs the ChatGPT-account Codex backend rejects with HTTP 400.
+
+    The openai-codex provider always authenticates via the ChatGPT-account
+    OAuth backend in Hermes (resolve_codex_runtime_credentials always sets
+    auth_mode="chatgpt"), so DEFAULT_CODEX_MODELS — used as the offline /
+    transient-failure fallback for the picker — must only contain models
+    that backend accepts.
+    """
+    rejected_on_chatgpt_account = {
+        "gpt-5.2-codex",
+        "gpt-5.1-codex-max",
+        "gpt-5.1-codex-mini",
+    }
+    assert rejected_on_chatgpt_account.isdisjoint(DEFAULT_CODEX_MODELS), (
+        "DEFAULT_CODEX_MODELS still contains models the ChatGPT-account "
+        "Codex backend rejects: "
+        f"{rejected_on_chatgpt_account.intersection(DEFAULT_CODEX_MODELS)}"
+    )
+
+
 def test_get_codex_model_ids_adds_forward_compat_models_from_templates(monkeypatch):
     monkeypatch.setattr(
         "hermes_cli.codex_models._fetch_models_from_api",


### PR DESCRIPTION
Codex /model picker no longer offers gpt-5.2-codex, gpt-5.1-codex-max, or gpt-5.1-codex-mini in its offline fallback — the ChatGPT-account Codex backend rejects them with HTTP 400.

## What changed and why
- `hermes_cli/codex_models.py`: removed `gpt-5.2-codex`, `gpt-5.1-codex-max`, and `gpt-5.1-codex-mini` from `DEFAULT_CODEX_MODELS`. The openai-codex provider always authenticates through the ChatGPT-account OAuth backend (`resolve_codex_runtime_credentials` hard-codes `auth_mode="chatgpt"` and points at `chatgpt.com/backend-api/codex`), which rejects those slugs with `HTTP 400: "The '<model>' model is not supported when using Codex with a ChatGPT account."` Whenever live model discovery isn't available (offline first run, transient API failure), the picker fell back to this list and let the user pick a model the backend would reject on the very next request.
- Comment block updated to record why the three slugs are intentionally absent and to point at the issue. They remain in `_PROVIDER_MODELS["openai"]` (api.openai.com) and the opencode-zen catalog because those backends still accept them.
- `tests/hermes_cli/test_codex_models.py`: added `test_default_codex_models_excludes_chatgpt_account_unsupported` asserting the three rejected slugs stay out of `DEFAULT_CODEX_MODELS`.

Forward-compat synthesis (`_FORWARD_COMPAT_TEMPLATE_MODELS`) is unchanged: `gpt-5.4`, `gpt-5.4-mini`, and `gpt-5.3-codex-spark` are still synthesized from `gpt-5.3-codex` (which stays in the fallback), so the offline picker still shows the full set of supported Codex slugs.

## How to test
- `pytest tests/hermes_cli/test_codex_models.py -q` — passes (20 tests, including the new regression test).
- `pytest tests/hermes_cli/test_codex_cli_model_picker.py tests/hermes_cli/test_model_validation.py tests/cli/test_cli_provider_resolution.py tests/cli/test_fast_command.py -q` — passes (139 tests covering picker credential discovery, model normalization, /fast model handling).
- Manual: with no live token reachable, run `hermes` `/model` on the openai-codex provider — the picker no longer offers `gpt-5.2-codex`, `gpt-5.1-codex-max`, or `gpt-5.1-codex-mini`.

## What platforms tested on
- macOS on darwin-arm64 (local)

Fixes #23097

<!-- autocontrib:worker-id=issue-new-23f4925b kind=pr-open -->