### PR TITLE
feat: add required artifact checker helper

### DIFF
--- a/artifact_checks.py
+++ b/artifact_checks.py
@@ -1,0 +1,185 @@
+"""Reusable helpers for verifying declared artifact paths.
+
+The helpers in this module intentionally check path existence only. They do not
+validate artifact contents because content schemas are workflow-specific.
+
+This is a dedicated artifact-verification module rather than a general-purpose
+``utils`` addition. Keeping it separate makes the API importable and testable
+without growing the existing top-level ``utils.py`` catch-all module.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Iterable, Mapping
+
+
+@dataclass(frozen=True)
+class ArtifactPathPolicy:
+    """Controls how artifact path declarations are resolved."""
+
+    base_dir: Path
+    workspace_root: Path | None = None
+    workspace_relative_prefixes: tuple[str, ...] = ()
+    allow_absolute: bool = True
+    require_file: bool = True
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.base_dir, Path):
+            raise TypeError("base_dir must be a pathlib.Path")
+        if self.workspace_root is not None and not isinstance(self.workspace_root, Path):
+            raise TypeError("workspace_root must be a pathlib.Path or None")
+        if not isinstance(self.workspace_relative_prefixes, tuple):
+            raise TypeError("workspace_relative_prefixes must be a tuple of strings")
+        if not all(isinstance(prefix, str) for prefix in self.workspace_relative_prefixes):
+            raise TypeError("workspace_relative_prefixes must contain only strings")
+
+
+@dataclass(frozen=True)
+class ArtifactCheckItem:
+    """Single artifact path check result."""
+
+    path: str
+    exists: bool
+    is_file: bool | None = None
+    resolved: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "path": self.path,
+            "exists": self.exists,
+            "is_file": self.is_file,
+            "resolved": self.resolved,
+        }
+
+
+@dataclass(frozen=True)
+class ArtifactCheckResult:
+    """Aggregate result for a required-artifact check."""
+
+    ok: bool
+    expected_count: int
+    present: list[str]
+    missing: list[str]
+    checked: list[ArtifactCheckItem]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "expected_count": self.expected_count,
+            "present": list(self.present),
+            "missing": list(self.missing),
+            "checked": [item.to_dict() for item in self.checked],
+        }
+
+
+def artifact_path_from_spec(spec: str | Mapping[str, Any]) -> str | None:
+    """Extract a path string from a string or ``{"path": ...}`` artifact spec."""
+
+    if isinstance(spec, str):
+        return spec if spec else None
+    if isinstance(spec, Mapping):
+        path = spec.get("path")
+        return path if isinstance(path, str) and path else None
+    return None
+
+
+def required_artifact_paths(
+    spec_owner: Mapping[str, Any],
+    *,
+    field: str = "required_artifacts",
+) -> list[str]:
+    """Return valid required artifact path declarations from ``spec_owner``.
+
+    Non-list values for ``field`` are treated as empty, meaning no artifacts
+    are declared.
+    """
+
+    raw_specs = spec_owner.get(field, [])
+    if not isinstance(raw_specs, list):
+        return []
+
+    paths: list[str] = []
+    for spec in raw_specs:
+        path = artifact_path_from_spec(spec)
+        if path is not None:
+            paths.append(path)
+    return paths
+
+
+def resolve_artifact_path(path_text: str, policy: ArtifactPathPolicy) -> Path:
+    """Resolve one artifact path according to an explicit path policy."""
+
+    path = Path(path_text).expanduser()
+    if path.is_absolute():
+        if not policy.allow_absolute:
+            raise ValueError("Absolute artifact paths are not allowed")
+        return path
+
+    if policy.workspace_root is not None:
+        normalized = path_text.replace("\\", "/")
+        for prefix in policy.workspace_relative_prefixes:
+            if prefix and normalized.startswith(prefix):
+                return policy.workspace_root / path
+
+    return policy.base_dir / path
+
+
+def _is_satisfied(path: Path, policy: ArtifactPathPolicy) -> tuple[bool, bool | None]:
+    exists = path.exists()
+    if not exists:
+        return False, None
+    is_file = path.is_file()
+    if policy.require_file and not is_file:
+        return False, is_file
+    return True, is_file
+
+
+def check_required_artifacts(
+    spec_owner: Mapping[str, Any],
+    *,
+    policy: ArtifactPathPolicy,
+    extra_paths: Iterable[str | Mapping[str, Any]] = (),
+    field: str = "required_artifacts",
+) -> ArtifactCheckResult:
+    """Check declared artifact paths for existence.
+
+    By default, a satisfying artifact must be an existing regular file. Set
+    ``policy.require_file=False`` when directory artifacts should count as
+    present. Content validation is intentionally left to callers.
+    """
+
+    paths = required_artifact_paths(spec_owner, field=field)
+    for spec in extra_paths:
+        path = artifact_path_from_spec(spec)
+        if path is not None:
+            paths.append(path)
+
+    checked: list[ArtifactCheckItem] = []
+    present: list[str] = []
+    missing: list[str] = []
+
+    for path_text in paths:
+        resolved_path = resolve_artifact_path(path_text, policy)
+        satisfied, is_file = _is_satisfied(resolved_path, policy)
+        checked.append(
+            ArtifactCheckItem(
+                path=path_text,
+                exists=resolved_path.exists(),
+                is_file=is_file,
+                resolved=str(resolved_path),
+            )
+        )
+        if satisfied:
+            present.append(path_text)
+        else:
+            missing.append(path_text)
+
+    return ArtifactCheckResult(
+        ok=not missing,
+        expected_count=len(paths),
+        present=present,
+        missing=missing,
+        checked=checked,
+    )

--- a/tests/test_artifact_checks.py
+++ b/tests/test_artifact_checks.py
@@ -1,0 +1,189 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from artifact_checks import (
+    ArtifactCheckItem,
+    ArtifactCheckResult,
+    ArtifactPathPolicy,
+    artifact_path_from_spec,
+    check_required_artifacts,
+    required_artifact_paths,
+    resolve_artifact_path,
+)
+
+
+def test_artifact_path_from_spec_accepts_string_and_dict() -> None:
+    assert artifact_path_from_spec("reports/out.md") == "reports/out.md"
+    assert artifact_path_from_spec({"path": "artifacts/result.json", "description": "ignored"}) == "artifacts/result.json"
+
+
+@pytest.mark.parametrize(
+    "spec",
+    [
+        {},
+        {"path": ""},
+        {"path": 123},
+        123,
+        None,
+    ],
+)
+def test_artifact_path_from_spec_ignores_malformed_specs(spec: object) -> None:
+    assert artifact_path_from_spec(spec) is None  # type: ignore[arg-type]
+
+
+def test_required_artifact_paths_handles_empty_and_mixed_specs() -> None:
+    assert required_artifact_paths({}) == []
+    assert required_artifact_paths({"required_artifacts": []}) == []
+    assert required_artifact_paths(
+        {
+            "required_artifacts": [
+                "one.md",
+                {"path": "two.json", "description": "ignored"},
+                {"description": "missing path"},
+                17,
+            ],
+        }
+    ) == ["one.md", "two.json"]
+
+
+def test_required_artifact_paths_supports_custom_field() -> None:
+    assert required_artifact_paths({"outputs": ["summary.md"]}, field="outputs") == ["summary.md"]
+
+
+def test_resolve_artifact_path_handles_base_workspace_and_absolute_paths(tmp_path: Path) -> None:
+    base_dir = tmp_path / "tasks" / "task-1"
+    workspace_root = tmp_path / "workspace"
+    base_dir.mkdir(parents=True)
+    workspace_root.mkdir()
+    policy = ArtifactPathPolicy(
+        base_dir=base_dir,
+        workspace_root=workspace_root,
+        workspace_relative_prefixes=("tasks/",),
+    )
+
+    assert resolve_artifact_path("local.md", policy) == base_dir / "local.md"
+    assert resolve_artifact_path("tasks/task-1/artifacts/out.md", policy) == workspace_root / "tasks/task-1/artifacts/out.md"
+    absolute = tmp_path / "absolute.md"
+    assert resolve_artifact_path(str(absolute), policy) == absolute
+
+
+def test_resolve_artifact_path_rejects_absolute_paths_when_disallowed(tmp_path: Path) -> None:
+    policy = ArtifactPathPolicy(base_dir=tmp_path, allow_absolute=False)
+
+    with pytest.raises(ValueError, match="Absolute artifact paths are not allowed"):
+        resolve_artifact_path(str(tmp_path / "absolute.md"), policy)
+
+
+def test_artifact_path_policy_requires_path_base_dir() -> None:
+    with pytest.raises(TypeError):
+        ArtifactPathPolicy(base_dir="not-a-path")  # type: ignore[arg-type]
+
+
+@pytest.mark.parametrize("missing", ["missing-a.md", "missing-b.json"])
+def test_check_required_artifacts_reports_all_missing(tmp_path: Path, missing: str) -> None:
+    result = check_required_artifacts(
+        {"required_artifacts": [missing]},
+        policy=ArtifactPathPolicy(base_dir=tmp_path),
+    )
+
+    assert result.ok is False
+    assert result.expected_count == 1
+    assert result.present == []
+    assert result.missing == [missing]
+    assert result.checked[0].exists is False
+    assert result.checked[0].is_file is None
+
+
+def test_check_required_artifacts_reports_all_present(tmp_path: Path) -> None:
+    (tmp_path / "report.md").write_text("done", encoding="utf-8")
+    (tmp_path / "result.json").write_text("{}", encoding="utf-8")
+
+    result = check_required_artifacts(
+        {"required_artifacts": ["report.md", {"path": "result.json"}]},
+        policy=ArtifactPathPolicy(base_dir=tmp_path),
+    )
+
+    assert result.ok is True
+    assert result.expected_count == 2
+    assert result.present == ["report.md", "result.json"]
+    assert result.missing == []
+    assert [item.exists for item in result.checked] == [True, True]
+    assert [item.is_file for item in result.checked] == [True, True]
+
+
+def test_check_required_artifacts_reports_mixed_present_missing_and_extra_paths(tmp_path: Path) -> None:
+    (tmp_path / "present.md").write_text("done", encoding="utf-8")
+    (tmp_path / "extra.md").write_text("extra", encoding="utf-8")
+
+    result = check_required_artifacts(
+        {"required_artifacts": ["present.md", "missing.md"]},
+        policy=ArtifactPathPolicy(base_dir=tmp_path),
+        extra_paths=["extra.md", {"path": "extra-missing.md"}],
+    )
+
+    assert result.ok is False
+    assert result.expected_count == 4
+    assert result.present == ["present.md", "extra.md"]
+    assert result.missing == ["missing.md", "extra-missing.md"]
+
+
+def test_check_required_artifacts_treats_directories_as_missing_by_default(tmp_path: Path) -> None:
+    (tmp_path / "artifact-dir").mkdir()
+
+    result = check_required_artifacts(
+        {"required_artifacts": ["artifact-dir"]},
+        policy=ArtifactPathPolicy(base_dir=tmp_path),
+    )
+
+    assert result.ok is False
+    assert result.present == []
+    assert result.missing == ["artifact-dir"]
+    assert result.checked[0].exists is True
+    assert result.checked[0].is_file is False
+
+
+def test_check_required_artifacts_can_accept_directories_when_configured(tmp_path: Path) -> None:
+    (tmp_path / "artifact-dir").mkdir()
+
+    result = check_required_artifacts(
+        {"required_artifacts": ["artifact-dir"]},
+        policy=ArtifactPathPolicy(base_dir=tmp_path, require_file=False),
+    )
+
+    assert result.ok is True
+    assert result.present == ["artifact-dir"]
+    assert result.missing == []
+    assert result.checked[0].exists is True
+    assert result.checked[0].is_file is False
+
+
+def test_check_result_to_dict_is_json_serializable() -> None:
+    result = ArtifactCheckResult(
+        ok=False,
+        expected_count=1,
+        present=[],
+        missing=["missing.md"],
+        checked=[ArtifactCheckItem(path="missing.md", exists=False, is_file=None, resolved="/tmp/missing.md")],
+    )
+
+    payload = result.to_dict()
+
+    assert payload == {
+        "ok": False,
+        "expected_count": 1,
+        "present": [],
+        "missing": ["missing.md"],
+        "checked": [
+            {
+                "path": "missing.md",
+                "exists": False,
+                "is_file": None,
+                "resolved": "/tmp/missing.md",
+            }
+        ],
+    }
+    json.dumps(payload)


### PR DESCRIPTION
## Summary

Adds a small reusable helper for checking declared required artifact paths.

## Why

Agent workflows often need to verify that a worker produced concrete files rather than trusting a textual summary. This helper makes that pattern reusable without introducing a task-runtime framework. It provides the file-existence layer for the independent verification / quality-gate primitive discussed in #406.

## Design

- Accepts string paths or `{path: ...}` declarations.
- Resolves paths through an explicit path policy.
- Verifies file existence only by default; content validation is intentionally the consumer's responsibility because content schemas are workflow-specific.
- Treats directories as not satisfying artifact declarations by default (`require_file=True`), with an explicit opt-out for directory artifacts.
- Returns structured JSON-serializable results.
- Does not print, mutate, or depend on any local task system.
- Lives as `artifact_checks.py` rather than `utils/artifact_checks.py` because upstream already has top-level `utils.py`; the dedicated module avoids import/package ambiguity while keeping the helper out of the general-purpose `utils.py` catch-all.

## Test plan

- [x] `python -m pytest tests/test_artifact_checks.py -q -o 'addopts='`
- [x] `python -m py_compile artifact_checks.py tests/test_artifact_checks.py`
- [x] `git diff --check`
