### PR TITLE
fix(kanban): restore HERMES_KANBAN_BOARD after scoped slash override

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -648,6 +648,16 @@ def kanban_command(args: argparse.Namespace) -> int:
     # keeps the patch small and inherits the exact same resolution the
     # dispatcher uses for workers — consistency is a feature here.
     board_override = getattr(args, "board", None)
+    prev_board_env = os.environ.get("HERMES_KANBAN_BOARD")
+    restore_board_env = False
+
+    def _restore_board_env() -> None:
+        if not restore_board_env:
+            return
+        if prev_board_env is None:
+            os.environ.pop("HERMES_KANBAN_BOARD", None)
+        else:
+            os.environ["HERMES_KANBAN_BOARD"] = prev_board_env
     if board_override:
         try:
             normed = kb._normalize_board_slug(board_override)
@@ -667,12 +677,16 @@ def kanban_command(args: argparse.Namespace) -> int:
             )
             return 1
         os.environ["HERMES_KANBAN_BOARD"] = normed
+        restore_board_env = True
 
     # Boards management doesn't touch the DB at all — dispatch early so
     # fresh installs that haven't initialized any DB can still use
     # `hermes kanban boards create …`.
     if action == "boards":
-        return _dispatch_boards(args)
+        try:
+            return _dispatch_boards(args)
+        finally:
+            _restore_board_env()
 
     # Auto-initialize the DB before dispatching any subcommand. init_db
     # is idempotent, so running it every invocation is cheap (one
@@ -685,6 +699,7 @@ def kanban_command(args: argparse.Namespace) -> int:
         kb.init_db()
     except Exception as exc:
         print(f"kanban: could not initialize database: {exc}", file=sys.stderr)
+        _restore_board_env()
         return 1
 
     handlers = {
@@ -726,12 +741,16 @@ def kanban_command(args: argparse.Namespace) -> int:
     handler = handlers.get(action)
     if not handler:
         print(f"kanban: unknown action {action!r}", file=sys.stderr)
+        _restore_board_env()
         return 2
     try:
         return int(handler(args) or 0)
     except (ValueError, RuntimeError) as exc:
         print(f"kanban: {exc}", file=sys.stderr)
+        _restore_board_env()
         return 1
+    finally:
+        _restore_board_env()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_cli.py
+++ b/tests/hermes_cli/test_kanban_cli.py
@@ -392,3 +392,13 @@ def test_run_slash_missing_required_arg_friendly_error(kanban_home):
     out = kc.run_slash("show")
     assert "/kanban show" in out
     assert "task_id" in out
+
+
+def test_run_slash_board_override_restores_prior_env(kanban_home, monkeypatch):
+    kb.create_board("alpha")
+    kb.create_board("beta")
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "beta")
+
+    kc.run_slash("--board alpha list")
+
+    assert os.environ.get("HERMES_KANBAN_BOARD") == "beta"


### PR DESCRIPTION
## Summary

This fixes a kanban board-state leak in in-process `/kanban` calls.

When `kanban_command()` handled `--board <slug>`, it set `HERMES_KANBAN_BOARD`
but did not restore the previous value afterwards. That was invisible in
one-shot CLI subprocesses, but it could leak across calls in long-lived
processes like the gateway, causing later implicit kanban operations to resolve
against the wrong board.

## What changed

- snapshot the previous `HERMES_KANBAN_BOARD` value before applying a scoped
  `--board` override
- restore the previous value after command dispatch, including early-return
  paths
- add a regression test covering the in-process `run_slash("--board ...")`
  flow

## Why this matters

The kanban CLI comments already describe `--board` as a per-call override.
Without restoration, a single board-scoped slash command could poison ambient
board resolution for later calls in the same process.

That is especially relevant for the gateway, where `/kanban` uses the shared
`run_slash()` path inside a long-lived process.

## Testing

Fail-first regression test added first:

- `python -m pytest -o addopts='' tests/hermes_cli/test_kanban_cli.py -k board_override_restores_prior_env -q`

Additional targeted verification:

- `python -m pytest -o addopts='' tests/hermes_cli/test_kanban_cli.py tests/hermes_cli/test_pin_kanban_board_env.py tests/hermes_cli/test_kanban_boards.py -k 'board_override_restores_prior_env or pin_ or connect_without_args_uses_current or connect_env_var_overrides_current or file_pointer_honoured or env_beats_file or invalid_env_falls_through' -q`

## Risk

Low.

The change does not alter board resolution during the command itself; it only
restores prior process state after a scoped override finishes.
