### PR TITLE
fix(tools): resolve BlueBubbles send_message targets by email and phone

### DIFF
--- a/gateway/channel_directory.py
+++ b/gateway/channel_directory.py
@@ -155,6 +155,8 @@ async def build_channel_directory(adapters: Dict[Any, Any]) -> Dict[str, Any]:
                 platforms["discord"] = await asyncio.to_thread(_build_discord, adapter)
             elif platform == Platform.SLACK:
                 platforms["slack"] = await _build_slack(adapter)
+            elif platform == Platform.BLUEBUBBLES:
+                platforms["bluebubbles"] = await _build_bluebubbles(adapter)
         except Exception as e:
             logger.warning("Channel directory: failed to build %s: %s", platform.value, e)
 
@@ -364,6 +366,64 @@ async def _build_slack(adapter) -> List[Dict[str, Any]]:
             except Exception as e:
                 logger.debug("Channel directory: failed to resolve %s: %s", entry["id"], e)
                 continue
+
+    return channels
+
+
+async def _build_bluebubbles(adapter) -> List[Dict[str, Any]]:
+    """Enumerate BlueBubbles chats via ``/api/v1/chat/query``.
+
+    Walks paginated chat results, recording each chat's GUID (used directly as
+    the send target — ``BlueBubblesAdapter._resolve_chat_guid`` returns raw
+    GUIDs as-is) plus a human-readable display name. Falls back to session
+    history when the adapter isn't connected.
+    """
+    if not getattr(adapter, "client", None):
+        return await asyncio.to_thread(_build_from_sessions, "bluebubbles")
+
+    channels: List[Dict[str, Any]] = []
+    seen_ids: set = set()
+
+    limit = 100
+    offset = 0
+    for _page in range(50):  # safety cap on pagination
+        try:
+            payload = await adapter._api_post(
+                "/api/v1/chat/query",
+                {"limit": limit, "offset": offset},
+            )
+        except Exception as e:
+            logger.warning(
+                "Channel directory: failed to query BlueBubbles chats: %s", e
+            )
+            break
+        chats = payload.get("data") or []
+        if not chats:
+            break
+        for chat in chats:
+            guid = chat.get("guid") or chat.get("chatGuid")
+            if not guid or guid in seen_ids:
+                continue
+            seen_ids.add(guid)
+            identifier = chat.get("chatIdentifier") or chat.get("identifier") or ""
+            display = chat.get("displayName") or identifier or guid
+            # ";+;" marks group chats in BlueBubbles GUIDs; ";-;" marks DMs.
+            chat_type = "group" if ";+;" in guid else "dm"
+            channels.append({
+                "id": guid,
+                "name": display,
+                "type": chat_type,
+            })
+        if len(chats) < limit:
+            break
+        offset += limit
+
+    # Merge in entries discovered from session history so DMs we've actually
+    # received messages from remain reachable even if the server query failed.
+    for entry in await asyncio.to_thread(_build_from_sessions, "bluebubbles"):
+        if entry.get("id") not in seen_ids:
+            channels.append(entry)
+            seen_ids.add(entry.get("id"))
 
     return channels
 

--- a/tests/gateway/test_channel_directory.py
+++ b/tests/gateway/test_channel_directory.py
@@ -14,6 +14,7 @@ from gateway.channel_directory import (
     format_directory_for_display,
     load_directory,
     _apply_channel_aliases,
+    _build_bluebubbles,
     _build_from_sessions,
     _build_slack,
     _slack_directory_warning_last,
@@ -444,6 +445,165 @@ class TestLookupChannelType:
         }
         with self._setup(tmp_path, platforms):
             assert lookup_channel_type("discord", "300") is None
+
+
+def _make_bluebubbles_adapter(pages):
+    """Build a stand-in for BlueBubblesAdapter exposing what _build_bluebubbles uses."""
+    adapter = SimpleNamespace(client=object())
+    adapter._api_post = AsyncMock(side_effect=pages)
+    return adapter
+
+
+class TestBuildBlueBubbles:
+    """_build_bluebubbles queries /api/v1/chat/query on the connected adapter."""
+
+    def test_no_client_falls_back_to_sessions(self, tmp_path):
+        sessions_path = tmp_path / "sessions" / "sessions.json"
+        sessions_path.parent.mkdir(parents=True)
+        sessions_path.write_text(json.dumps({
+            "s1": {
+                "origin": {
+                    "platform": "bluebubbles",
+                    "chat_id": "iMessage;-;user@example.com",
+                    "chat_name": "user@example.com",
+                },
+            },
+        }), encoding="utf-8")
+
+        adapter = SimpleNamespace(client=None)
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            entries = asyncio.run(_build_bluebubbles(adapter))
+
+        assert len(entries) == 1
+        assert entries[0]["id"] == "iMessage;-;user@example.com"
+
+    def test_enumerates_chats_from_chat_query(self, tmp_path):
+        adapter = _make_bluebubbles_adapter([
+            {
+                "data": [
+                    {
+                        "guid": "iMessage;-;alice@example.com",
+                        "chatIdentifier": "alice@example.com",
+                        "displayName": "",
+                    },
+                    {
+                        "guid": "iMessage;+;chatABC123",
+                        "chatIdentifier": "chatABC123",
+                        "displayName": "Family",
+                    },
+                ],
+            },
+        ])
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            entries = asyncio.run(_build_bluebubbles(adapter))
+
+        by_id = {e["id"]: e for e in entries}
+        assert "iMessage;-;alice@example.com" in by_id
+        assert by_id["iMessage;-;alice@example.com"]["type"] == "dm"
+        assert by_id["iMessage;-;alice@example.com"]["name"] == "alice@example.com"
+        assert by_id["iMessage;+;chatABC123"]["type"] == "group"
+        assert by_id["iMessage;+;chatABC123"]["name"] == "Family"
+        adapter._api_post.assert_awaited_once_with(
+            "/api/v1/chat/query", {"limit": 100, "offset": 0}
+        )
+
+    def test_no_client_session_scan_runs_off_event_loop_thread(self):
+        loop_thread = threading.get_ident()
+        calls = []
+
+        def fake_build_from_sessions(platform_name):
+            calls.append((platform_name, threading.get_ident()))
+            return [{"id": "iMessage;-;alice@example.com", "name": "Alice", "type": "dm"}]
+
+        adapter = SimpleNamespace(client=None)
+        with patch(
+            "gateway.channel_directory._build_from_sessions",
+            side_effect=fake_build_from_sessions,
+        ):
+            entries = asyncio.run(_build_bluebubbles(adapter))
+
+        assert entries == [{"id": "iMessage;-;alice@example.com", "name": "Alice", "type": "dm"}]
+        assert [platform_name for platform_name, _ in calls] == ["bluebubbles"]
+        assert calls[0][1] != loop_thread
+
+    def test_session_merge_runs_off_event_loop_thread(self):
+        loop_thread = threading.get_ident()
+        calls = []
+
+        def fake_build_from_sessions(platform_name):
+            calls.append((platform_name, threading.get_ident()))
+            return [{"id": "iMessage;-;alice@example.com", "name": "Alice", "type": "dm"}]
+
+        adapter = _make_bluebubbles_adapter([{"data": []}])
+        with patch(
+            "gateway.channel_directory._build_from_sessions",
+            side_effect=fake_build_from_sessions,
+        ):
+            entries = asyncio.run(_build_bluebubbles(adapter))
+
+        assert entries == [{"id": "iMessage;-;alice@example.com", "name": "Alice", "type": "dm"}]
+        assert [platform_name for platform_name, _ in calls] == ["bluebubbles"]
+        assert calls[0][1] != loop_thread
+
+    def test_paginates_until_short_page(self, tmp_path):
+        page1 = {"data": [{"guid": f"iMessage;-;u{i}@e.com"} for i in range(100)]}
+        page2 = {"data": [{"guid": "iMessage;-;last@e.com"}]}
+        adapter = _make_bluebubbles_adapter([page1, page2])
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            entries = asyncio.run(_build_bluebubbles(adapter))
+
+        ids = {e["id"] for e in entries}
+        assert "iMessage;-;u0@e.com" in ids
+        assert "iMessage;-;last@e.com" in ids
+        assert adapter._api_post.await_count == 2
+
+    def test_api_error_returns_empty(self, tmp_path):
+        adapter = SimpleNamespace(client=object())
+        adapter._api_post = AsyncMock(side_effect=RuntimeError("boom"))
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            entries = asyncio.run(_build_bluebubbles(adapter))
+        assert entries == []
+
+    def test_session_dms_merged_when_not_in_api_results(self, tmp_path):
+        sessions_path = tmp_path / "sessions" / "sessions.json"
+        sessions_path.parent.mkdir(parents=True)
+        sessions_path.write_text(json.dumps({
+            "s1": {
+                "origin": {
+                    "platform": "bluebubbles",
+                    "chat_id": "iMessage;-;bob@example.com",
+                    "chat_name": "bob@example.com",
+                },
+            },
+            "dup": {
+                "origin": {
+                    "platform": "bluebubbles",
+                    "chat_id": "iMessage;-;alice@example.com",
+                    "chat_name": "alice@example.com",
+                },
+            },
+        }), encoding="utf-8")
+        adapter = _make_bluebubbles_adapter([
+            {"data": [{"guid": "iMessage;-;alice@example.com", "chatIdentifier": "alice@example.com"}]},
+        ])
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            entries = asyncio.run(_build_bluebubbles(adapter))
+
+        ids = {e["id"] for e in entries}
+        assert "iMessage;-;alice@example.com" in ids
+        assert "iMessage;-;bob@example.com" in ids
+        assert sum(1 for e in entries if e["id"] == "iMessage;-;alice@example.com") == 1
+
+    def test_skips_chats_without_guid(self, tmp_path):
+        adapter = _make_bluebubbles_adapter([
+            {"data": [
+                {"chatIdentifier": "no-guid@example.com"},
+                {"guid": "iMessage;-;ok@example.com"},
+            ]},
+        ])
+        with patch.dict(os.environ, {"HERMES_HOME": str(tmp_path)}):
+            entries = asyncio.run(_build_bluebubbles(adapter))
+        assert {e["id"] for e in entries} == {"iMessage;-;ok@example.com"}
 
 
 def _make_slack_adapter(team_clients):

--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -1948,6 +1948,62 @@ class TestResolveSlackUserTargets:
         assert "im:write" in err["error"]
 
 
+class TestParseTargetRefBlueBubbles:
+    """_parse_target_ref recognizes BlueBubbles raw GUIDs, emails, and phone numbers."""
+
+    def test_raw_dm_guid_is_explicit(self):
+        chat_id, thread_id, is_explicit = _parse_target_ref(
+            "bluebubbles", "iMessage;-;user@example.com"
+        )
+        assert chat_id == "iMessage;-;user@example.com"
+        assert thread_id is None
+        assert is_explicit is True
+
+    def test_any_service_phone_guid_is_explicit(self):
+        chat_id, thread_id, is_explicit = _parse_target_ref(
+            "bluebubbles", "any;-;+15551234567"
+        )
+        assert chat_id == "any;-;+15551234567"
+        assert thread_id is None
+        assert is_explicit is True
+
+    def test_raw_group_guid_is_explicit(self):
+        chat_id, _, is_explicit = _parse_target_ref(
+            "bluebubbles", "iMessage;+;chat1234567890abcdef"
+        )
+        assert chat_id == "iMessage;+;chat1234567890abcdef"
+        assert is_explicit is True
+
+    def test_email_handle_is_explicit(self):
+        chat_id, thread_id, is_explicit = _parse_target_ref(
+            "bluebubbles", "user@example.com"
+        )
+        assert chat_id == "user@example.com"
+        assert thread_id is None
+        assert is_explicit is True
+
+    def test_phone_handle_is_explicit(self):
+        chat_id, _, is_explicit = _parse_target_ref("bluebubbles", "+15551234567")
+        assert chat_id == "+15551234567"
+        assert is_explicit is True
+
+    def test_whitespace_is_stripped(self):
+        chat_id, _, is_explicit = _parse_target_ref(
+            "bluebubbles", "  user@example.com  "
+        )
+        assert chat_id == "user@example.com"
+        assert is_explicit is True
+
+    def test_non_address_is_not_explicit(self):
+        assert _parse_target_ref("bluebubbles", "not-an-address")[2] is False
+        assert _parse_target_ref("bluebubbles", "incomplete@")[2] is False
+        assert _parse_target_ref("bluebubbles", "+")[2] is False
+
+    def test_bluebubbles_pattern_not_explicit_for_other_platforms(self):
+        """Email/phone handles must not flip is_explicit on unrelated platforms."""
+        assert _parse_target_ref("telegram", "user@example.com")[2] is False
+        assert _parse_target_ref("discord", "user@example.com")[2] is False
+
 class TestSendDiscordThreadId:
     """_send_discord uses thread_id when provided."""
 

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -54,6 +54,9 @@ _WHATSAPP_JID_RE = re.compile(
     r"^\s*[\w-]+@(?:g\.us|s\.whatsapp\.net|lid|broadcast|newsletter)\s*$",
     re.IGNORECASE,
 )
+# BlueBubbles addresses chats by raw chat GUID (for example,
+# "iMessage;-;handle" or "iMessage;+;groupId").
+_BLUEBUBBLES_GUID_RE = re.compile(r"^\s*[A-Za-z0-9_+-]+;[+-];[^\s;]+\s*$")
 # Email addresses — a valid email like "user@domain.com" should be treated as
 # an explicit target for the email platform, not fall through to channel-name
 # resolution which has no way to resolve a raw address.
@@ -611,6 +614,16 @@ def _parse_target_ref(platform_name: str, target_ref: str):
         # them off the channel directory (mirrors the react handler).
         if _PHOTON_DM_GUID_RE.fullmatch(target_ref.strip()):
             return target_ref.strip(), None, True
+    if platform_name == "bluebubbles":
+        target = target_ref.strip()
+        # Raw chat GUID — adapter._resolve_chat_guid returns it as-is.
+        if _BLUEBUBBLES_GUID_RE.fullmatch(target_ref):
+            return target, None, True
+        # Email handle or E.164 phone — the adapter resolves to a GUID
+        # via /api/v1/chat/query, with a private-API fallback that creates
+        # a fresh chat for the address.
+        if _EMAIL_TARGET_RE.fullmatch(target_ref) or _E164_TARGET_RE.fullmatch(target_ref):
+            return target, None, True
     if target_ref.lstrip("-").isdigit():
         return target_ref, None, True
     # Matrix room IDs (start with !) and user IDs (start with @) are explicit


### PR DESCRIPTION
Resolves BlueBubbles email and phone-number targets in `send_message`, mirroring the Slack fix from #15947.

## What changed and why
- `tools/send_message_tool.py:_parse_target_ref` now has a `bluebubbles` branch that recognizes raw chat GUIDs (`iMessage;-;handle` / `iMessage;+;groupId`), email handles, and E.164 phone numbers as explicit targets. Before, none of these patterns matched, so calls like `send_message(target="bluebubbles:user@example.com", ...)` fell through to channel-name resolution against an empty directory and returned `"Could not resolve"`.
- `gateway/channel_directory.py` now has a `_build_bluebubbles(adapter)` enumerator that paginates the BlueBubbles server's `/api/v1/chat/query` endpoint, records each chat's GUID and display name (typing it as `group` or `dm` based on the `;+;`/`;-;` GUID marker), and merges in session-discovered DMs as a backstop. `build_channel_directory` now calls it when a BlueBubbles adapter is connected, so `send_message(action='list')` reflects the server's real chat list.
- The `BlueBubblesAdapter.send()` path already handled raw handles (`_resolve_chat_guid` → `_create_chat_for_handle`); only the tool layer needed wiring.

## How to test
- `pytest tests/tools/test_send_message_tool.py::TestParseTargetRefBlueBubbles tests/gateway/test_channel_directory.py::TestBuildBlueBubbles -v`
- Manual: with BlueBubbles configured and the gateway running, call `send_message(target="bluebubbles:user@example.com", message="hi")` and verify it resolves and sends; also `send_message(action='list')` should now show BlueBubbles chats.

## What platforms tested on
- macOS on darwin-arm64 (local pytest, 13 new tests + 150 in touched files passing)

Fixes #23409

<!-- autocontrib:worker-id=issue-new-a1faf18c kind=pr-open -->