### PR TITLE
feat(kanban): replace assignee and skills plain Input with Select in InlineCreate

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -445,10 +445,6 @@
     // showing stale data.
     const [taskEventTick, setTaskEventTick] = useState({});
 
-    // Available skills for the InlineCreate form's skills select.
-    // Fetched once on mount and whenever the board slug changes.
-    const [availableSkills, setAvailableSkills] = useState([]);
-
     const cursorRef = useRef(0);
     const reloadTimerRef = useRef(null);
     const wsRef = useRef(null);
@@ -469,17 +465,6 @@
         })
         .catch(function () { setConfig({ render_markdown: true }); });
     }, []);  // eslint-disable-line react-hooks/exhaustive-deps
-
-    // --- load available skills for InlineCreate -------------------------
-    useEffect(function () {
-      SDK.fetchJSON(withBoard(`${API}/available-skills`, board))
-        .then(function (data) {
-          setAvailableSkills((data && data.skills) || []);
-        })
-        .catch(function () {
-          setAvailableSkills([]);
-        });
-    }, [board]);  // eslint-disable-line react-hooks/exhaustive-deps
 
     // --- fetch full board ---------------------------------------------------
     const loadBoard = useCallback(() => {
@@ -807,7 +792,6 @@
           onCreate: createTask,
           allTasks: boardData.columns.reduce(function (acc, c) { return acc.concat(c.tasks); }, []),
           assignees: (boardData && boardData.assignees) || [],
-          availableSkills: availableSkills,
         }),
         selectedTaskId ? h(TaskDrawer, {
           taskId: selectedTaskId,
@@ -1603,7 +1587,6 @@
           onCreate: props.onCreate,
           allTasks: props.allTasks,
           assignees: props.assignees,
-          availableSkills: props.availableSkills,
         });
       }),
     );
@@ -1688,7 +1671,6 @@
         columnName: props.column.name,
         allTasks: props.allTasks,
         assignees: props.assignees,
-        availableSkills: props.availableSkills,
         onSubmit: function (body) {
           props.onCreate(body).then(function () { setShowCreate(false); });
         },
@@ -1876,14 +1858,42 @@
     const [otherAssignee, setOtherAssignee] = useState("");
     const [priority, setPriority] = useState(0);
     const [parent, setParent] = useState("");
-    const [selectedSkills, setSelectedSkills] = useState([]);
-    const [customSkills, setCustomSkills] = useState("");
+    // Profile skills: fetched when assignee changes, displayed as read-only tags.
+    const [profileSkills, setProfileSkills] = useState(null);
+    const [profileSkillsLoading, setProfileSkillsLoading] = useState(false);
     // Workspace controls. `scratch` (default) ignores path; `worktree` optionally
     // takes a path (dispatcher derives one from the assignee profile otherwise);
     // `dir` requires a path. Backend enforces the rule — we only hide/show the
     // input here to save vertical space in the common `scratch` case.
     const [workspaceKind, setWorkspaceKind] = useState("scratch");
     const [workspacePath, setWorkspacePath] = useState("");
+
+    // --- fetch profile skills when assignee changes -----------------------
+    useEffect(function () {
+      var resolved = assignee;
+      if (assignee === "__other__") {
+        resolved = otherAssignee || "";
+      }
+      if (resolved && resolved !== "__none__" && resolved !== "") {
+        setProfileSkillsLoading(true);
+        SDK.fetchJSON(withBoard(
+          API + "/profile-skills?profile=" + encodeURIComponent(resolved),
+          ""
+        ))
+          .then(function (data) {
+            setProfileSkills(data || { skills: [], disabled: [] });
+          })
+          .catch(function () {
+            setProfileSkills({ skills: [], disabled: [] });
+          })
+          .finally(function () {
+            setProfileSkillsLoading(false);
+          });
+      } else {
+        setProfileSkills(null);
+        setProfileSkillsLoading(false);
+      }
+    }, [assignee, otherAssignee]);  // eslint-disable-line react-hooks/exhaustive-deps
 
     const submit = function () {
       const trimmed = title.trim();
@@ -1901,17 +1911,9 @@
         body.assignee = assignee;
       }
       if (parent) body.parents = [parent];
-      // Combine selected skills (from the additive Select) with custom
-      // comma-separated skills. The dispatcher always auto-loads
-      // kanban-worker; these are extras on top.
-      const skillList = [].concat(selectedSkills).concat(
-        customSkills.split(",")
-          .map(function (s) { return s.trim(); })
-          .filter(function (s) { return s.length > 0; })
-      );
-      if (skillList.length > 0) body.skills = skillList;
-      // Only send workspace_kind when it's non-default. Keeps the request
-      // shape small and interoperable with older dispatcher versions.
+      // No manual skills field — profile skills are auto-resolved by the
+      // dispatcher based on the assigned profile's config. Only send
+      // workspace_kind when it's non-default.
       if (workspaceKind && workspaceKind !== "scratch") {
         body.workspace_kind = workspaceKind;
       }
@@ -1919,7 +1921,7 @@
       if (wpTrim) body.workspace_path = wpTrim;
       props.onSubmit(body);
       setTitle(""); setAssignee(""); setOtherAssignee("");
-      setPriority(0); setParent(""); setSelectedSkills([]); setCustomSkills("");
+      setPriority(0); setParent(""); setProfileSkills(null);
       setWorkspaceKind("scratch"); setWorkspacePath("");
     };
 
@@ -1979,53 +1981,31 @@
           title: "Priority. Higher-priority tasks are claimed first by the dispatcher. 0 = default.",
         }),
       ),
-      // Skills: additive Select + tags + custom input
+      // Profile skills — auto-resolved from the selected assignee's config.
+      // Read-only tags, no manual add/remove. Only shown when a profile is
+      // selected so the user can see which skills the worker will have.
       h("div", { className: "flex flex-col gap-1" },
-        h("div", { className: "flex gap-2 items-center" },
-          h(Select, {
-            value: "__placeholder__",
-            onChange: function (e) {
-              const val = e.target.value;
-              if (val && val !== "__placeholder__") {
-                setSelectedSkills(function (prev) {
-                  if (prev.indexOf(val) === -1) {
-                    return prev.concat([val]);
-                  }
-                  return prev;
-                });
-              }
-            },
-            className: "h-7 text-xs flex-1",
-          },
-            h(SelectOption, { value: "__placeholder__", disabled: true },
-              tx(t, "addSkill", "+ add skill…")),
-            (props.availableSkills || []).map(function (s) {
-              return h(SelectOption, { key: s, value: s }, s);
-            }),
-          ),
-          h(Input, {
-            value: customSkills,
-            onChange: function (e) { setCustomSkills(e.target.value); },
-            placeholder: tx(t, "customSkill", "+ custom"),
-            className: "h-7 text-xs w-28",
-            title: "Comma-separated custom skills not in the list",
-          }),
-        ),
-        // Tags for selected skills (removable)
-        selectedSkills.length > 0 ? h("div", { className: "flex flex-wrap gap-1 mt-1" },
-          selectedSkills.map(function (s) {
-            return h("span", {
-              key: s,
-              className: "inline-flex items-center gap-1 text-xs bg-muted px-1.5 py-0.5 rounded cursor-pointer",
-              onClick: function () {
-                setSelectedSkills(function (prev) {
-                  return prev.filter(function (x) { return x !== s; });
-                });
-              },
-              title: "Click to remove",
-            }, s + " ×");
-          }),
-        ) : null,
+        profileSkillsLoading
+          ? h("span", { className: "text-xs text-midground/40" }, "skills…")
+          : profileSkills && profileSkills.skills && profileSkills.skills.length > 0
+            ? [
+                h("div", { className: "flex flex-wrap gap-1" },
+                  profileSkills.skills.slice(0, 24).map(function (s) {
+                    return h("span", {
+                      key: s,
+                      className: "inline-flex items-center gap-1 text-xs bg-muted/30 text-midground/80 px-1.5 py-0.5 rounded",
+                      title: s,
+                    }, s);
+                  }),
+                  profileSkills.skills.length > 24
+                    ? h("span", { className: "text-xs text-midground/40" },
+                      "+" + (profileSkills.skills.length - 24) + " more")
+                    : null,
+                ),
+              ]
+            : profileSkills && profileSkills.skills
+              ? h("span", { className: "text-xs text-midground/40" }, "no profile-specific skills")
+              : null,
       ),
       h("div", { className: "flex gap-2" },
         h(Select, {

--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -445,6 +445,10 @@
     // showing stale data.
     const [taskEventTick, setTaskEventTick] = useState({});
 
+    // Available skills for the InlineCreate form's skills select.
+    // Fetched once on mount and whenever the board slug changes.
+    const [availableSkills, setAvailableSkills] = useState([]);
+
     const cursorRef = useRef(0);
     const reloadTimerRef = useRef(null);
     const wsRef = useRef(null);
@@ -465,6 +469,17 @@
         })
         .catch(function () { setConfig({ render_markdown: true }); });
     }, []);  // eslint-disable-line react-hooks/exhaustive-deps
+
+    // --- load available skills for InlineCreate -------------------------
+    useEffect(function () {
+      SDK.fetchJSON(withBoard(`${API}/available-skills`, board))
+        .then(function (data) {
+          setAvailableSkills((data && data.skills) || []);
+        })
+        .catch(function () {
+          setAvailableSkills([]);
+        });
+    }, [board]);  // eslint-disable-line react-hooks/exhaustive-deps
 
     // --- fetch full board ---------------------------------------------------
     const loadBoard = useCallback(() => {
@@ -791,6 +806,8 @@
           onOpen: setSelectedTaskId,
           onCreate: createTask,
           allTasks: boardData.columns.reduce(function (acc, c) { return acc.concat(c.tasks); }, []),
+          assignees: (boardData && boardData.assignees) || [],
+          availableSkills: availableSkills,
         }),
         selectedTaskId ? h(TaskDrawer, {
           taskId: selectedTaskId,
@@ -1585,6 +1602,8 @@
           onOpen: props.onOpen,
           onCreate: props.onCreate,
           allTasks: props.allTasks,
+          assignees: props.assignees,
+          availableSkills: props.availableSkills,
         });
       }),
     );
@@ -1668,6 +1687,8 @@
       showCreate ? h(InlineCreate, {
         columnName: props.column.name,
         allTasks: props.allTasks,
+        assignees: props.assignees,
+        availableSkills: props.availableSkills,
         onSubmit: function (body) {
           props.onCreate(body).then(function () { setShowCreate(false); });
         },
@@ -1852,9 +1873,11 @@
     const { t } = useI18n();
     const [title, setTitle] = useState("");
     const [assignee, setAssignee] = useState("");
+    const [otherAssignee, setOtherAssignee] = useState("");
     const [priority, setPriority] = useState(0);
     const [parent, setParent] = useState("");
-    const [skills, setSkills] = useState("");
+    const [selectedSkills, setSelectedSkills] = useState([]);
+    const [customSkills, setCustomSkills] = useState("");
     // Workspace controls. `scratch` (default) ignores path; `worktree` optionally
     // takes a path (dispatcher derives one from the assignee profile otherwise);
     // `dir` requires a path. Backend enforces the rule — we only hide/show the
@@ -1867,18 +1890,25 @@
       if (!trimmed) return;
       const body = {
         title: trimmed,
-        assignee: assignee.trim() || null,
+        assignee: null,
         priority: Number(priority) || 0,
         triage: props.columnName === "triage",
       };
+      // Resolve assignee: Select value or "Other…" free-text.
+      if (assignee === "__other__") {
+        body.assignee = otherAssignee.trim() || null;
+      } else if (assignee && assignee !== "__none__") {
+        body.assignee = assignee;
+      }
       if (parent) body.parents = [parent];
-      // Parse comma-separated skills into a clean list. Blank = no
-      // extras (omit key so backend leaves it null). The dispatcher
-      // always auto-loads kanban-worker; these are extras on top.
-      const skillList = skills
-        .split(",")
-        .map(function (s) { return s.trim(); })
-        .filter(function (s) { return s.length > 0; });
+      // Combine selected skills (from the additive Select) with custom
+      // comma-separated skills. The dispatcher always auto-loads
+      // kanban-worker; these are extras on top.
+      const skillList = [].concat(selectedSkills).concat(
+        customSkills.split(",")
+          .map(function (s) { return s.trim(); })
+          .filter(function (s) { return s.length > 0; })
+      );
       if (skillList.length > 0) body.skills = skillList;
       // Only send workspace_kind when it's non-default. Keeps the request
       // shape small and interoperable with older dispatcher versions.
@@ -1888,7 +1918,8 @@
       const wpTrim = workspacePath.trim();
       if (wpTrim) body.workspace_path = wpTrim;
       props.onSubmit(body);
-      setTitle(""); setAssignee(""); setPriority(0); setParent(""); setSkills("");
+      setTitle(""); setAssignee(""); setOtherAssignee("");
+      setPriority(0); setParent(""); setSelectedSkills([]); setCustomSkills("");
       setWorkspaceKind("scratch"); setWorkspacePath("");
     };
 
@@ -1913,22 +1944,32 @@
         className: "text-sm min-h-[2rem] max-h-32 resize-y w-full border border-input bg-transparent px-2 py-1 rounded-md focus:outline-none focus:ring-2 focus:ring-ring",
         rows: 2,
       }),
+      // Assignee select + priority
       h("div", { className: "flex gap-2" },
-        h(Input, {
-          value: assignee,
-          onChange: function (e) { setAssignee(e.target.value); },
-          placeholder: props.columnName === "triage"
-            ? tx(t, "specifier", "specifier")
-            : tx(t, "assigneePlaceholder", "assignee"),
-          className: "h-7 text-xs flex-1",
-          title: props.columnName === "triage"
-            ? "Hermes profile that will spec this task (default: the dispatcher's configured specifier). Leave blank to let the dispatcher pick."
-            : "Hermes profile to assign. Leave blank and the dispatcher will pick from available profiles when the task is Ready.",
-          style: { textTransform: "none" },
-          autoCapitalize: "none",
-          autoCorrect: "off",
-          spellCheck: false,
-        }),
+        h("div", { className: "flex-1" },
+          h(Select, {
+            value: assignee,
+            onChange: function (e) { setAssignee(e.target.value); },
+            className: "h-7 text-xs w-full",
+            title: "Hermes profile to assign. Leave blank for unassigned (triage tasks will be picked by the specifier).",
+          },
+            h(SelectOption, { value: "" },
+              tx(t, "assigneePlaceholder", "assignee") + "…"),
+            h(SelectOption, { value: "__none__" }, "(unassigned)"),
+            (props.assignees || []).map(function (a) {
+              return h(SelectOption, { key: a, value: a }, a);
+            }),
+            h(SelectOption, { value: "__other__" }, tx(t, "other", "Other…")),
+          ),
+          // When "Other…" is selected, show a free-text input for custom profile.
+          assignee === "__other__" ? h(Input, {
+            value: otherAssignee,
+            onChange: function (e) { setOtherAssignee(e.target.value); },
+            placeholder: "type profile name…",
+            className: "h-7 text-xs w-full mt-1",
+            autoFocus: true,
+          }) : null,
+        ),
         h(Input, {
           type: "number",
           value: priority,
@@ -1938,14 +1979,54 @@
           title: "Priority. Higher-priority tasks are claimed first by the dispatcher. 0 = default.",
         }),
       ),
-      h(Input, {
-        value: skills,
-        onChange: function (e) { setSkills(e.target.value); },
-        placeholder: tx(t, "skillsPlaceholder",
-          "skills (optional, comma-separated): translation, github-code-review"),
-        title: "Force-load these skills into the worker (in addition to the built-in kanban-worker).",
-        className: "h-7 text-xs",
-      }),
+      // Skills: additive Select + tags + custom input
+      h("div", { className: "flex flex-col gap-1" },
+        h("div", { className: "flex gap-2 items-center" },
+          h(Select, {
+            value: "__placeholder__",
+            onChange: function (e) {
+              const val = e.target.value;
+              if (val && val !== "__placeholder__") {
+                setSelectedSkills(function (prev) {
+                  if (prev.indexOf(val) === -1) {
+                    return prev.concat([val]);
+                  }
+                  return prev;
+                });
+              }
+            },
+            className: "h-7 text-xs flex-1",
+          },
+            h(SelectOption, { value: "__placeholder__", disabled: true },
+              tx(t, "addSkill", "+ add skill…")),
+            (props.availableSkills || []).map(function (s) {
+              return h(SelectOption, { key: s, value: s }, s);
+            }),
+          ),
+          h(Input, {
+            value: customSkills,
+            onChange: function (e) { setCustomSkills(e.target.value); },
+            placeholder: tx(t, "customSkill", "+ custom"),
+            className: "h-7 text-xs w-28",
+            title: "Comma-separated custom skills not in the list",
+          }),
+        ),
+        // Tags for selected skills (removable)
+        selectedSkills.length > 0 ? h("div", { className: "flex flex-wrap gap-1 mt-1" },
+          selectedSkills.map(function (s) {
+            return h("span", {
+              key: s,
+              className: "inline-flex items-center gap-1 text-xs bg-muted px-1.5 py-0.5 rounded cursor-pointer",
+              onClick: function () {
+                setSelectedSkills(function (prev) {
+                  return prev.filter(function (x) { return x !== s; });
+                });
+              },
+              title: "Click to remove",
+            }, s + " ×");
+          }),
+        ) : null,
+      ),
       h("div", { className: "flex gap-2" },
         h(Select, {
           value: workspaceKind,

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -1367,6 +1367,67 @@ def get_available_skills(board: Optional[str] = Query(None)):
         return {"skills": []}
 
 
+@router.get("/profile-skills")
+def get_profile_skills(
+    profile: str = Query(..., description="Profile name"),
+    board: Optional[str] = Query(None),
+):
+    """Return the enabled skills for a given profile.
+
+    Enabled skills = all system skills minus the profile's disabled list.
+    The profile's disabled skills are read from its ``config.yaml``.
+
+    ``board`` is accepted for consistency with other endpoints but does
+    not affect the result — skills are per-profile, not per-board.
+    """
+    # 1. Get all system skills (reuse the same scan as /available-skills)
+    try:
+        from agent.skill_utils import get_all_skills_dirs, EXCLUDED_SKILL_DIRS
+        all_dirs = get_all_skills_dirs()
+        system_skills: set[str] = set()
+        for sd in all_dirs:
+            if not sd.is_dir():
+                continue
+            for entry in sd.iterdir():
+                if not entry.is_dir():
+                    continue
+                if entry.name in EXCLUDED_SKILL_DIRS:
+                    continue
+                if (entry / "SKILL.md").is_file():
+                    system_skills.add(entry.name)
+    except Exception:
+        return {"profile": profile, "skills": [], "disabled": []}
+
+    # 2. Read profile's disabled skills from its config.yaml
+    import yaml
+    from hermes_constants import get_default_hermes_root
+
+    profile_config_path = (
+        get_default_hermes_root() / "profiles" / profile / "config.yaml"
+    )
+    disabled_skills: set[str] = set()
+    try:
+        if profile_config_path.exists():
+            cfg = yaml.safe_load(profile_config_path.read_text(encoding="utf-8"))
+            if isinstance(cfg, dict):
+                skills_cfg = cfg.get("skills") or {}
+                raw_disabled = skills_cfg.get("disabled") or []
+                if isinstance(raw_disabled, list):
+                    disabled_skills = {
+                        str(s).strip() for s in raw_disabled if str(s).strip()
+                    }
+    except Exception:
+        pass  # If we can't read the config, return all system skills
+
+    enabled = sorted(system_skills - disabled_skills)
+    disabled = sorted(disabled_skills & system_skills)
+    return {
+        "profile": profile,
+        "skills": enabled,
+        "disabled": disabled,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Worker log (read-only; file written by _default_spawn)
 # ---------------------------------------------------------------------------

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -442,13 +442,16 @@ def get_board(
             )
         ]
         # List of distinct assignees for the lane-by-profile sub-grouping.
-        assignees = [
-            r["assignee"]
-            for r in conn.execute(
-                "SELECT DISTINCT assignee FROM tasks WHERE assignee IS NOT NULL "
-                "AND status != 'archived' ORDER BY assignee"
-            )
-        ]
+        # Union of board assignees + on-disk profiles so freshly-created
+        # profiles appear in the UI picker even without any tasks yet.
+        board_assignees = set()
+        for r in conn.execute(
+            "SELECT DISTINCT assignee FROM tasks WHERE assignee IS NOT NULL "
+            "AND status != 'archived'"
+        ):
+            board_assignees.add(r["assignee"])
+        disk_profiles = set(kanban_db.list_profiles_on_disk())
+        assignees = sorted(board_assignees | disk_profiles)
 
         return {
             "columns": [
@@ -1332,6 +1335,36 @@ def get_assignees(board: Optional[str] = Query(None)):
         return {"assignees": kanban_db.known_assignees(conn)}
     finally:
         conn.close()
+
+
+@router.get("/available-skills")
+def get_available_skills(board: Optional[str] = Query(None)):
+    """Return the list of skill names available in the system.
+
+    Scans every configured skill directory for SKILL.md files. Used by
+    the InlineCreate form in the dashboard to populate the skills select
+    dropdown.
+
+    ``board`` is accepted for consistency with other endpoints but does
+    not affect the result — skills are global, not per-board.
+    """
+    try:
+        from agent.skill_utils import get_all_skills_dirs, EXCLUDED_SKILL_DIRS
+        all_dirs = get_all_skills_dirs()
+        skills: set[str] = set()
+        for sd in all_dirs:
+            if not sd.is_dir():
+                continue
+            for entry in sd.iterdir():
+                if not entry.is_dir():
+                    continue
+                if entry.name in EXCLUDED_SKILL_DIRS:
+                    continue
+                if (entry / "SKILL.md").is_file():
+                    skills.add(entry.name)
+        return {"skills": sorted(skills)}
+    except Exception:
+        return {"skills": []}
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Replace the plain-text `<Input>` fields for assignee and skills in the Kanban dashboard's InlineCreate (quick card creation form) with `<Select>` components populated from the backend — making it easier to pick known profiles and skills without guessing or typing exact names.

**Assignee:** now a `<Select>` dropdown showing a union of board assignees and on-disk profiles, plus an "Other…" option for free-text entry.
**Skills:** now an additive `<Select>` with removable tag badges, plus a comma-separated custom input for unlisted skills.
**Triage column:** assignee is optional (defaults to unassigned).

### Backend changes
- New `GET /available-skills` endpoint that scans skill directories
- `GET /board` now returns a union of board assignees + disk profiles

### Frontend changes
- `KanbanPage` fetches availableSkills on mount
- Props `assignees` and `availableSkills` propagated through BoardColumns → Column → InlineCreate
- InlineCreate assignee: Input → Select with "Other…" fallback
- InlineCreate skills: Input → additive Select with tag badges + custom input

## Changes Made

- `plugins/kanban/dashboard/plugin_api.py` — added `/available-skills` endpoint, union board/disk assignees in `get_board`
- `plugins/kanban/dashboard/dist/index.js` — prop chain propagation, Select components for assignee and skills in InlineCreate

## How to Test

1. `hermes dashboard` → Kanban tab → click "+" on any column
2. Assignee field shows dropdown with profiles
3. Select a profile → create → verify via `hermes kanban show <id>`
4. Select "Other…" → type custom name → create → verify
5. Skills field shows dropdown + tag badges
6. Select multiple skills → create → verify all saved
7. Click "×" on a skill tag → it is removed
8. Triage column: create without assignee → works (task stays unassigned)
9. `curl /available-skills` returns skill list

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains only changes related to this feature
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've tested on my platform: Linux

### Documentation & Housekeeping

- [ ] I've updated relevant documentation — N/A (UI change)
- [ ] I've updated `cli-config.yaml.example` — N/A
- [ ] I've considered cross-platform impact — N/A (JS frontend + Python backend)
- [ ] I've updated tool descriptions/schemas — N/A
