### PR TITLE
fix(kanban): preserve assignee casing in dashboard (salvage #21459)

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -1924,6 +1924,10 @@
           title: props.columnName === "triage"
             ? "Hermes profile that will spec this task (default: the dispatcher's configured specifier). Leave blank to let the dispatcher pick."
             : "Hermes profile to assign. Leave blank and the dispatcher will pick from available profiles when the task is Ready.",
+          style: { textTransform: "none" },
+          autoCapitalize: "none",
+          autoCorrect: "off",
+          spellCheck: false,
         }),
         h(Input, {
           type: "number",
@@ -2517,6 +2521,10 @@
         },
         placeholder: tx(t, "emptyAssignee", "(empty = unassign)"),
         className: "h-7 text-xs flex-1",
+        style: { textTransform: "none" },
+        autoCapitalize: "none",
+        autoCorrect: "off",
+        spellCheck: false,
       }),
     );
   }

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -202,8 +202,10 @@
   align-items: center;
   gap: 0.4rem;
   font-size: 0.65rem;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  /* Assignee/profile names are case-sensitive. Do not visually uppercase
+   * lane headers, otherwise a valid `analyst` profile appears as `ANALYST`
+   * in the WebUI and users may copy the wrong casing back into edits. */
+  letter-spacing: 0.02em;
   color: var(--color-muted-foreground);
   padding: 0 0.1rem;
 }

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -713,6 +713,7 @@ AUTHOR_MAP = {
     "ty@tmrtn.com": "tymrtn",
     "elitovsky@zenproject.net": "kallidean",
     "5463986+baocin@users.noreply.github.com": "baocin",
+    "107296821+princepal9120@users.noreply.github.com": "princepal9120",
     "23434080+sicnuyudidi@users.noreply.github.com": "sicnuyudidi",
     "haimu0x0@proton.me": "haimu0x",
     "abdelmajidnidnasser1@gmail.com": "NIDNASSER-Abdelmajid",

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -1723,3 +1723,65 @@ def test_dashboard_requests_default_board_explicitly():
     assert "SDK.fetchJSON(withBoard(`${API}/config`, board))" in dist
     assert "SDK.fetchJSON(withBoard(`${API}/boards`, board))" in dist
     assert "}, [loadBoardList, switchBoard, board]);" in dist
+
+
+def test_dashboard_assignee_inputs_preserve_casing():
+    """Assignee/specifier inputs must disable browser auto-capitalization.
+
+    Hermes profile names are case-sensitive — the dispatcher uses the
+    assignee string as a literal directory/profile lookup. Mobile browsers
+    (iOS/Android) and some IMEs auto-capitalize the first letter of any
+    text input by default, so a user typing ``analyst`` ends up submitting
+    ``Analyst`` and the dispatcher fails to spawn a matching profile,
+    leading to the crash loop reported in #21320.
+
+    The fix sets ``autoCapitalize="none"``, ``autoCorrect="off"``,
+    ``spellCheck=false``, and ``style={textTransform: "none"}`` on the
+    two assignee ``<Input>`` elements (inline triage/lane create-task
+    input + task-edit panel "(empty = unassign)" input).
+
+    This test pins those attributes in the compiled dist bundle so a
+    future rebuild that loses them fails CI immediately.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    dist = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text()
+
+    # Both sites should have all four attributes. Count occurrences to
+    # ensure both inputs got the treatment, not just one.
+    assert dist.count('autoCapitalize: "none"') >= 2, (
+        "Expected autoCapitalize=\"none\" on both assignee inputs (inline "
+        "create + task-edit panel)"
+    )
+    assert dist.count('autoCorrect: "off"') >= 2
+    assert dist.count("spellCheck: false") >= 2
+    assert dist.count('textTransform: "none"') >= 2
+
+
+def test_dashboard_lane_head_preserves_assignee_casing():
+    """Lane headers must not visually uppercase profile names.
+
+    The previous CSS rule ``.hermes-kanban-lane-head { text-transform:
+    uppercase; letter-spacing: 0.08em }`` made a valid ``analyst`` profile
+    appear as ``ANALYST`` in column headers; users then copied the
+    uppercase form back into edits, hitting the same crash loop as the
+    auto-capitalization path. The fix removes ``text-transform: uppercase``
+    from the rule and tightens letter-spacing.
+
+    Static-asset regression test for the rule contents.
+    """
+    repo_root = Path(__file__).resolve().parents[2]
+    style = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "style.css").read_text()
+
+    # Locate the .hermes-kanban-lane-head block. Use a generous slice to
+    # keep this resilient to nearby unrelated CSS edits.
+    marker = ".hermes-kanban-lane-head {"
+    idx = style.find(marker)
+    assert idx != -1, "could not locate .hermes-kanban-lane-head rule"
+    end = style.find("}", idx)
+    assert end != -1
+    rule = style[idx:end]
+
+    assert "text-transform: uppercase" not in rule, (
+        "Lane head must not visually uppercase profile names — see #21320 "
+        "and the explanatory comment in the CSS rule."
+    )


### PR DESCRIPTION
## Summary
The Kanban dashboard's assignee/specifier inputs no longer silently auto-capitalize on mobile browsers and IMEs, and column headers no longer visually uppercase profile names. This stops the crash-loop reported in #21320 where users typing `analyst` had it submitted as `Analyst` (or copied the uppercase column header back into edits), failing the dispatcher's case-sensitive profile lookup.

## Root cause
Two visual paths to the same outcome:

1. The two assignee `<Input>` elements (inline triage/lane create + task-edit panel) didn't set `autoCapitalize`, `autoCorrect`, or `spellCheck`. iOS/Android (and some IMEs) auto-capitalize the first letter by default → `analyst` becomes `Analyst` on submit → dispatcher fails to spawn a matching profile → the worker crashes in a loop.
2. The `.hermes-kanban-lane-head` CSS had `text-transform: uppercase` — purely cosmetic, but it shows `analyst` as `ANALYST` in the column header. Users then copy `ANALYST` back into edits assuming it's the canonical form, hitting the same crash loop via a different door.

## Changes
- `plugins/kanban/dashboard/dist/index.js`: add `autoCapitalize="none"`, `autoCorrect="off"`, `spellCheck=false`, and `style={textTransform: "none"}` to both assignee `<Input>` elements (inline create + task-edit panel).
- `plugins/kanban/dashboard/dist/style.css`: drop `text-transform: uppercase` from `.hermes-kanban-lane-head`, tighten `letter-spacing` from `0.08em` to `0.02em`, and add an explanatory comment so a future restyling doesn't re-introduce the uppercase rule.
- `tests/plugins/test_kanban_dashboard_plugin.py`: two static-asset regression tests pinning the dist edits — one for the four input attributes (asserting each appears ≥ 2× so both inputs are covered), one for the absence of `text-transform: uppercase` in the lane-head CSS rule.

## What this does NOT cover
Issue #21320 lists six suggested mitigations; this PR addresses suggestion #1 (the casing-mangling root cause), which is the primary reproducer. The other five — crash-loop detection, pre-spawn profile existence validation, in-UI error surfacing, workspace folder naming, copy-task-id button — remain. Closing this PR does not close #21320; a follow-up comment links this PR as the fix for the primary leg and keeps the remaining legs tracked.

## Validation
| | Before | After |
|---|---|---|
| `tests/plugins/test_kanban_dashboard_plugin.py` | 75/75 | 77/77 |

Salvage of #21459. Original commit by @princepal9120 preserved with authorship. AUTHOR_MAP entry added.
