### PR TITLE
fix(gateway): stop default replace in service runs

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -563,7 +563,7 @@ def _gateway_run_args_for_profile(profile: str) -> list[str]:
     args = [get_python_path(), "-m", "hermes_cli.main"]
     if profile != "default":
         args.extend(["--profile", profile])
-    args.extend(["gateway", "run", "--replace"])
+    args.extend(["gateway", "run"])
     return args
 
 
@@ -2155,7 +2155,7 @@ StartLimitIntervalSec=0
 Type=simple
 User={username}
 Group={group_name}
-ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run --replace
+ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run
 WorkingDirectory={working_dir}
 Environment="HOME={home_dir}"
 Environment="USER={username}"
@@ -2193,7 +2193,7 @@ StartLimitIntervalSec=0
 
 [Service]
 Type=simple
-ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run --replace
+ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run
 WorkingDirectory={working_dir}
 Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"
@@ -2781,7 +2781,6 @@ def generate_launchd_plist() -> str:
     prog_args.extend([
         "<string>gateway</string>",
         "<string>run</string>",
-        "<string>--replace</string>",
     ])
     prog_args_xml = "\n        ".join(prog_args)
 

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -493,7 +493,10 @@ class TestLaunchdServiceRecovery:
 
         label = gateway_cli.get_launchd_label()
         domain = gateway_cli._launchd_domain()
-        assert "--replace" in plist_path.read_text(encoding="utf-8")
+        plist_text = plist_path.read_text(encoding="utf-8")
+        assert "<string>gateway</string>" in plist_text
+        assert "<string>run</string>" in plist_text
+        assert "--replace" not in plist_text
         assert calls[:2] == [
             ["launchctl", "bootout", f"{domain}/{label}"],
             ["launchctl", "bootstrap", domain, str(plist_path)],
@@ -1636,7 +1639,8 @@ class TestProfileArg:
         monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
         unit = gateway_cli.generate_systemd_unit(system=False)
         assert "--profile mybot" in unit
-        assert "gateway run --replace" in unit
+        assert "gateway run" in unit
+        assert "--replace" not in unit
 
     def test_launchd_plist_includes_profile(self, tmp_path, monkeypatch):
         """generate_launchd_plist should include --profile in ProgramArguments for named profiles."""
@@ -1648,6 +1652,24 @@ class TestProfileArg:
         plist = gateway_cli.generate_launchd_plist()
         assert "<string>--profile</string>" in plist
         assert "<string>mybot</string>" in plist
+        assert "<string>--replace</string>" not in plist
+
+    def test_gateway_run_args_for_profile_omit_replace(self, monkeypatch):
+        monkeypatch.setattr(gateway_cli, "get_python_path", lambda: "/venv/bin/python")
+
+        default_args = gateway_cli._gateway_run_args_for_profile("default")
+        named_args = gateway_cli._gateway_run_args_for_profile("mybot")
+
+        assert default_args == ["/venv/bin/python", "-m", "hermes_cli.main", "gateway", "run"]
+        assert named_args == [
+            "/venv/bin/python",
+            "-m",
+            "hermes_cli.main",
+            "--profile",
+            "mybot",
+            "gateway",
+            "run",
+        ]
 
     def test_launchd_plist_path_uses_real_user_home_not_profile_home(self, tmp_path, monkeypatch):
         profile_dir = tmp_path / ".hermes" / "profiles" / "orcha"


### PR DESCRIPTION
## What does this PR do?

Stops service-generated gateway runs from hardcoding `--replace` into their startup command. Service units, launchd plists, and detached profile restart helpers should start a fresh gateway process, not implicitly request a destructive in-place replacement.

This keeps manual `hermes gateway run --replace` available for operators, while making the default managed-service path safer and less likely to self-trigger restart loops.

## Related Issue

Fixes #23272

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Removed hardcoded `--replace` from `_gateway_run_args_for_profile()`
- Removed hardcoded `--replace` from generated systemd unit `ExecStart` lines
- Removed hardcoded `--replace` from generated launchd `ProgramArguments`
- Added regression coverage to ensure managed gateway launch paths omit `--replace`

## How to Test

1. Run `uv run --frozen pytest -q -o addopts='' tests/hermes_cli/test_gateway_service.py -k 'launchd_install_repairs_outdated_plist_without_force or systemd_unit_includes_profile or launchd_plist_includes_profile or gateway_run_args_for_profile_omit_replace'`
2. Generate a systemd unit or launchd plist and confirm it uses `gateway run` without `--replace`
3. Confirm manual CLI usage can still explicitly pass `--replace` when desired

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 / local CLI service test slice

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `uv run --frozen pytest -q -o addopts='' tests/hermes_cli/test_gateway_service.py -k 'launchd_install_repairs_outdated_plist_without_force or systemd_unit_includes_profile or launchd_plist_includes_profile or gateway_run_args_for_profile_omit_replace'`
- `uv run --frozen ruff check hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py`
