### PR TITLE
fix(aux-routing): infer codex_responses for named custom GPT-5 providers

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2716,7 +2716,6 @@ def resolve_provider_client(
             custom_key = custom_key or "no-key-required"
             # An explicit per-task api_mode override (from _resolve_task_provider_model)
             # wins; otherwise fall back to what the provider entry declared.
-            entry_api_mode = (api_mode or custom_entry.get("api_mode") or "").strip()
             if custom_base:
                 final_model = _normalize_resolved_model(
                     model
@@ -2726,6 +2725,19 @@ def resolve_provider_client(
                     or "gpt-4o-mini",
                     provider,
                 )
+                entry_api_mode = (api_mode or custom_entry.get("api_mode") or "").strip()
+                if not entry_api_mode:
+                    try:
+                        from hermes_cli.runtime_provider import (
+                            _infer_openai_compatible_api_mode,
+                        )
+
+                        entry_api_mode = (
+                            _infer_openai_compatible_api_mode(custom_base, final_model)
+                            or ""
+                        )
+                    except Exception:
+                        entry_api_mode = ""
                 # anthropic_messages talks to the /anthropic surface directly;
                 # OpenAI-wire paths (chat_completions / codex_responses) need the
                 # /v1 equivalent.  Rewrite only on the OpenAI-wire path so the

--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -86,6 +86,33 @@ def _detect_api_mode_for_url(base_url: str) -> Optional[str]:
     return None
 
 
+def _infer_openai_compatible_api_mode(
+    base_url: str,
+    model_name: Optional[str],
+) -> Optional[str]:
+    """Infer api_mode for OpenAI-compatible custom endpoints.
+
+    Mirrors the main agent's GPT-5 custom-endpoint upgrade while preserving
+    the Azure OpenAI exception: generic relays serving GPT-5.x models should
+    default to the Responses API, but Azure OpenAI keeps GPT-5 on the regular
+    chat completions path.
+    """
+    detected = _detect_api_mode_for_url(base_url)
+    if detected:
+        return detected
+
+    raw_base_url = str(base_url or "").strip().lower()
+    if "openai.azure.com" in raw_base_url:
+        return None
+
+    normalized_model = str(model_name or "").strip().lower()
+    if "/" in normalized_model:
+        normalized_model = normalized_model.rsplit("/", 1)[-1]
+    if normalized_model.startswith("gpt-5"):
+        return "codex_responses"
+    return None
+
+
 def _auto_detect_local_model(base_url: str) -> str:
     """Query a local server for its model name when only one model is loaded."""
     if not base_url:
@@ -320,6 +347,7 @@ def _try_resolve_from_custom_pool(
     provider_label: str,
     api_mode_override: Optional[str] = None,
     provider_name: Optional[str] = None,
+    model_name: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     """Check if a credential pool exists for a custom endpoint and return a runtime dict if so."""
     pool_key = get_custom_provider_pool_key(base_url, provider_name=provider_name)
@@ -337,7 +365,9 @@ def _try_resolve_from_custom_pool(
             return None
         return {
             "provider": provider_label,
-            "api_mode": api_mode_override or _detect_api_mode_for_url(base_url) or "chat_completions",
+            "api_mode": api_mode_override
+            or _infer_openai_compatible_api_mode(base_url, model_name)
+            or "chat_completions",
             "base_url": base_url,
             "api_key": pool_api_key,
             "source": f"pool:{pool_key}",
@@ -529,7 +559,13 @@ def _resolve_named_custom_runtime(
         return None
 
     # Check if a credential pool exists for this custom endpoint
-    pool_result = _try_resolve_from_custom_pool(base_url, "custom", custom_provider.get("api_mode"), provider_name=custom_provider.get("name"))
+    pool_result = _try_resolve_from_custom_pool(
+        base_url,
+        "custom",
+        custom_provider.get("api_mode"),
+        provider_name=custom_provider.get("name"),
+        model_name=custom_provider.get("model"),
+    )
     if pool_result:
         # Propagate the model name even when using pooled credentials —
         # the pool doesn't know about the custom_providers model field.
@@ -550,7 +586,7 @@ def _resolve_named_custom_runtime(
     result = {
         "provider": "custom",
         "api_mode": custom_provider.get("api_mode")
-        or _detect_api_mode_for_url(base_url)
+        or _infer_openai_compatible_api_mode(base_url, custom_provider.get("model"))
         or "chat_completions",
         "base_url": base_url,
         "api_key": api_key or "no-key-required",

--- a/tests/agent/test_auxiliary_named_custom_providers.py
+++ b/tests/agent/test_auxiliary_named_custom_providers.py
@@ -150,6 +150,24 @@ class TestResolveProviderClientNamedCustom:
         # Should use _read_main_model() fallback
         assert model == "main-model"
 
+    def test_main_named_custom_gpt5_without_api_mode_wraps_codex(self, tmp_path):
+        _write_config(tmp_path, {
+            "model": {"default": "gpt-5.4", "provider": "relay"},
+            "providers": {
+                "relay": {
+                    "base_url": "https://relay.example.com/v1",
+                    "api_key": "k",
+                    "default_model": "gpt-5.4",
+                }
+            },
+        })
+        from agent.auxiliary_client import CodexAuxiliaryClient, resolve_provider_client
+
+        client, model = resolve_provider_client("main")
+
+        assert isinstance(client, CodexAuxiliaryClient)
+        assert model == "gpt-5.4"
+
     def test_named_custom_no_api_key_uses_fallback(self, tmp_path):
         _write_config(tmp_path, {
             "model": {"default": "test"},

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -1114,6 +1114,25 @@ def test_named_custom_provider_without_api_mode_defaults(monkeypatch):
     assert resolved["api_mode"] == "chat_completions"
 
 
+def test_named_custom_provider_gpt5_without_api_mode_uses_responses(monkeypatch):
+    """GPT-5 named custom providers should auto-upgrade to Responses API."""
+    monkeypatch.setattr(rp, "resolve_provider", lambda *a, **k: "relay")
+    monkeypatch.setattr(
+        rp,
+        "_get_named_custom_provider",
+        lambda p: {
+            "name": "relay",
+            "base_url": "https://relay.example.com/v1",
+            "api_key": "sk-test",
+            "model": "gpt-5.4",
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="relay")
+
+    assert resolved["api_mode"] == "codex_responses"
+
+
 def test_anthropic_messages_in_valid_api_modes():
     """anthropic_messages should be accepted by _parse_api_mode."""
     assert rp._parse_api_mode("anthropic_messages") == "anthropic_messages"


### PR DESCRIPTION
## Summary

Fix named custom GPT-5 auxiliary routing when `api_mode` is omitted.

Named custom OpenAI-compatible providers could resolve auxiliary tasks through
`chat_completions` even when the configured/default model was `gpt-5.x`, while
the main agent path already upgrades those models to `codex_responses` on
compatible endpoints.

This patch aligns the named-custom runtime and auxiliary resolution paths so
GPT-5 models on OpenAI-compatible custom relays default to the Responses API
when `api_mode` is not explicitly set, while preserving the Azure OpenAI
exception.

## Problem

Before this change:

- `hermes_cli/runtime_provider._resolve_named_custom_runtime()` fell back to
  `chat_completions` when a named custom provider omitted `api_mode`
- `agent.auxiliary_client.resolve_provider_client()` only wrapped named custom
  providers for Responses when `api_mode=codex_responses` was explicitly set
- auxiliary tasks routed through `main` / named custom providers could therefore
  hit the wrong transport for `gpt-5.x` models on OpenAI-compatible relays

That created a mismatch between the main agent routing and auxiliary routing for
the same provider/model combination.

## What changed

- added a shared helper in `hermes_cli/runtime_provider.py` to infer the API
  mode for OpenAI-compatible custom endpoints from:
  - URL-based transport detection
  - GPT-5 model family fallback
  - Azure OpenAI exclusion
- used that helper in named custom runtime resolution
- used the same inference in the named custom auxiliary provider path so
  auxiliary clients wrap to `CodexAuxiliaryClient` when appropriate
- extended regression coverage for both runtime resolution and auxiliary client
  resolution

## Repro

Minimal local repro before the fix:

1. Configure a named custom provider with:
   - OpenAI-compatible `base_url`
   - `default_model: gpt-5.4`
   - no explicit `api_mode`
2. Resolve the runtime or route an auxiliary task through `main`
3. Observe that the provider resolves to `chat_completions` instead of
   `codex_responses`

## Tests

Added:

- `tests/hermes_cli/test_runtime_provider_resolution.py`
  - `test_named_custom_provider_gpt5_without_api_mode_uses_responses`
- `tests/agent/test_auxiliary_named_custom_providers.py`
  - `test_main_named_custom_gpt5_without_api_mode_wraps_codex`

Ran locally:

- targeted new runtime-provider test
- targeted new auxiliary named-custom test
- nearby regression coverage in both touched test files



