### PR TITLE
fix(gateway): skip finalize hook without prior session

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7655,13 +7655,16 @@ class GatewayRunner:
         self._clear_session_boundary_security_state(session_key)
 
         # Fire plugin on_session_finalize hook (session boundary)
-        try:
-            from hermes_cli.plugins import invoke_hook as _invoke_hook
-            _old_sid = old_entry.session_id if old_entry else None
-            _invoke_hook("on_session_finalize", session_id=_old_sid,
-                         platform=source.platform.value if source.platform else "")
-        except Exception:
-            pass
+        if old_entry is not None:
+            try:
+                from hermes_cli.plugins import invoke_hook as _invoke_hook
+                _invoke_hook(
+                    "on_session_finalize",
+                    session_id=old_entry.session_id,
+                    platform=source.platform.value if source.platform else "",
+                )
+            except Exception:
+                pass
 
         # Emit session:end hook (session is ending)
         await self.hooks.emit("session:end", {

--- a/tests/gateway/test_session_boundary_hooks.py
+++ b/tests/gateway/test_session_boundary_hooks.py
@@ -115,6 +115,24 @@ async def test_finalize_before_reset(mock_invoke_hook):
 
 @pytest.mark.asyncio
 @patch("hermes_cli.plugins.invoke_hook")
+async def test_reset_without_old_session_skips_finalize_hook(mock_invoke_hook):
+    runner = _make_runner()
+    session_key = build_session_key(_make_source())
+    runner.session_store._entries = {}
+
+    await runner._handle_reset_command(_make_event("/new"))
+
+    finalize_calls = [
+        c for c in mock_invoke_hook.call_args_list if c[0][0] == "on_session_finalize"
+    ]
+    assert finalize_calls == []
+    mock_invoke_hook.assert_any_call(
+        "on_session_reset", session_id="sess-new", platform="telegram"
+    )
+
+
+@pytest.mark.asyncio
+@patch("hermes_cli.plugins.invoke_hook")
 async def test_shutdown_fires_finalize_for_active_agents(mock_invoke_hook):
     """Gateway stop() must fire on_session_finalize for each active agent."""
     from gateway.run import GatewayRunner


### PR DESCRIPTION
## What does this PR do?

This fixes #12176 with a narrow bugfix that keeps the affected path aligned with the current Hermes behavior without widening the change surface.

## Related Issue

Fixes #12176

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- skip `on_session_finalize` when `/reset` or `/new` does not have an old session entry to finalize
- add a session-boundary regression test so empty resets stop firing finalize hooks with missing state
- Files: gateway/run.py, tests/gateway/test_session_boundary_hooks.py

## How to Test

1. Run `uv run --frozen pytest -q -o addopts='' tests/gateway/test_session_boundary_hooks.py -k 'reset_without_old_session_skips_finalize_hook or reset_fires_finalize_hook or finalize_before_reset'`
2. Run `uv run --frozen ruff check gateway/run.py tests/gateway/test_session_boundary_hooks.py`
3. Confirm the affected workflow in #12176 now follows the expected behavior.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Not applicable. -->

## Screenshots / Logs

Gateway session-boundary regression tests and Ruff checks passed locally on macOS.
