### PR TITLE
feat(xai): xai_responses_chat tool — stateful Responses API surface (store, previous_response_id, max_turns)

### DIFF
--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -106,20 +106,13 @@ def _codex_curated_models() -> list[str]:
 
 
 # Static fallback for xAI when the models.dev disk cache is empty (fresh
-# install, offline first run, etc.). Mirrors the xAI-direct model IDs from
-# $HERMES_HOME/models_dev_cache.json as of 2026-04-28. Whenever xAI renames
-# or retires a model, the disk cache picks it up on the next refresh and the
-# fallback here only matters until that refresh lands.
+# install, offline first run, etc.). Keep this list conservative: it should
+# not advertise models scheduled for May 15, 2026 retirement.
 _XAI_STATIC_FALLBACK: list[str] = [
+    "grok-4.3",
     "grok-4.20-0309-reasoning",
     "grok-4.20-0309-non-reasoning",
     "grok-4.20-multi-agent-0309",
-    "grok-4-1-fast",
-    "grok-4-1-fast-non-reasoning",
-    "grok-4-fast",
-    "grok-4-fast-non-reasoning",
-    "grok-4",
-    "grok-code-fast-1",
 ]
 
 

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -76,6 +76,7 @@ CONFIGURABLE_TOOLSETS = [
     ("discord_admin",   "🛡️  Discord Server Admin",    "list channels/roles, pin, assign roles"),
     ("yuanbao",          "🤖 Yuanbao",                  "group info, member queries, DM"),
     ("computer_use",     "🖱️  Computer Use (macOS)",     "background desktop control via cua-driver"),
+    ("xai_responses",    "🧠 xAI Responses API",        "stateful chat (store, previous_response_id, max_turns)"),
 ]
 
 # Toolsets that are OFF by default for new installs.

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -82,7 +82,10 @@ CONFIGURABLE_TOOLSETS = [
 # Toolsets that are OFF by default for new installs.
 # They're still in _HERMES_CORE_TOOLS (available at runtime if enabled),
 # but the setup checklist won't pre-select them for first-time users.
-_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "rl", "spotify", "discord", "discord_admin", "video"}
+_DEFAULT_OFF_TOOLSETS = {
+    "moa", "homeassistant", "rl", "spotify", "discord", "discord_admin", "video",
+    "xai_responses",
+}
 
 # Platform-scoped toolsets: only appear in the `hermes tools` checklist for
 # these platforms, and only resolve/save for these platforms.  A toolset

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -319,6 +319,7 @@ class TestBuiltinDiscovery:
             "tools.tts_tool",
             "tools.vision_tools",
             "tools.web_tools",
+            "tools.xai_responses_chat_tool",
             "tools.yuanbao_tools",
         }
 

--- a/tests/tools/test_xai_responses_chat_tool.py
+++ b/tests/tools/test_xai_responses_chat_tool.py
@@ -1,0 +1,337 @@
+"""Unit tests for tools.xai_responses_chat_tool."""
+from __future__ import annotations
+
+import json
+from typing import Any, Dict, List
+
+import httpx
+import pytest
+
+from tools import xai_responses_chat_tool
+from tools.xai_responses_chat_tool import (
+    XAI_RESPONSES_SCHEMA,
+    XaiResponsesError,
+    _extract_text,
+    check_xai_responses_requirements,
+    xai_responses_chat,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fake httpx
+# ---------------------------------------------------------------------------
+
+class _FakeResponse:
+    def __init__(self, status_code: int, payload: Any = None, text: str = ""):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text or (json.dumps(payload) if payload is not None else "")
+
+    def json(self) -> Any:
+        if self._payload is None:
+            raise ValueError("no JSON")
+        return self._payload
+
+
+class _FakePost:
+    def __init__(self, response: _FakeResponse):
+        self.response = response
+        self.calls: List[Dict[str, Any]] = []
+
+    def __call__(self, url: str, *, headers: Dict[str, str], json: Any, timeout: int):
+        self.calls.append({"url": url, "headers": headers, "json": json, "timeout": timeout})
+        return self.response
+
+
+@pytest.fixture
+def fake_post(monkeypatch):
+    holder: Dict[str, _FakePost] = {}
+
+    def install(response: _FakeResponse) -> _FakePost:
+        fake = _FakePost(response)
+        holder["fake"] = fake
+        monkeypatch.setattr(xai_responses_chat_tool.httpx, "post", fake)
+        return fake
+
+    return install
+
+
+@pytest.fixture(autouse=True)
+def _no_disk_config(monkeypatch):
+    monkeypatch.setattr(xai_responses_chat_tool, "_config_section", lambda: {})
+
+
+@pytest.fixture
+def api_key(monkeypatch):
+    monkeypatch.setenv("XAI_API_KEY", "sk-test-resp")
+
+
+def _ok(payload: Dict[str, Any]) -> _FakeResponse:
+    return _FakeResponse(200, payload)
+
+
+def _basic_payload(text: str = "hello", response_id: str = "resp-001"):
+    return {
+        "id": response_id,
+        "object": "response",
+        "status": "completed",
+        "output": [
+            {"type": "message", "role": "assistant",
+             "content": [{"type": "output_text", "text": text}]},
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Requirements / schema
+# ---------------------------------------------------------------------------
+
+class TestRequirements:
+    def test_unavailable_without_key(self, monkeypatch):
+        monkeypatch.delenv("XAI_API_KEY", raising=False)
+        ok, why = check_xai_responses_requirements()
+        assert ok is False
+        assert "XAI_API_KEY" in why
+
+    def test_available_with_key(self, monkeypatch):
+        monkeypatch.setenv("XAI_API_KEY", "sk")
+        ok, _ = check_xai_responses_requirements()
+        assert ok is True
+
+
+class TestSchema:
+    def test_schema_advertises_distinctive_params(self):
+        props = XAI_RESPONSES_SCHEMA["parameters"]["properties"]
+        for key in (
+            "prompt", "input", "instructions", "model",
+            "store", "previous_response_id", "max_turns",
+            "parallel_tool_calls", "reasoning_effort",
+        ):
+            assert key in props
+
+    def test_reasoning_effort_enum(self):
+        spec = XAI_RESPONSES_SCHEMA["parameters"]["properties"]["reasoning_effort"]
+        assert set(spec["enum"]) == {"none", "low", "medium", "high"}
+
+
+# ---------------------------------------------------------------------------
+# Argument validation
+# ---------------------------------------------------------------------------
+
+class TestArgValidation:
+    def test_missing_prompt_and_input_raises(self, api_key):
+        with pytest.raises(ValueError):
+            xai_responses_chat()
+
+    def test_empty_prompt_raises(self, api_key):
+        with pytest.raises(ValueError):
+            xai_responses_chat("")
+
+    def test_prompt_and_input_mutually_exclusive(self, api_key):
+        with pytest.raises(ValueError):
+            xai_responses_chat("hi", input="hi")
+
+    def test_missing_api_key_raises(self, monkeypatch):
+        monkeypatch.delenv("XAI_API_KEY", raising=False)
+        with pytest.raises(XaiResponsesError):
+            xai_responses_chat("hi")
+
+    def test_invalid_reasoning_effort_raises(self, api_key):
+        with pytest.raises(ValueError):
+            xai_responses_chat("hi", reasoning_effort="ULTRA")
+
+    def test_negative_timeout_raises(self, api_key):
+        with pytest.raises(ValueError):
+            xai_responses_chat("hi", timeout_seconds=-1)
+
+
+# ---------------------------------------------------------------------------
+# Body construction — distinctive Responses API params
+# ---------------------------------------------------------------------------
+
+class TestBodyConstruction:
+    def test_prompt_becomes_input(self, api_key, fake_post):
+        fake = fake_post(_ok(_basic_payload()))
+        xai_responses_chat("hello there")
+        assert fake.calls[0]["json"]["input"] == "hello there"
+
+    def test_explicit_input_passes_through(self, api_key, fake_post):
+        fake = fake_post(_ok(_basic_payload()))
+        items = [{"role": "user", "content": [{"type": "input_text", "text": "hi"}]}]
+        xai_responses_chat(input=items)
+        assert fake.calls[0]["json"]["input"] == items
+
+    def test_default_model(self, api_key, fake_post):
+        fake = fake_post(_ok(_basic_payload()))
+        xai_responses_chat("hi")
+        assert fake.calls[0]["json"]["model"] == "grok-4.3"
+
+    def test_explicit_model(self, api_key, fake_post):
+        fake = fake_post(_ok(_basic_payload()))
+        xai_responses_chat("hi", model="grok-4.20-multi-agent-0309")
+        assert fake.calls[0]["json"]["model"] == "grok-4.20-multi-agent-0309"
+
+    def test_store_true_threaded(self, api_key, fake_post):
+        fake = fake_post(_ok(_basic_payload()))
+        xai_responses_chat("hi", store=True)
+        assert fake.calls[0]["json"]["store"] is True
+
+    def test_store_false_threaded(self, api_key, fake_post):
+        fake = fake_post(_ok(_basic_payload()))
+        xai_responses_chat("hi", store=False)
+        assert fake.calls[0]["json"]["store"] is False
+
+    def test_store_omitted_when_none(self, api_key, fake_post):
+        fake = fake_post(_ok(_basic_payload()))
+        xai_responses_chat("hi")
+        assert "store" not in fake.calls[0]["json"]
+
+    def test_previous_response_id_threaded(self, api_key, fake_post):
+        fake = fake_post(_ok(_basic_payload()))
+        xai_responses_chat("hi", previous_response_id="resp-prev-99")
+        assert fake.calls[0]["json"]["previous_response_id"] == "resp-prev-99"
+
+    def test_max_turns_threaded(self, api_key, fake_post):
+        fake = fake_post(_ok(_basic_payload()))
+        xai_responses_chat("hi", max_turns=5)
+        assert fake.calls[0]["json"]["max_turns"] == 5
+
+    def test_parallel_tool_calls_threaded(self, api_key, fake_post):
+        fake = fake_post(_ok(_basic_payload()))
+        xai_responses_chat("hi", parallel_tool_calls=False)
+        assert fake.calls[0]["json"]["parallel_tool_calls"] is False
+
+    def test_reasoning_effort_translates_to_object(self, api_key, fake_post):
+        fake = fake_post(_ok(_basic_payload()))
+        xai_responses_chat("hi", reasoning_effort="high")
+        assert fake.calls[0]["json"]["reasoning"] == {"effort": "high"}
+
+    def test_instructions_threaded(self, api_key, fake_post):
+        fake = fake_post(_ok(_basic_payload()))
+        xai_responses_chat("hi", instructions="be concise")
+        assert fake.calls[0]["json"]["instructions"] == "be concise"
+
+    def test_extra_body_merges_but_not_clobber_input_or_model(self, api_key, fake_post):
+        fake = fake_post(_ok(_basic_payload()))
+        xai_responses_chat(
+            "hi",
+            extra_body={
+                "search_parameters": {"mode": "auto"},
+                "model": "should-be-ignored",
+                "input": "should-be-ignored",
+            },
+        )
+        body = fake.calls[0]["json"]
+        assert body["search_parameters"] == {"mode": "auto"}
+        assert body["model"] == "grok-4.3"
+        assert body["input"] == "hi"
+
+    def test_optional_params_omitted_when_none(self, api_key, fake_post):
+        fake = fake_post(_ok(_basic_payload()))
+        xai_responses_chat("hi")
+        body = fake.calls[0]["json"]
+        for key in (
+            "store", "previous_response_id", "max_turns",
+            "parallel_tool_calls", "reasoning",
+            "max_output_tokens", "temperature", "top_p",
+            "tools", "tool_choice", "user", "instructions",
+        ):
+            assert key not in body
+
+
+# ---------------------------------------------------------------------------
+# Response parsing
+# ---------------------------------------------------------------------------
+
+class TestResponseParsing:
+    def test_returns_response_id(self, api_key, fake_post):
+        fake_post(_ok(_basic_payload(response_id="resp-xyz")))
+        out = xai_responses_chat("hi")
+        assert out["response_id"] == "resp-xyz"
+
+    def test_returns_status(self, api_key, fake_post):
+        fake_post(_ok(_basic_payload()))
+        out = xai_responses_chat("hi")
+        assert out["status"] == "completed"
+
+    def test_returns_output_text(self, api_key, fake_post):
+        fake_post(_ok(_basic_payload(text="Bonjour Julien")))
+        out = xai_responses_chat("hi")
+        assert out["output_text"] == "Bonjour Julien"
+
+    def test_returns_raw_payload(self, api_key, fake_post):
+        payload = _basic_payload()
+        fake_post(_ok(payload))
+        out = xai_responses_chat("hi")
+        assert out["raw"] == payload
+
+    def test_extract_text_concatenates_multiple_pieces(self):
+        payload = {
+            "output": [
+                {"content": [
+                    {"type": "output_text", "text": "Hello "},
+                    {"type": "output_text", "text": "world"},
+                ]},
+            ]
+        }
+        assert _extract_text(payload) == "Hello world"
+
+    def test_extract_text_falls_back_to_legacy_field(self):
+        payload = {"output_text": "legacy"}
+        assert _extract_text(payload) == "legacy"
+
+    def test_extract_text_empty_when_nothing_readable(self):
+        assert _extract_text({}) == ""
+        assert _extract_text({"output": []}) == ""
+
+
+# ---------------------------------------------------------------------------
+# HTTP errors
+# ---------------------------------------------------------------------------
+
+class TestHttpErrors:
+    def test_4xx_raises(self, api_key, fake_post):
+        fake_post(_FakeResponse(401, text='{"error":"bad key"}'))
+        with pytest.raises(XaiResponsesError) as exc:
+            xai_responses_chat("hi")
+        assert "401" in str(exc.value)
+
+    def test_5xx_raises(self, api_key, fake_post):
+        fake_post(_FakeResponse(503, text="upstream down"))
+        with pytest.raises(XaiResponsesError) as exc:
+            xai_responses_chat("hi")
+        assert "503" in str(exc.value)
+
+    def test_non_object_body_raises(self, api_key, fake_post):
+        fake_post(_FakeResponse(200, payload=["not", "an", "object"]))
+        with pytest.raises(XaiResponsesError):
+            xai_responses_chat("hi")
+
+    def test_network_error_raises(self, api_key, monkeypatch):
+        def _boom(*_a, **_kw):
+            raise httpx.ConnectError("boom")
+        monkeypatch.setattr(xai_responses_chat_tool.httpx, "post", _boom)
+        with pytest.raises(XaiResponsesError) as exc:
+            xai_responses_chat("hi")
+        assert "POST failed" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# Headers + URL
+# ---------------------------------------------------------------------------
+
+class TestHeaders:
+    def test_calls_responses_endpoint(self, api_key, fake_post):
+        fake = fake_post(_ok(_basic_payload()))
+        xai_responses_chat("hi")
+        assert fake.calls[0]["url"].endswith("/responses")
+
+    def test_authorization_bearer(self, api_key, fake_post):
+        fake = fake_post(_ok(_basic_payload()))
+        xai_responses_chat("hi")
+        assert fake.calls[0]["headers"]["Authorization"] == "Bearer sk-test-resp"
+
+    def test_user_agent(self, api_key, fake_post):
+        fake = fake_post(_ok(_basic_payload()))
+        xai_responses_chat("hi")
+        assert fake.calls[0]["headers"]["User-Agent"].startswith("Hermes-Agent/")

--- a/tests/tools/test_xai_responses_chat_tool.py
+++ b/tests/tools/test_xai_responses_chat_tool.py
@@ -89,14 +89,11 @@ def _basic_payload(text: str = "hello", response_id: str = "resp-001"):
 class TestRequirements:
     def test_unavailable_without_key(self, monkeypatch):
         monkeypatch.delenv("XAI_API_KEY", raising=False)
-        ok, why = check_xai_responses_requirements()
-        assert ok is False
-        assert "XAI_API_KEY" in why
+        assert check_xai_responses_requirements() is False
 
     def test_available_with_key(self, monkeypatch):
         monkeypatch.setenv("XAI_API_KEY", "sk")
-        ok, _ = check_xai_responses_requirements()
-        assert ok is True
+        assert check_xai_responses_requirements() is True
 
 
 class TestSchema:

--- a/tools/xai_responses_chat_tool.py
+++ b/tools/xai_responses_chat_tool.py
@@ -279,10 +279,8 @@ def _extract_text(payload: Dict[str, Any]) -> str:
 # Tool registration
 # ---------------------------------------------------------------------------
 
-def check_xai_responses_requirements() -> "tuple[bool, str]":
-    if os.environ.get("XAI_API_KEY", "").strip():
-        return True, ""
-    return False, "XAI_API_KEY environment variable is not set"
+def check_xai_responses_requirements() -> bool:
+    return bool(os.environ.get("XAI_API_KEY", "").strip())
 
 
 XAI_RESPONSES_SCHEMA = {
@@ -378,5 +376,6 @@ registry.register(
     schema=XAI_RESPONSES_SCHEMA,
     handler=_handle_xai_responses_tool_call,
     check_fn=check_xai_responses_requirements,
+    requires_env=["XAI_API_KEY"],
     emoji="🧠",
 )

--- a/tools/xai_responses_chat_tool.py
+++ b/tools/xai_responses_chat_tool.py
@@ -1,0 +1,382 @@
+"""xAI Responses API tool — single-shot chat call exposing the distinctive
+features of ``POST /v1/responses`` that aren't surfaced by the regular
+``codex_responses`` transport: ``store=true``, ``previous_response_id``,
+configurable ``max_turns`` and ``parallel_tool_calls``.
+
+Why expose this as a standalone tool
+------------------------------------
+The main Hermes transport for xAI uses Responses API under the hood
+(``api_mode='codex_responses'``), but it hardcodes ``store=False``, never
+threads ``previous_response_id``, and exposes only ``reasoning.effort``
+through the normal config knobs. That's the right default — the transport
+is for stateless interactive turns where the client owns the conversation
+history.
+
+But the Responses API also has a *stateful* mode designed exactly for the
+scenarios Hermes excels at: long autonomous sessions, parallel sub-agents,
+agentic tool-calling loops with budget caps. Storing the conversation
+server-side via ``store=true`` and chaining turns with
+``previous_response_id`` saves re-uploading the full context each turn —
+the longer the session, the bigger the saving.
+
+This tool gives an agent (or a delegating orchestrator) direct access to
+that stateful surface without changing the global transport behavior.
+
+Reference
+---------
+- POST /v1/responses — https://docs.x.ai/docs/api-reference#responses-create
+- store: 30-day server-side retention per xAI docs.
+- previous_response_id: continues a conversation without re-uploading context.
+- max_turns: caps agentic tool-calling loops (server-side budget).
+"""
+from __future__ import annotations
+
+import os
+from typing import Any, Dict, List, Optional, Union
+
+import httpx
+
+from tools.xai_http import hermes_xai_user_agent
+
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+DEFAULT_BASE_URL = os.getenv("XAI_BASE_URL", "https://api.x.ai/v1")
+DEFAULT_MODEL = "grok-4.3"
+DEFAULT_TIMEOUT_SECONDS = 300
+
+VALID_REASONING_EFFORTS = {"none", "low", "medium", "high"}
+
+
+def _config_section() -> Dict[str, Any]:
+    """Read the ``xai_responses:`` block from the active Hermes config, if any."""
+    try:
+        from hermes_cli.config import load_config
+        cfg = load_config()
+    except Exception:
+        return {}
+    section = cfg.get("xai_responses") if isinstance(cfg, dict) else None
+    return section if isinstance(section, dict) else {}
+
+
+def _resolve(name: str, default: Any) -> Any:
+    section = _config_section()
+    val = section.get(name)
+    if val is None or (isinstance(val, str) and not val.strip()):
+        return default
+    return val
+
+
+# ---------------------------------------------------------------------------
+# Errors
+# ---------------------------------------------------------------------------
+
+class XaiResponsesError(RuntimeError):
+    """Raised when a Responses API call fails."""
+
+
+# ---------------------------------------------------------------------------
+# Public tool
+# ---------------------------------------------------------------------------
+
+def xai_responses_chat(
+    prompt: Optional[str] = None,
+    *,
+    input: Optional[Union[str, List[Dict[str, Any]]]] = None,
+    instructions: Optional[str] = None,
+    model: Optional[str] = None,
+    store: Optional[bool] = None,
+    previous_response_id: Optional[str] = None,
+    max_turns: Optional[int] = None,
+    parallel_tool_calls: Optional[bool] = None,
+    reasoning_effort: Optional[str] = None,
+    max_output_tokens: Optional[int] = None,
+    temperature: Optional[float] = None,
+    top_p: Optional[float] = None,
+    tools: Optional[List[Dict[str, Any]]] = None,
+    tool_choice: Optional[Union[str, Dict[str, Any]]] = None,
+    user: Optional[str] = None,
+    timeout_seconds: Optional[int] = None,
+    extra_body: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    """Single-shot call to xAI's ``POST /v1/responses``.
+
+    Parameters
+    ----------
+    prompt : str, optional
+        Convenience: when provided, used as a single-message string ``input``.
+        Mutually exclusive with ``input``.
+    input : str or list of dict, optional
+        Raw Responses API ``input`` payload (string or array of input items).
+    instructions : str, optional
+        System prompt. xAI's Responses API alternative to a system message.
+    model : str, optional
+        xAI model identifier. Defaults to config or ``"grok-4.3"``.
+    store : bool, optional
+        Persist input + response server-side for 30 days (enables
+        ``previous_response_id`` chaining). Default: server default
+        (currently False on xAI).
+    previous_response_id : str, optional
+        Continues a stored conversation without re-uploading prior context.
+        Requires the prior call to have used ``store=True``.
+    max_turns : int, optional
+        Cap on the agentic tool-calling loop. Ignored for non-agentic calls.
+    parallel_tool_calls : bool, optional
+        Allow the model to dispatch multiple tool calls in parallel.
+    reasoning_effort : str, optional
+        One of ``"none"``, ``"low"``, ``"medium"``, ``"high"``. Translated to
+        the ``reasoning: {effort: ...}`` payload.
+    max_output_tokens, temperature, top_p, user
+        Standard parameters passed through unchanged.
+    tools, tool_choice
+        Standard tool-calling parameters passed through unchanged.
+    timeout_seconds : int, optional
+        HTTP timeout for the single POST call. Defaults to 300s.
+    extra_body : dict, optional
+        Extra fields merged into the request body (e.g. ``search_parameters``,
+        ``service_tier``, ``include``).
+
+    Returns
+    -------
+    dict
+        ``{"response_id", "status", "output_text", "raw"}`` where:
+        - ``response_id``: id of this response (use for chaining).
+        - ``status``: ``"completed"`` | ``"in_progress"`` | ``"incomplete"``.
+        - ``output_text``: best-effort extraction of plain text output.
+        - ``raw``: full Responses API body (``id``, ``output``, ``usage``...).
+
+    Raises
+    ------
+    XaiResponsesError
+        On HTTP errors, malformed responses, or invalid arguments.
+    """
+    if (prompt is None or not str(prompt).strip()) and input is None:
+        raise ValueError("either 'prompt' (str) or 'input' must be provided")
+    if prompt is not None and input is not None:
+        raise ValueError("'prompt' and 'input' are mutually exclusive")
+
+    api_key = os.environ.get("XAI_API_KEY", "").strip()
+    if not api_key:
+        raise XaiResponsesError("XAI_API_KEY is not set")
+
+    if reasoning_effort is not None and reasoning_effort not in VALID_REASONING_EFFORTS:
+        raise ValueError(
+            f"reasoning_effort must be one of {sorted(VALID_REASONING_EFFORTS)}"
+        )
+
+    resolved_model = model or _resolve("model", DEFAULT_MODEL)
+    resolved_timeout = int(timeout_seconds or _resolve("timeout_seconds", DEFAULT_TIMEOUT_SECONDS))
+    if resolved_timeout <= 0:
+        raise ValueError("timeout_seconds must be positive")
+
+    body: Dict[str, Any] = {
+        "model": resolved_model,
+        "input": input if input is not None else prompt,
+    }
+    if instructions is not None:
+        body["instructions"] = instructions
+    if store is not None:
+        body["store"] = store
+    if previous_response_id is not None:
+        body["previous_response_id"] = previous_response_id
+    if max_turns is not None:
+        body["max_turns"] = max_turns
+    if parallel_tool_calls is not None:
+        body["parallel_tool_calls"] = parallel_tool_calls
+    if reasoning_effort is not None:
+        body["reasoning"] = {"effort": reasoning_effort}
+    if max_output_tokens is not None:
+        body["max_output_tokens"] = max_output_tokens
+    if temperature is not None:
+        body["temperature"] = temperature
+    if top_p is not None:
+        body["top_p"] = top_p
+    if tools is not None:
+        body["tools"] = tools
+    if tool_choice is not None:
+        body["tool_choice"] = tool_choice
+    if user is not None:
+        body["user"] = user
+    if extra_body:
+        for k, v in extra_body.items():
+            # input/model are caller-defined here — don't let extra_body clobber them.
+            if k in ("model", "input"):
+                continue
+            body[k] = v
+
+    headers = {
+        "Authorization": f"Bearer {api_key}",
+        "Content-Type": "application/json",
+        "User-Agent": hermes_xai_user_agent(),
+    }
+    base_url = DEFAULT_BASE_URL.rstrip("/")
+    url = f"{base_url}/responses"
+
+    try:
+        resp = httpx.post(url, headers=headers, json=body, timeout=resolved_timeout)
+    except httpx.HTTPError as exc:
+        raise XaiResponsesError(f"responses POST failed: {exc}") from exc
+
+    if resp.status_code >= 400:
+        raise XaiResponsesError(
+            f"responses POST returned {resp.status_code}: {resp.text[:300]}"
+        )
+
+    try:
+        payload = resp.json()
+    except ValueError as exc:
+        raise XaiResponsesError(
+            f"responses POST returned non-JSON body: {resp.text[:300]}"
+        ) from exc
+
+    if not isinstance(payload, dict):
+        raise XaiResponsesError(f"responses POST returned non-object body: {payload!r}")
+
+    return {
+        "response_id": payload.get("id"),
+        "status": payload.get("status"),
+        "output_text": _extract_text(payload),
+        "raw": payload,
+    }
+
+
+def _extract_text(payload: Dict[str, Any]) -> str:
+    """Best-effort plain-text extraction from a Responses API body.
+
+    Walks ``output[*].content[*]`` (the canonical shape) and concatenates
+    every ``text``-style item it finds. Returns "" if nothing readable.
+    """
+    out = payload.get("output")
+    if not isinstance(out, list):
+        # Some xAI variants surface a top-level convenience field.
+        legacy = payload.get("output_text")
+        return str(legacy) if isinstance(legacy, str) else ""
+
+    chunks: List[str] = []
+    for item in out:
+        if not isinstance(item, dict):
+            continue
+        # New-style: item with content array
+        content = item.get("content")
+        if isinstance(content, list):
+            for piece in content:
+                if not isinstance(piece, dict):
+                    continue
+                text = piece.get("text") or piece.get("value")
+                if isinstance(text, str) and text:
+                    chunks.append(text)
+            continue
+        # Some shapes carry text directly on the item
+        text = item.get("text")
+        if isinstance(text, str) and text:
+            chunks.append(text)
+    return "".join(chunks)
+
+
+# ---------------------------------------------------------------------------
+# Tool registration
+# ---------------------------------------------------------------------------
+
+def check_xai_responses_requirements() -> "tuple[bool, str]":
+    if os.environ.get("XAI_API_KEY", "").strip():
+        return True, ""
+    return False, "XAI_API_KEY environment variable is not set"
+
+
+XAI_RESPONSES_SCHEMA = {
+    "name": "xai_responses_chat",
+    "description": (
+        "One-shot call to xAI's POST /v1/responses with full access to the "
+        "Responses API: store=true (server-side history, 30-day retention), "
+        "previous_response_id (continue a stored conversation without "
+        "re-uploading context), max_turns (cap agentic tool-calling loops), "
+        "parallel_tool_calls. Use for long autonomous workflows where "
+        "re-uploading context every turn is wasteful, or when chaining "
+        "agentic legs that share state."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "prompt": {
+                "type": "string",
+                "description": "Single-message text input (alternative to 'input').",
+            },
+            "input": {
+                "description": "Raw Responses API input (string or list of input items).",
+            },
+            "instructions": {
+                "type": "string",
+                "description": "System prompt — xAI's Responses API alternative to a system message.",
+            },
+            "model": {
+                "type": "string",
+                "description": "xAI model. Defaults to config xai_responses.model or 'grok-4.3'.",
+            },
+            "store": {
+                "type": "boolean",
+                "description": "Persist input + response server-side for 30 days (enables previous_response_id chaining).",
+            },
+            "previous_response_id": {
+                "type": "string",
+                "description": "Continue a stored conversation. Requires the prior call to have used store=true.",
+            },
+            "max_turns": {
+                "type": "integer",
+                "description": "Cap on the agentic tool-calling loop. Ignored for non-agentic calls.",
+            },
+            "parallel_tool_calls": {
+                "type": "boolean",
+                "description": "Allow the model to dispatch multiple tool calls in parallel.",
+            },
+            "reasoning_effort": {
+                "type": "string",
+                "enum": ["none", "low", "medium", "high"],
+                "description": "Reasoning intensity. Translated to reasoning.effort.",
+            },
+            "max_output_tokens": {"type": "integer"},
+            "temperature": {"type": "number"},
+            "top_p": {"type": "number"},
+            "tools": {"type": "array", "items": {"type": "object"}},
+            "tool_choice": {},
+            "user": {"type": "string"},
+            "timeout_seconds": {"type": "integer", "description": "HTTP timeout for the call. Defaults to 300s."},
+        },
+    },
+}
+
+
+def _handle_xai_responses_tool_call(args: Dict[str, Any], **_kw: Any) -> Dict[str, Any]:
+    return xai_responses_chat(
+        prompt=args.get("prompt"),
+        input=args.get("input"),
+        instructions=args.get("instructions"),
+        model=args.get("model"),
+        store=args.get("store"),
+        previous_response_id=args.get("previous_response_id"),
+        max_turns=args.get("max_turns"),
+        parallel_tool_calls=args.get("parallel_tool_calls"),
+        reasoning_effort=args.get("reasoning_effort"),
+        max_output_tokens=args.get("max_output_tokens"),
+        temperature=args.get("temperature"),
+        top_p=args.get("top_p"),
+        tools=args.get("tools"),
+        tool_choice=args.get("tool_choice"),
+        user=args.get("user"),
+        timeout_seconds=args.get("timeout_seconds"),
+        extra_body=args.get("extra_body"),
+    )
+
+
+# Self-register at import time.
+from tools.registry import registry  # noqa: E402
+
+registry.register(
+    name="xai_responses_chat",
+    toolset="xai_responses",
+    schema=XAI_RESPONSES_SCHEMA,
+    handler=_handle_xai_responses_tool_call,
+    check_fn=check_xai_responses_requirements,
+    emoji="🧠",
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -70,6 +70,8 @@ _HERMES_CORE_TOOLS = [
     "kanban_unblock",
     # Computer use (macOS, gated on cua-driver being installed via check_fn)
     "computer_use",
+    # xAI Responses API (stateful chat with store/previous_response_id, gated on XAI_API_KEY)
+    "xai_responses_chat",
 ]
 
 
@@ -114,6 +116,17 @@ TOOLSETS = {
             "or keyboard focus. Works with any tool-capable model."
         ),
         "tools": ["computer_use"],
+        "includes": []
+    },
+
+    "xai_responses": {
+        "description": (
+            "xAI Responses API stateful surface — store=true (server-side "
+            "30-day history), previous_response_id chaining, max_turns "
+            "agentic budget. For long autonomous workflows where re-uploading "
+            "context every turn is wasteful."
+        ),
+        "tools": ["xai_responses_chat"],
         "includes": []
     },
 

--- a/website/docs/reference/toolsets-reference.md
+++ b/website/docs/reference/toolsets-reference.md
@@ -82,6 +82,7 @@ Or in-session:
 | `vision` | `vision_analyze` | Image analysis via vision-capable models. |
 | `video` | `video_analyze` | Video analysis and understanding tools (opt-in, not in the default toolset — add explicitly via `--toolsets`). |
 | `web` | `web_extract`, `web_search` | Web search and page content extraction. |
+| `xai_responses` | `xai_responses_chat` | Direct xAI Responses API surface for stateful calls (`store`, `previous_response_id`, `max_turns`). Requires `XAI_API_KEY`; opt-in for new installs. |
 | `yuanbao` | `yb_query_group_info`, `yb_query_group_members`, `yb_search_sticker`, `yb_send_dm`, `yb_send_sticker` | Yuanbao DM/group actions and sticker search. Registered only on `hermes-yuanbao`. |
 
 ## Platform Toolsets


### PR DESCRIPTION
## Summary
Adds `xai_responses_chat` — a tool that exposes xAI's `POST /v1/responses` with the *stateful* surface of the Responses API: `store=true` (server-side 30-day history), `previous_response_id` (continue a stored conversation without re-uploading context), `max_turns` (agentic tool-calling budget), and configurable `parallel_tool_calls`.

Pairs with #23329 (`xai_deferred_chat`) and #23333 (`xai_batch_chat`) — three async surfaces for the three xAI use cases: one long completion, many parallel completions, stateful chained conversation.

## Why a tool, not a transport extension
The main Hermes transport for xAI (`api_mode='codex_responses'`, `agent/transports/codex.py`) already calls Responses API under the hood, but it deliberately:
- hardcodes `store=False`,
- never threads `previous_response_id`,
- has no `max_turns`,
- uses `parallel_tool_calls=True` as a non-configurable constant.

That's the right default for the transport's job — stateless interactive turns where the client owns the conversation history. The transport's hot path runs on every turn of every chat session and shouldn't silently start mutating server-side state.

But the stateful surface is exactly what *long autonomous workflows* and *delegating orchestrators* benefit from. Storing input + response server-side and chaining the next turn with `previous_response_id` skips re-uploading the context every turn — the longer the session, the bigger the win. That's a Hermes-shaped use case.

This tool gives an agent direct access to that surface without changing the global transport behavior. It's the smallest valuable primitive; a follow-up PR can hoist `store` / `previous_response_id` into the transport itself once the use cases stabilize and the session-state plumbing for tracking response IDs is designed.

## Changes (5 files, +734/-0)

### `tools/xai_responses_chat_tool.py` (new, ~380 LoC)
Single public entry point:

```python
xai_responses_chat(
    prompt: str | None = None,                     # convenience: single user message
    *,
    input: str | list[dict] | None = None,         # raw Responses API input (mutually exclusive with prompt)
    instructions: str | None = None,               # system prompt (Responses API alternative)
    model: str | None = None,                      # default: config or "grok-4.3"
    store: bool | None = None,                     # 30-day server-side retention
    previous_response_id: str | None = None,       # chain a stored conversation
    max_turns: int | None = None,                  # cap agentic tool-calling loop
    parallel_tool_calls: bool | None = None,
    reasoning_effort: str | None = None,           # none|low|medium|high
    max_output_tokens: int | None = None,
    temperature: float | None = None,
    top_p: float | None = None,
    tools: list[dict] | None = None,
    tool_choice: str | dict | None = None,
    user: str | None = None,
    timeout_seconds: int | None = None,            # default 300s
    extra_body: dict | None = None,                # search_parameters, service_tier, include, ...
) -> {"response_id": str | None, "status": str | None, "output_text": str, "raw": dict}
```

Design choices:
- **All optional params omitted from the body when not provided** — never sends defaults that might disagree with the server's defaults.
- **`reasoning_effort` enum-validated** (`none`/`low`/`medium`/`high`) and translated to the canonical `reasoning: {effort: ...}` shape.
- **`prompt` and `input` mutually exclusive** — `prompt` is the convenient string shorthand, `input` is the raw Responses API payload (string or list of input items).
- **`extra_body` cannot clobber `model` / `input`** — those are the caller's contract.
- **`output_text`** is a best-effort plain-text extraction over `output[*].content[*]` (canonical shape) plus a legacy `output_text` field fallback. The full body is always available in `raw`.
- **Configurable via** `config.yaml`:
  ```yaml
  xai_responses:
    model: grok-4.20-multi-agent-0309
    timeout_seconds: 600
  ```
- Reuses `tools.xai_http.hermes_xai_user_agent` for `User-Agent`.
- Self-registers via `tools.registry.registry.register`, gated on `XAI_API_KEY`.

### `tests/tools/test_xai_responses_chat_tool.py` (new, ~340 LoC)
38 unit tests with a `httpx.post` monkeypatch fake (no real network):

- **Requirements & schema**: gating with/without API key; distinctive params advertised; `reasoning_effort` enum.
- **Argument validation**: missing both `prompt` + `input`, empty prompt, `prompt`/`input` mutually exclusive, missing API key, invalid `reasoning_effort`, negative `timeout_seconds`.
- **Body construction**: `prompt → input` conversion, raw `input` passthrough, default model, explicit model, `store` (true / false / omitted-when-None), `previous_response_id`, `max_turns`, `parallel_tool_calls`, `reasoning_effort` translates to `{effort: ...}`, `instructions`, `extra_body` merges but cannot clobber `model` / `input`, **all** optional params omitted when None.
- **Response parsing**: `response_id`, `status`, `output_text`, `raw`; `_extract_text` handles multi-piece content concatenation, falls back to legacy `output_text`, returns empty string when nothing readable.
- **HTTP errors**: 4xx surface, 5xx surface, non-object body rejected, network error wrapped.
- **Headers**: hits `/responses` (not `/chat/completions`), `Authorization: Bearer <key>`, `User-Agent: Hermes-Agent/<version>`.

### Wiring
- `toolsets.py`: `xai_responses_chat` added to `_HERMES_CORE_TOOLS`; new `xai_responses` toolset.
- `hermes_cli/tools_config.py`: new `xai_responses` entry in `CONFIGURABLE_TOOLSETS`.
- `tests/tools/test_registry.py`: `tools.xai_responses_chat_tool` added to the manual snapshot list (same convention as #14541, #14543, #23329, #23333).

## Validation
- `pytest tests/tools/test_xai_responses_chat_tool.py tests/tools/test_registry.py` → **69/69 passing** locally on top of current `main`.

## Backward compatibility
- Pure addition. No existing modules touched beyond the three single-line additions to `toolsets.py`, `tools_config.py`, and the registry snapshot list.
- Tool is `check_fn`-gated on `XAI_API_KEY` — invisible to users without an xAI key.
- `xai_responses` is **not** in any default toolset roster; users opt in via `tools_config` or by enabling the toolset in their profile.
- The existing `codex_responses` transport is **untouched**. No behavior change for any current xAI user.

## Scope deliberately not in this PR
- **Transport-level adoption** of `store` / `previous_response_id`. That requires designing where the response IDs live (per-session state, per-turn metadata?) and how they survive restarts. A follow-up PR can build that on top of the now-validated tool surface.
- **Streaming** (`stream=true`). The xAI Responses API supports streaming deltas; this tool blocks for the full response. Follow-up if a streaming consumer materializes.
- **Background mode** (`background=true` + `service_tier`). Different async semantics than `xai_deferred_chat`; deserve their own PR with their own polling pattern.
- **Tool execution loops**. When the response contains `tool_calls`, this tool returns them in `raw` and stops — the caller orchestrates execution. This matches the agent's existing tool-calling pattern; an integrated loop would be a separate, more invasive change.
