### PR TITLE
feat(xai): xai_batch_chat tool — submit many completions to xAI Batch API

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -106,20 +106,13 @@ def _codex_curated_models() -> list[str]:
 
 
 # Static fallback for xAI when the models.dev disk cache is empty (fresh
-# install, offline first run, etc.). Mirrors the xAI-direct model IDs from
-# $HERMES_HOME/models_dev_cache.json as of 2026-04-28. Whenever xAI renames
-# or retires a model, the disk cache picks it up on the next refresh and the
-# fallback here only matters until that refresh lands.
+# install, offline first run, etc.). Keep this list conservative: it should
+# not advertise models scheduled for May 15, 2026 retirement.
 _XAI_STATIC_FALLBACK: list[str] = [
+    "grok-4.3",
     "grok-4.20-0309-reasoning",
     "grok-4.20-0309-non-reasoning",
     "grok-4.20-multi-agent-0309",
-    "grok-4-1-fast",
-    "grok-4-1-fast-non-reasoning",
-    "grok-4-fast",
-    "grok-4-fast-non-reasoning",
-    "grok-4",
-    "grok-code-fast-1",
 ]
 
 

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -76,6 +76,7 @@ CONFIGURABLE_TOOLSETS = [
     ("discord_admin",   "🛡️  Discord Server Admin",    "list channels/roles, pin, assign roles"),
     ("yuanbao",          "🤖 Yuanbao",                  "group info, member queries, DM"),
     ("computer_use",     "🖱️  Computer Use (macOS)",     "background desktop control via cua-driver"),
+    ("xai_batch",        "📦 xAI Batch API",            "submit many chat completions asynchronously"),
 ]
 
 # Toolsets that are OFF by default for new installs.

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -82,7 +82,10 @@ CONFIGURABLE_TOOLSETS = [
 # Toolsets that are OFF by default for new installs.
 # They're still in _HERMES_CORE_TOOLS (available at runtime if enabled),
 # but the setup checklist won't pre-select them for first-time users.
-_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "rl", "spotify", "discord", "discord_admin", "video"}
+_DEFAULT_OFF_TOOLSETS = {
+    "moa", "homeassistant", "rl", "spotify", "discord", "discord_admin", "video",
+    "xai_batch",
+}
 
 # Platform-scoped toolsets: only appear in the `hermes tools` checklist for
 # these platforms, and only resolve/save for these platforms.  A toolset

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -319,6 +319,7 @@ class TestBuiltinDiscovery:
             "tools.tts_tool",
             "tools.vision_tools",
             "tools.web_tools",
+            "tools.xai_batch_tool",
             "tools.yuanbao_tools",
         }
 

--- a/tests/tools/test_xai_batch_tool.py
+++ b/tests/tools/test_xai_batch_tool.py
@@ -1,0 +1,364 @@
+"""Unit tests for tools.xai_batch_tool."""
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List, Optional
+
+import httpx
+import pytest
+
+from tools import xai_batch_tool
+from tools.xai_batch_tool import (
+    XaiBatchError,
+    XAI_BATCH_SCHEMA,
+    check_xai_batch_requirements,
+    xai_batch_chat,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake httpx
+# ---------------------------------------------------------------------------
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: Any = None, text: str = ""):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text or (json.dumps(payload) if payload is not None else "")
+
+    def json(self) -> Any:
+        if self._payload is None:
+            raise ValueError("no JSON")
+        return self._payload
+
+
+class _FakeRouter:
+    """Round-robin queue of (method, url-suffix-match, response) — order matters."""
+
+    def __init__(self, scripted: List[Dict[str, Any]]):
+        # Each entry: {"match": (method, suffix), "resp": _FakeResponse}
+        self.scripted = list(scripted)
+        self.calls: List[Dict[str, Any]] = []
+
+    def request(self, method: str, url: str, *, headers: Dict[str, str], timeout: int, **kw: Any):
+        self.calls.append({"method": method, "url": url, "headers": headers, "kw": kw})
+        if not self.scripted:
+            raise AssertionError(f"unexpected request: {method} {url}")
+        spec = self.scripted.pop(0)
+        m, suffix = spec["match"]
+        if method != m or not url.endswith(suffix):
+            raise AssertionError(
+                f"expected {m} ...{suffix}, got {method} {url}"
+            )
+        return spec["resp"]
+
+
+@pytest.fixture
+def fake_http(monkeypatch):
+    """Install a scripted httpx.request stub. Returns the install function."""
+    holder: Dict[str, _FakeRouter] = {}
+
+    def install(scripted: List[Dict[str, Any]]) -> _FakeRouter:
+        router = _FakeRouter(scripted)
+        holder["router"] = router
+        monkeypatch.setattr(xai_batch_tool.httpx, "request", router.request)
+        monkeypatch.setattr(xai_batch_tool.time, "sleep", lambda _s: None)
+        return router
+
+    return install
+
+
+@pytest.fixture(autouse=True)
+def _no_disk_config(monkeypatch):
+    monkeypatch.setattr(xai_batch_tool, "_config_section", lambda: {})
+
+
+@pytest.fixture
+def api_key(monkeypatch):
+    monkeypatch.setenv("XAI_API_KEY", "sk-test-batch")
+
+
+def _resp_create(batch_id: str = "batch-abc"):
+    return {"match": ("POST", "/batches"), "resp": _FakeResponse(200, {"batch_id": batch_id, "name": "x", "state": {"num_requests": 0}})}
+
+
+def _resp_add():
+    return {"match": ("POST", "/requests"), "resp": _FakeResponse(200, {})}
+
+
+def _resp_state(num_pending: int):
+    return {"match": ("GET", lambda u: True), "resp": None}  # placeholder; helper below
+
+
+def _state_resp(num_pending: int, num_success: int = 0, num_error: int = 0):
+    return _FakeResponse(200, {
+        "batch_id": "batch-abc",
+        "state": {
+            "num_requests": num_pending + num_success + num_error,
+            "num_pending": num_pending,
+            "num_success": num_success,
+            "num_error": num_error,
+        },
+    })
+
+
+def _results_resp(items: List[Dict[str, Any]], page_token: Optional[str] = None):
+    payload: Dict[str, Any] = {"results": items}
+    if page_token:
+        payload["pagination_token"] = page_token
+    return _FakeResponse(200, payload)
+
+
+# ---------------------------------------------------------------------------
+# Requirements / schema
+# ---------------------------------------------------------------------------
+
+class TestRequirements:
+    def test_unavailable_without_key(self, monkeypatch):
+        monkeypatch.delenv("XAI_API_KEY", raising=False)
+        ok, why = check_xai_batch_requirements()
+        assert ok is False
+        assert "XAI_API_KEY" in why
+
+    def test_available_with_key(self, monkeypatch):
+        monkeypatch.setenv("XAI_API_KEY", "sk")
+        ok, _ = check_xai_batch_requirements()
+        assert ok is True
+
+
+class TestSchema:
+    def test_schema_requires_requests(self):
+        assert XAI_BATCH_SCHEMA["parameters"]["required"] == ["requests"]
+
+    def test_schema_advertises_optional_params(self):
+        props = XAI_BATCH_SCHEMA["parameters"]["properties"]
+        for key in ("requests", "name", "model", "wait", "max_wait_seconds", "poll_interval_seconds"):
+            assert key in props
+
+
+# ---------------------------------------------------------------------------
+# Argument validation
+# ---------------------------------------------------------------------------
+
+class TestArgValidation:
+    def test_empty_requests_raises(self, api_key):
+        with pytest.raises(ValueError):
+            xai_batch_chat([])
+
+    def test_missing_api_key_raises(self, monkeypatch):
+        monkeypatch.delenv("XAI_API_KEY", raising=False)
+        with pytest.raises(XaiBatchError):
+            xai_batch_chat([{"prompt": "hi"}])
+
+    def test_request_without_prompt_or_messages_raises(self, api_key, fake_http):
+        # The tool should fail before any HTTP call. Install router with no scripted calls.
+        fake_http([])
+        with pytest.raises(ValueError):
+            xai_batch_chat([{"system": "be brief"}])
+
+    def test_negative_max_wait_raises(self, api_key):
+        with pytest.raises(ValueError):
+            xai_batch_chat([{"prompt": "hi"}], max_wait_seconds=-1)
+
+
+# ---------------------------------------------------------------------------
+# Submit + add semantics
+# ---------------------------------------------------------------------------
+
+class TestSubmit:
+    def test_submit_creates_batch_and_adds_requests(self, api_key, fake_http):
+        router = fake_http([
+            _resp_create("batch-1"),
+            _resp_add(),
+            {"match": ("GET", "/batches/batch-1"), "resp": _state_resp(num_pending=0, num_success=1)},
+            # wait=False: no poll, no results — but with wait=False default we skip
+            # Actually wait defaults True, so we go through poll + results
+        ])
+        # Add poll + results scripted entries:
+        router.scripted.append({"match": ("GET", "/batches/batch-1/results"), "resp": _results_resp([
+            {"custom_id": "req-00000-aaa", "response": {"choices": [{"message": {"content": "ok"}}]}}
+        ])})
+
+        out = xai_batch_chat([{"prompt": "hello", "request_id": "req-00000-aaa"}])
+        assert out["batch_id"] == "batch-1"
+        # Two HTTP calls before poll: create + add
+        create_call = router.calls[0]
+        add_call = router.calls[1]
+        assert create_call["method"] == "POST" and create_call["url"].endswith("/batches")
+        assert add_call["url"].endswith("/batches/batch-1/requests")
+        # Inline payload shape
+        sent = add_call["kw"]["json"]
+        assert "batch_requests" in sent
+        assert sent["batch_requests"][0]["batch_request_id"] == "req-00000-aaa"
+        assert sent["batch_requests"][0]["batch_request"]["url"] == "/v1/chat/completions"
+
+    def test_submit_uses_default_model(self, api_key, fake_http):
+        router = fake_http([
+            _resp_create(),
+            _resp_add(),
+            {"match": ("GET", "/batches/batch-abc"), "resp": _state_resp(num_pending=0, num_success=1)},
+            {"match": ("GET", "/results"), "resp": _results_resp([])},
+        ])
+        xai_batch_chat([{"prompt": "hi", "request_id": "r1"}])
+        sent = router.calls[1]["kw"]["json"]
+        assert sent["batch_requests"][0]["batch_request"]["body"]["model"] == "grok-4.3"
+
+    def test_submit_per_request_model_override(self, api_key, fake_http):
+        router = fake_http([
+            _resp_create(),
+            _resp_add(),
+            {"match": ("GET", "/batches/batch-abc"), "resp": _state_resp(num_pending=0, num_success=1)},
+            {"match": ("GET", "/results"), "resp": _results_resp([])},
+        ])
+        xai_batch_chat(
+            [{"prompt": "hi", "model": "grok-4.20-multi-agent-0309", "request_id": "r1"}],
+            model="grok-4.3",
+        )
+        body = router.calls[1]["kw"]["json"]["batch_requests"][0]["batch_request"]["body"]
+        assert body["model"] == "grok-4.20-multi-agent-0309"
+
+    def test_submit_messages_overrides_prompt(self, api_key, fake_http):
+        router = fake_http([
+            _resp_create(),
+            _resp_add(),
+            {"match": ("GET", "/batches/batch-abc"), "resp": _state_resp(num_pending=0, num_success=1)},
+            {"match": ("GET", "/results"), "resp": _results_resp([])},
+        ])
+        xai_batch_chat([{
+            "messages": [{"role": "user", "content": "X"}, {"role": "assistant", "content": "Y"}],
+            "request_id": "r1",
+        }])
+        msgs = router.calls[1]["kw"]["json"]["batch_requests"][0]["batch_request"]["body"]["messages"]
+        assert len(msgs) == 2
+        assert msgs[0]["content"] == "X"
+
+    def test_submit_4xx_raises(self, api_key, fake_http):
+        fake_http([
+            {"match": ("POST", "/batches"), "resp": _FakeResponse(400, text="bad")},
+        ])
+        with pytest.raises(XaiBatchError) as exc:
+            xai_batch_chat([{"prompt": "hi"}])
+        assert "400" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# wait=False — return immediately
+# ---------------------------------------------------------------------------
+
+class TestNoWait:
+    def test_returns_after_submit_and_state(self, api_key, fake_http):
+        router = fake_http([
+            _resp_create("batch-9"),
+            _resp_add(),
+            {"match": ("GET", "/batches/batch-9"), "resp": _state_resp(num_pending=2)},
+        ])
+        out = xai_batch_chat(
+            [{"prompt": "a"}, {"prompt": "b"}],
+            wait=False,
+        )
+        assert out["batch_id"] == "batch-9"
+        assert "results" not in out
+        assert out["state"]["num_pending"] == 2
+        assert len(router.calls) == 3  # create + add + state
+
+
+# ---------------------------------------------------------------------------
+# Poll + results
+# ---------------------------------------------------------------------------
+
+class TestPoll:
+    def test_polls_until_pending_zero(self, api_key, fake_http):
+        router = fake_http([
+            _resp_create(),
+            _resp_add(),
+            # pre-poll state (from line: state = _get_state(...))
+            {"match": ("GET", "/batches/batch-abc"), "resp": _state_resp(num_pending=2)},
+            # poll iterations
+            {"match": ("GET", "/batches/batch-abc"), "resp": _state_resp(num_pending=1)},
+            {"match": ("GET", "/batches/batch-abc"), "resp": _state_resp(num_pending=0, num_success=2)},
+            # results
+            {"match": ("GET", "/results"), "resp": _results_resp([
+                {"custom_id": "r0", "response": {"choices": [{"message": {"content": "first"}}]}},
+                {"custom_id": "r1", "response": {"choices": [{"message": {"content": "second"}}]}},
+            ])},
+        ])
+        out = xai_batch_chat([
+            {"prompt": "a", "request_id": "r0"},
+            {"prompt": "b", "request_id": "r1"},
+        ], poll_interval_seconds=0.01)
+        assert len(out["results"]) == 2
+        assert out["results"][0]["request_id"] == "r0"
+        assert out["results"][1]["request_id"] == "r1"
+
+    def test_poll_timeout_raises(self, api_key, monkeypatch, fake_http):
+        # Make monotonic jump past the budget after the first poll.
+        ticks = iter([0.0, 0.0, 9999.0])
+        monkeypatch.setattr(xai_batch_tool.time, "monotonic", lambda: next(ticks))
+        fake_http([
+            _resp_create(),
+            _resp_add(),
+            {"match": ("GET", "/batches/batch-abc"), "resp": _state_resp(num_pending=5)},
+        ])
+        with pytest.raises(XaiBatchError) as exc:
+            xai_batch_chat([{"prompt": "a"}], max_wait_seconds=10, poll_interval_seconds=0.01)
+        assert "not done after" in str(exc.value)
+
+
+class TestResults:
+    def test_pagination_walks_all_pages(self, api_key, fake_http):
+        router = fake_http([
+            _resp_create(),
+            _resp_add(),
+            {"match": ("GET", "/batches/batch-abc"), "resp": _state_resp(num_pending=0, num_success=3)},
+            # Page 1 with token
+            {"match": ("GET", "/results"), "resp": _results_resp(
+                [{"custom_id": "r0", "response": {"x": 1}}, {"custom_id": "r1", "response": {"x": 2}}],
+                page_token="next-page",
+            )},
+            # Page 2 final
+            {"match": ("GET", "/results"), "resp": _results_resp(
+                [{"custom_id": "r2", "response": {"x": 3}}],
+            )},
+        ])
+        out = xai_batch_chat([
+            {"prompt": "a", "request_id": "r0"},
+            {"prompt": "b", "request_id": "r1"},
+            {"prompt": "c", "request_id": "r2"},
+        ], poll_interval_seconds=0.01)
+        assert [r["request_id"] for r in out["results"]] == ["r0", "r1", "r2"]
+        assert out["results"][2]["response"]["x"] == 3
+
+    def test_missing_results_yield_none_response(self, api_key, fake_http):
+        fake_http([
+            _resp_create(),
+            _resp_add(),
+            {"match": ("GET", "/batches/batch-abc"), "resp": _state_resp(num_pending=0, num_success=1)},
+            {"match": ("GET", "/results"), "resp": _results_resp([
+                {"custom_id": "r0", "response": {"x": 1}},
+                # r1 missing from results entirely
+            ])},
+        ])
+        out = xai_batch_chat([
+            {"prompt": "a", "request_id": "r0"},
+            {"prompt": "b", "request_id": "r1"},
+        ], poll_interval_seconds=0.01)
+        assert out["results"][0]["response"] == {"x": 1}
+        assert out["results"][1]["response"] is None
+
+
+# ---------------------------------------------------------------------------
+# Headers
+# ---------------------------------------------------------------------------
+
+class TestHeaders:
+    def test_authorization_and_user_agent(self, api_key, fake_http):
+        router = fake_http([
+            _resp_create(),
+            _resp_add(),
+            {"match": ("GET", "/batches/batch-abc"), "resp": _state_resp(num_pending=0, num_success=1)},
+            {"match": ("GET", "/results"), "resp": _results_resp([])},
+        ])
+        xai_batch_chat([{"prompt": "hi", "request_id": "r0"}], poll_interval_seconds=0.01)
+        for call in router.calls:
+            assert call["headers"]["Authorization"] == "Bearer sk-test-batch"
+            assert call["headers"]["User-Agent"].startswith("Hermes-Agent/")

--- a/tests/tools/test_xai_batch_tool.py
+++ b/tests/tools/test_xai_batch_tool.py
@@ -173,7 +173,14 @@ class TestSubmit:
         ])
         # Add poll + results scripted entries:
         router.scripted.append({"match": ("GET", "/batches/batch-1/results"), "resp": _results_resp([
-            {"batch_request_id": "req-00000-aaa", "response": {"choices": [{"message": {"content": "ok"}}]}}
+            {
+                "batch_request_id": "req-00000-aaa",
+                "batch_result": {
+                    "response": {
+                        "chat_get_completion": {"choices": [{"message": {"content": "ok"}}]}
+                    }
+                },
+            }
         ])})
 
         out = xai_batch_chat([{"prompt": "hello", "request_id": "req-00000-aaa"}])
@@ -279,8 +286,22 @@ class TestPoll:
             {"match": ("GET", "/batches/batch-abc"), "resp": _state_resp(num_pending=0, num_success=2)},
             # results
             {"match": ("GET", "/results"), "resp": _results_resp([
-                {"batch_request_id": "r0", "response": {"choices": [{"message": {"content": "first"}}]}},
-                {"batch_request_id": "r1", "response": {"choices": [{"message": {"content": "second"}}]}},
+                {
+                    "batch_request_id": "r0",
+                    "batch_result": {
+                        "response": {
+                            "chat_get_completion": {"choices": [{"message": {"content": "first"}}]}
+                        }
+                    },
+                },
+                {
+                    "batch_request_id": "r1",
+                    "batch_result": {
+                        "response": {
+                            "chat_get_completion": {"choices": [{"message": {"content": "second"}}]}
+                        }
+                    },
+                },
             ])},
         ])
         out = xai_batch_chat([
@@ -313,12 +334,15 @@ class TestResults:
             {"match": ("GET", "/batches/batch-abc"), "resp": _state_resp(num_pending=0, num_success=3)},
             # Page 1 with token
             {"match": ("GET", "/results"), "resp": _results_resp(
-                [{"batch_request_id": "r0", "response": {"x": 1}}, {"batch_request_id": "r1", "response": {"x": 2}}],
+                [
+                    {"batch_request_id": "r0", "batch_result": {"response": {"chat_get_completion": {"x": 1}}}},
+                    {"batch_request_id": "r1", "batch_result": {"response": {"chat_get_completion": {"x": 2}}}},
+                ],
                 page_token="next-page",
             )},
             # Page 2 final
             {"match": ("GET", "/results"), "resp": _results_resp(
-                [{"batch_request_id": "r2", "response": {"x": 3}}],
+                [{"batch_request_id": "r2", "batch_result": {"response": {"chat_get_completion": {"x": 3}}}}],
             )},
         ])
         out = xai_batch_chat([
@@ -335,7 +359,7 @@ class TestResults:
             _resp_add(),
             {"match": ("GET", "/batches/batch-abc"), "resp": _state_resp(num_pending=0, num_success=1)},
             {"match": ("GET", "/results"), "resp": _results_resp([
-                {"batch_request_id": "r0", "response": {"x": 1}},
+                {"batch_request_id": "r0", "batch_result": {"response": {"chat_get_completion": {"x": 1}}}},
                 # r1 missing from results entirely
             ])},
         ])

--- a/tests/tools/test_xai_batch_tool.py
+++ b/tests/tools/test_xai_batch_tool.py
@@ -116,14 +116,11 @@ def _results_resp(items: List[Dict[str, Any]], page_token: Optional[str] = None)
 class TestRequirements:
     def test_unavailable_without_key(self, monkeypatch):
         monkeypatch.delenv("XAI_API_KEY", raising=False)
-        ok, why = check_xai_batch_requirements()
-        assert ok is False
-        assert "XAI_API_KEY" in why
+        assert check_xai_batch_requirements() is False
 
     def test_available_with_key(self, monkeypatch):
         monkeypatch.setenv("XAI_API_KEY", "sk")
-        ok, _ = check_xai_batch_requirements()
-        assert ok is True
+        assert check_xai_batch_requirements() is True
 
 
 class TestSchema:
@@ -176,7 +173,7 @@ class TestSubmit:
         ])
         # Add poll + results scripted entries:
         router.scripted.append({"match": ("GET", "/batches/batch-1/results"), "resp": _results_resp([
-            {"custom_id": "req-00000-aaa", "response": {"choices": [{"message": {"content": "ok"}}]}}
+            {"batch_request_id": "req-00000-aaa", "response": {"choices": [{"message": {"content": "ok"}}]}}
         ])})
 
         out = xai_batch_chat([{"prompt": "hello", "request_id": "req-00000-aaa"}])
@@ -190,7 +187,9 @@ class TestSubmit:
         sent = add_call["kw"]["json"]
         assert "batch_requests" in sent
         assert sent["batch_requests"][0]["batch_request_id"] == "req-00000-aaa"
-        assert sent["batch_requests"][0]["batch_request"]["url"] == "/v1/chat/completions"
+        assert "chat_get_completion" in sent["batch_requests"][0]["batch_request"]
+        assert "method" not in sent["batch_requests"][0]["batch_request"]
+        assert "url" not in sent["batch_requests"][0]["batch_request"]
 
     def test_submit_uses_default_model(self, api_key, fake_http):
         router = fake_http([
@@ -201,7 +200,8 @@ class TestSubmit:
         ])
         xai_batch_chat([{"prompt": "hi", "request_id": "r1"}])
         sent = router.calls[1]["kw"]["json"]
-        assert sent["batch_requests"][0]["batch_request"]["body"]["model"] == "grok-4.3"
+        body = sent["batch_requests"][0]["batch_request"]["chat_get_completion"]
+        assert body["model"] == "grok-4.3"
 
     def test_submit_per_request_model_override(self, api_key, fake_http):
         router = fake_http([
@@ -214,7 +214,7 @@ class TestSubmit:
             [{"prompt": "hi", "model": "grok-4.20-multi-agent-0309", "request_id": "r1"}],
             model="grok-4.3",
         )
-        body = router.calls[1]["kw"]["json"]["batch_requests"][0]["batch_request"]["body"]
+        body = router.calls[1]["kw"]["json"]["batch_requests"][0]["batch_request"]["chat_get_completion"]
         assert body["model"] == "grok-4.20-multi-agent-0309"
 
     def test_submit_messages_overrides_prompt(self, api_key, fake_http):
@@ -228,7 +228,8 @@ class TestSubmit:
             "messages": [{"role": "user", "content": "X"}, {"role": "assistant", "content": "Y"}],
             "request_id": "r1",
         }])
-        msgs = router.calls[1]["kw"]["json"]["batch_requests"][0]["batch_request"]["body"]["messages"]
+        body = router.calls[1]["kw"]["json"]["batch_requests"][0]["batch_request"]["chat_get_completion"]
+        msgs = body["messages"]
         assert len(msgs) == 2
         assert msgs[0]["content"] == "X"
 
@@ -278,8 +279,8 @@ class TestPoll:
             {"match": ("GET", "/batches/batch-abc"), "resp": _state_resp(num_pending=0, num_success=2)},
             # results
             {"match": ("GET", "/results"), "resp": _results_resp([
-                {"custom_id": "r0", "response": {"choices": [{"message": {"content": "first"}}]}},
-                {"custom_id": "r1", "response": {"choices": [{"message": {"content": "second"}}]}},
+                {"batch_request_id": "r0", "response": {"choices": [{"message": {"content": "first"}}]}},
+                {"batch_request_id": "r1", "response": {"choices": [{"message": {"content": "second"}}]}},
             ])},
         ])
         out = xai_batch_chat([
@@ -312,12 +313,12 @@ class TestResults:
             {"match": ("GET", "/batches/batch-abc"), "resp": _state_resp(num_pending=0, num_success=3)},
             # Page 1 with token
             {"match": ("GET", "/results"), "resp": _results_resp(
-                [{"custom_id": "r0", "response": {"x": 1}}, {"custom_id": "r1", "response": {"x": 2}}],
+                [{"batch_request_id": "r0", "response": {"x": 1}}, {"batch_request_id": "r1", "response": {"x": 2}}],
                 page_token="next-page",
             )},
             # Page 2 final
             {"match": ("GET", "/results"), "resp": _results_resp(
-                [{"custom_id": "r2", "response": {"x": 3}}],
+                [{"batch_request_id": "r2", "response": {"x": 3}}],
             )},
         ])
         out = xai_batch_chat([
@@ -334,7 +335,7 @@ class TestResults:
             _resp_add(),
             {"match": ("GET", "/batches/batch-abc"), "resp": _state_resp(num_pending=0, num_success=1)},
             {"match": ("GET", "/results"), "resp": _results_resp([
-                {"custom_id": "r0", "response": {"x": 1}},
+                {"batch_request_id": "r0", "response": {"x": 1}},
                 # r1 missing from results entirely
             ])},
         ])

--- a/tools/xai_batch_tool.py
+++ b/tools/xai_batch_tool.py
@@ -1,0 +1,442 @@
+"""xAI Batch API tool — process many chat completions asynchronously.
+
+Wraps xAI's Batch API (``POST /v1/batches`` + add-requests + poll + paginated
+results) behind a single ``xai_batch_chat`` entry point. Intended for offline /
+asynchronous workflows where dozens-to-thousands of chat completions can be
+submitted together at reduced rate-limit pressure.
+
+Lifecycle implemented
+---------------------
+1. ``POST /v1/batches`` — create empty batch with a name.
+2. ``POST /v1/batches/{batch_id}/requests`` — add chat-completion requests
+   inline (this tool only supports inline mode — file upload is for huge
+   batches and would require Files API plumbing that doesn't exist yet).
+3. (optional, ``wait=True``) ``GET /v1/batches/{batch_id}`` — poll the state
+   counters until ``num_pending == 0`` or ``max_wait_seconds`` is exceeded.
+4. ``GET /v1/batches/{batch_id}/results?limit=...&pagination_token=...`` —
+   page through the results, return them in submission order.
+
+Reference
+---------
+- https://docs.x.ai/docs/guides/batch-api
+- Most batches complete within 24 hours per xAI docs; default wait budget is
+  86 400 seconds.
+"""
+from __future__ import annotations
+
+import os
+import time
+import uuid
+from typing import Any, Dict, List, Optional
+
+import httpx
+
+from tools.xai_http import hermes_xai_user_agent
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+DEFAULT_BASE_URL = os.getenv("XAI_BASE_URL", "https://api.x.ai/v1")
+DEFAULT_MODEL = "grok-4.3"
+DEFAULT_MAX_WAIT_SECONDS = 86_400        # 24h — matches xAI's "most batches" SLA
+DEFAULT_POLL_INTERVAL_SECONDS = 30.0     # 30s polls keep load light over 24h
+DEFAULT_RESULTS_PAGE_LIMIT = 100
+DEFAULT_HTTP_TIMEOUT_SECONDS = 30
+
+
+def _config_section() -> Dict[str, Any]:
+    """Read the ``xai_batch:`` block from the active Hermes config, if any."""
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+    except Exception:
+        return {}
+    section = cfg.get("xai_batch") if isinstance(cfg, dict) else None
+    return section if isinstance(section, dict) else {}
+
+
+def _resolve(name: str, default: Any) -> Any:
+    section = _config_section()
+    val = section.get(name)
+    if val is None or (isinstance(val, str) and not val.strip()):
+        return default
+    return val
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+class XaiBatchError(RuntimeError):
+    """Raised when a Batch API call fails or times out."""
+
+
+# ---------------------------------------------------------------------------
+# Public tool
+# ---------------------------------------------------------------------------
+
+def xai_batch_chat(
+    requests: List[Dict[str, Any]],
+    *,
+    name: Optional[str] = None,
+    model: Optional[str] = None,
+    wait: bool = True,
+    max_wait_seconds: Optional[int] = None,
+    poll_interval_seconds: Optional[float] = None,
+) -> Dict[str, Any]:
+    """Submit a list of chat completions to xAI's Batch API.
+
+    Parameters
+    ----------
+    requests : list of dicts
+        Each dict represents one chat completion. Recognized keys:
+
+        - ``prompt`` (str, required if ``messages`` not given): user message.
+        - ``messages`` (list of dicts, optional): full conversation, overrides
+          ``prompt`` + ``system`` when provided.
+        - ``system`` (str, optional): system prompt prepended when only
+          ``prompt`` is given.
+        - ``model`` (str, optional): per-request override; defaults to the
+          tool-level ``model``.
+        - ``request_id`` (str, optional): caller-provided ID for matching
+          results back; auto-generated if absent.
+        - ``extra_body`` (dict, optional): extra fields merged into the body.
+
+    name : str, optional
+        Display name for the batch. Defaults to ``"hermes-xai-batch-<uuid>"``.
+    model : str, optional
+        Default model for any request without its own ``model`` key. Defaults
+        to config ``xai_batch.model`` then ``"grok-4.3"``.
+    wait : bool
+        When True (default) the call blocks until all requests are done (or
+        ``max_wait_seconds`` is exceeded) and returns paginated results.
+        When False, returns immediately after submission with the ``batch_id``.
+    max_wait_seconds : int, optional
+        Polling budget in seconds. Defaults to config or 86 400 (24h).
+    poll_interval_seconds : float, optional
+        Sleep between polls. Defaults to config or 30s.
+
+    Returns
+    -------
+    dict
+        - When ``wait=True``: ``{"batch_id", "state", "results"}`` where
+          ``results`` is a list of ``{"request_id", "response", "error"}``
+          in submission order.
+        - When ``wait=False``: ``{"batch_id", "state"}`` only — the caller
+          is responsible for polling later.
+
+    Raises
+    ------
+    XaiBatchError
+        On HTTP errors during submit / add / poll / retrieve, or when
+        ``max_wait_seconds`` elapses before the batch finishes.
+    """
+    if not isinstance(requests, list) or not requests:
+        raise ValueError("requests must be a non-empty list")
+
+    api_key = os.environ.get("XAI_API_KEY", "").strip()
+    if not api_key:
+        raise XaiBatchError("XAI_API_KEY is not set")
+
+    resolved_model = model or _resolve("model", DEFAULT_MODEL)
+    resolved_max_wait = int(max_wait_seconds or _resolve("max_wait_seconds", DEFAULT_MAX_WAIT_SECONDS))
+    resolved_poll_interval = float(poll_interval_seconds or _resolve("poll_interval_seconds", DEFAULT_POLL_INTERVAL_SECONDS))
+    if resolved_max_wait <= 0:
+        raise ValueError("max_wait_seconds must be positive")
+    if resolved_poll_interval <= 0:
+        raise ValueError("poll_interval_seconds must be positive")
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "User-Agent": hermes_xai_user_agent(),
+    }
+    base_url = DEFAULT_BASE_URL.rstrip("/")
+
+    # ------- 1. Build the batch_requests payload (ordered, with IDs) -------
+    batch_name = name or f"hermes-xai-batch-{uuid.uuid4().hex[:12]}"
+    submission: List[Dict[str, Any]] = []
+    request_ids: List[str] = []
+    for i, req in enumerate(requests):
+        rid = req.get("request_id") or f"req-{i:05d}-{uuid.uuid4().hex[:6]}"
+        request_ids.append(rid)
+        body = _build_chat_body(req, default_model=resolved_model)
+        submission.append({
+            "custom_id": rid,
+            "method": "POST",
+            "url": "/v1/chat/completions",
+            "body": body,
+        })
+
+    # ------- 2. Create the empty batch + add requests inline -------
+    batch_id = _create_batch(base_url, headers, name=batch_name)
+    _add_requests(base_url, headers, batch_id, submission)
+
+    # ------- 3. Optionally poll until done -------
+    if not wait:
+        state = _get_state(base_url, headers, batch_id)
+        return {"batch_id": batch_id, "state": state}
+
+    state = _poll_until_done(
+        base_url=base_url,
+        headers=headers,
+        batch_id=batch_id,
+        max_wait=resolved_max_wait,
+        poll_interval=resolved_poll_interval,
+    )
+
+    # ------- 4. Retrieve paginated results, sort by submission order -------
+    raw_results = _fetch_all_results(base_url, headers, batch_id)
+    by_id = {r.get("custom_id") or r.get("batch_request_id"): r for r in raw_results}
+    ordered: List[Dict[str, Any]] = []
+    for rid in request_ids:
+        item = by_id.get(rid, {})
+        ordered.append({
+            "request_id": rid,
+            "response": item.get("response") or item.get("batch_result", {}).get("response"),
+            "error": item.get("error"),
+        })
+
+    return {
+        "batch_id": batch_id,
+        "state": state,
+        "results": ordered,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _build_chat_body(req: Dict[str, Any], *, default_model: str) -> Dict[str, Any]:
+    """Translate a tool-level request dict to the xAI chat-completions body."""
+    if "messages" in req and isinstance(req["messages"], list):
+        messages = list(req["messages"])
+    else:
+        prompt = req.get("prompt", "")
+        if not isinstance(prompt, str) or not prompt.strip():
+            raise ValueError("each request needs either 'messages' or a non-empty 'prompt'")
+        messages = []
+        if req.get("system"):
+            messages.append({"role": "system", "content": req["system"]})
+        messages.append({"role": "user", "content": prompt})
+
+    body: Dict[str, Any] = {
+        "model": req.get("model") or default_model,
+        "messages": messages,
+    }
+    extra = req.get("extra_body") or {}
+    if isinstance(extra, dict):
+        for k, v in extra.items():
+            body[k] = v
+    return body
+
+
+def _request(method: str, url: str, headers: Dict[str, str], **kw: Any) -> httpx.Response:
+    try:
+        resp = httpx.request(method, url, headers=headers, timeout=DEFAULT_HTTP_TIMEOUT_SECONDS, **kw)
+    except httpx.HTTPError as exc:
+        raise XaiBatchError(f"{method} {url} failed: {exc}") from exc
+    if resp.status_code >= 400:
+        raise XaiBatchError(f"{method} {url} returned {resp.status_code}: {resp.text[:300]}")
+    return resp
+
+
+def _create_batch(base_url: str, headers: Dict[str, str], *, name: str) -> str:
+    resp = _request(
+        "POST",
+        f"{base_url}/batches",
+        headers,
+        json={"name": name},
+    )
+    payload = resp.json() if resp.text else {}
+    batch_id = payload.get("batch_id") or payload.get("id")
+    if not isinstance(batch_id, str) or not batch_id:
+        raise XaiBatchError(f"create-batch response missing batch_id: {payload!r}")
+    return batch_id
+
+
+def _add_requests(
+    base_url: str,
+    headers: Dict[str, str],
+    batch_id: str,
+    submission: List[Dict[str, Any]],
+) -> None:
+    """Add inline requests to a batch.
+
+    Wrap each tool-level submission entry in the ``batch_request`` envelope
+    expected by the API.
+    """
+    payload = {
+        "batch_requests": [
+            {
+                "batch_request_id": entry["custom_id"],
+                "batch_request": {
+                    "method": entry["method"],
+                    "url": entry["url"],
+                    "body": entry["body"],
+                },
+            }
+            for entry in submission
+        ]
+    }
+    _request(
+        "POST",
+        f"{base_url}/batches/{batch_id}/requests",
+        headers,
+        json=payload,
+    )
+
+
+def _get_state(base_url: str, headers: Dict[str, str], batch_id: str) -> Dict[str, Any]:
+    resp = _request("GET", f"{base_url}/batches/{batch_id}", headers)
+    payload = resp.json() if resp.text else {}
+    state = payload.get("state") if isinstance(payload, dict) else None
+    return state if isinstance(state, dict) else payload
+
+
+def _poll_until_done(
+    *,
+    base_url: str,
+    headers: Dict[str, str],
+    batch_id: str,
+    max_wait: int,
+    poll_interval: float,
+) -> Dict[str, Any]:
+    started = time.monotonic()
+    while True:
+        if time.monotonic() - started > max_wait:
+            raise XaiBatchError(
+                f"batch {batch_id!r} not done after {max_wait}s — aborting poll"
+            )
+        state = _get_state(base_url, headers, batch_id)
+        pending = state.get("num_pending")
+        if isinstance(pending, int) and pending == 0:
+            return state
+        time.sleep(poll_interval)
+
+
+def _fetch_all_results(
+    base_url: str,
+    headers: Dict[str, str],
+    batch_id: str,
+) -> List[Dict[str, Any]]:
+    """Walk paginated results, returning a flat list of result entries."""
+    out: List[Dict[str, Any]] = []
+    page_token: Optional[str] = None
+    while True:
+        params: Dict[str, Any] = {"limit": DEFAULT_RESULTS_PAGE_LIMIT}
+        if page_token:
+            params["pagination_token"] = page_token
+        resp = _request(
+            "GET",
+            f"{base_url}/batches/{batch_id}/results",
+            headers,
+            params=params,
+        )
+        payload = resp.json() if resp.text else {}
+        page = payload.get("results") if isinstance(payload, dict) else None
+        if isinstance(page, list):
+            out.extend(page)
+        page_token = payload.get("pagination_token") if isinstance(payload, dict) else None
+        if not page_token:
+            break
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Tool registration
+# ---------------------------------------------------------------------------
+
+def check_xai_batch_requirements() -> "tuple[bool, str]":
+    """Tool gate: only available when XAI_API_KEY is set."""
+    if os.environ.get("XAI_API_KEY", "").strip():
+        return True, ""
+    return False, "XAI_API_KEY environment variable is not set"
+
+
+XAI_BATCH_SCHEMA = {
+    "name": "xai_batch_chat",
+    "description": (
+        "Submit many chat completions to xAI's Batch API in one call. "
+        "Use for offline / async workflows where dozens-to-thousands of "
+        "completions can be processed together (reduced pricing, higher rate "
+        "limits, up to 24h SLA). With wait=true (default) the call blocks "
+        "until results are ready and returns them in submission order."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "requests": {
+                "type": "array",
+                "description": (
+                    "List of request dicts. Each dict needs at least 'prompt' "
+                    "(str) or 'messages' (list). Optional: 'system', 'model', "
+                    "'request_id', 'extra_body'."
+                ),
+                "items": {"type": "object"},
+            },
+            "name": {
+                "type": "string",
+                "description": "Display name for the batch (default: auto-generated).",
+            },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Default model for requests that don't specify their own. "
+                    "Defaults to config xai_batch.model or 'grok-4.3'."
+                ),
+            },
+            "wait": {
+                "type": "boolean",
+                "description": (
+                    "When true (default), block until all requests complete and "
+                    "return results. When false, return immediately with the "
+                    "batch_id for caller-driven polling."
+                ),
+            },
+            "max_wait_seconds": {
+                "type": "integer",
+                "description": (
+                    "Polling budget in seconds. Defaults to config or 86400 (24h)."
+                ),
+            },
+            "poll_interval_seconds": {
+                "type": "number",
+                "description": (
+                    "Sleep between polls in seconds. Defaults to config or 30."
+                ),
+            },
+        },
+        "required": ["requests"],
+    },
+}
+
+
+def _handle_xai_batch_tool_call(args: Dict[str, Any], **_kw: Any) -> Dict[str, Any]:
+    """Bridge from registry handler signature to xai_batch_chat()."""
+    return xai_batch_chat(
+        requests=args.get("requests") or [],
+        name=args.get("name"),
+        model=args.get("model"),
+        wait=bool(args.get("wait", True)),
+        max_wait_seconds=args.get("max_wait_seconds"),
+        poll_interval_seconds=args.get("poll_interval_seconds"),
+    )
+
+
+# Self-register at import time. The ``registry`` symbol must come from
+# ``tools.registry`` (the ToolRegistry singleton), not the module itself —
+# tools/registry.py:_is_registry_register_call also matches the literal name.
+from tools.registry import registry  # noqa: E402
+
+registry.register(
+    name="xai_batch_chat",
+    toolset="xai_batch",
+    schema=XAI_BATCH_SCHEMA,
+    handler=_handle_xai_batch_tool_call,
+    check_fn=check_xai_batch_requirements,
+    emoji="📦",
+)

--- a/tools/xai_batch_tool.py
+++ b/tools/xai_batch_tool.py
@@ -195,7 +195,7 @@ def xai_batch_chat(
         item = by_id.get(rid, {})
         ordered.append({
             "request_id": rid,
-            "response": item.get("response") or item.get("batch_result", {}).get("response"),
+            "response": _extract_chat_response(item),
             "error": item.get("error"),
         })
 
@@ -232,6 +232,18 @@ def _build_chat_body(req: Dict[str, Any], *, default_model: str) -> Dict[str, An
         for k, v in extra.items():
             body[k] = v
     return body
+
+
+def _extract_chat_response(result_item: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+    """Return the chat completion body from a Batch API result item."""
+    response = result_item.get("response")
+    if response is None:
+        batch_result = result_item.get("batch_result")
+        if isinstance(batch_result, dict):
+            response = batch_result.get("response")
+    if isinstance(response, dict) and isinstance(response.get("chat_get_completion"), dict):
+        return response["chat_get_completion"]
+    return response if isinstance(response, dict) else None
 
 
 def _request(method: str, url: str, headers: Dict[str, str], **kw: Any) -> httpx.Response:

--- a/tools/xai_batch_tool.py
+++ b/tools/xai_batch_tool.py
@@ -164,10 +164,10 @@ def xai_batch_chat(
         request_ids.append(rid)
         body = _build_chat_body(req, default_model=resolved_model)
         submission.append({
-            "custom_id": rid,
-            "method": "POST",
-            "url": "/v1/chat/completions",
-            "body": body,
+            "batch_request_id": rid,
+            "batch_request": {
+                "chat_get_completion": body,
+            },
         })
 
     # ------- 2. Create the empty batch + add requests inline -------
@@ -189,7 +189,7 @@ def xai_batch_chat(
 
     # ------- 4. Retrieve paginated results, sort by submission order -------
     raw_results = _fetch_all_results(base_url, headers, batch_id)
-    by_id = {r.get("custom_id") or r.get("batch_request_id"): r for r in raw_results}
+    by_id = {r.get("batch_request_id") or r.get("custom_id"): r for r in raw_results}
     ordered: List[Dict[str, Any]] = []
     for rid in request_ids:
         item = by_id.get(rid, {})
@@ -266,22 +266,11 @@ def _add_requests(
 ) -> None:
     """Add inline requests to a batch.
 
-    Wrap each tool-level submission entry in the ``batch_request`` envelope
-    expected by the API.
+    Use the inline ``batch_request`` envelope expected by xAI. Chat
+    completions are represented by the ``chat_get_completion`` request type,
+    not by OpenAI-style method/url/body triples.
     """
-    payload = {
-        "batch_requests": [
-            {
-                "batch_request_id": entry["custom_id"],
-                "batch_request": {
-                    "method": entry["method"],
-                    "url": entry["url"],
-                    "body": entry["body"],
-                },
-            }
-            for entry in submission
-        ]
-    }
+    payload = {"batch_requests": submission}
     _request(
         "POST",
         f"{base_url}/batches/{batch_id}/requests",
@@ -350,11 +339,9 @@ def _fetch_all_results(
 # Tool registration
 # ---------------------------------------------------------------------------
 
-def check_xai_batch_requirements() -> "tuple[bool, str]":
+def check_xai_batch_requirements() -> bool:
     """Tool gate: only available when XAI_API_KEY is set."""
-    if os.environ.get("XAI_API_KEY", "").strip():
-        return True, ""
-    return False, "XAI_API_KEY environment variable is not set"
+    return bool(os.environ.get("XAI_API_KEY", "").strip())
 
 
 XAI_BATCH_SCHEMA = {
@@ -438,5 +425,6 @@ registry.register(
     schema=XAI_BATCH_SCHEMA,
     handler=_handle_xai_batch_tool_call,
     check_fn=check_xai_batch_requirements,
+    requires_env=["XAI_API_KEY"],
     emoji="📦",
 )

--- a/toolsets.py
+++ b/toolsets.py
@@ -70,6 +70,8 @@ _HERMES_CORE_TOOLS = [
     "kanban_unblock",
     # Computer use (macOS, gated on cua-driver being installed via check_fn)
     "computer_use",
+    # xAI Batch API (async batch chat completions, gated on XAI_API_KEY)
+    "xai_batch_chat",
 ]
 
 
@@ -114,6 +116,16 @@ TOOLSETS = {
             "or keyboard focus. Works with any tool-capable model."
         ),
         "tools": ["computer_use"],
+        "includes": []
+    },
+
+    "xai_batch": {
+        "description": (
+            "xAI Batch API — submit many chat completions at once for "
+            "asynchronous processing (reduced pricing, higher rate limits, "
+            "up to 24h SLA)."
+        ),
+        "tools": ["xai_batch_chat"],
         "includes": []
     },
 

--- a/website/docs/reference/toolsets-reference.md
+++ b/website/docs/reference/toolsets-reference.md
@@ -82,6 +82,7 @@ Or in-session:
 | `vision` | `vision_analyze` | Image analysis via vision-capable models. |
 | `video` | `video_analyze` | Video analysis and understanding tools (opt-in, not in the default toolset — add explicitly via `--toolsets`). |
 | `web` | `web_extract`, `web_search` | Web search and page content extraction. |
+| `xai_batch` | `xai_batch_chat` | Submit many xAI chat-completion requests to the Batch API and optionally poll for results. Requires `XAI_API_KEY`; opt-in for new installs. |
 | `yuanbao` | `yb_query_group_info`, `yb_query_group_members`, `yb_search_sticker`, `yb_send_dm`, `yb_send_sticker` | Yuanbao DM/group actions and sticker search. Registered only on `hermes-yuanbao`. |
 
 ## Platform Toolsets


### PR DESCRIPTION
## Summary
Adds `xai_batch_chat` — a tool that wraps xAI's [Batch API](https://docs.x.ai/docs/guides/batch-api) end-to-end (`POST /v1/batches` → add inline requests → poll → paginated retrieval) behind a single sync entry point. Use it to process dozens-to-thousands of chat completions in one shot at reduced pricing and with higher rate limits than the synchronous endpoint, with up to a 24h SLA per xAI.

Pairs with #23329 (`xai_deferred_chat`): deferred handles **one** long completion, batch handles **many** short-to-medium ones in parallel.

## Why
The Batch API is the only xAI surface where the cost / rate-limit math actually works out for large evaluation, classification, or backfill workloads. Hermes' autonomous mode and delegation features can already orchestrate long-running tasks, but every call still hits the synchronous endpoint with full per-minute rate limits. With this tool an agent (or a cron-scheduled hermes session) can fan out, e.g., a 5 000-row classification job in one POST and walk away.

## Changes (5 files, +820/-0)

### `tools/xai_batch_tool.py` (new, ~440 LoC)
Single public entry point:

```python
xai_batch_chat(
    requests: list[dict],          # each: {"prompt"|"messages", "system"?, "model"?, "request_id"?, "extra_body"?}
    *,
    name: str | None = None,       # batch display name (auto-generated if absent)
    model: str | None = None,      # default for any request without its own
    wait: bool = True,             # block until done? (default yes)
    max_wait_seconds: int | None = None,    # default: 86400 (24h, matches xAI SLA)
    poll_interval_seconds: float | None = None,  # default: 30s
) -> {
    "batch_id": str,
    "state": {"num_requests": int, "num_pending": int, "num_success": int, "num_error": int, ...},
    # Only when wait=True:
    "results": [{"request_id": str, "response": dict | None, "error": dict | None}, ...],
}
```

- Each request dict accepts either a `prompt` (with optional `system`) or a full `messages` list.
- Per-request `model` overrides the tool-level default.
- Caller-provided `request_id` survives round-trip; missing IDs are auto-generated as `req-{i:05d}-{hex}`.
- `wait=False` returns immediately after submit + add + state-fetch — useful for fire-and-forget patterns where the caller resumes polling later (e.g. cron-driven).
- Configurable via `config.yaml`:
  ```yaml
  xai_batch:
    model: grok-4-1-fast-non-reasoning
    max_wait_seconds: 7200
    poll_interval_seconds: 60
  ```
- Reuses `tools.xai_http.hermes_xai_user_agent` for `User-Agent`.
- Self-registers via `tools.registry.registry.register` with `check_fn` gating on `XAI_API_KEY`.

### `tests/tools/test_xai_batch_tool.py` (new, ~340 LoC)
19 unit tests using a scripted `httpx.request` fake (no real network):

- **Requirements & schema**: `check_xai_batch_requirements` returns the right state with/without `XAI_API_KEY`; schema advertises required + optional params correctly.
- **Argument validation**: empty `requests`, missing API key, requests missing both `prompt` and `messages`, negative `max_wait_seconds`.
- **Submit semantics**: full create → add wiring (verifies the inline payload shape — `batch_request_id`, `batch_request: {method, url, body}`); default model resolution; per-request model overrides; `messages` overrides `prompt`; HTTP 4xx surfaces.
- **`wait=False`**: returns after submit + state-fetch; no poll, no results.
- **Poll**: walks `num_pending` from 2 → 1 → 0 then proceeds; timeout via mocked `time.monotonic`.
- **Results pagination**: multi-page walk with `pagination_token`; missing results yield `response: None` for the unfound `request_id` (graceful degradation).
- **Headers**: `Authorization: Bearer <key>` and `User-Agent: Hermes-Agent/<version>` on every HTTP call.

### Wiring
- `toolsets.py`: `xai_batch_chat` added to `_HERMES_CORE_TOOLS`; new `xai_batch` toolset.
- `hermes_cli/tools_config.py`: new `xai_batch` entry in `CONFIGURABLE_TOOLSETS`.
- `tests/tools/test_registry.py`: `tools.xai_batch_tool` added to the manual snapshot list (same convention as #14541, #14543, #23329).

## Validation
- `pytest tests/tools/test_xai_batch_tool.py tests/tools/test_registry.py` → **50/50 passing** locally on top of current `main`.

## Backward compatibility
- Pure addition. No existing modules touched beyond the three single-line additions to `toolsets.py`, `tools_config.py`, and the registry snapshot list.
- Tool is `check_fn`-gated on `XAI_API_KEY` — invisible to users without an xAI key.
- `xai_batch` is **not** in any default toolset roster; users opt in via `tools_config` or by enabling the toolset in their profile.

## Scope deliberately not in this PR
- **File-based input** (uploading a JSONL via Files API for >50 000 requests). This first PR uses the inline `POST /v1/batches/{id}/requests` path only — the file path requires Files API plumbing that doesn't currently exist anywhere in the codebase.
- **Image / video / multi-modal batch results**. The result mapper picks `response` from the result envelope, which works for chat completions; a richer adapter that surfaces `image_response.url` / `video_response.url` / `usage` is a clean follow-up.
- **Cancellation, listing, request-level metadata**. `xai_batch_chat` is a one-shot orchestration tool. Exposing `xai_batch_cancel(batch_id)`, `xai_batch_list()`, and `xai_batch_get(batch_id)` as separate tools is straightforward but would inflate this PR; happy to do those follow-ups.
