### PR TITLE
fix(telegram): route unsupported docs and cache errors to user, not agent

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -3725,12 +3725,14 @@ class TelegramAdapter(BasePlatformAdapter):
                 # document size limit by taking the image path.
                 MAX_DOC_BYTES = 20 * 1024 * 1024
                 if not doc.file_size or doc.file_size > MAX_DOC_BYTES:
-                    event.text = (
-                        "The document is too large or its size could not be verified. "
-                        "Maximum: 20 MB."
-                    )
                     logger.info("[Telegram] Document too large: %s bytes", doc.file_size)
-                    await self.handle_message(event)
+                    try:
+                        await update.message.reply_text(
+                            "⚠️ The document is too large or its size could not be verified. "
+                            "Maximum: 20 MB."
+                        )
+                    except Exception:
+                        logger.debug("[Telegram] Failed to reply size error", exc_info=True)
                     return
 
                 # Telegram may deliver screenshots/photos as documents. If the
@@ -3782,12 +3784,14 @@ class TelegramAdapter(BasePlatformAdapter):
                 # Check if supported
                 if ext not in SUPPORTED_DOCUMENT_TYPES:
                     supported_list = ", ".join(sorted(SUPPORTED_DOCUMENT_TYPES.keys()))
-                    event.text = (
-                        f"Unsupported document type '{ext or 'unknown'}'. "
-                        f"Supported types: {supported_list}"
-                    )
                     logger.info("[Telegram] Unsupported document type: %s", ext or "unknown")
-                    await self.handle_message(event)
+                    try:
+                        await update.message.reply_text(
+                            f"⚠️ Unsupported document type '{ext or 'unknown'}'. "
+                            f"Supported types: {supported_list}"
+                        )
+                    except Exception:
+                        logger.debug("[Telegram] Failed to reply unsupported type error", exc_info=True)
                     return
 
                 # Download and cache
@@ -3820,6 +3824,15 @@ class TelegramAdapter(BasePlatformAdapter):
 
             except Exception as e:
                 logger.warning("[Telegram] Failed to cache document: %s", e, exc_info=True)
+                try:
+                    filename_display = original_filename or ext or "unknown"
+                    await update.message.reply_text(
+                        f"⚠️ Couldn't download your attachment ({filename_display}): "
+                        f"{e.__class__.__name__}. Please try again."
+                    )
+                except Exception:
+                    logger.debug("[Telegram] Failed to reply cache error", exc_info=True)
+                return
 
         media_group_id = getattr(msg, "media_group_id", None)
         if media_group_id:

--- a/tests/gateway/test_telegram_documents.py
+++ b/tests/gateway/test_telegram_documents.py
@@ -108,6 +108,8 @@ def _make_message(document=None, caption=None, media_group_id=None, photo=None):
     msg.from_user.id = 1
     msg.from_user.full_name = "Test User"
     msg.message_thread_id = None
+    # reply_text is used to send user-facing errors directly (not through agent pipeline)
+    msg.reply_text = AsyncMock()
     return msg
 
 
@@ -301,8 +303,10 @@ class TestDocumentDownloadBlock:
         update = _make_update(msg)
 
         await adapter._handle_media_message(update, MagicMock())
-        event = adapter.handle_message.call_args[0][0]
-        assert "too large" in event.text
+        # Should reply directly to user, not route to agent
+        msg.reply_text.assert_awaited_once()
+        assert "too large" in msg.reply_text.await_args.args[0].lower()
+        adapter.handle_message.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_none_file_size_rejected(self, adapter):
@@ -312,8 +316,9 @@ class TestDocumentDownloadBlock:
         update = _make_update(msg)
 
         await adapter._handle_media_message(update, MagicMock())
-        event = adapter.handle_message.call_args[0][0]
-        assert "too large" in event.text or "could not be verified" in event.text
+        msg.reply_text.assert_awaited_once()
+        assert "too large" in msg.reply_text.await_args.args[0].lower() or "20 mb" in msg.reply_text.await_args.args[0].lower()
+        adapter.handle_message.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_missing_filename_uses_mime_lookup(self, adapter):
@@ -339,8 +344,9 @@ class TestDocumentDownloadBlock:
         update = _make_update(msg)
 
         await adapter._handle_media_message(update, MagicMock())
-        event = adapter.handle_message.call_args[0][0]
-        assert "Unsupported" in event.text
+        msg.reply_text.assert_awaited_once()
+        assert "unsupported" in msg.reply_text.await_args.args[0].lower()
+        adapter.handle_message.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_unicode_decode_error_handled(self, adapter):
@@ -383,7 +389,7 @@ class TestDocumentDownloadBlock:
 
     @pytest.mark.asyncio
     async def test_download_exception_handled(self, adapter):
-        """If get_file() raises, the handler logs the error without crashing."""
+        """If get_file() raises, the handler logs the error and notifies the user directly."""
         doc = _make_document(file_name="crash.pdf", file_size=100)
         doc.get_file = AsyncMock(side_effect=RuntimeError("Telegram API down"))
         msg = _make_message(document=doc)
@@ -391,8 +397,10 @@ class TestDocumentDownloadBlock:
 
         # Should not raise
         await adapter._handle_media_message(update, MagicMock())
-        # handle_message should still be called (the handler catches the exception)
-        adapter.handle_message.assert_called_once()
+        # Should notify user directly, not route to agent
+        msg.reply_text.assert_awaited_once()
+        assert "couldn't download" in msg.reply_text.await_args.args[0].lower()
+        adapter.handle_message.assert_not_called()
 
 
 class TestVideoDownloadBlock:


### PR DESCRIPTION
## Summary

Fixes two bugs in Telegram document handling where errors are incorrectly routed into the agent pipeline instead of being delivered directly to the user.

## Bug 1 — Unsupported document types

When a user sends an unsupported file (e.g. `.epub`), the gateway was setting `event.text` to an error message and calling `handle_message()`, making the agent think the user typed "Unsupported document type '.epub'..." as a message. The agent then goes in circles trying to help with a file it never received.

**Fix:** Send the error directly to the user via `update.message.reply_text()` and return early — the agent never sees it.

## Bug 2 — Cache failures silently lose attachments

When document download/caching fails (e.g. `httpx.ConnectError` to Telegram CDN), the broad `except Exception` handler only logged a warning and fell through to `handle_message()` with an empty event — no media, no text, no signal that an attachment was attempted. The user thinks the file was delivered; the agent thinks nothing happened.

**Fix:** Reply to the user with the error and return. The user knows the download failed and can retry.

## Additional fix

Applied the same direct-reply pattern to the "document too large" check (previously also routed through `handle_message` as a fake user message).

## Files changed

- `gateway/platforms/telegram.py` — 3 error paths changed from `handle_message()` to `update.message.reply_text()`
- `tests/gateway/test_telegram_documents.py` — updated 5 tests to verify direct reply behavior instead of `handle_message` interception

Fixes #23045

X: @rojassartorio