### PR TITLE
fix(yuanbao): clear _processing_msg_ids/_processing_msg_texts after each message

### DIFF
--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -4591,6 +4591,15 @@ class YuanbaoAdapter(BasePlatformAdapter):
             await super()._process_message_background(event, session_key)
         finally:
             self._outbound.cancel_slow_notifier(chat_id)
+            # Clear the RecallGuard tracking entries for this message only if
+            # our msg_id is still current.  A concurrent pending message may
+            # have already overwritten the entry in _dispatch_inbound_event
+            # while we were running; in that case the drain task owns it and
+            # we must not clear it.
+            msg_id = event.message_id
+            if not msg_id or self._processing_msg_ids.get(session_key) == msg_id:
+                self._processing_msg_ids.pop(session_key, None)
+                self._processing_msg_texts.pop(session_key, None)
 
     # ------------------------------------------------------------------
     # Group query (delegate to GroupQueryService)


### PR DESCRIPTION
## Problem

`_dispatch_inbound_event()` in `DispatchMiddleware.handle()` writes two tracking entries so `RecallGuardMiddleware._find_processing_session()` can detect and interrupt the currently-processing message:

```python
# yuanbao.py L2519-2521
if _sk and ctx.msg_id:
    adapter._processing_msg_ids[_sk] = ctx.msg_id
    adapter._processing_msg_texts[_sk] = ctx.raw_text or ""
```

These entries are **never removed** after a message finishes processing. `_process_message_background()` has no cleanup path, and `disconnect()` only clears `_group_queues`. Both dicts grow by one entry per unique session key and retain them for the lifetime of the bot — a memory leak proportional to the number of distinct conversations served.

Note that `_msg_content_cache` at the same write site already bounds itself to 200 entries (L2524-2527); the two tracking dicts had no such bound.

## Fix

Clear both entries in `YuanbaoAdapter._process_message_background()` inside the existing `finally` block, after `super()` returns.

The pop is guarded by a `msg_id` equality check to handle the **late-arrival drain** case: if a second message arrived while we were running, its `_dispatch_inbound_event()` has already overwritten `_processing_msg_ids[session_key]` with the new msg_id before our `finally` fires. Unconditionally popping the key would delete the drain task's tracking entry and silently break recall interrupts for that pending message. The guard ensures we only pop when the stored value is still ours:

```python
msg_id = event.message_id
if not msg_id or self._processing_msg_ids.get(session_key) == msg_id:
    self._processing_msg_ids.pop(session_key, None)
    self._processing_msg_texts.pop(session_key, None)
```

When `msg_id` is absent (the `if _sk and ctx.msg_id` guard at the write site was False), the pop is a no-op safe to perform unconditionally.

## Verification

- `_find_processing_session()` (L1316-1318) checks **both** `_processing_msg_ids` and `_active_sessions` — stale entries in the former do not cause false recall interrupts today, but they do accumulate indefinitely and can feed stale text to `_schedule_content_redact()` if a msg_id is reused.
- `session_key` in `_process_message_background` is symmetric with `_sk` in `DispatchMiddleware.handle()`: both use `build_session_key(source, ...)` with the same config flags (`group_sessions_per_user`, `thread_sessions_per_user`).
- The drain task spawned by the base class late-arrival path calls `_process_message_background(late_pending, session_key)` — its own `finally` will then clean up correctly using `late_pending.message_id`.

## Testing

Tested on: macOS