### PR TITLE
fix(telegram): refresh topic binding on compression session split

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14742,6 +14742,21 @@ class GatewayRunner:
                     entry.session_id = agent.session_id
                     self.session_store._save()
 
+                # Also refresh the Telegram topic binding so the next message
+                # in this topic lane uses the compressed child session, not
+                # the stale pre-compression parent.  Without this, the
+                # binding-lookup at the top of _handle_message_with_agent
+                # would switch right back to the old session_id, causing
+                # repeated preflight compression loops (#20470).
+                if self._is_telegram_topic_lane(source):
+                    try:
+                        self._record_telegram_topic_binding(source, entry)
+                    except Exception:
+                        logger.debug(
+                            "[Telegram] Failed to refresh topic binding after "
+                            "compression split", exc_info=True,
+                        )
+
             effective_session_id = getattr(agent, 'session_id', session_id) if agent else session_id
 
             # When compression created a new session, the messages list was


### PR DESCRIPTION
## Summary

When context compression splits a Telegram DM topic session, the gateway updates `session_store._entries[session_key].session_id` to the new child session, but does **not** refresh the separate SQLite topic binding (`telegram_dm_topic_bindings`).

## Root cause

In `gateway/run.py:_run_agent()`, after detecting a session split during compression:

```python
if entry:
    entry.session_id = agent.session_id
    self.session_store._save()
    # ❌ No call to _record_telegram_topic_binding()
```

On the next inbound message in that topic, the binding lookup at the top of `_handle_message_with_agent` resolves to the **stale** parent `session_id`, switching the lane back to the pre-compression transcript. This causes repeated preflight compression loops on every subsequent message.

## Fix

After updating `session_store`, also call `_record_telegram_topic_binding()` when the source is a Telegram topic lane. This mirrors the existing fix for `/new` (line 7721-7725) which already rebinds the topic after explicit session resets.

## Files changed

- `gateway/run.py` — +15 lines after the existing session-store update block

Fixes #20470

X: @rojassartorio