### PR TITLE
fix(cli): use prompt_toolkit prompt for confirmation input

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5863,7 +5863,8 @@ class HermesCLI:
 
         def _ask():
             try:
-                result[0] = input(prompt_text).strip() or None
+                from prompt_toolkit.shortcuts import prompt as pt_prompt
+                result[0] = pt_prompt(prompt_text).strip() or None
             except (KeyboardInterrupt, EOFError):
                 pass
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -62,6 +62,7 @@ AUTHOR_MAP = {
     "abdielv@proton.me": "AJV20",
     "mason@growagainorchids.com": "masonjames",
     "ytchen0719@gmail.com": "liquidchen",
+    "mehmet.kar@std.yildiz.edu.tr": "mehmetkr-31",
     "am@studio1.tailb672fe.ts.net": "subtract0",
     "axmaiqiu@gmail.com": "qWaitCrypto",
     "44045911+kidonng@users.noreply.github.com": "kidonng",


### PR DESCRIPTION
Replaces bare input() with prompt_toolkit.shortcuts.prompt inside _prompt_text_input() so keystrokes are captured by the TUI renderer instead of leaking into the chat composer. This fixes the /clear, /new, /reset, and /undo confirmation prompts on prompt_toolkit v3.0.52+ where run_in_terminal returns a coroutine.

Closes #22958