### PR TITLE
fix: dispatch LINE messages with session source

### DIFF
--- a/tests/gateway/test_line_plugin.py
+++ b/tests/gateway/test_line_plugin.py
@@ -642,3 +642,30 @@ class TestAdapterInit:
         assert asyncio.run(ad.get_chat_info("U123"))["type"] == "dm"
         assert asyncio.run(ad.get_chat_info("C123"))["type"] == "group"
         assert asyncio.run(ad.get_chat_info("R123"))["type"] == "channel"
+
+    def test_message_event_uses_base_source_builder(self, monkeypatch):
+        monkeypatch.setenv("LINE_CHANNEL_ACCESS_TOKEN", "t")
+        monkeypatch.setenv("LINE_CHANNEL_SECRET", "s")
+        from gateway.config import PlatformConfig
+
+        ad = LineAdapter(PlatformConfig(enabled=True))
+        captured = []
+
+        async def _capture(event):
+            captured.append(event)
+
+        ad.handle_message = _capture
+        event = {
+            "type": "message",
+            "replyToken": "reply-token",
+            "source": {"type": "user", "userId": "U123"},
+            "message": {"type": "text", "id": "m1", "text": "hello"},
+        }
+
+        asyncio.run(ad._handle_message_event(event))
+
+        assert len(captured) == 1
+        assert captured[0].text == "hello"
+        assert captured[0].source.chat_id == "U123"
+        assert captured[0].source.user_id == "U123"
+        assert captured[0].source.chat_type == "dm"


### PR DESCRIPTION
## Summary
- fix LINE inbound dispatch to build a `Source` via the base adapter API
- add a regression test covering LINE message event source construction

## Why
LINE message events were reaching the adapter, but dispatch crashed before the agent could respond because `LineAdapter` called a nonexistent `create_source` method. Other adapters use the base `build_source(...)` helper; this aligns LINE with that API.

## Test Plan
- `venv/bin/python -m pytest -q tests/gateway/test_line_plugin.py::TestAdapterInit::test_message_event_uses_base_source_builder tests/gateway/test_line_plugin.py`
