### PR TITLE
fix(approval): escalate gateway lifecycle smart denials

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13269,6 +13269,7 @@ class GatewayRunner:
     # Each entry is a tuple of (section, key) read from the raw config dict.
     # Add more here as new baked-at-construction config settings are added.
     _CACHE_BUSTING_CONFIG_KEYS: tuple = (
+        ("agent", "max_turns"),
         ("model", "context_length"),
         ("model", "max_tokens"),
         ("compression", "enabled"),

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -10,6 +10,7 @@ from tools.approval import (
     _get_approval_mode,
     _smart_approve,
     approve_session,
+    check_all_command_guards,
     detect_dangerous_command,
     is_approved,
     load_permanent,
@@ -41,6 +42,33 @@ class TestSmartApproval:
         assert mock_call.call_args.kwargs["task"] == "approval"
         assert mock_call.call_args.kwargs["temperature"] == 0
         assert mock_call.call_args.kwargs["max_tokens"] == 16
+
+    def test_smart_denied_gateway_restart_escalates_to_user_approval(self):
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="DENY"))]
+        )
+        with mock_patch("hermes_cli.config.load_config", return_value={"approvals": {"mode": "smart"}}), \
+             mock_patch("agent.auxiliary_client.call_llm", return_value=response), \
+             mock_patch.dict("os.environ", {"HERMES_GATEWAY_SESSION": "1", "HERMES_SESSION_KEY": "test_gateway_restart", "HERMES_CRON_SESSION": ""}, clear=False):
+            result = check_all_command_guards("hermes gateway restart", "local")
+
+        assert result["approved"] is False
+        assert result.get("status") == "approval_required"
+        assert "stop/restart hermes gateway" in result["description"]
+        assert "smart_denied" not in result
+
+    def test_smart_denied_non_lifecycle_command_stays_blocked(self):
+        response = SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="DENY"))]
+        )
+        with mock_patch("hermes_cli.config.load_config", return_value={"approvals": {"mode": "smart"}}), \
+             mock_patch("agent.auxiliary_client.call_llm", return_value=response), \
+             mock_patch.dict("os.environ", {"HERMES_GATEWAY_SESSION": "1", "HERMES_SESSION_KEY": "test_rm", "HERMES_CRON_SESSION": ""}, clear=False):
+            result = check_all_command_guards("rm -rf /tmp/something", "local")
+
+        assert result["approved"] is False
+        assert result.get("smart_denied") is True
+        assert "approval_required" not in result
 
 
 class TestDetectDangerousRm:

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -818,6 +818,28 @@ Respond with exactly one word: APPROVE, DENY, or ESCALATE"""
         return "escalate"
 
 
+_SMART_DENY_MUST_ESCALATE_DESCRIPTIONS = {
+    "stop/restart hermes gateway (kills running agents)",
+}
+
+
+def _smart_deny_must_escalate_to_user(command: str, warnings: list) -> bool:
+    """Return True for dangerous-but-user-approvable actions.
+
+    Smart approvals are a convenience layer, not the final authority for
+    operator-owned lifecycle actions. Restarting the Hermes gateway kills the
+    current agent turn, so it must never be auto-approved, but when Rob asks for
+    it the correct behavior is to surface the normal `/approve` prompt instead
+    of letting the auxiliary reviewer hard-deny the command before Rob can
+    respond.
+    """
+    del command  # Reserved for narrower command-specific exceptions later.
+    return any(
+        (not is_tirith) and desc in _SMART_DENY_MUST_ESCALATE_DESCRIPTIONS
+        for _key, desc, is_tirith in warnings
+    )
+
+
 def check_dangerous_command(command: str, env_type: str,
                             approval_callback=None) -> dict:
     """Check if a command is dangerous and handle approval.
@@ -1059,14 +1081,22 @@ def check_all_command_guards(command: str, env_type: str,
                     "smart_approved": True,
                     "description": combined_desc_for_llm}
         elif verdict == "deny":
-            combined_desc_for_llm = "; ".join(desc for _, desc, _ in warnings)
-            return {
-                "approved": False,
-                "message": f"BLOCKED by smart approval: {combined_desc_for_llm}. "
-                           "The command was assessed as genuinely dangerous. Do NOT retry.",
-                "smart_denied": True,
-            }
-        # verdict == "escalate" → fall through to manual prompt
+            if _smart_deny_must_escalate_to_user(command, warnings):
+                logger.info(
+                    "Smart approval denied user-approvable lifecycle command; "
+                    "escalating to explicit approval. command=%r warnings=%r",
+                    command[:200], combined_desc_for_llm,
+                )
+            else:
+                combined_desc_for_llm = "; ".join(desc for _, desc, _ in warnings)
+                return {
+                    "approved": False,
+                    "message": f"BLOCKED by smart approval: {combined_desc_for_llm}. "
+                               "The command was assessed as genuinely dangerous. Do NOT retry.",
+                    "smart_denied": True,
+                }
+        # verdict == "escalate", or a user-approvable lifecycle denial above,
+        # falls through to manual/gateway approval.
 
     # --- Phase 3: Approval ---
 


### PR DESCRIPTION
## Summary
- escalates user-requested Hermes gateway lifecycle smart-deny verdicts to explicit user approval instead of hard-blocking them
- keeps non-lifecycle smart DENY verdicts blocked
- adds `agent.max_turns` to gateway cached-agent config signatures so max-turn changes rebuild cached agents

## Test Plan
- `venv/bin/python -m py_compile gateway/run.py tools/approval.py`
- `venv/bin/python -m pytest tests/tools/test_approval.py`
