### PR TITLE
feat: add OpenClaw telemetry plugin

### DIFF
--- a/plugins/observability/openclaw_telemetry/__init__.py
+++ b/plugins/observability/openclaw_telemetry/__init__.py
@@ -1,0 +1,307 @@
+"""openclaw_telemetry — fire-and-log token usage telemetry for Hermes/Spark.
+
+This plugin emits one OpenClaw ``token_usage`` event per Hermes LLM API call
+using the ``post_api_request`` hook. It is intentionally optional and
+fail-open: missing configuration, malformed usage, network failures, and server
+errors are logged at warning/debug level but never raise into the dispatch path.
+
+Configuration is environment-only so hooks do not read Hermes config per call:
+  TELEMETRY_BASE_URL                      e.g. http://10.20.20.20:3001
+  HERMES_OPENCLAW_TELEMETRY_TOKEN         preferred Spark service token
+  TELEMETRY_TOKEN / TELEMETRY_WRITE_TOKEN fallback token names
+
+Optional linkage fields:
+  OPENCLAW_CARD_ID / HERMES_OPENCLAW_CARD_ID
+  OPENCLAW_RUN_ID / HERMES_OPENCLAW_RUN_ID
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import queue
+import threading
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional
+from urllib import error, request
+
+logger = logging.getLogger(__name__)
+
+_AGENT_ID = "spark"
+_QUOTA_POOL = "openai_api"
+_DEFAULT_TIMEOUT_SECONDS = 5.0
+_DEFAULT_QUEUE_SIZE = 100
+_INIT_FAILED = object()
+_CONFIG: object | Dict[str, Any] | None = None
+_CONFIG_LOCK = threading.Lock()
+_EVENT_QUEUE: queue.Queue[tuple[Dict[str, Any], Dict[str, Any]]] | None = None
+_QUEUE_LOCK = threading.Lock()
+_WORKER_STARTED = False
+
+
+def _env(name: str, default: str = "") -> str:
+    return os.environ.get(name, default).strip()
+
+
+def _first_env(*names: str) -> str:
+    for name in names:
+        value = _env(name)
+        if value:
+            return value
+    return ""
+
+
+def reset_cache_for_tests() -> None:
+    global _CONFIG, _EVENT_QUEUE, _WORKER_STARTED
+    with _CONFIG_LOCK:
+        _CONFIG = None
+    with _QUEUE_LOCK:
+        _EVENT_QUEUE = None
+        _WORKER_STARTED = False
+
+
+def _flush_for_tests() -> None:
+    queue_ref = _EVENT_QUEUE
+    if queue_ref is not None:
+        queue_ref.join()
+
+
+def _get_config() -> Optional[Dict[str, Any]]:
+    """Return cached runtime config, or None when telemetry is disabled.
+
+    Missing env is cached as _INIT_FAILED so hot post_api_request hooks do not
+    repeatedly re-read process env when the plugin is enabled but unconfigured.
+    """
+    global _CONFIG
+    with _CONFIG_LOCK:
+        if _CONFIG is _INIT_FAILED:
+            return None
+        if isinstance(_CONFIG, dict):
+            return _CONFIG
+
+        base_url = _first_env("HERMES_OPENCLAW_TELEMETRY_BASE_URL", "TELEMETRY_BASE_URL").rstrip("/")
+        token = _first_env(
+            "HERMES_OPENCLAW_TELEMETRY_TOKEN",
+            "TELEMETRY_TOKEN",
+            "TELEMETRY_WRITE_TOKEN",
+        )
+        if not (base_url and token):
+            _CONFIG = _INIT_FAILED
+            return None
+
+        try:
+            timeout_seconds = float(_env("HERMES_OPENCLAW_TELEMETRY_TIMEOUT_SECONDS", str(_DEFAULT_TIMEOUT_SECONDS)))
+        except ValueError:
+            logger.warning("Invalid HERMES_OPENCLAW_TELEMETRY_TIMEOUT_SECONDS; using default")
+            timeout_seconds = _DEFAULT_TIMEOUT_SECONDS
+        if timeout_seconds <= 0:
+            timeout_seconds = _DEFAULT_TIMEOUT_SECONDS
+
+        _CONFIG = {
+            "endpoint": f"{base_url}/v1/telemetry/token-usage",
+            "token": token,
+            "timeout_seconds": timeout_seconds,
+        }
+        return _CONFIG
+
+
+def _usage_int(usage: Dict[str, Any], *keys: str) -> int:
+    for key in keys:
+        value = usage.get(key)
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, int):
+            return max(0, value)
+        if isinstance(value, float) and value >= 0 and value.is_integer():
+            return int(value)
+    return 0
+
+
+def _extract_cache_read_tokens(usage: Dict[str, Any]) -> int:
+    direct = _usage_int(usage, "cache_read_tokens", "cacheReadTokens")
+    if direct:
+        return direct
+    details = usage.get("input_token_details") or usage.get("prompt_tokens_details") or {}
+    if isinstance(details, dict):
+        return _usage_int(details, "cached_tokens", "cache_read_tokens", "cacheReadTokens")
+    return 0
+
+
+def _extract_cache_creation_tokens(usage: Dict[str, Any]) -> int:
+    direct = _usage_int(
+        usage,
+        "cache_write_tokens",
+        "cache_creation_input_tokens",
+        "cache_creation_tokens",
+        "cacheCreationTokens",
+    )
+    if direct:
+        return direct
+    details = usage.get("input_token_details") or usage.get("prompt_tokens_details") or {}
+    if isinstance(details, dict):
+        return _usage_int(
+            details,
+            "cache_write_tokens",
+            "cache_creation_input_tokens",
+            "cache_creation_tokens",
+            "cacheCreationTokens",
+        )
+    return 0
+
+
+def _duration_ms(kwargs: Dict[str, Any]) -> int:
+    for key in ("duration_ms", "durationMs"):
+        value = kwargs.get(key)
+        if isinstance(value, bool):
+            continue
+        if isinstance(value, int):
+            return max(0, value)
+        if isinstance(value, float) and value >= 0:
+            return int(round(value))
+    value = kwargs.get("api_duration")
+    if isinstance(value, bool):
+        return 0
+    if isinstance(value, (int, float)) and value >= 0:
+        return int(round(float(value) * 1000))
+    return 0
+
+
+def _event_id(task_id: str, session_id: str, api_call_count: Any, model: str) -> str:
+    stable = f"spark:{task_id or ''}:{session_id or ''}:{api_call_count}:{model}"
+    if stable == "spark::::":
+        return str(uuid.uuid4())
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, stable))
+
+
+def _optional_linkage(name: str) -> Optional[str]:
+    value = _first_env(f"HERMES_OPENCLAW_{name}", f"OPENCLAW_{name}")
+    return value or None
+
+
+def _build_event(**kwargs: Any) -> Optional[Dict[str, Any]]:
+    usage = kwargs.get("usage")
+    if not isinstance(usage, dict):
+        return None
+
+    input_tokens = _usage_int(usage, "input_tokens", "prompt_tokens")
+    output_tokens = _usage_int(usage, "output_tokens", "completion_tokens")
+    if input_tokens == 0 and output_tokens == 0:
+        return None
+
+    model = str(kwargs.get("response_model") or kwargs.get("model") or "").strip()
+    if not model:
+        return None
+
+    return {
+        "eventId": _event_id(
+            str(kwargs.get("task_id") or ""),
+            str(kwargs.get("session_id") or ""),
+            kwargs.get("api_call_count", ""),
+            model,
+        ),
+        "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+        "agentId": _AGENT_ID,
+        "model": model,
+        "quotaPool": _QUOTA_POOL,
+        "inputTokens": input_tokens,
+        "outputTokens": output_tokens,
+        "cacheReadTokens": _extract_cache_read_tokens(usage),
+        "cacheCreationTokens": _extract_cache_creation_tokens(usage),
+        "runId": _optional_linkage("RUN_ID"),
+        "cardId": _optional_linkage("CARD_ID"),
+        "durationMs": _duration_ms(kwargs),
+        "apiEquivalentCostUsd": 0,
+    }
+
+
+def _post_event(config: Dict[str, Any], event: Dict[str, Any]) -> None:
+    body = json.dumps(event, separators=(",", ":")).encode("utf-8")
+    req = request.Request(
+        config["endpoint"],
+        data=body,
+        method="POST",
+        headers={
+            "Authorization": f"Bearer {config['token']}",
+            "Content-Type": "application/json",
+            "Accept": "application/json",
+        },
+    )
+    with request.urlopen(req, timeout=float(config["timeout_seconds"])) as response:
+        status = int(getattr(response, "status", 200))
+        if status >= 400:
+            raise RuntimeError(f"telemetry-service returned HTTP {status}")
+
+
+def _emit_event(config: Dict[str, Any], event: Dict[str, Any]) -> None:
+    try:
+        _post_event(config, event)
+        logger.info(
+            "OpenClaw telemetry accepted event_id=%s model=%s input_tokens=%s output_tokens=%s card_id=%s run_id=%s",
+            event["eventId"],
+            event["model"],
+            event["inputTokens"],
+            event["outputTokens"],
+            event.get("cardId"),
+            event.get("runId"),
+        )
+    except (error.URLError, TimeoutError, OSError, RuntimeError, ValueError, TypeError) as exc:
+        logger.warning("OpenClaw telemetry write failed; continuing without blocking dispatch: %s", exc)
+    except Exception as exc:  # pragma: no cover - belt-and-suspenders fail-open
+        logger.warning("OpenClaw telemetry unexpected failure; continuing without blocking dispatch: %s", exc)
+
+
+def _worker_loop(queue_ref: queue.Queue[tuple[Dict[str, Any], Dict[str, Any]]]) -> None:
+    while True:
+        config, event = queue_ref.get()
+        try:
+            _emit_event(config, event)
+        finally:
+            queue_ref.task_done()
+
+
+def _get_queue() -> queue.Queue[tuple[Dict[str, Any], Dict[str, Any]]]:
+    global _EVENT_QUEUE, _WORKER_STARTED
+    with _QUEUE_LOCK:
+        if _EVENT_QUEUE is None:
+            try:
+                maxsize = int(_env("HERMES_OPENCLAW_TELEMETRY_QUEUE_SIZE", str(_DEFAULT_QUEUE_SIZE)))
+            except ValueError:
+                maxsize = _DEFAULT_QUEUE_SIZE
+            _EVENT_QUEUE = queue.Queue(maxsize=max(1, maxsize))
+        if not _WORKER_STARTED:
+            worker = threading.Thread(
+                target=_worker_loop,
+                args=(_EVENT_QUEUE,),
+                name="openclaw-telemetry-writer",
+                daemon=True,
+            )
+            worker.start()
+            _WORKER_STARTED = True
+        return _EVENT_QUEUE
+
+
+def _enqueue_event(config: Dict[str, Any], event: Dict[str, Any]) -> None:
+    try:
+        _get_queue().put_nowait((config, event))
+    except queue.Full:
+        logger.warning("OpenClaw telemetry queue full; dropping event_id=%s", event.get("eventId"))
+
+
+def on_post_api_request(**kwargs: Any) -> None:
+    """Queue token usage for one LLM API call without blocking dispatch."""
+    config = _get_config()
+    if config is None:
+        return
+
+    try:
+        event = _build_event(**kwargs)
+        if event is None:
+            return
+        _enqueue_event(config, event)
+    except Exception as exc:  # pragma: no cover - fail-open at call site
+        logger.warning("OpenClaw telemetry enqueue failed; continuing without blocking dispatch: %s", exc)
+
+
+def register(ctx) -> None:
+    ctx.register_hook("post_api_request", on_post_api_request)

--- a/plugins/observability/openclaw_telemetry/plugin.yaml
+++ b/plugins/observability/openclaw_telemetry/plugin.yaml
@@ -1,0 +1,10 @@
+name: openclaw_telemetry
+version: "0.1.0"
+description: "Optional OpenClaw token-usage telemetry for Hermes/Spark LLM API calls. Posts token usage to the OpenClaw telemetry-service with fire-and-log isolation."
+author: NousResearch
+requires_env:
+  - HERMES_OPENCLAW_TELEMETRY_BASE_URL
+  - TELEMETRY_BASE_URL
+  - HERMES_OPENCLAW_TELEMETRY_TOKEN
+hooks:
+  - post_api_request

--- a/plugins/observability/openclaw_telemetry/plugin.yaml
+++ b/plugins/observability/openclaw_telemetry/plugin.yaml
@@ -4,7 +4,10 @@ description: "Optional OpenClaw token-usage telemetry for Hermes/Spark LLM API c
 author: NousResearch
 requires_env:
   - HERMES_OPENCLAW_TELEMETRY_BASE_URL
-  - TELEMETRY_BASE_URL
   - HERMES_OPENCLAW_TELEMETRY_TOKEN
+optional_env:
+  - TELEMETRY_BASE_URL
+  - TELEMETRY_TOKEN
+  - TELEMETRY_WRITE_TOKEN
 hooks:
   - post_api_request

--- a/tests/plugins/test_openclaw_telemetry_plugin.py
+++ b/tests/plugins/test_openclaw_telemetry_plugin.py
@@ -26,9 +26,15 @@ class TestManifest:
         assert data["name"] == "openclaw_telemetry"
         assert data["version"]
         assert set(data["hooks"]) == {"post_api_request"}
-        assert "TELEMETRY_BASE_URL" in data["requires_env"]
-        assert "HERMES_OPENCLAW_TELEMETRY_BASE_URL" in data["requires_env"]
-        assert "HERMES_OPENCLAW_TELEMETRY_TOKEN" in data["requires_env"]
+        assert data["requires_env"] == [
+            "HERMES_OPENCLAW_TELEMETRY_BASE_URL",
+            "HERMES_OPENCLAW_TELEMETRY_TOKEN",
+        ]
+        assert set(data["optional_env"]) == {
+            "TELEMETRY_BASE_URL",
+            "TELEMETRY_TOKEN",
+            "TELEMETRY_WRITE_TOKEN",
+        }
 
 
 class TestRuntimeGate:

--- a/tests/plugins/test_openclaw_telemetry_plugin.py
+++ b/tests/plugins/test_openclaw_telemetry_plugin.py
@@ -1,0 +1,247 @@
+"""Tests for the bundled observability/openclaw_telemetry plugin."""
+from __future__ import annotations
+
+import importlib
+import json
+import sys
+import time
+from pathlib import Path
+from urllib import error
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLUGIN_DIR = REPO_ROOT / "plugins" / "observability" / "openclaw_telemetry"
+
+
+class TestManifest:
+    def test_plugin_directory_exists(self):
+        assert PLUGIN_DIR.is_dir()
+        assert (PLUGIN_DIR / "plugin.yaml").exists()
+        assert (PLUGIN_DIR / "__init__.py").exists()
+
+    def test_manifest_fields(self):
+        data = yaml.safe_load((PLUGIN_DIR / "plugin.yaml").read_text())
+        assert data["name"] == "openclaw_telemetry"
+        assert data["version"]
+        assert set(data["hooks"]) == {"post_api_request"}
+        assert "TELEMETRY_BASE_URL" in data["requires_env"]
+        assert "HERMES_OPENCLAW_TELEMETRY_BASE_URL" in data["requires_env"]
+        assert "HERMES_OPENCLAW_TELEMETRY_TOKEN" in data["requires_env"]
+
+
+class TestRuntimeGate:
+    def _fresh_plugin(self):
+        mod_name = "plugins.observability.openclaw_telemetry"
+        sys.modules.pop(mod_name, None)
+        return importlib.import_module(mod_name)
+
+    def test_get_config_returns_none_without_credentials(self, monkeypatch):
+        for key in (
+            "HERMES_OPENCLAW_TELEMETRY_BASE_URL",
+            "TELEMETRY_BASE_URL",
+            "HERMES_OPENCLAW_TELEMETRY_TOKEN",
+            "TELEMETRY_TOKEN",
+            "TELEMETRY_WRITE_TOKEN",
+        ):
+            monkeypatch.delenv(key, raising=False)
+
+        plugin = self._fresh_plugin()
+        assert plugin._get_config() is None
+
+    def test_get_config_caches_missing_env(self, monkeypatch):
+        for key in (
+            "HERMES_OPENCLAW_TELEMETRY_BASE_URL",
+            "TELEMETRY_BASE_URL",
+            "HERMES_OPENCLAW_TELEMETRY_TOKEN",
+            "TELEMETRY_TOKEN",
+            "TELEMETRY_WRITE_TOKEN",
+        ):
+            monkeypatch.delenv(key, raising=False)
+
+        plugin = self._fresh_plugin()
+        assert plugin._get_config() is None
+
+        import os
+
+        called = {"n": 0}
+        real_get = os.environ.get
+
+        def tracking_get(key, default=None):
+            if key.startswith(("HERMES_OPENCLAW_", "TELEMETRY_")):
+                called["n"] += 1
+            return real_get(key, default)
+
+        monkeypatch.setattr(os.environ, "get", tracking_get)
+        for _ in range(10):
+            assert plugin._get_config() is None
+        assert called["n"] == 0
+
+    def test_get_config_prefers_spark_specific_token(self, monkeypatch):
+        plugin = self._fresh_plugin()
+        plugin.reset_cache_for_tests()
+        monkeypatch.setenv("TELEMETRY_BASE_URL", "http://control.example:3001/")
+        monkeypatch.setenv("TELEMETRY_TOKEN", "operator-token")
+        monkeypatch.setenv("HERMES_OPENCLAW_TELEMETRY_TOKEN", "spark-token")
+
+        config = plugin._get_config()
+
+        assert config["endpoint"] == "http://control.example:3001/v1/telemetry/token-usage"
+        assert config["token"] == "spark-token"
+
+
+class TestEventBuilder:
+    def _fresh_plugin(self):
+        mod_name = "plugins.observability.openclaw_telemetry"
+        sys.modules.pop(mod_name, None)
+        return importlib.import_module(mod_name)
+
+    def test_build_event_maps_usage_and_linkage(self, monkeypatch):
+        plugin = self._fresh_plugin()
+        monkeypatch.setenv("HERMES_OPENCLAW_CARD_ID", "card-123")
+        monkeypatch.setenv("HERMES_OPENCLAW_RUN_ID", "run-456")
+
+        event = plugin._build_event(
+            task_id="task-1",
+            session_id="session-1",
+            api_call_count=2,
+            response_model="openai/gpt-5.5",
+            usage={
+                "input_tokens": 123,
+                "output_tokens": 45,
+                "cache_read_tokens": 7,
+                "cache_write_tokens": 3,
+            },
+            api_duration=0.891,
+        )
+
+        assert event["agentId"] == "spark"
+        assert event["quotaPool"] == "openai_api"
+        assert event["model"] == "openai/gpt-5.5"
+        assert event["inputTokens"] == 123
+        assert event["outputTokens"] == 45
+        assert event["cacheReadTokens"] == 7
+        assert event["cacheCreationTokens"] == 3
+        assert event["durationMs"] == 891
+        assert event["cardId"] == "card-123"
+        assert event["runId"] == "run-456"
+
+    def test_event_id_is_deterministic_for_stable_call_identity(self):
+        plugin = self._fresh_plugin()
+        kwargs = dict(
+            task_id="task-1",
+            session_id="session-1",
+            api_call_count=2,
+            response_model="openai/gpt-5.5",
+            usage={"input_tokens": 1, "output_tokens": 2},
+        )
+
+        first = plugin._build_event(**kwargs)["eventId"]
+        second = plugin._build_event(**kwargs)["eventId"]
+
+        assert first == second
+
+    @pytest.mark.parametrize("usage", [None, {}, {"input_tokens": 0, "output_tokens": 0}])
+    def test_build_event_skips_absent_or_zero_usage(self, usage):
+        plugin = self._fresh_plugin()
+        assert plugin._build_event(response_model="openai/gpt-5.5", usage=usage) is None
+
+
+class TestHook:
+    def _fresh_plugin(self):
+        mod_name = "plugins.observability.openclaw_telemetry"
+        sys.modules.pop(mod_name, None)
+        return importlib.import_module(mod_name)
+
+    def test_post_api_request_posts_camel_case_json_without_raising(self, monkeypatch):
+        plugin = self._fresh_plugin()
+        plugin.reset_cache_for_tests()
+        monkeypatch.setenv("TELEMETRY_BASE_URL", "http://control.example:3001")
+        monkeypatch.setenv("HERMES_OPENCLAW_TELEMETRY_TOKEN", "spark-token")
+        captured = {}
+
+        class FakeResponse:
+            status = 201
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+        def fake_urlopen(req, timeout):
+            captured["url"] = req.full_url
+            captured["timeout"] = timeout
+            captured["auth"] = req.headers["Authorization"]
+            captured["body"] = json.loads(req.data.decode("utf-8"))
+            return FakeResponse()
+
+        monkeypatch.setattr(plugin.request, "urlopen", fake_urlopen)
+
+        plugin.on_post_api_request(
+            task_id="task-1",
+            session_id="session-1",
+            api_call_count=0,
+            model="configured-model",
+            response_model="openai/gpt-5.5",
+            usage={"input_tokens": 10, "output_tokens": 5},
+            api_duration=0.123,
+        )
+        plugin._flush_for_tests()
+
+        assert captured["url"] == "http://control.example:3001/v1/telemetry/token-usage"
+        assert captured["auth"] == "Bearer spark-token"
+        assert captured["timeout"] == 5.0
+        assert captured["body"]["agentId"] == "spark"
+        assert captured["body"]["quotaPool"] == "openai_api"
+        assert captured["body"]["inputTokens"] == 10
+        assert captured["body"]["outputTokens"] == 5
+
+    def test_post_api_request_fire_and_log_isolation(self, monkeypatch, caplog):
+        plugin = self._fresh_plugin()
+        plugin.reset_cache_for_tests()
+        monkeypatch.setenv("TELEMETRY_BASE_URL", "http://control.example:3001")
+        monkeypatch.setenv("HERMES_OPENCLAW_TELEMETRY_TOKEN", "spark-token")
+
+        def fake_urlopen(req, timeout):
+            raise error.URLError("boom")
+
+        monkeypatch.setattr(plugin.request, "urlopen", fake_urlopen)
+
+        plugin.on_post_api_request(
+            task_id="task-1",
+            session_id="session-1",
+            api_call_count=0,
+            response_model="openai/gpt-5.5",
+            usage={"input_tokens": 10, "output_tokens": 5},
+        )
+        plugin._flush_for_tests()
+
+        assert "continuing without blocking dispatch" in caplog.text
+        assert "spark-token" not in caplog.text
+
+    def test_post_api_request_does_not_wait_for_slow_http(self, monkeypatch):
+        plugin = self._fresh_plugin()
+        plugin.reset_cache_for_tests()
+        monkeypatch.setenv("TELEMETRY_BASE_URL", "http://control.example:3001")
+        monkeypatch.setenv("HERMES_OPENCLAW_TELEMETRY_TOKEN", "spark-token")
+
+        def fake_urlopen(req, timeout):
+            time.sleep(0.2)
+            raise error.URLError("slow boom")
+
+        monkeypatch.setattr(plugin.request, "urlopen", fake_urlopen)
+
+        start = time.monotonic()
+        plugin.on_post_api_request(
+            task_id="task-1",
+            session_id="session-1",
+            api_call_count=0,
+            response_model="openai/gpt-5.5",
+            usage={"input_tokens": 10, "output_tokens": 5},
+        )
+        elapsed = time.monotonic() - start
+        plugin._flush_for_tests()
+
+        assert elapsed < 0.1


### PR DESCRIPTION
## Summary
- add optional `observability/openclaw_telemetry` plugin for Spark/Hermes LLM token-usage telemetry
- emit `agentId: spark`, `quotaPool: openai_api`, model, token buckets, duration, and optional run/card linkage to `/v1/telemetry/token-usage`
- keep dispatch isolated with bounded background queue + fail-open logging; prefer `HERMES_OPENCLAW_TELEMETRY_TOKEN` over shared `TELEMETRY_TOKEN`

## M3.4a plan context
PR 1 of the M3.4a stack: client-wrapper hook. Follow-ups will wire DEV env/service identity and run closure smoke against CONTROL.

## Tests
- `python -m pytest tests/hermes_cli/test_plugins.py tests/plugins/test_openclaw_telemetry_plugin.py -q`
- `python -m py_compile plugins/observability/openclaw_telemetry/__init__.py tests/plugins/test_openclaw_telemetry_plugin.py`

## Safety
- No secrets are logged or committed.
- Telemetry failures never raise into the LLM dispatch path.
- HTTP write happens off the hook hot path and drops when queue is full.
