### PR TITLE
fix: surface missing gateway optional dependencies

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -5,6 +5,7 @@ Handles: hermes gateway [run|start|stop|restart|status|install|uninstall|setup]
 """
 
 import asyncio
+import importlib.util
 import os
 import shutil
 import signal
@@ -3649,6 +3650,32 @@ _PLATFORMS = [
         ],
     },
 ]
+
+_BUILTIN_PLATFORM_PYTHON_DEPENDENCIES = {
+    "telegram": ("telegram", "python-telegram-bot[webhooks]"),
+    "discord": ("discord", "discord.py[voice]"),
+    "slack": ("slack_bolt", "slack-bolt"),
+}
+
+
+def _missing_builtin_platform_dependency(platform: dict) -> str | None:
+    """Return the missing pip requirement for a configured built-in platform.
+
+    Setup summaries used after OpenClaw migration only looked at env vars, so
+    an imported TELEGRAM_BOT_TOKEN made Telegram appear fully configured even
+    when the install had fallen back to base dependencies and the adapter could
+    not import. Keep this lightweight: only check importable Python adapter
+    modules for platforms whose token/env sentinel is present.
+    """
+    dep = _BUILTIN_PLATFORM_PYTHON_DEPENDENCIES.get(platform.get("key"))
+    if dep is None:
+        return None
+    module_name, requirement = dep
+    if importlib.util.find_spec(module_name) is None:
+        return requirement
+    return None
+
+
 def _all_platforms() -> list[dict]:
     """Return the full list of platforms for setup menus.
 
@@ -3762,6 +3789,8 @@ def _platform_status(platform: dict) -> str:
             return "partially configured"
         return "not configured"
     if val:
+        if missing := _missing_builtin_platform_dependency(platform):
+            return f"configured, missing dependency: {missing}"
         return "configured"
     return "not configured"
 

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -2720,11 +2720,16 @@ def _get_section_config_summary(config: dict, section_key: str) -> Optional[str]
         # platforms like WhatsApp ("enabled, not paired"), Matrix ("configured
         # + E2EE"), and Signal ("partially configured") all indicate the user
         # has already started setup and we shouldn't force the section to rerun.
-        configured = [
-            _gateway_platform_short_label(plat["label"])
-            for plat in _all_platforms()
-            if _platform_status(plat) and _platform_status(plat) != "not configured"
-        ]
+        configured = []
+        for plat in _all_platforms():
+            status = _platform_status(plat)
+            if not status or status == "not configured":
+                continue
+            label = _gateway_platform_short_label(plat["label"])
+            if "missing dependency" in status:
+                configured.append(f"{label} ({status})")
+            else:
+                configured.append(label)
         if configured:
             return ", ".join(configured)
         return None  # No platforms configured — section must run

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1072,6 +1072,9 @@ install_deps() {
             log_info "Then re-run: cd $INSTALL_DIR && uv pip install -e '.[all]'"
             exit 1
         fi
+        log_warn "Base install completed, but optional extras were not installed."
+        log_warn "Messaging gateways may be missing adapter dependencies until you install the full profile."
+        log_info "To restore optional extras, run: cd $INSTALL_DIR && uv pip install -e '.[all]'"
     else
         rm -f "$ALL_INSTALL_LOG"
     fi

--- a/setup-hermes.sh
+++ b/setup-hermes.sh
@@ -188,11 +188,21 @@ else
         UV_PROJECT_ENVIRONMENT="$SCRIPT_DIR/venv" $UV_CMD sync --all-extras --locked 2>/dev/null && \
             echo -e "${GREEN}✓${NC} Dependencies installed (lockfile verified)" || {
             echo -e "${YELLOW}⚠${NC} Lockfile install failed (may be outdated), falling back to pip install..."
-            $UV_CMD pip install -e ".[all]" || $UV_CMD pip install -e "."
+            if ! $UV_CMD pip install -e ".[all]"; then
+                $UV_CMD pip install -e "."
+                echo -e "${YELLOW}⚠${NC} Base install completed, but optional extras were not installed."
+                echo -e "${YELLOW}⚠${NC} Messaging gateways may be missing adapter dependencies until you install the full profile."
+                echo "    To restore optional extras: cd $SCRIPT_DIR && uv pip install -e '.[all]'"
+            fi
             echo -e "${GREEN}✓${NC} Dependencies installed"
         }
     else
-        $UV_CMD pip install -e ".[all]" || $UV_CMD pip install -e "."
+        if ! $UV_CMD pip install -e ".[all]"; then
+            $UV_CMD pip install -e "."
+            echo -e "${YELLOW}⚠${NC} Base install completed, but optional extras were not installed."
+            echo -e "${YELLOW}⚠${NC} Messaging gateways may be missing adapter dependencies until you install the full profile."
+            echo "    To restore optional extras: cd $SCRIPT_DIR && uv pip install -e '.[all]'"
+        fi
         echo -e "${GREEN}✓${NC} Dependencies installed"
     fi
 fi

--- a/tests/hermes_cli/test_setup_openclaw_migration.py
+++ b/tests/hermes_cli/test_setup_openclaw_migration.py
@@ -429,6 +429,28 @@ class TestGetSectionConfigSummary:
         assert "Telegram" in result
         assert "Discord" in result
 
+    def test_gateway_summary_marks_configured_platform_with_missing_dependency(self):
+        """Imported platform tokens should not hide missing adapter packages.
+
+        OpenClaw migration can bring over TELEGRAM_BOT_TOKEN into an install
+        whose venv only has base dependencies. The setup summary should still
+        flag that Telegram cannot start until its optional adapter dependency
+        is installed, instead of presenting it as fully configured.
+        """
+        def env_side(key):
+            return "tok123" if key == "TELEGRAM_BOT_TOKEN" else ""
+
+        import hermes_cli.gateway as gateway_mod
+        with patch.object(setup_mod, "get_env_value", side_effect=env_side), \
+             patch.object(gateway_mod, "get_env_value", side_effect=env_side), \
+             patch("importlib.util.find_spec", return_value=None):
+            result = setup_mod._get_section_config_summary({}, "gateway")
+
+        assert result is not None
+        assert "Telegram" in result
+        assert "missing dependency" in result
+        assert "python-telegram-bot" in result
+
     def test_tools_returns_none_without_keys(self):
         with patch.object(setup_mod, "get_env_value", return_value=""):
             result = setup_mod._get_section_config_summary({}, "tools")

--- a/tests/test_install_sh_optional_extras_fallback.py
+++ b/tests/test_install_sh_optional_extras_fallback.py
@@ -1,0 +1,21 @@
+"""Regression tests for install.sh optional-extras fallback visibility."""
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+INSTALL_SH = REPO_ROOT / "scripts" / "install.sh"
+SETUP_HERMES_SH = REPO_ROOT / "setup-hermes.sh"
+
+
+def test_install_sh_warns_that_base_fallback_disables_optional_extras() -> None:
+    text = INSTALL_SH.read_text()
+    assert "Base install completed, but optional extras were not installed" in text
+    assert "Messaging gateways may be missing adapter dependencies" in text
+    assert "uv pip install -e '.[all]'" in text
+
+
+def test_setup_hermes_warns_that_base_fallback_disables_optional_extras() -> None:
+    text = SETUP_HERMES_SH.read_text()
+    assert "Base install completed, but optional extras were not installed" in text
+    assert "Messaging gateways may be missing adapter dependencies" in text
+    assert "uv pip install -e '.[all]'" in text


### PR DESCRIPTION
## Summary
- Mark configured gateway platforms as missing dependencies when their optional Python adapter package is not importable
- Include missing dependency details in setup/OpenClaw migration gateway summaries instead of showing platforms as fully configured
- Warn when install scripts fall back from all-extras to base install, including messaging gateway dependency guidance

## Test Plan
- uv run --with pytest python -m pytest tests/hermes_cli/test_setup_openclaw_migration.py tests/test_install_sh_optional_extras_fallback.py tests/test_install_sh_setup_wizard_tty_probe.py tests/test_install_sh_termux_network_prereqs.py -q -o 'addopts='
- ./venv/bin/python -m py_compile hermes_cli/gateway.py hermes_cli/setup.py
- bash -n scripts/install.sh
- bash -n setup-hermes.sh
- git diff --check