### PR TITLE
fix(slack): bound _thread_context_cache with eviction on overflow

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -317,6 +317,7 @@ class SlackAdapter(BasePlatformAdapter):
         # Cache for _fetch_thread_context results: cache_key → _ThreadContextCache
         self._thread_context_cache: Dict[str, _ThreadContextCache] = {}
         self._THREAD_CACHE_TTL = 60.0
+        self._THREAD_CACHE_MAX = 2500
         # Track message IDs that should get reaction lifecycle (DMs / @mentions).
         self._reacting_message_ids: set = set()
         # Track active assistant thread status indicators so stop_typing can
@@ -2631,6 +2632,13 @@ class SlackAdapter(BasePlatformAdapter):
                 message_count=len(context_parts),
                 parent_text=parent_text,
             )
+            if len(self._thread_context_cache) > self._THREAD_CACHE_MAX:
+                stale_keys = [
+                    k for k, v in self._thread_context_cache.items()
+                    if now - v.fetched_at >= self._THREAD_CACHE_TTL
+                ]
+                for k in stale_keys:
+                    del self._thread_context_cache[k]
             return content
 
         except Exception as e:

--- a/tests/gateway/test_slack.py
+++ b/tests/gateway/test_slack.py
@@ -3089,3 +3089,75 @@ class TestSlashEphemeralAck:
         # the normal single-user case; the ContextVar path is the precise one.
         # The key invariant is: when the ContextVar IS set, it matches exactly.
         assert ctx is not None  # fallback path finds the entry
+
+
+# ---------------------------------------------------------------------------
+# TestThreadContextCacheBounded
+# ---------------------------------------------------------------------------
+
+class TestThreadContextCacheBounded:
+    """_thread_context_cache must evict expired entries when it exceeds
+    _THREAD_CACHE_MAX, symmetric with _bot_message_ts / _mentioned_threads /
+    _assistant_threads which all enforce their respective MAX constants."""
+
+    @pytest.mark.asyncio
+    async def test_expired_entries_evicted_when_cache_exceeds_max(self, adapter):
+        import time
+        from gateway.platforms.slack import _ThreadContextCache
+
+        adapter._THREAD_CACHE_MAX = 2
+
+        stale_ts = time.monotonic() - 120.0  # 120 s ago, past TTL of 60 s
+        for i in range(3):
+            adapter._thread_context_cache[f"C_stale:{i}:"] = _ThreadContextCache(
+                content=f"old {i}", fetched_at=stale_ts
+            )
+        assert len(adapter._thread_context_cache) == 3
+
+        # Pre-load user name so _resolve_user_name skips the API call
+        adapter._user_name_cache["U1"] = "Alice"
+
+        adapter._app.client.conversations_replies = AsyncMock(
+            return_value={
+                "messages": [
+                    {"ts": "msg-a", "user": "U1", "text": "hello"}
+                ]
+            }
+        )
+
+        # Fetch a fresh key — triggers cache write → eviction fires
+        await adapter._fetch_thread_context(
+            channel_id="C_fresh", thread_ts="ts-new", current_ts="ts-new"
+        )
+
+        assert len(adapter._thread_context_cache) <= adapter._THREAD_CACHE_MAX
+
+    @pytest.mark.asyncio
+    async def test_fresh_entries_not_evicted(self, adapter):
+        import time
+        from gateway.platforms.slack import _ThreadContextCache
+
+        adapter._THREAD_CACHE_MAX = 2
+
+        fresh_ts = time.monotonic()
+        for i in range(2):
+            adapter._thread_context_cache[f"C_fresh:{i}:"] = _ThreadContextCache(
+                content=f"fresh {i}", fetched_at=fresh_ts
+            )
+
+        adapter._user_name_cache["U2"] = "Bob"
+        adapter._app.client.conversations_replies = AsyncMock(
+            return_value={
+                "messages": [
+                    {"ts": "msg-b", "user": "U2", "text": "hi"}
+                ]
+            }
+        )
+
+        await adapter._fetch_thread_context(
+            channel_id="C_extra", thread_ts="ts-extra", current_ts="ts-extra"
+        )
+
+        # Fresh entries must survive — only stale entries are evicted
+        for i in range(2):
+            assert f"C_fresh:{i}:" in adapter._thread_context_cache


### PR DESCRIPTION
## What does this PR do?

`_fetch_thread_context()` caches per-thread Slack history in `_thread_context_cache` under a 60-second TTL, but expired entries are never physically removed from memory. In the same `__init__`, three sibling caches each enforce an explicit MAX constant with active eviction — `_thread_context_cache` has `_THREAD_CACHE_TTL` declared but no matching eviction path, so entries accumulate without bound for the lifetime of the adapter.

Fix: add `_THREAD_CACHE_MAX = 2500` and purge entries whose `fetched_at` age exceeds `_THREAD_CACHE_TTL` whenever a new write pushes the cache past the limit. TTL-based eviction is used (rather than LRU) because evicting a fresh entry would immediately re-trigger a rate-limited `conversations.replies` call.

## Related Issue

N/A — identified via parity check against `_bot_message_ts` / `_mentioned_threads` / `_assistant_threads`, all of which enforce their MAX constants in the same class.

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `gateway/platforms/slack.py`: add `_THREAD_CACHE_MAX = 2500` to `__init__`; add eviction block after cache write in `_fetch_thread_context()` (+8 lines)
- `tests/gateway/test_slack.py`: add `TestThreadContextCacheBounded` with 2 tests (+72 lines)

## How to Test

```
python3.11 -m pytest tests/gateway/test_slack.py::TestThreadContextCacheBounded -v --override-ini="addopts="
```

## Checklist

- [x] Contributing Guide read | Conventional Commits | No duplicate PR
- [x] Single logical change | Tests added | Platform: macOS
- [x] Docs — N/A | Cross-platform — N/A