### PR TITLE
feat(web): add search fallback chain via web.search_fallback_backends

### DIFF
--- a/tests/tools/test_search_fallback.py
+++ b/tests/tools/test_search_fallback.py
@@ -1,0 +1,212 @@
+"""Tests for the web_search fallback chain.
+
+Covers:
+- ``_get_search_fallback_backends`` config parsing + availability filtering
+- ``_dispatch_search_backend`` returns provider response unchanged on success
+- ``_dispatch_search_backend`` converts provider exceptions to a
+  ``{"success": False, "error": ...}`` dict
+- ``web_search_tool`` falls back from a failing primary to the next backend
+- ``web_search_tool`` is unchanged when no fallbacks are configured
+- ``web_search_tool`` returns the last failure when all backends fail
+"""
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# _get_search_fallback_backends
+# ---------------------------------------------------------------------------
+
+
+class TestGetSearchFallbackBackends:
+    def test_empty_when_unconfigured(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(web_tools, "_load_web_config", lambda: {})
+        assert web_tools._get_search_fallback_backends(exclude="brave-free") == []
+
+    def test_filters_unavailable_backends(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {"search_fallback_backends": ["ddgs", "tavily"]},
+        )
+        # Tavily unconfigured, ddgs present
+        monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: True)
+        monkeypatch.delenv("TAVILY_API_KEY", raising=False)
+        assert web_tools._get_search_fallback_backends(exclude="brave-free") == ["ddgs"]
+
+    def test_excludes_primary(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {"search_fallback_backends": ["brave-free", "ddgs"]},
+        )
+        monkeypatch.setenv("BRAVE_SEARCH_API_KEY", "k")
+        monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: True)
+        # Even though brave-free is listed and available, it is the primary
+        # so we should skip it and only return ddgs.
+        assert web_tools._get_search_fallback_backends(exclude="brave-free") == ["ddgs"]
+
+    def test_dedupes(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {"search_fallback_backends": ["ddgs", "ddgs", "DDGS"]},
+        )
+        monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: True)
+        assert web_tools._get_search_fallback_backends(exclude="brave-free") == ["ddgs"]
+
+    def test_non_list_value_returns_empty(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {"search_fallback_backends": "ddgs"},
+        )
+        assert web_tools._get_search_fallback_backends(exclude="brave-free") == []
+
+    def test_preserves_order(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(
+            web_tools,
+            "_load_web_config",
+            lambda: {"search_fallback_backends": ["ddgs", "searxng"]},
+        )
+        monkeypatch.setattr(web_tools, "_ddgs_package_importable", lambda: True)
+        monkeypatch.setenv("SEARXNG_URL", "http://localhost:8080")
+        assert web_tools._get_search_fallback_backends(exclude="brave-free") == [
+            "ddgs",
+            "searxng",
+        ]
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_search_backend
+# ---------------------------------------------------------------------------
+
+
+class TestDispatchSearchBackend:
+    def test_returns_provider_response_on_success(self, monkeypatch):
+        from tools import web_tools
+        sentinel = {"success": True, "data": {"web": [{"title": "ok", "url": "https://x", "description": "", "position": 1}]}}
+
+        class FakeBrave:
+            def search(self, query, limit=5):
+                return sentinel
+
+        monkeypatch.setattr(
+            "tools.web_providers.brave_free.BraveFreeSearchProvider",
+            lambda: FakeBrave(),
+        )
+        out = web_tools._dispatch_search_backend("brave-free", "q", 5)
+        assert out is sentinel
+
+    def test_converts_exception_to_failure_dict(self, monkeypatch):
+        from tools import web_tools
+
+        class Boom:
+            def search(self, query, limit=5):
+                raise RuntimeError("boom")
+
+        monkeypatch.setattr(
+            "tools.web_providers.brave_free.BraveFreeSearchProvider",
+            lambda: Boom(),
+        )
+        out = web_tools._dispatch_search_backend("brave-free", "q", 5)
+        assert out["success"] is False
+        assert "Backend brave-free failed" in out["error"]
+        assert "boom" in out["error"]
+
+
+# ---------------------------------------------------------------------------
+# web_search_tool fallback behavior
+# ---------------------------------------------------------------------------
+
+
+class TestWebSearchToolFallback:
+    _OK_RESPONSE = {
+        "success": True,
+        "data": {
+            "web": [
+                {"title": "T", "url": "https://example.com", "description": "D", "position": 1},
+            ]
+        },
+    }
+    _FAIL_RESPONSE = {"success": False, "error": "rate limited"}
+
+    def test_no_fallback_returns_primary_response(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(web_tools, "_get_search_backend", lambda: "brave-free")
+        monkeypatch.setattr(web_tools, "_get_search_fallback_backends", lambda exclude: [])
+        with patch.object(
+            web_tools,
+            "_dispatch_search_backend",
+            return_value=self._OK_RESPONSE,
+        ) as mock_dispatch:
+            out = json.loads(web_tools.web_search_tool("q", 3))
+        assert out == self._OK_RESPONSE
+        mock_dispatch.assert_called_once_with("brave-free", "q", 3)
+
+    def test_falls_back_when_primary_fails(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(web_tools, "_get_search_backend", lambda: "brave-free")
+        monkeypatch.setattr(
+            web_tools,
+            "_get_search_fallback_backends",
+            lambda exclude: ["ddgs"],
+        )
+        responses = [self._FAIL_RESPONSE, self._OK_RESPONSE]
+
+        def fake_dispatch(backend, query, limit):
+            return responses.pop(0)
+
+        monkeypatch.setattr(web_tools, "_dispatch_search_backend", fake_dispatch)
+        out = json.loads(web_tools.web_search_tool("q", 3))
+        assert out["success"] is True
+        assert out["data"]["web"][0]["url"] == "https://example.com"
+        # Both backends consumed (primary + ddgs)
+        assert responses == []
+
+    def test_returns_last_failure_when_all_fail(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(web_tools, "_get_search_backend", lambda: "brave-free")
+        monkeypatch.setattr(
+            web_tools,
+            "_get_search_fallback_backends",
+            lambda exclude: ["ddgs"],
+        )
+        last_fail = {"success": False, "error": "ddgs no results"}
+        responses = [self._FAIL_RESPONSE, last_fail]
+
+        def fake_dispatch(backend, query, limit):
+            return responses.pop(0)
+
+        monkeypatch.setattr(web_tools, "_dispatch_search_backend", fake_dispatch)
+        out = json.loads(web_tools.web_search_tool("q", 3))
+        assert out["success"] is False
+        assert out["error"] == "ddgs no results"
+
+    def test_skips_fallback_when_primary_succeeds(self, monkeypatch):
+        from tools import web_tools
+        monkeypatch.setattr(web_tools, "_get_search_backend", lambda: "brave-free")
+        monkeypatch.setattr(
+            web_tools,
+            "_get_search_fallback_backends",
+            lambda exclude: ["ddgs"],
+        )
+        call_log = []
+
+        def fake_dispatch(backend, query, limit):
+            call_log.append(backend)
+            return self._OK_RESPONSE
+
+        monkeypatch.setattr(web_tools, "_dispatch_search_backend", fake_dispatch)
+        web_tools.web_search_tool("q", 3)
+        assert call_log == ["brave-free"]

--- a/tests/tools/test_web_tools_config.py
+++ b/tests/tools/test_web_tools_config.py
@@ -512,12 +512,17 @@ class TestWebSearchErrorHandling:
              patch.object(tools.web_tools._debug, "save"):
             result = json.loads(tools.web_tools.web_search_tool("test query", limit=3))
 
-        assert result == {"error": "Error searching web: boom"}
+        # Provider exceptions are now caught inside _dispatch_search_backend
+        # so the fallback chain can pick up. The shape is still a sanitized
+        # error dict — no traceback, no exception_type, no config.
+        assert result == {
+            "success": False,
+            "error": "Backend firecrawl failed: boom",
+        }
 
         debug_payload = mock_log_call.call_args.args[1]
-        assert debug_payload["error"] == "Error searching web: boom"
-        assert "traceback" not in debug_payload["error"]
-        assert "exception_type" not in debug_payload["error"]
+        assert "traceback" not in (debug_payload.get("error") or "")
+        assert "exception_type" not in (debug_payload.get("error") or "")
         assert "config" not in result
         assert "exception_type" not in result
         assert "exception_chain" not in result

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -221,6 +221,33 @@ def _ddgs_package_importable() -> bool:
     except ImportError:
         return False
 
+
+def _get_search_fallback_backends(exclude: str) -> List[str]:
+    """Ordered list of fallback search backends from ``web.search_fallback_backends``.
+
+    Reads the optional ``web.search_fallback_backends`` config list (e.g.
+    ``["ddgs"]``) and returns the entries that are currently available,
+    omitting ``exclude`` (typically the primary backend that just failed)
+    and any duplicates. Returns ``[]`` when no fallbacks are configured —
+    in which case ``web_search_tool`` retains its single-attempt behavior.
+    """
+    cfg = _load_web_config()
+    raw = cfg.get("search_fallback_backends") or []
+    if not isinstance(raw, list):
+        return []
+    fallbacks: List[str] = []
+    seen = {exclude}
+    for entry in raw:
+        name = str(entry).lower().strip()
+        if not name or name in seen:
+            continue
+        if not _is_backend_available(name):
+            continue
+        seen.add(name)
+        fallbacks.append(name)
+    return fallbacks
+
+
 # ─── Firecrawl Client ────────────────────────────────────────────────────────
 
 _firecrawl_client = None
@@ -1197,105 +1224,43 @@ def web_search_tool(query: str, limit: int = 5) -> str:
         if is_interrupted():
             return tool_error("Interrupted", success=False)
 
-        # Dispatch to the configured search backend
-        backend = _get_search_backend()
-        if backend == "parallel":
-            response_data = _parallel_search(query, limit)
-            debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
-            result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
-            debug_call_data["final_response_size"] = len(result_json)
-            _debug.log_call("web_search_tool", debug_call_data)
-            _debug.save()
-            return result_json
+        primary = _get_search_backend()
+        fallbacks = _get_search_fallback_backends(exclude=primary)
+        backends_to_try = [primary, *fallbacks]
+        debug_call_data["fallback_backends"] = fallbacks
 
-        if backend == "exa":
-            response_data = _exa_search(query, limit)
-            debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
-            result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
-            debug_call_data["final_response_size"] = len(result_json)
-            _debug.log_call("web_search_tool", debug_call_data)
-            _debug.save()
-            return result_json
+        last_response: Optional[dict] = None
+        for idx, backend in enumerate(backends_to_try):
+            response_data = _dispatch_search_backend(backend, query, limit)
+            last_response = response_data
+            if response_data.get("success"):
+                debug_call_data["backend_used"] = backend
+                if idx > 0:
+                    logger.info(
+                        "web_search succeeded via fallback %s after %d failed attempt(s)",
+                        backend, idx,
+                    )
+                break
+            if idx < len(backends_to_try) - 1:
+                logger.warning(
+                    "web_search backend %s failed (%s) — falling back to %s",
+                    backend,
+                    response_data.get("error", "unknown"),
+                    backends_to_try[idx + 1],
+                )
+            else:
+                debug_call_data["backend_used"] = backend
 
-        if backend == "searxng":
-            from tools.web_providers.searxng import SearXNGSearchProvider
-            response_data = SearXNGSearchProvider().search(query, limit)
-            debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
-            result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
-            debug_call_data["final_response_size"] = len(result_json)
-            _debug.log_call("web_search_tool", debug_call_data)
-            _debug.save()
-            return result_json
-
-        if backend == "brave-free":
-            from tools.web_providers.brave_free import BraveFreeSearchProvider
-            response_data = BraveFreeSearchProvider().search(query, limit)
-            debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
-            result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
-            debug_call_data["final_response_size"] = len(result_json)
-            _debug.log_call("web_search_tool", debug_call_data)
-            _debug.save()
-            return result_json
-
-        if backend == "ddgs":
-            from tools.web_providers.ddgs import DDGSSearchProvider
-            response_data = DDGSSearchProvider().search(query, limit)
-            debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
-            result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
-            debug_call_data["final_response_size"] = len(result_json)
-            _debug.log_call("web_search_tool", debug_call_data)
-            _debug.save()
-            return result_json
-
-        if backend == "tavily":
-            logger.info("Tavily search: '%s' (limit: %d)", query, limit)
-            raw = _tavily_request("search", {
-                "query": query,
-                "max_results": min(limit, 20),
-                "include_raw_content": False,
-                "include_images": False,
-            })
-            response_data = _normalize_tavily_search_results(raw)
-            debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
-            result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
-            debug_call_data["final_response_size"] = len(result_json)
-            _debug.log_call("web_search_tool", debug_call_data)
-            _debug.save()
-            return result_json
-
-        logger.info("Searching the web for: '%s' (limit: %d)", query, limit)
-
-        response = _get_firecrawl_client().search(
-            query=query,
-            limit=limit
+        response_data = last_response or {"success": False, "error": "no backend attempted"}
+        debug_call_data["results_count"] = len(
+            response_data.get("data", {}).get("web", [])
         )
-
-        web_results = _extract_web_search_results(response)
-        results_count = len(web_results)
-        logger.info("Found %d search results", results_count)
-        
-        # Build response with just search metadata (URLs, titles, descriptions)
-        response_data = {
-            "success": True,
-            "data": {
-                "web": web_results
-            }
-        }
-        
-        # Capture debug information
-        debug_call_data["results_count"] = results_count
-        
-        # Convert to JSON
         result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
-        
         debug_call_data["final_response_size"] = len(result_json)
-        
-        # Log debug information
         _debug.log_call("web_search_tool", debug_call_data)
         _debug.save()
-        
         return result_json
-        
+
     except Exception as e:
         error_msg = f"Error searching web: {str(e)}"
         logger.debug("%s", error_msg)
@@ -1305,6 +1270,67 @@ def web_search_tool(query: str, limit: int = 5) -> str:
         _debug.save()
 
         return tool_error(error_msg)
+
+
+def _dispatch_search_backend(backend: str, query: str, limit: int) -> dict:
+    """Run a single search backend and return its normalized response dict.
+
+    Each backend's per-call code path used to live inline in
+    ``web_search_tool``; it was extracted here so the fallback loop can
+    iterate cleanly over multiple providers. The returned dict matches the
+    public ``web_search`` shape (``{"success": bool, "data": {"web": [...]}, ...}``).
+
+    Provider exceptions are caught and converted to
+    ``{"success": False, "error": ...}`` so the caller can decide whether to
+    continue with the next configured fallback backend.
+    """
+    try:
+        if backend == "parallel":
+            return _parallel_search(query, limit)
+
+        if backend == "exa":
+            return _exa_search(query, limit)
+
+        if backend == "searxng":
+            from tools.web_providers.searxng import SearXNGSearchProvider
+            return SearXNGSearchProvider().search(query, limit)
+
+        if backend == "brave-free":
+            from tools.web_providers.brave_free import BraveFreeSearchProvider
+            return BraveFreeSearchProvider().search(query, limit)
+
+        if backend == "ddgs":
+            from tools.web_providers.ddgs import DDGSSearchProvider
+            return DDGSSearchProvider().search(query, limit)
+
+        if backend == "tavily":
+            logger.info("Tavily search: '%s' (limit: %d)", query, limit)
+            raw = _tavily_request("search", {
+                "query": query,
+                "max_results": min(limit, 20),
+                "include_raw_content": False,
+                "include_images": False,
+            })
+            return _normalize_tavily_search_results(raw)
+
+        logger.info("Searching the web for: '%s' (limit: %d)", query, limit)
+        response = _get_firecrawl_client().search(
+            query=query,
+            limit=limit,
+        )
+        web_results = _extract_web_search_results(response)
+        logger.info("Found %d search results", len(web_results))
+        return {
+            "success": True,
+            "data": {"web": web_results},
+        }
+
+    except Exception as e:  # noqa: BLE001
+        logger.debug("Search backend %s raised: %s", backend, e)
+        return {
+            "success": False,
+            "error": f"Backend {backend} failed: {e}",
+        }
 
 
 async def web_extract_tool(


### PR DESCRIPTION
## Summary

When a primary search backend returns `success: false`, `web_search_tool`
now optionally tries an ordered list of fallback backends configured under
`web.search_fallback_backends`. Behavior is unchanged when the new key is
absent.

Use case: Brave Search's free tier caps at 2k queries/mo and 1 qps. With
this change, operators can configure DDGS as a no-key fallback so quota
exhaustion or transient HTTP 429s don't take the agent's web access offline.

## Config

```yaml
web:
  backend: brave-free
  search_backend: brave-free
  search_fallback_backends:
    - ddgs
```

The fallback list is order-significant. Entries that aren't currently
available (missing API key, missing package) are filtered out at resolution
time so a misconfigured entry doesn't waste an attempt slot.

## Implementation

- **`_get_search_fallback_backends(exclude)`** — reads + validates the
  config list, dedupes, and excludes the primary backend so we don't retry
  the provider that just failed.
- **`_dispatch_search_backend(backend, query, limit)`** — extracts the
  per-backend dispatch (Parallel / Exa / SearXNG / Brave / DDGS / Tavily /
  Firecrawl) into a single helper. Provider exceptions are caught and
  converted into `{success: False, error: ...}` so the caller can decide
  whether to fall through to the next backend.
- **`web_search_tool`** — now iterates `[primary, *fallbacks]`, stops at
  the first success, and returns the last failure if all attempts fail.
  Debug payload gains `backend_used` and `fallback_backends`.

## Behavior change (intentional)

Provider exceptions previously bubbled out of `web_search_tool` and were
turned into `{"error": "Error searching web: ..."}` by the outer except.
They now produce `{"success": False, "error": "Backend X failed: ..."}` so
the fallback loop can react to them. Shape is still sanitized — no
traceback, exception_type, or config leakage. Existing test
`test_search_error_response_does_not_expose_diagnostics` updated to match
the new shape.

## Test plan

- [x] `pytest tests/tools/test_search_fallback.py` — 12 new tests pass
- [x] `pytest tests/tools/ -k "web or search or brave or ddgs or searxng or tavily"` — 312 pass, 1 skipped, 0 failed
- [x] Live: with brave-free patched to return failure and `search_fallback_backends: [ddgs]` configured, real DDGS results are returned (verified against `ddgs==9.14.2`)
- [x] Live: with no fallback configured, single-attempt behavior is preserved

## Notes for reviewers

- No new dependencies. `ddgs` is already an optional backend introduced in
  04193cf71; this PR doesn't change its installation surface.
- The dispatch refactor is behavior-preserving for all single-backend
  configurations and for all existing tests once the one error-shape
  expectation was updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
