### PR TITLE
fix(honcho): normalize manual cwd overrides

### DIFF
--- a/plugins/memory/honcho/client.py
+++ b/plugins/memory/honcho/client.py
@@ -615,8 +615,17 @@ class HonchoClientConfig:
         if not cwd:
             cwd = os.getcwd()
 
+        def _normalize_session_path(path: str) -> str:
+            return os.path.normcase(os.path.abspath(os.path.expanduser(path)))
+
         # Manual override always wins
+        normalized_cwd = _normalize_session_path(cwd)
         manual = self.sessions.get(cwd)
+        if not manual:
+            for configured_cwd, override in self.sessions.items():
+                if _normalize_session_path(configured_cwd) == normalized_cwd:
+                    manual = override
+                    break
         if manual:
             return manual
 

--- a/tests/honcho_plugin/test_async_memory.py
+++ b/tests/honcho_plugin/test_async_memory.py
@@ -170,6 +170,14 @@ class TestResolveSessionNameTitle:
         result = cfg.resolve_session_name("/some/dir", session_id="20260309_175514_9797dd")
         assert result == "pinned"
 
+    def test_manual_override_matches_equivalent_cwd_spelling(self):
+        cfg = HonchoClientConfig(
+            session_strategy="per-session",
+            sessions={"/tmp/project": "pinned"},
+        )
+        result = cfg.resolve_session_name("/tmp/project/", session_id="20260309_175514_9797dd")
+        assert result == "pinned"
+
     def test_global_strategy_returns_workspace(self):
         cfg = HonchoClientConfig(session_strategy="global", workspace_id="my-workspace")
         result = cfg.resolve_session_name("/some/dir")
@@ -459,4 +467,3 @@ class TestPrefetchCacheAccessors:
 
         assert mgr.pop_context_result("cli:test") == payload
         assert mgr.pop_context_result("cli:test") == {}
-


### PR DESCRIPTION
## What does this PR do?

This fixes #13284 with a narrow bugfix that keeps the affected path aligned with the current Hermes behavior without widening the change surface.

## Related Issue

Fixes #13284

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- normalize manual Honcho cwd overrides before comparing them to session cwd values
- add regression coverage for equivalent cwd spellings that should resolve to the same manual override
- Files: plugins/memory/honcho/client.py, tests/honcho_plugin/test_async_memory.py

## How to Test

1. Run `uv run --frozen pytest -q -o addopts='' tests/honcho_plugin/test_async_memory.py -k 'manual_override_matches_equivalent_cwd_spelling or manual_beats_session_id'`
2. Run `uv run --frozen ruff check plugins/memory/honcho/client.py tests/honcho_plugin/test_async_memory.py`
3. Confirm the affected workflow in #13284 now follows the expected behavior.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Not applicable. -->

## Screenshots / Logs

Honcho override regression tests and Ruff checks passed locally on macOS.
