### PR TITLE
fix: add OpenRouter "no endpoints found that support image" to image rejection phrases

### DIFF
--- a/agent/conversation_loop.py
+++ b/agent/conversation_loop.py
@@ -1825,6 +1825,7 @@ def run_conversation(
                     "does not support multimodal",
                     "does not support vision",
                     "model does not support image",
+                    "no endpoints found that support image",
                     # ChatGPT-account Codex backend
                     # (https://chatgpt.com/backend-api/codex) rejects
                     # data:image/...base64 URLs in input_image fields

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -134,6 +134,7 @@ AUTHOR_MAP = {
     "denisamania@gmail.com": "CalmProton",
     "308068+mbac@users.noreply.github.com": "mbac",
     "nicoechaniz@altermundi.net": "nicoechaniz",
+    "me@freeformz.me": "freeformz",
     "ninso112@proton.me": "Ninso112",
     "wesleysimplicio@live.com": "wesleysimplicio",
     "matthew.dean.cater@gmail.com": "SiliconID",

--- a/tests/run_agent/test_image_rejection_fallback.py
+++ b/tests/run_agent/test_image_rejection_fallback.py
@@ -195,6 +195,7 @@ class TestImageRejectionPhraseIsolation:
         "does not support vision",
         "model does not support image",
         "image_url'. expected",
+        "no endpoints found that support image",
     )
 
     def _matches(self, body: str) -> bool:
@@ -244,6 +245,7 @@ class TestImageRejectionPhraseIsolation:
             # match the agent cascaded into compression / context-too-large
             # recovery instead of just stripping the images.
             "Invalid 'input[56].content[1].image_url'. Expected a valid URL, but got a value with an invalid format.",
+            "No endpoints found that support image input",
         ]
         for body in bodies:
             assert self._matches(body) is True, f"false negative on: {body}"


### PR DESCRIPTION
## Bug Description

When using OpenRouter with a text-only model (e.g., deepseek-v4-pro) and a tool that produces multimodal results (e.g., `computer_use` capture), Hermes sends the image in the tool result. OpenRouter responds:

```
HTTP 404: No endpoints found that support image input
```

The intended recovery path in `run_agent.py` detects this as image rejection, strips images from messages, sets `_vision_supported = False`, and retries text-only. However, `_IMAGE_REJECTION_PHRASES` matches "does not support image input" — the substring "does not support" is absent from "No endpoints found that support image input", so the fallback never triggers. Hermes exhausts its 3 retries and fails.

## Steps to reproduce

1. Configure OpenRouter with a text-only model (e.g., deepseek-v4-pro)  
2. Enable computer_use toolset  
3. Call `computer_use(action='capture')`  
4. Observe: 3 retries then failure, no text-only fallback

## Fix

Added `"no endpoints found that support image"` to `_IMAGE_REJECTION_PHRASES` in `run_agent.py` and the matching test class tuple.

## Files changed

- `run_agent.py:13111` — added one phrase to `_IMAGE_REJECTION_PHRASES` tuple
- `tests/run_agent/test_image_rejection_fallback.py` — added phrase to test class tuple + test case body
- `scripts/release.py` — added `me@freeformz.me` → `freeformz` to `AUTHOR_MAP`

## Risk Assessment

**Low** — adds one string to a static tuple used for substring matching against API error bodies. No code paths changed. All existing tests pass.