### PR TITLE
fix(yuanbao): evict stale entries from _member_cache on TTL expiry

### DIFF
--- a/gateway/platforms/yuanbao.py
+++ b/gateway/platforms/yuanbao.py
@@ -4112,7 +4112,11 @@ class MessageSender:
         cached = self._adapter._member_cache.get(group_code)
         if cached:
             ts, member_list = cached
-            members = member_list if (time.time() - ts < self._adapter.MEMBER_CACHE_TTL_S) else []
+            if time.time() - ts < self._adapter.MEMBER_CACHE_TTL_S:
+                members = member_list
+            else:
+                del self._adapter._member_cache[group_code]
+                members = []
         else:
             members = []
         if not members:


### PR DESCRIPTION
## Problem

`_build_msg_body_with_mentions()` in `MessageSender` checks whether a cached member list has expired, but never removes the stale entry:

```python
# yuanbao.py L4112-4117 (before fix)
cached = self._adapter._member_cache.get(group_code)
if cached:
    ts, member_list = cached
    members = member_list if (time.time() - ts < self._adapter.MEMBER_CACHE_TTL_S) else []
```

When the TTL has elapsed, `members` is set to `[]` and the stale entry is silently kept in the dict. Every `group_code` the bot has ever queried retains a permanent entry in `_member_cache` — holding the full member list (potentially thousands of records per group) until `disconnect()`. In a long-running bot serving many groups, this becomes an unbounded memory leak.

`get_group_member_list_raw()` overwrites the entry on a fresh fetch for the same group, so active groups don't accumulate duplicates. But inactive or departed groups never get a fresh fetch, so their entry is never overwritten or removed.

## Fix

Delete the stale entry at the point it is detected as expired:

```python
cached = self._adapter._member_cache.get(group_code)
if cached:
    ts, member_list = cached
    if time.time() - ts < self._adapter.MEMBER_CACHE_TTL_S:
        members = member_list
    else:
        del self._adapter._member_cache[group_code]
        members = []
else:
    members = []
```

The next call to `get_group_member_list_raw()` for the same group will repopulate the cache with fresh data, as it did before.

## Notes

- `_build_msg_body_with_mentions` is the only read path for `_member_cache` (one call site at L4104). The only write path is `get_group_member_list_raw()` at L3615. No concurrency concern — asyncio is single-threaded.
- Symmetric with `MessageDeduplicator` (used for inbound dedup on the same adapter), which also evicts on access when TTL expires.
- `MEMBER_CACHE_TTL_S = 300.0` (5 minutes), same value as `MessageDeduplicator(ttl_seconds=300)`.

## Testing

Tested on: macOS