### PR TITLE
fix(gateway): delete partial message after fallback send on flood control (salvage of #17384)

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -640,6 +640,7 @@ class GatewayStreamConsumer:
         safe_limit = max(500, raw_limit - 100)
         chunks = self._split_text_chunks(continuation, safe_limit)
 
+        stale_message_id = self._message_id  # partial message to clean up
         last_message_id: Optional[str] = None
         last_successful_chunk = ""
         sent_any_chunk = False
@@ -686,6 +687,16 @@ class GatewayStreamConsumer:
             # Each fallback chunk is a fresh platform message — notify
             # so any stale tool-progress bubble gets closed off.
             self._notify_new_message()
+
+        # Remove the frozen partial message so the user only sees the
+        # complete fallback response.  Best-effort — if the delete fails
+        # (e.g. flood control still active, or bot lacks permission), the
+        # partial message remains but at least the full answer was delivered.
+        if stale_message_id and stale_message_id != last_message_id:
+            try:
+                await self.adapter.delete_message(self.chat_id, stale_message_id)
+            except Exception:
+                pass
 
         self._message_id = last_message_id
         self._already_sent = True

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -689,14 +689,20 @@ class GatewayStreamConsumer:
             self._notify_new_message()
 
         # Remove the frozen partial message so the user only sees the
-        # complete fallback response.  Best-effort — if the delete fails
-        # (e.g. flood control still active, or bot lacks permission), the
-        # partial message remains but at least the full answer was delivered.
+        # complete fallback response.  Best-effort — if the platform doesn't
+        # implement ``delete_message``, the delete fails (flood control still
+        # active, bot lacks permission, message too old to delete), the
+        # partial remains but at least the full answer was delivered.
         if stale_message_id and stale_message_id != last_message_id:
-            try:
-                await self.adapter.delete_message(self.chat_id, stale_message_id)
-            except Exception:
-                pass
+            delete_fn = getattr(self.adapter, "delete_message", None)
+            if delete_fn is not None:
+                try:
+                    await delete_fn(self.chat_id, stale_message_id)
+                except Exception as e:
+                    logger.debug(
+                        "Fallback partial cleanup failed (%s): %s",
+                        stale_message_id, e,
+                    )
 
         self._message_id = last_message_id
         self._already_sent = True

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -58,6 +58,7 @@ AUTHOR_MAP = {
     "128259593+Gutslabs@users.noreply.github.com": "Gutslabs",
     "50326054+nocturnum91@users.noreply.github.com": "nocturnum91",
     "223003280+Abd0r@users.noreply.github.com": "Abd0r",
+    "HuangYuChuh@users.noreply.github.com": "HuangYuChuh",
     "ra2157218@gmail.com": "Abd0r",
     "abdielv@proton.me": "AJV20",
     "mason@growagainorchids.com": "masonjames",

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -793,6 +793,79 @@ class TestSegmentBreakOnToolBoundary:
             "_send_fallback_final — the #10807 fix should prevent this"
         )
 
+    @pytest.mark.asyncio
+    async def test_fallback_final_deletes_partial_after_chunks_succeed(self):
+        """After fallback chunks land, the frozen partial must be deleted so
+        the user sees only the complete response (#16668)."""
+        adapter = MagicMock()
+        adapter.send = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="msg_new"),
+        )
+        adapter.edit_message = AsyncMock(
+            return_value=SimpleNamespace(success=True),
+        )
+        adapter.delete_message = AsyncMock(return_value=None)
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5)
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        # Seed the consumer as if it already edited a partial message that
+        # later got stuck (flood control etc.) — _message_id is the stale id.
+        consumer._message_id = "msg_partial"
+        consumer._last_sent_text = "Working on i"
+
+        await consumer._send_fallback_final("Working on it. Done!")
+
+        adapter.delete_message.assert_awaited_once_with("chat_123", "msg_partial")
+        assert consumer._final_response_sent is True
+
+    @pytest.mark.asyncio
+    async def test_fallback_final_does_not_delete_when_no_chunks_reach_user(self):
+        """If every fallback send fails, the partial is the only thing the
+        user has — must NOT be deleted."""
+        adapter = MagicMock()
+        adapter.send = AsyncMock(
+            return_value=SimpleNamespace(success=False, error="network down"),
+        )
+        adapter.edit_message = AsyncMock(
+            return_value=SimpleNamespace(success=True),
+        )
+        adapter.delete_message = AsyncMock(return_value=None)
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5)
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        consumer._message_id = "msg_partial"
+        consumer._last_sent_text = "Working on i"
+
+        await consumer._send_fallback_final("Working on it. Done!")
+
+        adapter.delete_message.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_fallback_final_skips_delete_when_adapter_lacks_method(self):
+        """Platforms without delete_message must not crash the fallback path."""
+        adapter = MagicMock(spec=["send", "edit_message", "MAX_MESSAGE_LENGTH"])
+        adapter.send = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="msg_new"),
+        )
+        adapter.edit_message = AsyncMock(
+            return_value=SimpleNamespace(success=True),
+        )
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5)
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        consumer._message_id = "msg_partial"
+        consumer._last_sent_text = "Working on i"
+
+        # Should not raise even though the adapter has no delete_message.
+        await consumer._send_fallback_final("Working on it. Done!")
+        assert consumer._final_response_sent is True
+
 
 class TestInterimCommentaryMessages:
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

When Telegram throttles the bot during a long streaming reply, the stream consumer falls back to sending fresh chunks via `adapter.send()`. Before this PR, the frozen partial that was being edited remained visible — users saw a stuck/cut-off message followed by a duplicate complete reply right below it.

After this PR, the partial gets deleted once the full fallback response lands so users see one clean answer.

## Changes

- `gateway/stream_consumer.py`: capture the stale `_message_id` before the fallback send loop in `_send_fallback_final`, and on the happy-path tail call `adapter.delete_message(stale_id)` best-effort. Skip the delete if no chunks reached the user (the partial is the only thing they have).
- `tests/gateway/test_stream_consumer.py`: three regression tests covering happy-path delete, no-delete-on-failed-send, and adapter-without-delete_message.
- `scripts/release.py`: AUTHOR_MAP entry for HuangYuChuh.

## Improvements during salvage

- Aligned the new delete block with the sibling `_try_send_fresh_final` cleanup pattern at L820+: defensive `getattr(adapter, "delete_message", None)` lookup + `logger.debug` on failure instead of bare `self.adapter.delete_message` + silent `except: pass`. Platforms without `delete_message` no longer raise; failures now leave a diagnostic breadcrumb.
- Added three regression tests; the original PR shipped no tests.

## Validation

`tests/gateway/test_stream_consumer.py`: 84/84 pass (3 new + 81 existing) in 3.9s.

Closes #16668 via salvage of #17384. Original work by @HuangYuChuh; cleanup commits and tests follow.
