### PR TITLE
fix(cli): reload default model from config on /reset and /new

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5393,6 +5393,21 @@ class HermesCLI:
             # First session or empty history — still finalize the old session
             self._notify_session_boundary("on_session_finalize")
 
+        # Reload default model from config when the user hasn't pinned one
+        # explicitly via -m, so /reset and /new revert to the current default
+        # instead of carrying over a previously switched model (issue #23131).
+        if getattr(self, "_model_is_default", True):
+            try:
+                cfg = load_cli_config()
+                _model_cfg = cfg.get("model", {})
+                _default = (
+                    _model_cfg.get("default") or _model_cfg.get("model") or ""
+                ) if isinstance(_model_cfg, dict) else (_model_cfg or "")
+                if _default:
+                    self.model = _default
+            except Exception:
+                pass
+
         old_session_id = self.session_id
         if self._session_db and old_session_id:
             try:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -62,6 +62,7 @@ AUTHOR_MAP = {
     "abdielv@proton.me": "AJV20",
     "mason@growagainorchids.com": "masonjames",
     "ytchen0719@gmail.com": "liquidchen",
+    "mehmet.kar@std.yildiz.edu.tr": "mehmetkr-31",
     "am@studio1.tailb672fe.ts.net": "subtract0",
     "axmaiqiu@gmail.com": "qWaitCrypto",
     "44045911+kidonng@users.noreply.github.com": "kidonng",


### PR DESCRIPTION
When a user switched models mid-session via /model, subsequent /reset or /new commands continued using the switched model instead of reverting to the config.yaml default. This reloads the default only when the original session was started without an explicit -m CLI override.

Closes #23131