### PR TITLE
fix(tui): use TERMINAL_CWD in _session_info for accurate status line path

### DIFF
--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1378,7 +1378,7 @@ def _session_info(agent) -> dict:
         "fast": service_tier == "priority",
         "tools": {},
         "skills": {},
-        "cwd": os.getcwd(),
+        "cwd": os.getenv("TERMINAL_CWD", os.getcwd()),
         "version": "",
         "release_date": "",
         "update_behind": None,


### PR DESCRIPTION
## Summary

`_session_info()` in `tui_gateway/server.py` used `os.getcwd()` to report the working directory in the TUI status line. However, the gateway process cwd can diverge from the user's actual working directory (e.g. after agent turns that call `os.chdir()` via the terminal tool).

`session.create` already correctly reads `TERMINAL_CWD` env var (set by the CLI launcher at startup), but `_session_info` — which is called after every agent turn to refresh the status bar — did not. This caused the status line to display an incorrect path.

## Fix

Change `os.getcwd()` to `os.getenv("TERMINAL_CWD", os.getcwd())` in `_session_info()`, consistent with `session.create`.

## Observed Behavior

Status line showed `[D:\HermesWork]` instead of `[D:\Hermes\HermesWork]` after the first agent turn.

## Test Plan

- [x] Verified fix locally: status line now shows correct path after agent turns
- [ ] Existing tests should pass (no behavioral change, just reads env var first)