### PR TITLE
fix(gateway): honor user_id_alt in send_message mirroring and lookups

### DIFF
--- a/gateway/mirror.py
+++ b/gateway/mirror.py
@@ -29,6 +29,7 @@ def mirror_to_session(
     source_label: str = "cli",
     thread_id: Optional[str] = None,
     user_id: Optional[str] = None,
+    user_id_alt: Optional[str] = None,
 ) -> bool:
     """
     Append a delivery-mirror message to the target session's transcript.
@@ -45,14 +46,16 @@ def mirror_to_session(
             str(chat_id),
             thread_id=thread_id,
             user_id=user_id,
+            user_id_alt=user_id_alt,
         )
         if not session_id:
             logger.debug(
-                "Mirror: no session found for %s:%s:%s:%s",
+                "Mirror: no session found for %s:%s:%s:%s:%s",
                 platform,
                 chat_id,
                 thread_id,
                 user_id,
+                user_id_alt,
             )
             return False
 
@@ -76,7 +79,7 @@ def mirror_to_session(
             platform,
             chat_id,
             thread_id,
-            user_id,
+            user_id or user_id_alt,
             e,
         )
         return False
@@ -87,6 +90,7 @@ def _find_session_id(
     chat_id: str,
     thread_id: Optional[str] = None,
     user_id: Optional[str] = None,
+    user_id_alt: Optional[str] = None,
 ) -> Optional[str]:
     """
     Find the active session_id for a platform + chat_id pair.
@@ -95,9 +99,10 @@ def _find_session_id(
     on the right platform.  DM session keys don't embed the chat_id
     (e.g. "agent:main:telegram:dm"), so we check the origin dict.
 
-    When *user_id* is provided, prefer exact sender matches. If multiple
-    same-chat candidates exist and none matches the user, return None instead
-    of guessing and contaminating another participant's session.
+    When *user_id* or *user_id_alt* is provided, prefer exact sender matches.
+    If multiple same-chat candidates exist and none matches the sender,
+    return None instead of guessing and contaminating another participant's
+    session.
     """
     if not _SESSIONS_INDEX.exists():
         return None
@@ -128,10 +133,24 @@ def _find_session_id(
     if not candidates:
         return None
 
-    if user_id:
+    requested_ids = {
+        str(value).strip()
+        for value in (user_id, user_id_alt)
+        if str(value or "").strip()
+    }
+
+    def _entry_identity_values(entry: dict) -> set[str]:
+        origin = entry.get("origin") or {}
+        return {
+            str(value).strip()
+            for value in (origin.get("user_id"), origin.get("user_id_alt"))
+            if str(value or "").strip()
+        }
+
+    if requested_ids:
         exact_user_matches = [
             entry for entry in candidates
-            if str((entry.get("origin") or {}).get("user_id") or "") == str(user_id)
+            if _entry_identity_values(entry) & requested_ids
         ]
         if exact_user_matches:
             candidates = exact_user_matches
@@ -139,9 +158,9 @@ def _find_session_id(
             return None
     elif len(candidates) > 1:
         distinct_user_ids = {
-            str((entry.get("origin") or {}).get("user_id") or "").strip()
+            identity
             for entry in candidates
-            if str((entry.get("origin") or {}).get("user_id") or "").strip()
+            for identity in _entry_identity_values(entry)
         }
         if len(distinct_user_ids) > 1:
             return None

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -12374,6 +12374,7 @@ class GatewayRunner:
             chat_name=context.source.chat_name or "",
             thread_id=str(context.source.thread_id) if context.source.thread_id else "",
             user_id=str(context.source.user_id) if context.source.user_id else "",
+            user_id_alt=str(context.source.user_id_alt) if context.source.user_id_alt else "",
             user_name=str(context.source.user_name) if context.source.user_name else "",
             session_key=context.session_key,
         )

--- a/gateway/session_context.py
+++ b/gateway/session_context.py
@@ -53,6 +53,7 @@ _SESSION_CHAT_ID: ContextVar = ContextVar("HERMES_SESSION_CHAT_ID", default=_UNS
 _SESSION_CHAT_NAME: ContextVar = ContextVar("HERMES_SESSION_CHAT_NAME", default=_UNSET)
 _SESSION_THREAD_ID: ContextVar = ContextVar("HERMES_SESSION_THREAD_ID", default=_UNSET)
 _SESSION_USER_ID: ContextVar = ContextVar("HERMES_SESSION_USER_ID", default=_UNSET)
+_SESSION_USER_ID_ALT: ContextVar = ContextVar("HERMES_SESSION_USER_ID_ALT", default=_UNSET)
 _SESSION_USER_NAME: ContextVar = ContextVar("HERMES_SESSION_USER_NAME", default=_UNSET)
 _SESSION_KEY: ContextVar = ContextVar("HERMES_SESSION_KEY", default=_UNSET)
 
@@ -68,6 +69,7 @@ _VAR_MAP = {
     "HERMES_SESSION_CHAT_NAME": _SESSION_CHAT_NAME,
     "HERMES_SESSION_THREAD_ID": _SESSION_THREAD_ID,
     "HERMES_SESSION_USER_ID": _SESSION_USER_ID,
+    "HERMES_SESSION_USER_ID_ALT": _SESSION_USER_ID_ALT,
     "HERMES_SESSION_USER_NAME": _SESSION_USER_NAME,
     "HERMES_SESSION_KEY": _SESSION_KEY,
     "HERMES_CRON_AUTO_DELIVER_PLATFORM": _CRON_AUTO_DELIVER_PLATFORM,
@@ -82,6 +84,7 @@ def set_session_vars(
     chat_name: str = "",
     thread_id: str = "",
     user_id: str = "",
+    user_id_alt: str = "",
     user_name: str = "",
     session_key: str = "",
 ) -> list:
@@ -99,6 +102,7 @@ def set_session_vars(
         _SESSION_CHAT_NAME.set(chat_name),
         _SESSION_THREAD_ID.set(thread_id),
         _SESSION_USER_ID.set(user_id),
+        _SESSION_USER_ID_ALT.set(user_id_alt),
         _SESSION_USER_NAME.set(user_name),
         _SESSION_KEY.set(session_key),
     ]
@@ -122,6 +126,7 @@ def clear_session_vars(tokens: list) -> None:
         _SESSION_CHAT_NAME,
         _SESSION_THREAD_ID,
         _SESSION_USER_ID,
+        _SESSION_USER_ID_ALT,
         _SESSION_USER_NAME,
         _SESSION_KEY,
     ):

--- a/tests/gateway/test_mirror.py
+++ b/tests/gateway/test_mirror.py
@@ -97,6 +97,26 @@ class TestFindSessionId:
 
         assert result == "sess_alice"
 
+    def test_user_id_alt_disambiguates_same_group_chat(self, tmp_path):
+        sessions_dir, index_file = _setup_sessions(tmp_path, {
+            "alice": {
+                "session_id": "sess_alice",
+                "origin": {"platform": "telegram", "chat_id": "-1001", "user_id_alt": "alt-alice"},
+                "updated_at": "2026-01-01T00:00:00",
+            },
+            "bob": {
+                "session_id": "sess_bob",
+                "origin": {"platform": "telegram", "chat_id": "-1001", "user_id_alt": "alt-bob"},
+                "updated_at": "2026-02-01T00:00:00",
+            },
+        })
+
+        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
+             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file):
+            result = _find_session_id("telegram", "-1001", user_id_alt="alt-alice")
+
+        assert result == "sess_alice"
+
     def test_ambiguous_same_group_chat_without_user_id_returns_none(self, tmp_path):
         sessions_dir, index_file = _setup_sessions(tmp_path, {
             "alice": {
@@ -107,6 +127,26 @@ class TestFindSessionId:
             "bob": {
                 "session_id": "sess_bob",
                 "origin": {"platform": "telegram", "chat_id": "-1001", "user_id": "bob"},
+                "updated_at": "2026-02-01T00:00:00",
+            },
+        })
+
+        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
+             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file):
+            result = _find_session_id("telegram", "-1001")
+
+        assert result is None
+
+    def test_ambiguous_same_group_chat_without_user_id_returns_none_for_alt_ids(self, tmp_path):
+        sessions_dir, index_file = _setup_sessions(tmp_path, {
+            "alice": {
+                "session_id": "sess_alice",
+                "origin": {"platform": "telegram", "chat_id": "-1001", "user_id_alt": "alt-alice"},
+                "updated_at": "2026-01-01T00:00:00",
+            },
+            "bob": {
+                "session_id": "sess_bob",
+                "origin": {"platform": "telegram", "chat_id": "-1001", "user_id_alt": "alt-bob"},
                 "updated_at": "2026-02-01T00:00:00",
             },
         })
@@ -252,6 +292,35 @@ class TestMirrorToSession:
                 "Hello group!",
                 source_label="cli",
                 user_id="alice",
+            )
+
+        assert result is True
+        assert (sessions_dir / "sess_alice.jsonl").exists()
+        assert not (sessions_dir / "sess_bob.jsonl").exists()
+
+    def test_successful_mirror_uses_user_id_alt_for_group_session(self, tmp_path):
+        sessions_dir, index_file = _setup_sessions(tmp_path, {
+            "alice": {
+                "session_id": "sess_alice",
+                "origin": {"platform": "telegram", "chat_id": "-1001", "user_id_alt": "alt-alice"},
+                "updated_at": "2026-01-01T00:00:00",
+            },
+            "bob": {
+                "session_id": "sess_bob",
+                "origin": {"platform": "telegram", "chat_id": "-1001", "user_id_alt": "alt-bob"},
+                "updated_at": "2026-02-01T00:00:00",
+            },
+        })
+
+        with patch.object(mirror_mod, "_SESSIONS_DIR", sessions_dir), \
+             patch.object(mirror_mod, "_SESSIONS_INDEX", index_file), \
+             patch("gateway.mirror._append_to_sqlite"):
+            result = mirror_to_session(
+                "telegram",
+                "-1001",
+                "Hello group!",
+                source_label="cli",
+                user_id_alt="alt-alice",
             )
 
         assert result is True

--- a/tests/gateway/test_session_env.py
+++ b/tests/gateway/test_session_env.py
@@ -39,6 +39,7 @@ def test_set_session_env_sets_contextvars(monkeypatch):
         chat_name="Group",
         chat_type="group",
         user_id="123456",
+        user_id_alt="union-123",
         user_name="alice",
         thread_id="17585",
     )
@@ -48,6 +49,7 @@ def test_set_session_env_sets_contextvars(monkeypatch):
     monkeypatch.delenv("HERMES_SESSION_CHAT_ID", raising=False)
     monkeypatch.delenv("HERMES_SESSION_CHAT_NAME", raising=False)
     monkeypatch.delenv("HERMES_SESSION_USER_ID", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_USER_ID_ALT", raising=False)
     monkeypatch.delenv("HERMES_SESSION_USER_NAME", raising=False)
     monkeypatch.delenv("HERMES_SESSION_THREAD_ID", raising=False)
 
@@ -58,6 +60,7 @@ def test_set_session_env_sets_contextvars(monkeypatch):
     assert get_session_env("HERMES_SESSION_CHAT_ID") == "-1001"
     assert get_session_env("HERMES_SESSION_CHAT_NAME") == "Group"
     assert get_session_env("HERMES_SESSION_USER_ID") == "123456"
+    assert get_session_env("HERMES_SESSION_USER_ID_ALT") == "union-123"
     assert get_session_env("HERMES_SESSION_USER_NAME") == "alice"
     assert get_session_env("HERMES_SESSION_THREAD_ID") == "17585"
 
@@ -77,6 +80,7 @@ def test_clear_session_env_restores_previous_state(monkeypatch):
     monkeypatch.delenv("HERMES_SESSION_CHAT_ID", raising=False)
     monkeypatch.delenv("HERMES_SESSION_CHAT_NAME", raising=False)
     monkeypatch.delenv("HERMES_SESSION_USER_ID", raising=False)
+    monkeypatch.delenv("HERMES_SESSION_USER_ID_ALT", raising=False)
     monkeypatch.delenv("HERMES_SESSION_USER_NAME", raising=False)
     monkeypatch.delenv("HERMES_SESSION_THREAD_ID", raising=False)
 
@@ -86,6 +90,7 @@ def test_clear_session_env_restores_previous_state(monkeypatch):
         chat_name="Group",
         chat_type="group",
         user_id="123456",
+        user_id_alt="union-123",
         user_name="alice",
         thread_id="17585",
     )
@@ -102,6 +107,7 @@ def test_clear_session_env_restores_previous_state(monkeypatch):
     assert get_session_env("HERMES_SESSION_CHAT_ID") == ""
     assert get_session_env("HERMES_SESSION_CHAT_NAME") == ""
     assert get_session_env("HERMES_SESSION_USER_ID") == ""
+    assert get_session_env("HERMES_SESSION_USER_ID_ALT") == ""
     assert get_session_env("HERMES_SESSION_USER_NAME") == ""
     assert get_session_env("HERMES_SESSION_THREAD_ID") == ""
 

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -213,6 +213,41 @@ class TestSendMessageTool:
             source_label="telegram",
             thread_id=None,
             user_id="user-123",
+            user_id_alt=None,
+        )
+
+    def test_mirror_receives_current_session_user_id_alt(self):
+        config, _telegram_cfg = _make_config()
+
+        with patch("gateway.config.load_gateway_config", return_value=config), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch("model_tools._run_async", side_effect=_run_async_immediately), \
+             patch("tools.send_message_tool._send_to_platform", new=AsyncMock(return_value={"success": True})), \
+             patch("gateway.session_context.get_session_env") as get_session_env_mock, \
+             patch("gateway.mirror.mirror_to_session", return_value=True) as mirror_mock:
+            get_session_env_mock.side_effect = lambda name, default="": {
+                "HERMES_SESSION_PLATFORM": "telegram",
+                "HERMES_SESSION_USER_ID_ALT": "alt-123",
+            }.get(name, default)
+            result = json.loads(
+                send_message_tool(
+                    {
+                        "action": "send",
+                        "target": "telegram:12345",
+                        "message": "hello",
+                    }
+                )
+            )
+
+        assert result["success"] is True
+        mirror_mock.assert_called_once_with(
+            "telegram",
+            "12345",
+            "hello",
+            source_label="telegram",
+            thread_id=None,
+            user_id=None,
+            user_id_alt="alt-123",
         )
 
     def test_top_level_send_failure_redacts_query_token(self):

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -296,6 +296,7 @@ def _handle_send(args):
                 from gateway.session_context import get_session_env
                 source_label = get_session_env("HERMES_SESSION_PLATFORM", "cli")
                 user_id = get_session_env("HERMES_SESSION_USER_ID", "") or None
+                user_id_alt = get_session_env("HERMES_SESSION_USER_ID_ALT", "") or None
                 if mirror_to_session(
                     platform_name,
                     chat_id,
@@ -303,6 +304,7 @@ def _handle_send(args):
                     source_label=source_label,
                     thread_id=thread_id,
                     user_id=user_id,
+                    user_id_alt=user_id_alt,
                 ):
                     result["mirrored"] = True
             except Exception:


### PR DESCRIPTION
## Summary

This fixes a session-routing gap in cross-platform message mirroring.

Gateway session isolation already treats `user_id_alt` as a first-class participant identity (for example stable provider-specific IDs like Signal UUIDs or Feishu `union_id`). However, the `send_message` mirroring path only forwarded `user_id`, and the mirror lookup only matched `origin.user_id`.

As a result, deliveries sent into chats whose sessions were isolated by `user_id_alt` could fail to mirror back into the correct transcript, or fall into ambiguous-session behavior.

## What changed

- Added `HERMES_SESSION_USER_ID_ALT` to gateway session contextvars.
- Bound `context.source.user_id_alt` in `GatewayRunner._set_session_env`.
- Forwarded `user_id_alt` from `send_message` into `mirror_to_session(...)`.
- Updated `gateway.mirror._find_session_id(...)` to:
  - accept `user_id_alt`
  - match against both `origin.user_id` and `origin.user_id_alt`
  - include `user_id_alt` in ambiguity detection

## Why this matters

This brings the mirror path into alignment with the repo’s existing session isolation model and prevents transcript contamination or missed mirrors for platforms that rely on alternate stable user identifiers.

## Tests

Added coverage for:

- `user_id_alt`-based disambiguation in mirror lookup
- ambiguity protection when only `user_id_alt` differs between candidate sessions
- successful mirroring into the correct `user_id_alt`-scoped session
- gateway session context propagation of `user_id_alt`
- `send_message` forwarding of `user_id_alt` into the mirror layer

## Validation

Passed:

- `tests/gateway/test_mirror.py`
- `tests/gateway/test_session_env.py`
- `tests/tools/test_send_message_tool.py` except one pre-existing Windows-unfriendly `/tmp` test unrelated to this change
