### PR TITLE
fix(xai): drop models being retired May 15, 2026 from pickers

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -110,16 +110,16 @@ def _codex_curated_models() -> list[str]:
 # $HERMES_HOME/models_dev_cache.json as of 2026-04-28. Whenever xAI renames
 # or retires a model, the disk cache picks it up on the next refresh and the
 # fallback here only matters until that refresh lands.
+#
+# Models retired by xAI on May 15, 2026 are excluded — see
+# https://docs.x.ai/developers/migration/may-15-retirement
+# (grok-4, grok-4-0709, grok-4-fast{,-reasoning,-non-reasoning},
+#  grok-4-1-fast{,-reasoning,-non-reasoning}, grok-code-fast-1 → grok-4.3).
 _XAI_STATIC_FALLBACK: list[str] = [
     "grok-4.20-0309-reasoning",
     "grok-4.20-0309-non-reasoning",
     "grok-4.20-multi-agent-0309",
-    "grok-4-1-fast",
-    "grok-4-1-fast-non-reasoning",
-    "grok-4-fast",
-    "grok-4-fast-non-reasoning",
-    "grok-4",
-    "grok-code-fast-1",
+    "grok-4.3",
 ]
 
 
@@ -210,7 +210,6 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "gemini-3-pro-preview",
         "gemini-3-flash-preview",
         "gemini-2.5-pro",
-        "grok-code-fast-1",
     ],
     "gemini": [
         "gemini-3.1-pro-preview",

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -89,7 +89,6 @@ _DEFAULT_PROVIDER_MODELS = {
         "claude-sonnet-4.5",
         "claude-haiku-4.5",
         "gemini-2.5-pro",
-        "grok-code-fast-1",
     ],
     "gemini": [
         "gemini-3.1-pro-preview", "gemini-3-pro-preview",


### PR DESCRIPTION
## Summary
xAI retires grok-4, grok-4-0709, grok-4-fast{,-reasoning,-non-reasoning}, grok-4-1-fast{,-reasoning,-non-reasoning}, and grok-code-fast-1 on **May 15, 2026 at 12:00 PT** ([migration guide](https://docs.x.ai/developers/migration/may-15-retirement)). Stop advertising them in pickers and the setup wizard.

## Changes
- `hermes_cli/models.py` — `_XAI_STATIC_FALLBACK` now lists only `grok-4.20-*` + `grok-4.3` (the live replacement). Comment block points at the migration guide.
- `hermes_cli/models.py` + `hermes_cli/setup.py` — copilot lists drop `grok-code-fast-1` (Copilot proxies it through xAI, so the upstream retirement breaks it there too).

Old configs that already reference retired IDs keep working until xAI flips the switch — `agent/model_metadata.py` context-length lookups and the cache-affinity-header logic in `provider_profiles` still recognise the old names.

Closes #23278 — same intent as that PR (heads-up on retirement) but via the simpler route of just not showing the dying models.

## Validation
| | Before | After |
|---|---|---|
| `hermes model` xAI-direct fallback list | 9 entries (6 retired) | 4 entries (live only) |
| Copilot picker | includes `grok-code-fast-1` | omitted |
| `tests/hermes_cli/test_model_validation.py` + `test_copilot_auth.py` + `tests/providers/test_provider_profiles.py` + `tests/agent/test_model_metadata.py` | — | 241/241 passing |