### PR TITLE
refactor(cron): DRY media extensions from gateway.platforms.base

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -1308,10 +1308,10 @@ def _resolve_delivery_target(job: dict) -> Optional[dict]:
     return targets[0] if targets else None
 
 
-# Media extension sets — audio routing is centralized in gateway.platforms.base
-# via should_send_media_as_audio() so Telegram-specific rules stay in one place.
-_VIDEO_EXTS = frozenset({'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'})
-_IMAGE_EXTS = frozenset({'.jpg', '.jpeg', '.png', '.webp', '.gif'})
+# Media extension sets — imported, not redeclared, so cron routes a given file
+# to exactly the adapter method a live turn would. Audio routing is likewise
+# centralized in gateway.platforms.base via should_send_media_as_audio().
+from gateway.platforms.base import _IMAGE_EXTS, _VIDEO_EXTS  # noqa: E402
 
 
 def _send_media_via_adapter(

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -46,6 +46,15 @@ _TELEGRAM_AUDIO_ATTACHMENT_EXTS = frozenset({'.mp3', '.m4a'})
 _TELEGRAM_VOICE_EXTS = frozenset({'.ogg', '.opus'})
 _POST_DELIVERY_CALLBACK_TIMEOUT_SECONDS = 30.0
 
+# Canonical media-routing extension sets. These decide which adapter method a
+# delivered file goes to (send_video / send_image_file / send_document), and
+# cron's out-of-band delivery must route identically — a set that drifts here
+# silently changes how the same file is delivered depending on whether it came
+# from a live turn or a scheduled job. Defined once, imported by
+# cron.scheduler, and previously duplicated three times in this repo.
+_VIDEO_EXTS = frozenset({'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'})
+_IMAGE_EXTS = frozenset({'.jpg', '.jpeg', '.png', '.webp', '.gif'})
+
 
 def _platform_name(platform) -> str:
     """Normalize a Platform enum / raw string into a lowercase name."""
@@ -4260,7 +4269,6 @@ class BasePlatformAdapter(ABC):
         must see a failure notice instead of a silent drop (#66797).
         """
         ext = Path(media_path).suffix.lower()
-        _VIDEO_EXTS = {".mp4", ".mov", ".avi", ".mkv", ".webm", ".3gp"}
         if is_voice or should_send_media_as_audio(self.platform, ext, is_voice=is_voice):
             text = "⚠️ Couldn't deliver the audio attachment."
         elif ext in _VIDEO_EXTS:
@@ -6121,9 +6129,6 @@ class BasePlatformAdapter(ABC):
 
 
                 # Send extracted media files — route by file type
-                _VIDEO_EXTS = {'.mp4', '.mov', '.avi', '.mkv', '.webm', '.3gp'}
-                _IMAGE_EXTS = {'.jpg', '.jpeg', '.png', '.webp', '.gif'}
-
                 # Partition images out of media_files + local_files so they
                 # can be sent as a single batch (Signal RPC). When
                 # ``[[as_document]]`` was set on the original response, image

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -1901,3 +1901,36 @@ class TestSetCronSessionTitle:
         db.get_next_title_in_lineage.assert_called_once_with("Nightly Synthesis")
 
 
+
+
+class TestMediaExtensionSetsAreShared:
+    """cron must route a delivered file exactly as a live turn would.
+
+    These sets decide which adapter method a file goes to (send_video /
+    send_image_file / send_document). cron redeclared its own copies, so the
+    same file could be delivered differently depending on whether it came
+    from a live turn or a scheduled job once either list changed. The repo
+    had drifted to three separate declarations.
+
+    Asserting identity rather than equality is deliberate: equal-but-separate
+    literals are exactly the state this change removes, and an equality
+    assertion would keep passing through a future re-duplication.
+    """
+
+    def test_cron_uses_the_base_adapter_sets_not_copies(self):
+        import cron.scheduler as scheduler
+        from gateway.platforms import base
+
+        assert scheduler._VIDEO_EXTS is base._VIDEO_EXTS
+        assert scheduler._IMAGE_EXTS is base._IMAGE_EXTS
+
+    def test_the_base_adapter_declares_them_once(self):
+        """No function-local shadow may re-introduce a private copy."""
+        import gateway.platforms.base as base
+
+        assert isinstance(base._VIDEO_EXTS, frozenset)
+        assert isinstance(base._IMAGE_EXTS, frozenset)
+        assert ".mp4" in base._VIDEO_EXTS and ".png" in base._IMAGE_EXTS
+        assert not (base._VIDEO_EXTS & base._IMAGE_EXTS), (
+            "an extension routed as both video and image is ambiguous"
+        )


### PR DESCRIPTION
Moves _VIDEO_EXTS and _IMAGE_EXTS to the canonical location in gateway/platforms/base.py and imports them from cron/scheduler.py instead of duplicating. This prevents drift when new formats are added (e.g. .heic images) and removes the "keep in sync" comment hazard.

Related to #23324.