### PR TITLE
fix(achievements): inject Authorization header in plugin API calls

### DIFF
--- a/plugins/hermes-achievements/dashboard/dist/index.js
+++ b/plugins/hermes-achievements/dashboard/dist/index.js
@@ -50,7 +50,9 @@
 
   async function api(path, options) {
     const url = "/api/plugins/hermes-achievements" + path;
-    const res = await fetch(url, options || {});
+    const token = window.__HERMES_SESSION_TOKEN__ || "";
+    const headers = { ...(options?.headers || {}), Authorization: `Bearer ${token}` };
+    const res = await fetch(url, { ...options, headers });
     if (!res.ok) {
       const text = await res.text().catch(function () { return res.statusText; });
       throw new Error(res.status + ": " + text);


### PR DESCRIPTION
## Fix: hermes-achievements 401 on all API calls

**Bug:** The `api()` function in `plugins/hermes-achievements/dashboard/dist/index.js` calls `fetch()` without forwarding the session Bearer token, but the FastAPI backend requires `Authorization: Bearer <token>` on all `/api/` routes.

**Result:** Every interaction with the Achievements page returns 401 Unauthorized.

**Root cause:** Compare with the `kanban` plugin (`dashboard/dist/index.js` ~line 530) which correctly reads `window.__HERMES_SESSION_TOKEN__` and passes it as `Authorization: Bearer <token>`. The achievements plugin was missing this.

**Fix:** Inject `Authorization: Bearer ${token}` header using the session token from `window.__HERMES_SESSION_TOKEN__`.

```diff
async function api(path, options) {
  const url = "/api/plugins/hermes-achievements" + path;
- const res = await fetch(url, options || {});
+ const token = window.__HERMES_SESSION_TOKEN__ || "";
+ const headers = { ...(options?.headers || {}), Authorization: `Bearer ${token}` };
+ const res = await fetch(url, { ...options, headers });
```
