### PR TITLE
fix(kanban): harden worker ownership and recovery paths

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -406,12 +406,12 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
 
     p_edit = sub.add_parser(
         "edit",
-        help="Edit recovery fields on an already-completed task",
+        help="Edit recovery fields on a task",
     )
     p_edit.add_argument("task_id")
     p_edit.add_argument(
         "--result",
-        required=True,
+        default=None,
         help="Backfilled task result text for a done task",
     )
     p_edit.add_argument(
@@ -423,6 +423,21 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
         "--metadata",
         default=None,
         help="JSON dict of structured facts to store on the latest completed run.",
+    )
+    p_edit.add_argument(
+        "--clear-skills",
+        action="store_true",
+        help="Clear persisted task skills on a non-running task.",
+    )
+    p_edit.add_argument(
+        "--reset-failures",
+        action="store_true",
+        help="Reset consecutive failure counter and last failure error.",
+    )
+    p_edit.add_argument(
+        "--clear-claim",
+        action="store_true",
+        help="Clear persisted claim fields on a non-running task.",
     )
 
     p_block = sub.add_parser("block", help="Mark one or more tasks blocked")
@@ -1555,6 +1570,81 @@ def _cmd_complete(args: argparse.Namespace) -> int:
 
 
 def _cmd_edit(args: argparse.Namespace) -> int:
+    recovery_flags = sum(bool(x) for x in [
+        getattr(args, "clear_skills", False),
+        getattr(args, "reset_failures", False),
+        getattr(args, "clear_claim", False),
+    ])
+    if recovery_flags > 1:
+        print(
+            "kanban: edit accepts at most one recovery action flag "
+            "(--clear-skills, --reset-failures, or --clear-claim)",
+            file=sys.stderr,
+        )
+        return 2
+    if getattr(args, "clear_skills", False) and any([
+        args.result is not None,
+        getattr(args, "summary", None) is not None,
+        getattr(args, "metadata", None) is not None,
+    ]):
+        print(
+            "kanban: edit --clear-skills cannot be combined with "
+            "--result/--summary/--metadata",
+            file=sys.stderr,
+        )
+        return 2
+    if getattr(args, "reset_failures", False) and any([
+        args.result is not None,
+        getattr(args, "summary", None) is not None,
+        getattr(args, "metadata", None) is not None,
+    ]):
+        print(
+            "kanban: edit --reset-failures cannot be combined with "
+            "--result/--summary/--metadata",
+            file=sys.stderr,
+        )
+        return 2
+    if getattr(args, "clear_claim", False) and any([
+        args.result is not None,
+        getattr(args, "summary", None) is not None,
+        getattr(args, "metadata", None) is not None,
+    ]):
+        print(
+            "kanban: edit --clear-claim cannot be combined with "
+            "--result/--summary/--metadata",
+            file=sys.stderr,
+        )
+        return 2
+    if not (
+        getattr(args, "clear_skills", False)
+        or getattr(args, "reset_failures", False)
+        or getattr(args, "clear_claim", False)
+    ) and args.result is None:
+        print("kanban: edit requires --result or a recovery action flag", file=sys.stderr)
+        return 2
+    if getattr(args, "reset_failures", False):
+        with kb.connect() as conn:
+            if not kb.reset_task_failures(conn, args.task_id):
+                print(f"cannot edit {args.task_id} (unknown id)", file=sys.stderr)
+                return 1
+        print(f"Edited {args.task_id}")
+        return 0
+    if getattr(args, "clear_claim", False):
+        with kb.connect() as conn:
+            ok = kb.edit_task_recovery_fields(
+                conn,
+                args.task_id,
+                clear_claim=True,
+            )
+            if not ok:
+                print(
+                    f"cannot clear claim on {args.task_id} "
+                    f"(unknown id or task is running)",
+                    file=sys.stderr,
+                )
+                return 1
+        print(f"Edited {args.task_id}")
+        return 0
     raw_meta = getattr(args, "metadata", None)
     metadata = None
     if raw_meta:
@@ -1566,13 +1656,29 @@ def _cmd_edit(args: argparse.Namespace) -> int:
             print(f"kanban: --metadata: {exc}", file=sys.stderr)
             return 2
     with kb.connect() as conn:
-        if not kb.edit_completed_task_result(
+        if not kb.edit_task_recovery_fields(
             conn,
             args.task_id,
             result=args.result,
             summary=getattr(args, "summary", None),
             metadata=metadata,
+            clear_skills=bool(getattr(args, "clear_skills", False)),
+            clear_claim=bool(getattr(args, "clear_claim", False)),
         ):
+            if getattr(args, "clear_skills", False):
+                print(
+                    f"cannot clear skills on {args.task_id} "
+                    f"(unknown id or task is running)",
+                    file=sys.stderr,
+                )
+                return 1
+            if getattr(args, "clear_claim", False):
+                print(
+                    f"cannot clear claim on {args.task_id} "
+                    f"(unknown id or task is running)",
+                    file=sys.stderr,
+                )
+                return 1
             print(
                 f"cannot edit {args.task_id} (unknown id or task is not done)",
                 file=sys.stderr,
@@ -1675,6 +1781,7 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
             ],
             "skipped_unassigned": res.skipped_unassigned,
             "skipped_nonspawnable": res.skipped_nonspawnable,
+            "skipped_invalid_skills": res.skipped_invalid_skills,
         }, indent=2))
         return 0
     print(f"Reclaimed:    {res.reclaimed}")
@@ -1698,6 +1805,11 @@ def _cmd_dispatch(args: argparse.Namespace) -> int:
         print(
             f"Skipped (non-spawnable assignee — terminal lane, OK): "
             f"{', '.join(res.skipped_nonspawnable)}"
+        )
+    if res.skipped_invalid_skills:
+        print(
+            f"Skipped (invalid task skills): "
+            f"{', '.join(res.skipped_invalid_skills)}"
         )
     return 0
 

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -727,6 +727,19 @@ class Run:
         )
 
 
+@dataclass(frozen=True)
+class WorkerStartupGuard:
+    """Read-only startup validation for dispatcher-spawned workers."""
+
+    allowed: bool
+    reason: Optional[str] = None
+    task_id: Optional[str] = None
+    run_id: Optional[int] = None
+    status: Optional[str] = None
+    current_run_id: Optional[int] = None
+    claim_lock: Optional[str] = None
+
+
 @dataclass
 class Comment:
     id: int
@@ -2106,6 +2119,86 @@ def reclaim_task(
     return True
 
 
+def check_worker_startup_guard(
+    conn: sqlite3.Connection,
+    *,
+    task_id: Optional[str],
+    expected_run_id: Optional[int],
+    expected_claim_lock: Optional[str],
+) -> WorkerStartupGuard:
+    """Validate that a dispatcher-spawned worker still owns its task.
+
+    This is a read-only preflight used by the worker process itself before it
+    enters the model loop. It protects the claim->spawn gap: by the time the
+    child boots, the task may already have been reclaimed, blocked, archived,
+    or re-claimed by a newer run.
+    """
+    if not task_id:
+        return WorkerStartupGuard(False, reason="missing_task_id")
+
+    row = conn.execute(
+        "SELECT id, status, current_run_id, claim_lock FROM tasks WHERE id = ?",
+        (task_id,),
+    ).fetchone()
+    if row is None:
+        return WorkerStartupGuard(False, reason="task_missing", task_id=task_id)
+
+    status = row["status"]
+    current_run_id = (
+        int(row["current_run_id"]) if row["current_run_id"] is not None else None
+    )
+    claim_lock = row["claim_lock"]
+
+    if status != "running":
+        return WorkerStartupGuard(
+            False,
+            reason=f"task_not_running:{status}",
+            task_id=task_id,
+            run_id=expected_run_id,
+            status=status,
+            current_run_id=current_run_id,
+            claim_lock=claim_lock,
+        )
+    if expected_run_id is not None and current_run_id != int(expected_run_id):
+        return WorkerStartupGuard(
+            False,
+            reason="run_mismatch",
+            task_id=task_id,
+            run_id=int(expected_run_id),
+            status=status,
+            current_run_id=current_run_id,
+            claim_lock=claim_lock,
+        )
+    if expected_claim_lock is None:
+        return WorkerStartupGuard(
+            False,
+            reason="missing_claim_lock",
+            task_id=task_id,
+            run_id=expected_run_id,
+            status=status,
+            current_run_id=current_run_id,
+            claim_lock=claim_lock,
+        )
+    if claim_lock != expected_claim_lock:
+        return WorkerStartupGuard(
+            False,
+            reason="claim_mismatch",
+            task_id=task_id,
+            run_id=expected_run_id,
+            status=status,
+            current_run_id=current_run_id,
+            claim_lock=claim_lock,
+        )
+    return WorkerStartupGuard(
+        True,
+        task_id=task_id,
+        run_id=expected_run_id,
+        status=status,
+        current_run_id=current_run_id,
+        claim_lock=claim_lock,
+    )
+
+
 def reassign_task(
     conn: sqlite3.Connection,
     task_id: str,
@@ -2435,21 +2528,106 @@ def complete_task(
     return True
 
 
-def edit_completed_task_result(
+def edit_task_recovery_fields(
     conn: sqlite3.Connection,
     task_id: str,
     *,
-    result: str,
+    result: Optional[str] = None,
     summary: Optional[str] = None,
     metadata: Optional[dict] = None,
+    clear_skills: bool = False,
+    clear_claim: bool = False,
 ) -> bool:
-    """Backfill the user-visible result for an already completed task."""
+    """Edit narrow recovery fields on a task.
+
+    Supported today:
+    * backfill result/summary/metadata on an already-completed task
+    * clear persisted ``skills`` on a non-running task
+    * clear a stale claim on a non-running task that still has claim state
+    """
+    if not clear_skills and not clear_claim and result is None:
+        raise ValueError(
+            "result is required unless clear_skills=True or clear_claim=True"
+        )
     handoff_summary = summary if summary is not None else result
     with write_txn(conn):
         row = conn.execute(
-            "SELECT status FROM tasks WHERE id = ?", (task_id,),
+            "SELECT status, claim_lock, claim_expires, worker_pid, current_run_id "
+            "FROM tasks WHERE id = ?", (task_id,),
         ).fetchone()
-        if not row or row["status"] != "done":
+        if not row:
+            return False
+        if clear_claim:
+            if row["status"] == "running":
+                return False
+            had_claim_state = not (
+                row["claim_lock"] is None
+                and row["claim_expires"] is None
+                and row["worker_pid"] is None
+                and row["current_run_id"] is None
+            )
+            if not had_claim_state:
+                return True
+            run_id = row["current_run_id"]
+            if run_id is not None:
+                run_row = conn.execute(
+                    "SELECT status, outcome FROM task_runs WHERE id = ?",
+                    (int(run_id),),
+                ).fetchone()
+                if (
+                    run_row is not None
+                    and run_row["status"] == "running"
+                    and run_row["outcome"] is None
+                ):
+                    _end_run(
+                        conn, task_id,
+                        outcome="reclaimed", status="reclaimed",
+                        error="operator_clear_claim",
+                    )
+            conn.execute(
+                "UPDATE tasks SET claim_lock = NULL, claim_expires = NULL, "
+                "worker_pid = NULL, last_heartbeat_at = NULL, "
+                "current_run_id = NULL WHERE id = ?",
+                (task_id,),
+            )
+            _append_event(
+                conn, task_id, "edited",
+                {
+                 "fields": [
+                     "claim_lock",
+                     "claim_expires",
+                     "worker_pid",
+                     "last_heartbeat_at",
+                     "current_run_id",
+                 ],
+                 "claim_cleared": True},
+                run_id=run_id,
+            )
+            return True
+        if clear_skills:
+            if row["status"] == "running":
+                return False
+            run_id = None
+            if row["status"] == "done":
+                run = conn.execute(
+                    """
+                    SELECT id FROM task_runs
+                     WHERE task_id = ?
+                       AND outcome = 'completed'
+                     ORDER BY COALESCE(ended_at, started_at, 0) DESC, id DESC
+                     LIMIT 1
+                    """,
+                    (task_id,),
+                ).fetchone()
+                run_id = int(run["id"]) if run else None
+            conn.execute("UPDATE tasks SET skills = NULL WHERE id = ?", (task_id,))
+            _append_event(
+                conn, task_id, "edited",
+                {"fields": ["skills"], "skills_cleared": True},
+                run_id=run_id,
+            )
+            return True
+        if row["status"] != "done":
             return False
         conn.execute(
             "UPDATE tasks SET result = ? WHERE id = ?",
@@ -2500,6 +2678,26 @@ def edit_completed_task_result(
             run_id=run_id,
         )
     return True
+
+
+def edit_completed_task_result(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    result: Optional[str] = None,
+    summary: Optional[str] = None,
+    metadata: Optional[dict] = None,
+    clear_skills: bool = False,
+) -> bool:
+    """Back-compat wrapper for the broader recovery-field editor."""
+    return edit_task_recovery_fields(
+        conn,
+        task_id,
+        result=result,
+        summary=summary,
+        metadata=metadata,
+        clear_skills=clear_skills,
+    )
 
 
 def block_task(
@@ -2832,6 +3030,11 @@ class DispatchResult:
     operator-actionable failure. Tracked separately so health telemetry
     can distinguish "real stuck" (nothing spawned but spawnable work
     available) from "correctly idle" (nothing spawnable in the queue)."""
+    skipped_invalid_skills: list[str] = field(default_factory=list)
+    """Ready task ids skipped because persisted ``task.skills`` contains
+    invalid toolset names. Operator-actionable configuration error: the
+    task stays ready but the dispatcher refuses to spawn it until the
+    bad skills are cleared or the task is recreated."""
     crashed: list[str] = field(default_factory=list)
     """Task ids reclaimed because their worker PID disappeared."""
     auto_blocked: list[str] = field(default_factory=list)
@@ -3548,6 +3751,30 @@ def _clear_failure_counter(conn: sqlite3.Connection, task_id: str) -> None:
         )
 
 
+def reset_task_failures(conn: sqlite3.Connection, task_id: str) -> bool:
+    """Clear a task's consecutive-failure counter as an operator recovery
+    action. Returns ``True`` if the task exists."""
+    with write_txn(conn):
+        row = conn.execute(
+            "SELECT status, current_run_id FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if row is None:
+            return False
+        conn.execute(
+            "UPDATE tasks SET consecutive_failures = 0, "
+            "last_failure_error = NULL WHERE id = ?",
+            (task_id,),
+        )
+        _append_event(
+            conn, task_id, "edited",
+            {"fields": ["consecutive_failures", "last_failure_error"],
+             "failures_reset": True},
+            run_id=row["current_run_id"],
+        )
+        return True
+
+
 # Legacy alias for test-code and anything else that still imports it.
 _clear_spawn_failures = _clear_failure_counter
 
@@ -3695,6 +3922,16 @@ def dispatch_once(
         if not row["assignee"]:
             result.skipped_unassigned.append(row["id"])
             continue
+        task = get_task(conn, row["id"])
+        if task is not None:
+            invalid_skills = [
+                str(s).casefold()
+                for s in (task.skills or [])
+                if str(s).strip().casefold() in KNOWN_TOOLSET_NAMES
+            ]
+            if invalid_skills:
+                result.skipped_invalid_skills.append(row["id"])
+                continue
         # Skip ready tasks whose assignee is not a real Hermes profile.
         # `_default_spawn` invokes ``hermes -p <assignee>`` which fails
         # with "Profile 'X' does not exist" when the assignee names a

--- a/hermes_cli/kanban_diagnostics.py
+++ b/hermes_cli/kanban_diagnostics.py
@@ -34,6 +34,8 @@ from typing import Any, Callable, Iterable, Optional
 import json
 import time
 
+from hermes_cli.kanban_db import KNOWN_TOOLSET_NAMES
+
 
 # Severity rungs, ordered least → most urgent. The UI colors them
 # amber (warning), orange (error), red (critical). Sorted outputs put
@@ -217,6 +219,37 @@ def _generic_recovery_actions(task: Any, *, running: bool) -> list[DiagnosticAct
         payload={"reclaim_first": running},
     ))
     return out
+
+
+def _profile_exists_safe(name: Optional[str]) -> Optional[bool]:
+    if not name:
+        return None
+    try:
+        from hermes_cli import profiles
+        return bool(profiles.profile_exists(name))
+    except Exception:
+        return None
+
+
+def _profile_toolsets_safe(name: Optional[str]) -> Optional[list[str]]:
+    if not name:
+        return None
+    try:
+        from hermes_cli import profiles
+        from hermes_cli import config as config_mod
+        from hermes_constants import _profile_override_context
+
+        profile_dir = profiles.get_profile_dir(name)
+        if not profile_dir.is_dir():
+            return None
+        with _profile_override_context(str(profile_dir)):
+            cfg = config_mod.read_raw_config()
+        toolsets = cfg.get("toolsets")
+        if not isinstance(toolsets, list):
+            return None
+        return [str(t).strip() for t in toolsets if str(t).strip()]
+    except Exception:
+        return None
 
 
 # ---------------------------------------------------------------------------
@@ -570,9 +603,138 @@ def _rule_stuck_in_blocked(task, events, runs, now, cfg) -> list[Diagnostic]:
     )]
 
 
+def _rule_invalid_task_skills(task, events, runs, now, cfg) -> list[Diagnostic]:
+    skills = _task_field(task, "skills") or []
+    if not skills:
+        return []
+    invalid = [s for s in skills if str(s).casefold() in KNOWN_TOOLSET_NAMES]
+    if not invalid:
+        return []
+    task_id = _task_field(task, "id") or "TASK_ID"
+    running = _task_field(task, "status") == "running"
+    actions: list[DiagnosticAction] = []
+    if not running:
+        actions.append(DiagnosticAction(
+            kind="cli_hint",
+            label=f"Clear invalid skills: hermes kanban edit {task_id} --clear-skills",
+            payload={"command": f"hermes kanban edit {task_id} --clear-skills"},
+            suggested=True,
+        ))
+    actions.append(DiagnosticAction(
+        kind="cli_hint",
+        label=f"Inspect task: hermes kanban show {task_id}",
+        payload={"command": f"hermes kanban show {task_id}"},
+    ))
+    actions.extend(_generic_recovery_actions(task, running=running))
+    return [Diagnostic(
+        kind="invalid_task_skills",
+        severity="error",
+        title="Task skills contain toolset names",
+        detail=(
+            "This task's skills list contains Hermes toolset names rather than "
+            "SKILL bundle names. Dispatcher-spawned workers forward task.skills "
+            "through `--skills ...`, so values like web/browser/terminal/file "
+            "eventually fail worker startup with unknown-skill errors."
+        ),
+        actions=actions,
+        first_seen_at=now,
+        last_seen_at=now,
+        count=len(invalid),
+        data={"invalid_skills": invalid},
+    )]
+
+
+def _rule_assignee_profile_not_found(task, events, runs, now, cfg) -> list[Diagnostic]:
+    assignee = _task_field(task, "assignee")
+    status = _task_field(task, "status")
+    if not assignee or status not in ("triage", "todo", "ready", "running", "blocked"):
+        return []
+    exists = _profile_exists_safe(assignee)
+    if exists is not False:
+        return []
+    running = status == "running"
+    actions = [
+        DiagnosticAction(
+            kind="cli_hint",
+            label=f"Create profile: hermes profile create {assignee}",
+            payload={"command": f"hermes profile create {assignee}"},
+        ),
+    ]
+    actions.extend(_generic_recovery_actions(task, running=running))
+    if actions:
+        actions[-1].suggested = True
+    return [Diagnostic(
+        kind="assignee_profile_not_found",
+        severity="error",
+        title="Assigned profile does not exist",
+        detail=(
+            f"This task is assigned to profile '{assignee}', but Hermes "
+            "cannot resolve that profile on disk. Dispatcher-driven spawn "
+            "will skip or fail until the profile is created or the task is "
+            "reassigned."
+        ),
+        actions=actions,
+        first_seen_at=now,
+        last_seen_at=now,
+        count=1,
+        data={"assignee": assignee},
+    )]
+
+
+def _rule_stale_running_claim(task, events, runs, now, cfg) -> list[Diagnostic]:
+    if _task_field(task, "status") != "running":
+        return []
+    claim_expires = _task_field(task, "claim_expires")
+    if claim_expires is None or int(claim_expires) >= now:
+        return []
+    task_id = _task_field(task, "id") or "TASK_ID"
+    age_seconds = max(0, now - int(claim_expires))
+    return [Diagnostic(
+        kind="stale_running_claim",
+        severity="critical",
+        title="Running task has an expired claim",
+        detail=(
+            "This task is still marked running, but its claim TTL has already "
+            "expired. The dispatcher normally reclaims expired claims on the "
+            "next tick; if it remains stuck, reclaim it manually and inspect "
+            "the worker log before retrying."
+        ),
+        actions=[
+            DiagnosticAction(
+                kind="reclaim",
+                label="Reclaim task",
+                payload={},
+                suggested=True,
+            ),
+            DiagnosticAction(
+                kind="cli_hint",
+                label=f"Check worker log: hermes kanban log {task_id}",
+                payload={"command": f"hermes kanban log {task_id}"},
+            ),
+            DiagnosticAction(
+                kind="reassign",
+                label="Reassign to different profile",
+                payload={"reclaim_first": True},
+            ),
+        ],
+        first_seen_at=int(claim_expires),
+        last_seen_at=now,
+        count=1,
+        data={
+            "claim_expires": int(claim_expires),
+            "age_seconds": age_seconds,
+            "worker_pid": _task_field(task, "worker_pid"),
+            "current_run_id": _task_field(task, "current_run_id"),
+        },
+    )]
+
+
 # Registry — order matters: rules higher on the list render first when
 # severity ties. Add new rules here.
 _RULES: list[RuleFn] = [
+    _rule_stale_running_claim,
+    _rule_invalid_task_skills,
+    _rule_assignee_profile_not_found,
     _rule_hallucinated_cards,
     _rule_prose_phantom_refs,
     _rule_repeated_failures,
@@ -584,6 +746,9 @@ _RULES: list[RuleFn] = [
 # Known kinds (for the UI's filter / legend / i18n keys). Update when
 # rules are added.
 DIAGNOSTIC_KINDS = (
+    "stale_running_claim",
+    "invalid_task_skills",
+    "assignee_profile_not_found",
     "hallucinated_cards",
     "prose_phantom_refs",
     "repeated_failures",

--- a/run_agent.py
+++ b/run_agent.py
@@ -100,6 +100,81 @@ class _OpenAIProxy:
 
 OpenAI = _OpenAIProxy()
 
+
+def _kanban_worker_startup_env() -> Optional[dict[str, Any]]:
+    task_id = os.environ.get("HERMES_KANBAN_TASK", "").strip()
+    if not task_id:
+        return None
+    run_raw = os.environ.get("HERMES_KANBAN_RUN_ID", "").strip()
+    if not run_raw:
+        return {
+            "task_id": task_id,
+            "run_id": None,
+            "claim_lock": os.environ.get("HERMES_KANBAN_CLAIM_LOCK", "").strip() or None,
+            "db_path": os.environ.get("HERMES_KANBAN_DB", "").strip() or None,
+            "env_error": "missing_run_id",
+        }
+    try:
+        run_id: Optional[int] = int(run_raw)
+    except ValueError:
+        return {
+            "task_id": task_id,
+            "run_id": None,
+            "claim_lock": os.environ.get("HERMES_KANBAN_CLAIM_LOCK", "").strip() or None,
+            "db_path": os.environ.get("HERMES_KANBAN_DB", "").strip() or None,
+            "env_error": "invalid_run_id",
+        }
+    return {
+        "task_id": task_id,
+        "run_id": run_id,
+        "claim_lock": os.environ.get("HERMES_KANBAN_CLAIM_LOCK", "").strip() or None,
+        "db_path": os.environ.get("HERMES_KANBAN_DB", "").strip() or None,
+        "env_error": None,
+    }
+
+
+def _terminal_run_result(
+    agent,
+    *,
+    final_response: str,
+    turn_exit_reason: Optional[str],
+    completed: bool = False,
+    messages: Optional[list[dict[str, Any]]] = None,
+    api_calls: int = 0,
+    interrupted: bool = False,
+    response_previewed: bool = False,
+    partial: bool = False,
+    last_reasoning: Optional[str] = None,
+    last_prompt_tokens: int = 0,
+) -> dict[str, Any]:
+    """Build the standard run_conversation terminal result shape."""
+    return {
+        "final_response": final_response,
+        "last_reasoning": last_reasoning,
+        "messages": messages or [],
+        "api_calls": api_calls,
+        "completed": completed,
+        "turn_exit_reason": turn_exit_reason,
+        "partial": partial,
+        "interrupted": interrupted,
+        "response_previewed": response_previewed,
+        "model": agent.model,
+        "provider": agent.provider,
+        "base_url": agent.base_url,
+        "input_tokens": agent.session_input_tokens,
+        "output_tokens": agent.session_output_tokens,
+        "cache_read_tokens": agent.session_cache_read_tokens,
+        "cache_write_tokens": agent.session_cache_write_tokens,
+        "reasoning_tokens": agent.session_reasoning_tokens,
+        "prompt_tokens": agent.session_prompt_tokens,
+        "completion_tokens": agent.session_completion_tokens,
+        "total_tokens": agent.session_total_tokens,
+        "last_prompt_tokens": last_prompt_tokens,
+        "estimated_cost_usd": agent.session_estimated_cost_usd,
+        "cost_status": agent.session_cost_status,
+        "cost_source": agent.session_cost_source,
+    }
+
 # Load .env from ~/.hermes/.env first, then project root as dev fallback.
 # User-managed env files should override stale shell exports on restart.
 from hermes_cli.env_loader import load_hermes_dotenv
@@ -11514,6 +11589,63 @@ class AIAgent:
         # rejection and kept False for the rest of the session so we never re-send
         # images to a text-only endpoint.  Scoped per `_run()` call, not per instance.
         self._vision_supported = True
+
+        # Dispatcher-spawned Kanban workers validate ownership/state before
+        # doing any model work. The task may have been reclaimed, blocked,
+        # archived, or superseded by a newer run in the claim->spawn gap.
+        _kanban_startup = _kanban_worker_startup_env()
+        if _kanban_startup is not None:
+            if _kanban_startup.get("env_error"):
+                reason = str(_kanban_startup["env_error"])
+                return _terminal_run_result(
+                    self,
+                    final_response=(
+                        "Kanban worker startup skipped because worker ownership "
+                        f"metadata is invalid ({reason})."
+                    ),
+                    turn_exit_reason=f"kanban_startup_guard:{reason}",
+                    last_prompt_tokens=0,
+                )
+            try:
+                from hermes_cli import kanban_db as _kanban_db
+
+                db_path = _kanban_startup.get("db_path")
+                if db_path:
+                    conn = _kanban_db.connect(Path(db_path))
+                else:
+                    conn = _kanban_db.connect()
+                try:
+                    verdict = _kanban_db.check_worker_startup_guard(
+                        conn,
+                        task_id=_kanban_startup["task_id"],
+                        expected_run_id=_kanban_startup["run_id"],
+                        expected_claim_lock=_kanban_startup["claim_lock"],
+                    )
+                finally:
+                    conn.close()
+                if not verdict.allowed:
+                    _turn_exit_reason = f"kanban_startup_guard:{verdict.reason}"
+                    final_response = (
+                        "Kanban worker startup skipped because the task no longer "
+                        f"belongs to this worker ({verdict.reason})."
+                    )
+                    logger.info(
+                        "Kanban startup guard skipped worker: task=%s reason=%s "
+                        "expected_run=%s current_run=%s status=%s",
+                        verdict.task_id,
+                        verdict.reason,
+                        verdict.run_id,
+                        verdict.current_run_id,
+                        verdict.status,
+                    )
+                    return _terminal_run_result(
+                        self,
+                        final_response=final_response,
+                        turn_exit_reason=_turn_exit_reason,
+                        last_prompt_tokens=0,
+                    )
+            except Exception:
+                logger.debug("kanban worker startup guard failed open", exc_info=True)
 
         # Pre-turn connection health check: detect and clean up dead TCP
         # connections left over from provider outages or dropped streams.

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -1464,6 +1464,87 @@ def test_stale_run_cannot_block_or_heartbeat_new_attempt(kanban_home, monkeypatc
         conn.close()
 
 
+def test_worker_startup_guard_rejects_reclaimed_run(kanban_home):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="startup-guard", assignee="worker")
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+        run_id = claimed.current_run_id
+        lock = claimed.claim_lock
+        assert run_id is not None and lock is not None
+
+        assert kb.reclaim_task(conn, tid, reason="operator reclaim")
+
+        verdict = kb.check_worker_startup_guard(
+            conn,
+            task_id=tid,
+            expected_run_id=run_id,
+            expected_claim_lock=lock,
+        )
+        assert verdict.allowed is False
+        assert verdict.reason == "task_not_running:ready"
+        task = kb.get_task(conn, tid)
+        assert task.status == "ready"
+        assert task.consecutive_failures == 0
+    finally:
+        conn.close()
+
+
+def test_worker_startup_guard_rejects_superseded_run_without_failure(kanban_home):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="startup-guard", assignee="worker")
+        first = kb.claim_task(conn, tid)
+        assert first is not None
+        run1 = first.current_run_id
+        lock1 = first.claim_lock
+        assert run1 is not None and lock1 is not None
+
+        assert kb.reclaim_task(conn, tid, reason="retry")
+        second = kb.claim_task(conn, tid)
+        assert second is not None
+        run2 = second.current_run_id
+        lock2 = second.claim_lock
+        assert run2 is not None and lock2 is not None and run2 != run1
+
+        verdict = kb.check_worker_startup_guard(
+            conn,
+            task_id=tid,
+            expected_run_id=run1,
+            expected_claim_lock=lock1,
+        )
+        assert verdict.allowed is False
+        assert verdict.reason == "run_mismatch"
+        task = kb.get_task(conn, tid)
+        assert task.status == "running"
+        assert task.current_run_id == run2
+        assert task.consecutive_failures == 0
+    finally:
+        conn.close()
+
+
+def test_worker_startup_guard_requires_claim_lock(kanban_home):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="startup-guard", assignee="worker")
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+        run_id = claimed.current_run_id
+        assert run_id is not None
+
+        verdict = kb.check_worker_startup_guard(
+            conn,
+            task_id=tid,
+            expected_run_id=run_id,
+            expected_claim_lock=None,
+        )
+        assert verdict.allowed is False
+        assert verdict.reason == "missing_claim_lock"
+    finally:
+        conn.close()
+
+
 def test_run_on_block_with_reason(kanban_home):
     conn = kb.connect()
     try:
@@ -1738,6 +1819,128 @@ def test_cli_edit_rejects_non_done_task(kanban_home):
 
     assert "not done" in out
 
+
+def test_cli_edit_clear_skills_on_non_running_task(kanban_home):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="x", assignee="worker", skills=["translation"])
+    finally:
+        conn.close()
+
+    out = run_slash(f"edit {tid} --clear-skills")
+
+    assert "Edited" in out
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, tid)
+        events = kb.list_events(conn, tid)
+    finally:
+        conn.close()
+    assert task.skills is None
+    assert events[-1].kind == "edited"
+    assert events[-1].payload["skills_cleared"] is True
+
+
+def test_cli_edit_clear_skills_rejects_running_task(kanban_home):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="x", assignee="worker", skills=["translation"])
+        kb.claim_task(conn, tid)
+    finally:
+        conn.close()
+
+    out = run_slash(f"edit {tid} --clear-skills")
+
+    assert "cannot clear skills" in out
+
+def test_cli_edit_clear_skills_rejects_result_fields(kanban_home):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="x", assignee="worker", skills=["translation"])
+    finally:
+        conn.close()
+    out = run_slash(f"edit {tid} --clear-skills --result nope")
+
+    assert "--clear-skills cannot be combined" in out
+
+def test_cli_edit_reset_failures(kanban_home):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="x", assignee="worker")
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET consecutive_failures = 3, "
+                "last_failure_error = 'bad run' WHERE id = ?",
+                (tid,),
+            )
+    finally:
+        conn.close()
+
+    out = run_slash(f"edit {tid} --reset-failures")
+
+    assert "Edited" in out
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, tid)
+        events = kb.list_events(conn, tid)
+    finally:
+        conn.close()
+    assert task.consecutive_failures == 0
+    assert task.last_failure_error is None
+    assert events[-1].kind == "edited"
+    assert events[-1].payload["failures_reset"] is True
+
+
+def test_cli_edit_reset_failures_rejects_result_fields(kanban_home):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="x", assignee="worker")
+    finally:
+        conn.close()
+
+    out = run_slash(f"edit {tid} --reset-failures --result nope")
+
+    assert "--reset-failures cannot be combined" in out
+
+
+def test_cli_edit_clear_claim(kanban_home):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="x", assignee="worker")
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status='ready', claim_lock=?, "
+                "claim_expires=?, worker_pid=? WHERE id=?",
+                ("lock-1", 1234567890, 9999, tid),
+            )
+    finally:
+        conn.close()
+
+    out = run_slash(f"edit {tid} --clear-claim")
+
+    assert "Edited" in out
+    conn = kb.connect()
+    try:
+        task = kb.get_task(conn, tid)
+        events = kb.list_events(conn, tid)
+    finally:
+        conn.close()
+    assert task.claim_lock is None
+    assert task.claim_expires is None
+    assert task.worker_pid is None
+    assert events[-1].payload["claim_cleared"] is True
+
+
+def test_cli_edit_clear_claim_rejects_result_fields(kanban_home):
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="x", assignee="worker")
+    finally:
+        conn.close()
+
+    out = run_slash(f"edit {tid} --clear-claim --result nope")
+
+    assert "--clear-claim cannot be combined" in out
 
 def test_cli_complete_bad_metadata_exits_nonzero(kanban_home):
     conn = kb.connect()
@@ -2838,7 +3041,6 @@ def test_cli_create_without_skill_flag_leaves_none(kanban_home):
     with kb.connect() as conn:
         task = kb.get_task(conn, tid)
     assert task.skills is None
-
 
 def test_cli_show_renders_skills(kanban_home):
     """`hermes kanban show <id>` prints a skills row when present."""

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -80,6 +80,16 @@ def test_workspace_kind_validation(kanban_home):
         kb.create_task(conn, title="bad ws", workspace_kind="cloud")
 
 
+def test_create_task_rejects_toolset_names_in_skills(kanban_home):
+    with kb.connect() as conn, pytest.raises(ValueError, match="toolset names"):
+        kb.create_task(
+            conn,
+            title="bad skills",
+            assignee="alice",
+            skills=["web", "browser"],
+        )
+
+
 # ---------------------------------------------------------------------------
 # Links + dependency resolution
 # ---------------------------------------------------------------------------
@@ -538,6 +548,119 @@ def test_dispatch_skips_nonspawnable_into_separate_bucket(kanban_home, monkeypat
     assert t in res.skipped_nonspawnable
     assert t not in res.skipped_unassigned
     assert not res.spawned
+
+
+def test_dispatch_skips_invalid_task_skills_and_keeps_ready(
+    kanban_home, all_assignees_spawnable
+):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="bad-skills", assignee="worker")
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET skills = ? WHERE id = ?",
+                ('["web", "translation"]', tid),
+            )
+        res = kb.dispatch_once(conn, dry_run=True)
+        task = kb.get_task(conn, tid)
+        events = kb.list_events(conn, tid)
+    assert tid in res.skipped_invalid_skills
+    assert tid not in res.spawned
+    assert task.status == "ready"
+    assert [e.kind for e in events] == ["created"]
+
+
+def test_dispatch_skips_invalid_task_skills_without_event_spam(
+    kanban_home, all_assignees_spawnable
+):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="bad-skills", assignee="worker")
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET skills = ? WHERE id = ?",
+                ('["web", "translation"]', tid),
+            )
+        res = kb.dispatch_once(conn, dry_run=False)
+        events = kb.list_events(conn, tid)
+    assert tid in res.skipped_invalid_skills
+    assert [e.kind for e in events] == ["created"]
+
+
+def test_reset_task_failures_clears_counter_and_emits_event(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="retrying", assignee="worker")
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET consecutive_failures = 4, "
+                "last_failure_error = 'boom' WHERE id = ?",
+                (tid,),
+            )
+        assert kb.reset_task_failures(conn, tid) is True
+        task = kb.get_task(conn, tid)
+        events = kb.list_events(conn, tid)
+    assert task.consecutive_failures == 0
+    assert task.last_failure_error is None
+    assert events[-1].kind == "edited"
+    assert events[-1].payload["failures_reset"] is True
+
+
+def test_edit_task_recovery_fields_clear_claim_on_non_running_task(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="stale", assignee="worker")
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+        run_id = claimed.current_run_id
+        assert run_id is not None
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET status = 'ready', claim_lock = ?, "
+                "claim_expires = ?, worker_pid = ?, last_heartbeat_at = ?, "
+                "current_run_id = ? WHERE id = ?",
+                ("lock-1", 1234567890, 9999, 1234567000, run_id, tid),
+            )
+        assert kb.edit_task_recovery_fields(conn, tid, clear_claim=True) is True
+        task = kb.get_task(conn, tid)
+        events = kb.list_events(conn, tid)
+        run_row = conn.execute(
+            "SELECT status, outcome, ended_at FROM task_runs WHERE id = ?",
+            (run_id,),
+        ).fetchone()
+    assert task.claim_lock is None
+    assert task.claim_expires is None
+    assert task.worker_pid is None
+    assert task.last_heartbeat_at is None
+    assert task.current_run_id is None
+    assert run_row["status"] == "reclaimed"
+    assert run_row["outcome"] == "reclaimed"
+    assert run_row["ended_at"] is not None
+    assert events[-1].kind == "edited"
+    assert events[-1].payload["claim_cleared"] is True
+
+
+def test_edit_task_recovery_fields_clear_claim_keeps_terminal_run_terminal(kanban_home):
+    with kb.connect() as conn:
+        tid = kb.create_task(conn, title="done-stale", assignee="worker")
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+        run_id = claimed.current_run_id
+        assert run_id is not None
+        assert kb.complete_task(conn, tid, summary="done")
+        with kb.write_txn(conn):
+            conn.execute(
+                "UPDATE tasks SET claim_lock = ?, claim_expires = ?, worker_pid = ?, "
+                "last_heartbeat_at = ?, current_run_id = ? WHERE id = ?",
+                ("lock-1", 1234567890, 9999, 1234567000, run_id, tid),
+            )
+        assert kb.edit_task_recovery_fields(conn, tid, clear_claim=True) is True
+        task = kb.get_task(conn, tid)
+        run_row = conn.execute(
+            "SELECT status, outcome, summary FROM task_runs WHERE id = ?",
+            (run_id,),
+        ).fetchone()
+    assert task.claim_lock is None
+    assert task.current_run_id is None
+    assert run_row["status"] == "done"
+    assert run_row["outcome"] == "completed"
+    assert run_row["summary"] == "done"
 
 
 def test_has_spawnable_ready_false_when_only_terminal_lanes(kanban_home, monkeypatch):

--- a/tests/hermes_cli/test_kanban_diagnostics.py
+++ b/tests/hermes_cli/test_kanban_diagnostics.py
@@ -33,6 +33,16 @@ def kanban_home(tmp_path, monkeypatch):
     return home
 
 
+@pytest.fixture(autouse=True)
+def profiles_resolve_by_default(monkeypatch):
+    """Most rule tests isolate one failure mode at a time.
+
+    Keep profile-existence diagnostics silent unless a test explicitly
+    overrides the helper to exercise that rule.
+    """
+    monkeypatch.setattr(kd, "_profile_exists_safe", lambda _name: True)
+
+
 def _task(**overrides):
     base = {
         "id": "t_demo00",
@@ -243,6 +253,60 @@ def test_stuck_in_blocked_silent_when_not_blocked():
     assert kd.compute_task_diagnostics(task, events, [], now=9999999) == []
 
 
+def test_invalid_task_skills_fires_on_toolset_names():
+    task = _task(status="ready", skills=["web", "browser", "translation"])
+    diags = kd.compute_task_diagnostics(task, [], [])
+    assert len(diags) == 1
+    d = diags[0]
+    assert d.kind == "invalid_task_skills"
+    assert d.severity == "error"
+    assert d.data["invalid_skills"] == ["web", "browser"]
+
+
+def test_invalid_task_skills_silent_for_real_skill_names():
+    task = _task(status="ready", skills=["translation", "github-code-review"])
+    assert kd.compute_task_diagnostics(task, [], []) == []
+
+
+def test_missing_assignee_profile_fires(monkeypatch):
+    monkeypatch.setattr(kd, "_profile_exists_safe", lambda _name: False)
+    task = _task(status="ready", assignee="ghost")
+    diags = kd.compute_task_diagnostics(task, [], [])
+    assert len(diags) == 1
+    d = diags[0]
+    assert d.kind == "assignee_profile_not_found"
+    assert d.severity == "error"
+    assert d.data["assignee"] == "ghost"
+
+
+def test_missing_assignee_profile_silent_when_profile_exists(monkeypatch):
+    monkeypatch.setattr(kd, "_profile_exists_safe", lambda _name: True)
+    task = _task(status="ready", assignee="worker")
+    assert kd.compute_task_diagnostics(task, [], []) == []
+
+
+def test_stale_running_claim_fires():
+    now = int(time.time())
+    task = _task(
+        status="running",
+        claim_expires=now - 3600,
+        worker_pid=1234,
+        current_run_id=99,
+    )
+    diags = kd.compute_task_diagnostics(task, [], [], now=now)
+    assert len(diags) == 1
+    d = diags[0]
+    assert d.kind == "stale_running_claim"
+    assert d.severity == "critical"
+    assert d.data["age_seconds"] >= 3600
+
+
+def test_stale_running_claim_silent_when_claim_not_expired():
+    now = int(time.time())
+    task = _task(status="running", claim_expires=now + 3600)
+    assert kd.compute_task_diagnostics(task, [], [], now=now) == []
+
+
 def test_repeated_crashes_surfaces_actual_error_in_title():
     """The title should lead with the actual error text so operators
     see WHAT broke (e.g. rate-limit, auth, OOM) without opening logs.
@@ -319,6 +383,20 @@ def test_diagnostics_sorted_critical_first():
     kinds = [d.kind for d in diags]
     assert kinds[0] == "repeated_failures"  # critical
     assert "prose_phantom_refs" in kinds
+
+
+def test_diagnostics_sorts_stale_running_claim_before_error(monkeypatch):
+    monkeypatch.setattr(kd, "_profile_exists_safe", lambda _name: False)
+    now = int(time.time())
+    task = _task(
+        status="running",
+        assignee="ghost",
+        claim_expires=now - 10,
+    )
+    diags = kd.compute_task_diagnostics(task, [], [], now=now)
+    kinds = [d.kind for d in diags]
+    assert kinds[0] == "stale_running_claim"
+    assert "assignee_profile_not_found" in kinds
 
 
 # ---------------------------------------------------------------------------

--- a/tests/run_agent/test_kanban_worker_startup_guard.py
+++ b/tests/run_agent/test_kanban_worker_startup_guard.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+from hermes_cli import kanban_db as kb
+from run_agent import AIAgent
+
+
+def test_run_conversation_skips_stale_kanban_worker_before_api(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="stale worker", assignee="worker")
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+        run_id = claimed.current_run_id
+        lock = claimed.claim_lock
+        assert run_id is not None and lock is not None
+        assert kb.reclaim_task(conn, tid, reason="operator reclaim")
+    finally:
+        conn.close()
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", lock)
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(kb.kanban_db_path()))
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("hermes_logging.setup_logging"),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://example.invalid/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            platform="cli",
+        )
+    agent.client = MagicMock()
+
+    result = agent.run_conversation("work kanban task")
+
+    assert result["completed"] is False
+    assert result["api_calls"] == 0
+    assert result["interrupted"] is False
+    assert result["partial"] is False
+    assert result["turn_exit_reason"] == "kanban_startup_guard:task_not_running:ready"
+    assert "no longer belongs to this worker" in result["final_response"]
+    assert not agent.client.chat.completions.create.called
+
+
+def test_run_conversation_skips_kanban_worker_with_invalid_run_id(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+
+    tid = "t_demo1234"
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", "not-an-int")
+    monkeypatch.setenv("HERMES_KANBAN_CLAIM_LOCK", "host:lock")
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(kb.kanban_db_path()))
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("hermes_logging.setup_logging"),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://example.invalid/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            platform="cli",
+        )
+    agent.client = MagicMock()
+
+    result = agent.run_conversation("work kanban task")
+
+    assert result["api_calls"] == 0
+    assert result["turn_exit_reason"] == "kanban_startup_guard:invalid_run_id"
+    assert "metadata is invalid" in result["final_response"]
+    assert not agent.client.chat.completions.create.called
+
+
+def test_run_conversation_skips_kanban_worker_with_missing_claim_lock(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="missing-claim-lock", assignee="worker")
+        claimed = kb.claim_task(conn, tid)
+        assert claimed is not None
+        run_id = claimed.current_run_id
+        assert run_id is not None
+    finally:
+        conn.close()
+
+    monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+    monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+    monkeypatch.delenv("HERMES_KANBAN_CLAIM_LOCK", raising=False)
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(kb.kanban_db_path()))
+
+    with (
+        patch("run_agent.get_tool_definitions", return_value=[]),
+        patch("run_agent.check_toolset_requirements", return_value={}),
+        patch("run_agent.OpenAI"),
+        patch("hermes_logging.setup_logging"),
+    ):
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://example.invalid/v1",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+            platform="cli",
+        )
+    agent.client = MagicMock()
+
+    result = agent.run_conversation("work kanban task")
+
+    assert result["api_calls"] == 0
+    assert result["turn_exit_reason"] == "kanban_startup_guard:missing_claim_lock"
+    assert not agent.client.chat.completions.create.called


### PR DESCRIPTION
## What does this PR do?

This PR is a focused Kanban resubmission against current `main`.

Create-time validation for toolset names in `task.skills` has already landed
separately in #23273. This PR intentionally does not reimplement that path.

It resubmits only the still-novel pieces from the earlier stacked PRs:

- diagnostics for stuck / undispatchable tasks
- narrow recovery commands and defensive dispatch preflight
- worker startup ownership guard before any model API call

## Related Issue

Related to #22925, #22926, #22927.

Follow-up to #23209.

Builds on #23273, which already landed create-time validation for toolset
names in `task.skills`.

Supersedes the earlier stacked PRs #22974, #23154, and #23183 by resubmitting
only the still-novel Kanban hardening pieces against current `main`.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Add read-only diagnostics for `invalid_task_skills`, `assignee_profile_not_found`, and `stale_running_claim`
- Add narrow operator recovery commands:
  - `hermes kanban edit <task> --clear-skills`
  - `hermes kanban edit <task> --reset-failures`
  - `hermes kanban edit <task> --clear-claim`
- Teach dispatch to hard-skip ready tasks whose persisted state already proves
  they cannot spawn correctly:
  - tasks with historical invalid persisted `skills`
  - tasks assigned to missing profiles
- Add a read-only worker startup ownership guard before any model API call
- Require the Kanban startup guard to validate task status, run ownership, and claim lock ownership
- Treat malformed Kanban worker ownership env as a benign startup-guard skip instead of silently disabling the check
- Factor the startup-guard early return through a shared helper in `run_agent.py` instead of hand-rolling large inline result dicts
- Add targeted regression tests for diagnostics, recovery commands, dispatch skip behavior, and worker startup guard behavior

## How to Test

1. Run targeted Kanban tests:
   `pytest -q tests/hermes_cli/test_kanban_diagnostics.py tests/hermes_cli/test_kanban_db.py::test_reset_task_failures_clears_counter_and_emits_event tests/hermes_cli/test_kanban_db.py::test_edit_task_recovery_fields_clear_claim_on_non_running_task tests/hermes_cli/test_kanban_db.py::test_edit_task_recovery_fields_clear_claim_keeps_terminal_run_terminal tests/hermes_cli/test_kanban_core_functionality.py::test_cli_edit_clear_skills_on_non_running_task tests/hermes_cli/test_kanban_core_functionality.py::test_cli_edit_clear_skills_rejects_running_task tests/hermes_cli/test_kanban_core_functionality.py::test_cli_edit_clear_skills_rejects_result_fields tests/hermes_cli/test_kanban_core_functionality.py::test_cli_edit_reset_failures tests/hermes_cli/test_kanban_core_functionality.py::test_cli_edit_reset_failures_rejects_result_fields tests/hermes_cli/test_kanban_core_functionality.py::test_cli_edit_clear_claim tests/hermes_cli/test_kanban_core_functionality.py::test_cli_edit_clear_claim_rejects_result_fields tests/hermes_cli/test_kanban_core_functionality.py::test_worker_startup_guard_rejects_reclaimed_run tests/hermes_cli/test_kanban_core_functionality.py::test_worker_startup_guard_rejects_superseded_run_without_failure tests/hermes_cli/test_kanban_core_functionality.py::test_worker_startup_guard_requires_claim_lock tests/run_agent/test_kanban_worker_startup_guard.py`
2. Run the focused dispatch-preflight regression:
   `pytest -q tests/hermes_cli/test_kanban_db.py::test_dispatch_skips_invalid_task_skills_and_keeps_ready`
3. Create or patch a `ready` task so `tasks.skills` contains a toolset name, then run `hermes kanban dispatch --json` and verify it is reported under `skipped_invalid_skills` and remains `ready`
4. Use `hermes kanban edit <task_id> --reset-failures` and `hermes kanban edit <task_id> --clear-claim` to verify both recovery actions succeed on eligible tasks
5. Start a dispatcher-spawned worker against a reclaimed or superseded task and confirm the worker exits before any model API call

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Linux (WSL-style dev environment)

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Targeted verification passed: `44 passed in 38.48s`
- Focused dispatch-preflight regression passed locally
