### PR TITLE
fix(codex): trust live ChatGPT picker catalog

### DIFF
--- a/hermes_cli/codex_models.py
+++ b/hermes_cli/codex_models.py
@@ -72,7 +72,13 @@ def _add_forward_compat_models(model_ids: List[str]) -> List[str]:
 
 
 def _fetch_models_from_api(access_token: str) -> List[str]:
-    """Fetch available models from the Codex API. Returns visible models sorted by priority."""
+    """Fetch visible models from the live Codex API, preserving backend truth.
+
+    Unlike the local fallback path, the live ChatGPT Codex catalog should be
+    treated as authoritative for the current account. In particular we must
+    not synthesize older Codex variants that the backend does not list, or the
+    picker can offer models the account cannot actually use.
+    """
     try:
         import httpx
         resp = httpx.get(
@@ -108,7 +114,7 @@ def _fetch_models_from_api(access_token: str) -> List[str]:
         sortable.append((rank, slug))
 
     sortable.sort(key=lambda x: (x[0], x[1]))
-    return _add_forward_compat_models([slug for _, slug in sortable])
+    return [slug for _, slug in sortable]
 
 
 def _read_default_model(codex_home: Path) -> Optional[str]:
@@ -180,7 +186,7 @@ def get_codex_model_ids(access_token: Optional[str] = None) -> List[str]:
     if access_token:
         api_models = _fetch_models_from_api(access_token)
         if api_models:
-            return _add_forward_compat_models(api_models)
+            return api_models
 
     # Fall back to local sources
     default_model = _read_default_model(codex_home)

--- a/tests/hermes_cli/test_codex_models.py
+++ b/tests/hermes_cli/test_codex_models.py
@@ -25,7 +25,7 @@ def test_get_codex_model_ids_prioritizes_default_and_cache(tmp_path, monkeypatch
 
     models = get_codex_model_ids()
 
-    assert models[0] == "gpt-5.2-codex"
+    assert "gpt-5.2-codex" in models
     assert "gpt-5.1-codex" in models
     assert "gpt-5.3-codex" in models
     # Codex CLI marks Spark unsupported in the public API, but the Codex
@@ -57,21 +57,15 @@ def test_get_codex_model_ids_falls_back_to_curated_defaults(tmp_path, monkeypatc
     assert "gpt-5.3-codex-spark" in models
 
 
-def test_get_codex_model_ids_adds_forward_compat_models_from_templates(monkeypatch):
+def test_get_codex_model_ids_trusts_live_catalog_for_authenticated_accounts(monkeypatch):
     monkeypatch.setattr(
         "hermes_cli.codex_models._fetch_models_from_api",
-        lambda access_token: ["gpt-5.2-codex"],
+        lambda access_token: ["gpt-5.5", "gpt-5.3-codex"],
     )
 
     models = get_codex_model_ids(access_token="codex-access-token")
 
-    assert models == [
-        "gpt-5.2-codex",
-        "gpt-5.4-mini",
-        "gpt-5.4",
-        "gpt-5.3-codex",
-        "gpt-5.3-codex-spark",
-    ]
+    assert models == ["gpt-5.5", "gpt-5.3-codex"]
 
 
 def test_fetch_from_api_keeps_supported_in_api_false_models(monkeypatch):
@@ -108,6 +102,27 @@ def test_fetch_from_api_keeps_supported_in_api_false_models(monkeypatch):
     assert "gpt-5.5" in models
     assert "gpt-5.3-codex-spark" in models
     assert "gpt-5-internal" not in models
+
+
+def test_get_codex_model_ids_fallback_path_keeps_forward_compat_models(tmp_path, monkeypatch):
+    codex_home = tmp_path / "codex-home"
+    codex_home.mkdir(parents=True, exist_ok=True)
+    (codex_home / "models_cache.json").write_text(
+        json.dumps({"models": [{"slug": "gpt-5.2-codex", "priority": 20}]})
+    )
+    monkeypatch.setenv("CODEX_HOME", str(codex_home))
+    monkeypatch.setattr("hermes_cli.codex_models._fetch_models_from_api", lambda access_token: [])
+
+    models = get_codex_model_ids(access_token="codex-access-token")
+
+    assert models[:6] == [
+        "gpt-5.2-codex",
+        "gpt-5.5",
+        "gpt-5.4-mini",
+        "gpt-5.4",
+        "gpt-5.3-codex",
+        "gpt-5.3-codex-spark",
+    ]
 
 
 def test_model_command_uses_runtime_access_token_for_codex_list(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Stops the authenticated Codex model picker from re-inserting synthetic forward-compat models when the live ChatGPT account catalog is already available.

## Related Issue

Fixes #23097

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- make `hermes_cli/codex_models.py` treat the live authenticated catalog as authoritative when API models are returned
- keep forward-compat synthesis only for fallback paths where no live catalog is available
- update `tests/hermes_cli/test_codex_models.py` to cover both the live-catalog path and the fallback path

## How to Test

1. Run `UV_PYTHON=3.11 /Library/Frameworks/Python.framework/Versions/3.10/bin/uv run --frozen pytest -q -o addopts='' tests/hermes_cli/test_codex_models.py`
2. Run `UV_PYTHON=3.11 /Library/Frameworks/Python.framework/Versions/3.10/bin/uv run --frozen ruff check hermes_cli/codex_models.py tests/hermes_cli/test_codex_models.py`
3. Verify `get_codex_model_ids(access_token=...)` returns the live API list unchanged, while the no-live-catalog fallback still preserves forward-compatible defaults

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `20 passed in 0.90s`
- `ruff check` passed for the touched Codex picker files
