### PR TITLE
fix(update): clear update cache under custom HERMES_HOME

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6526,6 +6526,15 @@ def _invalidate_update_cache():
         for entry in profiles_root.iterdir():
             if entry.is_dir():
                 homes.append(entry)
+    hermes_home = (os.environ.get("HERMES_HOME") or "").strip()
+    if hermes_home:
+        try:
+            custom_home = Path(hermes_home).expanduser().resolve()
+            known_homes = {home.expanduser().resolve() for home in homes}
+            if custom_home not in known_homes:
+                homes.append(custom_home)
+        except Exception:
+            pass
     for home in homes:
         try:
             cache_file = home / ".update_check"

--- a/tests/hermes_cli/test_update_check.py
+++ b/tests/hermes_cli/test_update_check.py
@@ -151,3 +151,24 @@ def test_invalidate_update_cache_no_profiles_dir(tmp_path):
         _invalidate_update_cache()
 
     assert not (default_home / ".update_check").exists()
+
+
+def test_invalidate_update_cache_clears_custom_hermes_home_outside_default_tree(tmp_path):
+    """Custom HERMES_HOME outside ~/.hermes must also lose its stale cache."""
+    from hermes_cli.main import _invalidate_update_cache
+
+    default_home = tmp_path / ".hermes"
+    default_home.mkdir()
+    (default_home / ".update_check").write_text('{"ts":1,"behind":2}')
+
+    custom_home = tmp_path / "project-profile"
+    custom_home.mkdir()
+    (custom_home / ".update_check").write_text('{"ts":1,"behind":9}')
+
+    with patch("hermes_constants.get_default_hermes_root", return_value=default_home), patch.dict(
+        os.environ, {"HERMES_HOME": str(custom_home)}
+    ):
+        _invalidate_update_cache()
+
+    assert not (default_home / ".update_check").exists()
+    assert not (custom_home / ".update_check").exists()


### PR DESCRIPTION
## What does this PR do?

This fixes #21526 with a narrow bugfix that keeps the affected path aligned with the current Hermes behavior without widening the change surface.

## Related Issue

Fixes #21526

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- invalidate update caches under a custom `HERMES_HOME` even when it lives outside the default tree
- add regression coverage for custom homes so stale update prompts do not survive cache invalidation
- Files: hermes_cli/main.py, tests/hermes_cli/test_update_check.py

## How to Test

1. Run `uv run --frozen pytest -q -o addopts='' tests/hermes_cli/test_update_check.py -k custom_hermes_home_outside_default_tree`
2. Run `uv run --frozen ruff check hermes_cli/main.py tests/hermes_cli/test_update_check.py`
3. Confirm the affected workflow in #21526 now follows the expected behavior.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Not applicable. -->

## Screenshots / Logs

Update-cache regression test and Ruff checks passed locally on macOS.
