### PR TITLE
feat: add agent roster enforcement plugin

### DIFF
--- a/plugins/agent-roster/__init__.py
+++ b/plugins/agent-roster/__init__.py
@@ -1,0 +1,91 @@
+"""Agent Roster plugin hooks.
+
+Operationalizes profile_role metadata by injecting compact role context into
+Kanban worker turns, enforcing forbidden tool actions in warn/block mode, and
+auditing tool calls for the dashboard.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Any, Optional
+
+
+def _load_core():
+    try:
+        from . import roster_core as core  # type: ignore
+        return core
+    except Exception:
+        path = Path(__file__).resolve().with_name("roster_core.py")
+        spec = importlib.util.spec_from_file_location("agent_roster_roster_core", path)
+        if spec is None or spec.loader is None:
+            raise ImportError(f"Cannot load {path}")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+
+
+def on_pre_llm_call(
+    *,
+    session_id: str = "",
+    user_message: str = "",
+    conversation_history: Optional[list] = None,
+    is_first_turn: bool = False,
+    model: str = "",
+    platform: str = "",
+    sender_id: str = "",
+    **_: Any,
+) -> Optional[dict[str, str]]:
+    core = _load_core()
+    context = core.role_context_for_current_turn()
+    if not context:
+        return None
+    return {"context": context}
+
+
+def on_pre_tool_call(
+    *,
+    tool_name: str = "",
+    args: Optional[dict[str, Any]] = None,
+    task_id: str = "",
+    session_id: str = "",
+    tool_call_id: str = "",
+    **_: Any,
+) -> Optional[dict[str, str]]:
+    core = _load_core()
+    return core.evaluate_tool_policy(
+        tool_name,
+        args if isinstance(args, dict) else {},
+        session_id=session_id,
+        task_id=task_id,
+        tool_call_id=tool_call_id,
+    )
+
+
+def on_post_tool_call(
+    *,
+    tool_name: str = "",
+    args: Optional[dict[str, Any]] = None,
+    result: Any = None,
+    task_id: str = "",
+    session_id: str = "",
+    tool_call_id: str = "",
+    duration_ms: int = 0,
+    **_: Any,
+) -> None:
+    core = _load_core()
+    core.audit_tool_result(
+        tool_name,
+        args if isinstance(args, dict) else {},
+        result,
+        session_id=session_id,
+        task_id=task_id,
+        tool_call_id=tool_call_id,
+        duration_ms=duration_ms,
+    )
+
+
+def register(ctx) -> None:
+    ctx.register_hook("pre_llm_call", on_pre_llm_call)
+    ctx.register_hook("pre_tool_call", on_pre_tool_call)
+    ctx.register_hook("post_tool_call", on_post_tool_call)

--- a/plugins/agent-roster/dashboard/dist/index.js
+++ b/plugins/agent-roster/dashboard/dist/index.js
@@ -1,0 +1,143 @@
+(function () {
+  "use strict";
+
+  const SDK = window.__HERMES_PLUGIN_SDK__;
+  if (!SDK || !window.__HERMES_PLUGINS__) return;
+
+  const React = SDK.React;
+  const h = React.createElement;
+  const hooks = SDK.hooks || {};
+  const useEffect = hooks.useEffect;
+  const useState = hooks.useState;
+  const components = SDK.components || {};
+  const Card = components.Card || "div";
+  const CardHeader = components.CardHeader || "div";
+  const CardTitle = components.CardTitle || "h2";
+  const CardContent = components.CardContent || "div";
+  const Badge = components.Badge || "span";
+  const Button = components.Button || "button";
+
+  const API = "/api/plugins/agent-roster";
+
+  function badgeClass(severity) {
+    if (severity === "high" || severity === "critical") return "agent-roster-badge-danger";
+    if (severity === "medium") return "agent-roster-badge-warning";
+    return "agent-roster-badge-muted";
+  }
+
+  function Stat(props) {
+    return h("div", { className: "agent-roster-stat" },
+      h("div", { className: "agent-roster-stat-value" }, String(props.value == null ? "—" : props.value)),
+      h("div", { className: "agent-roster-stat-label" }, props.label)
+    );
+  }
+
+  function AgentRosterPage() {
+    const _state = useState(null);
+    const data = _state[0];
+    const setData = _state[1];
+    const _err = useState(null);
+    const error = _err[0];
+    const setError = _err[1];
+    const _loading = useState(false);
+    const loading = _loading[0];
+    const setLoading = _loading[1];
+
+    function load() {
+      setLoading(true);
+      setError(null);
+      SDK.fetchJSON(API + "/roster")
+        .then(function (payload) { setData(payload); })
+        .catch(function (err) { setError(String(err && err.message ? err.message : err)); })
+        .finally(function () { setLoading(false); });
+    }
+
+    useEffect(function () { load(); }, []);
+
+    if (error) {
+      return h("div", { className: "agent-roster-page" },
+        h(Card, null,
+          h(CardHeader, null, h(CardTitle, null, "Agent Roster")),
+          h(CardContent, null,
+            h("p", { className: "agent-roster-error" }, error),
+            h(Button, { onClick: load }, "Retry")
+          )
+        )
+      );
+    }
+
+    if (!data) {
+      return h("div", { className: "agent-roster-page" }, "Loading Agent Roster…");
+    }
+
+    const summary = data.summary || {};
+    const profiles = data.profiles || [];
+    const violations = data.violations || [];
+    const stages = ((data.pipeline || {}).stages || []);
+
+    return h("div", { className: "agent-roster-page" },
+      h("div", { className: "agent-roster-header" },
+        h("div", null,
+          h("h1", null, "Agent Roster"),
+          h("p", null, "Profile roles, Kanban drift, PM/Reviewer gates, and policy enforcement.")
+        ),
+        h(Button, { onClick: load, disabled: loading }, loading ? "Refreshing…" : "Refresh")
+      ),
+      h("div", { className: "agent-roster-stats" },
+        h(Stat, { label: "Profiles", value: summary.profile_count }),
+        h(Stat, { label: "Roles", value: summary.role_count }),
+        h(Stat, { label: "Boards", value: summary.board_count }),
+        h(Stat, { label: "Tasks", value: summary.task_count }),
+        h(Stat, { label: "Violations", value: summary.violation_count })
+      ),
+      h(Card, null,
+        h(CardHeader, null, h(CardTitle, null, "Pipeline")),
+        h(CardContent, null,
+          h("div", { className: "agent-roster-pipeline" }, stages.map(function (stage) {
+            return h("div", { className: "agent-roster-stage", key: stage.key },
+              h("strong", null, stage.label || stage.key),
+              h("span", null, String(stage.task_count || 0) + " tasks"),
+              h("small", null, "ready " + (stage.ready_count || 0) + " · running " + (stage.running_count || 0) + " · blocked " + (stage.blocked_count || 0))
+            );
+          }))
+        )
+      ),
+      h(Card, null,
+        h(CardHeader, null, h(CardTitle, null, "Profiles")),
+        h(CardContent, null,
+          h("div", { className: "agent-roster-grid" }, profiles.map(function (profile) {
+            const role = profile.role || {};
+            return h("div", { className: "agent-roster-profile", key: profile.name },
+              h("div", { className: "agent-roster-profile-top" },
+                h("strong", null, profile.name),
+                h(Badge, null, role.status || "missing")
+              ),
+              h("p", null, role.mission || "No profile_role metadata."),
+              h("small", null, "Allowed: " + ((role.allowed_task_types || []).join(", ") || "—")),
+              h("small", null, "Forbidden: " + ((role.forbidden || []).join(", ") || "—"))
+            );
+          }))
+        )
+      ),
+      h(Card, null,
+        h(CardHeader, null, h(CardTitle, null, "Violations")),
+        h(CardContent, null,
+          violations.length === 0
+            ? h("p", null, "No drift detected.")
+            : h("div", { className: "agent-roster-violations" }, violations.slice(0, 50).map(function (violation, idx) {
+                return h("div", { className: "agent-roster-violation", key: violation.code + String(idx) },
+                  h("span", { className: badgeClass(violation.severity) }, violation.severity || "info"),
+                  h("div", null,
+                    h("strong", null, violation.code),
+                    h("p", null, violation.message),
+                    violation.task_id ? h("small", null, "Task " + violation.task_id + " · Board " + (violation.board || "default")) : null
+                  )
+                );
+              }))
+        )
+      )
+    );
+  }
+
+  window.__HERMES_PLUGINS__.register("agent-roster", AgentRosterPage);
+})();

--- a/plugins/agent-roster/dashboard/dist/style.css
+++ b/plugins/agent-roster/dashboard/dist/style.css
@@ -1,0 +1,111 @@
+.agent-roster-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1rem;
+}
+
+.agent-roster-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+}
+
+.agent-roster-header h1 {
+  margin: 0;
+  font-size: 1.8rem;
+}
+
+.agent-roster-header p {
+  margin: 0.25rem 0 0;
+  color: var(--muted-foreground, #6b7280);
+}
+
+.agent-roster-stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 0.75rem;
+}
+
+.agent-roster-stat,
+.agent-roster-stage,
+.agent-roster-profile,
+.agent-roster-violation {
+  border: 1px solid var(--border, #e5e7eb);
+  border-radius: 0.75rem;
+  padding: 0.85rem;
+  background: var(--card, rgba(255, 255, 255, 0.03));
+}
+
+.agent-roster-stat-value {
+  font-size: 1.6rem;
+  font-weight: 800;
+}
+
+.agent-roster-stat-label,
+.agent-roster-stage small,
+.agent-roster-profile small {
+  color: var(--muted-foreground, #6b7280);
+  display: block;
+}
+
+.agent-roster-pipeline,
+.agent-roster-grid,
+.agent-roster-violations {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.agent-roster-pipeline {
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+}
+
+.agent-roster-grid {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.agent-roster-profile-top,
+.agent-roster-violation {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.6rem;
+}
+
+.agent-roster-profile-top {
+  justify-content: space-between;
+}
+
+.agent-roster-profile p,
+.agent-roster-violation p {
+  margin: 0.35rem 0;
+}
+
+.agent-roster-badge-danger,
+.agent-roster-badge-warning,
+.agent-roster-badge-muted {
+  border-radius: 999px;
+  padding: 0.15rem 0.5rem;
+  font-size: 0.75rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.agent-roster-badge-danger {
+  background: rgba(239, 68, 68, 0.15);
+  color: #ef4444;
+}
+
+.agent-roster-badge-warning {
+  background: rgba(245, 158, 11, 0.15);
+  color: #d97706;
+}
+
+.agent-roster-badge-muted {
+  background: rgba(107, 114, 128, 0.15);
+  color: #6b7280;
+}
+
+.agent-roster-error {
+  color: #ef4444;
+}

--- a/plugins/agent-roster/dashboard/manifest.json
+++ b/plugins/agent-roster/dashboard/manifest.json
@@ -1,0 +1,14 @@
+{
+  "name": "agent-roster",
+  "label": "Agent Roster",
+  "description": "Read-only overview of Hermes profiles, role metadata, Kanban drift, reviewer gates, and policy audit state.",
+  "icon": "Users",
+  "version": "0.1.0",
+  "tab": {
+    "path": "/agent-roster",
+    "position": "after:kanban"
+  },
+  "entry": "dist/index.js",
+  "css": "dist/style.css",
+  "api": "plugin_api.py"
+}

--- a/plugins/agent-roster/dashboard/plugin_api.py
+++ b/plugins/agent-roster/dashboard/plugin_api.py
@@ -1,0 +1,78 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from typing import Optional
+
+from fastapi import APIRouter, Query
+
+router = APIRouter()
+
+
+def _load_core():
+    path = Path(__file__).resolve().parents[1] / "roster_core.py"
+    spec = importlib.util.spec_from_file_location("agent_roster_dashboard_core", path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Cannot load {path}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@router.get("/roster")
+def roster():
+    return _load_core().build_roster()
+
+
+@router.get("/profiles")
+def profiles():
+    data = _load_core().build_roster()
+    return {
+        "profiles": data["profiles"],
+        "summary": data["summary"],
+        "count": len(data["profiles"]),
+        "generated_at": data["generated_at"],
+    }
+
+
+@router.get("/boards")
+def boards():
+    data = _load_core().build_roster()
+    return {
+        "boards": data["boards"],
+        "summary": data["summary"],
+        "count": len(data["boards"]),
+        "generated_at": data["generated_at"],
+    }
+
+
+@router.get("/violations")
+def violations(severity: Optional[str] = Query(None)):
+    data = _load_core().build_roster()
+    items = data["violations"]
+    if severity:
+        wanted = severity.strip().lower()
+        items = [v for v in items if str(v.get("severity", "")).lower() == wanted]
+    return {
+        "violations": items,
+        "count": len(items),
+        "summary": data["summary"],
+        "generated_at": data["generated_at"],
+    }
+
+
+@router.get("/pipeline")
+def pipeline():
+    data = _load_core().build_roster()
+    payload = data["pipeline"]
+    return {
+        **payload,
+        "summary": data["summary"],
+        "generated_at": data["generated_at"],
+    }
+
+
+@router.get("/audit")
+def audit(limit: int = Query(200, ge=1, le=1000)):
+    rows = _load_core().read_audit(limit=limit)
+    return {"events": rows, "count": len(rows)}

--- a/plugins/agent-roster/plugin.yaml
+++ b/plugins/agent-roster/plugin.yaml
@@ -1,0 +1,8 @@
+name: agent-roster
+version: 0.1.0
+description: "Role registry, Kanban gate drift checks, and profile-role tool policy enforcement."
+author: NousResearch / Hermes Agent
+hooks:
+  - pre_llm_call
+  - pre_tool_call
+  - post_tool_call

--- a/plugins/agent-roster/roster_core.py
+++ b/plugins/agent-roster/roster_core.py
@@ -1,0 +1,878 @@
+"""Shared Agent Roster helpers for role enforcement and dashboard APIs.
+
+The plugin is intentionally read-mostly: profile roles are sourced from
+``profile_role`` in each profile's config.yaml, Kanban drift is surfaced as
+violations, and hook-time enforcement is driven by explicit role metadata.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+from pathlib import Path
+from typing import Any, Iterable, Optional
+
+import yaml
+
+from hermes_constants import get_default_hermes_root, get_hermes_home
+
+PLUGIN_NAME = "agent-roster"
+DEFAULT_ROLE_CONFIG_KEY = "profile_role"
+DEFAULT_STRICT_MODE = "audit"
+AUDIT_LOG_NAME = "agent-roster-audit.jsonl"
+
+PIPELINE_STAGES: list[dict[str, Any]] = [
+    {"key": "idea", "label": "Idea", "types": ["IDEA"], "profiles": ["default"]},
+    {"key": "research", "label": "Research", "types": ["RESEARCH", "SOURCECHECK", "BENCHMARK"], "profiles": ["researcher"]},
+    {"key": "analysis", "label": "Analysis", "types": ["ANALYSIS", "ANALYST"], "profiles": ["analyst"]},
+    {"key": "spec", "label": "Spec / PM", "types": ["SPEC", "PM", "PRD"], "profiles": ["pm"]},
+    {"key": "write", "label": "Writing / UX", "types": ["WRITE", "UX", "COPY"], "profiles": ["writer"]},
+    {"key": "build", "label": "Build", "types": ["BUILD", "CODE", "DEV", "FRONTEND", "BACKEND"], "profiles": ["default", "frontend-eng", "backend-eng"]},
+    {"key": "qa", "label": "QA / Review", "types": ["QA", "REVIEW", "TEST"], "profiles": ["reviewer"]},
+    {"key": "launch", "label": "Launch", "types": ["LAUNCH", "DEPLOY", "OPS"], "profiles": ["default", "ops"]},
+]
+
+DEFAULT_PRD_REQUIRED_FIELDS: dict[str, list[str]] = {
+    "goal": ["goal", "ziel"],
+    "non_goals": ["non-goal", "non goal", "nicht-ziel", "nicht ziel", "nichtziele"],
+    "target_user": ["target user", "user", "nutzer", "zielgruppe", "persona"],
+    "acceptance_criteria": ["acceptance criteria", "akzeptanzkriterien", "akzeptanz"],
+    "success_metric": ["success metric", "success metrics", "erfolgskriterium", "erfolgsmetrik"],
+    "risks": ["risk", "risiko", "risiken"],
+    "dependencies": ["dependency", "dependencies", "abhängigkeit", "abhaengigkeit", "abhängigkeiten", "abhaengigkeiten"],
+    "definition_of_done": ["definition of done", "dod", "done-kriter", "fertig wenn"],
+}
+
+QUALITY_GATE_TYPES = {"BUILD", "CODE", "DEV", "FRONTEND", "BACKEND", "LAUNCH", "DEPLOY", "OPS"}
+REVIEW_GATE_TYPES = QUALITY_GATE_TYPES
+
+
+def _now() -> int:
+    return int(time.time())
+
+
+def _read_yaml(path: Path) -> dict[str, Any]:
+    try:
+        if not path.exists():
+            return {}
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except Exception:
+        return {}
+
+
+def _root() -> Path:
+    return get_default_hermes_root()
+
+
+def _active_home() -> Path:
+    return get_hermes_home()
+
+
+def current_profile_name() -> str:
+    explicit = os.environ.get("HERMES_PROFILE", "").strip()
+    if explicit:
+        return explicit
+    home = _active_home()
+    if home.parent.name == "profiles":
+        return home.name
+    return "default"
+
+
+def root_config(root: Optional[Path] = None) -> dict[str, Any]:
+    return _read_yaml((root or _root()) / "config.yaml")
+
+
+def roster_config(root: Optional[Path] = None) -> dict[str, Any]:
+    cfg = root_config(root)
+    dashboard = cfg.get("dashboard") if isinstance(cfg.get("dashboard"), dict) else {}
+    raw = dashboard.get("agent_roster") if isinstance(dashboard.get("agent_roster"), dict) else {}
+    out = {
+        "enabled": True,
+        "source": "profile_config",
+        "role_config_key": DEFAULT_ROLE_CONFIG_KEY,
+        "strict_mode": DEFAULT_STRICT_MODE,
+        "check_kanban_assignments": True,
+        "check_task_prefix_compatibility": True,
+        "check_quality_gates": True,
+        "show_profiles_without_roles": True,
+        "inject_outside_kanban": False,
+        "audit_enabled": True,
+        "enforce_completion_gates": True,
+    }
+    out.update(raw)
+    mode = str(out.get("strict_mode") or DEFAULT_STRICT_MODE).strip().lower()
+    # Backward-compatible alias: early Agent Roster drafts used ``warn`` for
+    # audit-only behavior.  The runtime has no user-visible warning channel for
+    # pre-tool hooks, so expose the behavior honestly as ``audit`` instead of
+    # silently pretending to warn.
+    if mode == "warn":
+        mode = "audit"
+    if mode not in {"off", "audit", "block"}:
+        mode = DEFAULT_STRICT_MODE
+    out["strict_mode"] = mode
+    return out
+
+
+def is_enabled(root: Optional[Path] = None) -> bool:
+    return roster_config(root).get("enabled") is not False
+
+
+def _profile_home(root: Path, profile: str) -> Path:
+    return root if profile == "default" else root / "profiles" / profile
+
+
+def _iter_profile_homes(root: Path) -> list[tuple[str, Path]]:
+    homes: list[tuple[str, Path]] = []
+    if (root / "config.yaml").exists():
+        homes.append(("default", root))
+    profiles_dir = root / "profiles"
+    if profiles_dir.is_dir():
+        for child in sorted(profiles_dir.iterdir(), key=lambda p: p.name.lower()):
+            if child.is_dir() and (child / "config.yaml").exists():
+                homes.append((child.name, child))
+    if not homes:
+        homes.append(("default", root))
+    return homes
+
+
+def _clean_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        value = [value]
+    if not isinstance(value, Iterable):
+        return []
+    out: list[str] = []
+    for item in value:
+        text = str(item).strip()
+        if text:
+            out.append(text)
+    return out
+
+
+def _normalize_role(raw: Any, profile: str) -> Optional[dict[str, Any]]:
+    if not isinstance(raw, dict):
+        return None
+    role = dict(raw)
+    role_id = str(role.get("id") or profile).strip() or profile
+    role["id"] = role_id
+    role.setdefault("display_name", role_id)
+    role.setdefault("status", "active")
+    role["activity_fields"] = _clean_list(role.get("activity_fields"))
+    role["allowed_task_types"] = [t.upper() for t in _clean_list(role.get("allowed_task_types"))]
+    role["allowed_boards"] = _clean_list(role.get("allowed_boards"))
+    role["forbidden"] = [f.lower() for f in _clean_list(role.get("forbidden"))]
+    role["escalation"] = _clean_list(role.get("escalation"))
+    output_contract = role.get("output_contract") if isinstance(role.get("output_contract"), dict) else {}
+    output_contract["required_sections"] = _clean_list(output_contract.get("required_sections"))
+    role["output_contract"] = output_contract
+    return role
+
+
+def collect_profiles(root: Optional[Path] = None) -> list[dict[str, Any]]:
+    root = root or _root()
+    cfg = roster_config(root)
+    role_key = str(cfg.get("role_config_key") or DEFAULT_ROLE_CONFIG_KEY)
+    profiles: list[dict[str, Any]] = []
+    for name, home in _iter_profile_homes(root):
+        raw_cfg = _read_yaml(home / "config.yaml")
+        role = _normalize_role(raw_cfg.get(role_key), name)
+        profiles.append(
+            {
+                "name": name,
+                "home": str(home),
+                "is_default": name == "default",
+                "exists": home.exists(),
+                "role": role,
+                "has_role_metadata": role is not None,
+                "status": (role or {}).get("status", "missing"),
+                "toolsets": _clean_list(raw_cfg.get("toolsets")),
+            }
+        )
+    return profiles
+
+
+def profiles_by_name(profiles: Optional[list[dict[str, Any]]] = None) -> dict[str, dict[str, Any]]:
+    return {p["name"]: p for p in (profiles if profiles is not None else collect_profiles())}
+
+
+def _extract_task_type(title: str, body: Optional[str] = None) -> str:
+    text = (title or "").strip()
+    match = re.match(r"^\s*(?:\[\s*)?([A-Za-z][A-Za-z0-9_-]{1,24})(?:\s*\])?\s*[:\-]", text)
+    if match:
+        return match.group(1).upper().replace("-", "_")
+    bracket = re.match(r"^\s*\[\s*([A-Za-z][A-Za-z0-9_-]{1,24})\s*\]", text)
+    if bracket:
+        return bracket.group(1).upper().replace("-", "_")
+    hay = f"{title}\n{body or ''}".lower()
+    keyword_map = {
+        "build": "BUILD",
+        "code": "CODE",
+        "deploy": "DEPLOY",
+        "launch": "LAUNCH",
+        "review": "REVIEW",
+        "qa": "QA",
+        "research": "RESEARCH",
+        "analyse": "ANALYSIS",
+        "analysis": "ANALYSIS",
+        "prd": "PRD",
+        "spec": "SPEC",
+        "write": "WRITE",
+    }
+    for key, value in keyword_map.items():
+        if key in hay:
+            return value
+    return "GENERAL"
+
+
+def _task_stage(task_type: str, assignee: Optional[str]) -> str:
+    typ = task_type.upper()
+    for stage in PIPELINE_STAGES:
+        if typ in stage["types"]:
+            return stage["key"]
+    if assignee:
+        for stage in PIPELINE_STAGES:
+            if assignee in stage["profiles"]:
+                return stage["key"]
+    return "other"
+
+
+def _task_to_dict(kb: Any, conn: Any, task: Any, board: str) -> dict[str, Any]:
+    parents = kb.parent_ids(conn, task.id)
+    children = kb.child_ids(conn, task.id)
+    task_type = _extract_task_type(task.title, task.body)
+    return {
+        "id": task.id,
+        "board": board,
+        "title": task.title,
+        "body": task.body,
+        "assignee": task.assignee,
+        "status": task.status,
+        "priority": task.priority,
+        "tenant": task.tenant,
+        "created_by": task.created_by,
+        "created_at": task.created_at,
+        "started_at": task.started_at,
+        "completed_at": task.completed_at,
+        "workspace_kind": task.workspace_kind,
+        "workspace_path": task.workspace_path,
+        "task_type": task_type,
+        "stage": _task_stage(task_type, task.assignee),
+        "parents": parents,
+        "children": children,
+    }
+
+
+def collect_boards(root: Optional[Path] = None) -> list[dict[str, Any]]:
+    # kanban_db resolves its own root via HERMES_KANBAN_HOME / get_default_hermes_root.
+    from hermes_cli import kanban_db as kb
+
+    boards: list[dict[str, Any]] = []
+    try:
+        board_meta = kb.list_boards(include_archived=False)
+    except Exception:
+        board_meta = [{"slug": "default", "name": "Default", "archived": False}]
+    for meta in board_meta:
+        slug = str(meta.get("slug") or "default")
+        conn = None
+        tasks: list[dict[str, Any]] = []
+        stats: dict[str, Any] = {}
+        try:
+            conn = kb.connect(board=slug)
+            tasks = [_task_to_dict(kb, conn, t, slug) for t in kb.list_tasks(conn, include_archived=False, limit=500)]
+            try:
+                stats = kb.board_stats(conn)
+            except Exception:
+                stats = {}
+        except Exception as exc:
+            stats = {"error": str(exc)}
+        finally:
+            if conn is not None:
+                conn.close()
+        boards.append({"slug": slug, "metadata": meta, "tasks": tasks, "stats": stats})
+    return boards
+
+
+def _violation(code: str, severity: str, message: str, **extra: Any) -> dict[str, Any]:
+    return {
+        "code": code,
+        "severity": severity,
+        "message": message,
+        "created_at": _now(),
+        **extra,
+    }
+
+
+def _body_field_presence(body: Optional[str]) -> tuple[list[str], list[str]]:
+    hay = (body or "").lower()
+    present: list[str] = []
+    missing: list[str] = []
+    for field, aliases in DEFAULT_PRD_REQUIRED_FIELDS.items():
+        if any(alias.lower() in hay for alias in aliases):
+            present.append(field)
+        else:
+            missing.append(field)
+    return present, missing
+
+
+def _is_reviewer_profile(profile: Optional[dict[str, Any]]) -> bool:
+    if not profile:
+        return False
+    role = profile.get("role") or {}
+    values = [profile.get("name"), role.get("id"), role.get("category"), role.get("display_name")]
+    return any(str(v or "").strip().lower() in {"reviewer", "review", "qa"} for v in values)
+
+
+def _has_reviewer_gate(task: dict[str, Any], board_tasks: dict[str, dict[str, Any]], profile_map: dict[str, dict[str, Any]]) -> bool:
+    related = set(task.get("parents") or []) | set(task.get("children") or [])
+    for rid in related:
+        other = board_tasks.get(rid)
+        if not other:
+            continue
+        assignee = other.get("assignee")
+        if _is_reviewer_profile(profile_map.get(str(assignee)) if assignee else None):
+            return True
+        title = str(other.get("title") or "").lower()
+        if "review" in title or "qa" in title:
+            return True
+    return False
+
+
+def collect_violations(
+    profiles: list[dict[str, Any]],
+    boards: list[dict[str, Any]],
+    root: Optional[Path] = None,
+) -> list[dict[str, Any]]:
+    cfg = roster_config(root)
+    role_key = str(cfg.get("role_config_key") or DEFAULT_ROLE_CONFIG_KEY)
+    profile_map = profiles_by_name(profiles)
+    violations: list[dict[str, Any]] = []
+
+    for profile in profiles:
+        role = profile.get("role")
+        if not role:
+            if cfg.get("show_profiles_without_roles", True):
+                violations.append(
+                    _violation(
+                        "profile_missing_role_metadata",
+                        "warning",
+                        f"Profile {profile['name']} has no {role_key} metadata.",
+                        profile=profile["name"],
+                    )
+                )
+            continue
+        role_status = str(role.get("status") or "").lower()
+        if role_status in {"disabled", "blocked"}:
+            violations.append(
+                _violation(
+                    "profile_not_active",
+                    "high",
+                    f"Profile {profile['name']} role status is {role.get('status')}.",
+                    profile=profile["name"],
+                )
+            )
+        if role_status == "restricted":
+            continue
+        if not role.get("allowed_task_types"):
+            violations.append(
+                _violation(
+                    "role_missing_allowed_task_types",
+                    "warning",
+                    f"Profile {profile['name']} has no allowed_task_types.",
+                    profile=profile["name"],
+                )
+            )
+        if not role.get("allowed_boards"):
+            violations.append(
+                _violation(
+                    "role_missing_allowed_boards",
+                    "warning",
+                    f"Profile {profile['name']} has no allowed_boards.",
+                    profile=profile["name"],
+                )
+            )
+
+    for board in boards:
+        slug = board.get("slug") or "default"
+        board_tasks = {t["id"]: t for t in board.get("tasks", [])}
+        for task in board.get("tasks", []):
+            status = task.get("status")
+            assignee = task.get("assignee")
+            task_type = str(task.get("task_type") or "GENERAL").upper()
+            if status in {"ready", "running"} and not assignee:
+                violations.append(
+                    _violation(
+                        "ready_task_missing_assignee",
+                        "high",
+                        f"Task {task['id']} is {status} but has no assignee.",
+                        board=slug,
+                        task_id=task["id"],
+                    )
+                )
+            if assignee and assignee not in profile_map:
+                violations.append(
+                    _violation(
+                        "task_assignee_profile_missing",
+                        "high",
+                        f"Task {task['id']} is assigned to missing profile {assignee}.",
+                        board=slug,
+                        task_id=task["id"],
+                        assignee=assignee,
+                    )
+                )
+                continue
+            profile = profile_map.get(str(assignee)) if assignee else None
+            role = (profile or {}).get("role") or {}
+            if not role:
+                continue
+            allowed_boards = set(role.get("allowed_boards") or [])
+            if cfg.get("check_kanban_assignments", True) and allowed_boards and slug not in allowed_boards:
+                violations.append(
+                    _violation(
+                        "task_board_not_allowed_for_role",
+                        "medium",
+                        f"Task {task['id']} is on board {slug}, not in {assignee}'s allowed_boards.",
+                        board=slug,
+                        task_id=task["id"],
+                        assignee=assignee,
+                    )
+                )
+            allowed_types = set(str(t).upper() for t in (role.get("allowed_task_types") or []))
+            if (
+                cfg.get("check_task_prefix_compatibility", True)
+                and allowed_types
+                and task_type != "GENERAL"
+                and task_type not in allowed_types
+            ):
+                violations.append(
+                    _violation(
+                        "task_type_not_allowed_for_role",
+                        "medium",
+                        f"Task {task['id']} type {task_type} is not allowed for {assignee}.",
+                        board=slug,
+                        task_id=task["id"],
+                        assignee=assignee,
+                        task_type=task_type,
+                    )
+                )
+            if cfg.get("check_quality_gates", True) and task_type in QUALITY_GATE_TYPES:
+                present, missing = _body_field_presence(task.get("body"))
+                if missing:
+                    violations.append(
+                        _violation(
+                            "prd_lite_missing",
+                            "high",
+                            f"Task {task['id']} is {task_type} but lacks PRD-lite fields: {', '.join(missing)}.",
+                            board=slug,
+                            task_id=task["id"],
+                            assignee=assignee,
+                            task_type=task_type,
+                            present_fields=present,
+                            missing_fields=missing,
+                        )
+                    )
+            if (
+                cfg.get("check_quality_gates", True)
+                and task_type in REVIEW_GATE_TYPES
+                and not _has_reviewer_gate(task, board_tasks, profile_map)
+            ):
+                violations.append(
+                    _violation(
+                        "reviewer_gate_missing",
+                        "high",
+                        f"Task {task['id']} is {task_type} but has no linked reviewer/QA gate.",
+                        board=slug,
+                        task_id=task["id"],
+                        assignee=assignee,
+                        task_type=task_type,
+                    )
+                )
+    return violations
+
+
+def build_pipeline(boards: list[dict[str, Any]]) -> dict[str, Any]:
+    stage_defs = {stage["key"]: {**stage, "task_count": 0, "ready_count": 0, "blocked_count": 0, "running_count": 0, "done_count": 0, "tasks": []} for stage in PIPELINE_STAGES}
+    stage_defs["other"] = {"key": "other", "label": "Other", "types": [], "profiles": [], "task_count": 0, "ready_count": 0, "blocked_count": 0, "running_count": 0, "done_count": 0, "tasks": []}
+    for board in boards:
+        for task in board.get("tasks", []):
+            key = task.get("stage") or "other"
+            stage = stage_defs.setdefault(key, {"key": key, "label": key.title(), "types": [], "profiles": [], "task_count": 0, "ready_count": 0, "blocked_count": 0, "running_count": 0, "done_count": 0, "tasks": []})
+            stage["task_count"] += 1
+            status = task.get("status") or ""
+            status_key = f"{status}_count"
+            if status_key in stage:
+                stage[status_key] += 1
+            stage["tasks"].append({k: task.get(k) for k in ("id", "board", "title", "assignee", "status", "task_type")})
+    ordered = [stage_defs[s["key"]] for s in PIPELINE_STAGES] + [stage_defs["other"]]
+    return {"stages": ordered, "count": len(ordered)}
+
+
+def build_roster(root: Optional[Path] = None) -> dict[str, Any]:
+    root = root or _root()
+    profiles = collect_profiles(root)
+    boards = collect_boards(root)
+    violations = collect_violations(profiles, boards, root)
+    pipeline = build_pipeline(boards)
+    severity_counts: dict[str, int] = {}
+    for violation in violations:
+        sev = str(violation.get("severity") or "unknown")
+        severity_counts[sev] = severity_counts.get(sev, 0) + 1
+    return {
+        "generated_at": _now(),
+        "config": roster_config(root),
+        "summary": {
+            "profile_count": len(profiles),
+            "role_count": sum(1 for p in profiles if p.get("role")),
+            "profiles_missing_role_metadata": sum(1 for p in profiles if not p.get("role")),
+            "board_count": len(boards),
+            "task_count": sum(len(b.get("tasks", [])) for b in boards),
+            "violation_count": len(violations),
+            "severity_counts": severity_counts,
+        },
+        "profiles": profiles,
+        "boards": boards,
+        "violations": violations,
+        "pipeline": pipeline,
+    }
+
+
+def role_context_for_current_turn() -> Optional[str]:
+    if not is_enabled():
+        return None
+    cfg = roster_config()
+    task_id = os.environ.get("HERMES_KANBAN_TASK", "").strip()
+    if not task_id and not cfg.get("inject_outside_kanban", False):
+        return None
+
+    profile_name = current_profile_name()
+    profile = profiles_by_name().get(profile_name)
+    role = (profile or {}).get("role")
+    if not role:
+        return None
+
+    lines = [
+        "## Agent Roster Role Context",
+        f"Profile: {profile_name}",
+        f"Role: {role.get('display_name') or role.get('id')}",
+        f"Status: {role.get('status')}",
+    ]
+    mission = str(role.get("mission") or "").strip()
+    if mission:
+        lines.append(f"Mission: {mission}")
+    if role.get("activity_fields"):
+        lines.append("Activity fields: " + ", ".join(role["activity_fields"]))
+    if role.get("allowed_task_types"):
+        lines.append("Allowed task types: " + ", ".join(role["allowed_task_types"]))
+    if role.get("allowed_boards"):
+        lines.append("Allowed boards: " + ", ".join(role["allowed_boards"]))
+    if role.get("forbidden"):
+        lines.append("Forbidden actions: " + ", ".join(role["forbidden"]))
+    required = ((role.get("output_contract") or {}).get("required_sections") or [])
+    if required:
+        lines.append("Required output sections: " + ", ".join(required))
+    if role.get("escalation"):
+        lines.append("Escalate when: " + ", ".join(role["escalation"]))
+
+    if task_id:
+        task_context = _current_task_context(task_id)
+        if task_context:
+            lines.append(f"Task: {task_id} — {task_context['title']}")
+            lines.append(f"Task type: {task_context['task_type']}; board: {task_context['board']}; status: {task_context['status']}")
+    lines.append("Policy: stay inside this role. If the task conflicts with the role or lacks required gate data, block and explain the missing input instead of improvising.")
+    return "\n".join(lines)
+
+
+def _current_task_context(task_id: str) -> Optional[dict[str, Any]]:
+    from hermes_cli import kanban_db as kb
+
+    board = os.environ.get("HERMES_KANBAN_BOARD", "default") or "default"
+    conn = None
+    try:
+        conn = kb.connect(board=board)
+        task = kb.get_task(conn, task_id)
+        if not task:
+            return None
+        return _task_to_dict(kb, conn, task, board)
+    except Exception:
+        return None
+    finally:
+        if conn is not None:
+            conn.close()
+
+
+def classify_tool_actions(tool_name: str, args: Optional[dict[str, Any]] = None) -> list[str]:
+    args = args or {}
+    name = str(tool_name or "").strip()
+    actions: set[str] = set()
+    if name in {"write_file", "patch"}:
+        actions.add("code_changes")
+        paths = _tool_target_paths(name, args)
+        if any(_is_config_like_path(path) for path in paths):
+            actions.add("config_changes")
+    if name == "execute_code":
+        actions.update({"code_changes", "shell"})
+    if name == "terminal":
+        actions.add("shell")
+        command = str(args.get("command") or "").lower()
+        if re.search(r"\bgit\s+push\b", command):
+            actions.add("git_push")
+        if re.search(r"\bgit\s+commit\b", command):
+            actions.add("git_commit")
+        if re.search(r"\b(hermes\s+config|hermes\s+profile|hermes\s+tools|hermes\s+plugins|vim\s+.*config|nano\s+.*config)\b", command):
+            actions.add("config_changes")
+        if re.search(r"\b(wrangler\s+deploy|vercel\s+deploy|netlify\s+deploy|fly\s+deploy|railway\s+up|docker\s+push|kubectl\s+apply|terraform\s+apply)\b", command):
+            actions.add("deployment")
+        if re.search(r"\b(npm|pnpm|yarn)\s+run\s+(build|deploy|release)\b", command):
+            actions.add("deployment")
+        if re.search(r"\b(sed|perl|python|python3|node)\b.*\b(write_text|open\(|Path\(|sed -i|>\s*[^&])", command):
+            actions.add("code_changes")
+    if name.startswith("browser_"):
+        actions.add("browser_automation")
+        actions.add("network")
+    if name.startswith("web_"):
+        actions.add("network")
+    if name in {"memory", "viking_remember"}:
+        actions.add("memory_changes")
+    if name in {"skill_manage"}:
+        actions.add("skill_changes")
+    if name in {"cronjob"}:
+        actions.add("scheduling")
+    if name in {"send_message"}:
+        actions.add("external_message")
+    if name.startswith("kanban_"):
+        actions.add("kanban")
+        if name in {"kanban_create", "kanban_link", "kanban_unblock"}:
+            actions.add("kanban_routing")
+        if name == "kanban_complete":
+            actions.add("task_completion")
+    return sorted(actions)
+
+
+def _tool_target_paths(tool_name: str, args: dict[str, Any]) -> list[str]:
+    paths: list[str] = []
+    direct = args.get("path")
+    if direct:
+        paths.append(str(direct))
+    if tool_name == "patch":
+        patch_text = str(args.get("patch") or "")
+        for match in re.finditer(r"^\*\*\*\s+(?:Update|Add|Delete) File:\s+(.+?)\s*$", patch_text, re.MULTILINE):
+            paths.append(match.group(1).strip())
+    return paths
+
+
+def _is_config_like_path(path: str) -> bool:
+    lowered = path.lower()
+    markers = (
+        "config.yaml",
+        "config.yml",
+        ".env",
+        "auth.json",
+        "soul.md",
+        "agents.md",
+        "claude.md",
+        ".hermes.md",
+    )
+    return any(marker in lowered for marker in markers)
+
+
+def write_audit(event: str, **fields: Any) -> None:
+    try:
+        if not roster_config().get("audit_enabled", True):
+            return
+        root = _root()
+        path = root / "logs" / AUDIT_LOG_NAME
+        path.parent.mkdir(parents=True, exist_ok=True)
+        row = {"ts": _now(), "event": event, **fields}
+        with path.open("a", encoding="utf-8") as fh:
+            fh.write(json.dumps(row, ensure_ascii=False, default=str) + "\n")
+    except Exception:
+        # Hooks must never break the agent loop.
+        return
+
+
+def evaluate_tool_policy(
+    tool_name: str,
+    args: Optional[dict[str, Any]] = None,
+    *,
+    session_id: str = "",
+    task_id: str = "",
+    tool_call_id: str = "",
+) -> Optional[dict[str, str]]:
+    if not is_enabled():
+        return None
+    cfg = roster_config()
+    mode = str(cfg.get("strict_mode") or DEFAULT_STRICT_MODE).lower()
+    if mode == "off":
+        return None
+    profile_name = current_profile_name()
+    if mode == "block" and cfg.get("enforce_completion_gates", True):
+        gate_message = _completion_gate_block_message(tool_name, args, profile_name)
+        if gate_message:
+            write_audit(
+                "completion_gate_block",
+                profile=profile_name,
+                tool_name=tool_name,
+                session_id=session_id,
+                task_id=task_id or os.environ.get("HERMES_KANBAN_TASK", ""),
+                tool_call_id=tool_call_id,
+                mode=mode,
+            )
+            return {"action": "block", "message": gate_message}
+    profile = profiles_by_name().get(profile_name)
+    role = (profile or {}).get("role") or {}
+    forbidden = _forbidden_action_set(role)
+    if not forbidden:
+        return None
+    actions = set(classify_tool_actions(tool_name, args))
+    matched = sorted(actions & forbidden)
+    if not matched:
+        return None
+    message = (
+        f"Agent Roster policy: profile {profile_name!r} is forbidden from "
+        f"{', '.join(matched)}; blocked tool {tool_name!r}. Reassign this "
+        "task or ask the supervisor to create an allowed follow-up task."
+    )
+    audit_fields = {
+        "profile": profile_name,
+        "role_id": role.get("id"),
+        "tool_name": tool_name,
+        "actions": sorted(actions),
+        "matched_forbidden": matched,
+        "session_id": session_id,
+        "task_id": task_id or os.environ.get("HERMES_KANBAN_TASK", ""),
+        "tool_call_id": tool_call_id,
+        "mode": mode,
+    }
+    if mode == "block":
+        write_audit("tool_policy_block", **audit_fields)
+        return {"action": "block", "message": message}
+    write_audit("tool_policy_audit", **audit_fields)
+    return None
+
+
+def _completion_gate_block_message(tool_name: str, args: Optional[dict[str, Any]], profile_name: str) -> Optional[str]:
+    if str(tool_name or "") != "kanban_complete":
+        return None
+    args = args or {}
+    task_id = str(args.get("task_id") or os.environ.get("HERMES_KANBAN_TASK", "")).strip()
+    if not task_id:
+        return None
+    board = str(args.get("board") or os.environ.get("HERMES_KANBAN_BOARD", "default") or "default")
+    from hermes_cli import kanban_db as kb
+
+    conn = None
+    try:
+        conn = kb.connect(board=board)
+        task = kb.get_task(conn, task_id)
+        if not task:
+            return None
+        task_dict = _task_to_dict(kb, conn, task, board)
+        task_type = str(task_dict.get("task_type") or "GENERAL").upper()
+        if task_type not in QUALITY_GATE_TYPES:
+            return None
+        profiles = collect_profiles(_root())
+        profile_map = profiles_by_name(profiles)
+        board_tasks = {
+            t.id: _task_to_dict(kb, conn, t, board)
+            for t in kb.list_tasks(conn, include_archived=False, limit=500)
+        }
+        _, missing = _body_field_presence(task_dict.get("body"))
+        if missing:
+            return (
+                f"Agent Roster completion gate: task {task_id} is {task_type} but lacks "
+                f"PRD-lite fields: {', '.join(missing)}. Add goal, target user, "
+                "acceptance criteria, risks, dependencies, success metric, and definition of done before completion."
+            )
+        if not _has_reviewer_gate(task_dict, board_tasks, profile_map):
+            return (
+                f"Agent Roster completion gate: task {task_id} is {task_type} but has no linked reviewer/QA gate. "
+                "Create or link a QA/reviewer task before marking this done."
+            )
+    except Exception as exc:
+        write_audit(
+            "completion_gate_check_error",
+            profile=profile_name,
+            tool_name=tool_name,
+            task_id=task_id,
+            board=board,
+            error=str(exc),
+        )
+        return None
+    finally:
+        if conn is not None:
+            conn.close()
+    return None
+
+
+def _forbidden_action_set(role: dict[str, Any]) -> set[str]:
+    """Return canonical policy actions from free-form role metadata."""
+    out: set[str] = set()
+    for item in role.get("forbidden") or []:
+        raw = str(item).strip().lower()
+        if not raw:
+            continue
+        out.add(raw)
+        if "git push" in raw or "push" in raw:
+            out.add("git_push")
+        if "git commit" in raw or "commit" in raw:
+            out.add("git_commit")
+        if "deploy" in raw or "deployment" in raw or "veröffentlich" in raw or "veroeffentlich" in raw:
+            out.add("deployment")
+        if "config" in raw or "konfiguration" in raw or "eigenmächtig code/config" in raw or "eigenmaechtig code/config" in raw:
+            out.add("config_changes")
+        if "code" in raw or "änderung" in raw or "aenderung" in raw or "ändern" in raw or "aendern" in raw:
+            out.add("code_changes")
+        if "memory" in raw or "gedächtnis" in raw or "gedaechtnis" in raw:
+            out.add("memory_changes")
+        if "skill" in raw:
+            out.add("skill_changes")
+        if "message" in raw or "nachricht" in raw:
+            out.add("external_message")
+    return out
+
+
+def audit_tool_result(
+    tool_name: str,
+    args: Optional[dict[str, Any]] = None,
+    result: Any = None,
+    *,
+    session_id: str = "",
+    task_id: str = "",
+    tool_call_id: str = "",
+    duration_ms: int = 0,
+) -> None:
+    if not is_enabled():
+        return
+    write_audit(
+        "tool_call",
+        profile=current_profile_name(),
+        tool_name=tool_name,
+        actions=classify_tool_actions(tool_name, args),
+        session_id=session_id,
+        task_id=task_id or os.environ.get("HERMES_KANBAN_TASK", ""),
+        tool_call_id=tool_call_id,
+        duration_ms=duration_ms,
+        result_type=type(result).__name__,
+        result_redacted=True,
+    )
+
+
+def read_audit(limit: int = 200) -> list[dict[str, Any]]:
+    path = _root() / "logs" / AUDIT_LOG_NAME
+    if not path.exists():
+        return []
+    try:
+        lines = path.read_text(encoding="utf-8", errors="replace").splitlines()[-max(1, min(limit, 1000)):]
+        out = []
+        for line in lines:
+            try:
+                row = json.loads(line)
+                if isinstance(row, dict):
+                    out.append(row)
+            except Exception:
+                continue
+        return out
+    except Exception:
+        return []

--- a/tests/plugins/test_agent_roster_plugin.py
+++ b/tests/plugins/test_agent_roster_plugin.py
@@ -1,0 +1,349 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+import yaml
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from hermes_cli import kanban_db as kb
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLUGIN_DIR = REPO_ROOT / "plugins" / "agent-roster"
+
+
+def _load_module(name: str, path: Path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_core():
+    return _load_module("agent_roster_core_test", PLUGIN_DIR / "roster_core.py")
+
+
+def _load_hooks():
+    return _load_module("agent_roster_hooks_test", PLUGIN_DIR / "__init__.py")
+
+
+def _load_api():
+    return _load_module("agent_roster_plugin_api_test", PLUGIN_DIR / "dashboard" / "plugin_api.py")
+
+
+def _write_yaml(path: Path, payload: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+
+def _role(role_id: str, **extra) -> dict:
+    role = {
+        "id": role_id,
+        "display_name": role_id.title(),
+        "status": "active",
+        "category": "test",
+        "mission": f"Mission for {role_id}",
+        "allowed_task_types": [role_id.upper(), "RESEARCH"],
+        "allowed_boards": ["default", "geld-ideen-pipeline"],
+        "forbidden": [],
+        "output_contract": {"required_sections": ["Summary", "Evidence"]},
+    }
+    role.update(extra)
+    return role
+
+
+def _seed_profiles(root: Path) -> None:
+    _write_yaml(
+        root / "config.yaml",
+        {
+            "plugins": {"enabled": ["agent-roster"]},
+            "dashboard": {
+                "agent_roster": {
+                    "enabled": True,
+                    "strict_mode": "block",
+                    "role_config_key": "profile_role",
+                }
+            },
+            "profile_role": _role(
+                "default",
+                display_name="Clank",
+                allowed_task_types=["IDEA", "BUILD", "LAUNCH", "QA"],
+                forbidden=[],
+            ),
+        },
+    )
+    _write_yaml(
+        root / "profiles" / "researcher" / "config.yaml",
+        {"profile_role": _role("researcher", forbidden=["code_changes", "deployment", "git_push"])},
+    )
+    _write_yaml(
+        root / "profiles" / "reviewer" / "config.yaml",
+        {"profile_role": _role("reviewer", allowed_task_types=["QA", "REVIEW"], forbidden=["deployment"])},
+    )
+    _write_yaml(root / "profiles" / "no-role" / "config.yaml", {"model": {"provider": "test"}})
+
+
+def test_roster_reads_profile_roles_and_surfaces_missing_metadata(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(tmp_path))
+    _seed_profiles(tmp_path)
+
+    core = _load_core()
+    data = core.build_roster()
+
+    names = {p["name"] for p in data["profiles"]}
+    assert {"default", "researcher", "reviewer", "no-role"}.issubset(names)
+    researcher = next(p for p in data["profiles"] if p["name"] == "researcher")
+    assert researcher["role"]["id"] == "researcher"
+    assert "code_changes" in researcher["role"]["forbidden"]
+    assert data["summary"]["profiles_missing_role_metadata"] == 1
+    assert any(v["code"] == "profile_missing_role_metadata" and v["profile"] == "no-role" for v in data["violations"])
+
+
+def test_roster_flags_kanban_assignment_and_quality_gate_drift(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(tmp_path))
+    _seed_profiles(tmp_path)
+
+    conn = kb.connect(board="default")
+    try:
+        unknown_id = kb.create_task(conn, title="[BUILD] Ship production feature", body="Build it fast", assignee="ghost")
+        no_prd_id = kb.create_task(conn, title="[BUILD] Add checkout", body="Goal: sell faster", assignee="default")
+        review_id = kb.create_task(conn, title="[QA] Review checkout", body="Review build output", assignee="reviewer", parents=[no_prd_id])
+    finally:
+        conn.close()
+
+    core = _load_core()
+    data = core.build_roster()
+    by_code = {(v["code"], v.get("task_id")) for v in data["violations"]}
+
+    assert ("task_assignee_profile_missing", unknown_id) in by_code
+    assert ("prd_lite_missing", no_prd_id) in by_code
+    assert ("reviewer_gate_missing", no_prd_id) not in by_code
+    assert any(stage["key"] == "build" and stage["task_count"] >= 2 for stage in data["pipeline"]["stages"])
+    assert any(stage["key"] == "qa" and stage["task_count"] >= 1 for stage in data["pipeline"]["stages"])
+    assert review_id
+
+
+def test_reviewer_assigned_qa_task_does_not_require_second_reviewer_gate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(tmp_path))
+    _seed_profiles(tmp_path)
+
+    conn = kb.connect(board="default")
+    try:
+        qa_id = kb.create_task(conn, title="[QA] Review final output", body="Evidence: check the build", assignee="reviewer")
+    finally:
+        conn.close()
+
+    core = _load_core()
+    data = core.build_roster()
+    assert ("reviewer_gate_missing", qa_id) not in {(v["code"], v.get("task_id")) for v in data["violations"]}
+
+
+def test_pre_llm_call_injects_current_role_and_task_context(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profiles" / "researcher"))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_PROFILE", "researcher")
+    _seed_profiles(tmp_path)
+    conn = kb.connect(board="default")
+    try:
+        task_id = kb.create_task(conn, title="[RESEARCH] Compare tools", body="Find sources", assignee="researcher")
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "default")
+
+    hooks = _load_hooks()
+    result = hooks.on_pre_llm_call(session_id="s1", user_message="work")
+
+    assert isinstance(result, dict)
+    ctx = result["context"]
+    assert "Agent Roster Role Context" in ctx
+    assert "Profile: researcher" in ctx
+    assert "Forbidden actions: code_changes, deployment, git_push" in ctx
+    assert f"Task: {task_id} — [RESEARCH] Compare tools" in ctx
+
+
+def test_pre_tool_call_blocks_forbidden_actions_in_strict_mode_and_audits(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profiles" / "researcher"))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_PROFILE", "researcher")
+    _seed_profiles(tmp_path)
+
+    hooks = _load_hooks()
+    result = hooks.on_pre_tool_call(
+        tool_name="write_file",
+        args={"path": "app.py", "content": "print('x')"},
+        session_id="s1",
+        tool_call_id="tc1",
+    )
+
+    assert result["action"] == "block"
+    assert "code_changes" in result["message"]
+    audit_path = tmp_path / "logs" / "agent-roster-audit.jsonl"
+    rows = [json.loads(line) for line in audit_path.read_text(encoding="utf-8").splitlines()]
+    assert rows[-1]["event"] == "tool_policy_block"
+    assert rows[-1]["profile"] == "researcher"
+    assert rows[-1]["tool_name"] == "write_file"
+
+
+def test_freeform_german_forbidden_rules_map_to_canonical_actions(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profiles" / "researcher"))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_PROFILE", "researcher")
+    _seed_profiles(tmp_path)
+    _write_yaml(
+        tmp_path / "profiles" / "researcher" / "config.yaml",
+        {"profile_role": _role("researcher", forbidden=["Code ändern", "Konfiguration ändern", "Git push"])},
+    )
+
+    hooks = _load_hooks()
+    result = hooks.on_pre_tool_call(tool_name="write_file", args={"path": "app.py"}, session_id="s1")
+
+    assert result["action"] == "block"
+    assert "code_changes" in result["message"]
+
+
+def test_kanban_complete_blocks_build_task_without_prd_or_reviewer_gate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_PROFILE", "default")
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "default")
+    _seed_profiles(tmp_path)
+    conn = kb.connect(board="default")
+    try:
+        task_id = kb.create_task(conn, title="[BUILD] Ship checkout", body="Goal: ship", assignee="default")
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+
+    hooks = _load_hooks()
+    result = hooks.on_pre_tool_call(tool_name="kanban_complete", args={"task_id": task_id}, session_id="s1")
+
+    assert result["action"] == "block"
+    assert "PRD-lite fields" in result["message"]
+
+
+def test_kanban_complete_allows_build_task_with_prd_and_reviewer_gate(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_PROFILE", "default")
+    monkeypatch.setenv("HERMES_KANBAN_BOARD", "default")
+    _seed_profiles(tmp_path)
+    complete_body = """
+    Goal: ship checkout
+    Non-goal: subscriptions
+    Target user: buyer
+    Acceptance criteria: payment succeeds
+    Success metric: conversion
+    Risks: payment failure
+    Dependencies: provider
+    Definition of done: reviewer approved
+    """
+    conn = kb.connect(board="default")
+    try:
+        task_id = kb.create_task(conn, title="[BUILD] Ship checkout", body=complete_body, assignee="default")
+        kb.create_task(conn, title="[QA] Review checkout", body="Review evidence", assignee="reviewer", parents=[task_id])
+    finally:
+        conn.close()
+    monkeypatch.setenv("HERMES_KANBAN_TASK", task_id)
+
+    hooks = _load_hooks()
+    result = hooks.on_pre_tool_call(tool_name="kanban_complete", args={"task_id": task_id}, session_id="s1")
+
+    assert result is None
+
+
+def test_warn_strict_mode_alias_normalizes_to_audit_mode(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "profiles" / "researcher"))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_PROFILE", "researcher")
+    _seed_profiles(tmp_path)
+    cfg_path = tmp_path / "config.yaml"
+    cfg = yaml.safe_load(cfg_path.read_text(encoding="utf-8"))
+    cfg["dashboard"]["agent_roster"]["strict_mode"] = "warn"
+    cfg_path.write_text(yaml.safe_dump(cfg, sort_keys=False), encoding="utf-8")
+
+    core = _load_core()
+    hooks = _load_hooks()
+    result = hooks.on_pre_tool_call(tool_name="write_file", args={"path": "app.py"}, session_id="s1")
+
+    assert core.roster_config()["strict_mode"] == "audit"
+    assert result is None
+    audit_path = tmp_path / "logs" / "agent-roster-audit.jsonl"
+    rows = [json.loads(line) for line in audit_path.read_text(encoding="utf-8").splitlines()]
+    assert rows[-1]["event"] == "tool_policy_audit"
+    assert rows[-1]["mode"] == "audit"
+
+
+def test_patch_mode_config_files_are_classified_as_config_changes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(tmp_path))
+    _seed_profiles(tmp_path)
+
+    core = _load_core()
+    actions = core.classify_tool_actions(
+        "patch",
+        {
+            "mode": "patch",
+            "patch": "*** Begin Patch\n*** Update File: AGENTS.md\n@@\n-old\n+new\n*** End Patch",
+        },
+    )
+
+    assert "code_changes" in actions
+    assert "config_changes" in actions
+
+
+def test_post_tool_audit_does_not_persist_tool_result_excerpts(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_PROFILE", "default")
+    _seed_profiles(tmp_path)
+
+    hooks = _load_hooks()
+    sensitive_result = "private credential value: super-sensitive-value"
+    hooks.on_post_tool_call(tool_name="read_file", args={"path": ".env"}, result=sensitive_result, session_id="s1")
+
+    audit_path = tmp_path / "logs" / "agent-roster-audit.jsonl"
+    row = json.loads(audit_path.read_text(encoding="utf-8").splitlines()[-1])
+    assert row["event"] == "tool_call"
+    assert row["result_redacted"] is True
+    assert "result_excerpt" not in row
+    assert "super-sensitive-value" not in json.dumps(row)
+
+
+def test_dashboard_api_routes_return_roster_envelopes(tmp_path: Path, monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("HERMES_KANBAN_HOME", str(tmp_path))
+    _seed_profiles(tmp_path)
+
+    api = _load_api()
+    app = FastAPI()
+    app.include_router(api.router, prefix="/api/plugins/agent-roster")
+    client = TestClient(app)
+
+    roster = client.get("/api/plugins/agent-roster/roster").json()
+    violations = client.get("/api/plugins/agent-roster/violations").json()
+    pipeline = client.get("/api/plugins/agent-roster/pipeline").json()
+
+    assert roster["summary"]["profile_count"] >= 4
+    assert "profiles" in roster and "violations" in roster
+    assert violations["count"] == len(violations["violations"])
+    assert pipeline["count"] == len(pipeline["stages"])
+
+
+def test_dashboard_assets_register_agent_roster_plugin():
+    manifest = json.loads((PLUGIN_DIR / "dashboard" / "manifest.json").read_text(encoding="utf-8"))
+    js = (PLUGIN_DIR / "dashboard" / "dist" / "index.js").read_text(encoding="utf-8")
+
+    assert manifest["name"] == "agent-roster"
+    assert manifest["tab"]["path"] == "/agent-roster"
+    assert manifest["api"] == "plugin_api.py"
+    assert "SDK.fetchJSON" in js
+    assert "__HERMES_PLUGINS__.register(\"agent-roster\"" in js


### PR DESCRIPTION
## Summary
- add bundled agent-roster dashboard plugin with roster, profile, board, violation, pipeline, and audit APIs
- add profile_role-aware pre_llm role-context injection and pre_tool policy block/audit enforcement
- add redacted post_tool audit events plus Kanban PRD/reviewer-gate drift checks
- enforce `kanban_complete` gates for build/launch/ops task types in block mode until PRD-lite fields and a linked QA/reviewer task exist

## Verification
- `venv/bin/python -m py_compile plugins/agent-roster/__init__.py plugins/agent-roster/roster_core.py plugins/agent-roster/dashboard/plugin_api.py`
- `node --check plugins/agent-roster/dashboard/dist/index.js`
- `venv/bin/python -m pytest tests/plugins/test_agent_roster_plugin.py tests/hermes_cli/test_plugins.py::TestPreToolCallBlocking tests/hermes_cli/test_plugins.py::TestPreLlmCallTargetRouting tests/test_model_tools.py::TestPreToolCallBlocking tests/plugins/test_kanban_dashboard_plugin.py -q` → 109 passed
- `ulimit -n 4096 && venv/bin/python -m pytest tests/plugins/test_agent_roster_plugin.py tests/plugins/test_kanban_dashboard_plugin.py tests/plugins/test_langfuse_plugin.py tests/hermes_cli/test_plugins.py tests/test_model_tools.py -o 'addopts=' -q` → 192 passed

## Notes
- Full `tests/` run was attempted, but the local environment hit unrelated FD/env failures (`ulimit` 256 OSError and an existing OpenViking tenant expectation). Targeted plugin/runtime regression suites passed.
