### PR TITLE
fix(gateway): keep /goal running after streamed replies

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6211,10 +6211,16 @@ class GatewayRunner:
                     except Exception:
                         session_entry = None
                     if session_entry is not None:
+                        _response_already_delivered = (
+                            isinstance(_goal_agent_result, dict)
+                            and bool(_goal_agent_result.get("already_sent"))
+                            and not bool(_goal_agent_result.get("failed"))
+                        )
                         await self._post_turn_goal_continuation(
                             session_entry=session_entry,
                             source=source,
                             final_response=_final_text,
+                            response_already_delivered=_response_already_delivered,
                         )
             except Exception as _goal_exc:
                 logger.debug("goal continuation hook failed: %s", _goal_exc)
@@ -8915,6 +8921,7 @@ class GatewayRunner:
         session_entry: Any,
         source: Any,
         final_response: str,
+        response_already_delivered: bool = False,
     ) -> None:
         """Run the goal judge after a gateway turn and, if still active,
         enqueue a continuation prompt for the same session.
@@ -8946,13 +8953,14 @@ class GatewayRunner:
         msg = decision.get("message") or ""
 
         # Defer the status line until after the adapter has delivered the
-        # agent's visible final response. The judge runs after the response is
-        # produced but before BasePlatformAdapter sends it, so sending here
-        # would show "✓ Goal achieved" before the answer itself. Registering
-        # an awaited post-delivery callback preserves delivery reliability
-        # without reversing the user-visible ordering.
+        # agent's visible final response. When streaming already delivered the
+        # body, there is no later adapter send to trigger a post-delivery
+        # callback, so deliver the goal status immediately.
         if msg and source is not None:
-            await self._defer_goal_status_notice_after_delivery(source, msg)
+            if response_already_delivered:
+                await self._send_goal_status_notice(source, msg)
+            else:
+                await self._defer_goal_status_notice_after_delivery(source, msg)
 
         if not decision.get("should_continue"):
             return

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6183,6 +6183,13 @@ class GatewayRunner:
 
         try:
             _agent_result = await self._handle_message_with_agent(event, source, _quick_key, _run_generation)
+            _return_result = _agent_result
+            _goal_agent_result = _agent_result
+            _stashed_results = getattr(self, "_post_turn_agent_results", None)
+            if isinstance(_stashed_results, dict):
+                _stashed_result = _stashed_results.pop(_quick_key, None)
+                if _goal_agent_result is None:
+                    _goal_agent_result = _stashed_result
             # Goal continuation: after the agent returns a final response
             # for this turn, check any standing /goal — the judge will
             # either mark it done, pause it (budget), or enqueue a
@@ -6191,10 +6198,10 @@ class GatewayRunner:
             # broken judge never breaks normal message handling.
             try:
                 _final_text = ""
-                if isinstance(_agent_result, dict):
-                    _final_text = str(_agent_result.get("final_response") or "")
-                elif isinstance(_agent_result, str):
-                    _final_text = _agent_result
+                if isinstance(_goal_agent_result, dict):
+                    _final_text = str(_goal_agent_result.get("final_response") or "")
+                elif isinstance(_goal_agent_result, str):
+                    _final_text = _goal_agent_result
                 # Skip for empty responses (interrupted / errored) — the
                 # judge would almost always say "continue" and we'd loop
                 # on error. Let the user drive the next turn.
@@ -6211,7 +6218,7 @@ class GatewayRunner:
                         )
             except Exception as _goal_exc:
                 logger.debug("goal continuation hook failed: %s", _goal_exc)
-            return _agent_result
+            return _return_result
         finally:
             # If _run_agent replaced the sentinel with a real agent and
             # then cleaned it up, this is a no-op.  If we exited early
@@ -7412,6 +7419,11 @@ class GatewayRunner:
                             )
                     except Exception as _e:
                         logger.debug("trailing footer send failed: %s", _e)
+                _stashed_results = getattr(self, "_post_turn_agent_results", None)
+                if _stashed_results is None:
+                    _stashed_results = {}
+                    self._post_turn_agent_results = _stashed_results
+                _stashed_results[_quick_key] = agent_result
                 return None
 
             return response

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14846,6 +14846,12 @@ class GatewayRunner:
                     "Session split detected: %s → %s (compression)",
                     session_id, agent.session_id,
                 )
+                try:
+                    from hermes_cli.goals import migrate_active_goal
+
+                    migrate_active_goal(session_id, agent.session_id)
+                except Exception as exc:
+                    logger.debug("goal migration after session split failed: %s", exc)
                 entry = self.session_store._entries.get(session_key)
                 if entry:
                     entry.session_id = agent.session_id

--- a/hermes_cli/goals.py
+++ b/hermes_cli/goals.py
@@ -205,6 +205,64 @@ def save_goal(session_id: str, state: GoalState) -> None:
         logger.debug("GoalManager: set_meta failed: %s", exc)
 
 
+def _delete_goal(session_id: str) -> None:
+    """Remove a goal state key from SessionDB. No-op if DB unavailable."""
+    if not session_id:
+        return
+    db = _get_session_db()
+    if db is None:
+        return
+    key = _meta_key(session_id)
+    try:
+        if hasattr(db, "_execute_write"):
+            db._execute_write(lambda conn: conn.execute("DELETE FROM state_meta WHERE key = ?", (key,)))
+        else:  # pragma: no cover - defensive for non-SessionDB test doubles
+            conn = getattr(db, "_conn", None)
+            lock = getattr(db, "_lock", None)
+            if conn is None:
+                return
+            if lock is None:
+                conn.execute("DELETE FROM state_meta WHERE key = ?", (key,))
+                conn.commit()
+            else:
+                with lock:
+                    conn.execute("DELETE FROM state_meta WHERE key = ?", (key,))
+                    conn.commit()
+    except Exception as exc:
+        logger.debug("GoalManager: delete goal failed: %s", exc)
+
+
+def migrate_active_goal(old_session_id: str, new_session_id: str) -> bool:
+    """Move an active goal to a new session id after session compression.
+
+    The stored GoalState schema is unchanged: this renames the state_meta key
+    from ``goal:<old_session_id>`` to ``goal:<new_session_id>``.  If the
+    destination already has an active goal, skip to avoid two owners racing the
+    same loop.  Inactive destination state may be overwritten by the active
+    source goal.
+    """
+    if not old_session_id or not new_session_id or old_session_id == new_session_id:
+        return False
+
+    old_state = load_goal(old_session_id)
+    if old_state is None or old_state.status != "active":
+        return False
+
+    new_state = load_goal(new_session_id)
+    if new_state is not None and new_state.status == "active":
+        logger.warning(
+            "GoalManager: migration skipped; destination session already has active goal (%s -> %s)",
+            old_session_id,
+            new_session_id,
+        )
+        return False
+
+    save_goal(new_session_id, old_state)
+    _delete_goal(old_session_id)
+    logger.info("GoalManager: migrated active goal %s -> %s", old_session_id, new_session_id)
+    return True
+
+
 def clear_goal(session_id: str) -> None:
     """Mark a goal cleared in the DB (preserved for audit, status=cleared)."""
     state = load_goal(session_id)

--- a/tests/gateway/test_goal_verdict_send.py
+++ b/tests/gateway/test_goal_verdict_send.py
@@ -61,6 +61,15 @@ class _RecordingAdapter:
         return _R()
 
 
+class _CallbackRecordingAdapter(_RecordingAdapter):
+    def __init__(self) -> None:
+        super().__init__()
+        self.callbacks: dict = {}
+
+    def register_post_delivery_callback(self, session_key, callback, *, generation=None):
+        self.callbacks[session_key] = (generation, callback)
+
+
 def _make_runner_with_adapter(session_id: str = None):
     from gateway.run import GatewayRunner
     import uuid
@@ -121,6 +130,32 @@ async def test_goal_verdict_done_sent_via_adapter_send(hermes_home):
     assert msg["chat_id"] == "c1"
     assert "Goal achieved" in msg["content"]
     assert "the feature shipped" in msg["content"]
+
+
+@pytest.mark.asyncio
+async def test_goal_verdict_streamed_done_sends_status_immediately(hermes_home):
+    """When streaming already delivered the main body, the goal status must
+    be sent immediately instead of waiting for a post-delivery callback that
+    will never fire."""
+    runner, adapter, session_entry, src = _make_runner_with_adapter()
+    adapter = _CallbackRecordingAdapter()
+    runner.adapters[Platform.TELEGRAM] = adapter
+
+    from hermes_cli.goals import GoalManager
+
+    GoalManager(session_entry.session_id).set("ship the feature")
+
+    with patch("hermes_cli.goals.judge_goal", return_value=("done", "the feature shipped", False)):
+        await runner._post_turn_goal_continuation(
+            session_entry=session_entry,
+            source=src,
+            final_response="I shipped the feature.",
+            response_already_delivered=True,
+        )
+
+    assert len(adapter.sends) == 1
+    assert "Goal achieved" in adapter.sends[0]["content"]
+    assert adapter.callbacks == {}
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_session_race_guard.py
+++ b/tests/gateway/test_session_race_guard.py
@@ -125,6 +125,30 @@ async def test_sentinel_cleaned_up_after_handler_returns():
     )
 
 
+@pytest.mark.asyncio
+async def test_goal_continuation_uses_stashed_streamed_final_response():
+    """Streaming platforms return None to avoid duplicate sends, but the
+    post-turn goal hook still needs the already-delivered final text."""
+    runner = _make_runner()
+    event = _make_event()
+    final_response = "partial progress; keep going"
+
+    async def mock_inner(self_inner, ev, src, qk, generation):
+        runner._post_turn_agent_results = {
+            qk: {"final_response": final_response, "already_sent": True}
+        }
+        return None
+
+    runner._post_turn_goal_continuation = AsyncMock()
+
+    with patch.object(GatewayRunner, "_handle_message_with_agent", mock_inner):
+        response = await runner._handle_message(event)
+
+    assert response is None
+    runner._post_turn_goal_continuation.assert_awaited_once()
+    assert runner._post_turn_goal_continuation.await_args.kwargs["final_response"] == final_response
+
+
 # ------------------------------------------------------------------
 # Test 3: Sentinel cleaned up on exception
 # ------------------------------------------------------------------

--- a/tests/hermes_cli/test_goals.py
+++ b/tests/hermes_cli/test_goals.py
@@ -252,6 +252,67 @@ class TestGoalManager:
         assert mgr2.state.goal == "do the thing"
         assert mgr2.is_active()
 
+    def test_migrate_active_goal_moves_state_to_new_session(self, hermes_home):
+        """Compression-created session splits must not strand active goals on
+        the old session id."""
+        from hermes_cli.goals import GoalManager, load_goal, migrate_active_goal, save_goal
+
+        old_mgr = GoalManager(session_id="old-sid", default_max_turns=9)
+        state = old_mgr.set("finish the roadmap")
+        state.turns_used = 7
+        state.last_verdict = "continue"
+        state.last_reason = "not done"
+        save_goal("old-sid", state)
+
+        assert migrate_active_goal("old-sid", "new-sid") is True
+
+        assert load_goal("old-sid") is None
+        migrated = load_goal("new-sid")
+        assert migrated is not None
+        assert migrated.goal == "finish the roadmap"
+        assert migrated.status == "active"
+        assert migrated.turns_used == 7
+        assert migrated.max_turns == 9
+        assert migrated.last_verdict == "continue"
+        assert migrated.last_reason == "not done"
+
+    def test_migrate_active_goal_does_not_overwrite_destination_active_goal(self, hermes_home):
+        from hermes_cli.goals import GoalManager, load_goal, migrate_active_goal
+
+        GoalManager(session_id="old-active").set("old goal")
+        GoalManager(session_id="new-active").set("new goal")
+
+        assert migrate_active_goal("old-active", "new-active") is False
+
+        assert load_goal("old-active").goal == "old goal"
+        assert load_goal("new-active").goal == "new goal"
+
+    def test_migrate_active_goal_overwrites_destination_inactive_goal(self, hermes_home):
+        from hermes_cli.goals import GoalManager, load_goal, migrate_active_goal, save_goal
+
+        GoalManager(session_id="old-active-2").set("active goal")
+        done_mgr = GoalManager(session_id="new-done")
+        done_state = done_mgr.set("done goal")
+        done_state.status = "done"
+        save_goal("new-done", done_state)
+
+        assert migrate_active_goal("old-active-2", "new-done") is True
+
+        assert load_goal("old-active-2") is None
+        assert load_goal("new-done").goal == "active goal"
+        assert load_goal("new-done").status == "active"
+
+    def test_migrate_active_goal_ignores_inactive_source(self, hermes_home):
+        from hermes_cli.goals import GoalManager, load_goal, migrate_active_goal
+
+        old_mgr = GoalManager(session_id="old-paused")
+        old_mgr.set("paused goal")
+        old_mgr.pause("user paused")
+
+        assert migrate_active_goal("old-paused", "new-from-paused") is False
+        assert load_goal("old-paused").status == "paused"
+        assert load_goal("new-from-paused") is None
+
     def test_evaluate_after_turn_done(self, hermes_home):
         """Judge says done → status=done, no continuation."""
         from hermes_cli import goals


### PR DESCRIPTION
## Summary
- preserve streamed gateway responses so `/goal` post-turn evaluation still receives the final text
- send goal status notices immediately after streamed gateway replies so continue/done feedback is visible
- migrate active goal state when context compression splits a session, without adding new goal state fields

## Why
Gateway sessions can stream the final assistant reply before the normal delivery path runs. That keeps the adapter-facing return value as `None` to avoid duplicate sends, but it also meant `/goal` post-turn evaluation lost the final text and skipped continuation. A separate issue could lose active goals when compression created a new session id.

This was observed on Slack and Telegram, but the fix is in the shared gateway flow rather than a platform-specific adapter.

## How to test
- `python -m pytest tests/hermes_cli/test_goals.py tests/gateway/test_goal_verdict_send.py tests/gateway/test_goal_status_notice.py tests/gateway/test_session_race_guard.py -q -o 'addopts='`

## Platforms tested
- macOS local development checkout
- Slack gateway live thread: `/goal` continuation continued after streamed replies and in-place context compression

## Notes
- Session-split goal migration is covered by regression tests. In the live Slack thread, context compression occurred in place, so the session-split migration path did not trigger live.
