### PR TITLE
fix(cli): preserve startup scrollback on resize

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2647,10 +2647,18 @@ class HermesCLI:
             pass
 
     def _recover_after_resize(self, app, original_on_resize) -> None:
-        """Recover a resized classic CLI without desynchronizing cursor state."""
-        self._clear_prompt_toolkit_screen(app, rebuild_scrollback=True)
-        _replay_output_history()
-        original_on_resize()
+        """Recover a resized classic CLI without wiping banner scrollback."""
+        try:
+            original_on_resize()
+        finally:
+            try:
+                app.renderer.reset(leave_alternate_screen=False)
+            except Exception:
+                pass
+            try:
+                app.invalidate()
+            except Exception:
+                pass
 
     def _schedule_resize_recovery(self, app, original_on_resize, delay: float = 0.12) -> None:
         """Debounce resize redraws so footer chrome is not stamped into scrollback."""
@@ -12264,10 +12272,10 @@ class HermesCLI:
         # It's not just column-shrink: widening, row-shrinking, and
         # multiplexer-driven SIGWINCH-less redraws (cmux / tmux tab switch)
         # all produce the same class of drift, where the renderer's tracked
-        # _cursor_pos.y no longer matches terminal reality. The only reliable
-        # recovery is a full screen-clear (\x1b[2J\x1b[H) before the next
-        # redraw, so we force one on every resize rather than trying to
-        # compute the exact drift.
+        # _cursor_pos.y no longer matches terminal reality. We still need a
+        # hard renderer reset after each resize, but we must not wipe the
+        # physical scrollback here or we erase the startup banner/tool
+        # summary that was printed before prompt_toolkit owned the prompt.
         _original_on_resize = app._on_resize
 
         def _resize_clear_ghosts():

--- a/tests/cli/test_cli_force_redraw.py
+++ b/tests/cli/test_cli_force_redraw.py
@@ -71,32 +71,26 @@ class TestForceFullRedraw:
             "invalidate",
         ]
 
-    def test_resize_rebuilds_scrollback_before_prompt_toolkit_redraw(self, bare_cli, monkeypatch):
+    def test_resize_preserves_scrollback_and_invalidates_after_prompt_toolkit_redraw(self, bare_cli, monkeypatch):
         app = MagicMock()
         out = app.renderer.output
         events = []
-        out.reset_attributes.side_effect = lambda: events.append("reset_attrs")
-        out.erase_screen.side_effect = lambda: events.append("erase")
-        out.write_raw.side_effect = lambda text: events.append(("raw", text))
-        out.cursor_goto.side_effect = lambda *_: events.append("home")
-        out.flush.side_effect = lambda: events.append("flush")
         app.renderer.reset.side_effect = lambda **_: events.append("renderer_reset")
-        monkeypatch.setattr(cli_mod, "_replay_output_history", lambda: events.append("replay"))
         original_on_resize = lambda: events.append("original_resize")
+        app.invalidate.side_effect = lambda: events.append("invalidate")
 
         bare_cli._recover_after_resize(app, original_on_resize)
 
         assert events == [
-            "reset_attrs",
-            "erase",
-            ("raw", "\x1b[3J"),
-            "home",
-            "flush",
-            "renderer_reset",
-            "replay",
             "original_resize",
+            "renderer_reset",
+            "invalidate",
         ]
-        app.invalidate.assert_not_called()
+        out.reset_attributes.assert_not_called()
+        out.erase_screen.assert_not_called()
+        out.write_raw.assert_not_called()
+        out.cursor_goto.assert_not_called()
+        out.flush.assert_not_called()
 
     def test_force_redraw_uses_full_screen_clear_without_scrollback_clear(self, bare_cli):
         app = MagicMock()


### PR DESCRIPTION
## What does this PR do?

Preserve the classic CLI startup banner and tool summary during terminal resize recovery by resetting prompt_toolkit's renderer instead of wiping the physical terminal scrollback.

## Related Issue

Fixes #22999

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- update `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/hermes-22999-cli-resize-banner/cli.py` so resize recovery calls the original prompt_toolkit resize path first, then resets the renderer and invalidates for a clean repaint
- stop clearing physical scrollback during resize recovery so startup banner/tool summary content survives maximize and resize events
- update `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/hermes-22999-cli-resize-banner/tests/cli/test_cli_force_redraw.py` to assert the resize path preserves scrollback and still repaints the prompt chrome

## How to Test

1. Run `uv run --frozen pytest -q -o addopts='' tests/cli/test_cli_force_redraw.py`
2. Start classic CLI mode in a narrow terminal and confirm the startup banner/tool summary are visible
3. Maximize or resize the terminal and confirm the startup area stays visible instead of being wiped away

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `uv run --frozen pytest -q -o addopts='' tests/cli/test_cli_force_redraw.py` → `9 passed`
- `uv run --frozen ruff check cli.py tests/cli/test_cli_force_redraw.py` → passed
