### PR TITLE
fix(kanban): reject toolset names in task skills field (salvage #22933)

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -83,6 +83,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Iterable, Optional
 
+from toolsets import get_toolset_names
+
 
 # ---------------------------------------------------------------------------
 # Constants
@@ -90,6 +92,7 @@ from typing import Any, Iterable, Optional
 
 VALID_STATUSES = {"triage", "todo", "ready", "running", "blocked", "done", "archived"}
 VALID_WORKSPACE_KINDS = {"scratch", "worktree", "dir"}
+KNOWN_TOOLSET_NAMES = frozenset(name.casefold() for name in get_toolset_names())
 
 # A running task's claim is valid for 15 minutes; after that the next
 # dispatcher tick reclaims it.  Workers that outlive this window should call
@@ -1282,6 +1285,11 @@ def create_task(
                 raise ValueError(
                     f"skill name cannot contain comma: {name!r} "
                     f"(pass a list of separate names instead of a comma-joined string)"
+                )
+            if name.casefold() in KNOWN_TOOLSET_NAMES:
+                raise ValueError(
+                    f"{name!r} is a toolset name, not a skill name. "
+                    "Put it in the assignee profile's toolsets instead of task skills."
                 )
             if name in seen:
                 continue

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1275,6 +1275,12 @@ def create_task(
     if skills is not None:
         cleaned: list[str] = []
         seen: set[str] = set()
+        # Collect all toolset-name confusions up front so the user sees the
+        # whole list at once. Raising on the first hit is friendly when the
+        # input has one mistake, but agents that confuse skills with toolsets
+        # usually pass several at once (`skills=["web", "browser", "terminal"]`)
+        # and serial-correcting one per failure round-trips wastes tokens.
+        toolset_typos: list[str] = []
         for s in skills:
             if not s:
                 continue
@@ -1287,14 +1293,22 @@ def create_task(
                     f"(pass a list of separate names instead of a comma-joined string)"
                 )
             if name.casefold() in KNOWN_TOOLSET_NAMES:
-                raise ValueError(
-                    f"{name!r} is a toolset name, not a skill name. "
-                    "Put it in the assignee profile's toolsets instead of task skills."
-                )
+                toolset_typos.append(name)
+                continue
             if name in seen:
                 continue
             seen.add(name)
             cleaned.append(name)
+        if toolset_typos:
+            quoted = ", ".join(repr(n) for n in toolset_typos)
+            noun = "is a toolset name" if len(toolset_typos) == 1 else "are toolset names"
+            raise ValueError(
+                f"{quoted} {noun}, not skill name(s). "
+                "Put toolsets in the assignee profile's `toolsets:` config "
+                "instead of per-task skills. Skills are named skill bundles "
+                "(e.g. `kanban-worker`, `blogwatcher`); toolsets are runtime "
+                "capabilities (e.g. `web`, `browser`, `terminal`)."
+            )
         skills_list = cleaned
 
     # Idempotency check — return the existing task instead of creating a

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -2691,6 +2691,21 @@ def test_create_task_skills_rejects_comma_embedded(kanban_home):
         conn.close()
 
 
+def test_create_task_skills_rejects_toolset_names(kanban_home):
+    """Toolset names belong in profile config, not per-task skills."""
+    conn = kb.connect()
+    try:
+        with pytest.raises(ValueError, match="toolset name"):
+            kb.create_task(
+                conn,
+                title="bad toolset skill",
+                assignee="x",
+                skills=["web", "translation"],
+            )
+    finally:
+        conn.close()
+
+
 def test_default_spawn_appends_per_task_skills(kanban_home, monkeypatch):
     """Dispatcher argv must carry one `--skills X` pair per task skill,
     in addition to the built-in kanban-worker."""

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -2706,6 +2706,33 @@ def test_create_task_skills_rejects_toolset_names(kanban_home):
         conn.close()
 
 
+def test_create_task_skills_lists_all_toolset_typos(kanban_home):
+    """When several toolset names are passed, the error names every one.
+
+    Agents that confuse skills with toolsets usually pass several at once
+    (``skills=["web", "browser", "terminal"]``). Listing only the first
+    mistake forces serial fix-then-retry; listing all of them lets the
+    caller correct in one round-trip.
+    """
+    conn = kb.connect()
+    try:
+        with pytest.raises(ValueError) as exc_info:
+            kb.create_task(
+                conn,
+                title="three bad",
+                assignee="x",
+                skills=["web", "browser", "terminal"],
+            )
+        msg = str(exc_info.value)
+        assert "'web'" in msg
+        assert "'browser'" in msg
+        assert "'terminal'" in msg
+        # Plural noun form when multiple toolsets are flagged.
+        assert "are toolset names" in msg
+    finally:
+        conn.close()
+
+
 def test_default_spawn_appends_per_task_skills(kanban_home, monkeypatch):
     """Dispatcher argv must carry one `--skills X` pair per task skill,
     in addition to the built-in kanban-worker."""

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -1036,6 +1036,20 @@ def test_create_task_without_skills_defaults_to_empty_list(client):
     assert task.get("skills") in (None, [])
 
 
+def test_create_task_with_toolset_name_in_skills_is_rejected(client):
+    """POST /tasks fails fast when callers confuse toolsets with skills."""
+    r = client.post(
+        "/api/plugins/kanban/tasks",
+        json={
+            "title": "bad skills payload",
+            "assignee": "linguist",
+            "skills": ["web"],
+        },
+    )
+    assert r.status_code == 400, r.text
+    assert "toolset name" in r.json()["detail"]
+
+
 
 # ---------------------------------------------------------------------------
 # Dispatcher-presence warning in POST /tasks response

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -611,6 +611,8 @@ def _handle_create(args: dict, **kw) -> str:
             )
         finally:
             conn.close()
+    except ValueError as e:
+        return tool_error(f"kanban_create: {e}")
     except Exception as e:
         logger.exception("kanban_create failed")
         return tool_error(f"kanban_create: {e}")


### PR DESCRIPTION
## Summary
`kanban_create` (and every other entry point that lands in `kanban_db.create_task`) now rejects toolset names like `web`, `browser`, `terminal` in the `skills` field with a clean ValueError, instead of silently accepting them and crashing the worker at spawn time with `Error: Unknown skill(s): web, browser`.

## Why this layer
The validation lives in `kanban_db.create_task`, which is the single chokepoint every entry point hits — CLI (`hermes kanban create --skills web`), dashboard POST (`/api/plugins/kanban/tasks`), and the model tool surface (`kanban_create(...)`). Catching it at the DB layer rather than per-tool means future entry points (a future REST API, a future MCP server, etc.) inherit the validation for free.

## Why aggregate the typos
Agents that confuse skills with toolsets usually pass several at once (`skills=["web", "browser", "terminal"]`) — listing only the first mistake forces serial fix-then-retry; listing all of them lets the caller correct in one round-trip. The error message also names the YAML key (`toolsets:`) and gives concrete examples of both categories so the conceptual gap that produced the bug to begin with closes:

    'web', 'browser', 'terminal' are toolset names, not skill name(s).
    Put toolsets in the assignee profile's `toolsets:` config instead of
    per-task skills. Skills are named skill bundles (e.g. `kanban-worker`,
    `blogwatcher`); toolsets are runtime capabilities (e.g. `web`,
    `browser`, `terminal`).

## Changes
- `hermes_cli/kanban_db.py`: import `get_toolset_names` from `toolsets.py`, build a `KNOWN_TOOLSET_NAMES` frozenset (case-folded for friendliness), check each skill against it inside the existing `create_task` skills loop. Aggregate matches into one error rather than raising on the first.
- `tools/kanban_tools.py`: catch `ValueError` separately in `_handle_create` so the tool surface returns a clean `tool_error` payload instead of the generic exception path.
- `tests/hermes_cli/test_kanban_core_functionality.py`: original "single toolset name → reject" test plus a new "multi-toolset names → all listed in error" test pinning the aggregation behavior.
- `tests/plugins/test_kanban_dashboard_plugin.py`: dashboard POST level — `POST /tasks` with `skills=["web"]` returns 400 with "toolset name" in the detail.

## Validation
| | Before | After |
|---|---|---|
| `tests/hermes_cli/test_kanban_db.py + test_kanban_core_functionality.py` | n/a | 295/295 |
| `tests/plugins/test_kanban_dashboard_plugin.py` | 82/82 | 83/83 |
| `tests/tools/test_kanban_tools.py` | 55/55 | 55/55 |
| E2E DB-level rejection | n/a | rejects `["web", "browser"]` with ValueError |
| E2E tool surface | n/a | returns `{"error": "kanban_create: 'terminal' is a toolset name..."}` |
| E2E valid skill (`kanban-worker`) | n/a | accepted |
| E2E empty list | n/a | accepted |

Closes #22921 via salvage. Salvage of #22933; original commit by @LeonSGP43 preserved as the committing author. The aggregation improvement (collect all toolset typos before raising, expand the error message to name `toolsets:` explicitly + give concrete examples) is a separate follow-up commit. AUTHOR_MAP entry already existed.

Closes #23105 as superseded — that PR validated at the tool layer only (with a hardcoded toolset list); this PR validates at the DB layer (using `get_toolset_names()` as the source of truth) so it covers all entry points without a list-rot maintenance burden.
