### PR TITLE
fix: support Hermes ARC runtime prompt overrides

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -1075,7 +1075,6 @@ class AIAgent:
         provider_sort: str = None,
         provider_require_parameters: bool = False,
         provider_data_collection: str = None,
-        openrouter_min_coding_score: Optional[float] = None,
         session_id: str = None,
         tool_progress_callback: callable = None,
         tool_start_callback: callable = None,
@@ -1138,9 +1137,6 @@ class AIAgent:
             providers_ignored (List[str]): OpenRouter providers to ignore (optional)
             providers_order (List[str]): OpenRouter providers to try in order (optional)
             provider_sort (str): Sort providers by price/throughput/latency (optional)
-            openrouter_min_coding_score (float): Coding-score floor (0.0-1.0) for the
-                openrouter/pareto-code router. Only applied when model == "openrouter/pareto-code".
-                None or empty = let OpenRouter pick the strongest available coder.
             session_id (str): Pre-generated session ID for logging (optional, auto-generated if not provided)
             tool_progress_callback (callable): Callback function(tool_name, args_preview) for progress notifications
             clarify_callback (callable): Callback function(question, choices) -> str for interactive user questions.
@@ -1360,7 +1356,6 @@ class AIAgent:
         self.provider_sort = provider_sort
         self.provider_require_parameters = provider_require_parameters
         self.provider_data_collection = provider_data_collection
-        self.openrouter_min_coding_score = openrouter_min_coding_score
 
         # Store toolset filtering options
         self.enabled_toolsets = enabled_toolsets
@@ -1435,17 +1430,18 @@ class AIAgent:
             logger.info("Verbose logging enabled (third-party library logs suppressed)")
         else:
             if self.quiet_mode:
-                # In quiet mode (CLI default), keep console output clean —
-                # but DO NOT raise per-logger levels. Doing so prevents the
-                # root logger's file handlers (agent.log, errors.log) from
-                # ever seeing the records, because Python checks
-                # logger.isEnabledFor() before handler propagation. We rely
-                # on the fact that hermes_logging.setup_logging() does not
-                # install a console StreamHandler in quiet mode — so INFO
-                # records flow to the file handlers but never reach a
-                # console. Any future noise reduction belongs at the
-                # handler level inside hermes_logging.py, not here.
-                pass
+                # In quiet mode (CLI default), suppress all tool/infra log
+                # noise on the *console*. The TUI has its own rich display
+                # for status; logger INFO/WARNING messages just clutter it.
+                # File handlers (agent.log, errors.log) still capture everything.
+                for quiet_logger in [
+                    'tools',               # all tools.* (terminal, browser, web, file, etc.)
+                    'run_agent',            # agent runner internals
+                    'trajectory_compressor',
+                    'cron',                 # scheduler (only relevant in daemon mode)
+                    'hermes_cli',           # CLI helpers
+                ]:
+                    logging.getLogger(quiet_logger).setLevel(logging.ERROR)
         
         # Internal stream callback (set during streaming TTS).
         # Initialized here so _vprint can reference it before run_conversation.
@@ -1664,15 +1660,10 @@ class AIAgent:
                             _fb_entries = [fallback_model]
                         _fb_resolved = False
                         for _fb in _fb_entries:
-                            _fb_explicit_key = (_fb.get("api_key") or "").strip() or None
-                            if not _fb_explicit_key:
-                                _fb_key_env = (_fb.get("key_env") or _fb.get("api_key_env") or "").strip()
-                                if _fb_key_env:
-                                    _fb_explicit_key = os.getenv(_fb_key_env, "").strip() or None
                             _fb_client, _fb_model = resolve_provider_client(
                                 _fb["provider"], model=_fb["model"], raw_codex=True,
                                 explicit_base_url=_fb.get("base_url"),
-                                explicit_api_key=_fb_explicit_key,
+                                explicit_api_key=_fb.get("api_key"),
                             )
                             if _fb_client is not None:
                                 self.provider = _fb["provider"]
@@ -2405,25 +2396,6 @@ class AIAgent:
                 "is_anthropic_oauth": self._is_anthropic_oauth,
             })
 
-    def _get_session_db_for_recall(self):
-        """Return a SessionDB for recall, lazily creating it if an entrypoint forgot.
-
-        Most frontends pass ``session_db`` into ``AIAgent`` explicitly, but recall
-        is important enough that a missing constructor argument should degrade by
-        opening the default state DB instead of making the advertised
-        ``session_search`` tool unusable.
-        """
-        if self._session_db is not None:
-            return self._session_db
-        try:
-            from hermes_state import SessionDB
-
-            self._session_db = SessionDB()
-            return self._session_db
-        except Exception as exc:
-            logger.debug("SessionDB unavailable for recall", exc_info=True)
-            return None
-
     def _ensure_db_session(self) -> None:
         """Create session DB row on first use. Disables _session_db on failure."""
         if self._session_db_created or not self._session_db:
@@ -2821,250 +2793,6 @@ class AIAgent:
                 self.status_callback("warn", message)
             except Exception:
                 logger.debug("status_callback error in _emit_warning", exc_info=True)
-
-    # Headers we capture from the dying stream's HTTP response so post-mortem
-    # diagnosis can answer "which CF edge / which OpenRouter downstream
-    # provider / which request id".  Lowercased; httpx returns CIMultiDict.
-    _STREAM_DIAG_HEADERS = (
-        "cf-ray",
-        "cf-cache-status",
-        "x-openrouter-provider",
-        "x-openrouter-model",
-        "x-openrouter-id",
-        "x-request-id",
-        "x-vercel-id",
-        "via",
-        "server",
-        "x-forwarded-for",
-    )
-
-    @staticmethod
-    def _stream_diag_init() -> Dict[str, Any]:
-        """Return a fresh per-attempt diagnostic dict.
-
-        Mutated in-place by the streaming functions and read from the retry
-        block when a stream dies.  Lives on ``request_client_holder`` so it
-        survives across the closure boundary.
-        """
-        return {
-            "started_at": time.time(),
-            "first_chunk_at": None,
-            "chunks": 0,
-            "bytes": 0,
-            "headers": {},
-            "http_status": None,
-        }
-
-    def _stream_diag_capture_response(
-        self, diag: Dict[str, Any], http_response: Any
-    ) -> None:
-        """Snapshot interesting headers + HTTP status from the live stream.
-
-        Called once at stream open (before iterating chunks) so the metadata
-        survives even if the stream dies before any chunk arrives.  Failures
-        are swallowed — diag is best-effort.
-        """
-        if http_response is None or not isinstance(diag, dict):
-            return
-        try:
-            diag["http_status"] = getattr(http_response, "status_code", None)
-        except Exception:
-            pass
-        try:
-            headers = getattr(http_response, "headers", None) or {}
-            captured: Dict[str, str] = {}
-            for name in self._STREAM_DIAG_HEADERS:
-                try:
-                    val = headers.get(name)
-                    if val:
-                        # Truncate single-value to keep log lines bounded.
-                        captured[name] = str(val)[:120]
-                except Exception:
-                    continue
-            diag["headers"] = captured
-        except Exception:
-            pass
-
-    @staticmethod
-    def _flatten_exception_chain(error: BaseException) -> str:
-        """Return a compact ``Outer(msg) <- Inner(msg) <- ...`` rendering.
-
-        OpenAI SDK wraps httpx errors as ``APIConnectionError`` /
-        ``APIError`` and only the wrapper's class is visible at the catch
-        site — but the underlying ``RemoteProtocolError`` /
-        ``ConnectError`` / ``ReadError`` is what tells us WHY the stream
-        died.  Walks ``__cause__`` then ``__context__`` (deduped, max 4
-        deep) to surface the chain in one line.
-        """
-        seen: List[BaseException] = []
-        link: Optional[BaseException] = error
-        while link is not None and len(seen) < 4:
-            if link in seen:
-                break
-            seen.append(link)
-            nxt = getattr(link, "__cause__", None) or getattr(
-                link, "__context__", None
-            )
-            if nxt is None or nxt is link:
-                break
-            link = nxt
-        parts: List[str] = []
-        for e in seen:
-            msg = str(e).strip().replace("\n", " ")
-            if len(msg) > 140:
-                msg = msg[:140] + "…"
-            parts.append(f"{type(e).__name__}({msg})" if msg else type(e).__name__)
-        return " <- ".join(parts) if parts else type(error).__name__
-
-    def _log_stream_retry(
-        self,
-        *,
-        kind: str,
-        error: BaseException,
-        attempt: int,
-        max_attempts: int,
-        mid_tool_call: bool,
-        diag: Optional[Dict[str, Any]] = None,
-    ) -> None:
-        """Record a transient stream-drop and retry to ``agent.log``.
-
-        Always logs a structured WARNING so users have a breadcrumb regardless
-        of UI verbosity.  Subagents in particular benefit because their
-        retries no longer spam the parent's terminal — but the file log keeps
-        full detail (provider, error class, attempt, base_url, subagent_id).
-
-        When *diag* is provided (the per-attempt stream-diagnostic dict from
-        ``_stream_diag_init``), the WARNING also captures upstream headers
-        (cf-ray, x-openrouter-provider, x-openrouter-id), HTTP status, bytes
-        streamed before the drop, and elapsed time on the dying attempt.
-        These are the breadcrumbs needed to answer "is one CF edge / one
-        downstream provider responsible, or is it random across runs?"
-        """
-        try:
-            try:
-                _summary = self._summarize_api_error(error)
-            except Exception:
-                _summary = str(error)
-            if _summary and len(_summary) > 240:
-                _summary = _summary[:240] + "…"
-
-            # Inner-cause chain (httpx errors hide under openai.APIError).
-            try:
-                _chain = self._flatten_exception_chain(error)
-            except Exception:
-                _chain = type(error).__name__
-
-            # Per-attempt counters and upstream headers.
-            _now = time.time()
-            _bytes = 0
-            _chunks = 0
-            _elapsed = 0.0
-            _ttfb = None
-            _headers_repr = "-"
-            _http_status = "-"
-            if isinstance(diag, dict):
-                try:
-                    _bytes = int(diag.get("bytes") or 0)
-                    _chunks = int(diag.get("chunks") or 0)
-                    _started = float(diag.get("started_at") or _now)
-                    _elapsed = max(0.0, _now - _started)
-                    _first = diag.get("first_chunk_at")
-                    if _first is not None:
-                        _ttfb = max(0.0, float(_first) - _started)
-                    headers = diag.get("headers") or {}
-                    if isinstance(headers, dict) and headers:
-                        _headers_repr = " ".join(
-                            f"{k}={v}" for k, v in headers.items()
-                        )
-                    if diag.get("http_status") is not None:
-                        _http_status = str(diag.get("http_status"))
-                except Exception:
-                    pass
-
-            logger.warning(
-                "Stream %s on attempt %s/%s — retrying. "
-                "subagent_id=%s depth=%s provider=%s base_url=%s "
-                "error_type=%s error=%s "
-                "chain=%s "
-                "http_status=%s bytes=%d chunks=%d elapsed=%.2fs ttfb=%s "
-                "upstream=[%s]",
-                kind,
-                attempt,
-                max_attempts,
-                getattr(self, "_subagent_id", None) or "-",
-                getattr(self, "_delegate_depth", 0),
-                self.provider or "-",
-                self.base_url or "-",
-                type(error).__name__,
-                _summary,
-                _chain,
-                _http_status,
-                _bytes,
-                _chunks,
-                _elapsed,
-                f"{_ttfb:.2f}s" if _ttfb is not None else "-",
-                _headers_repr,
-                extra={"mid_tool_call": mid_tool_call},
-            )
-        except Exception:
-            logger.debug("stream-retry log emit failed", exc_info=True)
-
-    def _emit_stream_drop(
-        self,
-        *,
-        error: BaseException,
-        attempt: int,
-        max_attempts: int,
-        mid_tool_call: bool,
-        diag: Optional[Dict[str, Any]] = None,
-    ) -> None:
-        """Emit a single user-visible line for a stream drop+retry.
-
-        Both top-level agents and subagents announce drops in the UI — the
-        parent prefixes subagent lines with ``[subagent-N]`` via ``log_prefix``
-        so they're easy to attribute.  All cases also write a structured
-        WARNING to ``agent.log`` via :meth:`_log_stream_retry` with the full
-        diagnostic detail (subagent_id, provider, base_url, error_type,
-        cf-ray, x-openrouter-provider, bytes/chunks, elapsed) for post-hoc
-        analysis.
-
-        The user-visible status line is intentionally compact: provider,
-        error class, attempt N/M, plus ``after Xs`` when the stream dropped
-        mid-flight.  Full diagnostic detail goes to ``agent.log`` only —
-        ``hermes logs --level WARNING | grep "Stream drop"`` to inspect.
-        """
-        kind = "drop mid tool-call" if mid_tool_call else "drop"
-        self._log_stream_retry(
-            kind=kind,
-            error=error,
-            attempt=attempt,
-            max_attempts=max_attempts,
-            mid_tool_call=mid_tool_call,
-            diag=diag,
-        )
-        provider = self.provider or "provider"
-        # Compose a brief "after Xs" suffix when we have timing data — helps
-        # the user distinguish "couldn't connect" (0s) from "died after 30s
-        # of streaming" (likely upstream idle-kill or proxy timeout).
-        _suffix = ""
-        if isinstance(diag, dict):
-            try:
-                started = diag.get("started_at")
-                if started is not None:
-                    _suffix = f" after {max(0.0, time.time() - float(started)):.1f}s"
-            except Exception:
-                pass
-        try:
-            self._emit_status(
-                f"⚠️ {provider} stream {kind} ({type(error).__name__}){_suffix} "
-                f"— reconnecting, retry {attempt}/{max_attempts}"
-            )
-            self._touch_activity(
-                f"stream retry {attempt}/{max_attempts} "
-                f"after {type(error).__name__}"
-            )
-        except Exception:
-            pass
 
     def _emit_auxiliary_failure(self, task: str, exc: BaseException) -> None:
         """Surface a compact warning for failed auxiliary work."""
@@ -3801,19 +3529,6 @@ class AIAgent:
         # instead of returning structured reasoning fields.  Only fall back
         # to inline extraction when no structured reasoning was found.
         content = getattr(assistant_message, "content", None)
-        if not reasoning_parts and isinstance(content, list):
-            # DeepSeek V4 Pro (and compatible providers) return content as a
-            # list of typed blocks, e.g.:
-            #   [{"type": "thinking", "thinking": "..."}, {"type": "output", ...}]
-            # Without this branch the thinking text is silently dropped and the
-            # next turn fails with HTTP 400 ("thinking must be passed back").
-            # Refs #21944.
-            for block in content:
-                if isinstance(block, dict) and block.get("type") == "thinking":
-                    thinking_text = block.get("thinking") or block.get("text") or ""
-                    thinking_text = thinking_text.strip()
-                    if thinking_text and thinking_text not in reasoning_parts:
-                        reasoning_parts.append(thinking_text)
         if not reasoning_parts and isinstance(content, str) and content:
             inline_patterns = (
                 r"<think>(.*?)</think>",
@@ -3949,26 +3664,6 @@ class AIAgent:
         "skill that governs that task needs to carry the lesson.\n\n"
         "If you notice two existing skills that overlap, note it in your "
         "reply — the background curator handles consolidation at scale.\n\n"
-        "Do NOT capture (these become persistent self-imposed constraints "
-        "that bite you later when the environment changes):\n"
-        "  • Environment-dependent failures: missing binaries, fresh-install "
-        "errors, post-migration path mismatches, 'command not found', "
-        "unconfigured credentials, uninstalled packages. The user can fix "
-        "these — they are not durable rules.\n"
-        "  • Negative claims about tools or features ('browser tools do not "
-        "work', 'X tool is broken', 'cannot use Y from execute_code'). These "
-        "harden into refusals the agent cites against itself for months "
-        "after the actual problem was fixed.\n"
-        "  • Session-specific transient errors that resolved before the "
-        "conversation ended. If retrying worked, the lesson is the retry "
-        "pattern, not the original failure.\n"
-        "  • One-off task narratives. A user asking 'summarize today's "
-        "market' or 'analyze this PR' is not a class of work that warrants "
-        "a skill.\n\n"
-        "If a tool failed because of setup state, capture the FIX (install "
-        "command, config step, env var to set) under an existing setup or "
-        "troubleshooting skill — never 'this tool does not work' as a "
-        "standalone constraint.\n\n"
         "'Nothing to save.' is a real option but should NOT be the "
         "default. If the session ran smoothly with no corrections and "
         "produced no new technique, just say 'Nothing to save.' and stop. "
@@ -4026,26 +3721,6 @@ class AIAgent:
         "should carry user-preference lessons when relevant.\n\n"
         "If you notice overlapping existing skills, mention it — the "
         "background curator handles consolidation.\n\n"
-        "Do NOT capture as skills (these become persistent self-imposed "
-        "constraints that bite you later when the environment changes):\n"
-        "  • Environment-dependent failures: missing binaries, fresh-install "
-        "errors, post-migration path mismatches, 'command not found', "
-        "unconfigured credentials, uninstalled packages. The user can fix "
-        "these — they are not durable rules.\n"
-        "  • Negative claims about tools or features ('browser tools do not "
-        "work', 'X tool is broken', 'cannot use Y from execute_code'). These "
-        "harden into refusals the agent cites against itself for months "
-        "after the actual problem was fixed.\n"
-        "  • Session-specific transient errors that resolved before the "
-        "conversation ended. If retrying worked, the lesson is the retry "
-        "pattern, not the original failure.\n"
-        "  • One-off task narratives. A user asking 'summarize today's "
-        "market' or 'analyze this PR' is not a class of work that warrants "
-        "a skill.\n\n"
-        "If a tool failed because of setup state, capture the FIX (install "
-        "command, config step, env var to set) under an existing setup or "
-        "troubleshooting skill — never 'this tool does not work' as a "
-        "standalone constraint.\n\n"
         "Act on whichever of the two dimensions has real signal. If "
         "genuinely nothing stands out on either, say 'Nothing to save.' "
         "and stop — but don't reach for that conclusion as a default."
@@ -5392,25 +5067,12 @@ class AIAgent:
         Called when session_id rotates (e.g. /new, context compression);
         providers keep their state and continue running under the old
         session_id — they just flush pending extraction now."""
-        if self._memory_manager:
-            try:
-                self._memory_manager.on_session_end(messages or [])
-            except Exception:
-                pass
-        # Notify context engine of session end too — same lifecycle moment as
-        # the memory manager's on_session_end. Without this, engines that
-        # accumulate per-session state (DAGs, summaries) leak that state from
-        # the rotated-out session into whatever comes next under the same
-        # compressor instance. Mirrors the call in shutdown_memory_provider().
-        # See issue #22394.
-        if hasattr(self, "context_compressor") and self.context_compressor:
-            try:
-                self.context_compressor.on_session_end(
-                    self.session_id or "",
-                    messages or [],
-                )
-            except Exception:
-                pass
+        if not self._memory_manager:
+            return
+        try:
+            self._memory_manager.on_session_end(messages or [])
+        except Exception:
+            pass
 
     def _sync_external_memory_for_turn(
         self,
@@ -7582,7 +7244,7 @@ class AIAgent:
             return result["response"]
 
         result = {"response": None, "error": None, "partial_tool_names": []}
-        request_client_holder = {"client": None, "diag": None}
+        request_client_holder = {"client": None}
         first_delta_fired = {"done": False}
         deltas_were_sent = {"yes": False}  # Track if any deltas were fired (for fallback)
         # Wall-clock timestamp of the last real streaming chunk.  The outer
@@ -7644,21 +7306,12 @@ class AIAgent:
             # attempt's start, not a previous attempt's last chunk.
             last_chunk_time["t"] = time.time()
             self._touch_activity("waiting for provider response (streaming)")
-            # Initialize per-attempt stream diagnostics so the retry block can
-            # reach for them after the stream dies.  Lives on
-            # ``request_client_holder["diag"]`` for closure access.
-            _diag = self._stream_diag_init()
-            request_client_holder["diag"] = _diag
             stream = request_client_holder["client"].chat.completions.create(**stream_kwargs)
 
             # Capture rate limit headers from the initial HTTP response.
             # The OpenAI SDK Stream object exposes the underlying httpx
             # response via .response before any chunks are consumed.
             self._capture_rate_limits(getattr(stream, "response", None))
-            # Snapshot diagnostic headers (cf-ray, x-openrouter-provider, etc.)
-            # so they survive even when the stream dies before any chunk
-            # arrives.  Best-effort; never raises.
-            self._stream_diag_capture_response(_diag, getattr(stream, "response", None))
 
             # Log OpenRouter response cache status when present.
             self._check_openrouter_cache_status(getattr(stream, "response", None))
@@ -7680,24 +7333,6 @@ class AIAgent:
             for chunk in stream:
                 last_chunk_time["t"] = time.time()
                 self._touch_activity("receiving stream response")
-
-                # Update per-attempt diagnostic counters.  Best-effort —
-                # failures are swallowed so the streaming hot path is never
-                # interrupted by diagnostic accounting.
-                try:
-                    _diag["chunks"] = int(_diag.get("chunks", 0)) + 1
-                    if _diag.get("first_chunk_at") is None:
-                        _diag["first_chunk_at"] = last_chunk_time["t"]
-                    # Approximate byte size from the chunk's repr — exact wire
-                    # bytes aren't exposed by the SDK, but len(repr(chunk)) is
-                    # a stable proxy for "how much content arrived" that
-                    # survives stub provider differences.
-                    try:
-                        _diag["bytes"] = int(_diag.get("bytes", 0)) + len(repr(chunk))
-                    except Exception:
-                        pass
-                except Exception:
-                    pass
 
                 if self._interrupt_requested:
                     break
@@ -7893,21 +7528,8 @@ class AIAgent:
 
             # Reset stale-stream timer for this attempt
             last_chunk_time["t"] = time.time()
-            # Per-attempt diagnostic dict for the retry block to consume.
-            _diag = self._stream_diag_init()
-            request_client_holder["diag"] = _diag
             # Use the Anthropic SDK's streaming context manager
             with self._anthropic_client.messages.stream(**api_kwargs) as stream:
-                # The Anthropic SDK exposes the raw httpx response on
-                # ``stream.response``.  Snapshot diagnostic headers
-                # immediately so they survive a stream that dies before the
-                # first event.
-                try:
-                    self._stream_diag_capture_response(
-                        _diag, getattr(stream, "response", None)
-                    )
-                except Exception:
-                    pass
                 for event in stream:
                     # Update stale-stream timer on every event so the
                     # outer poll loop knows data is flowing.  Without
@@ -7917,18 +7539,6 @@ class AIAgent:
                     # already does this at the top of its chunk loop).
                     last_chunk_time["t"] = time.time()
                     self._touch_activity("receiving stream response")
-
-                    # Update per-attempt diagnostic counters (best-effort).
-                    try:
-                        _diag["chunks"] = int(_diag.get("chunks", 0)) + 1
-                        if _diag.get("first_chunk_at") is None:
-                            _diag["first_chunk_at"] = last_chunk_time["t"]
-                        try:
-                            _diag["bytes"] = int(_diag.get("bytes", 0)) + len(repr(event))
-                        except Exception:
-                            pass
-                    except Exception:
-                        pass
 
                     if self._interrupt_requested:
                         break
@@ -8054,9 +7664,17 @@ class AIAgent:
                             # retry silently.  Clear per-attempt state so the
                             # next stream starts clean.  Fire a "reconnecting"
                             # marker so the user sees why the preamble is
-                            # about to be re-streamed.  Structured WARNING is
-                            # emitted by ``_emit_stream_drop`` below; no
-                            # additional INFO line needed.
+                            # about to be re-streamed.
+                            logger.info(
+                                "Streaming attempt %s/%s died mid tool-call "
+                                "(%s: %s) after user-visible text; retrying "
+                                "silently to avoid losing the action. "
+                                "Preamble will re-stream.",
+                                _stream_attempt + 1,
+                                _max_stream_retries + 1,
+                                type(e).__name__,
+                                e,
+                            )
                             try:
                                 self._fire_stream_delta(
                                     "\n\n⚠ Connection dropped mid tool-call; "
@@ -8078,12 +7696,14 @@ class AIAgent:
                             result["partial_tool_names"] = []
                             deltas_were_sent["yes"] = False
                             first_delta_fired["done"] = False
-                            self._emit_stream_drop(
-                                error=e,
-                                attempt=_stream_attempt + 2,
-                                max_attempts=_max_stream_retries + 1,
-                                mid_tool_call=True,
-                                diag=request_client_holder.get("diag"),
+                            self._emit_status(
+                                f"⚠️ Connection dropped mid tool-call "
+                                f"({type(e).__name__}). Reconnecting… "
+                                f"(attempt {_stream_attempt + 2}/{_max_stream_retries + 1})"
+                            )
+                            self._touch_activity(
+                                f"stream retry {_stream_attempt + 2}/{_max_stream_retries + 1} "
+                                f"mid tool-call after {type(e).__name__}"
                             )
                             stale = request_client_holder.get("client")
                             if stale is not None:
@@ -8097,6 +7717,7 @@ class AIAgent:
                                 )
                             except Exception:
                                 pass
+                            self._emit_status("🔄 Reconnected — resuming…")
                             continue
 
                         # SSE error events from proxies (e.g. OpenRouter sends
@@ -8133,12 +7754,22 @@ class AIAgent:
                             # Transient network / timeout error. Retry the
                             # streaming request with a fresh connection first.
                             if _stream_attempt < _max_stream_retries:
-                                self._emit_stream_drop(
-                                    error=e,
-                                    attempt=_stream_attempt + 2,
-                                    max_attempts=_max_stream_retries + 1,
-                                    mid_tool_call=False,
-                                    diag=request_client_holder.get("diag"),
+                                logger.info(
+                                    "Streaming attempt %s/%s failed (%s: %s), "
+                                    "retrying with fresh connection...",
+                                    _stream_attempt + 1,
+                                    _max_stream_retries + 1,
+                                    type(e).__name__,
+                                    e,
+                                )
+                                self._emit_status(
+                                    f"⚠️ Connection to provider dropped "
+                                    f"({type(e).__name__}). Reconnecting… "
+                                    f"(attempt {_stream_attempt + 2}/{_max_stream_retries + 1})"
+                                )
+                                self._touch_activity(
+                                    f"stream retry {_stream_attempt + 2}/{_max_stream_retries + 1} "
+                                    f"after {type(e).__name__}"
                                 )
                                 # Close the stale request client before retry
                                 stale = request_client_holder.get("client")
@@ -8155,26 +7786,18 @@ class AIAgent:
                                     )
                                 except Exception:
                                     pass
+                                self._emit_status("🔄 Reconnected — resuming…")
                                 continue
-                            # Retries exhausted. Log the final failure with
-                            # full diagnostic detail (chain, headers,
-                            # bytes/elapsed) via the same helper used for
-                            # mid-flight retries — subagent lines get the
-                            # ``[subagent-N]`` log_prefix so the parent can
-                            # attribute them.
-                            self._log_stream_retry(
-                                kind="exhausted",
-                                error=e,
-                                attempt=_max_stream_retries + 1,
-                                max_attempts=_max_stream_retries + 1,
-                                mid_tool_call=False,
-                                diag=request_client_holder.get("diag"),
-                            )
                             self._emit_status(
                                 "❌ Connection to provider failed after "
                                 f"{_max_stream_retries + 1} attempts. "
                                 "The provider may be experiencing issues — "
                                 "try again in a moment."
+                            )
+                            logger.warning(
+                                "Streaming exhausted %s retries on transient error: %s",
+                                _max_stream_retries + 1,
+                                e,
                             )
                         else:
                             _err_lower = str(e).lower()
@@ -8406,32 +8029,6 @@ class AIAgent:
         if not fb_provider or not fb_model:
             return self._try_activate_fallback()  # skip invalid, try next
 
-        # Skip entries that resolve to the current (provider, model) — falling
-        # back to the same backend that just failed loops the failure. Compare
-        # base_url too so two distinct custom_providers entries pointing at the
-        # same shim/proxy URL also dedup. See issue #22548.
-        current_provider = (getattr(self, "provider", "") or "").strip().lower()
-        current_model = (getattr(self, "model", "") or "").strip()
-        current_base_url = str(getattr(self, "base_url", "") or "").rstrip("/").lower()
-        fb_base_url_for_dedup = (fb.get("base_url") or "").strip().rstrip("/").lower()
-        if fb_provider == current_provider and fb_model == current_model:
-            logging.warning(
-                "Fallback skip: chain entry %s/%s matches current provider/model",
-                fb_provider, fb_model,
-            )
-            return self._try_activate_fallback()
-        if (
-            fb_base_url_for_dedup
-            and current_base_url
-            and fb_base_url_for_dedup == current_base_url
-            and fb_model == current_model
-        ):
-            logging.warning(
-                "Fallback skip: chain entry base_url %s matches current backend",
-                fb_base_url_for_dedup,
-            )
-            return self._try_activate_fallback()
-
         # Use centralized router for client construction.
         # raw_codex=True because the main agent needs direct responses.stream()
         # access for Codex providers.
@@ -8443,9 +8040,7 @@ class AIAgent:
             fb_base_url_hint = (fb.get("base_url") or "").strip() or None
             fb_api_key_hint = (fb.get("api_key") or "").strip() or None
             if not fb_api_key_hint:
-                # key_env and api_key_env are both documented aliases (see
-                # _normalize_custom_provider_entry in hermes_cli/config.py).
-                fb_key_env = (fb.get("key_env") or fb.get("api_key_env") or "").strip()
+                fb_key_env = (fb.get("key_env") or "").strip()
                 if fb_key_env:
                     fb_api_key_hint = os.getenv(fb_key_env, "").strip() or None
             # For Ollama Cloud endpoints, pull OLLAMA_API_KEY from env
@@ -9363,7 +8958,6 @@ class AIAgent:
                 ollama_num_ctx=self._ollama_num_ctx,
                 # Context forwarded to profile hooks:
                 provider_preferences=_prefs or None,
-                openrouter_min_coding_score=self.openrouter_min_coding_score,
                 anthropic_max_output=_ant_max,
                 supports_reasoning=self._supports_reasoning_extra_body(),
                 qwen_session_metadata=_qwen_meta,
@@ -9403,7 +8997,6 @@ class AIAgent:
             is_custom_provider=self.provider == "custom",
             ollama_num_ctx=self._ollama_num_ctx,
             provider_preferences=_prefs or None,
-            openrouter_min_coding_score=self.openrouter_min_coding_score,
             qwen_prepare_fn=self._qwen_prepare_chat_messages if _is_qwen else None,
             qwen_prepare_inplace_fn=self._qwen_prepare_chat_messages_inplace if _is_qwen else None,
             qwen_session_metadata=_qwen_meta,
@@ -10275,16 +9868,14 @@ class AIAgent:
                 store=self._todo_store,
             )
         elif function_name == "session_search":
-            session_db = self._get_session_db_for_recall()
-            if not session_db:
-                from hermes_state import format_session_db_unavailable
-                return json.dumps({"success": False, "error": format_session_db_unavailable()})
+            if not self._session_db:
+                return json.dumps({"success": False, "error": "Session database not available."})
             from tools.session_search_tool import session_search as _session_search
             return _session_search(
                 query=function_args.get("query", ""),
                 role_filter=function_args.get("role_filter"),
                 limit=function_args.get("limit", 3),
-                db=session_db,
+                db=self._session_db,
                 current_session_id=self.session_id,
             )
         elif function_name == "memory":
@@ -10900,17 +10491,15 @@ class AIAgent:
                 if self._should_emit_quiet_tool_messages():
                     self._vprint(f"  {_get_cute_tool_message_impl('todo', function_args, tool_duration, result=function_result)}")
             elif function_name == "session_search":
-                session_db = self._get_session_db_for_recall()
-                if not session_db:
-                    from hermes_state import format_session_db_unavailable
-                    function_result = json.dumps({"success": False, "error": format_session_db_unavailable()})
+                if not self._session_db:
+                    function_result = json.dumps({"success": False, "error": "Session database not available."})
                 else:
                     from tools.session_search_tool import session_search as _session_search
                     function_result = _session_search(
                         query=function_args.get("query", ""),
                         role_filter=function_args.get("role_filter"),
                         limit=function_args.get("limit", 3),
-                        db=session_db,
+                        db=self._session_db,
                         current_session_id=self.session_id,
                     )
                 tool_duration = time.time() - tool_start_time
@@ -11310,27 +10899,6 @@ class AIAgent:
                 ):
                     summary_extra_body["provider"] = provider_preferences
 
-                # Pareto Code router plugin — model-gated. Same shape as
-                # the main-loop emission so summary calls on
-                # openrouter/pareto-code respect the user's coding-score floor.
-                if (
-                    self.model == "openrouter/pareto-code"
-                    and (
-                        (self.provider or "").strip().lower() == "openrouter"
-                        or self._is_openrouter_url()
-                    )
-                    and self.openrouter_min_coding_score is not None
-                    and self.openrouter_min_coding_score != ""
-                ):
-                    try:
-                        _ps = float(self.openrouter_min_coding_score)
-                    except (TypeError, ValueError):
-                        _ps = None
-                    if _ps is not None and 0.0 <= _ps <= 1.0:
-                        summary_extra_body["plugins"] = [
-                            {"id": "pareto-router", "min_coding_score": _ps}
-                        ]
-
                 if summary_extra_body:
                     summary_kwargs["extra_body"] = summary_extra_body
 
@@ -11441,20 +11009,6 @@ class AIAgent:
 
         self._ensure_db_session()
 
-        # Tell auxiliary_client what the live main provider/model are for
-        # this turn. Used by tools whose behaviour depends on the active
-        # main model (e.g. vision_analyze's native fast path) so they see
-        # the CLI/gateway override instead of the stale config.yaml
-        # default. Idempotent — fine to call every turn.
-        try:
-            from agent.auxiliary_client import set_runtime_main
-            set_runtime_main(
-                getattr(self, "provider", "") or "",
-                getattr(self, "model", "") or "",
-            )
-        except Exception:
-            pass
-
         # Tag all log records on this thread with the session ID so
         # ``hermes logs --session <id>`` can filter a single conversation.
         from hermes_logging import set_session_context
@@ -11558,29 +11112,7 @@ class AIAgent:
         # recover the todo state from the most recent todo tool response in history)
         if conversation_history and not self._todo_store.has_items():
             self._hydrate_todo_store(conversation_history)
-
-        # Hydrate per-session nudge counters from persisted history.
-        # Gateway creates a fresh AIAgent per inbound message (cache miss /
-        # 1h idle eviction / config-signature mismatch / process restart), so
-        # _turns_since_memory and _user_turn_count start at 0 every turn and
-        # the memory.nudge_interval trigger may never be reached. Reconstruct
-        # an effective count from prior user turns in conversation_history.
-        # Idempotent: a cached agent that already accumulated counters keeps
-        # them; only a freshly-built agent with empty in-memory state hydrates.
-        # See issue #22357.
-        if conversation_history and self._user_turn_count == 0:
-            prior_user_turns = sum(
-                1 for m in conversation_history if m.get("role") == "user"
-            )
-            if prior_user_turns > 0:
-                self._user_turn_count = prior_user_turns
-                if self._memory_nudge_interval > 0 and self._turns_since_memory == 0:
-                    # % preserves original 1-in-N cadence rather than firing a
-                    # review immediately on resume (which would surprise users
-                    # whose session happened to land just past a multiple of N).
-                    self._turns_since_memory = prior_user_turns % self._memory_nudge_interval
-
-
+        
         # Prefill messages (few-shot priming) are injected at API-call time only,
         # never stored in the messages list. This keeps them ephemeral: they won't
         # be saved to session DB, session logs, or batch trajectories, but they're
@@ -11768,17 +11300,91 @@ class AIAgent:
                 conversation_history=list(messages),
                 is_first_turn=(not bool(conversation_history)),
                 model=self.model,
+                provider=self.provider,
+                base_url=self.base_url,
                 platform=getattr(self, "platform", None) or "",
                 sender_id=getattr(self, "_user_id", None) or "",
             )
             _ctx_parts: list[str] = []
-            for r in _pre_results:
-                if isinstance(r, dict) and r.get("context"):
-                    _ctx_parts.append(str(r["context"]))
+            _runtime_override = None
+            for r in _pre_results if isinstance(_pre_results, (list, tuple)) else []:
+                if isinstance(r, dict):
+                    # Context injection
+                    if r.get("context"):
+                        _ctx_parts.append(str(r["context"]))
+                    # Runtime override
+                    if r.get("runtime_override"):
+                        _runtime_override = r["runtime_override"]
                 elif isinstance(r, str) and r.strip():
                     _ctx_parts.append(r)
             if _ctx_parts:
                 _plugin_user_context = "\n\n".join(_ctx_parts)
+
+            # Apply runtime override from plugin
+            if isinstance(_runtime_override, dict):
+                _new_model = _runtime_override.get("model") or self.model
+                _new_provider = _runtime_override.get("provider") or self.provider
+                _new_base = _runtime_override.get("base_url") or self.base_url
+                _new_key = _runtime_override.get("api_key") or self.api_key
+
+                logger.info(
+                    "Applying runtime override: provider=%s model=%s",
+                    _new_provider,
+                    _new_model,
+                )
+                logger.info(
+                    "Current runtime before switch: provider=%s model=%s",
+                    self.provider,
+                    self.model,
+                )
+
+                try:
+                    self.switch_model(
+                        new_model=_new_model,
+                        new_provider=_new_provider,
+                        api_key=_new_key,
+                        base_url=_new_base,
+                    )
+
+                    logger.info(
+                        "Runtime after switch: provider=%s model=%s",
+                        self.provider,
+                        self.model,
+                    )
+
+                except Exception as _override_exc:
+                    logger.warning(
+                        "Failed applying runtime override: %s",
+                        _override_exc,
+                    )
+
+                # Apply system_prompt override from plugin
+                _plugin_system_prompt = _runtime_override.get("system_prompt")
+                if _plugin_system_prompt and isinstance(_plugin_system_prompt, str):
+                    _plugin_system_prompt = _plugin_system_prompt.strip()
+                    if _plugin_system_prompt:
+                        logger.info(
+                            "Applying system_prompt override from plugin (%d chars)",
+                            len(_plugin_system_prompt),
+                        )
+                        if self.ephemeral_system_prompt:
+                            self.ephemeral_system_prompt = (
+                                self.ephemeral_system_prompt + "\n\n" + _plugin_system_prompt
+                            ).strip()
+                        else:
+                            self.ephemeral_system_prompt = _plugin_system_prompt
+
+                # Capture response_suffix from plugin for post-processing
+                _plugin_response_suffix = _runtime_override.get("response_suffix")
+                if _plugin_response_suffix and isinstance(_plugin_response_suffix, str):
+                    _plugin_stripped = _plugin_response_suffix.strip()
+                    if _plugin_stripped:
+                        logger.info(
+                            "Captured response_suffix from plugin (%d chars)",
+                            len(_plugin_stripped),
+                        )
+                        self._pending_response_suffix = _plugin_stripped
+
         except Exception as exc:
             logger.warning("pre_llm_call hook failed: %s", exc)
 
@@ -14561,7 +14167,20 @@ class AIAgent:
                 else:
                     # No tool calls - this is the final response
                     final_response = assistant_message.content or ""
-                    
+
+                    # Append response_suffix from plugin (e.g. signature tag)
+                    _resp_suffix = getattr(self, "_pending_response_suffix", None)
+                    if _resp_suffix and isinstance(_resp_suffix, str):
+                        _resp_suffix = _resp_suffix.strip()
+                        if _resp_suffix:
+                            logger.info(
+                                "Appending response_suffix to final_response (%d chars)",
+                                len(_resp_suffix),
+                            )
+                            final_response = (final_response + _resp_suffix).strip()
+                    # Clear after use so it doesn't persist across turns
+                    self._pending_response_suffix = None
+
                     # Fix: unmute output when entering the no-tool-call branch
                     # so the user can see empty-response warnings and recovery
                     # status messages.  _mute_post_response was set during a


### PR DESCRIPTION
## Summary
- Adds runtime_override support for topic/plugin-provided system_prompt injection.
- Captures and appends runtime_override response_suffix to final responses, then clears it after use.
- Preserves existing model/provider/base_url/api_key override behavior and context injection compatibility.

## Verification
- python3 -m py_compile /usr/local/lib/hermes-agent/run_agent.py
- python3 /root/.hermes/plugins/topic_detect/patch_run_agent.py --check
- git diff --check

## Notes
This enables Hermes ARC / topic_detect to route model, persona prompt, and transparent response signature at runtime without renaming the internal plugin package.