### PR TITLE
fix(memory): 4 holographic memory bug fixes (#14024 #17899 #17350 #22907)

### DIFF
--- a/plugins/memory/holographic/__init__.py
+++ b/plugins/memory/holographic/__init__.py
@@ -180,6 +180,20 @@ class HolographicMemoryProvider(MemoryProvider):
         )
         self._session_id = session_id
 
+        # Warn if numpy is missing — HRR operations silently disabled (#17350)
+        try:
+            from . import holographic as _hrr
+            self._hrr_available = _hrr._HAS_NUMPY
+        except ImportError:
+            self._hrr_available = False
+
+        if not self._hrr_available:
+            logger.warning(
+                "Holographic memory: numpy not found. HRR vector operations disabled. "
+                "Only FTS5 keyword search will be available. "
+                "Install numpy to enable compositional retrieval (probe/reason/contradict)."
+            )
+
     def system_prompt_block(self) -> str:
         if not self._store:
             return ""
@@ -189,18 +203,29 @@ class HolographicMemoryProvider(MemoryProvider):
             ).fetchone()[0]
         except Exception:
             total = 0
+
+        hrr_status = ""
+        if not self._hrr_available:
+            hrr_status = (
+                "\nWARNING: numpy not installed — HRR vector operations disabled. "
+                "Only keyword search works. probe/reason/contradict will use FTS5 fallback. "
+                "Install numpy for full compositional retrieval."
+            )
+
         if total == 0:
             return (
                 "# Holographic Memory\n"
                 "Active. Empty fact store — proactively add facts the user would expect you to remember.\n"
                 "Use fact_store(action='add') to store durable structured facts about people, projects, preferences, decisions.\n"
                 "Use fact_feedback to rate facts after using them (trains trust scores)."
+                + hrr_status
             )
         return (
             f"# Holographic Memory\n"
             f"Active. {total} facts stored with entity resolution and trust scoring.\n"
             f"Use fact_store to search, probe entities, reason across entities, or add facts.\n"
             f"Use fact_feedback to rate facts after using them (trains trust scores)."
+            + hrr_status
         )
 
     def prefetch(self, query: str, *, session_id: str = "") -> str:
@@ -357,14 +382,19 @@ class HolographicMemoryProvider(MemoryProvider):
     # -- Auto-extraction (on_session_end) ------------------------------------
 
     def _auto_extract_facts(self, messages: list) -> None:
+        """Extract structured facts from user messages at session end.
+
+        Instead of dumping raw messages verbatim (the old behavior that caused
+        #22907), this extracts the matching portion and wraps it as a clean
+        declarative statement. Only extracts from messages that match clear
+        preference/decision patterns, and deduplicates against existing facts.
+        """
         _PREF_PATTERNS = [
-            re.compile(r'\bI\s+(?:prefer|like|love|use|want|need)\s+(.+)', re.IGNORECASE),
-            re.compile(r'\bmy\s+(?:favorite|preferred|default)\s+\w+\s+is\s+(.+)', re.IGNORECASE),
-            re.compile(r'\bI\s+(?:always|never|usually)\s+(.+)', re.IGNORECASE),
-        ]
-        _DECISION_PATTERNS = [
-            re.compile(r'\bwe\s+(?:decided|agreed|chose)\s+(?:to\s+)?(.+)', re.IGNORECASE),
-            re.compile(r'\bthe\s+project\s+(?:uses|needs|requires)\s+(.+)', re.IGNORECASE),
+            (re.compile(r'\bI\s+prefer\s+(.+?)(?:\s+(?:over|instead of|rather than)\s+(.+?))?(?:\.|!|$)', re.IGNORECASE), "pref"),
+            (re.compile(r'\bI\s+(?:always|never|usually)\s+(.+?)(?:\.|!|$)', re.IGNORECASE), "habit"),
+            (re.compile(r'\bmy\s+(?:favorite|preferred|default)\s+(\w+)\s+is\s+(.+?)(?:\.|!|$)', re.IGNORECASE), "pref"),
+            (re.compile(r'\bwe\s+(?:decided|agreed|chose)\s+(?:to\s+)?(.+?)(?:\.|!|$)', re.IGNORECASE), "decision"),
+            (re.compile(r'\bthe\s+project\s+(?:uses|needs|requires)\s+(.+?)(?:\.|!|$)', re.IGNORECASE), "project"),
         ]
 
         extracted = 0
@@ -375,23 +405,43 @@ class HolographicMemoryProvider(MemoryProvider):
             if not isinstance(content, str) or len(content) < 10:
                 continue
 
-            for pattern in _PREF_PATTERNS:
-                if pattern.search(content):
-                    try:
-                        self._store.add_fact(content[:400], category="user_pref")
-                        extracted += 1
-                    except Exception:
-                        pass
-                    break
+            for pattern, kind in _PREF_PATTERNS:
+                m = pattern.search(content)
+                if not m:
+                    continue
 
-            for pattern in _DECISION_PATTERNS:
-                if pattern.search(content):
-                    try:
-                        self._store.add_fact(content[:400], category="project")
-                        extracted += 1
-                    except Exception:
-                        pass
-                    break
+                # Build a clean declarative fact from the captured groups
+                groups = [g.strip().rstrip('.,;!') for g in m.groups() if g]
+                if not groups:
+                    continue
+
+                if kind == "pref" and len(groups) >= 2 and " over " in content[m.start():m.end()].lower():
+                    fact_text = f"prefers {groups[0]} over {groups[1]}"
+                elif kind == "pref":
+                    fact_text = f"prefers {groups[0]}"
+                elif kind == "habit":
+                    habit_word = "always" if "always" in content[m.start():m.end()].lower() else ("never" if "never" in content[m.start():m.end()].lower() else "usually")
+                    fact_text = f"{habit_word} {groups[0]}"
+                elif kind == "decision":
+                    fact_text = f"decided to {groups[0]}"
+                elif kind == "project":
+                    fact_text = f"project requires {groups[0]}"
+                else:
+                    fact_text = groups[0]
+
+                # Cap length to avoid storing entire conversations
+                if len(fact_text) > 200:
+                    fact_text = fact_text[:200]
+
+                category_map = {"pref": "user_pref", "habit": "user_pref", "decision": "project", "project": "project"}
+                cat = category_map.get(kind, "general")
+
+                try:
+                    self._store.add_fact(fact_text, category=cat)
+                    extracted += 1
+                except Exception:
+                    pass
+                break  # one fact per message max
 
         if extracted:
             logger.info("Auto-extracted %d facts from conversation", extracted)

--- a/plugins/memory/holographic/retrieval.py
+++ b/plugins/memory/holographic/retrieval.py
@@ -6,9 +6,13 @@ Jaccard similarity reranking and trust-weighted scoring.
 
 from __future__ import annotations
 
+import logging
 import math
+import re
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
+
+logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from .store import MemoryStore
@@ -106,6 +110,20 @@ class FactRetriever:
         # Sort by score descending, return top limit
         scored.sort(key=lambda x: x["score"], reverse=True)
         results = scored[:limit]
+
+        # Increment retrieval_count for returned facts (fixes #17899)
+        if results:
+            try:
+                ids = [r["fact_id"] for r in results]
+                placeholders = ",".join("?" * len(ids))
+                self.store._conn.execute(
+                    f"UPDATE facts SET retrieval_count = retrieval_count + 1 WHERE fact_id IN ({placeholders})",
+                    ids,
+                )
+                self.store._conn.commit()
+            except Exception:
+                logger.debug("Failed to increment retrieval_count", exc_info=True)
+
         # Strip raw HRR bytes — callers expect JSON-serializable dicts
         for fact in results:
             fact.pop("hrr_vector", None)
@@ -492,11 +510,16 @@ class FactRetriever:
         """
         conn = self.store._conn
 
+        # Sanitize query for FTS5: hyphens and special chars break MATCH.
+        # Strategy: try original first; on failure, fall back to AND of
+        # individual tokens; on further failure, fall back to OR.
+        sanitized = self._sanitize_fts_query(query)
+
         # Build query - FTS5 rank is negative (lower = better match)
         # We need to join facts_fts with facts to get all columns
         params: list = []
         where_clauses = ["facts_fts MATCH ?"]
-        params.append(query)
+        params.append(sanitized)
 
         if category:
             where_clauses.append("f.category = ?")
@@ -517,11 +540,15 @@ class FactRetriever:
         """
         params.append(limit)
 
-        try:
-            rows = conn.execute(sql, params).fetchall()
-        except Exception:
-            # FTS5 MATCH can fail on malformed queries — fall back to empty
-            return []
+        rows = []
+        for attempt_query in (sanitized, self._sanitize_fts_query(query, mode="and"), self._sanitize_fts_query(query, mode="or")):
+            attempt_params = [attempt_query] + params[1:]
+            try:
+                rows = conn.execute(sql, attempt_params).fetchall()
+                if rows:
+                    break
+            except Exception:
+                continue
 
         if not rows:
             return []
@@ -540,6 +567,35 @@ class FactRetriever:
             results.append(fact)
 
         return results
+
+    @staticmethod
+    def _sanitize_fts_query(query: str, mode: str = "default") -> str:
+        """Sanitize a query string for FTS5 MATCH.
+
+        FTS5 treats hyphens as column-filter operators and several other
+        characters as query syntax. This strips or escapes them to prevent
+        "no such column" errors.
+
+        Modes:
+          - "default": quote each token individually (handles hyphens)
+          - "and": space-separated tokens (implicit AND)
+          - "or": OR-joined tokens (broader fallback)
+        """
+        # Remove FTS5 operators: AND, OR, NOT, *, ^, column:
+        tokens = re.split(r'[\s\-\.]+', query.strip())
+        tokens = [t.strip('.,;:!?\"\'()[]{}#@<>') for t in tokens]
+        tokens = [t for t in tokens if t]
+
+        if not tokens:
+            return query  # give up, let FTS5 handle it
+
+        if mode == "or":
+            return " OR ".join(f'"{t}"' for t in tokens)
+        elif mode == "and":
+            return " ".join(f'"{t}"' for t in tokens)
+        else:
+            # default: quote each token to handle hyphens
+            return " ".join(f'"{t}"' for t in tokens)
 
     @staticmethod
     def _tokenize(text: str) -> set[str]:

--- a/tests/plugins/memory/test_holographic_fixes.py
+++ b/tests/plugins/memory/test_holographic_fixes.py
@@ -1,0 +1,338 @@
+"""Tests for holographic memory plugin fixes.
+
+Covers:
+  - FTS5 query sanitization (#14024, #21102)
+  - retrieval_count increment (#17899)
+  - numpy degradation warning (#17350)
+  - auto_extract structured extraction (#22907)
+  - Fuzzing edge cases for FTS5 queries
+"""
+
+import os
+import sqlite3
+import tempfile
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# Ensure the plugin is importable
+import sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", ".."))
+
+from plugins.memory.holographic.store import MemoryStore
+from plugins.memory.holographic.retrieval import FactRetriever
+
+
+@pytest.fixture
+def store(tmp_path):
+    """Create a fresh MemoryStore with a temp DB."""
+    db = str(tmp_path / "test_memory.db")
+    return MemoryStore(db_path=db, default_trust=0.5, hrr_dim=128)
+
+
+@pytest.fixture
+def retriever(store):
+    """Create a FactRetriever for the temp store."""
+    return FactRetriever(store=store, hrr_dim=128, hrr_weight=0.0)
+
+
+# =========================================================================
+# FTS5 query sanitization (#14024)
+# =========================================================================
+
+class TestFTS5Sanitization:
+    """Hyphenated and special-char queries must not crash FTS5."""
+
+    def test_hyphenated_query(self, store, retriever):
+        """pve-01 should work without 'no such column' error."""
+        store.add_fact("PVE-01 hardware: i5-13500T, IP 10.20.90.00", category="hardware", tags="pve-01")
+        results = retriever.search("pve-01", min_trust=0.0)
+        assert len(results) >= 1
+        assert "PVE-01" in results[0]["content"]
+
+    def test_hyphenated_hostnames(self, store, retriever):
+        """Multiple hyphenated hostnames should all be findable."""
+        store.add_fact("pihole-02 blocks ads on DNS", tags="pihole-02")
+        store.add_fact("lxc-103 runs Ubuntu 24.04", tags="lxc-103")
+        store.add_fact("gw-router handles VLAN trunking", tags="gw-router")
+
+        assert len(retriever.search("pihole-02", min_trust=0.0)) >= 1
+        assert len(retriever.search("lxc-103", min_trust=0.0)) >= 1
+        assert len(retriever.search("gw-router", min_trust=0.0)) >= 1
+
+    def test_special_fts5_operators(self, store, retriever):
+        """Characters that are FTS5 operators: AND, OR, NOT, *, ^, :"""
+        store.add_fact("C++ programming language is widely used")
+        store.add_fact("search:elasticsearch for logging")
+        store.add_fact("NOT a drill, this is real")
+
+        # These should not crash
+        results = retriever.search("C++", min_trust=0.0)
+        assert isinstance(results, list)
+
+        results = retriever.search("search:elasticsearch", min_trust=0.0)
+        assert isinstance(results, list)
+
+        results = retriever.search("NOT drill", min_trust=0.0)
+        assert isinstance(results, list)
+
+    def test_sanitize_fts_query_modes(self):
+        """Test the _sanitize_fts_query static method directly."""
+        from plugins.memory.holographic.retrieval import FactRetriever
+
+        # default mode: tokens quoted
+        assert FactRetriever._sanitize_fts_query("pve-01") == '"pve" "01"'
+
+        # and mode: same as default
+        assert FactRetriever._sanitize_fts_query("pve-01", mode="and") == '"pve" "01"'
+
+        # or mode: OR-joined
+        result = FactRetriever._sanitize_fts_query("pve-01", mode="or")
+        assert "OR" in result
+        assert '"pve"' in result
+        assert '"01"' in result
+
+    def test_empty_query(self, retriever):
+        """Empty query should return empty results, not crash."""
+        assert retriever.search("", min_trust=0.0) == []
+
+    def test_query_only_hyphens(self, store, retriever):
+        """Query that is only hyphens/punctuation should not crash."""
+        store.add_fact("some regular fact content here")
+        results = retriever.search("---", min_trust=0.0)
+        assert isinstance(results, list)  # may be empty, just don't crash
+
+
+# =========================================================================
+# FTS5 query fuzzing
+# =========================================================================
+
+class TestFTS5Fuzzing:
+    """Fuzz the FTS5 query path with adversarial inputs."""
+
+    @pytest.mark.parametrize("query", [
+        "'; DROP TABLE facts; --",
+        "null\x00byte",
+        "UPPER CASE QUERY",
+        "   lots   of   spaces   ",
+        "emoji 🎉 unicode café résumé",
+        "a",
+        "x" * 500,
+        "1+1=2",
+        "field:value",
+        '"already quoted"',
+        "'single quoted'",
+        "fact AND fiction OR reality NOT dream",
+        "term*",
+        "^boosted",
+        "NEAR/3 term",
+        "pve-01 lxc-103",
+        "10.20.90.00",
+        "path/to/file.py",
+        "user@domain.com",
+        "a-b-c-d-e",
+        "!@#$%^&*()",
+    ])
+    def test_fuzz_queries(self, store, retriever, query):
+        """None of these queries should crash the search."""
+        store.add_fact("Regular fact about Python and Rust programming languages")
+        store.add_fact("PVE-01 server at 10.20.90.00 running Proxmox")
+        results = retriever.search(query, min_trust=0.0)
+        assert isinstance(results, list)
+
+
+# =========================================================================
+# retrieval_count increment (#17899)
+# =========================================================================
+
+class TestRetrievalCount:
+    """retrieval_count should be incremented when facts are retrieved."""
+
+    def test_search_increments_count(self, store, retriever):
+        """After searching, retrieval_count should go from 0 to 1."""
+        fact_id = store.add_fact("Python is a programming language")
+
+        # Verify starting at 0
+        row = store._conn.execute(
+            "SELECT retrieval_count FROM facts WHERE fact_id = ?", (fact_id,)
+        ).fetchone()
+        assert row["retrieval_count"] == 0
+
+        # Search and find it
+        results = retriever.search("Python", min_trust=0.0)
+        assert len(results) >= 1
+
+        # Verify incremented
+        row = store._conn.execute(
+            "SELECT retrieval_count FROM facts WHERE fact_id = ?", (fact_id,)
+        ).fetchone()
+        assert row["retrieval_count"] >= 1
+
+    def test_multiple_searches_accumulate(self, store, retriever):
+        """Multiple searches should keep incrementing."""
+        store.add_fact("Rust is memory safe")
+
+        retriever.search("Rust", min_trust=0.0)
+        retriever.search("Rust", min_trust=0.0)
+        retriever.search("Rust", min_trust=0.0)
+
+        row = store._conn.execute(
+            "SELECT retrieval_count FROM facts WHERE content LIKE '%Rust%'"
+        ).fetchone()
+        assert row["retrieval_count"] >= 3
+
+    def test_unrelated_search_no_increment(self, store, retriever):
+        """Searching for something else shouldn't increment unrelated facts."""
+        fact_id = store.add_fact("Haskell is purely functional")
+        store.add_fact("Rust is memory safe")
+
+        retriever.search("Rust", min_trust=0.0)
+
+        row = store._conn.execute(
+            "SELECT retrieval_count FROM facts WHERE fact_id = ?", (fact_id,)
+        ).fetchone()
+        assert row["retrieval_count"] == 0
+
+
+# =========================================================================
+# auto_extract structured extraction (#22907)
+# =========================================================================
+
+class TestAutoExtract:
+    """auto_extract should produce clean declarative facts, not raw messages."""
+
+    def _make_provider(self, store):
+        """Create a minimal HolographicMemoryProvider for testing auto_extract."""
+        from plugins.memory.holographic import HolographicMemoryProvider
+        provider = HolographicMemoryProvider.__new__(HolographicMemoryProvider)
+        provider._store = store
+        provider._config = {"auto_extract": True}
+        provider._hrr_available = True
+        return provider
+
+    def test_preference_extraction(self, store):
+        """'I prefer dark mode' should extract 'prefers dark mode'."""
+        provider = self._make_provider(store)
+        provider._auto_extract_facts([
+            {"role": "user", "content": "I prefer dark mode over light mode"}
+        ])
+        facts = store.list_facts(category="user_pref")
+        assert any("dark mode" in f["content"] for f in facts)
+        # Should NOT contain the raw message
+        assert not any("over light mode" not in f["content"] and "I prefer" in f["content"] for f in facts)
+
+    def test_no_raw_message_dump(self, store):
+        """'I like that, sounds good' should NOT be stored as a fact."""
+        provider = self._make_provider(store)
+        provider._auto_extract_facts([
+            {"role": "user", "content": "I like that, sounds good"}
+        ])
+        facts = store.list_facts()
+        # "I like" no longer matches — we removed "like" from the pattern
+        assert not any("I like that" in f["content"] for f in facts)
+
+    def test_decision_extraction(self, store):
+        """'We decided to use PostgreSQL' should extract 'decided to use PostgreSQL'."""
+        provider = self._make_provider(store)
+        provider._auto_extract_facts([
+            {"role": "user", "content": "We decided to use PostgreSQL for the backend"}
+        ])
+        facts = store.list_facts(category="project")
+        assert any("PostgreSQL" in f["content"] for f in facts)
+        assert any(f["content"].startswith("decided to") for f in facts)
+
+    def test_habit_extraction(self, store):
+        """'I always check git status' should extract 'always check git status'."""
+        provider = self._make_provider(store)
+        provider._auto_extract_facts([
+            {"role": "user", "content": "I always check git status before committing"}
+        ])
+        facts = store.list_facts(category="user_pref")
+        assert any("always check git status" in f["content"] for f in facts)
+
+    def test_assistant_messages_ignored(self, store):
+        """Assistant messages should not produce facts."""
+        provider = self._make_provider(store)
+        provider._auto_extract_facts([
+            {"role": "assistant", "content": "I prefer to use structured outputs"}
+        ])
+        facts = store.list_facts()
+        assert len(facts) == 0
+
+    def test_short_messages_ignored(self, store):
+        """Messages under 10 chars should be skipped."""
+        provider = self._make_provider(store)
+        provider._auto_extract_facts([
+            {"role": "user", "content": "I like"}
+        ])
+        facts = store.list_facts()
+        assert len(facts) == 0
+
+    def test_one_fact_per_message(self, store):
+        """A single message should produce at most one fact."""
+        provider = self._make_provider(store)
+        provider._auto_extract_facts([
+            {"role": "user", "content": "I prefer Rust. We decided to use Rust. I always use Rust."}
+        ])
+        facts = store.list_facts(category="user_pref")
+        # Should produce at most 1 fact for this message (first match wins)
+        assert len([f for f in facts if "Rust" in f["content"]]) <= 1
+
+    def test_fact_length_capped(self, store):
+        """Extracted facts should not exceed 200 characters."""
+        provider = self._make_provider(store)
+        long_pref = "x" * 300
+        provider._auto_extract_facts([
+            {"role": "user", "content": f"I prefer {long_pref}"}
+        ])
+        facts = store.list_facts()
+        for f in facts:
+            assert len(f["content"]) <= 200
+
+
+# =========================================================================
+# numpy degradation warning (#17350)
+# =========================================================================
+
+class TestNumpyWarning:
+    """Holographic memory should warn when numpy is unavailable."""
+
+    def test_system_prompt_with_numpy(self):
+        """With numpy available, system prompt should not show warning."""
+        from plugins.memory.holographic import HolographicMemoryProvider
+        provider = HolographicMemoryProvider.__new__(HolographicMemoryProvider)
+        provider._store = MagicMock()
+        provider._hrr_available = True
+        provider._store._conn.execute.return_value.fetchone.return_value = (5,)
+
+        prompt = provider.system_prompt_block()
+        assert "WARNING" not in prompt
+        assert "5 facts" in prompt
+
+    def test_system_prompt_without_numpy(self):
+        """Without numpy, system prompt should show degradation warning."""
+        from plugins.memory.holographic import HolographicMemoryProvider
+        provider = HolographicMemoryProvider.__new__(HolographicMemoryProvider)
+        provider._store = MagicMock()
+        provider._hrr_available = False
+        provider._store._conn.execute.return_value.fetchone.return_value = (3,)
+
+        prompt = provider.system_prompt_block()
+        assert "WARNING" in prompt
+        assert "numpy" in prompt
+        assert "3 facts" in prompt
+
+    def test_init_warns_without_numpy(self, caplog):
+        """initialize() should log a warning when numpy is missing."""
+        import logging
+        from plugins.memory.holographic import HolographicMemoryProvider
+        with tempfile.TemporaryDirectory() as tmp:
+            provider = HolographicMemoryProvider(config={
+                "db_path": os.path.join(tmp, "test.db"),
+            })
+            with patch("plugins.memory.holographic.holographic._HAS_NUMPY", False):
+                with caplog.at_level(logging.WARNING, logger="plugins.memory.holographic"):
+                    provider.initialize("test-session")
+                assert hasattr(provider, "_hrr_available")
+                assert not provider._hrr_available
+                assert any("numpy not found" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

Four bug fixes for the holographic memory plugin, all reported and validated by the community.

### 1. FTS5 query sanitization (#14024, #21102)
Hyphenated tokens (`pve-01`, `lxc-103`) crashed FTS5 MATCH with "no such column" errors. The unicode61 tokenizer treats `-` as a column filter operator.

**Fix:** `_sanitize_fts_query()` splits on hyphens/punctuation and double-quotes each token. Three-tier fallback: quoted AND → quoted AND retry → OR. Also handles `C++`, `field:value`, `AND/OR/NOT`, wildcards, SQL injection attempts.

### 2. retrieval_count never incremented (#17899)
`FactRetriever.search()` bypassed `store.search_facts()`, the only place that bumped the counter. The field was always 0.

**Fix:** Increment `retrieval_count` for returned facts directly in `FactRetriever.search()`, with silent error handling.

### 3. Silent numpy degradation (#17350)
When numpy was missing, HRR operations silently fell back to FTS5-only. No warning, no `hermes doctor` detection. Users had no idea probe/reason/contradict were degraded.

**Fix:** `initialize()` logs a WARNING. `system_prompt_block()` includes a visible WARNING so the agent (and user) know HRR is disabled.

### 4. auto_extract saves raw messages (#22907)
The regex patterns matched "I like / I want / I need" and dumped the entire user message verbatim as a fact. "I like that, sounds good" became a stored fact.

**Fix:** Removed noisy "like/love/want/need" patterns. Remaining patterns extract captured groups into clean declarative statements: `"prefers dark mode over light mode"` instead of `"I prefer dark mode over light mode, can you set it up?"`. 200 char cap, one fact per message, assistant messages skipped.

## Test plan

- 41 new tests in `tests/plugins/memory/test_holographic_fixes.py`
- 21 parametrized fuzz tests with adversarial inputs (SQL injection, null bytes, FTS5 operators, emojis, etc.)
- All 201 tests in `tests/plugins/memory/` passing
- End-to-end verified against real `memory_store.db`:
  - `pve-01`, `pihole-02`, `lxc-103` searches: 1 result each (was crashing)
  - `retrieval_count` incremented on search
  - All 9 fuzz queries: zero crashes
  - auto_extract produces clean declarative facts, no raw dumps