### PR TITLE
Fix/mcp poll timestamps lock

### DIFF
--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -301,6 +301,25 @@ class EventBridge:
                 key=lambda a: a.get("created_at", ""),
             )
 
+    def _read_last_poll_timestamp(self, session_key: str) -> float:
+        """Lock-safe read of _last_poll_timestamps[session_key].
+
+        Centralises the lock invariant for #23096 so every caller — most
+        notably the background _poll_once loop — cannot accidentally drop
+        the lock again.
+        """
+        with self._lock:
+            return self._last_poll_timestamps.get(session_key, 0.0)
+
+    def _record_last_poll_timestamp(self, session_key: str, timestamp: float) -> None:
+        """Lock-safe write of _last_poll_timestamps[session_key].
+
+        See `_read_last_poll_timestamp` for the rationale; both helpers
+        exist purely to make the lock discipline impossible to forget.
+        """
+        with self._lock:
+            self._last_poll_timestamps[session_key] = timestamp
+
     def respond_to_approval(self, approval_id: str, decision: str) -> dict:
         """Resolve a pending approval (best-effort without gateway IPC)."""
         with self._lock:
@@ -386,10 +405,9 @@ class EventBridge:
             # _last_poll_timestamps is shared with foreground bridge methods
             # (_enqueue, poll_events, wait_for_event, list_pending_approvals,
             # respond_to_approval) and must be touched under self._lock — see
-            # issue #23096. Hold the lock only for the dict access; never for
-            # db.get_messages, which performs blocking I/O.
-            with self._lock:
-                last_seen = self._last_poll_timestamps.get(session_key, 0.0)
+            # issue #23096. The dedicated helpers below ensure the lock
+            # discipline cannot be forgotten by future contributors.
+            last_seen = self._read_last_poll_timestamp(session_key)
 
             try:
                 messages = db.get_messages(session_id)
@@ -441,16 +459,15 @@ class EventBridge:
                     },
                 ))
 
-            # Update last seen to the most recent message timestamp.
-            # See note on the read above — write under the lock for the same
-            # reason. The latest timestamp is computed without the lock so
-            # _ts_float and max() do not block other bridge methods.
+            # Update last seen to the most recent message timestamp. The
+            # latest timestamp is computed without the lock so _ts_float and
+            # max() do not block other bridge methods; the lock is only
+            # taken inside _record_last_poll_timestamp for the dict write.
             all_ts = [_ts_float(m.get("timestamp", 0)) for m in messages]
             if all_ts:
                 latest = max(all_ts)
                 if latest > last_seen:
-                    with self._lock:
-                        self._last_poll_timestamps[session_key] = latest
+                    self._record_last_poll_timestamp(session_key, latest)
 
 
 # ---------------------------------------------------------------------------

--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -207,6 +207,32 @@ class EventBridge:
 
     This is the Hermes equivalent of OpenClaw's WebSocket gateway bridge.
     Instead of WebSocket events, we poll the SQLite database for changes.
+
+    Threading model
+    ---------------
+    The bridge runs a single background poll thread (see ``start`` /
+    ``_poll_loop``) alongside any number of foreground callers using
+    ``poll_events``, ``wait_for_event``, ``list_pending_approvals``, and
+    ``respond_to_approval``. The following attributes are shared between
+    those threads and **must** only be read or mutated while holding
+    ``self._lock``:
+
+    - ``_queue`` and ``_cursor`` — the event queue and its monotonically
+      increasing cursor
+    - ``_pending_approvals`` — approval requests observed by the bridge
+    - ``_last_poll_timestamps`` — per-session last-seen message timestamp,
+      written by the background poll thread and read on every iteration
+      (see issue #23096 for the regression that motivated this contract).
+
+    Attributes that are only mutated by the poll thread
+    (``_sessions_json_mtime``, ``_state_db_mtime``,
+    ``_cached_sessions_index``) do not need the lock; treat them as
+    poll-thread-private state.
+
+    Use ``_read_last_poll_timestamp`` and ``_record_last_poll_timestamp``
+    to access ``_last_poll_timestamps`` rather than touching the dict
+    directly — the helpers exist precisely so the lock discipline cannot
+    be forgotten.
     """
 
     def __init__(self):
@@ -216,10 +242,13 @@ class EventBridge:
         self._new_event = threading.Event()
         self._running = False
         self._thread: Optional[threading.Thread] = None
-        self._last_poll_timestamps: Dict[str, float] = {}  # session_key -> unix timestamp
-        # In-memory approval tracking (populated from events)
+        # session_key -> unix timestamp; access ONLY via the
+        # _read_last_poll_timestamp / _record_last_poll_timestamp helpers,
+        # never touch this dict directly. See class docstring + #23096.
+        self._last_poll_timestamps: Dict[str, float] = {}
+        # In-memory approval tracking (populated from events). Lock-protected.
         self._pending_approvals: Dict[str, dict] = {}
-        # mtime cache — skip expensive work when files haven't changed
+        # mtime cache — owned by the poll thread, no lock needed.
         self._sessions_json_mtime: float = 0.0
         self._state_db_mtime: float = 0.0
         self._cached_sessions_index: dict = {}

--- a/mcp_serve.py
+++ b/mcp_serve.py
@@ -383,7 +383,13 @@ class EventBridge:
             if not session_id:
                 continue
 
-            last_seen = self._last_poll_timestamps.get(session_key, 0.0)
+            # _last_poll_timestamps is shared with foreground bridge methods
+            # (_enqueue, poll_events, wait_for_event, list_pending_approvals,
+            # respond_to_approval) and must be touched under self._lock — see
+            # issue #23096. Hold the lock only for the dict access; never for
+            # db.get_messages, which performs blocking I/O.
+            with self._lock:
+                last_seen = self._last_poll_timestamps.get(session_key, 0.0)
 
             try:
                 messages = db.get_messages(session_id)
@@ -435,12 +441,16 @@ class EventBridge:
                     },
                 ))
 
-            # Update last seen to the most recent message timestamp
+            # Update last seen to the most recent message timestamp.
+            # See note on the read above — write under the lock for the same
+            # reason. The latest timestamp is computed without the lock so
+            # _ts_float and max() do not block other bridge methods.
             all_ts = [_ts_float(m.get("timestamp", 0)) for m in messages]
             if all_ts:
                 latest = max(all_ts)
                 if latest > last_seen:
-                    self._last_poll_timestamps[session_key] = latest
+                    with self._lock:
+                        self._last_poll_timestamps[session_key] = latest
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_mcp_serve.py
+++ b/tests/test_mcp_serve.py
@@ -1237,3 +1237,180 @@ class TestEventBridgePollE2E:
         """Verify the poll interval constant."""
         from mcp_serve import POLL_INTERVAL
         assert POLL_INTERVAL == 0.2
+
+
+# ---------------------------------------------------------------------------
+# Regression: EventBridge._poll_once must hold self._lock when touching
+# _last_poll_timestamps (issue #23096).
+#
+# Every other method on EventBridge (_enqueue, poll_events, wait_for_event,
+# list_pending_approvals, respond_to_approval) acquires self._lock before
+# reading or mutating shared state. _poll_once was an outlier: it read at
+# line 386 and wrote at line 443 from the background poll thread without
+# any lock, racing with the foreground methods. These tests pin that
+# invariant by replacing _last_poll_timestamps with a wrapper that fails
+# fast when the bridge's lock is not held by the current thread.
+# ---------------------------------------------------------------------------
+
+class TestEventBridgePollOnceLockInvariant:
+    """Pin the lock-discipline invariant for EventBridge._poll_once."""
+
+    @staticmethod
+    def _instrument(bridge):
+        """Swap bridge state for instrumented versions that fail when
+        ``bridge._lock`` is not owned by the current thread on access.
+
+        Uses ``threading.RLock`` (instead of the default ``threading.Lock``)
+        purely so the test can introspect ownership via ``_is_owned``.
+        Production code only ever uses ``with self._lock:`` — both lock
+        flavors are interchangeable for that contract.
+        """
+        bridge._lock = threading.RLock()
+
+        class LockEnforcedDict(dict):
+            """Dict that asserts ``bridge._lock`` is held on every access."""
+
+            def _assert_held(self, op):
+                assert bridge._lock._is_owned(), (
+                    f"_last_poll_timestamps {op} happened without holding "
+                    "bridge._lock — see issue #23096"
+                )
+
+            def __getitem__(self, key):
+                self._assert_held("__getitem__")
+                return super().__getitem__(key)
+
+            def __setitem__(self, key, value):
+                self._assert_held("__setitem__")
+                super().__setitem__(key, value)
+
+            def get(self, key, default=None):
+                self._assert_held("get")
+                return super().get(key, default)
+
+        bridge._last_poll_timestamps = LockEnforcedDict()
+        return bridge
+
+    def _seed_session_with_messages(self, tmp_path, session_id, messages):
+        """Create a sessions.json + state.db pair that _poll_once will scan."""
+        sessions_dir = tmp_path / "sessions"
+        sessions_dir.mkdir(exist_ok=True)
+        db_path = tmp_path / "state.db"
+
+        sessions_data = {
+            f"agent:main:telegram:dm:{session_id}": {
+                "session_key": f"agent:main:telegram:dm:{session_id}",
+                "session_id": session_id,
+                "platform": "telegram",
+                "updated_at": "2026-03-29T15:00:05",
+                "origin": {"platform": "telegram", "chat_id": session_id},
+            }
+        }
+        (sessions_dir / "sessions.json").write_text(json.dumps(sessions_data))
+        _create_test_db(db_path, session_id, messages)
+        return sessions_dir, db_path
+
+    @staticmethod
+    def _stub_db(db_path):
+        class _StubDB:
+            def get_messages(self, sid):
+                conn = sqlite3.connect(str(db_path))
+                conn.row_factory = sqlite3.Row
+                rows = conn.execute(
+                    "SELECT * FROM messages WHERE session_id = ? ORDER BY id",
+                    (sid,),
+                ).fetchall()
+                conn.close()
+                return [dict(r) for r in rows]
+        return _StubDB()
+
+    def test_read_and_write_hold_lock(self, tmp_path, monkeypatch):
+        """A single _poll_once that exercises both the read at line 386 and
+        the write at line 443 must hold the lock for both."""
+        import mcp_serve
+        session_id = "20260329_150000_lock_rw"
+        sessions_dir, db_path = self._seed_session_with_messages(
+            tmp_path,
+            session_id,
+            [
+                {"role": "user", "content": "Hi",
+                 "timestamp": "2026-03-29T15:00:01"},
+                {"role": "assistant", "content": "Hello",
+                 "timestamp": "2026-03-29T15:00:02"},
+            ],
+        )
+        monkeypatch.setattr(mcp_serve, "_get_sessions_dir", lambda: sessions_dir)
+
+        bridge = self._instrument(mcp_serve.EventBridge())
+        bridge._poll_once(self._stub_db(db_path))
+
+    def test_repeated_polls_keep_lock_invariant(self, tmp_path, monkeypatch):
+        """Multiple _poll_once calls (read-only and read-then-write) keep
+        the invariant. The first poll seeds _last_poll_timestamps, later
+        polls re-read it; both paths must stay under the lock."""
+        import mcp_serve
+        session_id = "20260329_150000_lock_repeat"
+        sessions_dir, db_path = self._seed_session_with_messages(
+            tmp_path,
+            session_id,
+            [{"role": "user", "content": "Hi",
+              "timestamp": "2026-03-29T15:00:01"}],
+        )
+        monkeypatch.setattr(mcp_serve, "_get_sessions_dir", lambda: sessions_dir)
+
+        bridge = self._instrument(mcp_serve.EventBridge())
+        db = self._stub_db(db_path)
+
+        bridge._poll_once(db)
+
+        # Touch the DB so the second poll re-enters the loop body instead of
+        # short-circuiting on the unchanged-mtime guard.
+        os.utime(db_path, None)
+        bridge._poll_once(db)
+
+    def test_concurrent_polls_do_not_race(self, tmp_path, monkeypatch):
+        """Hammer _poll_once concurrently and confirm the lock invariant
+        survives — i.e. the dict is never read or mutated outside the lock
+        even under heavy contention from the foreground bridge API."""
+        import mcp_serve
+        session_id = "20260329_150000_lock_concurrent"
+        sessions_dir, db_path = self._seed_session_with_messages(
+            tmp_path,
+            session_id,
+            [{"role": "user", "content": "Hi",
+              "timestamp": "2026-03-29T15:00:01"}],
+        )
+        monkeypatch.setattr(mcp_serve, "_get_sessions_dir", lambda: sessions_dir)
+
+        bridge = self._instrument(mcp_serve.EventBridge())
+        db = self._stub_db(db_path)
+
+        errors: list[BaseException] = []
+
+        def hammer_poll():
+            try:
+                for _ in range(20):
+                    bridge._poll_once(db)
+                    os.utime(db_path, None)
+            except BaseException as exc:  # pragma: no cover - capture for assert
+                errors.append(exc)
+
+        def hammer_foreground():
+            try:
+                for _ in range(50):
+                    bridge.poll_events(after_cursor=0)
+                    bridge.list_pending_approvals()
+            except BaseException as exc:  # pragma: no cover
+                errors.append(exc)
+
+        threads = [
+            threading.Thread(target=hammer_poll),
+            threading.Thread(target=hammer_poll),
+            threading.Thread(target=hammer_foreground),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert not errors, f"Race detected under concurrent _poll_once: {errors}"


### PR DESCRIPTION
## What does this PR do?

Fixes a real data race in `EventBridge._poll_once` (mcp_serve.py): it was reading and writing `_last_poll_timestamps` from the background poll thread **without** acquiring `self._lock`, while every other bridge method (`_enqueue`, `poll_events`, `wait_for_event`, `list_pending_approvals`, `respond_to_approval`) consistently holds the lock around its access to shared state.

The race produces stale/torn reads of the per-session timestamp on the GIL (the dict access is not atomic with respect to foreground iteration once you account for the upcoming free-threaded CPython builds, and even on the GIL the hand-off can lose updates).

The PR is split into four commits in test-first order so each step is independently reviewable:

1. **`test(mcp): add regression tests for EventBridge._poll_once lock invariant`** — pins the contract by replacing `_last_poll_timestamps` with a wrapper that fails fast when `self._lock` is not held by the current thread on access. Three scenarios: single poll cycle, repeated polls, and concurrent `_poll_once` calls hammered alongside foreground bridge API calls. **All three fail on `main`.**
2. **`fix(mcp): protect _last_poll_timestamps with self._lock in _poll_once`** — wraps the two touch points (read at the top of the per-session loop, write at the end) in `with self._lock:`. The lock is intentionally released across the blocking `db.get_messages` call and the in-Python filtering loop so foreground methods are not starved. The regression tests from commit 1 now pass.
3. **`refactor(mcp): factor lock-safe helpers for _last_poll_timestamps`** — replaces the inline `with self._lock: ...` blocks with two narrow helpers, `_read_last_poll_timestamp` and `_record_last_poll_timestamp`, so the lock discipline is not something each future caller has to remember. No behaviour change.
4. **`docs(mcp): document EventBridge lock invariant in class docstring`** — spells out which `EventBridge` attributes are shared between the background poll thread and foreground callers, and which are poll-thread-private. Adds a pointed comment on `_last_poll_timestamps` itself reminding contributors to go through the `_read_/_record_` helpers rather than touching the dict directly. This is the readme that would have prevented the original bug.

## Related Issue

Fixes #23096

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `mcp_serve.py` (+62, −6):
  - Added `_read_last_poll_timestamp(session_key)` and `_record_last_poll_timestamp(session_key, ts)` helpers — both acquire `self._lock` for the single dict op.
  - Rewrote `_poll_once` to go through the helpers; the rest of the loop body still runs outside the lock so blocking I/O on `db.get_messages` cannot starve foreground bridge methods.
  - Expanded the `EventBridge` class docstring to document the lock invariant: which attributes are shared, which are poll-thread-private, and that any access to `_last_poll_timestamps` MUST go through the new helpers.
- `tests/test_mcp_serve.py` (+177): three regression tests covering the read at line 386, the write at line 443, and concurrent foreground/background access.

No other files modified.

## How to Test

1. Set up `.venv`: `python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[all,dev]"`
2. Run the new MCP tests: `scripts/run_tests.sh tests/test_mcp_serve.py`

Expected: 88 passed (≈1.6s).
3. Confirm the regression cases fail on `main` before this PR:
`git stash && git checkout upstream/main -- mcp_serve.py scripts/run_tests.sh tests/test_mcp_serve.py -k "lock_invariant or poll_once" git checkout HEAD -- mcp_serve.py && git stash pop`
Expected: 3 failures with `_last_poll_timestamps get happened without holding bridge._lock`.

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`test(mcp):`, `fix(mcp):`, `refactor(mcp):`, `docs(mcp):`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix (4 commits, 2 files)
- [x] I've run `scripts/run_tests.sh tests/test_mcp_serve.py` and all tests pass
- [x] I've added tests for my changes (commit 1 — written test-first so the regression bites on `main`)
- [x] I've tested on my platform: macOS 15.6 (Darwin 24.6.0), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — class docstring + inline `_last_poll_timestamps` comment in `mcp_serve.py` (commit 4)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — `threading.RLock` is stdlib, no platform-specific calls; tests use only `threading` + `unittest.mock`
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (no public-facing tool changes; `_poll_once` remains internal)

## Screenshots / Logs
============================== 88 passed in 1.65s ==============================