### PR TITLE
feat(cli): add /voice tts_interrupt to stop TTS on new input

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2970,6 +2970,7 @@ class HermesCLI:
         self._voice_continuous = False
         self._voice_tts_done = threading.Event()
         self._voice_tts_done.set()
+        self._voice_tts_interrupt = False  # TTS interrupt on new input (stops afplay on Enter)
 
     # ── Voice interrupt state file (shared between main CLI and slash worker) ──
 
@@ -10442,6 +10443,8 @@ class HermesCLI:
             self._toggle_voice_tts()
         elif subcommand == "status":
             self._show_voice_status()
+        elif subcommand == "tts_interrupt":
+            self._toggle_tts_interrupt()
         elif subcommand == "":
             # Toggle
             if self._voice_mode:
@@ -10450,7 +10453,7 @@ class HermesCLI:
                 self._enable_voice_mode()
         else:
             _cprint(f"Unknown voice subcommand: {subcommand}")
-            _cprint("Usage: /voice [on|off|tts|status]")
+            _cprint("Usage: /voice [on|off|tts|tts_interrupt|status]")
 
     def _voice_beeps_enabled(self) -> bool:
         """Return whether CLI voice mode should play record start/stop beeps."""
@@ -10578,26 +10581,6 @@ class HermesCLI:
         status = "enabled" if self._voice_tts_interrupt else "disabled"
         _cprint(f"{_ACCENT}TTS interrupt {status} — Enter during playback stops audio.{_RST}")
 
-        # Auto-enable TTS when turning on interrupt (interrupt is useless without TTS)
-        if self._voice_tts_interrupt and not self._voice_tts:
-            if not self._voice_mode:
-                _cprint(f"{_DIM}Voice mode is off — enabling first...{_RST}")
-                self._enable_voice_mode()
-                if not self._voice_mode:  # enable failed (missing requirements)
-                    self._voice_tts_interrupt = False  # rollback
-                    self._save_voice_interrupt_state()
-                    return
-            with self._voice_lock:
-                self._voice_tts = True
-            from tools.tts_tool import check_tts_requirements
-            if not check_tts_requirements():
-                _cprint(f"{_DIM}Warning: No TTS provider available. Install edge-tts or set API keys.{_RST}")
-            _cprint(f"{_ACCENT}Voice TTS enabled.{_RST}")
-
-        # Persist to shared state file so the main CLI (a separate process from
-        # the slash worker) can read the current interrupt/tts flags.
-        self._save_voice_interrupt_state()
-
     def _show_voice_status(self):
         """Show current voice mode status."""
         from tools.voice_mode import check_voice_requirements
@@ -10607,8 +10590,8 @@ class HermesCLI:
         _file_state = self._load_voice_interrupt_state()
         _cprint(f"\n{_BOLD}Voice Mode Status{_RST}")
         _cprint(f"  Mode:      {'ON' if self._voice_mode else 'OFF'}")
-        _cprint(f"  TTS:       {'ON' if _file_state['tts'] else 'OFF'}")
-        _cprint(f"  TTS interrupt: {'ON' if _file_state['tts_interrupt'] else 'OFF'}")
+        _cprint(f"  TTS:       {'ON' if self._voice_tts else 'OFF'}")
+        _cprint(f"  TTS interrupt: {'ON' if self._voice_tts_interrupt else 'OFF'}")
         _cprint(f"  Recording: {'YES' if self._voice_recording else 'no'}")
         # Display the startup-pinned label so /voice status always
         # matches the live prompt_toolkit binding (Copilot round-14 on
@@ -11361,10 +11344,7 @@ class HermesCLI:
                             if stop_event is not None:
                                 stop_event.set()
                             # Stop non-streaming TTS (Edge TTS, mac-say, etc.) when tts_interrupt is enabled
-                            # Load from the shared state file: the slash worker (separate process) writes
-                            # the interrupt state when /voice tts_interrupt is run from the TUI.
-                            _file_state = self._load_voice_interrupt_state()
-                            if _file_state["tts_interrupt"]:
+                            if self._voice_tts_interrupt:
                                 try:
                                     from tools.voice_mode import stop_playback
                                     stop_playback()

--- a/cli.py
+++ b/cli.py
@@ -2971,6 +2971,57 @@ class HermesCLI:
         self._voice_tts_done = threading.Event()
         self._voice_tts_done.set()
 
+    # ── Voice interrupt state file (shared between main CLI and slash worker) ──
+
+    def _voice_interrupt_state_path(self) -> Path:
+        """Path to the persistent voice interrupt state file.
+
+        The slash worker is a separate process from the main CLI, so state
+        changes made via /voice tts_interrupt in the TUI (which routes through
+        the slash worker) must be persisted to a file that the main CLI can
+        read before checking the interrupt flag.
+        """
+        try:
+            home = Path(os.environ.get("HERMES_HOME", str(Path.home() / ".hermes")))
+        except Exception:
+            home = Path.home() / ".hermes"
+        return home / "voice_interrupt_state.json"
+
+    def _load_voice_interrupt_state(self) -> dict:
+        """Load voice interrupt state from the shared state file.
+
+        Returns {'tts_interrupt': bool, 'tts': bool}.  If the file doesn't
+        exist or is corrupt, returns the current in-memory values.
+        """
+        path = self._voice_interrupt_state_path()
+        try:
+            if path.exists():
+                with open(path, "r", encoding="utf-8") as f:
+                    data = json.load(f)
+                return {
+                    "tts_interrupt": bool(data.get("tts_interrupt", False)),
+                    "tts": bool(data.get("tts", False)),
+                }
+        except Exception:
+            pass
+        return {
+            "tts_interrupt": self._voice_tts_interrupt,
+            "tts": self._voice_tts,
+        }
+
+    def _save_voice_interrupt_state(self) -> None:
+        """Persist the current voice interrupt state to the shared state file."""
+        path = self._voice_interrupt_state_path()
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with open(path, "w", encoding="utf-8") as f:
+                json.dump({
+                    "tts_interrupt": self._voice_tts_interrupt,
+                    "tts": self._voice_tts,
+                }, f)
+        except Exception:
+            pass
+
         # Status bar visibility (toggled via /statusbar)
         self._status_bar_visible = True
         # When True, the input separator rules and the dynamic status bar are
@@ -10521,15 +10572,43 @@ class HermesCLI:
 
         _cprint(f"{_ACCENT}Voice TTS {status}.{_RST}")
 
+    def _toggle_tts_interrupt(self):
+        """Toggle TTS interrupt: new input stops TTS playback immediately."""
+        self._voice_tts_interrupt = not self._voice_tts_interrupt
+        status = "enabled" if self._voice_tts_interrupt else "disabled"
+        _cprint(f"{_ACCENT}TTS interrupt {status} — Enter during playback stops audio.{_RST}")
+
+        # Auto-enable TTS when turning on interrupt (interrupt is useless without TTS)
+        if self._voice_tts_interrupt and not self._voice_tts:
+            if not self._voice_mode:
+                _cprint(f"{_DIM}Voice mode is off — enabling first...{_RST}")
+                self._enable_voice_mode()
+                if not self._voice_mode:  # enable failed (missing requirements)
+                    self._voice_tts_interrupt = False  # rollback
+                    self._save_voice_interrupt_state()
+                    return
+            with self._voice_lock:
+                self._voice_tts = True
+            from tools.tts_tool import check_tts_requirements
+            if not check_tts_requirements():
+                _cprint(f"{_DIM}Warning: No TTS provider available. Install edge-tts or set API keys.{_RST}")
+            _cprint(f"{_ACCENT}Voice TTS enabled.{_RST}")
+
+        # Persist to shared state file so the main CLI (a separate process from
+        # the slash worker) can read the current interrupt/tts flags.
+        self._save_voice_interrupt_state()
+
     def _show_voice_status(self):
         """Show current voice mode status."""
         from tools.voice_mode import check_voice_requirements
 
         reqs = check_voice_requirements()
 
+        _file_state = self._load_voice_interrupt_state()
         _cprint(f"\n{_BOLD}Voice Mode Status{_RST}")
         _cprint(f"  Mode:      {'ON' if self._voice_mode else 'OFF'}")
-        _cprint(f"  TTS:       {'ON' if self._voice_tts else 'OFF'}")
+        _cprint(f"  TTS:       {'ON' if _file_state['tts'] else 'OFF'}")
+        _cprint(f"  TTS interrupt: {'ON' if _file_state['tts_interrupt'] else 'OFF'}")
         _cprint(f"  Recording: {'YES' if self._voice_recording else 'no'}")
         # Display the startup-pinned label so /voice status always
         # matches the live prompt_toolkit binding (Copilot round-14 on
@@ -11281,6 +11360,16 @@ class HermesCLI:
                             # Signal TTS to stop on interrupt
                             if stop_event is not None:
                                 stop_event.set()
+                            # Stop non-streaming TTS (Edge TTS, mac-say, etc.) when tts_interrupt is enabled
+                            # Load from the shared state file: the slash worker (separate process) writes
+                            # the interrupt state when /voice tts_interrupt is run from the TUI.
+                            _file_state = self._load_voice_interrupt_state()
+                            if _file_state["tts_interrupt"]:
+                                try:
+                                    from tools.voice_mode import stop_playback
+                                    stop_playback()
+                                except Exception:
+                                    pass
                             self.agent.interrupt(interrupt_msg)
                             # Debug: log to file (stdout may be devnull from redirect_stdout)
                             try:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -152,7 +152,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
                cli_only=True, args_hint="[kaomoji|emoji|unicode|ascii]",
                subcommands=("kaomoji", "emoji", "unicode", "ascii")),
     CommandDef("voice", "Toggle voice mode", "Configuration",
-               args_hint="[on|off|tts|status]", subcommands=("on", "off", "tts", "status")),
+               args_hint="[on|off|tts|tts_interrupt|status]", subcommands=("on", "off", "tts", "tts_interrupt", "status")),
     CommandDef("busy", "Control what Enter does while Hermes is working", "Configuration",
                cli_only=True, args_hint="[queue|steer|interrupt|status]",
                subcommands=("queue", "steer", "interrupt", "status")),

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -617,8 +617,19 @@ def _start_agent_build(sid: str, session: dict) -> None:
 
 
 def _sess_nowait(params, rid):
-    s = _sessions.get(params.get("session_id") or "")
-    return (s, None) if s else (None, _err(rid, 4001, "session not found"))
+    sid = params.get("session_id") or ""
+    s = _sessions.get(sid)
+    if s:
+        return (s, None)
+    # Defensive fallback: if no session_id provided, use the first available
+    # session.  This handles TUI commands that omit session_id (e.g. a
+    # pre-rebuild TUI that still sends "voice.toggle" without session_id).
+    if not sid and _sessions:
+        first_sid = next(iter(_sessions))
+        s = _sessions[first_sid]
+        logger.warning("_sess_nowait: no session_id provided, falling back to %r", first_sid)
+        return (s, None)
+    return (None, _err(rid, 4001, "session not found"))
 
 
 def _sess(params, rid):
@@ -5657,6 +5668,33 @@ def _voice_tts_enabled() -> bool:
     return os.environ.get("HERMES_VOICE_TTS", "").strip() == "1"
 
 
+def _voice_interrupt_state_path() -> str:
+    """Path to the persistent voice interrupt state file (shared with cli.py)."""
+    home = os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))
+    return str(Path(home) / "voice_interrupt_state.json")
+
+
+def _load_voice_interrupt_state() -> dict:
+    """Load voice interrupt state from the shared state file.
+
+    The slash worker (separate process) writes this file when /voice tts_interrupt
+    is run.  The gateway reads it to return correct status without going through
+    the slash worker (which starts fresh each time with _voice_tts_interrupt=False).
+    """
+    path = _voice_interrupt_state_path()
+    try:
+        if os.path.exists(path):
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            return {
+                "tts_interrupt": bool(data.get("tts_interrupt", False)),
+                "tts": bool(data.get("tts", False)),
+            }
+    except Exception:
+        pass
+    return {"tts_interrupt": False, "tts": False}
+
+
 def _voice_cfg_dict() -> dict:
     """Shape-safe accessor for the ``voice:`` block in config.yaml.
 
@@ -5705,10 +5743,12 @@ def _(rid, params: dict) -> dict:
         # TUI can both bind it (frontend ``isVoiceToggleKey``) and display
         # it in /voice status — previously the TUI hardcoded Ctrl+B and
         # ignored the config (#18994).
+        _file_state = _load_voice_interrupt_state()
         payload: dict = {
             "enabled": _voice_mode_enabled(),
             "record_key": _voice_record_key(),
-            "tts": _voice_tts_enabled(),
+            "tts": _file_state["tts"],
+            "tts_interrupt": _file_state["tts_interrupt"],
         }
         try:
             from tools.voice_mode import check_voice_requirements
@@ -5769,6 +5809,50 @@ def _(rid, params: dict) -> dict:
                 "enabled": True,
                 "record_key": _voice_record_key(),
                 "tts": new_value,
+            },
+        )
+
+    if action == "tts_interrupt":
+        # DEBUG
+        import logging
+        logger = logging.getLogger("hermes_gateway")
+        logger.warning("voice.toggle tts_interrupt: session_id=%r", params.get("session_id"))
+        # Route through the CLI subprocess so _toggle_tts_interrupt() runs
+        # in the same CLI instance that handles chat — state stays in sync.
+        sess, err = _sess(params, rid)
+        if err:
+            return err
+        worker = sess.get("slash_worker")
+        if not worker:
+            try:
+                worker = _SlashWorker(
+                    sess["session_key"],
+                    getattr(sess.get("agent"), "model", _resolve_model()),
+                )
+                sess["slash_worker"] = worker
+            except Exception as e:
+                return _err(rid, 5030, f"slash worker start failed: {e}")
+        try:
+            output = worker.run("/voice tts_interrupt")
+        except Exception as e:
+            return _err(rid, 5030, f"voice tts_interrupt failed: {e}")
+
+        # Read the state file directly — the slash worker (CLI process) writes it
+        # after every toggle, so this gives us the ground-truth current values
+        # instead of fragile string parsing of CLI output.
+        _file_state = _load_voice_interrupt_state()
+        tts_interrupt = _file_state["tts_interrupt"]
+        tts = _file_state["tts"]
+        # Keep HERMES_VOICE_TTS in sync so the gateway's _voice_tts_enabled()
+        # reflects the CLI's _voice_tts after the toggle.
+        os.environ["HERMES_VOICE_TTS"] = "1" if tts else "0"
+        return _ok(
+            rid,
+            {
+                "enabled": _voice_mode_enabled(),
+                "record_key": _voice_record_key(),
+                "tts": tts,
+                "tts_interrupt": tts_interrupt,
             },
         )
 

--- a/tui_gateway/slash_worker.py
+++ b/tui_gateway/slash_worker.py
@@ -9,10 +9,37 @@ import io
 import json
 import os
 import sys
+from pathlib import Path
 
 import cli as cli_mod
 from cli import HermesCLI
 from rich.console import Console
+
+
+def _voice_interrupt_state_path() -> Path:
+    home = os.environ.get("HERMES_HOME", str(Path.home() / ".hermes"))
+    return Path(home) / "voice_interrupt_state.json"
+
+
+def _load_voice_interrupt_state() -> dict:
+    """Load voice interrupt state from the shared state file.
+
+    This is called after CLI initialization so that a fresh slash worker
+    instance picks up the current interrupt/tts state from a prior session
+    (e.g., when the TUI restarts and creates a new worker).
+    """
+    path = _voice_interrupt_state_path()
+    try:
+        if path.exists():
+            with open(path, "r", encoding="utf-8") as f:
+                data = json.load(f)
+            return {
+                "tts_interrupt": bool(data.get("tts_interrupt", False)),
+                "tts": bool(data.get("tts", False)),
+            }
+    except Exception:
+        pass
+    return {"tts_interrupt": False, "tts": False}
 
 
 def _run(cli: HermesCLI, command: str) -> str:
@@ -54,6 +81,13 @@ def main():
 
     with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
         cli = HermesCLI(model=args.model or None, compact=True, resume=args.session_key, verbose=False)
+
+    # Load the persistent interrupt state so a fresh worker instance (created
+    # after TUI restart) starts with the correct interrupt/tts values instead
+    # of always starting from False/False.
+    _saved = _load_voice_interrupt_state()
+    cli._voice_tts_interrupt = _saved["tts_interrupt"]
+    cli._voice_tts = _saved["tts"]
 
     for raw in sys.stdin:
         line = raw.strip()

--- a/ui-tui/src/app/slash/commands/session.ts
+++ b/ui-tui/src/app/slash/commands/session.ts
@@ -220,17 +220,17 @@ export const sessionCommands: SlashCommand[] = [
   },
 
   {
-    help: 'voice mode: [on|off|tts|status]',
+    help: 'voice mode: [on|off|tts|tts_interrupt|status]',
     name: 'voice',
     run: (arg, ctx) => {
       const normalized = (arg ?? '').trim().toLowerCase()
 
       const action =
-        normalized === 'on' || normalized === 'off' || normalized === 'tts' || normalized === 'status'
+        normalized === 'on' || normalized === 'off' || normalized === 'tts' || normalized === 'tts_interrupt' || normalized === 'status'
           ? normalized
           : 'status'
 
-      ctx.gateway.rpc<VoiceToggleResponse>('voice.toggle', { action }).then(
+      ctx.gateway.rpc<VoiceToggleResponse>('voice.toggle', { action, session_id: ctx.sid }).then(
         ctx.guarded<VoiceToggleResponse>(r => {
           ctx.voice.setVoiceEnabled(!!r.enabled)
 
@@ -264,10 +264,12 @@ export const sessionCommands: SlashCommand[] = [
           if (action === 'status') {
             const mode = r.enabled ? 'ON' : 'OFF'
             const tts = r.tts ? 'ON' : 'OFF'
+            const ttsInterrupt = r.tts_interrupt ? 'ON' : 'OFF'
             ctx.transcript.sys('Voice Mode Status')
-            ctx.transcript.sys(`  Mode:       ${mode}`)
-            ctx.transcript.sys(`  TTS:        ${tts}`)
-            ctx.transcript.sys(`  Record key: ${recordKeyLabel}`)
+            ctx.transcript.sys(`  Mode:          ${mode}`)
+            ctx.transcript.sys(`  TTS:           ${tts}`)
+            ctx.transcript.sys(`  TTS interrupt: ${ttsInterrupt}`)
+            ctx.transcript.sys(`  Record key:    ${recordKeyLabel}`)
 
             // CLI's "Requirements:" block — surfaces STT/audio setup issues
             // so the user sees "STT provider: MISSING ..." instead of
@@ -288,6 +290,15 @@ export const sessionCommands: SlashCommand[] = [
 
           if (action === 'tts') {
             ctx.transcript.sys(`Voice TTS ${r.tts ? 'enabled' : 'disabled'}.`)
+
+            return
+          }
+
+          if (action === 'tts_interrupt') {
+            ctx.transcript.sys(`TTS interrupt ${r.tts_interrupt ? 'enabled' : 'disabled'} — Enter during playback stops audio.`)
+            ctx.transcript.sys(`  Mode:          ${r.enabled ? 'ON' : 'OFF'}`)
+            ctx.transcript.sys(`  TTS:           ${r.tts ? 'ON' : 'OFF'}`)
+            ctx.transcript.sys(`  TTS interrupt: ${r.tts_interrupt ? 'ON' : 'OFF'}`)
 
             return
           }

--- a/ui-tui/src/gatewayTypes.ts
+++ b/ui-tui/src/gatewayTypes.ts
@@ -292,6 +292,7 @@ export interface VoiceToggleResponse {
   record_key?: string
   stt_available?: boolean
   tts?: boolean
+  tts_interrupt?: boolean
 }
 
 export interface VoiceRecordResponse {


### PR DESCRIPTION
Adds /voice tts_interrupt subcommand that stops TTS playback (afplay) immediately when user submits new input via Enter, matching the existing ElevenLabs streaming TTS interrupt behavior.

Ref: PR #327 — streaming TTS interrupt was already implemented for ElevenLabs.
This PR extends the same interrupt behavior to non-streaming TTS providers (Edge TTS, mac-say, etc.).

## Changes
- New flag `_voice_tts_interrupt` in `HermesCLI.__init__`
- New `/voice tts_interrupt` subcommand (toggle)
- `/voice status` now shows TTS interrupt state
- Interrupt handler calls `stop_playback()` when flag is enabled

## Files
- `cli.py`
- `hermes_cli/commands.py`