### PR TITLE
fix(tools): route encrypted matrix send_message through adapter

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -503,9 +503,9 @@ class TestSendToPlatformChunking:
         assert all(call == [] for call in sent_calls[:-1])
         assert sent_calls[-1] == media
 
-    def test_matrix_media_uses_native_adapter_helper(self):
+    def test_matrix_media_uses_native_adapter_helper(self, tmp_path):
 
-        doc_path = Path("/tmp/test-send-message-matrix.pdf")
+        doc_path = tmp_path / "test-send-message-matrix.pdf"
         doc_path.write_bytes(b"%PDF-1.4 test")
 
         try:
@@ -531,7 +531,7 @@ class TestSendToPlatformChunking:
             doc_path.unlink(missing_ok=True)
 
     def test_matrix_text_only_uses_lightweight_path(self):
-        """Text-only Matrix sends should NOT go through the heavy adapter path."""
+        """Text-only Matrix sends stay lightweight when E2EE is disabled."""
         helper = AsyncMock()
         lightweight = AsyncMock(return_value={"success": True, "platform": "matrix", "chat_id": "!room:ex.com", "message_id": "$txt"})
         with patch("tools.send_message_tool._send_matrix_via_adapter", helper), \
@@ -539,7 +539,7 @@ class TestSendToPlatformChunking:
             result = asyncio.run(
                 _send_to_platform(
                     Platform.MATRIX,
-                    SimpleNamespace(enabled=True, token="tok", extra={"homeserver": "https://matrix.example.com"}),
+                    SimpleNamespace(enabled=True, token="tok", extra={"homeserver": "https://matrix.example.com", "encryption": False}),
                     "!room:ex.com",
                     "just text, no files",
                 )
@@ -548,6 +548,54 @@ class TestSendToPlatformChunking:
         assert result["success"] is True
         helper.assert_not_awaited()
         lightweight.assert_awaited_once()
+
+    def test_matrix_text_only_uses_adapter_when_encryption_enabled(self):
+        helper = AsyncMock(return_value={"success": True, "platform": "matrix", "chat_id": "!room:ex.com", "message_id": "$txt"})
+        lightweight = AsyncMock()
+        with patch("tools.send_message_tool._send_matrix_via_adapter", helper), \
+             patch("tools.send_message_tool._send_matrix", lightweight):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.MATRIX,
+                    SimpleNamespace(enabled=True, token="tok", extra={"homeserver": "https://matrix.example.com", "encryption": True}),
+                    "!room:ex.com",
+                    "encrypted text",
+                )
+            )
+
+        assert result["success"] is True
+        helper.assert_awaited_once()
+        lightweight.assert_not_awaited()
+
+    def test_send_matrix_via_adapter_reuses_live_gateway_adapter(self):
+        calls = []
+
+        class FakeAdapter:
+            async def send(self, chat_id, message, metadata=None):
+                calls.append(("send", chat_id, message, metadata))
+                return SimpleNamespace(success=True, message_id="$live")
+
+        fake_runner = SimpleNamespace(adapters={Platform.MATRIX: FakeAdapter()})
+
+        with patch("gateway.run._gateway_runner_ref", return_value=fake_runner):
+            result = asyncio.run(
+                _send_matrix_via_adapter(
+                    SimpleNamespace(enabled=True, token="tok", extra={"homeserver": "https://matrix.example.com", "encryption": True}),
+                    "!room:example.com",
+                    "hello from live adapter",
+                    thread_id="$thread",
+                )
+            )
+
+        assert result == {
+            "success": True,
+            "platform": "matrix",
+            "chat_id": "!room:example.com",
+            "message_id": "$live",
+        }
+        assert calls == [
+            ("send", "!room:example.com", "hello from live adapter", {"thread_id": "$thread"})
+        ]
 
     def test_send_matrix_via_adapter_sends_document(self, tmp_path):
         file_path = tmp_path / "report.pdf"

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -616,8 +616,15 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             last_result = result
         return last_result
 
-    # --- Matrix: use the native adapter helper when media is present ---
-    if platform == Platform.MATRIX and media_files:
+    # --- Matrix: use the native adapter helper for media and E2EE rooms ---
+    matrix_extra = getattr(pconfig, "extra", {}) or {}
+    matrix_encryption = False
+    if platform == Platform.MATRIX:
+        matrix_encryption = bool(
+            matrix_extra.get("encryption")
+            or os.getenv("MATRIX_ENCRYPTION", "").lower() in ("true", "1", "yes")
+        )
+    if platform == Platform.MATRIX and (media_files or matrix_encryption):
         last_result = None
         for i, chunk in enumerate(chunks):
             is_last = (i == len(chunks) - 1)
@@ -1512,18 +1519,32 @@ async def _send_matrix(token, extra, chat_id, message):
 
 async def _send_matrix_via_adapter(pconfig, chat_id, message, media_files=None, thread_id=None):
     """Send via the Matrix adapter so native Matrix media uploads are preserved."""
-    try:
-        from gateway.platforms.matrix import MatrixAdapter
-    except ImportError:
-        return {"error": "Matrix dependencies not installed. Run: pip install 'mautrix[encryption]'"}
-
     media_files = media_files or []
+    adapter = None
+    owns_adapter = False
 
     try:
-        adapter = MatrixAdapter(pconfig)
-        connected = await adapter.connect()
-        if not connected:
-            return _error("Matrix connect failed")
+        try:
+            from gateway.config import Platform
+            from gateway.run import _gateway_runner_ref
+
+            runner = _gateway_runner_ref()
+            if runner is not None:
+                adapter = runner.adapters.get(Platform.MATRIX)
+        except Exception:
+            adapter = None
+
+        if adapter is None:
+            try:
+                from gateway.platforms.matrix import MatrixAdapter
+            except ImportError:
+                return {"error": "Matrix dependencies not installed. Run: pip install 'mautrix[encryption]'"}
+
+            adapter = MatrixAdapter(pconfig)
+            connected = await adapter.connect()
+            if not connected:
+                return _error("Matrix connect failed")
+            owns_adapter = True
 
         metadata = {"thread_id": thread_id} if thread_id else None
         last_result = None
@@ -1564,10 +1585,11 @@ async def _send_matrix_via_adapter(pconfig, chat_id, message, media_files=None, 
     except Exception as e:
         return _error(f"Matrix send failed: {e}")
     finally:
-        try:
-            await adapter.disconnect()
-        except Exception:
-            pass
+        if owns_adapter and adapter is not None:
+            try:
+                await adapter.disconnect()
+            except Exception:
+                pass
 
 
 async def _send_homeassistant(token, extra, chat_id, message):


### PR DESCRIPTION
## What does this PR do?

Fixes Matrix `send_message` delivery for encrypted rooms. Before this change, text-only Matrix sends used the lightweight direct `/_matrix/client/v3/rooms/.../send/m.room.message/...` path, which bypassed the gateway's `mautrix` E2EE client and caused plaintext sends to fail in encrypted rooms. This PR routes encrypted Matrix sends through the adapter path that already handles E2EE correctly, while preserving the lightweight direct send path for non-E2EE text-only sends.

## Related Issue

Fixes #23055

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated [tools/send_message_tool.py](E:/github_workspace/hermes-agent/tools/send_message_tool.py) so Matrix sends use `_send_matrix_via_adapter()` whenever media is attached or Matrix encryption is enabled.
- Preserved the existing lightweight direct REST send path for text-only Matrix sends when E2EE is disabled.
- Updated `_send_matrix_via_adapter()` to reuse the live gateway Matrix adapter when available before creating a temporary adapter instance.
- Added regression tests for:
  - text-only Matrix sends staying on the lightweight path when encryption is disabled
  - text-only Matrix sends using the adapter path when encryption is enabled
  - reusing the live Matrix gateway adapter
- Fixed an existing cross-platform test issue by switching a Matrix media test from a hardcoded `/tmp/...` path to `tmp_path`, so it passes on Windows.

## How to Test

1. Configure Matrix with `MATRIX_ENCRYPTION=true` and a reachable encrypted room.
2. Use `send_message` to send a text-only message to that Matrix target.
3. Confirm the message is delivered successfully via the adapter/E2EE path instead of the bare client-server `m.room.message` REST send.
4. Run automated coverage:
   - `uv run pytest -q tests/tools/test_send_message_tool.py -q`
   - `uv run pytest -q tests/tools/test_send_message_missing_platforms.py -q`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Windows 11

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Verified with targeted `uv run pytest` coverage for the affected Matrix send_message paths.
- Note: pytest emits a Windows temp-directory cleanup `PermissionError` at interpreter exit in this environment; the test runs themselves complete successfully.
