### PR TITLE
fix(achievements): include dashboard session token in plugin API calls

### DIFF
--- a/plugins/hermes-achievements/dashboard/dist/index.js
+++ b/plugins/hermes-achievements/dashboard/dist/index.js
@@ -50,7 +50,11 @@
 
   async function api(path, options) {
     const url = "/api/plugins/hermes-achievements" + path;
-    const res = await fetch(url, options || {});
+    const headers = new Headers((options && options.headers) || {});
+    const token = typeof window !== "undefined" && window.__HERMES_SESSION_TOKEN__;
+    if (token) headers.set("X-Hermes-Session-Token", token);
+    const opts = Object.assign({}, options, { headers: headers });
+    const res = await fetch(url, opts);
     if (!res.ok) {
       const text = await res.text().catch(function () { return res.statusText; });
       throw new Error(res.status + ": " + text);


### PR DESCRIPTION
## Problem

The hermes-achievements dashboard plugin frontend makes API calls via its own `api()` function, which sends requests to `/api/plugins/hermes-achievements/*` without the `X-Hermes-Session-Token` header. Since all `/api/` routes are gated by the dashboard auth middleware (see `hermes_cli/web_server.py:_require_token`), these calls always return **401 Unauthorized**.

This means the Achievements tab in the dashboard has never been functional out-of-the-box for any installation where the dashboard auth middleware is active.

## Fix

Read `window.__HERMES_SESSION_TOKEN__` (injected by the server into `index.html`) and attach it as the `X-Hermes-Session-Token` header on every plugin API request. This matches exactly how the main dashboard's `fetchJSON()` works in `web/src/lib/api.ts`.

## Changes

`plugins/hermes-achievements/dashboard/dist/index.js` — the `api()` function now:
1. Creates a `Headers` object from any existing request headers
2. Looks for `window.__HERMES_SESSION_TOKEN__`
3. Sets the `X-Hermes-Session-Token` header if the token is present
4. Passes the augmented options to `fetch()`

## Verification

Before the fix: `curl http://localhost:9119/api/plugins/hermes-achievements/achievements` → `401 {"detail":"Unauthorized"}`

After the fix (with valid token): → `200 {"achievements": [...], "unlocked_count": 18, ...}`

The JS change is client-side only — no server restart needed. Users simply refresh the Achievements tab.