### PR TITLE
fix(discord): honor thread_require_mention config

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -758,6 +758,8 @@ def load_gateway_config() -> GatewayConfig:
                     bridged["reply_in_thread"] = platform_cfg["reply_in_thread"]
                 if "require_mention" in platform_cfg:
                     bridged["require_mention"] = platform_cfg["require_mention"]
+                if "thread_require_mention" in platform_cfg:
+                    bridged["thread_require_mention"] = platform_cfg["thread_require_mention"]
                 if "free_response_channels" in platform_cfg:
                     bridged["free_response_channels"] = platform_cfg["free_response_channels"]
                 if "mention_patterns" in platform_cfg:
@@ -823,6 +825,8 @@ def load_gateway_config() -> GatewayConfig:
             if isinstance(discord_cfg, dict):
                 if "require_mention" in discord_cfg and not os.getenv("DISCORD_REQUIRE_MENTION"):
                     os.environ["DISCORD_REQUIRE_MENTION"] = str(discord_cfg["require_mention"]).lower()
+                if "thread_require_mention" in discord_cfg and not os.getenv("DISCORD_THREAD_REQUIRE_MENTION"):
+                    os.environ["DISCORD_THREAD_REQUIRE_MENTION"] = str(discord_cfg["thread_require_mention"]).lower()
                 frc = discord_cfg.get("free_response_channels")
                 if frc is not None and not os.getenv("DISCORD_FREE_RESPONSE_CHANNELS"):
                     if isinstance(frc, list):

--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3528,6 +3528,15 @@ class DiscordAdapter(BasePlatformAdapter):
             return bool(configured)
         return os.getenv("DISCORD_REQUIRE_MENTION", "true").lower() not in ("false", "0", "no", "off")
 
+    def _discord_thread_require_mention(self) -> bool:
+        """Return whether Discord threads should still require a bot mention."""
+        configured = self.config.extra.get("thread_require_mention")
+        if configured is not None:
+            if isinstance(configured, str):
+                return configured.lower() not in ("false", "0", "no", "off")
+            return bool(configured)
+        return os.getenv("DISCORD_THREAD_REQUIRE_MENTION", "false").lower() not in ("false", "0", "no", "off")
+
     def _discord_free_response_channels(self) -> set:
         """Return Discord channel IDs where no bot mention is required.
 
@@ -4107,8 +4116,9 @@ class DiscordAdapter(BasePlatformAdapter):
             # Skip the mention check if the message is in a thread where
             # the bot has previously participated (auto-created or replied in).
             in_bot_thread = is_thread and thread_id in self._threads
+            thread_require_mention = self._discord_thread_require_mention()
 
-            if require_mention and not is_free_channel and not in_bot_thread:
+            if require_mention and not is_free_channel and not (in_bot_thread and not thread_require_mention):
                 if self._client.user not in message.mentions and not mention_prefix:
                     return
         # Auto-thread: when enabled, automatically create a thread for every

--- a/tests/gateway/test_discord_free_response.py
+++ b/tests/gateway/test_discord_free_response.py
@@ -359,6 +359,7 @@ async def test_discord_auto_thread_can_be_disabled(adapter, monkeypatch):
 async def test_discord_bot_thread_skips_mention_requirement(adapter, monkeypatch):
     """Messages in a thread the bot has participated in should not require @mention."""
     monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_THREAD_REQUIRE_MENTION", raising=False)
     monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
     monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
 
@@ -374,6 +375,41 @@ async def test_discord_bot_thread_skips_mention_requirement(adapter, monkeypatch
     event = adapter.handle_message.await_args.args[0]
     assert event.text == "follow-up without mention"
     assert event.source.chat_type == "thread"
+
+
+@pytest.mark.asyncio
+async def test_discord_bot_thread_can_require_mentions_when_thread_gate_enabled_via_env(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.setenv("DISCORD_THREAD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+
+    adapter._threads.mark("456")
+
+    thread = FakeThread(channel_id=456, name="existing thread")
+    message = make_message(channel=thread, content="follow-up without mention")
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_discord_bot_thread_can_require_mentions_when_thread_gate_enabled_in_config(adapter, monkeypatch):
+    monkeypatch.setenv("DISCORD_REQUIRE_MENTION", "true")
+    monkeypatch.delenv("DISCORD_THREAD_REQUIRE_MENTION", raising=False)
+    monkeypatch.delenv("DISCORD_FREE_RESPONSE_CHANNELS", raising=False)
+    monkeypatch.setenv("DISCORD_AUTO_THREAD", "false")
+
+    adapter.config.extra["thread_require_mention"] = True
+    adapter._threads.mark("456")
+
+    thread = FakeThread(channel_id=456, name="existing thread")
+    message = make_message(channel=thread, content="follow-up without mention")
+
+    await adapter._handle_message(message)
+
+    adapter.handle_message.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/gateway/test_discord_thread_require_mention_config.py
+++ b/tests/gateway/test_discord_thread_require_mention_config.py
@@ -1,0 +1,28 @@
+"""Tests for the config.yaml bridge of discord.thread_require_mention."""
+
+import os
+
+from gateway.config import Platform, load_gateway_config
+
+
+def test_discord_thread_require_mention_yaml_bridges_to_platform_extra_and_env(tmp_path, monkeypatch):
+    hermes_home = tmp_path / ".hermes"
+    hermes_home.mkdir()
+    (hermes_home / "config.yaml").write_text(
+        "discord:\n"
+        "  require_mention: true\n"
+        "  thread_require_mention: true\n",
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr("gateway.config.get_hermes_home", lambda: hermes_home)
+    monkeypatch.delenv("DISCORD_REQUIRE_MENTION", raising=False)
+    monkeypatch.delenv("DISCORD_THREAD_REQUIRE_MENTION", raising=False)
+
+    config = load_gateway_config()
+
+    discord_cfg = config.platforms[Platform.DISCORD]
+    assert discord_cfg.extra["require_mention"] is True
+    assert discord_cfg.extra["thread_require_mention"] is True
+    assert os.getenv("DISCORD_REQUIRE_MENTION") == "true"
+    assert os.getenv("DISCORD_THREAD_REQUIRE_MENTION") == "true"


### PR DESCRIPTION
## What does this PR do?

Restores the missing `discord.thread_require_mention` config path so Discord thread replies can require an explicit mention again when operators opt into that behavior.

## Related Issue

Fixes #23084

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- bridge `discord.thread_require_mention` from gateway config into the Discord platform extra/env layer in `gateway/config.py`
- add a dedicated thread mention gate in `gateway/platforms/discord.py` so prior bot participation only bypasses mentions when thread gating is disabled
- extend `tests/gateway/test_discord_free_response.py`
- add `tests/gateway/test_discord_thread_require_mention_config.py` to cover YAML/config bridging

## How to Test

1. Run `UV_PYTHON=3.11 /Library/Frameworks/Python.framework/Versions/3.10/bin/uv run --frozen pytest -q -o addopts='' tests/gateway/test_discord_free_response.py tests/gateway/test_discord_thread_require_mention_config.py`
2. Run `UV_PYTHON=3.11 /Library/Frameworks/Python.framework/Versions/3.10/bin/uv run --frozen ruff check gateway/config.py gateway/platforms/discord.py tests/gateway/test_discord_free_response.py tests/gateway/test_discord_thread_require_mention_config.py`
3. Confirm threads with prior bot participation still require a mention when `thread_require_mention` is enabled by env or config

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `24 passed in 0.56s`
- `ruff check` passed for the touched gateway files and tests
