### PR TITLE
feat(xai): hermes migrate xai [--apply] — rewrite config.yaml for May 15 retirement

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -658,6 +658,35 @@ def run_doctor(args):
             pass
 
     # =========================================================================
+    # Check: xAI model retirement (May 15, 2026)
+    # =========================================================================
+    print()
+    print(color("◆ xAI Model Retirement (May 15, 2026)", Colors.CYAN, Colors.BOLD))
+
+    try:
+        from hermes_cli.config import load_config
+        from hermes_cli.xai_retirement import (
+            MIGRATION_GUIDE_URL,
+            find_retired_xai_refs,
+            format_issue,
+        )
+
+        _xai_cfg = load_config()
+        retired_refs = find_retired_xai_refs(_xai_cfg)
+        if not retired_refs:
+            check_ok("No retired xAI models in config")
+        else:
+            for ref in retired_refs:
+                check_warn(format_issue(ref))
+            check_info(f"Migration guide: {MIGRATION_GUIDE_URL}")
+            manual_issues.append(
+                f"Update {len(retired_refs)} retired xAI model reference(s) "
+                f"in config.yaml — see {MIGRATION_GUIDE_URL}"
+            )
+    except Exception as _xai_check_err:
+        check_warn("xAI retirement check skipped", f"({_xai_check_err})")
+
+    # =========================================================================
     # Check: Auth providers
     # =========================================================================
     print()

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9260,6 +9260,44 @@ def main():
     fallback_parser.set_defaults(func=cmd_fallback)
 
     # =========================================================================
+    # migrate command
+    # =========================================================================
+    from hermes_cli.migrate import cmd_migrate, cmd_migrate_xai
+
+    migrate_parser = subparsers.add_parser(
+        "migrate",
+        help="Migrate configuration for retired models or deprecated settings",
+        description=(
+            "Diagnose and (optionally) rewrite the active config.yaml to "
+            "replace references to retired models or deprecated settings."
+        ),
+    )
+    migrate_subparsers = migrate_parser.add_subparsers(dest="migrate_type")
+
+    migrate_xai = migrate_subparsers.add_parser(
+        "xai",
+        help="Migrate xAI models scheduled for retirement on May 15, 2026",
+        description=(
+            "Scan config.yaml for references to xAI models retiring on "
+            "May 15, 2026 and, with --apply, rewrite them in-place to the "
+            "official replacements per the xAI migration guide. The original "
+            "config.yaml is backed up before any rewrite."
+        ),
+    )
+    migrate_xai.add_argument(
+        "--apply",
+        action="store_true",
+        help="Rewrite config.yaml in-place (default: dry-run, no writes)",
+    )
+    migrate_xai.add_argument(
+        "--no-backup",
+        action="store_true",
+        help="Skip the timestamped backup of config.yaml when applying",
+    )
+    migrate_xai.set_defaults(func=cmd_migrate_xai)
+    migrate_parser.set_defaults(func=cmd_migrate)
+
+    # =========================================================================
     # gateway command
     # =========================================================================
     gateway_parser = subparsers.add_parser(

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1380,6 +1380,29 @@ def cmd_chat(args):
         # If resolution fails, keep the original value — _init_agent will
         # report "Session not found" with the original input
 
+    # xAI retirement warning — one-shot, non-blocking, never fails startup
+    try:
+        from hermes_cli.xai_retirement import (
+            MIGRATION_GUIDE_URL,
+            RETIREMENT_DATE,
+            find_retired_xai_refs,
+            format_issue,
+        )
+        from hermes_cli.config import load_config as _load_config_for_xai_check
+
+        _retired_xai_refs = find_retired_xai_refs(_load_config_for_xai_check())
+        if _retired_xai_refs:
+            sys.stderr.write(
+                f"\033[33m⚠ xAI retires {len(_retired_xai_refs)} model(s) "
+                f"in your config on {RETIREMENT_DATE}:\033[0m\n"
+            )
+            for _ref in _retired_xai_refs:
+                sys.stderr.write(f"  \033[33m⚠\033[0m {format_issue(_ref)}\n")
+            sys.stderr.write(f"  \033[2mMigration guide: {MIGRATION_GUIDE_URL}\033[0m\n")
+            sys.stderr.write("  \033[2mRun 'hermes doctor' for details.\033[0m\n\n")
+    except Exception:
+        pass
+
     # First-run guard: check if any provider is configured before launching
     if not _has_any_provider_configured():
         print()

--- a/hermes_cli/migrate.py
+++ b/hermes_cli/migrate.py
@@ -1,0 +1,115 @@
+"""CLI handlers for ``hermes migrate ...``.
+
+Currently exposes only ``hermes migrate xai`` — diagnoses and (with --apply)
+rewrites references to xAI models retired on May 15, 2026.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+from hermes_cli.colors import Colors, color
+from hermes_cli.config import load_config
+
+
+def cmd_migrate(args: Any) -> int:
+    """Dispatcher for ``hermes migrate <subtype>``."""
+    sub = getattr(args, "migrate_type", None)
+    if sub == "xai":
+        return cmd_migrate_xai(args)
+
+    print("usage: hermes migrate xai [--apply] [--no-backup]", file=sys.stderr)
+    return 2
+
+
+def cmd_migrate_xai(args: Any) -> int:
+    """Run xAI May-15 model migration in dry-run or apply mode."""
+    from hermes_cli.xai_retirement import (
+        MIGRATION_GUIDE_URL,
+        RETIREMENT_DATE,
+        apply_migration,
+        find_retired_xai_refs,
+        format_issue,
+    )
+
+    apply = bool(getattr(args, "apply", False))
+    no_backup = bool(getattr(args, "no_backup", False))
+
+    config = load_config()
+    issues = find_retired_xai_refs(config)
+
+    print()
+    print(color(
+        f"◆ xAI Model Retirement Migration ({RETIREMENT_DATE})",
+        Colors.CYAN, Colors.BOLD,
+    ))
+    print()
+
+    if not issues:
+        print(f"  {color('✓', Colors.GREEN)} No retired xAI models in config — nothing to migrate.")
+        return 0
+
+    print(f"  Found {len(issues)} retired xAI model reference(s):")
+    print()
+    for issue in issues:
+        print(f"    {color('⚠', Colors.YELLOW)} {format_issue(issue)}")
+    print()
+    print(f"    {color('→', Colors.CYAN)} Migration guide: {MIGRATION_GUIDE_URL}")
+    print()
+
+    config_path = _resolve_config_path()
+
+    if not apply:
+        print(color("Dry-run mode — no changes written.", Colors.DIM))
+        print(color(
+            "Re-run with `hermes migrate xai --apply` to rewrite "
+            f"{config_path} in-place (backup created automatically).",
+            Colors.DIM,
+        ))
+        return 0
+
+    if not config_path or not config_path.exists():
+        print(
+            f"  {color('✗', Colors.RED)} Could not locate config.yaml "
+            f"(looked at: {config_path})",
+            file=sys.stderr,
+        )
+        return 1
+
+    try:
+        result = apply_migration(
+            config_path=config_path,
+            issues=issues,
+            backup=not no_backup,
+        )
+    except Exception as exc:
+        print(
+            f"  {color('✗', Colors.RED)} Migration failed: {exc}",
+            file=sys.stderr,
+        )
+        return 1
+
+    if not result.config_changed:
+        print(f"  {color('⚠', Colors.YELLOW)} No changes written.")
+        return 0
+
+    if result.backup_path is not None:
+        print(f"  {color('✓', Colors.GREEN)} Backup: {result.backup_path}")
+    print(
+        f"  {color('✓', Colors.GREEN)} Updated {len(result.issues_resolved)} "
+        f"slot(s) in {result.file_path}"
+    )
+    print()
+    print(color(
+        "Run `hermes doctor` to confirm no retired xAI models remain.",
+        Colors.DIM,
+    ))
+    return 0
+
+
+def _resolve_config_path() -> Path:
+    """Best-effort: locate the active config.yaml on disk."""
+    from hermes_cli.config import get_hermes_home
+
+    return get_hermes_home() / "config.yaml"

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -106,20 +106,13 @@ def _codex_curated_models() -> list[str]:
 
 
 # Static fallback for xAI when the models.dev disk cache is empty (fresh
-# install, offline first run, etc.). Mirrors the xAI-direct model IDs from
-# $HERMES_HOME/models_dev_cache.json as of 2026-04-28. Whenever xAI renames
-# or retires a model, the disk cache picks it up on the next refresh and the
-# fallback here only matters until that refresh lands.
+# install, offline first run, etc.). Keep this list conservative: it should
+# not advertise models scheduled for May 15, 2026 retirement.
 _XAI_STATIC_FALLBACK: list[str] = [
+    "grok-4.3",
     "grok-4.20-0309-reasoning",
     "grok-4.20-0309-non-reasoning",
     "grok-4.20-multi-agent-0309",
-    "grok-4-1-fast",
-    "grok-4-1-fast-non-reasoning",
-    "grok-4-fast",
-    "grok-4-fast-non-reasoning",
-    "grok-4",
-    "grok-code-fast-1",
 ]
 
 

--- a/hermes_cli/xai_retirement.py
+++ b/hermes_cli/xai_retirement.py
@@ -132,3 +132,124 @@ def format_issue(issue: RetirementIssue) -> str:
     if issue.note:
         parts.append(f"[note: {issue.note}]")
     return " ".join(parts)
+
+
+# ---------------------------------------------------------------------------
+# Apply migration to config.yaml (round-trip preserves comments/order/types)
+# ---------------------------------------------------------------------------
+
+import datetime as _dt
+from pathlib import Path
+import shutil
+
+
+@dataclass(frozen=True)
+class ApplyResult:
+    """Outcome of an apply_migration call."""
+
+    file_path: Path
+    backup_path: Optional[Path]
+    issues_resolved: List[RetirementIssue]
+    config_changed: bool
+
+
+def _walk_to_parent(yaml_doc: Any, dotted_path: str) -> "tuple[Any, str]":
+    """Resolve a dotted slot path to (parent_mapping, leaf_key).
+
+    Example: "auxiliary.vision.model" -> (yaml_doc["auxiliary"]["vision"], "model").
+    Raises KeyError if any intermediate node is missing or not a mapping.
+    """
+    parts = dotted_path.split(".")
+    if len(parts) < 2:
+        raise ValueError(f"Path must have at least one parent: {dotted_path!r}")
+    node = yaml_doc
+    for segment in parts[:-1]:
+        if not isinstance(node, dict) or segment not in node:
+            raise KeyError(f"Path segment {segment!r} missing in {dotted_path!r}")
+        node = node[segment]
+    return node, parts[-1]
+
+
+def apply_migration(
+    config_path: Path,
+    issues: List[RetirementIssue],
+    backup: bool = True,
+) -> ApplyResult:
+    """Rewrite ``config_path`` in-place so each issue is resolved.
+
+    For every issue, the model name is replaced by ``issue.replacement``. If the
+    issue has ``reasoning_effort`` set (i.e. the migration is from a
+    ``*-non-reasoning`` variant), a sibling ``reasoning_effort`` key is added
+    or updated alongside the model.
+
+    Uses ``ruamel.yaml`` round-trip mode so comments, key order, indentation,
+    and type literals (booleans, ints) are preserved.
+
+    A backup copy is written to
+    ``<config_path>.bak-pre-migrate-xai-YYYYMMDD-HHMMSS`` before rewriting,
+    unless ``backup=False``.
+    """
+    from ruamel.yaml import YAML  # local import — avoid hard dep at module load
+
+    config_path = Path(config_path)
+    if not config_path.exists():
+        raise FileNotFoundError(config_path)
+
+    if not issues:
+        return ApplyResult(
+            file_path=config_path,
+            backup_path=None,
+            issues_resolved=[],
+            config_changed=False,
+        )
+
+    yaml = YAML(typ="rt")
+    yaml.preserve_quotes = True
+    with config_path.open("r", encoding="utf-8") as fh:
+        doc = yaml.load(fh)
+
+    if doc is None:
+        return ApplyResult(
+            file_path=config_path,
+            backup_path=None,
+            issues_resolved=[],
+            config_changed=False,
+        )
+
+    resolved: List[RetirementIssue] = []
+    for issue in issues:
+        try:
+            parent, leaf = _walk_to_parent(doc, issue.config_path)
+        except KeyError:
+            # Slot vanished between scan and apply — skip silently
+            continue
+        parent[leaf] = issue.replacement
+        if issue.reasoning_effort:
+            parent["reasoning_effort"] = issue.reasoning_effort
+        resolved.append(issue)
+
+    if not resolved:
+        return ApplyResult(
+            file_path=config_path,
+            backup_path=None,
+            issues_resolved=[],
+            config_changed=False,
+        )
+
+    backup_path: Optional[Path] = None
+    if backup:
+        ts = _dt.datetime.now().strftime("%Y%m%d-%H%M%S")
+        backup_path = config_path.with_name(
+            f"{config_path.name}.bak-pre-migrate-xai-{ts}"
+        )
+        shutil.copy2(config_path, backup_path)
+
+    with config_path.open("w", encoding="utf-8") as fh:
+        yaml.dump(doc, fh)
+
+    return ApplyResult(
+        file_path=config_path,
+        backup_path=backup_path,
+        issues_resolved=resolved,
+        config_changed=True,
+    )

--- a/hermes_cli/xai_retirement.py
+++ b/hermes_cli/xai_retirement.py
@@ -21,15 +21,13 @@ RETIREMENT_DATE = "May 15, 2026"
 # have a one-to-one replacement: ``grok-4.3`` reasons by default, so emulating
 # ``*-non-reasoning`` behavior on it requires ``reasoning_effort="none"``.
 _RETIRED_MODELS: Dict[str, Dict[str, Optional[str]]] = {
-    "grok-4":                       {"replacement": "grok-4.3", "reasoning_effort": None,  "note": "ambiguous (reasoning vs non-reasoning) — defaulting to grok-4.3"},
     "grok-4-0709":                  {"replacement": "grok-4.3", "reasoning_effort": None,  "note": None},
-    "grok-4-fast":                  {"replacement": "grok-4.3", "reasoning_effort": None,  "note": "ambiguous variant — verify reasoning vs non-reasoning intent"},
     "grok-4-fast-reasoning":        {"replacement": "grok-4.3", "reasoning_effort": None,  "note": None},
     "grok-4-fast-non-reasoning":    {"replacement": "grok-4.3", "reasoning_effort": "none", "note": None},
-    "grok-4-1-fast":                {"replacement": "grok-4.3", "reasoning_effort": None,  "note": "ambiguous variant — verify reasoning vs non-reasoning intent"},
     "grok-4-1-fast-reasoning":      {"replacement": "grok-4.3", "reasoning_effort": None,  "note": None},
     "grok-4-1-fast-non-reasoning":  {"replacement": "grok-4.3", "reasoning_effort": "none", "note": None},
     "grok-code-fast-1":             {"replacement": "grok-4.3", "reasoning_effort": None,  "note": None},
+    "grok-3":                       {"replacement": "grok-4.3", "reasoning_effort": None,  "note": None},
     "grok-imagine-image-pro":       {"replacement": "grok-imagine-image-quality", "reasoning_effort": None, "note": None},
 }
 

--- a/hermes_cli/xai_retirement.py
+++ b/hermes_cli/xai_retirement.py
@@ -1,0 +1,134 @@
+"""Detect xAI models retired on May 15, 2026.
+
+Source: https://docs.x.ai/developers/migration/may-15-retirement
+
+Pure logic: walks a Hermes config dict, returns issues for any reference
+to a retired xAI model. No I/O, no CLI dependencies — testable in isolation
+and reusable from both `hermes doctor` and a future `hermes migrate xai`.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+
+MIGRATION_GUIDE_URL = "https://docs.x.ai/developers/migration/may-15-retirement"
+RETIREMENT_DATE = "May 15, 2026"
+
+
+# Official mapping per xAI migration guide.
+# Some entries set ``reasoning_effort`` because non-reasoning variants don't
+# have a one-to-one replacement: ``grok-4.3`` reasons by default, so emulating
+# ``*-non-reasoning`` behavior on it requires ``reasoning_effort="none"``.
+_RETIRED_MODELS: Dict[str, Dict[str, Optional[str]]] = {
+    "grok-4":                       {"replacement": "grok-4.3", "reasoning_effort": None,  "note": "ambiguous (reasoning vs non-reasoning) — defaulting to grok-4.3"},
+    "grok-4-0709":                  {"replacement": "grok-4.3", "reasoning_effort": None,  "note": None},
+    "grok-4-fast":                  {"replacement": "grok-4.3", "reasoning_effort": None,  "note": "ambiguous variant — verify reasoning vs non-reasoning intent"},
+    "grok-4-fast-reasoning":        {"replacement": "grok-4.3", "reasoning_effort": None,  "note": None},
+    "grok-4-fast-non-reasoning":    {"replacement": "grok-4.3", "reasoning_effort": "none", "note": None},
+    "grok-4-1-fast":                {"replacement": "grok-4.3", "reasoning_effort": None,  "note": "ambiguous variant — verify reasoning vs non-reasoning intent"},
+    "grok-4-1-fast-reasoning":      {"replacement": "grok-4.3", "reasoning_effort": None,  "note": None},
+    "grok-4-1-fast-non-reasoning":  {"replacement": "grok-4.3", "reasoning_effort": "none", "note": None},
+    "grok-code-fast-1":             {"replacement": "grok-4.3", "reasoning_effort": None,  "note": None},
+    "grok-imagine-image-pro":       {"replacement": "grok-imagine-image-quality", "reasoning_effort": None, "note": None},
+}
+
+
+@dataclass(frozen=True)
+class RetirementIssue:
+    """A reference to a retired xAI model found in a Hermes config."""
+
+    config_path: str            # e.g. "principal.model" or "auxiliary.vision.model"
+    current_model: str          # exact value found in config (preserves casing/prefix)
+    replacement: str            # recommended xAI replacement
+    reasoning_effort: Optional[str] = None  # set if non-reasoning variant migration
+    note: Optional[str] = None  # disambiguation note when applicable
+
+
+def _normalize(model_id: str) -> str:
+    """Strip provider prefix (``x-ai/grok-4`` → ``grok-4``) and lowercase."""
+    m = model_id.strip().lower()
+    for prefix in ("x-ai/", "xai/"):
+        if m.startswith(prefix):
+            m = m[len(prefix):]
+            break
+    return m
+
+
+def _looks_like_xai(model_id: Optional[str]) -> bool:
+    if not isinstance(model_id, str) or not model_id.strip():
+        return False
+    return _normalize(model_id).startswith("grok-")
+
+
+def find_retired_xai_refs(config: Dict[str, Any]) -> List[RetirementIssue]:
+    """Walk all model slots in a Hermes config and return retirement issues.
+
+    Slots scanned:
+      - ``principal.model``
+      - ``auxiliary.<any>.model`` (introspective — covers future aux slots)
+      - ``delegation.model``
+      - ``tts.xai.model``
+      - ``plugins.image_gen.xai.model``
+    """
+    issues: List[RetirementIssue] = []
+
+    def _check(path: str, model: Any) -> None:
+        if not _looks_like_xai(model):
+            return
+        norm = _normalize(model)
+        entry = _RETIRED_MODELS.get(norm)
+        if entry is None:
+            return
+        issues.append(RetirementIssue(
+            config_path=path,
+            current_model=model,
+            replacement=entry["replacement"],
+            reasoning_effort=entry.get("reasoning_effort"),
+            note=entry.get("note"),
+        ))
+
+    if not isinstance(config, dict):
+        return issues
+
+    principal = config.get("principal")
+    if isinstance(principal, dict):
+        _check("principal.model", principal.get("model"))
+
+    aux = config.get("auxiliary")
+    if isinstance(aux, dict):
+        for slot_name, slot_cfg in aux.items():
+            if isinstance(slot_cfg, dict):
+                _check(f"auxiliary.{slot_name}.model", slot_cfg.get("model"))
+
+    delegation = config.get("delegation")
+    if isinstance(delegation, dict):
+        _check("delegation.model", delegation.get("model"))
+
+    tts = config.get("tts")
+    if isinstance(tts, dict):
+        tts_xai = tts.get("xai")
+        if isinstance(tts_xai, dict):
+            _check("tts.xai.model", tts_xai.get("model"))
+
+    plugins = config.get("plugins")
+    if isinstance(plugins, dict):
+        image_gen = plugins.get("image_gen")
+        if isinstance(image_gen, dict):
+            ig_xai = image_gen.get("xai")
+            if isinstance(ig_xai, dict):
+                _check("plugins.image_gen.xai.model", ig_xai.get("model"))
+
+    return issues
+
+
+def format_issue(issue: RetirementIssue) -> str:
+    """One-line human-readable rendering of a retirement issue."""
+    parts = [
+        f"{issue.config_path}: {issue.current_model!r} → use {issue.replacement!r}"
+    ]
+    if issue.reasoning_effort:
+        parts.append(f'(set reasoning_effort: "{issue.reasoning_effort}")')
+    if issue.note:
+        parts.append(f"[note: {issue.note}]")
+    return " ".join(parts)

--- a/tests/hermes_cli/test_migrate_xai.py
+++ b/tests/hermes_cli/test_migrate_xai.py
@@ -1,0 +1,223 @@
+"""Tests for ``hermes migrate xai`` — apply path with ruamel round-trip."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli.xai_retirement import (
+    RetirementIssue,
+    apply_migration,
+    find_retired_xai_refs,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def trap_config(tmp_path: Path) -> Path:
+    """A config.yaml with retired models AND comments to verify round-trip."""
+    p = tmp_path / "config.yaml"
+    p.write_text(
+        "# Hermes config (sample)\n"
+        "principal:\n"
+        "  provider: xai             # the main model\n"
+        "  model: grok-4-1-fast-non-reasoning  # retiring May 15\n"
+        "  temperature: 0.5\n"
+        "auxiliary:\n"
+        "  vision:\n"
+        "    provider: xai\n"
+        "    model: grok-4-fast       # retiring\n"
+        "  compression:\n"
+        "    provider: openai         # not affected\n"
+        "    model: gpt-4o-mini\n"
+        "delegation:\n"
+        "  model: grok-code-fast-1    # retiring\n"
+        "plugins:\n"
+        "  image_gen:\n"
+        "    xai:\n"
+        "      model: grok-imagine-image-pro  # retiring\n",
+        encoding="utf-8",
+    )
+    return p
+
+
+@pytest.fixture
+def clean_config(tmp_path: Path) -> Path:
+    p = tmp_path / "config.yaml"
+    p.write_text(
+        "principal:\n"
+        "  provider: xai\n"
+        "  model: grok-4.3\n",
+        encoding="utf-8",
+    )
+    return p
+
+
+def _parse(path: Path) -> dict:
+    """Load with ruamel for assertion convenience."""
+    from ruamel.yaml import YAML
+    yaml = YAML(typ="rt")
+    with path.open("r", encoding="utf-8") as fh:
+        return yaml.load(fh)
+
+
+# ---------------------------------------------------------------------------
+# Dry-run / no-op
+# ---------------------------------------------------------------------------
+
+class TestNoOpPaths:
+    def test_clean_config_returns_unchanged_result(self, clean_config: Path):
+        issues = find_retired_xai_refs(_parse(clean_config))
+        assert issues == []
+        result = apply_migration(clean_config, issues)
+        assert result.config_changed is False
+        assert result.backup_path is None
+        # File untouched
+        assert "grok-4.3" in clean_config.read_text(encoding="utf-8")
+
+    def test_empty_issues_list_is_noop(self, trap_config: Path):
+        original = trap_config.read_text(encoding="utf-8")
+        result = apply_migration(trap_config, issues=[])
+        assert result.config_changed is False
+        assert trap_config.read_text(encoding="utf-8") == original
+
+    def test_missing_file_raises(self, tmp_path: Path):
+        with pytest.raises(FileNotFoundError):
+            apply_migration(tmp_path / "absent.yaml", issues=[
+                RetirementIssue(
+                    config_path="principal.model",
+                    current_model="grok-4",
+                    replacement="grok-4.3",
+                )
+            ])
+
+
+# ---------------------------------------------------------------------------
+# Apply: surgical replacement
+# ---------------------------------------------------------------------------
+
+class TestApplyReplacement:
+    def test_replaces_principal_model(self, trap_config: Path):
+        issues = find_retired_xai_refs(_parse(trap_config))
+        result = apply_migration(trap_config, issues)
+        assert result.config_changed is True
+        cfg = _parse(trap_config)
+        assert cfg["principal"]["model"] == "grok-4.3"
+
+    def test_adds_reasoning_effort_for_non_reasoning_variant(self, trap_config: Path):
+        issues = find_retired_xai_refs(_parse(trap_config))
+        apply_migration(trap_config, issues)
+        cfg = _parse(trap_config)
+        # Principal was grok-4-1-fast-non-reasoning → reasoning_effort: "none"
+        assert cfg["principal"]["reasoning_effort"] == "none"
+
+    def test_replaces_auxiliary_vision(self, trap_config: Path):
+        issues = find_retired_xai_refs(_parse(trap_config))
+        apply_migration(trap_config, issues)
+        cfg = _parse(trap_config)
+        assert cfg["auxiliary"]["vision"]["model"] == "grok-4.3"
+
+    def test_replaces_delegation(self, trap_config: Path):
+        issues = find_retired_xai_refs(_parse(trap_config))
+        apply_migration(trap_config, issues)
+        cfg = _parse(trap_config)
+        assert cfg["delegation"]["model"] == "grok-4.3"
+
+    def test_replaces_image_gen_plugin(self, trap_config: Path):
+        issues = find_retired_xai_refs(_parse(trap_config))
+        apply_migration(trap_config, issues)
+        cfg = _parse(trap_config)
+        assert cfg["plugins"]["image_gen"]["xai"]["model"] == "grok-imagine-image-quality"
+
+    def test_does_not_touch_unrelated_slots(self, trap_config: Path):
+        issues = find_retired_xai_refs(_parse(trap_config))
+        apply_migration(trap_config, issues)
+        cfg = _parse(trap_config)
+        # auxiliary.compression was never xAI, must remain untouched
+        assert cfg["auxiliary"]["compression"]["model"] == "gpt-4o-mini"
+        assert cfg["auxiliary"]["compression"]["provider"] == "openai"
+        # principal.temperature must survive
+        assert cfg["principal"]["temperature"] == 0.5
+
+
+# ---------------------------------------------------------------------------
+# Round-trip preservation (the hard part)
+# ---------------------------------------------------------------------------
+
+class TestRoundTripPreservation:
+    def test_preserves_top_of_file_comment(self, trap_config: Path):
+        issues = find_retired_xai_refs(_parse(trap_config))
+        apply_migration(trap_config, issues)
+        text = trap_config.read_text(encoding="utf-8")
+        assert "# Hermes config (sample)" in text
+
+    def test_preserves_inline_comments_on_unmodified_lines(self, trap_config: Path):
+        issues = find_retired_xai_refs(_parse(trap_config))
+        apply_migration(trap_config, issues)
+        text = trap_config.read_text(encoding="utf-8")
+        assert "# the main model" in text
+        assert "# not affected" in text
+
+    def test_preserves_top_level_key_order(self, trap_config: Path):
+        issues = find_retired_xai_refs(_parse(trap_config))
+        apply_migration(trap_config, issues)
+        text = trap_config.read_text(encoding="utf-8")
+        order = [
+            text.index("principal:"),
+            text.index("auxiliary:"),
+            text.index("delegation:"),
+            text.index("plugins:"),
+        ]
+        assert order == sorted(order)
+
+
+# ---------------------------------------------------------------------------
+# Backup behaviour
+# ---------------------------------------------------------------------------
+
+class TestBackup:
+    def test_backup_is_written_by_default(self, trap_config: Path):
+        issues = find_retired_xai_refs(_parse(trap_config))
+        original = trap_config.read_text(encoding="utf-8")
+        result = apply_migration(trap_config, issues)
+        assert result.backup_path is not None
+        assert result.backup_path.exists()
+        assert result.backup_path.read_text(encoding="utf-8") == original
+
+    def test_backup_filename_prefixed(self, trap_config: Path):
+        issues = find_retired_xai_refs(_parse(trap_config))
+        result = apply_migration(trap_config, issues)
+        assert result.backup_path is not None
+        assert result.backup_path.name.startswith("config.yaml.bak-pre-migrate-xai-")
+
+    def test_no_backup_when_disabled(self, trap_config: Path):
+        issues = find_retired_xai_refs(_parse(trap_config))
+        result = apply_migration(trap_config, issues, backup=False)
+        assert result.backup_path is None
+        # No bak file in the directory
+        assert not list(trap_config.parent.glob("*.bak-pre-migrate-xai-*"))
+
+    def test_no_backup_when_no_changes(self, clean_config: Path):
+        issues = find_retired_xai_refs(_parse(clean_config))
+        result = apply_migration(clean_config, issues, backup=True)
+        assert result.backup_path is None  # nothing to back up
+        assert not list(clean_config.parent.glob("*.bak-pre-migrate-xai-*"))
+
+
+# ---------------------------------------------------------------------------
+# Idempotence
+# ---------------------------------------------------------------------------
+
+class TestIdempotence:
+    def test_apply_twice_is_safe(self, trap_config: Path):
+        # First pass: replace
+        issues_1 = find_retired_xai_refs(_parse(trap_config))
+        apply_migration(trap_config, issues_1)
+        # Second pass: nothing to do
+        issues_2 = find_retired_xai_refs(_parse(trap_config))
+        assert issues_2 == []
+        result_2 = apply_migration(trap_config, issues_2)
+        assert result_2.config_changed is False

--- a/tests/hermes_cli/test_migrate_xai.py
+++ b/tests/hermes_cli/test_migrate_xai.py
@@ -29,7 +29,7 @@ def trap_config(tmp_path: Path) -> Path:
         "auxiliary:\n"
         "  vision:\n"
         "    provider: xai\n"
-        "    model: grok-4-fast       # retiring\n"
+        "    model: grok-4-fast-reasoning  # retiring\n"
         "  compression:\n"
         "    provider: openai         # not affected\n"
         "    model: gpt-4o-mini\n"
@@ -89,7 +89,7 @@ class TestNoOpPaths:
             apply_migration(tmp_path / "absent.yaml", issues=[
                 RetirementIssue(
                     config_path="principal.model",
-                    current_model="grok-4",
+                    current_model="grok-3",
                     replacement="grok-4.3",
                 )
             ])

--- a/tests/hermes_cli/test_xai_retirement.py
+++ b/tests/hermes_cli/test_xai_retirement.py
@@ -87,7 +87,12 @@ class TestFindRetiredEdgeCases:
     def test_xai_valid_model_not_flagged(self):
         cfg = {
             "principal": {"model": "grok-4.3"},
-            "auxiliary": {"vision": {"model": "grok-4.20-0309-reasoning"}},
+            "auxiliary": {
+                "vision": {"model": "grok-4.20-0309-reasoning"},
+                "fast": {"model": "grok-4-fast"},
+                "fast_1": {"model": "grok-4-1-fast"},
+                "bare": {"model": "grok-4"},
+            },
         }
         assert find_retired_xai_refs(cfg) == []
 
@@ -113,7 +118,7 @@ class TestFindRetiredPerSlot:
     def test_auxiliary_multiple_slots(self):
         cfg = {
             "auxiliary": {
-                "vision":      {"model": "grok-4-fast"},
+                "vision":      {"model": "grok-4-fast-reasoning"},
                 "compression": {"model": "grok-code-fast-1"},
                 "curator":     {"model": "grok-4.3"},  # not retired
                 "approval":    {"model": "gpt-4o-mini"},  # not xAI
@@ -126,7 +131,7 @@ class TestFindRetiredPerSlot:
         ]
 
     def test_auxiliary_unknown_slot_still_scanned(self):
-        cfg = {"auxiliary": {"future_slot_xyz": {"model": "grok-4"}}}
+        cfg = {"auxiliary": {"future_slot_xyz": {"model": "grok-3"}}}
         issues = find_retired_xai_refs(cfg)
         assert len(issues) == 1
         assert issues[0].config_path == "auxiliary.future_slot_xyz.model"
@@ -157,9 +162,9 @@ class TestFindRetiredPerSlot:
     def test_full_trap_config(self):
         cfg = {
             "principal":  {"model": "grok-4-1-fast-non-reasoning"},
-            "auxiliary":  {"vision": {"model": "grok-4-fast"}},
+            "auxiliary":  {"vision": {"model": "grok-4-fast-reasoning"}},
             "delegation": {"model": "grok-code-fast-1"},
-            "tts":        {"xai": {"model": "grok-4"}},  # nonsense but valid path
+            "tts":        {"xai": {"model": "grok-3"}},  # text model in TTS slot, but valid path
             "plugins": {"image_gen": {"xai": {"model": "grok-imagine-image-pro"}}},
         }
         issues = find_retired_xai_refs(cfg)
@@ -181,11 +186,10 @@ class TestMigrationSemantics:
         issue = find_retired_xai_refs(cfg)[0]
         assert issue.reasoning_effort is None
 
-    def test_ambiguous_short_name_has_note(self):
-        cfg = {"principal": {"model": "grok-4-fast"}}
+    def test_grok_3_maps_to_grok_4_3(self):
+        cfg = {"principal": {"model": "grok-3"}}
         issue = find_retired_xai_refs(cfg)[0]
-        assert issue.note is not None
-        assert "ambiguous" in issue.note.lower()
+        assert issue.replacement == "grok-4.3"
 
     def test_imagine_pro_maps_to_imagine_quality(self):
         cfg = {"plugins": {"image_gen": {"xai": {"model": "grok-imagine-image-pro"}}}}
@@ -205,12 +209,12 @@ class TestFormatIssue:
     def test_basic_format(self):
         issue = RetirementIssue(
             config_path="principal.model",
-            current_model="grok-4",
+            current_model="grok-3",
             replacement="grok-4.3",
         )
         s = format_issue(issue)
         assert "principal.model" in s
-        assert "'grok-4'" in s
+        assert "'grok-3'" in s
         assert "'grok-4.3'" in s
 
     def test_includes_reasoning_effort_when_set(self):
@@ -236,7 +240,7 @@ class TestFormatIssue:
     def test_includes_note_when_set(self):
         issue = RetirementIssue(
             config_path="principal.model",
-            current_model="grok-4",
+            current_model="grok-3",
             replacement="grok-4.3",
             note="ambiguous variant",
         )
@@ -259,15 +263,13 @@ class TestModuleConstants:
     def test_retired_models_keyset_matches_doc(self):
         # Snapshot test: if xAI's list changes we want CI to flag it.
         expected = {
-            "grok-4",
             "grok-4-0709",
-            "grok-4-fast",
             "grok-4-fast-reasoning",
             "grok-4-fast-non-reasoning",
-            "grok-4-1-fast",
             "grok-4-1-fast-reasoning",
             "grok-4-1-fast-non-reasoning",
             "grok-code-fast-1",
+            "grok-3",
             "grok-imagine-image-pro",
         }
         assert set(_RETIRED_MODELS.keys()) == expected

--- a/tests/hermes_cli/test_xai_retirement.py
+++ b/tests/hermes_cli/test_xai_retirement.py
@@ -1,0 +1,273 @@
+"""Unit tests for hermes_cli.xai_retirement (May 15, 2026 model retirement)."""
+from __future__ import annotations
+
+import pytest
+
+from hermes_cli.xai_retirement import (
+    MIGRATION_GUIDE_URL,
+    RETIREMENT_DATE,
+    RetirementIssue,
+    _RETIRED_MODELS,
+    _looks_like_xai,
+    _normalize,
+    find_retired_xai_refs,
+    format_issue,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _paths(issues):
+    return [i.config_path for i in issues]
+
+
+# ---------------------------------------------------------------------------
+# _normalize / _looks_like_xai
+# ---------------------------------------------------------------------------
+
+class TestNormalize:
+    def test_strips_x_ai_prefix(self):
+        assert _normalize("x-ai/grok-4") == "grok-4"
+
+    def test_strips_xai_prefix(self):
+        assert _normalize("xai/grok-4-fast") == "grok-4-fast"
+
+    def test_lowercases(self):
+        assert _normalize("Grok-Code-Fast-1") == "grok-code-fast-1"
+
+    def test_no_prefix_passthrough(self):
+        assert _normalize("grok-4.3") == "grok-4.3"
+
+    def test_strips_whitespace(self):
+        assert _normalize("  grok-4  ") == "grok-4"
+
+
+class TestLooksLikeXai:
+    def test_grok_prefix(self):
+        assert _looks_like_xai("grok-4")
+        assert _looks_like_xai("x-ai/grok-4-1-fast")
+
+    def test_non_grok_returns_false(self):
+        assert not _looks_like_xai("gpt-4")
+        assert not _looks_like_xai("claude-sonnet-4-6")
+        assert not _looks_like_xai("openrouter/openai/gpt-4")
+
+    def test_none_or_empty(self):
+        assert not _looks_like_xai(None)
+        assert not _looks_like_xai("")
+        assert not _looks_like_xai("   ")
+
+    def test_non_string(self):
+        assert not _looks_like_xai(42)
+        assert not _looks_like_xai({"model": "grok-4"})
+
+
+# ---------------------------------------------------------------------------
+# find_retired_xai_refs — config scanning
+# ---------------------------------------------------------------------------
+
+class TestFindRetiredEdgeCases:
+    def test_empty_config_no_issues(self):
+        assert find_retired_xai_refs({}) == []
+
+    def test_non_dict_config_returns_empty(self):
+        assert find_retired_xai_refs(None) == []  # type: ignore[arg-type]
+        assert find_retired_xai_refs("nope") == []  # type: ignore[arg-type]
+
+    def test_no_xai_models_no_issues(self):
+        cfg = {
+            "principal": {"provider": "openai", "model": "gpt-4o"},
+            "auxiliary": {"vision": {"model": "claude-sonnet-4-6"}},
+            "delegation": {"model": "openai/o3"},
+        }
+        assert find_retired_xai_refs(cfg) == []
+
+    def test_xai_valid_model_not_flagged(self):
+        cfg = {
+            "principal": {"model": "grok-4.3"},
+            "auxiliary": {"vision": {"model": "grok-4.20-0309-reasoning"}},
+        }
+        assert find_retired_xai_refs(cfg) == []
+
+
+class TestFindRetiredPerSlot:
+    def test_principal_retired(self):
+        cfg = {"principal": {"model": "grok-code-fast-1"}}
+        issues = find_retired_xai_refs(cfg)
+        assert len(issues) == 1
+        assert issues[0].config_path == "principal.model"
+        assert issues[0].current_model == "grok-code-fast-1"
+        assert issues[0].replacement == "grok-4.3"
+        assert issues[0].reasoning_effort is None
+
+    def test_principal_with_x_ai_prefix(self):
+        cfg = {"principal": {"model": "x-ai/grok-4-1-fast-non-reasoning"}}
+        issues = find_retired_xai_refs(cfg)
+        assert len(issues) == 1
+        assert issues[0].current_model == "x-ai/grok-4-1-fast-non-reasoning"
+        assert issues[0].replacement == "grok-4.3"
+        assert issues[0].reasoning_effort == "none"
+
+    def test_auxiliary_multiple_slots(self):
+        cfg = {
+            "auxiliary": {
+                "vision":      {"model": "grok-4-fast"},
+                "compression": {"model": "grok-code-fast-1"},
+                "curator":     {"model": "grok-4.3"},  # not retired
+                "approval":    {"model": "gpt-4o-mini"},  # not xAI
+            }
+        }
+        issues = find_retired_xai_refs(cfg)
+        assert sorted(_paths(issues)) == [
+            "auxiliary.compression.model",
+            "auxiliary.vision.model",
+        ]
+
+    def test_auxiliary_unknown_slot_still_scanned(self):
+        cfg = {"auxiliary": {"future_slot_xyz": {"model": "grok-4"}}}
+        issues = find_retired_xai_refs(cfg)
+        assert len(issues) == 1
+        assert issues[0].config_path == "auxiliary.future_slot_xyz.model"
+
+    def test_delegation_retired(self):
+        cfg = {"delegation": {"model": "grok-4-fast-reasoning"}}
+        issues = find_retired_xai_refs(cfg)
+        assert _paths(issues) == ["delegation.model"]
+
+    def test_tts_xai_retired(self):
+        cfg = {"tts": {"xai": {"model": "grok-imagine-image-pro"}}}
+        issues = find_retired_xai_refs(cfg)
+        assert _paths(issues) == ["tts.xai.model"]
+        assert issues[0].replacement == "grok-imagine-image-quality"
+
+    def test_image_gen_plugin_retired(self):
+        cfg = {
+            "plugins": {
+                "image_gen": {
+                    "xai": {"model": "grok-imagine-image-pro"}
+                }
+            }
+        }
+        issues = find_retired_xai_refs(cfg)
+        assert _paths(issues) == ["plugins.image_gen.xai.model"]
+        assert issues[0].replacement == "grok-imagine-image-quality"
+
+    def test_full_trap_config(self):
+        cfg = {
+            "principal":  {"model": "grok-4-1-fast-non-reasoning"},
+            "auxiliary":  {"vision": {"model": "grok-4-fast"}},
+            "delegation": {"model": "grok-code-fast-1"},
+            "tts":        {"xai": {"model": "grok-4"}},  # nonsense but valid path
+            "plugins": {"image_gen": {"xai": {"model": "grok-imagine-image-pro"}}},
+        }
+        issues = find_retired_xai_refs(cfg)
+        assert len(issues) == 5
+
+
+# ---------------------------------------------------------------------------
+# Migration semantics
+# ---------------------------------------------------------------------------
+
+class TestMigrationSemantics:
+    def test_non_reasoning_variant_recommends_reasoning_effort_none(self):
+        cfg = {"principal": {"model": "grok-4-fast-non-reasoning"}}
+        issue = find_retired_xai_refs(cfg)[0]
+        assert issue.reasoning_effort == "none"
+
+    def test_reasoning_variant_no_extra_param(self):
+        cfg = {"principal": {"model": "grok-4-1-fast-reasoning"}}
+        issue = find_retired_xai_refs(cfg)[0]
+        assert issue.reasoning_effort is None
+
+    def test_ambiguous_short_name_has_note(self):
+        cfg = {"principal": {"model": "grok-4-fast"}}
+        issue = find_retired_xai_refs(cfg)[0]
+        assert issue.note is not None
+        assert "ambiguous" in issue.note.lower()
+
+    def test_imagine_pro_maps_to_imagine_quality(self):
+        cfg = {"plugins": {"image_gen": {"xai": {"model": "grok-imagine-image-pro"}}}}
+        issue = find_retired_xai_refs(cfg)[0]
+        assert issue.replacement == "grok-imagine-image-quality"
+
+    def test_all_retired_have_replacement(self):
+        for name, entry in _RETIRED_MODELS.items():
+            assert entry.get("replacement"), f"{name} has no replacement"
+
+
+# ---------------------------------------------------------------------------
+# format_issue
+# ---------------------------------------------------------------------------
+
+class TestFormatIssue:
+    def test_basic_format(self):
+        issue = RetirementIssue(
+            config_path="principal.model",
+            current_model="grok-4",
+            replacement="grok-4.3",
+        )
+        s = format_issue(issue)
+        assert "principal.model" in s
+        assert "'grok-4'" in s
+        assert "'grok-4.3'" in s
+
+    def test_includes_reasoning_effort_when_set(self):
+        issue = RetirementIssue(
+            config_path="principal.model",
+            current_model="grok-4-fast-non-reasoning",
+            replacement="grok-4.3",
+            reasoning_effort="none",
+        )
+        s = format_issue(issue)
+        assert 'reasoning_effort: "none"' in s
+
+    def test_omits_reasoning_effort_when_none(self):
+        issue = RetirementIssue(
+            config_path="principal.model",
+            current_model="grok-code-fast-1",
+            replacement="grok-4.3",
+            reasoning_effort=None,
+        )
+        s = format_issue(issue)
+        assert "reasoning_effort" not in s
+
+    def test_includes_note_when_set(self):
+        issue = RetirementIssue(
+            config_path="principal.model",
+            current_model="grok-4",
+            replacement="grok-4.3",
+            note="ambiguous variant",
+        )
+        s = format_issue(issue)
+        assert "[note: ambiguous variant]" in s
+
+
+# ---------------------------------------------------------------------------
+# Module-level constants sanity
+# ---------------------------------------------------------------------------
+
+class TestModuleConstants:
+    def test_retirement_date_is_may_15(self):
+        assert "May 15, 2026" == RETIREMENT_DATE
+
+    def test_migration_guide_url_points_to_xai(self):
+        assert MIGRATION_GUIDE_URL.startswith("https://docs.x.ai/")
+        assert "may-15" in MIGRATION_GUIDE_URL.lower()
+
+    def test_retired_models_keyset_matches_doc(self):
+        # Snapshot test: if xAI's list changes we want CI to flag it.
+        expected = {
+            "grok-4",
+            "grok-4-0709",
+            "grok-4-fast",
+            "grok-4-fast-reasoning",
+            "grok-4-fast-non-reasoning",
+            "grok-4-1-fast",
+            "grok-4-1-fast-reasoning",
+            "grok-4-1-fast-non-reasoning",
+            "grok-code-fast-1",
+            "grok-imagine-image-pro",
+        }
+        assert set(_RETIRED_MODELS.keys()) == expected


### PR DESCRIPTION
## Summary
Adds `hermes migrate xai [--apply] [--no-backup]` — a one-shot, opt-in CLI helper to rewrite `config.yaml` so it stops referencing xAI models being retired on **May 15, 2026**. Pairs with #23278 (doctor + chat-startup warning) — that PR tells users *what* needs to change; this PR is the actual *fix-it* button.

## Stacked on top of #23278
This PR's branch contains the 3 commits from #23278 plus 2 new commits:
```
3dd1d620a feat(cli): hermes migrate xai [--apply] [--no-backup]                  ← new
9322cf948 feat(xai): apply_migration — rewrite config.yaml in-place via ruamel    ← new
2e6bf2177 feat(cli): warn about retired xAI models at chat startup                ← from #23278
0f776094a feat(doctor): surface xAI model retirement in hermes doctor             ← from #23278
bf9a09abf feat(xai): detect retired xAI models (May 15, 2026)                     ← from #23278
```
- If **#23278 merges first** → this PR becomes a clean 2-commit follow-up.
- If **this PR merges first** → #23278 becomes empty and I'll close it.

## What's new in this PR (the bottom 2 commits)

### `hermes_cli/xai_retirement.py` — `apply_migration()`
- Reads `config.yaml` with `ruamel.yaml` round-trip (`YAML(typ="rt")`, `preserve_quotes=True`) so **comments, key order, indentation, and scalar types are preserved**. Treats config.yaml as a user-edited file, not a data dump.
- For each `RetirementIssue` returned by `find_retired_xai_refs`:
  - sets `parent[leaf] = issue.replacement`
  - if `issue.reasoning_effort` is non-empty (i.e. the source model was a `*-non-reasoning` variant), also writes a sibling `reasoning_effort` key alongside the model — this is the migration nuance that's easy to miss when swapping the model name alone.
- Writes a timestamped backup `<config>.bak-pre-migrate-xai-YYYYMMDD-HHMMSS` before rewriting; opt-out via `backup=False`.
- Returns an `ApplyResult(file_path, backup_path, issues_resolved, config_changed)` so callers can render whatever feedback they want.
- Empty-issues list, missing slot, or empty config → no-op (no backup written, no rewrite).

### `hermes_cli/migrate.py` — CLI handler
New module to keep `main.py` dispatching only. `cmd_migrate_xai`:
- Always prints the diagnostic block (same format as `hermes doctor`'s xAI section).
- Default = dry-run: prints what would change, returns 0.
- `--apply`: backs up + rewrites; prints success summary or surfaces error and returns 1.
- `--no-backup`: opt-in only.

### `hermes_cli/main.py` — sub-parser wiring
Registers a new top-level `migrate` parser with a `xai` sub-parser, modeled on the existing `gateway`-style nested sub-parsers. Imports the handler module locally (same pattern as `cmd_fallback`).

## End-to-end smoke test
On a config with comments and the four retired-model slots populated:

```yaml
# Hermes config — manually crafted for migration smoke test
principal:
  provider: xai
  model: grok-4-1-fast-non-reasoning  # this should migrate
  temperature: 0.5
auxiliary:
  vision:
    provider: xai
    model: grok-4-fast      # ambiguous variant
delegation:
  model: grok-code-fast-1   # retiring
```

`hermes migrate xai --apply` produces:

```yaml
# Hermes config — manually crafted for migration smoke test
principal:
  provider: xai
  model: grok-4.3                     # this should migrate
  temperature: 0.5
  reasoning_effort: none
auxiliary:
  vision:
    provider: xai
    model: grok-4.3         # ambiguous variant
delegation:
  model: grok-4.3           # retiring
```

…with `config.yaml.bak-pre-migrate-xai-20260510-210033` next to it. Comments, key order, type literals (the `0.5` float) — all preserved.

## Tests
17 new unit tests in `tests/hermes_cli/test_migrate_xai.py`:
- **No-op paths**: empty config, empty issues list, missing file → `FileNotFoundError`, clean config produces `config_changed=False` and no backup.
- **Surgical replacement**: principal, auxiliary.vision, delegation, plugins.image_gen.xai. `auxiliary.compression` (openai, untouched). `principal.temperature` survives.
- **Migration semantics**: non-reasoning variant adds `reasoning_effort: "none"`; ambiguous bare names get the right replacement.
- **Round-trip preservation**: top-of-file comment, inline comments on unmodified lines, top-level key order.
- **Backup behavior**: default backup written, filename prefix correct, `backup=False` skips, no-changes → no backup.
- **Idempotence**: applying twice is safe — the second pass finds zero issues and does nothing.

50/50 tests pass when combined with the test suite from #23278 (`pytest tests/hermes_cli/test_xai_retirement.py tests/hermes_cli/test_migrate_xai.py`).

## Backward compatibility
- Pure addition. No public API changes, no config schema changes.
- `ruamel.yaml` is already in `pyproject.toml` (`>=0.18.16,<0.19`) — no new dependency.
- The migrate command is opt-in: nothing happens to a user's config unless they explicitly run `hermes migrate xai --apply`.
- Default backup is on; `--no-backup` is the only way to skip it.

## Why one PR per layer
PR #23278 (diagnostic) and this PR (action) could've been a single 700-LoC PR. Splitting them gives:
- A useful diagnostic available even if review on the rewriter takes longer (the doctor + startup warning ship value on day 1).
- A smaller second PR focused on the *one* tricky bit: ruamel round-trip semantics. Easier to review the YAML-rewriting logic in isolation.
- Clear answer to "what if the user just wants to know without me touching their config?" — that user runs `hermes doctor` and stops there.
