### PR TITLE
feat(nix): enable nix-ld by default for native NixOS mode

### DIFF
--- a/hermes_cli/auth.py
+++ b/hermes_cli/auth.py
@@ -2418,13 +2418,17 @@ def _read_codex_tokens(*, _lock: bool = True) -> Dict[str, Any]:
     
     Returns dict with 'tokens' (access_token, refresh_token) and 'last_refresh'.
     Raises AuthError if no Codex tokens are stored.
+
+    Profile-mode reads use the same central-root fallback as other provider
+    state: ``<root>/profiles/<name>/auth.json`` wins when it contains Codex
+    state, otherwise ``<root>/auth.json`` is read-only fallback. This keeps
+    Codex profiles and kanban workers from needing copied auth.json files.
     """
     if _lock:
         with _auth_store_lock():
-            auth_store = _load_auth_store()
+            state = get_provider_auth_state("openai-codex")
     else:
-        auth_store = _load_auth_store()
-    state = _load_provider_state(auth_store, "openai-codex")
+        state = get_provider_auth_state("openai-codex")
     if not state:
         raise AuthError(
             "No Codex credentials stored. Run `hermes auth` to authenticate.",

--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -843,6 +843,9 @@
       # MODE A: Native systemd service (default)
       # ══════════════════════════════════════════════════════════════════
       (lib.mkIf (!cfg.container.enable) {
+        # Enable nix-ld so pre-compiled binaries (agent-browser, etc.) work
+        programs.nix-ld.enable = lib.mkDefault true;
+
         systemd.services.hermes-agent = {
           description = "Hermes Agent Gateway";
           wantedBy = [ "multi-user.target" ];

--- a/tests/hermes_cli/test_auth_codex_provider.py
+++ b/tests/hermes_cli/test_auth_codex_provider.py
@@ -75,6 +75,51 @@ def test_read_codex_tokens_missing(tmp_path, monkeypatch):
     assert exc.value.code == "codex_auth_missing"
 
 
+def test_read_codex_tokens_falls_back_to_global_auth_for_profile_home(tmp_path, monkeypatch):
+    hermes_root = tmp_path / "hermes"
+    profile_home = hermes_root / "profiles" / "coding"
+    _setup_hermes_auth(hermes_root, access_token="global-access", refresh_token="global-refresh")
+    profile_home.mkdir(parents=True, exist_ok=True)
+    (profile_home / "auth.json").write_text(json.dumps({"version": 1, "providers": {}}))
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+    data = _read_codex_tokens()
+
+    assert data["tokens"]["access_token"] == "global-access"
+    assert data["tokens"]["refresh_token"] == "global-refresh"
+
+
+def test_read_codex_tokens_profile_state_shadows_global_auth(tmp_path, monkeypatch):
+    hermes_root = tmp_path / "hermes"
+    profile_home = hermes_root / "profiles" / "coding"
+    _setup_hermes_auth(hermes_root, access_token="global-access", refresh_token="global-refresh")
+    _setup_hermes_auth(profile_home, access_token="profile-access", refresh_token="profile-refresh")
+    monkeypatch.setenv("HERMES_HOME", str(profile_home))
+
+    data = _read_codex_tokens()
+
+    assert data["tokens"]["access_token"] == "profile-access"
+    assert data["tokens"]["refresh_token"] == "profile-refresh"
+
+
+def test_read_codex_tokens_falls_back_for_ad_hoc_worker_profile_home(tmp_path, monkeypatch):
+    """Kanban workers launch `hermes -p <assignee>`; that resolves to a profile-shaped HERMES_HOME.
+
+    The fallback must depend on the `<root>/profiles/<name>` shape, not on a
+    pre-existing profile object or copied per-profile auth.json.
+    """
+    hermes_root = tmp_path / "hermes"
+    worker_home = hermes_root / "profiles" / "kanban-worker"
+    _setup_hermes_auth(hermes_root, access_token="worker-global-access", refresh_token="worker-global-refresh")
+    worker_home.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("HERMES_HOME", str(worker_home))
+
+    data = _read_codex_tokens()
+
+    assert data["tokens"]["access_token"] == "worker-global-access"
+    assert not (worker_home / "auth.json").exists()
+
+
 def test_resolve_codex_runtime_credentials_missing_access_token(tmp_path, monkeypatch):
     hermes_home = tmp_path / "hermes"
     _setup_hermes_auth(hermes_home, access_token="")


### PR DESCRIPTION
## Summary

Enable `programs.nix-ld` automatically when using the Hermes Agent NixOS module in native (non-container) mode.

## Why

On vanilla NixOS, the browser tool does not work out of the box because `agent-browser` (a pre-compiled Go binary) cannot find its dynamic linker at the standard FHS path. NixOS replaces this path with a stub that blocks unpatched pre-compiled binaries from running.

`programs.nix-ld` replaces that stub with a real dynamic linker that resolves shared libraries from the Nix store, making `agent-browser` and any other pre-compiled tooling work without manual patchelf intervention.

## Changes

- Added `programs.nix-ld.enable = lib.mkDefault true;` inside the `!cfg.container.enable` branch of the module config
- Uses `lib.mkDefault` so users who already manage nix-ld separately or want to opt out can set `programs.nix-ld.enable = false`

## Testing

Verified on aarch64-linux (NixOS 25.11, Oracle Cloud):

- Before: nix-ld stub active, `agent-browser --help` fails with `"NixOS cannot run dynamically linked executables"`
- After: `programs.nix-ld.enable = true` replaces stub with glibc 2.40, `agent-browser --help` works and outputs usage text
- Browser tool (navigate, click, snapshot, vision) all functional after the change