### PR TITLE
fix(web): tolerate non-string model picker entries

### DIFF
--- a/web/src/components/ModelPickerDialog.tsx
+++ b/web/src/components/ModelPickerDialog.tsx
@@ -4,7 +4,7 @@ import { Spinner } from "@nous-research/ui/ui/components/spinner";
 import { Input } from "@/components/ui/input";
 import type { GatewayClient } from "@/lib/gatewayClient";
 import { Check, Search, X } from "lucide-react";
-import { useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 /**
  * Two-stage model picker modal.
@@ -147,6 +147,11 @@ export function ModelPickerDialog(props: Props) {
   );
 
   const needle = query.trim().toLowerCase();
+  const matchesNeedle = useCallback(
+    (value: unknown) =>
+      value != null && String(value).toLowerCase().includes(needle),
+    [needle],
+  );
 
   const filteredProviders = useMemo(
     () =>
@@ -154,17 +159,16 @@ export function ModelPickerDialog(props: Props) {
         ? providers
         : providers.filter(
             (p) =>
-              p.name.toLowerCase().includes(needle) ||
-              p.slug.toLowerCase().includes(needle) ||
-              (p.models ?? []).some((m) => m.toLowerCase().includes(needle)),
+              matchesNeedle(p.name) ||
+              matchesNeedle(p.slug) ||
+              (p.models ?? []).some((m) => matchesNeedle(m)),
           ),
-    [providers, needle],
+    [providers, matchesNeedle, needle],
   );
 
   const filteredModels = useMemo(
-    () =>
-      !needle ? models : models.filter((m) => m.toLowerCase().includes(needle)),
-    [models, needle],
+    () => !needle ? models : models.filter((m) => matchesNeedle(m)),
+    [models, matchesNeedle, needle],
   );
 
   const canConfirm = !!selectedProvider && !!selectedModel && !applying;


### PR DESCRIPTION
## What does this PR do?

Fixes the web model picker crash when a provider returns a non-string entry in its `models` list. The filter path previously called `.toLowerCase()` directly on every entry, so `null`, numbers, or other non-string values could crash the dialog while typing.

This change normalizes values through `String(...)` only when they are non-null, which keeps the filter resilient without changing the picker flow.

## Related Issue

Fixes #23231

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `web/src/components/ModelPickerDialog.tsx`
- Added a small `matchesNeedle` helper that safely normalizes unknown values before filtering
- Replaced direct `.toLowerCase()` calls on provider/model entries with the safe matcher

## How to Test

1. Open the web model picker
2. Use a provider payload that includes a non-string model entry
3. Type into the filter and confirm the dialog no longer crashes

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 / local web toolchain

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `pnpm exec eslint src/components/ModelPickerDialog.tsx`
- `pnpm exec tsc -p tsconfig.app.json --noEmit`
