### PR TITLE
fix(gateway): keep auto-title failures silent

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14756,15 +14756,7 @@ class GatewayRunner:
                 try:
                     from agent.title_generator import maybe_auto_title
                     all_msgs = result_holder[0].get("messages", []) if result_holder[0] else []
-                    # Route title-generation failures through the agent's
-                    # user-visible warning channel so a depleted auxiliary
-                    # provider doesn't silently leave sessions untitled
-                    # (issue #15775).
-                    _title_failure_cb = getattr(
-                        agent, "_emit_auxiliary_failure", None
-                    )
                     maybe_auto_title_kwargs = {
-                        "failure_callback": _title_failure_cb,
                         "main_runtime": {
                             "model": getattr(agent, "model", None),
                             "provider": getattr(agent, "provider", None),

--- a/tests/gateway/test_fast_command.py
+++ b/tests/gateway/test_fast_command.py
@@ -4,7 +4,7 @@ import sys
 import threading
 import types
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 import yaml
@@ -21,7 +21,15 @@ class _CapturingAgent:
 
     def __init__(self, *args, **kwargs):
         type(self).last_init = dict(kwargs)
+        self.model = kwargs.get("model")
+        self.provider = kwargs.get("provider")
+        self.base_url = kwargs.get("base_url")
+        self.api_key = kwargs.get("api_key")
+        self.api_mode = kwargs.get("api_mode")
         self.tools = []
+
+    def _emit_auxiliary_failure(self, *_args, **_kwargs):
+        raise AssertionError("gateway auto-title failures should stay silent")
 
     def run_conversation(self, user_message, conversation_history=None, task_id=None, persist_user_message=None):
         type(self).last_run = {
@@ -176,3 +184,45 @@ async def test_run_agent_passes_priority_processing_to_gateway_agent(monkeypatch
     assert result["final_response"] == "ok"
     assert _CapturingAgent.last_init["service_tier"] == "priority"
     assert _CapturingAgent.last_init["request_overrides"] == {"service_tier": "priority"}
+
+
+@pytest.mark.asyncio
+async def test_run_agent_keeps_auto_title_failures_silent(monkeypatch, tmp_path):
+    _install_fake_agent(monkeypatch)
+    runner = _make_runner()
+
+    runner._session_db = SimpleNamespace(get_session_title=lambda _sid: None)
+
+    (tmp_path / "config.yaml").write_text("", encoding="utf-8")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(gateway_run, "_env_path", tmp_path / ".env")
+    monkeypatch.setattr(gateway_run, "load_dotenv", lambda *args, **kwargs: None)
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: {})
+    monkeypatch.setattr(gateway_run, "_resolve_gateway_model", lambda config=None: "gpt-5.4")
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {
+            "provider": "openrouter",
+            "api_mode": "chat_completions",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_key": "***",
+        },
+    )
+
+    import hermes_cli.tools_config as tools_config
+    monkeypatch.setattr(tools_config, "_get_platform_tools", lambda user_config, platform_key: {"core"})
+
+    with patch("agent.title_generator.maybe_auto_title") as mock_title:
+        result = await runner._run_agent(
+            message="hi",
+            context_prompt="",
+            history=[],
+            source=_make_source(),
+            session_id="session-1",
+            session_key="agent:main:telegram:dm:12345",
+        )
+
+    assert result["final_response"] == "ok"
+    mock_title.assert_called_once()
+    assert "failure_callback" not in mock_title.call_args.kwargs


### PR DESCRIPTION
## What does this PR do?

Stops gateway turns from surfacing auxiliary auto-title generation failures to end users. Gateway sessions should still attempt background title generation, but a depleted or misconfigured auxiliary provider should not inject warning text into Slack, Telegram, or other platform replies.

This keeps gateway output focused on the actual turn result while preserving background title generation.

## Related Issue

Fixes #23246

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `gateway/run.py`
- Stopped forwarding `agent._emit_auxiliary_failure` into gateway `maybe_auto_title(...)`
- Added a regression test in `tests/gateway/test_fast_command.py` that verifies gateway auto-title calls stay silent even when the agent exposes an auxiliary failure emitter

## How to Test

1. Run `uv run --frozen pytest -q -o addopts='' tests/gateway/test_fast_command.py`
2. Send a normal gateway message that produces a final response
3. Confirm `maybe_auto_title(...)` still runs but no `failure_callback` is forwarded into the gateway path

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 / local gateway test suite

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `uv run --frozen ruff check gateway/run.py tests/gateway/test_fast_command.py`
- `uv run --frozen pytest -q -o addopts='' tests/gateway/test_fast_command.py`
