### PR TITLE
fix(web): guard ModelPicker filter against non-string model entries (#23231)

### DIFF
--- a/web/src/components/ModelPickerDialog.tsx
+++ b/web/src/components/ModelPickerDialog.tsx
@@ -160,14 +160,21 @@ export function ModelPickerDialog(props: Props) {
             (p) =>
               p.name.toLowerCase().includes(needle) ||
               p.slug.toLowerCase().includes(needle) ||
-              (p.models ?? []).some((m) => m.toLowerCase().includes(needle)),
+              (p.models ?? []).some(
+                (m) =>
+                  typeof m === "string" && m.toLowerCase().includes(needle),
+              ),
           ),
     [providers, needle],
   );
 
   const filteredModels = useMemo(
     () =>
-      !needle ? models : models.filter((m) => m.toLowerCase().includes(needle)),
+      !needle
+        ? models
+        : models.filter(
+            (m) => typeof m === "string" && m.toLowerCase().includes(needle),
+          ),
     [models, needle],
   );
 


### PR DESCRIPTION
## Summary

- Typing in the dashboard's *Filter providers and models...* input crashed `ModelPickerDialog` with `TypeError: re.toLowerCase is not a function`, blanking the dashboard.
- Two filter callbacks at `web/src/components/ModelPickerDialog.tsx:159` and `:166` called `m.toLowerCase()` on every entry of `provider.models` without checking it was actually a string.

## The bug

The TypeScript declaration is `models?: string[]`, but the runtime data is fetched from a JSON-RPC `model.options` response (or the standalone REST loader) and assigned directly without validation:

```tsx
const next = r?.providers ?? [];
setProviders(next);
```

When a provider yields a `models` array with `null`/`undefined` entries (one observed source: providers whose listing endpoint partially fails and falls back to a sentinel), `m.toLowerCase()` throws on the first non-string entry, the React render aborts, and the dashboard goes blank.

## The fix

Add a `typeof m === "string"` guard before `.toLowerCase()` in both filter call sites. Skipping non-string entries is preferable to coercing them via `String(m)`, which would let `String(null) === "null"` accidentally match a search for `"null"`.

```tsx
(p.models ?? []).some(
  (m) => typeof m === "string" && m.toLowerCase().includes(needle),
),
// and
models.filter(
  (m) => typeof m === "string" && m.toLowerCase().includes(needle),
),
```

## Test plan

- [x] `npx tsc -b` clean — no type errors.
- [x] `npx eslint src/components/ModelPickerDialog.tsx` clean.
- [x] Manual logic check: `typeof null === "object"`, `typeof undefined === "undefined"`, `typeof 123 === "number"` — all short-circuit to `false` and are silently skipped; only string entries reach `.toLowerCase()`.
- [x] No frontend test runner is configured in `web/package.json`, so no unit test added.

> Sibling code paths that may need similar defensive normalization: the load site at `web/src/components/ModelPickerDialog.tsx:104` (`const next = r?.providers ?? []`) trusts the JSON-RPC response shape without validation, so any other consumer of `provider.models` (e.g. counts, rendering) could also misbehave on non-string entries. Intentionally left out of this PR's scope to keep the diff small — happy to widen if preferred.

## Related

- Fixes #23231