### PR TITLE
feat: per-task model override for kanban workers

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -595,6 +595,7 @@ class Task:
     # JSON array of skill names. None = use only the defaults; empty
     # list = explicitly no extra skills.
     skills: Optional[list] = None
+    model_override: Optional[str] = None
     # Per-task override for the consecutive-failure circuit breaker.
     # The value is the failure count at which the breaker trips — e.g.
     # ``max_retries=1`` blocks on the first failure (zero retries),
@@ -664,6 +665,7 @@ class Task:
                 row["current_step_key"] if "current_step_key" in keys else None
             ),
             skills=skills_value,
+            model_override=row["model_override"] if "model_override" in keys and row["model_override"] else None,
             max_retries=(
                 row["max_retries"] if "max_retries" in keys else None
             ),
@@ -788,6 +790,10 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- Appended to the dispatcher's built-in `--skills kanban-worker`.
     -- NULL or empty array = no extras.
     skills               TEXT,
+    -- Per-task model override. When set, the dispatcher passes -m <model>
+    -- to the worker, overriding the profile's default model. NULL = use
+    -- the profile default.
+    model_override       TEXT,
     -- Per-task override for the consecutive-failure circuit breaker.
     -- The value is the failure count at which the breaker trips — e.g.
     -- ``max_retries=1`` blocks on the first failure. NULL (the common
@@ -1032,6 +1038,9 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         # which is the correct default (they keep the global behaviour
         # they were getting before the column existed).
         conn.execute("ALTER TABLE tasks ADD COLUMN max_retries INTEGER")
+
+    if "model_override" not in cols:
+        conn.execute("ALTER TABLE tasks ADD COLUMN model_override TEXT")
 
     # task_events gained a run_id column; back-fill it as NULL for
     # historical events (they predate runs and can't be attributed).
@@ -3741,6 +3750,8 @@ def _default_spawn(
         for sk in task.skills:
             if sk and sk != "kanban-worker":
                 cmd.extend(["--skills", sk])
+    if task.model_override:
+        cmd.extend(["-m", task.model_override])
     cmd.extend([
         "chat",
         "-q", prompt,


### PR DESCRIPTION
## Summary
Allow Producer to set per-Consumer model via `model_override` field on kanban tasks.

## Changes
- `Task.model_override` field (Optional[str])
- Schema migration for existing databases
- `_default_spawn` passes `-m model` when model_override is set
- SCHEMA_SQL includes model_override TEXT column

## Motivation
Without per-task model override, ALL workers run on the profile's default model. This means:
- Simple tasks waste Pro compute
- Complex tasks can't opt into Pro for quality
- Flash/Pro routing is impossible at the kanban level

This enables Hands allocation matrix to route per-Consumer model selection.

## Usage
```python
kanban_create(title="Consumer: simple task", assignee="harness", model_override="deepseek-v4-flash")
kanban_create(title="Consumer: code review", assignee="harness", model_override="deepseek-v4-pro")
```