### PR TITLE
fix(doctor): use get_env_value for API keys and base URLs instead of os.getenv

### DIFF
--- a/hermes_cli/doctor.py
+++ b/hermes_cli/doctor.py
@@ -11,7 +11,7 @@ import shutil
 import importlib.util
 from pathlib import Path
 
-from hermes_cli.config import get_project_root, get_hermes_home, get_env_path
+from hermes_cli.config import get_project_root, get_hermes_home, get_env_path, get_env_value
 from hermes_cli.env_loader import load_hermes_dotenv
 from hermes_constants import display_hermes_home
 
@@ -1203,7 +1203,7 @@ def run_doctor(args):
     _probes: list = []  # list of (label, callable) submitted in display order
 
     def _probe_openrouter() -> _ConnectivityResult:
-        key = os.getenv("OPENROUTER_API_KEY")
+        key = get_env_value("OPENROUTER_API_KEY") or os.getenv("OPENROUTER_API_KEY")
         if not key:
             return _ConnectivityResult(
                 "OpenRouter API",
@@ -1336,7 +1336,7 @@ def run_doctor(args):
                                supports_health_check) -> _ConnectivityResult:
         key = ""
         for ev in env_vars:
-            key = os.getenv(ev, "")
+            key = get_env_value(ev) or os.getenv(ev, "")
             if key:
                 break
         if not key:
@@ -1351,7 +1351,7 @@ def run_doctor(args):
             )
         try:
             import httpx
-            base = os.getenv(base_env, "") if base_env else ""
+            base = (get_env_value(base_env) or os.getenv(base_env, "")) if base_env else ""
             # Auto-detect Kimi Code keys (sk-kimi-) → api.kimi.com/coding/v1
             # (OpenAI-compat surface, which exposes /models for health check).
             if not base and key.startswith("sk-kimi-"):


### PR DESCRIPTION
fix(doctor): use get_env_value for API keys and base URLs instead of os.getenv

## Problem

`hermes_cli/doctor.py` uses `os.getenv()` to read API keys and base URL env vars. `os.getenv()` only reads from `os.environ`, so values stored in `~/.hermes/.env` (the standard location for API keys) are silently missed.

This causes:
- **API key blindspot**: `hermes doctor` reports keys as "not configured" when they exist only in `~/.hermes/.env`
- **Base URL fallback**: providers with a custom `BASE_URL` in `.env` (like `DASHSCOPE_BASE_URL`) fall back to wrong registry defaults, causing false "invalid key" reports

Same pattern as #18757 (fixed in `auth.py`) — the `os.getenv()` vs `get_env_value()` inconsistency.

## Fix

Replace `os.getenv()` with `get_env_value()` (with `os.getenv()` fallback) at 3 call sites:

1. **Line 1206** (`_probe_openrouter`): `os.getenv("OPENROUTER_API_KEY")` → `get_env_value("OPENROUTER_API_KEY") or os.getenv(...)`
2. **Line 1339** (`_probe_apikey_provider` key loop): `os.getenv(ev, "")` → `get_env_value(ev) or os.getenv(ev, "")`
3. **Line 1354** (`_probe_apikey_provider` base URL): `os.getenv(base_env, "")` → `get_env_value(base_env) or os.getenv(base_env, "")`

Also imports `get_env_value` at the top of the file alongside existing `hermes_cli.config` imports.

## Related

- #18757 — same fix applied to `auth.py` and `runtime_provider.py`
- #18989 — the earlier PR for this same fix (now 1021 commits behind main and shows DIRTY merge state)

---

Supersedes #18989 (rebased onto current origin/main, avoiding the stale DIRTY branch).
