### PR TITLE
fix(email): fall back on malformed numeric env settings

### DIFF
--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -65,6 +65,24 @@ MAX_MESSAGE_LENGTH = 50_000
 # Supported image extensions for inline detection
 _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".webp"}
 
+
+def _safe_int_env(name: str, default: int) -> int:
+    """Parse an integer env var, falling back to the documented default."""
+    raw = os.getenv(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "[Email] Invalid %s=%r; falling back to %d",
+            name,
+            raw,
+            default,
+        )
+        return default
+
+
 def _send_imap_id(imap: "imaplib.IMAP4") -> None:
     """Send RFC 2971 IMAP ID command identifying this client.
 
@@ -251,10 +269,10 @@ class EmailAdapter(BasePlatformAdapter):
         self._address = os.getenv("EMAIL_ADDRESS", "")
         self._password = os.getenv("EMAIL_PASSWORD", "")
         self._imap_host = os.getenv("EMAIL_IMAP_HOST", "")
-        self._imap_port = int(os.getenv("EMAIL_IMAP_PORT", "993"))
+        self._imap_port = _safe_int_env("EMAIL_IMAP_PORT", 993)
         self._smtp_host = os.getenv("EMAIL_SMTP_HOST", "")
-        self._smtp_port = int(os.getenv("EMAIL_SMTP_PORT", "587"))
-        self._poll_interval = int(os.getenv("EMAIL_POLL_INTERVAL", "15"))
+        self._smtp_port = _safe_int_env("EMAIL_SMTP_PORT", 587)
+        self._poll_interval = _safe_int_env("EMAIL_POLL_INTERVAL", 15)
 
         # Skip attachments — configured via config.yaml:
         #   platforms:

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -254,6 +254,26 @@ class TestDispatchMessage(unittest.TestCase):
             adapter = EmailAdapter(PlatformConfig(enabled=True))
         return adapter
 
+    def test_malformed_numeric_env_values_fall_back_to_defaults(self):
+        """Malformed numeric env vars should not crash adapter init."""
+        from gateway.config import PlatformConfig
+
+        with patch.dict(os.environ, {
+            "EMAIL_ADDRESS": "hermes@test.com",
+            "EMAIL_PASSWORD": "secret",
+            "EMAIL_IMAP_HOST": "imap.test.com",
+            "EMAIL_IMAP_PORT": "oops",
+            "EMAIL_SMTP_HOST": "smtp.test.com",
+            "EMAIL_SMTP_PORT": "broken",
+            "EMAIL_POLL_INTERVAL": "later",
+        }):
+            from gateway.platforms.email import EmailAdapter
+            adapter = EmailAdapter(PlatformConfig(enabled=True))
+
+        self.assertEqual(adapter._imap_port, 993)
+        self.assertEqual(adapter._smtp_port, 587)
+        self.assertEqual(adapter._poll_interval, 15)
+
     def test_self_message_filtered(self):
         """Messages from the agent's own address should be skipped."""
         import asyncio


### PR DESCRIPTION
This is a small robustness fix for the email gateway adapter.

Right now, `EmailAdapter` reads `EMAIL_IMAP_PORT`, `EMAIL_SMTP_PORT`, and `EMAIL_POLL_INTERVAL` with direct `int(...)` casts during initialization. That means a simple typo in env config can take the adapter down before it even tries to connect.

Example bad values like these were enough to crash init:

- `EMAIL_IMAP_PORT=oops`
- `EMAIL_SMTP_PORT=broken`
- `EMAIL_POLL_INTERVAL=later`

With this change, those values no longer raise `ValueError` during adapter construction. Instead, Hermes logs a warning and falls back to the existing documented defaults:

- IMAP: `993`
- SMTP: `587`
- poll interval: `15`

I kept the scope intentionally narrow:
- one small helper in `gateway/platforms/email.py`
- no behavior change for valid configs
- one regression test covering the malformed-env path

### Why this is worth fixing

This is the kind of failure that is easy for users to create and annoying to debug: the config is "almost right", but the platform dies at startup because one env var is malformed. Falling back cleanly is a better outcome here and matches the recent config/env hardening work elsewhere in the repo.

### Test coverage

Added a test that builds `EmailAdapter` with invalid numeric env values and checks that it still initializes with the expected defaults.

### What I ran locally

I ran the new regression test directly, and then the rest of `tests/gateway/test_email.py` excluding one unrelated existing environment-specific failure.

Passing runs:
- `pytest tests/gateway/test_email.py -n 0 -k malformed_numeric_env_values_fall_back_to_defaults -q`
- `pytest tests/gateway/test_email.py -n 0 -k "not test_email_not_loaded_without_env" -q`

