### PR TITLE
feat(xai): xai_deferred_chat tool — long-running completions via submit + poll

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -106,20 +106,13 @@ def _codex_curated_models() -> list[str]:
 
 
 # Static fallback for xAI when the models.dev disk cache is empty (fresh
-# install, offline first run, etc.). Mirrors the xAI-direct model IDs from
-# $HERMES_HOME/models_dev_cache.json as of 2026-04-28. Whenever xAI renames
-# or retires a model, the disk cache picks it up on the next refresh and the
-# fallback here only matters until that refresh lands.
+# install, offline first run, etc.). Keep this list conservative: it should
+# not advertise models scheduled for May 15, 2026 retirement.
 _XAI_STATIC_FALLBACK: list[str] = [
+    "grok-4.3",
     "grok-4.20-0309-reasoning",
     "grok-4.20-0309-non-reasoning",
     "grok-4.20-multi-agent-0309",
-    "grok-4-1-fast",
-    "grok-4-1-fast-non-reasoning",
-    "grok-4-fast",
-    "grok-4-fast-non-reasoning",
-    "grok-4",
-    "grok-code-fast-1",
 ]
 
 

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -82,7 +82,10 @@ CONFIGURABLE_TOOLSETS = [
 # Toolsets that are OFF by default for new installs.
 # They're still in _HERMES_CORE_TOOLS (available at runtime if enabled),
 # but the setup checklist won't pre-select them for first-time users.
-_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "rl", "spotify", "discord", "discord_admin", "video"}
+_DEFAULT_OFF_TOOLSETS = {
+    "moa", "homeassistant", "rl", "spotify", "discord", "discord_admin", "video",
+    "xai_deferred",
+}
 
 # Platform-scoped toolsets: only appear in the `hermes tools` checklist for
 # these platforms, and only resolve/save for these platforms.  A toolset

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -76,6 +76,7 @@ CONFIGURABLE_TOOLSETS = [
     ("discord_admin",   "🛡️  Discord Server Admin",    "list channels/roles, pin, assign roles"),
     ("yuanbao",          "🤖 Yuanbao",                  "group info, member queries, DM"),
     ("computer_use",     "🖱️  Computer Use (macOS)",     "background desktop control via cua-driver"),
+    ("xai_deferred",     "⏳ xAI deferred chat",        "long-running completions via submit + poll"),
 ]
 
 # Toolsets that are OFF by default for new installs.

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -319,6 +319,7 @@ class TestBuiltinDiscovery:
             "tools.tts_tool",
             "tools.vision_tools",
             "tools.web_tools",
+            "tools.xai_deferred_tool",
             "tools.yuanbao_tools",
         }
 

--- a/tests/tools/test_xai_deferred_tool.py
+++ b/tests/tools/test_xai_deferred_tool.py
@@ -1,0 +1,291 @@
+"""Unit tests for tools.xai_deferred_tool."""
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List
+
+import httpx
+import pytest
+
+from tools import xai_deferred_tool
+from tools.xai_deferred_tool import (
+    XaiDeferredError,
+    XAI_DEFERRED_SCHEMA,
+    check_xai_deferred_requirements,
+    xai_deferred_chat,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers — minimal httpx mocking via monkeypatch
+# ---------------------------------------------------------------------------
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: Any = None, text: str = ""):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text or (json.dumps(payload) if payload is not None else "")
+
+    def json(self) -> Any:
+        if self._payload is None:
+            raise ValueError("no JSON")
+        return self._payload
+
+
+class _FakeHttp:
+    """Capture submit + sequence of poll responses for one xai_deferred_chat call."""
+
+    def __init__(self, submit: _FakeResponse, polls: List[_FakeResponse]):
+        self.submit_resp = submit
+        self.poll_responses = list(polls)
+        self.submit_calls: List[Dict[str, Any]] = []
+        self.poll_calls: List[Dict[str, Any]] = []
+
+    def post(self, url: str, *, headers: Dict[str, str], json: Any, timeout: int):
+        self.submit_calls.append({"url": url, "headers": headers, "json": json, "timeout": timeout})
+        return self.submit_resp
+
+    def get(self, url: str, *, headers: Dict[str, str], timeout: int):
+        self.poll_calls.append({"url": url, "headers": headers, "timeout": timeout})
+        if not self.poll_responses:
+            raise AssertionError("Test ran out of mocked poll responses")
+        return self.poll_responses.pop(0)
+
+
+@pytest.fixture
+def fake_http(monkeypatch):
+    """Install a stub for both httpx.post and httpx.get; tests mutate .next()."""
+    holder: Dict[str, _FakeHttp] = {}
+
+    def install(submit: _FakeResponse, polls: List[_FakeResponse]) -> _FakeHttp:
+        fake = _FakeHttp(submit=submit, polls=polls)
+        holder["fake"] = fake
+        monkeypatch.setattr(xai_deferred_tool.httpx, "post", fake.post)
+        monkeypatch.setattr(xai_deferred_tool.httpx, "get", fake.get)
+        # No real sleeping in unit tests
+        monkeypatch.setattr(xai_deferred_tool.time, "sleep", lambda _s: None)
+        return fake
+
+    return install
+
+
+@pytest.fixture(autouse=True)
+def _no_disk_config(monkeypatch):
+    """Don't let load_config touch a real ~/.hermes/config.yaml during tests."""
+    monkeypatch.setattr(xai_deferred_tool, "_config_section", lambda: {})
+
+
+@pytest.fixture
+def api_key(monkeypatch):
+    monkeypatch.setenv("XAI_API_KEY", "sk-test-deferred")
+
+
+# ---------------------------------------------------------------------------
+# check_xai_deferred_requirements / schema
+# ---------------------------------------------------------------------------
+
+class TestRequirements:
+    def test_unavailable_without_key(self, monkeypatch):
+        monkeypatch.delenv("XAI_API_KEY", raising=False)
+        ok, why = check_xai_deferred_requirements()
+        assert ok is False
+        assert "XAI_API_KEY" in why
+
+    def test_unavailable_with_blank_key(self, monkeypatch):
+        monkeypatch.setenv("XAI_API_KEY", "   ")
+        ok, _ = check_xai_deferred_requirements()
+        assert ok is False
+
+    def test_available_with_key(self, monkeypatch):
+        monkeypatch.setenv("XAI_API_KEY", "sk-x")
+        ok, why = check_xai_deferred_requirements()
+        assert ok is True
+        assert why == ""
+
+
+class TestSchema:
+    def test_schema_has_required_prompt(self):
+        assert XAI_DEFERRED_SCHEMA["parameters"]["required"] == ["prompt"]
+
+    def test_schema_advertises_optional_params(self):
+        props = XAI_DEFERRED_SCHEMA["parameters"]["properties"]
+        for key in ("prompt", "model", "system", "max_wait_seconds", "poll_interval_seconds"):
+            assert key in props
+
+
+# ---------------------------------------------------------------------------
+# Argument validation
+# ---------------------------------------------------------------------------
+
+class TestArgValidation:
+    def test_empty_prompt_raises(self, api_key):
+        with pytest.raises(ValueError):
+            xai_deferred_chat("")
+
+    def test_whitespace_prompt_raises(self, api_key):
+        with pytest.raises(ValueError):
+            xai_deferred_chat("   ")
+
+    def test_missing_api_key_raises(self, monkeypatch):
+        monkeypatch.delenv("XAI_API_KEY", raising=False)
+        with pytest.raises(XaiDeferredError):
+            xai_deferred_chat("hello")
+
+    def test_negative_max_wait_raises(self, api_key):
+        with pytest.raises(ValueError):
+            xai_deferred_chat("hi", max_wait_seconds=-1)
+
+    def test_negative_poll_interval_raises(self, api_key):
+        with pytest.raises(ValueError):
+            xai_deferred_chat("hi", poll_interval_seconds=-0.5)
+
+
+# ---------------------------------------------------------------------------
+# Submit semantics
+# ---------------------------------------------------------------------------
+
+class TestSubmit:
+    def test_submit_sets_deferred_true_in_body(self, api_key, fake_http):
+        fake = fake_http(
+            submit=_FakeResponse(200, {"request_id": "req-123"}),
+            polls=[_FakeResponse(200, {"id": "cmpl-1", "choices": []})],
+        )
+        xai_deferred_chat("hi")
+        assert fake.submit_calls[0]["json"]["deferred"] is True
+
+    def test_submit_uses_default_model(self, api_key, fake_http):
+        fake = fake_http(
+            submit=_FakeResponse(200, {"request_id": "r"}),
+            polls=[_FakeResponse(200, {"id": "x", "choices": []})],
+        )
+        xai_deferred_chat("hi")
+        assert fake.submit_calls[0]["json"]["model"] == "grok-4.3"
+
+    def test_submit_passes_explicit_model(self, api_key, fake_http):
+        fake = fake_http(
+            submit=_FakeResponse(200, {"request_id": "r"}),
+            polls=[_FakeResponse(200, {"id": "x", "choices": []})],
+        )
+        xai_deferred_chat("hi", model="grok-4.20-multi-agent-0309")
+        assert fake.submit_calls[0]["json"]["model"] == "grok-4.20-multi-agent-0309"
+
+    def test_submit_includes_system_message(self, api_key, fake_http):
+        fake = fake_http(
+            submit=_FakeResponse(200, {"request_id": "r"}),
+            polls=[_FakeResponse(200, {"id": "x", "choices": []})],
+        )
+        xai_deferred_chat("user", system="be concise")
+        msgs = fake.submit_calls[0]["json"]["messages"]
+        assert msgs[0]["role"] == "system"
+        assert msgs[0]["content"] == "be concise"
+        assert msgs[-1]["content"] == "user"
+
+    def test_submit_extra_body_cannot_override_deferred(self, api_key, fake_http):
+        fake = fake_http(
+            submit=_FakeResponse(200, {"request_id": "r"}),
+            polls=[_FakeResponse(200, {"id": "x", "choices": []})],
+        )
+        xai_deferred_chat("hi", extra_body={"deferred": False, "temperature": 0.2})
+        assert fake.submit_calls[0]["json"]["deferred"] is True
+        assert fake.submit_calls[0]["json"]["temperature"] == 0.2
+
+    def test_submit_4xx_raises(self, api_key, fake_http):
+        fake_http(
+            submit=_FakeResponse(401, payload={"error": "bad key"}, text='{"error":"bad key"}'),
+            polls=[],
+        )
+        with pytest.raises(XaiDeferredError) as exc:
+            xai_deferred_chat("hi")
+        assert "401" in str(exc.value)
+
+    def test_submit_response_missing_request_id_raises(self, api_key, fake_http):
+        fake_http(
+            submit=_FakeResponse(200, {"unrelated": "field"}),
+            polls=[],
+        )
+        with pytest.raises(XaiDeferredError) as exc:
+            xai_deferred_chat("hi")
+        assert "request_id" in str(exc.value)
+
+    def test_submit_network_error_raises(self, api_key, monkeypatch):
+        def _boom(*_a, **_kw):
+            raise httpx.ConnectError("nope")
+        monkeypatch.setattr(xai_deferred_tool.httpx, "post", _boom)
+        with pytest.raises(XaiDeferredError) as exc:
+            xai_deferred_chat("hi")
+        assert "submit failed" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# Poll semantics
+# ---------------------------------------------------------------------------
+
+class TestPoll:
+    def test_completes_on_first_200(self, api_key, fake_http):
+        fake = fake_http(
+            submit=_FakeResponse(200, {"request_id": "abc"}),
+            polls=[_FakeResponse(200, {"id": "cmpl", "choices": [{"message": {"role": "assistant", "content": "ok"}}]})],
+        )
+        result = xai_deferred_chat("hi")
+        assert result["request_id"] == "abc"
+        assert result["completion"]["choices"][0]["message"]["content"] == "ok"
+        assert len(fake.poll_calls) == 1
+        assert "deferred-completion/abc" in fake.poll_calls[0]["url"]
+
+    def test_polls_until_ready(self, api_key, fake_http):
+        fake = fake_http(
+            submit=_FakeResponse(200, {"request_id": "r"}),
+            polls=[
+                _FakeResponse(202),
+                _FakeResponse(202),
+                _FakeResponse(200, {"id": "cmpl", "choices": []}),
+            ],
+        )
+        result = xai_deferred_chat("hi", poll_interval_seconds=0.01)
+        assert len(fake.poll_calls) == 3
+        assert result["completion"]["id"] == "cmpl"
+
+    def test_poll_5xx_raises(self, api_key, fake_http):
+        fake_http(
+            submit=_FakeResponse(200, {"request_id": "r"}),
+            polls=[_FakeResponse(500, text="upstream down")],
+        )
+        with pytest.raises(XaiDeferredError) as exc:
+            xai_deferred_chat("hi", poll_interval_seconds=0.01)
+        assert "500" in str(exc.value)
+
+    def test_poll_timeout_raises(self, api_key, monkeypatch, fake_http):
+        # Fake monotonic that jumps past max_wait on the second call.
+        ticks = iter([0.0, 0.0, 9999.0])
+        monkeypatch.setattr(xai_deferred_tool.time, "monotonic", lambda: next(ticks))
+        fake_http(
+            submit=_FakeResponse(200, {"request_id": "r"}),
+            polls=[_FakeResponse(202)],
+        )
+        with pytest.raises(XaiDeferredError) as exc:
+            xai_deferred_chat("hi", max_wait_seconds=10, poll_interval_seconds=0.01)
+        assert "not ready after" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# Headers
+# ---------------------------------------------------------------------------
+
+class TestHeaders:
+    def test_authorization_bearer(self, api_key, fake_http):
+        fake = fake_http(
+            submit=_FakeResponse(200, {"request_id": "r"}),
+            polls=[_FakeResponse(200, {"id": "x", "choices": []})],
+        )
+        xai_deferred_chat("hi")
+        assert fake.submit_calls[0]["headers"]["Authorization"] == "Bearer sk-test-deferred"
+        assert fake.poll_calls[0]["headers"]["Authorization"] == "Bearer sk-test-deferred"
+
+    def test_user_agent_present(self, api_key, fake_http):
+        fake = fake_http(
+            submit=_FakeResponse(200, {"request_id": "r"}),
+            polls=[_FakeResponse(200, {"id": "x", "choices": []})],
+        )
+        xai_deferred_chat("hi")
+        ua = fake.submit_calls[0]["headers"]["User-Agent"]
+        assert ua.startswith("Hermes-Agent/")

--- a/tests/tools/test_xai_deferred_tool.py
+++ b/tests/tools/test_xai_deferred_tool.py
@@ -87,20 +87,15 @@ def api_key(monkeypatch):
 class TestRequirements:
     def test_unavailable_without_key(self, monkeypatch):
         monkeypatch.delenv("XAI_API_KEY", raising=False)
-        ok, why = check_xai_deferred_requirements()
-        assert ok is False
-        assert "XAI_API_KEY" in why
+        assert check_xai_deferred_requirements() is False
 
     def test_unavailable_with_blank_key(self, monkeypatch):
         monkeypatch.setenv("XAI_API_KEY", "   ")
-        ok, _ = check_xai_deferred_requirements()
-        assert ok is False
+        assert check_xai_deferred_requirements() is False
 
     def test_available_with_key(self, monkeypatch):
         monkeypatch.setenv("XAI_API_KEY", "sk-x")
-        ok, why = check_xai_deferred_requirements()
-        assert ok is True
-        assert why == ""
+        assert check_xai_deferred_requirements() is True
 
 
 class TestSchema:

--- a/tools/xai_deferred_tool.py
+++ b/tools/xai_deferred_tool.py
@@ -1,0 +1,348 @@
+"""xAI deferred chat completion tool.
+
+Submits a chat request with ``deferred=true`` to xAI's
+``POST /v1/chat/completions`` and polls
+``GET /v1/chat/deferred-completion/{request_id}`` until the response is ready.
+
+Use case
+--------
+xAI's deferred mode is designed for **long-running** completions (extended
+thinking, large context, multi-agent reasoning) where holding an open HTTP
+connection for several minutes is impractical. Submitting deferred decouples
+the request lifecycle from the network connection — the client can disconnect,
+crash, retry, or yield to other work, and pick up the result whenever it's
+ready.
+
+This tool implements the simplest pattern: submit + poll until done or until
+``max_wait_seconds`` elapses.
+
+References
+----------
+- Submit:  POST /v1/chat/completions with body field ``deferred: true``
+- Poll:    GET /v1/chat/deferred-completion/{request_id}
+           - 202 Accepted = still pending
+           - 200 OK + standard chat completion body = ready
+- Docs:    https://docs.x.ai/docs/api-reference#chat-deferred-completion
+"""
+from __future__ import annotations
+
+import os
+import time
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from tools.xai_http import hermes_xai_user_agent
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+DEFAULT_BASE_URL = os.getenv("XAI_BASE_URL", "https://api.x.ai/v1")
+DEFAULT_MODEL = "grok-4.3"
+DEFAULT_MAX_WAIT_SECONDS = 600        # 10 minutes
+DEFAULT_POLL_INTERVAL_SECONDS = 2.0
+DEFAULT_SUBMIT_TIMEOUT_SECONDS = 30
+DEFAULT_POLL_TIMEOUT_SECONDS = 30
+
+
+def _config_section() -> Dict[str, Any]:
+    """Read the ``xai_deferred:`` block from the active Hermes config, if any."""
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+    except Exception:
+        return {}
+    section = cfg.get("xai_deferred") if isinstance(cfg, dict) else None
+    return section if isinstance(section, dict) else {}
+
+
+def _resolve(name: str, default: Any) -> Any:
+    section = _config_section()
+    val = section.get(name)
+    if val is None or (isinstance(val, str) and not val.strip()):
+        return default
+    return val
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+class XaiDeferredError(RuntimeError):
+    """Raised when the deferred completion fails or times out."""
+
+
+# ---------------------------------------------------------------------------
+# Public tool
+# ---------------------------------------------------------------------------
+
+def xai_deferred_chat(
+    prompt: str,
+    *,
+    model: Optional[str] = None,
+    system: Optional[str] = None,
+    max_wait_seconds: Optional[int] = None,
+    poll_interval_seconds: Optional[float] = None,
+    extra_messages: Optional[List[Dict[str, Any]]] = None,
+    extra_body: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Run a chat completion via xAI's deferred mode.
+
+    Parameters
+    ----------
+    prompt : str
+        The user message.
+    model : str, optional
+        xAI model identifier. Defaults to config ``xai_deferred.model`` then
+        ``"grok-4.3"``.
+    system : str, optional
+        Optional system message prepended to the conversation.
+    max_wait_seconds : int, optional
+        Total polling budget. Defaults to config ``xai_deferred.max_wait_seconds``
+        then 600 (10 minutes).
+    poll_interval_seconds : float, optional
+        Sleep between polls. Defaults to config ``xai_deferred.poll_interval_seconds``
+        then 2.0.
+    extra_messages : list of message dicts, optional
+        Conversation history to prepend (between system and user).
+    extra_body : dict, optional
+        Extra fields merged into the submit body (e.g. ``reasoning_effort``,
+        ``temperature``). ``deferred: true`` is always set.
+
+    Returns
+    -------
+    dict
+        ``{"request_id": str, "completion": <chat completion dict>, "elapsed_seconds": float}``
+
+    Raises
+    ------
+    XaiDeferredError
+        On HTTP errors at submit, on poll timeout, or if the polling budget
+        is exhausted before the request completes.
+    """
+    if not isinstance(prompt, str) or not prompt.strip():
+        raise ValueError("prompt must be a non-empty string")
+
+    api_key = os.environ.get("XAI_API_KEY", "").strip()
+    if not api_key:
+        raise XaiDeferredError("XAI_API_KEY is not set")
+
+    resolved_model = model or _resolve("model", DEFAULT_MODEL)
+    resolved_max_wait = int(max_wait_seconds or _resolve("max_wait_seconds", DEFAULT_MAX_WAIT_SECONDS))
+    resolved_poll_interval = float(poll_interval_seconds or _resolve("poll_interval_seconds", DEFAULT_POLL_INTERVAL_SECONDS))
+
+    if resolved_max_wait <= 0:
+        raise ValueError("max_wait_seconds must be positive")
+    if resolved_poll_interval <= 0:
+        raise ValueError("poll_interval_seconds must be positive")
+
+    messages: List[Dict[str, Any]] = []
+    if system:
+        messages.append({"role": "system", "content": system})
+    if extra_messages:
+        messages.extend(extra_messages)
+    messages.append({"role": "user", "content": prompt})
+
+    body: Dict[str, Any] = {
+        "model": resolved_model,
+        "messages": messages,
+        "deferred": True,
+    }
+    if extra_body:
+        for k, v in extra_body.items():
+            if k == "deferred":
+                # Hard-coded — deferred mode is the entire point of this tool.
+                continue
+            body[k] = v
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "User-Agent": hermes_xai_user_agent(),
+    }
+
+    base_url = DEFAULT_BASE_URL.rstrip("/")
+    submit_url = f"{base_url}/chat/completions"
+
+    started = time.monotonic()
+    request_id = _submit(submit_url, headers, body)
+    completion = _poll(
+        base_url=base_url,
+        headers=headers,
+        request_id=request_id,
+        started=started,
+        max_wait=resolved_max_wait,
+        poll_interval=resolved_poll_interval,
+    )
+    return {
+        "request_id": request_id,
+        "completion": completion,
+        "elapsed_seconds": time.monotonic() - started,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Internals
+# ---------------------------------------------------------------------------
+
+def _submit(url: str, headers: Dict[str, str], body: Dict[str, Any]) -> str:
+    """Submit the deferred request and return the ``request_id``."""
+    try:
+        resp = httpx.post(
+            url,
+            headers=headers,
+            json=body,
+            timeout=DEFAULT_SUBMIT_TIMEOUT_SECONDS,
+        )
+    except httpx.HTTPError as exc:
+        raise XaiDeferredError(f"deferred submit failed: {exc}") from exc
+
+    if resp.status_code >= 400:
+        raise XaiDeferredError(
+            f"deferred submit returned {resp.status_code}: "
+            f"{resp.text[:300]}"
+        )
+
+    try:
+        payload = resp.json()
+    except ValueError as exc:
+        raise XaiDeferredError(
+            f"deferred submit returned non-JSON body: {resp.text[:300]}"
+        ) from exc
+
+    request_id = payload.get("request_id") if isinstance(payload, dict) else None
+    if not request_id or not isinstance(request_id, str):
+        raise XaiDeferredError(
+            f"deferred submit response missing 'request_id': {payload!r}"
+        )
+    return request_id
+
+
+def _poll(
+    *,
+    base_url: str,
+    headers: Dict[str, str],
+    request_id: str,
+    started: float,
+    max_wait: int,
+    poll_interval: float,
+) -> Dict[str, Any]:
+    """Poll until the deferred completion is ready or the budget is exhausted."""
+    poll_url = f"{base_url}/chat/deferred-completion/{request_id}"
+    while True:
+        if time.monotonic() - started > max_wait:
+            raise XaiDeferredError(
+                f"deferred completion {request_id!r} not ready after "
+                f"{max_wait}s — aborting poll"
+            )
+        try:
+            resp = httpx.get(
+                poll_url,
+                headers=headers,
+                timeout=DEFAULT_POLL_TIMEOUT_SECONDS,
+            )
+        except httpx.HTTPError as exc:
+            raise XaiDeferredError(
+                f"deferred poll failed for {request_id!r}: {exc}"
+            ) from exc
+
+        if resp.status_code == 200:
+            try:
+                return resp.json()
+            except ValueError as exc:
+                raise XaiDeferredError(
+                    f"deferred completion {request_id!r} returned non-JSON: "
+                    f"{resp.text[:300]}"
+                ) from exc
+        if resp.status_code == 202:
+            time.sleep(poll_interval)
+            continue
+        raise XaiDeferredError(
+            f"deferred poll for {request_id!r} returned "
+            f"{resp.status_code}: {resp.text[:300]}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tool registration
+# ---------------------------------------------------------------------------
+
+def check_xai_deferred_requirements() -> "tuple[bool, str]":
+    """Tool gate: only available when XAI_API_KEY is set."""
+    if os.environ.get("XAI_API_KEY", "").strip():
+        return True, ""
+    return False, "XAI_API_KEY environment variable is not set"
+
+
+XAI_DEFERRED_SCHEMA = {
+    "name": "xai_deferred_chat",
+    "description": (
+        "Run a long-running chat completion against xAI in deferred mode "
+        "(submit + poll). Use for extended-thinking / large-context calls "
+        "that would exceed normal HTTP timeouts. The tool blocks the caller "
+        "until the response is ready or until max_wait_seconds elapses."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": "The user message to send.",
+            },
+            "model": {
+                "type": "string",
+                "description": (
+                    "xAI model identifier (e.g. 'grok-4.3'). Defaults to "
+                    "config xai_deferred.model or 'grok-4.3'."
+                ),
+            },
+            "system": {
+                "type": "string",
+                "description": "Optional system prompt prepended to the conversation.",
+            },
+            "max_wait_seconds": {
+                "type": "integer",
+                "description": (
+                    "Total polling budget in seconds. Defaults to config "
+                    "xai_deferred.max_wait_seconds or 600 (10 minutes)."
+                ),
+            },
+            "poll_interval_seconds": {
+                "type": "number",
+                "description": (
+                    "Sleep between polls in seconds. Defaults to config "
+                    "xai_deferred.poll_interval_seconds or 2.0."
+                ),
+            },
+        },
+        "required": ["prompt"],
+    },
+}
+
+
+def _handle_xai_deferred_tool_call(args: Dict[str, Any], **_kw: Any) -> Dict[str, Any]:
+    """Bridge from the registry handler signature to xai_deferred_chat()."""
+    return xai_deferred_chat(
+        prompt=args.get("prompt", ""),
+        model=args.get("model"),
+        system=args.get("system"),
+        max_wait_seconds=args.get("max_wait_seconds"),
+        poll_interval_seconds=args.get("poll_interval_seconds"),
+    )
+
+
+# Self-register at import time. The ``registry`` symbol must come from
+# ``tools.registry`` (the ToolRegistry singleton), not the module itself —
+# tools/registry.py:_is_registry_register_call also matches the literal name.
+from tools.registry import registry  # noqa: E402
+
+registry.register(
+    name="xai_deferred_chat",
+    toolset="xai_deferred",
+    schema=XAI_DEFERRED_SCHEMA,
+    handler=_handle_xai_deferred_tool_call,
+    check_fn=check_xai_deferred_requirements,
+    emoji="⏳",
+)

--- a/tools/xai_deferred_tool.py
+++ b/tools/xai_deferred_tool.py
@@ -269,11 +269,9 @@ def _poll(
 # Tool registration
 # ---------------------------------------------------------------------------
 
-def check_xai_deferred_requirements() -> "tuple[bool, str]":
+def check_xai_deferred_requirements() -> bool:
     """Tool gate: only available when XAI_API_KEY is set."""
-    if os.environ.get("XAI_API_KEY", "").strip():
-        return True, ""
-    return False, "XAI_API_KEY environment variable is not set"
+    return bool(os.environ.get("XAI_API_KEY", "").strip())
 
 
 XAI_DEFERRED_SCHEMA = {
@@ -344,5 +342,6 @@ registry.register(
     schema=XAI_DEFERRED_SCHEMA,
     handler=_handle_xai_deferred_tool_call,
     check_fn=check_xai_deferred_requirements,
+    requires_env=["XAI_API_KEY"],
     emoji="⏳",
 )

--- a/toolsets.py
+++ b/toolsets.py
@@ -70,6 +70,8 @@ _HERMES_CORE_TOOLS = [
     "kanban_unblock",
     # Computer use (macOS, gated on cua-driver being installed via check_fn)
     "computer_use",
+    # xAI deferred chat (long-running completions via submit + poll, gated on XAI_API_KEY)
+    "xai_deferred_chat",
 ]
 
 
@@ -114,6 +116,16 @@ TOOLSETS = {
             "or keyboard focus. Works with any tool-capable model."
         ),
         "tools": ["computer_use"],
+        "includes": []
+    },
+
+    "xai_deferred": {
+        "description": (
+            "Long-running xAI chat completions via submit + poll "
+            "(deferred mode). Useful for extended thinking or large context "
+            "calls that exceed normal HTTP timeouts."
+        ),
+        "tools": ["xai_deferred_chat"],
         "includes": []
     },
 

--- a/website/docs/reference/toolsets-reference.md
+++ b/website/docs/reference/toolsets-reference.md
@@ -82,6 +82,7 @@ Or in-session:
 | `vision` | `vision_analyze` | Image analysis via vision-capable models. |
 | `video` | `video_analyze` | Video analysis and understanding tools (opt-in, not in the default toolset — add explicitly via `--toolsets`). |
 | `web` | `web_extract`, `web_search` | Web search and page content extraction. |
+| `xai_deferred` | `xai_deferred_chat` | Submit long-running xAI chat completions with deferred mode and poll until ready. Requires `XAI_API_KEY`; opt-in for new installs. |
 | `yuanbao` | `yb_query_group_info`, `yb_query_group_members`, `yb_search_sticker`, `yb_send_dm`, `yb_send_sticker` | Yuanbao DM/group actions and sticker search. Registered only on `hermes-yuanbao`. |
 
 ## Platform Toolsets


### PR DESCRIPTION
## Summary
Adds `xai_deferred_chat` — a tool that runs a long-running chat completion against xAI in **deferred mode**: submits to `POST /v1/chat/completions` with `deferred: true`, polls `GET /v1/chat/deferred-completion/{request_id}` (202 → still pending, 200 → done) until the response is ready or the per-call budget is exhausted.

## Why
xAI's deferred mode is built for completions that take many minutes (extended thinking, multi-agent reasoning, large-context calls) — long enough that holding an open HTTP connection is unreliable. Deferred decouples the request lifecycle from the network: the client can disconnect, crash, retry, or yield, and pick the result up later. This pairs naturally with Hermes' autonomous mode (long-running sessions) and with the `grok-4.20-multi-agent-0309` model whose orchestrator legs can run several minutes.

This tool is the smallest possible primitive: one tool that submits + polls and blocks the caller until done. A future, more sophisticated transport could layer parallelism / persistence / cross-session resumption on top of the same primitives, but the existing autonomous + delegation patterns already get most of the value out of this minimal shape.

## Changes (5 files, +653/-0)

### `tools/xai_deferred_tool.py` (new, ~350 LoC)
Self-contained tool. Public surface:

```python
xai_deferred_chat(
    prompt: str,
    *,
    model: str | None = None,                 # default: config xai_deferred.model or "grok-4.3"
    system: str | None = None,                # optional system prompt
    max_wait_seconds: int | None = None,      # default: config or 600 (10 min)
    poll_interval_seconds: float | None = None,  # default: config or 2.0
    extra_messages: list[dict] | None = None, # conversation history to prepend
    extra_body: dict | None = None,           # merged into submit body (deferred=true is locked)
) -> {"request_id": str, "completion": dict, "elapsed_seconds": float}
```

- Reuses `tools.xai_http.hermes_xai_user_agent` for `User-Agent`.
- `extra_body` cannot override `deferred=true` (the entire point of the tool).
- Self-registers via `tools.registry.registry.register` with `check_fn` gating on `XAI_API_KEY`.
- Configurable via `config.yaml`:
  ```yaml
  xai_deferred:
    model: grok-4.20-multi-agent-0309
    max_wait_seconds: 1200
    poll_interval_seconds: 5
  ```

### `tests/tools/test_xai_deferred_tool.py` (new, ~280 LoC)
24 unit tests, all using a tiny `_FakeHttp` monkeypatch (no real network):

- **Requirements & schema**: with/without/blank API key; required + optional schema params.
- **Argument validation**: empty/whitespace prompt, missing API key, negative `max_wait_seconds`, negative `poll_interval_seconds`.
- **Submit**: `deferred=true` always set, default model resolution, explicit-model override, system message ordering, `extra_body` merging (cannot clobber `deferred`), 4xx HTTP error, missing `request_id` in response, network error.
- **Poll**: completes on first 200, polls through multiple 202s, 5xx surface, **timeout** (mocked `time.monotonic`).
- **Headers**: `Authorization: Bearer <key>` on both submit + poll, `User-Agent: Hermes-Agent/<version>` on submit.

### Wiring
- `toolsets.py`: `xai_deferred_chat` added to `_HERMES_CORE_TOOLS`; new `xai_deferred` toolset.
- `hermes_cli/tools_config.py`: new `xai_deferred` entry in `CONFIGURABLE_TOOLSETS`.
- `tests/tools/test_registry.py`: `tools.xai_deferred_tool` added to the manual snapshot list (same convention as #14541, #14543).

## Validation
- `pytest tests/tools/test_xai_deferred_tool.py tests/tools/test_registry.py` → **55/55 passing** locally on top of current `main`.
- The 24 new tool tests + the 31 existing registry tests all green.

## Backward compatibility
- Pure addition. New tool, new toolset entry, new test file. No existing modules touched beyond the three single-line additions to `toolsets.py`, `tools_config.py`, and the registry snapshot list.
- Tool is `check_fn`-gated on `XAI_API_KEY` — invisible to users without an xAI key.
- `xai_deferred` is **not** in the default toolset roster; users opt in via `tools_config` or by enabling the toolset in their profile.

## Follow-up scope (not in this PR)
- A streaming flavor that yields incremental token deltas as the completion progresses (the current xAI deferred GET only returns the final body).
- A persistent flavor that survives Hermes restarts: store `request_id` to disk, resume polling on next launch. Useful for autonomous sessions whose backing process gets restarted mid-thought.
- A transport-layer integration (so any model call can opt into deferred mode based on a config knob, not just calls routed through this tool).
