### PR TITLE
fix(gateway): only mark final response sent when split-overflow chunks actually land

### DIFF
--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -362,13 +362,21 @@ class GatewayStreamConsumer:
                         chunks = self.adapter.truncate_message(
                             self._accumulated, _safe_limit
                         )
+                        chunks_delivered = False
+                        reply_to = self._message_id
                         for chunk in chunks:
-                            await self._send_new_chunk(chunk, self._message_id)
+                            new_id = await self._send_new_chunk(chunk, reply_to)
+                            if new_id is not None and new_id != reply_to:
+                                chunks_delivered = True
                         self._accumulated = ""
                         self._last_sent_text = ""
                         self._last_edit_time = time.monotonic()
                         if got_done:
-                            self._final_response_sent = self._already_sent
+                            # Only claim final delivery if THESE chunks actually
+                            # landed.  ``_already_sent`` may be True from prior
+                            # tool-progress edits or fallback-mode promotion (#10748)
+                            # — that doesn't mean the final answer reached the user.
+                            self._final_response_sent = chunks_delivered
                             return
                         if got_segment_break:
                             self._message_id = None

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -867,6 +867,78 @@ class TestSegmentBreakOnToolBoundary:
         assert consumer._final_response_sent is True
 
 
+class TestFinalResponseDeliveryGuard:
+    """Regression coverage for #10748 — _final_response_sent must reflect
+    actual delivery of the *current* chunked send, not the cumulative
+    `_already_sent` flag (which earlier tool-progress edits or fallback-mode
+    promotion can taint)."""
+
+    @pytest.mark.asyncio
+    async def test_split_overflow_failed_send_does_not_mark_final_sent(self):
+        """Split-overflow path: if every chunk send fails on done frame,
+        _final_response_sent must stay False so the gateway falls back."""
+        adapter = MagicMock()
+        # Every send fails — _send_new_chunk returns the passed-in reply_to.
+        adapter.send = AsyncMock(
+            return_value=SimpleNamespace(success=False, error="network down"),
+        )
+        adapter.edit_message = AsyncMock(
+            return_value=SimpleNamespace(success=True),
+        )
+        adapter.MAX_MESSAGE_LENGTH = 100
+        adapter.truncate_message = MagicMock(
+            side_effect=lambda text, limit: [text[:limit], text[limit:]],
+        )
+
+        config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5)
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        # Simulate prior tool-progress edits that set _already_sent
+        consumer._already_sent = True
+
+        # Long text > MAX_MESSAGE_LENGTH, no existing message id (fresh send path)
+        long_text = "x" * 200
+        consumer.on_delta(long_text)
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.05)
+        consumer.finish()
+        await task
+
+        assert consumer._final_response_sent is False, (
+            "_already_sent leaked into _final_response_sent — gateway will "
+            "wrongly suppress its fallback delivery (#10748)"
+        )
+
+    @pytest.mark.asyncio
+    async def test_split_overflow_partial_send_marks_final_sent(self):
+        """Split-overflow path: if at least one chunk lands on done frame,
+        we did deliver the final answer — _final_response_sent must be True."""
+        adapter = MagicMock()
+        adapter.send = AsyncMock(side_effect=[
+            SimpleNamespace(success=True, message_id="msg_1"),
+            SimpleNamespace(success=True, message_id="msg_2"),
+        ])
+        adapter.edit_message = AsyncMock(
+            return_value=SimpleNamespace(success=True),
+        )
+        adapter.MAX_MESSAGE_LENGTH = 100
+        adapter.truncate_message = MagicMock(
+            side_effect=lambda text, limit: [text[:limit], text[limit:]],
+        )
+
+        config = StreamConsumerConfig(edit_interval=0.01, buffer_threshold=5)
+        consumer = GatewayStreamConsumer(adapter, "chat_123", config)
+
+        long_text = "x" * 200
+        consumer.on_delta(long_text)
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.05)
+        consumer.finish()
+        await task
+
+        assert consumer._final_response_sent is True
+
+
 class TestInterimCommentaryMessages:
     @pytest.mark.asyncio
     async def test_commentary_message_stays_separate_from_final_stream(self):


### PR DESCRIPTION
## Summary

Telegram streaming used to silently drop the final answer after tool calls — users saw only the "working on it" tool-progress bubbles. The split-overflow path was claiming "final delivered" based on a cumulative flag that didn't reflect whether the *current* chunked send actually landed.

## What was wrong

`_send_or_edit` in `gateway/stream_consumer.py` runs a chunked-send loop when accumulated text exceeds the platform limit and there's no message to edit. On the done frame it was copying `self._already_sent` into `self._final_response_sent`:

```python
for chunk in chunks:
    await self._send_new_chunk(chunk, self._message_id)  # return value ignored
...
if got_done:
    self._final_response_sent = self._already_sent  # WRONG — doesn't reflect *these* chunks
    return
```

`_already_sent` goes `True` on any successful prior edit (e.g. tool-progress display) and on fallback-mode promotion when an edit fails. Neither proves the chunked send above delivered the final answer. When all chunks failed, the consumer told the gateway "final delivered" and the gateway's fallback path in `run.py` got suppressed. The answer never reached the user.

## Fix

Track per-chunk success locally. `_send_new_chunk` returns the new message_id on success or the passed-in `reply_to` unchanged on failure, so a returned id that differs from the input means the chunk landed:

```python
chunks_delivered = False
reply_to = self._message_id
for chunk in chunks:
    new_id = await self._send_new_chunk(chunk, reply_to)
    if new_id is not None and new_id != reply_to:
        chunks_delivered = True
...
if got_done:
    self._final_response_sent = chunks_delivered
    return
```

If no chunks landed → `_final_response_sent` stays `False` → gateway runs its independent fallback.

## Note on the issue's second cited site

The reporter cited two locations. The CancelledError handler at L417-418 was already fixed by commit `3b5572ded` on 2026-04-16 (`fix(stream-consumer): only confirm final delivery on successful best-effort send`). Only the split-overflow site remained.

## Validation

- `tests/gateway/test_stream_consumer.py`: 86/86 pass (2 new + 84 existing).
- New `TestFinalResponseDeliveryGuard` class with two tests:
  - `test_split_overflow_failed_send_does_not_mark_final_sent` — primes `_already_sent=True`, makes every send fail, asserts `_final_response_sent` stays `False`.
  - `test_split_overflow_partial_send_marks_final_sent` — happy path, asserts `_final_response_sent` goes `True`.

Closes #10748.
