### PR TITLE
fix(telegram): reply to user on unsupported docs and cache failures

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -3782,12 +3782,16 @@ class TelegramAdapter(BasePlatformAdapter):
                 # Check if supported
                 if ext not in SUPPORTED_DOCUMENT_TYPES:
                     supported_list = ", ".join(sorted(SUPPORTED_DOCUMENT_TYPES.keys()))
-                    event.text = (
+                    reply_text = (
                         f"Unsupported document type '{ext or 'unknown'}'. "
                         f"Supported types: {supported_list}"
                     )
                     logger.info("[Telegram] Unsupported document type: %s", ext or "unknown")
-                    await self.handle_message(event)
+                    await self.send_message(
+                        chat_id=event.source.chat_id,
+                        text=reply_text,
+                        reply_to=event.source.message_id,
+                    )
                     return
 
                 # Download and cache
@@ -3820,6 +3824,12 @@ class TelegramAdapter(BasePlatformAdapter):
 
             except Exception as e:
                 logger.warning("[Telegram] Failed to cache document: %s", e, exc_info=True)
+                await self.send_message(
+                    chat_id=event.source.chat_id,
+                    text="Sorry, I couldn't download that attachment. Please try again.",
+                    reply_to=event.source.message_id,
+                )
+                return
 
         media_group_id = getattr(msg, "media_group_id", None)
         if media_group_id:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -62,6 +62,7 @@ AUTHOR_MAP = {
     "abdielv@proton.me": "AJV20",
     "mason@growagainorchids.com": "masonjames",
     "ytchen0719@gmail.com": "liquidchen",
+    "mehmet.kar@std.yildiz.edu.tr": "mehmetkr-31",
     "am@studio1.tailb672fe.ts.net": "subtract0",
     "axmaiqiu@gmail.com": "qWaitCrypto",
     "44045911+kidonng@users.noreply.github.com": "kidonng",


### PR DESCRIPTION
Stops routing unsupported document types and CDN cache download failures into the agent pipeline as fake user messages. Instead, sends a direct reply to the user and drops the event.

- Unsupported documents: reply with the supported type list instead of forging event.text and treating it as a user message.
- Cache/download failures: reply with an error message instead of silently swallowing the exception and sending an empty event to the agent.

Closes #23045