### PR TITLE
fix(gateway): reject multi-line `/model` with clear error

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -991,6 +991,28 @@ class MessageEvent:
         args = args.replace("\u2014\u2014", "--").replace("\u2014", "--").replace("\u2013", "-")
         return args
 
+    def get_command_remainder(self) -> str:
+        """Return the text that follows the first newline of a command message.
+
+        Slash commands like ``/model`` are single-line by design. When a user
+        sends a multi-line message such as ``/model X\\nfollow-up question``
+        (e.g. via Element/Matrix's Shift+Enter), command handlers can use
+        this helper to recover the trailing text — for example, to surface
+        a clearer error or route the remainder as a regular user message.
+
+        Returns an empty string when:
+
+        * the message is not a command (``is_command()`` is false),
+        * the message has no newline,
+        * or the remainder is empty after stripping.
+        """
+        if not self.is_command():
+            return ""
+        _, sep, rest = self.text.partition("\n")
+        if not sep:
+            return ""
+        return rest.strip()
+
 
 _PLAINTEXT_GATEWAY_RESTART_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"^(?:please\s+)?restart\s+(?:the\s+)?gateway[.!?\s]*$", re.IGNORECASE),

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -8325,6 +8325,30 @@ class GatewayRunner:
         )
         from hermes_cli.providers import get_label
 
+        # `/model` is a single-line command by design. When a user sends a
+        # multi-line message — e.g. Element/Matrix's Shift+Enter inserts a
+        # newline within one send — the newline + follow-up text propagate
+        # into the model name and trigger the misleading
+        # "Model names cannot contain spaces" error from `apply_model`. Reject
+        # the multi-line form early with an accurate, actionable message
+        # instead. Refs issue #22716.
+        if event.get_command_remainder():
+            raw_args = event.get_command_args()
+            # `/model X\nFoo`  → get_command_args() = "X\nFoo" → take "X"
+            # `/model\nFoo`    → get_command_args() consumes the \n as the
+            #                    arg separator and returns "Foo", which is
+            #                    really the remainder. Treat the model arg
+            #                    as empty in that case.
+            if "\n" in raw_args:
+                args_only = raw_args.split("\n", 1)[0].strip()
+            else:
+                args_only = ""
+            suggestion = f"`/model {args_only}`" if args_only else "`/model <name>`"
+            return (
+                f"`/model` is a single-line command. "
+                f"Send {suggestion} first, then send your follow-up message "
+                f"separately."
+            )
         raw_args = event.get_command_args().strip()
 
         # Parse --provider and --global flags

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -947,6 +947,7 @@ AUTHOR_MAP = {
     "zhicheng.han@mathematik.uni-goettingen.de": "hanzckernel",  # PR #20311 (api-server approval events)
     "agentsmithlaor@gmail.com": "oferlaor",  # PR #22356 salvage (cron origin sender identity)
     "jhin.lee@unity3d.com": "leehack",  # PR #22053 salvage (telegram DM topic reply fallback)
+    "dockerpaula@gmail.com": "dockerpaula",  # PR #22716 fix (multi-line /model error)
     # pander: empty email, salvaged via PR #19665 from #16126 by @ms-alan
     "ayman.a.kamal@hotmail.com": "A-kamal",  # PR #18678 (xAI image resolution fix)
 }

--- a/tests/gateway/test_model_command_multiline.py
+++ b/tests/gateway/test_model_command_multiline.py
@@ -1,0 +1,104 @@
+"""Regression tests for gateway ``/model`` multi-line input handling.
+
+When a user sends a single message that begins with ``/model X`` and then
+contains a newline followed by additional text (e.g. via Element/Matrix's
+``Shift+Enter``), the gateway used to forward the entire remainder into the
+model name parser, which then replied with the misleading
+``"Model names cannot contain spaces"`` error. The fix is to detect the
+newline up front and return a clear, accurate single-line-command message
+instead. Refs issue #22716.
+"""
+
+import pytest
+
+from gateway.config import Platform
+from gateway.platforms.base import MessageEvent, MessageType
+from gateway.run import GatewayRunner
+from gateway.session import SessionSource
+
+
+def _make_runner():
+    runner = object.__new__(GatewayRunner)
+    runner.adapters = {}
+    runner._voice_mode = {}
+    runner._session_model_overrides = {}
+    return runner
+
+
+def _make_event(text: str) -> MessageEvent:
+    return MessageEvent(
+        text=text,
+        message_type=MessageType.TEXT,
+        source=SessionSource(
+            platform=Platform.TELEGRAM, chat_id="12345", chat_type="dm"
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_multiline_model_command_returns_clear_error():
+    """``/model X\\nfollow-up`` returns a single-line-command guidance reply."""
+    event = _make_event("/model ollama-cloud/glm-5.1\nBonjour test, repond OK")
+
+    result = await _make_runner()._handle_model_command(event)
+
+    assert result is not None
+    # The misleading historic error must NOT appear:
+    assert "cannot contain spaces" not in result.lower()
+    # The new error explains the actual constraint:
+    assert "single-line command" in result.lower()
+    # And nudges the user toward the right two-message split, surfacing
+    # the model arg they originally asked for so they can resend it as-is.
+    assert "/model ollama-cloud/glm-5.1" in result
+
+
+@pytest.mark.asyncio
+async def test_multiline_model_command_preserves_global_flag_in_first_line():
+    """Multi-line input with ``--global`` on the first line is still rejected.
+
+    The user's intent on the first line — including any flags — is echoed
+    back verbatim in the suggested command, so they can copy-paste it as a
+    follow-up single-line message.
+    """
+    event = _make_event(
+        "/model openai/gpt-5.5 --global\nUse this for the rest of the day"
+    )
+
+    result = await _make_runner()._handle_model_command(event)
+
+    assert result is not None
+    assert "single-line command" in result.lower()
+    assert "/model openai/gpt-5.5 --global" in result
+
+
+@pytest.mark.asyncio
+async def test_trailing_newline_only_is_not_multiline():
+    """``/model X\\n`` (stray trailing newline, no follow-up text) is benign.
+
+    Chat clients commonly append a stray trailing newline; we should NOT
+    treat that as a multi-line command and refuse the switch. The model
+    name on the first line is well-formed, so the switch must proceed.
+    """
+    event = _make_event("/model openai/gpt-5.5\n")
+
+    # With no follow-up text after the newline, get_command_remainder() is
+    # empty → the early return is skipped → the regular switch path runs.
+    # We don't fully exercise the switch here (no config/network) but we do
+    # assert that the response is NOT the new multi-line guidance error.
+    result = await _make_runner()._handle_model_command(event)
+
+    assert result is None or "single-line command" not in result.lower()
+
+
+@pytest.mark.asyncio
+async def test_multiline_model_command_empty_first_line_falls_back_to_generic_hint():
+    """``/model\\nQuestion`` — empty model arg — points at the bare command."""
+    event = _make_event("/model\nWhat is the capital of France?")
+
+    result = await _make_runner()._handle_model_command(event)
+
+    assert result is not None
+    assert "single-line command" in result.lower()
+    # Empty first line means we don't echo a partial model name; we
+    # fall back to the generic placeholder.
+    assert "/model <name>" in result

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -119,6 +119,50 @@ class TestMessageEventGetCommandArgs:
         assert event.get_command_args() == "hello world"
 
 
+class TestMessageEventGetCommandRemainder:
+    """Regression tests for ``MessageEvent.get_command_remainder``.
+
+    Covers the multi-line slash command path described in issue #22716,
+    where Matrix/Element ``Shift+Enter`` produces ``/cmd X\\nfollow-up``
+    in a single message.
+    """
+
+    def test_single_line_command_has_no_remainder(self):
+        event = MessageEvent(text="/model openai/gpt-5.5")
+        assert event.get_command_remainder() == ""
+
+    def test_command_only_no_remainder(self):
+        event = MessageEvent(text="/model")
+        assert event.get_command_remainder() == ""
+
+    def test_multiline_command_returns_remainder(self):
+        event = MessageEvent(text="/model openai/gpt-5.5\nWhat is 2+2?")
+        assert event.get_command_remainder() == "What is 2+2?"
+
+    def test_multiline_command_strips_remainder(self):
+        event = MessageEvent(text="/model openai/gpt-5.5\n   Bonjour test  \n")
+        assert event.get_command_remainder() == "Bonjour test"
+
+    def test_multiline_command_preserves_inner_newlines(self):
+        event = MessageEvent(text="/model openai/gpt-5.5\nline 1\nline 2")
+        assert event.get_command_remainder() == "line 1\nline 2"
+
+    def test_command_followed_by_blank_line_returns_empty(self):
+        event = MessageEvent(text="/model openai/gpt-5.5\n   \n  ")
+        assert event.get_command_remainder() == ""
+
+    def test_not_a_command_returns_empty(self):
+        event = MessageEvent(text="hello\nworld")
+        assert event.get_command_remainder() == ""
+
+    def test_remainder_does_not_alter_get_command_args(self):
+        # get_command_args() must keep its existing behavior so callers
+        # like /queue and /steer that legitimately accept multi-line text
+        # continue to work unchanged.
+        event = MessageEvent(text="/queue line1\nline2\nline3")
+        assert event.get_command_args() == "line1\nline2\nline3"
+
+
 # ---------------------------------------------------------------------------
 # extract_images
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes [#22716](https://github.com/NousResearch/hermes-agent/issues/22716) — a multi-line `/model` command (e.g. `Shift+Enter` in Element/Matrix produces `/model openai/gpt-5.5\nFollow-up question` in a single send) is currently rejected with the misleading error **`Model names cannot contain spaces`**, and the user's follow-up text is silently swallowed. The error message is wrong in two ways: there are no spaces in the model name, and the real problem is that `\n` was forwarded into the model-name parser at all.

This PR detects the multi-line form *early* in `_handle_model_command` and returns a clear, actionable message that quotes the intended single-line command back to the user, e.g.:

> `` `/model` is a single-line command. Send `/model openai/gpt-5.5` first, then send your follow-up message separately. ``

The fix is intentionally surgical — no behavior change for legitimate single-line `/model` invocations, and no change to other commands that *do* accept multi-line text (`/queue`, `/steer`, `/agent`, etc.) because the new helper only short-circuits when called from the `/model` handler.

## Related Issue

Fixes #22716

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- **`gateway/platforms/base.py`** — added `MessageEvent.get_command_remainder()` helper. Returns the text that follows the *first* newline of a command message (e.g. `/model X\nFoo` → `"Foo"`), with strip semantics; returns `""` for non-commands, single-line commands, command-only messages, or messages whose remainder is whitespace-only. Sits next to the existing `get_command_args()`/`is_command()` helpers.
- **`gateway/run.py`** — added an early multi-line detection block in `_handle_model_command()` that uses `get_command_remainder()` to short-circuit before reaching the model-name parser. Handles two distinct multi-line shapes:
  - `/model X\nFoo` — `get_command_args()` returns `"X\nFoo"`, so the suggestion is `` `/model X` ``.
  - `/model\nFoo` — `get_command_args()` consumes the `\n` as the arg separator and returns `"Foo"`, so the suggestion falls back to `` `/model <name>` ``.
- **`tests/gateway/test_platform_base.py`** — added `TestMessageEventGetCommandRemainder` (8 tests) covering: single-line no-remainder, command-only no-remainder, multi-line returns remainder, remainder is stripped, inner newlines in remainder preserved, blank-only remainder returns `""`, non-command returns `""`, and a non-regression check that `get_command_args()` still returns the full multi-line tail for commands like `/queue line1\nline2\nline3` that legitimately accept multi-line text.
- **`tests/gateway/test_model_command_multiline.py`** *(new file, 4 tests)* — async regression tests for `_handle_model_command()` covering: the canonical `/model X\nFoo` case, multi-line with flags (`/model X --global\nFoo`), benign trailing-newline (`/model X\n` with no follow-up — should NOT trigger the multi-line error), and the empty-first-line fallback (`/model\nFoo` — should suggest the generic `/model <name>` form).
- **`scripts/release.py`** — adds `dockerpaula@gmail.com → dockerpaula` to `AUTHOR_MAP` so the contributor-attribution check resolves the email when generating release notes.

## How to Test

Reproduction (before the fix):

```bash
# In any platform that delivers a single message containing \n (Element/Matrix
# Shift+Enter, Slack composer multi-line, etc.):
/model openai/gpt-5.5
What is 2+2?
```

Before — the gateway replies: `Model names cannot contain spaces` (and the question is dropped).
After — the gateway replies: `` `/model` is a single-line command. Send `/model openai/gpt-5.5` first, then send your follow-up message separately. ``

Automated:

```bash
# 1. New regression tests for both the helper and the handler — 102 passed, 2 skipped
scripts/run_tests.sh tests/gateway/test_platform_base.py tests/gateway/test_model_command_multiline.py -q

# 2. All existing /model command tests — 113 passed, 2 skipped — confirms no regression
scripts/run_tests.sh tests/gateway/test_model_command_*.py tests/gateway/test_model_switch_*.py tests/gateway/test_discord_model_picker.py -q

# 3. Lint + Windows-footguns
ruff check gateway/platforms/base.py gateway/run.py tests/gateway/test_platform_base.py tests/gateway/test_model_command_multiline.py scripts/release.py
python scripts/check-windows-footguns.py --all
```

All green locally.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(gateway): …`, `chore(release): …`)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate — none reference #22716
- [x] My PR contains **only** changes related to this fix
- [x] I've run targeted pytest and all tests pass
- [x] I've added tests for my changes (12 new tests: 8 helper + 4 handler)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] N/A — user-visible behavior change is the error message itself; no docs page documented the previous wrong message
- [x] N/A — no config keys added/changed
- [x] N/A — no architecture or workflow change
- [x] Cross-platform: pure-Python string handling (`str.partition`, `str.split`); no platform-specific calls
- [x] N/A — no tool descriptions/schemas changed

## Screenshots / Logs

```
$ pytest tests/gateway/test_platform_base.py tests/gateway/test_model_command_multiline.py -q
........................................................................ [ 69%]
.........................s.s....                                         [100%]
102 passed, 2 skipped in 3.09s
```
