### PR TITLE
fix(kanban): inject HERMES_HOME into worker subprocess env

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -3851,6 +3851,18 @@ def _default_spawn(
 
     prompt = f"work kanban task {task.id}"
     env = dict(os.environ)
+
+    # Inject HERMES_HOME so the worker reads the profile-scoped config.yaml
+    # (fallback_providers, toolsets, agent settings, etc.) instead of the root
+    # config.  Without this, `env = dict(os.environ)` copies only the parent's
+    # env, and when the child process starts `hermes -p <name>` the
+    # _apply_profile_override() runs *before* hermes_constants is imported.
+    # If HERMES_HOME is absent from the child's env, get_hermes_home() falls
+    # back to Path.home() / ".hermes" (the DEFAULT profile root), ignoring the
+    # profile-specific config entirely.  Fixes profile-scoped fallback_providers
+    # being invisible to kanban workers.
+    from hermes_cli.profiles import resolve_profile_env
+    env["HERMES_HOME"] = resolve_profile_env(profile_arg)
     if task.tenant:
         env["HERMES_TENANT"] = task.tenant
     env["HERMES_KANBAN_TASK"] = task.id


### PR DESCRIPTION
## Bug

Kanban workers spawned via `_default_spawn()` do not read their profile-scoped `config.yaml`.

When a worker is forked, its environment is copied via `dict(os.environ)`. This copy does **not** contain `HERMES_HOME`. When the child then starts `hermes -p <profile>`, the CLI's `_apply_profile_override()` runs before `hermes_constants` is imported. Since `HERMES_HOME` is absent, `get_hermes_home()` falls back to `~/.hermes` (the **default** profile root) instead of `~/.hermes/profiles/<profile>`.

The practical effect: any profile-scoped setting in `~/.hermes/profiles/<profile>/config.yaml` is invisible to kanban workers. Most critically, `fallback_providers` is ignored — workers only see the root config where `fallback_providers: []`.

## Fix

Inject `HERMES_HOME` into the worker's env using `resolve_profile_env(profile_arg)`:

```python
from hermes_cli.profiles import resolve_profile_env
env["HERMES_HOME"] = resolve_profile_env(profile_arg)
```

Added immediately after `env = dict(os.environ)` in `_default_spawn()`.

## Testing

1. Configure `fallback_providers` in `~/.hermes/profiles/<profile>/config.yaml`
2. Start a kanban task assigned to that profile
3. Confirm the worker logs show the fallback chain (`🔄 Fallback chain`) on startup
4. Watch `hermes logs | grep fallback` to verify the chain is populated

## Related

- Fixes the issue documented in `provider-fallback-config-bug.md` in profile skills
- Related issues: #18442 (kanban DB profile-scoped), #18594 (get_hermes_home fallback warning)