### PR TITLE
fix(nix): avoid heavyweight Python checks on aarch64-darwin

### DIFF
--- a/nix/python.nix
+++ b/nix/python.nix
@@ -7,11 +7,10 @@
   pyproject-nix,
   pyproject-build-systems,
   stdenv,
-  dependency-groups ? [ "all" ],
-}:
-let
-  workspace = uv2nix.lib.workspace.loadWorkspace { workspaceRoot = ./..; };
-  hacks = callPackage pyproject-nix.build.hacks { };
+  dependency-groups ? ["all"],
+}: let
+  workspace = uv2nix.lib.workspace.loadWorkspace {workspaceRoot = ./..;};
+  hacks = callPackage pyproject-nix.build.hacks {};
 
   overlay = workspace.mkPyprojectOverlay {
     sourcePreference = "wheel";
@@ -23,25 +22,27 @@ let
   # from nixpkgs so wheel-only transitive artifacts do not break evaluation.
   mkPrebuiltPassthru = dependencies: {
     inherit dependencies;
-    optional-dependencies = { };
-    dependency-groups = { };
+    optional-dependencies = {};
+    dependency-groups = {};
   };
 
   mkPrebuiltOverride = final: from: dependencies:
     hacks.nixpkgsPrebuilt {
       inherit from;
       prev = {
-        nativeBuildInputs = [ final.pyprojectHook ];
+        nativeBuildInputs = [final.pyprojectHook];
         passthru = mkPrebuiltPassthru dependencies;
       };
     };
 
   # Legacy alibabacloud packages ship only sdists with setup.py/setup.cfg
   # and no pyproject.toml, so setuptools isn't declared as a build dep.
-  buildSystemOverrides = final: prev: builtins.mapAttrs
-    (name: _: prev.${name}.overrideAttrs (old: {
-      nativeBuildInputs = (old.nativeBuildInputs or [ ]) ++ [ final.setuptools ];
-    }))
+  buildSystemOverrides = final: prev:
+    builtins.mapAttrs
+    (name: _:
+      prev.${name}.overrideAttrs (old: {
+        nativeBuildInputs = (old.nativeBuildInputs or []) ++ [final.setuptools];
+      }))
     (lib.genAttrs [
       "alibabacloud-credentials-api"
       "alibabacloud-endpoint-util"
@@ -50,52 +51,91 @@ let
       "alibabacloud-tea"
     ] (_: null));
 
+  withoutChecks = package:
+    package.overridePythonAttrs (_old: {
+      # These packages are consumed as prebuilt runtime inputs for the uv2nix
+      # environment. On small aarch64-darwin builders, their upstream check
+      # suites either OOM-kill directly (PyAV) or pull heavyweight test stacks
+      # such as transformers/datasets/torch through check-only dependencies.
+      doCheck = false;
+      doInstallCheck = false;
+      nativeCheckInputs = [];
+      checkInputs = [];
+      installCheckInputs = [];
+      pythonImportsCheck = [];
+    });
+
   pythonPackageOverrides = final: _prev:
-    if isAarch64Darwin then {
-      numpy = mkPrebuiltOverride final python312.pkgs.numpy { };
+    if isAarch64Darwin
+    then let
+      numpy = withoutChecks python312.pkgs.numpy;
+      pyarrow = withoutChecks python312.pkgs.pyarrow;
+      av = withoutChecks python312.pkgs.av;
+      humanfriendly = withoutChecks python312.pkgs.humanfriendly;
+      coloredlogs = withoutChecks (python312.pkgs.coloredlogs.override {
+        inherit humanfriendly;
+      });
+      huggingface-hub = withoutChecks python312.pkgs.huggingface-hub;
+      onnxruntime = withoutChecks (python312.pkgs.onnxruntime.override {
+        inherit coloredlogs numpy;
+      });
+      tokenizers = withoutChecks (python312.pkgs.tokenizers.override {
+        inherit huggingface-hub;
+      });
+      ctranslate2 = withoutChecks (python312.pkgs.ctranslate2.override {
+        inherit numpy;
+        torch = null;
+        transformers = null;
+      });
+      faster-whisper = withoutChecks (python312.pkgs.faster-whisper.override {
+        inherit av ctranslate2 huggingface-hub onnxruntime tokenizers;
+      });
+    in {
+      numpy = mkPrebuiltOverride final numpy {};
 
-      pyarrow = mkPrebuiltOverride final python312.pkgs.pyarrow { };
+      pyarrow = mkPrebuiltOverride final pyarrow {};
 
-      av = mkPrebuiltOverride final python312.pkgs.av { };
+      av = mkPrebuiltOverride final av {};
 
-      humanfriendly = mkPrebuiltOverride final python312.pkgs.humanfriendly { };
+      humanfriendly = mkPrebuiltOverride final humanfriendly {};
 
-      coloredlogs = mkPrebuiltOverride final python312.pkgs.coloredlogs {
-        humanfriendly = [ ];
+      coloredlogs = mkPrebuiltOverride final coloredlogs {
+        humanfriendly = [];
       };
 
-      onnxruntime = mkPrebuiltOverride final python312.pkgs.onnxruntime {
-        coloredlogs = [ ];
-        numpy = [ ];
-        packaging = [ ];
+      onnxruntime = mkPrebuiltOverride final onnxruntime {
+        coloredlogs = [];
+        numpy = [];
+        packaging = [];
       };
 
-      ctranslate2 = mkPrebuiltOverride final python312.pkgs.ctranslate2 {
-        numpy = [ ];
-        pyyaml = [ ];
+      ctranslate2 = mkPrebuiltOverride final ctranslate2 {
+        numpy = [];
+        pyyaml = [];
       };
 
-      faster-whisper = mkPrebuiltOverride final python312.pkgs.faster-whisper {
-        av = [ ];
-        ctranslate2 = [ ];
-        huggingface-hub = [ ];
-        onnxruntime = [ ];
-        tokenizers = [ ];
-        tqdm = [ ];
+      faster-whisper = mkPrebuiltOverride final faster-whisper {
+        av = [];
+        ctranslate2 = [];
+        huggingface-hub = [];
+        onnxruntime = [];
+        tokenizers = [];
+        tqdm = [];
       };
-    } else {};
+    }
+    else {};
 
   pythonSet =
     (callPackage pyproject-nix.build.packages {
       python = python312;
     }).overrideScope
-      (lib.composeManyExtensions [
-        pyproject-build-systems.overlays.default
-        overlay
-        buildSystemOverrides
-        pythonPackageOverrides
-      ]);
+    (lib.composeManyExtensions [
+      pyproject-build-systems.overlays.default
+      overlay
+      buildSystemOverrides
+      pythonPackageOverrides
+    ]);
 in
-pythonSet.mkVirtualEnv "hermes-agent-env" {
-  hermes-agent = dependency-groups;
-}
+  pythonSet.mkVirtualEnv "hermes-agent-env" {
+    hermes-agent = dependency-groups;
+  }


### PR DESCRIPTION
## Summary
- disables heavyweight upstream check phases for the aarch64-darwin prebuilt Python packages used by the uv2nix Hermes environment
- removes check-only `torch`/`transformers` inputs from the `ctranslate2` prebuilt package path on aarch64-darwin
- fixes small macOS builders getting SIGKILLed while building the `faster-whisper`/PyAV dependency chain

## Why
On `hermione` (Apple Silicon, low-memory builder), `python3.12-av-16.1.0` built successfully but died in `pythonImportsCheckPhase` with `Killed: 9`. After removing only PyAV import checks, the same package died in `pytestCheckPhase`. After that, the `ctranslate2` check stack pulled in `torch`, `transformers`, `datasets`, and related heavyweight check-only dependencies.

These packages are only being used as runtime prebuilt inputs for the Hermes uv2nix environment. Running the upstream package test suites while importing them into the venv is too expensive on aarch64-darwin and is not necessary for the Hermes package build.

## Validation
- Verified through downstream `jmmaloney4/garden` on `jack@hermione`:
  - `nix build .#darwinConfigurations.hermione.config.services.hermes-agent.package.passthru.hermesVenv -L` passed
  - `nix build .#hermione -L` passed after the garden lockfile pinned this branch plus a jackpkgs spooktacular hash refresh
- Confirmed dry-run no longer includes the check-only `python3.12-torch` path for the Hermes environment.

## Risk
- Scoped to `aarch64-darwin` only.
- Linux and non-aarch64 Darwin builds keep the existing package checks.
- Runtime imports still happen through the final Hermes environment; this only avoids running upstream package check suites while constructing prebuilt inputs.
