### PR TITLE
fix(cron): route whatsapp deliver jobs to home channel

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -111,6 +111,7 @@ _HOME_TARGET_ENV_VARS = {
     "weixin": "WEIXIN_HOME_CHANNEL",
     "bluebubbles": "BLUEBUBBLES_HOME_CHANNEL",
     "qqbot": "QQBOT_HOME_CHANNEL",
+    "whatsapp": "WHATSAPP_HOME_CHANNEL",
 }
 
 # Legacy env var names kept for back-compat.  Each entry is the current

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -100,6 +100,7 @@ class TestResolveDeliveryTarget:
             ("wecom", "WECOM_HOME_CHANNEL", "wecom-home"),
             ("weixin", "WEIXIN_HOME_CHANNEL", "wxid_home"),
             ("qqbot", "QQ_HOME_CHANNEL", "group-openid-home"),
+            ("whatsapp", "WHATSAPP_HOME_CHANNEL", "15551234567@s.whatsapp.net"),
         ],
     )
     def test_origin_delivery_without_origin_falls_back_to_supported_home_channels(
@@ -121,6 +122,7 @@ class TestResolveDeliveryTarget:
             "WECOM_HOME_CHANNEL",
             "WEIXIN_HOME_CHANNEL",
             "QQ_HOME_CHANNEL",
+            "WHATSAPP_HOME_CHANNEL",
         ):
             monkeypatch.delenv(fallback_env, raising=False)
         monkeypatch.setenv(env_var, chat_id)


### PR DESCRIPTION
## What does this PR do?

Fixes cron delivery target resolution for `deliver: whatsapp` jobs that rely on a configured home channel. `whatsapp` was already recognized as a supported delivery platform, but `_HOME_TARGET_ENV_VARS` was missing the `WHATSAPP_HOME_CHANNEL` mapping, so cron fell through and silently dropped the target.

This keeps the fix narrow: add the missing mapping and extend the existing scheduler regression test matrix to cover the WhatsApp fallback path.

## Related Issue

Fixes #22997

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added the missing `whatsapp -> WHATSAPP_HOME_CHANNEL` entry in `cron/scheduler.py`
- Extended the existing delivery-target fallback regression test matrix in `tests/cron/test_scheduler.py`
- Covered the WhatsApp home-channel env path with the same assertions already used for other supported platforms

## How to Test

1. Run `uv run --frozen pytest -q -o addopts='' tests/cron/test_scheduler.py -k "origin_delivery_without_origin_falls_back_to_supported_home_channels"`
2. Confirm the new `whatsapp` case resolves to `WHATSAPP_HOME_CHANNEL`
3. Optionally reproduce the old bug by removing the mapping and observing the WhatsApp target stop resolving

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted regression test passed locally:

```text
11 passed, 111 deselected
```
