### PR TITLE
fix(gateway): remove --replace from systemd/launchd service definitions (fixes #23272)

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -563,7 +563,7 @@ def _gateway_run_args_for_profile(profile: str) -> list[str]:
     args = [get_python_path(), "-m", "hermes_cli.main"]
     if profile != "default":
         args.extend(["--profile", profile])
-    args.extend(["gateway", "run", "--replace"])
+    args.extend(["gateway", "run"])
     return args
 
 
@@ -2155,7 +2155,7 @@ StartLimitIntervalSec=0
 Type=simple
 User={username}
 Group={group_name}
-ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run --replace
+ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run
 WorkingDirectory={working_dir}
 Environment="HOME={home_dir}"
 Environment="USER={username}"
@@ -2193,7 +2193,7 @@ StartLimitIntervalSec=0
 
 [Service]
 Type=simple
-ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run --replace
+ExecStart={python_path} -m hermes_cli.main{f" {profile_arg}" if profile_arg else ""} gateway run
 WorkingDirectory={working_dir}
 Environment="PATH={sane_path}"
 Environment="VIRTUAL_ENV={venv_dir}"
@@ -2781,7 +2781,6 @@ def generate_launchd_plist() -> str:
     prog_args.extend([
         "<string>gateway</string>",
         "<string>run</string>",
-        "<string>--replace</string>",
     ])
     prog_args_xml = "\n        ".join(prog_args)
 

--- a/hermes_cli/gateway_windows.py
+++ b/hermes_cli/gateway_windows.py
@@ -13,7 +13,7 @@ Design notes
   ``schtasks /Run`` immediately after install so the gateway starts right
   away without waiting for the next logon.
 * We write two files: a shared ``gateway.cmd`` wrapper script (cwd + env + the
-  actual ``python -m hermes_cli.main gateway run --replace`` invocation) and
+  actual ``python -m hermes_cli.main gateway run`` invocation) and
   EITHER a schtasks entry pointing at it OR a Startup-folder ``.cmd`` that
   spawns it detached.
 * Status = merge of "is the schtasks entry registered?" + "is the startup
@@ -206,7 +206,7 @@ def _build_gateway_cmd_script(
     The script:
       - cd's into the project directory
       - exports HERMES_HOME, PYTHONIOENCODING, VIRTUAL_ENV
-      - invokes ``python -m hermes_cli.main [--profile X] gateway run --replace``
+      - invokes ``python -m hermes_cli.main [--profile X] gateway run``
 
     We intentionally do NOT inline PATH overrides here — cmd.exe inherits
     the per-user PATH the Scheduled Task was created with, and forcibly
@@ -225,7 +225,7 @@ def _build_gateway_cmd_script(
     prog_args = [python_path, "-m", "hermes_cli.main"]
     if profile_arg:
         prog_args.extend(profile_arg.split())
-    prog_args.extend(["gateway", "run", "--replace"])
+    prog_args.extend(["gateway", "run"])
     lines.append(" ".join(_quote_cmd_script_arg(a) for a in prog_args))
     return "\r\n".join(lines) + "\r\n"
 
@@ -367,7 +367,7 @@ def _build_gateway_argv() -> tuple[list[str], str, dict[str, str]]:
     argv = [python_exe, "-m", "hermes_cli.main"]
     if profile_arg:
         argv.extend(profile_arg.split())
-    argv.extend(["gateway", "run", "--replace"])
+    argv.extend(["gateway", "run"])
 
     env_overlay = {
         "HERMES_HOME": hermes_home,
@@ -381,7 +381,7 @@ def _build_gateway_argv() -> tuple[list[str], str, dict[str, str]]:
 def _spawn_detached(script_path: Path | None = None) -> int:
     """Launch the gateway as a fully detached background process.
 
-    We spawn ``pythonw.exe -m hermes_cli.main gateway run --replace``
+    We spawn ``pythonw.exe -m hermes_cli.main gateway run``
     directly — NOT through a cmd.exe shim — because on Windows a cmd.exe
     child inherits the parent session's console handle and tends to get
     reaped when the spawning shell exits. pythonw.exe has no console, and

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -493,7 +493,7 @@ class TestLaunchdServiceRecovery:
 
         label = gateway_cli.get_launchd_label()
         domain = gateway_cli._launchd_domain()
-        assert "--replace" in plist_path.read_text(encoding="utf-8")
+        assert "--replace" not in plist_path.read_text(encoding="utf-8")
         assert calls[:2] == [
             ["launchctl", "bootout", f"{domain}/{label}"],
             ["launchctl", "bootstrap", domain, str(plist_path)],
@@ -1636,7 +1636,8 @@ class TestProfileArg:
         monkeypatch.setattr(gateway_cli, "get_hermes_home", lambda: profile_dir)
         unit = gateway_cli.generate_systemd_unit(system=False)
         assert "--profile mybot" in unit
-        assert "gateway run --replace" in unit
+        assert "gateway run" in unit
+        assert "--replace" not in unit
 
     def test_launchd_plist_includes_profile(self, tmp_path, monkeypatch):
         """generate_launchd_plist should include --profile in ProgramArguments for named profiles."""
@@ -1832,7 +1833,7 @@ class TestLegacyHermesUnitDetection:
     # Minimal ExecStart that looks like our gateway
     _OUR_UNIT_TEXT = (
         "[Unit]\nDescription=Hermes Gateway\n[Service]\n"
-        "ExecStart=/usr/bin/python -m hermes_cli.main gateway run --replace\n"
+        "ExecStart=/usr/bin/python -m hermes_cli.main gateway run\n"
     )
 
     @staticmethod
@@ -1948,9 +1949,9 @@ class TestLegacyHermesUnitDetection:
         """
         user_dir, _ = self._setup_search_paths(tmp_path, monkeypatch)
         variants = [
-            "ExecStart=/venv/bin/python -m hermes_cli.main gateway run --replace",
+            "ExecStart=/venv/bin/python -m hermes_cli.main gateway run",
             "ExecStart=/venv/bin/python /opt/hermes/hermes_cli/main.py gateway run",
-            "ExecStart=/usr/local/bin/hermes gateway run --replace",
+            "ExecStart=/usr/local/bin/hermes gateway run",
             "ExecStart=/venv/bin/python /opt/hermes/gateway/run.py",
         ]
         for i, execstart in enumerate(variants):
@@ -2007,7 +2008,7 @@ class TestRemoveLegacyHermesUnits:
 
     _OUR_UNIT_TEXT = (
         "[Unit]\nDescription=Hermes Gateway\n[Service]\n"
-        "ExecStart=/usr/bin/python -m hermes_cli.main gateway run --replace\n"
+        "ExecStart=/usr/bin/python -m hermes_cli.main gateway run\n"
     )
 
     @staticmethod

--- a/tests/hermes_cli/test_update_gateway_restart.py
+++ b/tests/hermes_cli/test_update_gateway_restart.py
@@ -129,23 +129,19 @@ class TestLaunchdPlistReplace:
 
     def test_plist_contains_replace_flag(self):
         plist = gateway_cli.generate_launchd_plist()
-        assert "--replace" in plist
+        assert "--replace" not in plist
 
     def test_plist_program_arguments_order(self):
-        """--replace comes after 'run' in the ProgramArguments."""
+        """'run' must be the final argument in ProgramArguments."""
         plist = gateway_cli.generate_launchd_plist()
         lines = [line.strip() for line in plist.splitlines()]
-        # Find 'run' and '--replace' in the string entries
         string_values = [
             line.replace("<string>", "").replace("</string>", "")
             for line in lines
             if "<string>" in line and "</string>" in line
         ]
         assert "run" in string_values
-        assert "--replace" in string_values
-        run_idx = string_values.index("run")
-        replace_idx = string_values.index("--replace")
-        assert replace_idx == run_idx + 1
+        assert "--replace" not in string_values
 
 
 class TestLaunchdPlistPath:
@@ -249,8 +245,8 @@ class TestLaunchdPlistRefresh:
         result = gateway_cli.refresh_launchd_plist_if_needed()
 
         assert result is True
-        # Plist should now contain the generated content (which includes --replace)
-        assert "--replace" in plist_path.read_text()
+        # Plist should now contain the generated content (no longer includes --replace)
+        assert "--replace" not in plist_path.read_text()
         # Should have booted out then bootstrapped
         assert any("bootout" in str(c) for c in calls)
         assert any("bootstrap" in str(c) for c in calls)
@@ -318,7 +314,7 @@ class TestLaunchdPlistRefresh:
 
         # Should have created the plist
         assert plist_path.exists()
-        assert "--replace" in plist_path.read_text()
+        assert "--replace" not in plist_path.read_text()
 
         cmd_strs = [" ".join(c) for c in calls]
         # Should bootstrap the new plist, then kickstart


### PR DESCRIPTION
## Summary

Removes the `--replace` flag from all **service-installed** gateway launch paths (systemd, launchd, Windows Scheduled Task, Startup folder). The `--replace` flag remains available for explicit manual use via `hermes gateway run --replace`, but services no longer auto-kill sibling instances, which prevents the infinite restart cycle described in issue #23272.

## What changed

| File | Change |
|---|---|
| `hermes_cli/gateway.py` | `generate_systemd_unit()`: drop `--replace` from `ExecStart` (both system & user). `generate_launchd_plist()`: drop `<string>--replace</string>`. `_gateway_run_args_for_profile()`: drop `--replace` from detached-restart argv. |
| `hermes_cli/gateway_windows.py` | `_build_gateway_cmd_script()` and `_build_gateway_argv()`: drop `--replace` from Windows service/Scheduled Task argv. Updated docstring references. |
| `tests/` | Updated assertions that verify plist/unit content to expect `--replace` absence. Legacy-unit detection tests now use the new ExecStart signature. |

## Why

Issue #23272 describes a gateway restart-loop when:
1. `ExecStopPost=/bin/kill -9 $MAINPID` (a systemd drop-in) fires on every service stop.
2. The service is configured with `gateway run --replace`, so a clean restart SIGTERMs the existing instance.
3. The `ExecStopPost` SIGKILLs the newly spawned instance before it stabilizes.
4. systemd `Restart=always` respawns → loop.

By removing `--replace` from service definitions, the gateway starts without killing an already-running sibling. When a real restart is needed, `hermes gateway restart` (or systemd native restart) handles orderly handoff via takeover markers, avoiding the `ExecStopPost` trap.

## Backwards compatibility

- Manual `hermes gateway run --replace` still works; the flag is only removed from **auto-generated** service files.
- Existing installed services will pick up the new unit definition on next `hermes gateway install` or auto-refresh at boot time.
- No CLI option was removed; `--replace` is still present in `argparse`.

Fixes #23272