### PR TITLE
fix(cli): warn before archiving a task with dependent children

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -436,6 +436,20 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
 
     p_archive = sub.add_parser("archive", help="Archive one or more tasks")
     p_archive.add_argument("task_ids", nargs="+")
+    # When a task has non-archived children, archiving silently leaves them
+    # stuck in 'todo' (recompute_ready only promotes when parents are 'done').
+    # These flags let callers pick an outcome non-interactively; without one,
+    # an interactive shell prompts and a non-interactive shell refuses.
+    p_archive_children = p_archive.add_mutually_exclusive_group()
+    p_archive_children.add_argument(
+        "--cascade", action="store_true",
+        help="Also archive every non-archived descendant of each task",
+    )
+    p_archive_children.add_argument(
+        "--unlink-children", action="store_true",
+        help="Remove dependency edges to non-archived children, then archive "
+             "the parent (children proceed once their other parents are done)",
+    )
 
     # --- tail ---
     p_tail = sub.add_parser("tail", help="Follow a task's event stream")
@@ -1625,15 +1639,106 @@ def _cmd_archive(args: argparse.Namespace) -> int:
     if not ids:
         print("at least one task_id is required", file=sys.stderr)
         return 1
+    cascade = bool(getattr(args, "cascade", False))
+    unlink = bool(getattr(args, "unlink_children", False))
     failed: list[str] = []
     with kb.connect() as conn:
         for tid in ids:
-            if not kb.archive_task(conn, tid):
+            children = kb.dependent_child_ids(conn, tid)
+            if children:
+                if cascade:
+                    action = "cascade"
+                elif unlink:
+                    action = "unlink"
+                else:
+                    action = _prompt_archive_with_children(tid, children)
+            else:
+                action = "archive"
+
+            if action == "cancel":
+                failed.append(tid)
+                print(f"skipped {tid} (has dependent children)", file=sys.stderr)
+                continue
+            if action == "unlink":
+                _unlink_children(conn, tid, children)
+                ok = kb.archive_task(conn, tid)
+            elif action == "cascade":
+                ok = _cascade_archive(conn, tid)
+            else:
+                ok = kb.archive_task(conn, tid)
+
+            if ok:
+                print(f"Archived {tid}")
+            else:
                 failed.append(tid)
                 print(f"cannot archive {tid}", file=sys.stderr)
-            else:
-                print(f"Archived {tid}")
     return 0 if not failed else 1
+
+
+def _prompt_archive_with_children(tid: str, children: list[str]) -> str:
+    """Ask the user how to handle non-archived dependent children.
+
+    Returns one of ``"unlink"``, ``"cascade"``, ``"cancel"``. When stdin is
+    not a TTY we cannot prompt safely, so we return ``"cancel"`` and tell
+    the caller to re-run with ``--cascade`` or ``--unlink-children``.
+    """
+    preview = ", ".join(children[:5])
+    if len(children) > 5:
+        preview += f", … (+{len(children) - 5} more)"
+    if not sys.stdin.isatty():
+        print(
+            f"refusing to archive {tid}: {len(children)} dependent child task(s) "
+            f"({preview}) would be stranded in 'todo'. "
+            "Re-run with --cascade or --unlink-children.",
+            file=sys.stderr,
+        )
+        return "cancel"
+    print(
+        f"\nTask {tid} has {len(children)} dependent child task(s): {preview}\n"
+        "What should happen to them?\n"
+        "  [u] Unlink — remove the dependency on this task\n"
+        "  [a] Archive — also archive every non-archived descendant\n"
+        "  [c] Cancel — leave this task as-is",
+    )
+    try:
+        reply = input("Choice [u/a/c]: ").strip().lower()
+    except (EOFError, KeyboardInterrupt):
+        print("\n(cancelled)")
+        return "cancel"
+    if reply in ("u", "unlink"):
+        return "unlink"
+    if reply in ("a", "archive"):
+        return "cascade"
+    return "cancel"
+
+
+def _unlink_children(conn, parent_id: str, children: list[str]) -> None:
+    for child in children:
+        kb.unlink_tasks(conn, parent_id, child)
+
+
+def _cascade_archive(conn, root_id: str) -> bool:
+    """Archive ``root_id`` and every non-archived descendant.
+
+    Walks the subtree once, archives leaves first so each ``archive_task``
+    call sees a consistent picture, then archives the root last.
+    """
+    order: list[str] = []
+    seen: set[str] = set()
+    stack = [root_id]
+    while stack:
+        node = stack.pop()
+        if node in seen:
+            continue
+        seen.add(node)
+        order.append(node)
+        stack.extend(kb.dependent_child_ids(conn, node))
+    # Archive descendants first (deepest -> shallowest), root last.
+    for tid in reversed(order):
+        if tid == root_id:
+            continue
+        kb.archive_task(conn, tid)
+    return kb.archive_task(conn, root_id)
 
 
 def _cmd_tail(args: argparse.Namespace) -> int:

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1587,6 +1587,24 @@ def child_ids(conn: sqlite3.Connection, task_id: str) -> list[str]:
     return [r["child_id"] for r in rows]
 
 
+def dependent_child_ids(conn: sqlite3.Connection, task_id: str) -> list[str]:
+    """Return ids of non-archived children of ``task_id``.
+
+    Used by archive flows: ``recompute_ready`` only promotes a child when
+    every parent is ``done``, so an ``archived`` parent leaves its children
+    stranded in ``todo``. Callers check this before archiving so they can
+    surface a choice (unlink the children, cascade-archive them, or abort).
+    """
+    rows = conn.execute(
+        "SELECT l.child_id FROM task_links l "
+        "JOIN tasks t ON t.id = l.child_id "
+        "WHERE l.parent_id = ? AND t.status != 'archived' "
+        "ORDER BY l.child_id",
+        (task_id,),
+    ).fetchall()
+    return [r["child_id"] for r in rows]
+
+
 def parent_results(conn: sqlite3.Connection, task_id: str) -> list[tuple[str, Optional[str]]]:
     """Return ``(parent_id, result)`` for every done parent of ``task_id``."""
     rows = conn.execute(

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -681,6 +681,73 @@ def test_cli_archive_bulk(kanban_home):
         conn.close()
 
 
+def test_cli_archive_with_dependent_children_refused_non_interactive(kanban_home):
+    # Without --cascade or --unlink-children the CLI must refuse rather
+    # than silently leave children stranded in 'todo' (#23180).
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(conn, title="parent")
+        child = kb.create_task(conn, title="child", parents=[parent])
+    finally:
+        conn.close()
+    out = run_slash(f"archive {parent}")
+    assert "refusing" in out.lower() or "skipped" in out.lower()
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, parent).status != "archived"
+        assert kb.get_task(conn, child).status == "todo"
+    finally:
+        conn.close()
+
+
+def test_cli_archive_unlink_children_promotes_child(kanban_home):
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(conn, title="parent")
+        child = kb.create_task(conn, title="child", parents=[parent])
+    finally:
+        conn.close()
+    out = run_slash(f"archive {parent} --unlink-children")
+    assert "Archived" in out
+    conn = kb.connect()
+    try:
+        assert kb.get_task(conn, parent).status == "archived"
+        # With its only parent unlinked, child has no open parents and
+        # recompute_ready (called by unlink_tasks) flipped it to 'ready'.
+        assert kb.get_task(conn, child).status == "ready"
+        assert kb.parent_ids(conn, child) == []
+    finally:
+        conn.close()
+
+
+def test_cli_archive_cascade_archives_subtree(kanban_home):
+    conn = kb.connect()
+    try:
+        parent = kb.create_task(conn, title="parent")
+        child = kb.create_task(conn, title="child", parents=[parent])
+        grandchild = kb.create_task(conn, title="grand", parents=[child])
+    finally:
+        conn.close()
+    out = run_slash(f"archive {parent} --cascade")
+    assert "Archived" in out
+    conn = kb.connect()
+    try:
+        for tid in (parent, child, grandchild):
+            assert kb.get_task(conn, tid).status == "archived"
+    finally:
+        conn.close()
+
+
+def test_cli_archive_flags_are_mutually_exclusive(kanban_home):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="x")
+    finally:
+        conn.close()
+    out = run_slash(f"archive {tid} --cascade --unlink-children")
+    assert "usage error" in out.lower() or "not allowed" in out.lower()
+
+
 def test_cli_unblock_bulk(kanban_home):
     conn = kb.connect()
     try:

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -454,6 +454,38 @@ def test_archive_hides_from_default_list(kanban_home):
         assert len(kb.list_tasks(conn, include_archived=True)) == 1
 
 
+def test_dependent_child_ids_returns_only_non_archived(kanban_home):
+    with kb.connect() as conn:
+        a = kb.create_task(conn, title="parent")
+        b = kb.create_task(conn, title="b", parents=[a])
+        c = kb.create_task(conn, title="c", parents=[a])
+        d = kb.create_task(conn, title="d", parents=[a])
+        # Archive one child; it should drop out of the dependent set.
+        kb.archive_task(conn, d)
+        deps = kb.dependent_child_ids(conn, a)
+    assert deps == sorted([b, c])
+
+
+def test_dependent_child_ids_empty_when_no_links(kanban_home):
+    with kb.connect() as conn:
+        a = kb.create_task(conn, title="solo")
+        assert kb.dependent_child_ids(conn, a) == []
+
+
+def test_archive_parent_strands_children_without_intervention(kanban_home):
+    # Reproducer: with no unlink/cascade, archiving a parent leaves dependent
+    # children stuck in 'todo' because recompute_ready only promotes when
+    # parents are 'done'. The CLI surfaces a choice; this asserts the raw
+    # DB behavior the helper exists to detect.
+    with kb.connect() as conn:
+        a = kb.create_task(conn, title="parent")
+        b = kb.create_task(conn, title="child", parents=[a])
+        assert kb.get_task(conn, b).status == "todo"
+        assert kb.archive_task(conn, a)
+        kb.recompute_ready(conn)
+        assert kb.get_task(conn, b).status == "todo"
+
+
 # ---------------------------------------------------------------------------
 # Comments / events / worker context
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Archiving a task with non-archived children silently strands them in `todo`: `recompute_ready` only promotes a child once every parent is `done`, so an `archived` parent never satisfies the gate.

## What changed and why
- `hermes_cli/kanban_db.py`: new `dependent_child_ids(conn, task_id)` returning ids of non-archived children. The DB-level `archive_task()` is intentionally unchanged so existing automation (and the dashboard REST callsite at `plugins/kanban/dashboard/plugin_api.py`) keep working; the helper is the building block for the new check.
- `hermes_cli/kanban.py` (`/kanban archive`):
  - Adds mutually-exclusive `--cascade` and `--unlink-children` flags.
  - When a task has dependent children and neither flag is set: prompts interactively (`[u]nlink / [a]rchive / [c]ancel`) on a TTY; refuses with an actionable stderr message off-TTY (so scripted callers fail loudly instead of stranding tasks).
  - `--cascade` walks the subtree and archives descendants leaf-first, then the root.
  - `--unlink-children` calls `unlink_tasks` for each edge (which already triggers `recompute_ready`), then archives the parent.
- Tasks with no dependent children archive exactly as before — no behavior change for the common path.

## How to test
- `pytest tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_core_functionality.py -q` (236 passed, 1 skipped locally).
- New tests cover: helper returns only non-archived children; helper is empty for orphan tasks; raw-DB reproducer of the stranded-child bug; CLI refuses without flags + non-TTY; `--unlink-children` promotes the child to ready; `--cascade` archives the entire subtree; flags are mutually exclusive.
- Manual: `hermes kanban archive <parent>` on a TTY now shows the prompt; off-TTY (e.g. `run_slash`) prints the refusal and exits 1.

## What platforms tested on
- macOS on darwin-arm64 (local pytest run on Python 3.11)

The broader `tests/hermes_cli/` run shows 14 unrelated pre-existing failures (gateway service/wsl, model_switch custom providers, web_server plugin auth, list_picker, update hangup) on baseline `main`; those are not touched by this change.

Fixes #23180

<!-- autocontrib:worker-id=issue-new-08cc24dc kind=pr-open -->