### PR TITLE
feat(gateway): add discord_slash flag to manage 100-command limit

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -3071,6 +3071,8 @@ class DiscordAdapter(BasePlatformAdapter):
             for cmd_def in COMMAND_REGISTRY:
                 if not _is_gateway_available(cmd_def, config_overrides):
                     continue
+                if not getattr(cmd_def, 'discord_slash', True):
+                    continue
                 # Discord command names: lowercase, hyphens OK, max 32 chars.
                 discord_name = cmd_def.name.lower()[:32]
                 if discord_name in already_registered:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -55,6 +55,7 @@ class CommandDef:
     cli_only: bool = False             # only available in CLI
     gateway_only: bool = False         # only available in gateway/messaging
     gateway_config_gate: str | None = None  # config dotpath; when truthy, overrides cli_only for gateway
+    discord_slash: bool = True         # register as native Discord slash command
 
 
 # ---------------------------------------------------------------------------
@@ -66,7 +67,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("new", "Start a new session (fresh session ID + history)", "Session",
                aliases=("reset",), args_hint="[name]"),
     CommandDef("topic", "Enable or inspect Telegram DM topic sessions", "Session",
-               gateway_only=True, args_hint="[off|help|session-id]"),
+               gateway_only=True, args_hint="[off|help|session-id]",
+               discord_slash=False),
     CommandDef("clear", "Clear screen and start a new session", "Session",
                cli_only=True),
     CommandDef("redraw", "Force a full UI repaint (recovers from terminal drift)", "Session",
@@ -80,11 +82,11 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("title", "Set a title for the current session", "Session",
                args_hint="[name]"),
     CommandDef("branch", "Branch the current session (explore a different path)", "Session",
-               aliases=("fork",), args_hint="[name]"),
+               aliases=("fork",), args_hint="[name]", discord_slash=False),
     CommandDef("compress", "Manually compress conversation context", "Session",
                args_hint="[focus topic]"),
     CommandDef("rollback", "List or restore filesystem checkpoints", "Session",
-               args_hint="[number]"),
+               args_hint="[number]", discord_slash=False),
     CommandDef("snapshot", "Create or restore state snapshots of Hermes config/state", "Session",
                cli_only=True, aliases=("snap",), args_hint="[create|restore <id>|prune]"),
     CommandDef("stop", "Kill all running background processes", "Session"),
@@ -101,16 +103,18 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("steer", "Inject a message after the next tool call without interrupting", "Session",
                args_hint="<prompt>"),
     CommandDef("goal", "Set a standing goal Hermes works on across turns until achieved", "Session",
-               args_hint="[text | pause | resume | clear | status]"),
+               args_hint="[text | pause | resume | clear | status]", discord_slash=False),
     CommandDef("status", "Show session info", "Session"),
-    CommandDef("profile", "Show active profile name and home directory", "Info"),
+    CommandDef("profile", "Show active profile name and home directory", "Info",
+               discord_slash=False),
     CommandDef("sethome", "Set this chat as the home channel", "Session",
                gateway_only=True, aliases=("set-home",)),
     CommandDef("resume", "Resume a previously-named session", "Session",
                args_hint="[name]"),
 
     # Configuration
-    CommandDef("sessions", "Browse and resume previous sessions", "Session"),
+    CommandDef("sessions", "Browse and resume previous sessions", "Session",
+               discord_slash=False),
 
     # Configuration
     CommandDef("config", "Show current configuration", "Configuration",
@@ -137,7 +141,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                subcommands=("none", "minimal", "low", "medium", "high", "xhigh", "show", "hide", "on", "off")),
     CommandDef("fast", "Toggle fast mode — OpenAI Priority Processing / Anthropic Fast Mode (Normal/Fast)", "Configuration",
                args_hint="[normal|fast|status]",
-               subcommands=("normal", "fast", "status", "on", "off")),
+               subcommands=("normal", "fast", "status", "on", "off"),
+               discord_slash=False),
     CommandDef("skin", "Show or change the display skin/theme", "Configuration",
                cli_only=True, args_hint="[name]"),
     CommandDef("indicator", "Pick the TUI busy-indicator style", "Configuration",
@@ -162,12 +167,14 @@ COMMAND_REGISTRY: list[CommandDef] = [
                subcommands=("list", "add", "create", "edit", "pause", "resume", "run", "remove")),
     CommandDef("curator", "Background skill maintenance (status, run, pin, archive, list-archived)",
                "Tools & Skills", args_hint="[subcommand]",
-               subcommands=("status", "run", "pause", "resume", "pin", "unpin", "restore", "list-archived")),
+               subcommands=("status", "run", "pause", "resume", "pin", "unpin", "restore", "list-archived"),
+               discord_slash=False),
     CommandDef("kanban", "Multi-profile collaboration board (tasks, links, comments)",
                "Tools & Skills", args_hint="[subcommand]",
                subcommands=("list", "ls", "show", "create", "assign", "link", "unlink",
                             "claim", "comment", "complete", "block", "unblock", "archive",
-                            "tail", "dispatch", "context", "init", "gc")),
+                            "tail", "dispatch", "context", "init", "gc"),
+               discord_slash=False),
     CommandDef("reload", "Reload .env variables into the running session", "Tools & Skills",
                cli_only=True),
     CommandDef("reload-mcp", "Reload MCP servers from config", "Tools & Skills",
@@ -182,7 +189,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
 
     # Info
     CommandDef("commands", "Browse all commands and skills (paginated)", "Info",
-               gateway_only=True, args_hint="[page]"),
+               gateway_only=True, args_hint="[page]",
+               discord_slash=False),
     CommandDef("help", "Show available commands", "Info"),
     CommandDef("restart", "Gracefully restart the gateway after draining active runs", "Session",
                gateway_only=True),
@@ -199,7 +207,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                cli_only=True, args_hint="<path>"),
     CommandDef("update", "Update Hermes Agent to the latest version", "Info",
                gateway_only=True),
-    CommandDef("debug", "Upload debug report (system info + logs) and get shareable links", "Info"),
+    CommandDef("debug", "Upload debug report (system info + logs) and get shareable links", "Info",
+               discord_slash=False),
 
     # Exit
     CommandDef("quit", "Exit the CLI", "Exit",

--- a/tests/gateway/test_discord_slash_commands.py
+++ b/tests/gateway/test_discord_slash_commands.py
@@ -174,7 +174,7 @@ async def test_auto_registers_missing_gateway_commands(adapter):
 
     # These commands are gateway-available but were not in the original
     # hardcoded registration list — they should be auto-registered.
-    expected_auto = {"debug", "yolo", "profile"}
+    expected_auto = {"yolo", "agents", "footer"}
     for name in expected_auto:
         assert name in tree_names, f"/{name} should be auto-registered on Discord"
 
@@ -185,12 +185,12 @@ async def test_auto_registered_command_dispatches_correctly(adapter):
     adapter._run_simple_slash = AsyncMock()
     adapter._register_slash_commands()
 
-    # /debug has no args — test parameterless dispatch
-    debug_cmd = adapter._client.tree.commands["debug"]
+    # /yolo has no args — test parameterless dispatch
+    yolo_cmd = adapter._client.tree.commands["yolo"]
     interaction = SimpleNamespace()
     adapter._run_simple_slash.reset_mock()
-    await debug_cmd.callback(interaction)
-    adapter._run_simple_slash.assert_awaited_once_with(interaction, "/debug")
+    await yolo_cmd.callback(interaction)
+    adapter._run_simple_slash.assert_awaited_once_with(interaction, "/yolo")
 
 
 @pytest.mark.asyncio
@@ -199,13 +199,13 @@ async def test_auto_registered_command_with_args(adapter):
     adapter._run_simple_slash = AsyncMock()
     adapter._register_slash_commands()
 
-    # /branch has args_hint="[name]" — test dispatch with args
-    branch_cmd = adapter._client.tree.commands["branch"]
+    # /footer has args_hint="[on|off|status]" — test dispatch with args
+    footer_cmd = adapter._client.tree.commands["footer"]
     interaction = SimpleNamespace()
     adapter._run_simple_slash.reset_mock()
-    await branch_cmd.callback(interaction, args="my-branch")
+    await footer_cmd.callback(interaction, args="on")
     adapter._run_simple_slash.assert_awaited_once_with(
-        interaction, "/branch my-branch"
+        interaction, "/footer on"
     )
 
 


### PR DESCRIPTION
- Add discord_slash field to CommandDef in hermes_cli/commands.py
- Filter commands in discord.py auto-registration based on discord_slash flag
- Mark 11 CLI-focused commands as discord_slash=False to save API slots: branch, rollback, goal, profile, sessions, curator, kanban, fast, commands, debug, topic
- Commands remain fully functional via text input but are excluded from Discord's native picker

## What does this PR do?

This PR introduces a mechanism to selectively exclude commands from native Discord slash registration, solving the discord.errors.HTTPException: 400 Bad Request (error code: 30032): Maximum number of application commands reached (100) error. 

By adding a discord_slash flag to the CommandDef dataclass, we can reduce the number of commands registered with the Discord API while keeping all commands fully functional via text input (e.g., typing /branch in the chat still works). This approach preserves the CLI experience while adhering to Discord's hard limit.

## Type of Change

[x] ✨ New feature (non-breaking change that adds functionality)

## Changes Made

- hermes_cli/commands.py: Added discord_slash: bool = True field to the CommandDef dataclass. Marked 11 CLI-focused commands as discord_slash=False to save API slots: branch, rollback, goal, profile, sessions, curator, kanban, fast, commands, debug, topic.
- gateway/platforms/discord.py: Updated _register_slash_commands to check the discord_slash flag during auto-registration and skip commands where the flag is False.
- tests/gateway/test_discord_slash_commands.py: Updated tests to use currently registered commands (yolo, agents, footer) instead of excluded ones (debug, branch, profile) to ensure auto-registration logic is still verified.

## How to Test

1. Start the gateway with these changes.
2. Observe the logs: the 30032 error (if previously present) should be gone, and command sync should succeed.
3. In Discord, type / to open the command picker — confirm that commands like branch, rollback, and debug do NOT appear in the list.
4. Manually type /branch (or any excluded command) in the chat — confirm it executes correctly as a text-based slash command.

## Checklist

### Code

[x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
[x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (fix(scope):, feat(scope):, etc.)
[x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
[x] My PR contains only changes related to this fix/feature (no unrelated commits)
[x] I've run 'scripts/run_tests.sh tests/gateway/test_discord_slash_commands.py' and all tests pass
[X] I've added tests for my changes (updated tests/gateway/test_discord_slash_commands.py to use registered commands)
[x] I've tested on my platform: Linux (Docker)

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

[N/A] I've updated relevant documentation (README, docs/, docstrings)
[N/A] I've updated cli-config.yaml.example if I added/changed config keys
[N/A] I've updated CONTRIBUTING.md or AGENTS.md if I changed architecture or workflows
[x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility)
[N/A] I've updated tool descriptions/schemas if I changed tool behavior
