### PR TITLE
Harden gateway batch-delay env parsing for Telegram, Discord, and WeCom

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -50,7 +50,11 @@ sys.path.insert(0, str(_Path(__file__).resolve().parents[2]))
 from gateway.config import Platform, PlatformConfig
 import re
 
-from gateway.platforms.helpers import MessageDeduplicator, ThreadParticipationTracker
+from gateway.platforms.helpers import (
+    MessageDeduplicator,
+    ThreadParticipationTracker,
+    safe_float_env,
+)
 from utils import atomic_json_write
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -537,8 +541,14 @@ class DiscordAdapter(BasePlatformAdapter):
         self._voice_clients: Dict[int, Any] = {}  # guild_id -> VoiceClient
         self._voice_locks: Dict[int, asyncio.Lock] = {}  # guild_id -> serialize join/leave
         # Text batching: merge rapid successive messages (Telegram-style)
-        self._text_batch_delay_seconds = float(os.getenv("HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS", "0.6"))
-        self._text_batch_split_delay_seconds = float(os.getenv("HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0"))
+        self._text_batch_delay_seconds = safe_float_env(
+            "HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS",
+            0.6,
+        )
+        self._text_batch_split_delay_seconds = safe_float_env(
+            "HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS",
+            2.0,
+        )
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
         self._voice_text_channels: Dict[int, int] = {}  # guild_id -> text_channel_id

--- a/gateway/platforms/helpers.py
+++ b/gateway/platforms/helpers.py
@@ -8,6 +8,7 @@ and thread participation tracking.
 import asyncio
 import json
 import logging
+import os
 import re
 import time
 from pathlib import Path
@@ -19,6 +20,23 @@ if TYPE_CHECKING:
     from gateway.platforms.base import MessageEvent
 
 logger = logging.getLogger(__name__)
+
+
+def safe_float_env(name: str, default: float) -> float:
+    """Parse a float env var with warning + fallback on malformed values."""
+    raw = os.getenv(name)
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "Invalid %s=%r; falling back to default %.3f",
+            name,
+            raw,
+            default,
+        )
+        return default
 
 
 # ─── Message Deduplication ────────────────────────────────────────────────────

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -63,6 +63,7 @@ from pathlib import Path as _Path
 sys.path.insert(0, str(_Path(__file__).resolve().parents[2]))
 
 from gateway.config import Platform, PlatformConfig
+from gateway.platforms.helpers import safe_float_env
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
@@ -293,15 +294,24 @@ class TelegramAdapter(BasePlatformAdapter):
         self._disable_link_previews: bool = self._coerce_bool_extra("disable_link_previews", False)
         # Buffer rapid/album photo updates so Telegram image bursts are handled
         # as a single MessageEvent instead of self-interrupting multiple turns.
-        self._media_batch_delay_seconds = float(os.getenv("HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS", "0.8"))
+        self._media_batch_delay_seconds = safe_float_env(
+            "HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS",
+            0.8,
+        )
         self._pending_photo_batches: Dict[str, MessageEvent] = {}
         self._pending_photo_batch_tasks: Dict[str, asyncio.Task] = {}
         self._media_group_events: Dict[str, MessageEvent] = {}
         self._media_group_tasks: Dict[str, asyncio.Task] = {}
         # Buffer rapid text messages so Telegram client-side splits of long
         # messages are aggregated into a single MessageEvent.
-        self._text_batch_delay_seconds = float(os.getenv("HERMES_TELEGRAM_TEXT_BATCH_DELAY_SECONDS", "0.6"))
-        self._text_batch_split_delay_seconds = float(os.getenv("HERMES_TELEGRAM_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0"))
+        self._text_batch_delay_seconds = safe_float_env(
+            "HERMES_TELEGRAM_TEXT_BATCH_DELAY_SECONDS",
+            0.6,
+        )
+        self._text_batch_split_delay_seconds = safe_float_env(
+            "HERMES_TELEGRAM_TEXT_BATCH_SPLIT_DELAY_SECONDS",
+            2.0,
+        )
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
         self._polling_error_task: Optional[asyncio.Task] = None

--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -59,7 +59,7 @@ except ImportError:
     httpx = None  # type: ignore[assignment]
 
 from gateway.config import Platform, PlatformConfig
-from gateway.platforms.helpers import MessageDeduplicator
+from gateway.platforms.helpers import MessageDeduplicator, safe_float_env
 from gateway.platforms.base import (
     BasePlatformAdapter,
     MessageEvent,
@@ -178,8 +178,14 @@ class WeComAdapter(BasePlatformAdapter):
 
         # Text batching: merge rapid successive messages (Telegram-style).
         # WeCom clients split long messages around 4000 chars.
-        self._text_batch_delay_seconds = float(os.getenv("HERMES_WECOM_TEXT_BATCH_DELAY_SECONDS", "0.6"))
-        self._text_batch_split_delay_seconds = float(os.getenv("HERMES_WECOM_TEXT_BATCH_SPLIT_DELAY_SECONDS", "2.0"))
+        self._text_batch_delay_seconds = safe_float_env(
+            "HERMES_WECOM_TEXT_BATCH_DELAY_SECONDS",
+            0.6,
+        )
+        self._text_batch_split_delay_seconds = safe_float_env(
+            "HERMES_WECOM_TEXT_BATCH_SPLIT_DELAY_SECONDS",
+            2.0,
+        )
         self._pending_text_batches: Dict[str, MessageEvent] = {}
         self._pending_text_batch_tasks: Dict[str, asyncio.Task] = {}
         self._device_id = uuid.uuid4().hex

--- a/tests/gateway/test_discord_reply_mode.py
+++ b/tests/gateway/test_discord_reply_mode.py
@@ -99,6 +99,15 @@ class TestReplyToModeConfig:
         adapter = DiscordAdapter(config)
         assert adapter._reply_to_mode == "first"
 
+    def test_invalid_batch_delay_envs_fall_back_to_defaults(self, monkeypatch):
+        monkeypatch.setenv("HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS", "nope")
+        monkeypatch.setenv("HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS", "bad")
+
+        adapter = DiscordAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+        assert adapter._text_batch_delay_seconds == 0.6
+        assert adapter._text_batch_split_delay_seconds == 2.0
+
 
 def _make_discord_adapter(reply_to_mode: str = "first"):
     """Create a DiscordAdapter with mocked client and channel for send() tests."""

--- a/tests/gateway/test_telegram_reply_mode.py
+++ b/tests/gateway/test_telegram_reply_mode.py
@@ -77,6 +77,17 @@ class TestReplyToModeConfig:
         adapter = TelegramAdapter(config)
         assert adapter._reply_to_mode == "first"
 
+    def test_invalid_batch_delay_envs_fall_back_to_defaults(self, monkeypatch):
+        monkeypatch.setenv("HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS", "nope")
+        monkeypatch.setenv("HERMES_TELEGRAM_TEXT_BATCH_DELAY_SECONDS", "still-nope")
+        monkeypatch.setenv("HERMES_TELEGRAM_TEXT_BATCH_SPLIT_DELAY_SECONDS", "bad")
+
+        adapter = TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+        assert adapter._media_batch_delay_seconds == 0.8
+        assert adapter._text_batch_delay_seconds == 0.6
+        assert adapter._text_batch_split_delay_seconds == 2.0
+
 
 class TestShouldThreadReply:
     """Tests for _should_thread_reply method."""

--- a/tests/gateway/test_wecom.py
+++ b/tests/gateway/test_wecom.py
@@ -73,6 +73,16 @@ class TestWeComAdapterInit:
         assert adapter._secret == "env-secret"
         assert adapter._ws_url == "wss://env.example/ws"
 
+    def test_invalid_batch_delay_envs_fall_back_to_defaults(self, monkeypatch):
+        monkeypatch.setenv("HERMES_WECOM_TEXT_BATCH_DELAY_SECONDS", "nope")
+        monkeypatch.setenv("HERMES_WECOM_TEXT_BATCH_SPLIT_DELAY_SECONDS", "bad")
+        from gateway.platforms.wecom import WeComAdapter
+
+        adapter = WeComAdapter(PlatformConfig(enabled=True))
+
+        assert adapter._text_batch_delay_seconds == 0.6
+        assert adapter._text_batch_split_delay_seconds == 2.0
+
 
 class TestWeComConnect:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

This hardens gateway adapter startup against malformed batch-delay environment variables.

Previously, these adapters parsed batch-delay env vars with raw `float(...)` calls during initialization:

- `TelegramAdapter`
- `DiscordAdapter`
- `WeComAdapter`

If a user had an invalid value such as `HERMES_TELEGRAM_TEXT_BATCH_DELAY_SECONDS=nope`, the adapter constructor raised `ValueError` and the gateway could fail to start.

This change adds a shared safe parsing helper and falls back to documented defaults with a warning log instead of crashing.

## Changes

- Added `safe_float_env(name, default)` in `gateway/platforms/helpers.py`
- Switched these env reads to use safe fallback parsing:
  - `HERMES_TELEGRAM_MEDIA_BATCH_DELAY_SECONDS`
  - `HERMES_TELEGRAM_TEXT_BATCH_DELAY_SECONDS`
  - `HERMES_TELEGRAM_TEXT_BATCH_SPLIT_DELAY_SECONDS`
  - `HERMES_DISCORD_TEXT_BATCH_DELAY_SECONDS`
  - `HERMES_DISCORD_TEXT_BATCH_SPLIT_DELAY_SECONDS`
  - `HERMES_WECOM_TEXT_BATCH_DELAY_SECONDS`
  - `HERMES_WECOM_TEXT_BATCH_SPLIT_DELAY_SECONDS`
- Added regression tests covering invalid env values for all three adapters

## Why

This matches the repo’s recent hardening pattern for malformed config/env handling:
invalid user-provided values should not crash gateway startup when a safe default is available.

## Testing

Passed targeted regression tests:

- `tests/gateway/test_telegram_reply_mode.py::TestReplyToModeConfig::test_invalid_batch_delay_envs_fall_back_to_defaults`
- `tests/gateway/test_discord_reply_mode.py::TestReplyToModeConfig::test_invalid_batch_delay_envs_fall_back_to_defaults`
- `tests/gateway/test_wecom.py::TestWeComAdapterInit::test_invalid_batch_delay_envs_fall_back_to_defaults`

Result:

- `3 passed`

