### PR TITLE
fix(gateway): surface incomplete tool turns

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1107,6 +1107,33 @@ def _normalize_empty_agent_response(
             "Try again or use /reset to start a fresh session."
         )
 
+    messages = agent_result.get("messages") or []
+    last_role = messages[-1].get("role") if messages and isinstance(messages[-1], dict) else None
+    has_tool_activity = any(
+        isinstance(msg, dict)
+        and (
+            msg.get("role") == "tool"
+            or bool(msg.get("tool_calls"))
+        )
+        for msg in messages
+    )
+    if (
+        has_tool_activity
+        and last_role == "tool"
+        and not agent_result.get("interrupted")
+    ):
+        return (
+            "⚠️ Processing stopped after a tool result, before the agent "
+            "produced a final reply. Try again to continue from the saved "
+            "tool output, or use /reset to start fresh."
+        )
+
+    if agent_result.get("completed") is False and not agent_result.get("interrupted"):
+        return (
+            "⚠️ Processing stopped before a final reply was generated. "
+            "Try again to continue, or use /reset to start fresh."
+        )
+
     api_calls = int(agent_result.get("api_calls", 0) or 0)
     if api_calls > 0 and not agent_result.get("interrupted"):
         if agent_result.get("partial"):

--- a/tests/gateway/test_duplicate_reply_suppression.py
+++ b/tests/gateway/test_duplicate_reply_suppression.py
@@ -26,6 +26,7 @@ from gateway.platforms.base import (
     ProcessingOutcome,
     SendResult,
 )
+from gateway.run import _normalize_empty_agent_response
 from gateway.session import SessionSource, build_session_key
 
 
@@ -311,6 +312,51 @@ class TestEmptyResponseNotSuppressed:
         response = {"final_response": "(empty)", "failed": True}
         self._apply_suppression_logic(response, sc)
         assert "already_sent" not in response
+
+
+class TestIncompleteToolTurnGetsVisibleResponse:
+    def test_tool_tail_without_final_response_gets_visible_failure(self):
+        agent_result = {
+            "final_response": "",
+            "messages": [
+                {"role": "user", "content": "do work"},
+                {
+                    "role": "assistant",
+                    "content": "",
+                    "tool_calls": [
+                        {"function": {"name": "session_search"}},
+                    ],
+                },
+                {
+                    "role": "tool",
+                    "name": "session_search",
+                    "content": '{"success": true, "results": []}',
+                    "tool_call_id": "call_1",
+                },
+            ],
+            "api_calls": 0,
+            "completed": False,
+        }
+
+        response = _normalize_empty_agent_response(agent_result, "", history_len=3)
+
+        assert response
+        assert "Processing stopped after a tool result" in response
+
+    def test_interrupted_tool_tail_stays_empty_for_stop_flow(self):
+        agent_result = {
+            "final_response": "",
+            "messages": [
+                {"role": "tool", "name": "terminal", "content": "cancelled"},
+            ],
+            "api_calls": 0,
+            "completed": False,
+            "interrupted": True,
+        }
+
+        response = _normalize_empty_agent_response(agent_result, "", history_len=3)
+
+        assert response == ""
 
 class TestQueuedMessageAlreadyStreamed:
     """The queued-message path should skip the first response only when the

--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -1,6 +1,7 @@
 """Tests for tools/session_search_tool.py — helper functions and search dispatcher."""
 
 import asyncio
+import concurrent.futures
 import json
 import time
 import pytest
@@ -399,6 +400,48 @@ class TestSessionSearch:
         # Current session should be skipped, only other_sid should appear
         assert result["sessions_searched"] == 1
         assert current_sid not in [r.get("session_id") for r in result.get("results", [])]
+
+    def test_summarization_bridge_timeout_returns_raw_preview(self, monkeypatch):
+        from unittest.mock import MagicMock
+        from tools.session_search_tool import session_search
+
+        mock_db = MagicMock()
+        mock_db.search_messages.return_value = [
+            {
+                "session_id": "old_sid",
+                "content": "important old context",
+                "source": "telegram",
+                "session_started": 1709400000,
+                "model": "test",
+            },
+        ]
+        mock_db.get_session.return_value = {
+            "id": "old_sid",
+            "parent_session_id": None,
+            "source": "telegram",
+            "started_at": 1709400000,
+            "model": "test",
+        }
+        mock_db.get_messages_as_conversation.return_value = [
+            {"role": "user", "content": "important old context"},
+            {"role": "assistant", "content": "prior answer"},
+        ]
+
+        def _raise_timeout(_coro):
+            _coro.close()
+            raise concurrent.futures.TimeoutError()
+
+        monkeypatch.setattr("model_tools._run_async", _raise_timeout)
+
+        result = json.loads(session_search(query="important", db=mock_db))
+
+        assert result["success"] is True
+        assert result["degraded"] is True
+        assert result["count"] == 1
+        entry = result["results"][0]
+        assert entry["degraded"] is True
+        assert "Raw preview" in entry["summary"]
+        assert "important old context" in entry["summary"]
 
     def test_current_child_session_excludes_parent_lineage(self):
         """Compression/delegation parents should be excluded for the active child session."""

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -473,6 +473,8 @@ def session_search(
             ]
             return await asyncio.gather(*coros, return_exceptions=True)
 
+        summary_degraded = False
+        summarization_error = None
         try:
             # Use _run_async() which properly manages event loops across
             # CLI, gateway, and worker-thread contexts.  The previous
@@ -484,13 +486,14 @@ def session_search(
             results = _run_async(_summarize_all())
         except concurrent.futures.TimeoutError:
             logging.warning(
-                "Session summarization timed out after 60 seconds",
+                "Session summarization timed out; returning raw previews",
                 exc_info=True,
             )
-            return json.dumps({
-                "success": False,
-                "error": "Session summarization timed out. Try a more specific query or reduce the limit.",
-            }, ensure_ascii=False)
+            summary_degraded = True
+            summarization_error = (
+                "Session summarization timed out. Returning raw previews."
+            )
+            results = [None] * len(tasks)
 
         summaries = []
         for (session_id, match_info, conversation_text, session_meta), result in zip(tasks, results):
@@ -522,16 +525,23 @@ def session_search(
                 # dropped when the summarizer is unavailable (fixes #3409).
                 preview = (conversation_text[:500] + "\n…[truncated]") if conversation_text else "No preview available."
                 entry["summary"] = f"[Raw preview — summarization unavailable]\n{preview}"
+                entry["degraded"] = True
+                if summarization_error:
+                    entry["summarization_error"] = summarization_error
 
             summaries.append(entry)
 
-        return json.dumps({
+        payload = {
             "success": True,
             "query": query,
             "results": summaries,
             "count": len(summaries),
             "sessions_searched": len(seen_sessions),
-        }, ensure_ascii=False)
+        }
+        if summary_degraded:
+            payload["degraded"] = True
+            payload["warning"] = summarization_error
+        return json.dumps(payload, ensure_ascii=False)
 
     except Exception as e:
         logging.error("Session search failed: %s", e, exc_info=True)


### PR DESCRIPTION
## What does this PR do?

Fixes a gateway silent-stop class where a turn can become inactive after tool activity without delivering a final user-visible response. The gateway now turns incomplete, non-interrupted tool-tail results into an explicit failure message so the user is not left with `active_agents=0` and no reply.

It also makes `session_search` summarization bridge timeouts degrade to raw transcript previews instead of returning a failed tool result. That keeps recall best-effort and lets the main agent continue when auxiliary summarization is slow or unavailable.

## Related Issue

Related: https://github.com/NousResearch/hermes-agent/issues/23081

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/run.py`: normalize incomplete, non-interrupted tool-tail turns into a visible gateway response.
- `tools/session_search_tool.py`: return successful degraded raw-preview results when summarization bridge execution times out.
- `tests/gateway/test_duplicate_reply_suppression.py`: cover incomplete tool-tail response normalization and preserve interrupted stop flow behavior.
- `tests/tools/test_session_search.py`: cover `session_search` timeout degradation to raw previews.

## How to Test

1. Run focused gateway/session-search regression tests:
   ```bash
   scripts/run_tests.sh tests/gateway/test_duplicate_reply_suppression.py tests/tools/test_session_search.py
   ```
2. Compile changed Python files:
   ```bash
   python3 -m py_compile gateway/run.py tools/session_search_tool.py tests/gateway/test_duplicate_reply_suppression.py tests/tools/test_session_search.py
   ```
3. Check whitespace and Windows footguns for this diff:
   ```bash
   git diff --check
   python3 scripts/check-windows-footguns.py --diff origin/main
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS Darwin arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Focused validation passed:

```text
scripts/run_tests.sh tests/gateway/test_duplicate_reply_suppression.py tests/tools/test_session_search.py
63 passed
```

Additional checks passed:

```text
python3 -m py_compile gateway/run.py tools/session_search_tool.py tests/gateway/test_duplicate_reply_suppression.py tests/tools/test_session_search.py
git diff --check
python3 scripts/check-windows-footguns.py --diff origin/main
```
