### PR TITLE
feat(gateway): add Sentry alert PR action cards

### DIFF
--- a/docs/sentry-alert-action-cards.md
+++ b/docs/sentry-alert-action-cards.md
@@ -1,0 +1,56 @@
+# Sentry alert triage action cards
+
+Hermes webhook routes can attach action buttons to cross-platform deliveries by
+adding an `actions` list under `deliver_extra`. Telegram renders these as inline
+buttons. The first supported action is a Sentry `Create PR` button that stores
+the webhook payload locally and starts a detached Codex task when an authorised
+user taps it.
+
+Example route:
+
+```yaml
+platforms:
+  webhook:
+    enabled: true
+    extra:
+      routes:
+        sentry-alerts:
+          secret: "${SENTRY_WEBHOOK_SECRET}"
+          prompt: |
+            🚨 Sentry · {project}
+
+            **Signal:** {title}
+            **Issue:** {url}
+            **Environment:** {environment}
+
+            Suggested next step: review the issue and create a PR if this is a code-shaped production regression.
+          deliver: telegram
+          deliver_extra:
+            chat_id: "8046206740"
+            actions:
+              - label: "Create PR"
+                kind: sentry
+                action: create_pr
+```
+
+Repo mapping lives at `~/.hermes/sentry_repo_map.json`:
+
+```json
+{
+  "incremnt": "/home/colm/onemore",
+  "scenr": "/home/colm/scenr"
+}
+```
+
+When tapped, Hermes launches `scripts/sentry_create_pr_from_packet.py`, which
+writes logs under `~/.hermes/sentry-actions/<id>/` and starts a fresh detached
+tmux/Codex task. The generated prompt explicitly says to commit, push, AND create
+PR, and to not merge.
+
+Limitations:
+
+- Telegram action buttons are implemented first.
+- Discord delivery currently receives the text but not arbitrary action-card
+  components; add Discord component rendering before relying on this in Discord.
+- Sentry payload shape varies by integration, so route prompts should include the
+  fields your alert actually sends.

--- a/gateway/action_requests.py
+++ b/gateway/action_requests.py
@@ -1,0 +1,110 @@
+"""Persistent gateway action requests for chat buttons.
+
+Action requests let a delivered message include compact callback-data buttons
+without stuffing the whole task payload into Telegram/Discord component IDs.
+The stored JSON is intentionally boring and local: no secrets, no execution on
+read, and filenames are opaque random IDs.
+"""
+
+from __future__ import annotations
+
+import json
+import secrets
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+_ACTIONS_DIR = "action_requests"
+
+
+@dataclass(frozen=True)
+class ActionRequest:
+    id: str
+    kind: str
+    action: str
+    payload: dict[str, Any]
+
+
+def _safe_part(value: str) -> str:
+    return "".join(ch for ch in value if ch.isalnum() or ch in {"-", "_"})[:80]
+
+
+def actions_root() -> Path:
+    root = get_hermes_home() / _ACTIONS_DIR
+    root.mkdir(parents=True, exist_ok=True)
+    return root
+
+
+def store_action_request(kind: str, action: str, payload: dict[str, Any]) -> ActionRequest:
+    """Store an action request and return its opaque ID."""
+    kind_safe = _safe_part(kind or "generic") or "generic"
+    action_safe = _safe_part(action or "run") or "run"
+    request_id = f"{kind_safe}-{secrets.token_urlsafe(12)}"
+    path = actions_root() / f"{request_id}.json"
+    body = {
+        "id": request_id,
+        "kind": kind_safe,
+        "action": action_safe,
+        "payload": payload or {},
+    }
+    path.write_text(json.dumps(body, indent=2, sort_keys=True), encoding="utf-8")
+    path.chmod(0o600)
+    return ActionRequest(id=request_id, kind=kind_safe, action=action_safe, payload=payload or {})
+
+
+def load_action_request(request_id: str) -> ActionRequest:
+    request_id = _safe_part(request_id)
+    if not request_id:
+        raise ValueError("Invalid action request ID")
+    path = actions_root() / f"{request_id}.json"
+    data = json.loads(path.read_text(encoding="utf-8"))
+    return ActionRequest(
+        id=str(data.get("id") or request_id),
+        kind=str(data.get("kind") or "generic"),
+        action=str(data.get("action") or "run"),
+        payload=data.get("payload") if isinstance(data.get("payload"), dict) else {},
+    )
+
+
+def dispatch_action_request(request_id: str) -> subprocess.Popen:
+    """Dispatch an action request in the background.
+
+    Currently supported:
+      - kind=sentry, action=create_pr: launch the Sentry create-PR helper.
+    """
+    req = load_action_request(request_id)
+    if req.kind == "sentry" and req.action == "create_pr":
+        helper = Path(__file__).resolve().parents[1] / "scripts" / "sentry_create_pr_from_packet.py"
+        return subprocess.Popen(
+            [sys.executable, str(helper), str(actions_root() / f"{req.id}.json")],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+            start_new_session=True,
+        )
+    raise ValueError(f"Unsupported action request: {req.kind}/{req.action}")
+
+
+def build_action_buttons(actions: list[dict[str, Any]], payload: dict[str, Any] | None = None) -> list[dict[str, str]]:
+    """Convert route metadata actions into compact button descriptors.
+
+    Each input action supports:
+      - label: button text
+      - kind: e.g. "sentry"
+      - action: e.g. "create_pr"
+      - payload: optional payload override; defaults to the webhook payload
+    """
+    buttons: list[dict[str, str]] = []
+    for item in actions or []:
+        if not isinstance(item, dict):
+            continue
+        label = str(item.get("label") or item.get("action") or "Run").strip()[:64]
+        kind = str(item.get("kind") or "generic")
+        action = str(item.get("action") or "run")
+        action_payload = item.get("payload") if isinstance(item.get("payload"), dict) else payload or {}
+        req = store_action_request(kind, action, action_payload)
+        buttons.append({"label": label, "callback_data": f"ar:{req.id}"})
+    return buttons

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1426,6 +1426,19 @@ class TelegramAdapter(BasePlatformAdapter):
                 )
                 effective_thread_id = thread_kwargs.get("message_thread_id")
 
+                action_buttons = None
+                if i == 0 and metadata and isinstance(metadata.get("action_buttons"), list):
+                    rows = []
+                    for button in metadata.get("action_buttons") or []:
+                        if not isinstance(button, dict):
+                            continue
+                        label = str(button.get("label") or "Run")[:64]
+                        callback_data = str(button.get("callback_data") or "")[:64]
+                        if callback_data:
+                            rows.append([InlineKeyboardButton(label, callback_data=callback_data)])
+                    if rows:
+                        action_buttons = InlineKeyboardMarkup(rows)
+
                 msg = None
                 for _send_attempt in range(3):
                     try:
@@ -1436,6 +1449,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                 text=chunk,
                                 parse_mode=ParseMode.MARKDOWN_V2,
                                 reply_to_message_id=reply_to_id,
+                                reply_markup=action_buttons,
                                 **thread_kwargs,
                                 **self._link_preview_kwargs(),
                                 **self._notification_kwargs(metadata),
@@ -1450,6 +1464,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                     text=plain_chunk,
                                     parse_mode=None,
                                     reply_to_message_id=reply_to_id,
+                                    reply_markup=action_buttons,
                                     **thread_kwargs,
                                     **self._link_preview_kwargs(),
                                     **self._notification_kwargs(metadata),
@@ -2308,6 +2323,39 @@ class TelegramAdapter(BasePlatformAdapter):
                         await self._bot.send_message(**send_kwargs)
                 except Exception as exc:
                     logger.error("[%s] slash-confirm callback failed: %s", self.name, exc, exc_info=True)
+            return
+
+        # --- Gateway action-card callbacks (ar:<request_id>) ---
+        if data.startswith("ar:"):
+            request_id = data.split(":", 1)[1]
+            caller_id = str(getattr(query.from_user, "id", ""))
+            if not self._is_callback_user_authorized(
+                caller_id,
+                chat_id=query_chat_id,
+                chat_type=str(query_chat_type) if query_chat_type is not None else None,
+                thread_id=str(query_thread_id) if query_thread_id is not None else None,
+                user_name=query_user_name,
+            ):
+                await query.answer(text="⛔ You are not authorized to run this action.")
+                return
+            try:
+                from gateway.action_requests import dispatch_action_request
+                dispatch_action_request(request_id)
+                await query.answer(text="Starting PR task…")
+                try:
+                    await query.edit_message_reply_markup(reply_markup=None)
+                except Exception:
+                    pass
+                if query.message:
+                    await self._bot.send_message(
+                        chat_id=int(query.message.chat_id),
+                        text="I’m starting a fresh Codex PR task for that Sentry issue. I’ll report back with the PR link.",
+                        parse_mode=ParseMode.MARKDOWN,
+                        **self._link_preview_kwargs(),
+                    )
+            except Exception as exc:
+                logger.error("[%s] action callback failed: %s", self.name, exc, exc_info=True)
+                await query.answer(text="Could not start action. Check Hermes logs.")
             return
 
         # --- Update prompt callbacks ---

--- a/gateway/platforms/webhook.py
+++ b/gateway/platforms/webhook.py
@@ -51,6 +51,7 @@ from gateway.platforms.base import (
     MessageType,
     SendResult,
 )
+from gateway.action_requests import build_action_buttons
 
 logger = logging.getLogger(__name__)
 
@@ -664,14 +665,21 @@ class WebhookAdapter(BasePlatformAdapter):
     def _render_delivery_extra(
         self, extra: dict, payload: dict
     ) -> dict:
-        """Render delivery_extra template values with payload data."""
-        rendered: Dict[str, Any] = {}
-        for key, value in extra.items():
+        """Render delivery_extra template values with payload data.
+
+        Values may be nested dicts/lists so routes can define action button
+        metadata without writing a custom webhook adapter.
+        """
+        def _render(value: Any) -> Any:
             if isinstance(value, str):
-                rendered[key] = self._render_prompt(value, payload, "", "")
-            else:
-                rendered[key] = value
-        return rendered
+                return self._render_prompt(value, payload, "", "")
+            if isinstance(value, list):
+                return [_render(item) for item in value]
+            if isinstance(value, dict):
+                return {str(k): _render(v) for k, v in value.items()}
+            return value
+
+        return {str(key): _render(value) for key, value in extra.items()}
 
     # ------------------------------------------------------------------
     # Response delivery
@@ -796,10 +804,17 @@ class WebhookAdapter(BasePlatformAdapter):
                     error=f"No chat_id or home channel for {platform_name}",
                 )
 
-        # Pass thread_id from deliver_extra so Telegram forum topics work
-        metadata = None
+        # Pass thread_id/action metadata from deliver_extra so Telegram forum
+        # topics and action-card buttons work on cross-platform deliveries.
+        metadata: Dict[str, Any] = {}
         thread_id = extra.get("message_thread_id") or extra.get("thread_id")
         if thread_id:
-            metadata = {"thread_id": thread_id}
+            metadata["thread_id"] = thread_id
+        actions = extra.get("actions")
+        if isinstance(actions, list):
+            metadata["action_buttons"] = build_action_buttons(
+                actions,
+                delivery.get("payload") if isinstance(delivery.get("payload"), dict) else {},
+            )
 
-        return await adapter.send(chat_id, content, metadata=metadata)
+        return await adapter.send(chat_id, content, metadata=metadata or None)

--- a/scripts/sentry_create_pr_from_packet.py
+++ b/scripts/sentry_create_pr_from_packet.py
@@ -1,0 +1,160 @@
+#!/usr/bin/env python3
+"""Launch a Codex create-PR task from a stored Sentry action packet.
+
+This helper is intentionally conservative: it validates the local repo mapping,
+writes a complete prompt/log bundle under ~/.hermes/sentry-actions/<id>/, and
+starts a detached tmux session. Codex is instructed to commit, push, AND create
+PR, and never merge.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from hermes_constants import get_hermes_home
+
+DEFAULT_REPO_MAP = {
+    "incremnt": "/home/colm/onemore",
+    "onemore": "/home/colm/onemore",
+    "scenr": "/home/colm/scenr",
+    "happenings": "/home/colm/scenr",
+}
+
+
+def _slug(value: str, fallback: str = "sentry") -> str:
+    value = re.sub(r"[^a-zA-Z0-9._-]+", "-", value.strip()).strip("-._").lower()
+    return value[:80] or fallback
+
+
+def _deep_get(data: dict[str, Any], *paths: str) -> Any:
+    for path in paths:
+        cur: Any = data
+        ok = True
+        for part in path.split("."):
+            if isinstance(cur, dict) and part in cur:
+                cur = cur[part]
+            else:
+                ok = False
+                break
+        if ok and cur not in (None, ""):
+            return cur
+    return None
+
+
+def _load_repo_map() -> dict[str, str]:
+    mapping = dict(DEFAULT_REPO_MAP)
+    cfg = get_hermes_home() / "sentry_repo_map.json"
+    if cfg.exists():
+        loaded = json.loads(cfg.read_text(encoding="utf-8"))
+        if isinstance(loaded, dict):
+            mapping.update({str(k).lower(): str(v) for k, v in loaded.items()})
+    return mapping
+
+
+def _resolve_repo(payload: dict[str, Any]) -> tuple[str, Path]:
+    project = str(
+        _deep_get(payload, "project", "data.project", "event.project", "issue.project.slug", "issue.project")
+        or ""
+    )
+    slug = _slug(project)
+    repo_map = _load_repo_map()
+    repo_path = repo_map.get(slug)
+    if not repo_path:
+        raise SystemExit(
+            f"No repo mapping for Sentry project '{project or slug}'. Add it to "
+            f"{get_hermes_home() / 'sentry_repo_map.json'}"
+        )
+    path = Path(repo_path).expanduser().resolve()
+    if not (path / ".git").exists():
+        raise SystemExit(f"Mapped repo path is not a git repo: {path}")
+    return slug, path
+
+
+def build_codex_prompt(action_packet: dict[str, Any]) -> str:
+    payload = action_packet.get("payload") if isinstance(action_packet.get("payload"), dict) else {}
+    project_slug, repo_path = _resolve_repo(payload)
+    issue_url = _deep_get(payload, "url", "issue.url", "web_url", "data.url") or ""
+    issue_id = _deep_get(payload, "id", "issue.id", "issue.shortId", "data.issue.id") or action_packet.get("id")
+    title = _deep_get(payload, "title", "issue.title", "message", "data.title") or "Sentry alert"
+    environment = _deep_get(payload, "environment", "event.environment", "data.environment") or "unknown"
+    release = _deep_get(payload, "release", "event.release", "data.release") or "unknown"
+
+    raw = json.dumps(payload, indent=2, sort_keys=True)[:12000]
+    return f"""Fix Sentry issue and create a PR.
+
+Sentry context:
+- Project: {project_slug}
+- Issue: {issue_id}
+- Title: {title}
+- Environment: {environment}
+- Release: {release}
+- URL: {issue_url}
+
+Repo:
+- Path: {repo_path}
+
+Raw Sentry webhook payload, possibly truncated:
+```json
+{raw}
+```
+
+Instructions:
+1. Investigate the root cause from the Sentry payload, stack trace, tags, release, and local code.
+2. Make the smallest safe code fix.
+3. Add or update a regression test where practical.
+4. Run the relevant tests.
+5. Commit, push, AND create PR.
+6. Do not merge the PR.
+7. Report the PR URL and a concise root-cause summary.
+"""
+
+
+def launch(action_path: Path) -> Path:
+    packet = json.loads(action_path.read_text(encoding="utf-8"))
+    payload = packet.get("payload") if isinstance(packet.get("payload"), dict) else {}
+    project_slug, repo_path = _resolve_repo(payload)
+    action_id = _slug(str(packet.get("id") or action_path.stem), "sentry-action")
+    run_dir = get_hermes_home() / "sentry-actions" / action_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    prompt = build_codex_prompt(packet)
+    prompt_path = run_dir / "prompt.md"
+    prompt_path.write_text(prompt, encoding="utf-8")
+    log_path = run_dir / "codex.log"
+
+    session = _slug(f"sentry-{project_slug}-{action_id}")[:80]
+    cmd = (
+        f"cd {shlex.quote(str(repo_path))} && "
+        f"codex exec --full-auto {shlex.quote(prompt)} "
+        f"> {shlex.quote(str(log_path))} 2>&1; "
+        f"printf '\\nDONE rc=%s at {datetime.now(timezone.utc).isoformat()}\\n' \"$?\" >> {shlex.quote(str(log_path))}"
+    )
+    subprocess.run(["tmux", "new-session", "-d", "-s", session, cmd], check=True)
+    (run_dir / "session.txt").write_text(session + "\n", encoding="utf-8")
+    return run_dir
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("action_packet", type=Path)
+    parser.add_argument("--print-prompt", action="store_true")
+    args = parser.parse_args()
+    packet = json.loads(args.action_packet.read_text(encoding="utf-8"))
+    if args.print_prompt:
+        print(build_codex_prompt(packet))
+        return 0
+    run_dir = launch(args.action_packet)
+    print(f"Launched Sentry Create PR action. Logs: {run_dir}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/gateway/test_action_requests.py
+++ b/tests/gateway/test_action_requests.py
@@ -1,0 +1,48 @@
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+from gateway.action_requests import build_action_buttons, store_action_request
+from scripts.sentry_create_pr_from_packet import build_codex_prompt
+
+
+def test_build_action_buttons_stores_payload(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    buttons = build_action_buttons(
+        [{"label": "Create PR", "kind": "sentry", "action": "create_pr"}],
+        {"project": "incremnt", "issue": {"id": "INCR-1"}},
+    )
+
+    assert buttons == [{"label": "Create PR", "callback_data": buttons[0]["callback_data"]}]
+    assert buttons[0]["callback_data"].startswith("ar:sentry-")
+    request_id = buttons[0]["callback_data"].split(":", 1)[1]
+    stored = json.loads((tmp_path / "action_requests" / f"{request_id}.json").read_text())
+    assert stored["kind"] == "sentry"
+    assert stored["action"] == "create_pr"
+    assert stored["payload"]["project"] == "incremnt"
+
+
+def test_sentry_create_pr_prompt_contains_required_guardrails(tmp_path, monkeypatch):
+    repo = tmp_path / "onemore"
+    (repo / ".git").mkdir(parents=True)
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    (tmp_path / "sentry_repo_map.json").write_text(json.dumps({"incremnt": str(repo)}))
+
+    prompt = build_codex_prompt(
+        {
+            "id": "sentry-test",
+            "payload": {
+                "project": "incremnt",
+                "issue": {"id": "INCR-1", "url": "https://sentry.example/issues/1"},
+                "title": "Crash in onboarding",
+                "environment": "production",
+            },
+        }
+    )
+
+    assert "Commit, push, AND create PR" in prompt
+    assert "Do not merge" in prompt
+    assert str(repo) in prompt
+    assert "Crash in onboarding" in prompt

--- a/tests/gateway/test_webhook_integration.py
+++ b/tests/gateway/test_webhook_integration.py
@@ -264,6 +264,59 @@ class TestCrossPlatformDelivery:
         assert chat_id in adapter._delivery_info
 
 
+    @pytest.mark.asyncio
+    async def test_cross_platform_delivery_includes_action_buttons(self):
+        routes = {
+            "sentry": {
+                "secret": _INSECURE_NO_AUTH,
+                "prompt": "🚨 Sentry: {title}",
+                "deliver": "telegram",
+                "deliver_extra": {
+                    "chat_id": "12345",
+                    "actions": [
+                        {"label": "Create PR", "kind": "sentry", "action": "create_pr"}
+                    ],
+                },
+            }
+        }
+        adapter = _make_adapter(routes)
+        adapter.handle_message = AsyncMock()
+
+        mock_tg_adapter = AsyncMock()
+        mock_tg_adapter.send = AsyncMock(return_value=SendResult(success=True))
+
+        mock_runner = MagicMock()
+        mock_runner.adapters = {Platform.TELEGRAM: mock_tg_adapter}
+        mock_runner.config = GatewayConfig(
+            platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")}
+        )
+        adapter.gateway_runner = mock_runner
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/webhooks/sentry",
+                json={"project": "incremnt", "title": "Crash in onboarding"},
+                headers={"X-GitHub-Delivery": "sentry-001"},
+            )
+            assert resp.status == 202
+
+        chat_id = "webhook:sentry:sentry-001"
+        with patch(
+            "gateway.platforms.webhook.build_action_buttons",
+            return_value=[{"label": "Create PR", "callback_data": "ar:sentry-abc"}],
+        ) as mock_build:
+            result = await adapter.send(chat_id, "Likely onboarding crash. Create a PR?")
+
+        assert result.success is True
+        mock_build.assert_called_once()
+        mock_tg_adapter.send.assert_awaited_once_with(
+            "12345",
+            "Likely onboarding crash. Create a PR?",
+            metadata={"action_buttons": [{"label": "Create PR", "callback_data": "ar:sentry-abc"}]},
+        )
+
+
 # ===================================================================
 # Test 4: GitHub comment delivery via gh CLI
 # ===================================================================


### PR DESCRIPTION
## Summary
- add webhook action-card metadata so Sentry alerts can include a Telegram `Create PR` button
- persist compact action payloads under Hermes home and dispatch Sentry `create_pr` actions from authorised Telegram callbacks
- add a Sentry helper that launches a detached tmux/Codex task with explicit `commit, push, AND create PR` / `do not merge` guardrails
- document route configuration and repo mapping

## Tests
- `scripts/run_tests.sh tests/gateway/test_action_requests.py tests/gateway/test_webhook_integration.py -q`

## Notes
- Telegram action buttons are implemented in this PR.
- Discord arbitrary action-card components remain documented as a follow-up limitation.