### PR TITLE
refactor(kanban-orchestrator): drop hardcoded roster, prescribe Step-0 discovery (salvage #21131)

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -716,6 +716,8 @@ AUTHOR_MAP = {
     "5463986+baocin@users.noreply.github.com": "baocin",
     "107296821+princepal9120@users.noreply.github.com": "princepal9120",
     "gufo0125@gmail.com": "guglielmofonda",
+    "102474490+yehuosi@users.noreply.github.com": "yehuosi",
+    "yehuosi@users.noreply.github.com": "yehuosi",
     "23434080+sicnuyudidi@users.noreply.github.com": "sicnuyudidi",
     "haimu0x0@proton.me": "haimu0x",
     "abdelmajidnidnasser1@gmail.com": "NIDNASSER-Abdelmajid",

--- a/skills/devops/kanban-orchestrator/SKILL.md
+++ b/skills/devops/kanban-orchestrator/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: kanban-orchestrator
-description: Decomposition playbook + specialist-roster conventions + anti-temptation rules for an orchestrator profile routing work through Kanban. The "don't do the work yourself" rule and the basic lifecycle are auto-injected into every kanban worker's system prompt; this skill is the deeper playbook when you're specifically playing the orchestrator role.
-version: 2.0.0
+description: Decomposition playbook + anti-temptation rules for an orchestrator profile routing work through Kanban. The "don't do the work yourself" rule and the basic lifecycle are auto-injected into every kanban worker's system prompt; this skill is the deeper playbook when you're specifically playing the orchestrator role.
+version: 3.0.0
 platforms: [linux, macos, windows]
 metadata:
   hermes:
@@ -12,6 +12,22 @@ metadata:
 # Kanban Orchestrator — Decomposition Playbook
 
 > The **core worker lifecycle** (including the `kanban_create` fan-out pattern and the "decompose, don't execute" rule) is auto-injected into every kanban process via the `KANBAN_GUIDANCE` system-prompt block. This skill is the deeper playbook when you're an orchestrator profile whose whole job is routing.
+
+## Profiles are user-configured — not a fixed roster
+
+Hermes setups vary widely. Some users run a single profile that does everything; some run a small fleet (`docker-worker`, `cron-worker`); some run a curated specialist team they've named themselves. There is **no default specialist roster** — the orchestrator skill does not know what profiles exist on this machine.
+
+Before fanning out, you must ground the decomposition in the profiles that actually exist. The dispatcher silently fails to spawn unknown assignee names — it doesn't autocorrect, doesn't suggest, doesn't fall back. So a card assigned to `researcher` on a setup that only has `docker-worker` just sits in `ready` forever.
+
+**Step 0: discover available profiles before planning.**
+
+Use one of these:
+
+- `hermes profile list` — prints the table of profiles configured on this machine. Run it through your terminal tool if you have one; otherwise ask the user.
+- `kanban_list(assignee="<some-name>")` — sanity-check a single name. Returns an empty list (rather than an error) for an unknown assignee, so this only confirms a name you're already considering.
+- **Just ask the user.** "What profiles do you have set up?" is a fine first turn when the goal needs more than one specialist.
+
+Cache the result in your working memory for the rest of the conversation. Re-asking every turn wastes a tool call.
 
 ## When to use the board (vs. just doing the work)
 
@@ -34,23 +50,8 @@ Your job description says "route, don't execute." The rules that enforce that:
 - **For any concrete task, create a Kanban task and assign it.** Every single time.
 - **Split multi-lane requests before creating cards.** A user prompt can contain several independent workstreams. Extract those lanes first, then create one card per lane instead of bundling unrelated work into a single implementer card.
 - **Run independent lanes in parallel.** If two cards do not need each other's output, leave them unlinked so the dispatcher can fan them out. Link only true data dependencies.
-- **If no specialist fits, ask the user which profile to create.** Do not default to doing it yourself under "close enough."
+- **If no specialist fits the available profiles, ask the user which profile to create or which existing profile to use.** Do not invent profile names; the dispatcher will silently drop unknown assignees.
 - **Decompose, route, and summarize — that's the whole job.**
-
-## The standard specialist roster (convention)
-
-Unless the user's setup has customized profiles, assume these exist. Adjust to whatever the user actually has — ask if you're unsure.
-
-| Profile | Does | Typical workspace |
-|---|---|---|
-| `researcher` | Reads sources, gathers facts, writes findings | `scratch` |
-| `analyst` | Synthesizes, ranks, de-dupes. Consumes multiple `researcher` outputs | `scratch` |
-| `writer` | Drafts prose in the user's voice | `scratch` or `dir:` into their Obsidian vault |
-| `reviewer` | Reads output, leaves findings, gates approval | `scratch` |
-| `backend-eng` | Writes server-side code | `worktree` |
-| `frontend-eng` | Writes client-side code | `worktree` |
-| `ops` | Runs scripts, manages services, handles deployments | `dir:` into ops scripts repo |
-| `pm` | Writes specs, acceptance criteria | `scratch` |
 
 ## Decomposition playbook
 
@@ -63,57 +64,50 @@ Ask clarifying questions if the goal is ambiguous. Cheap to ask; expensive to sp
 Before creating anything, draft the graph out loud (in your response to the user). Treat every concrete workstream as a candidate card:
 
 1. Extract the lanes from the request.
-2. Assign each lane to the best specialist.
+2. Map each lane to one of the profiles you discovered in Step 0. If a lane doesn't fit any existing profile, ask the user which to use or create.
 3. Decide whether each lane is independent or gated by another lane.
 4. Create independent lanes as parallel cards with no parent links.
 5. Create synthesis/review/integration cards with parent links to the lanes they depend on.
 
-Examples of prompts that should fan out:
+Examples of prompts that should fan out (using placeholder profile names — substitute whatever exists on the user's setup):
 
-- "Build an app" -> `designer` for product/UI direction and `frontend-eng` or `backend-eng` for implementation, with a later integration/review card if needed.
-- "Fix blockers and check model variants" -> one implementation card for the blocker fixes plus one discovery/research card for config/source verification. A final reviewer card can depend on both.
-- "Research docs and implement" -> a docs-research card can run in parallel with a codebase-discovery card; implementation waits only if it truly needs those findings.
-- "Analyze this screenshot and find the related code" -> `observer` handles visual analysis while an explorer-style profile searches the codebase.
+- "Build an app" → one card to a design-oriented profile for product/UI direction, one or two cards to engineering profiles for implementation, plus a later integration/review card if the user has a reviewer profile.
+- "Fix blockers and check model variants" → one implementation card for the blocker fixes plus one discovery/research card for config/source verification. A final reviewer card can depend on both.
+- "Research docs and implement" → a docs-research card can run in parallel with a codebase-discovery card; implementation waits only if it truly needs those findings.
+- "Analyze this screenshot and find the related code" → one card to a vision-capable profile for the visual analysis while another searches the codebase.
 
 Words like "also," "finally," or "and" do not automatically imply a dependency. They often mean "make sure this is covered before reporting back." Only link tasks when one card cannot start until another card's output exists.
 
-Example for "Analyze whether we should migrate to Postgres":
-
-```
-T1  researcher        research: Postgres cost vs current
-T2  researcher        research: Postgres performance vs current
-T3  analyst           synthesize migration recommendation       parents: T1, T2
-T4  writer            draft decision memo                       parents: T3
-```
-
-Show this to the user. Let them correct it before you create anything.
+Show the graph to the user before creating cards. Let them correct it — including which actual profile name should own each lane.
 
 ### Step 3 — Create tasks and link
+
+Use the profile names from Step 0. The example below uses placeholders `<profile-A>`, `<profile-B>`, `<profile-C>` — replace them with what the user actually has.
 
 ```python
 t1 = kanban_create(
     title="research: Postgres cost vs current",
-    assignee="researcher",
+    assignee="<profile-A>",  # whichever profile handles research on this setup
     body="Compare estimated infrastructure costs, migration costs, and ongoing ops costs over a 3-year window. Sources: AWS/GCP pricing, team time estimates, current Postgres bills from peers.",
     tenant=os.environ.get("HERMES_TENANT"),
 )["task_id"]
 
 t2 = kanban_create(
     title="research: Postgres performance vs current",
-    assignee="researcher",
+    assignee="<profile-A>",  # same profile, run in parallel
     body="Compare query latency, throughput, and scaling characteristics at our expected data volume (~500GB, 10k QPS peak). Sources: benchmark papers, public case studies, pgbench results if easy.",
 )["task_id"]
 
 t3 = kanban_create(
     title="synthesize migration recommendation",
-    assignee="analyst",
+    assignee="<profile-B>",  # whichever profile does synthesis/analysis
     body="Read the findings from T1 (cost) and T2 (performance). Produce a 1-page recommendation with explicit trade-offs and a go/no-go call.",
     parents=[t1, t2],
 )["task_id"]
 
 t4 = kanban_create(
     title="draft decision memo",
-    assignee="writer",
+    assignee="<profile-C>",  # whichever profile drafts user-facing prose
     body="Turn the analyst's recommendation into a 2-page memo for the CTO. Match the tone of previous decision memos in the team's knowledge base.",
     parents=[t3],
 )["task_id"]
@@ -123,17 +117,17 @@ t4 = kanban_create(
 
 ### Step 4 — Complete your own task
 
-If you were spawned as a task yourself (e.g. `planner` profile was assigned `T0: "investigate Postgres migration"`), mark it done with a summary of what you created:
+If you were spawned as a task yourself (e.g. a planner profile was assigned `T0: "investigate Postgres migration"`), mark it done with a summary of what you created:
 
 ```python
 kanban_complete(
-    summary="decomposed into T1-T4: 2 researchers parallel, 1 analyst on their outputs, 1 writer on the recommendation",
+    summary="decomposed into T1-T4: 2 research lanes in parallel, 1 synthesis on their outputs, 1 prose draft on the recommendation",
     metadata={
         "task_graph": {
-            "T1": {"assignee": "researcher", "parents": []},
-            "T2": {"assignee": "researcher", "parents": []},
-            "T3": {"assignee": "analyst", "parents": ["T1", "T2"]},
-            "T4": {"assignee": "writer", "parents": ["T3"]},
+            "T1": {"assignee": "<profile-A>", "parents": []},
+            "T2": {"assignee": "<profile-A>", "parents": []},
+            "T3": {"assignee": "<profile-B>", "parents": ["T1", "T2"]},
+            "T4": {"assignee": "<profile-C>", "parents": ["T3"]},
         },
     },
 )
@@ -141,29 +135,31 @@ kanban_complete(
 
 ### Step 5 — Report back to the user
 
-Tell them what you created in plain prose:
+Tell them what you created in plain prose, naming the actual profiles you used:
 
 > I've queued 4 tasks:
-> - **T1** (researcher): cost comparison
-> - **T2** (researcher): performance comparison, in parallel with T1
-> - **T3** (analyst): synthesizes T1 + T2 into a recommendation
-> - **T4** (writer): turns T3 into a CTO memo
+> - **T1** (`<profile-A>`): cost comparison
+> - **T2** (`<profile-A>`): performance comparison, in parallel with T1
+> - **T3** (`<profile-B>`): synthesizes T1 + T2 into a recommendation
+> - **T4** (`<profile-C>`): turns T3 into a CTO memo
 >
 > The dispatcher will pick up T1 and T2 now. T3 starts when both finish. You'll get a gateway ping when T4 completes. Use the dashboard or `hermes kanban tail <id>` to follow along.
 
 ## Common patterns
 
-**Fan-out + fan-in (research → synthesize):** N `researcher` tasks with no parents, one `analyst` task with all of them as parents.
+**Fan-out + fan-in (research → synthesize):** N research-style cards with no parents, one synthesis card with all of them as parents.
 
 **Parallel implementation + validation:** one implementer card makes the change while one explorer/researcher card verifies config, docs, or source mapping. A reviewer card can depend on both. Do not make the implementer own unrelated verification just because the user mentioned both in one sentence.
 
-**Pipeline with gates:** `pm → backend-eng → reviewer`. Each stage's `parents=[previous_task]`. Reviewer blocks or completes; if reviewer blocks, the operator unblocks with feedback and respawns.
+**Pipeline with gates:** `planner → implementer → reviewer`. Each stage's `parents=[previous_task]`. Reviewer blocks or completes; if reviewer blocks, the operator unblocks with feedback and respawns.
 
-**Same-profile queue:** 50 tasks, all assigned to `translator`, no dependencies between them. Dispatcher serializes — translator processes them in priority order, accumulating experience in their own memory.
+**Same-profile queue:** N tasks, all assigned to the same profile, no dependencies between them. Dispatcher serializes — that profile processes them in priority order, accumulating experience in its own memory.
 
 **Human-in-the-loop:** Any task can `kanban_block()` to wait for input. Dispatcher respawns after `/unblock`. The comment thread carries the full context.
 
 ## Pitfalls
+
+**Inventing profile names that don't exist.** The dispatcher silently fails to spawn unknown assignees — the card just sits in `ready` forever. Always assign to a profile from your Step 0 discovery; ask the user if you're unsure.
 
 **Bundling independent lanes into one card.** If the user asks for two independent outcomes, create two cards. Example: "fix blockers and check model variants" is not one fixer task; create a fixer/engineer card for the fixes and an explorer/researcher card for the variant check, then optionally gate review on both.
 
@@ -184,7 +180,7 @@ Tell them what you created in plain prose:
 When a worker profile keeps crashing, hallucinating, or getting blocked by its own mistakes (usually: wrong model, missing skill, broken credential), the kanban dashboard flags the task with a ⚠ badge and opens a **Recovery** section in the drawer. Three primary actions:
 
 1. **Reclaim** (or `hermes kanban reclaim <task_id>`) — abort the running worker immediately and reset the task to `ready`. The existing claim TTL is ~15 min; this is the fast path out.
-2. **Reassign** (or `hermes kanban reassign <task_id> <new-profile> --reclaim`) — switch the task to a different profile and let the dispatcher pick it up with a fresh worker.
+2. **Reassign** (or `hermes kanban reassign <task_id> <new-profile> --reclaim`) — switch the task to a different profile (one that exists on this setup) and let the dispatcher pick it up with a fresh worker.
 3. **Change profile model** — the dashboard prints a copy-paste hint for `hermes -p <profile> model` since profile config lives on disk; edit it in a terminal, then Reclaim to retry with the new model.
 
 Hallucination warnings appear on tasks where a worker's `kanban_complete(created_cards=[...])` claim included card ids that don't exist or weren't created by the worker's profile (the gate blocks the completion), or where the free-form summary references `t_<hex>` ids that don't resolve (advisory prose scan, non-blocking). Both produce audit events that persist even after recovery actions — the trail stays for debugging.

--- a/website/docs/reference/skills-catalog.md
+++ b/website/docs/reference/skills-catalog.md
@@ -65,7 +65,7 @@ If a skill is missing from this list but present in the repo, the catalog is reg
 
 | Skill | Description | Path |
 |-------|-------------|------|
-| [`kanban-orchestrator`](/docs/user-guide/skills/bundled/devops/devops-kanban-orchestrator) | Decomposition playbook + specialist-roster conventions + anti-temptation rules for an orchestrator profile routing work through Kanban. The "don't do the work yourself" rule and the basic lifecycle are auto-injected into every kanban wor... | `devops/kanban-orchestrator` |
+| [`kanban-orchestrator`](/docs/user-guide/skills/bundled/devops/devops-kanban-orchestrator) | Decomposition playbook + anti-temptation rules for an orchestrator profile routing work through Kanban. The "don't do the work yourself" rule and the basic lifecycle are auto-injected into every kanban worker's system prompt; this skill... | `devops/kanban-orchestrator` |
 | [`kanban-worker`](/docs/user-guide/skills/bundled/devops/devops-kanban-worker) | Pitfalls, examples, and edge cases for Hermes Kanban workers. The lifecycle itself is auto-injected into every worker's system prompt as KANBAN_GUIDANCE (from agent/prompt_builder.py); this skill is what you load when you want deeper det... | `devops/kanban-worker` |
 | [`webhook-subscriptions`](/docs/user-guide/skills/bundled/devops/devops-webhook-subscriptions) | Webhook subscriptions: event-driven agent runs. | `devops/webhook-subscriptions` |
 

--- a/website/docs/user-guide/features/kanban.md
+++ b/website/docs/user-guide/features/kanban.md
@@ -393,7 +393,7 @@ These skills are **additive** to the built-in `kanban-worker` — the dispatcher
 
 ### The orchestrator skill
 
-A **well-behaved orchestrator does not do the work itself.** It decomposes the user's goal into tasks, links them, assigns each to a specialist, and steps back. The `kanban-orchestrator` skill encodes this as tool-call patterns: anti-temptation rules, a standard specialist roster (`researcher`, `writer`, `analyst`, `backend-eng`, `reviewer`, `ops`), and a decomposition playbook keyed on `kanban_create` / `kanban_link` / `kanban_comment`.
+A **well-behaved orchestrator does not do the work itself.** It decomposes the user's goal into tasks, links them, assigns each to one of the profiles you've set up, and steps back. The `kanban-orchestrator` skill encodes this as tool-call patterns: anti-temptation rules, a Step-0 profile-discovery prompt (the dispatcher silently fails on unknown assignee names, so the orchestrator must ground every card in profiles that actually exist on your machine), and a decomposition playbook keyed on `kanban_create` / `kanban_link` / `kanban_comment`.
 
 A canonical orchestrator turn (two parallel researchers handing off to a writer):
 

--- a/website/docs/user-guide/skills/bundled/devops/devops-kanban-orchestrator.md
+++ b/website/docs/user-guide/skills/bundled/devops/devops-kanban-orchestrator.md
@@ -1,14 +1,14 @@
 ---
 title: "Kanban Orchestrator"
 sidebar_label: "Kanban Orchestrator"
-description: "Decomposition playbook + specialist-roster conventions + anti-temptation rules for an orchestrator profile routing work through Kanban"
+description: "Decomposition playbook + anti-temptation rules for an orchestrator profile routing work through Kanban"
 ---
 
 {/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
 
 # Kanban Orchestrator
 
-Decomposition playbook + specialist-roster conventions + anti-temptation rules for an orchestrator profile routing work through Kanban. The "don't do the work yourself" rule and the basic lifecycle are auto-injected into every kanban worker's system prompt; this skill is the deeper playbook when you're specifically playing the orchestrator role.
+Decomposition playbook + anti-temptation rules for an orchestrator profile routing work through Kanban. The "don't do the work yourself" rule and the basic lifecycle are auto-injected into every kanban worker's system prompt; this skill is the deeper playbook when you're specifically playing the orchestrator role.
 
 ## Skill metadata
 
@@ -16,7 +16,7 @@ Decomposition playbook + specialist-roster conventions + anti-temptation rules f
 |---|---|
 | Source | Bundled (installed by default) |
 | Path | `skills/devops/kanban-orchestrator` |
-| Version | `2.0.0` |
+| Version | `3.0.0` |
 | Platforms | linux, macos, windows |
 | Tags | `kanban`, `multi-agent`, `orchestration`, `routing` |
 | Related skills | [`kanban-worker`](/docs/user-guide/skills/bundled/devops/devops-kanban-worker) |
@@ -30,6 +30,22 @@ The following is the complete skill definition that Hermes loads when this skill
 # Kanban Orchestrator — Decomposition Playbook
 
 > The **core worker lifecycle** (including the `kanban_create` fan-out pattern and the "decompose, don't execute" rule) is auto-injected into every kanban process via the `KANBAN_GUIDANCE` system-prompt block. This skill is the deeper playbook when you're an orchestrator profile whose whole job is routing.
+
+## Profiles are user-configured — not a fixed roster
+
+Hermes setups vary widely. Some users run a single profile that does everything; some run a small fleet (`docker-worker`, `cron-worker`); some run a curated specialist team they've named themselves. There is **no default specialist roster** — the orchestrator skill does not know what profiles exist on this machine.
+
+Before fanning out, you must ground the decomposition in the profiles that actually exist. The dispatcher silently fails to spawn unknown assignee names — it doesn't autocorrect, doesn't suggest, doesn't fall back. So a card assigned to `researcher` on a setup that only has `docker-worker` just sits in `ready` forever.
+
+**Step 0: discover available profiles before planning.**
+
+Use one of these:
+
+- `hermes profile list` — prints the table of profiles configured on this machine. Run it through your terminal tool if you have one; otherwise ask the user.
+- `kanban_list(assignee="<some-name>")` — sanity-check a single name. Returns an empty list (rather than an error) for an unknown assignee, so this only confirms a name you're already considering.
+- **Just ask the user.** "What profiles do you have set up?" is a fine first turn when the goal needs more than one specialist.
+
+Cache the result in your working memory for the rest of the conversation. Re-asking every turn wastes a tool call.
 
 ## When to use the board (vs. just doing the work)
 
@@ -50,23 +66,10 @@ Your job description says "route, don't execute." The rules that enforce that:
 
 - **Do not execute the work yourself.** Your restricted toolset usually doesn't even include terminal/file/code/web for implementation. If you find yourself "just fixing this quickly" — stop and create a task for the right specialist.
 - **For any concrete task, create a Kanban task and assign it.** Every single time.
-- **If no specialist fits, ask the user which profile to create.** Do not default to doing it yourself under "close enough."
+- **Split multi-lane requests before creating cards.** A user prompt can contain several independent workstreams. Extract those lanes first, then create one card per lane instead of bundling unrelated work into a single implementer card.
+- **Run independent lanes in parallel.** If two cards do not need each other's output, leave them unlinked so the dispatcher can fan them out. Link only true data dependencies.
+- **If no specialist fits the available profiles, ask the user which profile to create or which existing profile to use.** Do not invent profile names; the dispatcher will silently drop unknown assignees.
 - **Decompose, route, and summarize — that's the whole job.**
-
-## The standard specialist roster (convention)
-
-Unless the user's setup has customized profiles, assume these exist. Adjust to whatever the user actually has — ask if you're unsure.
-
-| Profile | Does | Typical workspace |
-|---|---|---|
-| `researcher` | Reads sources, gathers facts, writes findings | `scratch` |
-| `analyst` | Synthesizes, ranks, de-dupes. Consumes multiple `researcher` outputs | `scratch` |
-| `writer` | Drafts prose in the user's voice | `scratch` or `dir:` into their Obsidian vault |
-| `reviewer` | Reads output, leaves findings, gates approval | `scratch` |
-| `backend-eng` | Writes server-side code | `worktree` |
-| `frontend-eng` | Writes client-side code | `worktree` |
-| `ops` | Runs scripts, manages services, handles deployments | `dir:` into ops scripts repo |
-| `pm` | Writes specs, acceptance criteria | `scratch` |
 
 ## Decomposition playbook
 
@@ -76,43 +79,53 @@ Ask clarifying questions if the goal is ambiguous. Cheap to ask; expensive to sp
 
 ### Step 2 — Sketch the task graph
 
-Before creating anything, draft the graph out loud (in your response to the user). Example for "Analyze whether we should migrate to Postgres":
+Before creating anything, draft the graph out loud (in your response to the user). Treat every concrete workstream as a candidate card:
 
-```
-T1  researcher        research: Postgres cost vs current
-T2  researcher        research: Postgres performance vs current
-T3  analyst           synthesize migration recommendation       parents: T1, T2
-T4  writer            draft decision memo                       parents: T3
-```
+1. Extract the lanes from the request.
+2. Map each lane to one of the profiles you discovered in Step 0. If a lane doesn't fit any existing profile, ask the user which to use or create.
+3. Decide whether each lane is independent or gated by another lane.
+4. Create independent lanes as parallel cards with no parent links.
+5. Create synthesis/review/integration cards with parent links to the lanes they depend on.
 
-Show this to the user. Let them correct it before you create anything.
+Examples of prompts that should fan out (using placeholder profile names — substitute whatever exists on the user's setup):
+
+- "Build an app" → one card to a design-oriented profile for product/UI direction, one or two cards to engineering profiles for implementation, plus a later integration/review card if the user has a reviewer profile.
+- "Fix blockers and check model variants" → one implementation card for the blocker fixes plus one discovery/research card for config/source verification. A final reviewer card can depend on both.
+- "Research docs and implement" → a docs-research card can run in parallel with a codebase-discovery card; implementation waits only if it truly needs those findings.
+- "Analyze this screenshot and find the related code" → one card to a vision-capable profile for the visual analysis while another searches the codebase.
+
+Words like "also," "finally," or "and" do not automatically imply a dependency. They often mean "make sure this is covered before reporting back." Only link tasks when one card cannot start until another card's output exists.
+
+Show the graph to the user before creating cards. Let them correct it — including which actual profile name should own each lane.
 
 ### Step 3 — Create tasks and link
+
+Use the profile names from Step 0. The example below uses placeholders `<profile-A>`, `<profile-B>`, `<profile-C>` — replace them with what the user actually has.
 
 ```python
 t1 = kanban_create(
     title="research: Postgres cost vs current",
-    assignee="researcher",
+    assignee="<profile-A>",  # whichever profile handles research on this setup
     body="Compare estimated infrastructure costs, migration costs, and ongoing ops costs over a 3-year window. Sources: AWS/GCP pricing, team time estimates, current Postgres bills from peers.",
     tenant=os.environ.get("HERMES_TENANT"),
 )["task_id"]
 
 t2 = kanban_create(
     title="research: Postgres performance vs current",
-    assignee="researcher",
+    assignee="<profile-A>",  # same profile, run in parallel
     body="Compare query latency, throughput, and scaling characteristics at our expected data volume (~500GB, 10k QPS peak). Sources: benchmark papers, public case studies, pgbench results if easy.",
 )["task_id"]
 
 t3 = kanban_create(
     title="synthesize migration recommendation",
-    assignee="analyst",
+    assignee="<profile-B>",  # whichever profile does synthesis/analysis
     body="Read the findings from T1 (cost) and T2 (performance). Produce a 1-page recommendation with explicit trade-offs and a go/no-go call.",
     parents=[t1, t2],
 )["task_id"]
 
 t4 = kanban_create(
     title="draft decision memo",
-    assignee="writer",
+    assignee="<profile-C>",  # whichever profile drafts user-facing prose
     body="Turn the analyst's recommendation into a 2-page memo for the CTO. Match the tone of previous decision memos in the team's knowledge base.",
     parents=[t3],
 )["task_id"]
@@ -122,17 +135,17 @@ t4 = kanban_create(
 
 ### Step 4 — Complete your own task
 
-If you were spawned as a task yourself (e.g. `planner` profile was assigned `T0: "investigate Postgres migration"`), mark it done with a summary of what you created:
+If you were spawned as a task yourself (e.g. a planner profile was assigned `T0: "investigate Postgres migration"`), mark it done with a summary of what you created:
 
 ```python
 kanban_complete(
-    summary="decomposed into T1-T4: 2 researchers parallel, 1 analyst on their outputs, 1 writer on the recommendation",
+    summary="decomposed into T1-T4: 2 research lanes in parallel, 1 synthesis on their outputs, 1 prose draft on the recommendation",
     metadata={
         "task_graph": {
-            "T1": {"assignee": "researcher", "parents": []},
-            "T2": {"assignee": "researcher", "parents": []},
-            "T3": {"assignee": "analyst", "parents": ["T1", "T2"]},
-            "T4": {"assignee": "writer", "parents": ["T3"]},
+            "T1": {"assignee": "<profile-A>", "parents": []},
+            "T2": {"assignee": "<profile-A>", "parents": []},
+            "T3": {"assignee": "<profile-B>", "parents": ["T1", "T2"]},
+            "T4": {"assignee": "<profile-C>", "parents": ["T3"]},
         },
     },
 )
@@ -140,27 +153,37 @@ kanban_complete(
 
 ### Step 5 — Report back to the user
 
-Tell them what you created in plain prose:
+Tell them what you created in plain prose, naming the actual profiles you used:
 
 > I've queued 4 tasks:
-> - **T1** (researcher): cost comparison
-> - **T2** (researcher): performance comparison, in parallel with T1
-> - **T3** (analyst): synthesizes T1 + T2 into a recommendation
-> - **T4** (writer): turns T3 into a CTO memo
+> - **T1** (`<profile-A>`): cost comparison
+> - **T2** (`<profile-A>`): performance comparison, in parallel with T1
+> - **T3** (`<profile-B>`): synthesizes T1 + T2 into a recommendation
+> - **T4** (`<profile-C>`): turns T3 into a CTO memo
 >
 > The dispatcher will pick up T1 and T2 now. T3 starts when both finish. You'll get a gateway ping when T4 completes. Use the dashboard or `hermes kanban tail <id>` to follow along.
 
 ## Common patterns
 
-**Fan-out + fan-in (research → synthesize):** N `researcher` tasks with no parents, one `analyst` task with all of them as parents.
+**Fan-out + fan-in (research → synthesize):** N research-style cards with no parents, one synthesis card with all of them as parents.
 
-**Pipeline with gates:** `pm → backend-eng → reviewer`. Each stage's `parents=[previous_task]`. Reviewer blocks or completes; if reviewer blocks, the operator unblocks with feedback and respawns.
+**Parallel implementation + validation:** one implementer card makes the change while one explorer/researcher card verifies config, docs, or source mapping. A reviewer card can depend on both. Do not make the implementer own unrelated verification just because the user mentioned both in one sentence.
 
-**Same-profile queue:** 50 tasks, all assigned to `translator`, no dependencies between them. Dispatcher serializes — translator processes them in priority order, accumulating experience in their own memory.
+**Pipeline with gates:** `planner → implementer → reviewer`. Each stage's `parents=[previous_task]`. Reviewer blocks or completes; if reviewer blocks, the operator unblocks with feedback and respawns.
+
+**Same-profile queue:** N tasks, all assigned to the same profile, no dependencies between them. Dispatcher serializes — that profile processes them in priority order, accumulating experience in its own memory.
 
 **Human-in-the-loop:** Any task can `kanban_block()` to wait for input. Dispatcher respawns after `/unblock`. The comment thread carries the full context.
 
 ## Pitfalls
+
+**Inventing profile names that don't exist.** The dispatcher silently fails to spawn unknown assignees — the card just sits in `ready` forever. Always assign to a profile from your Step 0 discovery; ask the user if you're unsure.
+
+**Bundling independent lanes into one card.** If the user asks for two independent outcomes, create two cards. Example: "fix blockers and check model variants" is not one fixer task; create a fixer/engineer card for the fixes and an explorer/researcher card for the variant check, then optionally gate review on both.
+
+**Over-linking because of wording.** "Finally check X" may still be parallel with implementation if X is static config, docs, or source discovery. Link it after implementation only when the check depends on the implementation result.
+
+**Forgetting dependency links.** If the task graph says `research -> implement -> review`, do not create all tasks as independent ready cards. Use parent links so implement/review cannot run before their inputs exist.
 
 **Reassignment vs. new task.** If a reviewer blocks with "needs changes," create a NEW task linked from the reviewer's task — don't re-run the same task with a stern look. The new task is assigned to the original implementer profile.
 
@@ -175,7 +198,7 @@ Tell them what you created in plain prose:
 When a worker profile keeps crashing, hallucinating, or getting blocked by its own mistakes (usually: wrong model, missing skill, broken credential), the kanban dashboard flags the task with a ⚠ badge and opens a **Recovery** section in the drawer. Three primary actions:
 
 1. **Reclaim** (or `hermes kanban reclaim <task_id>`) — abort the running worker immediately and reset the task to `ready`. The existing claim TTL is ~15 min; this is the fast path out.
-2. **Reassign** (or `hermes kanban reassign <task_id> <new-profile> --reclaim`) — switch the task to a different profile and let the dispatcher pick it up with a fresh worker.
+2. **Reassign** (or `hermes kanban reassign <task_id> <new-profile> --reclaim`) — switch the task to a different profile (one that exists on this setup) and let the dispatcher pick it up with a fresh worker.
 3. **Change profile model** — the dashboard prints a copy-paste hint for `hermes -p <profile> model` since profile config lives on disk; edit it in a terminal, then Reclaim to retry with the new model.
 
 Hallucination warnings appear on tasks where a worker's `kanban_complete(created_cards=[...])` claim included card ids that don't exist or weren't created by the worker's profile (the gate blocks the completion), or where the free-form summary references `t_<hex>` ids that don't resolve (advisory prose scan, non-blocking). Both produce audit events that persist even after recovery actions — the trail stays for debugging.


### PR DESCRIPTION
## Summary
The kanban-orchestrator skill no longer enumerates a hardcoded "standard specialist roster" of 8 profile names. Replaced with a Step-0 profile-discovery instruction that grounds the decomposition in profiles that actually exist on the user's machine — the dispatcher silently fails to spawn unknown assignee names, so the previous "assume these exist" framing was a hallucination factory.

## Why
The previous skill listed `researcher`, `analyst`, `writer`, `reviewer`, `backend-eng`, `frontend-eng`, `ops`, `pm` and said "Unless the user's setup has customized profiles, assume these exist." Almost no real Hermes setup matches that fleet — single-profile setups, Docker-worker setups, and curated-team setups all violate it. Following the skill literally produced cards assigned to non-existent profiles, which the dispatcher silently dropped (no autocorrect, no fallback, just sits in `ready` forever).

This PR addresses the same root cause as #21131 (which proposed dynamic discovery) but with a different shape: delete the roster table entirely rather than replace each concrete name with a placeholder. The worked example is preserved with explicit `<profile-A>` / `<profile-B>` / `<profile-C>` placeholders so the structure is still teachable without inviting copy-paste of role names.

## Changes
- `skills/devops/kanban-orchestrator/SKILL.md`:
  - Drop the standard-specialist-roster table.
  - Add a top section "Profiles are user-configured — not a fixed roster" with **Step 0: discover available profiles before planning** prescribing `hermes profile list` (or asking the user) and caching the result.
  - Rewrite the worked Postgres example with placeholder profile names so the structure is still teachable.
  - Reframe the "If no specialist fits" anti-temptation rule: don't invent profile names; ask the user.
  - Add an "Inventing profile names that don't exist" entry to Pitfalls.
  - Update fan-out examples in Step 2 to use generic role descriptions ("a design-oriented profile", "a vision-capable profile") rather than presumed concrete names.
  - Bump version 2.0.0 → 3.0.0.
- `website/docs/user-guide/features/kanban.md`: drop the matching `(researcher, writer, analyst, backend-eng, reviewer, ops)` line and explain the discovery prompt instead.
- Auto-regenerated `website/docs/user-guide/skills/bundled/devops/devops-kanban-orchestrator.md` + `website/docs/reference/skills-catalog.md` from the updated SKILL.md.

## Validation
Pure documentation change. The skill is loaded by name (not parsed for structured data), and no source code consumes the previously-listed specialist names. The video orchestrator workflow (`optional-skills/creative/kanban-video-orchestrator/`) which `related_skills`-references this skill still works — it carries its own role-archetypes reference that defines its specific Director/Researcher/Writer/Animator/Composer fleet, and the orchestrator skill remains the deeper playbook for the cross-cutting decomposition rules.

Closes #21131 in spirit. The original PR by @yehuosi proposed dynamic discovery via runtime helper; this lands the same instinct as a Step-0 prompt-level instruction with placeholder examples instead. @yehuosi credited via `Co-authored-by:` on the commit and AUTHOR_MAP entry. Issue/PR thread carries the full context.
