### PR TITLE
fix(dashboard): guard ModelPickerDialog filter toLowerCase against nullish model names

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -62,6 +62,7 @@ AUTHOR_MAP = {
     "abdielv@proton.me": "AJV20",
     "mason@growagainorchids.com": "masonjames",
     "ytchen0719@gmail.com": "liquidchen",
+    "mehmet.kar@std.yildiz.edu.tr": "mehmetkr-31",
     "am@studio1.tailb672fe.ts.net": "subtract0",
     "axmaiqiu@gmail.com": "qWaitCrypto",
     "44045911+kidonng@users.noreply.github.com": "kidonng",

--- a/web/src/components/ModelPickerDialog.tsx
+++ b/web/src/components/ModelPickerDialog.tsx
@@ -156,14 +156,14 @@ export function ModelPickerDialog(props: Props) {
             (p) =>
               p.name.toLowerCase().includes(needle) ||
               p.slug.toLowerCase().includes(needle) ||
-              (p.models ?? []).some((m) => m.toLowerCase().includes(needle)),
+              (p.models ?? []).some((m) => m?.toLowerCase().includes(needle)),
           ),
     [providers, needle],
   );
 
   const filteredModels = useMemo(
     () =>
-      !needle ? models : models.filter((m) => m.toLowerCase().includes(needle)),
+      !needle ? models : models.filter((m) => m?.toLowerCase().includes(needle)),
     [models, needle],
   );
 


### PR DESCRIPTION
Closes #23231

The model picker filter crashes when a model value in the list is null or undefined because "toLowerCase is not a function". This adds optional chaining to both the provider-models and flat-models filter paths.