### PR TITLE
fix(plugins): ignore non-mapping plugin manifests

### DIFF
--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -957,6 +957,13 @@ class PluginManager:
                 logger.warning("PyYAML not installed – cannot load %s", manifest_file)
                 return None
             data = yaml.safe_load(manifest_file.read_text(encoding="utf-8")) or {}
+            if not isinstance(data, dict):
+                logger.warning(
+                    "Skipping %s: plugin.yaml must be a mapping, got %s",
+                    manifest_file,
+                    type(data).__name__,
+                )
+                return None
 
             name = data.get("name", plugin_dir.name)
             key = f"{prefix}/{plugin_dir.name}" if prefix else name

--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -164,7 +164,8 @@ def _read_manifest(plugin_dir: Path) -> dict:
         import yaml
 
         with open(manifest_file, encoding="utf-8") as f:
-            return yaml.safe_load(f) or {}
+            manifest = yaml.safe_load(f) or {}
+        return manifest if isinstance(manifest, dict) else {}
     except Exception as e:
         logger.warning("Failed to read plugin.yaml in %s: %s", plugin_dir, e)
         return {}
@@ -745,6 +746,8 @@ def _discover_all_plugins() -> list:
                 try:
                     with open(manifest_file, encoding="utf-8") as f:
                         manifest = yaml.safe_load(f) or {}
+                        if not isinstance(manifest, dict):
+                            manifest = {}
                     name = manifest.get("name", d.name)
                     version = manifest.get("version", "")
                     description = manifest.get("description", "")

--- a/tests/hermes_cli/test_plugins.py
+++ b/tests/hermes_cli/test_plugins.py
@@ -162,6 +162,23 @@ class TestPluginDiscovery:
         }
         assert len(non_bundled) == 0
 
+    def test_discover_skips_non_mapping_manifest(self, tmp_path, monkeypatch):
+        plugins_dir = tmp_path / "hermes_test" / "plugins"
+        plugin_dir = plugins_dir / "bad_manifest"
+        plugin_dir.mkdir(parents=True)
+        (plugin_dir / "plugin.yaml").write_text("- just\n- a\n- list\n", encoding="utf-8")
+        (plugin_dir / "__init__.py").write_text("def register(ctx):\n    return None\n", encoding="utf-8")
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))
+
+        mgr = PluginManager()
+        mgr.discover_and_load()
+
+        non_bundled = {
+            n: p for n, p in mgr._plugins.items()
+            if p.manifest.source != "bundled"
+        }
+        assert non_bundled == {}
+
     def test_entry_points_scanned(self, tmp_path, monkeypatch):
         """Entry-point based plugins are discovered (mocked)."""
         monkeypatch.setenv("HERMES_HOME", str(tmp_path / "hermes_test"))

--- a/tests/hermes_cli/test_plugins_cmd.py
+++ b/tests/hermes_cli/test_plugins_cmd.py
@@ -220,6 +220,11 @@ class TestReadManifest:
         result = _read_manifest(tmp_path)
         assert result == {}
 
+    def test_non_mapping_yaml_returns_empty(self, tmp_path):
+        (tmp_path / "plugin.yaml").write_text("- not\n- a\n- mapping\n")
+        result = _read_manifest(tmp_path)
+        assert result == {}
+
 
 # ── cmd_install tests ─────────────────────────────────────────────────────────
 


### PR DESCRIPTION
## What does this PR do?

This fixes #14066 with a narrow bugfix that keeps the affected path aligned with the current Hermes behavior without widening the change surface.

## Related Issue

Fixes #14066

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- treat scalar/list YAML plugin manifests as invalid metadata instead of crashing discovery or `plugins inspect`
- cover both command and discovery paths with regression tests for non-mapping manifests
- Files: hermes_cli/plugins_cmd.py, hermes_cli/plugins.py, tests/hermes_cli/test_plugins_cmd.py, tests/hermes_cli/test_plugins.py

## How to Test

1. Run `uv run --frozen pytest -q -o addopts='' tests/hermes_cli/test_plugins_cmd.py tests/hermes_cli/test_plugins.py -k 'non_mapping_yaml_returns_empty or non_mapping_manifest'`
2. Run `uv run --frozen ruff check hermes_cli/plugins_cmd.py hermes_cli/plugins.py tests/hermes_cli/test_plugins_cmd.py tests/hermes_cli/test_plugins.py`
3. Confirm the affected workflow in #14066 now follows the expected behavior.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Not applicable. -->

## Screenshots / Logs

Targeted manifest parsing tests and Ruff checks passed locally on macOS.
