### PR TITLE
docs(core): add hermes-basic-memory to Community plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ scripts/run_tests.sh
 - 📚 [Skills Hub](https://agentskills.io)
 - 🐛 [Issues](https://github.com/NousResearch/hermes-agent/issues)
 - 🔌 [HermesClaw](https://github.com/AaronWong1999/hermesclaw) — Community WeChat bridge: Run Hermes Agent and OpenClaw on the same WeChat account.
+- 🔌 [hermes-basic-memory](https://github.com/basicmachines-co/hermes-basic-memory) — Memory Provider plugin backed by [Basic Memory](https://github.com/basicmachines-co/basic-memory)'s knowledge graph. Per-turn capture, end-of-session summaries, local or cloud routing.
 
 ---
 


### PR DESCRIPTION
## Summary

Adds a one-line entry to the existing Community section in the README pointing at [hermes-basic-memory](https://github.com/basicmachines-co/hermes-basic-memory) — a Memory Provider plugin that wraps the [basic-memory](https://github.com/basicmachines-co/basic-memory) MCP server. Same shape as the existing HermesClaw line.

## What the plugin does

Gives Hermes a persistent knowledge-graph memory: 7 `bm_*` agent tools (`search`/`read`/`write`/`edit`/`context`/`delete`/`move`), per-turn capture into a session-transcript note, and an end-of-session summary linked back via a `summary_of` relation. Local mode is the default; a single `bm project set-cloud` flips a project to direct cloud routing through Basic Memory Cloud (no bisync, tool calls go straight to `<cloud_host>/proxy`).

## Quality signals

- **AGPL-3.0** — matches Basic Memory upstream's license.
- **169-test pytest suite**, with gated integration tests (`BM_INTEGRATION=1`) that run every tool against a real `bm` MCP server in a per-session throwaway BM project. CI runs the unit suite on push/PR against Python 3.11 and 3.12.
- **Six tagged releases** (v0.1.0 → v0.1.5) with a CHANGELOG. Each release was verified end-to-end on a real Hermes install before tagging.
- **Self-installs** — `is_available()` reports True if either `bm` or `uv` is on disk; on first init the plugin runs `uv tool install basic-memory --quiet` if `bm` is missing. The bm binary lands at `~/.local/bin/bm`, the same canonical path a manual `uv tool install` produces, so later manual installs/upgrades converge rather than fork.
- **Bundled skill** — `register()` calls `ctx.register_skill("basic-memory", SKILL_PATH, ...)` so install via `hermes plugins install` wires up both the memory provider and a usage-reference skill.

## Verified install flow

```
hermes plugins install basicmachines-co/hermes-basic-memory --enable
# config.yaml: memory.provider: basic-memory
hermes gateway restart
hermes memory status   # Provider: basic-memory, Status: available ✓
```

End-to-end verified on a fresh deployment: agent loop runs, session note written to `~/hermes-memory/hermes-sessions/`, `hermes skills list` shows the bundled skill enabled.

## Parallel signal

A submission to the awesome-hermes-agent community list is in flight: 0xNyk/awesome-hermes-agent#69.

## Test plan

- [x] PR title matches `.github/workflows/pr-title.yml` semantic format
- [x] Commit is signed off (`-s`)
- [ ] Review the README diff (one-line addition under `## Community`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)