### PR TITLE
fix(cron): retry Telegram DM topic delivery with reply anchor on thread-not-found

### DIFF
--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -840,6 +840,48 @@ async def _send_telegram(token, chat_id, message, media_files=None, thread_id=No
                         chat_id=int_chat_id, text=plain,
                         parse_mode=None, **thread_kwargs
                     )
+                elif (
+                    effective_thread_id is not None
+                    and "thread not found" in str(md_error).lower()
+                ):
+                    # Bot API 10.0+: sending to a private DM topic with bare
+                    # message_thread_id fails.  Work around by sending a
+                    # placeholder anchor message first, then using it as the
+                    # reply_to_message_id so the actual message lands in the
+                    # topic.  The placeholder is deleted immediately after.
+                    logger.info(
+                        "[Telegram] thread not found with message_thread_id=%s — "
+                        "retrying with reply anchor (DM topic workaround)",
+                        effective_thread_id,
+                    )
+                    try:
+                        placeholder = await _send_telegram_message_with_retry(
+                            bot, chat_id=int_chat_id, text=".", attempts=1,
+                        )
+                        thread_kwargs["reply_to_message_id"] = placeholder.message_id
+                        last_msg = await _send_telegram_message_with_retry(
+                            bot,
+                            chat_id=int_chat_id, text=formatted,
+                            parse_mode=send_parse_mode, **thread_kwargs,
+                        )
+                        try:
+                            await bot.delete_message(
+                                chat_id=int_chat_id,
+                                message_id=placeholder.message_id,
+                            )
+                        except Exception:
+                            logger.debug(
+                                "[Telegram] Failed to delete placeholder anchor",
+                                exc_info=True,
+                            )
+                    except Exception as anchor_error:
+                        logger.warning(
+                            "[Telegram] DM topic anchor retry also failed: %s",
+                            _sanitize_error_text(anchor_error),
+                        )
+                        # Re-raise the original error to preserve the trace
+                        raise md_error from anchor_error
+                    thread_kwargs.pop("reply_to_message_id", None)
                 else:
                     raise
 


### PR DESCRIPTION
## Summary

When a cron job delivers output to a Telegram DM topic via `telegram:chat_id:thread_id`, the `_send_telegram` function in `send_message_tool.py` sends with bare `message_thread_id` — which Bot API 10.0+ (server-side change ~2026-05-08) rejects for private chats with topics. The gateway adapter was fixed in PR #22410, but the cron delivery path was missed.

## Root cause

`_send_telegram()` at line 787-808 sets `thread_kwargs["message_thread_id"]` for topic delivery. Bot API 10.0 requires `message_thread_id` + `reply_to_message_id` (anchor) together for private DM topics. Without the anchor, the API returns "Message thread not found".

## Fix

Added an `elif` branch in the existing send-error handler: when the error contains "thread not found" and `message_thread_id` was set:

1. **Send anchor**: send a minimal placeholder message (`.`) to the main chat to get a `message_id`
2. **Retry**: resend the actual message with `message_thread_id` + `reply_to_message_id` pointing to the placeholder
3. **Cleanup**: delete the placeholder (best-effort)

If the anchor retry also fails, the original error is re-raised so the caller sees the root cause.

## Three-mode routing now covered

| Mode | Channel type | Parameters | Status |
|------|-------------|-----------|--------|
| 1 | Forum/supergroup topic | `message_thread_id` | ✅ Works (unchanged) |
| 2 | Bot API DM topic (`direct_messages_topic_id`) | `direct_messages_topic_id` | ✅ Adapter only (out of scope) |
| 3 | Hermes-created private DM topic lane | `message_thread_id` + `reply_to_message_id` | ✅ **New** in tool |

## Files changed

- `tools/send_message_tool.py` — +42 lines in `_send_telegram()` error handler

Fixes #22773

X: @rojassartorio