### PR TITLE
fix(kanban): treat stream-stall fallback as crashed, not protocol_violation

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -2557,6 +2557,99 @@ def block_task(
         return True
 
 
+def record_stream_stall_fallback(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    expected_run_id: Optional[int] = None,
+    detail: Optional[str] = None,
+) -> bool:
+    """Record a stream-stall fallback transition on a kanban worker's task.
+
+    Called by the agent loop in ``run_agent.py`` when a partial-stream-stub
+    response is the terminal assistant message inside a kanban worker
+    (``HERMES_KANBAN_TASK`` is set). The worker exhausted
+    ``HERMES_STREAM_RETRIES`` mid tool-call and the streaming layer
+    injected the stub finish_reason='stop' message; without this hook the
+    process would exit cleanly while the task is still ``running``, which
+    ``detect_crashed_workers`` flags as a hardcoded-1-trip
+    ``protocol_violation``.
+
+    Semantics: closes the current run with ``outcome='crashed'`` (NOT
+    ``blocked``) so the run history reads as a normal transient crash,
+    transitions the task back to ``ready``, releases the claim, and
+    increments ``consecutive_failures`` via the standard
+    ``_record_task_failure`` path with the default ``failure_limit``
+    (NOT the protocol-violation 1-trip). On the first stall this leaves
+    the task in ``ready`` with ``consecutive_failures=1``; on the
+    ``DEFAULT_FAILURE_LIMIT``th stall the breaker trips and the task
+    moves to ``blocked`` with a ``gave_up`` event, same as any other
+    repeated transient crash.
+
+    The run's ``error`` and metadata both carry
+    ``STREAM_STALL_FALLBACK_SENTINEL`` so observability tooling and the
+    ``detect_crashed_workers`` belt-and-suspenders guard can distinguish
+    stream stalls from other crashes.
+
+    Returns True on success (status flipped, run closed). Returns False
+    when the row didn't update — task wasn't ``running``, or the
+    ``expected_run_id`` guard didn't match. Caller (the agent loop)
+    should treat False as best-effort: the dispatcher will eventually
+    reclaim/retry via the usual stale-claim path.
+    """
+    error_text = STREAM_STALL_FALLBACK_SENTINEL
+    if detail:
+        # Cap the detail so it fits inside the task's ``last_failure_error``
+        # column (500 char SQL truncation in ``_record_task_failure``).
+        clean = str(detail).strip()
+        if clean:
+            error_text = f"{STREAM_STALL_FALLBACK_SENTINEL}: {clean}"
+    metadata = {"sentinel": STREAM_STALL_FALLBACK_SENTINEL}
+    flipped = False
+    with write_txn(conn):
+        if expected_run_id is None:
+            cur = conn.execute(
+                "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+                "claim_expires = NULL, worker_pid = NULL "
+                "WHERE id = ? AND status = 'running'",
+                (task_id,),
+            )
+        else:
+            cur = conn.execute(
+                "UPDATE tasks SET status = 'ready', claim_lock = NULL, "
+                "claim_expires = NULL, worker_pid = NULL "
+                "WHERE id = ? AND status = 'running' AND current_run_id = ?",
+                (task_id, int(expected_run_id)),
+            )
+        if cur.rowcount != 1:
+            return False
+        run_id = _end_run(
+            conn, task_id,
+            outcome="crashed", status="crashed",
+            error=error_text,
+            metadata=metadata,
+        )
+        _append_event(
+            conn, task_id, "stream_stall_fallback",
+            dict(metadata, error=error_text),
+            run_id=run_id,
+        )
+        flipped = True
+    if flipped:
+        # Outside the main txn — increments consecutive_failures and
+        # may auto-block at DEFAULT_FAILURE_LIMIT (NOT 1).
+        _record_task_failure(
+            conn, task_id,
+            error=error_text,
+            outcome="crashed",
+            failure_limit=None,  # use default budget, not the 1-trip
+            release_claim=False,  # status is already ``ready``, claim cleared
+            end_run=False,        # run already closed above
+            event_payload_extra={"sentinel": STREAM_STALL_FALLBACK_SENTINEL},
+        )
+    return flipped
+
+
 def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
     """Transition ``blocked -> ready``.
 
@@ -2808,6 +2901,21 @@ def set_workspace_path(
 DEFAULT_FAILURE_LIMIT = 2
 # Legacy alias — callers / tests still reference the old name.
 DEFAULT_SPAWN_FAILURE_LIMIT = DEFAULT_FAILURE_LIMIT
+
+# Sentinel string a kanban worker uses to mark a stream-stall fallback
+# transition. Stamped on the run's ``error`` field, on the
+# ``stream_stall_fallback`` event payload, and on the ``last_failure_error``
+# task field by ``record_stream_stall_fallback`` below. The
+# ``detect_crashed_workers`` belt-and-suspenders guard greps for this prefix
+# on the most recent run's ``error`` so a worker that crashed AFTER stamping
+# the sentinel but BEFORE flipping status (atomicity escape hatch) still
+# gets classified as a normal crash, not a protocol violation.
+#
+# When changing the literal, update both producers (run_agent.py
+# ``_maybe_record_stream_stall_kanban_fallback`` and tests/run_agent/test_streaming.py)
+# and consumers (``record_stream_stall_fallback`` here and
+# ``detect_crashed_workers`` belt-and-suspenders).
+STREAM_STALL_FALLBACK_SENTINEL = "stream_stall_fallback"
 
 # Max bytes to keep in a single worker log file. The dispatcher truncates
 # and rotates on spawn if the file is larger than this at spawn time.
@@ -3258,17 +3366,58 @@ def detect_crashed_workers(conn: sqlite3.Connection) -> list[str]:
                 # ``running`` in the DB — it exited without calling
                 # ``kanban_complete`` / ``kanban_block``. Retrying won't
                 # help.
-                protocol_violation = True
-                error_text = (
-                    "worker exited cleanly (rc=0) without calling "
-                    "kanban_complete or kanban_block — protocol violation"
-                )
-                event_kind = "protocol_violation"
-                event_payload = {
-                    "pid": pid,
-                    "claimer": row["claim_lock"],
-                    "exit_code": code,
-                }
+                #
+                # Belt-and-suspenders for stream-stall fallbacks: if the
+                # most recent run for this task carries the
+                # ``STREAM_STALL_FALLBACK_SENTINEL`` on its ``error``
+                # field, the worker reached
+                # ``record_stream_stall_fallback`` and stamped the
+                # sentinel but somehow left the task in ``running``
+                # (atomicity escape hatch — the txn that flips status
+                # back to ``ready`` is paired with the run-close, so
+                # this is unexpected, but we guard anyway). Treat as a
+                # plain crash so the failure consumes the default
+                # budget instead of the 1-trip protocol-violation
+                # path. Genuine clean-exit-without-transition (LLM
+                # answered conversationally without calling
+                # kanban_complete) keeps the protocol_violation
+                # classification.
+                last_run_error = ""
+                try:
+                    last_run_row = conn.execute(
+                        "SELECT error FROM task_runs WHERE task_id = ? "
+                        "ORDER BY id DESC LIMIT 1",
+                        (row["id"],),
+                    ).fetchone()
+                    if last_run_row and last_run_row["error"]:
+                        last_run_error = str(last_run_row["error"])
+                except sqlite3.Error:
+                    last_run_error = ""
+                if last_run_error.startswith(STREAM_STALL_FALLBACK_SENTINEL):
+                    protocol_violation = False
+                    error_text = (
+                        f"clean exit after stream-stall fallback "
+                        f"({last_run_error[:200]})"
+                    )
+                    event_kind = "crashed"
+                    event_payload = {
+                        "pid": pid,
+                        "claimer": row["claim_lock"],
+                        "exit_code": code,
+                        "stream_stall_fallback": True,
+                    }
+                else:
+                    protocol_violation = True
+                    error_text = (
+                        "worker exited cleanly (rc=0) without calling "
+                        "kanban_complete or kanban_block — protocol violation"
+                    )
+                    event_kind = "protocol_violation"
+                    event_payload = {
+                        "pid": pid,
+                        "claimer": row["claim_lock"],
+                        "exit_code": code,
+                    }
             else:
                 protocol_violation = False
                 if kind == "nonzero_exit":
@@ -3877,6 +4026,17 @@ def _default_spawn(
     # what the tool reads — set it explicitly here so comments are
     # attributed correctly regardless of how the child loads config.
     env["HERMES_PROFILE"] = profile_arg
+
+    # Belt-and-suspenders for stream-stall fallbacks: kanban workers
+    # respawn cheaply but every protocol_violation/crash burns a slot
+    # on a small failure budget (default DEFAULT_FAILURE_LIMIT=2). Bump
+    # HERMES_STREAM_RETRIES from its global default of 2 to 4 for
+    # dispatched workers so a single transient upstream stall mid
+    # tool-call almost never reaches the partial-stream-stub path.
+    # Only set it when the operator hasn't pinned a different value
+    # in their environment (so tests / forced low-retry debugging
+    # still work).
+    env.setdefault("HERMES_STREAM_RETRIES", "4")
 
     cmd = [
         *_resolve_hermes_argv(),

--- a/run_agent.py
+++ b/run_agent.py
@@ -4302,6 +4302,114 @@ class AIAgent:
             if isinstance(msg, dict) and msg.get("role") == "user":
                 msg["content"] = override
 
+    def _maybe_record_stream_stall_kanban_fallback(self, response) -> bool:
+        """Record a stream-stall fallback transition on the kanban task, if applicable.
+
+        Called from the no-tool-calls branch of the agent loop when the
+        terminal assistant message is the ``partial-stream-stub``
+        SimpleNamespace produced by ``_interruptible_streaming_api_call``
+        after exhausting ``HERMES_STREAM_RETRIES`` mid tool-call.
+
+        Without this hook, a kanban worker process exits cleanly while
+        the task is still ``running`` in the kanban DB. The dispatcher's
+        ``detect_crashed_workers`` then classifies the clean exit as a
+        ``protocol_violation`` and trips the breaker on the FIRST stall
+        (hardcoded ``failure_limit=1``). Stream stalls are transient
+        upstream issues that should consume the normal failure budget,
+        not the 1-trip path reserved for genuine LLM protocol violations
+        (model answered conversationally without calling
+        kanban_complete / kanban_block).
+
+        Behaviour:
+
+        * No-op (returns False) unless ``HERMES_KANBAN_TASK`` is set in
+          the environment AND ``response`` is the partial-stream stub
+          (id == "partial-stream-stub"). The stub id is the only stable
+          marker — finish_reason='stop' alone is too broad.
+        * On match: imports ``hermes_cli.kanban_db`` lazily and calls
+          ``record_stream_stall_fallback`` which closes the run with
+          outcome='crashed' + ``STREAM_STALL_FALLBACK_SENTINEL``,
+          transitions the task back to ``ready``, and increments
+          ``consecutive_failures`` via the standard counter (default
+          budget, NOT the 1-trip protocol-violation path).
+        * Always best-effort: catches every exception so a bookkeeping
+          failure never crashes the worker process. Returns True only
+          when the kanban DB call succeeded.
+
+        ``HERMES_KANBAN_RUN_ID`` (when set by the dispatcher at spawn
+        time, see ``_default_spawn`` in ``hermes_cli/kanban_db.py``)
+        is passed as ``expected_run_id`` so the SQL UPDATE no-ops if
+        another dispatcher pass already reclaimed the task.
+        """
+        task_id = os.environ.get("HERMES_KANBAN_TASK")
+        if not task_id:
+            return False
+        if getattr(response, "id", None) != "partial-stream-stub":
+            return False
+        try:
+            from hermes_cli import kanban_db as kb
+        except Exception:
+            logger.exception(
+                "Stream-stall stub detected for kanban task %s but "
+                "kanban_db import failed", task_id,
+            )
+            return False
+        # Pull the partial tool-call names (if any) out of the stub
+        # content so the dispatcher dashboard surfaces *what* was
+        # interrupted. The stub content carries the user-visible warning
+        # appended by ``_interruptible_streaming_api_call``; we just
+        # stamp a short detail string.
+        detail = "HERMES_STREAM_RETRIES exhausted mid tool-call"
+        try:
+            stub_msg = (response.choices[0].message
+                        if getattr(response, "choices", None) else None)
+            content = getattr(stub_msg, "content", None) or ""
+            # Grab the first 120 chars of the content as a hint.
+            snippet = content.strip().splitlines()[-1] if content.strip() else ""
+            if snippet:
+                detail = f"{detail} — {snippet[:120]}"
+        except Exception:
+            pass
+        try:
+            run_id_env = os.environ.get("HERMES_KANBAN_RUN_ID", "").strip()
+            expected_run_id = int(run_id_env) if run_id_env else None
+        except (TypeError, ValueError):
+            expected_run_id = None
+        try:
+            conn = kb.connect()
+            try:
+                ok = kb.record_stream_stall_fallback(
+                    conn, task_id,
+                    expected_run_id=expected_run_id,
+                    detail=detail,
+                )
+            finally:
+                conn.close()
+        except Exception:
+            logger.exception(
+                "record_stream_stall_fallback raised for task %s; "
+                "worker will exit cleanly and dispatcher will "
+                "classify based on the run/event log", task_id,
+            )
+            return False
+        if ok:
+            logger.warning(
+                "Stream-stall stub detected in kanban worker — "
+                "recorded stream_stall_fallback for task %s "
+                "(consecutive_failures incremented, task back to ready)",
+                task_id,
+            )
+        else:
+            # Most common False case: another dispatcher pass already
+            # reclaimed the task between the stub injection and now.
+            # Logging at INFO because it's expected churn, not a bug.
+            logger.info(
+                "record_stream_stall_fallback returned False for task %s "
+                "(task no longer running, or run_id mismatch); skipping",
+                task_id,
+            )
+        return ok
+
     def _persist_session(self, messages: List[Dict], conversation_history: List[Dict] = None):
         """Save session state to both JSON log and SQLite on any exit path.
 
@@ -14561,7 +14669,21 @@ class AIAgent:
                 else:
                     # No tool calls - this is the final response
                     final_response = assistant_message.content or ""
-                    
+
+                    # ── Stream-stall kanban fallback ──────────────────
+                    # If we landed here because the streaming layer
+                    # injected the partial-stream-stub (HERMES_STREAM_RETRIES
+                    # exhausted mid tool-call), and we're running as a
+                    # kanban worker, record a stream_stall_fallback
+                    # transition on the kanban task BEFORE the loop
+                    # exits. Without this the worker process exits rc=0
+                    # while the task is still ``running``, and the
+                    # dispatcher's detect_crashed_workers flags it as a
+                    # protocol_violation (hardcoded 1-trip).
+                    # No-op for non-kanban contexts and for genuine final
+                    # responses. See helper docstring for rationale.
+                    self._maybe_record_stream_stall_kanban_fallback(response)
+
                     # Fix: unmute output when entering the no-tool-call branch
                     # so the user can see empty-response warnings and recovery
                     # status messages.  _mute_post_response was set during a

--- a/tests/hermes_cli/test_kanban_core_functionality.py
+++ b/tests/hermes_cli/test_kanban_core_functionality.py
@@ -3965,3 +3965,326 @@ def test_reclaim_task_clears_failure_counter(kanban_home):
         assert task.status == "ready"
     finally:
         conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Stream-stall fallback (record_stream_stall_fallback +
+# detect_crashed_workers belt-and-suspenders for STREAM_STALL_FALLBACK_SENTINEL)
+# ---------------------------------------------------------------------------
+
+def test_record_stream_stall_fallback_first_stall_keeps_ready(kanban_home):
+    """A worker that hit the stream-stall stub mid tool-call calls
+    record_stream_stall_fallback. First stall: status flips back to
+    ready, consecutive_failures=1, sentinel stamped on the closed run.
+
+    This is the criterion-3 path from the parent task: stream stalls
+    must consume the normal failure budget instead of the
+    protocol_violation 1-trip.
+    """
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="stalled", assignee="worker")
+        kb.claim_task(conn, tid)
+        task_before = kb.get_task(conn, tid)
+        assert task_before.status == "running"
+        run_id = task_before.current_run_id
+
+        ok = kb.record_stream_stall_fallback(
+            conn, tid, expected_run_id=run_id,
+            detail="HERMES_STREAM_RETRIES exhausted mid tool-call (write_file)",
+        )
+        assert ok is True
+
+        task = kb.get_task(conn, tid)
+        assert task.status == "ready", (
+            f"first stall should leave task ready, got {task.status}"
+        )
+        assert task.consecutive_failures == 1
+        assert task.last_failure_error is not None
+        assert task.last_failure_error.startswith(
+            kb.STREAM_STALL_FALLBACK_SENTINEL
+        ), (
+            f"sentinel missing from last_failure_error: "
+            f"{task.last_failure_error!r}"
+        )
+
+        # Run closed with outcome=crashed and the sentinel error.
+        runs = list(conn.execute(
+            "SELECT outcome, error FROM task_runs WHERE task_id = ? "
+            "ORDER BY id DESC LIMIT 1", (tid,),
+        ))
+        assert runs[0]["outcome"] == "crashed"
+        assert kb.STREAM_STALL_FALLBACK_SENTINEL in (runs[0]["error"] or "")
+
+        # Stream-stall event was emitted, blocked event was NOT.
+        events = kb.list_events(conn, tid)
+        kinds = [e.kind for e in events]
+        assert "stream_stall_fallback" in kinds, kinds
+        assert "blocked" not in kinds, kinds
+        # 'crashed' event is a separate kind emitted by the standard
+        # _record_task_failure under-the-limit path? Actually no — the
+        # under-the-limit path with end_run=False/release_claim=False
+        # doesn't emit an additional event (see comment "Timeout/crash
+        # path's caller already emitted its own event").
+    finally:
+        conn.close()
+
+
+def test_record_stream_stall_fallback_repeated_stalls_trip_default_breaker(kanban_home):
+    """After DEFAULT_FAILURE_LIMIT consecutive stalls the task lands
+    in 'blocked' via the standard 'gave_up' path — never via
+    'protocol_violation'.
+    """
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="repeatedly stalled", assignee="worker")
+
+        for attempt in range(kb.DEFAULT_FAILURE_LIMIT):
+            kb.claim_task(conn, tid)
+            task = kb.get_task(conn, tid)
+            assert task.status == "running"
+            run_id = task.current_run_id
+            ok = kb.record_stream_stall_fallback(
+                conn, tid, expected_run_id=run_id,
+            )
+            assert ok, f"attempt {attempt + 1} should succeed"
+
+        task = kb.get_task(conn, tid)
+        assert task.status == "blocked", (
+            f"after {kb.DEFAULT_FAILURE_LIMIT} stalls the breaker "
+            f"should have tripped, got {task.status}"
+        )
+        assert task.consecutive_failures == kb.DEFAULT_FAILURE_LIMIT
+        events = kb.list_events(conn, tid)
+        kinds = [e.kind for e in events]
+        assert "gave_up" in kinds
+        assert "protocol_violation" not in kinds, (
+            f"stream_stall path should NEVER emit protocol_violation, "
+            f"kinds={kinds}"
+        )
+        assert kinds.count("stream_stall_fallback") == kb.DEFAULT_FAILURE_LIMIT
+    finally:
+        conn.close()
+
+
+def test_record_stream_stall_fallback_run_id_guard(kanban_home):
+    """Calling record_stream_stall_fallback with a stale expected_run_id
+    no-ops cleanly (returns False, doesn't touch the row).
+    """
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="run-id guard", assignee="worker")
+        kb.claim_task(conn, tid)
+        task = kb.get_task(conn, tid)
+        wrong_run_id = task.current_run_id + 99999
+
+        ok = kb.record_stream_stall_fallback(
+            conn, tid, expected_run_id=wrong_run_id,
+        )
+        assert ok is False, (
+            "stale run_id should make the helper a no-op (False)"
+        )
+
+        # Task untouched.
+        task_after = kb.get_task(conn, tid)
+        assert task_after.status == "running", (
+            f"task should still be running, got {task_after.status}"
+        )
+        assert task_after.consecutive_failures == 0
+    finally:
+        conn.close()
+
+
+def test_record_stream_stall_fallback_no_op_on_non_running_task(kanban_home):
+    """Helper returns False if the task isn't in 'running' (e.g. it
+    was already reclaimed by another dispatcher pass).
+    """
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="not running", assignee="worker")
+        # Task is in 'todo'/'ready', NOT 'running'.
+
+        ok = kb.record_stream_stall_fallback(conn, tid)
+        assert ok is False
+    finally:
+        conn.close()
+
+
+def test_detect_crashed_workers_clean_exit_with_sentinel_downgrades(kanban_home):
+    """Belt-and-suspenders: if a worker exits rc=0 while the task is
+    still in 'running' BUT the most recent run's error starts with the
+    stream_stall_fallback sentinel (atomicity escape: stamped sentinel
+    but failed to flip status back), the dispatcher classifies the
+    crash as a normal 'crashed' (default budget) — NOT a
+    'protocol_violation' (1-trip).
+
+    This is the dispatcher-side guard requested in the parent task.
+    """
+    import hermes_cli.kanban_db as _kb
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="stall-then-crash", assignee="worker")
+        host_prefix = _kb._claimer_id().split(":", 1)[0]
+        lock = f"{host_prefix}:mock"
+        kb.claim_task(conn, tid, claimer=lock)
+        fake_pid = 999996
+        kb._set_worker_pid(conn, tid, fake_pid)
+
+        # Synthesize a closed run carrying the sentinel on its error
+        # field, while the task itself is still 'running'. This models
+        # the (unlikely) atomicity escape where the worker's
+        # record_stream_stall_fallback partially completed.
+        with kb.write_txn(conn):
+            row = conn.execute(
+                "SELECT current_run_id FROM tasks WHERE id = ?", (tid,),
+            ).fetchone()
+            run_id = row["current_run_id"]
+            conn.execute(
+                "UPDATE task_runs SET error = ? WHERE id = ?",
+                (
+                    f"{kb.STREAM_STALL_FALLBACK_SENTINEL}: stream stalled "
+                    f"mid tool-call (write_file)",
+                    run_id,
+                ),
+            )
+
+        # Worker exited rc=0 (clean_exit) while task is still 'running'.
+        _kb._record_worker_exit(fake_pid, 0)
+        original_alive = _kb._pid_alive
+        _kb._pid_alive = lambda p: False
+        try:
+            crashed = kb.detect_crashed_workers(conn)
+        finally:
+            _kb._pid_alive = original_alive
+
+        assert tid in crashed
+        task = kb.get_task(conn, tid)
+        # Belt-and-suspenders downgraded to a normal crash → first
+        # failure leaves task 'ready' (default budget=2), NOT 'blocked'.
+        assert task.status == "ready", (
+            f"sentinel-marked clean_exit should downgrade to plain crash, "
+            f"got status={task.status}"
+        )
+        assert task.consecutive_failures == 1
+
+        events = kb.list_events(conn, tid)
+        kinds = [e.kind for e in events]
+        # Standard 'crashed' event was emitted; protocol_violation was NOT.
+        assert "crashed" in kinds, kinds
+        assert "protocol_violation" not in kinds, kinds
+    finally:
+        conn.close()
+
+
+def test_detect_crashed_workers_clean_exit_without_sentinel_still_protocol_violation(kanban_home):
+    """Sanity check the inverse: a clean_exit on a task with NO sentinel
+    on its run error still trips protocol_violation. Otherwise we'd
+    be regressing the existing genuine-violation safety net.
+    """
+    import hermes_cli.kanban_db as _kb
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="quiet-no-sentinel", assignee="worker")
+        host_prefix = _kb._claimer_id().split(":", 1)[0]
+        lock = f"{host_prefix}:mock"
+        kb.claim_task(conn, tid, claimer=lock)
+        fake_pid = 999995
+        kb._set_worker_pid(conn, tid, fake_pid)
+
+        # No sentinel stamped on the run.
+        _kb._record_worker_exit(fake_pid, 0)
+        original_alive = _kb._pid_alive
+        _kb._pid_alive = lambda p: False
+        try:
+            crashed = kb.detect_crashed_workers(conn)
+        finally:
+            _kb._pid_alive = original_alive
+
+        assert tid in crashed
+        task = kb.get_task(conn, tid)
+        # Genuine protocol violations still trip the breaker.
+        assert task.status == "blocked", (
+            f"genuine clean_exit without sentinel should auto-block, "
+            f"got status={task.status}"
+        )
+        events = kb.list_events(conn, tid)
+        kinds = [e.kind for e in events]
+        assert "protocol_violation" in kinds
+        assert "gave_up" in kinds
+    finally:
+        conn.close()
+
+
+def test_default_spawn_sets_stream_retries_default(kanban_home, monkeypatch):
+    """Belt-and-suspenders #2: dispatcher-spawned workers get
+    HERMES_STREAM_RETRIES bumped from 2 (global default) to 4 unless
+    the operator pinned a different value in the dispatcher's
+    environment.
+
+    We don't actually spawn a process here — we patch subprocess.Popen
+    to capture the env dict and assert the value.
+    """
+    import hermes_cli.kanban_db as _kb
+    import subprocess
+
+    monkeypatch.delenv("HERMES_STREAM_RETRIES", raising=False)
+
+    captured = {}
+
+    class _FakeProc:
+        pid = 12345
+
+    def _fake_popen(cmd, **kwargs):
+        captured["env"] = kwargs.get("env", {})
+        return _FakeProc()
+
+    monkeypatch.setattr(subprocess, "Popen", _fake_popen)
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="spawn me", assignee="worker")
+        kb.claim_task(conn, tid)
+        task = kb.get_task(conn, tid)
+    finally:
+        conn.close()
+
+    pid = _kb._default_spawn(task, str(kanban_home))
+    assert pid == 12345
+    env = captured.get("env", {})
+    assert env.get("HERMES_STREAM_RETRIES") == "4", (
+        f"dispatcher should bump HERMES_STREAM_RETRIES to 4 by default, "
+        f"got {env.get('HERMES_STREAM_RETRIES')!r}"
+    )
+
+
+def test_default_spawn_respects_operator_stream_retries(kanban_home, monkeypatch):
+    """If the operator pinned HERMES_STREAM_RETRIES in the dispatcher's
+    environment, _default_spawn should NOT clobber it (env.setdefault).
+    """
+    import hermes_cli.kanban_db as _kb
+    import subprocess
+
+    monkeypatch.setenv("HERMES_STREAM_RETRIES", "0")  # forced low for testing
+
+    captured = {}
+
+    class _FakeProc:
+        pid = 12346
+
+    monkeypatch.setattr(
+        subprocess, "Popen",
+        lambda cmd, **kw: (captured.update(env=kw.get("env", {})) or _FakeProc()),
+    )
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="spawn me 2", assignee="worker")
+        kb.claim_task(conn, tid)
+        task = kb.get_task(conn, tid)
+    finally:
+        conn.close()
+
+    _kb._default_spawn(task, str(kanban_home))
+    assert captured["env"].get("HERMES_STREAM_RETRIES") == "0", (
+        "operator override of HERMES_STREAM_RETRIES must be preserved"
+    )

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -1505,3 +1505,223 @@ class TestCopilotACPStreamingDecision:
 
         assert _use_streaming is True
 
+
+class TestStreamStallKanbanFallback:
+    """Regression: when the streaming layer injects the partial-stream-stub
+    (HERMES_STREAM_RETRIES exhausted mid tool-call) inside a kanban
+    worker, the agent loop must record a ``stream_stall_fallback``
+    transition on the kanban task BEFORE clean exit. Without this
+    hook, the dispatcher's ``detect_crashed_workers`` flags the
+    rc=0 exit as a hardcoded-1-trip ``protocol_violation``.
+
+    Sister coverage on the dispatcher side lives in
+    ``tests/hermes_cli/test_kanban_core_functionality.py``.
+    """
+
+    def _make_agent(self):
+        from run_agent import AIAgent
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://openrouter.ai/api/v1",
+            model="test/model",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "chat_completions"
+        return agent
+
+    def _make_stub_response(
+        self, *, content="...\n\n⚠ Stream stalled mid tool-call (write_file); the action was not executed.",
+    ):
+        """Build the SimpleNamespace shape ``_interruptible_streaming_api_call``
+        returns when the stream dies mid tool-call after partial delivery."""
+        msg = SimpleNamespace(
+            role="assistant", content=content, tool_calls=None,
+            reasoning_content=None,
+        )
+        return SimpleNamespace(
+            id="partial-stream-stub",
+            model="test/model",
+            choices=[SimpleNamespace(index=0, message=msg, finish_reason="stop")],
+            usage=None,
+        )
+
+    def test_no_op_outside_kanban_context(self, monkeypatch):
+        """Helper is a no-op when HERMES_KANBAN_TASK is unset (the common
+        non-worker case)."""
+        monkeypatch.delenv("HERMES_KANBAN_TASK", raising=False)
+        agent = self._make_agent()
+        result = agent._maybe_record_stream_stall_kanban_fallback(
+            self._make_stub_response()
+        )
+        assert result is False
+
+    def test_no_op_for_non_stub_response(self, monkeypatch):
+        """Helper is a no-op for normal (non-stub) responses even inside a
+        kanban worker — only response.id == 'partial-stream-stub' triggers
+        the fallback."""
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_test123")
+        agent = self._make_agent()
+        normal_response = SimpleNamespace(
+            id="chatcmpl-real",
+            model="test/model",
+            choices=[SimpleNamespace(
+                index=0,
+                message=SimpleNamespace(
+                    role="assistant", content="hi", tool_calls=None,
+                ),
+                finish_reason="stop",
+            )],
+        )
+        result = agent._maybe_record_stream_stall_kanban_fallback(
+            normal_response
+        )
+        assert result is False
+
+    def test_calls_record_stream_stall_fallback_on_stub(
+        self, monkeypatch, tmp_path,
+    ):
+        """When HERMES_KANBAN_TASK is set AND response.id is the stub id,
+        the helper opens a kanban DB connection and calls
+        ``record_stream_stall_fallback`` with the env-pinned run id."""
+        # Pin a kanban home so kb.connect() doesn't touch the real DB.
+        monkeypatch.setenv("HERMES_KANBAN_HOME", str(tmp_path))
+        # Initialize the DB and create a running task to operate on.
+        # connect() auto-initializes on first open.
+        import hermes_cli.kanban_db as kb
+        conn = kb.connect()
+        try:
+            tid = kb.create_task(conn, title="stall test", assignee="worker")
+            kb.claim_task(conn, tid)
+            task = kb.get_task(conn, tid)
+            run_id = task.current_run_id
+            assert task.status == "running"
+        finally:
+            conn.close()
+
+        # Pin task id and run id to match what we just inserted.
+        monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+        monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+
+        agent = self._make_agent()
+        result = agent._maybe_record_stream_stall_kanban_fallback(
+            self._make_stub_response()
+        )
+        assert result is True, "fallback should be recorded successfully"
+
+        # Verify task state: ready, consecutive_failures=1, sentinel
+        # stamped on the closed run's error.
+        conn = kb.connect()
+        try:
+            task = kb.get_task(conn, tid)
+            assert task.status == "ready", (
+                f"first stall should leave task in ready (default budget=2), "
+                f"got status={task.status}"
+            )
+            assert task.consecutive_failures == 1
+            # last_failure_error carries the sentinel.
+            assert task.last_failure_error and (
+                task.last_failure_error.startswith(
+                    kb.STREAM_STALL_FALLBACK_SENTINEL
+                )
+            ), (
+                f"last_failure_error should start with the sentinel, "
+                f"got {task.last_failure_error!r}"
+            )
+
+            # An event with kind 'stream_stall_fallback' should have been
+            # appended.
+            events = kb.list_events(conn, tid)
+            kinds = [e.kind for e in events]
+            assert "stream_stall_fallback" in kinds, (
+                f"stream_stall_fallback event not found, kinds={kinds}"
+            )
+            # We did NOT call kanban_block, so no 'blocked' event yet.
+            assert "blocked" not in kinds, (
+                f"first stall should NOT block the task, got kinds={kinds}"
+            )
+        finally:
+            conn.close()
+
+    def test_breaker_trips_at_default_failure_limit(
+        self, monkeypatch, tmp_path,
+    ):
+        """Repeated stalls eventually trip the standard breaker at
+        DEFAULT_FAILURE_LIMIT (NOT the protocol-violation 1-trip)."""
+        monkeypatch.setenv("HERMES_KANBAN_HOME", str(tmp_path))
+
+        import hermes_cli.kanban_db as kb
+        conn = kb.connect()
+        try:
+            tid = kb.create_task(conn, title="repeated stall", assignee="worker")
+        finally:
+            conn.close()
+
+        monkeypatch.setenv("HERMES_KANBAN_TASK", tid)
+        agent = self._make_agent()
+
+        # Simulate DEFAULT_FAILURE_LIMIT consecutive stalls. Between each
+        # one the task transitions ready→running again (as the dispatcher
+        # would on respawn).
+        for attempt in range(kb.DEFAULT_FAILURE_LIMIT):
+            conn = kb.connect()
+            try:
+                kb.claim_task(conn, tid)
+                task = kb.get_task(conn, tid)
+                assert task.status == "running"
+                run_id = task.current_run_id
+            finally:
+                conn.close()
+            monkeypatch.setenv("HERMES_KANBAN_RUN_ID", str(run_id))
+            ok = agent._maybe_record_stream_stall_kanban_fallback(
+                self._make_stub_response()
+            )
+            assert ok, f"attempt {attempt + 1} should record successfully"
+
+        conn = kb.connect()
+        try:
+            task = kb.get_task(conn, tid)
+            assert task.status == "blocked", (
+                f"after {kb.DEFAULT_FAILURE_LIMIT} stalls the breaker "
+                f"should trip (status=blocked), got {task.status}"
+            )
+            assert task.consecutive_failures == kb.DEFAULT_FAILURE_LIMIT
+            events = kb.list_events(conn, tid)
+            kinds = [e.kind for e in events]
+            # Standard counter-based block emits 'gave_up', not
+            # 'protocol_violation'.
+            assert "gave_up" in kinds, (
+                f"expected 'gave_up' event after counter trip, kinds={kinds}"
+            )
+            assert "protocol_violation" not in kinds, (
+                f"stream_stall path should NEVER emit protocol_violation, "
+                f"kinds={kinds}"
+            )
+        finally:
+            conn.close()
+
+    def test_robust_to_db_failure(self, monkeypatch, tmp_path):
+        """If kanban_db.connect raises (e.g. DB locked or unreadable),
+        the helper swallows the exception and returns False — never
+        crashes the worker process. Worker continues to clean exit;
+        dispatcher's detect_crashed_workers fallback handles it."""
+        monkeypatch.setenv("HERMES_KANBAN_TASK", "t_doesnotexist")
+        # Point at an unreadable HERMES_KANBAN_DB to force a connect failure.
+        bad_db = tmp_path / "nonexistent" / "no.db"
+        monkeypatch.setenv("HERMES_KANBAN_DB", str(bad_db))
+
+        agent = self._make_agent()
+        # Force record_stream_stall_fallback to raise via monkeypatch.
+        import hermes_cli.kanban_db as kb
+        monkeypatch.setattr(
+            kb, "record_stream_stall_fallback",
+            lambda *a, **kw: (_ for _ in ()).throw(RuntimeError("simulated")),
+        )
+        result = agent._maybe_record_stream_stall_kanban_fallback(
+            self._make_stub_response()
+        )
+        assert result is False, (
+            "helper should return False on any kb error, never raise"
+        )
+


### PR DESCRIPTION
Fixes a footgun where a single transient upstream stream stall mid tool-call inside a kanban worker auto-blocks the task on the FIRST occurrence (hardcoded `failure_limit=1` via the `protocol_violation` path).

## Problem

When the streaming layer exhausts `HERMES_STREAM_RETRIES` mid tool-call, `_interruptible_streaming_api_call` returns a `partial-stream-stub` SimpleNamespace with `finish_reason='stop'` and `tool_calls=None`. The agent loop sees "no tool calls = final response" and terminates cleanly. The worker process exits `rc=0` while the task is still `status='running'` in the kanban DB.

The dispatcher's `detect_crashed_workers` then classifies the rc=0 exit as a `protocol_violation` (model answered conversationally without calling `kanban_complete` / `kanban_block`) and trips the breaker on the FIRST stall (`failure_limit=1`, vs `DEFAULT_FAILURE_LIMIT=2` for normal crashes).

Stream stalls are transient upstream issues — they should consume the standard failure budget, not the 1-trip path reserved for genuine LLM protocol violations.

## Fix

Three layers, smallest first:

1. **Bump `HERMES_STREAM_RETRIES` from 2 → 4 for dispatcher-spawned workers** (`hermes_cli/kanban_db.py` `_default_spawn`). `env.setdefault` so operator overrides still win. Reduces the rate at which a stall reaches the stub path at all.

2. **Worker side** (`run_agent.py`): `AIAgent._maybe_record_stream_stall_kanban_fallback` runs in the no-tool-calls branch. No-op unless `HERMES_KANBAN_TASK` is set AND `response.id == 'partial-stream-stub'`. On match, calls a new `hermes_cli.kanban_db.record_stream_stall_fallback` which:
   - Closes the run with `outcome='crashed'` + `STREAM_STALL_FALLBACK_SENTINEL` stamped on the error
   - Transitions the task back to `ready`
   - Increments `consecutive_failures` via `_record_task_failure` with the **default** `failure_limit` (NOT the protocol-violation 1-trip)
   
   Best-effort: every exception swallowed so bookkeeping failures never crash the worker.

3. **Dispatcher belt-and-suspenders** (`hermes_cli/kanban_db.py` `detect_crashed_workers`): if a worker exits rc=0 while the task is still `running` BUT the most recent run.error starts with `STREAM_STALL_FALLBACK_SENTINEL` (atomicity escape: stamped sentinel but failed to flip status), classify as `crashed` (default budget) instead of `protocol_violation` (1-trip). Genuine clean-exit-without-transition still trips the breaker.

## Testing

11 new tests:

- `tests/run_agent/test_streaming.py::TestStreamStallKanbanFallback` — 5 tests covering the AIAgent helper (no-op outside kanban context, no-op for non-stub responses, full success path, breaker trips at `DEFAULT_FAILURE_LIMIT`, exception safety).
- `tests/hermes_cli/test_kanban_core_functionality.py` — 6 tests covering `record_stream_stall_fallback` (first stall keeps ready, repeated stalls trip default breaker, run_id guard, no-op on non-running task), the dispatcher belt-and-suspenders (sentinel downgrades, no-sentinel still flags protocol_violation), and `HERMES_STREAM_RETRIES` default behaviour in `_default_spawn`.

All pass. Existing failures in main (`test_idempotency_key_returns_existing_task`, `test_cli_create_on_fresh_home_auto_inits`, etc.) are pre-existing parallel-state flakes unrelated to this PR.

## Acceptance criteria (from parent task t_257219e2)

- [x] Worker exhausting `HERMES_STREAM_RETRIES` mid tool-call terminates via a recognizable stream-stall transition, not a clean exit.
- [x] Dispatcher no longer classifies stream-stall fallbacks as `protocol_violation`; they consume the normal failure budget.
- [x] First stream stall increments `consecutive_failures` to 1 and leaves the task in `ready`.
- [x] New tests cover the stall-in-kanban-worker path.
- [x] Existing genuine protocol violations still trip the breaker.

Refs kanban task t_1869e307.
