### PR TITLE
fix(cli): avoid run_in_terminal from worker threads

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5867,7 +5867,9 @@ class HermesCLI:
             except (KeyboardInterrupt, EOFError):
                 pass
 
-        if self._app:
+        in_main_thread = threading.current_thread() is threading.main_thread()
+
+        if self._app and in_main_thread:
             from prompt_toolkit.application import run_in_terminal
             was_visible = self._status_bar_visible
             self._status_bar_visible = False

--- a/tests/cli/test_destructive_slash_confirm.py
+++ b/tests/cli/test_destructive_slash_confirm.py
@@ -150,3 +150,45 @@ def test_gate_default_true_when_config_missing():
     # treated as on despite the config error.  If the gate had been off
     # this would have returned 'once' without consulting the prompt.
     assert result is None
+
+
+def test_prompt_text_input_uses_direct_input_off_main_thread():
+    from cli import HermesCLI
+
+    app = SimpleNamespace(invalidate=lambda: None)
+    self_ = SimpleNamespace(_app=app, _status_bar_visible=True)
+
+    with patch("cli.threading.current_thread", return_value=object()), patch(
+        "cli.threading.main_thread", return_value=object()
+    ), patch("builtins.input", return_value="  1  ") as mock_input, patch(
+        "prompt_toolkit.application.run_in_terminal"
+    ) as mock_run_in_terminal:
+        result = _bound(HermesCLI._prompt_text_input, self_)("Choice: ")
+
+    assert result == "1"
+    mock_input.assert_called_once_with("Choice: ")
+    mock_run_in_terminal.assert_not_called()
+
+
+def test_prompt_text_input_uses_run_in_terminal_on_main_thread():
+    from cli import HermesCLI
+
+    app = SimpleNamespace(invalidate=lambda: None)
+    self_ = SimpleNamespace(_app=app, _status_bar_visible=True)
+
+    sentinel = object()
+
+    def _fake_run_in_terminal(func):
+        func()
+        return sentinel
+
+    with patch("cli.threading.current_thread", return_value=sentinel), patch(
+        "cli.threading.main_thread", return_value=sentinel
+    ), patch("builtins.input", return_value="  2  ") as mock_input, patch(
+        "prompt_toolkit.application.run_in_terminal", side_effect=_fake_run_in_terminal
+    ) as mock_run_in_terminal:
+        result = _bound(HermesCLI._prompt_text_input, self_)("Choice: ")
+
+    assert result == "2"
+    mock_input.assert_called_once_with("Choice: ")
+    mock_run_in_terminal.assert_called_once()


### PR DESCRIPTION
## What does this PR do?

This fixes #23009 with a narrow bugfix that keeps the affected path aligned with the current Hermes behavior without widening the change surface.

## Related Issue

Fixes #23009

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- use direct `input()` when `_prompt_text_input()` is called off the main thread instead of forcing `run_in_terminal()`
- add main-thread and worker-thread regression tests for the destructive slash confirm prompt path
- Files: cli.py, tests/cli/test_destructive_slash_confirm.py

## How to Test

1. Run `uv run --frozen pytest -q -o addopts='' tests/cli/test_destructive_slash_confirm.py -k 'prompt_text_input or gate_'`
2. Run `uv run --frozen ruff check cli.py tests/cli/test_destructive_slash_confirm.py`
3. Confirm the affected workflow in #23009 now follows the expected behavior.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Not applicable. -->

## Screenshots / Logs

Prompt-thread regression tests and Ruff checks passed locally on macOS.
