### PR TITLE
fix(cli): wire sessions and indicator slash commands

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6922,6 +6922,10 @@ class HermesCLI:
             self.new_session(title=title)
         elif canonical == "resume":
             self._handle_resume_command(cmd_original)
+        elif canonical == "sessions":
+            if not self._show_recent_sessions(reason="resume"):
+                print("  No recent sessions yet.")
+                print()
         elif canonical == "model":
             self._handle_model_switch(cmd_original)
         elif canonical == "gquota":
@@ -7075,6 +7079,8 @@ class HermesCLI:
             self._handle_skin_command(cmd_original)
         elif canonical == "voice":
             self._handle_voice_command(cmd_original)
+        elif canonical == "indicator":
+            self._handle_indicator_command(cmd_original)
         elif canonical == "busy":
             self._handle_busy_command(cmd_original)
         else:
@@ -7999,6 +8005,46 @@ class HermesCLI:
             _cprint(f"  {_DIM}{behavior}{_RST}")
         else:
             _cprint(f"  {_ACCENT}✓ Busy input mode set to '{arg}' (session only){_RST}")
+
+    def _handle_indicator_command(self, cmd: str):
+        """Handle /indicator in classic CLI mode.
+
+        Usage:
+            /indicator            Show the current busy-indicator style
+            /indicator status     Show the current busy-indicator style
+            /indicator ascii      Use ASCII spinner frames
+            /indicator emoji      Use emoji spinner frames
+            /indicator kaomoji    Use kaomoji spinner frames
+            /indicator unicode    Use unicode spinner frames
+        """
+        from hermes_cli.config import load_config
+
+        allowed = ("kaomoji", "emoji", "unicode", "ascii")
+        default = "kaomoji"
+
+        parts = (cmd or "").strip().split(maxsplit=1)
+        arg = parts[1].strip().lower() if len(parts) > 1 else "status"
+
+        cfg = load_config() or {}
+        raw = ((cfg.get("display") or {}).get("tui_status_indicator", ""))
+        current = str(raw).strip().lower()
+        if current not in allowed:
+            current = default
+
+        if arg in ("", "status", "?"):
+            _cprint(f"  {_ACCENT}Busy indicator: {current}{_RST}")
+            _cprint(f"  {_DIM}Usage: /indicator [kaomoji|emoji|unicode|ascii|status]{_RST}")
+            return
+
+        if arg not in allowed:
+            _cprint(f"  {_DIM}(._.) Unknown indicator: {arg}{_RST}")
+            _cprint(f"  {_DIM}Usage: /indicator [kaomoji|emoji|unicode|ascii|status]{_RST}")
+            return
+
+        if save_config_value("display.tui_status_indicator", arg):
+            _cprint(f"  {_ACCENT}✓ Busy indicator set to '{arg}' (saved to config){_RST}")
+        else:
+            _cprint("  Failed to save indicator setting to config.yaml")
 
     def _handle_fast_command(self, cmd: str):
         """Handle /fast — toggle fast mode (OpenAI Priority Processing / Anthropic Fast Mode)."""

--- a/tests/cli/test_sessions_indicator_commands.py
+++ b/tests/cli/test_sessions_indicator_commands.py
@@ -1,0 +1,124 @@
+"""Tests for /sessions and /indicator slash command handling in classic CLI."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+def _import_cli():
+    import hermes_cli.config as config_mod
+
+    if not hasattr(config_mod, "save_env_value_secure"):
+        config_mod.save_env_value_secure = lambda key, value: {
+            "success": True,
+            "stored_as": key,
+            "validated": False,
+        }
+
+    import cli as cli_mod
+
+    return cli_mod
+
+
+def _make_cli():
+    cli_mod = _import_cli()
+    cli_obj = cli_mod.HermesCLI.__new__(cli_mod.HermesCLI)
+    cli_obj.config = {}
+    cli_obj.console = MagicMock()
+    cli_obj.agent = None
+    cli_obj.conversation_history = []
+    cli_obj.session_id = None
+    cli_obj._pending_input = MagicMock()
+    return cli_mod, cli_obj
+
+
+class TestSessionsCommand:
+    def test_sessions_dispatches_recent_sessions_view(self):
+        _, cli_obj = _make_cli()
+
+        with patch.object(cli_obj, "_show_recent_sessions", return_value=True) as mock_show:
+            cli_obj.process_command("/sessions")
+
+        mock_show.assert_called_once_with(reason="resume")
+
+    def test_sessions_prints_empty_state_when_no_sessions_exist(self):
+        _, cli_obj = _make_cli()
+
+        with (
+            patch.object(cli_obj, "_show_recent_sessions", return_value=False),
+            patch("builtins.print") as mock_print,
+        ):
+            cli_obj.process_command("/sessions")
+
+        printed = " ".join(str(call) for call in mock_print.call_args_list)
+        assert "No recent sessions yet." in printed
+
+
+class TestIndicatorCommand:
+    def _make_stub(self):
+        return SimpleNamespace()
+
+    def test_indicator_without_args_shows_normalized_status(self):
+        cli_mod = _import_cli()
+        stub = self._make_stub()
+
+        with (
+            patch.object(cli_mod, "_cprint") as mock_cprint,
+            patch.object(cli_mod, "save_config_value") as mock_save,
+            patch("hermes_cli.config.load_config", return_value={"display": {"tui_status_indicator": "  EMOJI "}}),
+        ):
+            cli_mod.HermesCLI._handle_indicator_command(stub, "/indicator")
+
+        mock_save.assert_not_called()
+        printed = " ".join(str(call) for call in mock_cprint.call_args_list)
+        assert "emoji" in printed.lower()
+        assert "Usage: /indicator" in printed
+
+    def test_indicator_status_falls_back_to_default_for_unknown_config(self):
+        cli_mod = _import_cli()
+        stub = self._make_stub()
+
+        with (
+            patch.object(cli_mod, "_cprint") as mock_cprint,
+            patch("hermes_cli.config.load_config", return_value={"display": {"tui_status_indicator": "sparkles"}}),
+        ):
+            cli_mod.HermesCLI._handle_indicator_command(stub, "/indicator status")
+
+        printed = " ".join(str(call) for call in mock_cprint.call_args_list)
+        assert "kaomoji" in printed.lower()
+
+    def test_indicator_valid_value_saves_config(self):
+        cli_mod = _import_cli()
+        stub = self._make_stub()
+
+        with (
+            patch.object(cli_mod, "_cprint") as mock_cprint,
+            patch.object(cli_mod, "save_config_value", return_value=True) as mock_save,
+        ):
+            cli_mod.HermesCLI._handle_indicator_command(stub, "/indicator ascii")
+
+        mock_save.assert_called_once_with("display.tui_status_indicator", "ascii")
+        printed = " ".join(str(call) for call in mock_cprint.call_args_list)
+        assert "ascii" in printed.lower()
+
+    def test_indicator_invalid_value_prints_usage(self):
+        cli_mod = _import_cli()
+        stub = self._make_stub()
+
+        with (
+            patch.object(cli_mod, "_cprint") as mock_cprint,
+            patch.object(cli_mod, "save_config_value") as mock_save,
+        ):
+            cli_mod.HermesCLI._handle_indicator_command(stub, "/indicator glitter")
+
+        mock_save.assert_not_called()
+        printed = " ".join(str(call) for call in mock_cprint.call_args_list)
+        assert "Unknown indicator" in printed
+        assert "Usage: /indicator" in printed
+
+    def test_indicator_dispatches_from_process_command(self):
+        _, cli_obj = _make_cli()
+
+        with patch.object(cli_obj, "_handle_indicator_command") as mock_indicator:
+            cli_obj.process_command("/indicator unicode")
+
+        mock_indicator.assert_called_once_with("/indicator unicode")


### PR DESCRIPTION
## What does this PR do?

Wire two already-registered slash commands into the classic CLI command dispatcher so they no longer silently do nothing outside TUI mode.

## Related Issue

Fixes #22960

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- add `/sessions` dispatch in `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/hermes-22960-cli-sessions-indicator/cli.py` to reuse `_show_recent_sessions(reason="resume")`
- add a small empty-state message when no resumable CLI sessions exist
- add `/indicator` handling in classic CLI mode, including normalized status display and config writes to `display.tui_status_indicator`
- add focused regression coverage in `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/hermes-22960-cli-sessions-indicator/tests/cli/test_sessions_indicator_commands.py`

## How to Test

1. Run `uv run --frozen pytest -q -o addopts='' tests/cli/test_sessions_indicator_commands.py`
2. Start classic CLI mode (no TUI) and run `/sessions` to confirm recent sessions render or show the empty-state message
3. Run `/indicator status` and `/indicator emoji` to confirm status normalization and config persistence both work in CLI mode

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `uv run --frozen pytest -q -o addopts='' tests/cli/test_sessions_indicator_commands.py` → `7 passed`
- `uv run --frozen ruff check cli.py tests/cli/test_sessions_indicator_commands.py` → passed
