### PR TITLE
refactor: extract kanban operator service

### DIFF
--- a/hermes_cli/kanban_operator.py
+++ b/hermes_cli/kanban_operator.py
@@ -1,0 +1,364 @@
+"""Shared Kanban operator semantics.
+
+This module holds mutation behavior that is needed by both the built-in
+Kanban dashboard plugin and external operator surfaces.  It intentionally
+stays close to :mod:`hermes_cli.kanban_db`: callers still own authentication,
+RBAC, request validation, and response serialization; this layer centralizes
+state-machine/event semantics that previously lived only in the dashboard
+plugin.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from typing import Any, Optional
+
+import sqlite3
+
+from hermes_cli import kanban_db
+
+
+def set_status_direct(
+    conn: sqlite3.Connection,
+    task_id: str,
+    new_status: str,
+) -> bool:
+    """Direct status write for operator drag/drop moves.
+
+    This is for transitions not covered by structured verbs such as
+    ``complete_task``/``block_task``/``archive_task``.  It preserves the
+    historical dashboard semantics:
+
+    * moving to ``ready`` is refused while any parent is not ``done``;
+    * leaving ``running`` clears claim fields and closes the active run as
+      ``reclaimed`` with the legacy dashboard summary;
+    * a ``status`` task event is appended for the live feed;
+    * ``done``/``ready`` moves trigger dependency recomputation.
+
+    The dashboard's single-task route rejects direct ``running`` transitions
+    before calling this helper.  Bulk dashboard semantics historically allowed
+    direct ``running`` writes, so this helper does not add a new guard.
+    """
+    with kanban_db.write_txn(conn):
+        prev = conn.execute(
+            "SELECT status, current_run_id FROM tasks WHERE id = ?",
+            (task_id,),
+        ).fetchone()
+        if prev is None:
+            return False
+
+        if new_status == "ready":
+            parent_statuses = conn.execute(
+                "SELECT t.status FROM tasks t "
+                "JOIN task_links l ON l.parent_id = t.id "
+                "WHERE l.child_id = ?",
+                (task_id,),
+            ).fetchall()
+            if parent_statuses and not all(
+                p["status"] == "done" for p in parent_statuses
+            ):
+                return False
+
+        was_running = prev["status"] == "running"
+        cur = conn.execute(
+            "UPDATE tasks SET status = ?, "
+            "  claim_lock = CASE WHEN ? = 'running' THEN claim_lock ELSE NULL END, "
+            "  claim_expires = CASE WHEN ? = 'running' THEN claim_expires ELSE NULL END, "
+            "  worker_pid = CASE WHEN ? = 'running' THEN worker_pid ELSE NULL END "
+            "WHERE id = ?",
+            (new_status, new_status, new_status, new_status, task_id),
+        )
+        if cur.rowcount != 1:
+            return False
+
+        run_id = None
+        if was_running and new_status != "running" and prev["current_run_id"]:
+            run_id = kanban_db._end_run(
+                conn,
+                task_id,
+                outcome="reclaimed",
+                status="reclaimed",
+                summary=f"status changed to {new_status} (dashboard/direct)",
+            )
+
+        kanban_db._append_event(
+            conn,
+            task_id,
+            "status",
+            {"status": new_status},
+            run_id=run_id,
+        )
+
+    if new_status in ("done", "ready"):
+        kanban_db.recompute_ready(conn)
+    return True
+
+
+def update_priority(
+    conn: sqlite3.Connection,
+    task_id: str,
+    priority: int,
+) -> bool:
+    """Set task priority and emit the dashboard-parity ``reprioritized`` event."""
+    value = int(priority)
+    with kanban_db.write_txn(conn):
+        cur = conn.execute(
+            "UPDATE tasks SET priority = ? WHERE id = ?",
+            (value, task_id),
+        )
+        if cur.rowcount != 1:
+            return False
+        kanban_db._append_event(conn, task_id, "reprioritized", {"priority": value})
+    return True
+
+
+def edit_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    title: Optional[str] = None,
+    body: Optional[str] = None,
+) -> bool:
+    """Update task title/body fields and emit the dashboard-parity ``edited`` event.
+
+    ``None`` means the field was omitted and should not be changed.  An empty
+    or whitespace-only title is rejected with ``ValueError`` so HTTP callers can
+    translate it to a 400 without duplicating the validation.
+    """
+    if title is None and body is None:
+        return True
+
+    sets: list[str] = []
+    vals: list[Any] = []
+    if title is not None:
+        cleaned = title.strip()
+        if not cleaned:
+            raise ValueError("title cannot be empty")
+        sets.append("title = ?")
+        vals.append(cleaned)
+    if body is not None:
+        sets.append("body = ?")
+        vals.append(body)
+
+    vals.append(task_id)
+    with kanban_db.write_txn(conn):
+        cur = conn.execute(
+            f"UPDATE tasks SET {', '.join(sets)} WHERE id = ?",
+            vals,
+        )
+        if cur.rowcount != 1:
+            return False
+        kanban_db._append_event(conn, task_id, "edited", None)
+    return True
+
+
+def bulk_update(
+    conn: sqlite3.Connection,
+    *,
+    ids: list[str],
+    status: Optional[str] = None,
+    assignee: Optional[str] = None,
+    priority: Optional[int] = None,
+    archive: bool = False,
+    result: Optional[str] = None,
+    summary: Optional[str] = None,
+    metadata: Optional[dict] = None,
+) -> dict[str, list[dict[str, Any]]]:
+    """Apply dashboard bulk-update semantics and return per-id outcomes.
+
+    Each id is independent: failures are captured on that row and do not abort
+    sibling updates.  Later requested fields for the same id continue to run
+    even if an earlier requested field failed, matching the original dashboard
+    route behavior.
+    """
+    results: list[dict[str, Any]] = []
+    for tid in [i for i in (ids or []) if i]:
+        entry: dict[str, Any] = {"id": tid, "ok": True}
+        try:
+            task = kanban_db.get_task(conn, tid)
+            if task is None:
+                entry.update(ok=False, error="not found")
+                results.append(entry)
+                continue
+
+            if archive:
+                if not kanban_db.archive_task(conn, tid):
+                    entry.update(ok=False, error="archive refused")
+
+            if status is not None and not archive:
+                s = status
+                if s == "done":
+                    ok = kanban_db.complete_task(
+                        conn,
+                        tid,
+                        result=result,
+                        summary=summary,
+                        metadata=metadata,
+                    )
+                elif s == "blocked":
+                    ok = kanban_db.block_task(conn, tid)
+                elif s == "ready":
+                    cur = kanban_db.get_task(conn, tid)
+                    if cur and cur.status == "blocked":
+                        ok = kanban_db.unblock_task(conn, tid)
+                    else:
+                        ok = set_status_direct(conn, tid, "ready")
+                elif s in ("todo", "running", "triage"):
+                    ok = set_status_direct(conn, tid, s)
+                else:
+                    entry.update(ok=False, error=f"unknown status {s!r}")
+                    results.append(entry)
+                    continue
+                if not ok:
+                    entry.update(ok=False, error=f"transition to {s!r} refused")
+
+            if assignee is not None:
+                try:
+                    if not kanban_db.assign_task(conn, tid, assignee or None):
+                        entry.update(ok=False, error="assign refused")
+                except RuntimeError as exc:
+                    entry.update(ok=False, error=str(exc))
+
+            if priority is not None:
+                if not update_priority(conn, tid, int(priority)):
+                    entry.update(ok=False, error="priority refused")
+        except Exception as exc:  # defensive — one bad id shouldn't kill the batch
+            entry.update(ok=False, error=str(exc))
+        results.append(entry)
+    return {"results": results}
+
+
+def reclaim_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    *,
+    reason: Optional[str] = None,
+) -> bool:
+    """Thin wrapper around the kernel reclaim primitive."""
+    return kanban_db.reclaim_task(conn, task_id, reason=reason)
+
+
+def reassign_task(
+    conn: sqlite3.Connection,
+    task_id: str,
+    profile: Optional[str],
+    *,
+    reclaim_first: bool = False,
+    reason: Optional[str] = None,
+) -> bool:
+    """Thin wrapper around the kernel reassign primitive."""
+    return kanban_db.reassign_task(
+        conn,
+        task_id,
+        profile,
+        reclaim_first=reclaim_first,
+        reason=reason,
+    )
+
+
+def dispatch_once(
+    conn: sqlite3.Connection,
+    *,
+    dry_run: bool = False,
+    max_spawn: int = 8,
+    board: Optional[str] = None,
+) -> dict[str, Any]:
+    """Run one dispatcher tick and serialize its result for operator APIs."""
+    result = kanban_db.dispatch_once(
+        conn,
+        dry_run=dry_run,
+        max_spawn=max_spawn,
+        board=board,
+    )
+    try:
+        return asdict(result)
+    except TypeError:
+        return {"result": str(result)}
+
+
+def board_counts(slug: str) -> dict[str, int]:
+    """Return ``{status: count}`` for a board. Safe on an empty DB."""
+    try:
+        path = kanban_db.kanban_db_path(board=slug)
+        if not path.exists():
+            return {}
+        conn = kanban_db.connect(board=slug)
+        try:
+            rows = conn.execute(
+                "SELECT status, COUNT(*) AS n FROM tasks GROUP BY status"
+            ).fetchall()
+            return {r["status"]: int(r["n"]) for r in rows}
+        finally:
+            conn.close()
+    except Exception:
+        return {}
+
+
+def list_boards(*, include_archived: bool = False) -> dict[str, Any]:
+    """Return all boards with task counts and the active slug."""
+    boards = kanban_db.list_boards(include_archived=include_archived)
+    current = kanban_db.get_current_board()
+    for board in boards:
+        board["is_current"] = board["slug"] == current
+        board["counts"] = board_counts(board["slug"])
+        board["total"] = sum(board["counts"].values())
+    return {"boards": boards, "current": current}
+
+
+def create_board(
+    slug: str,
+    *,
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+    icon: Optional[str] = None,
+    color: Optional[str] = None,
+    switch: bool = False,
+) -> dict[str, Any]:
+    """Create a board and optionally persist it as current."""
+    meta = kanban_db.create_board(
+        slug,
+        name=name,
+        description=description,
+        icon=icon,
+        color=color,
+    )
+    if switch:
+        kanban_db.set_current_board(meta["slug"])
+    return {"board": meta, "current": kanban_db.get_current_board()}
+
+
+def update_board_metadata(
+    slug: str,
+    *,
+    name: Optional[str] = None,
+    description: Optional[str] = None,
+    icon: Optional[str] = None,
+    color: Optional[str] = None,
+) -> dict[str, Any]:
+    """Update display metadata for an existing board."""
+    normed = kanban_db._normalize_board_slug(slug)
+    if not normed or not kanban_db.board_exists(normed):
+        raise FileNotFoundError(f"board {slug!r} does not exist")
+    meta = kanban_db.write_board_metadata(
+        normed,
+        name=name,
+        description=description,
+        icon=icon,
+        color=color,
+    )
+    return {"board": meta}
+
+
+def remove_board(slug: str, *, delete: bool = False) -> dict[str, Any]:
+    """Archive or hard-delete a board and return the current board pointer."""
+    result = kanban_db.remove_board(slug, archive=not delete)
+    return {"result": result, "current": kanban_db.get_current_board()}
+
+
+def switch_board(slug: str) -> dict[str, str]:
+    """Persist an existing board as current."""
+    normed = kanban_db._normalize_board_slug(slug)
+    if not normed or not kanban_db.board_exists(normed):
+        raise FileNotFoundError(f"board {slug!r} does not exist")
+    kanban_db.set_current_board(normed)
+    return {"current": normed}

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -48,7 +48,7 @@ from typing import Any, Optional
 from fastapi import APIRouter, HTTPException, Query, WebSocket, WebSocketDisconnect, status as http_status
 from pydantic import BaseModel, Field
 
-from hermes_cli import kanban_db
+from hermes_cli import kanban_db, kanban_operator
 
 log = logging.getLogger(__name__)
 
@@ -620,7 +620,7 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                     ok = kanban_db.unblock_task(conn, task_id)
                 else:
                     # Direct status write for drag-drop (todo -> ready etc).
-                    ok = _set_status_direct(conn, task_id, "ready")
+                    ok = kanban_operator.set_status_direct(conn, task_id, "ready")
             elif s == "archived":
                 ok = kanban_db.archive_task(conn, task_id)
             elif s == "running":
@@ -629,7 +629,7 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
                     detail="Cannot set status to 'running' directly; use the dispatcher/claim path",
                 )
             elif s in ("todo", "triage"):
-                ok = _set_status_direct(conn, task_id, s)
+                ok = kanban_operator.set_status_direct(conn, task_id, s)
             else:
                 raise HTTPException(status_code=400, detail=f"unknown status: {s}")
             if not ok:
@@ -640,111 +640,27 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
 
         # --- priority -----------------------------------------------------
         if payload.priority is not None:
-            with kanban_db.write_txn(conn):
-                conn.execute(
-                    "UPDATE tasks SET priority = ? WHERE id = ?",
-                    (int(payload.priority), task_id),
-                )
-                conn.execute(
-                    "INSERT INTO task_events (task_id, kind, payload, created_at) "
-                    "VALUES (?, 'reprioritized', ?, ?)",
-                    (task_id, json.dumps({"priority": int(payload.priority)}),
-                     int(time.time())),
-                )
+            if not kanban_operator.update_priority(conn, task_id, int(payload.priority)):
+                raise HTTPException(status_code=404, detail="task not found")
 
         # --- title / body -------------------------------------------------
         if payload.title is not None or payload.body is not None:
-            with kanban_db.write_txn(conn):
-                sets, vals = [], []
-                if payload.title is not None:
-                    if not payload.title.strip():
-                        raise HTTPException(status_code=400, detail="title cannot be empty")
-                    sets.append("title = ?")
-                    vals.append(payload.title.strip())
-                if payload.body is not None:
-                    sets.append("body = ?")
-                    vals.append(payload.body)
-                vals.append(task_id)
-                conn.execute(
-                    f"UPDATE tasks SET {', '.join(sets)} WHERE id = ?", vals,
+            try:
+                ok = kanban_operator.edit_task(
+                    conn,
+                    task_id,
+                    title=payload.title,
+                    body=payload.body,
                 )
-                conn.execute(
-                    "INSERT INTO task_events (task_id, kind, payload, created_at) "
-                    "VALUES (?, 'edited', NULL, ?)",
-                    (task_id, int(time.time())),
-                )
+            except ValueError as exc:
+                raise HTTPException(status_code=400, detail=str(exc))
+            if not ok:
+                raise HTTPException(status_code=404, detail="task not found")
 
         updated = kanban_db.get_task(conn, task_id)
         return {"task": _task_dict(updated) if updated else None}
     finally:
         conn.close()
-
-
-def _set_status_direct(
-    conn: sqlite3.Connection, task_id: str, new_status: str,
-) -> bool:
-    """Direct status write for drag-drop moves that aren't covered by the
-    structured complete/block/unblock/archive verbs (e.g. todo<->ready,
-    running<->ready). Appends a ``status`` event row for the live feed.
-
-    When this transitions OFF ``running`` to anything other than the
-    terminal verbs above (which own their own run closing), we close the
-    active run with outcome='reclaimed' so attempt history isn't
-    orphaned. ``running -> ready`` via drag-drop is the common case
-    (user yanking a stuck worker back to the queue).
-    """
-    with kanban_db.write_txn(conn):
-        # Snapshot current state so we know whether to close a run.
-        prev = conn.execute(
-            "SELECT status, current_run_id FROM tasks WHERE id = ?",
-            (task_id,),
-        ).fetchone()
-        if prev is None:
-            return False
-
-        # Guard: don't allow promoting to 'ready' unless all parents are done.
-        # Prevents the dispatcher from spawning a child whose upstream work
-        # hasn't completed (e.g. T4 dispatched while T3 is still blocked).
-        if new_status == "ready":
-            parent_statuses = conn.execute(
-                "SELECT t.status FROM tasks t "
-                "JOIN task_links l ON l.parent_id = t.id "
-                "WHERE l.child_id = ?",
-                (task_id,),
-            ).fetchall()
-            if parent_statuses and not all(
-                p["status"] == "done" for p in parent_statuses
-            ):
-                return False
-
-        was_running = prev["status"] == "running"
-
-        cur = conn.execute(
-            "UPDATE tasks SET status = ?, "
-            "  claim_lock = CASE WHEN ? = 'running' THEN claim_lock ELSE NULL END, "
-            "  claim_expires = CASE WHEN ? = 'running' THEN claim_expires ELSE NULL END, "
-            "  worker_pid = CASE WHEN ? = 'running' THEN worker_pid ELSE NULL END "
-            "WHERE id = ?",
-            (new_status, new_status, new_status, new_status, task_id),
-        )
-        if cur.rowcount != 1:
-            return False
-        run_id = None
-        if was_running and new_status != "running" and prev["current_run_id"]:
-            run_id = kanban_db._end_run(
-                conn, task_id,
-                outcome="reclaimed", status="reclaimed",
-                summary=f"status changed to {new_status} (dashboard/direct)",
-            )
-        conn.execute(
-            "INSERT INTO task_events (task_id, run_id, kind, payload, created_at) "
-            "VALUES (?, ?, 'status', ?, ?)",
-            (task_id, run_id, json.dumps({"status": new_status}), int(time.time())),
-        )
-    # If we re-opened something, children may have gone stale.
-    if new_status in ("done", "ready"):
-        kanban_db.recompute_ready(conn)
-    return True
 
 
 # ---------------------------------------------------------------------------
@@ -835,70 +751,20 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
     ids = [i for i in (payload.ids or []) if i]
     if not ids:
         raise HTTPException(status_code=400, detail="ids is required")
-    results: list[dict] = []
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
-        for tid in ids:
-            entry: dict[str, Any] = {"id": tid, "ok": True}
-            try:
-                task = kanban_db.get_task(conn, tid)
-                if task is None:
-                    entry.update(ok=False, error="not found")
-                    results.append(entry)
-                    continue
-                if payload.archive:
-                    if not kanban_db.archive_task(conn, tid):
-                        entry.update(ok=False, error="archive refused")
-                if payload.status is not None and not payload.archive:
-                    s = payload.status
-                    if s == "done":
-                        ok = kanban_db.complete_task(
-                            conn, tid,
-                            result=payload.result,
-                            summary=payload.summary,
-                            metadata=payload.metadata,
-                        )
-                    elif s == "blocked":
-                        ok = kanban_db.block_task(conn, tid)
-                    elif s == "ready":
-                        cur = kanban_db.get_task(conn, tid)
-                        if cur and cur.status == "blocked":
-                            ok = kanban_db.unblock_task(conn, tid)
-                        else:
-                            ok = _set_status_direct(conn, tid, "ready")
-                    elif s in ("todo", "running", "triage"):
-                        ok = _set_status_direct(conn, tid, s)
-                    else:
-                        entry.update(ok=False, error=f"unknown status {s!r}")
-                        results.append(entry)
-                        continue
-                    if not ok:
-                        entry.update(ok=False, error=f"transition to {s!r} refused")
-                if payload.assignee is not None:
-                    try:
-                        if not kanban_db.assign_task(
-                            conn, tid, payload.assignee or None,
-                        ):
-                            entry.update(ok=False, error="assign refused")
-                    except RuntimeError as e:
-                        entry.update(ok=False, error=str(e))
-                if payload.priority is not None:
-                    with kanban_db.write_txn(conn):
-                        conn.execute(
-                            "UPDATE tasks SET priority = ? WHERE id = ?",
-                            (int(payload.priority), tid),
-                        )
-                        conn.execute(
-                            "INSERT INTO task_events (task_id, kind, payload, created_at) "
-                            "VALUES (?, 'reprioritized', ?, ?)",
-                            (tid, json.dumps({"priority": int(payload.priority)}),
-                             int(time.time())),
-                        )
-            except Exception as e:  # defensive — one bad id shouldn't kill the batch
-                entry.update(ok=False, error=str(e))
-            results.append(entry)
-        return {"results": results}
+        return kanban_operator.bulk_update(
+            conn,
+            ids=ids,
+            status=payload.status,
+            assignee=payload.assignee,
+            priority=payload.priority,
+            archive=payload.archive,
+            result=payload.result,
+            summary=payload.summary,
+            metadata=payload.metadata,
+        )
     finally:
         conn.close()
 
@@ -1010,7 +876,7 @@ def reclaim_task_endpoint(
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
-        ok = kanban_db.reclaim_task(conn, task_id, reason=payload.reason)
+        ok = kanban_operator.reclaim_task(conn, task_id, reason=payload.reason)
         if not ok:
             raise HTTPException(
                 status_code=409,
@@ -1101,7 +967,7 @@ def reassign_task_endpoint(
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
-        ok = kanban_db.reassign_task(
+        ok = kanban_operator.reassign_task(
             conn, task_id,
             payload.profile or None,
             reclaim_first=bool(payload.reclaim_first),
@@ -1387,14 +1253,9 @@ def dispatch(
     board = _resolve_board(board)
     conn = _conn(board=board)
     try:
-        result = kanban_db.dispatch_once(
+        return kanban_operator.dispatch_once(
             conn, dry_run=dry_run, max_spawn=max_n, board=board,
         )
-        # DispatchResult is a dataclass.
-        try:
-            return asdict(result)
-        except TypeError:
-            return {"result": str(result)}
     finally:
         conn.close()
 
@@ -1419,42 +1280,34 @@ class RenameBoardBody(BaseModel):
     color: Optional[str] = None
 
 
-def _board_counts(slug: str) -> dict[str, int]:
-    """Return ``{status: count}`` for a board. Safe on an empty DB."""
-    try:
-        path = kanban_db.kanban_db_path(board=slug)
-        if not path.exists():
-            return {}
-        conn = kanban_db.connect(board=slug)
-        try:
-            rows = conn.execute(
-                "SELECT status, COUNT(*) AS n FROM tasks GROUP BY status"
-            ).fetchall()
-            return {r["status"]: int(r["n"]) for r in rows}
-        finally:
-            conn.close()
-    except Exception:
-        return {}
-
-
 @router.get("/boards")
 def list_boards(include_archived: bool = Query(False)):
     """Return every board on disk with task counts and the active slug."""
-    boards = kanban_db.list_boards(include_archived=include_archived)
-    current = kanban_db.get_current_board()
-    for b in boards:
-        b["is_current"] = (b["slug"] == current)
-        b["counts"] = _board_counts(b["slug"])
-        b["total"] = sum(b["counts"].values())
-    return {"boards": boards, "current": current}
+    return kanban_operator.list_boards(include_archived=include_archived)
 
 
 @router.post("/boards")
 def create_board_endpoint(payload: CreateBoardBody):
     """Create a new board. Idempotent — ``slug`` collision returns existing."""
     try:
-        meta = kanban_db.create_board(
+        return kanban_operator.create_board(
             payload.slug,
+            name=payload.name,
+            description=payload.description,
+            icon=payload.icon,
+            color=payload.color,
+            switch=payload.switch,
+        )
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+
+@router.patch("/boards/{slug}")
+def rename_board(slug: str, payload: RenameBoardBody):
+    """Update a board's display metadata (slug is immutable — create a new one to rename the directory)."""
+    try:
+        return kanban_operator.update_board_metadata(
+            slug,
             name=payload.name,
             description=payload.description,
             icon=payload.icon,
@@ -1462,41 +1315,17 @@ def create_board_endpoint(payload: CreateBoardBody):
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
-    if payload.switch:
-        try:
-            kanban_db.set_current_board(meta["slug"])
-        except ValueError as exc:
-            raise HTTPException(status_code=400, detail=str(exc))
-    return {"board": meta, "current": kanban_db.get_current_board()}
-
-
-@router.patch("/boards/{slug}")
-def rename_board(slug: str, payload: RenameBoardBody):
-    """Update a board's display metadata (slug is immutable — create a new one to rename the directory)."""
-    try:
-        normed = kanban_db._normalize_board_slug(slug)
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc))
-    if not normed or not kanban_db.board_exists(normed):
+    except FileNotFoundError:
         raise HTTPException(status_code=404, detail=f"board {slug!r} does not exist")
-    meta = kanban_db.write_board_metadata(
-        normed,
-        name=payload.name,
-        description=payload.description,
-        icon=payload.icon,
-        color=payload.color,
-    )
-    return {"board": meta}
 
 
 @router.delete("/boards/{slug}")
 def delete_board(slug: str, delete: bool = Query(False, description="Hard-delete instead of archive")):
     """Archive (default) or hard-delete a board."""
     try:
-        res = kanban_db.remove_board(slug, archive=not delete)
+        return kanban_operator.remove_board(slug, delete=delete)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
-    return {"result": res, "current": kanban_db.get_current_board()}
 
 
 @router.post("/boards/{slug}/switch")
@@ -1508,13 +1337,11 @@ def switch_board(slug: str):
     commands and the CLI share the same current-board pointer.
     """
     try:
-        normed = kanban_db._normalize_board_slug(slug)
+        return kanban_operator.switch_board(slug)
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
-    if not normed or not kanban_db.board_exists(normed):
+    except FileNotFoundError:
         raise HTTPException(status_code=404, detail=f"board {slug!r} does not exist")
-    kanban_db.set_current_board(normed)
-    return {"current": normed}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/hermes_cli/test_kanban_operator.py
+++ b/tests/hermes_cli/test_kanban_operator.py
@@ -1,0 +1,119 @@
+"""Tests for shared Kanban operator semantics."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+from hermes_cli import kanban_operator as op
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    """Isolated HERMES_HOME with an empty kanban DB."""
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _payload(event):
+    if event.payload is None:
+        return None
+    if isinstance(event.payload, str):
+        return json.loads(event.payload)
+    return event.payload
+
+
+def test_set_status_direct_enforces_parent_guard_and_emits_status_event(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent")
+        child = kb.create_task(conn, title="child", parents=[parent])
+
+        assert kb.get_task(conn, child).status == "todo"
+        assert op.set_status_direct(conn, child, "ready") is False
+        assert kb.get_task(conn, child).status == "todo"
+        assert [event.kind for event in kb.list_events(conn, child)] == ["created"]
+
+        assert kb.complete_task(conn, parent)
+        assert kb.get_task(conn, child).status == "ready"
+        assert op.set_status_direct(conn, child, "triage") is True
+        assert kb.get_task(conn, child).status == "triage"
+
+        event = kb.list_events(conn, child)[-1]
+        assert event.kind == "status"
+        assert _payload(event) == {"status": "triage"}
+
+
+def test_set_status_direct_closes_running_run_as_reclaimed(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="work", assignee="worker")
+        claimed = kb.claim_task(conn, task_id, claimer="test-worker")
+        assert claimed is not None
+        run_id = claimed.current_run_id
+
+        assert op.set_status_direct(conn, task_id, "ready") is True
+
+        task = kb.get_task(conn, task_id)
+        assert task.status == "ready"
+        assert task.claim_lock is None
+        assert task.claim_expires is None
+        assert task.worker_pid is None
+        run = conn.execute("SELECT * FROM task_runs WHERE id = ?", (run_id,)).fetchone()
+        assert run["status"] == "reclaimed"
+        assert run["outcome"] == "reclaimed"
+        assert run["summary"] == "status changed to ready (dashboard/direct)"
+        event = kb.list_events(conn, task_id)[-1]
+        assert event.kind == "status"
+        assert event.run_id == run_id
+        assert _payload(event) == {"status": "ready"}
+
+
+def test_update_priority_and_edit_task_emit_dashboard_parity_events(kanban_home):
+    with kb.connect() as conn:
+        task_id = kb.create_task(conn, title="old", body="old body")
+
+        assert op.update_priority(conn, task_id, 7) is True
+        assert op.edit_task(conn, task_id, title="  new title  ", body="new body") is True
+
+        task = kb.get_task(conn, task_id)
+        assert task.priority == 7
+        assert task.title == "new title"
+        assert task.body == "new body"
+        events = kb.list_events(conn, task_id)
+        assert [event.kind for event in events[-2:]] == ["reprioritized", "edited"]
+        assert _payload(events[-2]) == {"priority": 7}
+        assert events[-1].payload is None
+
+
+def test_bulk_update_preserves_dashboard_partial_success_semantics(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="parent")
+        child = kb.create_task(conn, title="child", parents=[parent])
+        movable = kb.create_task(conn, title="movable")
+
+        result = op.bulk_update(
+            conn,
+            ids=[child, "missing", movable],
+            status="ready",
+            priority=5,
+        )
+
+        assert result == {
+            "results": [
+                {"id": child, "ok": False, "error": "transition to 'ready' refused"},
+                {"id": "missing", "ok": False, "error": "not found"},
+                {"id": movable, "ok": True},
+            ]
+        }
+        # Bulk keeps applying later requested fields even when an earlier field
+        # on the same task failed, matching the existing dashboard route.
+        assert kb.get_task(conn, child).status == "todo"
+        assert kb.get_task(conn, child).priority == 5
+        assert kb.get_task(conn, movable).status == "ready"
+        assert kb.get_task(conn, movable).priority == 5

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -467,6 +467,34 @@ def test_patch_status_triage_works(client):
     assert r.json()["task"]["status"] == "todo"
 
 
+def test_patch_status_uses_shared_operator_service(client, monkeypatch):
+    """Dashboard direct moves must call the shared operator service.
+
+    This prevents the dashboard route and external operator backends from
+    growing separate SQL/state-machine semantics for drag/drop moves.
+    """
+    from hermes_cli import kanban_operator as op
+
+    calls = []
+    original = op.set_status_direct
+
+    def spy(conn, task_id, status):
+        calls.append((task_id, status))
+        return original(conn, task_id, status)
+
+    monkeypatch.setattr(op, "set_status_direct", spy)
+    t = client.post(
+        "/api/plugins/kanban/tasks", json={"title": "x"},
+    ).json()["task"]
+
+    r = client.patch(
+        f"/api/plugins/kanban/tasks/{t['id']}", json={"status": "triage"},
+    )
+
+    assert r.status_code == 200
+    assert calls == [(t["id"], "triage")]
+
+
 # ---------------------------------------------------------------------------
 # Progress rollup (done children / total children)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Adds `hermes_cli.kanban_operator` as a shared service for Kanban board/operator mutations.
- Updates the dashboard plugin to delegate mutation/board/dispatch semantics to the shared operator layer.
- Adds focused regression coverage for operator parity and dashboard delegation.

## Runtime dependency
Pathfinder Kanban viewer backend PR #6 imports `hermes_cli.kanban_operator`; that integration requires a Hermes checkout/package containing this module (this PR branch or equivalent commit) via `HERMES_AGENT_PATH` or an installed Hermes package.

## Test Plan
- `env -u HERMES_KANBAN_DB -u HERMES_KANBAN_HOME -u HERMES_KANBAN_BOARD -u HERMES_KANBAN_WORKSPACES_ROOT python -m pytest tests/hermes_cli/test_kanban_operator.py tests/hermes_cli/test_kanban_db.py tests/plugins/test_kanban_dashboard_plugin.py -q -o 'addopts='` — 168 passed\n- `python -m ruff check hermes_cli/kanban_operator.py plugins/kanban/dashboard/plugin_api.py tests/hermes_cli/test_kanban_operator.py tests/plugins/test_kanban_dashboard_plugin.py` — passed\n\nDo not merge until the Pathfinder viewer runtime can be pointed at this Hermes version (or a release/package containing the module).\n