### PR TITLE
feat(mcp): add lifecycle hooks for context compression events

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -10005,6 +10005,7 @@ class AIAgent:
             (compressed_messages, new_system_prompt) tuple
         """
         _pre_msg_count = len(messages)
+        old_session_id = ""
         logger.info(
             "context compression started: session=%s messages=%d tokens=~%s model=%s focus=%r",
             self.session_id or "none", _pre_msg_count,
@@ -10018,6 +10019,35 @@ class AIAgent:
                 self._memory_manager.on_pre_compress(messages)
             except Exception:
                 pass
+
+        # Notify MCP servers that expose lifecycle hook tools (opt-in).
+        # Servers declare interest by registering a tool named
+        # ``hermes_lifecycle_pre_compress``.  See tools/mcp_tool.py
+        # ``call_mcp_lifecycle_hooks`` for the full convention.
+        _mcp_pre_compress_context = ""
+        try:
+            from tools.mcp_tool import call_mcp_lifecycle_hooks
+            _mcp_pre_compress_context = call_mcp_lifecycle_hooks(
+                "pre_compress",
+                {
+                    "event": "pre_compress",
+                    "session_id": self.session_id or "",
+                    "message_count": _pre_msg_count,
+                    "approx_tokens": approx_tokens or 0,
+                },
+            )
+        except Exception as exc:
+            logger.debug("MCP pre_compress lifecycle hook failed: %s", exc)
+
+        # If MCP servers returned context to preserve, merge it into the
+        # focus topic so the compression summary includes it — same pattern
+        # as MemoryManager.on_pre_compress return values.
+        if _mcp_pre_compress_context:
+            focus_topic = (
+                f"{focus_topic}\n{_mcp_pre_compress_context}"
+                if focus_topic
+                else _mcp_pre_compress_context
+            )
 
         try:
             compressed = self.context_compressor.compress(messages, current_tokens=approx_tokens, focus_topic=focus_topic)
@@ -10163,6 +10193,24 @@ class AIAgent:
             self.session_id or "none", _pre_msg_count, len(compressed),
             f"{_compressed_est:,}",
         )
+
+        # Notify MCP servers that the compression is complete.
+        # Servers expose ``hermes_lifecycle_post_compress`` to receive this.
+        try:
+            from tools.mcp_tool import call_mcp_lifecycle_hooks
+            call_mcp_lifecycle_hooks(
+                "post_compress",
+                {
+                    "event": "post_compress",
+                    "session_id": self.session_id or "",
+                    "old_session_id": old_session_id,
+                    "pre_message_count": _pre_msg_count,
+                    "post_message_count": len(compressed),
+                    "post_approx_tokens": _compressed_est,
+                },
+            )
+        except Exception as exc:
+            logger.debug("MCP post_compress lifecycle hook failed: %s", exc)
         return compressed, new_system_prompt
 
     def _set_tool_guardrail_halt(self, decision: ToolGuardrailDecision) -> None:

--- a/tests/tools/test_mcp_tool.py
+++ b/tests/tools/test_mcp_tool.py
@@ -3654,3 +3654,217 @@ class TestRegisterMcpServers:
                 )
 
         _servers.pop("srv", None)
+
+
+# ---------------------------------------------------------------------------
+# MCP lifecycle hooks
+# ---------------------------------------------------------------------------
+
+class TestMCPLifecycleHooks:
+    """Tests for call_mcp_lifecycle_hooks (Option C: tool-naming convention)."""
+
+    @staticmethod
+    def _mock_run_on_mcp_loop(return_value=None, side_effect=None):
+        """Create a mock for _run_on_mcp_loop that closes unawaited coroutines.
+
+        When _run_on_mcp_loop is patched, the coroutine passed to it is never
+        awaited, which triggers RuntimeWarning.  This helper closes the
+        coroutine in the mock to suppress the warning.
+
+        When *side_effect* is a list, each call returns the next item and
+        ``_fake_run.call_count`` tracks invocations (similar to MagicMock).
+        """
+        if isinstance(side_effect, list):
+            it = iter(side_effect)
+            def _fake_run(coro, **kwargs):
+                _fake_run.call_count += 1
+                coro.close()
+                return next(it)
+            _fake_run.call_count = 0
+            return _fake_run
+
+        def _fake_run(coro, **kwargs):
+            coro.close()
+            if side_effect is not None:
+                raise side_effect
+            return return_value
+        return _fake_run
+
+    def test_no_servers_returns_empty(self):
+        """No connected MCP servers -> empty string, no errors."""
+        from tools.mcp_tool import call_mcp_lifecycle_hooks, _servers
+        _servers.clear()
+        result = call_mcp_lifecycle_hooks("pre_compress", {"event": "pre_compress"})
+        assert result == ""
+
+    def test_no_hook_tool_registered_returns_empty(self):
+        """Server without the lifecycle hook tool -> skipped, empty result."""
+        from tools.mcp_tool import call_mcp_lifecycle_hooks, _servers
+        server = _make_mock_server("kb")
+        server._registered_tool_names = ["mcp_kb_retain", "mcp_kb_search"]
+        _servers["kb"] = server
+        try:
+            with patch("tools.mcp_tool._MCP_AVAILABLE", True):
+                result = call_mcp_lifecycle_hooks("pre_compress", {"event": "pre_compress"})
+            assert result == ""
+        finally:
+            _servers.pop("kb", None)
+
+    def test_hook_tool_registered_and_called(self):
+        """Server with the lifecycle hook tool -> called, result returned."""
+        from tools.mcp_tool import call_mcp_lifecycle_hooks, _servers
+
+        server = _make_mock_server("kb")
+        server._registered_tool_names = [
+            "mcp_kb_retain",
+            "hermes_lifecycle_pre_compress",
+        ]
+        _servers["kb"] = server
+
+        try:
+            with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+                 patch("tools.mcp_tool._run_on_mcp_loop",
+                       self._mock_run_on_mcp_loop(
+                           return_value="[kb] Context backed up before compression.")):
+                result = call_mcp_lifecycle_hooks(
+                    "pre_compress",
+                    {"event": "pre_compress", "session_id": "abc123"},
+                )
+
+            assert "[kb] Context backed up before compression." in result
+        finally:
+            _servers.pop("kb", None)
+
+    def test_hook_error_skipped_gracefully(self):
+        """MCP hook that raises -> logged and skipped."""
+        from tools.mcp_tool import call_mcp_lifecycle_hooks, _servers
+
+        server = _make_mock_server("kb")
+        server._registered_tool_names = ["hermes_lifecycle_pre_compress"]
+        _servers["kb"] = server
+
+        try:
+            with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+                 patch("tools.mcp_tool._run_on_mcp_loop",
+                       self._mock_run_on_mcp_loop(
+                           side_effect=Exception("server crashed"))):
+                result = call_mcp_lifecycle_hooks(
+                    "pre_compress",
+                    {"event": "pre_compress"},
+                )
+
+            # Should not raise, just return empty
+            assert result == ""
+        finally:
+            _servers.pop("kb", None)
+
+    def test_hook_timeout_skipped_gracefully(self):
+        """MCP hook that times out -> logged and skipped."""
+        from tools.mcp_tool import call_mcp_lifecycle_hooks, _servers
+
+        server = _make_mock_server("kb")
+        server._registered_tool_names = ["hermes_lifecycle_pre_compress"]
+        _servers["kb"] = server
+
+        try:
+            with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+                 patch("tools.mcp_tool._run_on_mcp_loop",
+                       self._mock_run_on_mcp_loop(
+                           side_effect=TimeoutError("timed out"))):
+                result = call_mcp_lifecycle_hooks(
+                    "pre_compress",
+                    {"event": "pre_compress"},
+                )
+
+            assert result == ""
+        finally:
+            _servers.pop("kb", None)
+
+    def test_multiple_servers_with_hooks(self):
+        """Multiple servers with lifecycle hooks -> all called, results joined."""
+        from tools.mcp_tool import call_mcp_lifecycle_hooks, _servers
+
+        server_a = _make_mock_server("kb")
+        server_a._registered_tool_names = ["hermes_lifecycle_pre_compress"]
+        _servers["kb"] = server_a
+
+        server_b = _make_mock_server("notes")
+        server_b._registered_tool_names = [
+            "mcp_notes_read",
+            "hermes_lifecycle_pre_compress",
+        ]
+        _servers["notes"] = server_b
+
+        # Server without hook — should be ignored
+        server_c = _make_mock_server("github")
+        server_c._registered_tool_names = ["mcp_github_pr_list"]
+        _servers["github"] = server_c
+
+        try:
+            mock_run = self._mock_run_on_mcp_loop(
+                side_effect=[
+                    "[kb] Backed up context.",
+                    "[notes] Snapshot saved.",
+                ],
+            )
+            with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+                 patch("tools.mcp_tool._run_on_mcp_loop", mock_run):
+                result = call_mcp_lifecycle_hooks(
+                    "pre_compress",
+                    {"event": "pre_compress", "session_id": "s1"},
+                )
+
+            assert "[kb] Backed up context." in result
+            assert "[notes] Snapshot saved." in result
+            # GitHub should not have been called
+            assert mock_run.call_count == 2
+        finally:
+            for name in ("kb", "notes", "github"):
+                _servers.pop(name, None)
+
+    def test_post_compress_event(self):
+        """post_compress event uses correct tool name."""
+        from tools.mcp_tool import call_mcp_lifecycle_hooks, _servers
+
+        server = _make_mock_server("kb")
+        server._registered_tool_names = [
+            "hermes_lifecycle_pre_compress",
+            "hermes_lifecycle_post_compress",
+        ]
+        _servers["kb"] = server
+
+        try:
+            with patch("tools.mcp_tool._MCP_AVAILABLE", True), \
+                 patch("tools.mcp_tool._run_on_mcp_loop",
+                       self._mock_run_on_mcp_loop(
+                           return_value="[kb] Post-compress cleanup done.")):
+                result = call_mcp_lifecycle_hooks(
+                    "post_compress",
+                    {
+                        "event": "post_compress",
+                        "session_id": "new_session",
+                        "old_session_id": "old_session",
+                    },
+                )
+
+            assert "[kb] Post-compress cleanup done." in result
+        finally:
+            _servers.pop("kb", None)
+
+    def test_mcp_unavailable_returns_empty(self):
+        """When MCP SDK is not installed, returns empty string."""
+        from tools.mcp_tool import call_mcp_lifecycle_hooks, _servers
+
+        server = _make_mock_server("kb")
+        server._registered_tool_names = ["hermes_lifecycle_pre_compress"]
+        _servers["kb"] = server
+
+        try:
+            with patch("tools.mcp_tool._MCP_AVAILABLE", False):
+                result = call_mcp_lifecycle_hooks(
+                    "pre_compress",
+                    {"event": "pre_compress"},
+                )
+            assert result == ""
+        finally:
+            _servers.pop("kb", None)

--- a/tools/mcp_tool.py
+++ b/tools/mcp_tool.py
@@ -3323,6 +3323,139 @@ def shutdown_mcp_servers():
     _stop_mcp_loop()
 
 
+# ---------------------------------------------------------------------------
+# MCP lifecycle hooks
+# ---------------------------------------------------------------------------
+
+# Naming convention for MCP lifecycle hook tools.
+# MCP servers that wish to receive lifecycle notifications expose tools
+# following this pattern:  ``hermes_lifecycle_{event}``
+# Currently defined events:
+#   - pre_compress   : called before context compression discards messages
+#   - post_compress  : called after context compression completes
+#
+# The hook receives a single JSON-string argument ``event`` containing a
+# dict with at least ``event`` and ``session_id`` keys.
+#
+# Example MCP server (opt-in)::
+#
+#     @mcp.tool()
+#     def hermes_lifecycle_pre_compress(event: str) -> str:
+#         data = json.loads(event)
+#         self._backup_context(data["session_id"])
+#         return "[my-server] Context backed up before compression."
+
+_LIFECYCLE_HOOK_PREFIX = "hermes_lifecycle_"
+_LIFECYCLE_HOOK_TIMEOUT = 30  # seconds — don't block compression indefinitely
+
+
+def call_mcp_lifecycle_hooks(event: str, payload: dict) -> str:
+    """Call lifecycle hook tools on all connected MCP servers (opt-in).
+
+    Scans each server's registered tool list for a tool named
+    ``hermes_lifecycle_{event}``.  If found, calls it with the serialised
+    *payload* dict and collects the text results.
+
+    Failures are logged and skipped — a slow or broken MCP hook must not
+    prevent Hermes from compressing context.
+
+    Args:
+        event: Lifecycle event name (e.g. ``"pre_compress"``).
+        payload: Dict of event-specific data.  Must be JSON-serialisable.
+
+    Returns:
+        Combined text from all responding servers (joined with ``\\n\\n``).
+        Empty string if no server has a matching hook.
+    """
+    if not _MCP_AVAILABLE:
+        return ""
+
+    hook_tool_name = f"{_LIFECYCLE_HOOK_PREFIX}{event}"
+
+    with _lock:
+        servers_snapshot = dict(_servers)
+
+    if not servers_snapshot:
+        return ""
+
+    # Pre-filter: only contact servers that registered the hook tool.
+    candidates: List[tuple] = []  # (server_name, MCPServerTask)
+    for srv_name, srv in servers_snapshot.items():
+        registered = getattr(srv, "_registered_tool_names", [])
+        if hook_tool_name in registered:
+            candidates.append((srv_name, srv))
+
+    if not candidates:
+        return ""
+
+    event_json = json.dumps(payload, ensure_ascii=False)
+    parts: List[str] = []
+
+    async def _call_hook(
+        srv: MCPServerTask,
+        srv_name: str,
+    ) -> Optional[str]:
+        if not srv or not srv.session:
+            return None
+        async with srv._rpc_lock:
+            result = await srv.session.call_tool(
+                hook_tool_name, arguments={"event": event_json},
+            )
+        if result.isError:
+            error_text = ""
+            for block in (result.content or []):
+                if hasattr(block, "text"):
+                    error_text += block.text
+            logger.warning(
+                "MCP lifecycle hook '%s' on server '%s' returned error: %s",
+                hook_tool_name, srv_name,
+                error_text or "unknown error",
+            )
+            return None
+        text_parts = []
+        for block in (result.content or []):
+            if hasattr(block, "text") and block.text:
+                text_parts.append(block.text)
+        return "\n".join(text_parts) if text_parts else None
+
+    for srv_name, srv in candidates:
+        try:
+            result = _run_on_mcp_loop(
+                _call_hook(srv, srv_name), timeout=_LIFECYCLE_HOOK_TIMEOUT,
+            )
+            if result and result.strip():
+                parts.append(result.strip())
+                logger.debug(
+                    "MCP lifecycle hook '%s' on server '%s' responded (%d chars)",
+                    hook_tool_name, srv_name, len(result),
+                )
+        except TimeoutError:
+            logger.warning(
+                "MCP lifecycle hook '%s' on server '%s' timed out after %ds — skipping",
+                hook_tool_name, srv_name, _LIFECYCLE_HOOK_TIMEOUT,
+            )
+        except InterruptedError:
+            # User sent a new message while we were calling hooks — abort.
+            logger.debug(
+                "MCP lifecycle hook '%s' interrupted — user sent new message",
+                hook_tool_name,
+            )
+            break
+        except Exception as exc:
+            logger.warning(
+                "MCP lifecycle hook '%s' on server '%s' failed: %s",
+                hook_tool_name, srv_name, exc,
+            )
+
+    if parts:
+        logger.info(
+            "MCP lifecycle hook '%s': %d server(s) responded",
+            hook_tool_name, len(parts),
+        )
+
+    return "\n\n".join(parts)
+
+
 def _kill_orphaned_mcp_children(include_active: bool = False) -> None:
     """Best-effort graceful shutdown of stdio MCP subprocesses to reap orphans.
 


### PR DESCRIPTION
## Related Issue

#22929 

# Summary

Add MCP lifecycle hook support for Hermes context compression events.

MCP servers can now opt in to lifecycle notifications by registering
tools following the naming convention:

```
hermes_lifecycle_{event}
```

This PR adds support for two lifecycle events:

* `pre_compress`
* `post_compress`

The implementation exposes lifecycle integration through the existing
MCP tool abstraction rather than introducing new runtime-side APIs or
protocol extensions.

---

# Problem

Hermes already exposes `on_pre_compress()` for native `MemoryProvider`
plugins, allowing providers to preserve or back up state before context
compression discards conversation history.

However, MCP servers operate outside the `MemoryProvider` lifecycle.
Because they run as independent protocol peers, they currently receive
no notification before compression occurs.

This creates a gap for stateful MCP services (for example memory or
knowledge-base servers):

* context compression fires
* old messages are discarded
* subsequent MCP tool calls only see compacted context

As a result, MCP-based memory systems can lose access to information
that existed before compression.

---

# Design Rationale

This implementation intentionally does **not** introduce a dedicated
runtime hook such as:

```python
server.on_pre_compress(...)
```

MCP servers are not in-process Hermes runtime objects. They are
independent protocol peers that may run in different processes,
containers, runtimes, or even programming languages.

Direct runtime hooks would:

* tightly couple Hermes to MCP server implementations
* break protocol abstraction boundaries
* introduce Python-specific assumptions
* require special runtime-side integration paths

Instead, lifecycle integration is modeled as an optional MCP capability
exposed through the existing tool system.

Servers opt in simply by registering tools matching the naming
convention:

```text
hermes_lifecycle_{event}
```

This preserves MCP protocol purity while remaining fully backward
compatible with existing MCP servers and transports.

---

# Supported Events

## `pre_compress`

Invoked before context compression discards messages.

Payload includes:

* `event`
* `session_id`
* `message_count`
* `approx_tokens`

Servers may return text that Hermes preserves by merging it into the
compression summary (`focus_topic`).

This is intentionally append-only and informational. Hooks cannot
directly mutate compression state or alter the compression algorithm.

## `post_compress`

Invoked after compression completes.

Payload includes:

* `event`
* `session_id`
* `old_session_id`
* `pre_message_count`
* `post_message_count`
* `post_approx_tokens`

This event is informational and intended for cleanup, logging, metrics,
or synchronization workflows.

---

# Failure Isolation

Lifecycle hooks are executed as best-effort operations.

Failures are isolated so MCP hooks cannot indefinitely block or break
compression behavior.

Current protections include:

* bounded timeout per hook call
* exception isolation
* graceful handling of unavailable MCP servers
* warning-level logging for failures
* fail-open behavior

If a hook fails, times out, or returns an error, compression continues
normally.

---

# Implementation

## `tools/mcp_tool.py`

Added:

* `call_mcp_lifecycle_hooks()`

Responsibilities:

* scan connected MCP servers for matching lifecycle tool names
* invoke matching tools with JSON payloads
* collect returned text results
* isolate failures and timeouts
* return aggregated lifecycle output

## `run_agent.py`

Integrated lifecycle hooks into the context compression flow.

Behavior:

* invoke `pre_compress` hooks before compression
* merge returned text into `focus_topic`
* invoke `post_compress` hooks after compression completes
* isolate all hook failures from the compression pipeline

## `tests/tools/test_mcp_tool.py`

Added comprehensive lifecycle hook coverage including:

* no MCP servers connected
* no lifecycle hook registered
* successful hook execution
* exception handling
* timeout handling
* multiple servers
* `post_compress` dispatch
* MCP unavailable handling

---

# Backward Compatibility

This change is fully backward compatible.

Existing MCP servers are unaffected unless they explicitly opt in by
registering lifecycle hook tools.

No MCP protocol changes are introduced.

No SDK changes are required.

---

# Example MCP Hook

```python
@mcp.tool()
async def hermes_lifecycle_pre_compress(event):
    return "Important memory summary to preserve"
```

---

# Test Plan

* [x] No connected servers returns empty result
* [x] Server without lifecycle hook is skipped
* [x] Matching lifecycle hook is invoked successfully
* [x] Hook exceptions are isolated and logged
* [x] Hook timeouts are isolated and logged
* [x] Multiple servers are supported
* [x] `post_compress` dispatch uses correct tool name
* [x] MCP unavailable handling returns gracefully
Additionally, full coverage testing has been completed via test scripts.


