### PR TITLE
Preserve Anthropic thinking blocks for compatible custom providers

### DIFF
--- a/acp_adapter/session.py
+++ b/acp_adapter/session.py
@@ -613,6 +613,9 @@ class SessionManager:
                     "api_mode": api_mode or runtime.get("api_mode"),
                     "base_url": base_url or runtime.get("base_url"),
                     "api_key": runtime.get("api_key"),
+                    "preserve_anthropic_thinking_blocks": runtime.get(
+                        "preserve_anthropic_thinking_blocks", False
+                    ),
                     "command": runtime.get("command"),
                     "args": list(runtime.get("args") or []),
                 }

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1452,6 +1452,7 @@ def convert_messages_to_anthropic(
     messages: List[Dict],
     base_url: str | None = None,
     model: str | None = None,
+    preserve_thinking_for_third_party: bool = False,
 ) -> Tuple[Optional[Any], List[Dict]]:
     """Convert OpenAI-format messages to Anthropic format.
 
@@ -1463,6 +1464,8 @@ def convert_messages_to_anthropic(
     endpoint, all thinking block signatures are stripped.  Signatures are
     Anthropic-proprietary — third-party endpoints cannot validate them and will
     reject them with HTTP 400 "Invalid signature in thinking block".
+    Set *preserve_thinking_for_third_party* only for compatible endpoints that
+    explicitly accept Anthropic-native thinking/signature replay.
 
     When *model* is provided and matches the Kimi / Moonshot family (or
     *base_url* is a Kimi / Moonshot host), unsigned thinking blocks
@@ -1730,6 +1733,7 @@ def convert_messages_to_anthropic(
     #    cache markers can interfere with signature validation.
     _THINKING_TYPES = frozenset(("thinking", "redacted_thinking"))
     _is_third_party = _is_third_party_anthropic_endpoint(base_url)
+    _strip_all_thinking = _is_third_party and not preserve_thinking_for_third_party
     # Kimi /coding and DeepSeek /anthropic share a contract: both speak the
     # Anthropic Messages protocol upstream but require that thinking blocks
     # synthesised from reasoning_content round-trip on subsequent turns when
@@ -1769,7 +1773,7 @@ def convert_messages_to_anthropic(
                 # keep it: the upstream needs it for message-history validation.
                 new_content.append(b)
             m["content"] = new_content or [{"type": "text", "text": "(empty)"}]
-        elif _is_third_party or idx != last_assistant_idx:
+        elif _strip_all_thinking or idx != last_assistant_idx:
             # Third-party endpoint: strip ALL thinking blocks from every
             # assistant message — signatures are Anthropic-proprietary.
             # Direct Anthropic: strip from non-latest assistant messages only.
@@ -1856,6 +1860,7 @@ def build_anthropic_kwargs(
     base_url: str | None = None,
     fast_mode: bool = False,
     drop_context_1m_beta: bool = False,
+    preserve_thinking_for_third_party: bool = False,
 ) -> Dict[str, Any]:
     """Build kwargs for anthropic.messages.create().
 
@@ -1889,6 +1894,8 @@ def build_anthropic_kwargs(
 
     When *base_url* points to a third-party Anthropic-compatible endpoint,
     thinking block signatures are stripped (they are Anthropic-proprietary).
+    Set *preserve_thinking_for_third_party* only for compatible endpoints that
+    explicitly accept Anthropic-native thinking/signature replay.
 
     When *fast_mode* is True, adds ``extra_body["speed"] = "fast"`` and the
     fast-mode beta header for ~2.5x faster output throughput on Opus 4.6.
@@ -1896,7 +1903,10 @@ def build_anthropic_kwargs(
     compatible ones).
     """
     system, anthropic_messages = convert_messages_to_anthropic(
-        messages, base_url=base_url, model=model
+        messages,
+        base_url=base_url,
+        model=model,
+        preserve_thinking_for_third_party=preserve_thinking_for_third_party,
     )
     anthropic_tools = convert_tools_to_anthropic(tools) if tools else []
 
@@ -2060,5 +2070,4 @@ def build_anthropic_kwargs(
         kwargs["extra_headers"] = {"anthropic-beta": ",".join(betas)}
 
     return kwargs
-
 

--- a/agent/curator.py
+++ b/agent/curator.py
@@ -1649,6 +1649,7 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
     _base_url = None
     _api_mode = None
     _resolved_provider = None
+    _preserve_anthropic_thinking_blocks = False
     _model_name = ""
     try:
         from hermes_cli.config import load_config
@@ -1665,6 +1666,9 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
         _api_key = _rp.get("api_key")
         _base_url = _rp.get("base_url")
         _api_mode = _rp.get("api_mode")
+        _preserve_anthropic_thinking_blocks = bool(
+            _rp.get("preserve_anthropic_thinking_blocks", False)
+        )
         _resolved_provider = _rp.get("provider") or _provider
     except Exception as e:
         logger.debug("Curator provider resolution failed: %s", e, exc_info=True)
@@ -1680,6 +1684,7 @@ def _run_llm_review(prompt: str) -> Dict[str, Any]:
             api_key=_api_key,
             base_url=_base_url,
             api_mode=_api_mode,
+            preserve_anthropic_thinking_blocks=_preserve_anthropic_thinking_blocks,
             # Umbrella-building over a large skill collection is worth a
             # high iteration ceiling — the pass typically takes 50-100
             # API calls against hundreds of candidate skills. The

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -26,11 +26,18 @@ class AnthropicTransport(ProviderTransport):
 
         kwargs:
             base_url: Optional[str] — affects thinking signature handling.
+            preserve_thinking_for_third_party: bool — opt-in signature replay.
         """
         from agent.anthropic_adapter import convert_messages_to_anthropic
 
         base_url = kwargs.get("base_url")
-        return convert_messages_to_anthropic(messages, base_url=base_url)
+        return convert_messages_to_anthropic(
+            messages,
+            base_url=base_url,
+            preserve_thinking_for_third_party=kwargs.get(
+                "preserve_thinking_for_third_party", False
+            ),
+        )
 
     def convert_tools(self, tools: List[Dict[str, Any]]) -> Any:
         """Convert OpenAI tool schemas to Anthropic input_schema format."""
@@ -59,6 +66,7 @@ class AnthropicTransport(ProviderTransport):
             base_url: str | None
             fast_mode: bool
             drop_context_1m_beta: bool
+            preserve_thinking_for_third_party: bool
         """
         from agent.anthropic_adapter import build_anthropic_kwargs
 
@@ -75,6 +83,9 @@ class AnthropicTransport(ProviderTransport):
             base_url=params.get("base_url"),
             fast_mode=params.get("fast_mode", False),
             drop_context_1m_beta=params.get("drop_context_1m_beta", False),
+            preserve_thinking_for_third_party=params.get(
+                "preserve_thinking_for_third_party", False
+            ),
         )
 
     def normalize_response(self, response: Any, **kwargs) -> NormalizedResponse:

--- a/cli.py
+++ b/cli.py
@@ -4014,6 +4014,9 @@ class HermesCLI:
                 acp_command=runtime.get("command"),
                 acp_args=runtime.get("args"),
                 credential_pool=runtime.get("credential_pool"),
+                preserve_anthropic_thinking_blocks=runtime.get(
+                    "preserve_anthropic_thinking_blocks", False
+                ),
                 max_iterations=self.max_turns,
                 enabled_toolsets=self.enabled_toolsets,
                 disabled_toolsets=self.disabled_toolsets,
@@ -5958,6 +5961,9 @@ class HermesCLI:
                     api_key=result.api_key,
                     base_url=result.base_url,
                     api_mode=result.api_mode,
+                    preserve_anthropic_thinking_blocks=(
+                        result.preserve_anthropic_thinking_blocks
+                    ),
                 )
             except Exception as exc:
                 _cprint(f"  ⚠ Agent swap failed ({exc}); change applied to next session.")
@@ -6185,6 +6191,9 @@ class HermesCLI:
                     api_key=result.api_key,
                     base_url=result.base_url,
                     api_mode=result.api_mode,
+                    preserve_anthropic_thinking_blocks=(
+                        result.preserve_anthropic_thinking_blocks
+                    ),
                 )
             except Exception as exc:
                 _cprint(f"  ⚠ Agent swap failed ({exc}); change applied to next session.")
@@ -7233,6 +7242,9 @@ class HermesCLI:
                     api_mode=turn_route["runtime"].get("api_mode"),
                     acp_command=turn_route["runtime"].get("command"),
                     acp_args=turn_route["runtime"].get("args"),
+                    preserve_anthropic_thinking_blocks=turn_route["runtime"].get(
+                        "preserve_anthropic_thinking_blocks", False
+                    ),
                     max_iterations=self.max_turns,
                     enabled_toolsets=self.enabled_toolsets,
                     quiet_mode=True,

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1428,6 +1428,9 @@ def run_job(job: dict) -> tuple[bool, str, str, Optional[str]]:
             base_url=runtime.get("base_url"),
             provider=runtime.get("provider"),
             api_mode=runtime.get("api_mode"),
+            preserve_anthropic_thinking_blocks=runtime.get(
+                "preserve_anthropic_thinking_blocks", False
+            ),
             acp_command=runtime.get("command"),
             acp_args=runtime.get("args"),
             max_iterations=max_iterations,

--- a/gateway/platforms/feishu_comment.py
+++ b/gateway/platforms/feishu_comment.py
@@ -1077,6 +1077,9 @@ def _run_comment_agent(prompt: str, client: Any, session_key: str = "") -> str:
             api_key=runtime_kwargs.get("api_key"),
             provider=runtime_kwargs.get("provider"),
             api_mode=runtime_kwargs.get("api_mode"),
+            preserve_anthropic_thinking_blocks=runtime_kwargs.get(
+                "preserve_anthropic_thinking_blocks", False
+            ),
             credential_pool=runtime_kwargs.get("credential_pool"),
             quiet_mode=True,
             skip_context_files=True,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -704,6 +704,9 @@ def _resolve_runtime_agent_kwargs() -> dict:
         "base_url": runtime.get("base_url"),
         "provider": runtime.get("provider"),
         "api_mode": runtime.get("api_mode"),
+        "preserve_anthropic_thinking_blocks": runtime.get(
+            "preserve_anthropic_thinking_blocks", False
+        ),
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
         "credential_pool": runtime.get("credential_pool"),
@@ -8363,6 +8366,9 @@ class GatewayRunner:
                                     api_key=result.api_key,
                                     base_url=result.base_url,
                                     api_mode=result.api_mode,
+                                    preserve_anthropic_thinking_blocks=(
+                                        result.preserve_anthropic_thinking_blocks
+                                    ),
                                 )
                             except Exception as exc:
                                 logger.warning("Picker model switch failed for cached agent: %s", exc)
@@ -8500,6 +8506,9 @@ class GatewayRunner:
                     api_key=result.api_key,
                     base_url=result.base_url,
                     api_mode=result.api_mode,
+                    preserve_anthropic_thinking_blocks=(
+                        result.preserve_anthropic_thinking_blocks
+                    ),
                 )
             except Exception as exc:
                 logger.warning("In-place model switch failed for cached agent: %s", exc)
@@ -12939,6 +12948,7 @@ class GatewayRunner:
                 runtime.get("base_url", ""),
                 runtime.get("provider", ""),
                 runtime.get("api_mode", ""),
+                bool(runtime.get("preserve_anthropic_thinking_blocks", False)),
                 sorted(enabled_toolsets) if enabled_toolsets else [],
                 # reasoning_config excluded — it's set per-message on the
                 # cached agent and doesn't affect system prompt or tools.

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2694,6 +2694,7 @@ def _normalize_custom_provider_entry(
         "defaultModel": "default_model",
         "contextLength": "context_length",
         "rateLimitDelay": "rate_limit_delay",
+        "preserveAnthropicThinkingBlocks": "preserve_anthropic_thinking_blocks",
     }
     # api_key_env is a documented snake_case alias for key_env (see
     # website/docs/guides/azure-foundry.md).  Normalize it up front so the
@@ -2704,6 +2705,7 @@ def _normalize_custom_provider_entry(
         "name", "api", "url", "base_url", "api_key", "key_env", "api_key_env",
         "api_mode", "transport", "model", "default_model", "models",
         "context_length", "rate_limit_delay",
+        "preserve_anthropic_thinking_blocks",
         "request_timeout_seconds", "stale_timeout_seconds",
     }
     for camel, snake in _CAMEL_ALIASES.items():
@@ -2794,6 +2796,10 @@ def _normalize_custom_provider_entry(
     rate_limit_delay = entry.get("rate_limit_delay")
     if isinstance(rate_limit_delay, (int, float)) and rate_limit_delay >= 0:
         normalized["rate_limit_delay"] = rate_limit_delay
+
+    preserve_thinking = entry.get("preserve_anthropic_thinking_blocks")
+    if isinstance(preserve_thinking, bool):
+        normalized["preserve_anthropic_thinking_blocks"] = preserve_thinking
 
     return normalized
 
@@ -2955,7 +2961,7 @@ _KNOWN_ROOT_KEYS = {
 # Valid fields inside a custom_providers list entry
 _VALID_CUSTOM_PROVIDER_FIELDS = {
     "name", "base_url", "api_key", "api_mode", "model", "models",
-    "context_length", "rate_limit_delay",
+    "context_length", "rate_limit_delay", "preserve_anthropic_thinking_blocks",
     # key_env is read at runtime by runtime_provider.py and auxiliary_client.py
     # — include it here so the set accurately describes the supported schema.
     "key_env",

--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -270,6 +270,7 @@ class ModelSwitchResult:
     api_key: str = ""
     base_url: str = ""
     api_mode: str = ""
+    preserve_anthropic_thinking_blocks: bool = False
     error_message: str = ""
     warning_message: str = ""
     provider_label: str = ""
@@ -858,6 +859,7 @@ def switch_model(
     api_key = current_api_key
     base_url = current_base_url
     api_mode = ""
+    preserve_anthropic_thinking_blocks = False
 
     if provider_changed or explicit_provider:
         try:
@@ -868,6 +870,9 @@ def switch_model(
             api_key = runtime.get("api_key", "")
             base_url = runtime.get("base_url", "")
             api_mode = runtime.get("api_mode", "")
+            preserve_anthropic_thinking_blocks = bool(
+                runtime.get("preserve_anthropic_thinking_blocks", False)
+            )
         except Exception as e:
             return ModelSwitchResult(
                 success=False,
@@ -892,6 +897,9 @@ def switch_model(
             api_key = runtime.get("api_key", "")
             base_url = runtime.get("base_url", "")
             api_mode = runtime.get("api_mode", "")
+            preserve_anthropic_thinking_blocks = bool(
+                runtime.get("preserve_anthropic_thinking_blocks", False)
+            )
         except Exception:
             pass
 
@@ -1031,6 +1039,7 @@ def switch_model(
         api_key=api_key,
         base_url=base_url,
         api_mode=api_mode,
+        preserve_anthropic_thinking_blocks=preserve_anthropic_thinking_blocks,
         warning_message=" | ".join(warnings) if warnings else "",
         provider_label=provider_label,
         resolved_via_alias=resolved_alias,

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -307,6 +307,9 @@ def _run_agent(
         base_url=runtime.get("base_url"),
         provider=runtime.get("provider"),
         api_mode=runtime.get("api_mode"),
+        preserve_anthropic_thinking_blocks=runtime.get(
+            "preserve_anthropic_thinking_blocks", False
+        ),
         model=effective_model,
         enabled_toolsets=toolsets_list,
         quiet_mode=True,

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -176,6 +176,14 @@ def _parse_api_mode(raw: Any) -> Optional[str]:
     return None
 
 
+def _copy_preserve_anthropic_thinking_flag(source: Dict[str, Any], target: Dict[str, Any]) -> None:
+    if (
+        source.get("preserve_anthropic_thinking_blocks") is True
+        or source.get("preserveAnthropicThinkingBlocks") is True
+    ):
+        target["preserve_anthropic_thinking_blocks"] = True
+
+
 def _resolve_runtime_from_pool_entry(
     *,
     provider: str,
@@ -320,6 +328,7 @@ def _try_resolve_from_custom_pool(
     provider_label: str,
     api_mode_override: Optional[str] = None,
     provider_name: Optional[str] = None,
+    preserve_anthropic_thinking_blocks: bool = False,
 ) -> Optional[Dict[str, Any]]:
     """Check if a credential pool exists for a custom endpoint and return a runtime dict if so."""
     pool_key = get_custom_provider_pool_key(base_url, provider_name=provider_name)
@@ -335,7 +344,7 @@ def _try_resolve_from_custom_pool(
         pool_api_key = getattr(entry, "runtime_api_key", None) or getattr(entry, "access_token", "")
         if not pool_api_key:
             return None
-        return {
+        result = {
             "provider": provider_label,
             "api_mode": api_mode_override or _detect_api_mode_for_url(base_url) or "chat_completions",
             "base_url": base_url,
@@ -343,6 +352,9 @@ def _try_resolve_from_custom_pool(
             "source": f"pool:{pool_key}",
             "credential_pool": pool,
         }
+        if preserve_anthropic_thinking_blocks:
+            result["preserve_anthropic_thinking_blocks"] = True
+        return result
     except Exception:
         return None
 
@@ -411,6 +423,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                     api_mode = _parse_api_mode(entry.get("api_mode") or entry.get("transport"))
                     if api_mode:
                         result["api_mode"] = api_mode
+                    _copy_preserve_anthropic_thinking_flag(entry, result)
                     return result
             # Also check the 'name' field if present
             display_name = entry.get("name", "")
@@ -429,6 +442,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
                         api_mode = _parse_api_mode(entry.get("api_mode") or entry.get("transport"))
                         if api_mode:
                             result["api_mode"] = api_mode
+                        _copy_preserve_anthropic_thinking_flag(entry, result)
                         return result
 
     # Fall back to custom_providers: list (legacy format)
@@ -472,6 +486,7 @@ def _get_named_custom_provider(requested_provider: str) -> Optional[Dict[str, An
         api_mode = _parse_api_mode(entry.get("api_mode"))
         if api_mode:
             result["api_mode"] = api_mode
+        _copy_preserve_anthropic_thinking_flag(entry, result)
         model_name = str(entry.get("model", "") or "").strip()
         if model_name:
             result["model"] = model_name
@@ -529,7 +544,13 @@ def _resolve_named_custom_runtime(
         return None
 
     # Check if a credential pool exists for this custom endpoint
-    pool_result = _try_resolve_from_custom_pool(base_url, "custom", custom_provider.get("api_mode"), provider_name=custom_provider.get("name"))
+    pool_result = _try_resolve_from_custom_pool(
+        base_url,
+        "custom",
+        custom_provider.get("api_mode"),
+        provider_name=custom_provider.get("name"),
+        preserve_anthropic_thinking_blocks=custom_provider.get("preserve_anthropic_thinking_blocks") is True,
+    )
     if pool_result:
         # Propagate the model name even when using pooled credentials —
         # the pool doesn't know about the custom_providers model field.
@@ -560,6 +581,7 @@ def _resolve_named_custom_runtime(
     # provider name differs from the actual model string the API expects.
     if custom_provider.get("model"):
         result["model"] = custom_provider["model"]
+    _copy_preserve_anthropic_thinking_flag(custom_provider, result)
     return result
 
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -1109,6 +1109,7 @@ class AIAgent:
         iteration_budget: "IterationBudget" = None,
         fallback_model: Dict[str, Any] = None,
         credential_pool=None,
+        preserve_anthropic_thinking_blocks: bool = False,
         checkpoints_enabled: bool = False,
         checkpoint_max_snapshots: int = 20,
         checkpoint_max_total_size_mb: int = 500,
@@ -1148,6 +1149,8 @@ class AIAgent:
             max_tokens (int): Maximum tokens for model responses (optional, uses model default if not set)
             reasoning_config (Dict): OpenRouter reasoning configuration override (e.g. {"effort": "none"} to disable thinking).
                 If None, defaults to {"enabled": True, "effort": "medium"} for OpenRouter. Set to disable/customize reasoning.
+            preserve_anthropic_thinking_blocks (bool): For non-Anthropic anthropic_messages endpoints, opt in to replaying
+                Anthropic thinking/signature blocks instead of stripping them.
             prefill_messages (List[Dict]): Messages to prepend to conversation history as prefilled context.
                 Useful for injecting a few-shot example or priming the model's response style.
                 Example: [{"role": "user", "content": "Hi!"}, {"role": "assistant", "content": "Hello!"}]
@@ -1193,6 +1196,7 @@ class AIAgent:
         self.load_soul_identity = load_soul_identity
         self.pass_session_id = pass_session_id
         self._credential_pool = credential_pool
+        self.preserve_anthropic_thinking_blocks = bool(preserve_anthropic_thinking_blocks)
         self.log_prefix_chars = log_prefix_chars
         self.log_prefix = f"{log_prefix} " if log_prefix else ""
         # Store effective base URL for feature detection (prompt caching, reasoning, etc.)
@@ -2385,6 +2389,7 @@ class AIAgent:
             "base_url": self.base_url,
             "api_mode": self.api_mode,
             "api_key": getattr(self, "api_key", ""),
+            "preserve_anthropic_thinking_blocks": self.preserve_anthropic_thinking_blocks,
             "client_kwargs": dict(self._client_kwargs),
             "use_prompt_caching": self._use_prompt_caching,
             "use_native_cache_layout": self._use_native_cache_layout,
@@ -2518,7 +2523,15 @@ class AIAgent:
         except Exception as err:
             logger.debug("LM Studio preload skipped: %s", err)
 
-    def switch_model(self, new_model, new_provider, api_key='', base_url='', api_mode=''):
+    def switch_model(
+        self,
+        new_model,
+        new_provider,
+        api_key='',
+        base_url='',
+        api_mode='',
+        preserve_anthropic_thinking_blocks=False,
+    ):
         """Switch the model/provider in-place for a live agent.
 
         Called by the /model command handlers (CLI and gateway) after
@@ -2565,6 +2578,7 @@ class AIAgent:
         if base_url:
             self.base_url = base_url
         self.api_mode = api_mode
+        self.preserve_anthropic_thinking_blocks = bool(preserve_anthropic_thinking_blocks)
         # Invalidate transport cache — new api_mode may need a different transport
         if hasattr(self, "_transport_cache"):
             self._transport_cache.clear()
@@ -2663,6 +2677,7 @@ class AIAgent:
             "base_url": self.base_url,
             "api_mode": self.api_mode,
             "api_key": getattr(self, "api_key", ""),
+            "preserve_anthropic_thinking_blocks": self.preserve_anthropic_thinking_blocks,
             "client_kwargs": dict(self._client_kwargs),
             "use_prompt_caching": self._use_prompt_caching,
             "use_native_cache_layout": self._use_native_cache_layout,
@@ -3077,7 +3092,7 @@ class AIAgent:
             detail = detail[:217].rstrip() + "..."
         self._emit_warning(f"⚠ Auxiliary {task} failed: {detail}")
 
-    def _current_main_runtime(self) -> Dict[str, str]:
+    def _current_main_runtime(self) -> Dict[str, Any]:
         """Return the live main runtime for session-scoped auxiliary routing."""
         return {
             "model": getattr(self, "model", "") or "",
@@ -3085,6 +3100,9 @@ class AIAgent:
             "base_url": getattr(self, "base_url", "") or "",
             "api_key": getattr(self, "api_key", "") or "",
             "api_mode": getattr(self, "api_mode", "") or "",
+            "preserve_anthropic_thinking_blocks": bool(
+                getattr(self, "preserve_anthropic_thinking_blocks", False)
+            ),
         }
 
     def _check_compression_model_feasibility(self) -> None:
@@ -4177,6 +4195,9 @@ class AIAgent:
                         api_mode=_parent_runtime.get("api_mode") or None,
                         base_url=_parent_runtime.get("base_url") or None,
                         api_key=_parent_runtime.get("api_key") or None,
+                        preserve_anthropic_thinking_blocks=bool(
+                            _parent_runtime.get("preserve_anthropic_thinking_blocks", False)
+                        ),
                         credential_pool=getattr(self, "_credential_pool", None),
                         parent_session_id=self.session_id,
                         enabled_toolsets=["memory", "skills"],
@@ -8502,6 +8523,7 @@ class AIAgent:
             self.provider = fb_provider
             self.base_url = fb_base_url
             self.api_mode = fb_api_mode
+            self.preserve_anthropic_thinking_blocks = False
             if hasattr(self, "_transport_cache"):
                 self._transport_cache.clear()
             self._fallback_activated = True
@@ -8625,6 +8647,9 @@ class AIAgent:
             self.provider = rt["provider"]
             self.base_url = rt["base_url"]           # setter updates _base_url_lower
             self.api_mode = rt["api_mode"]
+            self.preserve_anthropic_thinking_blocks = bool(
+                rt.get("preserve_anthropic_thinking_blocks", False)
+            )
             if hasattr(self, "_transport_cache"):
                 self._transport_cache.clear()
             self.api_key = rt["api_key"]
@@ -8733,6 +8758,9 @@ class AIAgent:
             self.provider = rt["provider"]
             self.base_url = rt["base_url"]
             self.api_mode = rt["api_mode"]
+            self.preserve_anthropic_thinking_blocks = bool(
+                rt.get("preserve_anthropic_thinking_blocks", False)
+            )
             if hasattr(self, "_transport_cache"):
                 self._transport_cache.clear()
             self.api_key = rt["api_key"]
@@ -9224,6 +9252,7 @@ class AIAgent:
                 base_url=getattr(self, "_anthropic_base_url", None),
                 fast_mode=(self.request_overrides or {}).get("speed") == "fast",
                 drop_context_1m_beta=bool(getattr(self, "_oauth_1m_beta_disabled", False)),
+                preserve_thinking_for_third_party=self.preserve_anthropic_thinking_blocks,
             )
 
         # AWS Bedrock native Converse API — bypasses the OpenAI client entirely.
@@ -11336,10 +11365,16 @@ class AIAgent:
 
                 if self.api_mode == "anthropic_messages":
                     _tsum = self._get_transport()
-                    _ant_kw = _tsum.build_kwargs(model=self.model, messages=api_messages, tools=None,
-                                   max_tokens=self.max_tokens, reasoning_config=self.reasoning_config,
-                                   is_oauth=self._is_anthropic_oauth,
-                                   preserve_dots=self._anthropic_preserve_dots())
+                    _ant_kw = _tsum.build_kwargs(
+                        model=self.model,
+                        messages=api_messages,
+                        tools=None,
+                        max_tokens=self.max_tokens,
+                        reasoning_config=self.reasoning_config,
+                        is_oauth=self._is_anthropic_oauth,
+                        preserve_dots=self._anthropic_preserve_dots(),
+                        preserve_thinking_for_third_party=self.preserve_anthropic_thinking_blocks,
+                    )
                     summary_response = self._anthropic_messages_create(_ant_kw)
                     _summary_result = _tsum.normalize_response(summary_response, strip_tool_prefix=self._is_anthropic_oauth)
                     final_response = (_summary_result.content or "").strip()
@@ -11366,10 +11401,16 @@ class AIAgent:
                     final_response = (_cnr_retry.content or "").strip()
                 elif self.api_mode == "anthropic_messages":
                     _tretry = self._get_transport()
-                    _ant_kw2 = _tretry.build_kwargs(model=self.model, messages=api_messages, tools=None,
-                                    is_oauth=self._is_anthropic_oauth,
-                                    max_tokens=self.max_tokens, reasoning_config=self.reasoning_config,
-                                    preserve_dots=self._anthropic_preserve_dots())
+                    _ant_kw2 = _tretry.build_kwargs(
+                        model=self.model,
+                        messages=api_messages,
+                        tools=None,
+                        is_oauth=self._is_anthropic_oauth,
+                        max_tokens=self.max_tokens,
+                        reasoning_config=self.reasoning_config,
+                        preserve_dots=self._anthropic_preserve_dots(),
+                        preserve_thinking_for_third_party=self.preserve_anthropic_thinking_blocks,
+                    )
                     retry_response = self._anthropic_messages_create(_ant_kw2)
                     _retry_result = _tretry.normalize_response(retry_response, strip_tool_prefix=self._is_anthropic_oauth)
                     final_response = (_retry_result.content or "").strip()

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1628,6 +1628,88 @@ class TestThinkingBlockSignatureManagement:
         blocks = result[0]["content"]
         assert not any(b.get("type") == "redacted_thinking" for b in blocks)
 
+    def test_third_party_thinking_stripped_by_default(self):
+        """Third-party Anthropic-compatible endpoints still strip all thinking by default."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": "Response.",
+                "reasoning_details": [
+                    {"type": "thinking", "thinking": "Private reasoning.", "signature": "sig_valid"},
+                    {"type": "redacted_thinking", "data": "opaque_signature_data"},
+                ],
+            },
+        ]
+        _, result = convert_messages_to_anthropic(
+            messages,
+            base_url="https://proxy.example.com/anthropic",
+        )
+        blocks = result[0]["content"]
+
+        assert not any(block.get("type") in {"thinking", "redacted_thinking"} for block in blocks)
+
+    def test_third_party_can_preserve_latest_signed_thinking_when_enabled(self):
+        """Opt-in third-party replay uses direct Anthropic signature handling."""
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"id": "tc_old", "function": {"name": "tool1", "arguments": "{}"}},
+                ],
+                "reasoning_details": [
+                    {"type": "thinking", "thinking": "Old reasoning.", "signature": "sig_old"},
+                ],
+            },
+            {"role": "tool", "tool_call_id": "tc_old", "content": "old result"},
+            {
+                "role": "assistant",
+                "content": "Latest answer.",
+                "reasoning_details": [
+                    {"type": "thinking", "thinking": "Latest reasoning.", "signature": "sig_new"},
+                    {"type": "redacted_thinking", "data": "opaque_signature_data"},
+                ],
+            },
+        ]
+        _, result = convert_messages_to_anthropic(
+            messages,
+            base_url="https://proxy.example.com/anthropic",
+            preserve_thinking_for_third_party=True,
+        )
+
+        assistants = [m for m in result if m["role"] == "assistant"]
+        assert not any(
+            b.get("type") in {"thinking", "redacted_thinking"}
+            for b in assistants[0]["content"]
+        )
+        latest_blocks = assistants[-1]["content"]
+        thinking = [b for b in latest_blocks if b.get("type") == "thinking"]
+        redacted = [b for b in latest_blocks if b.get("type") == "redacted_thinking"]
+        assert thinking[0]["signature"] == "sig_new"
+        assert redacted[0]["data"] == "opaque_signature_data"
+
+    def test_third_party_unsigned_latest_thinking_downgraded_when_enabled(self):
+        messages = [
+            {
+                "role": "assistant",
+                "content": "Response text.",
+                "reasoning_details": [
+                    {"type": "thinking", "thinking": "Unsigned reasoning."},
+                ],
+            },
+        ]
+        _, result = convert_messages_to_anthropic(
+            messages,
+            base_url="https://proxy.example.com/anthropic",
+            preserve_thinking_for_third_party=True,
+        )
+        blocks = result[0]["content"]
+
+        assert not any(b.get("type") == "thinking" for b in blocks)
+        assert "Unsigned reasoning." in [
+            b.get("text", "") for b in blocks if b.get("type") == "text"
+        ]
+
     def test_cache_control_stripped_from_thinking_blocks(self):
         """cache_control markers are removed from thinking/redacted_thinking blocks."""
         messages = [

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -2140,6 +2140,122 @@ class TestProviderEntryApiKeyEnvAlias:
         key_env so the set stays in sync with what the runtime actually reads."""
         from hermes_cli.config import _VALID_CUSTOM_PROVIDER_FIELDS
         assert "key_env" in _VALID_CUSTOM_PROVIDER_FIELDS
+
+
+class TestPreserveAnthropicThinkingBlocksConfig:
+    def test_provider_entry_normalizes_preserve_thinking_flag(self):
+        from hermes_cli.config import _normalize_custom_provider_entry
+        entry = {
+            "name": "vendor",
+            "base_url": "https://api.vendor.example.com/anthropic",
+            "preserve_anthropic_thinking_blocks": True,
+        }
+
+        normalized = _normalize_custom_provider_entry(dict(entry), provider_key="vendor")
+
+        assert normalized is not None
+        assert normalized.get("preserve_anthropic_thinking_blocks") is True
+
+    def test_camel_case_preserve_thinking_flag_normalizes(self):
+        from hermes_cli.config import _normalize_custom_provider_entry
+        entry = {
+            "name": "vendor",
+            "base_url": "https://api.vendor.example.com/anthropic",
+            "preserveAnthropicThinkingBlocks": True,
+        }
+
+        normalized = _normalize_custom_provider_entry(dict(entry), provider_key="vendor")
+
+        assert normalized is not None
+        assert normalized.get("preserve_anthropic_thinking_blocks") is True
+
+    def test_valid_fields_set_lists_preserve_thinking_flag(self):
+        from hermes_cli.config import _VALID_CUSTOM_PROVIDER_FIELDS
+
+        assert "preserve_anthropic_thinking_blocks" in _VALID_CUSTOM_PROVIDER_FIELDS
+
+    def test_named_provider_runtime_propagates_preserve_thinking_flag(self, monkeypatch):
+        monkeypatch.setattr(
+            rp,
+            "load_config",
+            lambda: {
+                "providers": {
+                    "vendor": {
+                        "base_url": "https://api.vendor.example.com/anthropic",
+                        "api_key": "test-key",
+                        "api_mode": "anthropic_messages",
+                        "preserve_anthropic_thinking_blocks": True,
+                    },
+                },
+            },
+        )
+
+        resolved = rp.resolve_runtime_provider(requested="custom:vendor")
+
+        assert resolved["api_mode"] == "anthropic_messages"
+        assert resolved["preserve_anthropic_thinking_blocks"] is True
+
+    def test_named_provider_runtime_accepts_camel_case_preserve_thinking_flag(self, monkeypatch):
+        monkeypatch.setattr(
+            rp,
+            "load_config",
+            lambda: {
+                "providers": {
+                    "vendor": {
+                        "base_url": "https://api.vendor.example.com/anthropic",
+                        "api_key": "test-key",
+                        "api_mode": "anthropic_messages",
+                        "preserveAnthropicThinkingBlocks": True,
+                    },
+                },
+            },
+        )
+
+        resolved = rp.resolve_runtime_provider(requested="custom:vendor")
+
+        assert resolved["api_mode"] == "anthropic_messages"
+        assert resolved["preserve_anthropic_thinking_blocks"] is True
+
+    def test_legacy_custom_provider_runtime_propagates_preserve_thinking_flag(self, monkeypatch):
+        monkeypatch.setattr(
+            rp,
+            "load_config",
+            lambda: {
+                "custom_providers": [
+                    {
+                        "name": "vendor",
+                        "base_url": "https://api.vendor.example.com/anthropic",
+                        "api_key": "test-key",
+                        "api_mode": "anthropic_messages",
+                        "preserve_anthropic_thinking_blocks": True,
+                    },
+                ],
+            },
+        )
+
+        resolved = rp.resolve_runtime_provider(requested="custom:vendor")
+
+        assert resolved["api_mode"] == "anthropic_messages"
+        assert resolved["preserve_anthropic_thinking_blocks"] is True
+
+    def test_missing_preserve_thinking_flag_is_not_added_to_runtime(self, monkeypatch):
+        monkeypatch.setattr(
+            rp,
+            "load_config",
+            lambda: {
+                "providers": {
+                    "vendor": {
+                        "base_url": "https://api.vendor.example.com/anthropic",
+                        "api_key": "test-key",
+                        "api_mode": "anthropic_messages",
+                    },
+                },
+            },
+        )
+
+        resolved = rp.resolve_runtime_provider(requested="custom:vendor")
+
+        assert "preserve_anthropic_thinking_blocks" not in resolved
 # =============================================================================
 # Tencent TokenHub — API-key provider runtime resolution
 # =============================================================================

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -876,6 +876,7 @@ def _build_child_agent(
     override_base_url: Optional[str] = None,
     override_api_key: Optional[str] = None,
     override_api_mode: Optional[str] = None,
+    override_preserve_anthropic_thinking_blocks: bool = False,
     # ACP transport overrides — lets a non-ACP parent spawn ACP child agents
     override_acp_command: Optional[str] = None,
     override_acp_args: Optional[List[str]] = None,
@@ -1018,6 +1019,11 @@ def _build_child_agent(
     effective_base_url = override_base_url or parent_agent.base_url
     effective_api_key = override_api_key or parent_api_key
     effective_api_mode = override_api_mode or getattr(parent_agent, "api_mode", None)
+    effective_preserve_anthropic_thinking_blocks = (
+        bool(override_preserve_anthropic_thinking_blocks)
+        if override_provider
+        else bool(getattr(parent_agent, "preserve_anthropic_thinking_blocks", False))
+    )
     effective_acp_command = override_acp_command or getattr(
         parent_agent, "acp_command", None
     )
@@ -1093,6 +1099,7 @@ def _build_child_agent(
         model=effective_model,
         provider=effective_provider,
         api_mode=effective_api_mode,
+        preserve_anthropic_thinking_blocks=effective_preserve_anthropic_thinking_blocks,
         acp_command=effective_acp_command,
         acp_args=effective_acp_args,
         max_iterations=max_iterations,
@@ -2051,6 +2058,9 @@ def delegate_task(
                 override_base_url=creds["base_url"],
                 override_api_key=creds["api_key"],
                 override_api_mode=creds["api_mode"],
+                override_preserve_anthropic_thinking_blocks=creds.get(
+                    "preserve_anthropic_thinking_blocks", False
+                ),
                 override_acp_command=t.get("acp_command")
                 or acp_command
                 or creds.get("command"),
@@ -2417,6 +2427,9 @@ def _resolve_delegation_credentials(cfg: dict, parent_agent) -> dict:
         "base_url": runtime.get("base_url"),
         "api_key": api_key,
         "api_mode": runtime.get("api_mode"),
+        "preserve_anthropic_thinking_blocks": bool(
+            runtime.get("preserve_anthropic_thinking_blocks", False)
+        ),
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
     }

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1799,6 +1799,9 @@ def _background_agent_kwargs(agent, task_id: str) -> dict:
         "api_key": getattr(agent, "api_key", None) or None,
         "provider": getattr(agent, "provider", None) or None,
         "api_mode": getattr(agent, "api_mode", None) or None,
+        "preserve_anthropic_thinking_blocks": bool(
+            getattr(agent, "preserve_anthropic_thinking_blocks", False)
+        ),
         "acp_command": getattr(agent, "acp_command", None) or None,
         "acp_args": getattr(agent, "acp_args", None) or None,
         "model": getattr(agent, "model", None) or _resolve_model(),
@@ -1887,6 +1890,9 @@ def _make_agent(sid: str, key: str, session_id: str | None = None):
         base_url=runtime.get("base_url"),
         api_key=runtime.get("api_key"),
         api_mode=runtime.get("api_mode"),
+        preserve_anthropic_thinking_blocks=runtime.get(
+            "preserve_anthropic_thinking_blocks", False
+        ),
         acp_command=runtime.get("command"),
         acp_args=runtime.get("args"),
         credential_pool=runtime.get("credential_pool"),


### PR DESCRIPTION
## Summary

- Add provider-level `preserve_anthropic_thinking_blocks` config with camelCase alias `preserveAnthropicThinkingBlocks`.
- Propagate the flag from named `providers.<name>` and legacy `custom_providers[]` through runtime resolution into `AIAgent` and Anthropic transport request building.
- Keep default third-party Anthropic-compatible behavior unchanged: strip all thinking blocks unless explicitly opted in.
- When enabled for compatible third-party `anthropic_messages` endpoints, reuse direct Anthropic thinking handling: preserve latest signed `thinking` / valid `redacted_thinking`, strip older turn thinking, and downgrade unsigned latest thinking to text.
- Preserve existing Kimi / DeepSeek unsigned thinking behavior ahead of the new opt-in path.

## Verification

- `.venv/bin/python -m pytest -o addopts='' tests/agent/test_anthropic_adapter.py::TestThinkingBlockSignatureManagement tests/agent/test_kimi_coding_anthropic_thinking.py tests/agent/test_deepseek_anthropic_thinking.py tests/agent/test_minimax_provider.py -q`
- `.venv/bin/python -m pytest -o addopts='' tests/hermes_cli/test_runtime_provider_resolution.py::test_named_custom_provider_anthropic_api_mode tests/hermes_cli/test_runtime_provider_resolution.py::TestPreserveAnthropicThinkingBlocksConfig -q`
- `.venv/bin/python -m py_compile agent/anthropic_adapter.py agent/transports/anthropic.py hermes_cli/config.py hermes_cli/runtime_provider.py run_agent.py cli.py gateway/run.py hermes_cli/model_switch.py hermes_cli/oneshot.py cron/scheduler.py tui_gateway/server.py acp_adapter/session.py gateway/platforms/feishu_comment.py agent/curator.py tools/delegate_tool.py`
- `git diff --check`

## Notes

Full-file test runs for `tests/agent/test_anthropic_adapter.py` and `tests/hermes_cli/test_runtime_provider_resolution.py tests/hermes_cli/test_config.py` are affected on this workstation by existing local credential/keychain state, so the verification above targets the changed behavior and related compatibility tests directly.
