### PR TITLE
fix(cli): discover mcp tools on direct startup

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -12758,6 +12758,15 @@ def main(
     
     # Handle query shorthand
     query = query or q
+
+    # Keep direct ``python cli.py`` invocation in parity with the wrapper
+    # entrypoints: discover MCP tools before resolving the live CLI toolset.
+    try:
+        from tools.mcp_tool import discover_mcp_tools
+
+        discover_mcp_tools()
+    except Exception:
+        pass
     
     # Parse toolsets - handle both string and tuple/list inputs
     # Default to hermes-cli toolset which includes cronjob management tools

--- a/tests/cli/test_cli_preloaded_skills.py
+++ b/tests/cli/test_cli_preloaded_skills.py
@@ -106,6 +106,35 @@ def test_main_raises_for_unknown_preloaded_skill(monkeypatch):
         cli_mod.main(skills="missing-skill", list_tools=True)
 
 
+def test_main_discovers_mcp_tools_before_cli_init(monkeypatch):
+    import cli as cli_mod
+    import hermes_cli.tools_config as tools_config_mod
+    import tools.mcp_tool as mcp_tool_mod
+
+    call_order = []
+
+    def fake_cli(**kwargs):
+        call_order.append("cli")
+        return _DummyCLI(**kwargs)
+
+    monkeypatch.setattr(cli_mod, "HermesCLI", fake_cli)
+    monkeypatch.setattr(
+        mcp_tool_mod,
+        "discover_mcp_tools",
+        lambda: call_order.append("discover"),
+    )
+    monkeypatch.setattr(
+        tools_config_mod,
+        "_get_platform_tools",
+        lambda *_args, **_kwargs: [],
+    )
+
+    with pytest.raises(SystemExit):
+        cli_mod.main(list_tools=True)
+
+    assert call_order[:2] == ["discover", "cli"]
+
+
 def test_show_banner_does_not_print_skills():
     """show_banner() no longer prints the activated skills line — it moved to run()."""
     cli_obj = _make_real_cli(compact=False)


### PR DESCRIPTION
## What does this PR do?

This fixes #21663 with a narrow bugfix that keeps the affected path aligned with the current Hermes behavior without widening the change surface.

## Related Issue

Fixes #21663

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- run `discover_mcp_tools()` from `cli.py main()` so direct startup matches wrapper entrypoints before tool resolution
- add a regression test that asserts MCP discovery runs before `HermesCLI` initialization
- Files: cli.py, tests/cli/test_cli_preloaded_skills.py

## How to Test

1. Run `uv run --frozen pytest -q -o addopts='' tests/cli/test_cli_preloaded_skills.py -k discovers_mcp_tools_before_cli_init`
2. Run `uv run --frozen ruff check cli.py tests/cli/test_cli_preloaded_skills.py`
3. Confirm the affected workflow in #21663 now follows the expected behavior.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Not applicable. -->

## Screenshots / Logs

CLI MCP discovery regression test and Ruff checks passed locally on macOS.
