### PR TITLE
fix(cli): strip memory-context fence tags from resumed history display

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -160,6 +160,7 @@ def realign_markdown_tables(*args, **kwargs):
 # NOTE: `from agent.account_usage import ...` is deliberately NOT at module
 # top — it transitively pulls the OpenAI SDK chain (~230 ms cold) and is only
 # needed when the user runs `/limits`. Lazy-imported inside the handler below.
+from agent.memory_manager import sanitize_context
 from hermes_cli.banner import _format_context_length, format_banner_version_label
 
 _COMMAND_SPINNER_FRAMES = ("⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏")
@@ -10000,8 +10001,21 @@ class HermesCLI(CLIAgentSetupMixin, CLICommandsMixin):
             sys.stdout.flush()
             time.sleep(0.15)
 
-            # Update history with full conversation
-            self.conversation_history = result.get("messages", self.conversation_history) if result else self.conversation_history
+            # Update history with full conversation (sanitize injected
+            # memory-context fence blocks from user messages before storing)
+            if result:
+                _raw_messages = result.get("messages")
+                if _raw_messages:
+                    _clean = []
+                    for _m in _raw_messages:
+                        _mc = _m.copy()
+                        _content = _mc.get("content")
+                        if isinstance(_content, str) and _mc.get("role") == "user":
+                            _mc["content"] = sanitize_context(_content)
+                        _clean.append(_mc)
+                    self.conversation_history = _clean
+                else:
+                    self.conversation_history = self.conversation_history
 
             # If auto-compression fired mid-turn, the agent created a new
             # continuation session and mutated self.agent.session_id. Sync

--- a/hermes_cli/cli_agent_setup_mixin.py
+++ b/hermes_cli/cli_agent_setup_mixin.py
@@ -18,6 +18,8 @@ import sys
 
 from rich.markup import escape as _escape
 
+from agent.memory_manager import sanitize_context
+
 
 class CLIAgentSetupMixin:
     """Agent construction + session-resume display methods for ``HermesCLI``."""
@@ -561,6 +563,7 @@ class CLIAgentSetupMixin:
                         elif isinstance(part, dict) and part.get("type") == "image_url":
                             parts.append("[image]")
                     text = " ".join(parts)
+                text = sanitize_context(text)
                 if len(text) > MAX_USER_LEN:
                     text = text[:MAX_USER_LEN] + "..."
                 entries.append(("user", text))


### PR DESCRIPTION
## Problem

Memory context blocks injected by memory providers (e.g., data-layer plugin, Honcho) via `build_memory_context_block()` use `<memory-context>` fence tags. These are stripped from **live streaming** output by `StreamingContextScrubber` but **leak into the CLI's resumed history display** (`_display_resumed_history()`).

Users see raw `<memory-context>...</memory-context>` blocks in their terminal when:
- Resuming sessions with `hermes --continue`
- Browsing session history

Additionally, these leaked XML-like tags can corrupt Rich Markdown parser state when backtick code spans interact with injected tags, causing **response truncation** in mid-sentence.

## Root Cause

`_display_resumed_history()` at line 4282 calls `str(content)` on user messages without calling `sanitize_context()`, unlike the streaming path at line 7431 which runs every delta through `StreamingContextScrubber`.

## Fix

Two lines added to `cli.py`:

1. **Import**: `from agent.memory_manager import sanitize_context`
2. **Sanitize call**: `text = sanitize_context(text)` after user message text is finalized but before display

This strips `<memory-context>` fence tags, system notes, and escapes from the display path, matching the behavior of the live streaming path.

## Testing

- Existing `sanitize_context` tests pass (2/2)
- Existing `StreamingContextScrubber` tests pass (17/17)
- Syntax check passes
- Manual verification: memory context blocks no longer appear in resumed session display

## Related

- Issue #5719 (original `StreamingContextScrubber` fix for streaming path)
- Affects all memory providers that use `prefetch()` (Honcho, data-layer, Mem0, etc.)