### PR TITLE
feat(delegate): per-task model and provider overrides

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -2495,5 +2495,143 @@ class TestFallbackModelInheritance(unittest.TestCase):
         self.assertIsNone(kwargs["fallback_model"])
 
 
+# =========================================================================
+# Per-task model/provider override
+# =========================================================================
+
+
+class TestPerTaskModelOverride(unittest.TestCase):
+    """Tests that per-task model/provider fields route each subagent correctly."""
+
+    def _make_parent(self):
+        parent = _make_mock_parent(depth=0)
+        parent.enabled_toolsets = ["terminal", "file"]
+        return parent
+
+    def _make_mock_child(self):
+        m = MagicMock()
+        m.run_conversation.return_value = {
+            "final_response": "done", "completed": True,
+            "api_calls": 1, "messages": [],
+        }
+        m._delegate_saved_tool_names = []
+        m._credential_pool = None
+        m.session_prompt_tokens = 0
+        m.session_completion_tokens = 0
+        m.model = "test-model"
+        return m
+
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_schema_has_model_and_provider_per_task(self, _cfg, _creds):
+        """DELEGATE_TASK_SCHEMA exposes model and provider inside tasks[].items."""
+        from tools.delegate_tool import DELEGATE_TASK_SCHEMA
+        task_props = DELEGATE_TASK_SCHEMA["parameters"]["properties"]["tasks"]["items"]["properties"]
+        self.assertIn("model", task_props)
+        self.assertIn("provider", task_props)
+        self.assertEqual(task_props["model"]["type"], "string")
+        self.assertEqual(task_props["provider"]["type"], "string")
+
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_per_task_model_overrides_global_creds(self, mock_cfg, mock_creds):
+        """When a task specifies model='opus', that task's child is built with it."""
+        # Global creds return the default model
+        global_creds = {
+            "model": "default-model", "provider": "openrouter",
+            "base_url": None, "api_key": "key", "api_mode": None,
+        }
+        # Per-task creds (called when task has model override)
+        per_task_creds = {
+            "model": "anthropic/claude-opus-4", "provider": "openrouter",
+            "base_url": None, "api_key": "key", "api_mode": None,
+        }
+        mock_creds.side_effect = [global_creds, per_task_creds]
+
+        parent = self._make_parent()
+        built_models = []
+
+        def _factory(*a, **kw):
+            built_models.append(kw.get("model"))
+            return self._make_mock_child()
+
+        with patch("run_agent.AIAgent", side_effect=_factory):
+            delegate_task(
+                tasks=[
+                    {"goal": "easy task"},
+                    {"goal": "hard task", "model": "anthropic/claude-opus-4"},
+                ],
+                parent_agent=parent,
+            )
+
+        # First task uses global creds, second uses per-task creds
+        self.assertEqual(built_models[0], "default-model")
+        self.assertEqual(built_models[1], "anthropic/claude-opus-4")
+
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_task_without_model_uses_global_creds(self, mock_cfg, mock_creds):
+        """Tasks that omit model use the global delegation creds unchanged."""
+        global_creds = {
+            "model": "global-model", "provider": None,
+            "base_url": None, "api_key": None, "api_mode": None,
+        }
+        mock_creds.return_value = global_creds
+
+        parent = self._make_parent()
+        built_models = []
+
+        def _factory(*a, **kw):
+            built_models.append(kw.get("model"))
+            return self._make_mock_child()
+
+        with patch("run_agent.AIAgent", side_effect=_factory):
+            delegate_task(
+                tasks=[{"goal": "task A"}, {"goal": "task B"}],
+                parent_agent=parent,
+            )
+
+        self.assertEqual(built_models, ["global-model", "global-model"])
+        # _resolve_delegation_credentials called once for global creds only
+        mock_creds.assert_called_once()
+
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    @patch("tools.delegate_tool._load_config", return_value={})
+    def test_per_task_provider_triggers_credential_re_resolution(self, mock_cfg, mock_creds):
+        """A per-task provider triggers a second _resolve_delegation_credentials call
+        with the per-task config overlay."""
+        global_creds = {
+            "model": None, "provider": None,
+            "base_url": None, "api_key": None, "api_mode": None,
+        }
+        task_creds = {
+            "model": None, "provider": "anthropic",
+            "base_url": "https://api.anthropic.com/v1", "api_key": "ak",
+            "api_mode": "anthropic_messages",
+        }
+        mock_creds.side_effect = [global_creds, task_creds]
+
+        parent = self._make_parent()
+        built_providers = []
+
+        def _factory(*a, **kw):
+            built_providers.append(kw.get("provider"))
+            return self._make_mock_child()
+
+        with patch("run_agent.AIAgent", side_effect=_factory):
+            delegate_task(
+                tasks=[
+                    {"goal": "default provider task"},
+                    {"goal": "anthropic task", "provider": "anthropic"},
+                ],
+                parent_agent=parent,
+            )
+
+        # Two calls: initial global resolve + one per-task re-resolve
+        self.assertEqual(mock_creds.call_count, 2)
+        # Second child got the anthropic provider
+        self.assertEqual(built_providers[1], "anthropic")
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -1966,19 +1966,36 @@ def delegate_task(
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
+            # Per-task model/provider override: if the task specifies its own
+            # model or provider, resolve a fresh credential bundle for that task.
+            # Falls back to the global delegation creds when absent.
+            task_model = t.get("model") or None
+            task_provider = t.get("provider") or None
+            if task_model or task_provider:
+                task_cfg = dict(cfg)
+                if task_model:
+                    task_cfg["model"] = task_model
+                if task_provider:
+                    task_cfg["provider"] = task_provider
+                try:
+                    task_creds = _resolve_delegation_credentials(task_cfg, parent_agent)
+                except ValueError as exc:
+                    return tool_error(str(exc))
+            else:
+                task_creds = creds
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
                 context=t.get("context"),
                 toolsets=t.get("toolsets") or toolsets,
-                model=creds["model"],
+                model=task_creds["model"],
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
-                override_provider=creds["provider"],
-                override_base_url=creds["base_url"],
-                override_api_key=creds["api_key"],
-                override_api_mode=creds["api_mode"],
+                override_provider=task_creds["provider"],
+                override_base_url=task_creds["base_url"],
+                override_api_key=task_creds["api_key"],
+                override_api_mode=task_creds["api_mode"],
                 override_acp_command=t.get("acp_command")
                 or acp_command
                 or creds.get("command"),
@@ -2390,6 +2407,11 @@ DELEGATE_TASK_SCHEMA = {
         "1. Single task: provide 'goal' (+ optional context, toolsets)\n"
         "2. Batch (parallel): provide 'tasks' array with up to delegation.max_concurrent_children items (default 3, configurable via config.yaml, no hard ceiling). "
         "All run concurrently and results are returned together. Nested delegation requires role='orchestrator' and delegation.max_spawn_depth >= 2.\n\n"
+        "MODEL ROUTING: Each task in 'tasks' accepts optional 'model' and 'provider' fields "
+        "to run that specific subtask on a different model (e.g. route a hard reasoning task "
+        "to 'anthropic/claude-opus-4' via provider='openrouter' while lighter tasks use the "
+        "default). Requires OpenRouter or another multi-model provider. Falls back to "
+        "delegation.model from config.yaml when omitted.\n\n"
         "WHEN TO USE delegate_task:\n"
         "- Reasoning-heavy subtasks (debugging, code review, research synthesis)\n"
         "- Tasks that would flood your context with intermediate data\n"
@@ -2490,6 +2512,23 @@ DELEGATE_TASK_SCHEMA = {
                             "type": "string",
                             "enum": ["leaf", "orchestrator"],
                             "description": "Per-task role override. See top-level 'role' for semantics.",
+                        },
+                        "model": {
+                            "type": "string",
+                            "description": (
+                                "Per-task model override (e.g. 'anthropic/claude-opus-4', "
+                                "'openai/gpt-4o'). Overrides delegation.model from config.yaml "
+                                "for this task only. Useful when one subtask needs a more capable "
+                                "model while others use the default."
+                            ),
+                        },
+                        "provider": {
+                            "type": "string",
+                            "description": (
+                                "Per-task provider override (e.g. 'openrouter', 'anthropic'). "
+                                "Use together with 'model' when the target model lives on a "
+                                "different provider than the parent. Omit to inherit."
+                            ),
                         },
                     },
                     "required": ["goal"],


### PR DESCRIPTION
## Problem

`delegate_task` applies a single global model to every child agent (from `delegation.model` in config.yaml). There's no way to route individual subtasks to different models without changing the global config between runs.

Cron jobs already support per-job `model` + `provider` overrides. This PR brings `delegate_task` to parity.

## Solution

Add optional `model` and `provider` fields to each task object in the `tasks` batch array. When present, that task's child agent is built with a task-specific credential bundle. When absent, the task inherits global delegation creds — no behavior change for existing callers.

```python
delegate_task(tasks=[
    {"goal": "quick summary"},  # uses default model
    {"goal": "deep reasoning task", "model": "anthropic/claude-opus-4", "provider": "openrouter"},
])
```

## Changes

- `tools/delegate_tool.py`: resolve per-task creds when `task.model` or `task.provider` is set; pass `task_creds` into `_build_child_agent` for that task
- `tools/delegate_tool.py`: add `model` and `provider` to `DELEGATE_TASK_SCHEMA tasks[].items.properties`
- `tools/delegate_tool.py`: add MODEL ROUTING section to tool description
- `tests/tools/test_delegate.py`: 4 new tests in `TestPerTaskModelOverride`

## Test plan

```
python -m pytest tests/tools/test_delegate.py -o 'addopts=' -q
```

124 pass (same as before + 4 new). The 4 pre-existing failures in `TestDelegationCredentialResolution` and `TestDelegateHeartbeat` are unrelated to this change and reproduce on `main`.