### PR TITLE
fix(gateway): forward discord.thread_require_mention YAML key to env var

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -823,6 +823,8 @@ def load_gateway_config() -> GatewayConfig:
             if isinstance(discord_cfg, dict):
                 if "require_mention" in discord_cfg and not os.getenv("DISCORD_REQUIRE_MENTION"):
                     os.environ["DISCORD_REQUIRE_MENTION"] = str(discord_cfg["require_mention"]).lower()
+                if "thread_require_mention" in discord_cfg and not os.getenv("DISCORD_THREAD_REQUIRE_MENTION"):
+                    os.environ["DISCORD_THREAD_REQUIRE_MENTION"] = str(discord_cfg["thread_require_mention"]).lower()
                 frc = discord_cfg.get("free_response_channels")
                 if frc is not None and not os.getenv("DISCORD_FREE_RESPONSE_CHANNELS"):
                     if isinstance(frc, list):


### PR DESCRIPTION
Closes #23084

`gateway/config.py` was forwarding `discord.require_mention` from YAML into `DISCORD_REQUIRE_MENTION` but had no equivalent for `thread_require_mention`. This caused the YAML key to be silently ignored while the env var (`DISCORD_THREAD_REQUIRE_MENTION`) worked as a workaround.

Add the missing block to mirror the `require_mention` handling for `thread_require_mention`, so both YAML keys are honored with env vars taking precedence.