### PR TITLE
fix(agent): sanitize memory provider tool schemas on registration

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1981,15 +1981,32 @@ class AIAgent:
                 for t in self.tools
                 if isinstance(t, dict)
             }
+            _raw_schemas = []
             for _schema in self._memory_manager.get_all_tool_schemas():
                 _tname = _schema.get("name", "")
                 if _tname and _tname in _existing_tool_names:
                     continue  # already registered via plugin path
-                _wrapped = {"type": "function", "function": _schema}
-                self.tools.append(_wrapped)
+                _raw_schemas.append(_schema)
                 if _tname:
-                    self.valid_tool_names.add(_tname)
                     _existing_tool_names.add(_tname)
+            # Sanitize memory provider schemas (same as get_tool_definitions)
+            try:
+                from tools.schema_sanitizer import sanitize_tool_schemas
+                _wrapped_all = [{"type": "function", "function": s} for s in _raw_schemas]
+                _sanitized = sanitize_tool_schemas(_wrapped_all)
+                for _w in _sanitized:
+                    self.tools.append(_w)
+                    _n = _w.get("function", {}).get("name", "")
+                    if _n:
+                        self.valid_tool_names.add(_n)
+            except Exception:
+                # Fallback: append unsanitized
+                for _schema in _raw_schemas:
+                    _wrapped = {"type": "function", "function": _schema}
+                    self.tools.append(_wrapped)
+                    _tname = _schema.get("name", "")
+                    if _tname:
+                        self.valid_tool_names.add(_tname)
 
         # Skills config: nudge interval for skill creation reminders
         self._skill_nudge_interval = 10


### PR DESCRIPTION
## Problem

Memory providers (e.g. honcho) may return tool schemas with JSON Schema constructs that strict backends like llama.cpp reject:

- `anyOf`/`oneOf` unions for nullable fields
- `pattern`/`format` keywords  
- Unconstrained `additionalProperties`

This causes HTTP 400 errors when using local models with memory providers:
```
Unable to generate parser for this template.
Automatic parser generation failed: JSON schema conversion failed:
Unrecognized schema: "object"
```

## Current Behavior

Schema sanitization is only applied **reactively** — after llama.cpp returns an error, the agent strips the problematic keywords and retries. This works but:
1. Adds an extra failed API call per tool invocation
2. Doesn't help other strict backends that fail silently
3. Memory provider schemas bypass the sanitization applied to MCP/bundled tools

## Proposed Change

Apply `sanitize_tool_schemas()` **proactively** at memory provider schema registration time, matching the treatment already given to MCP and bundled tools in `get_tool_definitions()`.

The sanitization is conservative — it only modifies shapes that strict backends couldn't use anyway. A fallback path preserves the original behavior if the sanitizer fails.

## Testing

- Verified with honcho memory provider + ollama (carnice-9b)
- Tool schemas with `anyOf` nullable fields are correctly collapsed
- Fallback path works when sanitizer is unavailable