### PR TITLE
fix: resolve project context for gquota

### DIFF
--- a/hermes_cli/cli_commands_mixin.py
+++ b/hermes_cli/cli_commands_mixin.py
@@ -920,8 +920,9 @@ class CLICommandsMixin:
     def _handle_gquota_command(self, cmd_original: str) -> None:
         """Show Google Gemini Code Assist quota usage for the current OAuth account."""
         try:
+            from agent import google_oauth
             from agent.google_oauth import get_valid_access_token, GoogleOAuthError, load_credentials
-            from agent.google_code_assist import retrieve_user_quota, CodeAssistError
+            from agent.google_code_assist import retrieve_user_quota, resolve_project_context, CodeAssistError
         except ImportError as exc:
             self._console_print(f"  [red]Gemini modules unavailable: {exc}[/]")
             return
@@ -935,6 +936,24 @@ class CLICommandsMixin:
 
         creds = load_credentials()
         project_id = (creds.project_id if creds else "") or ""
+        project_source = "stored" if project_id else "auto / free-tier"
+
+        if not project_id:
+            try:
+                ctx = resolve_project_context(
+                    access_token,
+                    env_project_id=google_oauth.resolve_project_id_from_env(),
+                    user_agent_model=str(getattr(self, "current_model", "") or ""),
+                )
+                project_id = ctx.project_id or ""
+                project_source = ctx.source or project_source
+                if project_id or ctx.managed_project_id:
+                    google_oauth.update_project_ids(
+                        project_id=project_id,
+                        managed_project_id=ctx.managed_project_id,
+                    )
+            except CodeAssistError as exc:
+                self._console_print(f"  [yellow]Project discovery failed; falling back to auto quota lookup:[/] {exc}")
 
         try:
             buckets = retrieve_user_quota(access_token, project_id=project_id)
@@ -949,7 +968,9 @@ class CLICommandsMixin:
         # Sort for stable display, group by model
         buckets.sort(key=lambda b: (b.model_id, b.token_type))
         self._console_print()
-        self._console_print(f"  [bold]Gemini Code Assist quota[/]  (project: {project_id or '(auto / free-tier)'})")
+        project_label = project_id or "(auto / free-tier)"
+        self._console_print(f"  [bold]Gemini Code Assist quota[/]  (project: {project_label}, source: {project_source})")
+        self._console_print("  [dim]/gquota shows daily Code Assist buckets only; hidden RPM/TPM, web-search, account, and model-capacity limits can still return 429.[/]")
         self._console_print()
         for b in buckets:
             pct = max(0.0, min(1.0, b.remaining_fraction))

--- a/tests/cli/test_gquota_command.py
+++ b/tests/cli/test_gquota_command.py
@@ -1,3 +1,4 @@
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 
@@ -19,3 +20,86 @@ def test_gquota_uses_chat_console_when_tui_is_live():
 
     assert live_console.print.call_count == 2
     cli.console.print.assert_not_called()
+
+
+def test_gquota_resolves_project_context_before_quota_lookup():
+    from cli import HermesCLI
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.console = MagicMock()
+    cli._app = None
+    cli.current_model = "gemini-3.1-pro-preview"
+
+    bucket = SimpleNamespace(
+        model_id="gemini-3.1-pro-preview",
+        token_type="daily",
+        remaining_fraction=0.5,
+    )
+    ctx = SimpleNamespace(
+        project_id="resolved-project",
+        managed_project_id="managed-project",
+        source="discovered",
+    )
+
+    with patch("agent.google_oauth.get_valid_access_token", return_value="access-token"), \
+         patch("agent.google_oauth.load_credentials", return_value=SimpleNamespace(project_id="")), \
+         patch("agent.google_oauth.resolve_project_id_from_env", return_value=""), \
+         patch("agent.google_oauth.update_project_ids") as update_project_ids, \
+         patch("agent.google_code_assist.resolve_project_context", return_value=ctx) as resolve_project_context, \
+         patch("agent.google_code_assist.retrieve_user_quota", return_value=[bucket]) as retrieve_user_quota:
+        cli._handle_gquota_command("/gquota")
+
+    resolve_project_context.assert_called_once_with(
+        "access-token",
+        env_project_id="",
+        user_agent_model="gemini-3.1-pro-preview",
+    )
+    update_project_ids.assert_called_once_with(
+        project_id="resolved-project",
+        managed_project_id="managed-project",
+    )
+    retrieve_user_quota.assert_called_once_with(
+        "access-token",
+        project_id="resolved-project",
+    )
+    rendered = "\n".join(str(call.args[0]) for call in cli.console.print.call_args_list if call.args)
+    assert "resolved-project" in rendered
+    assert "source: discovered" in rendered
+
+
+def test_gquota_falls_back_to_auto_quota_when_project_discovery_fails():
+    from agent.google_code_assist import CodeAssistError
+    from cli import HermesCLI
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli.console = MagicMock()
+    cli._app = None
+    cli.current_model = "gemini-3.1-pro-preview"
+
+    bucket = SimpleNamespace(
+        model_id="gemini-3.1-pro-preview",
+        token_type="daily",
+        remaining_fraction=0.25,
+    )
+
+    with patch("agent.google_oauth.get_valid_access_token", return_value="access-token"), \
+         patch("agent.google_oauth.load_credentials", return_value=SimpleNamespace(project_id="")), \
+         patch("agent.google_oauth.resolve_project_id_from_env", return_value=""), \
+         patch("agent.google_oauth.update_project_ids") as update_project_ids, \
+         patch("agent.google_code_assist.resolve_project_context", side_effect=CodeAssistError("discovery failed")) as resolve_project_context, \
+         patch("agent.google_code_assist.retrieve_user_quota", return_value=[bucket]) as retrieve_user_quota:
+        cli._handle_gquota_command("/gquota")
+
+    resolve_project_context.assert_called_once_with(
+        "access-token",
+        env_project_id="",
+        user_agent_model="gemini-3.1-pro-preview",
+    )
+    update_project_ids.assert_not_called()
+    retrieve_user_quota.assert_called_once_with(
+        "access-token",
+        project_id="",
+    )
+    rendered = "\n".join(str(call.args[0]) for call in cli.console.print.call_args_list if call.args)
+    assert "Project discovery failed" in rendered
+    assert "project: (auto / free-tier)" in rendered


### PR DESCRIPTION
## Summary
- Resolve Google Gemini Code Assist project context before `/gquota` calls `retrieve_user_quota` when stored OAuth credentials do not already have a project id.
- Persist discovered project/managed project ids for future quota calls.
- Show project source in `/gquota` output and clarify that daily Code Assist buckets do not cover hidden RPM/TPM/capacity limits.
- Add regression coverage for successful project discovery and fallback when project discovery fails.

## Why
`resolve_project_context()` is already used by the Gemini Cloud Code adapter before model requests. `/gquota` skipped that step and passed an empty project id when credentials lacked one, which can report generic quota buckets instead of the actual Code Assist project/account buckets.

## Test Plan
- `python -m pytest tests/cli/test_gquota_command.py -q -o addopts=` → 3 passed
- `python -m pytest tests/cli/test_gquota_command.py tests/agent/test_gemini_cloudcode.py -q -o addopts=` → 92 passed
