### PR TITLE
feat(dashboard): show real chat identity in chat sidebar

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -79,6 +79,35 @@ def test_dispatch_rejects_non_object_params():
     }
 
 
+def test_session_info_includes_profile_provider_and_title(monkeypatch):
+    class _Db:
+        def get_session_title(self, _session_key):
+            return "db title"
+
+    monkeypatch.setattr(server, "_get_db", lambda: _Db())
+    monkeypatch.setattr(server, "_active_profile_name", lambda: "coder")
+
+    agent = types.SimpleNamespace(
+        model="anthropic/claude-sonnet-4",
+        provider="anthropic",
+        reasoning_config={"enabled": True, "effort": "high"},
+        service_tier=None,
+        session_id="sess-123",
+        tools=[],
+        _cached_system_prompt="",
+    )
+
+    info = server._session_info(
+        agent,
+        {"session_key": "sess-123", "pending_title": "Draft title"},
+    )
+
+    assert info["profile"] == "coder"
+    assert info["provider"] == "anthropic"
+    assert info["session_key"] == "sess-123"
+    assert info["session_title"] == "Draft title"
+
+
 def test_voice_toggle_returns_configured_record_key(monkeypatch):
     monkeypatch.setattr(
         server,

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -134,6 +134,35 @@ _SLASH_WORKER_TIMEOUT_S = max(5.0, _slash_timeout)
 _DETAIL_SECTION_NAMES = ("thinking", "tools", "subagents", "activity")
 _DETAIL_MODES = frozenset({"hidden", "collapsed", "expanded"})
 
+
+def _active_profile_name() -> str:
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        return get_active_profile_name() or "default"
+    except Exception:
+        return ""
+
+
+def _session_title(session_key: str, session: dict | None = None) -> str:
+    title = ""
+    if session is not None:
+        title = str(session.get("pending_title") or "").strip()
+    if title:
+        return title
+
+    if not session_key:
+        return ""
+
+    db = _get_db()
+    if db is None:
+        return ""
+
+    try:
+        return str(db.get_session_title(session_key) or "").strip()
+    except Exception:
+        return ""
+
 # ── Async RPC dispatch (#12546) ──────────────────────────────────────
 # A handful of handlers block the dispatcher loop in entry.py for seconds
 # to minutes (slash.exec, cli.exec, shell.exec, session.resume,
@@ -581,7 +610,7 @@ def _start_agent_build(sid: str, session: dict) -> None:
             _wire_callbacks(sid)
             _notify_session_boundary("on_session_reset", key)
 
-            info = _session_info(agent)
+            info = _session_info(agent, current)
             warn = _probe_credentials(agent)
             if warn:
                 info["credential_warning"] = warn
@@ -1121,7 +1150,7 @@ def _apply_model_switch(sid: str, session: dict, raw_input: str) -> dict:
             api_mode=result.api_mode,
         )
         _restart_slash_worker(session)
-        _emit("session.info", sid, _session_info(agent))
+        _emit("session.info", sid, _session_info(agent, session))
 
     os.environ["HERMES_MODEL"] = result.new_model
     os.environ["HERMES_INFERENCE_MODEL"] = result.new_model
@@ -1362,7 +1391,7 @@ def _probe_config_health(cfg: dict) -> str:
     return " ".join(warnings).strip()
 
 
-def _session_info(agent) -> dict:
+def _session_info(agent, session: dict | None = None) -> dict:
     reasoning_config = getattr(agent, "reasoning_config", None)
     reasoning_effort = ""
     if (
@@ -1371,11 +1400,20 @@ def _session_info(agent) -> dict:
     ):
         reasoning_effort = str(reasoning_config.get("effort", "") or "")
     service_tier = getattr(agent, "service_tier", None) or ""
+    session_key = ""
+    if session is not None:
+        session_key = str(session.get("session_key") or "")
+    if not session_key:
+        session_key = str(getattr(agent, "session_id", "") or "")
     info: dict = {
         "model": getattr(agent, "model", ""),
+        "provider": getattr(agent, "provider", "") or "",
         "reasoning_effort": reasoning_effort,
         "service_tier": service_tier,
         "fast": service_tier == "priority",
+        "profile": _active_profile_name(),
+        "session_key": session_key,
+        "session_title": _session_title(session_key, session),
         "tools": {},
         "skills": {},
         "cwd": os.getcwd(),
@@ -1762,7 +1800,7 @@ def _apply_personality_to_session(
         with session["history_lock"]:
             session["history"].append({"role": "user", "content": marker})
             session["history_version"] = int(session.get("history_version", 0)) + 1
-        info = _session_info(agent)
+        info = _session_info(agent, session)
         _emit("session.info", sid, info)
         return False, info
     return False, None
@@ -1848,7 +1886,7 @@ def _reset_session_agent(sid: str, session: dict) -> dict:
     with session["history_lock"]:
         session["history"] = []
         session["history_version"] = int(session.get("history_version", 0)) + 1
-    info = _session_info(new_agent)
+    info = _session_info(new_agent, session)
     _emit("session.info", sid, info)
     _restart_slash_worker(session)
     return info
@@ -1956,7 +1994,7 @@ def _init_session(sid: str, key: str, agent, history: list, cols: int = 80):
         pass
     _wire_callbacks(sid)
     _notify_session_boundary("on_session_reset", key)
-    _emit("session.info", sid, _session_info(agent))
+    _emit("session.info", sid, _session_info(agent, _sessions.get(sid)))
 
 
 def _new_session_key() -> str:
@@ -2136,6 +2174,10 @@ def _(rid, params: dict) -> dict:
             "session_id": sid,
             "info": {
                 "model": _resolve_model(),
+                "provider": "",
+                "profile": _active_profile_name(),
+                "session_key": key,
+                "session_title": "",
                 "tools": {},
                 "skills": {},
                 "cwd": os.getenv("TERMINAL_CWD", os.getcwd()),
@@ -2274,7 +2316,7 @@ def _(rid, params: dict) -> dict:
             "resumed": target,
             "message_count": len(messages),
             "messages": messages,
-            "info": _session_info(agent),
+            "info": _session_info(agent, _sessions.get(sid)),
         },
     )
 
@@ -2577,7 +2619,7 @@ def _(rid, params: dict) -> dict:
             summary = summarize_manual_compression(
                 before_messages, messages, before_tokens, after_tokens
             )
-            info = _session_info(agent)
+            info = _session_info(agent, session)
             _emit("session.info", sid, info)
             return _ok(
                 rid,
@@ -3710,7 +3752,7 @@ def _(rid, params: dict) -> dict:
             _emit(
                 "session.info",
                 params.get("session_id", ""),
-                _session_info(agent),
+                _session_info(agent, session),
             )
         return _ok(rid, {"key": key, "value": nv})
 
@@ -4198,7 +4240,7 @@ def _(rid, params: dict) -> dict:
             agent = session["agent"]
             if hasattr(agent, "refresh_tools"):
                 agent.refresh_tools()
-            _emit("session.info", params.get("session_id", ""), _session_info(agent))
+            _emit("session.info", params.get("session_id", ""), _session_info(agent, session))
 
         # Honor `always=true` by persisting the opt-out to config.
         if bool(params.get("always", False)):
@@ -5423,14 +5465,14 @@ def _mirror_slash_side_effects(sid: str, session: dict, command: str) -> str:
         elif name == "compress" and agent:
             _compress_session_history(session, arg)
             _sync_session_key_after_compress(sid, session)
-            _emit("session.info", sid, _session_info(agent))
+            _emit("session.info", sid, _session_info(agent, session))
         elif name == "fast" and agent:
             mode = arg.lower()
             if mode in {"fast", "on"}:
                 agent.service_tier = "priority"
             elif mode in {"normal", "off"}:
                 agent.service_tier = None
-            _emit("session.info", sid, _session_info(agent))
+            _emit("session.info", sid, _session_info(agent, session))
         elif name == "reload-mcp" and agent and hasattr(agent, "reload_mcp_tools"):
             agent.reload_mcp_tools()
         elif name == "stop":

--- a/web/src/components/ChatSidebar.tsx
+++ b/web/src/components/ChatSidebar.tsx
@@ -6,10 +6,9 @@
  *
  *   1. **JSON-RPC sidecar** (`GatewayClient` → /api/ws) — drives the
  *      sidebar's own slot of the dashboard's in-process gateway.  Owns
- *      the model badge / picker / connection state / error banner.
+ *      the model picker / connection state / reconnect affordance.
  *      Independent of the PTY pane's session by design — those are the
- *      pieces the sidebar needs to be able to drive directly (model
- *      switch via slash.exec, etc.).
+ *      pieces the sidebar needs to be able to drive directly.
  *
  *   2. **Event subscriber** (/api/events?channel=…) — passive, receives
  *      every dispatcher emit from the PTY-side `tui_gateway.entry` that
@@ -36,10 +35,14 @@ import { AlertCircle, ChevronDown, RefreshCw } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 interface SessionInfo {
+  config_warning?: string;
   cwd?: string;
-  model?: string;
-  provider?: string;
   credential_warning?: string;
+  model?: string;
+  profile?: string;
+  provider?: string;
+  session_key?: string;
+  session_title?: string;
 }
 
 interface RpcEnvelope {
@@ -48,6 +51,20 @@ interface RpcEnvelope {
 }
 
 const TOOL_LIMIT = 20;
+
+function shortSessionKey(value?: string): string {
+  const key = (value ?? "").trim();
+
+  if (!key) {
+    return "pending…";
+  }
+
+  if (key.length <= 18) {
+    return key;
+  }
+
+  return `${key.slice(0, 12)}…${key.slice(-6)}`;
+}
 
 const STATE_LABEL: Record<ConnectionState, string> = {
   idle: "idle",
@@ -83,7 +100,7 @@ export function ChatSidebar({ channel, className }: ChatSidebarProps) {
   const gw = useMemo(() => new GatewayClient(), [version]);
 
   const [state, setState] = useState<ConnectionState>("idle");
-  const [sessionId, setSessionId] = useState<string | null>(null);
+  const [controlSessionId, setControlSessionId] = useState<string | null>(null);
   const [info, setInfo] = useState<SessionInfo>({});
   const [tools, setTools] = useState<ToolEntry[]>([]);
   const [modelOpen, setModelOpen] = useState(false);
@@ -92,16 +109,6 @@ export function ChatSidebar({ channel, className }: ChatSidebarProps) {
   useEffect(() => {
     let cancelled = false;
     const offState = gw.onState(setState);
-
-    const offSessionInfo = gw.on<SessionInfo>("session.info", (ev) => {
-      if (ev.session_id) {
-        setSessionId(ev.session_id);
-      }
-
-      if (ev.payload) {
-        setInfo((prev) => ({ ...prev, ...ev.payload }));
-      }
-    });
 
     const offError = gw.on<{ message?: string }>("error", (ev) => {
       const message = ev.payload?.message;
@@ -125,7 +132,7 @@ export function ChatSidebar({ channel, className }: ChatSidebarProps) {
         if (cancelled || !created?.session_id) {
           return;
         }
-        setSessionId(created.session_id);
+        setControlSessionId(created.session_id);
       })
       .catch((e: Error) => {
         if (!cancelled) {
@@ -136,7 +143,6 @@ export function ChatSidebar({ channel, className }: ChatSidebarProps) {
     return () => {
       cancelled = true;
       offState();
-      offSessionInfo();
       offError();
       gw.close();
     };
@@ -156,6 +162,9 @@ export function ChatSidebar({ channel, className }: ChatSidebarProps) {
     if (!token || !channel) {
       return;
     }
+
+    setInfo({});
+    setTools([]);
 
     const proto = window.location.protocol === "https:" ? "wss:" : "ws:";
     const qs = new URLSearchParams({ token, channel });
@@ -195,7 +204,13 @@ export function ChatSidebar({ channel, className }: ChatSidebarProps) {
 
       const { type, payload } = frame.params;
 
-      if (type === "tool.start") {
+      if (type === "session.info") {
+        const p = payload as SessionInfo | undefined;
+
+        if (p) {
+          setInfo((prev) => ({ ...prev, ...p }));
+        }
+      } else if (type === "tool.start") {
         const p = payload as
           | { tool_id?: string; name?: string; context?: string }
           | undefined;
@@ -274,6 +289,7 @@ export function ChatSidebar({ channel, className }: ChatSidebarProps) {
 
   const reconnect = useCallback(() => {
     setError(null);
+    setInfo({});
     setTools([]);
     setVersion((v) => v + 1);
   }, []);
@@ -283,22 +299,26 @@ export function ChatSidebar({ channel, className }: ChatSidebarProps) {
   // via PTY, so the sidebar doesn't need to surface output of its own.
   const onModelSubmit = useCallback(
     (slashCommand: string) => {
-      if (!sessionId) {
+      if (!controlSessionId) {
         return;
       }
 
       void gw.request("slash.exec", {
-        session_id: sessionId,
+        session_id: controlSessionId,
         command: slashCommand,
       });
       setModelOpen(false);
     },
-    [gw, sessionId],
+    [controlSessionId, gw],
   );
 
-  const canPickModel = state === "open" && !!sessionId;
+  const canPickModel = state === "open" && !!controlSessionId;
   const modelLabel = (info.model ?? "—").split("/").slice(-1)[0] ?? "—";
-  const banner = error ?? info.credential_warning ?? null;
+  const providerLabel = (info.provider ?? "").trim() || "unknown";
+  const profileLabel = (info.profile ?? "").trim() || "default";
+  const sessionTitleLabel = (info.session_title ?? "").trim();
+  const sessionKeyLabel = shortSessionKey(info.session_key);
+  const banner = error ?? info.config_warning ?? info.credential_warning ?? null;
 
   return (
     <aside
@@ -308,9 +328,9 @@ export function ChatSidebar({ channel, className }: ChatSidebarProps) {
       )}
     >
       <Card className="flex items-center justify-between gap-2 px-3 py-2">
-        <div className="min-w-0">
+        <div className="min-w-0 flex-1">
           <div className="text-xs uppercase tracking-wider text-muted-foreground">
-            model
+            identity
           </div>
 
           <Button
@@ -328,6 +348,32 @@ export function ChatSidebar({ channel, className }: ChatSidebarProps) {
           >
             <span className="truncate">{modelLabel}</span>
           </Button>
+
+          <div className="mt-2 space-y-1 text-xs">
+            <div className="flex items-start gap-2">
+              <span className="w-14 shrink-0 text-muted-foreground">profile</span>
+              <span className="min-w-0 truncate font-mono">{profileLabel}</span>
+            </div>
+
+            <div className="flex items-start gap-2">
+              <span className="w-14 shrink-0 text-muted-foreground">provider</span>
+              <span className="min-w-0 truncate font-mono">{providerLabel}</span>
+            </div>
+
+            <div className="flex items-start gap-2">
+              <span className="w-14 shrink-0 text-muted-foreground">session</span>
+              <div className="min-w-0 flex-1">
+                <div className="truncate">
+                  {sessionTitleLabel || sessionKeyLabel}
+                </div>
+                {sessionTitleLabel && (
+                  <div className="truncate font-mono text-muted-foreground">
+                    {sessionKeyLabel}
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
         </div>
 
         <Badge tone={STATE_TONE[state]}>{STATE_LABEL[state]}</Badge>
@@ -371,10 +417,10 @@ export function ChatSidebar({ channel, className }: ChatSidebarProps) {
         </div>
       </Card>
 
-      {modelOpen && canPickModel && sessionId && (
+      {modelOpen && canPickModel && controlSessionId && (
         <ModelPickerDialog
           gw={gw}
-          sessionId={sessionId}
+          sessionId={controlSessionId}
           onClose={() => setModelOpen(false)}
           onSubmit={onModelSubmit}
         />


### PR DESCRIPTION
## What does this PR do?

This PR makes the dashboard `/chat` sidebar show the identity of the **real embedded PTY/TUI session** instead of the sidebar sidecar's own control session.

Issue #22142 called out that `/chat` did not clearly show which profile / provider / session the user was actually talking to. That is especially risky in multi-profile setups because the existing sidebar could show model state from its own independent sidecar connection, not from the PTY-backed chat session.

This change fixes that by extending PTY-emitted `session.info` metadata with `profile`, `provider`, `session_key`, and `session_title`, then rendering those fields in the dashboard sidebar from the PTY event stream. The model picker still uses the sidecar control channel for `/model`, but the identity display now reflects the real chat session.

## Related Issue

Fixes #22142

## Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Updated `tui_gateway/server.py` so `_session_info(...)` includes:
  - active profile name
  - active provider
  - real session key
  - current session title (including pending title fallback)
- Updated all relevant TUI/session-info emit paths in `tui_gateway/server.py` so refreshed metadata continues to flow after:
  - session startup
  - session resume
  - model switch
  - manual compression
  - fast mode toggle
  - MCP/tool refresh paths
- Updated `session.create` lazy bootstrap info to include identity placeholders immediately.
- Updated `web/src/components/ChatSidebar.tsx` to:
  - consume `session.info` from the PTY rebroadcast event stream
  - display `profile`, `provider`, and `session`
  - keep the model picker on the sidecar control session
  - stop using sidecar `session.info` as the source of truth for displayed identity
- Added regression coverage in `tests/test_tui_gateway_server.py` for the new `session.info` identity fields.

## How to Test

1. Start the dashboard and open `/chat`.
2. Confirm the right sidebar shows the current model plus:
   - profile
   - provider
   - session title or session key
3. In the embedded chat:
   - start a new session
   - resume an existing session
   - set a title with `/title ...`
   - switch models with `/model`
4. Confirm the sidebar identity fields continue to reflect the real PTY chat session rather than the sidebar sidecar session.
5. Verify targeted tests pass:
   - `uv run pytest -q tests/test_tui_gateway_server.py tests/hermes_cli/test_web_server.py -k "session_info or pty or events"`
   - `uv run pytest -q tests/test_tui_gateway_server.py -k "session_info"`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11 / PowerShell

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted test results:

```text
uv run pytest -q tests/test_tui_gateway_server.py tests/hermes_cli/test_web_server.py -k "session_info or pty or events"
16 passed, 11 skipped in 6.68s