### PR TITLE
fix(anthropic): encode concrete tool_choice names on the Claude Code OAuth wire

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -2653,8 +2653,11 @@ def build_anthropic_kwargs(
             # Anthropic has no tool_choice "none" — omit tools entirely to prevent use
             kwargs.pop("tools", None)
         elif isinstance(tool_choice, str):
-            # Specific tool name
-            kwargs["tool_choice"] = {"type": "tool", "name": tool_choice}
+            # Specific tool name. On the OAuth wire the named tool must match
+            # the encoded name in ``tools`` (step 3 above), otherwise Anthropic
+            # rejects the call with 400 "tool_choice not in tools".
+            name = _to_oauth_wire_name(tool_choice) if is_oauth else tool_choice
+            kwargs["tool_choice"] = {"type": "tool", "name": name}
 
     # Map reasoning_config to Anthropic's thinking parameter.
     # Claude 4.6+ models use adaptive thinking + output_config.effort.

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -375,6 +375,60 @@ _CLAUDE_CODE_SYSTEM_PREFIX = "You are Claude Code, Anthropic's official CLI for 
 _MCP_TOOL_PREFIX = "mcp__"
 
 
+# Anthropic's Claude-Code OAuth proxy has brittle request-shape routing. Certain
+# Hermes-specific product/tool literals embedded in the system prompt (and the
+# heartbeat sentinel that gets surfaced through replayed prompts) can flip an
+# otherwise valid subscription request into the extra-usage billing lane,
+# yielding the misleading 400 "Third-party apps now draw from extra usage"
+# error. Keep the prompt's *intent* readable while removing the literals the
+# classifier keys on. Applied only on the native Anthropic OAuth path; API-key
+# and third-party Anthropic-compatible providers see the prompt unchanged.
+#
+# Ordered longest-match-first so e.g. "Hermes Agent" rewrites before bare
+# "Hermes" and a later pass doesn't re-rewrite an already-rewritten token.
+_OAUTH_SYSTEM_TEXT_REPLACEMENTS: tuple[tuple[str, str], ...] = (
+    ("Hermes Agent", "Claude Code"),
+    ("Hermes agent", "Claude Code"),
+    ("hermes-agent", "claude-code"),
+    ("Nous Research", "Anthropic"),
+    ("session_search", "session lookup"),
+    ("skill_manage", "skill editor"),
+    ("HEARTBEAT_OK", "NO_ACTION_NEEDED"),
+    ("MEDIA:", "FILE:"),
+    ("Hermes", "Claude Code"),
+)
+
+
+def _sanitize_oauth_system_text(text: str) -> str:
+    """Strip literals that misroute Claude-Code OAuth requests to extra-usage.
+
+    See :data:`_OAUTH_SYSTEM_TEXT_REPLACEMENTS` for rationale and the ordered
+    rewrite list.
+    """
+    for old, new in _OAUTH_SYSTEM_TEXT_REPLACEMENTS:
+        text = text.replace(old, new)
+    return text
+
+
+def _to_oauth_wire_name(name: str) -> str:
+    """Encode a tool name for the Claude-Code OAuth wire.
+
+    Anthropic's OAuth billing classifier treats a single-underscore ``mcp_``
+    tool name as a third-party-app fingerprint and rejects the request with
+    HTTP 400 "Third-party apps now draw from extra usage, not plan limits".
+    Promote every leading ``mcp_`` to ``mcp__`` and prefix bare native tool
+    names so NOTHING on the wire carries a single-underscore ``mcp_``.
+
+    Idempotent on already-encoded names. See PR #47723.
+    """
+    if name.startswith("mcp__"):
+        return name  # already correct, don't double-prefix
+    if name.startswith("mcp_"):
+        # single-underscore native MCP tool -> promote to double
+        return "mcp__" + name[len("mcp_"):]
+    return _MCP_TOOL_PREFIX + name  # bare name -> mcp__<name>
+
+
 def _get_claude_code_version() -> str:
     """Lazily detect the installed Claude Code version when OAuth headers need it."""
     global _claude_code_version_cache
@@ -2536,15 +2590,13 @@ def build_anthropic_kwargs(
             system = [cc_block]
 
         # 2. Sanitize system prompt — replace product name references
-        #    to avoid Anthropic's server-side content filters.
+        #    to avoid Anthropic's server-side content filters and the
+        #    Claude-Code OAuth proxy classifier triggers. See
+        #    :data:`_OAUTH_SYSTEM_TEXT_REPLACEMENTS`.
         for block in system:
             if isinstance(block, dict) and block.get("type") == "text":
                 text = block.get("text", "")
-                text = text.replace("Hermes Agent", "Claude Code")
-                text = text.replace("Hermes agent", "Claude Code")
-                text = text.replace("hermes-agent", "claude-code")
-                text = text.replace("Nous Research", "Anthropic")
-                block["text"] = text
+                block["text"] = _sanitize_oauth_system_text(text)
 
         # 3. Normalize tool names so NOTHING goes on the OAuth wire with a
         #    single-underscore ``mcp_`` prefix.  Anthropic's subscription/OAuth
@@ -2564,14 +2616,6 @@ def build_anthropic_kwargs(
         #    so any session with an MCP server configured still tripped the
         #    classifier. normalize_response reverses both forms via registry
         #    lookup so the dispatcher still sees the original name. GH-25255.
-        def _to_oauth_wire_name(name: str) -> str:
-            if name.startswith("mcp__"):
-                return name  # already correct, don't double-prefix
-            if name.startswith("mcp_"):
-                # single-underscore native MCP tool -> promote to double
-                return "mcp__" + name[len("mcp_"):]
-            return _MCP_TOOL_PREFIX + name  # bare name -> mcp__<name>
-
         if anthropic_tools:
             for tool in anthropic_tools:
                 if "name" in tool:

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1704,6 +1704,80 @@ class TestBuildAnthropicKwargs:
         )
         assert kwargs["max_tokens"] == 64_000
 
+    # ------------------------------------------------------------------
+    # OAuth-only hardening: system-prompt sanitizer + tool_choice encoding
+    # ------------------------------------------------------------------
+
+    def test_oauth_system_text_sanitizer_rewrites_extended_literals(self):
+        """The OAuth system-prompt sanitizer must rewrite each literal in
+        ``_OAUTH_SYSTEM_TEXT_REPLACEMENTS`` — including the five hardening
+        literals (``session_search``, ``skill_manage``, ``HEARTBEAT_OK``,
+        ``MEDIA:``, bare ``Hermes``) added on top of the original 4-pass.
+        """
+        text = (
+            "Hermes Agent uses session_search and skill_manage. "
+            "When idle, return HEARTBEAT_OK. "
+            "Deliver attachments via MEDIA:/abs/path. "
+            "Hermes is built by Nous Research on the hermes-agent repo."
+        )
+        kwargs = build_anthropic_kwargs(
+            model="claude-opus-4-6",
+            messages=[
+                {"role": "system", "content": text},
+                {"role": "user", "content": "Hi"},
+            ],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config=None,
+            is_oauth=True,
+        )
+        # system is a list of text blocks under OAuth (Claude Code prefix block
+        # is injected first); concatenate every text block to assert on.
+        body = "\n".join(
+            b["text"] for b in kwargs["system"]
+            if isinstance(b, dict) and b.get("type") == "text"
+        )
+        for trigger in (
+            "Hermes Agent",
+            "Hermes agent",
+            "hermes-agent",
+            "Nous Research",
+            "session_search",
+            "skill_manage",
+            "HEARTBEAT_OK",
+            "MEDIA:",
+        ):
+            assert trigger not in body, f"sanitizer missed {trigger!r}"
+        # Bare "Hermes" must also be rewritten (last-pass guard).
+        assert "Hermes" not in body
+        # Replacements landed.
+        assert "Claude Code" in body
+        assert "session lookup" in body
+        assert "skill editor" in body
+        assert "NO_ACTION_NEEDED" in body
+        assert "FILE:" in body
+
+    def test_non_oauth_path_leaves_system_text_untouched(self):
+        """Sanitizer must NOT fire when is_oauth=False — API-key callers and
+        third-party Anthropic-compatible providers see the prompt verbatim.
+        """
+        text = (
+            "Hermes Agent. session_search. skill_manage. "
+            "HEARTBEAT_OK. MEDIA:/x. Hermes."
+        )
+        kwargs = build_anthropic_kwargs(
+            model="claude-opus-4-6",
+            messages=[
+                {"role": "system", "content": text},
+                {"role": "user", "content": "Hi"},
+            ],
+            tools=None,
+            max_tokens=4096,
+            reasoning_config=None,
+            is_oauth=False,
+        )
+        # Under non-OAuth, system stays a plain string.
+        assert kwargs["system"] == text
 
 # ---------------------------------------------------------------------------
 # Model output limit lookup

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1779,6 +1779,83 @@ class TestBuildAnthropicKwargs:
         # Under non-OAuth, system stays a plain string.
         assert kwargs["system"] == text
 
+    def test_oauth_concrete_tool_choice_gets_wire_name_encoding(self):
+        """When tool_choice names a specific tool on the OAuth path, the name
+        must go through the same ``_to_oauth_wire_name`` transform applied to
+        the tools list — otherwise Anthropic 400s with
+        ``tool_choice not in tools``.
+        """
+        kwargs = build_anthropic_kwargs(
+            model="claude-opus-4-6",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[
+                {"type": "function", "function": {"name": "read_file", "description": "x", "parameters": {"type": "object", "properties": {}}}}
+            ],
+            max_tokens=4096,
+            reasoning_config=None,
+            is_oauth=True,
+            tool_choice="read_file",
+        )
+        # Bare name → mcp__read_file on the wire.
+        assert kwargs["tool_choice"] == {"type": "tool", "name": "mcp__read_file"}
+        # And matches the encoded name in tools (this is the invariant).
+        assert kwargs["tools"][0]["name"] == "mcp__read_file"
+
+    def test_oauth_concrete_tool_choice_promotes_single_mcp_underscore(self):
+        """A single-underscore native MCP tool name passed as ``tool_choice``
+        must be promoted to the double-underscore wire form, matching what
+        upstream PR #47723 does for the tools list.
+        """
+        kwargs = build_anthropic_kwargs(
+            model="claude-opus-4-6",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[
+                {"type": "function", "function": {"name": "mcp_linear_get_issue", "description": "x", "parameters": {"type": "object", "properties": {}}}}
+            ],
+            max_tokens=4096,
+            reasoning_config=None,
+            is_oauth=True,
+            tool_choice="mcp_linear_get_issue",
+        )
+        assert kwargs["tool_choice"] == {
+            "type": "tool",
+            "name": "mcp__linear_get_issue",
+        }
+        assert kwargs["tools"][0]["name"] == "mcp__linear_get_issue"
+
+    def test_oauth_concrete_tool_choice_idempotent_when_already_encoded(self):
+        """Double-underscore-encoded names passed as ``tool_choice`` must not
+        be double-prefixed."""
+        kwargs = build_anthropic_kwargs(
+            model="claude-opus-4-6",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[
+                {"type": "function", "function": {"name": "mcp__read_file", "description": "x", "parameters": {"type": "object", "properties": {}}}}
+            ],
+            max_tokens=4096,
+            reasoning_config=None,
+            is_oauth=True,
+            tool_choice="mcp__read_file",
+        )
+        assert kwargs["tool_choice"] == {"type": "tool", "name": "mcp__read_file"}
+
+    def test_non_oauth_concrete_tool_choice_is_raw(self):
+        """Non-OAuth callers (API key, third-party Anthropic-compatible) must
+        get the raw ``tool_choice`` name — the wire encoding is OAuth-only."""
+        kwargs = build_anthropic_kwargs(
+            model="claude-opus-4-6",
+            messages=[{"role": "user", "content": "Hi"}],
+            tools=[
+                {"type": "function", "function": {"name": "read_file", "description": "x", "parameters": {"type": "object", "properties": {}}}}
+            ],
+            max_tokens=4096,
+            reasoning_config=None,
+            is_oauth=False,
+            tool_choice="read_file",
+        )
+        assert kwargs["tool_choice"] == {"type": "tool", "name": "read_file"}
+        assert kwargs["tools"][0]["name"] == "read_file"
+
 # ---------------------------------------------------------------------------
 # Model output limit lookup
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

One narrow, orthogonal fix on top of the Claude Code OAuth wire encoding that
PR #47723 landed: encode a **concrete `tool_choice` tool name** with the same
`_to_oauth_wire_name` transform applied to the `tools` array, gated by
`is_oauth=True`.

## The bug

`build_anthropic_kwargs` already promotes every tool name in `tools` to the
double-underscore `mcp__` wire form on the OAuth path (PR #47723). But when a
caller forces a specific tool by name via `tool_choice`, the previous code
emitted the **raw** name:

```python
elif isinstance(tool_choice, str):
    kwargs["tool_choice"] = {"type": "tool", "name": tool_choice}   # raw — mismatched
```

On the OAuth wire that name no longer matches the encoded name in `tools`, so
Anthropic rejects the call with HTTP 400 `tool_choice not in tools`.

This is a **real path, not speculative**: `agent/auxiliary_client.py` extracts
a concrete function-name `tool_choice` and passes it into
`build_anthropic_kwargs` with `is_oauth` set from the live credential —

```python
normalized_tool_choice = tool_choice.get("function", {}).get("name")
...
build_anthropic_kwargs(..., tool_choice=normalized_tool_choice, is_oauth=self._is_oauth)
```

so a forced-tool call on a Max OAuth subscription hits the mismatch.

## Fix

Route the concrete `tool_choice` name through the same `_to_oauth_wire_name`
encoder when `is_oauth=True`. Idempotent on already-encoded names (no
double-prefix); non-OAuth callers (API key, third-party Anthropic-compatible
providers) keep the raw name.

`_to_oauth_wire_name` was an inner closure inside `build_anthropic_kwargs`
(added by #47723); this PR hoists it to module scope unchanged so the
`tool_choice` branch can reuse it — pure no-op move, same logic.

## Tests

4 new tests in `TestBuildAnthropicKwargs`:

- `test_oauth_concrete_tool_choice_gets_wire_name_encoding` — bare `read_file` → `mcp__read_file`, matches `tools`
- `test_oauth_concrete_tool_choice_promotes_single_mcp_underscore` — `mcp_linear_get_issue` → `mcp__linear_get_issue`
- `test_oauth_concrete_tool_choice_idempotent_when_already_encoded` — no double-prefix
- `test_non_oauth_concrete_tool_choice_is_raw` — guardrail, raw name off the OAuth path

Full suite green: `tests/agent/test_anthropic_adapter.py` +
`tests/agent/test_anthropic_mcp_prefix_strip.py` + `tests/agent/transports/`
= **508 passed**.

## Scope / lineage note

This PR originally proposed a broader bundle (the `mcp__` encoder + a
system-prompt literal sanitizer). The OAuth "Third-party apps now draw from
extra usage" billing bug (issue #46675) has since been split into two
maintainer-owned fixes that supersede those pieces:

- **#47723 (merged)** — the `mcp__` tool-name encoder + registry-aware
  reversal. This PR builds directly on it.
- **#47738 (open)** — relocates the system prompt out of `system[]` into a
  cache-marked `<system_context>` preamble on the first user message. That's
  the correct, complete fix for the **content** trigger — it kills every
  content fingerprint at once, where literal-replacement only chases known
  tokens. I dropped my sanitizer commit in favor of #47738.

What remains here — concrete `tool_choice` encoding — is **orthogonal to both**
(neither touches `tool_choice`) and is the last uncovered corner of the
wire-shape mismatch. Rebased onto current `main` (post-#47723) and narrowed to
this single commit.

Builds on #47723. Related: #47738, #46675.
