### PR TITLE
feat(i18n): expand Russian docs localization

### DIFF
--- a/website/docusaurus.config.ts
+++ b/website/docusaurus.config.ts
@@ -24,7 +24,7 @@ const config: Config = {
 
   i18n: {
     defaultLocale: 'en',
-    locales: ['en', 'zh-Hans', 'ko'],
+    locales: ['en', 'zh-Hans', 'ko', 'ru'],
     localeConfigs: {
       en: {
         label: 'English',
@@ -37,6 +37,10 @@ const config: Config = {
         label: '한국어',
         htmlLang: 'ko',
       },
+      ru: {
+        label: 'Русский',
+        htmlLang: 'ru',
+      },
     },
   },
 
@@ -47,7 +51,7 @@ const config: Config = {
       /** @type {import("@easyops-cn/docusaurus-search-local").PluginOptions} */
       ({
         hashed: true,
-        language: ['en', 'zh'],
+        language: ['en', 'zh', 'ru'],
         indexBlog: false,
         docsRouteBasePath: '/',
         // Disabled: appends ?_highlight=... to URLs (before the #anchor),

--- a/website/i18n/ru/docusaurus-plugin-content-docs/current/getting-started/installation.md
+++ b/website/i18n/ru/docusaurus-plugin-content-docs/current/getting-started/installation.md
@@ -1,0 +1,191 @@
+---
+sidebar_position: 2
+title: "Установка"
+description: "Установите Hermes Agent на Linux, macOS, WSL2, нативный Windows (ранняя бета) или Android через Termux"
+---
+
+# Установка
+
+Запустите Hermes Agent меньше чем за две минуты с помощью установщика одной командой.
+
+## Быстрая установка
+
+### Установка одной командой (Linux / macOS / WSL2)
+
+Если вам нужна Git-установка, которая идёт за `main` и сразу подхватывает свежие изменения:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+```
+
+### Windows (нативный PowerShell) — ранняя бета
+
+:::warning РАННЯЯ БЕТА
+Поддержка нативного Windows пока находится в **ранней бете**. Установка работает для типовых сценариев, но её пока не гоняли так же широко, как POSIX-установщики. Если наткнётесь на шероховатости, пожалуйста, [сообщайте о проблемах](https://github.com/NousResearch/hermes-agent/issues). Для самого проверенного варианта на Windows сегодня используйте линейную установку Linux/macOS внутри **WSL2**.
+:::
+
+Откройте PowerShell и выполните:
+
+```powershell
+iex (irm https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.ps1)
+```
+
+Установщик берёт на себя **всё**: `uv`, Python 3.11, Node.js 22, `ripgrep`, `ffmpeg` и **портативный Git Bash** (PortableGit — самодостаточный дистрибутив Git for Windows, который поставляет `bash.exe` и весь POSIX toolchain, используемый Hermes для shell-команд; на 32-битном Windows установщик переключается на MinGit, где bash нет и terminal-tool / agent-browser функции отключаются). Он клонирует репозиторий в `%LOCALAPPDATA%\hermes\hermes-agent`, создаёт виртуальное окружение и добавляет `hermes` в **User PATH**. После установки перезапустите терминал (или откройте новое окно PowerShell), чтобы PATH подхватился.
+
+**Как обрабатывается Git:**
+1. Если `git` уже есть в PATH, установщик использует его.
+2. Иначе он скачивает портативный **PortableGit** (~50MB, из официального GitHub-релиза `git-for-windows`) и распаковывает его в `%LOCALAPPDATA%\hermes\git`. Админские права не нужны. Всё изолировано и не конфликтует с системным Git, каким бы он ни был. (На 32-битном Windows установщик откатывается на MinGit, потому что PortableGit публикуется только для 64-bit и ARM64; зависящие от bash возможности Hermes на 32-битных хостах работать не будут.)
+
+**Почему не winget?** Раньше Git ставили через `winget install Git.Git`, но winget часто ломается, если системный Git уже частично повреждён именно в тот момент, когда пользователю нужен просто рабочий установщик. Портативный Git обходит winget, реестр установщика Windows и любой уже установленный system Git. Если когда-нибудь сломается сам Git-установщик Hermes, удалите `%LOCALAPPDATA%\hermes\git` и запустите установку заново — без последствий для системы и без сценариев с деинсталляцией.
+
+Установщик также выставляет `HERMES_GIT_BASH_PATH` на найденный `bash.exe`, чтобы Hermes в свежих shell-сессиях детерминированно находил Bash.
+
+Если вы предпочитаете WSL2, Linux-установщик выше работает и там; native и WSL-установки могут сосуществовать без конфликтов (нативные данные живут в `%LOCALAPPDATA%\hermes`, данные WSL — в `~/.hermes`).
+
+**Альтернатива: Desktop installer.** Для Hermes Desktop также доступен тонкий GUI-установщик: скачайте Hermes Desktop, запустите `.exe`, и при первом старте он сам вызовет `install.ps1`, чтобы подготовить Python (через `uv`), Node, PortableGit и остальные зависимости. Desktop-приложение и CLI, установленный через PowerShell, используют одни и те же папки установки и данных, так что можно пользоваться любым вариантом или обоими сразу. Подробности см. в [руководстве по нативному Windows](/user-guide/windows-native#desktop-installer-alternative).
+
+### Android / Termux
+
+Hermes теперь поддерживает и путь установки, учитывающий Termux:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+```
+
+Установщик автоматически распознаёт Termux и переключается на проверенный Android-flow:
+- использует `pkg` для системных зависимостей (`git`, `python`, `nodejs`, `ripgrep`, `ffmpeg`, build tools)
+- создаёт виртуальное окружение через `python -m venv`
+- автоматически экспортирует `ANDROID_API_LEVEL` для сборки Android wheels
+- сначала пробует широкий extra `.[termux-all]`, затем откатывается на более компактный `.[termux]` (и, если нужно, на базовую установку)
+- по умолчанию пропускает непроверенный bootstrap для браузера и WhatsApp
+
+Если нужен полностью явный сценарий, откройте отдельное [руководство по Termux](/getting-started/termux).
+
+:::note Паритет возможностей Windows (ранняя бета)
+
+Нативный Windows сейчас в **ранней бете**. Всё, кроме встроенного терминала чата в dashboard, запускается нативно на Windows:
+- **CLI (`hermes chat`, `hermes setup`, `hermes gateway`, …)** — native, использует ваш терминал по умолчанию
+- **Gateway (Telegram, Discord, Slack, …)** — native, работает как фоновый PowerShell-процесс
+- **Cron scheduler** — native
+- **Browser tool** — native (Chromium через Node.js)
+- **MCP servers** — native (поддерживаются и stdio, и HTTP transport)
+- **Dashboard `/chat` terminal pane** — **только WSL2** (использует POSIX PTY; у native Windows нет эквивалента). Остальная часть dashboard (sessions, jobs, metrics) работает нативно — ограничение касается только встроенной PTY-вкладки.
+
+Если столкнётесь с проблемой кодировки и захотите вернуться к старому cp1252 stdio path, установите `HERMES_DISABLE_WINDOWS_UTF8=1` в окружении. Это удобно для бисектов.
+:::
+
+### Что делает установщик
+
+Установщик автоматически закрывает все базовые шаги: зависимости (Python, Node.js, ripgrep, ffmpeg), клон репозитория, виртуальное окружение, глобальный `hermes` и настройку LLM-провайдера. После этого можно сразу начинать работу.
+
+#### Схема установки
+
+Где именно окажутся файлы, зависит от того, ставите ли вы Hermes как обычный пользователь или от root:
+
+| Установщик | Где лежит код | `hermes` binary | Папка данных |
+|---|---|---|---|
+| pip install | Python site-packages | `~/.local/bin/hermes` (console_scripts) | `~/.hermes/` |
+| Per-user (git installer) | `~/.hermes/hermes-agent/` | `~/.local/bin/hermes` (symlink) | `~/.hermes/` |
+| Root-mode (`sudo curl … \| sudo bash`) | `/usr/local/lib/hermes-agent/` | `/usr/local/bin/hermes` | `/root/.hermes/` (или `$HERMES_HOME`) |
+
+Root-mode **FHS layout** (`/usr/local/lib/…`, `/usr/local/bin/hermes`) совпадает с тем, как обычно раскладывают системные developer tools в Linux. Это удобно для shared-machine deployments, когда одна системная установка должна обслуживать всех пользователей. Персональные настройки (auth, skills, sessions) по-прежнему живут в `~/.hermes/` каждого пользователя или в явном `HERMES_HOME`.
+
+### После установки
+
+Перезагрузите shell и начните чат:
+
+```bash
+source ~/.bashrc   # or: source ~/.zshrc
+hermes             # Start chatting!
+```
+
+Чтобы позже изменить отдельные настройки, используйте специальные команды:
+
+```bash
+hermes model          # Choose your LLM provider and model
+hermes tools          # Configure which tools are enabled
+hermes gateway setup  # Set up messaging platforms
+hermes config set     # Set individual config values
+hermes setup          # Or run the full setup wizard to configure everything at once
+```
+
+---
+
+## Требования
+
+**pip install:** кроме Python 3.11+ ничего не требуется. Всё остальное установщик возьмёт на себя.
+
+**Git installer:** единственное обязательное условие — **Git**. Дальше установщик автоматизирует всё сам:
+
+- **uv** (быстрый пакетный менеджер для Python)
+- **Python 3.11** (через uv, без sudo)
+- **Node.js v22** (для браузерной автоматизации и WhatsApp bridge)
+- **ripgrep** (быстрый поиск по файлам)
+- **ffmpeg** (конвертация аудио для TTS)
+
+:::info
+Вручную ставить Python, Node.js, ripgrep или ffmpeg **не нужно**. Установщик сам поймёт, чего не хватает, и поставит это. Просто убедитесь, что `git` доступен (`git --version`).
+:::
+
+:::tip Для пользователей Nix
+Если вы используете Nix (на NixOS, macOS или Linux), у проекта есть отдельный путь установки с Nix flake, декларативным NixOS module и опциональным контейнерным режимом. Смотрите **[настройку Nix и NixOS](/getting-started/nix-setup)**.
+:::
+
+---
+
+## Ручная / developer-установка
+
+Если хотите клонировать репозиторий и ставить из исходников — для контрибьюта, запуска с конкретной ветки или полного контроля над virtualenv — см. раздел [настройки для разработки](/developer-guide/contributing#development-setup) в руководстве для участников.
+
+---
+
+## Установка без sudo / для service user
+
+Запуск Hermes от отдельного непривилегированного пользователя (например, systemd service account `hermes` или любого пользователя без `sudo`) поддерживается. Единственное место, где реально нужен root, — это шаг `--with-deps` у Playwright: он ставит системные библиотеки (`libnss3`, `libxkbcommon` и т. п.), которые использует Chromium. Установщик проверяет наличие sudo и аккуратно деградирует, если его нет: он установит Chromium в локальный cache Playwright для service user и выведет точную команду, которую должен выполнить администратор отдельно.
+
+**Рекомендуемая схема (Debian/Ubuntu):**
+
+1. **Один раз, от admin-пользователя с sudo**, поставьте системные библиотеки для Chromium:
+   ```bash
+   sudo npx playwright install-deps chromium
+   ```
+   (Команду можно запускать из любой директории — `npx` сам подтянет Playwright.)
+
+2. **От имени непривилегированного service user** запустите обычный установщик. Он увидит отсутствие sudo, пропустит `--with-deps` и поставит Chromium в локальный cache Playwright:
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+   ```
+
+   Если хотите вообще пропустить шаг Playwright — например, когда работаете headless и браузерная автоматизация не нужна, — добавьте `--skip-browser`:
+   ```bash
+   curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash -s -- --skip-browser
+   ```
+
+3. **Сделайте `hermes` доступным в shell service user.** Установщик пишет launcher в `~/.local/bin/hermes`. У service account часто урезанный PATH без `~/.local/bin`. Добавьте его в профиль пользователя или создайте системный symlink:
+   ```bash
+   # Option A — add to the service user's profile
+   echo 'export PATH="$HOME/.local/bin:$PATH"' >> ~/.bashrc
+
+   # Option B — symlink system-wide (run as an admin)
+   sudo ln -s /home/hermes/.hermes/hermes-agent/venv/bin/hermes /usr/local/bin/hermes
+   ```
+
+4. **Проверка:** `hermes doctor` должен пройти без ошибок. Если видите `ModuleNotFoundError: No module named 'dotenv'`, значит вы запускаете source-версию `hermes` (`~/.hermes/hermes-agent/hermes`) системным Python вместо launcher из venv (`~/.hermes/hermes-agent/venv/bin/hermes`) — вернитесь к шагу 3.
+
+Та же схема работает на Arch (установщик использует pacman с той же логикой определения sudo), Fedora/RHEL и openSUSE — там `--with-deps` вообще не поддерживается, поэтому системные библиотеки всегда ставит администратор отдельно. Соответствующие `dnf`/`zypper` команды установщик печатает сам.
+
+---
+
+## Устранение неполадок
+
+| Проблема | Решение |
+|---------|----------|
+| `hermes: command not found` | Перезагрузите shell (`source ~/.bashrc`) или проверьте PATH |
+| `API key not set` | Запустите `hermes model`, чтобы настроить провайдера, или `hermes config set OPENROUTER_API_KEY your_key` |
+| После обновления пропала конфигурация | Выполните `hermes config check`, затем `hermes config migrate` |
+
+Для более глубокой диагностики запустите `hermes doctor` — он покажет, чего именно не хватает и как это исправить.
+
+## Автоопределение способа установки
+
+Hermes сам определяет, был ли он установлен через `pip`, Git installer, Homebrew или NixOS, и `hermes update` выводит соответствующую команду обновления для этого способа. Отдельный env var не нужен — определение строится по схеме установки (Python site-packages, `~/.hermes/hermes-agent/`, Homebrew prefix или путь Nix store). `hermes doctor` тоже показывает распознанный способ в сводке окружения.

--- a/website/i18n/ru/docusaurus-plugin-content-docs/current/getting-started/learning-path.md
+++ b/website/i18n/ru/docusaurus-plugin-content-docs/current/getting-started/learning-path.md
@@ -1,0 +1,154 @@
+---
+sidebar_position: 3
+title: "Путь обучения"
+description: "Выберите маршрут по документации Hermes Agent в зависимости от опыта и целей"
+---
+
+# Путь обучения
+
+Hermes Agent умеет многое — CLI-ассистент, Telegram/Discord-бот, автоматизация задач, RL training и не только. Эта страница помогает понять, с чего начать и что читать дальше в зависимости от вашего уровня и того, чего вы хотите добиться.
+
+:::tip Начните отсюда
+Если Hermes Agent ещё не установлен, сначала откройте [руководство по установке](/getting-started/installation), а затем пройдите [Быстрый старт](/getting-started/quickstart). Всё, что написано ниже, предполагает уже рабочую установку.
+:::
+
+## Как пользоваться этой страницей
+
+- **Знаете свой уровень?** Перейдите к [таблице по уровню опыта](#by-experience-level) и следуйте рекомендованному порядку чтения.
+- **Есть конкретная цель?** Перейдите к разделу [По сценарию](#by-use-case) и выберите сценарий, который вам подходит.
+- **Просто смотрите вокруг?** Посмотрите таблицу [Ключевые возможности](#key-features-at-a-glance), чтобы быстро понять, что умеет Hermes Agent.
+
+## По уровню опыта {#by-experience-level}
+
+| Уровень | Цель | Рекомендуемое чтение | Время |
+|---|---|---|---|
+| **Начальный** | Встать на ноги, начать базовый чат, пользоваться встроенными инструментами | [Установка](/getting-started/installation) → [Быстрый старт](/getting-started/quickstart) → [Использование CLI](/user-guide/cli) → [Конфигурация](/user-guide/configuration) | ~1 час |
+| **Средний** | Настроить messaging-ботов, освоить продвинутые возможности вроде memory, cron jobs и skills | [Сеансы](/user-guide/sessions) → [Сообщения](/user-guide/messaging) → [Инструменты](/user-guide/features/tools) → [Навыки](/user-guide/features/skills) → [Память](/user-guide/features/memory) → [Cron](/user-guide/features/cron) | ~2–3 часа |
+| **Продвинутый** | Создавать собственные инструменты, писать skills, обучать модели через RL и вносить вклад в проект | [Архитектура](/developer-guide/architecture) → [Добавление инструментов](/developer-guide/adding-tools) → [Создание навыков](/developer-guide/creating-skills) → RL training → [Вклад в проект](/developer-guide/contributing) | ~4–6 часов |
+
+## По сценарию {#by-use-case}
+
+Выберите сценарий, который лучше всего описывает вашу задачу. Каждый пункт ведёт к нужным страницам в том порядке, в каком их лучше читать.
+
+### «Хочу CLI-ассистента для кода»
+
+Используйте Hermes Agent как интерактивный терминальный ассистент для написания, ревью и запуска кода.
+
+1. [Установка](/getting-started/installation)
+2. [Быстрый старт](/getting-started/quickstart)
+3. [Использование CLI](/user-guide/cli)
+4. [Выполнение кода](/user-guide/features/code-execution)
+5. [Файлы контекста](/user-guide/features/context-files)
+6. [Советы и приёмы](/guides/tips)
+
+:::tip
+Передавайте файлы прямо в разговор через context files. Hermes Agent умеет читать, редактировать и запускать код в ваших проектах.
+:::
+
+### «Хочу Telegram/Discord-бота»
+
+Разверните Hermes Agent как бота на любимой messaging platform.
+
+1. [Установка](/getting-started/installation)
+2. [Конфигурация](/user-guide/configuration)
+3. [Обзор messaging](/user-guide/messaging)
+4. [Настройка Telegram](/user-guide/messaging/telegram)
+5. [Настройка Discord](/user-guide/messaging/discord)
+6. [Голосовой режим](/user-guide/features/voice-mode)
+7. [Использование голосового режима с Hermes](/guides/use-voice-mode-with-hermes)
+8. [Безопасность](/user-guide/security)
+
+Для полноценных примеров проектов смотрите:
+- [Daily Briefing Bot](/guides/daily-briefing-bot)
+- [Team Telegram Assistant](/guides/team-telegram-assistant)
+
+### «Хочу автоматизировать задачи»
+
+Запускайте повторяющиеся задачи по расписанию, пакетные процессы или цепочки действий агента.
+
+1. [Быстрый старт](/getting-started/quickstart)
+2. [Планирование задач Cron](/user-guide/features/cron)
+3. [Пакетная обработка](/user-guide/features/batch-processing)
+4. [Делегирование](/user-guide/features/delegation)
+5. [Хуки](/user-guide/features/hooks)
+
+:::tip
+Cron jobs позволяют Hermes Agent запускать задачи по расписанию — ежедневные сводки, периодические проверки, автоматические отчёты — без вашего присутствия.
+:::
+
+### «Хочу писать собственные инструменты/skills»
+
+Расширяйте Hermes Agent своими инструментами и reusable skill-пакетами.
+
+1. [Плагины](/user-guide/features/plugins)
+2. [Создание плагина Hermes](/guides/build-a-hermes-plugin)
+3. [Обзор инструментов](/user-guide/features/tools)
+4. [Обзор навыков](/user-guide/features/skills)
+5. [MCP (Model Context Protocol)](/user-guide/features/mcp)
+6. [Архитектура](/developer-guide/architecture)
+7. [Добавление инструментов](/developer-guide/adding-tools)
+8. [Создание навыков](/developer-guide/creating-skills)
+
+:::tip
+Для большинства пользовательских инструментов лучше начинать с плагинов. Страница [Добавление инструментов](/developer-guide/adding-tools) относится к встроенной core-разработке Hermes, а не к обычному пути пользовательских расширений.
+:::
+
+### «Хочу обучать модели»
+
+Используйте reinforcement learning, чтобы донастроить поведение модели с помощью встроенного RL training pipeline Hermes Agent.
+
+1. [Быстрый старт](/getting-started/quickstart)
+2. [Конфигурация](/user-guide/configuration)
+3. RL training
+4. [Маршрутизация провайдеров](/user-guide/features/provider-routing)
+5. [Архитектура](/developer-guide/architecture)
+
+:::tip
+RL training лучше всего работает, когда вы уже понимаете базовые принципы разговоров и tool calls в Hermes Agent. Если вы новичок, сначала пройдите маршрут для начального уровня.
+:::
+
+### «Хочу использовать его как Python library»
+
+Интегрируйте Hermes Agent в собственные Python-приложения программно.
+
+1. [Установка](/getting-started/installation)
+2. [Быстрый старт](/getting-started/quickstart)
+3. [Руководство по Python-библиотеке](/guides/python-library)
+4. [Архитектура](/developer-guide/architecture)
+5. [Инструменты](/user-guide/features/tools)
+6. [Сеансы](/user-guide/sessions)
+
+## Ключевые возможности в одном месте {#key-features-at-a-glance}
+
+Не уверены, что именно доступно? Вот короткий справочник по основным возможностям:
+
+| Возможность | Что делает | Ссылка |
+|---|---|---|
+| **Инструменты** | Встроенные инструменты, которые агент может вызывать (file I/O, search, shell и т. п.) | [Инструменты](/user-guide/features/tools) |
+| **Навыки** | Устанавливаемые plugin-пакеты, которые добавляют новые возможности | [Навыки](/user-guide/features/skills) |
+| **Память** | Постоянная память между сессиями | [Память](/user-guide/features/memory) |
+| **Файлы контекста** | Передача файлов и директорий в разговор | [Файлы контекста](/user-guide/features/context-files) |
+| **MCP** | Подключение к внешним tool servers через Model Context Protocol | [MCP](/user-guide/features/mcp) |
+| **Cron** | Планирование повторяющихся задач агента | [Cron](/user-guide/features/cron) |
+| **Делегирование** | Запуск подагентов для параллельной работы | [Делегирование](/user-guide/features/delegation) |
+| **Выполнение кода** | Запуск Python-скриптов, которые программно обращаются к инструментам Hermes | [Выполнение кода](/user-guide/features/code-execution) |
+| **Браузер** | Веб-обзор и scraping | [Браузер](/user-guide/features/browser) |
+| **Хуки** | Событийные callbacks и middleware | [Хуки](/user-guide/features/hooks) |
+| **Пакетная обработка** | Пакетная обработка нескольких входов | [Пакетная обработка](/user-guide/features/batch-processing) |
+| **RL training** | Дообучение моделей с reinforcement learning | RL training |
+| **Маршрутизация провайдеров** | Маршрутизация запросов между несколькими LLM-провайдерами | [Маршрутизация провайдеров](/user-guide/features/provider-routing) |
+
+## Что читать дальше
+
+В зависимости от того, где вы сейчас:
+
+- **Только что закончили установку?** → Идите в [Быстрый старт](/getting-started/quickstart), чтобы провести первый разговор.
+- **Закончили быстрый старт?** → Читайте [Использование CLI](/user-guide/cli) и [Конфигурация](/user-guide/configuration), чтобы подстроить систему под себя.
+- **Уже уверенно чувствуете себя на базовом уровне?** → Исследуйте [Инструменты](/user-guide/features/tools), [Навыки](/user-guide/features/skills) и [Память](/user-guide/features/memory), чтобы раскрыть агент по максимуму.
+- **Настраиваете всё для команды?** → Читайте [Безопасность](/user-guide/security) и [Сеансы](/user-guide/sessions), чтобы понять контроль доступа и управление разговорами.
+- **Готовы строить своё?** → Переходите в [Руководство для разработчиков](/developer-guide/architecture), чтобы разобраться во внутренностях и начать вклад в проект.
+- **Нужны практические примеры?** → Посмотрите раздел [Гайды](/guides/tips) — там собраны реальные проекты и советы.
+
+:::tip
+Не обязательно читать всё подряд. Выберите маршрут под свою цель, идите по ссылкам в указанном порядке — и довольно быстро станете продуктивны. К этой странице всегда можно вернуться, когда понадобится следующий шаг.
+:::

--- a/website/i18n/ru/docusaurus-plugin-content-docs/current/getting-started/quickstart.md
+++ b/website/i18n/ru/docusaurus-plugin-content-docs/current/getting-started/quickstart.md
@@ -1,0 +1,345 @@
+---
+sidebar_position: 1
+title: "Быстрый старт"
+description: "Ваш первый разговор с Hermes Agent — от установки до чата меньше чем за 5 минут"
+---
+
+# Быстрый старт
+
+Этот гид проведёт вас от нуля до рабочей установки Hermes, которая выдерживает реальную нагрузку. Мы поставим агент, выберем провайдера, проверим живой чат и разберёмся, что делать, если что-то сломалось.
+
+## Хотите посмотреть видео?
+
+**Onchain AI Garage** подготовили мастер-класс по установке, настройке и базовым командам — удобный спутник к этой странице, если вам проще следовать по видео. Полный плейлист с разбором Hermes Agent Tutorials & Use Cases доступен [здесь](https://www.youtube.com/channel/UCqB1bhMwGsW-yefBxYwFCCg).
+
+<div style={{position: 'relative', paddingBottom: '56.25%', height: 0, overflow: 'hidden', maxWidth: '100%', marginBottom: '1.5rem'}}>
+  <iframe
+    style={{position: 'absolute', top: 0, left: 0, width: '100%', height: '100%'}}
+    src="https://www.youtube-nocookie.com/embed/R3YOGfTBcQg"
+    title="Hermes Agent Masterclass: Installation, Setup, Basic Commands"
+    frameBorder="0"
+    allow="accelerometer; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+    allowFullScreen
+  ></iframe>
+</div>
+
+## Для кого эта страница
+
+- Для тех, кто только что начал и хочет самый короткий путь к рабочей настройке
+- Для тех, кто переключает провайдера и не хочет терять время на ошибки в конфиге
+- Для тех, кто настраивает Hermes для команды, бота или постоянно работающего workflow
+- Для тех, кто устал от сценария «установилось, но всё равно ничего не делает»
+
+## Самый быстрый путь
+
+Выберите строку, которая лучше всего подходит под вашу задачу:
+
+| Цель | Что сделать сначала | Что сделать потом |
+|---|---|---|
+| Хочу, чтобы Hermes просто работал на моей машине | `hermes setup` | Запустите реальный чат и проверьте, что он отвечает |
+| Провайдер уже выбран | `hermes model` | Сохраните конфиг, затем начинайте чат |
+| Нужен бот или режим «всегда онлайн» | `hermes gateway setup` после того, как CLI уже работает | Подключите Telegram, Discord, Slack или другую платформу |
+| Нужна локальная или self-hosted модель | `hermes model` → custom endpoint | Проверьте endpoint, имя модели и длину контекста |
+| Нужен fallback между несколькими провайдерами | Сначала `hermes model` | Добавляйте routing и fallback только после того, как базовый чат уже работает |
+
+**Правило большого пальца:** если Hermes не может пройти обычный чат, не добавляйте пока новые возможности. Сначала добейтесь одного чистого разговора, а потом уже подключайте gateway, cron, skills, voice или routing.
+
+---
+
+## 1. Установка Hermes Agent
+
+**Вариант A — pip (самый простой):**
+
+```bash
+pip install hermes-agent
+hermes postinstall     # optional: installs Node.js, browser, ripgrep, ffmpeg + runs setup
+```
+
+Релизы PyPI следуют за тегированными версиями (major/minor releases), а не за каждым коммитом в `main`. Если нужен bleeding-edge, используйте Вариант B.
+
+**Вариант B — git installer (следит за веткой main):**
+
+```bash
+# Linux / macOS / WSL2 / Android (Termux)
+curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+```
+
+:::tip Android / Termux
+Если ставите на телефон, откройте отдельное [руководство по Termux](/getting-started/termux) — там описан проверенный ручной путь, поддерживаемые extras и текущие ограничения Android.
+:::
+
+:::tip Пользователям Windows
+Сначала установите [WSL2](https://learn.microsoft.com/en-us/windows/wsl/install), а затем выполните команду выше внутри WSL2-терминала.
+:::
+
+Когда установка завершится, обновите shell:
+
+```bash
+source ~/.bashrc   # or source ~/.zshrc
+```
+
+За подробностями по способам установки, требованиям и troubleshooting см. [руководство по установке](/getting-started/installation).
+
+## 2. Выберите провайдера
+
+Самый важный шаг настройки. Используйте `hermes model`, чтобы пройти выбор интерактивно:
+
+```bash
+hermes model
+```
+
+Хорошие варианты по умолчанию:
+
+| Провайдер | Что это такое | Как настроить |
+|----------|-----------|---------------|
+| **Nous Portal** | Подписка без лишней настройки | OAuth-логин через `hermes model` |
+| **OpenAI Codex** | ChatGPT OAuth, использует модели Codex | Device code auth через `hermes model` |
+| **Anthropic** | Модели Claude напрямую — либо Max plan + extra usage credits (OAuth), либо API key для pay-per-token | `hermes model` → OAuth-логин (нужны Max + extra credits) или Anthropic API key |
+| **OpenRouter** | Маршрутизация между множеством моделей | Введите API key |
+| **Z.AI** | Модели GLM / Zhipu-hosted | Укажите `GLM_API_KEY` / `ZAI_API_KEY` |
+| **Kimi / Moonshot** | coding и chat-модели Moonshot | Укажите `KIMI_API_KEY` (или `KIMI_CODING_API_KEY` для Kimi-Coding) |
+| **Kimi / Moonshot China** | Moonshot endpoint для китайского региона | Укажите `KIMI_CN_API_KEY` |
+| **Arcee AI** | Trinity models | Укажите `ARCEEAI_API_KEY` |
+| **GMI Cloud** | Direct API с несколькими моделями | Укажите `GMI_API_KEY` |
+| **MiniMax (OAuth)** | MiniMax-M2.7 через browser OAuth — без API key | `hermes model` → MiniMax (OAuth) |
+| **MiniMax** | Международный endpoint MiniMax | Укажите `MINIMAX_API_KEY` |
+| **MiniMax China** | Region-specific endpoint MiniMax | Укажите `MINIMAX_CN_API_KEY` |
+| **Alibaba Cloud** | Qwen через DashScope | Укажите `DASHSCOPE_API_KEY` |
+| **Hugging Face** | Более 20 open models через unified router (Qwen, DeepSeek, Kimi и др.) | Укажите `HF_TOKEN` |
+| **AWS Bedrock** | Claude, Nova, Llama, DeepSeek через нативный Converse API | IAM role или `aws configure` ([руководство](/integrations/providers)) |
+| **Kilo Code** | Модели, хостимые KiloCode | Укажите `KILOCODE_API_KEY` |
+| **OpenCode Zen** | Pay-as-you-go доступ к curated моделям | Укажите `OPENCODE_ZEN_API_KEY` |
+| **OpenCode Go** | Подписка за $10/месяц на open models | Укажите `OPENCODE_GO_API_KEY` |
+| **DeepSeek** | Прямой доступ к DeepSeek API | Укажите `DEEPSEEK_API_KEY` |
+| **NVIDIA NIM** | Nemotron через build.nvidia.com или локальный NIM | Укажите `NVIDIA_API_KEY` (опционально `NVIDIA_BASE_URL`) |
+| **GitHub Copilot** | Подписка GitHub Copilot (GPT-5.x, Claude, Gemini и др.) | OAuth через `hermes model`, либо `COPILOT_GITHUB_TOKEN` / `GH_TOKEN` |
+| **GitHub Copilot ACP** | Backend Copilot ACP (запускает локальный `copilot` CLI) | `hermes model` (нужны `copilot` CLI + `copilot login`) |
+| **Vercel AI Gateway** | Маршрутизация через Vercel AI Gateway | Укажите `AI_GATEWAY_API_KEY` |
+| **Custom Endpoint** | VLLM, SGLang, Ollama или любой OpenAI-compatible API | Укажите base URL и API key |
+
+Для большинства новичков лучший путь простой: выберите провайдера и принимайте дефолты, если только не знаете, зачем вам их менять. Полный каталог провайдеров с env vars и шагами настройки лежит на странице [Providers](/integrations/providers).
+
+:::caution Минимальный контекст: 64K tokens
+Hermes Agent требует модель минимум с **64,000 tokens** контекста. Модели с меньшим окном не смогут удерживать достаточно рабочей памяти для многошаговых tool-calling workflows и будут отклонены при старте. Большинство hosted-моделей (Claude, GPT, Gemini, Qwen, DeepSeek) это требование покрывают. Если используете локальную модель, выставьте context size не меньше 64K (например, `--ctx-size 65536` для llama.cpp или `-c 65536` для Ollama).
+:::
+
+:::tip
+Переключить провайдера можно в любой момент через `hermes model` — никакой привязки нет. Полный список поддерживаемых провайдеров и подробности настройки смотрите на [Провайдеры ИИ](/integrations/providers).
+:::
+
+### Где хранятся настройки
+
+Hermes разделяет секреты и обычный конфиг:
+
+- **Secrets и tokens** → `~/.hermes/.env`
+- **Не секретные настройки** → `~/.hermes/config.yaml`
+
+Проще всего задавать значения через CLI:
+
+```bash
+hermes config set model anthropic/claude-opus-4.6
+hermes config set terminal.backend docker
+hermes config set OPENROUTER_API_KEY sk-or-...
+```
+
+Правильное значение само попадёт в нужный файл.
+
+## 3. Запустите первый чат
+
+```bash
+hermes            # classic CLI
+hermes --tui      # modern TUI (recommended)
+```
+
+Вы увидите welcome banner с выбранной моделью, доступными инструментами и skills. Используйте запрос, который легко проверить:
+
+:::tip Выберите интерфейс
+Hermes поставляется с двумя терминальными интерфейсами: классическим `prompt_toolkit` CLI и более новым [TUI](/user-guide/tui) с модальными окнами, выбором мышью и неблокирующим вводом. У них общие sessions, slash commands и config — попробуйте оба варианта: `hermes` и `hermes --tui`.
+:::
+
+```
+Summarize this repo in 5 bullets and tell me what the main entrypoint is.
+```
+
+```
+Check my current directory and tell me what looks like the main project file.
+```
+
+```
+Help me set up a clean GitHub PR workflow for this codebase.
+```
+
+**Как выглядит успех:**
+
+- banner показывает выбранную модель / провайдера
+- Hermes отвечает без ошибок
+- при необходимости он может использовать tool (terminal, file read, web search)
+- разговор нормально продолжается больше чем на один turn
+
+Если это работает, вы уже прошли самую сложную часть.
+
+## 4. Проверьте, что sessions работают
+
+Перед следующим шагом убедитесь, что resume работает:
+
+```bash
+hermes --continue    # Resume the most recent session
+hermes -c            # Short form
+```
+
+Это должно вернуть вас в только что созданную сессию. Если не возвращает, проверьте, не сменили ли вы профиль и действительно ли session сохранилась. Это важно, когда потом появятся несколько конфигураций или устройств.
+
+## 5. Попробуйте ключевые возможности
+
+### Используйте терминал
+
+```
+❯ What's my disk usage? Show the top 5 largest directories.
+```
+
+Агент выполняет команды в терминале от вашего имени и показывает результат.
+
+### Slash commands
+
+Введите `/`, чтобы увидеть автодополнение со всеми командами:
+
+| Команда | Что она делает |
+|---------|----------------|
+| `/help` | Показать все доступные команды |
+| `/tools` | Показать список доступных инструментов |
+| `/model` | Переключить модель интерактивно |
+| `/personality pirate` | Попробовать забавную personality |
+| `/save` | Сохранить conversation |
+
+### Многострочный ввод
+
+Нажмите `Alt+Enter`, `Ctrl+J` или `Shift+Enter`, чтобы добавить новую строку. `Shift+Enter` работает только в терминалах, которые отправляют его как отдельную последовательность (по умолчанию Kitty / foot / WezTerm / Ghostty; в iTerm2 / Alacritty / VS Code terminal — после включения Kitty keyboard protocol). `Alt+Enter` и `Ctrl+J` работают в любом терминале.
+
+### Прервать агента
+
+Если агент слишком долго думает, введите новое сообщение и нажмите Enter — это прервёт текущую задачу и переключит Hermes на ваш новый запрос. `Ctrl+C` тоже работает.
+
+## 6. Добавьте следующий слой
+
+Только после того, как базовый чат уже работает. Выберите то, что вам нужно:
+
+### Бот или shared assistant
+
+```bash
+hermes gateway setup    # Interactive platform configuration
+```
+
+Подключите [Telegram](/user-guide/messaging/telegram), [Discord](/user-guide/messaging/discord), [Slack](/user-guide/messaging/slack), [WhatsApp](/user-guide/messaging/whatsapp), [Signal](/user-guide/messaging/signal), [Email](/user-guide/messaging/email), [Home Assistant](/user-guide/messaging/homeassistant) или [Microsoft Teams](/user-guide/messaging/teams).
+
+### Автоматизация и инструменты
+
+- `hermes tools` — настройте доступ к инструментам для каждой платформы
+- `hermes skills` — просматривайте и устанавливайте reusable workflows
+- Cron — только после того, как бот или CLI уже стабильно настроены
+
+### Безопасный terminal
+
+Для безопасности запускайте агента в Docker-контейнере или на удалённом сервере:
+
+```bash
+hermes config set terminal.backend docker    # Docker isolation
+hermes config set terminal.backend ssh       # Remote server
+```
+
+### Voice mode
+
+```bash
+# From the Hermes install directory (the curl installer placed it at
+# ~/.hermes/hermes-agent on Linux/macOS or %LOCALAPPDATA%\hermes\hermes-agent on Windows):
+cd ~/.hermes/hermes-agent
+uv pip install -e ".[voice]"
+# Includes faster-whisper for free local speech-to-text
+```
+
+Затем в CLI включите `/voice on`. Для записи нажмите `Ctrl+B`. Подробнее см. [Голосовой режим](/user-guide/features/voice-mode).
+
+### Skills
+
+```bash
+hermes skills search kubernetes
+hermes skills install openai/skills/k8s
+```
+
+Или используйте `/skills` внутри чата.
+
+### MCP servers
+
+```yaml
+# Add to ~/.hermes/config.yaml
+mcp_servers:
+  github:
+    command: npx
+    args: ["-y", "@modelcontextprotocol/server-github"]
+    env:
+      GITHUB_PERSONAL_ACCESS_TOKEN: "ghp_xxx"
+```
+
+### Интеграция с editor (ACP)
+
+Поддержка ACP входит в стандартный extra `[all]`, так что curl-установщик уже всё включает. Просто выполните:
+
+```bash
+hermes acp
+```
+
+(Если ставили без `[all]`, сначала выполните `cd ~/.hermes/hermes-agent && uv pip install -e ".[acp]"`.)
+
+См. [интеграцию ACP в редактор](/user-guide/features/acp).
+
+---
+
+## Типовые ошибки
+
+Вот проблемы, на которые чаще всего уходит время:
+
+| Симптом | Вероятная причина | Что делать |
+|---|---|---|
+| Hermes открывается, но отвечает пусто или с поломанным текстом | Ошибка в аутентификации провайдера или в выборе модели | Снова запустите `hermes model` и проверьте провайдера, модель и auth |
+| Custom endpoint «работает», но выдаёт мусор | Неверный base URL, имя модели или endpoint вообще не OpenAI-compatible | Сначала проверьте endpoint в отдельном клиенте |
+| Gateway стартует, но никто не может ему писать | Не завершена настройка bot token, allowlist или платформы | Снова запустите `hermes gateway setup` и проверьте `hermes gateway status` |
+| `hermes --continue` не находит старую сессию | Вы сменили профиль или session не сохранилась | Проверьте `hermes sessions list` и убедитесь, что вы в правильном профиле |
+| Модель недоступна или fallback ведёт себя странно | Routing или fallback слишком агрессивны | Оставьте routing выключенным, пока не стабилизируете базового провайдера |
+| `hermes doctor` ругается на проблемы в конфиге | Часть значений отсутствует или устарела | Исправьте конфиг, затем ещё раз проверьте обычный чат, прежде чем подключать новые возможности |
+
+## Набор для восстановления
+
+Если что-то пошло не так, используйте такой порядок:
+
+1. `hermes doctor`
+2. `hermes model`
+3. `hermes setup`
+4. `hermes sessions list`
+5. `hermes --continue`
+6. `hermes gateway status`
+
+Этот порядок быстро возвращает вас из состояния «что-то не так» в понятную и проверенную конфигурацию.
+
+---
+
+## Краткая справка
+
+| Команда | Что делает |
+|---------|------------|
+| `hermes` | Начать чат |
+| `hermes model` | Выбрать LLM-провайдера и модель |
+| `hermes tools` | Настроить, какие инструменты включены для каждой платформы |
+| `hermes setup` | Полный мастер настройки (настраивает всё сразу) |
+| `hermes doctor` | Диагностика проблем |
+| `hermes update` | Обновить до последней версии |
+| `hermes gateway` | Запустить messaging gateway |
+| `hermes --continue` | Возобновить последнюю сессию |
+
+## Что делать дальше
+
+- **[Руководство по CLI](/user-guide/cli)** — Освойте terminal interface
+- **[Конфигурация](/user-guide/configuration)** — Настройте Hermes под себя
+- **[Шлюз сообщений](/user-guide/messaging)** — Подключите Telegram, Discord, Slack, WhatsApp, Signal, Email, Home Assistant, Teams и другие платформы
+- **[Инструменты и toolsets](/user-guide/features/tools)** — Изучите доступные возможности
+- **[Провайдеры ИИ](/integrations/providers)** — Полный список провайдеров и способы настройки
+- **[Система навыков](/user-guide/features/skills)** — Reusable workflows и знания
+- **[Советы и лучшие практики](/guides/tips)** — Советы для опытных пользователей

--- a/website/i18n/ru/docusaurus-plugin-content-docs/current/user-guide/windows-wsl-quickstart.md
+++ b/website/i18n/ru/docusaurus-plugin-content-docs/current/user-guide/windows-wsl-quickstart.md
@@ -1,0 +1,328 @@
+---
+title: "Руководство по Windows (WSL2)"
+description: "Запустите Hermes Agent на Windows через WSL2: установка, доступ к файловой системе между Windows и Linux, сеть и типовые проблемы"
+sidebar_label: "Windows (WSL2)"
+sidebar_position: 2
+---
+
+# Руководство по Windows (WSL2)
+
+Hermes Agent теперь поддерживает **и нативный Windows, и WSL2**. Эта страница описывает именно путь через WSL2; для нативной установки из PowerShell откройте отдельное **[руководство по нативной Windows-установке](/user-guide/windows-native)**.
+
+**Когда стоит выбрать WSL2 вместо native:**
+- вам нужен встроенный терминал dashboard (`/chat` tab) — эта панель требует POSIX PTY и работает только в WSL2
+- вы ведёте POSIX-heavy разработку и хотите, чтобы сессии Hermes разделяли ту же файловую систему и те же пути, что и ваши инструменты разработки
+- у вас уже есть WSL2, и вы не хотите поддерживать ещё одну отдельную установку
+
+**Когда нативный Windows вполне подходит (или даже лучше):**
+- для интерактивного чата, gateway (Telegram/Discord и т. п.), cron scheduler, browser tool, MCP servers и большинства возможностей Hermes нативный Windows работает нормально
+- вам не хочется каждый раз думать, через какую сторону границы WSL↔Windows вы сейчас ходите
+
+В WSL2 по сути есть два компьютера: ваш Windows-host и Linux VM, которую управляет WSL. Большая часть путаницы возникает тогда, когда вы перестаёте понимать, на какой именно стороне находитесь в конкретный момент.
+
+Этот гид разбирает именно те части этой границы, которые важны для Hermes: установка WSL2, перенос файлов между Windows и Linux, сеть в обе стороны и реальные проблемы, на которые люди натыкаются чаще всего.
+
+## Зачем WSL2, а не нативный Windows
+
+Нативная установка Windows работает прямо в Windows: ваш Windows terminal (PowerShell, Windows Terminal и т. п.), пути Windows filesystem (`C:\Users\…`) и процессы Windows. Hermes использует Git Bash для выполнения shell-команд, и именно так сегодня работают Claude Code и похожие агенты на Windows — это позволяет обойти gap между POSIX и Windows без полной переписки.
+
+WSL2 запускает настоящий Linux kernel в лёгкой виртуальной машине, поэтому Hermes внутри него по сути ведёт себя так же, как на Ubuntu. Это ценно, когда вам нужен настоящий POSIX-environment: `fork`, `/tmp`, UNIX sockets, signal semantics, PTY-backed terminals, `bash`/`zsh` и инструменты вроде `rg`, `git`, `ffmpeg`, которые работают именно так, как вы привыкли на Linux.
+
+Практические следствия WSL2:
+
+- Hermes CLI, gateway, sessions, memory, skills и tool runtimes живут внутри Linux VM
+- Windows-программы (браузеры, нативные приложения, Chrome с вашим залогиненным профилем) живут снаружи
+- Каждый раз, когда вам нужно, чтобы они взаимодействовали — поделиться файлами, открыть URL, управлять Chrome, достучаться до локального model server, показать Hermes gateway телефону — вы пересекаете границу. Именно о таких границах и идёт речь в этом руководстве
+
+## Установите WSL2
+
+В **Admin PowerShell** или Windows Terminal выполните:
+
+```powershell
+wsl --install
+```
+
+На свежем Windows 10 22H2+ или Windows 11 это установит WSL2 kernel, Virtual Machine Platform и Ubuntu по умолчанию. После установки перезагрузитесь. Затем Ubuntu спросит имя и пароль Linux-пользователя — это **новый Linux-аккаунт**, не связанный с вашей Windows-учёткой.
+
+Проверьте, что у вас именно WSL2, а не устаревший WSL1:
+
+```powershell
+wsl --list --verbose
+```
+
+В списке должна быть `VERSION  2`. Если какая-то дистрибуция показывает `VERSION  1`, переведите её:
+
+```powershell
+wsl --set-version Ubuntu 2
+wsl --set-default-version 2
+```
+
+Hermes не работает надёжно на WSL1 — там Linux syscall-ы транслируются на лету, и часть поведения (procfs, signals, network) заметно отличается от настоящего Linux.
+
+### Выбор дистрибутива
+
+Ubuntu LTS — тот вариант, на котором мы тестируем. Debian тоже подходит. Arch и NixOS работают у тех, кому они нужны, но однокомандный установщик предполагает Debian-подобный `apt` — для Nix-пути смотрите [руководство по настройке Nix](/getting-started/nix-setup).
+
+### Включите systemd (рекомендуется)
+
+Hermes gateway и вообще любые long-lived процессы удобнее держать под systemd. В современных сборках WSL включите его один раз внутри дистрибутива:
+
+```bash
+sudo tee /etc/wsl.conf >/dev/null <<'EOF'
+[boot]
+systemd=true
+
+[interop]
+enabled=true
+appendWindowsPath=true
+
+[automount]
+options = "metadata,umask=22,fmask=11"
+EOF
+```
+
+Затем из PowerShell:
+
+```powershell
+wsl --shutdown
+```
+
+Снова откройте терминал WSL. Команда `ps -p 1 -o comm=` должна показать `systemd`.
+
+Опция `metadata` выше важна: без неё файлы на `/mnt/c/...` не могут хранить настоящие Linux permission bits, и из-за этого ломаются вещи вроде `chmod +x` для скриптов на Windows-пути.
+
+### Установите Hermes внутри WSL
+
+Как только у вас открыт shell в WSL2:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh | bash
+source ~/.bashrc
+hermes
+```
+
+Установщик считает WSL2 обычным Linux — ничего специфичного для WSL делать не нужно. Полная схема установки описана в [Установке](/getting-started/installation).
+
+## Файловая система: как пересекать границу Windows ↔ WSL2
+
+Вот здесь чаще всего и случается путаница. У вас есть **две файловые системы**, и то, куда вы положите файлы, влияет на производительность, корректность и на то, какие инструменты вообще их увидят.
+
+### Два направления
+
+| Направление | Вид изнутри | Что использовать |
+|---|---|---|
+| Windows disk, видимый из WSL | `C:\Users\you\Documents` | `/mnt/c/Users/you/Documents` |
+| WSL disk, видимый из Windows | `/home/you/code` | `\\wsl$\Ubuntu\home\you\code` (или `\\wsl.localhost\Ubuntu\...` на новых сборках) |
+
+Оба варианта реальны и рабочие, но это **не одна и та же файловая система** — под капотом их связывает 9P network protocol. У этого есть серьёзные последствия по скорости и семантике.
+
+### Где хранить Hermes и проекты
+
+**Правило большого пальца: всё Linux-подобное держите внутри Linux filesystem.**
+
+- Hermes install (`~/.hermes/`) — на Linux side. Установщик уже делает именно так.
+- Git-репозитории, с которыми вы работаете из WSL — на Linux side (`~/code/...`, `~/projects/...`).
+- Модели, датасеты, venv — тоже на Linux side.
+
+Что вы выигрываете, если следуете этому правилу:
+
+- **Быстрый I/O.** Операции над `/mnt/c/...` идут через 9P и могут быть в 10–100 раз медленнее, чем на нативном ext4. `git status` на репозитории с 10k файлов, который под `~/code` кажется мгновенным, под `/mnt/c` легко превращается в 15+ секунд.
+- **Корректные права.** Linux permissions на `/mnt/c` эмулируются примерно. Проблемы вроде `ssh`-ключа с ошибкой `bad permissions` или тихо не сработавшего `chmod +x` встречаются постоянно.
+- **Надёжные file watchers.** inotify через 9P работает нестабильно — dev server-ы и тест-раннеры часто пропускают изменения на `/mnt/c`.
+- **Без сюрпризов с case-sensitivity.** Windows-пути обычно case-insensitive; Linux — case-sensitive. Проекты с `Readme.md` и `README.md` ведут себя по-разному в зависимости от стороны.
+
+Кладите всё на `/mnt/c` только если вам **обязательно** нужно, чтобы файл жил на Windows-side — например, вы хотите открыть его в Windows GUI-приложении или Chrome DevTools MCP должен работать из Windows-reachable пути.
+
+### Как переносить файлы туда и обратно
+
+**Из Windows в WSL:** проще всего открыть Explorer и ввести `\\wsl.localhost\Ubuntu` в адресную строку. Дальше можно перетаскивать файлы в `\home\<you>\...`. Или из PowerShell:
+
+```powershell
+wsl cp /mnt/c/Users/you/Downloads/file.pdf ~/incoming/
+```
+
+**Из WSL в Windows:** скопируйте файл в `/mnt/c/Users/<you>/...`, и он сразу появится в Windows Explorer:
+
+```bash
+cp ~/reports/output.pdf /mnt/c/Users/you/Desktop/
+```
+
+**Открыть файл из WSL в Windows-приложении** (GUI-editor, browser и т. п.): используйте `explorer.exe` или `wslview`:
+
+```bash
+sudo apt install wslu     # once — gives you wslview, wslpath, wslopen, etc.
+wslview ~/reports/output.pdf    # opens with the Windows default handler
+explorer.exe .                  # opens the current WSL dir in Windows Explorer
+```
+
+**Конвертировать пути между двумя мирами:**
+
+```bash
+wslpath -w ~/code/project        # → \\wsl.localhost\Ubuntu\home\you\code\project
+wslpath -u 'C:\Users\you'        # → /mnt/c/Users/you
+```
+
+### Line endings, BOMs и git
+
+Если вы редактируете файлы на Windows-side в Windows-редакторе, они могут получить `CRLF` line endings. Когда `bash` или Python на Linux-side читает такие файлы, shell scripts ломаются с `bad interpreter: /bin/bash^M`, а Python может споткнуться о `.env` с BOM.
+
+Лечится это нормальной git config внутри WSL (не на Windows):
+
+```bash
+git config --global core.autocrlf input
+git config --global core.eol lf
+```
+
+Если файлы уже с CRLF:
+
+```bash
+sudo apt install dos2unix
+dos2unix path/to/script.sh
+```
+
+### Что лучше: клонировать внутри WSL или на `/mnt/c`?
+
+Клонируйте внутри WSL. Всегда, если только у вас нет конкретной причины делать иначе. Типичный Hermes workflow (`hermes chat`, tool calls, которые `rg`-ают репозиторий, file watchers, background gateway) будет намного быстрее и надёжнее на `~/code/myrepo`, чем на `/mnt/c/Users/you/myrepo`.
+
+Единственное исключение — **MCP bridges, которые запускают Windows binaries**. Если вы используете `chrome-devtools-mcp` через `cmd.exe` (см. [руководство MCP: WSL → Windows Chrome](/guides/use-mcp-with-hermes#wsl2-bridge-hermes-in-wsl-to-windows-chrome)), Windows может выдать `UNC` warning, если текущая директория Hermes находится в `~`. В этом случае запускайте Hermes из `/mnt/c/`, чтобы Windows-процесс видел cwd с буквой диска.
+
+## Сеть: WSL ↔ Windows
+
+WSL2 живёт в лёгкой VM со своим network stack. Это значит, что `localhost` внутри WSL — **не то же самое**, что `localhost` на Windows. Для каждого сервиса нужно отдельно решить, в какую сторону идёт трафик, и выбрать подходящий bridge.
+
+Чаще всего встречаются два сценария.
+
+### Сценарий 1 — Hermes в WSL ходит к сервису на Windows
+
+Самый частый случай: у вас на Windows запущен **Ollama, LM Studio или llama-server**, а Hermes внутри WSL должен к нему обращаться.
+
+Подробная инструкция лежит в гайде по провайдерам: **[WSL2 Networking for Local Models →](/integrations/providers#wsl2-networking-windows-users)**
+
+Коротко:
+
+- **Windows 11 22H2+**: включите mirrored networking mode (`networkingMode=mirrored` в `%USERPROFILE%\.wslconfig`, затем `wsl --shutdown`). Тогда `localhost` работает в обе стороны.
+- **Windows 10 и более старые сборки**: используйте Windows host IP (default gateway виртуальной сети WSL) и убедитесь, что сервер на Windows слушает `0.0.0.0`, а не только `127.0.0.1`. Обычно ещё нужен firewall rule на порт.
+
+Полная таблица с bind address для Ollama / LM Studio / vLLM / SGLang, one-liner-ами для firewall, помощниками для динамического IP и workaround для Hyper-V firewall — в ссылке выше. Здесь мы не дублируем всё это заново.
+
+### Сценарий 2 — что-то на Windows (или в LAN) ходит к Hermes в WSL
+
+Это reverse direction и про него обычно говорят меньше, но он нужен для:
+
+- использования Hermes web dashboard из Windows browser;
+- использования **OpenAI-compatible API server** (который даёт `hermes gateway`, если `API_SERVER_ENABLED=true`) из Windows-side tool. См. [страницу API Server](/user-guide/features/api-server);
+- тестирования **messaging gateway** (Telegram, Discord и т. п.), когда платформа присылает webhook на локальный URL — тут чаще всего лучше использовать `cloudflared`/`ngrok`, а не прямой port forwarding.
+
+#### Подсценарий 2a: с самого Windows host
+
+На **Windows 11 22H2+ с включённым mirrored mode** ничего делать не нужно. Процесс в WSL, который слушает `0.0.0.0:8080` (или даже `127.0.0.1:8080`), доступен из Windows browser по `http://localhost:8080`. WSL автоматически пробрасывает bind обратно на host.
+
+В **NAT mode** (Windows 10 / старые Windows 11) стандартный localhost forwarding в WSL2 обычно пробрасывает Linux-side `127.0.0.1` на Windows `localhost`, так что Hermes service, запущенный с `--host 127.0.0.1`, обычно доступен как `http://localhost:PORT` из Windows. Если нет:
+
+- явно привяжитесь к `0.0.0.0` внутри WSL;
+- узнайте IP WSL VM через `ip -4 addr show eth0 | grep inet` и обращайтесь к нему из Windows.
+
+#### Подсценарий 2b: с другого устройства в вашей LAN (телефон, планшет, другой ПК)
+
+Вот это и есть самый неприятный случай. Трафик идёт **LAN device → Windows host → WSL VM**, и вам нужно настроить оба перехода:
+
+1. **Привяжитесь ко всем интерфейсам внутри WSL.** Процесс, слушающий `127.0.0.1`, никогда не будет доступен снаружи VM. Используйте `0.0.0.0`.
+
+2. **Настройте port-forward Windows → WSL VM.** В mirrored mode это делается автоматически. В NAT mode всё нужно прописать вручную, для каждого порта, в Admin PowerShell:
+
+   ```powershell
+   # Grab the WSL VM's current IP (it changes on every WSL restart under NAT)
+   $wslIp = (wsl hostname -I).Trim().Split(' ')[0]
+
+   # Forward Windows port 8080 → WSL:8080
+   netsh interface portproxy add v4tov4 `
+     listenaddress=0.0.0.0 listenport=8080 `
+     connectaddress=$wslIp connectport=8080
+
+   # Allow it through Windows Firewall
+   New-NetFirewallRule -DisplayName "Hermes WSL 8080" `
+     -Direction Inbound -Protocol TCP -LocalPort 8080 -Action Allow
+   ```
+
+   Удалить правило потом можно так: `netsh interface portproxy delete v4tov4 listenaddress=0.0.0.0 listenport=8080`.
+
+3. **Направьте LAN device на `http://<windows-lan-ip>:8080`.**
+
+Поскольку IP WSL VM при NAT mode меняется после каждого `wsl --shutdown`, одноразовое правило живёт только до следующего рестарта WSL. Для постоянной схемы либо используйте mirrored mode, либо вынесите port-proxy в скрипт, который запускается при входе в Windows.
+
+Для webhook-ов от cloud messaging providers (Telegram `setWebhook`, Slack events и т. п.) не мучайте себя port-forwarding-ом — используйте `cloudflared` tunnels. См. [руководство по webhook-ам](/user-guide/messaging/webhooks).
+
+## Как долго держать Hermes services на Windows
+
+Hermes [Tool Gateway](/user-guide/features/tool-gateway) и API server — long-lived processes. В WSL2 у вас есть несколько вариантов, как держать их живыми.
+
+### Внутри WSL с systemd (рекомендуется)
+
+Если вы включили systemd по инструкции выше, `hermes gateway` и API server работают так же, как на любом Linux. Используйте wizard настройки gateway:
+
+```bash
+hermes gateway setup
+```
+
+Он предложит установить systemd user unit, чтобы gateway стартовал автоматически вместе с WSL.
+
+### Чтобы сам WSL запускался при входе в Windows
+
+WSL VM живёт только пока её кто-то использует. Чтобы gateway оставался доступен даже без открытого окна терминала, запустите WSL process через Task Scheduler при логине Windows:
+
+- **Trigger:** At log on (ваш пользователь)
+- **Action:** Start a program
+  - Program: `C:\Windows\System32\wsl.exe`
+  - Arguments: `-d Ubuntu --exec /bin/sh -c "sleep infinity"`
+
+Так VM будет жить, а systemd-managed gateway останется поднятым. На Windows 11 также работают более новые потоки автозапуска WSL, но `sleep infinity` — самый переносимый вариант.
+
+## GPU passthrough (local models)
+
+WSL2 нативно поддерживает **NVIDIA** GPU начиная с WSL kernel 5.10.43+. Поставьте обычный NVIDIA driver на Windows (Linux NVIDIA driver внутри WSL ставить **не нужно**), и `nvidia-smi` внутри WSL увидит GPU. После этого CUDA toolkits, `torch`, `vllm`, `sglang` и `llama-server` собираются и работают на реальном GPU как обычно.
+
+Поддержка AMD ROCm и Intel Arc внутри WSL2 всё ещё развивается и находится вне тестовой матрицы Hermes — возможно, оно и работает с текущими драйверами, но мы не можем дать надёжную рекомендуемую схему.
+
+Если вы запускаете **Windows-native** local-model server (Ollama for Windows, LM Studio), который уже использует ваш GPU через Windows driver, WSL GPU passthrough вам не нужен вовсе — просто следуйте Сценарию 1 и обращайтесь к нему по сети из WSL.
+
+## Типовые проблемы
+
+**"Connection refused" к моему Windows-hosted Ollama / LM Studio.**
+Смотрите [WSL2 Networking](/integrations/providers#wsl2-networking-windows-users). В девяти случаях из десяти сервер привязан к `127.0.0.1` и его нужно перевести на `0.0.0.0` (для Ollama: `OLLAMA_HOST=0.0.0.0`), либо у вас не хватает firewall rule.
+
+**Сильная медлительность `git status` / `hermes chat` в репозитории.**
+Скорее всего, проект лежит под `/mnt/c/...`. Перенесите его в `~/code/...` (Linux side). Разница по скорости обычно на порядок.
+
+**`bad interpreter: /bin/bash^M` у скриптов.**
+Это CRLF line endings из Windows-редактора. Прогоните `dos2unix script.sh` и задайте `core.autocrlf input` в git config внутри WSL.
+
+**Предупреждение "UNC paths are not supported" от Windows binaries, запущенных через MCP.**
+cwd Hermes находится внутри Linux filesystem, а `cmd.exe` на Windows не знает, что с ним делать. Запускайте Hermes из `/mnt/c/...` в этой сессии либо используйте wrapper, который перед вызовом Windows executable делает `cd` в путь, доступный Windows.
+
+**Clock drift после sleep / hibernate.**
+Часы WSL2 могут отставать на несколько минут после пробуждения хоста, а это ломает всё, что завязано на сертификаты и OAuth. Исправляется так:
+
+```bash
+sudo hwclock -s
+```
+
+Или установите `ntpdate` и запускайте его при логине.
+
+**После включения mirrored mode или при VPN пропадает DNS.**
+Mirrored mode проксирует настройки сети хоста в WSL — если DNS на Windows сломан (VPN split-tunnel, корпоративный resolver), WSL унаследует ту же проблему. Workaround: вручную переопределите `resolv.conf` (поставьте `generateResolvConf=false` в `/etc/wsl.conf`, затем пропишите свой `/etc/resolv.conf` с `1.1.1.1` или DNS вашего VPN).
+
+**`hermes` не найден после установки.**
+Установщик добавляет `~/.local/bin` в PATH через `~/.bashrc`. Чтобы это заработало в текущей сессии, выполните `source ~/.bashrc` (или откройте новый терминал).
+
+**Windows Defender тормозит WSL-файлы.**
+Defender сканирует файлы через 9P-bridge при обращении из Windows, и из-за этого замедление `/mnt/c` только усиливается. Если вы работаете с WSL-файлами только изнутри WSL, это не критично. Если вы часто открываете `\\wsl$\...` из Windows-инструментов, подумайте об исключении пути дистрибутива WSL из real-time scanning.
+
+**Заканчивается диск.**
+WSL2 хранит VM disk как sparse VHDX в `%LOCALAPPDATA%\Packages\...`. Он растёт, но не shrinks автоматически после удаления файлов. Чтобы вернуть место: `wsl --shutdown`, затем из Admin PowerShell выполните `Optimize-VHD -Path <path-to-ext4.vhdx> -Mode Full` (нужны Hyper-V tools) — либо используйте более простой `diskpart` путь, который описан в документации WSL.
+
+## Куда идти дальше
+
+- **[Установка](/getting-started/installation)** — реальные шаги установки (Linux/WSL2/Termux используют один и тот же installer)
+- **[Integrations → Providers → WSL2 Networking](/integrations/providers#wsl2-networking-windows-users)** — canonical deep-dive по сети для local model servers
+- **[Руководство MCP → WSL → Windows Chrome](/guides/use-mcp-with-hermes#wsl2-bridge-hermes-in-wsl-to-windows-chrome)** — управление вашим уже залогиненным Windows Chrome из Hermes в WSL
+- **[Шлюз инструментов](/user-guide/features/tool-gateway)** и **[Веб-панель](/user-guide/features/web-dashboard)** — long-lived services, которые чаще всего хочется открыть из WSL в остальную сеть


### PR DESCRIPTION
## What\n- Adds a Russian docs locale for the main onboarding and entrypoint pages: landing page, installation, quickstart, learning path, CLI/TUI, providers, voice mode, and Windows WSL quickstart.\n- Enables ru in Docusaurus and keeps the UI copy aligned with the existing Russian catalog.\n- Normalizes the Windows docs cross-links so the localized pages resolve cleanly.\n\n## Why\n- This continues the mainline Russian localization effort from upstream PR #22914.\n- The goal is a polished, professional Russian experience for the first pages users hit in the website and docs.\n\n## How to test\n- cd website && npm run typecheck\n- cd website && npm run build\n\n## Notes\n- The website build succeeds. Docusaurus still reports unrelated legacy broken-link warnings in older zh-Hans/source pages that are outside this PR scope.