### PR TITLE
fix(cron): use POSIX paths for bash scripts on native Windows

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -769,7 +769,16 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
                 "On Windows, install Git for Windows (which ships Git Bash) "
                 "or rewrite the script as Python (.py)."
             )
-        argv = [_bash, str(path)]
+        # On Windows, bash (Git Bash / MSYS2) interprets backslashes in
+        # paths as escape sequences, silently mangling them — a path like
+        # C:\Users\... becomes C:Users... and the script is never found.
+        # path.as_posix() normalizes to POSIX forward-slash form
+        # (/c/Users/...) which MSYS2 bash understands natively.
+        # On non-Windows platforms, str(path) is already a valid POSIX path.
+        if os.name == "nt":
+            argv = [_bash, path.as_posix()]
+        else:
+            argv = [_bash, str(path)]
     else:
         argv = [sys.executable, str(path)]
 


### PR DESCRIPTION
## Summary

On native Windows with Git Bash, `.sh` / `.bash` cron scripts always fail because bash interprets backslashes in the path argument as escape sequences, mangling `C:\Users\...` into `C:Users...` (exit code 127, script not found).

This PR gates a one-line fix behind `os.name == "nt"`: use `path.as_posix()` to produce forward-slash paths (`/c/Users/...`) that MSYS2 bash understands natively. Non-Windows platforms are completely unaffected — they continue to use `str(path)`.

## How to Test

1. On native Windows with Git Bash, create a cron job with `no_agent: true` and a `.sh` script
2. Confirm the script runs successfully instead of failing with exit code 127

Or use the existing test suite:

```bash
python -m pytest tests/cron/test_cron_no_agent.py -v
```

The test `test_run_job_script_shell_script_runs_via_bash` already exercises this code path and passes both before and after the change (the test uses POSIX paths, so the fix is invisible to it — as intended).

## Platform Tested

- OS: Windows 11 (native, git-bash)
- Python: 3.11.14
- Hermes: v0.13.0

## Pre-submit checks

- `scripts/check-windows-footguns.py` — zero footguns found
- `tests/cron/test_cron_no_agent.py` — all 18 tests pass

## Related

Closes #23404