### PR TITLE
Fix/docker exec hermes path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -108,6 +108,6 @@ RUN uv pip install --no-cache-dir --no-deps -e "."
 # ---------- Runtime ----------
 ENV HERMES_WEB_DIST=/opt/hermes/hermes_cli/web_dist
 ENV HERMES_HOME=/opt/data
-ENV PATH="/opt/data/.local/bin:${PATH}"
+ENV PATH="/opt/data/.local/bin:/opt/hermes/.venv/bin:${PATH}"
 VOLUME [ "/opt/data" ]
 ENTRYPOINT [ "/usr/bin/tini", "-g", "--", "/opt/hermes/docker/entrypoint.sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -109,5 +109,6 @@ RUN uv pip install --no-cache-dir --no-deps -e "."
 ENV HERMES_WEB_DIST=/opt/hermes/hermes_cli/web_dist
 ENV HERMES_HOME=/opt/data
 ENV PATH="/opt/data/.local/bin:/opt/hermes/.venv/bin:${PATH}"
+RUN printf '%s\n' 'export PATH="/opt/data/.local/bin:/opt/hermes/.venv/bin:$PATH"' > /etc/profile.d/hermes-path.sh
 VOLUME [ "/opt/data" ]
 ENTRYPOINT [ "/usr/bin/tini", "-g", "--", "/opt/hermes/docker/entrypoint.sh" ]

--- a/tests/tools/test_dockerfile_pid1_reaping.py
+++ b/tests/tools/test_dockerfile_pid1_reaping.py
@@ -143,6 +143,18 @@ def test_dockerfile_exposes_venv_cli_on_runtime_path(dockerfile_text):
     )
 
 
+def test_dockerfile_preserves_venv_cli_in_login_shells(dockerfile_text):
+    assert "/etc/profile.d/hermes-path.sh" in dockerfile_text, (
+        "Dockerfile must install a profile.d PATH hook so login shells keep "
+        "/opt/hermes/.venv/bin after /etc/profile resets PATH. See issues "
+        "#9792 and #18673."
+    )
+    assert "export PATH=\"/opt/data/.local/bin:/opt/hermes/.venv/bin:$PATH\"" in dockerfile_text, (
+        "Dockerfile login-shell PATH hook must restore /opt/hermes/.venv/bin so "
+        "`docker exec ... bash -l -c \"hermes\"` works without an absolute path."
+    )
+
+
 def test_dockerfile_materializes_local_tui_ink_package(dockerfile_text):
     # ``hermes-ink`` is a bundled workspace package referenced from
     # ``ui-tui/package.json`` via ``file:`` — not pulled from the npm

--- a/tests/tools/test_dockerfile_pid1_reaping.py
+++ b/tests/tools/test_dockerfile_pid1_reaping.py
@@ -128,6 +128,21 @@ def test_dockerfile_builds_tui_assets(dockerfile_text):
     )
 
 
+def test_dockerfile_exposes_venv_cli_on_runtime_path(dockerfile_text):
+    env_lines = [
+        line.strip()
+        for line in dockerfile_text.splitlines()
+        if line.strip().startswith("ENV PATH=")
+    ]
+
+    assert env_lines, "Dockerfile must define a runtime PATH"
+    assert any("/opt/hermes/.venv/bin" in line for line in env_lines), (
+        "Dockerfile must add /opt/hermes/.venv/bin to PATH so `docker exec ... hermes` "
+        "and external interactive shells can resolve the CLI without entrypoint-time "
+        "virtualenv activation. See issues #9792 and #18673."
+    )
+
+
 def test_dockerfile_materializes_local_tui_ink_package(dockerfile_text):
     # ``hermes-ink`` is a bundled workspace package referenced from
     # ``ui-tui/package.json`` via ``file:`` — not pulled from the npm


### PR DESCRIPTION
## What does this PR do?
Fixes a Docker packaging regression where `hermes` was only available after the entrypoint activated `/opt/hermes/.venv`. That meant direct `docker exec` sessions and external interactive shells could not resolve the CLI unless users knew the absolute venv path.
This PR fixes both reported failure modes:
- direct execs like `docker exec -it <container> hermes`
- login-shell execs like `docker exec -it <container> bash -l -c "hermes"`
The fix uses two small runtime guarantees:
- add `/opt/hermes/.venv/bin` to the image `PATH`
- add a `/etc/profile.d` hook so login shells keep that path after `/etc/profile` resets `PATH`
This is the smallest reliable fix because `ENV PATH=...` alone is not enough for `bash -l`, which rewrites `PATH` during login-shell startup.
## Related Issue
Fixes #9792  
Fixes #18673
## Type of Change
- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)
## Changes Made
- Updated `Dockerfile` to add `/opt/hermes/.venv/bin` to the runtime `PATH`
- Updated `Dockerfile` to install `/etc/profile.d/hermes-path.sh` so login shells preserve the Hermes venv path
- Added Dockerfile contract coverage in `tests/tools/test_dockerfile_pid1_reaping.py` for:
  - runtime `PATH` exposure
  - login-shell `PATH` preservation
- Validated the fix with a local Docker build and live `docker exec` repro commands
## How to Test
1. Run `scripts/run_tests.sh tests/tools/test_dockerfile_pid1_reaping.py tests/tools/test_dockerfile_node_modules_perms.py`
2. Run `scripts/run_tests.sh tests/tools/test_dockerfile_pid1_reaping.py tests/tools/test_dockerfile_node_modules_perms.py tests/tools/test_docker_environment.py tests/hermes_cli/test_gateway.py`
3. Build and run the Docker image, then verify both repro paths work:
   - `docker exec -it <container> hermes --version`
   - `docker exec -it <container> bash -l -c "hermes --version"`
## Checklist
### Code
- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x, local Docker Desktop Linux container runtime
### Documentation & Housekeeping
- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A
## Screenshots / Logs
Local Docker validation after the fix:
```text
$ docker exec hermes-path-test hermes --version
Hermes Agent v0.13.0 (2026.5.7)
$ docker exec hermes-path-test bash -l -c "hermes --version"
Hermes Agent v0.13.0 (2026.5.7)
$ docker exec hermes-path-test bash -l -c 'echo PATH=$PATH; command -v hermes'
PATH=/opt/data/.local/bin:/opt/hermes/.venv/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
/opt/hermes/.venv/bin/hermes

