### PR TITLE
fix(process): align completion notifications to line boundaries

### DIFF
--- a/tests/tools/test_notify_on_complete.py
+++ b/tests/tools/test_notify_on_complete.py
@@ -154,7 +154,26 @@ class TestCompletionQueue:
             registry._move_to_finished(s)
 
         completion = registry.completion_queue.get_nowait()
-        assert len(completion["output"]) == 2000
+        assert len(completion["output"]) <= 2000
+        assert completion["output"].startswith("[output truncated: showing final lines]\n")
+
+    def test_truncated_output_prefers_line_boundary(self, registry):
+        """Completion previews should avoid starting mid-line when possible."""
+        output = "".join(f"line {i:03d}\n" for i in range(400))
+        s = _make_session(
+            notify_on_complete=True,
+            output=output,
+        )
+        s.exited = True
+        s.exit_code = 0
+        registry._running[s.id] = s
+        with patch.object(registry, "_write_checkpoint"):
+            registry._move_to_finished(s)
+
+        completion = registry.completion_queue.get_nowait()
+        assert completion["output"].startswith("[output truncated: showing final lines]\n")
+        first_visible_line = completion["output"].splitlines()[1]
+        assert first_visible_line.startswith("line ")
 
     def test_multiple_completions_queued(self, registry):
         """Multiple notify processes all push to the same queue."""

--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -186,6 +186,34 @@ class ProcessRegistry:
             lines.pop(0)
         return "\n".join(lines)
 
+    @staticmethod
+    def _format_completion_output(output_buffer: str, max_chars: int = 2000) -> str:
+        """Format completion output for gateway notifications.
+
+        Keep notifications compact, but when we have to truncate, try to start
+        at a line boundary and explicitly mark that we're only showing the tail.
+        """
+        from tools.ansi_strip import strip_ansi
+
+        if not output_buffer:
+            return ""
+
+        output_tail = strip_ansi(output_buffer)
+        if len(output_tail) <= max_chars:
+            return output_tail
+
+        marker = "[output truncated: showing final lines]\n"
+        tail_budget = max(0, max_chars - len(marker))
+        tail = output_tail[-tail_budget:]
+
+        first_newline = tail.find("\n")
+        if first_newline != -1:
+            line_aligned_tail = tail[first_newline + 1:]
+            if line_aligned_tail:
+                tail = line_aligned_tail
+
+        return marker + tail
+
     def _check_watch_patterns(self, session: ProcessSession, new_text: str) -> None:
         """Scan new output for watch patterns and queue notifications.
 
@@ -810,14 +838,12 @@ class ProcessRegistry:
         # this guard, kill_process() and the reader thread can both call
         # _move_to_finished(), producing duplicate [IMPORTANT: ...] messages.
         if was_running and session.notify_on_complete:
-            from tools.ansi_strip import strip_ansi
-            output_tail = strip_ansi(session.output_buffer[-2000:]) if session.output_buffer else ""
             self.completion_queue.put({
                 "type": "completion",
                 "session_id": session.id,
                 "command": session.command,
                 "exit_code": session.exit_code,
-                "output": output_tail,
+                "output": self._format_completion_output(session.output_buffer),
             })
 
     # ----- Query Methods -----


### PR DESCRIPTION
## What does this PR do?

Fixes background-process completion notifications so truncated output is easier to read in gateway channels. Instead of slicing the last 2000 characters raw, completion previews now add an explicit truncation marker and align to the next full line when possible.

## Related Issue

Fixes #23284

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- added `ProcessRegistry._format_completion_output()` in `tools/process_registry.py`
- switched completion notifications to use a line-aware truncated tail with `[output truncated: showing final lines]`
- extended `tests/tools/test_notify_on_complete.py` to cover the new truncation marker and line-boundary behavior

## How to Test

1. Run `uv run --frozen pytest -q -o addopts='' tests/tools/test_notify_on_complete.py`
2. Confirm `TestCompletionQueue::test_truncated_output_prefers_line_boundary` passes
3. Optionally reproduce with a long background process output and verify the completion notification starts with the truncation marker instead of a partial line

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `uv run --frozen pytest -q -o addopts='' tests/tools/test_notify_on_complete.py` -> `22 passed`
- `uv run --frozen ruff check tools/process_registry.py tests/tools/test_notify_on_complete.py` -> passed
- Full local `python3 -m pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e --tb=short -o addopts=''` fails during collection on both this branch and a clean `origin/main` worktree because the local Python 3.10 environment is missing repo-required modules/features (`tomllib`, `acp`, `websockets.asyncio`, `StrEnum`)
