### PR TITLE
fix(kimi): strip trailing v1 for anthropic endpoints

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -282,7 +282,12 @@ def _resolve_runtime_from_pool_entry(
     # Anthropic SDK prepends its own /v1/messages to the base_url.  Strip the
     # trailing /v1 so the SDK constructs the correct path (e.g.
     # https://opencode.ai/zen/go/v1/messages instead of .../v1/v1/messages).
-    if api_mode == "anthropic_messages" and provider in ("opencode-zen", "opencode-go"):
+    if api_mode == "anthropic_messages" and provider in (
+        "opencode-zen",
+        "opencode-go",
+        "kimi-coding",
+        "kimi-coding-cn",
+    ):
         base_url = re.sub(r"/v1/?$", "", base_url)
 
     return {
@@ -888,6 +893,14 @@ def _resolve_explicit_runtime(
                 if detected:
                     api_mode = detected
 
+        if api_mode == "anthropic_messages" and provider in (
+            "opencode-zen",
+            "opencode-go",
+            "kimi-coding",
+            "kimi-coding-cn",
+        ):
+            base_url = re.sub(r"/v1/?$", "", base_url)
+
         return {
             "provider": provider,
             "api_mode": api_mode,
@@ -1324,8 +1337,14 @@ def resolve_runtime_provider(
                 detected = _detect_api_mode_for_url(base_url)
                 if detected:
                     api_mode = detected
-        # Strip trailing /v1 for OpenCode Anthropic models (see comment above).
-        if api_mode == "anthropic_messages" and provider in ("opencode-zen", "opencode-go"):
+        # Strip trailing /v1 for Anthropic-style providers whose SDK appends
+        # /v1/messages internally.
+        if api_mode == "anthropic_messages" and provider in (
+            "opencode-zen",
+            "opencode-go",
+            "kimi-coding",
+            "kimi-coding-cn",
+        ):
             base_url = re.sub(r"/v1/?$", "", base_url)
         return {
             "provider": provider,

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1364,6 +1364,25 @@ def test_opencode_go_model_derivation_beats_stale_persisted_api_mode(monkeypatch
     assert resolved["api_mode"] == "anthropic_messages"
 
 
+def test_kimi_coding_anthropic_mode_strips_trailing_v1(monkeypatch):
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "kimi-coding")
+    monkeypatch.setattr(rp, "_get_model_config", lambda: {})
+    monkeypatch.setattr(
+        rp,
+        "resolve_api_key_provider_credentials",
+        lambda _provider: {
+            "api_key": "test-kimi-key",
+            "base_url": "https://api.kimi.com/coding/v1",
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="kimi-coding")
+
+    assert resolved["provider"] == "kimi-coding"
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved["base_url"] == "https://api.kimi.com/coding"
+
+
 def test_named_custom_provider_anthropic_api_mode(monkeypatch):
     """Custom providers should accept api_mode: anthropic_messages."""
     monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "my-anthropic-proxy")


### PR DESCRIPTION
## What does this PR do?

This fixes #21297 with a narrow bugfix that keeps the affected path aligned with the current Hermes behavior without widening the change surface.

## Related Issue

Fixes #21297

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- strip trailing `/v1` for `kimi-coding` and `kimi-coding-cn` when they resolve to `anthropic_messages` mode across both runtime-provider return paths
- add a regression test for Kimi coding endpoints so the Anthropic SDK does not build double-`/v1/messages` URLs
- Files: hermes_cli/runtime_provider.py, tests/hermes_cli/test_runtime_provider_resolution.py

## How to Test

1. Run `uv run --frozen pytest -q -o addopts='' tests/hermes_cli/test_runtime_provider_resolution.py -k kimi_coding_anthropic_mode_strips_trailing_v1`
2. Run `uv run --frozen ruff check hermes_cli/runtime_provider.py tests/hermes_cli/test_runtime_provider_resolution.py`
3. Confirm the affected workflow in #21297 now follows the expected behavior.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Not applicable. -->

## Screenshots / Logs

Kimi endpoint regression test and Ruff checks passed locally on macOS.
