### PR TITLE
fix(retry): use float() for Retry-After header to handle sub-second values

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -13993,7 +13993,7 @@ class AIAgent:
                             _ra_raw = _resp_headers.get("retry-after") or _resp_headers.get("Retry-After")
                             if _ra_raw:
                                 try:
-                                    _retry_after = min(int(_ra_raw), 120)  # Cap at 2 minutes
+                                    _retry_after = min(float(_ra_raw), 120)  # Cap at 2 minutes
                                 except (TypeError, ValueError):
                                     pass
                     wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)


### PR DESCRIPTION
## Summary

`int()` silently drops fractional `Retry-After` header values via `ValueError`, which is caught and ignored — falling back to generic exponential backoff instead of respecting the provider's requested delay.

**Before:** `int("2.5")` → `ValueError` (silently swallowed, falls through to `jittered_backoff`)
**After:** `float("2.5")` → `2.5` ✓

Integer values are unaffected: `float(2) == 2.0`.

## Type of change
- Bug fix (non-breaking change which fixes an issue)

## Test plan
- [x] Existing tests pass (33/33 memory tool tests)
- [x] Manual verification: `float()` accepts both integer and fractional strings
- [x] CI will run full test suite on PR