### PR TITLE
fix(gateway,cli): keep auto-title generation failures silent

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -10106,20 +10106,15 @@ class HermesCLI:
             if response and result and not result.get("failed") and not result.get("partial"):
                 try:
                     from agent.title_generator import maybe_auto_title
-                    # Route title-generation failures through the agent's
-                    # user-visible warning channel so a depleted auxiliary
-                    # provider doesn't silently leave sessions untitled
-                    # (issue #15775).
-                    _title_failure_cb = getattr(
-                        self.agent, "_emit_auxiliary_failure", None
-                    ) if self.agent else None
+                    # Keep title-generation failures silent in the user
+                    # channel; they are already logged at WARNING level by
+                    # the title generator (issue #23246).
                     maybe_auto_title(
                         self._session_db,
                         self.session_id,
                         message,
                         response,
                         self.conversation_history,
-                        failure_callback=_title_failure_cb,
                         main_runtime={
                             "model": self.model,
                             "provider": self.provider,

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14823,15 +14823,10 @@ class GatewayRunner:
                 try:
                     from agent.title_generator import maybe_auto_title
                     all_msgs = result_holder[0].get("messages", []) if result_holder[0] else []
-                    # Route title-generation failures through the agent's
-                    # user-visible warning channel so a depleted auxiliary
-                    # provider doesn't silently leave sessions untitled
-                    # (issue #15775).
-                    _title_failure_cb = getattr(
-                        agent, "_emit_auxiliary_failure", None
-                    )
+                    # Keep title-generation failures silent in the user
+                    # channel; they are already logged at WARNING level by
+                    # the title generator (issue #23246).
                     maybe_auto_title_kwargs = {
-                        "failure_callback": _title_failure_cb,
                         "main_runtime": {
                             "model": getattr(agent, "model", None),
                             "provider": getattr(agent, "provider", None),

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -62,6 +62,7 @@ AUTHOR_MAP = {
     "abdielv@proton.me": "AJV20",
     "mason@growagainorchids.com": "masonjames",
     "ytchen0719@gmail.com": "liquidchen",
+    "mehmet.kar@std.yildiz.edu.tr": "mehmetkr-31",
     "am@studio1.tailb672fe.ts.net": "subtract0",
     "axmaiqiu@gmail.com": "qWaitCrypto",
     "44045911+kidonng@users.noreply.github.com": "kidonng",


### PR DESCRIPTION
Removes the user-visible failure callback wiring for auto-title generation. Auxiliary LLM errors (e.g., HTTP 401/402) now surface only in agent.log at WARNING level, not as chat messages that clutter the user conversation.

Closes #23246