### PR TITLE
fix(cli): recursively expand nested paste references

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3346,7 +3346,12 @@ class HermesCLI:
         return "\n".join(preview_lines)
 
     def _expand_paste_references(self, text: str | None) -> str:
-        """Expand [Pasted text #N -> file] placeholders into file contents."""
+        """Expand [Pasted text #N -> file] placeholders into file contents.
+
+        Loops until all nested paste references are resolved (e.g. when a paste
+        file contains a reference to another paste file via chained pastes).
+        A recursion guard prevents infinite loops from circular references.
+        """
         if not isinstance(text, str) or "[Pasted text #" not in text:
             return text or ""
         paste_ref_re = re.compile(r'\[Pasted text #\d+: \d+ lines \u2192 (.+?)\]')
@@ -3362,7 +3367,24 @@ class HermesCLI:
                 logger.warning("Paste file gone or unreadable, returning placeholder: %s", path)
                 return match.group(0)
 
-        return paste_ref_re.sub(_expand_ref, text)
+        # Loop until no more paste references remain (handles nested pastes)
+        expanded = text
+        seen = set()  # guard against circular references
+        max_iterations = 10
+        for _ in range(max_iterations):
+            if "[Pasted text #" not in expanded:
+                break
+            new_text = paste_ref_re.sub(_expand_ref, expanded)
+            if new_text == expanded:
+                break  # no more files to expand
+            expanded = new_text
+            # Guard: track file paths to detect circular references
+            refs = set(paste_ref_re.findall(expanded))
+            if refs == seen:
+                break
+            seen = refs
+
+        return expanded
 
     def _print_user_message_preview(self, user_input: str) -> None:
         """Render a user message using the normal chat scrollback style."""

--- a/tests/cli/test_cli_external_editor.py
+++ b/tests/cli/test_cli_external_editor.py
@@ -70,14 +70,75 @@ def test_open_external_editor_uses_explicit_buffer_when_provided():
 
 
 def test_expand_paste_references_replaces_placeholder_with_file_contents(tmp_path):
+    """Single-level paste reference expansion (original behavior)."""
     cli_obj = _make_cli()
     paste_file = tmp_path / "paste.txt"
     paste_file.write_text("line one\nline two", encoding="utf-8")
 
-    text = f"before [Pasted text #1: 2 lines → {paste_file}] after"
+    text = f"before [Pasted text #1: 2 lines \u2192 {paste_file}] after"
     expanded = cli_obj._expand_paste_references(text)
 
     assert expanded == "before line one\nline two after"
+
+
+def test_expand_paste_references_expands_nested_references_recursively(tmp_path):
+    """Nested paste files (chained pastes) should all expand into full content."""
+    cli_obj = _make_cli()
+
+    # Simulate chained pastes: paste_2.txt contains a reference to paste_1.txt
+    paste_1 = tmp_path / "paste_1.txt"
+    paste_1.write_text("Hello from paste_1\nLine 2 of paste_1", encoding="utf-8")
+
+    paste_2 = tmp_path / "paste_2.txt"
+    paste_2.write_text(
+        f"[Pasted text #1: 2 lines \u2192 {paste_1}]\nLine from paste_2",
+        encoding="utf-8",
+    )
+
+    # paste_3 contains a reference to paste_2, which contains a reference to paste_1
+    paste_3 = tmp_path / "paste_3.txt"
+    paste_3.write_text(
+        f"[Pasted text #2: 2 lines \u2192 {paste_2}]\nLine from paste_3",
+        encoding="utf-8",
+    )
+
+    # The top-level input references paste_3
+    text = f"before [Pasted text #3: 2 lines \u2192 {paste_3}] after"
+    expanded = cli_obj._expand_paste_references(text)
+
+    expected = (
+        "before Hello from paste_1\n"
+        "Line 2 of paste_1\n"
+        "Line from paste_2\n"
+        "Line from paste_3 after"
+    )
+    assert expanded == expected, f"Got: {expanded!r}"
+
+
+def test_expand_paste_references_guards_against_circular_references(tmp_path):
+    """Circular references should not cause infinite loops."""
+    cli_obj = _make_cli()
+
+    paste_a = tmp_path / "paste_a.txt"
+    paste_b = tmp_path / "paste_b.txt"
+
+    # A references B, B references A (circular)
+    paste_a.write_text(
+        f"[Pasted text #1: 1 lines \u2192 {paste_b}]\nExtra from A",
+        encoding="utf-8",
+    )
+    paste_b.write_text(
+        f"[Pasted text #2: 1 lines \u2192 {paste_a}]\nExtra from B",
+        encoding="utf-8",
+    )
+
+    text = f"start [Pasted text #1: 2 lines \u2192 {paste_a}] end"
+    expanded = cli_obj._expand_paste_references(text)
+
+    # Should not hang; should return something containing the expanded content
+    assert "Extra from A" in expanded or "Extra from B" in expanded
+    assert "start" in expanded
+    assert "end" in expanded
 
 
 def test_open_external_editor_expands_paste_placeholders_before_open(tmp_path):


### PR DESCRIPTION
## Summary

`_expand_paste_references()` in `cli.py` uses `re.sub()` which only does one pass. When a paste file's content contains a reference to another paste file (chained pastes from multiple sequential pastes), nested references are left as literal `[Pasted text #N]` placeholders — silently dropping content from the agent's input.

**Fix:** Loop expansion until no references remain, with a circular reference guard (max 10 iterations + seen set).

## How to Test

1. Paste 3+ blocks of 5+ lines each in sequence (chain pastes)
2. Submit the message
3. Verify all pasted content appears in the agent's input

Unit tests cover:
- Single-level expansion (existing behavior)
- 3-level nested expansion
- Circular reference guard

## Platform Tested

- Windows 11 with git-bash
- Python 3.11.14
- Hermes main (a28243430)

## Related

Closes #23430