### PR TITLE
feat: hermes models / hermes providers — non-interactive inventory CLI (#23359)

### DIFF
--- a/hermes_cli/inventory.py
+++ b/hermes_cli/inventory.py
@@ -1,0 +1,600 @@
+"""Provider/model inventory — single source of truth for the picker,
+dashboard ``/api/model/options``, TUI ``model.options``, and the new
+``hermes models``/``hermes providers`` CLI surfaces.
+
+Issue #23359 documents the four pre-PR surfaces that each duplicated
+config-slice + post-processing inline. This module owns that traversal so
+consumers reduce to ``build_payload(kind, ctx=load_picker_context())``.
+
+Substrate facts (verified May 2026):
+
+- ``CANONICAL_PROVIDERS`` (35) is the universe — the picker iterates it.
+  ``PROVIDER_REGISTRY`` (33) and ``_PROVIDER_MODELS`` (32) each miss
+  different providers; iterating either drops real providers.
+- ``profile.fetch_models()`` returns the unfiltered raw catalog
+  (OpenRouter raw=367 vs picker-filtered=34). Always go through
+  ``provider_model_ids()``.
+- ``_PROVIDER_MODELS["openrouter"]`` is ``None``. Use the
+  ``OPENROUTER_MODELS`` constant directly for the offline path.
+- ``list_authenticated_providers`` section 3 emits rows from the
+  ``providers:`` config dict with ``is_user_defined=True`` even when the
+  slug is canonical. Reorder must key on slug∈CANONICAL, not the flag.
+- ``provider_model_ids`` has no auth precheck — it'll attempt HTTP for
+  every slug. ``_skip_live_for`` gates that.
+- ``get_compatible_custom_providers(cfg)`` is the canonical merged view
+  of legacy ``custom_providers`` list + v12+ keyed ``providers`` dict.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass, replace
+from typing import Optional
+
+SCHEMA_VERSION = 1
+
+# Curated allowlist: the only ``oauth_external`` provider with a real
+# ``/models`` REST endpoint. Most use proprietary URI schemes
+# (``cloudcode-pa://google``) where probing falls through to curated and
+# masks failure. See substrate notes in references/.
+_OAUTH_EXTERNAL_HAS_MODELS = frozenset({"openai-codex"})
+
+
+# ─── Public types ────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class ConfigContext:
+    """Snapshot of model + provider config used by every inventory caller."""
+
+    current_provider: str
+    current_model: str
+    current_base_url: str
+    user_providers: dict
+    custom_providers: list
+
+    def with_overrides(
+        self,
+        *,
+        current_provider: Optional[str] = None,
+        current_model: Optional[str] = None,
+        current_base_url: Optional[str] = None,
+    ) -> "ConfigContext":
+        """Return a copy with truthy overrides applied (TUI session state)."""
+        kw: dict = {}
+        if current_provider:
+            kw["current_provider"] = current_provider
+        if current_model:
+            kw["current_model"] = current_model
+        if current_base_url:
+            kw["current_base_url"] = current_base_url
+        return replace(self, **kw) if kw else self
+
+
+def load_picker_context() -> ConfigContext:
+    """Load the disk-config snapshot every consumer needs.
+
+    Replaces the inline 17-LOC config-slice that web_server.py,
+    tui_gateway/server.py, and the CLI handlers each used to do.
+    """
+    from hermes_cli.config import get_compatible_custom_providers, load_config
+
+    cfg = load_config()
+    model_cfg = cfg.get("model", {})
+    if isinstance(model_cfg, dict):
+        current_model = model_cfg.get("default", model_cfg.get("name", "")) or ""
+        current_provider = model_cfg.get("provider", "") or ""
+        current_base_url = model_cfg.get("base_url", "") or ""
+    else:
+        # config.model can be a bare string in older configs.
+        current_model = str(model_cfg) if model_cfg else ""
+        current_provider = ""
+        current_base_url = ""
+    raw = cfg.get("providers")
+    return ConfigContext(
+        current_provider=current_provider,
+        current_model=current_model,
+        current_base_url=current_base_url,
+        user_providers=raw if isinstance(raw, dict) else {},
+        custom_providers=get_compatible_custom_providers(cfg),
+    )
+
+
+# ─── Internal: per-provider HTTP gate ───────────────────────────────────
+
+
+def _skip_live_for(slug: str) -> bool:
+    """Return True if calling ``provider_model_ids(slug)`` will likely fail
+    or fall through to curated catalogs (masking failure as success).
+
+    Gates the live HTTP path so ``--all`` doesn't make ~20 spurious calls.
+    """
+    from hermes_cli.auth import PROVIDER_REGISTRY
+    from providers import get_provider_profile
+
+    profile = get_provider_profile(slug)
+    cfg = PROVIDER_REGISTRY.get(slug)
+    if profile is None:
+        # Legacy provider (lmstudio, tencent-tokenhub) — registry-only.
+        return cfg is None
+    if profile.auth_type in ("aws_sdk", "external_process"):
+        return True
+    if profile.auth_type == "oauth_external":
+        return slug not in _OAUTH_EXTERNAL_HAS_MODELS
+    if profile.auth_type == "oauth_device_code":
+        try:
+            from hermes_cli.auth import resolve_nous_runtime_credentials
+
+            return not resolve_nous_runtime_credentials()
+        except Exception:
+            return True
+    if profile.auth_type == "copilot":
+        return False
+    # api_key — skip if no env var
+    return not _is_configured_env_only(slug)
+
+
+def _is_configured_env_only(slug: str) -> bool:
+    """Env-var-only auth check for the ``--offline`` path.
+
+    Examines ``profile.env_vars`` ∪ ``PROVIDER_REGISTRY[slug].api_key_env_vars``
+    ∪ ``HERMES_OVERLAYS[slug].extra_env_vars``. No ``auth.json`` /
+    credential pool / Claude-Code creds — deterministic from environment.
+    """
+    from hermes_cli.auth import PROVIDER_REGISTRY
+    from providers import get_provider_profile
+
+    candidates: list[str] = []
+    profile = get_provider_profile(slug)
+    if profile and profile.env_vars:
+        candidates.extend(profile.env_vars)
+    cfg = PROVIDER_REGISTRY.get(slug)
+    if cfg and cfg.api_key_env_vars:
+        candidates.extend(cfg.api_key_env_vars)
+    try:
+        from hermes_cli.providers import HERMES_OVERLAYS
+
+        overlay = HERMES_OVERLAYS.get(slug)
+        if overlay and overlay.extra_env_vars:
+            candidates.extend(overlay.extra_env_vars)
+    except Exception:
+        pass
+    return any(os.environ.get(v) for v in candidates)
+
+
+# ─── Internal: model resolution ─────────────────────────────────────────
+
+
+def _models_for(slug: str, *, live: bool) -> tuple[list[str], str]:
+    """Return ``(model_ids, source)`` for a canonical provider slug.
+
+    ``source`` ∈ {"catalog","curated","fallback","empty"}. Static path
+    NEVER calls ``model_ids()`` / ``get_curated_nous_model_ids()`` /
+    ``fetch_openrouter_models()`` — all three remote-fetch.
+    """
+    from hermes_cli.models import OPENROUTER_MODELS, _PROVIDER_MODELS
+    from providers import get_provider_profile
+
+    if live and not _skip_live_for(slug):
+        try:
+            from hermes_cli.models import provider_model_ids
+
+            ids = provider_model_ids(slug)
+            if ids:
+                return list(ids), "catalog"
+        except Exception:
+            pass
+    if slug == "openrouter":
+        ids = [m for m, _ in OPENROUTER_MODELS]
+        if ids:
+            return ids, "curated"
+    curated = list(_PROVIDER_MODELS.get(slug, []) or [])
+    if curated:
+        return curated, "curated"
+    profile = get_provider_profile(slug)
+    if profile and profile.fallback_models:
+        return list(profile.fallback_models), "fallback"
+    return [], "empty"
+
+
+# ─── Internal: row enrichment ───────────────────────────────────────────
+
+
+def _enrich_row(row: dict) -> dict:
+    """Attach ``api_mode``/``auth_type``/``base_url``/``env_vars``/
+    ``env_vars_present`` from profile or registry. Mutates and returns.
+    Env-var values are NEVER recorded — only presence booleans.
+    """
+    from hermes_cli.auth import PROVIDER_REGISTRY
+    from providers import get_provider_profile
+
+    slug = row["slug"]
+    profile = get_provider_profile(slug)
+    cfg = PROVIDER_REGISTRY.get(slug)
+    if profile:
+        row.setdefault("api_mode", profile.api_mode)
+        row.setdefault("auth_type", profile.auth_type)
+        row.setdefault("base_url", profile.base_url)
+        env_vars = list(profile.env_vars)
+    elif cfg:
+        # Legacy (lmstudio, tencent-tokenhub) — both OpenAI-compatible.
+        row.setdefault("api_mode", "chat_completions")
+        row.setdefault("auth_type", cfg.auth_type)
+        row.setdefault("base_url", cfg.inference_base_url)
+        env_vars = list(cfg.api_key_env_vars)
+    else:
+        row.setdefault("api_mode", "unknown")
+        row.setdefault("auth_type", "unknown")
+        row.setdefault("base_url", "")
+        env_vars = []
+    try:
+        from hermes_cli.providers import HERMES_OVERLAYS
+
+        overlay = HERMES_OVERLAYS.get(slug)
+        if overlay and overlay.extra_env_vars:
+            for ev in overlay.extra_env_vars:
+                if ev not in env_vars:
+                    env_vars.append(ev)
+    except Exception:
+        pass
+    row["env_vars"] = env_vars
+    row["env_vars_present"] = [bool(os.environ.get(v)) for v in env_vars]
+    return row
+
+
+# ─── Internal: enumeration ──────────────────────────────────────────────
+
+
+def _enumerate(
+    ctx: ConfigContext, *, live: bool, include_unconfigured: bool, max_models: int
+) -> list[dict]:
+    """Build the row list. ``live=False`` synthesizes from in-repo data
+    only (no HTTP, env-only auth derivation); ``live=True`` delegates to
+    ``list_authenticated_providers`` (the canonical picker code path).
+    """
+    from hermes_cli.models import CANONICAL_PROVIDERS, _PROVIDER_LABELS
+
+    if live:
+        from hermes_cli.model_switch import list_authenticated_providers
+
+        rows: list[dict] = []
+        for r in list_authenticated_providers(
+            current_provider=ctx.current_provider,
+            current_base_url=ctx.current_base_url,
+            current_model=ctx.current_model,
+            user_providers=ctx.user_providers,
+            custom_providers=ctx.custom_providers,
+            max_models=max_models,
+        ):
+            r = dict(r)
+            r["auth_state"] = "configured"
+            _enrich_row(r)
+            rows.append(r)
+        if include_unconfigured:
+            seen = {r["slug"].lower() for r in rows}
+            cur = (ctx.current_provider or "").lower()
+            for entry in CANONICAL_PROVIDERS:
+                if entry.slug.lower() in seen:
+                    continue
+                row = {
+                    "slug": entry.slug,
+                    "name": _PROVIDER_LABELS.get(entry.slug, entry.label),
+                    "is_current": entry.slug.lower() == cur,
+                    "is_user_defined": False,
+                    "models": [],
+                    "total_models": 0,
+                    "source": "canonical",
+                    "auth_state": "unconfigured",
+                }
+                _enrich_row(row)
+                rows.append(row)
+        # Live rows already have models; tag source for renderers.
+        for row in rows:
+            row.setdefault(
+                "model_source",
+                "user-config" if row.get("is_user_defined") else "catalog",
+            )
+        return rows
+
+    # Static path.
+    rows = []
+    cur = (ctx.current_provider or "").lower()
+    for entry in CANONICAL_PROVIDERS:
+        configured = _is_configured_env_only(entry.slug)
+        if not configured and not include_unconfigured:
+            continue
+        ids, source = _models_for(entry.slug, live=False)
+        row = {
+            "slug": entry.slug,
+            "name": _PROVIDER_LABELS.get(entry.slug, entry.label),
+            "is_current": entry.slug.lower() == cur,
+            "is_user_defined": False,
+            "models": ids,
+            "total_models": len(ids),
+            "source": "canonical",
+            "model_source": source,
+            "auth_state": "configured" if configured else "unconfigured",
+        }
+        _enrich_row(row)
+        rows.append(row)
+    cur_url = (ctx.current_base_url or "").rstrip("/").lower()
+    for cp in ctx.custom_providers:
+        if not isinstance(cp, dict):
+            continue
+        name = str(cp.get("name") or "").strip()
+        if not name:
+            continue
+        api_key = str(cp.get("api_key") or "").strip()
+        configured = bool(cp.get("base_url"))
+        if api_key:
+            if api_key.startswith("${") and api_key.endswith("}"):
+                configured = bool(os.environ.get(api_key[2:-1]))
+            else:
+                configured = True
+        if not configured and not include_unconfigured:
+            continue
+        cp_url = str(cp.get("base_url") or "").strip().rstrip("/").lower()
+        models = [
+            m if isinstance(m, str) else (m.get("id") or m.get("name") or "")
+            for m in (cp.get("models") or [])
+            if (isinstance(m, str) and m) or (isinstance(m, dict) and (m.get("id") or m.get("name")))
+        ]
+        rows.append(
+            {
+                "slug": f"custom:{name}",
+                "name": name,
+                "is_current": bool(cp_url) and cp_url == cur_url,
+                "is_user_defined": True,
+                "models": models,
+                "total_models": len(models),
+                "source": "user-config",
+                "model_source": "user-config",
+                "auth_state": "configured" if configured else "unconfigured",
+                "api_mode": "chat_completions",
+                "auth_type": "api_key",
+                "base_url": str(cp.get("base_url") or ""),
+                "env_vars": [],
+                "env_vars_present": [],
+            }
+        )
+    return rows
+
+
+# ─── Internal: picker-shape post-processing ─────────────────────────────
+
+
+def _apply_picker_hints(rows: list[dict]) -> None:
+    """Add ``authenticated``/``key_env``/``warning`` per row (TUI consumer)."""
+    from hermes_cli.auth import PROVIDER_REGISTRY
+
+    for row in rows:
+        if "authenticated" in row:
+            continue
+        configured = row.get("auth_state") == "configured"
+        row["authenticated"] = configured
+        if configured or row.get("is_user_defined"):
+            continue
+        cfg = PROVIDER_REGISTRY.get(row["slug"])
+        auth_type = cfg.auth_type if cfg else row.get("auth_type", "api_key")
+        key_env = (
+            cfg.api_key_env_vars[0]
+            if (cfg and cfg.api_key_env_vars)
+            else ""
+        )
+        row.setdefault("auth_type", auth_type)
+        row["key_env"] = key_env
+        row["warning"] = (
+            f"paste {key_env} to activate"
+            if auth_type == "api_key" and key_env
+            else f"run `hermes model` to configure ({auth_type})"
+        )
+
+
+def _reorder_canonical(rows: list[dict]) -> list[dict]:
+    """Canonical slugs in CANONICAL_PROVIDERS order; truly-custom rows last.
+
+    Keys on slug membership, NOT ``is_user_defined`` — section 3 of
+    ``list_authenticated_providers`` sets ``is_user_defined=True`` for
+    rows from ``providers:`` config dict even when the slug is canonical.
+    """
+    from hermes_cli.models import CANONICAL_PROVIDERS
+
+    order = {e.slug: i for i, e in enumerate(CANONICAL_PROVIDERS)}
+    canon = sorted((r for r in rows if r["slug"] in order), key=lambda r: order[r["slug"]])
+    extras = [r for r in rows if r["slug"] not in order]
+    return canon + extras
+
+
+# ─── Internal: provider-arg resolution ──────────────────────────────────
+
+
+def _resolve_provider(slug: str, ctx: ConfigContext) -> Optional[dict]:
+    """Resolve a user-supplied ``--provider NAME`` argument.
+
+    Returns ``{"slug": canonical_slug, "kind": "canonical"|"custom",
+    "name": display_name}`` or ``None`` if unknown.
+    """
+    from hermes_cli.models import CANONICAL_PROVIDERS, _PROVIDER_LABELS, normalize_provider
+    from providers import get_provider_profile
+
+    if not slug:
+        return None
+    if slug.startswith("custom:"):
+        bare = slug[7:].strip()
+        for cp in ctx.custom_providers:
+            if isinstance(cp, dict) and str(cp.get("name") or "").strip().lower() == bare.lower():
+                return {"slug": str(cp["name"]).strip(), "kind": "custom", "name": str(cp["name"]).strip()}
+        return None
+    profile = get_provider_profile(slug)
+    if profile is not None:
+        return {
+            "slug": profile.name,
+            "kind": "canonical",
+            "name": _PROVIDER_LABELS.get(profile.name, profile.name),
+        }
+    canon = normalize_provider(slug)
+    canonical_set = {p.slug: p for p in CANONICAL_PROVIDERS}
+    if canon in canonical_set:
+        p = canonical_set[canon]
+        return {"slug": canon, "kind": "canonical", "name": _PROVIDER_LABELS.get(canon, p.label)}
+    for cp in ctx.custom_providers:
+        if isinstance(cp, dict) and str(cp.get("name") or "").strip().lower() == slug.lower():
+            return {"slug": str(cp["name"]).strip(), "kind": "custom", "name": str(cp["name"]).strip()}
+    return None
+
+
+# ─── Public: payload builder ────────────────────────────────────────────
+
+
+def build_payload(
+    kind: str,
+    *,
+    ctx: Optional[ConfigContext] = None,
+    provider: Optional[str] = None,
+    include_unconfigured: bool = False,
+    live: bool = True,
+    offline: bool = False,
+    picker_hints: bool = False,
+    canonical_order: bool = False,
+    max_models: int = 50,
+) -> dict:
+    """Single payload builder for all 3 surfaces.
+
+    ``kind`` ∈ {"models", "providers", "status"}:
+      - models: per-row models list; supports scoped ``provider=`` lookup.
+      - providers: same row shape; ignores models field for the renderer.
+      - status: row shape minus the models payload (auth snapshot only).
+
+    ``offline=True`` forces ``live=False`` and bypasses
+    ``list_authenticated_providers`` (which has unconditional HTTP).
+    ``picker_hints``/``canonical_order`` are TUI shape extras.
+    """
+    if kind not in ("models", "providers", "status"):
+        raise ValueError(f"unknown kind: {kind!r}")
+    if offline:
+        live = False
+    if ctx is None:
+        ctx = load_picker_context()
+
+    if kind == "models" and provider:
+        # Scoped lookup — always returns one row, never filtered by creds.
+        r = _resolve_provider(provider, ctx)
+        if r is None:
+            raise ValueError(f"unknown provider: {provider!r}")
+        if r["kind"] == "canonical":
+            ids, source = _models_for(r["slug"], live=live)
+            row = {
+                "slug": r["slug"],
+                "name": r["name"],
+                "is_current": r["slug"].lower() == (ctx.current_provider or "").lower(),
+                "is_user_defined": False,
+                "models": ids,
+                "total_models": len(ids),
+                "source": "canonical",
+                "model_source": source,
+                "auth_state": "configured" if _is_configured_env_only(r["slug"]) else "unconfigured",
+            }
+            _enrich_row(row)
+        else:
+            cp_entry = next(
+                (cp for cp in ctx.custom_providers if isinstance(cp, dict)
+                 and str(cp.get("name") or "").strip() == r["slug"]),
+                None,
+            )
+            if cp_entry is None:
+                raise ValueError(f"custom provider not found: {r['slug']!r}")
+            models = [m for m in (cp_entry.get("models") or []) if isinstance(m, str)]
+            row = {
+                "slug": f"custom:{r['slug']}",
+                "name": r["name"],
+                "is_current": False,
+                "is_user_defined": True,
+                "models": models,
+                "total_models": len(models),
+                "source": "user-config",
+                "model_source": "user-config",
+                "auth_state": "configured",
+                "api_mode": "chat_completions",
+                "auth_type": "api_key",
+                "base_url": str(cp_entry.get("base_url") or ""),
+                "env_vars": [],
+                "env_vars_present": [],
+            }
+        rows = [row]
+    else:
+        rows = _enumerate(
+            ctx,
+            live=live,
+            include_unconfigured=include_unconfigured or kind == "status",
+            max_models=max_models,
+        )
+
+    if kind == "status":
+        # Drop the models payload; status is an auth snapshot.
+        for row in rows:
+            row.pop("models", None)
+            row.pop("total_models", None)
+            row.pop("model_source", None)
+
+    if picker_hints:
+        _apply_picker_hints(rows)
+    if canonical_order:
+        rows = _reorder_canonical(rows)
+
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "current": {"provider": ctx.current_provider, "model": ctx.current_model},
+        "providers": rows,
+    }
+
+
+# ─── Public: rendering ──────────────────────────────────────────────────
+
+
+def _format_table(headers: list[str], rows: list[list[str]]) -> str:
+    widths = [len(h) for h in headers]
+    for row in rows:
+        for i, cell in enumerate(row):
+            if i < len(widths) and len(cell) > widths[i]:
+                widths[i] = len(cell)
+    lines = ["  ".join(c.ljust(widths[i]) for i, c in enumerate(cells)) for cells in [headers, *rows]]
+    return "\n".join(lines)
+
+
+def render_text(payload: dict, kind: str) -> str:
+    """Plain-text rendering for the default (non-``--json``) CLI mode."""
+    rows = payload.get("providers", [])
+    if not rows:
+        return f"(no {kind})"
+    if kind == "providers":
+        body = [
+            [r["slug"], str(r.get("auth_state", "unknown")),
+             str(r.get("api_mode", "")), str(r.get("base_url", ""))]
+            for r in rows
+        ]
+        configured = sum(1 for r in rows if r.get("auth_state") == "configured")
+        return _format_table(
+            ["SLUG", "AUTH", "API_MODE", "BASE_URL"], body
+        ) + f"\n\n{configured} of {len(rows)} providers configured"
+    if kind == "status":
+        body = [[r["slug"], str(r.get("auth_state", "unknown"))] for r in rows]
+        return _format_table(["PROVIDER", "AUTH"], body) + f"\n\n{len(rows)} providers"
+    # models
+    cur_p = payload.get("current", {}).get("provider", "")
+    cur_m = payload.get("current", {}).get("model", "")
+    body = []
+    for r in rows:
+        for m in r.get("models", []) or []:
+            mark = " *current*" if r["slug"] == cur_p and m == cur_m else ""
+            body.append([r["slug"], f"{m}{mark}", str(r.get("model_source", "?"))])
+    if not body:
+        return "(no models)"
+    total = sum(len(r.get("models", []) or []) for r in rows)
+    return _format_table(
+        ["PROVIDER", "MODEL", "SOURCE"], body
+    ) + f"\n\n{total} models across {len(rows)} provider(s)"
+
+
+def dump_json(payload: dict) -> str:
+    return json.dumps(payload, indent=2, ensure_ascii=False)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1729,6 +1729,56 @@ def cmd_model(args):
     select_provider_and_model(args=args)
 
 
+# ─── Non-interactive inventory commands (issue #23359) ────────────────────
+
+
+def _emit(payload: dict, kind: str, as_json: bool) -> None:
+    from hermes_cli.inventory import dump_json, render_text
+
+    print(dump_json(payload) if as_json else render_text(payload, kind))
+
+
+def cmd_models_list(args):
+    """``hermes models list`` — JSON or text inventory of models."""
+    from hermes_cli.inventory import build_payload
+
+    try:
+        payload = build_payload(
+            "models", provider=args.provider,
+            include_unconfigured=args.all,
+            live=not (args.no_live or args.offline),
+            offline=args.offline,
+        )
+    except ValueError as exc:
+        args._parser.error(f"{exc}. Run `hermes providers list --all` to see slugs.")
+        return
+    _emit(payload, "models", args.json)
+
+
+def cmd_models_status(args):
+    """``hermes models status`` — auth snapshot per provider."""
+    from hermes_cli.inventory import build_payload
+
+    try:
+        payload = build_payload(
+            "status", provider=args.provider, offline=args.offline,
+        )
+    except ValueError as exc:
+        args._parser.error(f"{exc}. Run `hermes providers list --all` to see slugs.")
+        return
+    _emit(payload, "status", args.json)
+
+
+def cmd_providers_list(args):
+    """``hermes providers list`` — provider registry inventory."""
+    from hermes_cli.inventory import build_payload
+
+    payload = build_payload(
+        "providers", include_unconfigured=args.all, offline=args.offline,
+    )
+    _emit(payload, "providers", args.json)
+
+
 def _is_profile_api_key_provider(provider_id: str) -> bool:
     """Return True when provider_id maps to a profile with auth_type='api_key'.
 
@@ -8413,6 +8463,8 @@ def _coalesce_session_name_args(argv: list) -> list:
     _SUBCOMMANDS = {
         "chat",
         "model",
+        "models",
+        "providers",
         "gateway",
         "setup",
         "whatsapp",
@@ -9157,6 +9209,7 @@ _BUILTIN_SUBCOMMANDS = frozenset(
         "config", "cron", "curator", "dashboard", "debug", "doctor",
         "dump", "fallback", "gateway", "hooks", "import", "insights",
         "kanban", "login", "logout", "logs", "mcp", "memory", "model",
+        "models", "providers",
         "pairing", "plugins", "profile", "sessions", "setup", "skills",
         "slack", "status", "tools", "uninstall", "update", "version",
         "webhook", "whatsapp", "chat",
@@ -9315,6 +9368,42 @@ def main():
         help="Disable TLS verification for Nous login (testing only)",
     )
     model_parser.set_defaults(func=cmd_model)
+
+    # ── Non-interactive inventory subcommands (issue #23359) ──
+    models_parser = subparsers.add_parser(
+        "models",
+        help="List and inspect available models (non-interactive)",
+        description="Non-interactive model inventory for cron / CI / scripts. "
+                    "Use `hermes model` for the interactive picker.",
+    )
+    _ms = models_parser.add_subparsers(dest="models_command", required=True)
+    _ml = _ms.add_parser("list", help="List models for one or all configured providers")
+    _ml.add_argument("--provider", default=None, help="Limit to one slug (bypasses configured-only filter)")
+    _ml.add_argument("--json", action="store_true", help="Emit JSON")
+    _ml.add_argument("--no-live", action="store_true", help="Skip provider live API; show curated only")
+    _ml.add_argument("--all", action="store_true", help="Include unconfigured providers")
+    _ml.add_argument("--offline", action="store_true", help="No HTTP at all; env-only auth")
+    _ml.set_defaults(func=cmd_models_list, _parser=_ml)
+    _mst = _ms.add_parser("status", help="Show auth state per provider")
+    _mst.add_argument("--provider", default=None)
+    _mst.add_argument("--json", action="store_true")
+    _mst.add_argument("--offline", action="store_true", help="No HTTP at all; env-only auth")
+    # TODO(#23614): add --probe for live reachability checks. Tracked
+    # separately because provider_model_ids() falls back to curated lists,
+    # so a true reachability surface needs an explicit endpoint probe
+    # rather than the existing model-discovery wrapper.
+    _mst.set_defaults(func=cmd_models_status, _parser=_mst)
+
+    providers_parser = subparsers.add_parser(
+        "providers",
+        help="List provider registry (non-interactive)",
+    )
+    _ps = providers_parser.add_subparsers(dest="providers_command", required=True)
+    _pl = _ps.add_parser("list", help="List configured providers")
+    _pl.add_argument("--json", action="store_true")
+    _pl.add_argument("--all", action="store_true", help="Include unconfigured providers")
+    _pl.add_argument("--offline", action="store_true", help="No HTTP at all; env-only auth")
+    _pl.set_defaults(func=cmd_providers_list, _parser=_pl)
 
     # =========================================================================
     # fallback command — manage the fallback provider chain

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -980,38 +980,14 @@ def get_model_options():
     can share the same types.
     """
     try:
-        from hermes_cli.model_switch import list_authenticated_providers
+        from hermes_cli.inventory import build_payload, load_picker_context
 
-        cfg = load_config()
-        model_cfg = cfg.get("model", {})
-        if isinstance(model_cfg, dict):
-            current_model = model_cfg.get("default", model_cfg.get("name", "")) or ""
-            current_provider = model_cfg.get("provider", "") or ""
-            current_base_url = model_cfg.get("base_url", "") or ""
-        else:
-            current_model = str(model_cfg) if model_cfg else ""
-            current_provider = ""
-            current_base_url = ""
-
-        user_providers = cfg.get("providers") if isinstance(cfg.get("providers"), dict) else {}
-        custom_providers = (
-            cfg.get("custom_providers")
-            if isinstance(cfg.get("custom_providers"), list)
-            else []
-        )
-
-        providers = list_authenticated_providers(
-            current_provider=current_provider,
-            current_base_url=current_base_url,
-            current_model=current_model,
-            user_providers=user_providers,
-            custom_providers=custom_providers,
-            max_models=50,
-        )
+        ctx = load_picker_context()
+        payload = build_payload("models", ctx=ctx, max_models=50)
         return {
-            "providers": providers,
-            "model": current_model,
-            "provider": current_provider,
+            "providers": payload["providers"],
+            "model": ctx.current_model,
+            "provider": ctx.current_provider,
         }
     except Exception:
         _log.exception("GET /api/model/options failed")

--- a/tests/hermes_cli/test_inventory.py
+++ b/tests/hermes_cli/test_inventory.py
@@ -1,0 +1,678 @@
+"""Tests for ``hermes_cli.inventory`` — the issue #23359 consolidation.
+
+Locks invariants only:
+  - Concept A: ``offline=True`` does not call ``fetch_models_dev``.
+  - Concept B: ``offline=True`` does not call any provider live HTTP.
+  - Concept C: status payload is HTTP-free (no ``provider_model_ids``).
+  - H2: probe-skip predicate covers oauth_external + aws_sdk + api_key
+        without env var.
+  - H3: openrouter offline uses the local OPENROUTER_MODELS constant.
+  - H4: ``--all`` populates models from curated/static for unconfigured.
+  - H5: provider-arg resolution accepts canonical, custom:NAME, profile
+        aliases, and bare custom names.
+  - H6: env-only auth derivation (offline path) doesn't read auth.json /
+        credential pool / external auth stores.
+  - W1: canonical-slug rows from ``providers:`` config dict slot into
+        canonical position (not user-defined tail).
+  - Schema: payload always has ``schema_version``/``current``/``providers``.
+  - Mutex: unknown provider raises ``ValueError``; CLI exits 2.
+  - Credential leak: env-var values never appear in the JSON payload.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any
+
+import pytest
+
+
+# ─── Fixtures ────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def isolated_home(tmp_path, monkeypatch):
+    h = tmp_path / "hermes_home"
+    h.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(h))
+    for var in [
+        "ARCEEAI_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_TOKEN",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+        "OPENAI_API_KEY",
+        "OPENROUTER_API_KEY",
+        "NOUS_API_KEY",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_PROFILE",
+        "GH_TOKEN",
+        "COPILOT_GITHUB_TOKEN",
+        "DEEPSEEK_API_KEY",
+        "GLM_API_KEY",
+        "ZAI_API_KEY",
+        "STEPFUN_API_KEY",
+        "GMI_API_KEY",
+        "LM_BASE_URL",
+        "LM_API_KEY",
+        "TOGETHER_API_KEY",
+        "FIREWORKS_API_KEY",
+        "GROQ_API_KEY",
+        "GOOGLE_API_KEY",
+        "QWEN_API_KEY",
+        "MOONSHOT_API_KEY",
+        "MINIMAX_API_KEY",
+        "BEDROCK_API_KEY",
+        "CEREBRAS_API_KEY",
+        "VERCEL_API_KEY",
+    ]:
+        monkeypatch.delenv(var, raising=False)
+    return h
+
+
+@pytest.fixture
+def fail_on_network(monkeypatch):
+    """Concept A+B canary: monkeypatch every live-fetch helper to fail."""
+    sentinels: list[str] = []
+
+    def _fail(name: str):
+        def _f(*a: Any, **k: Any) -> Any:
+            sentinels.append(name)
+            raise AssertionError(f"network call to {name} during offline path")
+
+        return _f
+
+    from agent import models_dev as md
+    from hermes_cli import auth as ha
+    from hermes_cli import models as hm
+    from hermes_cli import model_switch as ms
+
+    for fn in [
+        "fetch_anthropic_models",
+        "fetch_ai_gateway_models",
+        "fetch_ollama_cloud_models",
+        "fetch_lmstudio_models",
+        "fetch_openrouter_models",
+        "_fetch_github_models",
+        "fetch_api_models",
+        "fetch_nous_models",
+    ]:
+        if hasattr(hm, fn):
+            monkeypatch.setattr(hm, fn, _fail(f"hermes_cli.models.{fn}"))
+        if hasattr(ha, fn):
+            monkeypatch.setattr(ha, fn, _fail(f"hermes_cli.auth.{fn}"))
+    for fn in [
+        "fetch_models_dev",
+        "fetch_ollama_cloud_models",
+        "fetch_lmstudio_models",
+        "fetch_openrouter_models",
+    ]:
+        if hasattr(md, fn):
+            monkeypatch.setattr(md, fn, _fail(f"agent.models_dev.{fn}"))
+    if hasattr(hm, "model_ids"):
+        monkeypatch.setattr(hm, "model_ids", _fail("hermes_cli.models.model_ids"))
+    if hasattr(hm, "get_curated_nous_model_ids"):
+        monkeypatch.setattr(hm, "get_curated_nous_model_ids", _fail("get_curated_nous_model_ids"))
+    try:
+        from agent import bedrock_adapter as ba
+    except ImportError:
+        ba = None
+    if ba is not None and hasattr(ba, "bedrock_model_ids_or_none"):
+        monkeypatch.setattr(ba, "bedrock_model_ids_or_none", _fail("bedrock_model_ids_or_none"))
+    monkeypatch.setattr(ms, "list_authenticated_providers", _fail("list_authenticated_providers"))
+    return sentinels
+
+
+# ─── Concept canaries ───────────────────────────────────────────────────
+
+
+def test_concept_a_offline_skips_models_dev(isolated_home, fail_on_network):
+    from hermes_cli import inventory
+
+    inventory.build_payload("providers", include_unconfigured=True, offline=True)
+    inventory.build_payload("models", live=False, include_unconfigured=True, offline=True)
+    inventory.build_payload("status", offline=True)
+
+    leaked = [s for s in fail_on_network if "models_dev" in s]
+    assert leaked == [], f"models.dev fetched when offline: {leaked}"
+
+
+def test_concept_b_offline_skips_provider_live(isolated_home, fail_on_network):
+    from hermes_cli import inventory
+
+    inventory.build_payload("providers", include_unconfigured=True, offline=True)
+    inventory.build_payload("models", live=False, include_unconfigured=True, offline=True)
+    inventory.build_payload("status", offline=True)
+
+    assert fail_on_network == [], (
+        f"provider HTTP / remote-catalog leaked when offline: {fail_on_network}"
+    )
+
+
+def test_concept_c_status_does_not_call_provider_model_ids(isolated_home, monkeypatch):
+    """``build_payload('status')`` is an auth snapshot — no probe."""
+    from hermes_cli import inventory
+    from hermes_cli import models
+
+    seen: list[str] = []
+    real = models.provider_model_ids
+
+    def _spy(slug: str, *a: Any, **k: Any) -> Any:
+        seen.append(slug)
+        return real(slug, *a, **k)
+
+    monkeypatch.setattr(models, "provider_model_ids", _spy)
+    inventory.build_payload("status", offline=True)
+    assert seen == [], f"provider_model_ids called {seen} from build_payload('status')"
+
+
+def test_status_payload_omits_models(isolated_home):
+    """status rows must drop ``models``/``total_models``/``model_source``."""
+    from hermes_cli import inventory
+
+    payload = inventory.build_payload("status", offline=True)
+    assert payload["providers"]
+    for r in payload["providers"]:
+        assert "models" not in r, f"status row {r['slug']!r} has models"
+        assert "total_models" not in r
+        assert "model_source" not in r
+
+
+# ─── H2: probe-skip predicate ───────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "slug,expected_skip",
+    [
+        ("openai-codex", False),  # in allowlist
+        ("google-gemini-cli", True),  # oauth_external; no /models REST
+        ("qwen-oauth", True),  # oauth_external; no /models REST
+        ("bedrock", True),  # aws_sdk
+        ("anthropic", True),  # api_key, no env var set in isolated_home
+    ],
+)
+def test_h2_skip_live_for(isolated_home, slug, expected_skip):
+    from hermes_cli.inventory import _skip_live_for
+
+    assert _skip_live_for(slug) is expected_skip, (
+        f"_skip_live_for({slug!r}) != {expected_skip}"
+    )
+
+
+# ─── H3: openrouter offline gotcha ──────────────────────────────────────
+
+
+def test_h3_openrouter_offline_uses_local_constant(isolated_home, fail_on_network):
+    """``_PROVIDER_MODELS['openrouter']`` is None — must use OPENROUTER_MODELS."""
+    from hermes_cli import inventory
+    from hermes_cli.models import OPENROUTER_MODELS
+
+    payload = inventory.build_payload("models", provider="openrouter", offline=True)
+    row = payload["providers"][0]
+    assert row["total_models"] == len(OPENROUTER_MODELS), (
+        f"openrouter offline got {row['total_models']} models; "
+        f"expected len(OPENROUTER_MODELS)={len(OPENROUTER_MODELS)}"
+    )
+    # And no network calls fired.
+    assert fail_on_network == []
+
+
+# ─── H4: --all populates models from curated/static for unconfigured ────
+
+
+def test_h4_all_offline_populates_models(isolated_home, fail_on_network):
+    from hermes_cli import inventory
+
+    payload = inventory.build_payload(
+        "models", include_unconfigured=True, offline=True
+    )
+    rows = {r["slug"]: r for r in payload["providers"]}
+    assert "anthropic" in rows
+    # Anthropic is unconfigured in isolated_home but should still get curated.
+    assert rows["anthropic"]["total_models"] > 0
+    assert rows["anthropic"]["auth_state"] == "unconfigured"
+    assert rows["anthropic"]["model_source"] in ("curated", "fallback")
+    assert fail_on_network == []
+
+
+# ─── H5: provider-arg resolution ────────────────────────────────────────
+
+
+def test_h5_canonical_slug_resolves(isolated_home):
+    from hermes_cli.inventory import _resolve_provider, load_picker_context
+
+    ctx = load_picker_context()
+    r = _resolve_provider("anthropic", ctx)
+    assert r is not None and r["slug"] == "anthropic" and r["kind"] == "canonical"
+
+
+def test_h5_alias_resolves(isolated_home):
+    """``google`` should resolve via profile alias to ``gemini``."""
+    from hermes_cli.inventory import _resolve_provider, load_picker_context
+
+    ctx = load_picker_context()
+    r = _resolve_provider("google", ctx)
+    # Some installs alias google → gemini-cli, others google → gemini.
+    assert r is not None and r["kind"] == "canonical"
+    assert r["slug"] in {"gemini", "gemini-cli", "google", "google-gemini-cli"}
+
+
+def test_h5_unknown_slug_returns_none(isolated_home):
+    from hermes_cli.inventory import _resolve_provider, load_picker_context
+
+    assert _resolve_provider("does-not-exist-xyz", load_picker_context()) is None
+
+
+# ─── H6: offline auth-state is env-only ─────────────────────────────────
+
+
+def test_h6_offline_auth_state_env_only(isolated_home, monkeypatch):
+    """``--offline`` must derive ``auth_state`` from env vars only."""
+    from hermes_cli import inventory
+
+    # Set ARCEEAI_API_KEY (arcee's only env var, no auth_store seeding).
+    monkeypatch.setenv("ARCEEAI_API_KEY", "test-canary")
+
+    payload = inventory.build_payload(
+        "providers", include_unconfigured=True, offline=True
+    )
+    rows = {r["slug"]: r for r in payload["providers"]}
+    assert "arcee" in rows
+    assert rows["arcee"]["auth_state"] == "configured", (
+        f"arcee should be configured via ARCEEAI_API_KEY env var; got {rows['arcee']['auth_state']!r}"
+    )
+
+
+def test_h6_openrouter_overlay_bridge(isolated_home, monkeypatch):
+    """OpenRouter accepts ``OPENAI_API_KEY`` via HERMES_OVERLAYS."""
+    from hermes_cli import inventory
+
+    monkeypatch.setenv("OPENAI_API_KEY", "test-canary")
+    payload = inventory.build_payload(
+        "providers", include_unconfigured=True, offline=True
+    )
+    rows = {r["slug"]: r for r in payload["providers"]}
+    assert rows["openrouter"]["auth_state"] == "configured"
+
+
+# ─── W1: canonical-slug rows from providers: config dict ────────────────
+
+
+def test_w1_canonical_slug_in_user_providers_keeps_canonical_position(
+    isolated_home, monkeypatch
+):
+    """``list_authenticated_providers`` section 3 emits rows with
+    ``is_user_defined=True`` even for canonical slugs (when the user has
+    ``providers: { openrouter: {...} }`` in config). They must slot into
+    canonical position under ``canonical_order=True``, NOT the tail.
+    """
+    from hermes_cli import inventory
+    from hermes_cli import model_switch
+
+    fixture = [
+        {
+            "slug": "my-custom",
+            "name": "My Custom",
+            "is_current": False,
+            "is_user_defined": True,
+            "models": ["foo"],
+            "total_models": 1,
+            "source": "user-config",
+        },
+        {
+            "slug": "openrouter",
+            "name": "OpenRouter",
+            "is_current": False,
+            "is_user_defined": True,  # section 3 sets True even for canonical slug
+            "models": ["anthropic/claude-opus-4.7"],
+            "total_models": 1,
+            "source": "user-config",
+        },
+        {
+            "slug": "anthropic",
+            "name": "Anthropic",
+            "is_current": False,
+            "is_user_defined": False,
+            "models": ["claude-opus-4-7"],
+            "total_models": 1,
+            "source": "built-in",
+        },
+    ]
+    monkeypatch.setattr(
+        model_switch, "list_authenticated_providers", lambda **_: [dict(r) for r in fixture],
+    )
+    payload = inventory.build_payload(
+        "models", include_unconfigured=False,
+        picker_hints=True, canonical_order=True,
+    )
+    slugs = [r["slug"] for r in payload["providers"]]
+    # openrouter and anthropic are both canonical; must precede my-custom.
+    assert slugs.index("openrouter") < slugs.index("my-custom")
+    assert slugs.index("anthropic") < slugs.index("my-custom")
+
+
+# ─── Picker hints ────────────────────────────────────────────────────────
+
+
+def test_picker_hints_emits_authenticated_quartet(isolated_home):
+    """``picker_hints=True`` adds ``authenticated``/``key_env``/``warning``
+    on every row. Configured rows: authenticated=True, no warning.
+    Unconfigured api-key rows: authenticated=False + warning.
+    """
+    from hermes_cli import inventory
+
+    payload = inventory.build_payload(
+        "models", include_unconfigured=True, picker_hints=True, offline=True
+    )
+    rows = {r["slug"]: r for r in payload["providers"]}
+    assert "anthropic" in rows
+    assert rows["anthropic"]["authenticated"] is False
+    assert "key_env" in rows["anthropic"]
+    assert "warning" in rows["anthropic"]
+    assert "ANTHROPIC" in rows["anthropic"]["key_env"]
+
+
+def test_without_picker_hints_omits_authenticated(isolated_home):
+    from hermes_cli import inventory
+
+    payload = inventory.build_payload(
+        "models", include_unconfigured=True, offline=True
+    )
+    for r in payload["providers"]:
+        assert "authenticated" not in r, f"{r['slug']} leaked authenticated field"
+
+
+# ─── ConfigContext.with_overrides ───────────────────────────────────────
+
+
+def test_with_overrides_truthy_only(isolated_home):
+    from hermes_cli.inventory import ConfigContext
+
+    base = ConfigContext("a", "m", "u", {}, [])
+    # Empty values preserve original.
+    assert base.with_overrides(current_provider="").current_provider == "a"
+    # Truthy overrides apply.
+    assert base.with_overrides(current_provider="b").current_provider == "b"
+
+
+# ─── ctx kwarg bypasses load_picker_context ─────────────────────────────
+
+
+def test_ctx_kwarg_bypasses_load(isolated_home, monkeypatch):
+    from hermes_cli import inventory
+
+    sentinel: list[str] = []
+
+    def _spy():
+        sentinel.append("called")
+        return inventory.ConfigContext("", "", "", {}, [])
+
+    monkeypatch.setattr(inventory, "load_picker_context", _spy)
+    custom = inventory.ConfigContext("openrouter", "x/y", "", {}, [])
+    inventory.build_payload("models", ctx=custom, include_unconfigured=True, offline=True)
+    assert sentinel == [], f"load_picker_context called despite ctx kwarg"
+
+
+# ─── Schema invariants ──────────────────────────────────────────────────
+
+
+def test_payload_has_schema_version(isolated_home):
+    from hermes_cli import inventory
+
+    for kind in ("providers", "models", "status"):
+        p = inventory.build_payload(kind, include_unconfigured=True, offline=True)
+        assert p["schema_version"] == 1
+        assert "current" in p
+        assert "providers" in p and isinstance(p["providers"], list)
+
+
+def test_unknown_kind_raises(isolated_home):
+    from hermes_cli import inventory
+
+    with pytest.raises(ValueError, match="unknown kind"):
+        inventory.build_payload("nonsense")
+
+
+def test_unknown_provider_raises(isolated_home):
+    from hermes_cli import inventory
+
+    with pytest.raises(ValueError, match="unknown provider"):
+        inventory.build_payload("models", provider="does-not-exist")
+
+
+# ─── Credential leak negative test ──────────────────────────────────────
+
+
+def test_credential_values_never_appear_in_payload(isolated_home, monkeypatch):
+    """env_vars contains NAMES only; env_vars_present is BOOLEANS only."""
+    from hermes_cli import inventory
+
+    canary = "sk-LEAK-CANARY-DO-NOT-RECORD-89f0a1b2c3d4e5"
+    for var in [
+        "ANTHROPIC_API_KEY",
+        "OPENROUTER_API_KEY",
+        "ARCEEAI_API_KEY",
+        "OPENAI_API_KEY",
+        "NOUS_API_KEY",
+        "GROQ_API_KEY",
+    ]:
+        monkeypatch.setenv(var, canary)
+
+    for kind in ("providers", "models", "status"):
+        payload = inventory.build_payload(kind, include_unconfigured=True, offline=True)
+        s = inventory.dump_json(payload)
+        assert canary not in s, f"credential leaked into {kind!r} payload"
+
+
+# ─── Universe: must iterate CANONICAL_PROVIDERS ─────────────────────────
+
+
+def test_universe_iterates_canonical_providers(isolated_home):
+    """``providers list --all --offline`` returns >= every CANONICAL slug."""
+    from hermes_cli import inventory
+    from hermes_cli.models import CANONICAL_PROVIDERS
+
+    payload = inventory.build_payload(
+        "providers", include_unconfigured=True, offline=True
+    )
+    canonical_slugs = {p.slug for p in CANONICAL_PROVIDERS}
+    payload_slugs = {r["slug"] for r in payload["providers"] if not r.get("is_user_defined")}
+    missing = canonical_slugs - payload_slugs
+    assert not missing, f"missing canonical providers: {missing}"
+    # The two legacy registry-only providers must appear.
+    assert "lmstudio" in payload_slugs
+    assert "tencent-tokenhub" in payload_slugs
+
+
+# ─── Renderers smoke ────────────────────────────────────────────────────
+
+
+def test_render_text_smoke(isolated_home):
+    from hermes_cli import inventory
+
+    p1 = inventory.build_payload("providers", include_unconfigured=True, offline=True)
+    p2 = inventory.build_payload("models", provider="openrouter", offline=True)
+    p3 = inventory.build_payload("status", offline=True)
+    assert "SLUG" in inventory.render_text(p1, "providers")
+    assert "PROVIDER" in inventory.render_text(p2, "models")
+    assert "PROVIDER" in inventory.render_text(p3, "status")
+
+
+def test_dump_json_round_trips(isolated_home):
+    import json
+    from hermes_cli import inventory
+
+    p = inventory.build_payload("providers", include_unconfigured=True, offline=True)
+    parsed = json.loads(inventory.dump_json(p))
+    assert parsed["schema_version"] == 1
+    assert len(parsed["providers"]) == len(p["providers"])
+
+
+# ─── Web-server / TUI consumer parity (the consolidation contract) ──────
+
+
+def test_web_server_payload_preserves_list_authenticated_providers_shape(
+    isolated_home, monkeypatch
+):
+    """``build_payload('models', ctx=ctx, max_models=50)`` (web_server consumer)
+    returns the same row set + order as the OLD direct
+    ``list_authenticated_providers`` call. Required dashboard contract
+    fields are preserved with original values.
+    """
+    from hermes_cli import inventory, model_switch
+
+    fixture = [
+        {
+            "slug": "openrouter", "name": "OpenRouter",
+            "is_current": True, "is_user_defined": False,
+            "models": ["anthropic/claude-opus-4.7"], "total_models": 1,
+            "source": "models.dev",
+        },
+        {
+            "slug": "anthropic", "name": "Anthropic",
+            "is_current": False, "is_user_defined": False,
+            "models": ["claude-opus-4-7"], "total_models": 1,
+            "source": "built-in",
+        },
+    ]
+    monkeypatch.setattr(
+        model_switch, "list_authenticated_providers",
+        lambda **_: [dict(r) for r in fixture],
+    )
+    payload = inventory.build_payload("models", max_models=50)
+    assert [r["slug"] for r in payload["providers"]] == [r["slug"] for r in fixture]
+    for got, want in zip(payload["providers"], fixture):
+        for f in ("slug", "name", "is_current", "is_user_defined",
+                  "models", "total_models", "source"):
+            assert got[f] == want[f], f"{got['slug']}: {f} drifted"
+
+
+def test_tui_consumer_payload_has_picker_hints_on_every_row(
+    isolated_home, monkeypatch
+):
+    """TUI ``model.options`` consumer pattern:
+    ``build_payload('models', include_unconfigured=True, picker_hints=True,
+    canonical_order=True)``. EVERY row must carry ``authenticated``.
+    """
+    from hermes_cli import inventory, model_switch
+
+    fixture = [
+        {
+            "slug": "openrouter", "name": "OpenRouter",
+            "is_current": False, "is_user_defined": False,
+            "models": ["x"], "total_models": 1, "source": "built-in",
+        },
+    ]
+    monkeypatch.setattr(
+        model_switch, "list_authenticated_providers",
+        lambda **_: [dict(r) for r in fixture],
+    )
+    payload = inventory.build_payload(
+        "models", include_unconfigured=True,
+        picker_hints=True, canonical_order=True, max_models=50,
+    )
+    for r in payload["providers"]:
+        assert "authenticated" in r, f"{r['slug']} missing authenticated"
+
+
+# ─── TUI live-path contract canary ──────────────────────────────────────
+
+
+def test_live_path_does_not_call_models_for(isolated_home, monkeypatch):
+    """TUI/dashboard contract: ``model.options`` must NOT call ``_models_for``
+    per row in the live path.
+
+    ``list_authenticated_providers`` already populates each row's
+    ``models`` with the picker-curated list. Calling ``_models_for`` again
+    would either (a) double the live HTTP/OAuth work per invocation, or
+    (b) for some providers (Nous), pull non-agentic models — TTS,
+    embeddings, rerankers, image/video generators (see longstanding
+    warning in tui_gateway/server.py).
+
+    Strategy: spy on ``_models_for`` (the post-processing hook that COULD
+    refill rows) and assert it fires zero times on the live ``kind="models"``
+    path with ``include_unconfigured=True`` (the TUI's exact call shape).
+    """
+    from hermes_cli import inventory
+
+    spy_calls: list[str] = []
+    real = inventory._models_for
+
+    def _spy(slug, *, live):
+        spy_calls.append(slug)
+        return real(slug, live=live)
+
+    monkeypatch.setattr(inventory, "_models_for", _spy)
+
+    inventory.build_payload(
+        "models",
+        include_unconfigured=True,
+        picker_hints=True,
+        canonical_order=True,
+        max_models=50,
+    )
+
+    assert spy_calls == [], (
+        f"_models_for called {spy_calls} from build_payload live path. "
+        "list_authenticated_providers should have populated models already; "
+        "refilling would pull non-agentic models (TTS/embeddings) on Nous "
+        "and double live HTTP work elsewhere. See tui_gateway/server.py "
+        "longstanding warning."
+    )
+
+
+# ─── model.save_key migration coverage ──────────────────────────────────
+
+
+def test_save_key_migration_returns_populated_row(isolated_home, monkeypatch):
+    """``model.save_key`` (in tui_gateway) calls ``build_payload("models",
+    ctx=…, picker_hints=True)`` after persisting a key, and looks up the
+    saved slug in the result. This test verifies the build_payload
+    contract that backs that handler:
+
+      1. A slug present in ``list_authenticated_providers``'s output IS
+         present in the payload's providers list (no off-by-name lookup).
+      2. The matched row carries ``models`` populated from the
+         list_authenticated_providers response (not stripped or replaced).
+      3. ``picker_hints=True`` adds ``authenticated`` per row, including
+         the freshly-saved one.
+    """
+    from hermes_cli import inventory, model_switch
+
+    fake_authed = [
+        {
+            "slug": "anthropic",
+            "name": "Anthropic",
+            "is_current": False,
+            "is_user_defined": False,
+            "models": ["claude-opus-4-7", "claude-sonnet-4-6"],
+            "total_models": 2,
+            "source": "built-in",
+        }
+    ]
+    monkeypatch.setattr(
+        model_switch, "list_authenticated_providers", lambda **kw: fake_authed
+    )
+
+    payload = inventory.build_payload(
+        "models", include_unconfigured=True, picker_hints=True, max_models=50
+    )
+
+    # save_key handler does: next((p for p in providers if p["slug"] == slug), None)
+    # against this exact payload shape. Verify the saved-slug lookup works.
+    matched = next(
+        (p for p in payload["providers"] if p["slug"] == "anthropic"), None
+    )
+    assert matched is not None, (
+        "save_key's next(... slug == saved_slug ...) lookup would return "
+        "None for a slug that IS in list_authenticated_providers's output"
+    )
+    assert matched["models"] == ["claude-opus-4-7", "claude-sonnet-4-6"], (
+        "build_payload stripped models from the live row; save_key would "
+        "return an empty model list to the TUI even when the key is valid"
+    )
+    assert matched["total_models"] == 2
+    assert matched["authenticated"] is True, (
+        "picker_hints=True must set authenticated for every configured row"
+    )

--- a/tests/hermes_cli/test_inventory_cli.py
+++ b/tests/hermes_cli/test_inventory_cli.py
@@ -1,0 +1,136 @@
+"""E2E subprocess tests for ``hermes models``/``hermes providers`` CLI."""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+
+import pytest
+
+
+HERMES = shutil.which("hermes")
+
+pytestmark = pytest.mark.skipif(
+    HERMES is None,
+    reason="`hermes` console script not on PATH; install with `pip install -e .`",
+)
+
+
+@pytest.fixture
+def clean_env(tmp_path):
+    h = tmp_path / "hermes_home"
+    h.mkdir()
+    env = os.environ.copy()
+    env["HERMES_HOME"] = str(h)
+    env.pop("PYTHONPATH", None)  # don't shadow the worktree install
+    for var in [
+        "ARCEEAI_API_KEY",
+        "ARCEE_API_KEY",
+        "ANTHROPIC_API_KEY",
+        "ANTHROPIC_TOKEN",
+        "CLAUDE_CODE_OAUTH_TOKEN",
+        "OPENAI_API_KEY",
+        "OPENROUTER_API_KEY",
+        "NOUS_API_KEY",
+        "GH_TOKEN",
+        "COPILOT_GITHUB_TOKEN",
+        "DEEPSEEK_API_KEY",
+        "GLM_API_KEY",
+        "ZAI_API_KEY",
+        "STEPFUN_API_KEY",
+        "GMI_API_KEY",
+        "TOGETHER_API_KEY",
+        "FIREWORKS_API_KEY",
+        "GROQ_API_KEY",
+        "GOOGLE_API_KEY",
+        "QWEN_API_KEY",
+        "MOONSHOT_API_KEY",
+        "MINIMAX_API_KEY",
+        "BEDROCK_API_KEY",
+        "CEREBRAS_API_KEY",
+        "VERCEL_API_KEY",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "AWS_PROFILE",
+    ]:
+        env.pop(var, None)
+    return env
+
+
+def _run(args: list[str], env: dict, timeout: int = 30) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [HERMES, *args], env=env, capture_output=True, text=True, timeout=timeout
+    )
+
+
+def test_providers_list_offline_all_json(clean_env):
+    r = _run(["providers", "list", "--offline", "--all", "--json"], clean_env)
+    assert r.returncode == 0, r.stderr
+    data = json.loads(r.stdout)
+    assert data["schema_version"] == 1
+    assert len(data["providers"]) >= 35  # CANONICAL_PROVIDERS universe
+
+
+def test_models_list_openrouter_offline_uses_constant(clean_env):
+    """H3 regression via CLI: openrouter offline must match OPENROUTER_MODELS."""
+    from hermes_cli.models import OPENROUTER_MODELS
+
+    r = _run(
+        ["models", "list", "--provider=openrouter", "--offline", "--json"],
+        clean_env,
+    )
+    assert r.returncode == 0, r.stderr
+    data = json.loads(r.stdout)
+    assert data["providers"][0]["total_models"] == len(OPENROUTER_MODELS)
+
+
+def test_models_list_unknown_provider_exits_2(clean_env):
+    r = _run(["models", "list", "--provider=does-not-exist"], clean_env)
+    assert r.returncode == 2
+    assert "unknown provider" in r.stderr.lower()
+
+
+def test_models_missing_subcommand_exits_2(clean_env):
+    r = _run(["models"], clean_env)
+    assert r.returncode == 2
+
+
+def test_models_unknown_subcommand_exits_2(clean_env):
+    r = _run(["models", "foo"], clean_env)
+    assert r.returncode == 2
+
+
+def test_providers_missing_subcommand_exits_2(clean_env):
+    r = _run(["providers"], clean_env)
+    assert r.returncode == 2
+
+
+def test_status_offline_returns_unconfigured_baseline(clean_env):
+    """In a clean env, no providers should be configured."""
+    r = _run(["models", "status", "--offline", "--json"], clean_env)
+    assert r.returncode == 0, r.stderr
+    data = json.loads(r.stdout)
+    # arcee is the canonical clean-baseline target (single env var, no
+    # auth_store seeding) — guaranteed unconfigured here.
+    arcee = next((r for r in data["providers"] if r["slug"] == "arcee"), None)
+    assert arcee is not None
+    assert arcee["auth_state"] == "unconfigured"
+
+
+def test_arcee_env_var_flips_to_configured(clean_env):
+    """H6 regression via CLI: ARCEEAI_API_KEY env var → auth_state=configured."""
+    clean_env["ARCEEAI_API_KEY"] = "test-canary"
+    r = _run(["providers", "list", "--all", "--offline", "--json"], clean_env)
+    assert r.returncode == 0, r.stderr
+    data = json.loads(r.stdout)
+    arcee = next((r for r in data["providers"] if r["slug"] == "arcee"), None)
+    assert arcee is not None and arcee["auth_state"] == "configured"
+
+
+def test_text_renderers_smoke(clean_env):
+    r = _run(["providers", "list", "--offline", "--all"], clean_env)
+    assert r.returncode == 0, r.stderr
+    assert "SLUG" in r.stdout
+    assert "providers configured" in r.stdout

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -5156,92 +5156,37 @@ def _(rid, params: dict) -> dict:
 @method("model.options")
 def _(rid, params: dict) -> dict:
     try:
-        from hermes_cli.model_switch import list_authenticated_providers
-        from hermes_cli.models import CANONICAL_PROVIDERS, _PROVIDER_LABELS
+        from hermes_cli.inventory import build_payload, load_picker_context
 
         session = _sessions.get(params.get("session_id", ""))
         agent = session.get("agent") if session else None
-        cfg = _load_cfg()
-        current_provider = getattr(agent, "provider", "") or ""
-        current_model = getattr(agent, "model", "") or _resolve_model()
-        current_base_url = getattr(agent, "base_url", "") or ""
-        # list_authenticated_providers already populates each provider's
-        # "models" with the curated list (same source as `hermes model` and
-        # classic CLI's /model picker). Do NOT overwrite with live
-        # provider_model_ids() — that bypasses curation and pulls in
-        # non-agentic models (e.g. Nous /models returns ~400 IDs including
-        # TTS, embeddings, rerankers, image/video generators).
-        user_provs = (
-            cfg.get("providers") if isinstance(cfg.get("providers"), dict) else {}
+
+        # Layer agent-session state on top of disk config — the agent owns
+        # the live provider/model/base_url once spawned. _resolve_model()
+        # is the existing fallback when no agent is active yet.
+        ctx = load_picker_context().with_overrides(
+            current_provider=getattr(agent, "provider", "") if agent else "",
+            current_model=(
+                getattr(agent, "model", "") if agent else ""
+            ) or _resolve_model(),
+            current_base_url=getattr(agent, "base_url", "") if agent else "",
         )
-        custom_provs = (
-            cfg.get("custom_providers")
-            if isinstance(cfg.get("custom_providers"), list)
-            else []
+        # picker_hints + canonical_order layer the TUI's required shape
+        # (authenticated/auth_type/key_env/warning per row, CANONICAL_PROVIDERS
+        # ordering). Curated model lists are preserved — provider_model_ids
+        # is NOT called per row (that would pull non-agentic models like
+        # TTS/embeddings/etc.).
+        payload = build_payload(
+            "models", ctx=ctx,
+            include_unconfigured=True, picker_hints=True,
+            canonical_order=True, max_models=50,
         )
-        authenticated = list_authenticated_providers(
-            current_provider=current_provider,
-            current_base_url=current_base_url,
-            current_model=current_model,
-            user_providers=user_provs,
-            custom_providers=custom_provs,
-            max_models=50,
-        )
-
-        # Mark authenticated providers and build lookup by slug
-        authed_map: dict = {}
-        authed_extra: list = []  # user-defined/custom not in CANONICAL_PROVIDERS
-        canonical_slugs = {e.slug for e in CANONICAL_PROVIDERS}
-        for p in authenticated:
-            p["authenticated"] = True
-            authed_map[p["slug"]] = p
-            if p["slug"] not in canonical_slugs:
-                authed_extra.append(p)
-
-        # Build final list in CANONICAL_PROVIDERS order, merging auth data
-        from hermes_cli.auth import PROVIDER_REGISTRY as _auth_reg
-
-        ordered: list = []
-        for entry in CANONICAL_PROVIDERS:
-            if entry.slug in authed_map:
-                ordered.append(authed_map[entry.slug])
-            else:
-                pconfig = _auth_reg.get(entry.slug)
-                auth_type = pconfig.auth_type if pconfig else "api_key"
-                key_env = (
-                    pconfig.api_key_env_vars[0]
-                    if (pconfig and pconfig.api_key_env_vars)
-                    else ""
-                )
-                if auth_type == "api_key" and key_env:
-                    warning = f"paste {key_env} to activate"
-                else:
-                    warning = f"run `hermes model` to configure ({auth_type})"
-                ordered.append(
-                    {
-                        "slug": entry.slug,
-                        "name": _PROVIDER_LABELS.get(entry.slug, entry.label),
-                        "is_current": entry.slug == current_provider,
-                        "is_user_defined": False,
-                        "models": [],
-                        "total_models": 0,
-                        "source": "built-in",
-                        "authenticated": False,
-                        "auth_type": auth_type,
-                        "key_env": key_env,
-                        "warning": warning,
-                    }
-                )
-
-        # Append user-defined/custom providers not in canonical list
-        ordered.extend(authed_extra)
-
         return _ok(
             rid,
             {
-                "providers": ordered,
-                "model": current_model,
-                "provider": current_provider,
+                "providers": payload["providers"],
+                "model": ctx.current_model,
+                "provider": ctx.current_provider,
             },
         )
     except Exception as e:
@@ -5262,7 +5207,7 @@ def _(rid, params: dict) -> dict:
     try:
         from hermes_cli.auth import PROVIDER_REGISTRY
         from hermes_cli.config import is_managed, save_env_value
-        from hermes_cli.model_switch import list_authenticated_providers
+        from hermes_cli.inventory import build_payload, load_picker_context
 
         slug = (params.get("slug") or "").strip()
         api_key = (params.get("api_key") or "").strip()
@@ -5288,43 +5233,32 @@ def _(rid, params: dict) -> dict:
         # Save the key to ~/.hermes/.env
         env_var = pconfig.api_key_env_vars[0]
         save_env_value(env_var, api_key)
-        # Also set in current process so list_authenticated_providers sees it
+        # Also set in current process so the refreshed inventory sees it.
         import os
 
         os.environ[env_var] = api_key
 
-        # Refresh provider data
-        cfg = _load_cfg()
+        # Refresh provider data via the shared inventory builder so this
+        # surface stays in lock-step with model.options + dashboard
+        # /api/model/options. picker_hints=True ensures the returned row
+        # carries `authenticated` for the TUI frontend.
         session = _sessions.get(params.get("session_id", ""))
         agent = session.get("agent") if session else None
-        current_provider = getattr(agent, "provider", "") or ""
-        current_model = getattr(agent, "model", "") or _resolve_model()
-        current_base_url = getattr(agent, "base_url", "") or ""
-
-        providers = list_authenticated_providers(
-            current_provider=current_provider,
-            current_base_url=current_base_url,
-            current_model=current_model,
-            user_providers=(
-                cfg.get("providers") if isinstance(cfg.get("providers"), dict) else {}
-            ),
-            custom_providers=(
-                cfg.get("custom_providers")
-                if isinstance(cfg.get("custom_providers"), list)
-                else []
-            ),
-            max_models=50,
+        ctx = load_picker_context().with_overrides(
+            current_provider=getattr(agent, "provider", "") if agent else "",
+            current_model=(
+                getattr(agent, "model", "") if agent else ""
+            ) or _resolve_model(),
+            current_base_url=getattr(agent, "base_url", "") if agent else "",
         )
-
-        # Find the newly-authenticated provider
-        provider_data = None
-        for p in providers:
-            if p["slug"] == slug:
-                provider_data = p
-                break
-
-        if not provider_data:
-            # Key was saved but provider didn't appear — still return success
+        payload = build_payload(
+            "models", ctx=ctx, picker_hints=True, max_models=50,
+        )
+        provider_data = next(
+            (p for p in payload["providers"] if p["slug"] == slug), None
+        )
+        if provider_data is None:
+            # Key was saved but provider didn't appear — still return success.
             provider_data = {
                 "slug": slug,
                 "name": pconfig.name,
@@ -5333,7 +5267,8 @@ def _(rid, params: dict) -> dict:
                 "total_models": 0,
                 "authenticated": True,
             }
-
+        # picker_hints sets `authenticated` from auth_state, but the synthetic
+        # fallback above doesn't go through that path.
         provider_data["authenticated"] = True
         return _ok(rid, {"provider": provider_data})
     except Exception as e:

--- a/website/docs/reference/cli-commands.md
+++ b/website/docs/reference/cli-commands.md
@@ -194,6 +194,90 @@ If you've only configured OpenRouter, `/model` will only show OpenRouter models.
 
 Provider and base URL changes are persisted to `config.yaml` automatically. When switching away from a custom endpoint, the stale base URL is cleared to prevent it leaking into other providers.
 
+## `hermes models` and `hermes providers`
+
+Non-interactive scriptable inventory commands for cron, CI, dashboards, or
+agents introspecting their own environment. These do **not** replace
+`hermes model` (the interactive picker) — they expose the same data the
+picker / dashboard / TUI already use, in JSON-friendly form, sharing a
+single source of truth (`hermes_cli/inventory.py`).
+
+```bash
+hermes models list   [--provider NAME] [--json] [--all] [--no-live] [--offline]
+hermes models status [--provider NAME] [--json]                     [--offline]
+hermes providers list                  [--json] [--all]             [--offline]
+```
+
+**Modes:**
+
+- **default** — same network behaviour as the picker / dashboard. Returns
+  configured providers only (live API + cached models.dev catalog).
+- **`--all`** — also include unconfigured providers (universe = ~35 canonical
+  providers). No-op when `--provider` is set.
+- **`--no-live`** (`models list` only) — skip per-provider live API discovery;
+  show curated / fallback model lists only. `models.dev` cache may still be
+  consulted.
+- **`--offline`** — fully offline: no `models.dev`, no provider HTTP, no
+  remote catalog fetches, no credential pool / external auth-store probes.
+  Auth state is derived from environment variables alone. Best for cron / CI
+  / scripts that should not block on the network.
+
+A reachability-probe flag (`--probe`) for `models status` is tracked
+separately in [#23614](https://github.com/NousResearch/hermes-agent/issues/23614).
+
+**JSON shape:**
+
+```json
+{
+  "schema_version": 1,
+  "current": {"provider": "...", "model": "..."},
+  "providers": [
+    {
+      "slug": "anthropic",
+      "name": "Anthropic",
+      "is_current": false,
+      "is_user_defined": false,
+      "auth_state": "configured",
+      "api_mode": "anthropic_messages",
+      "auth_type": "api_key",
+      "base_url": "https://api.anthropic.com",
+      "env_vars": ["ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "..."],
+      "env_vars_present": [true, false, false],
+      "models": ["claude-opus-4-7", "..."],
+      "total_models": 8,
+      "source": "canonical",
+      "model_source": "curated"
+    }
+  ]
+}
+```
+
+`env_vars` lists the variable **names** the provider accepts (including
+[`HERMES_OVERLAYS`](https://github.com/NousResearch/hermes-agent/blob/main/hermes_cli/providers.py)
+bridges — e.g. OpenRouter accepts `OPENAI_API_KEY`).
+`env_vars_present` is the corresponding `bool` array. **Values are never
+included in the payload.**
+
+**Examples:**
+
+```bash
+# Cron-safe inventory snapshot
+hermes providers list --offline --all --json | jq '.providers[] | select(.auth_state=="configured") | .slug'
+
+# What models can I switch to right now?
+hermes models list --json | jq '.providers[] | {slug, total_models, current: .is_current}'
+
+# Verify a provider's auth before a batch
+hermes models status --provider=openrouter --json | jq '.providers[0].auth_state'
+
+# List curated models without hitting the network
+hermes models list --provider=anthropic --offline --json | jq '.providers[0].models'
+```
+
+`hermes models list` and `hermes providers list` exit `0` when the inventory
+was built (even if zero providers are configured). Unknown provider, missing
+subcommand, or unknown subcommand exits `2` with an explanatory message.
+
 ## `hermes gateway`
 
 ```bash


### PR DESCRIPTION
## What this PR does

Adds three scriptable, non-interactive CLI surfaces and **consolidates four existing inventory call-sites onto a single source of truth**:

```
hermes models list   [--provider NAME] [--json] [--all] [--no-live] [--offline]
hermes models status [--provider NAME] [--json]                     [--offline]
hermes providers list                  [--json] [--all]             [--offline]
```

Closes #23359 (jointly with #3503 once that PR migrates to consume the shared formatter).

The new `hermes_cli/inventory.py` module (600 LOC) is the single source of truth for inventory traversal. The dashboard (`/api/model/options`), TUI (`model.options` JSON-RPC), and TUI (`model.save_key` JSON-RPC) have been migrated to consume it, dropping ~140 lines of duplicated config-load / canonical-merge / picker-hint logic across the three consumer files. `--offline` mode synthesises from in-repo static data so cron and CI callers don't block on the network.

A reachability-probe surface (`--probe` for `models status`) is tracked separately in **#23614** — `provider_model_ids()` falls back to curated lists, so a true reachability check needs an explicit endpoint probe that isn't wired through the existing model-discovery wrapper.

## Why

Hermes had **four** independent ways to list providers/models — each interactive (TTY required) or HTTP (gateway running), each reproducing the same five-step config dance, and each post-processing the result a slightly different way. There was no scriptable / cron-friendly entry point.

| Surface | Before | After |
|---|---|---|
| Interactive picker (`cli.py`) | `list_authenticated_providers` directly | (unchanged) |
| Dashboard (`/api/model/options`) | Inline 17-line config dance + raw `cfg.get("custom_providers")` (which **misses v12+ keyed providers — bug fix**) + `list_authenticated_providers` | `inventory.build_payload("models", ctx=load_picker_context(), max_models=50)` |
| TUI (`model.options` JSON-RPC) | Inline 17-line config dance + `list_authenticated_providers` + 45-line canonical-merge / picker-hint post-processing | `inventory.build_payload("models", ctx, picker_hints=True, canonical_order=True)` with `with_overrides()` for agent-session state |
| TUI (`model.save_key` JSON-RPC) | Inline `list_authenticated_providers` + slug match | `inventory.build_payload("models", ctx, picker_hints=True)` then slug match |
| **NEW: scriptable CLI** | (didn't exist) | `hermes models list/status` + `hermes providers list` |

Five open PRs have each reinvented the same traversal for one narrow purpose: #3503 (`/models` slash), #21695 (plugin provider runtime resolver), #19526 (`model.picker_mode`), #17994 (`/free-models`), #21785 (`hermes doctor` skip-by-endpoint). Each adds ~50-150 LOC of inventory walking. Now they have a single helper to consume.

Full motivation, pain points, and ecosystem evidence in tracking issue **#23359**.

## What this PR is NOT doing

- **Not** refactoring `list_authenticated_providers` — only delegating to it. No behaviour change.
- **Not** changing the existing `hermes model` interactive picker.
- **Not** adding write-side symmetry for `hermes model` → `providers.<slug>.models` — that's #16622 (separate ~50 LOC follow-up).
- **Not** implementing `model.allowlist` / `model.picker_mode` — that's #19526.
- **Not** adding model-discovery for built-in providers — that's #13055 / #21695.
- **Not** adding a reachability-probe — that's #23614.

## Modes / network behaviour

| Flag | `models.dev` HTTP | Per-provider live HTTP |
|---|---|---|
| (default) | ✓ via cache | ✓ for configured providers |
| `--no-live` (`models list` only) | ✓ via cache | ✗ |
| `--offline` | ✗ | ✗ |

`--offline` bypasses `list_authenticated_providers` entirely and synthesises inventory from `CANONICAL_PROVIDERS` (universe of ~35) + `_PROVIDER_MODELS` (curated) + `OPENROUTER_MODELS` (local constant) + `profile.fallback_models`. Auth state is derived from environment variables alone — `profile.env_vars` ∪ `PROVIDER_REGISTRY[slug].api_key_env_vars` ∪ `HERMES_OVERLAYS[slug].extra_env_vars`. **No** consultation of `auth.json`, credential pool, Claude Code creds, or Hermes OAuth files.

## Public API exposed by `hermes_cli/inventory.py`

```python
load_picker_context() -> ConfigContext
    # Replaces the 17-LOC config dance in dashboard / TUI / picker.

ConfigContext.with_overrides(*, current_provider, current_model, current_base_url) -> ConfigContext
    # Layer agent-session state on top of disk config (TUI override path).

build_payload(kind, *, ctx=None, provider=None, include_unconfigured=False,
              live=True, offline=False, picker_hints=False,
              canonical_order=False, max_models=50) -> dict
    # kind ∈ {"models", "status", "providers"}
```

Optional flags:
- `ctx` — pre-loaded context, bypassing `load_picker_context()` (TUI override path).
- `picker_hints=True` — adds `authenticated` per row, plus `auth_type` / `key_env` / `warning` for unconfigured canonical rows (the dashboard frontend's `ModelPickerDialog` shape).
- `canonical_order=True` — reorder rows to `CANONICAL_PROVIDERS` declaration order (TUI display order).

`authenticated` is **only** emitted under `picker_hints=True`. Default scriptable shape uses `auth_state: "configured" | "unconfigured"` exclusively — clean schema for cron/CI scripts.

## JSON contract (default scriptable shape)

```json
{
  "schema_version": 1,
  "current": {"provider": "openrouter", "model": "anthropic/claude-sonnet-4.6"},
  "providers": [
    {
      "slug": "anthropic",
      "name": "Anthropic",
      "is_current": false,
      "is_user_defined": false,
      "auth_state": "configured",
      "api_mode": "anthropic_messages",
      "auth_type": "api_key",
      "base_url": "https://api.anthropic.com",
      "env_vars": ["ANTHROPIC_API_KEY", "ANTHROPIC_TOKEN", "CLAUDE_CODE_OAUTH_TOKEN"],
      "env_vars_present": [true, false, false],
      "models": ["claude-opus-4-7", "..."],
      "total_models": 8,
      "source": "canonical",
      "model_source": "curated"
    }
  ]
}
```

`env_vars` lists variable **names** (including HERMES_OVERLAYS bridges — e.g. OpenRouter accepts `OPENAI_API_KEY`). `env_vars_present` is the corresponding `bool` array. **Values are never included in the payload** — explicit invariant; canary-tested.

## Substrate gotchas the implementation respects

These are documented in `references/provider-inventory-surface.md` (hermes-agent-dev skill) and were each verified against `main` before implementation:

1. **Four registries don't fully overlap.** Inventory iterates `CANONICAL_PROVIDERS` (the universe, ~35).
2. **`profile.fetch_models()` returns models the runtime rejects.** OpenRouter raw=367 vs picker=34. Module never calls it directly. Canary test enforces.
3. **Custom providers split across two config shapes.** Module reads via `get_compatible_custom_providers(config)` — fixes a latent bug in dashboard's `/api/model/options` (was missing v12+ keyed entries).
4. **OpenRouter offline gotcha.** `_PROVIDER_MODELS["openrouter"]` is `None`; module uses `OPENROUTER_MODELS` constant. ~31 entries, no HTTP. Canary asserts equality against the constant length.
5. **CLI exit-code propagation.** `hermes_cli/main.py:11688` does `args.func(args)` and discards the return value. Handlers use `parser.error()` / `required=True` / `SystemExit(2)` instead of `return 2`.
6. **TUI contract preserved: `model.options` does NOT call `provider_model_ids` per-row in the live path.** That would pull non-agentic models (TTS, embeddings). Canary test (`test_live_path_does_not_call_models_for`) enforces.
7. **`model.save_key` migration verified.** `build_payload("models", picker_hints=True)` returns the freshly-keyed slug with populated models. Canary test (`test_save_key_migration_returns_populated_row`) enforces.
8. **Anthropic credential discovery has 5+ paths.** A clean-env E2E asserting "anthropic is unconfigured" can fail on dev machines with Claude Code installed. E2E uses `arcee` (single env var, no extras) as the canonical clean-baseline target.

## Tests

| File | Tests | What |
|---|---:|---|
| `tests/hermes_cli/test_inventory.py` | 32 | Three concept canaries (no models.dev / no provider HTTP / status HTTP-free) + H2-H6 + W1 regressions + alias canonicalisation + universe assertions + schema/mutex + consumer-shape parity (web_server + TUI) + **TUI live-path canary** + **save_key migration canary** |
| `tests/hermes_cli/test_inventory_cli.py` | 9 | Subprocess E2E via `hermes` console script |
| `tests/test_tui_gateway_server.py::test_model_options_does_not_overwrite_curated_models` | 1 | Existing test, still passes (TUI contract gate) |

Concept B canary monkeypatches every per-provider live-fetch helper (`fetch_anthropic_models`, `fetch_openrouter_models`, `fetch_ai_gateway_models`, `fetch_ollama_cloud_models`, `fetch_lmstudio_models`, `_fetch_github_models`, `fetch_api_models`, `fetch_nous_models`, `fetch_models_dev`, `model_ids`, `get_curated_nous_model_ids`, `bedrock_model_ids_or_none`, `list_authenticated_providers`) to fail-on-call, then asserts none fire when `--offline` is passed.

The TUI contract canary monkeypatches `_models_for` and asserts it fires zero times in the live path with `picker_hints=True, canonical_order=True` (the TUI's exact call shape) — guaranteeing `build_payload` doesn't pull non-agentic models when consumed via `model.options`.

The save_key migration canary monkeypatches `list_authenticated_providers` to return a fake row, then asserts the saved slug is found in `build_payload`'s output with populated models — locking the contract `tui_gateway/server.py:5247-5256` relies on.

```
$ pytest tests/hermes_cli/test_inventory.py tests/hermes_cli/test_inventory_cli.py \
        tests/test_tui_gateway_server.py::test_model_options_does_not_overwrite_curated_models -q
42 passed in 5.8s
```

Full `tests/hermes_cli/` + `tests/test_tui_gateway_server.py`: 13 pre-existing failures verified to fail identically on `origin/main` (gateway systemd / WSL / kanban / plugins / web-server auth / update hangup / browser launch hint — none related to this PR).

## Lint diff

```
ruff — Total: 0 on HEAD, 0 on base (➖ 0)  🆕 New issues: none
ty   — 0 issues in hermes_cli/inventory.py
```

## Files changed

```
hermes_cli/inventory.py                | 600 +++++++++++++++++++ (new, single source of truth)
hermes_cli/main.py                     |  89 ++ (subparsers + 3 handlers + #23614 TODO marker)
hermes_cli/web_server.py               |  36 +- (-29 net: migrated to inventory)
tui_gateway/server.py                  | 155 +- (migrated model.options + model.save_key)
tests/hermes_cli/test_inventory.py     | 678 ++++ (new)
tests/hermes_cli/test_inventory_cli.py | 136 ++ (new)
website/docs/reference/cli-commands.md |  84 +++
7 files changed, 1638 insertions(+), 140 deletions(-)
```

Of the 140 lines deleted from web_server.py + tui_gateway/server.py, ~125 were **literal duplicates** of the config dance + canonical merge, now living in one place.

No `setup.py` files. No env-var-value logging (canary-tested). No changes to `list_authenticated_providers`, `provider_model_ids`, or any provider plugin.

## How to verify

```bash
# Universe + offline correctness
hermes providers list --offline --all --json | jq '.providers | length'           # 35
hermes models list --provider=openrouter --offline --json | jq '.providers[0].total_models'   # ≈31

# Default mode (live, same as picker)
hermes providers list --json | jq '.providers | length'                            # configured providers count

# OpenRouter regression check
hermes models list --provider=openrouter --json | jq '.providers[0].total_models'  # ≤50, NOT 367

# Mutex + exit codes
hermes models list --provider=does-not-exist; echo $?   # 2
hermes models foo; echo $?    # 2
hermes providers; echo $?     # 2

# Dashboard / TUI integration: their existing endpoints work unchanged
curl http://localhost:7172/api/model/options | jq '.providers | length'   # ≥1
# (TUI model.options + model.save_key exercised by tests/test_tui_gateway_server.py)
```

## Out of scope (tracked separately)

- **#23614** — `--probe` reachability flag for `models status`. TODO marker added at the argparse site.
- **#16622** — write-side symmetry for `hermes model` → `providers.<slug>.models` (~50 LOC follow-up).
- **Substrate audit** — empirical findings in #23359 (registry overlaps, `profile.fetch_models()` unfiltered, Nous offline gap, `list_authenticated_providers` unconditional fetches) — separate audit issue once this lands.
- **#3503** — `/models` slash unification. After merge, comment proposing migration to `inventory.build_payload`.
- **CLI picker (`hermes model`) consumption.** Interactive-only, has filtering logic (drops empty rows) that doesn't belong on a scriptable surface.

## Refs

- Tracking issue: #23359
- Probe follow-up: #23614
- Substrate: #20324 (merged 2026-05-05)
- Original refactor: #14424
- Issues this helps close: #3500, #13055
- Open PRs that should consume the new surface: #3503, #19526, #21695, #17994, #21785