### PR TITLE
fix(cli): prevent RuntimeWarning from fire-and-forget run_in_terminal coroutine

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1506,13 +1506,18 @@ def _cprint(text: str):
         _pt_print(_PT_ANSI(text))
         return
 
-    # Cross-thread emission: ask the app's event loop to schedule a
-    # ``run_in_terminal`` that wraps ``_pt_print``.  This hides the
-    # prompt, prints, and redraws.  Fire-and-forget — if scheduling
-    # fails we fall back to a direct print so the line isn't lost.
+    # Track the returned Task so the inner ``run()`` coroutine isn't
+    # garbage-collected before the event loop executes it, which would
+    # trigger ``RuntimeWarning: coroutine 'run_in_terminal.<locals>.run'
+    # was never awaited`` (observed during ``/new`` session resets).
+    if not hasattr(_cprint, "_pending_tasks"):
+        _cprint._pending_tasks = set()
+
     def _schedule():
         try:
-            run_in_terminal(lambda: _pt_print(_PT_ANSI(text)))
+            _task = run_in_terminal(lambda: _pt_print(_PT_ANSI(text)))
+            _cprint._pending_tasks.add(_task)
+            _task.add_done_callback(_cprint._pending_tasks.discard)
         except Exception:
             try:
                 _pt_print(_PT_ANSI(text))


### PR DESCRIPTION
## Summary

When `_cprint()` routes cross-thread output through prompt_toolkit's `run_in_terminal()` via `call_soon_threadsafe`, the returned `Task` was discarded (fire-and-forget). During `/new` session resets, the event loop may not execute the `Task` before garbage collection, triggering:

```
RuntimeWarning: coroutine 'run_in_terminal.<locals>.run' was never awaited
```

## Root Cause

`run_in_terminal()` internally calls `asyncio.ensure_future(run())` where `run()` is an inner async def. This creates a `Task` on the event loop. When `/new` resets the session state, the event loop may not get CPU time to run the `Task` before it is garbage-collected. Python's coroutine `__del__` then emits the `RuntimeWarning`.

## Fix

Track the returned `Task` in a `_cprint._pending_tasks` set with a done-callback that removes it on completion. This keeps a strong reference to the `Task` object until the event loop executes it, preventing premature garbage collection of the inner `run()` coroutine.

## Verification

- `py_compile.compile()`: syntax OK
- Only `cli.py` modified (+10/-5 lines)
- All other `run_in_terminal` call sites in the codebase use blocking patterns (`curses_single_select`, `input()`, `os.kill+SIGTSTP`) where the `Task` always completes before the caller returns