### PR TITLE
fix(kanban): route gateway create auto-subscribe to explicit board

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7776,6 +7776,7 @@ class GatewayRunner:
         """
         import asyncio
         import re
+        import shlex
         from hermes_cli.kanban import run_slash
 
         text = (event.text or "").strip()
@@ -7785,7 +7786,26 @@ class GatewayRunner:
         if text.startswith("kanban"):
             text = text[len("kanban"):].lstrip()
 
-        is_create = text.split(None, 1)[:1] == ["create"]
+        tokens = shlex.split(text) if text else []
+        requested_board = None
+        action = None
+        i = 0
+        while i < len(tokens):
+            tok = tokens[i]
+            if tok == "--board":
+                if i + 1 >= len(tokens):
+                    break
+                requested_board = tokens[i + 1]
+                i += 2
+                continue
+            if tok.startswith("--board="):
+                requested_board = tok.split("=", 1)[1]
+                i += 1
+                continue
+            action = tok
+            break
+
+        is_create = action == "create"
 
         try:
             output = await asyncio.to_thread(run_slash, text)
@@ -7812,7 +7832,7 @@ class GatewayRunner:
                     if platform_str and chat_id:
                         def _sub():
                             from hermes_cli import kanban_db as _kb
-                            conn = _kb.connect()
+                            conn = _kb.connect(board=requested_board)
                             try:
                                 _kb.add_notify_sub(
                                     conn, task_id=task_id,

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -2,6 +2,7 @@ import asyncio
 import pytest
 
 from pathlib import Path
+from types import SimpleNamespace
 from hermes_cli import kanban_db as kb
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -301,3 +302,52 @@ def test_dispatcher_tick_does_not_call_init_db(kanban_home, monkeypatch):
         "_kanban_notifier_watcher must not call _kb.init_db(board=slug) — "
         "see issue #21378."
     )
+
+
+@pytest.mark.asyncio
+async def test_gateway_create_autosubscribes_on_explicit_board(kanban_home):
+    """`/kanban --board <slug> create ...` must subscribe on that board.
+
+    The gateway handler currently auto-subscribes after `/kanban create`,
+    but the create detection must still work when the shared `--board`
+    flag appears before the subcommand, and the subscription must land in
+    that board's DB rather than the ambient/default board.
+    """
+    from gateway.run import GatewayRunner
+    from gateway.config import Platform
+
+    kb.create_board("projx")
+
+    runner = object.__new__(GatewayRunner)
+    source = SimpleNamespace(
+        platform=Platform.TELEGRAM,
+        chat_id="chat1",
+        thread_id="th1",
+        user_id="u1",
+    )
+    event = SimpleNamespace(
+        text='/kanban --board projx create "hello" --assignee alice',
+        source=source,
+    )
+
+    out = await GatewayRunner._handle_kanban_command(runner, event)
+
+    assert "subscribed" in out.lower()
+
+    conn = kb.connect(board="projx")
+    try:
+        subs = kb.list_notify_subs(conn)
+        tasks = kb.list_tasks(conn)
+    finally:
+        conn.close()
+
+    assert [t.title for t in tasks] == ["hello"]
+    assert len(subs) == 1
+    assert subs[0]["chat_id"] == "chat1"
+    assert subs[0]["thread_id"] == "th1"
+
+    conn = kb.connect(board="default")
+    try:
+        assert kb.list_notify_subs(conn) == []
+    finally:
+        conn.close()


### PR DESCRIPTION
## Summary

Fix gateway `/kanban create` auto-subscribe when the command uses the global `--board` flag.

Before this change, a command like:

`/kanban --board projx create "hello" --assignee alice`

would create the task on `projx`, but the gateway would fail to auto-subscribe the originating chat to task notifications. The handler only detected `create` when it was the first token, and the follow-up subscription write did not carry the explicit board through to the DB connection.

## Root cause

`GatewayRunner._handle_kanban_command()` used a naive first-token check:

- `text.split(None, 1)[:1] == ["create"]`

That breaks as soon as `--board` appears before the subcommand.

The auto-subscribe path also opened a plain kanban connection without the explicit board override, so even if create detection had succeeded, the subscription write could drift to the ambient/current board instead of the requested one.

## Fix

- Parse the slash command tokens with `shlex`
- Skip the global `--board` flag when determining the actual subcommand
- Capture the requested board slug and use it when opening the DB connection for the auto-subscribe write

This keeps the patch local to the gateway handler and avoids broader parser refactors.

## Tests

Added a regression test covering:

- `/kanban --board projx create ...` from the gateway surface
- task creation on the named board
- auto-subscription stored on that same board
- no subscription leak into `default`

Test run:

- `python -m pytest -o "addopts=" tests/hermes_cli/test_kanban_notify.py -q`
