### PR TITLE
feat(codex): add provider-native tool support

### DIFF
--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -202,6 +202,16 @@ def _derive_responses_function_call_id(
 # Schema conversion
 # ---------------------------------------------------------------------------
 
+def _codex_tool_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return False
+    if isinstance(value, (int, float)):
+        return bool(value)
+    return str(value).strip().lower() in {"1", "true", "yes", "on", "live", "enabled"}
+
+
 def _responses_tools(tools: Optional[List[Dict[str, Any]]] = None) -> Optional[List[Dict[str, Any]]]:
     """Convert chat-completions tool schemas to Responses function-tool schemas."""
     if not tools:
@@ -688,7 +698,20 @@ def _preflight_codex_api_kwargs(
         for idx, tool in enumerate(tools):
             if not isinstance(tool, dict):
                 raise ValueError(f"Codex Responses tools[{idx}] must be an object.")
-            if tool.get("type") != "function":
+            tool_type = tool.get("type")
+            if tool_type in {"web_search", "web_search_preview"}:
+                normalized_web_search: Dict[str, Any] = {"type": tool_type}
+                if "external_web_access" in tool:
+                    normalized_web_search["external_web_access"] = _codex_tool_bool(tool.get("external_web_access"))
+                for optional_key in ("search_context_size", "user_location"):
+                    if optional_key in tool:
+                        normalized_web_search[optional_key] = tool[optional_key]
+                normalized_tools.append(normalized_web_search)
+                continue
+            if tool_type == "image_generation":
+                normalized_tools.append({"type": "image_generation"})
+                continue
+            if tool_type != "function":
                 raise ValueError(f"Codex Responses tools[{idx}] has unsupported type {tool.get('type')!r}.")
 
             name = tool.get("name")
@@ -876,6 +899,7 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
     reasoning_parts: List[str] = []
     reasoning_items_raw: List[Dict[str, Any]] = []
     message_items_raw: List[Dict[str, Any]] = []
+    image_generation_items_raw: List[Dict[str, Any]] = []
     tool_calls: List[Any] = []
     has_incomplete_items = response_status in {"queued", "in_progress", "incomplete"}
     saw_commentary_phase = False
@@ -939,6 +963,13 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
                             raw_summary.append({"type": "summary_text", "text": text})
                     raw_item["summary"] = raw_summary
                 reasoning_items_raw.append(raw_item)
+        elif item_type == "image_generation_call":
+            raw_image_item: Dict[str, Any] = {"type": "image_generation_call"}
+            for attr in ("id", "status", "revised_prompt", "result"):
+                value = getattr(item, attr, None)
+                if isinstance(value, str) and value:
+                    raw_image_item[attr] = value
+            image_generation_items_raw.append(raw_image_item)
         elif item_type == "function_call":
             if item_status in {"queued", "in_progress", "incomplete"}:
                 continue
@@ -1029,6 +1060,7 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
         reasoning_details=None,
         codex_reasoning_items=reasoning_items_raw or None,
         codex_message_items=message_items_raw or None,
+        codex_image_generation_items=image_generation_items_raw or None,
     )
 
     if tool_calls:

--- a/agent/codex_responses_adapter.py
+++ b/agent/codex_responses_adapter.py
@@ -822,6 +822,32 @@ def _preflight_codex_api_kwargs(
 # Response extraction helpers
 # ---------------------------------------------------------------------------
 
+def _jsonable_response_value(value: Any) -> Any:
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    if isinstance(value, list):
+        return [_jsonable_response_value(item) for item in value]
+    if isinstance(value, dict):
+        return {str(k): _jsonable_response_value(v) for k, v in value.items()}
+    if hasattr(value, "model_dump"):
+        try:
+            return _jsonable_response_value(value.model_dump())
+        except Exception:
+            pass
+    if hasattr(value, "to_dict"):
+        try:
+            return _jsonable_response_value(value.to_dict())
+        except Exception:
+            pass
+    if hasattr(value, "__dict__"):
+        return {
+            str(k): _jsonable_response_value(v)
+            for k, v in vars(value).items()
+            if not str(k).startswith("_")
+        }
+    return str(value)
+
+
 def _extract_responses_message_text(item: Any) -> str:
     """Extract assistant text from a Responses message output item."""
     content = getattr(item, "content", None)
@@ -900,6 +926,7 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
     reasoning_items_raw: List[Dict[str, Any]] = []
     message_items_raw: List[Dict[str, Any]] = []
     image_generation_items_raw: List[Dict[str, Any]] = []
+    web_search_items_raw: List[Dict[str, Any]] = []
     tool_calls: List[Any] = []
     has_incomplete_items = response_status in {"queued", "in_progress", "incomplete"}
     saw_commentary_phase = False
@@ -970,6 +997,16 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
                 if isinstance(value, str) and value:
                     raw_image_item[attr] = value
             image_generation_items_raw.append(raw_image_item)
+        elif item_type == "web_search_call":
+            raw_search_item: Dict[str, Any] = {"type": "web_search_call"}
+            for attr in ("id", "status"):
+                value = getattr(item, attr, None)
+                if isinstance(value, str) and value:
+                    raw_search_item[attr] = value
+            action = _jsonable_response_value(getattr(item, "action", None))
+            if action is not None:
+                raw_search_item["action"] = action
+            web_search_items_raw.append(raw_search_item)
         elif item_type == "function_call":
             if item_status in {"queued", "in_progress", "incomplete"}:
                 continue
@@ -1061,6 +1098,7 @@ def _normalize_codex_response(response: Any) -> tuple[Any, str]:
         codex_reasoning_items=reasoning_items_raw or None,
         codex_message_items=message_items_raw or None,
         codex_image_generation_items=image_generation_items_raw or None,
+        codex_web_search_items=web_search_items_raw or None,
     )
 
     if tool_calls:

--- a/agent/provider_native_tools.py
+++ b/agent/provider_native_tools.py
@@ -1,0 +1,181 @@
+"""Provider-native tool capability helpers.
+
+Hermes managed tools are normal function tools implemented by Hermes. Some
+providers also expose hosted/native tools that must be declared on the model
+request itself (for example OpenAI/Codex Responses ``web_search``).  This module
+keeps that policy separate from provider transports so transports only need to
+map a small ``NativeToolSpec`` into their wire format.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Iterable, Mapping, Sequence
+
+
+@dataclass(frozen=True)
+class NativeToolSpec:
+    """Logical description of a provider-native tool exposed for one request."""
+
+    logical_name: str
+    provider_tool_type: str
+    mode: str
+    suppress_managed_tools: tuple[str, ...] = ()
+    include: tuple[str, ...] = ()
+
+
+def _normalize_mode(value: Any) -> str | None:
+    if isinstance(value, bool):
+        return "enabled" if value else None
+    if value is None:
+        return None
+    text = str(value).strip().lower().replace("_", "-")
+    if not text or text in {"0", "false", "off", "no", "none", "disabled", "disable"}:
+        return None
+    if text in {"1", "true", "on", "yes", "enabled", "enable"}:
+        return "enabled"
+    if text == "live":
+        return "live"
+    if text in {"cached", "cache", "no-live", "no-live-web", "offline"}:
+        return "cached"
+    return None
+
+
+def _is_codex_responses_backend(*, provider: str | None, api_mode: str | None, base_url: str | None) -> bool:
+    if api_mode and str(api_mode).strip() != "codex_responses":
+        return False
+    provider_name = (provider or "").strip().lower()
+    if provider_name == "openai-codex":
+        return True
+    base = (base_url or "").strip().lower()
+    return "chatgpt.com" in base and "/backend-api/codex" in base
+
+
+def _mapping(value: Any) -> Mapping[str, Any]:
+    return value if isinstance(value, Mapping) else {}
+
+
+def resolve_provider_native_tools(
+    config: Mapping[str, Any] | None,
+    *,
+    provider: str | None,
+    api_mode: str | None,
+    base_url: str | None = None,
+) -> list[NativeToolSpec]:
+    """Resolve configured provider-native tools for the active provider.
+
+    Supports the established short Codex config shape::
+
+        codex:
+          web_search: live   # disabled | cached | live
+
+    and a generic future-friendly shape::
+
+        provider_native_tools:
+          openai-codex:
+            web_search: live
+    """
+
+    cfg = _mapping(config)
+    if not _is_codex_responses_backend(provider=provider, api_mode=api_mode, base_url=base_url):
+        return []
+
+    generic_cfg = _mapping(_mapping(cfg.get("provider_native_tools")).get("openai-codex"))
+    codex_cfg = _mapping(cfg.get("codex"))
+
+    specs: list[NativeToolSpec] = []
+
+    web_search_value = generic_cfg.get("web_search", codex_cfg.get("web_search"))
+    web_search_mode = _normalize_mode(web_search_value)
+    if web_search_mode == "enabled":
+        web_search_mode = "live"
+    if web_search_mode in {"live", "cached"}:
+        specs.append(
+            NativeToolSpec(
+                logical_name="web_search",
+                provider_tool_type="web_search",
+                mode=web_search_mode,
+                suppress_managed_tools=("web_search",),
+                include=("web_search_call.action.sources",),
+            )
+        )
+
+    image_generation_value = generic_cfg.get(
+        "image_generation",
+        codex_cfg.get("image_generation", codex_cfg.get("image_generate")),
+    )
+    image_generation_mode = _normalize_mode(image_generation_value)
+    if image_generation_mode == "live":
+        image_generation_mode = "enabled"
+    if image_generation_mode == "enabled":
+        specs.append(
+            NativeToolSpec(
+                logical_name="image_generate",
+                provider_tool_type="image_generation",
+                mode="enabled",
+                suppress_managed_tools=("image_generate",),
+            )
+        )
+
+    return specs
+
+
+def filter_managed_tools_for_native_tools(
+    tools: Sequence[Mapping[str, Any]] | None,
+    native_tools: Sequence[NativeToolSpec] | None,
+) -> list[Mapping[str, Any]] | None:
+    """Return managed function tools with native-tool conflicts removed."""
+
+    if tools is None:
+        return None
+    suppress = {
+        name
+        for spec in native_tools or ()
+        for name in spec.suppress_managed_tools
+        if name
+    }
+    if not suppress:
+        return list(tools)
+
+    filtered: list[Mapping[str, Any]] = []
+    for tool in tools:
+        function = tool.get("function") if isinstance(tool, Mapping) else None
+        name = function.get("name") if isinstance(function, Mapping) else None
+        if name in suppress:
+            continue
+        filtered.append(tool)
+    return filtered
+
+
+def codex_responses_tool_for_native_tool(spec: NativeToolSpec) -> dict[str, Any] | None:
+    """Map a native tool spec to an OpenAI/Codex Responses hosted tool."""
+
+    if spec.provider_tool_type == "web_search":
+        return {
+            "type": "web_search",
+            "external_web_access": spec.mode == "live",
+        }
+    if spec.provider_tool_type == "image_generation":
+        return {"type": "image_generation"}
+    return None
+
+
+def codex_responses_tools_for_native_tools(native_tools: Iterable[NativeToolSpec]) -> list[dict[str, Any]]:
+    tools: list[dict[str, Any]] = []
+    for spec in native_tools:
+        tool = codex_responses_tool_for_native_tool(spec)
+        if tool is not None:
+            tools.append(tool)
+    return tools
+
+
+def merge_include_values(existing: Any, additions: Iterable[str]) -> list[str]:
+    merged: list[str] = []
+    if isinstance(existing, list):
+        for item in existing:
+            if isinstance(item, str) and item not in merged:
+                merged.append(item)
+    for item in additions:
+        if isinstance(item, str) and item and item not in merged:
+            merged.append(item)
+    return merged

--- a/agent/provider_native_tools.py
+++ b/agent/provider_native_tools.py
@@ -10,6 +10,7 @@ map a small ``NativeToolSpec`` into their wire format.
 from __future__ import annotations
 
 from dataclasses import dataclass
+import re
 from typing import Any, Iterable, Mapping, Sequence
 
 
@@ -22,6 +23,7 @@ class NativeToolSpec:
     mode: str
     suppress_managed_tools: tuple[str, ...] = ()
     include: tuple[str, ...] = ()
+    tool_choice: str = "auto"
 
 
 def _normalize_mode(value: Any) -> str | None:
@@ -38,6 +40,86 @@ def _normalize_mode(value: Any) -> str | None:
         return "live"
     if text in {"cached", "cache", "no-live", "no-live-web", "offline"}:
         return "cached"
+    return None
+
+
+def _normalize_tool_choice_mode(value: Any) -> str:
+    if value is None:
+        return "auto"
+    text = str(value).strip().lower().replace("_", "-")
+    if not text or text in {"0", "false", "off", "no", "none", "disabled", "disable"}:
+        return "none"
+    if text in {"1", "true", "on", "yes", "required", "require", "force", "forced", "always"}:
+        return "required"
+    if text in {"auto", "automatic", "detect", "fresh", "freshness"}:
+        return "auto"
+    return "auto"
+
+
+_FRESHNESS_PATTERN = re.compile(
+    r"\b("
+    r"today|latest|current|currently|recent|breaking|news|headline|headlines|"
+    r"now|live|this week|this month|as of|update|updates|price|prices|"
+    r"weather|forecast|score|scores|schedule|release|version|"
+    r"сегодня|сейчас|актуальн|последн|свеж|новост|заголов|"
+    r"курс|цен[аы]|погод|прогноз|сч[её]т|расписан|релиз|верси"
+    r")\b",
+    re.IGNORECASE,
+)
+
+
+def _message_content_text(content: Any) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts: list[str] = []
+        for part in content:
+            if isinstance(part, str):
+                parts.append(part)
+            elif isinstance(part, Mapping):
+                value = part.get("text") or part.get("content")
+                if isinstance(value, str):
+                    parts.append(value)
+        return "\n".join(parts)
+    return ""
+
+
+def latest_user_text(messages: Sequence[Mapping[str, Any]] | None) -> str:
+    for message in reversed(messages or []):
+        if isinstance(message, Mapping) and message.get("role") == "user":
+            return _message_content_text(message.get("content"))
+    return ""
+
+
+def is_freshness_sensitive_request(messages: Sequence[Mapping[str, Any]] | None) -> bool:
+    return bool(_FRESHNESS_PATTERN.search(latest_user_text(messages)))
+
+
+def codex_native_tool_choice_for_request(
+    native_tools: Sequence[NativeToolSpec] | None,
+    messages: Sequence[Mapping[str, Any]] | None,
+) -> dict[str, Any] | None:
+    """Return a Codex Responses tool_choice override for native hosted tools.
+
+    Hosted tools remain normal ``auto`` tools for ordinary prompts.  For native
+    web search, ``tool_choice=auto`` on the API call can still let the model
+    answer freshness-sensitive prompts from its parametric knowledge without a
+    visible ``web_search_call`` trace.  When configured as ``auto`` we require
+    the hosted web_search tool only for requests that look freshness-sensitive;
+    ``required`` forces it for every request, and ``none`` disables forcing.
+    """
+
+    for spec in native_tools or ():
+        if spec.provider_tool_type != "web_search":
+            continue
+        if spec.tool_choice == "none":
+            continue
+        if spec.tool_choice == "required" or is_freshness_sensitive_request(messages):
+            return {
+                "type": "allowed_tools",
+                "mode": "required",
+                "tools": [{"type": "web_search"}],
+            }
     return None
 
 
@@ -87,6 +169,9 @@ def resolve_provider_native_tools(
 
     web_search_value = generic_cfg.get("web_search", codex_cfg.get("web_search"))
     web_search_mode = _normalize_mode(web_search_value)
+    web_search_tool_choice = _normalize_tool_choice_mode(
+        generic_cfg.get("web_search_tool_choice", codex_cfg.get("web_search_tool_choice"))
+    )
     if web_search_mode == "enabled":
         web_search_mode = "live"
     if web_search_mode in {"live", "cached"}:
@@ -97,6 +182,7 @@ def resolve_provider_native_tools(
                 mode=web_search_mode,
                 suppress_managed_tools=("web_search",),
                 include=("web_search_call.action.sources",),
+                tool_choice=web_search_tool_choice,
             )
         )
 

--- a/agent/provider_native_tools.py
+++ b/agent/provider_native_tools.py
@@ -68,6 +68,17 @@ _FRESHNESS_PATTERN = re.compile(
 )
 
 
+_IMAGE_GENERATION_PATTERN = re.compile(
+    r"\b("
+    r"generate|create|draw|make|render|paint|illustrate|image|picture|avatar|logo|"
+    r"photo|poster|icon|wallpaper|sticker|"
+    r"сгенерируй|создай|нарисуй|сделай|картинк|изображен|аватар|логотип|"
+    r"фото|постер|иконк|обо[ий]|стикер"
+    r")\b",
+    re.IGNORECASE,
+)
+
+
 def _message_content_text(content: Any) -> str:
     if isinstance(content, str):
         return content
@@ -95,6 +106,10 @@ def is_freshness_sensitive_request(messages: Sequence[Mapping[str, Any]] | None)
     return bool(_FRESHNESS_PATTERN.search(latest_user_text(messages)))
 
 
+def is_image_generation_request(messages: Sequence[Mapping[str, Any]] | None) -> bool:
+    return bool(_IMAGE_GENERATION_PATTERN.search(latest_user_text(messages)))
+
+
 def codex_native_tool_choice_for_request(
     native_tools: Sequence[NativeToolSpec] | None,
     messages: Sequence[Mapping[str, Any]] | None,
@@ -108,6 +123,18 @@ def codex_native_tool_choice_for_request(
     the hosted web_search tool only for requests that look freshness-sensitive;
     ``required`` forces it for every request, and ``none`` disables forcing.
     """
+
+    for spec in native_tools or ():
+        if spec.provider_tool_type != "image_generation":
+            continue
+        if spec.tool_choice == "none":
+            continue
+        if spec.tool_choice == "required" or is_image_generation_request(messages):
+            return {
+                "type": "allowed_tools",
+                "mode": "required",
+                "tools": [{"type": "image_generation"}],
+            }
 
     for spec in native_tools or ():
         if spec.provider_tool_type != "web_search":
@@ -191,6 +218,9 @@ def resolve_provider_native_tools(
         codex_cfg.get("image_generation", codex_cfg.get("image_generate")),
     )
     image_generation_mode = _normalize_mode(image_generation_value)
+    image_generation_tool_choice = _normalize_tool_choice_mode(
+        generic_cfg.get("image_generation_tool_choice", codex_cfg.get("image_generation_tool_choice"))
+    )
     if image_generation_mode == "live":
         image_generation_mode = "enabled"
     if image_generation_mode == "enabled":
@@ -200,6 +230,7 @@ def resolve_provider_native_tools(
                 provider_tool_type="image_generation",
                 mode="enabled",
                 suppress_managed_tools=("image_generate",),
+                tool_choice=image_generation_tool_choice,
             )
         )
 

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -121,6 +121,36 @@ class ResponsesApiTransport(ProviderTransport):
         if request_overrides:
             kwargs.update(request_overrides)
 
+        native_tools = params.get("native_tools") or []
+        if native_tools:
+            from agent.provider_native_tools import (
+                codex_responses_tools_for_native_tools,
+                merge_include_values,
+            )
+
+            response_native_tools = codex_responses_tools_for_native_tools(native_tools)
+            if response_native_tools:
+                existing_tools = kwargs.get("tools")
+                merged_tools = list(existing_tools) if isinstance(existing_tools, list) else []
+                existing_native_types = {
+                    tool.get("type")
+                    for tool in merged_tools
+                    if isinstance(tool, dict) and tool.get("type") != "function"
+                }
+                for native_tool in response_native_tools:
+                    if native_tool.get("type") not in existing_native_types:
+                        merged_tools.append(native_tool)
+                        existing_native_types.add(native_tool.get("type"))
+                kwargs["tools"] = merged_tools or None
+
+            include_additions = [
+                include_value
+                for spec in native_tools
+                for include_value in getattr(spec, "include", ())
+            ]
+            if include_additions:
+                kwargs["include"] = merge_include_values(kwargs.get("include"), include_additions)
+
         if is_codex_backend:
             prompt_cache_key = kwargs.get("prompt_cache_key")
             cache_scope_id = str(prompt_cache_key or session_id or "").strip()
@@ -190,6 +220,8 @@ class ResponsesApiTransport(ProviderTransport):
             provider_data["codex_reasoning_items"] = msg.codex_reasoning_items
         if msg and hasattr(msg, "codex_message_items") and msg.codex_message_items:
             provider_data["codex_message_items"] = msg.codex_message_items
+        if msg and hasattr(msg, "codex_image_generation_items") and msg.codex_image_generation_items:
+            provider_data["codex_image_generation_items"] = msg.codex_image_generation_items
         if msg and hasattr(msg, "reasoning_details") and msg.reasoning_details:
             provider_data["reasoning_details"] = msg.reasoning_details
 

--- a/agent/transports/codex.py
+++ b/agent/transports/codex.py
@@ -124,6 +124,7 @@ class ResponsesApiTransport(ProviderTransport):
         native_tools = params.get("native_tools") or []
         if native_tools:
             from agent.provider_native_tools import (
+                codex_native_tool_choice_for_request,
                 codex_responses_tools_for_native_tools,
                 merge_include_values,
             )
@@ -150,6 +151,10 @@ class ResponsesApiTransport(ProviderTransport):
             ]
             if include_additions:
                 kwargs["include"] = merge_include_values(kwargs.get("include"), include_additions)
+
+            forced_tool_choice = codex_native_tool_choice_for_request(native_tools, messages)
+            if forced_tool_choice and kwargs.get("tool_choice") == "auto":
+                kwargs["tool_choice"] = forced_tool_choice
 
         if is_codex_backend:
             prompt_cache_key = kwargs.get("prompt_cache_key")
@@ -222,6 +227,8 @@ class ResponsesApiTransport(ProviderTransport):
             provider_data["codex_message_items"] = msg.codex_message_items
         if msg and hasattr(msg, "codex_image_generation_items") and msg.codex_image_generation_items:
             provider_data["codex_image_generation_items"] = msg.codex_image_generation_items
+        if msg and hasattr(msg, "codex_web_search_items") and msg.codex_web_search_items:
+            provider_data["codex_web_search_items"] = msg.codex_web_search_items
         if msg and hasattr(msg, "reasoning_details") and msg.reasoning_details:
             provider_data["reasoning_details"] = msg.reasoning_details
 

--- a/agent/transports/types.py
+++ b/agent/transports/types.py
@@ -131,6 +131,11 @@ class NormalizedResponse:
         pd = self.provider_data or {}
         return pd.get("codex_message_items")
 
+    @property
+    def codex_image_generation_items(self):
+        pd = self.provider_data or {}
+        return pd.get("codex_image_generation_items")
+
 
 # ---------------------------------------------------------------------------
 # Factory helpers

--- a/agent/transports/types.py
+++ b/agent/transports/types.py
@@ -136,6 +136,11 @@ class NormalizedResponse:
         pd = self.provider_data or {}
         return pd.get("codex_image_generation_items")
 
+    @property
+    def codex_web_search_items(self):
+        pd = self.provider_data or {}
+        return pd.get("codex_web_search_items")
+
 
 # ---------------------------------------------------------------------------
 # Factory helpers

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -560,6 +560,16 @@ DEFAULT_CONFIG = {
         "extract_backend": "",   # per-capability override for web_extract (e.g. "native")
     },
 
+    "codex": {
+        # Provider-native Responses tools for the OpenAI Codex backend.
+        # web_search: "disabled" | "cached" | "live"
+        "web_search": "disabled",
+        # image_generation: "disabled" | "enabled"
+        "image_generation": "disabled",
+    },
+
+    "provider_native_tools": {},
+
     "browser": {
         "inactivity_timeout": 120,
         "command_timeout": 30,  # Timeout for browser commands in seconds (screenshot, navigate, etc.)

--- a/run_agent.py
+++ b/run_agent.py
@@ -1371,6 +1371,7 @@ class AIAgent:
         self.reasoning_config = reasoning_config  # None = use default (medium for OpenRouter)
         self.service_tier = service_tier
         self.request_overrides = dict(request_overrides or {})
+        self._provider_native_tools = []
         self.prefill_messages = prefill_messages or []  # Prefilled conversation turns
         self._force_ascii_payload = False
         
@@ -1868,6 +1869,18 @@ class AIAgent:
             _agent_cfg = _load_agent_config()
         except Exception:
             _agent_cfg = {}
+        try:
+            from agent.provider_native_tools import resolve_provider_native_tools
+
+            self._provider_native_tools = resolve_provider_native_tools(
+                _agent_cfg,
+                provider=self.provider,
+                api_mode=self.api_mode,
+                base_url=self.base_url,
+            )
+        except Exception as _pnt_err:
+            logger.debug("Provider-native tool config ignored: %s", _pnt_err)
+            self._provider_native_tools = []
         try:
             self._tool_guardrails = ToolCallGuardrailController(
                 ToolCallGuardrailConfig.from_mapping(
@@ -9256,10 +9269,17 @@ class AIAgent:
             )
             is_xai_responses = self.provider == "xai" or self._base_url_hostname == "api.x.ai"
             _msgs_for_codex = self._prepare_messages_for_non_vision_model(api_messages)
+            native_tools = list(getattr(self, "_provider_native_tools", []) or []) if is_codex_backend else []
+            tools_for_codex = self.tools
+            if native_tools:
+                from agent.provider_native_tools import filter_managed_tools_for_native_tools
+
+                tools_for_codex = filter_managed_tools_for_native_tools(self.tools, native_tools)
             return _ct.build_kwargs(
                 model=self.model,
                 messages=_msgs_for_codex,
-                tools=self.tools,
+                tools=tools_for_codex,
+                native_tools=native_tools,
                 reasoning_config=self.reasoning_config,
                 session_id=getattr(self, "session_id", None),
                 max_tokens=self.max_tokens,
@@ -9538,6 +9558,77 @@ class AIAgent:
 
         return {"effort": requested_effort}
 
+    def _persist_codex_image_generation_artifacts(self, assistant_message) -> list[str]:
+        """Decode Codex native image_generation_call results into MEDIA files.
+
+        The Responses API returns generated images as base64 strings on
+        `image_generation_call.result`. Store them as files under Hermes cache and
+        replace the raw base64 in provider metadata with lightweight artifact
+        paths before session persistence.
+        """
+
+        items = getattr(assistant_message, "codex_image_generation_items", None)
+        if not isinstance(items, list) or not items:
+            provider_data = getattr(assistant_message, "provider_data", None)
+            if isinstance(provider_data, dict):
+                items = provider_data.get("codex_image_generation_items")
+        if not isinstance(items, list) or not items:
+            return []
+
+        images_dir = get_hermes_home() / "cache" / "images"
+        images_dir.mkdir(parents=True, exist_ok=True)
+
+        media_paths: list[str] = []
+        sanitized_items: list[dict[str, Any]] = []
+        for idx, item in enumerate(items):
+            if not isinstance(item, dict):
+                continue
+            sanitized = {key: value for key, value in item.items() if key != "result"}
+            raw_result = item.get("result")
+            if not isinstance(raw_result, str) or not raw_result.strip():
+                sanitized_items.append(sanitized)
+                continue
+
+            encoded = raw_result.strip()
+            if encoded.startswith("data:") and "," in encoded:
+                encoded = encoded.split(",", 1)[1]
+            try:
+                image_bytes = base64.b64decode(encoded, validate=True)
+            except Exception:
+                logger.warning("Skipping invalid Codex image_generation result", exc_info=True)
+                sanitized_items.append(sanitized)
+                continue
+            if not image_bytes:
+                sanitized_items.append(sanitized)
+                continue
+
+            item_id = str(item.get("id") or f"image_{idx}")
+            safe_id = re.sub(r"[^A-Za-z0-9_.-]+", "_", item_id).strip("._") or f"image_{idx}"
+            digest = hashlib.sha256(image_bytes).hexdigest()[:12]
+            output_path = images_dir / f"codex_{safe_id}_{digest}.png"
+            try:
+                output_path.write_bytes(image_bytes)
+            except Exception:
+                logger.warning("Failed to write Codex image_generation artifact", exc_info=True)
+                sanitized_items.append(sanitized)
+                continue
+
+            sanitized["output_path"] = str(output_path)
+            sanitized["result_sha256"] = hashlib.sha256(image_bytes).hexdigest()
+            sanitized["mime_type"] = "image/png"
+            sanitized_items.append(sanitized)
+            media_paths.append(str(output_path))
+
+        provider_data = getattr(assistant_message, "provider_data", None)
+        if isinstance(provider_data, dict):
+            provider_data["codex_image_generation_items"] = sanitized_items or None
+        elif hasattr(assistant_message, "codex_image_generation_items"):
+            try:
+                assistant_message.codex_image_generation_items = sanitized_items or None
+            except Exception:
+                pass
+        return media_paths
+
     def _build_assistant_message(self, assistant_message, finish_reason: str) -> dict:
         """Build a normalized assistant message dict from an API response message.
 
@@ -9679,6 +9770,14 @@ class AIAgent:
         codex_message_items = getattr(assistant_message, "codex_message_items", None)
         if codex_message_items:
             msg["codex_message_items"] = codex_message_items
+
+        # Codex Responses API: preserve image-generation artifact metadata after
+        # the base64 payload has been decoded to MEDIA files. The raw result is
+        # intentionally stripped by _persist_codex_image_generation_artifacts()
+        # before this message is persisted so session history does not balloon.
+        codex_image_generation_items = getattr(assistant_message, "codex_image_generation_items", None)
+        if codex_image_generation_items:
+            msg["codex_image_generation_items"] = codex_image_generation_items
 
         if assistant_tool_calls:
             tool_calls = []
@@ -14561,6 +14660,13 @@ class AIAgent:
                 else:
                     # No tool calls - this is the final response
                     final_response = assistant_message.content or ""
+                    codex_image_media_paths = self._persist_codex_image_generation_artifacts(assistant_message)
+                    if codex_image_media_paths:
+                        media_lines = [f"MEDIA:{path}" for path in codex_image_media_paths]
+                        if self._has_content_after_think_block(final_response):
+                            final_response = final_response.rstrip() + "\n\n" + "\n".join(media_lines)
+                        else:
+                            final_response = "Generated image:" + "\n" + "\n".join(media_lines)
                     
                     # Fix: unmute output when entering the no-tool-call branch
                     # so the user can see empty-response warnings and recovery
@@ -14865,6 +14971,11 @@ class AIAgent:
                         length_continue_retries = 0
                     
                     final_response = self._strip_think_blocks(final_response).strip()
+                    if codex_image_media_paths:
+                        try:
+                            assistant_message.content = final_response
+                        except Exception:
+                            pass
                     
                     final_msg = self._build_assistant_message(assistant_message, finish_reason)
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -9558,6 +9558,41 @@ class AIAgent:
 
         return {"effort": requested_effort}
 
+    @staticmethod
+    def _get_codex_provider_metadata_items(assistant_message, key: str) -> list[dict[str, Any]] | None:
+        """Return Codex hosted-tool metadata from either provider_data or legacy attrs.
+
+        NormalizedResponse exposes Codex metadata as properties backed by
+        provider_data, while the older Codex adapter path returns a
+        SimpleNamespace with top-level attributes. Keep reads centralized so
+        hosted tools like web_search and image_generation persist traces
+        uniformly regardless of which response shape reached the agent loop.
+        """
+
+        provider_data = getattr(assistant_message, "provider_data", None)
+        if isinstance(provider_data, dict):
+            value = provider_data.get(key)
+            if isinstance(value, list) and value:
+                return value
+
+        value = getattr(assistant_message, key, None)
+        if isinstance(value, list) and value:
+            return value
+        return None
+
+    @staticmethod
+    def _set_codex_provider_metadata_items(assistant_message, key: str, items: list[dict[str, Any]] | None) -> None:
+        """Write Codex hosted-tool metadata back onto the active response object."""
+
+        provider_data = getattr(assistant_message, "provider_data", None)
+        if isinstance(provider_data, dict):
+            provider_data[key] = items or None
+            return
+        try:
+            setattr(assistant_message, key, items or None)
+        except Exception:
+            pass
+
     def _persist_codex_image_generation_artifacts(self, assistant_message) -> list[str]:
         """Decode Codex native image_generation_call results into MEDIA files.
 
@@ -9567,12 +9602,8 @@ class AIAgent:
         paths before session persistence.
         """
 
-        items = getattr(assistant_message, "codex_image_generation_items", None)
-        if not isinstance(items, list) or not items:
-            provider_data = getattr(assistant_message, "provider_data", None)
-            if isinstance(provider_data, dict):
-                items = provider_data.get("codex_image_generation_items")
-        if not isinstance(items, list) or not items:
+        items = self._get_codex_provider_metadata_items(assistant_message, "codex_image_generation_items")
+        if not items:
             return []
 
         images_dir = get_hermes_home() / "cache" / "images"
@@ -9619,14 +9650,11 @@ class AIAgent:
             sanitized_items.append(sanitized)
             media_paths.append(str(output_path))
 
-        provider_data = getattr(assistant_message, "provider_data", None)
-        if isinstance(provider_data, dict):
-            provider_data["codex_image_generation_items"] = sanitized_items or None
-        elif hasattr(assistant_message, "codex_image_generation_items"):
-            try:
-                assistant_message.codex_image_generation_items = sanitized_items or None
-            except Exception:
-                pass
+        self._set_codex_provider_metadata_items(
+            assistant_message,
+            "codex_image_generation_items",
+            sanitized_items or None,
+        )
         return media_paths
 
     def _build_assistant_message(self, assistant_message, finish_reason: str) -> dict:
@@ -9771,20 +9799,18 @@ class AIAgent:
         if codex_message_items:
             msg["codex_message_items"] = codex_message_items
 
-        # Codex Responses API: preserve image-generation artifact metadata after
-        # the base64 payload has been decoded to MEDIA files. The raw result is
-        # intentionally stripped by _persist_codex_image_generation_artifacts()
-        # before this message is persisted so session history does not balloon.
-        codex_image_generation_items = getattr(assistant_message, "codex_image_generation_items", None)
-        if codex_image_generation_items:
-            msg["codex_image_generation_items"] = codex_image_generation_items
-
-        # Codex Responses API: preserve hosted web_search traces for
-        # observability/debugging. These are metadata-only items and are not
-        # replayed as assistant input on follow-up turns.
-        codex_web_search_items = getattr(assistant_message, "codex_web_search_items", None)
-        if codex_web_search_items:
-            msg["codex_web_search_items"] = codex_web_search_items
+        # Codex Responses API: preserve hosted-tool traces for
+        # observability/debugging. These metadata-only items are not replayed
+        # as assistant input on follow-up turns. Image generation results are
+        # sanitized by _persist_codex_image_generation_artifacts() before this
+        # message is persisted so session history does not balloon with base64.
+        for codex_metadata_key in ("codex_image_generation_items", "codex_web_search_items"):
+            codex_metadata_items = self._get_codex_provider_metadata_items(
+                assistant_message,
+                codex_metadata_key,
+            )
+            if codex_metadata_items:
+                msg[codex_metadata_key] = codex_metadata_items
 
         if assistant_tool_calls:
             tool_calls = []

--- a/run_agent.py
+++ b/run_agent.py
@@ -9779,6 +9779,13 @@ class AIAgent:
         if codex_image_generation_items:
             msg["codex_image_generation_items"] = codex_image_generation_items
 
+        # Codex Responses API: preserve hosted web_search traces for
+        # observability/debugging. These are metadata-only items and are not
+        # replayed as assistant input on follow-up turns.
+        codex_web_search_items = getattr(assistant_message, "codex_web_search_items", None)
+        if codex_web_search_items:
+            msg["codex_web_search_items"] = codex_web_search_items
+
         if assistant_tool_calls:
             tool_calls = []
             for tool_call in assistant_tool_calls:

--- a/tests/agent/test_provider_native_tools.py
+++ b/tests/agent/test_provider_native_tools.py
@@ -112,3 +112,71 @@ def test_filter_managed_tools_can_suppress_native_image_generation():
     filtered = filter_managed_tools_for_native_tools(tools, specs)
 
     assert [tool["function"]["name"] for tool in filtered] == ["vision_analyze", "web_search"]
+
+
+def test_codex_native_tool_choice_for_freshness_request():
+    from agent.provider_native_tools import codex_native_tool_choice_for_request
+
+    specs = resolve_provider_native_tools(
+        {"codex": {"web_search": "live", "web_search_tool_choice": "auto"}},
+        provider="openai-codex",
+        api_mode="codex_responses",
+        base_url="https://chatgpt.com/backend-api/codex",
+    )
+
+    assert codex_native_tool_choice_for_request(
+        specs,
+        [{"role": "user", "content": "Поищи актуальные новости на сегодня"}],
+    ) == {
+        "type": "allowed_tools",
+        "mode": "required",
+        "tools": [{"type": "web_search"}],
+    }
+
+
+def test_codex_native_tool_choice_auto_ignores_non_freshness_request():
+    from agent.provider_native_tools import codex_native_tool_choice_for_request
+
+    specs = resolve_provider_native_tools(
+        {"codex": {"web_search": "live", "web_search_tool_choice": "auto"}},
+        provider="openai-codex",
+        api_mode="codex_responses",
+        base_url="https://chatgpt.com/backend-api/codex",
+    )
+
+    assert codex_native_tool_choice_for_request(
+        specs,
+        [{"role": "user", "content": "Explain binary search."}],
+    ) is None
+
+
+def test_codex_native_tool_choice_required_forces_every_request():
+    from agent.provider_native_tools import codex_native_tool_choice_for_request
+
+    specs = resolve_provider_native_tools(
+        {"codex": {"web_search": "live", "web_search_tool_choice": "required"}},
+        provider="openai-codex",
+        api_mode="codex_responses",
+        base_url="https://chatgpt.com/backend-api/codex",
+    )
+
+    assert codex_native_tool_choice_for_request(
+        specs,
+        [{"role": "user", "content": "Explain binary search."}],
+    )["mode"] == "required"
+
+
+def test_codex_native_tool_choice_none_never_forces():
+    from agent.provider_native_tools import codex_native_tool_choice_for_request
+
+    specs = resolve_provider_native_tools(
+        {"codex": {"web_search": "live", "web_search_tool_choice": "none"}},
+        provider="openai-codex",
+        api_mode="codex_responses",
+        base_url="https://chatgpt.com/backend-api/codex",
+    )
+
+    assert codex_native_tool_choice_for_request(
+        specs,
+        [{"role": "user", "content": "latest news today"}],
+    ) is None

--- a/tests/agent/test_provider_native_tools.py
+++ b/tests/agent/test_provider_native_tools.py
@@ -1,0 +1,114 @@
+from agent.provider_native_tools import (
+    NativeToolSpec,
+    filter_managed_tools_for_native_tools,
+    resolve_provider_native_tools,
+)
+
+
+def _tool(name: str) -> dict:
+    return {
+        "type": "function",
+        "function": {
+            "name": name,
+            "description": f"{name} tool",
+            "parameters": {"type": "object", "properties": {}},
+        },
+    }
+
+
+def test_resolve_codex_native_web_search_from_config():
+    specs = resolve_provider_native_tools(
+        {"codex": {"web_search": "live"}},
+        provider="openai-codex",
+        api_mode="codex_responses",
+        base_url="https://chatgpt.com/backend-api/codex",
+    )
+
+    assert specs == [
+        NativeToolSpec(
+            logical_name="web_search",
+            provider_tool_type="web_search",
+            mode="live",
+            suppress_managed_tools=("web_search",),
+            include=("web_search_call.action.sources",),
+        )
+    ]
+
+
+def test_resolve_codex_native_web_search_from_generic_config():
+    specs = resolve_provider_native_tools(
+        {"provider_native_tools": {"openai-codex": {"web_search": "cached"}}},
+        provider="openai-codex",
+        api_mode="codex_responses",
+        base_url="https://chatgpt.com/backend-api/codex",
+    )
+
+    assert len(specs) == 1
+    assert specs[0].logical_name == "web_search"
+    assert specs[0].mode == "cached"
+
+
+def test_resolve_codex_native_image_generation_from_config():
+    specs = resolve_provider_native_tools(
+        {"codex": {"image_generation": "enabled"}},
+        provider="openai-codex",
+        api_mode="codex_responses",
+        base_url="https://chatgpt.com/backend-api/codex",
+    )
+
+    assert specs == [
+        NativeToolSpec(
+            logical_name="image_generate",
+            provider_tool_type="image_generation",
+            mode="enabled",
+            suppress_managed_tools=("image_generate",),
+        )
+    ]
+
+
+def test_resolve_native_tools_ignores_disabled_and_non_codex_providers():
+    assert resolve_provider_native_tools(
+        {"codex": {"web_search": "disabled"}},
+        provider="openai-codex",
+        api_mode="codex_responses",
+        base_url="https://chatgpt.com/backend-api/codex",
+    ) == []
+    assert resolve_provider_native_tools(
+        {"codex": {"web_search": "live"}},
+        provider="openrouter",
+        api_mode="chat_completions",
+        base_url="https://openrouter.ai/api/v1",
+    ) == []
+
+
+def test_filter_managed_tools_suppresses_only_conflicting_native_tools():
+    specs = [
+        NativeToolSpec(
+            logical_name="web_search",
+            provider_tool_type="web_search",
+            mode="live",
+            suppress_managed_tools=("web_search",),
+        )
+    ]
+    tools = [_tool("web_search"), _tool("web_extract"), _tool("terminal")]
+
+    filtered = filter_managed_tools_for_native_tools(tools, specs)
+
+    assert [tool["function"]["name"] for tool in filtered] == ["web_extract", "terminal"]
+    assert [tool["function"]["name"] for tool in tools] == ["web_search", "web_extract", "terminal"]
+
+
+def test_filter_managed_tools_can_suppress_native_image_generation():
+    specs = [
+        NativeToolSpec(
+            logical_name="image_generate",
+            provider_tool_type="image_generation",
+            mode="enabled",
+            suppress_managed_tools=("image_generate",),
+        )
+    ]
+    tools = [_tool("image_generate"), _tool("vision_analyze"), _tool("web_search")]
+
+    filtered = filter_managed_tools_for_native_tools(tools, specs)
+
+    assert [tool["function"]["name"] for tool in filtered] == ["vision_analyze", "web_search"]

--- a/tests/agent/test_provider_native_tools.py
+++ b/tests/agent/test_provider_native_tools.py
@@ -180,3 +180,62 @@ def test_codex_native_tool_choice_none_never_forces():
         specs,
         [{"role": "user", "content": "latest news today"}],
     ) is None
+
+
+def test_codex_native_tool_choice_for_image_generation_request():
+    from agent.provider_native_tools import codex_native_tool_choice_for_request
+
+    specs = resolve_provider_native_tools(
+        {"codex": {"image_generation": "enabled", "image_generation_tool_choice": "auto"}},
+        provider="openai-codex",
+        api_mode="codex_responses",
+        base_url="https://chatgpt.com/backend-api/codex",
+    )
+
+    assert codex_native_tool_choice_for_request(
+        specs,
+        [{"role": "user", "content": "Сгенерируй маленькую тестовую картинку: синий квадрат"}],
+    ) == {
+        "type": "allowed_tools",
+        "mode": "required",
+        "tools": [{"type": "image_generation"}],
+    }
+
+
+def test_codex_native_tool_choice_prefers_image_generation_over_freshness_when_prompt_asks_for_image():
+    from agent.provider_native_tools import codex_native_tool_choice_for_request
+
+    specs = resolve_provider_native_tools(
+        {
+            "codex": {
+                "web_search": "live",
+                "web_search_tool_choice": "auto",
+                "image_generation": "enabled",
+                "image_generation_tool_choice": "auto",
+            }
+        },
+        provider="openai-codex",
+        api_mode="codex_responses",
+        base_url="https://chatgpt.com/backend-api/codex",
+    )
+
+    assert codex_native_tool_choice_for_request(
+        specs,
+        [{"role": "user", "content": "Сгенерируй актуальную картинку для новости сегодня"}],
+    )["tools"] == [{"type": "image_generation"}]
+
+
+def test_codex_native_image_generation_tool_choice_none_never_forces():
+    from agent.provider_native_tools import codex_native_tool_choice_for_request
+
+    specs = resolve_provider_native_tools(
+        {"codex": {"image_generation": "enabled", "image_generation_tool_choice": "none"}},
+        provider="openai-codex",
+        api_mode="codex_responses",
+        base_url="https://chatgpt.com/backend-api/codex",
+    )
+
+    assert codex_native_tool_choice_for_request(
+        specs,
+        [{"role": "user", "content": "Generate an avatar image"}],
+    ) is None

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -312,6 +312,30 @@ class TestCodexBuildKwargs:
         assert {"type": "image_generation"} in kw["tools"]
 
 
+    def test_native_image_generation_forces_tool_choice_for_image_prompt(self, transport):
+        from agent.provider_native_tools import NativeToolSpec
+
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=[{"role": "user", "content": "Generate a blue square image"}],
+            tools=[],
+            native_tools=[
+                NativeToolSpec(
+                    logical_name="image_generate",
+                    provider_tool_type="image_generation",
+                    mode="enabled",
+                    suppress_managed_tools=("image_generate",),
+                    tool_choice="auto",
+                )
+            ],
+        )
+
+        assert kw["tool_choice"] == {
+            "type": "allowed_tools",
+            "mode": "required",
+            "tools": [{"type": "image_generation"}],
+        }
+
 class TestCodexValidateResponse:
 
     def test_none_response(self, transport):

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -180,6 +180,91 @@ class TestCodexBuildKwargs:
         # "minimal" should be clamped to "low" for xAI as well
         assert kw.get("reasoning", {}).get("effort") == "low"
 
+    def test_native_web_search_live_adds_hosted_responses_tool(self, transport):
+        from agent.provider_native_tools import NativeToolSpec
+
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=messages,
+            tools=[],
+            native_tools=[
+                NativeToolSpec(
+                    logical_name="web_search",
+                    provider_tool_type="web_search",
+                    mode="live",
+                    suppress_managed_tools=("web_search",),
+                    include=("web_search_call.action.sources",),
+                )
+            ],
+        )
+
+        assert {"type": "web_search", "external_web_access": True} in kw["tools"]
+        assert "web_search_call.action.sources" in kw["include"]
+
+    def test_native_web_search_cached_adds_hosted_responses_tool(self, transport):
+        from agent.provider_native_tools import NativeToolSpec
+
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=messages,
+            tools=[],
+            native_tools=[
+                NativeToolSpec(
+                    logical_name="web_search",
+                    provider_tool_type="web_search",
+                    mode="cached",
+                    suppress_managed_tools=("web_search",),
+                )
+            ],
+        )
+
+        assert {"type": "web_search", "external_web_access": False} in kw["tools"]
+
+    def test_native_web_search_merges_include_without_duplicates(self, transport):
+        from agent.provider_native_tools import NativeToolSpec
+
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=messages,
+            tools=[],
+            native_tools=[
+                NativeToolSpec(
+                    logical_name="web_search",
+                    provider_tool_type="web_search",
+                    mode="live",
+                    suppress_managed_tools=("web_search",),
+                    include=("web_search_call.action.sources",),
+                )
+            ],
+            request_overrides={"include": ["reasoning.encrypted_content", "web_search_call.action.sources"]},
+        )
+
+        assert kw["include"].count("web_search_call.action.sources") == 1
+        assert kw["include"] == ["reasoning.encrypted_content", "web_search_call.action.sources"]
+
+    def test_native_image_generation_adds_hosted_responses_tool(self, transport):
+        from agent.provider_native_tools import NativeToolSpec
+
+        messages = [{"role": "user", "content": "Hi"}]
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=messages,
+            tools=[],
+            native_tools=[
+                NativeToolSpec(
+                    logical_name="image_generate",
+                    provider_tool_type="image_generation",
+                    mode="enabled",
+                    suppress_managed_tools=("image_generate",),
+                )
+            ],
+        )
+
+        assert {"type": "image_generation"} in kw["tools"]
+
 
 class TestCodexValidateResponse:
 
@@ -266,6 +351,41 @@ class TestCodexNormalizeResponse:
                 "content": [{"type": "output_text", "text": "Hello world"}],
                 "id": "msg_abc",
                 "phase": "final_answer",
+            }
+        ]
+
+    def test_image_generation_items_preserved_in_provider_data(self, transport):
+        r = SimpleNamespace(
+            output=[
+                SimpleNamespace(
+                    type="image_generation_call",
+                    id="ig_abc",
+                    status="completed",
+                    revised_prompt="A small cat",
+                    result="aW1hZ2UtYnl0ZXM=",
+                ),
+                SimpleNamespace(
+                    type="message",
+                    role="assistant",
+                    content=[SimpleNamespace(type="output_text", text="Generated it.")],
+                    status="completed",
+                ),
+            ],
+            status="completed",
+            incomplete_details=None,
+            usage=SimpleNamespace(input_tokens=10, output_tokens=5,
+                                  input_tokens_details=None, output_tokens_details=None),
+        )
+
+        nr = transport.normalize_response(r)
+
+        assert nr.codex_image_generation_items == [
+            {
+                "type": "image_generation_call",
+                "id": "ig_abc",
+                "status": "completed",
+                "revised_prompt": "A small cat",
+                "result": "aW1hZ2UtYnl0ZXM=",
             }
         ]
 

--- a/tests/agent/transports/test_codex_transport.py
+++ b/tests/agent/transports/test_codex_transport.py
@@ -245,6 +245,52 @@ class TestCodexBuildKwargs:
         assert kw["include"].count("web_search_call.action.sources") == 1
         assert kw["include"] == ["reasoning.encrypted_content", "web_search_call.action.sources"]
 
+    def test_native_web_search_forces_tool_choice_for_freshness_prompt(self, transport):
+        from agent.provider_native_tools import NativeToolSpec
+
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=[{"role": "user", "content": "latest news today"}],
+            tools=[],
+            native_tools=[
+                NativeToolSpec(
+                    logical_name="web_search",
+                    provider_tool_type="web_search",
+                    mode="live",
+                    suppress_managed_tools=("web_search",),
+                    include=("web_search_call.action.sources",),
+                    tool_choice="auto",
+                )
+            ],
+        )
+
+        assert kw["tool_choice"] == {
+            "type": "allowed_tools",
+            "mode": "required",
+            "tools": [{"type": "web_search"}],
+        }
+
+    def test_native_web_search_respects_explicit_request_override_tool_choice(self, transport):
+        from agent.provider_native_tools import NativeToolSpec
+
+        kw = transport.build_kwargs(
+            model="gpt-5.4",
+            messages=[{"role": "user", "content": "latest news today"}],
+            tools=[],
+            native_tools=[
+                NativeToolSpec(
+                    logical_name="web_search",
+                    provider_tool_type="web_search",
+                    mode="live",
+                    suppress_managed_tools=("web_search",),
+                    tool_choice="auto",
+                )
+            ],
+            request_overrides={"tool_choice": "none"},
+        )
+
+        assert kw["tool_choice"] == "none"
+
     def test_native_image_generation_adds_hosted_responses_tool(self, transport):
         from agent.provider_native_tools import NativeToolSpec
 
@@ -386,6 +432,47 @@ class TestCodexNormalizeResponse:
                 "status": "completed",
                 "revised_prompt": "A small cat",
                 "result": "aW1hZ2UtYnl0ZXM=",
+            }
+        ]
+
+    def test_web_search_items_preserved_in_provider_data(self, transport):
+        r = SimpleNamespace(
+            output=[
+                SimpleNamespace(
+                    type="web_search_call",
+                    id="ws_abc",
+                    status="completed",
+                    action=SimpleNamespace(
+                        type="search",
+                        query="latest news",
+                        sources=[SimpleNamespace(type="url", url="https://example.com/news")],
+                    ),
+                ),
+                SimpleNamespace(
+                    type="message",
+                    role="assistant",
+                    content=[SimpleNamespace(type="output_text", text="Found it.")],
+                    status="completed",
+                ),
+            ],
+            status="completed",
+            incomplete_details=None,
+            usage=SimpleNamespace(input_tokens=10, output_tokens=5,
+                                  input_tokens_details=None, output_tokens_details=None),
+        )
+
+        nr = transport.normalize_response(r)
+
+        assert nr.codex_web_search_items == [
+            {
+                "type": "web_search_call",
+                "id": "ws_abc",
+                "status": "completed",
+                "action": {
+                    "type": "search",
+                    "query": "latest news",
+                    "sources": [{"type": "url", "url": "https://example.com/news"}],
+                },
             }
         ]
 

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -313,6 +313,147 @@ def test_build_api_kwargs_codex(monkeypatch):
     assert "extra_body" not in kwargs
 
 
+def test_preflight_codex_api_kwargs_allows_native_web_search_tool():
+    from agent.codex_responses_adapter import _preflight_codex_api_kwargs
+
+    result = _preflight_codex_api_kwargs(
+        {
+            "model": "gpt-5-codex",
+            "instructions": "sys",
+            "input": [{"role": "user", "content": "hi"}],
+            "tools": [{"type": "web_search", "external_web_access": "true"}],
+            "store": False,
+        }
+    )
+
+    assert result["tools"] == [{"type": "web_search", "external_web_access": True}]
+
+
+def test_preflight_codex_api_kwargs_allows_native_image_generation_tool():
+    from agent.codex_responses_adapter import _preflight_codex_api_kwargs
+
+    result = _preflight_codex_api_kwargs(
+        {
+            "model": "gpt-5-codex",
+            "instructions": "sys",
+            "input": [{"role": "user", "content": "hi"}],
+            "tools": [{"type": "image_generation"}],
+            "store": False,
+        }
+    )
+
+    assert result["tools"] == [{"type": "image_generation"}]
+
+
+def test_build_api_kwargs_codex_native_search_suppresses_managed_search(monkeypatch):
+    def _fake_tools(**kwargs):
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": "web_search",
+                    "description": "Search the web.",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "web_extract",
+                    "description": "Extract a page.",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "terminal",
+                    "description": "Run shell commands.",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
+        ]
+
+    import hermes_cli.config
+
+    monkeypatch.setattr(run_agent, "get_tool_definitions", _fake_tools)
+    monkeypatch.setattr(run_agent, "check_toolset_requirements", lambda: {})
+    monkeypatch.setattr(hermes_cli.config, "load_config", lambda *a, **k: {"codex": {"web_search": "live"}})
+
+    agent = run_agent.AIAgent(
+        model="gpt-5-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="codex-token",
+        quiet_mode=True,
+        max_iterations=4,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    kwargs = agent._build_api_kwargs(
+        [
+            {"role": "system", "content": "You are Hermes."},
+            {"role": "user", "content": "Search current news"},
+        ]
+    )
+
+    tool_names = [tool.get("name") for tool in kwargs["tools"] if tool.get("type") == "function"]
+    assert "web_search" not in tool_names
+    assert "web_extract" in tool_names
+    assert "terminal" in tool_names
+    assert {"type": "web_search", "external_web_access": True} in kwargs["tools"]
+
+
+def test_build_api_kwargs_codex_native_image_generation_suppresses_managed_image(monkeypatch):
+    def _fake_tools(**kwargs):
+        return [
+            {
+                "type": "function",
+                "function": {
+                    "name": "image_generate",
+                    "description": "Generate an image.",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
+            {
+                "type": "function",
+                "function": {
+                    "name": "vision_analyze",
+                    "description": "Analyze an image.",
+                    "parameters": {"type": "object", "properties": {}},
+                },
+            },
+        ]
+
+    import hermes_cli.config
+
+    monkeypatch.setattr(run_agent, "get_tool_definitions", _fake_tools)
+    monkeypatch.setattr(run_agent, "check_toolset_requirements", lambda: {})
+    monkeypatch.setattr(hermes_cli.config, "load_config", lambda *a, **k: {"codex": {"image_generation": "enabled"}})
+
+    agent = run_agent.AIAgent(
+        model="gpt-5-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="codex-token",
+        quiet_mode=True,
+        max_iterations=4,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    kwargs = agent._build_api_kwargs(
+        [
+            {"role": "system", "content": "You are Hermes."},
+            {"role": "user", "content": "Generate an image"},
+        ]
+    )
+
+    tool_names = [tool.get("name") for tool in kwargs["tools"] if tool.get("type") == "function"]
+    assert "image_generate" not in tool_names
+    assert "vision_analyze" in tool_names
+    assert {"type": "image_generation"} in kwargs["tools"]
+
+
 def test_build_api_kwargs_codex_clamps_minimal_effort(monkeypatch):
     """'minimal' reasoning effort is clamped to 'low' on the Responses API.
 
@@ -1768,3 +1909,34 @@ def test_preflight_codex_input_deduplicates_reasoning_ids(monkeypatch):
     # IDs must be stripped — with store=False the API 404s on id lookups.
     for it in reasoning_items:
         assert "id" not in it
+
+
+def test_persist_codex_image_generation_artifacts_writes_media_file(monkeypatch, tmp_path):
+    monkeypatch.setattr(run_agent, "get_hermes_home", lambda: tmp_path)
+    agent = SimpleNamespace()
+    method = run_agent.AIAgent._persist_codex_image_generation_artifacts
+    assistant_message = SimpleNamespace(
+        provider_data={
+            "codex_image_generation_items": [
+                {
+                    "type": "image_generation_call",
+                    "id": "ig_abc",
+                    "status": "completed",
+                    "revised_prompt": "A small cat",
+                    "result": "aW1hZ2UtYnl0ZXM=",
+                }
+            ]
+        },
+    )
+
+    media_paths = method(agent, assistant_message)
+
+    assert len(media_paths) == 1
+    assert media_paths[0].startswith(str(tmp_path / "cache" / "images"))
+    assert media_paths[0].endswith(".png")
+    assert (tmp_path / "cache" / "images").exists()
+    assert open(media_paths[0], "rb").read() == b"image-bytes"
+    sanitized = assistant_message.provider_data["codex_image_generation_items"][0]
+    assert "result" not in sanitized
+    assert sanitized["output_path"] == media_paths[0]
+    assert sanitized["mime_type"] == "image/png"

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -404,6 +404,59 @@ def test_build_api_kwargs_codex_native_search_suppresses_managed_search(monkeypa
     assert {"type": "web_search", "external_web_access": True} in kwargs["tools"]
 
 
+def test_build_api_kwargs_codex_native_search_forces_freshness_prompt(monkeypatch):
+    def _fake_tools(**kwargs):
+        return []
+
+    import hermes_cli.config
+
+    monkeypatch.setattr(run_agent, "get_tool_definitions", _fake_tools)
+    monkeypatch.setattr(run_agent, "check_toolset_requirements", lambda: {})
+    monkeypatch.setattr(
+        hermes_cli.config,
+        "load_config",
+        lambda *a, **k: {"codex": {"web_search": "live", "web_search_tool_choice": "auto"}},
+    )
+
+    agent = run_agent.AIAgent(
+        model="gpt-5-codex",
+        base_url="https://chatgpt.com/backend-api/codex",
+        api_key="codex-token",
+        quiet_mode=True,
+        skip_context_files=True,
+        skip_memory=True,
+    )
+
+    kwargs = agent._build_api_kwargs([{"role": "user", "content": "Поищи новости актуальные на сегодня"}])
+
+    assert kwargs["tool_choice"] == {
+        "type": "allowed_tools",
+        "mode": "required",
+        "tools": [{"type": "web_search"}],
+    }
+
+
+def test_build_assistant_message_persists_codex_web_search_items(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    assistant = SimpleNamespace(
+        content="Found it.",
+        tool_calls=None,
+        reasoning=None,
+        codex_web_search_items=[
+            {
+                "type": "web_search_call",
+                "id": "ws_abc",
+                "status": "completed",
+                "action": {"query": "latest news"},
+            }
+        ],
+    )
+
+    msg = agent._build_assistant_message(assistant, "stop")
+
+    assert msg["codex_web_search_items"] == assistant.codex_web_search_items
+
+
 def test_build_api_kwargs_codex_native_image_generation_suppresses_managed_image(monkeypatch):
     def _fake_tools(**kwargs):
         return [

--- a/tests/run_agent/test_run_agent_codex_responses.py
+++ b/tests/run_agent/test_run_agent_codex_responses.py
@@ -1966,7 +1966,7 @@ def test_preflight_codex_input_deduplicates_reasoning_ids(monkeypatch):
 
 def test_persist_codex_image_generation_artifacts_writes_media_file(monkeypatch, tmp_path):
     monkeypatch.setattr(run_agent, "get_hermes_home", lambda: tmp_path)
-    agent = SimpleNamespace()
+    agent = _build_agent(monkeypatch)
     method = run_agent.AIAgent._persist_codex_image_generation_artifacts
     assistant_message = SimpleNamespace(
         provider_data={
@@ -1993,3 +1993,66 @@ def test_persist_codex_image_generation_artifacts_writes_media_file(monkeypatch,
     assert "result" not in sanitized
     assert sanitized["output_path"] == media_paths[0]
     assert sanitized["mime_type"] == "image/png"
+
+
+def test_persisted_codex_image_metadata_is_saved_by_build_assistant_message(monkeypatch, tmp_path):
+    monkeypatch.setattr(run_agent, "get_hermes_home", lambda: tmp_path)
+    agent = _build_agent(monkeypatch)
+    assistant_message = SimpleNamespace(
+        content="",
+        tool_calls=None,
+        reasoning=None,
+        provider_data={
+            "codex_image_generation_items": [
+                {
+                    "type": "image_generation_call",
+                    "id": "ig_trace",
+                    "status": "completed",
+                    "revised_prompt": "A robot avatar",
+                    "result": "aW1hZ2UtYnl0ZXM=",
+                }
+            ]
+        },
+    )
+
+    media_paths = agent._persist_codex_image_generation_artifacts(assistant_message)
+    assistant_message.content = "Generated image:\n" + "\n".join(f"MEDIA:{path}" for path in media_paths)
+    msg = agent._build_assistant_message(assistant_message, "stop")
+
+    assert media_paths
+    assert "codex_image_generation_items" in msg
+    persisted = msg["codex_image_generation_items"][0]
+    assert persisted["type"] == "image_generation_call"
+    assert persisted["id"] == "ig_trace"
+    assert persisted["output_path"] == media_paths[0]
+    assert persisted["mime_type"] == "image/png"
+    assert persisted["result_sha256"]
+    assert "result" not in persisted
+
+
+def test_build_assistant_message_reads_codex_metadata_from_provider_data(monkeypatch):
+    agent = _build_agent(monkeypatch)
+    assistant = SimpleNamespace(
+        content="Native traces present.",
+        tool_calls=None,
+        reasoning=None,
+        provider_data={
+            "codex_web_search_items": [
+                {"type": "web_search_call", "id": "ws_123", "status": "completed"},
+            ],
+            "codex_image_generation_items": [
+                {
+                    "type": "image_generation_call",
+                    "id": "ig_123",
+                    "status": "completed",
+                    "output_path": "/tmp/codex_ig_123.png",
+                    "mime_type": "image/png",
+                },
+            ],
+        },
+    )
+
+    msg = agent._build_assistant_message(assistant, "stop")
+
+    assert msg["codex_web_search_items"] == assistant.provider_data["codex_web_search_items"]
+    assert msg["codex_image_generation_items"] == assistant.provider_data["codex_image_generation_items"]

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -136,6 +136,18 @@ with the Generative Language API enabled.
 
 :::info Codex Note
 The OpenAI Codex provider authenticates via device code (open a URL, enter a code). Hermes stores the resulting credentials in its own auth store under `~/.hermes/auth.json` and can import existing Codex CLI credentials from `~/.codex/auth.json` when present. No Codex CLI installation is required.
+
+Codex can also expose provider-native Responses API tools without launching Codex CLI as a subprocess. Native tools are opt-in:
+
+```bash
+hermes config set codex.web_search live           # live external web access
+hermes config set codex.web_search cached         # cached/no-live mode
+hermes config set codex.web_search disabled       # off
+hermes config set codex.image_generation enabled  # hosted image generation
+hermes config set codex.image_generation disabled # off
+```
+
+When enabled for the OpenAI Codex provider, Hermes declares hosted Responses tools on the current model call and suppresses conflicting managed Hermes function tools to avoid presenting two tools with the same logical name. Enabling native `web_search` suppresses managed `web_search` while leaving tools such as `web_extract` available. Enabling native `image_generation` suppresses managed `image_generate`; generated image results are decoded from the Responses `image_generation_call` payload into `MEDIA:` files under Hermes cache for normal CLI/gateway delivery.
 :::
 
 :::warning

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -1441,3 +1441,6 @@ Fallback is configured exclusively through `config.yaml` — or interactively vi
 
 - [Configuration](/docs/user-guide/configuration) — General configuration (directory structure, config precedence, terminal backends, memory, compression, and more)
 - [Environment Variables](/docs/reference/environment-variables) — Complete reference of all environment variables
+
+
+Codex native web search can force the hosted search tool for freshness-sensitive prompts with `codex.web_search_tool_choice: auto` (default). Use `required` to force it on every request or `none` to leave tool choice fully to the model.


### PR DESCRIPTION
## Summary
- Add a small provider-native tool layer that describes hosted/native provider capabilities separately from Hermes managed function tools.
- Use that layer to expose Codex Responses native `web_search` in the current model call via `codex.web_search: live|cached|disabled`.
- Suppress the managed Hermes `web_search` function tool only when the Codex native search tool is enabled, while leaving `web_extract` and other managed tools available.

## Why this shape
This is a smaller alternative/successor to #20918: it avoids launching Codex CLI as a nested agent and avoids wiring Codex-specific UX/metadata into gateway/runtime footer in the first step. The abstraction should also accommodate future Codex/provider-native hosted tools.

## Test Plan
- `python -m ruff check agent/provider_native_tools.py agent/codex_responses_adapter.py agent/transports/codex.py run_agent.py hermes_cli/config.py tests/agent/test_provider_native_tools.py tests/agent/transports/test_codex_transport.py tests/run_agent/test_run_agent_codex_responses.py`
- `python -m pytest tests/agent/test_provider_native_tools.py tests/agent/transports/test_codex_transport.py tests/run_agent/test_run_agent_codex_responses.py -q -o 'addopts='`

Related to #16634 and #20918.
