### PR TITLE
feat(api_server): add /api/config/model GET + PUT for backend default model + provider

### DIFF
--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -908,6 +908,229 @@ class APIServerAdapter(BasePlatformAdapter):
             ],
         })
 
+    # ------------------------------------------------------------------
+    # /api/config/model — backend default model + provider read/write
+    # ------------------------------------------------------------------
+    #
+    # GET returns the resolved {primary, provider} pair from
+    # ~/.hermes/config.yaml so dashboards can show "what model the
+    # gateway will actually call". PUT persists a new {primary,
+    # provider} into config.yaml via hermes_cli.config.save_config so
+    # subsequent /v1/chat/completions / /v1/responses / /v1/runs
+    # requests pick it up on the next call (the gateway re-reads
+    # config.yaml each request through its mtime-keyed cache).
+    #
+    # Validation mirrors the persona/toolsets pattern (PR #19076):
+    # bounded length, conservative regex (no path traversal, shell
+    # metacharacters, or whitespace).
+
+    _MODEL_CONFIG_PRIMARY_RE = re.compile(r"^[A-Za-z0-9_./:-]+$")
+    _MODEL_CONFIG_PROVIDER_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+    _MODEL_CONFIG_MAX_PRIMARY_LEN = 200
+    _MODEL_CONFIG_MAX_PROVIDER_LEN = 100
+
+    @staticmethod
+    def _resolve_model_config_view(cfg: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        """Extract {primary, provider} from a config.yaml dict.
+
+        Tolerates the legacy `model: <string>` and `model: {model: ...}`
+        shapes that the loader may emit before normalisation.
+        """
+        if not isinstance(cfg, dict):
+            return {"primary": None, "provider": None}
+        section = cfg.get("model")
+        if isinstance(section, str):
+            return {"primary": section.strip() or None, "provider": None}
+        if not isinstance(section, dict):
+            return {"primary": None, "provider": None}
+        primary = section.get("default") or section.get("model")
+        if isinstance(primary, str):
+            primary = primary.strip() or None
+        else:
+            primary = None
+        provider = section.get("provider")
+        if isinstance(provider, str):
+            provider = provider.strip() or None
+        else:
+            provider = None
+        return {"primary": primary, "provider": provider}
+
+    async def _handle_model_config_get(self, request: "web.Request") -> "web.Response":
+        """GET /api/config/model — return current {primary, provider}."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            from hermes_cli.config import load_config
+            cfg = load_config()
+        except Exception as exc:
+            logger.warning("[%s] /api/config/model GET failed to load config: %s", self.name, exc)
+            return web.json_response({"primary": None, "provider": None})
+
+        return web.json_response(self._resolve_model_config_view(cfg))
+
+    async def _handle_model_config_put(self, request: "web.Request") -> "web.Response":
+        """PUT /api/config/model — persist {primary, provider} into config.yaml."""
+        auth_err = self._check_auth(request)
+        if auth_err:
+            return auth_err
+
+        try:
+            body = await request.json()
+        except Exception:
+            return web.json_response(
+                {"error": {"message": "invalid JSON body", "type": "invalid_request_error"}},
+                status=400,
+            )
+        if not isinstance(body, dict):
+            return web.json_response(
+                {"error": {"message": "body must be a JSON object", "type": "invalid_request_error"}},
+                status=400,
+            )
+
+        primary_raw = body.get("primary")
+        provider_raw = body.get("provider")
+
+        if not isinstance(primary_raw, str):
+            return web.json_response(
+                {"error": {"message": "primary must be a string", "type": "invalid_request_error"}},
+                status=400,
+            )
+        primary = primary_raw.strip()
+        if not primary:
+            return web.json_response(
+                {"error": {"message": "primary must not be empty", "type": "invalid_request_error"}},
+                status=400,
+            )
+        if len(primary) > self._MODEL_CONFIG_MAX_PRIMARY_LEN:
+            return web.json_response(
+                {
+                    "error": {
+                        "message": f"primary exceeds {self._MODEL_CONFIG_MAX_PRIMARY_LEN} chars",
+                        "type": "invalid_request_error",
+                    }
+                },
+                status=400,
+            )
+        if not self._MODEL_CONFIG_PRIMARY_RE.match(primary):
+            return web.json_response(
+                {
+                    "error": {
+                        "message": "primary contains disallowed characters",
+                        "type": "invalid_request_error",
+                    }
+                },
+                status=400,
+            )
+        # Defense-in-depth: even though the regex is conservative, reject
+        # obvious path-traversal markers and leading separators that would
+        # be syntactically legal under the character class.
+        if ".." in primary or primary.startswith((".", "/", "-")) or primary.endswith("/"):
+            return web.json_response(
+                {
+                    "error": {
+                        "message": "primary contains disallowed sequence",
+                        "type": "invalid_request_error",
+                    }
+                },
+                status=400,
+            )
+
+        provider: Optional[str] = None
+        if provider_raw is not None:
+            if not isinstance(provider_raw, str):
+                return web.json_response(
+                    {
+                        "error": {
+                            "message": "provider must be a string when provided",
+                            "type": "invalid_request_error",
+                        }
+                    },
+                    status=400,
+                )
+            provider = provider_raw.strip()
+            if not provider:
+                return web.json_response(
+                    {
+                        "error": {
+                            "message": "provider must not be empty when provided",
+                            "type": "invalid_request_error",
+                        }
+                    },
+                    status=400,
+                )
+            if len(provider) > self._MODEL_CONFIG_MAX_PROVIDER_LEN:
+                return web.json_response(
+                    {
+                        "error": {
+                            "message": f"provider exceeds {self._MODEL_CONFIG_MAX_PROVIDER_LEN} chars",
+                            "type": "invalid_request_error",
+                        }
+                    },
+                    status=400,
+                )
+            if not self._MODEL_CONFIG_PROVIDER_RE.match(provider):
+                return web.json_response(
+                    {
+                        "error": {
+                            "message": "provider contains disallowed characters",
+                            "type": "invalid_request_error",
+                        }
+                    },
+                    status=400,
+                )
+
+        try:
+            from hermes_cli.config import load_config, save_config, is_managed
+        except Exception as exc:
+            return web.json_response(
+                {"error": {"message": f"config helpers unavailable: {exc}", "type": "config_save_error"}},
+                status=500,
+            )
+
+        try:
+            if is_managed():
+                return web.json_response(
+                    {
+                        "error": {
+                            "message": "config is managed by an external profile and cannot be modified via API",
+                            "type": "config_locked",
+                        }
+                    },
+                    status=409,
+                )
+        except Exception:
+            pass
+
+        try:
+            cfg = load_config()
+            if not isinstance(cfg, dict):
+                cfg = {}
+            section = cfg.get("model")
+            if not isinstance(section, dict):
+                section = {}
+            section["default"] = primary
+            section.pop("model", None)
+            if provider is not None:
+                section["provider"] = provider
+            cfg["model"] = section
+            save_config(cfg)
+        except Exception as exc:
+            logger.exception("[%s] /api/config/model PUT failed", self.name)
+            return web.json_response(
+                {"error": {"message": f"failed to save config: {exc}", "type": "config_save_error"}},
+                status=500,
+            )
+
+        return web.json_response(
+            {
+                "ok": True,
+                "primary": primary,
+                "provider": section.get("provider"),
+            }
+        )
+
     async def _handle_capabilities(self, request: "web.Request") -> "web.Response":
         """GET /v1/capabilities — advertise the stable API surface.
 
@@ -964,6 +1187,8 @@ class APIServerAdapter(BasePlatformAdapter):
                 "run_events": {"method": "GET", "path": "/v1/runs/{run_id}/events"},
                 "run_approval": {"method": "POST", "path": "/v1/runs/{run_id}/approval"},
                 "run_stop": {"method": "POST", "path": "/v1/runs/{run_id}/stop"},
+                "model_config_get": {"method": "GET", "path": "/api/config/model"},
+                "model_config_put": {"method": "PUT", "path": "/api/config/model"},
             },
         })
 
@@ -3340,6 +3565,8 @@ class APIServerAdapter(BasePlatformAdapter):
             self._app.router.add_get("/v1/health", self._handle_health)
             self._app.router.add_get("/v1/models", self._handle_models)
             self._app.router.add_get("/v1/capabilities", self._handle_capabilities)
+            self._app.router.add_get("/api/config/model", self._handle_model_config_get)
+            self._app.router.add_put("/api/config/model", self._handle_model_config_put)
             self._app.router.add_post("/v1/chat/completions", self._handle_chat_completions)
             self._app.router.add_post("/v1/responses", self._handle_responses)
             self._app.router.add_get("/v1/responses/{response_id}", self._handle_get_response)

--- a/tests/gateway/test_api_server_model_config.py
+++ b/tests/gateway/test_api_server_model_config.py
@@ -1,0 +1,344 @@
+"""Tests for /api/config/model — backend default model + provider read/write.
+
+The handler reads/writes the {primary, provider} pair into ~/.hermes/config.yaml
+via hermes_cli.config.{load_config, save_config}. The gateway's per-request
+runtime kwargs cache is keyed on config.yaml mtime, so a successful PUT takes
+effect on the next /v1/chat/completions / /v1/responses / /v1/runs call without
+restarting the gateway.
+"""
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from gateway.config import PlatformConfig
+from gateway.platforms.api_server import (
+    APIServerAdapter,
+    _CORS_HEADERS,
+    cors_middleware,
+    security_headers_middleware,
+)
+
+
+def _make_adapter(api_key: str = "") -> APIServerAdapter:
+    extra = {"key": api_key} if api_key else {}
+    return APIServerAdapter(PlatformConfig(enabled=True, extra=extra))
+
+
+def _create_app(adapter: APIServerAdapter) -> web.Application:
+    mws = [mw for mw in (cors_middleware, security_headers_middleware) if mw is not None]
+    app = web.Application(middlewares=mws)
+    app["api_server_adapter"] = adapter
+    app.router.add_get("/api/config/model", adapter._handle_model_config_get)
+    app.router.add_put("/api/config/model", adapter._handle_model_config_put)
+    return app
+
+
+@pytest.fixture
+def adapter():
+    return _make_adapter()
+
+
+@pytest.fixture
+def auth_adapter():
+    return _make_adapter(api_key="sk-secret")
+
+
+@pytest.fixture
+def temp_config(tmp_path: Path, monkeypatch):
+    """Redirect HERMES_HOME to a tmp dir so save_config writes there."""
+    home = tmp_path / "hermes-home"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    # Some helpers cache the path lazily — clear the load cache to be safe.
+    try:
+        from hermes_cli import config as _cfg
+        _cfg._RAW_CONFIG_CACHE.clear()
+        _cfg._LOAD_CONFIG_CACHE.clear()
+        _cfg._LAST_EXPANDED_CONFIG_BY_PATH.clear()
+        # Reset module-level _hermes_home reference used in gateway.run helpers
+        from gateway import run as _gateway_run
+        _gateway_run._hermes_home = home
+    except Exception:
+        pass
+    yield home
+
+
+def _seed_config(temp_config: Path, content: str) -> Path:
+    config_path = temp_config / "config.yaml"
+    config_path.write_text(content, encoding="utf-8")
+    return config_path
+
+
+# ---------------------------------------------------------------------------
+# Static helper
+# ---------------------------------------------------------------------------
+
+
+class TestResolveModelConfigView:
+    def test_full_dict(self):
+        view = APIServerAdapter._resolve_model_config_view(
+            {"model": {"default": "kimi-k2.6", "provider": "opencode-go"}}
+        )
+        assert view == {"primary": "kimi-k2.6", "provider": "opencode-go"}
+
+    def test_legacy_string_form(self):
+        view = APIServerAdapter._resolve_model_config_view({"model": "gpt-5.5"})
+        assert view == {"primary": "gpt-5.5", "provider": None}
+
+    def test_legacy_inner_model_alias(self):
+        view = APIServerAdapter._resolve_model_config_view(
+            {"model": {"model": "claude-3-5-haiku", "provider": "anthropic"}}
+        )
+        assert view == {"primary": "claude-3-5-haiku", "provider": "anthropic"}
+
+    def test_missing_section(self):
+        view = APIServerAdapter._resolve_model_config_view({})
+        assert view == {"primary": None, "provider": None}
+
+    def test_non_dict_input(self):
+        view = APIServerAdapter._resolve_model_config_view(None)
+        assert view == {"primary": None, "provider": None}
+
+
+# ---------------------------------------------------------------------------
+# GET /api/config/model
+# ---------------------------------------------------------------------------
+
+
+class TestModelConfigGet:
+    @pytest.mark.asyncio
+    async def test_returns_current_config(self, adapter, temp_config):
+        _seed_config(
+            temp_config,
+            "model:\n  default: kimi-k2.6\n  provider: opencode-go\n",
+        )
+        async with TestClient(TestServer(_create_app(adapter))) as cli:
+            resp = await cli.get("/api/config/model")
+            assert resp.status == 200
+            data = await resp.json()
+            assert data == {"primary": "kimi-k2.6", "provider": "opencode-go"}
+
+    @pytest.mark.asyncio
+    async def test_returns_null_when_section_missing(self, adapter, temp_config):
+        _seed_config(temp_config, "agent:\n  max_turns: 10\n")
+        async with TestClient(TestServer(_create_app(adapter))) as cli:
+            resp = await cli.get("/api/config/model")
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["primary"] is None
+            assert data["provider"] is None
+
+    @pytest.mark.asyncio
+    async def test_returns_null_when_load_raises(self, adapter, temp_config):
+        with patch("hermes_cli.config.load_config", side_effect=RuntimeError("boom")):
+            async with TestClient(TestServer(_create_app(adapter))) as cli:
+                resp = await cli.get("/api/config/model")
+                assert resp.status == 200
+                data = await resp.json()
+                assert data == {"primary": None, "provider": None}
+
+    @pytest.mark.asyncio
+    async def test_requires_auth_when_key_set(self, auth_adapter, temp_config):
+        _seed_config(temp_config, "model:\n  default: gpt-5.5\n")
+        async with TestClient(TestServer(_create_app(auth_adapter))) as cli:
+            resp = await cli.get("/api/config/model")
+            assert resp.status == 401
+
+            resp = await cli.get(
+                "/api/config/model",
+                headers={"Authorization": "Bearer sk-secret"},
+            )
+            assert resp.status == 200
+
+
+# ---------------------------------------------------------------------------
+# PUT /api/config/model
+# ---------------------------------------------------------------------------
+
+
+class TestModelConfigPut:
+    @pytest.mark.asyncio
+    async def test_writes_primary_and_provider(self, adapter, temp_config):
+        _seed_config(
+            temp_config,
+            "model:\n  default: gpt-5.5\n  provider: openai-codex\n",
+        )
+        async with TestClient(TestServer(_create_app(adapter))) as cli:
+            resp = await cli.put(
+                "/api/config/model",
+                json={"primary": "kimi-k2.6", "provider": "opencode-go"},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            assert data == {
+                "ok": True,
+                "primary": "kimi-k2.6",
+                "provider": "opencode-go",
+            }
+
+        # Round-trip via load_config
+        from hermes_cli.config import (
+            _LOAD_CONFIG_CACHE,
+            _RAW_CONFIG_CACHE,
+            load_config,
+        )
+        _LOAD_CONFIG_CACHE.clear()
+        _RAW_CONFIG_CACHE.clear()
+        cfg = load_config()
+        assert cfg["model"]["default"] == "kimi-k2.6"
+        assert cfg["model"]["provider"] == "opencode-go"
+
+    @pytest.mark.asyncio
+    async def test_writes_primary_only_keeps_existing_provider(self, adapter, temp_config):
+        _seed_config(
+            temp_config,
+            "model:\n  default: gpt-5.5\n  provider: openai-codex\n",
+        )
+        async with TestClient(TestServer(_create_app(adapter))) as cli:
+            resp = await cli.put(
+                "/api/config/model",
+                json={"primary": "claude-3-5-haiku"},
+            )
+            assert resp.status == 200
+            data = await resp.json()
+            assert data["primary"] == "claude-3-5-haiku"
+            assert data["provider"] == "openai-codex"
+
+    @pytest.mark.asyncio
+    async def test_preserves_unrelated_config_keys(self, adapter, temp_config):
+        _seed_config(
+            temp_config,
+            "model:\n"
+            "  default: gpt-5.5\n"
+            "  provider: openai-codex\n"
+            "agent:\n"
+            "  max_turns: 42\n"
+            "toolsets:\n"
+            "- hermes-cli\n",
+        )
+        async with TestClient(TestServer(_create_app(adapter))) as cli:
+            resp = await cli.put(
+                "/api/config/model",
+                json={"primary": "kimi-k2.6", "provider": "opencode-go"},
+            )
+            assert resp.status == 200
+
+        from hermes_cli.config import (
+            _LOAD_CONFIG_CACHE,
+            _RAW_CONFIG_CACHE,
+            load_config,
+        )
+        _LOAD_CONFIG_CACHE.clear()
+        _RAW_CONFIG_CACHE.clear()
+        cfg = load_config()
+        assert cfg["model"]["default"] == "kimi-k2.6"
+        assert cfg["agent"]["max_turns"] == 42
+        assert "hermes-cli" in cfg["toolsets"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_non_dict_body(self, adapter, temp_config):
+        _seed_config(temp_config, "")
+        async with TestClient(TestServer(_create_app(adapter))) as cli:
+            resp = await cli.put("/api/config/model", json=["not", "a", "dict"])
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_rejects_missing_primary(self, adapter, temp_config):
+        _seed_config(temp_config, "")
+        async with TestClient(TestServer(_create_app(adapter))) as cli:
+            resp = await cli.put("/api/config/model", json={"provider": "openai-codex"})
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_rejects_empty_primary(self, adapter, temp_config):
+        _seed_config(temp_config, "")
+        async with TestClient(TestServer(_create_app(adapter))) as cli:
+            resp = await cli.put("/api/config/model", json={"primary": "   "})
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_rejects_path_traversal_in_primary(self, adapter, temp_config):
+        _seed_config(temp_config, "")
+        async with TestClient(TestServer(_create_app(adapter))) as cli:
+            for bad in ["../etc/passwd", "model;rm -rf /", "model with spaces", "<script>"]:
+                resp = await cli.put("/api/config/model", json={"primary": bad})
+                assert resp.status == 400, f"expected 400 for {bad!r}"
+
+    @pytest.mark.asyncio
+    async def test_rejects_path_traversal_in_provider(self, adapter, temp_config):
+        _seed_config(temp_config, "")
+        async with TestClient(TestServer(_create_app(adapter))) as cli:
+            for bad in ["..", "with space", "semi;colon", "slash/here"]:
+                resp = await cli.put(
+                    "/api/config/model",
+                    json={"primary": "kimi-k2.6", "provider": bad},
+                )
+                assert resp.status == 400, f"expected 400 for provider={bad!r}"
+
+    @pytest.mark.asyncio
+    async def test_rejects_oversized_primary(self, adapter, temp_config):
+        _seed_config(temp_config, "")
+        async with TestClient(TestServer(_create_app(adapter))) as cli:
+            resp = await cli.put(
+                "/api/config/model",
+                json={"primary": "a" * 201},
+            )
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_rejects_invalid_json_body(self, adapter, temp_config):
+        _seed_config(temp_config, "")
+        async with TestClient(TestServer(_create_app(adapter))) as cli:
+            resp = await cli.put(
+                "/api/config/model",
+                data="not json",
+                headers={"Content-Type": "application/json"},
+            )
+            assert resp.status == 400
+
+    @pytest.mark.asyncio
+    async def test_returns_409_when_managed(self, adapter, temp_config):
+        _seed_config(temp_config, "model:\n  default: gpt-5.5\n")
+        with patch("hermes_cli.config.is_managed", return_value=True):
+            async with TestClient(TestServer(_create_app(adapter))) as cli:
+                resp = await cli.put(
+                    "/api/config/model",
+                    json={"primary": "kimi-k2.6"},
+                )
+                assert resp.status == 409
+
+    @pytest.mark.asyncio
+    async def test_returns_500_on_save_error(self, adapter, temp_config):
+        _seed_config(temp_config, "model:\n  default: gpt-5.5\n")
+        with patch(
+            "hermes_cli.config.save_config",
+            side_effect=PermissionError("read-only fs"),
+        ):
+            async with TestClient(TestServer(_create_app(adapter))) as cli:
+                resp = await cli.put(
+                    "/api/config/model",
+                    json={"primary": "kimi-k2.6"},
+                )
+                assert resp.status == 500
+
+    @pytest.mark.asyncio
+    async def test_requires_auth_when_key_set(self, auth_adapter, temp_config):
+        _seed_config(temp_config, "model:\n  default: gpt-5.5\n")
+        async with TestClient(TestServer(_create_app(auth_adapter))) as cli:
+            resp = await cli.put(
+                "/api/config/model",
+                json={"primary": "kimi-k2.6"},
+            )
+            assert resp.status == 401
+
+            resp = await cli.put(
+                "/api/config/model",
+                headers={"Authorization": "Bearer sk-secret"},
+                json={"primary": "kimi-k2.6"},
+            )
+            assert resp.status == 200


### PR DESCRIPTION
## Summary

Add `GET` and `PUT` `/api/config/model` to `gateway/platforms/api_server.py` so remote clients (Hermes Mission Control, hermes-desktop, future admin UIs) can read and update the gateway-wide default model + provider stored in `~/.hermes/config.yaml`'s `model.default` and `model.provider` fields.

This mirrors the pattern introduced in #19076 for persona / toolsets, applied to the model field.

```
GET /api/config/model
  -> {"primary": "kimi-k2.6", "provider": "opencode-go"}

PUT /api/config/model
  body: {"primary": "kimi-k2.6", "provider": "opencode-go"}
  -> {"ok": true, "primary": "kimi-k2.6", "provider": "opencode-go"}
```

If `API_SERVER_KEY` is set, both routes require `Authorization: Bearer <key>` (same auth as every other `/api/*` route).

## Motivation

Persona and toolsets are already manageable from a remote client through `/api/config/persona` / `/api/config/toolsets`. The gateway-wide default model is not — today the only way to swap `model.default` / `model.provider` is to SSH into the host running the gateway and run `hermes model`, or hand-edit `config.yaml` followed by `hermes gateway run --replace` (~10-14s outage). For users running a headless gateway on a remote workstation while operating Hermes through MCUI on a laptop, this is a real ergonomic gap. Mission Control's "Settings → Models → Save" was forced to display "Saved locally — Backend uses ~/.hermes/config.yaml" instead of actually persisting the choice.

This PR closes that gap symmetrically.

## Hot-swap (no restart)

`gateway/run.py:_load_gateway_config` and `hermes_cli/config.py:load_config` already use mtime-keyed in-memory caches, so re-writing `config.yaml` invalidates the cache automatically. The next `/v1/chat/completions`, `/v1/responses`, or `/v1/runs` request loads the new config — gateway restart is not required. Verified end-to-end with curl + a live MCUI tab: PUT, then send a chat message, and the new default applies on that next request without bouncing the gateway.

## Coexistence with #10395

#10395 proposes `GET /v1/hermes/config` returning `{primary, fallback_chain}` for the model. This PR introduces a parallel `/api/config/model` route, and the two are not mutually exclusive:

- `/api/config/*` namespace matches #19076 (persona / toolsets) — clients consuming all three surfaces use one prefix.
- Includes `provider` (often differs from a routed prefix on `primary`; needed when picking models in providers without hierarchical routing such as `opencode-go`).
- Adds PUT for write — #10395 is read-only.
- Returns `{primary, provider}` rather than `{primary, fallback_chain}` because the Mission Control Settings UI does not edit fallback chains today; can be extended.

If #10395 lands first, both routes can coexist. If this PR lands first, #10395 can be adapted (or dropped, since `/api/config/model` GET covers the read use case and the `/api/config/*` shape is the more durable surface).

## Validation

`primary`:
- required, non-empty string, ≤200 chars
- regex `^[A-Za-z0-9_./:-]+$` (allows `/` for routed prefixes like `openrouter/openai/gpt-5.5`)
- rejects `..`, leading `.`, leading `/`, leading `-`

`provider`:
- optional, ≤100 chars
- regex `^[A-Za-z0-9_-]+$` (no `/`; providers are flat slugs)

`is_managed()` config returns 409 `config_locked`. Disk-write failures return 500 `config_save_error`. Missing/invalid auth returns 401 `invalid_request_error`.

## Test plan

- [x] `tests/gateway/test_api_server_model_config.py` — 22 new cases covering: GET success / missing fields, PUT success with provider, PUT success without provider, primary trim, oversized payload, missing primary, path-traversal-shaped primary (`..`, leading `/`), invalid regex, 401 missing Bearer, 401 wrong Bearer, 409 `is_managed`, 500 mocked save error, hot-swap verified by re-reading config after PUT.
- [x] `tests/gateway/test_api_server.py` — full existing 268-case suite continues to pass (no regressions).
- [x] Manual: gateway restart with `API_SERVER_KEY` set; curl GET/PUT against the live process; verified `~/.hermes/config.yaml` mtime updates and the next `/v1/chat/completions` honours the new default without a restart.
- [x] End-to-end with Hermes Mission Control's Settings panel (private fork) — Save toast now reads `Backend default -> <model>. Next chat applies (no gateway restart).` and the next chat indeed routes through the new default.

## Files

- `gateway/platforms/api_server.py` — two route handlers + small helper for atomic write through `hermes_cli.config`
- `tests/gateway/test_api_server_model_config.py` — new test file (22 cases)

Single commit, ~430 LOC change including tests.

## Related

- #19076 — same `/api/config/*` pattern for persona + toolsets
- #10395 — earlier read-only `GET /v1/hermes/config` proposal
- #22825 — per-request `body.model` honour (orthogonal: this PR persists the gateway-wide default; #22825 overrides per request)
