### PR TITLE
fix(langfuse): reject placeholder credentials

### DIFF
--- a/plugins/observability/langfuse/__init__.py
+++ b/plugins/observability/langfuse/__init__.py
@@ -63,6 +63,29 @@ def _env(name: str, default: str = "") -> str:
     return os.environ.get(name, default).strip()
 
 
+_PLACEHOLDER_CREDENTIAL_VALUES = {
+    "*",
+    "**",
+    "***",
+    "changeme",
+    "your_api_key",
+    "your-api-key",
+    "placeholder",
+    "example",
+    "dummy",
+    "null",
+    "none",
+    "test-key",
+}
+
+
+def _looks_placeholder_credential(value: str) -> bool:
+    cleaned = value.strip()
+    if not cleaned:
+        return True
+    return cleaned.lower() in _PLACEHOLDER_CREDENTIAL_VALUES
+
+
 def _env_bool(*names: str) -> bool:
     for name in names:
         value = _env(name).lower()
@@ -108,6 +131,13 @@ def _get_langfuse() -> Optional[Langfuse]:
     public_key = _env("HERMES_LANGFUSE_PUBLIC_KEY") or _env("LANGFUSE_PUBLIC_KEY")
     secret_key = _env("HERMES_LANGFUSE_SECRET_KEY") or _env("LANGFUSE_SECRET_KEY")
     if not (public_key and secret_key):
+        _LANGFUSE_CLIENT = _INIT_FAILED
+        return None
+    if _looks_placeholder_credential(public_key) or _looks_placeholder_credential(secret_key):
+        logger.warning(
+            "Langfuse tracing disabled: placeholder credentials detected. "
+            "Set real HERMES_LANGFUSE_PUBLIC_KEY / HERMES_LANGFUSE_SECRET_KEY values."
+        )
         _LANGFUSE_CLIENT = _INIT_FAILED
         return None
 

--- a/tests/plugins/test_langfuse_plugin.py
+++ b/tests/plugins/test_langfuse_plugin.py
@@ -90,6 +90,17 @@ class TestRuntimeGate:
         langfuse_plugin = self._fresh_plugin()
         assert langfuse_plugin._get_langfuse() is None
 
+    def test_get_langfuse_rejects_placeholder_credentials(self, monkeypatch, caplog):
+        monkeypatch.setenv("HERMES_LANGFUSE_PUBLIC_KEY", "placeholder")
+        monkeypatch.setenv("HERMES_LANGFUSE_SECRET_KEY", "test-key")
+
+        langfuse_plugin = self._fresh_plugin()
+        monkeypatch.setattr(langfuse_plugin, "Langfuse", lambda **kwargs: object())
+        caplog.set_level("WARNING")
+
+        assert langfuse_plugin._get_langfuse() is None
+        assert "placeholder credentials detected" in caplog.text.lower()
+
     def test_get_langfuse_caches_failure_no_config_load(self, monkeypatch):
         """A miss must be cached — no per-hook config.yaml reads, no env re-reads."""
         for k in (


### PR DESCRIPTION
## What does this PR do?

Detects obvious placeholder Langfuse credentials and fails loudly instead of silently treating the plugin as configured.

## Related Issue

Fixes #22763

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- add placeholder-value detection helpers in `plugins/observability/langfuse/__init__.py`
- warn and short-circuit initialization when public/secret keys are obvious placeholders
- extend `tests/plugins/test_langfuse_plugin.py` with a regression test for placeholder credentials

## How to Test

1. Run `UV_PYTHON=3.11 /Library/Frameworks/Python.framework/Versions/3.10/bin/uv run --frozen pytest -q -o addopts='' tests/plugins/test_langfuse_plugin.py`
2. Run `UV_PYTHON=3.11 /Library/Frameworks/Python.framework/Versions/3.10/bin/uv run --frozen ruff check plugins/observability/langfuse/__init__.py tests/plugins/test_langfuse_plugin.py`
3. Verify `_get_langfuse()` returns `None` and logs a warning when `LANGFUSE_PUBLIC_KEY` / `LANGFUSE_SECRET_KEY` are placeholder values

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `8 passed in 0.59s`
- `ruff check` passed for the touched Langfuse files
