### PR TITLE
fix(gateway): skip --replace when running under systemd

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -3109,6 +3109,13 @@ def run_gateway(verbose: int = 0, quiet: bool = False, replace: bool = False):
                  This prevents systemd restart loops when the old process
                  hasn't fully exited yet.
     """
+    # When running under systemd, ignore --replace to avoid conflicts with
+    # systemd's own process management (Restart=always, ExecStopPost) that
+    # can create an infinite restart loop (#23272).
+    if replace and (os.environ.get("INVOCATION_ID") or os.environ.get("SYSTEMD_EXEC_PID")):
+        logger.info("Running under systemd; ignoring --replace to avoid restart loops.")
+        replace = False
+
     _guard_official_docker_root_gateway()
     sys.path.insert(0, str(PROJECT_ROOT))
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -62,6 +62,7 @@ AUTHOR_MAP = {
     "abdielv@proton.me": "AJV20",
     "mason@growagainorchids.com": "masonjames",
     "ytchen0719@gmail.com": "liquidchen",
+    "mehmet.kar@std.yildiz.edu.tr": "mehmetkr-31",
     "am@studio1.tailb672fe.ts.net": "subtract0",
     "axmaiqiu@gmail.com": "qWaitCrypto",
     "44045911+kidonng@users.noreply.github.com": "kidonng",


### PR DESCRIPTION
Ignores the --replace flag when the gateway detects it is running under systemd (via INVOCATION_ID or SYSTEMD_EXEC_PID environment variables). This prevents infinite restart loops caused by systemd's Restart=always policy colliding with the gateway's own process replacement logic, especially when combined with custom ExecStopPost hooks.

Closes #23272