### PR TITLE
fix(tui): render destructive slash confirmations via cprint

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -8396,21 +8396,21 @@ class HermesCLI:
         if not confirm_required:
             return "once"
 
-        # Render warning + prompt — single-line composer prompt, mirrors
-        # ``_confirm_and_reload_mcp``.
-        print()
-        print(f"⚠️  /{command} — destroys conversation state")
-        print()
+        # Render warning + prompt through the TUI-safe print path so the
+        # dialog doesn't show up as raw text when prompt_toolkit is active.
+        _cprint("")
+        _cprint(f"⚠️  /{command} — destroys conversation state")
+        _cprint("")
         for line in detail.splitlines():
-            print(f"  {line}")
-        print()
-        print("  [1] Approve Once   — proceed this time only")
-        print("  [2] Always Approve — proceed and silence this prompt permanently")
-        print("  [3] Cancel         — keep current conversation")
-        print()
+            _cprint(f"  {line}")
+        _cprint("")
+        _cprint("  [1] Approve Once   — proceed this time only")
+        _cprint("  [2] Always Approve — proceed and silence this prompt permanently")
+        _cprint("  [3] Cancel         — keep current conversation")
+        _cprint("")
         raw = self._prompt_text_input("Choice [1/2/3]: ")
         if raw is None:
-            print(f"🟡 /{command} cancelled (no input).")
+            _cprint(f"🟡 /{command} cancelled (no input).")
             return None
         choice_raw = raw.strip().lower()
         if choice_raw in ("1", "once", "approve", "yes", "y", "ok"):
@@ -8420,19 +8420,19 @@ class HermesCLI:
         elif choice_raw in ("3", "cancel", "nevermind", "no", "n", ""):
             choice = "cancel"
         else:
-            print(f"🟡 Unrecognized choice '{raw}'. /{command} cancelled.")
+            _cprint(f"🟡 Unrecognized choice '{raw}'. /{command} cancelled.")
             return None
 
         if choice == "cancel":
-            print(f"🟡 /{command} cancelled. Conversation unchanged.")
+            _cprint(f"🟡 /{command} cancelled. Conversation unchanged.")
             return None
 
         if choice == "always":
             if save_config_value("approvals.destructive_slash_confirm", False):
-                print("🔒 Future /clear, /new, /reset, and /undo will run without confirmation.")
-                print("   Re-enable via `approvals.destructive_slash_confirm: true` in config.yaml.")
+                _cprint("🔒 Future /clear, /new, /reset, and /undo will run without confirmation.")
+                _cprint("   Re-enable via `approvals.destructive_slash_confirm: true` in config.yaml.")
             else:
-                print("⚠️  Couldn't persist opt-out — proceeding once.")
+                _cprint("⚠️  Couldn't persist opt-out — proceeding once.")
 
         return choice
 

--- a/tests/cli/test_destructive_slash_confirm.py
+++ b/tests/cli/test_destructive_slash_confirm.py
@@ -150,3 +150,29 @@ def test_gate_default_true_when_config_missing():
     # treated as on despite the config error.  If the gate had been off
     # this would have returned 'once' without consulting the prompt.
     assert result is None
+
+
+def test_tui_mode_renders_dialog_via_cprint():
+    """When prompt_toolkit is active, the dialog should use the TUI-safe
+    output path instead of raw print()."""
+    from cli import HermesCLI
+
+    self_ = SimpleNamespace(
+        _app=object(),
+        _prompt_text_input=lambda _prompt: "1",
+    )
+
+    with patch(
+        "cli.load_cli_config",
+        return_value={"approvals": {"destructive_slash_confirm": True}},
+    ), patch("cli._cprint") as mock_cprint:
+        result = _bound(HermesCLI._confirm_destructive_slash, self_)(
+            "clear", "line one\nline two",
+        )
+
+    assert result == "once"
+    rendered = " ".join(str(call.args[0]) for call in mock_cprint.call_args_list if call.args)
+    assert "destroys conversation state" in rendered
+    assert "[1] Approve Once" in rendered
+    assert "line one" in rendered
+    assert "line two" in rendered


### PR DESCRIPTION
## What does this PR do?

Fixes the destructive slash confirmation dialog in TUI mode by routing the warning text through Hermes' prompt_toolkit-safe output path instead of raw `print()`. That keeps `/clear`, `/new`, `/reset`, and `/undo` confirmations rendered consistently inside the live TUI.

## Related Issue

Fixes #23155

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Replace raw `print()` calls in `HermesCLI._confirm_destructive_slash()` with `_cprint()` so the dialog uses the TUI-safe render path
- Route cancel / unknown-choice / opt-out feedback through the same output path for consistency
- Add regression coverage in `tests/cli/test_destructive_slash_confirm.py` to assert TUI mode uses `_cprint()` and still preserves the existing confirmation behavior

## How to Test

1. `UV_PYTHON=3.11 /Library/Frameworks/Python.framework/Versions/3.10/bin/uv run --frozen pytest -q -o addopts='' tests/cli/test_destructive_slash_confirm.py`
2. `UV_PYTHON=3.11 /Library/Frameworks/Python.framework/Versions/3.10/bin/uv run --frozen ruff check cli.py tests/cli/test_destructive_slash_confirm.py`
3. In TUI mode, trigger `/clear` or `/new` and verify the confirmation text renders through the managed UI instead of appearing as raw terminal text

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `8 passed in 1.00s`
- `ruff check ... All checks passed!`
