### PR TITLE
fix(telegram): pass source.thread_id explicitly on auto-reset notice (carve-out of #7404)

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7025,7 +7025,7 @@ class GatewayRunner:
                             pass
                         await adapter.send(
                             source.chat_id, notice,
-                            metadata=getattr(event, 'metadata', None),
+                            metadata=self._thread_metadata_for_source(source),
                         )
             except Exception as e:
                 logger.debug("Auto-reset notification failed (non-fatal): %s", e)


### PR DESCRIPTION
## Summary

Telegram auto-reset notices ("◐ Session automatically reset…") could land in the wrong forum topic — General or a sibling topic — instead of the topic the user was last active in. Now the notice carries `source.thread_id` explicitly via the existing `_thread_metadata_for_source` helper.

## What was wrong

`gateway/run.py:7026-7028` sent the notice with `metadata=getattr(event, 'metadata', None)`. The `event.metadata` isn't guaranteed to carry the originating `thread_id` (varies by adapter and by which code path constructed the event), so the notice could route to a different topic.

## Fix

```python
await adapter.send(
    source.chat_id, notice,
    metadata=self._thread_metadata_for_source(source),
)
```

The helper builds `{thread_id, ...}` and also handles Telegram DM topic reply-fallback metadata (`telegram_dm_topic_reply_fallback`, `telegram_reply_to_message_id`) — used everywhere else in the gateway for thread-aware sends.

## Carve-out from PR #7404

PR #7404 by @keyuyuan had two hunks:
- **Auto-reset notice (line 2464 of #7404)** → kept as this carve-out, with the contributor's intent preserved but routed through `_thread_metadata_for_source` instead of inlining the `{"thread_id": ...}` dict (matches the existing pattern at `_status_thread_metadata`).
- **Queued first-response (line 7578 of #7404)** → dropped. Already redundant on current main: `gateway/run.py:15782` has used `_status_thread_metadata` since the `_thread_metadata_for_source` plumbing landed.

## Validation

`tests/gateway/test_telegram_thread_fallback.py`, `test_session_reset_notify.py`, `test_fresh_reset_skill_injection.py`: 56/56 pass.

The existing helper is covered by `test_base_gateway_metadata_marks_telegram_dm_topics_as_reply_fallback` and adjacent fallback tests; this one-line change opts the auto-reset path into that contract.

## Note on issue #7355

This is path B (auto-reset notice). Path A (final response chunk) was already on main via `_status_thread_metadata`. Path C (stream consumer first message) was closed in PR #23437 (salvage of #13077). With this carve-out, all three paths in #7355 are addressed.

Closes #7355 (final).
Carve-out of #7404; @keyuyuan's authorship preserved.
