### PR TITLE
fix: reload default model from config.yaml on /reset and /new

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5408,6 +5408,16 @@ class HermesCLI:
         self._pending_title = None
         self._resumed = False
 
+        # Reload default model from config.yaml if the user didn't explicitly
+        # choose a model (e.g. hermes -m). This ensures /reset and /new pick
+        # up config changes made mid-session. Fixes #23131.
+        if self._model_is_default:
+            _fresh_cfg = load_cli_config()
+            _mc = _fresh_cfg.get("model", {})
+            _cfg_model = (_mc.get("default") or _mc.get("model") or "") if isinstance(_mc, dict) else ""
+            if _cfg_model and _cfg_model != self.model:
+                self.model = _cfg_model
+
         if self.agent:
             self.agent.session_id = self.session_id
             self.agent.session_start = self.session_start

--- a/tests/cli/test_cli_new_session.py
+++ b/tests/cli/test_cli_new_session.py
@@ -280,3 +280,65 @@ def test_new_session_with_duplicate_title_surfaces_error(capsys):
     captured = capsys.readouterr()
     assert "New session started: Dup" not in captured.out
     assert "New session started!" in captured.out
+
+
+def test_reset_reloads_default_model_from_config(tmp_path):
+    """Regression test for #23131: /reset must reload the default model
+    from config.yaml when the user didn't explicitly choose a model."""
+    # Empty model config → _model_is_default=True
+    cli = _make_cli(config_overrides={
+        "model": {
+            "default": "",
+            "base_url": "https://openrouter.ai/api/v1",
+            "provider": "auto",
+        },
+    })
+    cli._session_db = SessionDB(db_path=tmp_path / "state.db")
+    cli._session_db.create_session(session_id=cli.session_id, source="cli", model=cli.model)
+    cli.agent = _FakeAgent(cli.session_id, cli.session_start)
+    cli.conversation_history = [{"role": "user", "content": "hello"}]
+    cli._confirm_destructive_slash = lambda *_a, **_kw: "once"
+
+    assert cli._model_is_default is True  # no -m flag, no config model
+
+    # Simulate: model was changed mid-session (e.g. auto-detected or /model)
+    cli.model = "openai/gpt-5"
+
+    # Simulate config.yaml updated with a new default
+    _updated_config = {
+        "model": {
+            "default": "anthropic/claude-sonnet-4-6",
+            "base_url": "https://openrouter.ai/api/v1",
+            "provider": "auto",
+        },
+        "display": {"compact": False, "tool_progress": "all"},
+        "agent": {},
+        "terminal": {"env_type": "local"},
+    }
+    method_globals = cli.new_session.__globals__
+    original_load = method_globals["load_cli_config"]
+    method_globals["load_cli_config"] = lambda: _updated_config
+    try:
+        cli.process_command("/reset")
+    finally:
+        method_globals["load_cli_config"] = original_load
+
+    assert cli.model == "anthropic/claude-sonnet-4-6"
+
+
+def test_reset_preserves_explicit_model(tmp_path):
+    """/reset must NOT change the model when the user explicitly chose one
+    via -m flag (_model_is_default=False)."""
+    cli = _make_cli(model="anthropic/claude-haiku-4-5-20251001")
+    cli._session_db = SessionDB(db_path=tmp_path / "state.db")
+    cli._session_db.create_session(session_id=cli.session_id, source="cli", model=cli.model)
+    cli.agent = _FakeAgent(cli.session_id, cli.session_start)
+    cli.conversation_history = [{"role": "user", "content": "hello"}]
+    cli._confirm_destructive_slash = lambda *_a, **_kw: "once"
+
+    assert cli._model_is_default is False  # explicit -m
+    explicit_model = cli.model
+
+    cli.process_command("/reset")
+
+    assert cli.model == explicit_model


### PR DESCRIPTION
## Summary

Fixes #23131

- `new_session()` in `cli.py` now re-reads the default model from `config.yaml` when `_model_is_default` is True
- Explicit model choices via `-m` flag are preserved (won't be overridden)
- Picks up mid-session config.yaml changes on `/reset` and `/new`

## Root Cause

The model was loaded once in `__init__` and never re-read on session reset. Users who changed models mid-session (e.g. `/model gpt-5`) or updated `config.yaml` between sessions would not see their config default restored.

## Changes

- **`cli.py`**: Added model reload from fresh `load_cli_config()` in `new_session()` when `_model_is_default` is True
- **`tests/cli/test_cli_new_session.py`**: Added 2 regression tests:
  - `test_reset_reloads_default_model_from_config` — verifies config default is restored
  - `test_reset_preserves_explicit_model` — verifies explicit `-m` choices are kept

## Test plan

- [x] All 8 tests in `test_cli_new_session.py` pass
- [ ] Manual: set `model.default: openrouter/auto` in config.yaml, run `hermes`, change model with `/model`, run `/reset` → should revert to `openrouter/auto`
- [ ] Manual: run `hermes -m anthropic/claude-haiku-4-5-20251001`, run `/reset` → model should stay `claude-haiku-4-5-20251001`

🤖 Generated with [Claude Code](https://claude.com/claude-code)