### PR TITLE
fix: keep runtime metadata out of cached system prompt

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -5759,16 +5759,11 @@ class AIAgent:
             if context_files_prompt:
                 prompt_parts.append(context_files_prompt)
 
-        from hermes_time import now as _hermes_now
-        now = _hermes_now()
-        timestamp_line = f"Conversation started: {now.strftime('%A, %B %d, %Y %I:%M %p')}"
-        if self.pass_session_id and self.session_id:
-            timestamp_line += f"\nSession ID: {self.session_id}"
-        if self.model:
-            timestamp_line += f"\nModel: {self.model}"
-        if self.provider:
-            timestamp_line += f"\nProvider: {self.provider}"
-        prompt_parts.append(timestamp_line)
+        # Dynamic per-call metadata (timestamp/session/model/provider) is
+        # intentionally NOT included in the cached/stored system prompt.
+        # It is injected into the API copy of the current user message by
+        # _build_runtime_metadata_prompt(). Keeping it out of this prompt
+        # preserves Anthropic prompt-cache prefixes across recurring cron runs.
 
         # Alibaba Coding Plan API always returns "glm-4.7" as model name regardless
         # of the requested model. Inject explicit model identity into the system prompt
@@ -5802,6 +5797,27 @@ class AIAgent:
                 pass
 
         return "\n\n".join(p.strip() for p in prompt_parts if p.strip())
+
+    def _build_runtime_metadata_prompt(self) -> str:
+        """Return per-call runtime metadata kept out of the cached system prompt.
+
+        This metadata includes values that legitimately change between Hermes
+        spawns (notably the wall-clock timestamp and optional session id).
+        It is injected into the API-only copy of the current user message so
+        Anthropic prompt caching can reuse the stable system+tools prefix
+        across recurring cron cycles.
+        """
+        from hermes_time import now as _hermes_now
+
+        now = _hermes_now()
+        lines = [f"Conversation started: {now.strftime('%A, %B %d, %Y %I:%M %p')}"]
+        if self.pass_session_id and self.session_id:
+            lines.append(f"Session ID: {self.session_id}")
+        if self.model:
+            lines.append(f"Model: {self.model}")
+        if self.provider:
+            lines.append(f"Provider: {self.provider}")
+        return "\n".join(lines)
 
     # =========================================================================
     # Pre/post-call guardrails (inspired by PR #1321 — @alireza78a)
@@ -11976,6 +11992,8 @@ class AIAgent:
                     self.session_id or "-",
                 )
 
+            runtime_metadata_prompt = self._build_runtime_metadata_prompt()
+
             api_messages = []
             for idx, msg in enumerate(messages):
                 api_msg = msg.copy()
@@ -11987,6 +12005,8 @@ class AIAgent:
                 # never mutated, so nothing leaks into session persistence.
                 if idx == current_turn_user_idx and msg.get("role") == "user":
                     _injections = []
+                    if runtime_metadata_prompt:
+                        _injections.append(runtime_metadata_prompt)
                     if _ext_prefetch_cache:
                         _fenced = build_memory_context_block(_ext_prefetch_cache)
                         if _fenced:

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -984,10 +984,16 @@ class TestBuildSystemPrompt:
         prompt = agent._build_system_prompt()
         assert MEMORY_GUIDANCE not in prompt
 
-    def test_includes_datetime(self, agent):
+    def test_runtime_metadata_kept_out_of_cached_system_prompt(self, agent):
         prompt = agent._build_system_prompt()
-        # Should contain current date info like "Conversation started:"
-        assert "Conversation started:" in prompt
+        assert "Conversation started:" not in prompt
+
+        agent.model = "claude-test"
+        agent.provider = "anthropic"
+        metadata = agent._build_runtime_metadata_prompt()
+        assert "Conversation started:" in metadata
+        assert "Model:" in metadata
+        assert "Provider:" in metadata
 
     def test_includes_nous_subscription_prompt(self, agent, monkeypatch):
         monkeypatch.setattr(run_agent, "build_nous_subscription_prompt", lambda tool_names: "NOUS SUBSCRIPTION BLOCK")
@@ -2475,6 +2481,29 @@ class TestRunConversation:
             result = agent.run_conversation("hello")
         assert result["final_response"] == "Final answer"
         assert result["completed"] is True
+
+    def test_runtime_metadata_injected_into_api_user_message_only(self, agent):
+        self._setup_agent(agent)
+        agent.model = "claude-test"
+        agent.provider = "anthropic"
+        resp = _mock_response(content="Final answer", finish_reason="stop")
+        agent.client.chat.completions.create.return_value = resp
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        sent = agent.client.chat.completions.create.call_args.kwargs["messages"]
+        assert sent[0] == {"role": "system", "content": "You are helpful."}
+        assert sent[1]["role"] == "user"
+        assert sent[1]["content"].startswith("hello\n\nConversation started:")
+        assert "Model:" in sent[1]["content"]
+        assert "Provider:" in sent[1]["content"]
+        assert agent._cached_system_prompt == "You are helpful."
+        assert result["messages"][0] == {"role": "user", "content": "hello"}
 
     def test_tool_calls_then_stop(self, agent):
         self._setup_agent(agent)


### PR DESCRIPTION
## Summary
- removes per-spawn runtime metadata from the cached/stored system prompt
- injects `Conversation started`, optional session id, model, and provider into the API-only copy of the current user message
- preserves the stable system prompt prefix for prompt caching across recurring cron runs

## Test Plan
- `python -m py_compile run_agent.py agent/prompt_caching.py`
- `python -m pytest tests/run_agent/test_run_agent.py -q`
- `python -m pytest tests/agent/test_prompt_caching.py tests/run_agent/test_anthropic_prompt_cache_policy.py -q`

Context: https://varsity.atlassian.net/browse/TEGI-1848