### PR TITLE
fix: keep gateway title failures silent

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13853,15 +13853,11 @@ class GatewayRunner:
                 try:
                     from agent.title_generator import maybe_auto_title
                     all_msgs = result_holder[0].get("messages", []) if result_holder[0] else []
-                    # Route title-generation failures through the agent's
-                    # user-visible warning channel so a depleted auxiliary
-                    # provider doesn't silently leave sessions untitled
-                    # (issue #15775).
-                    _title_failure_cb = getattr(
-                        agent, "_emit_auxiliary_failure", None
-                    )
+                    # In the gateway this is a fire-and-forget background side
+                    # task.  Title-generation failures should remain logged by
+                    # agent.title_generator, not delivered as user-visible Slack
+                    # warnings after the main reply has already completed.
                     maybe_auto_title_kwargs = {
-                        "failure_callback": _title_failure_cb,
                         "main_runtime": {
                             "model": getattr(agent, "model", None),
                             "provider": getattr(agent, "provider", None),

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -22,6 +22,12 @@ class _CapturingAgent:
     def __init__(self, *args, **kwargs):
         type(self).last_init = dict(kwargs)
         self.tools = []
+        self.model = kwargs.get("model")
+        self.provider = kwargs.get("provider")
+        self.base_url = kwargs.get("base_url")
+        self.api_key = kwargs.get("api_key")
+        self.api_mode = kwargs.get("api_mode")
+        self.session_id = kwargs.get("session_id")
 
     def run_conversation(self, user_message, conversation_history=None, task_id=None, persist_user_message=None):
         type(self).last_run = {
@@ -67,6 +73,11 @@ def _make_runner():
     )
     runner._get_or_create_gateway_honcho = lambda session_key: (None, None)
     runner._enrich_message_with_vision = AsyncMock(return_value="ENRICHED")
+
+    async def _run_inline(fn):
+        return fn()
+
+    runner._run_in_executor_with_context = _run_inline
     return runner
 
 
@@ -176,3 +187,57 @@ async def test_run_agent_passes_priority_processing_to_gateway_agent(monkeypatch
     assert result["final_response"] == "ok"
     assert _CapturingAgent.last_init["service_tier"] == "priority"
     assert _CapturingAgent.last_init["request_overrides"] == {"service_tier": "priority"}
+
+
+@pytest.mark.asyncio
+async def test_run_agent_keeps_gateway_auto_title_failures_silent(monkeypatch, tmp_path):
+    _install_fake_agent(monkeypatch)
+    runner = _make_runner()
+    runner._session_db = object()
+    runner._is_telegram_topic_lane = lambda source: False
+
+    captured = {}
+
+    def _capture_auto_title(*args, **kwargs):
+        captured["args"] = args
+        captured["kwargs"] = kwargs
+
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "***",
+        },
+    )
+    monkeypatch.setattr("agent.title_generator.maybe_auto_title", _capture_auto_title)
+
+    import hermes_cli.tools_config as tools_config
+    monkeypatch.setattr(tools_config, "_get_platform_tools", lambda user_config, platform_key: {"core"})
+
+    result = await runner._run_agent(
+        message="hi",
+        context_prompt="",
+        history=[],
+        source=_make_source(),
+        session_id="session-1",
+        session_key="agent:main:telegram:dm:12345",
+    )
+
+    assert result["final_response"] == "ok"
+    assert captured["args"][:4] == (runner._session_db, "session-1", "hi", "ok")
+    assert captured["kwargs"]["main_runtime"] == {
+        "model": "gpt-5.4",
+        "provider": "openrouter",
+        "base_url": "https://openrouter.ai/api/v1",
+        "api_key": "***",
+        "api_mode": "chat_completions",
+    }
+    assert "failure_callback" not in captured["kwargs"]


### PR DESCRIPTION
## Summary
- keep gateway fire-and-forget auto-title generation failures out of user-visible warning delivery
- preserve runtime forwarding for title generation so provider/model selection is unchanged
- add a gateway regression test that asserts `failure_callback` is not passed for gateway auto-title dispatch

Closes #23246

## Test Plan
- `source /root/.hermes/hermes-agent/venv/bin/activate && pytest -q -n0 tests/gateway/test_fast_command.py tests/agent/test_title_generator.py`
