### PR TITLE
fix(cli): reload configured default model on new session

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5408,6 +5408,24 @@ class HermesCLI:
         self._pending_title = None
         self._resumed = False
 
+        try:
+            from hermes_cli.config import load_config
+
+            refreshed_cfg = load_config() or {}
+            refreshed_model_cfg = refreshed_cfg.get("model", {})
+            if isinstance(refreshed_model_cfg, dict):
+                refreshed_model = (
+                    refreshed_model_cfg.get("default")
+                    or refreshed_model_cfg.get("model")
+                    or ""
+                )
+            else:
+                refreshed_model = refreshed_model_cfg or ""
+            if refreshed_model:
+                self.model = refreshed_model
+        except Exception:
+            pass
+
         if self.agent:
             self.agent.session_id = self.session_id
             self.agent.session_start = self.session_start

--- a/tests/cli/test_cli_new_session.py
+++ b/tests/cli/test_cli_new_session.py
@@ -280,3 +280,22 @@ def test_new_session_with_duplicate_title_surfaces_error(capsys):
     captured = capsys.readouterr()
     assert "New session started: Dup" not in captured.out
     assert "New session started!" in captured.out
+
+
+def test_new_session_reloads_default_model_from_config():
+    """Session resets should restore the current config default model."""
+    cli = _make_cli(
+        model="anthropic/claude-haiku-4-5-20251001",
+        config_overrides={
+            "model": {
+                "default": "openrouter/auto",
+                "base_url": "https://openrouter.ai/api/v1",
+                "provider": "auto",
+            }
+        },
+    )
+
+    with patch("hermes_cli.config.load_config", return_value={"model": {"default": "openrouter/auto"}}):
+        cli.new_session(silent=True)
+
+    assert cli.model == "openrouter/auto"


### PR DESCRIPTION
## What does this PR do?

This fixes #23131 with a narrow bugfix that keeps the affected path aligned with the current Hermes behavior without widening the change surface.

## Related Issue

Fixes #23131

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- reload `model.default` / `model.model` from config when `/new` or session resets rebuild the CLI session state
- add a regression test that proves a configured default model overrides the transient startup model after `new_session()`
- Files: cli.py, tests/cli/test_cli_new_session.py

## How to Test

1. Run `uv run --frozen pytest -q -o addopts='' tests/cli/test_cli_new_session.py -k reloads_default_model_from_config`
2. Run `uv run --frozen ruff check cli.py tests/cli/test_cli_new_session.py`
3. Confirm the affected workflow in #23131 now follows the expected behavior.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Not applicable. -->

## Screenshots / Logs

New-session model reload regression test and Ruff checks passed locally on macOS.
