### PR TITLE
fix(kanban): enforce significant-work review gates

### DIFF
--- a/hermes_cli/kanban.py
+++ b/hermes_cli/kanban.py
@@ -71,6 +71,7 @@ def _task_to_dict(t: kb.Task) -> dict[str, Any]:
         "result": t.result,
         "skills": list(t.skills) if t.skills else [],
         "max_retries": t.max_retries,
+        "metadata": t.metadata or {},
     }
 
 
@@ -294,6 +295,10 @@ def build_parser(parent_subparsers: argparse._SubParsersAction) -> argparse.Argu
                                "two retries. Omit to use the dispatcher's "
                                "kanban.failure_limit config "
                                f"(default {kb.DEFAULT_FAILURE_LIMIT}).")
+    p_create.add_argument("--metadata", default=None,
+                          help="JSON object for task-level policy metadata. "
+                               "Use significant_work/guardrail_group/guardrail_role "
+                               "to activate hard C/D/E gate enforcement.")
     p_create.add_argument("--json", action="store_true", help="Emit JSON output")
 
     # --- list ---
@@ -1030,6 +1035,16 @@ def _cmd_create(args: argparse.Namespace) -> int:
         print(f"kanban: --max-runtime: {exc}", file=sys.stderr)
         return 2
     max_retries = getattr(args, "max_retries", None)
+    metadata = None
+    if getattr(args, "metadata", None):
+        try:
+            metadata = json.loads(args.metadata)
+        except json.JSONDecodeError as exc:
+            print(f"kanban: --metadata must be valid JSON: {exc}", file=sys.stderr)
+            return 2
+        if not isinstance(metadata, dict):
+            print("kanban: --metadata must decode to a JSON object", file=sys.stderr)
+            return 2
     if max_retries is not None and max_retries < 1:
         print(
             f"kanban: --max-retries must be >= 1 (got {max_retries}); "
@@ -1054,6 +1069,7 @@ def _cmd_create(args: argparse.Namespace) -> int:
             max_runtime_seconds=max_runtime,
             skills=getattr(args, "skills", None) or None,
             max_retries=max_retries,
+            metadata=metadata,
         )
         task = kb.get_task(conn, task_id)
     if getattr(args, "json", False):

--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -606,6 +606,7 @@ class Task:
     # ``kanban.failure_limit`` config, and then to ``DEFAULT_FAILURE_LIMIT``.
     # Name matches the ``--max-retries`` CLI flag on ``kanban create``.
     max_retries: Optional[int] = None
+    metadata: Optional[dict] = None
 
     @classmethod
     def from_row(cls, row: sqlite3.Row) -> "Task":
@@ -619,6 +620,14 @@ class Task:
                     skills_value = [str(s) for s in parsed if s]
             except Exception:
                 skills_value = None
+        metadata_value: Optional[dict] = None
+        if "metadata" in keys and row["metadata"]:
+            try:
+                parsed = json.loads(row["metadata"])
+                if isinstance(parsed, dict):
+                    metadata_value = parsed
+            except Exception:
+                metadata_value = None
         return cls(
             id=row["id"],
             title=row["title"],
@@ -670,6 +679,7 @@ class Task:
             max_retries=(
                 row["max_retries"] if "max_retries" in keys else None
             ),
+            metadata=metadata_value,
         )
 
 
@@ -796,7 +806,11 @@ CREATE TABLE IF NOT EXISTS tasks (
     -- ``max_retries=1`` blocks on the first failure. NULL (the common
     -- case) falls through to the dispatcher-level ``kanban.failure_limit``
     -- config and then ``DEFAULT_FAILURE_LIMIT``.
-    max_retries          INTEGER
+    max_retries          INTEGER,
+    -- Structured task-level policy metadata. This is distinct from
+    -- task_runs.metadata (worker handoff facts). Used for hard guardrails
+    -- such as significant-work C/D/E gate roles.
+    metadata             TEXT
 );
 
 CREATE TABLE IF NOT EXISTS task_links (
@@ -1074,6 +1088,11 @@ def _migrate_add_optional_columns(conn: sqlite3.Connection) -> None:
         # which is the correct default (they keep the global behaviour
         # they were getting before the column existed).
         _add_column_if_missing(conn, "tasks", "max_retries", "max_retries INTEGER")
+    if "metadata" not in cols:
+        # JSON object for task-level policy metadata. Existing tasks are
+        # grandfathered by NULL metadata; guardrails only activate when
+        # significant_work / guardrail_role keys are present.
+        _add_column_if_missing(conn, "tasks", "metadata", "metadata TEXT")
 
     # task_events gained a run_id column; back-fill it as NULL for
     # historical events (they predate runs and can't be attributed).
@@ -1202,6 +1221,326 @@ def _claimer_id() -> str:
 
 
 # ---------------------------------------------------------------------------
+# Significant-work C/D/E guardrails
+# ---------------------------------------------------------------------------
+
+class SignificantWorkGuardrailError(ValueError):
+    """Raised when hard significant-work gate policy is violated."""
+
+
+LANE_ROLES = {"codex_lane", "claude_lane"}
+GATE_ROLES = LANE_ROLES | {"reconciler"}
+REQUIRED_LANE_METADATA = ("artifact_commit", "findings_artifact", "model", "verdict")
+
+
+def _normalise_metadata(metadata: Optional[dict]) -> Optional[dict]:
+    if metadata is None:
+        return None
+    if not isinstance(metadata, dict):
+        raise ValueError("metadata must be a JSON object / dict")
+    return dict(metadata)
+
+
+def _metadata_json(metadata: Optional[dict]) -> Optional[str]:
+    meta = _normalise_metadata(metadata)
+    return json.dumps(meta, ensure_ascii=False) if meta is not None else None
+
+
+def _task_meta(conn: sqlite3.Connection, task_id: str) -> dict:
+    row = conn.execute("SELECT metadata FROM tasks WHERE id = ?", (task_id,)).fetchone()
+    if not row or not row["metadata"]:
+        return {}
+    try:
+        parsed = json.loads(row["metadata"])
+        return parsed if isinstance(parsed, dict) else {}
+    except Exception:
+        return {}
+
+
+def _guardrail_role(meta: dict) -> Optional[str]:
+    role = meta.get("guardrail_role")
+    return str(role) if role else None
+
+
+def _guardrail_group(meta: dict) -> Optional[str]:
+    group = meta.get("guardrail_group")
+    return str(group) if group else None
+
+
+def _is_significant(meta: dict) -> bool:
+    return bool(meta.get("significant_work"))
+
+
+def _has_single_controller_waiver(meta: dict) -> bool:
+    return meta.get("single_controller_acceptable") is True
+
+
+def _model_family(model: str) -> str:
+    m = (model or "").strip().lower()
+    if not m:
+        return ""
+    if "claude" in m or "anthropic" in m:
+        return "anthropic"
+    if "gpt" in m or "openai" in m or "codex" in m or re.match(r"^o\d", m):
+        return "openai"
+    if "gemini" in m or "google" in m:
+        return "google"
+    if "kimi" in m or "moonshot" in m:
+        return "moonshot"
+    if "qwen" in m or "dashscope" in m:
+        return "qwen"
+    return m.split("/", 1)[0].split(":", 1)[0]
+
+
+def _latest_completed_run_info(conn: sqlite3.Connection, task_id: str) -> tuple[dict, Optional[str]]:
+    row = conn.execute(
+        """
+        SELECT metadata, profile FROM task_runs
+         WHERE task_id = ?
+           AND outcome = 'completed'
+           AND metadata IS NOT NULL
+         ORDER BY COALESCE(ended_at, started_at, 0) DESC, id DESC
+         LIMIT 1
+        """,
+        (task_id,),
+    ).fetchone()
+    if not row:
+        return {}, None
+    metadata = {}
+    if row["metadata"]:
+        try:
+            parsed = json.loads(row["metadata"])
+            metadata = parsed if isinstance(parsed, dict) else {}
+        except Exception:
+            metadata = {}
+    return metadata, row["profile"]
+
+
+def _latest_completed_metadata(conn: sqlite3.Connection, task_id: str) -> dict:
+    metadata, _profile = _latest_completed_run_info(conn, task_id)
+    return metadata
+
+
+def _guardrail_parents(conn: sqlite3.Connection, child_id: str) -> list[tuple[str, dict]]:
+    rows = conn.execute(
+        "SELECT parent_id FROM task_links WHERE child_id = ? ORDER BY parent_id",
+        (child_id,),
+    ).fetchall()
+    return [(r["parent_id"], _task_meta(conn, r["parent_id"])) for r in rows]
+
+
+def _lane_significant_parent_ids(conn: sqlite3.Connection, lane_id: str, group: str) -> set[str]:
+    subjects: set[str] = set()
+    for pid, meta in _guardrail_parents(conn, lane_id):
+        if _is_significant(meta) and _guardrail_group(meta) == group:
+            subjects.add(pid)
+    return subjects
+
+
+def _task_assignee(conn: sqlite3.Connection, task_id: str) -> Optional[str]:
+    row = conn.execute("SELECT assignee FROM tasks WHERE id = ?", (task_id,)).fetchone()
+    return row["assignee"] if row else None
+
+
+def _task_status(conn: sqlite3.Connection, task_id: str) -> Optional[str]:
+    row = conn.execute("SELECT status FROM tasks WHERE id = ?", (task_id,)).fetchone()
+    return row["status"] if row else None
+
+
+def _validate_lane_assignee(role: str, assignee: Optional[str]) -> None:
+    value = (assignee or "").strip().lower()
+    if not value:
+        raise SignificantWorkGuardrailError(
+            "guardrail review lanes require explicit assignee profiles"
+        )
+    if role == "codex_lane" and not any(token in value for token in ("codex", "openai", "gpt")):
+        raise SignificantWorkGuardrailError(
+            "codex_lane must be assigned to a Codex/OpenAI worker profile"
+        )
+    if role == "claude_lane" and not any(token in value for token in ("claude", "anthropic")):
+        raise SignificantWorkGuardrailError(
+            "claude_lane must be assigned to a Claude/Anthropic worker profile"
+        )
+
+
+def _validate_guardrail_link(
+    conn: sqlite3.Connection,
+    parent_id: str,
+    child_id: str,
+    *,
+    child_metadata: Optional[dict] = None,
+    child_assignee: Optional[str] = None,
+) -> None:
+    parent_meta = _task_meta(conn, parent_id)
+    child_meta = child_metadata if child_metadata is not None else _task_meta(conn, child_id)
+    parent_role = _guardrail_role(parent_meta)
+    child_role = _guardrail_role(child_meta)
+    parent_group = _guardrail_group(parent_meta)
+    child_group = _guardrail_group(child_meta)
+
+    if _is_significant(parent_meta) and not parent_group:
+        raise SignificantWorkGuardrailError(
+            "significant-work tasks require a non-empty guardrail_group"
+        )
+
+    if _is_significant(parent_meta) and not _has_single_controller_waiver(parent_meta):
+        if child_role not in LANE_ROLES or child_group != parent_group:
+            raise SignificantWorkGuardrailError(
+                "significant-work direct downstream is blocked: create Codex "
+                "and Claude review lanes in the same guardrail_group, or set "
+                "single_controller_acceptable=true for mechanical work"
+            )
+
+    if child_role in LANE_ROLES:
+        if _is_significant(parent_meta) and _task_status(conn, child_id) == "done":
+            raise SignificantWorkGuardrailError(
+                "completed guardrail lane cannot be linked to significant work after the fact"
+            )
+        _validate_lane_assignee(
+            child_role,
+            child_assignee if child_assignee is not None else _task_assignee(conn, child_id),
+        )
+
+    if parent_role in LANE_ROLES:
+        if not parent_group:
+            raise SignificantWorkGuardrailError(
+                "guardrail review lanes require a non-empty guardrail_group"
+            )
+        if child_role != "reconciler" or child_group != parent_group:
+            raise SignificantWorkGuardrailError(
+                "review lane cannot feed direct downstream work; downstream "
+                "must depend on a reconciler in the same guardrail_group"
+            )
+
+
+def _validate_reconciler_shape(
+    conn: sqlite3.Connection,
+    task_id: str,
+    child_meta: dict,
+    parent_ids_for_new_task: Optional[Iterable[str]] = None,
+) -> None:
+    if _guardrail_role(child_meta) != "reconciler":
+        return
+    group = _guardrail_group(child_meta)
+    if not group:
+        raise SignificantWorkGuardrailError(
+            "reconciler requires a non-empty guardrail_group"
+        )
+    if parent_ids_for_new_task is None:
+        parents = _guardrail_parents(conn, task_id)
+    else:
+        parents = [(pid, _task_meta(conn, pid)) for pid in parent_ids_for_new_task]
+    lane_ids: dict[str, list[str]] = {"codex_lane": [], "claude_lane": []}
+    for pid, meta in parents:
+        role = _guardrail_role(meta)
+        if role in LANE_ROLES:
+            lane_ids[role].append(pid)
+    if len(lane_ids["codex_lane"]) != 1:
+        raise SignificantWorkGuardrailError(
+            "reconciler must depend on exactly one codex_lane parent"
+        )
+    if len(lane_ids["claude_lane"]) != 1:
+        raise SignificantWorkGuardrailError(
+            "reconciler must depend on exactly one claude_lane parent"
+        )
+    roles = {"codex_lane": lane_ids["codex_lane"][0], "claude_lane": lane_ids["claude_lane"][0]}
+    for _pid, meta in parents:
+        if _guardrail_role(meta) in LANE_ROLES and _guardrail_group(meta) != group:
+            raise SignificantWorkGuardrailError(
+                "reconciler and review lanes must share the same guardrail_group"
+            )
+    codex_subjects = _lane_significant_parent_ids(conn, roles["codex_lane"], group)
+    claude_subjects = _lane_significant_parent_ids(conn, roles["claude_lane"], group)
+    if not (codex_subjects & claude_subjects):
+        raise SignificantWorkGuardrailError(
+            "reconciler review lanes must share the same significant parent"
+        )
+
+
+def _validate_guardrail_completion(
+    conn: sqlite3.Connection,
+    task_id: str,
+    metadata: Optional[dict],
+) -> None:
+    task_meta = _task_meta(conn, task_id)
+    role = _guardrail_role(task_meta)
+    if role not in GATE_ROLES:
+        return
+    group = _guardrail_group(task_meta)
+    if not group:
+        raise SignificantWorkGuardrailError(
+            "guardrail_role tasks require a non-empty guardrail_group before completion"
+        )
+    handoff = _normalise_metadata(metadata) or {}
+    if role in LANE_ROLES:
+        missing = [k for k in REQUIRED_LANE_METADATA if not handoff.get(k)]
+        if missing:
+            raise SignificantWorkGuardrailError(
+                "review lane completion missing required metadata: " + ", ".join(missing)
+            )
+        return
+
+    _validate_reconciler_shape(conn, task_id, task_meta)
+    missing = [k for k in ("artifact_commit", "findings_artifact", "verdict") if not handoff.get(k)]
+    if missing:
+        raise SignificantWorkGuardrailError(
+            "reconciler completion missing required metadata: " + ", ".join(missing)
+        )
+    parents = _guardrail_parents(conn, task_id)
+    by_role = {_guardrail_role(meta): pid for pid, meta in parents}
+    for lane_name in ("codex_lane", "claude_lane"):
+        status = _task_status(conn, by_role[lane_name])
+        if status != "done":
+            raise SignificantWorkGuardrailError(
+                f"{lane_name} current status must be done before reconciler completion"
+            )
+    codex_meta, codex_profile = _latest_completed_run_info(conn, by_role["codex_lane"])
+    claude_meta, claude_profile = _latest_completed_run_info(conn, by_role["claude_lane"])
+    for lane_name, lane_meta in (("codex_lane", codex_meta), ("claude_lane", claude_meta)):
+        missing = [k for k in REQUIRED_LANE_METADATA if not lane_meta.get(k)]
+        if missing:
+            raise SignificantWorkGuardrailError(
+                f"{lane_name} has not completed with required metadata: " + ", ".join(missing)
+            )
+    if not codex_profile or not claude_profile or codex_profile == claude_profile:
+        raise SignificantWorkGuardrailError(
+            "codex_lane and claude_lane must complete under different worker profiles"
+        )
+    if _model_family(str(codex_meta.get("model", ""))) == _model_family(str(claude_meta.get("model", ""))):
+        raise SignificantWorkGuardrailError(
+            "codex_lane and claude_lane must use different model families"
+        )
+    if _model_family(str(codex_meta.get("model", ""))) != "openai":
+        raise SignificantWorkGuardrailError(
+            "codex_lane must be reviewed by an OpenAI/Codex model family"
+        )
+    if _model_family(str(claude_meta.get("model", ""))) != "anthropic":
+        raise SignificantWorkGuardrailError(
+            "claude_lane must be reviewed by an Anthropic/Claude model family"
+        )
+    if str(codex_meta.get("artifact_commit")) != str(claude_meta.get("artifact_commit")):
+        raise SignificantWorkGuardrailError(
+            "artifact_commit mismatch between review lanes"
+        )
+    if str(handoff.get("artifact_commit")) != str(codex_meta.get("artifact_commit")):
+        raise SignificantWorkGuardrailError(
+            "reconciler artifact_commit must match reviewed artifact_commit"
+        )
+    if str(codex_meta.get("verdict", "")).upper() != str(claude_meta.get("verdict", "")).upper():
+        raise SignificantWorkGuardrailError(
+            "verdict disagreement between review lanes"
+        )
+    if str(codex_meta.get("verdict", "")).upper() != "APPROVE":
+        raise SignificantWorkGuardrailError(
+            "non-approving review consensus blocks downstream work"
+        )
+    if str(handoff.get("verdict", "")).upper() != "APPROVE":
+        raise SignificantWorkGuardrailError(
+            "reconciler verdict must be APPROVE before downstream work can proceed"
+        )
+
+
+# ---------------------------------------------------------------------------
 # Task creation / mutation
 # ---------------------------------------------------------------------------
 
@@ -1231,6 +1570,7 @@ def create_task(
     max_runtime_seconds: Optional[int] = None,
     skills: Optional[Iterable[str]] = None,
     max_retries: Optional[int] = None,
+    metadata: Optional[dict] = None,
 ) -> str:
     """Create a new task and optionally link it under parent tasks.
 
@@ -1265,6 +1605,7 @@ def create_task(
             f"got {workspace_kind!r}"
         )
     parents = tuple(p for p in parents if p)
+    task_metadata = _normalise_metadata(metadata)
 
     # Normalise + validate skills: strip whitespace, drop empties, dedupe
     # (preserving order). Refuse commas inside a single name so we don't
@@ -1339,10 +1680,32 @@ def create_task(
                     initial_status = "triage"
                 else:
                     initial_status = "ready"
-                    if parents:
-                        missing = _find_missing_parents(conn, parents)
-                        if missing:
-                            raise ValueError(f"unknown parent task(s): {', '.join(missing)}")
+                if _is_significant(task_metadata or {}) and not _guardrail_group(task_metadata or {}):
+                    raise SignificantWorkGuardrailError(
+                        "significant-work tasks require a non-empty guardrail_group"
+                    )
+                if _guardrail_role(task_metadata or {}) in GATE_ROLES and not _guardrail_group(task_metadata or {}):
+                    raise SignificantWorkGuardrailError(
+                        "guardrail_role tasks require a non-empty guardrail_group"
+                    )
+                if _guardrail_role(task_metadata or {}) in LANE_ROLES:
+                    _validate_lane_assignee(_guardrail_role(task_metadata or {}) or "", assignee)
+                if parents:
+                    missing = _find_missing_parents(conn, parents)
+                    if missing:
+                        raise ValueError(f"unknown parent task(s): {', '.join(missing)}")
+                    for pid in parents:
+                        _validate_guardrail_link(
+                            conn,
+                            pid,
+                            task_id,
+                            child_metadata=task_metadata or {},
+                            child_assignee=assignee,
+                        )
+                    _validate_reconciler_shape(
+                        conn, task_id, task_metadata or {}, parents
+                    )
+                    if not triage:
                         # If any parent is not yet done, we're todo.
                         rows = conn.execute(
                             "SELECT status FROM tasks WHERE id IN "
@@ -1351,12 +1714,6 @@ def create_task(
                         ).fetchall()
                         if any(r["status"] != "done" for r in rows):
                             initial_status = "todo"
-                # Even in triage mode we still need to validate parent ids
-                # so the eventual link rows don't dangle.
-                if triage and parents:
-                    missing = _find_missing_parents(conn, parents)
-                    if missing:
-                        raise ValueError(f"unknown parent task(s): {', '.join(missing)}")
 
                 conn.execute(
                     """
@@ -1364,8 +1721,8 @@ def create_task(
                         id, title, body, assignee, status, priority,
                         created_by, created_at, workspace_kind, workspace_path,
                         tenant, idempotency_key, max_runtime_seconds, skills,
-                        max_retries
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        max_retries, metadata
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                     """,
                     (
                         task_id,
@@ -1383,6 +1740,7 @@ def create_task(
                         int(max_runtime_seconds) if max_runtime_seconds else None,
                         json.dumps(skills_list) if skills_list is not None else None,
                         int(max_retries) if max_retries is not None else None,
+                        _metadata_json(task_metadata),
                     ),
                 )
                 for pid in parents:
@@ -1400,6 +1758,7 @@ def create_task(
                         "parents": list(parents),
                         "tenant": tenant,
                         "skills": list(skills_list) if skills_list else None,
+                        "metadata": task_metadata,
                     },
                 )
             return task_id
@@ -1478,6 +1837,9 @@ def assign_task(conn: sqlite3.Connection, task_id: str, profile: Optional[str]) 
                 f"cannot reassign {task_id}: currently running (claimed). "
                 "Wait for completion or reclaim the stale lock first."
             )
+        role = _guardrail_role(_task_meta(conn, task_id))
+        if role in LANE_ROLES:
+            _validate_lane_assignee(role, profile)
         if row["assignee"] != profile:
             # The retry guard is scoped to the task/profile combination. A
             # human reassigning the task is an explicit recovery action, so the
@@ -1508,6 +1870,30 @@ def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
             raise ValueError(
                 f"linking {parent_id} -> {child_id} would create a cycle"
             )
+        _validate_guardrail_link(conn, parent_id, child_id)
+        parent_meta = _task_meta(conn, parent_id)
+        parent_role = _guardrail_role(parent_meta)
+        child_status = _task_status(conn, child_id)
+        if child_status == "running" and (_is_significant(parent_meta) or parent_role in GATE_ROLES):
+            raise SignificantWorkGuardrailError(
+                "running downstream work cannot be linked under an unfinished guardrail gate"
+            )
+        if child_status == "done" and (_is_significant(parent_meta) or parent_role in GATE_ROLES):
+            raise SignificantWorkGuardrailError(
+                "completed downstream work cannot be retroactively linked under a guardrail gate"
+            )
+        candidate_parents = [r["parent_id"] for r in conn.execute(
+            "SELECT parent_id FROM task_links WHERE child_id = ? ORDER BY parent_id",
+            (child_id,),
+        ).fetchall()]
+        if parent_id not in candidate_parents:
+            candidate_parents.append(parent_id)
+        _validate_reconciler_shape(
+            conn,
+            child_id,
+            _task_meta(conn, child_id),
+            parent_ids_for_new_task=candidate_parents,
+        )
         conn.execute(
             "INSERT OR IGNORE INTO task_links (parent_id, child_id) VALUES (?, ?)",
             (parent_id, child_id),
@@ -1552,6 +1938,17 @@ def _would_cycle(conn: sqlite3.Connection, parent_id: str, child_id: str) -> boo
 
 def unlink_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> bool:
     with write_txn(conn):
+        parent_meta = _task_meta(conn, parent_id)
+        child_meta = _task_meta(conn, child_id)
+        if (
+            _is_significant(parent_meta)
+            or _guardrail_role(parent_meta) in GATE_ROLES
+            or _is_significant(child_meta)
+            or _guardrail_role(child_meta) in GATE_ROLES
+        ):
+            raise SignificantWorkGuardrailError(
+                "cannot unlink guardrail dependency; create a new explicit gate/waiver instead"
+            )
         cur = conn.execute(
             "DELETE FROM task_links WHERE parent_id = ? AND child_id = ?",
             (parent_id, child_id),
@@ -2337,6 +2734,7 @@ def complete_task(
         verified_cards = []
 
     with write_txn(conn):
+        _validate_guardrail_completion(conn, task_id, metadata)
         if expected_run_id is None:
             cur = conn.execute(
                 """
@@ -2451,6 +2849,10 @@ def edit_completed_task_result(
         ).fetchone()
         if not row or row["status"] != "done":
             return False
+        if metadata is not None and _guardrail_role(_task_meta(conn, task_id)) in GATE_ROLES:
+            raise SignificantWorkGuardrailError(
+                "completed guardrail review metadata is immutable; rerun the lane instead"
+            )
         conn.execute(
             "UPDATE tasks SET result = ? WHERE id = ?",
             (result, task_id),
@@ -2573,7 +2975,15 @@ def unblock_task(conn: sqlite3.Connection, task_id: str) -> bool:
             "SELECT current_run_id FROM tasks WHERE id = ? AND status = 'blocked'",
             (task_id,),
         ).fetchone()
-        if stale and stale["current_run_id"]:
+        if not stale:
+            return False
+        parent_rows = conn.execute(
+            "SELECT t.status FROM tasks t JOIN task_links l ON l.parent_id = t.id WHERE l.child_id = ?",
+            (task_id,),
+        ).fetchall()
+        if parent_rows and any(r["status"] != "done" for r in parent_rows):
+            return False
+        if stale["current_run_id"]:
             conn.execute(
                 """
                 UPDATE task_runs
@@ -2699,6 +3109,11 @@ def specify_triage_task(
 
 def archive_task(conn: sqlite3.Connection, task_id: str) -> bool:
     with write_txn(conn):
+        meta = _task_meta(conn, task_id)
+        if _is_significant(meta) or _guardrail_role(meta) in GATE_ROLES:
+            raise SignificantWorkGuardrailError(
+                "cannot archive guardrail/significant-work task; create an explicit superseding gate instead"
+            )
         cur = conn.execute(
             "UPDATE tasks SET status = 'archived', "
             "    claim_lock = NULL, claim_expires = NULL, worker_pid = NULL "

--- a/plugins/kanban/dashboard/plugin_api.py
+++ b/plugins/kanban/dashboard/plugin_api.py
@@ -515,6 +515,7 @@ class CreateTaskBody(BaseModel):
     idempotency_key: Optional[str] = None
     max_runtime_seconds: Optional[int] = None
     skills: Optional[list[str]] = None
+    metadata: Optional[dict] = None
 
 
 @router.post("/tasks")
@@ -537,6 +538,7 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
             idempotency_key=payload.idempotency_key,
             max_runtime_seconds=payload.max_runtime_seconds,
             skills=payload.skills,
+            metadata=payload.metadata,
         )
         task = kanban_db.get_task(conn, task_id)
         body: dict[str, Any] = {"task": _task_dict(task) if task else None}
@@ -555,6 +557,8 @@ def create_task(payload: CreateTaskBody, board: Optional[str] = Query(None)):
                 # Probe failure must never block the create itself.
                 pass
         return body
+    except kanban_db.SignificantWorkGuardrailError as e:
+        raise HTTPException(status_code=409, detail=str(e))
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     finally:
@@ -604,6 +608,13 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
         if payload.status is not None:
             s = payload.status
             ok = True
+            if s in ("ready", "todo", "triage"):
+                meta = kanban_db._task_meta(conn, task_id)
+                if kanban_db._guardrail_role(meta) in kanban_db.GATE_ROLES or kanban_db._is_significant(meta):
+                    raise HTTPException(
+                        status_code=409,
+                        detail="guardrail lane/reconciler status cannot be changed directly; use structured completion",
+                    )
             if s == "done":
                 ok = kanban_db.complete_task(
                     conn, task_id,
@@ -676,6 +687,8 @@ def update_task(task_id: str, payload: UpdateTaskBody, board: Optional[str] = Qu
 
         updated = kanban_db.get_task(conn, task_id)
         return {"task": _task_dict(updated) if updated else None}
+    except kanban_db.SignificantWorkGuardrailError as e:
+        raise HTTPException(status_code=409, detail=str(e))
     finally:
         conn.close()
 
@@ -700,6 +713,14 @@ def _set_status_direct(
             (task_id,),
         ).fetchone()
         if prev is None:
+            return False
+
+        # Guard: direct dashboard status writes cannot reopen or promote
+        # significant-work gate cards. Guardrail lanes/reconcilers must move
+        # through structured completion paths so custody metadata and child
+        # demotion invariants stay authoritative in kanban_db.
+        meta = kanban_db._task_meta(conn, task_id)
+        if kanban_db._guardrail_role(meta) in kanban_db.GATE_ROLES or kanban_db._is_significant(meta):
             return False
 
         # Guard: don't allow promoting to 'ready' unless all parents are done.
@@ -789,6 +810,8 @@ def add_link(payload: LinkBody, board: Optional[str] = Query(None)):
     try:
         kanban_db.link_tasks(conn, payload.parent_id, payload.child_id)
         return {"ok": True}
+    except kanban_db.SignificantWorkGuardrailError as e:
+        raise HTTPException(status_code=409, detail=str(e))
     except ValueError as e:
         raise HTTPException(status_code=400, detail=str(e))
     finally:
@@ -806,6 +829,8 @@ def delete_link(
     try:
         ok = kanban_db.unlink_tasks(conn, parent_id, child_id)
         return {"ok": bool(ok)}
+    except kanban_db.SignificantWorkGuardrailError as e:
+        raise HTTPException(status_code=409, detail=str(e))
     finally:
         conn.close()
 
@@ -852,6 +877,12 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                         entry.update(ok=False, error="archive refused")
                 if payload.status is not None and not payload.archive:
                     s = payload.status
+                    if s in ("ready", "todo", "triage"):
+                        meta = kanban_db._task_meta(conn, tid)
+                        if kanban_db._guardrail_role(meta) in kanban_db.GATE_ROLES or kanban_db._is_significant(meta):
+                            entry.update(ok=False, error="guardrail lane/reconciler status cannot be changed directly")
+                            results.append(entry)
+                            continue
                     if s == "done":
                         ok = kanban_db.complete_task(
                             conn, tid,
@@ -867,8 +898,14 @@ def bulk_update(payload: BulkTaskBody, board: Optional[str] = Query(None)):
                             ok = kanban_db.unblock_task(conn, tid)
                         else:
                             ok = _set_status_direct(conn, tid, "ready")
-                    elif s in ("todo", "running", "triage"):
+                    elif s == "todo":
                         ok = _set_status_direct(conn, tid, s)
+                    elif s == "triage":
+                        ok = _set_status_direct(conn, tid, s)
+                    elif s == "running":
+                        entry.update(ok=False, error="running status requires dispatcher claim_task")
+                        results.append(entry)
+                        continue
                     else:
                         entry.update(ok=False, error=f"unknown status {s!r}")
                         results.append(entry)
@@ -1116,6 +1153,8 @@ def reassign_task_endpoint(
                 ),
             )
         return {"ok": True, "task_id": task_id, "assignee": payload.profile or None}
+    except kanban_db.SignificantWorkGuardrailError as e:
+        raise HTTPException(status_code=409, detail=str(e))
     finally:
         conn.close()
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -377,12 +377,12 @@ def test_create_with_parents_stays_todo_until_parents_done(kanban_home):
         assert kb.get_task(conn, child).status == "ready"
 
 
-def test_unblock_with_pending_parents_goes_to_todo(kanban_home):
-    """unblock_task must re-gate on parent completion (Fix 3).
+def test_unblock_with_pending_parents_refuses_until_parent_done(kanban_home):
+    """unblock_task must refuse while any parent remains unfinished.
 
-    A task blocked while parents are still in progress must return to
-    'todo' (not 'ready') on unblock. Otherwise the dispatcher will claim
-    it immediately, repeating Bug 2 from the RCA.
+    Keeping a manually blocked child blocked avoids bypassing unfinished
+    upstream gates. The operator/worker can unblock it after the parent is
+    complete, at which point normal ready-state recomputation applies.
     """
     with kb.connect() as conn:
         parent = kb.create_task(conn, title="parent", assignee="a")
@@ -395,12 +395,12 @@ def test_unblock_with_pending_parents_goes_to_todo(kanban_home):
             "UPDATE tasks SET status='blocked' WHERE id=?", (child,),
         )
         conn.commit()
-        assert kb.unblock_task(conn, child)
-        assert kb.get_task(conn, child).status == "todo"
-        # After parent completes + recompute, the child is ready.
+        assert not kb.unblock_task(conn, child)
+        assert kb.get_task(conn, child).status == "blocked"
+        # After parent completes, the explicit unblock can promote the child.
         kb.claim_task(conn, parent)
         kb.complete_task(conn, parent, result="ok")
-        kb.recompute_ready(conn)
+        assert kb.unblock_task(conn, child)
         assert kb.get_task(conn, child).status == "ready"
 
 

--- a/tests/hermes_cli/test_kanban_significant_guardrails.py
+++ b/tests/hermes_cli/test_kanban_significant_guardrails.py
@@ -1,0 +1,478 @@
+"""Hard guardrails for significant Kanban work.
+
+These tests pin the non-advisory C/D/E mixed-agent gate:
+significant work cannot dispatch downstream work directly unless it has an
+explicit single-controller waiver, and review lanes/reconcilers must provide
+structured custody metadata before the graph can advance.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from hermes_cli import kanban_db as kb
+
+
+@pytest.fixture
+def kanban_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    kb.init_db()
+    return home
+
+
+def _significant(group="gate-1"):
+    return {"significant_work": True, "guardrail_group": group}
+
+
+def _lane(role: str, group="gate-1"):
+    return {"guardrail_group": group, "guardrail_role": role}
+
+
+def _handoff(model: str, verdict="APPROVE", artifact="abc123"):
+    return {
+        "artifact_commit": artifact,
+        "findings_artifact": f"reviews/{model}.md",
+        "model": model,
+        "verdict": verdict,
+    }
+
+
+def _reconciler_handoff(verdict="APPROVE", artifact="abc123"):
+    return {
+        "artifact_commit": artifact,
+        "findings_artifact": "reviews/reconciler.md",
+        "verdict": verdict,
+    }
+
+
+def _create_gate(conn, parent: str, group="gate-1"):
+    codex = kb.create_task(
+        conn,
+        title="Codex review lane",
+        assignee="codex-reviewer",
+        parents=[parent],
+        metadata=_lane("codex_lane", group),
+    )
+    claude = kb.create_task(
+        conn,
+        title="Claude review lane",
+        assignee="claude-reviewer",
+        parents=[parent],
+        metadata=_lane("claude_lane", group),
+    )
+    recon = kb.create_task(
+        conn,
+        title="Reconcile reviews",
+        assignee="controller",
+        parents=[codex, claude],
+        metadata=_lane("reconciler", group),
+    )
+    return codex, claude, recon
+
+
+def test_significant_task_rejects_direct_downstream_without_waiver(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="nontrivial control-plane work", metadata=_significant())
+        with pytest.raises(kb.SignificantWorkGuardrailError, match="direct downstream"):
+            kb.create_task(conn, title="implement directly", parents=[parent])
+
+
+def test_single_controller_waiver_allows_direct_downstream(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(
+            conn,
+            title="mechanical typo",
+            metadata={
+                "significant_work": True,
+                "single_controller_acceptable": True,
+                "guardrail_group": "gate-1",
+            },
+        )
+        child = kb.create_task(conn, title="mechanical follow-up", parents=[parent])
+        assert kb.get_task(conn, child).status == "todo"
+
+
+def test_significant_task_allows_codex_claude_reconciler_gate_shape(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="nontrivial work", metadata=_significant())
+        codex, claude, recon = _create_gate(conn, parent)
+        assert kb.parent_ids(conn, recon) == sorted([claude, codex])
+        assert kb.get_task(conn, codex).status == "todo"
+        assert kb.get_task(conn, claude).status == "todo"
+        assert kb.get_task(conn, recon).status == "todo"
+
+
+def test_downstream_cannot_parent_directly_on_review_lane(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="nontrivial work", metadata=_significant())
+        codex, _claude, _recon = _create_gate(conn, parent)
+        with pytest.raises(kb.SignificantWorkGuardrailError, match="review lane"):
+            kb.create_task(conn, title="bad downstream", parents=[codex])
+
+
+def test_review_lane_completion_requires_structured_metadata(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="nontrivial work", metadata=_significant())
+        codex, _claude, _recon = _create_gate(conn, parent)
+        kb.complete_task(conn, parent, result="ready for review")
+        with pytest.raises(kb.SignificantWorkGuardrailError, match="artifact_commit"):
+            kb.complete_task(conn, codex, result="approved", metadata={"model": "gpt-5.5"})
+
+
+def test_standalone_guardrail_role_cannot_be_created_without_group(kanban_home):
+    with kb.connect() as conn:
+        with pytest.raises(kb.SignificantWorkGuardrailError, match="guardrail_group"):
+            kb.create_task(
+                conn,
+                title="ungrouped codex lane",
+                assignee="codex-reviewer",
+                metadata={"guardrail_role": "codex_lane"},
+            )
+
+
+def test_reconciler_rejects_swapped_lane_model_families(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="nontrivial work", metadata=_significant())
+        codex, claude, recon = _create_gate(conn, parent)
+        kb.complete_task(conn, parent, result="ready for review")
+        kb.complete_task(conn, codex, metadata=_handoff("claude-opus-4-7"))
+        kb.complete_task(conn, claude, metadata=_handoff("gpt-5.5"))
+        with pytest.raises(kb.SignificantWorkGuardrailError, match="codex_lane.*OpenAI"):
+            kb.complete_task(conn, recon, metadata=_reconciler_handoff())
+
+
+def test_reconciler_rejects_same_model_family(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="nontrivial work", metadata=_significant())
+        codex, claude, recon = _create_gate(conn, parent)
+        kb.complete_task(conn, parent, result="ready for review")
+        kb.complete_task(conn, codex, metadata=_handoff("gpt-5.5"))
+        kb.complete_task(conn, claude, metadata=_handoff("openai-codex/gpt-5.5"))
+        with pytest.raises(kb.SignificantWorkGuardrailError, match="different model families"):
+            kb.complete_task(conn, recon, metadata=_reconciler_handoff())
+
+
+def test_reconciler_rejects_artifact_commit_mismatch(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="nontrivial work", metadata=_significant())
+        codex, claude, recon = _create_gate(conn, parent)
+        kb.complete_task(conn, parent, result="ready for review")
+        kb.complete_task(conn, codex, metadata=_handoff("gpt-5.5", artifact="abc123"))
+        kb.complete_task(conn, claude, metadata=_handoff("claude-opus-4-7", artifact="def456"))
+        with pytest.raises(kb.SignificantWorkGuardrailError, match="artifact_commit mismatch"):
+            kb.complete_task(conn, recon, metadata=_reconciler_handoff())
+
+
+def test_reconciler_rejects_verdict_disagreement(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="nontrivial work", metadata=_significant())
+        codex, claude, recon = _create_gate(conn, parent)
+        kb.complete_task(conn, parent, result="ready for review")
+        kb.complete_task(conn, codex, metadata=_handoff("gpt-5.5", verdict="APPROVE"))
+        kb.complete_task(conn, claude, metadata=_handoff("claude-opus-4-7", verdict="BLOCK"))
+        with pytest.raises(kb.SignificantWorkGuardrailError, match="verdict disagreement"):
+            kb.complete_task(conn, recon, metadata=_reconciler_handoff())
+
+
+def test_reconciler_rejects_non_approving_consensus(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="nontrivial work", metadata=_significant())
+        codex, claude, recon = _create_gate(conn, parent)
+        kb.complete_task(conn, parent, result="ready for review")
+        kb.complete_task(conn, codex, metadata=_handoff("gpt-5.5", verdict="BLOCK"))
+        kb.complete_task(conn, claude, metadata=_handoff("claude-opus-4-7", verdict="BLOCK"))
+        with pytest.raises(kb.SignificantWorkGuardrailError, match="non-approving"):
+            kb.complete_task(conn, recon, metadata=_reconciler_handoff(verdict="BLOCK"))
+
+
+def test_string_false_is_not_a_single_controller_waiver(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(
+            conn,
+            title="nontrivial work",
+            metadata={
+                "significant_work": True,
+                "single_controller_acceptable": "false",
+                "guardrail_group": "gate-1",
+            },
+        )
+        with pytest.raises(kb.SignificantWorkGuardrailError, match="direct downstream"):
+            kb.create_task(conn, title="bad downstream", parents=[parent])
+
+
+def test_significant_and_gate_roles_require_guardrail_group(kanban_home):
+    with kb.connect() as conn:
+        with pytest.raises(kb.SignificantWorkGuardrailError, match="guardrail_group"):
+            kb.create_task(conn, title="nontrivial work", metadata={"significant_work": True})
+        parent = kb.create_task(conn, title="nontrivial work", metadata=_significant())
+        with pytest.raises(kb.SignificantWorkGuardrailError, match="guardrail_group"):
+            kb.create_task(
+                conn,
+                title="ungrouped lane",
+                parents=[parent],
+                assignee="codex-reviewer",
+                metadata={"guardrail_role": "codex_lane"},
+            )
+
+
+def test_openai_o_series_counts_as_openai_family(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="nontrivial work", metadata=_significant())
+        codex, claude, recon = _create_gate(conn, parent)
+        kb.complete_task(conn, parent, result="ready for review")
+        kb.complete_task(conn, codex, metadata=_handoff("o3"))
+        kb.complete_task(conn, claude, metadata=_handoff("openai-codex/gpt-5.5"))
+        with pytest.raises(kb.SignificantWorkGuardrailError, match="different model families"):
+            kb.complete_task(conn, recon, metadata=_reconciler_handoff())
+
+
+def test_reconciler_requires_own_custody_metadata(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="nontrivial work", metadata=_significant())
+        codex, claude, recon = _create_gate(conn, parent)
+        kb.complete_task(conn, parent, result="ready for review")
+        kb.complete_task(conn, codex, metadata=_handoff("gpt-5.5"))
+        kb.complete_task(conn, claude, metadata=_handoff("claude-opus-4-7"))
+        with pytest.raises(kb.SignificantWorkGuardrailError, match="reconciler completion missing"):
+            kb.complete_task(conn, recon, metadata=None)
+
+
+def test_same_profile_cannot_complete_both_review_lanes(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="nontrivial work", metadata=_significant())
+        codex = kb.create_task(
+            conn,
+            title="Codex lane",
+            assignee="codex-claude-controller",
+            parents=[parent],
+            metadata=_lane("codex_lane"),
+        )
+        claude = kb.create_task(
+            conn,
+            title="Claude lane",
+            assignee="codex-claude-controller",
+            parents=[parent],
+            metadata=_lane("claude_lane"),
+        )
+        recon = kb.create_task(
+            conn,
+            title="Reconcile",
+            assignee="controller",
+            parents=[codex, claude],
+            metadata=_lane("reconciler"),
+        )
+        kb.complete_task(conn, parent, result="ready for review")
+        kb.complete_task(conn, codex, metadata=_handoff("gpt-5.5"))
+        kb.complete_task(conn, claude, metadata=_handoff("claude-opus-4-7"))
+        with pytest.raises(kb.SignificantWorkGuardrailError, match="different worker profiles"):
+            kb.complete_task(conn, recon, metadata=_reconciler_handoff())
+
+
+def test_unlink_cannot_remove_guardrail_dependency_to_promote_downstream(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="nontrivial work", metadata=_significant())
+        _codex, _claude, recon = _create_gate(conn, parent)
+        downstream = kb.create_task(conn, title="safe downstream", parents=[recon])
+        assert kb.get_task(conn, downstream).status == "todo"
+        with pytest.raises(kb.SignificantWorkGuardrailError, match="cannot unlink guardrail"):
+            kb.unlink_tasks(conn, recon, downstream)
+        kb.recompute_ready(conn)
+        assert kb.get_task(conn, downstream).status == "todo"
+
+
+def test_reconciler_lanes_must_share_same_significant_parent(kanban_home):
+    with kb.connect() as conn:
+        parent_a = kb.create_task(conn, title="nontrivial work A", metadata=_significant("gate-1"))
+        parent_b = kb.create_task(conn, title="nontrivial work B", metadata=_significant("gate-1"))
+        codex = kb.create_task(
+            conn,
+            title="Codex lane A",
+            assignee="codex-reviewer",
+            parents=[parent_a],
+            metadata=_lane("codex_lane"),
+        )
+        claude = kb.create_task(
+            conn,
+            title="Claude lane B",
+            assignee="claude-reviewer",
+            parents=[parent_b],
+            metadata=_lane("claude_lane"),
+        )
+        with pytest.raises(kb.SignificantWorkGuardrailError, match="same significant parent"):
+            kb.create_task(
+                conn,
+                title="Bad reconcile",
+                assignee="controller",
+                parents=[codex, claude],
+                metadata=_lane("reconciler"),
+            )
+
+
+def test_reconciler_own_verdict_must_approve(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="nontrivial work", metadata=_significant())
+        codex, claude, recon = _create_gate(conn, parent)
+        kb.complete_task(conn, parent, result="ready for review")
+        kb.complete_task(conn, codex, metadata=_handoff("gpt-5.5", verdict="APPROVE"))
+        kb.complete_task(conn, claude, metadata=_handoff("claude-opus-4-7", verdict="APPROVE"))
+        with pytest.raises(kb.SignificantWorkGuardrailError, match="reconciler verdict"):
+            kb.complete_task(conn, recon, metadata=_reconciler_handoff(verdict="BLOCK"))
+
+
+def test_completed_fake_lane_cannot_be_linked_under_significant_parent(kanban_home):
+    with kb.connect() as conn:
+        significant = kb.create_task(conn, title="nontrivial work", metadata=_significant())
+        unrelated_parent = kb.create_task(conn, title="unrelated source")
+        codex = kb.create_task(
+            conn,
+            title="precompleted fake codex lane",
+            assignee="codex-reviewer",
+            parents=[unrelated_parent],
+            metadata=_lane("codex_lane"),
+        )
+        kb.complete_task(conn, unrelated_parent, result="not the reviewed work")
+        kb.complete_task(conn, codex, metadata=_handoff("gpt-5.5"))
+        with pytest.raises(kb.SignificantWorkGuardrailError, match="completed guardrail lane"):
+            kb.link_tasks(conn, significant, codex)
+
+
+def test_significant_waiver_still_requires_guardrail_group(kanban_home):
+    with kb.connect() as conn:
+        with pytest.raises(kb.SignificantWorkGuardrailError, match="non-empty guardrail_group"):
+            kb.create_task(
+                conn,
+                title="mechanical but significant",
+                metadata={"significant_work": True, "single_controller_acceptable": True},
+            )
+
+
+def test_lane_reassignment_preserves_profile_family(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="nontrivial work", metadata=_significant())
+        codex, claude, _recon = _create_gate(conn, parent)
+        with pytest.raises(kb.SignificantWorkGuardrailError, match="Codex/OpenAI"):
+            kb.assign_task(conn, codex, "claude-reviewer")
+        with pytest.raises(kb.SignificantWorkGuardrailError, match="Claude/Anthropic"):
+            kb.assign_task(conn, claude, "codex-reviewer")
+
+
+def test_edit_completed_review_lane_cannot_fabricate_approval_metadata(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="nontrivial work", metadata=_significant())
+        codex, _claude, _recon = _create_gate(conn, parent)
+        kb.complete_task(conn, parent, result="ready for review")
+        kb.complete_task(conn, codex, metadata=_handoff("gpt-5.5", verdict="BLOCK"))
+        with pytest.raises(kb.SignificantWorkGuardrailError, match="completed guardrail review metadata"):
+            kb.edit_completed_task_result(
+                conn,
+                codex,
+                result="retroactive approval",
+                metadata=_handoff("gpt-5.5", verdict="APPROVE"),
+            )
+
+
+def test_running_downstream_cannot_be_linked_under_unfinished_reconciler(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="nontrivial work", metadata=_significant())
+        _codex, _claude, recon = _create_gate(conn, parent)
+        downstream = kb.create_task(conn, title="already running downstream", assignee="worker")
+        run = kb.claim_task(conn, downstream, claimer="worker")
+        assert run is not None
+        assert kb.get_task(conn, downstream).status == "running"
+        with pytest.raises(kb.SignificantWorkGuardrailError, match="running downstream"):
+            kb.link_tasks(conn, recon, downstream)
+        assert kb.complete_task(conn, downstream, result="finished unrelated work") is True
+
+
+def test_reconciler_requires_current_lanes_still_done(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="nontrivial work", metadata=_significant())
+        codex, claude, recon = _create_gate(conn, parent)
+        kb.complete_task(conn, parent, result="ready for review")
+        kb.complete_task(conn, codex, metadata=_handoff("gpt-5.5"))
+        kb.complete_task(conn, claude, metadata=_handoff("claude-opus-4-7"))
+        conn.execute("UPDATE tasks SET status = 'todo' WHERE id = ?", (codex,))
+        with pytest.raises(kb.SignificantWorkGuardrailError, match="current status"):
+            kb.complete_task(conn, recon, metadata=_reconciler_handoff())
+
+
+def test_blocked_downstream_linked_under_reconciler_is_not_unblocked_ready(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="nontrivial work", metadata=_significant())
+        codex, claude, recon = _create_gate(conn, parent)
+        downstream = kb.create_task(conn, title="ship")
+        kb.block_task(conn, downstream, reason="manual hold")
+        kb.link_tasks(conn, recon, downstream)
+        assert kb.get_task(conn, downstream).status == "blocked"
+        assert kb.unblock_task(conn, downstream) is False
+        kb.complete_task(conn, parent, result="ready for review")
+        kb.complete_task(conn, codex, metadata=_handoff("gpt-5.5"))
+        kb.complete_task(conn, claude, metadata=_handoff("claude-opus-4-7"))
+        kb.complete_task(conn, recon, metadata=_reconciler_handoff())
+        assert kb.get_task(conn, downstream).status == "blocked"
+
+
+def test_done_downstream_cannot_be_retroactively_linked_under_reconciler(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="nontrivial work", metadata=_significant())
+        _codex, _claude, recon = _create_gate(conn, parent)
+        downstream = kb.create_task(conn, title="already completed work", assignee="worker")
+        kb.complete_task(conn, downstream, result="ran before the gate")
+        with pytest.raises(kb.SignificantWorkGuardrailError, match="completed downstream"):
+            kb.link_tasks(conn, recon, downstream)
+
+
+def test_reconciler_rejects_duplicate_review_lane_parents(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="nontrivial work", metadata=_significant())
+        codex_block, claude, recon = _create_gate(conn, parent)
+        kb.complete_task(conn, parent, result="ready for review")
+        kb.complete_task(conn, codex_block, metadata=_handoff("gpt-5.5", verdict="BLOCK"))
+        kb.complete_task(conn, claude, metadata=_handoff("claude-opus-4-7", verdict="APPROVE"))
+        codex_approve = kb.create_task(
+            conn,
+            title="duplicate approving codex lane",
+            assignee="codex-reviewer-2",
+            parents=[parent],
+            metadata=_lane("codex_lane"),
+        )
+        kb.complete_task(conn, codex_approve, metadata=_handoff("gpt-5.5", verdict="APPROVE"))
+        with pytest.raises(kb.SignificantWorkGuardrailError, match="exactly one codex_lane"):
+            kb.link_tasks(conn, codex_approve, recon)
+        with pytest.raises(kb.SignificantWorkGuardrailError, match="verdict disagreement"):
+            kb.complete_task(conn, recon, metadata=_reconciler_handoff())
+
+
+def test_guardrail_gate_cards_cannot_be_archived_after_completion(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="nontrivial work", metadata=_significant())
+        codex, claude, recon = _create_gate(conn, parent)
+        downstream = kb.create_task(conn, title="safe downstream", assignee="worker", parents=[recon])
+        kb.complete_task(conn, parent, result="ready for review")
+        kb.complete_task(conn, codex, metadata=_handoff("gpt-5.5"))
+        kb.complete_task(conn, claude, metadata=_handoff("claude-opus-4-7"))
+        kb.complete_task(conn, recon, metadata=_reconciler_handoff())
+        assert kb.get_task(conn, downstream).status == "ready"
+        with pytest.raises(kb.SignificantWorkGuardrailError, match="cannot archive guardrail"):
+            kb.archive_task(conn, recon)
+        assert kb.get_task(conn, recon).status == "done"
+        assert kb.claim_task(conn, downstream, claimer="worker") is not None
+
+
+def test_downstream_becomes_ready_only_after_valid_reconciler(kanban_home):
+    with kb.connect() as conn:
+        parent = kb.create_task(conn, title="nontrivial work", metadata=_significant())
+        codex, claude, recon = _create_gate(conn, parent)
+        downstream = kb.create_task(conn, title="safe downstream", parents=[recon])
+        kb.complete_task(conn, parent, result="ready for review")
+        kb.complete_task(conn, codex, metadata=_handoff("gpt-5.5"))
+        assert kb.get_task(conn, downstream).status == "todo"
+        kb.complete_task(conn, claude, metadata=_handoff("claude-opus-4-7"))
+        assert kb.get_task(conn, downstream).status == "todo"
+        kb.complete_task(conn, recon, metadata=_reconciler_handoff())
+        assert kb.get_task(conn, downstream).status == "ready"

--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -331,6 +331,197 @@ def test_patch_status_running_rejected(client):
     assert statuses.get(t["id"]) != "running"
 
 
+def test_bulk_running_status_rejected(client):
+    t = client.post("/api/plugins/kanban/tasks", json={"title": "bulk x"}).json()["task"]
+    r = client.post(
+        "/api/plugins/kanban/tasks/bulk",
+        json={"ids": [t["id"]], "status": "running"},
+    )
+    assert r.status_code == 200
+    result = r.json()["results"][0]
+    assert result["ok"] is False
+    assert "running" in result["error"]
+
+
+def test_guardrail_lane_direct_patch_reopen_rejected(client):
+    with kb.connect() as conn:
+        parent = kb.create_task(
+            conn,
+            title="nontrivial work",
+            metadata={"significant_work": True, "guardrail_group": "gate-1"},
+        )
+        codex = kb.create_task(
+            conn,
+            title="Codex lane",
+            assignee="codex-reviewer",
+            parents=[parent],
+            metadata={"guardrail_group": "gate-1", "guardrail_role": "codex_lane"},
+        )
+        kb.complete_task(conn, parent, result="ready")
+        kb.complete_task(
+            conn,
+            codex,
+            metadata={
+                "artifact_commit": "abc123",
+                "findings_artifact": "reviews/codex.md",
+                "model": "gpt-5.5",
+                "verdict": "APPROVE",
+            },
+        )
+    r = client.patch(f"/api/plugins/kanban/tasks/{codex}", json={"status": "todo"})
+    assert r.status_code == 409
+    assert "guardrail" in r.json()["detail"]
+
+
+def test_guardrail_lane_bulk_reopen_rejected(client):
+    with kb.connect() as conn:
+        parent = kb.create_task(
+            conn,
+            title="nontrivial work",
+            metadata={"significant_work": True, "guardrail_group": "gate-1"},
+        )
+        claude = kb.create_task(
+            conn,
+            title="Claude lane",
+            assignee="claude-reviewer",
+            parents=[parent],
+            metadata={"guardrail_group": "gate-1", "guardrail_role": "claude_lane"},
+        )
+        kb.complete_task(conn, parent, result="ready")
+        kb.complete_task(
+            conn,
+            claude,
+            metadata={
+                "artifact_commit": "abc123",
+                "findings_artifact": "reviews/claude.md",
+                "model": "claude-opus-4-7",
+                "verdict": "APPROVE",
+            },
+        )
+    r = client.post(
+        "/api/plugins/kanban/tasks/bulk",
+        json={"ids": [claude], "status": "triage"},
+    )
+    assert r.status_code == 200
+    result = r.json()["results"][0]
+    assert result["ok"] is False
+    assert "guardrail" in result["error"]
+
+
+def test_guardrail_single_endpoints_return_409_not_500(client):
+    with kb.connect() as conn:
+        parent = kb.create_task(
+            conn,
+            title="nontrivial work",
+            metadata={"significant_work": True, "guardrail_group": "gate-1"},
+        )
+        codex = kb.create_task(
+            conn,
+            title="Codex lane",
+            assignee="codex-reviewer",
+            parents=[parent],
+            metadata={"guardrail_group": "gate-1", "guardrail_role": "codex_lane"},
+        )
+        claude = kb.create_task(
+            conn,
+            title="Claude lane",
+            assignee="claude-reviewer",
+            parents=[parent],
+            metadata={"guardrail_group": "gate-1", "guardrail_role": "claude_lane"},
+        )
+        recon = kb.create_task(
+            conn,
+            title="Reconcile",
+            assignee="controller",
+            parents=[codex, claude],
+            metadata={"guardrail_group": "gate-1", "guardrail_role": "reconciler"},
+        )
+        kb.complete_task(conn, parent, result="ready")
+    done = client.patch(f"/api/plugins/kanban/tasks/{codex}", json={"status": "done"})
+    assert done.status_code == 409
+    assert "required metadata" in done.json()["detail"]
+    archive = client.patch(f"/api/plugins/kanban/tasks/{codex}", json={"status": "archived"})
+    assert archive.status_code == 409
+    assert "guardrail" in archive.json()["detail"]
+    assign = client.patch(f"/api/plugins/kanban/tasks/{codex}", json={"assignee": "claude-reviewer"})
+    assert assign.status_code == 409
+    assert "codex_lane" in assign.json()["detail"]
+    unlink = client.delete(
+        "/api/plugins/kanban/links",
+        params={"parent_id": codex, "child_id": recon},
+    )
+    assert unlink.status_code == 409
+    assert "guardrail" in unlink.json()["detail"]
+    reassign = client.post(
+        f"/api/plugins/kanban/tasks/{claude}/reassign",
+        json={"profile": "codex-reviewer"},
+    )
+    assert reassign.status_code == 409
+    assert "claude_lane" in reassign.json()["detail"]
+
+
+def test_dashboard_create_invalid_guardrail_task_returns_409_not_500(client):
+    with kb.connect() as conn:
+        parent = kb.create_task(
+            conn,
+            title="nontrivial work",
+            metadata={"significant_work": True, "guardrail_group": "gate-1"},
+        )
+    r = client.post(
+        "/api/plugins/kanban/tasks",
+        json={
+            "title": "direct downstream bypass",
+            "parents": [parent],
+        },
+    )
+    assert r.status_code == 409
+    assert "significant-work" in r.json()["detail"]
+
+
+def test_significant_root_direct_patch_reopen_rejected(client):
+    with kb.connect() as conn:
+        parent = kb.create_task(
+            conn,
+            title="nontrivial work",
+            metadata={"significant_work": True, "guardrail_group": "gate-1"},
+        )
+        kb.complete_task(conn, parent, result="approved")
+    r = client.patch(f"/api/plugins/kanban/tasks/{parent}", json={"status": "todo"})
+    assert r.status_code == 409
+    assert "guardrail" in r.json()["detail"]
+
+
+def test_significant_root_bulk_reopen_rejected(client):
+    with kb.connect() as conn:
+        parent = kb.create_task(
+            conn,
+            title="nontrivial work",
+            metadata={"significant_work": True, "guardrail_group": "gate-1"},
+        )
+        kb.complete_task(conn, parent, result="approved")
+    r = client.post(
+        "/api/plugins/kanban/tasks/bulk",
+        json={"ids": [parent], "status": "triage"},
+    )
+    assert r.status_code == 200
+    result = r.json()["results"][0]
+    assert result["ok"] is False
+    assert "guardrail" in result["error"]
+
+
+def test_dashboard_create_malformed_standalone_guardrail_returns_409(client):
+    r = client.post(
+        "/api/plugins/kanban/tasks",
+        json={
+            "title": "bad codex lane",
+            "assignee": "codex-reviewer",
+            "metadata": {"guardrail_role": "codex_lane"},
+        },
+    )
+    assert r.status_code == 409
+    assert "guardrail_group" in r.json()["detail"]
+
+
 # ---------------------------------------------------------------------------
 # Comments + Links
 # ---------------------------------------------------------------------------

--- a/tools/kanban_tools.py
+++ b/tools/kanban_tools.py
@@ -258,6 +258,7 @@ def _handle_show(args: dict, **kw) -> str:
                     "completed_at": t.completed_at,
                     "result": t.result,
                     "current_run_id": t.current_run_id,
+                    "metadata": t.metadata or {},
                 }
 
             def _run_dict(r):
@@ -568,6 +569,11 @@ def _handle_create(args: dict, **kw) -> str:
         return tool_error(bool_error)
     idempotency_key = args.get("idempotency_key")
     max_runtime_seconds = args.get("max_runtime_seconds")
+    metadata = args.get("metadata")
+    if metadata is not None and not isinstance(metadata, dict):
+        return tool_error(
+            f"metadata must be a JSON object, got {type(metadata).__name__}"
+        )
     skills = args.get("skills")
     if isinstance(skills, str):
         # Accept a single skill name as a string for convenience.
@@ -602,6 +608,7 @@ def _handle_create(args: dict, **kw) -> str:
                     if max_runtime_seconds is not None else None
                 ),
                 skills=skills,
+                metadata=metadata,
                 created_by=os.environ.get("HERMES_PROFILE") or "worker",
             )
             new_task = kb.get_task(conn, new_tid)
@@ -1000,6 +1007,15 @@ KANBAN_CREATE_SCHEMA = {
                     "task, ['github-code-review'] for a reviewer task. "
                     "The names must match skills installed on the "
                     "assignee's profile."
+                ),
+            },
+            "metadata": {
+                "type": "object",
+                "description": (
+                    "Task-level policy metadata. For significant work use "
+                    "significant_work, guardrail_group, guardrail_role "
+                    "(codex_lane, claude_lane, reconciler), or "
+                    "single_controller_acceptable for mechanical waivers."
                 ),
             },
         },


### PR DESCRIPTION
## Summary

Hard-enforces the C/D/E mixed-agent gate for significant Hermes Kanban work across the DB core, CLI/tool metadata surfaces, and dashboard API.

This turns the significant-work review pattern from convention into mechanically enforced behavior:

- `significant_work` / `guardrail_role` tasks require a non-empty `guardrail_group` at create time.
- C/D/E gate shape requires exactly one Codex/OpenAI lane, exactly one Claude/Anthropic lane, and one reconciler.
- Lane/reconciler completion requires structured custody metadata: `artifact_commit`, `findings_artifact`, `model`, and `verdict`.
- Reconciler completion requires both independent lanes to be currently `done`, both `APPROVE`, both reviewing the same artifact, and the reconciler itself to approve.
- Bypass paths are blocked: relinking running/done work under unfinished gates, direct status flips, metadata fabrication after completion, archive/unlink/reassign bypasses, and dashboard bulk reopen paths.
- Dashboard guardrail policy errors now return HTTP 409 on create/update/link/unlink/reassign/bulk surfaces.

## Files changed

- `hermes_cli/kanban_db.py`
- `hermes_cli/kanban.py`
- `tools/kanban_tools.py`
- `plugins/kanban/dashboard/plugin_api.py`
- `tests/hermes_cli/test_kanban_db.py`
- `tests/hermes_cli/test_kanban_significant_guardrails.py`
- `tests/plugins/test_kanban_dashboard_plugin.py`

## Verification

Local verification was run with `HERMES_KANBAN_BOARD=default` because the controller environment had a non-default active board set (`atlas-training-experiment`), which changes the dashboard auto-init DB path expected by an existing test.

Commands:

```bash
python3 -m py_compile hermes_cli/kanban_db.py hermes_cli/kanban.py tools/kanban_tools.py plugins/kanban/dashboard/plugin_api.py
HERMES_KANBAN_BOARD=default venv/bin/python -m pytest -o 'addopts=' -q tests/hermes_cli/test_kanban_significant_guardrails.py tests/plugins/test_kanban_dashboard_plugin.py
HERMES_KANBAN_BOARD=default venv/bin/python -m pytest -o 'addopts=' -q tests/hermes_cli/test_kanban_significant_guardrails.py tests/hermes_cli/test_kanban_db.py tests/hermes_cli/test_kanban_cli.py tests/tools/test_kanban_tools.py tests/plugins/test_kanban_dashboard_plugin.py -k 'not test_max_runtime_uses_current_run_start_after_retry and not test_run_slash_missing_required_arg_friendly_error'
```

Results:

- `py_compile`: clean
- Focused guardrail/dashboard slice: `121 passed in 2.30s`
- Broader Kanban regression suite excluding two upstream-baseline failures: `290 passed, 2 deselected in 5.44s`
- Static staged-diff scan for secret-like assignments / shell injection / eval / pickle / SQL formatting patterns: no findings

Baseline note: on current `upstream/main`, these two tests fail before this PR's changes and were excluded from the local broad run:

- `tests/hermes_cli/test_kanban_db.py::test_max_runtime_uses_current_run_start_after_retry`
- `tests/hermes_cli/test_kanban_cli.py::test_run_slash_missing_required_arg_friendly_error`

Also note: running with macOS system Python 3.9 fails before tests execute because current code uses Python 3.10+ union type syntax (`Callable | None`) in existing modules. The repo venv Python is 3.14.4 and passes the relevant suite above.

## Mixed-agent review custody

Initial reviewed artifact before clean rebase to current `upstream/main`:

- `/tmp/hard-kanban-guardrails-with-tests.diff`
- SHA256: `b134d07892273f6eee3b076f80cc24d71424fef60ab9b328dd6c3ae0daa80057`

Independent review verdicts on that artifact:

- Codex GPT-5.5: `APPROVE`
- Claude Code/Max: `APPROVE`

Clean PR head was then rebased/cherry-picked onto current `upstream/main` to remove fork-only ancestry from the GitHub PR. During that clean rebase, one upstream test was updated to reflect the intentional broader `unblock_task` behavior change described below.

Current clean PR head:

- commit: `2e416ccc1935a53acd76859bd31fe9346ca970c9`
- diff SHA256: `ee56cb960b1091e78be46a642e16ad92d369ef2d9de05e25a4b9e2e87a03eda7`
- stable patch-id: `5b33a7773c85282cfd06d3b4c00571e3ab7fe6e7`

## Caveat / behavior change

`unblock_task` now refuses to unblock a task while any parent is unfinished. This applies globally, not only to guardrail subgraphs. That broader semantic is intentional for no-bypass behavior, and the existing DB test was updated to assert the new behavior.

## Side effects

No live service side effects were performed during implementation or PR preparation:

- no gateway restart
- no deployment
- no GPU/Foundry calls
- no live Kanban mutation/export/push
- only local tests, local commits, branch push, and PR creation/update
