### PR TITLE
fix(kanban): keep notifier subscriptions alive across retry cycles (salvage #21398)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -4098,10 +4098,18 @@ class GatewayRunner:
             return
 
         TERMINAL_KINDS = ("completed", "blocked", "gave_up", "crashed", "timed_out")
-        # Terminal event kinds trigger automatic unsubscription — the task
-        # is done or in a retry-needed state that the human
-        # shouldn't keep pinging a stale chat for.
-        TERMINAL_EVENT_KINDS = ("completed", "gave_up", "crashed", "timed_out")
+        # Subscriptions are removed only when the task reaches a truly final
+        # status (done / archived). We used to also unsub on any terminal
+        # event kind (gave_up / crashed / timed_out / blocked), but that
+        # silently dropped the user out of the loop whenever the dispatcher
+        # respawned the task: a worker that crashes, gets reclaimed, runs
+        # again, and crashes a second time would only notify on the first
+        # crash because the subscription was deleted after the first event.
+        # Same shape as the reblock-after-unblock cycle that PR #22941
+        # fixed for `blocked`. Keeping the subscription alive until the
+        # task is genuinely done lets the cursor (advanced atomically by
+        # claim_unseen_events_for_sub) handle dedup, and any retry-loop
+        # event reaches the user.
         # Per-subscription send-failure counter. Adapter.send raising
         # means the chat is dead (deleted, bot kicked, etc.) — after N
         # consecutive send failures the sub is dropped so we don't spin
@@ -4339,19 +4347,21 @@ class GatewayRunner:
                             # dropping the subscription is the terminal action.
                             break
                     else:
-                        # All events delivered; advance cursor + maybe unsub.
+                        # All events delivered; advance cursor. The cursor
+                        # is the dedup mechanism — it prevents re-delivery
+                        # of the same event on subsequent ticks.
                         await asyncio.to_thread(
                             self._kanban_advance, sub, d["cursor"], board_slug,
                         )
-                        # Unsubscribe when the LAST delivered event is a
-                        # terminal kind (the task hit a "no further updates"
-                        # state), not just on task.status in {done, archived}.
-                        # Covers blocked / gave_up / crashed / timed_out which
-                        # used to leak subs forever.
-                        last_kind = d["events"][-1].kind if d["events"] else None
+                        # Unsubscribe only when the task has reached a truly
+                        # final status (done / archived). For blocked /
+                        # gave_up / crashed / timed_out the subscription is
+                        # kept alive so the user gets notified again if the
+                        # dispatcher respawns the task and it cycles into the
+                        # same state. See the longer comment on TERMINAL_KINDS
+                        # above for the failure mode this prevents.
                         task_terminal = task and task.status in ("done", "archived")
-                        event_terminal = last_kind in TERMINAL_EVENT_KINDS
-                        if task_terminal or event_terminal:
+                        if task_terminal:
                             await asyncio.to_thread(
                                 self._kanban_unsub, sub, board_slug,
                             )

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -719,6 +719,7 @@ AUTHOR_MAP = {
     "gufo0125@gmail.com": "guglielmofonda",
     "102474490+yehuosi@users.noreply.github.com": "yehuosi",
     "yehuosi@users.noreply.github.com": "yehuosi",
+    "31932854+jelrod27@users.noreply.github.com": "jelrod27",
     "23434080+sicnuyudidi@users.noreply.github.com": "sicnuyudidi",
     "haimu0x0@proton.me": "haimu0x",
     "abdelmajidnidnasser1@gmail.com": "NIDNASSER-Abdelmajid",

--- a/tests/gateway/test_kanban_notifier.py
+++ b/tests/gateway/test_kanban_notifier.py
@@ -172,3 +172,65 @@ def test_kanban_notifier_rewinds_claim_on_send_exception(tmp_path, monkeypatch):
     # still returns the event for retry on the next tick.
     assert adapter.attempts >= 1, "send should have been attempted at least once"
     assert [ev.kind for ev in _unseen_terminal_events(tid)] == ["completed"]
+
+
+def test_notifier_redelivers_same_kind_on_dispatch_cycle(tmp_path, monkeypatch):
+    """A retry cycle (crashed → reclaimed → crashed) notifies the user twice.
+
+    Before #21398 the notifier auto-unsubscribed on any terminal event kind
+    (gave_up / crashed / timed_out), so the second crash in a respawn cycle
+    silently dropped — the subscription was already gone. This test pins the
+    new contract: subscription survives non-final terminal events; the
+    cursor handles dedup.
+
+    Two crashes ten seconds apart on the same task — both should land on
+    the adapter.
+    """
+    db_path = tmp_path / "redeliver-cycle.db"
+    monkeypatch.setenv("HERMES_KANBAN_DB", str(db_path))
+    kb.init_db()
+
+    conn = kb.connect()
+    try:
+        tid = kb.create_task(conn, title="cycle test", assignee="worker")
+        kb.add_notify_sub(conn, task_id=tid, platform="telegram", chat_id="chat-1")
+        # First crash — fired by the dispatcher when the worker PID dies.
+        kb._append_event(conn, tid, kind="crashed")
+    finally:
+        conn.close()
+
+    adapter = RecordingAdapter()
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    # First crash delivered.
+    assert len(adapter.sent) == 1
+    assert "crashed" in adapter.sent[0]["text"].lower()
+
+    # Subscription survives — the cursor advanced past event #1, but the
+    # row is still there.
+    conn = kb.connect()
+    try:
+        subs = kb.list_notify_subs(conn, tid)
+        assert len(subs) == 1, (
+            "Subscription must survive a crashed event so a respawn-cycle "
+            "second crash also notifies the user (issue #21398)."
+        )
+
+        # Second crash — same task, same dispatcher (or a respawn). Append
+        # another event to simulate the dispatcher firing crashed a second
+        # time during retry.
+        kb._append_event(conn, tid, kind="crashed")
+    finally:
+        conn.close()
+
+    # New tick: the second event has a fresh id past the cursor advance,
+    # so it gets claimed and delivered.
+    runner = _make_runner(adapter)
+    asyncio.run(_run_one_notifier_tick(monkeypatch, runner))
+
+    assert len(adapter.sent) == 2, (
+        f"Second crashed event should also notify; got {len(adapter.sent)} "
+        f"deliveries (texts: {[d['text'] for d in adapter.sent]})"
+    )
+    assert "crashed" in adapter.sent[1]["text"].lower()

--- a/tests/hermes_cli/test_kanban_notify.py
+++ b/tests/hermes_cli/test_kanban_notify.py
@@ -76,7 +76,13 @@ async def test_notifier_unsubs_after_completed_event(kanban_home):
 @pytest.mark.parametrize('kind', ["gave_up", "crashed", "timed_out"])
 async def test_notifier_unsubs_after_abnormal_events(kind, kanban_home):
     """
-    Event kind of gave_up, crashed, time_out would be cover, and remove subscription
+    Event kinds gave_up / crashed / timed_out send a notification but DO
+    NOT delete the subscription. The dispatcher may respawn the task and
+    fire the same event kind again (e.g. a worker that crashes, gets
+    reclaimed, and crashes a second time); the user must hear about the
+    second event too. Subscriptions are removed only when the task hits
+    a truly final status (done / archived) — see the comment on
+    TERMINAL_KINDS in gateway/run.py and PR #21398.
     """
     import hermes_cli.kanban_db as kb
     from gateway.run import GatewayRunner
@@ -114,15 +120,27 @@ async def test_notifier_unsubs_after_abnormal_events(kind, kanban_home):
             timeout=10.0,
         )
 
+    # The user is notified about the abnormal event...
     fake_adapter.send.assert_called_once()
     assert kind.replace('_', ' ') in fake_adapter.send.call_args[0][1]
 
+    # ...but the subscription survives so a respawn-then-same-event cycle
+    # reaches the user too. The cursor (last_event_id) advanced inside
+    # the same write txn as the claim, so the same event won't re-fire.
     conn = kb.connect()
     try:
         subs = kb.list_notify_subs(conn, tid)
     finally:
         conn.close()
-    assert subs == [], "Subscription should be unsub after abnormal crash"
+    assert len(subs) == 1, (
+        f"Subscription should survive {kind!r} so the next cycle of the "
+        f"same event reaches the user; got {subs!r}"
+    )
+    assert int(subs[0]["last_event_id"]) >= 1, (
+        "Cursor should have advanced past the delivered event "
+        "(claim_unseen_events_for_sub advances atomically inside the "
+        "same write txn as the read)."
+    )
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
Kanban notifier subscriptions now survive non-final terminal events (`gave_up`, `crashed`, `timed_out`) so a respawn cycle's second occurrence of the same event also reaches the user. Subscriptions are removed only when the task hits a truly final status (`done` / `archived`).

## Root cause
The notifier auto-unsubscribed on any kind in `TERMINAL_EVENT_KINDS` (`completed`, `gave_up`, `crashed`, `timed_out`). For `completed` that's correct — the task is done. For the other three, it silently dropped the user out of the loop whenever the dispatcher respawned the task: a worker that crashed, got reclaimed, ran again, and crashed a second time would only notify on the first crash because the subscription was deleted after the first event.

Same shape as the reblock-after-unblock cycle that PR #22941 fixed for `blocked` (which is no longer in `TERMINAL_EVENT_KINDS`). This PR closes the parallel cycle for the other three event kinds.

## Why the cursor handles dedup safely
With #23401's atomic `claim_unseen_events_for_sub` (advances the cursor inside `BEGIN IMMEDIATE` in the same write txn as the read), the same event can't fire twice on the same row. Keeping the subscription alive lets the cursor be the sole dedup mechanism — there's no scenario where a stale cursor lets the same `crashed` event re-fire next tick.

## Changes
- `gateway/run.py`: drop the `event_terminal = last_kind in TERMINAL_EVENT_KINDS` branch from the unsub trigger; remove the `TERMINAL_EVENT_KINDS` constant. Subscriptions are removed only on `task.status in ("done", "archived")`. Updated comment block above `TERMINAL_KINDS` and at the trigger site.
- `tests/gateway/test_kanban_notifier.py`: new `test_notifier_redelivers_same_kind_on_dispatch_cycle` directly pinning the new contract — two crashes, two deliveries, subscription survives between them.
- `tests/hermes_cli/test_kanban_notify.py::test_notifier_unsubs_after_abnormal_events[gave_up|crashed|timed_out]`: flipped from "subscription should be deleted" to "subscription should survive + cursor advanced." Updated docstring.

## Validation
| | Before | After |
|---|---|---|
| `tests/gateway/test_kanban_notifier.py` | 5/5 | 6/6 |
| `tests/hermes_cli/test_kanban_notify.py` | 7/7 (3 expecting old behavior) | 7/7 (3 flipped to expect new behavior) |
| `tests/hermes_cli/test_kanban_db.py` + `tests/plugins/test_kanban_dashboard_plugin.py` | n/a | 176/176 |

Salvage of #21398. Original commit `814aa6f1d` by @jelrod27 cherry-picked with authorship preserved (re-attributed from the contributor's local-machine email `justinelrod@Justin-Agent.local` to the GitHub-noreply form). AUTHOR_MAP entry added.

The carve-out kept just the substantive notifier fix. The PR's earlier commits in the chain (`feat(kanban): max_retries per-task override`, `feat(kanban): CLI --max-retries flag`, and 5 max_retries tests) are NOT carried — they already merged via PR #21330 (commit `ac51c4c1a`) on May 7. The contributor's branch carried duplicates because they merged main into their branch before opening the PR.

Note: the contributor's PR description framed the bug as "every-tick spam from a failed unsub leaving a stale cursor=0." That mechanism doesn't actually fire on current main because the cursor advance precedes the unsub call (and post-#23401 they're inside the same write txn). The real bug is the cycle described above — subscription deletion after a non-final event silently drops retry-loop notifications. The fix is correct and minimal; just rewrote the surrounding comment to match the actual mechanism.
