### PR TITLE
feat: add delegate pre-spawn guard

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -32,6 +32,9 @@ from tools.delegate_tool import (
     _strip_blocked_tools,
     _resolve_child_credential_pool,
     _resolve_delegation_credentials,
+    _resolve_pre_spawn_guard_config,
+    _build_pre_spawn_guard_payload,
+    _evaluate_pre_spawn_guard,
 )
 
 
@@ -157,6 +160,186 @@ class TestStripBlockedTools(unittest.TestCase):
         self.assertEqual(result, [])
 
 
+class TestDelegatePreSpawnGuardAdapter(unittest.TestCase):
+    def test_disabled_guard_returns_allowed_noop(self):
+        decision = _evaluate_pre_spawn_guard(
+            config={"enabled": False},
+            parent_agent=_make_mock_parent(),
+            task={"goal": "safe research"},
+            task_index=0,
+            task_count=1,
+            subagent_id="subagent-test",
+            role="leaf",
+        )
+
+        self.assertTrue(decision["allowed"])
+        self.assertEqual(decision["decision"], "disabled")
+        self.assertFalse(decision["should_call_guard"])
+
+    def test_runtime_mode_resolution_prefers_config_then_env_then_manual(self):
+        with patch.dict(os.environ, {"HERMES_RUNTIME_MODE": "autonomous"}):
+            cfg = _resolve_pre_spawn_guard_config({"pre_spawn_guard": {"enabled": True}})
+            self.assertEqual(cfg["runtime_mode"], "autonomous")
+            cfg = _resolve_pre_spawn_guard_config({"pre_spawn_guard": {"enabled": True, "runtime_mode": "manual"}})
+            self.assertEqual(cfg["runtime_mode"], "manual")
+        with patch.dict(os.environ, {}, clear=True):
+            cfg = _resolve_pre_spawn_guard_config({"pre_spawn_guard": {"enabled": True}})
+            self.assertEqual(cfg["runtime_mode"], "manual")
+
+    def test_missing_task_context_blocks_when_required(self):
+        decision = _evaluate_pre_spawn_guard(
+            config={"enabled": True, "require_task_context": True, "runtime_mode": "autonomous"},
+            parent_agent=_make_mock_parent(),
+            task={"goal": "mutate prod"},
+            task_index=0,
+            task_count=1,
+            subagent_id="subagent-test",
+            role="leaf",
+        )
+
+        self.assertFalse(decision["allowed"])
+        self.assertEqual(decision["decision"], "missing_task_context")
+        self.assertFalse(decision["should_call_guard"])
+
+    def test_missing_task_context_passes_without_telemetry_by_default(self):
+        decision = _evaluate_pre_spawn_guard(
+            config={"enabled": True, "require_task_context": False, "runtime_mode": "manual"},
+            parent_agent=_make_mock_parent(),
+            task={"goal": "manual scratch"},
+            task_index=0,
+            task_count=1,
+            subagent_id="subagent-test",
+            role="leaf",
+        )
+
+        self.assertTrue(decision["allowed"])
+        self.assertEqual(decision["decision"], "no_task_context_allowed")
+        self.assertFalse(decision["should_call_guard"])
+        self.assertFalse(decision.get("telemetry"))
+
+    def test_fail_policy_auto_manual_unknown_fails_open_with_warning(self):
+        decision = _evaluate_pre_spawn_guard(
+            config={"enabled": True, "runtime_mode": "manual", "fail_policy": "auto"},
+            parent_agent=_make_mock_parent(),
+            task={"goal": "test", "guard_context_id": "pm-1"},
+            task_index=0,
+            task_count=1,
+            subagent_id="subagent-test",
+            role="leaf",
+            command_runner=TimeoutError("boom"),
+        )
+
+        self.assertTrue(decision["allowed"])
+        self.assertEqual(decision["decision"], "hook_error_fail_open")
+        self.assertIn("warning", decision)
+
+    def test_fail_policy_auto_autonomous_unknown_fails_closed(self):
+        decision = _evaluate_pre_spawn_guard(
+            config={"enabled": True, "runtime_mode": "autonomous", "fail_policy": "auto"},
+            parent_agent=_make_mock_parent(),
+            task={"goal": "test", "guard_context_id": "pm-1"},
+            task_index=0,
+            task_count=1,
+            subagent_id="subagent-test",
+            role="leaf",
+            command_runner=TimeoutError("boom"),
+        )
+
+        self.assertFalse(decision["allowed"])
+        self.assertEqual(decision["decision"], "hook_error_fail_closed")
+
+    def test_explicit_fail_policy_overrides_auto(self):
+        parent = _make_mock_parent()
+        base = {
+            "enabled": True,
+            "runtime_mode": "autonomous",
+            "require_task_context": False,
+        }
+        open_decision = _evaluate_pre_spawn_guard(
+            config={**base, "fail_policy": "fail_open"},
+            parent_agent=parent,
+            task={"goal": "test", "guard_context_id": "pm-1"},
+            task_index=0,
+            task_count=1,
+            subagent_id="subagent-test",
+            role="leaf",
+            command_runner=RuntimeError("guard unavailable"),
+        )
+        closed_decision = _evaluate_pre_spawn_guard(
+            config={**base, "fail_policy": "fail_closed"},
+            parent_agent=parent,
+            task={"goal": "test", "guard_context_id": "pm-1"},
+            task_index=0,
+            task_count=1,
+            subagent_id="subagent-test",
+            role="leaf",
+            command_runner=RuntimeError("guard unavailable"),
+        )
+
+        self.assertTrue(open_decision["allowed"])
+        self.assertFalse(closed_decision["allowed"])
+
+    def test_command_decisions_are_normalized(self):
+        allowed = _evaluate_pre_spawn_guard(
+            config={"enabled": True, "command": "/bin/guard"},
+            parent_agent=_make_mock_parent(),
+            task={"goal": "test", "guard_context_id": "pm-1"},
+            task_index=0,
+            task_count=1,
+            subagent_id="subagent-test",
+            role="leaf",
+            command_runner=lambda payload, config: {"ok": True, "allowed": True, "reason": "go"},
+        )
+        blocked = _evaluate_pre_spawn_guard(
+            config={"enabled": True, "command": "/bin/guard"},
+            parent_agent=_make_mock_parent(),
+            task={"goal": "test", "guard_context_id": "pm-1"},
+            task_index=0,
+            task_count=1,
+            subagent_id="subagent-test",
+            role="leaf",
+            command_runner=lambda payload, config: {"ok": True, "allowed": False, "reason": "missing approval"},
+        )
+
+        self.assertTrue(allowed["allowed"])
+        self.assertEqual(allowed["decision"], "allowed")
+        self.assertFalse(blocked["allowed"])
+        self.assertEqual(blocked["decision"], "blocked")
+
+    def test_payload_truncates_goal_and_excludes_full_context(self):
+        parent = _make_mock_parent()
+        parent._guard_context_id = "pm-1"
+        parent._session_id = "session-1"
+        payload = _build_pre_spawn_guard_payload(
+            parent_agent=parent,
+            task={"goal": "g" * 400, "context": "SECRET CONTEXT"},
+            task_index=0,
+            task_count=1,
+            subagent_id="subagent-test",
+            role="leaf",
+            config={"require_task_context": False},
+        )
+
+        self.assertEqual(payload["guard_context_id"], "pm-1")
+        self.assertLessEqual(len(payload["goal_preview"]), 243)
+        self.assertNotIn("context", payload)
+        self.assertNotIn("SECRET CONTEXT", json.dumps(payload))
+
+    def test_bypass_config_is_unsupported_in_first_slice(self):
+        decision = _evaluate_pre_spawn_guard(
+            config={"enabled": True, "bypass_enabled": True, "require_task_context": True},
+            parent_agent=_make_mock_parent(),
+            task={"goal": "test"},
+            task_index=0,
+            task_count=1,
+            subagent_id="subagent-test",
+            role="leaf",
+        )
+
+        self.assertFalse(decision["allowed"])
+        self.assertIn("bypass_unsupported", decision.get("warnings", []))
+
+
 class TestDelegateTask(unittest.TestCase):
     def test_no_parent_agent(self):
         result = json.loads(delegate_task(goal="test"))
@@ -183,6 +366,89 @@ class TestDelegateTask(unittest.TestCase):
         parent = _make_mock_parent()
         result = json.loads(delegate_task(tasks=[{"context": "no goal here"}], parent_agent=parent))
         self.assertIn("error", result)
+
+    @patch("tools.delegate_tool._build_child_agent")
+    @patch("tools.delegate_tool._run_single_child")
+    @patch("tools.delegate_tool._evaluate_pre_spawn_guard")
+    @patch("tools.delegate_tool._resolve_pre_spawn_guard_config")
+    def test_pre_spawn_guard_block_prevents_child_construction(self, mock_config, mock_guard, mock_run, mock_build):
+        mock_config.return_value = {"enabled": True, "require_task_context": False}
+        mock_guard.return_value = {
+            "ok": True,
+            "allowed": False,
+            "decision": "blocked",
+            "reason": "missing approval_required",
+        }
+        parent = _make_mock_parent()
+        parent._guard_context_id = "pm-1"
+
+        result = json.loads(delegate_task(goal="Fix tests", context="error log...", parent_agent=parent))
+
+        self.assertIn("error", result)
+        self.assertIn("pre-spawn guard blocked task 0", result["error"])
+        self.assertEqual(result["guard"]["decisions"][0]["reason"], "missing approval_required")
+        mock_build.assert_not_called()
+        mock_run.assert_not_called()
+
+    @patch("tools.delegate_tool._run_single_child")
+    @patch("tools.delegate_tool._evaluate_pre_spawn_guard")
+    @patch("tools.delegate_tool._resolve_pre_spawn_guard_config")
+    def test_pre_spawn_guard_allowed_preserves_single_task_flow(self, mock_config, mock_guard, mock_run):
+        mock_config.return_value = {"enabled": True, "require_task_context": False}
+        mock_guard.return_value = {"ok": True, "allowed": True, "decision": "allowed"}
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed",
+            "summary": "Done!", "api_calls": 3, "duration_seconds": 5.0
+        }
+        parent = _make_mock_parent()
+        parent._guard_context_id = "pm-1"
+
+        result = json.loads(delegate_task(goal="Fix tests", context="error log...", parent_agent=parent))
+
+        self.assertIn("results", result)
+        self.assertEqual(result["results"][0]["summary"], "Done!")
+        mock_guard.assert_called_once()
+        mock_run.assert_called_once()
+
+    @patch("tools.delegate_tool._build_child_agent")
+    @patch("tools.delegate_tool._run_single_child")
+    @patch("tools.delegate_tool._evaluate_pre_spawn_guard")
+    @patch("tools.delegate_tool._resolve_pre_spawn_guard_config")
+    def test_pre_spawn_guard_blocks_whole_batch_before_any_child_construction(self, mock_config, mock_guard, mock_run, mock_build):
+        mock_config.return_value = {"enabled": True, "require_task_context": False}
+        mock_guard.side_effect = [
+            {"ok": True, "allowed": True, "decision": "allowed"},
+            {"ok": True, "allowed": False, "decision": "blocked", "reason": "missing approval"},
+        ]
+        parent = _make_mock_parent()
+        parent._guard_context_id = "pm-1"
+        tasks = [{"goal": "Task A"}, {"goal": "Task B"}]
+
+        result = json.loads(delegate_task(tasks=tasks, parent_agent=parent))
+
+        self.assertIn("error", result)
+        self.assertIn("pre-spawn guard blocked task 1", result["error"])
+        self.assertEqual(len(result["guard"]["decisions"]), 2)
+        mock_build.assert_not_called()
+        mock_run.assert_not_called()
+
+    @patch("tools.delegate_tool._run_single_child")
+    @patch("tools.delegate_tool._evaluate_pre_spawn_guard")
+    @patch("tools.delegate_tool._resolve_pre_spawn_guard_config")
+    def test_disabled_pre_spawn_guard_preserves_existing_single_task_flow(self, mock_config, mock_guard, mock_run):
+        mock_config.return_value = {"enabled": False}
+        mock_run.return_value = {
+            "task_index": 0, "status": "completed",
+            "summary": "Done!", "api_calls": 3, "duration_seconds": 5.0
+        }
+        parent = _make_mock_parent()
+
+        result = json.loads(delegate_task(goal="Fix tests", context="error log...", parent_agent=parent))
+
+        self.assertIn("results", result)
+        self.assertEqual(result["results"][0]["summary"], "Done!")
+        mock_guard.assert_not_called()
+        mock_run.assert_called_once()
 
     @patch("tools.delegate_tool._run_single_child")
     def test_single_task_mode(self, mock_run):

--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -597,6 +597,43 @@ class TestDelegateTask(unittest.TestCase):
             delegate_task(goal="Test depth", parent_agent=parent)
             self.assertEqual(mock_child._delegate_depth, 1)
 
+    def test_build_child_agent_propagates_parent_guard_context_id(self):
+        parent = _make_mock_parent(depth=0)
+        parent._guard_context_id = "pm-parent-1"
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            MockAgent.return_value = mock_child
+
+            _build_child_agent(
+                task_index=0,
+                goal="Keep PM context",
+                context=None,
+                toolsets=None,
+                model=None,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        self.assertEqual(mock_child._guard_context_id, "pm-parent-1")
+
+    @patch("tools.delegate_tool._run_single_child")
+    def test_delegate_task_propagates_task_guard_context_id_to_child(self, mock_run):
+        captured = {}
+
+        def _capture(task_index, goal, child, parent_agent):
+            captured["guard_context_id"] = getattr(child, "_guard_context_id", None)
+            return {"task_index": task_index, "status": "completed", "summary": "Done", "api_calls": 1, "duration_seconds": 0.1}
+
+        mock_run.side_effect = _capture
+        parent = _make_mock_parent(depth=0)
+
+        result = json.loads(delegate_task(tasks=[{"goal": "Task with guard context", "guard_context_id": "pm-task-1"}], parent_agent=parent))
+
+        self.assertIn("results", result)
+        self.assertEqual(captured["guard_context_id"], "pm-task-1")
+
     def test_active_children_tracking(self):
         """Verify children are registered/unregistered for interrupt propagation."""
         parent = _make_mock_parent(depth=0)

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1120,6 +1120,7 @@ def _build_child_agent(
     # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
     subagent_id: Optional[str] = None,
+    guard_context_id: Optional[str] = None,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -1366,6 +1367,7 @@ def _build_child_agent(
     child._subagent_id = subagent_id
     child._parent_subagent_id = parent_subagent_id
     child._subagent_goal = goal
+    child._guard_context_id = guard_context_id or _guard_context_id(parent_agent, {})
 
     # Share a credential pool with the child when possible so subagents can
     # rotate credentials on rate limits instead of getting pinned to one key.
@@ -2259,6 +2261,7 @@ def delegate_task(
                 "task": task,
                 "role": _normalize_role(task.get("role") or top_role),
                 "subagent_id": _new_subagent_id(i),
+                "guard_context_id": _guard_context_id(parent_agent, task),
             }
         )
 
@@ -2326,6 +2329,7 @@ def delegate_task(
                 ),
                 role=effective_role,
                 subagent_id=planned["subagent_id"],
+                guard_context_id=planned.get("guard_context_id"),
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -22,8 +22,10 @@ import logging
 
 logger = logging.getLogger(__name__)
 import os
+import subprocess
 import threading
 import time
+import uuid as _uuid
 from concurrent.futures import (
     ThreadPoolExecutor,
     TimeoutError as FuturesTimeoutError,
@@ -319,6 +321,240 @@ def _normalize_role(r: Optional[str]) -> str:
         return r_norm
     logger.warning("Unknown delegate_task role=%r, coercing to 'leaf'", r)
     return "leaf"
+
+
+def _normalize_guard_policy(value: Any, default: str = "auto") -> str:
+    norm = str(value or default).strip().lower().replace("-", "_")
+    return norm if norm in {"auto", "fail_open", "fail_closed"} else default
+
+
+def _normalize_runtime_mode(value: Any) -> str:
+    norm = str(value or "").strip().lower()
+    return norm if norm in {"manual", "autonomous"} else "manual"
+
+
+def _resolve_pre_spawn_guard_config(delegation_config: Optional[dict] = None) -> Dict[str, Any]:
+    """Return normalized delegation.pre_spawn_guard configuration.
+
+    This helper is deliberately pure-ish and does not call the guard.  It gives
+    the native delegate_task hook a stable config surface while keeping the
+    default upstream behavior a no-op.
+    """
+    raw = (delegation_config or {}).get("pre_spawn_guard") or {}
+    runtime_mode = raw.get("runtime_mode")
+    if runtime_mode is None:
+        runtime_mode = os.getenv("HERMES_RUNTIME_MODE")
+    cfg: Dict[str, Any] = {
+        "enabled": is_truthy_value(raw.get("enabled"), default=False),
+        "mode": str(raw.get("mode") or "command"),
+        "command": raw.get("command"),
+        "timeout_seconds": 3.0,
+        "runtime_mode": _normalize_runtime_mode(runtime_mode),
+        "fail_policy": _normalize_guard_policy(raw.get("fail_policy")),
+        "require_task_context": is_truthy_value(raw.get("require_task_context"), default=False),
+        "record_all_allowed": is_truthy_value(raw.get("record_all_allowed"), default=False),
+        "bypass_enabled": is_truthy_value(raw.get("bypass_enabled"), default=False),
+    }
+    try:
+        cfg["timeout_seconds"] = max(0.1, float(raw.get("timeout_seconds", 3.0)))
+    except (TypeError, ValueError):
+        cfg["timeout_seconds"] = 3.0
+    return cfg
+
+
+def _parent_attr(parent_agent: Any, name: str) -> Any:
+    """Read real attrs from objects or MagicMocks without auto-creating mocks."""
+    try:
+        if hasattr(parent_agent, "__dict__") and name in vars(parent_agent):
+            return vars(parent_agent)[name]
+    except Exception:
+        pass
+    value = getattr(parent_agent, name, None)
+    return value if isinstance(value, (str, int, float, bool, list, dict, tuple)) else None
+
+
+def _guard_context_id(parent_agent: Any, task: dict[str, Any]) -> Optional[str]:
+    value = _parent_attr(parent_agent, "_guard_context_id")
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    value = task.get("guard_context_id") or task.get("external_task_id")
+    return str(value).strip() if value else None
+
+
+def _truncate_preview(value: Any, limit: int = 240) -> str:
+    text = str(value or "")
+    return text[:limit] + "..." if len(text) > limit else text
+
+
+def _new_subagent_id(task_index: int) -> str:
+    return f"sa-{task_index}-{_uuid.uuid4().hex[:8]}"
+
+
+def _pre_spawn_guard_error(decision: dict[str, Any], decisions: list[dict[str, Any]]) -> str:
+    idx = decision.get("task_index", 0)
+    reason = decision.get("reason") or decision.get("decision") or "blocked"
+    return json.dumps(
+        {
+            "error": f"delegate_task pre-spawn guard blocked task {idx}: {reason}",
+            "guard": {"decisions": decisions},
+        }
+    )
+
+
+def _build_pre_spawn_guard_payload(
+    *,
+    parent_agent: Any,
+    task: dict[str, Any],
+    task_index: int,
+    task_count: int,
+    subagent_id: str,
+    role: str,
+    config: dict[str, Any],
+) -> Dict[str, Any]:
+    """Build the JSON payload sent to a pre-spawn guard command."""
+    guard_context_id = _guard_context_id(parent_agent, task)
+    parent_sid = _parent_attr(parent_agent, "_subagent_id")
+    session_id = _parent_attr(parent_agent, "session_id") or _parent_attr(parent_agent, "_session_id")
+    return {
+        "version": 1,
+        "event": "delegate_pre_spawn",
+        "parent_session_id": session_id,
+        "parent_task_id": _parent_attr(parent_agent, "_current_task_id"),
+        "guard_context_id": guard_context_id,
+        "subagent_id": subagent_id,
+        "parent_subagent_id": parent_sid if isinstance(parent_sid, str) else None,
+        "delegate_depth": int(_parent_attr(parent_agent, "_delegate_depth") or 0),
+        "task_index": int(task_index),
+        "task_count": int(task_count),
+        "role": _normalize_role(role),
+        "profile": str(task.get("profile") or _parent_attr(parent_agent, "profile") or "delegate"),
+        "goal_preview": _truncate_preview(task.get("goal")),
+        "toolsets": list(task.get("toolsets") or []),
+        "action_id": str(task.get("action_id") or f"delegate_task:{task_index}"),
+        "requires_task_context": bool(config.get("require_task_context")),
+        "runtime_mode": config.get("runtime_mode", "manual"),
+    }
+
+
+def _run_pre_spawn_guard_command(payload: dict[str, Any], config: dict[str, Any]) -> dict[str, Any]:
+    command = config.get("command")
+    if not command:
+        raise RuntimeError("pre-spawn guard command is not configured")
+    proc = subprocess.run(
+        [str(command)],
+        input=json.dumps(payload, ensure_ascii=False),
+        text=True,
+        capture_output=True,
+        timeout=float(config.get("timeout_seconds", 3.0)),
+        check=False,
+    )
+    if proc.returncode != 0:
+        raise RuntimeError((proc.stderr or proc.stdout or f"guard exited {proc.returncode}").strip())
+    try:
+        data = json.loads(proc.stdout or "{}")
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"guard returned invalid JSON: {exc.msg}") from exc
+    if not isinstance(data, dict):
+        raise RuntimeError("guard returned non-object JSON")
+    return data
+
+
+def _hook_error_decision(config: dict[str, Any], reason: str) -> Dict[str, Any]:
+    policy = _normalize_guard_policy(config.get("fail_policy"))
+    runtime_mode = _normalize_runtime_mode(config.get("runtime_mode"))
+    fail_closed = policy == "fail_closed" or (
+        policy == "auto" and (runtime_mode == "autonomous" or bool(config.get("require_task_context")))
+    )
+    decision = "hook_error_fail_closed" if fail_closed else "hook_error_fail_open"
+    payload: Dict[str, Any] = {
+        "ok": False,
+        "allowed": not fail_closed,
+        "decision": decision,
+        "reason": reason,
+        "should_call_guard": False,
+    }
+    if not fail_closed:
+        payload["warning"] = reason
+    return payload
+
+
+def _evaluate_pre_spawn_guard(
+    *,
+    config: dict[str, Any],
+    parent_agent: Any,
+    task: dict[str, Any],
+    task_index: int,
+    task_count: int,
+    subagent_id: str,
+    role: str,
+    command_runner: Any = None,
+) -> Dict[str, Any]:
+    """Evaluate pre-spawn guard semantics without constructing a child agent."""
+    cfg = dict(config or {})
+    cfg.setdefault("runtime_mode", "manual")
+    cfg.setdefault("fail_policy", "auto")
+    cfg.setdefault("require_task_context", False)
+    warnings: list[str] = []
+    if cfg.get("bypass_enabled"):
+        warnings.append("bypass_unsupported")
+    if not is_truthy_value(cfg.get("enabled"), default=False):
+        return {"ok": True, "allowed": True, "decision": "disabled", "should_call_guard": False}
+
+    context_id = _guard_context_id(parent_agent, task)
+    if not context_id:
+        if cfg.get("require_task_context"):
+            return {
+                "ok": False,
+                "allowed": False,
+                "decision": "missing_task_context",
+                "reason": "delegate_task pre-spawn guard requires a guard context",
+                "should_call_guard": False,
+                "warnings": warnings,
+            }
+        payload: Dict[str, Any] = {
+            "ok": True,
+            "allowed": True,
+            "decision": "no_task_context_allowed",
+            "should_call_guard": False,
+            "warnings": warnings,
+        }
+        if cfg.get("record_all_allowed"):
+            payload["warning"] = "delegate_task allowed without guard context"
+        return payload
+
+    payload = _build_pre_spawn_guard_payload(
+        parent_agent=parent_agent,
+        task=task,
+        task_index=task_index,
+        task_count=task_count,
+        subagent_id=subagent_id,
+        role=role,
+        config=cfg,
+    )
+    try:
+        if isinstance(command_runner, BaseException):
+            raise command_runner
+        raw = command_runner(payload, cfg) if callable(command_runner) else _run_pre_spawn_guard_command(payload, cfg)
+    except Exception as exc:
+        decision = _hook_error_decision(cfg, str(exc))
+        if warnings:
+            decision["warnings"] = warnings
+        return decision
+
+    allowed = bool(raw.get("allowed"))
+    result: Dict[str, Any] = {
+        "ok": bool(raw.get("ok", True)),
+        "allowed": allowed,
+        "decision": "allowed" if allowed else "blocked",
+        "reason": raw.get("reason") or ("allowed" if allowed else "blocked"),
+        "should_call_guard": True,
+        "guard": raw,
+    }
+    if raw.get("event") is not None:
+        result["event"] = raw.get("event")
+    if warnings:
+        result["warnings"] = warnings
+    return result
 
 
 def _get_max_concurrent_children() -> int:
@@ -883,6 +1119,7 @@ def _build_child_agent(
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
+    subagent_id: Optional[str] = None,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -894,7 +1131,6 @@ def _build_child_agent(
     model on OpenRouter while the parent runs on Nous Portal).
     """
     from run_agent import AIAgent
-    import uuid as _uuid
 
     # ── Role resolution ─────────────────────────────────────────────────
     # Honor the caller's role only when BOTH the kill switch and the
@@ -912,7 +1148,7 @@ def _build_child_agent(
     # spawn_requested event, and the _active_subagents registry all share
     # one key.  parent_id is non-None when THIS parent is itself a subagent
     # (nested orchestrator -> worker chain).
-    subagent_id = f"sa-{task_index}-{_uuid.uuid4().hex[:8]}"
+    subagent_id = subagent_id or _new_subagent_id(task_index)
     parent_subagent_id = getattr(parent_agent, "_subagent_id", None)
     tui_depth = max(0, child_depth - 1)  # 0 = first-level child for the UI
 
@@ -2014,10 +2250,39 @@ def delegate_task(
         if not task.get("goal", "").strip():
             return tool_error(f"Task {i} is missing a 'goal'.")
 
+    n_tasks = len(task_list)
+    planned_children = []
+    for i, task in enumerate(task_list):
+        planned_children.append(
+            {
+                "task_index": i,
+                "task": task,
+                "role": _normalize_role(task.get("role") or top_role),
+                "subagent_id": _new_subagent_id(i),
+            }
+        )
+
+    pre_spawn_guard = _resolve_pre_spawn_guard_config(cfg)
+    guard_decisions: list[dict[str, Any]] = []
+    if is_truthy_value(pre_spawn_guard.get("enabled"), default=False):
+        for planned in planned_children:
+            decision = _evaluate_pre_spawn_guard(
+                config=pre_spawn_guard,
+                parent_agent=parent_agent,
+                task=planned["task"],
+                task_index=planned["task_index"],
+                task_count=n_tasks,
+                subagent_id=planned["subagent_id"],
+                role=planned["role"],
+            )
+            decision.setdefault("task_index", planned["task_index"])
+            guard_decisions.append(decision)
+            if not decision.get("allowed"):
+                return _pre_spawn_guard_error(decision, guard_decisions)
+
     overall_start = time.monotonic()
     results = []
 
-    n_tasks = len(task_list)
     # Track goal labels for progress display (truncated for readability)
     task_labels = [t["goal"][:40] for t in task_list]
 
@@ -2033,11 +2298,11 @@ def delegate_task(
     # child build raises (otherwise _last_resolved_tool_names stays corrupted).
     children = []
     try:
-        for i, t in enumerate(task_list):
+        for planned in planned_children:
+            i = planned["task_index"]
+            t = planned["task"]
             task_acp_args = t.get("acp_args") if "acp_args" in t else None
-            # Per-task role beats top-level; normalise again so unknown
-            # per-task values warn and degrade to leaf uniformly.
-            effective_role = _normalize_role(t.get("role") or top_role)
+            effective_role = planned["role"]
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
@@ -2060,6 +2325,7 @@ def delegate_task(
                     else (acp_args if acp_args is not None else creds.get("args"))
                 ),
                 role=effective_role,
+                subagent_id=planned["subagent_id"],
             )
             # Override with correct parent tool names (before child construction mutated global)
             child._delegate_saved_tool_names = _parent_tool_names

--- a/website/docs/user-guide/features/delegation.md
+++ b/website/docs/user-guide/features/delegation.md
@@ -129,6 +129,70 @@ When you provide a `tasks` array, subagents run in **parallel** using a thread p
 
 Single-task delegation runs directly without thread pool overhead.
 
+## Pre-Spawn Guard
+
+Installations that need an external policy check before subagents are constructed can enable a disabled-by-default pre-spawn guard. This is useful for permission brokers, budget gates, compliance systems, or any local workflow that needs to approve or deny a worker before Hermes allocates a child agent.
+
+```yaml
+# In ~/.hermes/config.yaml
+delegation:
+  pre_spawn_guard:
+    enabled: true
+    command: /usr/local/bin/permission-broker
+    timeout_seconds: 3.0
+    runtime_mode: manual      # manual | autonomous
+    fail_policy: auto         # auto | fail_open | fail_closed
+    require_task_context: false
+```
+
+When enabled, Hermes sends one JSON object on stdin to the configured command for each planned child before calling the child-agent constructor. The payload is intentionally small and does **not** include the full task context:
+
+```json
+{
+  "version": 1,
+  "event": "delegate_pre_spawn",
+  "guard_context_id": "optional-external-context-id",
+  "subagent_id": "sa-0-abc12345",
+  "parent_subagent_id": null,
+  "delegate_depth": 0,
+  "task_index": 0,
+  "task_count": 1,
+  "role": "leaf",
+  "profile": "delegate",
+  "goal_preview": "Short truncated goal preview...",
+  "toolsets": ["terminal", "file"],
+  "action_id": "delegate_task:0",
+  "requires_task_context": false,
+  "runtime_mode": "manual"
+}
+```
+
+When the guard is disabled (the default), delegation behavior is unchanged. `manual` is for interactive sessions where an operator can react to warnings; `autonomous` is for unattended dispatchers where unknown states should fail closed.
+
+The `goal_preview` field is truncated to 240 characters so external policy commands can make a coarse routing/approval decision without receiving the full task context.
+
+The command should print a JSON decision on stdout:
+
+```json
+{ "ok": true, "allowed": true, "reason": "approved" }
+```
+
+or:
+
+```json
+{ "ok": true, "allowed": false, "reason": "missing approval" }
+```
+
+`allowed: false` is treated as a policy decision, not a hook crash. For batches, Hermes evaluates every planned child first and uses all-or-nothing semantics: if any child is denied, no child in that batch is constructed. The command's exit code is not used to encode the policy decision: return exit 0 with `allowed: false` for a valid denial; non-zero exit, timeout, or invalid JSON are treated as hook failures and resolved by `fail_policy`.
+
+Failure handling is controlled by `fail_policy`:
+
+- `fail_open`: hook errors allow the spawn and attach a warning.
+- `fail_closed`: hook errors block the spawn.
+- `auto`: fail closed for autonomous/runtime-enforced contexts (`runtime_mode: autonomous` or `require_task_context: true`), otherwise fail open with a warning for manual sessions.
+
+If `require_task_context: true`, Hermes blocks without calling the command unless a guard context exists. Parent agents can carry a guard context (attribute name: `_guard_context_id`), and individual tasks may also include `guard_context_id` or `external_task_id` for integrations that map delegation to an external work item.
+
 ## Model Override
 
 You can configure a different model for subagents via `config.yaml` — useful for delegating simple tasks to cheaper/faster models:


### PR DESCRIPTION
## Summary

Adds a disabled-by-default `delegate_task` pre-spawn guard so installations can call an external policy system before Hermes constructs child agents.

- Adds `delegation.pre_spawn_guard` config with command-based JSON stdin/stdout protocol.
- Blocks child construction before `_build_child_agent(...)` when a guard denies a planned child.
- Uses all-or-nothing semantics for batches: if any planned child is denied, none are constructed.
- Keeps default behavior unchanged when the guard is disabled.
- Propagates a generic `guard_context_id` into delegated children so recursive delegation can stay attached to the same external work item.
- Documents the configuration and command protocol in the delegation feature docs.

## Why

Some operators need a local policy/budget/permission broker to approve subagent creation before resources are allocated or side effects become possible. The hook is generic: Hermes Core only knows about an optional guard context; integrations decide what that context means.

Example uses:

- approval gates before autonomous subagent dispatch;
- budget or quota checks before spawning expensive workers;
- compliance/policy checks for enterprise deployments;
- local project-control systems that track worker starts externally.

## Design

The guard is disabled by default, and when it is disabled delegation behavior is unchanged:

```yaml
delegation:
  pre_spawn_guard:
    enabled: true
    command: /usr/local/bin/permission-broker
    timeout_seconds: 3.0
    runtime_mode: manual
    fail_policy: auto
    require_task_context: false
```

For each planned child, Hermes sends a compact JSON payload to the command on stdin. It deliberately includes a `goal_preview` truncated to 240 characters, not the full task context. The command returns JSON such as:

```json
{ "ok": true, "allowed": true, "reason": "approved" }
```

or:

```json
{ "ok": true, "allowed": false, "reason": "missing approval" }
```

`manual` is for interactive sessions where an operator can react to warnings; `autonomous` is for unattended dispatchers where unknown states should fail closed.

`allowed: false` is treated as a policy decision. A valid denial should return exit 0 with `allowed: false`; non-zero exit, timeout, or invalid JSON are treated as hook failures and resolved by `fail_policy`.

## Commit structure

This branch is intentionally two commits:

1. `feat: add delegate pre-spawn guard` — core hook, tests, docs.
2. `feat: propagate delegate guard context to children` — recursive delegation context propagation.

## Test plan

```bash
python -m pytest tests/tools/test_delegate.py -q -o 'addopts='
python -m py_compile tools/delegate_tool.py tests/tools/test_delegate.py
git diff --check
```

Local result:

```text
143 passed
```

Additional local integration smoke against an external adapter verified:

```text
Core pre-spawn hook -> command adapter -> external guard-start
blocked path: worker_start_blocked
allowed path: worker_started
```

That adapter is local-only and not part of this PR.

## Upstream-safety checks

Core code/tests were checked for local integration names:

```bash
grep -RInE 'tars|TARS|pm_task|tars_task_id|_tars' tools/delegate_tool.py tests/tools/test_delegate.py
# 0 matches
```
