### PR TITLE
fix(skills): replace force-install symlink destinations

### DIFF
--- a/tests/tools/test_skills_hub.py
+++ b/tests/tools/test_skills_hub.py
@@ -26,7 +26,9 @@ from tools.skills_hub import (
     append_audit_log,
     _skill_meta_to_dict,
     quarantine_bundle,
+    install_from_quarantine,
 )
+from tools.skills_guard import ScanResult
 
 
 # ---------------------------------------------------------------------------
@@ -1674,3 +1676,53 @@ class TestDownloadDirectoryRecursive:
 
         assert "SKILL.md" in files
         assert "scripts/run.py" not in files  # lost due to rate limit
+
+
+class TestInstallFromQuarantine:
+    def test_force_install_replaces_symlink_destination(self, tmp_path, monkeypatch):
+        import tools.skills_hub as hub
+
+        hermes_home = tmp_path / "hermes-home"
+        skills_dir = hermes_home / "skills"
+        skills_dir.mkdir(parents=True)
+        monkeypatch.setattr(hub, "HERMES_HOME", hermes_home)
+        monkeypatch.setattr(hub, "SKILLS_DIR", skills_dir)
+        monkeypatch.setattr(hub, "HUB_DIR", skills_dir / ".hub")
+        monkeypatch.setattr(hub, "LOCK_FILE", skills_dir / ".hub" / "lock.json")
+        monkeypatch.setattr(hub, "QUARANTINE_DIR", skills_dir / ".hub" / "quarantine")
+
+        quarantine = (skills_dir / ".hub" / "quarantine" / "browserbase")
+        quarantine.mkdir(parents=True)
+        (quarantine / "SKILL.md").write_text("# Browserbase\n", encoding="utf-8")
+
+        external_target = tmp_path / "external-browserbase"
+        external_target.mkdir()
+        install_dir = skills_dir / "browserbase"
+        install_dir.symlink_to(external_target, target_is_directory=True)
+
+        bundle = SkillBundle(
+            name="browserbase",
+            files={"SKILL.md": "# Browserbase\n"},
+            source="github",
+            identifier="skills-sh/browserbase",
+            trust_level="trusted",
+            metadata={"description": "test skill"},
+        )
+
+        install_path = install_from_quarantine(
+            quarantine,
+            "browserbase",
+            None,
+            bundle,
+            ScanResult(
+                skill_name="browserbase",
+                source="github",
+                trust_level="trusted",
+                verdict="safe",
+            ),
+        )
+
+        assert install_path == install_dir
+        assert install_dir.is_dir()
+        assert not install_dir.is_symlink()
+        assert (install_dir / "SKILL.md").read_text(encoding="utf-8") == "# Browserbase\n"

--- a/tools/skills_hub.py
+++ b/tools/skills_hub.py
@@ -2767,7 +2767,9 @@ def install_from_quarantine(
     else:
         install_dir = SKILLS_DIR / safe_skill_name
 
-    if install_dir.exists():
+    if install_dir.is_symlink():
+        install_dir.unlink()
+    elif install_dir.exists():
         shutil.rmtree(install_dir)
 
     # Warn (but don't block) if SKILL.md is very large


### PR DESCRIPTION
## What does this PR do?

This fixes #21735 with a narrow bugfix that keeps the affected path aligned with the current Hermes behavior without widening the change surface.

## Related Issue

Fixes #21735

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- teach `install_from_quarantine()` to replace an existing symlink destination without deleting the real target behind it
- add regression coverage for `--force` installs that land on a symlinked skill path
- Files: tools/skills_hub.py, tests/tools/test_skills_hub.py

## How to Test

1. Run `uv run --frozen pytest -q -o addopts='' tests/tools/test_skills_hub.py -k force_install_replaces_symlink_destination`
2. Run `uv run --frozen ruff check tools/skills_hub.py tests/tools/test_skills_hub.py`
3. Confirm the affected workflow in #21735 now follows the expected behavior.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Not applicable. -->

## Screenshots / Logs

Targeted skill-install regression test and Ruff checks passed locally on macOS.
