### PR TITLE
feat(kanban): dashboard batch QOL upgrade

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -606,14 +606,15 @@
         } else {
           setFailedIds(new Set());
         }
-        clearSelected();
+        setSelectedIds(new Set());
+        setLastSelectedId(null);
         loadBoard();
       }).catch(function (err) {
         setError(`Move failed: ${err.message || err}`);
         setFailedIds(new Set(selectedIds));
         loadBoard();
       });
-    }, [selectedIds, loadBoard, clearSelected, board]);
+    }, [selectedIds, loadBoard, board]);
 
     const createTask = useCallback(function (body) {
       return SDK.fetchJSON(withBoard(`${API}/tasks`, board), {
@@ -722,14 +723,15 @@
           } else {
             setFailedIds(new Set());
           }
-          clearSelected();
+          setSelectedIds(new Set());
+          setLastSelectedId(null);
           loadBoard();
         })
         .catch(function (e) {
           setError(String(e.message || e));
           setFailedIds(new Set(selectedIds));
         });
-    }, [selectedIds, loadBoard, clearSelected, board]);
+    }, [selectedIds, loadBoard, board]);
 
     // --- board switching ----------------------------------------------------
     const switchBoard = useCallback(function (nextSlug) {
@@ -1715,7 +1717,7 @@
       }
       el.addEventListener("hermes-kanban:drop", onTouchDrop);
       return function () { el.removeEventListener("hermes-kanban:drop", onTouchDrop); };
-    }, [props.column.name, props.onMove]);
+    }, [props.column.name, props.onMove, props.selectedIds, props.onMoveSelected]);
 
     const handleDragOver = function (e) {
       e.preventDefault();

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -371,6 +371,8 @@
 
     const [selectedTaskId, setSelectedTaskId] = useState(null);
     const [selectedIds, setSelectedIds] = useState(() => new Set());
+    const [lastSelectedId, setLastSelectedId] = useState(null);
+    const [failedIds, setFailedIds] = useState(() => new Set());
     // Per-task event counter incremented whenever the WS stream reports
     // a new event for that task id. TaskDrawer useEffect-depends on its
     // own task's counter so it reloads itself on live events instead of
@@ -520,7 +522,7 @@
         if (tenantFilter && t.tenant !== tenantFilter) return false;
         if (assigneeFilter && t.assignee !== assigneeFilter) return false;
         if (q) {
-          const hay = `${t.id} ${t.title || ""} ${t.assignee || ""} ${t.tenant || ""}`.toLowerCase();
+          const hay = `${t.id} ${t.title || ""} ${t.body || ""} ${t.result || ""} ${t.latest_summary || ""} ${t.summary || ""} ${t.assignee || ""} ${t.tenant || ""}`.toLowerCase();
           if (hay.indexOf(q) === -1) return false;
         }
         return true;
@@ -564,6 +566,55 @@
       });
     }, [loadBoard, board]);
 
+    const clearSelected = useCallback(function () {
+      setSelectedIds(new Set());
+      setLastSelectedId(null);
+      setFailedIds(new Set());
+    }, []);
+    const moveSelected = useCallback(function (newStatus) {
+      const confirmMsg = DESTRUCTIVE_TRANSITIONS[newStatus];
+      if (confirmMsg && !window.confirm(confirmMsg)) return;
+      if (selectedIds.size === 0) return;
+      const patch = withCompletionSummary({ status: newStatus }, selectedIds.size);
+      if (!patch) return;
+      const ids = Array.from(selectedIds);
+      // Optimistic UI: remove selected from all columns and prepend to target.
+      setBoardData(function (b) {
+        if (!b) return b;
+        const moved = [];
+        const columns = b.columns.map(function (col) {
+          const kept = [];
+          for (const t of col.tasks) {
+            if (selectedIds.has(t.id)) moved.push(Object.assign({}, t, { status: newStatus }));
+            else kept.push(t);
+          }
+          return Object.assign({}, col, { tasks: kept });
+        });
+        const dest = columns.find(function (c) { return c.name === newStatus; });
+        if (dest) dest.tasks = moved.concat(dest.tasks);
+        return Object.assign({}, b, { columns });
+      });
+      SDK.fetchJSON(withBoard(`${API}/tasks/bulk`, board), {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(Object.assign({ ids }, patch)),
+      }).then(function (res) {
+        const failed = (res.results || []).filter(function (r) { return !r.ok; });
+        if (failed.length > 0) {
+          setError(`Bulk move: ${failed.length} of ${res.results.length} failed`);
+          setFailedIds(new Set(failed.map(function (f) { return f.id; })));
+        } else {
+          setFailedIds(new Set());
+        }
+        clearSelected();
+        loadBoard();
+      }).catch(function (err) {
+        setError(`Move failed: ${err.message || err}`);
+        setFailedIds(new Set(selectedIds));
+        loadBoard();
+      });
+    }, [selectedIds, loadBoard, clearSelected, board]);
+
     const createTask = useCallback(function (body) {
       return SDK.fetchJSON(withBoard(`${API}/tasks`, board), {
         method: "POST",
@@ -590,8 +641,66 @@
         else next.add(id);
         return next;
       });
+      setLastSelectedId(id);
+      setFailedIds(function (prev) {
+        if (prev.has(id)) {
+          const next = new Set(prev);
+          next.delete(id);
+          return next;
+        }
+        return prev;
+      });
     }, []);
-    const clearSelected = useCallback(function () { setSelectedIds(new Set()); }, []);
+
+    const toggleRange = useCallback(function (toId) {
+      // Build flat visible task order from filteredBoard columns.
+      setSelectedIds(function (prev) {
+        const next = new Set(prev);
+        if (!filteredBoard || !filteredBoard.columns) return next;
+        const order = [];
+        for (const col of filteredBoard.columns) {
+          for (const t of col.tasks || []) order.push(t.id);
+        }
+        const anchor = lastSelectedId;
+        if (!anchor || anchor === toId) {
+          next.has(toId) ? next.delete(toId) : next.add(toId);
+          return next;
+        }
+        const aIdx = order.indexOf(anchor);
+        const bIdx = order.indexOf(toId);
+        if (aIdx === -1 || bIdx === -1) {
+          next.has(toId) ? next.delete(toId) : next.add(toId);
+          return next;
+        }
+        const lo = Math.min(aIdx, bIdx);
+        const hi = Math.max(aIdx, bIdx);
+        for (let i = lo; i <= hi; i++) next.add(order[i]);
+        return next;
+      });
+    }, [filteredBoard, lastSelectedId]);
+
+    const selectAllVisible = useCallback(function () {
+      if (!filteredBoard || !filteredBoard.columns) return;
+      const next = new Set();
+      for (const col of filteredBoard.columns) {
+        for (const t of col.tasks || []) next.add(t.id);
+      }
+      setSelectedIds(next);
+      if (next.size > 0) {
+        const first = Array.from(next)[0];
+        setLastSelectedId(first);
+      }
+    }, [filteredBoard]);
+
+    const selectAllInColumn = useCallback(function (columnName) {
+      if (!filteredBoard || !filteredBoard.columns) return;
+      const col = filteredBoard.columns.find(function (c) { return c.name === columnName; });
+      if (!col) return;
+      const next = new Set(selectedIds);
+      for (const t of col.tasks || []) next.add(t.id);
+      setSelectedIds(next);
+      if (col.tasks && col.tasks.length > 0) setLastSelectedId(col.tasks[0].id);
+    }, [filteredBoard, selectedIds]);
 
     const applyBulk = useCallback(function (patch, confirmMsg) {
       if (selectedIds.size === 0) return;
@@ -609,11 +718,17 @@
           if (failed.length > 0) {
             setError(`Bulk: ${failed.length} of ${res.results.length} failed: ` +
               failed.slice(0, 3).map(function (f) { return `${f.id} (${f.error})`; }).join("; "));
+            setFailedIds(new Set(failed.map(function (f) { return f.id; })));
+          } else {
+            setFailedIds(new Set());
           }
           clearSelected();
           loadBoard();
         })
-        .catch(function (e) { setError(String(e.message || e)); });
+        .catch(function (e) {
+          setError(String(e.message || e));
+          setFailedIds(new Set(selectedIds));
+        });
     }, [selectedIds, loadBoard, clearSelected, board]);
 
     // --- board switching ----------------------------------------------------
@@ -627,7 +742,13 @@
       setLoading(true);
       setBoard(nextSlug);
       writeSelectedBoard(nextSlug);
-    }, [board]);
+      // Reset filters so stale search/tenant/assignee don't persist across boards.
+      setSearch("");
+      setTenantFilter("");
+      setAssigneeFilter("");
+      setIncludeArchived(false);
+      clearSelected();
+    }, [board, clearSelected]);
 
     const createNewBoard = useCallback(function (payload) {
       return SDK.fetchJSON(`${API}/boards`, {
@@ -709,14 +830,19 @@
           assignees: (boardData && boardData.assignees) || [],
           onApply: applyBulk,
           onClear: clearSelected,
+          onSelectAllVisible: selectAllVisible,
         }) : null,
         error ? h("div", { className: "text-xs text-destructive px-2" }, error) : null,
         h(BoardColumns, {
           board: filteredBoard,
           laneByProfile,
           selectedIds,
+          failedIds,
           toggleSelected,
+          toggleRange,
+          selectAllInColumn,
           onMove: moveTask,
+          onMoveSelected: moveSelected,
           onOpen: setSelectedTaskId,
           onCreate: createTask,
           allTasks: boardData.columns.reduce(function (acc, c) { return acc.concat(c.tasks); }, []),
@@ -1415,6 +1541,16 @@
         size: "sm",
         title: "Reload the board from the database. The board auto-refreshes on task events; this is for forcing a re-read.",
       }, "Refresh"),
+      h(Button, {
+        onClick: function () {
+          props.setSearch("");
+          props.setTenantFilter("");
+          props.setAssigneeFilter("");
+          props.setIncludeArchived(false);
+        },
+        size: "sm",
+        title: "Clear all active filters (search, tenant, assignee, archived).",
+      }, "Clear filters"),
     );
   }
 
@@ -1424,14 +1560,33 @@
 
   function BulkActionBar(props) {
     const [assignee, setAssignee] = useState("");
+    const [reclaimFirst, setReclaimFirst] = useState(false);
+    const [priority, setPriority] = useState("");
     return h("div", { className: "hermes-kanban-bulk" },
       h("span", { className: "hermes-kanban-bulk-count" },
         `${props.count} selected`),
+      h(Button, {
+        onClick: function () { props.onApply({ status: "todo" }); },
+        size: "sm",
+        title: "Move selected tasks to Todo.",
+      }, "→ todo"),
       h(Button, {
         onClick: function () { props.onApply({ status: "ready" }); },
         size: "sm",
         title: "Move selected tasks to Ready. Ready tasks are picked up by the dispatcher on the next tick.",
       }, "→ ready"),
+      h(Button, {
+        onClick: function () { props.onApply({ status: "blocked" },
+          `Block ${props.count} task(s)?`); },
+        size: "sm",
+        title: "Block selected tasks. Releases any active claims.",
+      }, "Block"),
+      h(Button, {
+        onClick: function () { props.onApply({ status: "ready" },
+          `Unblock ${props.count} task(s)?`); },
+        size: "sm",
+        title: "Unblock selected tasks (promote to Ready).",
+      }, "Unblock"),
       h(Button, {
         onClick: function () {
           props.onApply({ status: "done" },
@@ -1448,6 +1603,25 @@
         size: "sm",
         title: "Archive selected tasks. They disappear from the default board view but remain in the database.",
       }, "Archive"),
+      h("div", { className: "hermes-kanban-bulk-priority",
+                 title: "Set priority on selected tasks. Higher = claimed first." },
+        h(Input, {
+          type: "number",
+          value: priority,
+          onChange: function (e) { setPriority(e.target.value); },
+          placeholder: "pri",
+          className: "h-7 text-xs w-16",
+        }),
+        h(Button, {
+          onClick: function () {
+            if (priority === "") return;
+            props.onApply({ priority: Number(priority) });
+            setPriority("");
+          },
+          disabled: priority === "",
+          size: "sm",
+        }, "Set priority"),
+      ),
       h("div", { className: "hermes-kanban-bulk-reassign",
                  title: "Reassign selected tasks to a different Hermes profile. Pick a profile (or unassign) and click Apply." },
         h(Select, {
@@ -1464,7 +1638,7 @@
         h(Button, {
           onClick: function () {
             if (!assignee) return;
-            props.onApply({ assignee: assignee === "__none__" ? "" : assignee });
+            props.onApply({ assignee: assignee === "__none__" ? "" : assignee, reclaim_first: reclaimFirst });
             setAssignee("");
           },
           disabled: !assignee,
@@ -1472,7 +1646,20 @@
           title: "Apply the selected assignee to all selected tasks.",
         }, "Apply"),
       ),
+      h("label", { className: "hermes-kanban-bulk-reclaim-first", title: "Reclaim any active claims before reassigning" },
+        h("input", {
+          type: "checkbox",
+          checked: reclaimFirst,
+          onChange: function (e) { setReclaimFirst(e.target.checked); },
+        }),
+        "Reclaim first",
+      ),
       h("div", { className: "flex-1" }),
+      h(Button, {
+        onClick: props.onSelectAllVisible,
+        size: "sm",
+        title: "Select all visible cards across columns.",
+      }, "Select all visible"),
       h(Button, {
         onClick: props.onClear,
         size: "sm",
@@ -1493,8 +1680,12 @@
           column: col,
           laneByProfile: props.laneByProfile,
           selectedIds: props.selectedIds,
+          failedIds: props.failedIds,
           toggleSelected: props.toggleSelected,
+          toggleRange: props.toggleRange,
+          selectAllInColumn: props.selectAllInColumn,
           onMove: props.onMove,
+          onMoveSelected: props.onMoveSelected,
           onOpen: props.onOpen,
           onCreate: props.onCreate,
           allTasks: props.allTasks,
@@ -1514,7 +1705,12 @@
       const el = colRef.current;
       function onTouchDrop(e) {
         if (e.detail && e.detail.status === props.column.name) {
-          props.onMove(e.detail.taskId, props.column.name);
+          const taskId = e.detail.taskId;
+          if (props.selectedIds && props.selectedIds.has(taskId) && props.selectedIds.size > 1 && props.onMoveSelected) {
+            props.onMoveSelected(props.column.name);
+          } else {
+            props.onMove(taskId, props.column.name);
+          }
         }
       }
       el.addEventListener("hermes-kanban:drop", onTouchDrop);
@@ -1531,7 +1727,12 @@
       e.preventDefault();
       setDragOver(false);
       const taskId = e.dataTransfer.getData(MIME_TASK);
-      if (taskId) props.onMove(taskId, props.column.name);
+      if (!taskId) return;
+      if (props.selectedIds && props.selectedIds.has(taskId) && props.selectedIds.size > 1) {
+        if (props.onMoveSelected) props.onMoveSelected(props.column.name);
+      } else {
+        props.onMove(taskId, props.column.name);
+      }
     };
 
     const lanes = useMemo(function () {
@@ -1559,6 +1760,18 @@
     },
       h("div", { className: "hermes-kanban-column-header",
                  title: COLUMN_HELP[props.column.name] || "" },
+        h("input", {
+          type: "checkbox",
+          className: "hermes-kanban-col-check",
+          title: "Select all tasks in this column",
+          "aria-label": `Select all tasks in ${COLUMN_LABEL[props.column.name] || props.column.name}`,
+          checked: props.column.tasks.length > 0 && props.column.tasks.every(function (t) { return props.selectedIds.has(t.id); }),
+          onChange: function (e) {
+            e.stopPropagation();
+            if (props.selectAllInColumn) props.selectAllInColumn(props.column.name);
+          },
+          onClick: function (e) { e.stopPropagation(); },
+        }),
         h("span", { className: cn("hermes-kanban-dot", COLUMN_DOT[props.column.name]) }),
         h("span", { className: "hermes-kanban-column-label" },
           COLUMN_LABEL[props.column.name] || props.column.name),
@@ -1596,7 +1809,9 @@
                     return h(TaskCard, {
                       key: t.id, task: t,
                       selected: props.selectedIds.has(t.id),
+                      failed: props.failedIds && props.failedIds.has(t.id),
                       toggleSelected: props.toggleSelected,
+                      toggleRange: props.toggleRange,
                       onOpen: props.onOpen,
                     });
                   }),
@@ -1606,7 +1821,9 @@
                 return h(TaskCard, {
                   key: t.id, task: t,
                   selected: props.selectedIds.has(t.id),
+                  failed: props.failedIds && props.failedIds.has(t.id),
                   toggleSelected: props.toggleSelected,
+                  toggleRange: props.toggleRange,
                   onOpen: props.onOpen,
                 });
               }),
@@ -1652,14 +1869,28 @@
       e.dataTransfer.effectAllowed = "move";
     };
     const handleClick = function (e) {
-      // Shift-click or ctrl/cmd-click toggles selection instead of opening.
-      if (e.shiftKey || e.ctrlKey || e.metaKey) {
+      if (e.shiftKey) {
         e.preventDefault();
         e.stopPropagation();
-        props.toggleSelected(t.id, e.ctrlKey || e.metaKey);
+        if (props.toggleRange) props.toggleRange(t.id);
+        return;
+      }
+      if (e.ctrlKey || e.metaKey) {
+        e.preventDefault();
+        e.stopPropagation();
+        props.toggleSelected(t.id, true);
         return;
       }
       props.onOpen(t.id);
+    };
+    const handleKeyDown = function (e) {
+      if (e.key === "Enter" || e.key === " ") {
+        e.preventDefault();
+        props.onOpen(t.id);
+      }
+      if (e.key === "Escape") {
+        if (props.toggleSelected) props.toggleSelected(t.id, false);
+      }
     };
     const handleCheckbox = function (e) {
       e.stopPropagation();
@@ -1673,23 +1904,34 @@
       className: cn(
         "hermes-kanban-card",
         props.selected ? "hermes-kanban-card--selected" : "",
+        props.failed ? "hermes-kanban-card--failed" : "",
         stalenessClass(t),
       ),
       draggable: true,
+      tabIndex: 0,
+      role: "button",
+      "aria-label": `${t.title || "untitled"} — ${t.id} — ${t.status}`,
       onDragStart: handleDragStart,
       onClick: handleClick,
+      onKeyDown: handleKeyDown,
     },
       h(Card, null,
         h(CardContent, { className: "hermes-kanban-card-content" },
           h("div", { className: "hermes-kanban-card-row" },
-            h("input", {
-              type: "checkbox",
-              className: "hermes-kanban-card-check",
-              checked: props.selected,
-              onChange: handleCheckbox,
-              onClick: function (e) { e.stopPropagation(); },
+            h("label", {
+              className: "hermes-kanban-card-check-wrap",
               title: "Select for bulk actions",
-            }),
+              onClick: function (e) { e.stopPropagation(); },
+            },
+              h("input", {
+                type: "checkbox",
+                className: "hermes-kanban-card-check",
+                checked: props.selected,
+                onChange: handleCheckbox,
+                onClick: function (e) { e.stopPropagation(); },
+                "aria-label": `Select task ${t.id}`,
+              }),
+            ),
             h("span", { className: "hermes-kanban-card-id",
                         title: `Task id: ${t.id}. Use this id with kanban_show, /kanban show, or hermes kanban show.` }, t.id),
             t.warnings && t.warnings.count > 0

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -667,13 +667,13 @@
         }
         const anchor = lastSelectedId;
         if (!anchor || anchor === toId) {
-          next.has(toId) ? next.delete(toId) : next.add(toId);
+          next.add(toId);
           return next;
         }
         const aIdx = order.indexOf(anchor);
         const bIdx = order.indexOf(toId);
         if (aIdx === -1 || bIdx === -1) {
-          next.has(toId) ? next.delete(toId) : next.add(toId);
+          next.add(toId);
           return next;
         }
         const lo = Math.min(aIdx, bIdx);
@@ -681,6 +681,7 @@
         for (let i = lo; i <= hi; i++) next.add(order[i]);
         return next;
       });
+      setLastSelectedId(toId);
     }, [filteredBoard, lastSelectedId]);
 
     const selectAllVisible = useCallback(function () {
@@ -700,8 +701,13 @@
       if (!filteredBoard || !filteredBoard.columns) return;
       const col = filteredBoard.columns.find(function (c) { return c.name === columnName; });
       if (!col) return;
+      const allSelected = col.tasks && col.tasks.length > 0 && col.tasks.every(function (t) { return selectedIds.has(t.id); });
       const next = new Set(selectedIds);
-      for (const t of col.tasks || []) next.add(t.id);
+      if (allSelected) {
+        for (const t of col.tasks || []) next.delete(t.id);
+      } else {
+        for (const t of col.tasks || []) next.add(t.id);
+      }
       setSelectedIds(next);
       if (col.tasks && col.tasks.length > 0) setLastSelectedId(col.tasks[0].id);
     }, [filteredBoard, selectedIds]);
@@ -712,6 +718,24 @@
       const finalPatch = withCompletionSummary(patch, selectedIds.size);
       if (!finalPatch) return;
       const body = Object.assign({ ids: Array.from(selectedIds) }, finalPatch);
+      // Optimistic UI for status moves (same pattern as moveSelected).
+      if (finalPatch.status) {
+        setBoardData(function (b) {
+          if (!b) return b;
+          const moved = [];
+          const columns = b.columns.map(function (col) {
+            const kept = [];
+            for (const t of col.tasks) {
+              if (selectedIds.has(t.id)) moved.push(Object.assign({}, t, { status: finalPatch.status }));
+              else kept.push(t);
+            }
+            return Object.assign({}, col, { tasks: kept });
+          });
+          const dest = columns.find(function (c) { return c.name === finalPatch.status; });
+          if (dest) dest.tasks = moved.concat(dest.tasks);
+          return Object.assign({}, b, { columns });
+        });
+      }
       SDK.fetchJSON(withBoard(`${API}/tasks/bulk`, board), {
         method: "POST",
         headers: { "Content-Type": "application/json" },
@@ -733,6 +757,7 @@
         .catch(function (e) {
           setError(String(e.message || e));
           setFailedIds(new Set(selectedIds));
+          loadBoard();
         });
     }, [selectedIds, loadBoard, board]);
 

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -525,7 +525,7 @@
         if (tenantFilter && t.tenant !== tenantFilter) return false;
         if (assigneeFilter && t.assignee !== assigneeFilter) return false;
         if (q) {
-          const hay = `${t.id} ${t.title || ""} ${t.body || ""} ${t.result || ""} ${t.latest_summary || ""} ${t.summary || ""} ${t.assignee || ""} ${t.tenant || ""}`.toLowerCase();
+          const hay = `${t.id} ${t.title || ""} ${t.body || ""} ${t.result || ""} ${t.latest_summary || ""} ${t.assignee || ""} ${t.tenant || ""}`.toLowerCase();
           if (hay.indexOf(q) === -1) return false;
         }
         return true;

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -373,6 +373,9 @@
     const [selectedIds, setSelectedIds] = useState(() => new Set());
     const [lastSelectedId, setLastSelectedId] = useState(null);
     const [failedIds, setFailedIds] = useState(() => new Set());
+    const [draggingTaskId, setDraggingTaskId] = useState(null);
+    const handleDragStart = useCallback(function (taskId) { setDraggingTaskId(taskId); }, []);
+    const handleDragEnd = useCallback(function () { setDraggingTaskId(null); }, []);
     // Per-task event counter incremented whenever the WS stream reports
     // a new event for that task id. TaskDrawer useEffect-depends on its
     // own task's counter so it reloads itself on live events instead of
@@ -840,6 +843,9 @@
           laneByProfile,
           selectedIds,
           failedIds,
+          draggingTaskId,
+          onDragStart: handleDragStart,
+          onDragEnd: handleDragEnd,
           toggleSelected,
           toggleRange,
           selectAllInColumn,
@@ -1675,7 +1681,16 @@
   // -------------------------------------------------------------------------
 
   function BoardColumns(props) {
-    return h("div", { className: "hermes-kanban-columns" },
+    const handleDragStart = useCallback(function (e) {
+      const card = e.target.closest && e.target.closest(".hermes-kanban-card");
+      if (!card) return;
+      const taskId = card.getAttribute("data-task-id");
+      if (taskId && props.onDragStart) props.onDragStart(taskId);
+    }, [props.onDragStart]);
+    const handleDragEnd = useCallback(function () {
+      if (props.onDragEnd) props.onDragEnd();
+    }, [props.onDragEnd]);
+    return h("div", { className: "hermes-kanban-columns", onDragStart: handleDragStart, onDragEnd: handleDragEnd },
       props.board.columns.map(function (col) {
         return h(Column, {
           key: col.name,
@@ -1683,6 +1698,7 @@
           laneByProfile: props.laneByProfile,
           selectedIds: props.selectedIds,
           failedIds: props.failedIds,
+          draggingTaskId: props.draggingTaskId,
           toggleSelected: props.toggleSelected,
           toggleRange: props.toggleRange,
           selectAllInColumn: props.selectAllInColumn,
@@ -1812,6 +1828,8 @@
                       key: t.id, task: t,
                       selected: props.selectedIds.has(t.id),
                       failed: props.failedIds && props.failedIds.has(t.id),
+                      draggingTaskId: props.draggingTaskId,
+                      draggingSource: props.draggingTaskId && props.selectedIds.has(props.draggingTaskId) && props.selectedIds.size > 1 && props.selectedIds.has(t.id),
                       toggleSelected: props.toggleSelected,
                       toggleRange: props.toggleRange,
                       onOpen: props.onOpen,
@@ -1824,6 +1842,8 @@
                   key: t.id, task: t,
                   selected: props.selectedIds.has(t.id),
                   failed: props.failedIds && props.failedIds.has(t.id),
+                  draggingTaskId: props.draggingTaskId,
+                  draggingSource: props.draggingTaskId && props.selectedIds.has(props.draggingTaskId) && props.selectedIds.size > 1 && props.selectedIds.has(t.id),
                   toggleSelected: props.toggleSelected,
                   toggleRange: props.toggleRange,
                   onOpen: props.onOpen,
@@ -1869,6 +1889,17 @@
     const handleDragStart = function (e) {
       e.dataTransfer.setData(MIME_TASK, t.id);
       e.dataTransfer.effectAllowed = "move";
+      const selectedCards = document.querySelectorAll(".hermes-kanban-card--selected");
+      if (selectedCards.length > 1 && props.selected) {
+        const ghost = document.createElement("div");
+        ghost.className = "hermes-kanban-drag-ghost";
+        ghost.textContent = selectedCards.length + " cards";
+        document.body.appendChild(ghost);
+        e.dataTransfer.setDragImage(ghost, 0, 0);
+        requestAnimationFrame(function () {
+          if (ghost.parentNode) document.body.removeChild(ghost);
+        });
+      }
     };
     const handleClick = function (e) {
       if (e.shiftKey) {
@@ -1903,10 +1934,12 @@
 
     return h("div", {
       ref: cardRef,
+      "data-task-id": t.id,
       className: cn(
         "hermes-kanban-card",
         props.selected ? "hermes-kanban-card--selected" : "",
         props.failed ? "hermes-kanban-card--failed" : "",
+        props.draggingSource ? "hermes-kanban-card--dragging-source" : "",
         stalenessClass(t),
       ),
       draggable: true,

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -1374,3 +1374,51 @@
   color: #ff8b6b;
   border: 1px solid rgba(255, 107, 61, 0.3);
 }
+/* ---- Partial failure highlight --------------------------------------- */
+.hermes-kanban-card--failed :where(.hermes-kanban-card-content) {
+  box-shadow: 0 0 0 2px var(--color-destructive, #d14a4a) inset,
+              0 0 8px color-mix(in srgb, var(--color-destructive, #d14a4a) 30%, transparent);
+}
+
+/* ---- Larger checkbox hit target -------------------------------------- */
+.hermes-kanban-card-check-wrap {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 1.5rem;
+  height: 1.5rem;
+  margin: -0.3rem;
+  cursor: pointer;
+}
+.hermes-kanban-card-check {
+  width: 0.95rem;
+  height: 0.95rem;
+  margin: 0;
+  cursor: pointer;
+  accent-color: var(--color-ring);
+}
+
+/* ---- Column select-all checkbox -------------------------------------- */
+.hermes-kanban-col-check {
+  width: 0.9rem;
+  height: 0.9rem;
+  margin: 0 0.15rem 0 0;
+  cursor: pointer;
+  accent-color: var(--color-ring);
+}
+
+/* ---- Bulk action bar extras ------------------------------------------ */
+.hermes-kanban-bulk-priority {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
+  padding-left: 0.5rem;
+  border-left: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
+}
+.hermes-kanban-bulk-reclaim-first {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-size: 0.7rem;
+  cursor: pointer;
+}

--- a/plugins/kanban/dashboard/dist/style.css
+++ b/plugins/kanban/dashboard/dist/style.css
@@ -536,6 +536,15 @@
   background: color-mix(in srgb, var(--color-ring) 6%, var(--color-card));
 }
 
+/* Batch drag source styling — cards that are part of the current multi-drag.
+   The browser ghost image floats; we dim the original DOM nodes so the user
+   sees the whole set is in-flight. */
+.hermes-kanban-card--dragging-source :where(.hermes-kanban-card-content) {
+  opacity: 0.45;
+  filter: grayscale(0.6);
+  transition: opacity 120ms ease, filter 120ms ease;
+}
+
 .hermes-kanban-card-check {
   width: 0.85rem;
   height: 0.85rem;
@@ -774,6 +783,22 @@
   transition: none;
 }
 
+/* ---- Multi-drag ghost ----------------------------------------------- */
+
+.hermes-kanban-drag-ghost {
+  position: fixed;
+  left: -9999px;
+  padding: 0.45rem 0.8rem;
+  background: var(--color-card);
+  border: 2px solid var(--color-ring);
+  border-radius: var(--radius);
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--color-foreground);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.25);
+  pointer-events: none;
+  opacity: 0.95;
+}
 
 /* ---- Staleness tiers ------------------------------------------------ */
 

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -811,6 +811,7 @@ class BulkTaskBody(BaseModel):
     result: Optional[str] = None
     summary: Optional[str] = None
     metadata: Optional[dict] = None
+    reclaim_first: bool = False
 
 
 @router.post("/tasks/bulk")
@@ -865,9 +866,16 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                         entry.update(ok=False, error=f"transition to {s!r} refused")
                 if payload.assignee is not None:
                     try:
-                        if not kanban_db.assign_task(
-                            conn, tid, payload.assignee or None,
-                        ):
+                        if payload.reclaim_first:
+                            ok = kanban_db.reassign_task(
+                                conn, tid, payload.assignee or None,
+                                reclaim_first=True,
+                            )
+                        else:
+                            ok = kanban_db.assign_task(
+                                conn, tid, payload.assignee or None,
+                            )
+                        if not ok:
                             entry.update(ok=False, error="assign refused")
                     except RuntimeError as e:
                         entry.update(ok=False, error=str(e))

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -1723,3 +1723,58 @@ def test_dashboard_requests_default_board_explicitly():
     assert "SDK.fetchJSON(withBoard(`${API}/config`, board))" in dist
     assert "SDK.fetchJSON(withBoard(`${API}/boards`, board))" in dist
     assert "}, [loadBoardList, switchBoard, board]);" in dist
+
+
+def test_dashboard_search_includes_body_and_result():
+    """Client-side search must match body, result, latest_summary, and summary
+    so full card contents are findable."""
+    repo_root = Path(__file__).resolve().parents[2]
+    dist = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text()
+
+    assert "t.body || \"\"" in dist
+    assert "t.result || \"\"" in dist
+    assert "t.latest_summary || \"\"" in dist
+    assert "t.summary || \"\"" in dist
+
+
+def test_dashboard_bulk_actions_include_reclaim_first():
+    """Bulk action bar must expose reclaim_first checkbox and expanded status buttons."""
+    repo_root = Path(__file__).resolve().parents[2]
+    dist = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text()
+
+    assert "reclaim_first: reclaimFirst" in dist
+    assert "hermes-kanban-bulk-reclaim-first" in dist
+    assert '"→ todo"' in dist
+    assert '"Block"' in dist
+    assert '"Unblock"' in dist
+
+
+def test_dashboard_shift_click_range_selection_exists():
+    """Shift-click must trigger range selection via toggleRange."""
+    repo_root = Path(__file__).resolve().parents[2]
+    dist = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text()
+
+    assert "function toggleRange" in dist or "const toggleRange =" in dist
+    assert "props.toggleRange(t.id)" in dist or "props.toggleRange" in dist
+    assert "e.shiftKey" in dist
+
+
+def test_dashboard_multi_move_bulk_exists():
+    """Dragging a selected card with other selections must use /tasks/bulk."""
+    repo_root = Path(__file__).resolve().parents[2]
+    dist = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text()
+
+    assert "onMoveSelected" in dist
+    assert "props.onMoveSelected" in dist
+    assert "`${API}/tasks/bulk`" in dist
+
+
+def test_dashboard_failed_card_highlight_class_exists():
+    """Partial bulk failures must highlight failing cards."""
+    repo_root = Path(__file__).resolve().parents[2]
+    js = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "index.js").read_text()
+    css = (repo_root / "plugins" / "kanban" / "dashboard" / "dist" / "style.css").read_text()
+
+    assert "hermes-kanban-card--failed" in js
+    assert "hermes-kanban-card--failed" in css
+    assert "failedIds" in js

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -534,6 +534,9 @@ def test_board_auto_initializes_missing_db(tmp_path, monkeypatch):
     home = tmp_path / ".hermes"
     home.mkdir()
     monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.delenv("HERMES_KANBAN_BOARD", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_DB", raising=False)
+    monkeypatch.delenv("HERMES_KANBAN_HOME", raising=False)
     monkeypatch.setattr(Path, "home", lambda: tmp_path)
     # Deliberately DO NOT call kb.init_db().
 
@@ -1734,7 +1737,6 @@ def test_dashboard_search_includes_body_and_result():
     assert "t.body || \"\"" in dist
     assert "t.result || \"\"" in dist
     assert "t.latest_summary || \"\"" in dist
-    assert "t.summary || \"\"" in dist
 
 
 def test_dashboard_bulk_actions_include_reclaim_first():


### PR DESCRIPTION
## Summary

Upgrade the Kanban dashboard with batch card selection, multi-card drag & drop, expanded bulk actions, and full-text search.

## Changes

- **Backend**: extend `BulkTaskBody` with `reclaim_first: bool = False` so the dashboard can bulk-reassign running tasks by reclaiming their claims first
- **Frontend selection**: shift-click range selection, column select-all toggle, select-all-visible, larger checkbox hit targets
- **Frontend drag & drop**: multi-card drag via selectedIds + `/tasks/bulk`; N-card ghost badge and dimmed source cards during drag
- **Frontend bulk actions bar**: todo/ready/blocked/unblock/complete/archive, priority setter, reassign with `reclaim_first` checkbox, optimistic UI updates
- **Partial-failure highlight**: `failedIds` + `hermes-kanban-card--failed` CSS class when bulk operations partially fail
- **Search expansion**: include `body`, `result`, and `latest_summary` in client-side haystack (remove stale `t.summary` no-op)
- **Filters**: clear filters button + auto-reset on board switch
- **Accessibility**: `tabIndex` / `role` / `aria-label`, Enter/Space/Esc keyboard handlers

## Validation

- `scripts/run_tests.sh tests/plugins/test_kanban_dashboard_plugin.py`
  - 75 passed, 5 pre-existing failures unrelated to this change
- Credential scan: `git diff` inspected for tokens/credentials — clean
- Branch: `feat/kanban-batch-qol` rebased on latest `upstream/main`

Closes #23239
