### PR TITLE
feat(spotify): add save_to_spotify core upload toolset

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -76,6 +76,7 @@ CONFIGURABLE_TOOLSETS = [
     ("messaging",       "📨 Cross-Platform Messaging",  "send_message"),
     ("homeassistant",    "🏠 Home Assistant",           "smart home device control"),
     ("spotify",          "🎵 Spotify",                  "playback, search, playlists, library"),
+    ("save_to_spotify",  "🎙️ Save to Spotify",          "upload personal audio, manage shows/episodes/timelines"),
     ("discord",         "💬 Discord (read/participate)", "fetch messages, search members, create thread"),
     ("discord_admin",   "🛡️  Discord Server Admin",    "list channels/roles, pin, assign roles"),
     ("yuanbao",          "🤖 Yuanbao",                  "group info, member queries, DM"),
@@ -96,7 +97,10 @@ CONFIGURABLE_TOOLSETS = [
 # `hermes tools` → X (Twitter) Search setup walks users through credential
 # setup. The tool's check_fn means the schema still won't appear to the
 # model if the credential later goes missing or expires.
-_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "spotify", "discord", "discord_admin", "video", "video_gen", "x_search"}
+_DEFAULT_OFF_TOOLSETS = {
+    "moa", "homeassistant", "spotify", "save_to_spotify",
+    "discord", "discord_admin", "video", "video_gen", "x_search",
+}
 
 
 def _xai_credentials_present() -> bool:

--- a/plugins/save_to_spotify/__init__.py
+++ b/plugins/save_to_spotify/__init__.py
@@ -1,0 +1,38 @@
+"""Bundled Save to Spotify integration.
+
+Registers CLI-backed tools that save personal audio content to Spotify via the
+official ``save-to-spotify`` binary. This is intentionally separate from the
+existing Spotify playback/search plugin.
+"""
+
+from __future__ import annotations
+
+from plugins.save_to_spotify.tools import (
+    SAVE_TO_SPOTIFY_EPISODES_SCHEMA,
+    SAVE_TO_SPOTIFY_SHOWS_SCHEMA,
+    SAVE_TO_SPOTIFY_TIMELINE_SCHEMA,
+    SAVE_TO_SPOTIFY_UPLOAD_SCHEMA,
+    handle_save_to_spotify_episodes,
+    handle_save_to_spotify_shows,
+    handle_save_to_spotify_timeline,
+    handle_save_to_spotify_upload,
+)
+
+_TOOLS = (
+    ("save_to_spotify_upload", SAVE_TO_SPOTIFY_UPLOAD_SCHEMA, handle_save_to_spotify_upload, "📤"),
+    ("save_to_spotify_shows", SAVE_TO_SPOTIFY_SHOWS_SCHEMA, handle_save_to_spotify_shows, "🎙️"),
+    ("save_to_spotify_episodes", SAVE_TO_SPOTIFY_EPISODES_SCHEMA, handle_save_to_spotify_episodes, "🎧"),
+    ("save_to_spotify_timeline", SAVE_TO_SPOTIFY_TIMELINE_SCHEMA, handle_save_to_spotify_timeline, "⏱️"),
+)
+
+
+def register(ctx) -> None:
+    """Register Save to Spotify tools."""
+    for name, schema, handler, emoji in _TOOLS:
+        ctx.register_tool(
+            name=name,
+            toolset="save_to_spotify",
+            schema=schema,
+            handler=handler,
+            emoji=emoji,
+        )

--- a/plugins/save_to_spotify/plugin.yaml
+++ b/plugins/save_to_spotify/plugin.yaml
@@ -1,0 +1,10 @@
+name: save_to_spotify
+version: 1.0.0
+description: "CLI-backed Save to Spotify integration for uploading personal audio, managing shows/episodes, and setting companion timelines."
+author: NousResearch
+kind: backend
+provides_tools:
+  - save_to_spotify_upload
+  - save_to_spotify_shows
+  - save_to_spotify_episodes
+  - save_to_spotify_timeline

--- a/plugins/save_to_spotify/tools.py
+++ b/plugins/save_to_spotify/tools.py
@@ -1,0 +1,435 @@
+"""CLI-backed Save to Spotify tools."""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any
+
+from tools.registry import tool_error, tool_result
+
+COMMON_STRING = {"type": "string"}
+COMMON_BOOL = {"type": "boolean"}
+
+_CLI_NAME = "save-to-spotify"
+_DEFAULT_TIMEOUT_SECONDS = 45
+_DEFAULT_WAIT_SECONDS = 300
+_WAIT_TIMEOUT_BUFFER_SECONDS = 30
+_AUTH_REQUIRED_MESSAGE = (
+    "Save to Spotify is not authenticated. Run `save-to-spotify auth login` first."
+)
+_INSTALL_MESSAGE = (
+    "Save to Spotify CLI is not installed. Install the `save-to-spotify` binary first."
+)
+_HANG_TIMEOUT_MESSAGE = (
+    "Save to Spotify CLI timed out unexpectedly before finishing. This is a system timeout, "
+    "not the normal episode readiness timeout."
+)
+
+
+class SaveToSpotifyError(RuntimeError):
+    """Raised when the CLI returns a structured or execution error."""
+
+
+def _check_binary() -> str:
+    binary = shutil.which(_CLI_NAME)
+    if not binary:
+        raise SaveToSpotifyError(_INSTALL_MESSAGE)
+    return binary
+
+
+def _validate_existing_file(path_value: Any, field_name: str) -> str:
+    value = str(path_value or "").strip()
+    if not value:
+        raise SaveToSpotifyError(f"{field_name} is required")
+    path = Path(value).expanduser()
+    if not path.exists():
+        raise SaveToSpotifyError(f"{field_name} does not exist: {path}")
+    if not path.is_file():
+        raise SaveToSpotifyError(f"{field_name} is not a file: {path}")
+    return str(path)
+
+
+def _validate_optional_file(path_value: Any, field_name: str) -> str | None:
+    if path_value in (None, ""):
+        return None
+    return _validate_existing_file(path_value, field_name)
+
+
+def _coerce_bool(raw: Any, default: bool = False) -> bool:
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, str):
+        cleaned = raw.strip().lower()
+        if cleaned in {"1", "true", "yes", "on"}:
+            return True
+        if cleaned in {"0", "false", "no", "off"}:
+            return False
+    return default
+
+
+def _parse_duration_to_seconds(value: str) -> float:
+    text = str(value or "").strip()
+    if not text:
+        raise SaveToSpotifyError("wait_timeout must be a non-empty duration string")
+    total = 0.0
+    idx = 0
+    pattern = re.compile(r"(\d+(?:\.\d+)?)(ms|s|m|h)")
+    for match in pattern.finditer(text):
+        if match.start() != idx:
+            raise SaveToSpotifyError(
+                "wait_timeout must use Go-style duration units like `90s` or `2m`"
+            )
+        amount = float(match.group(1))
+        unit = match.group(2)
+        if unit == "ms":
+            total += amount / 1000.0
+        elif unit == "s":
+            total += amount
+        elif unit == "m":
+            total += amount * 60.0
+        elif unit == "h":
+            total += amount * 3600.0
+        idx = match.end()
+    if idx != len(text):
+        raise SaveToSpotifyError(
+            "wait_timeout must use Go-style duration units like `90s` or `2m`"
+        )
+    return total
+
+
+def _hard_timeout_seconds(*, wait: bool = False, wait_timeout: str | None = None) -> float:
+    if not wait:
+        return _DEFAULT_TIMEOUT_SECONDS
+    if wait_timeout:
+        return _parse_duration_to_seconds(wait_timeout) + _WAIT_TIMEOUT_BUFFER_SECONDS
+    return _DEFAULT_WAIT_SECONDS + _WAIT_TIMEOUT_BUFFER_SECONDS
+
+
+def _auth_error_from_message(message: str) -> str | None:
+    lowered = message.lower()
+    if "auth login" in lowered:
+        return _AUTH_REQUIRED_MESSAGE
+    if "not authenticated" in lowered or "not logged in" in lowered:
+        return _AUTH_REQUIRED_MESSAGE
+    if "login required" in lowered or "unauthorized" in lowered:
+        return _AUTH_REQUIRED_MESSAGE
+    return None
+
+
+def _extract_cli_message(payload: Any) -> str:
+    if isinstance(payload, dict):
+        for key in ("error", "message", "detail"):
+            value = payload.get(key)
+            if isinstance(value, str) and value.strip():
+                return value.strip()
+    if isinstance(payload, str):
+        return payload.strip()
+    return ""
+
+
+def _normalize_json_payload(stdout: str) -> dict[str, Any] | list[Any]:
+    try:
+        payload = json.loads(stdout)
+    except json.JSONDecodeError as exc:
+        raise SaveToSpotifyError(
+            f"Save to Spotify returned invalid JSON: {exc.msg}"
+        ) from exc
+    if isinstance(payload, dict) and payload.get("error"):
+        message = _extract_cli_message(payload)
+        raise SaveToSpotifyError(_auth_error_from_message(message) or message)
+    return payload
+
+
+def _run_cli(
+    command: list[str],
+    *,
+    wait: bool = False,
+    wait_timeout: str | None = None,
+) -> dict[str, Any] | list[Any]:
+    binary = _check_binary()
+    full_cmd = [binary, "--json", *command]
+    try:
+        completed = subprocess.run(
+            full_cmd,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=_hard_timeout_seconds(wait=wait, wait_timeout=wait_timeout),
+        )
+    except subprocess.TimeoutExpired as exc:
+        raise SaveToSpotifyError(_HANG_TIMEOUT_MESSAGE) from exc
+
+    stdout = (completed.stdout or "").strip()
+    stderr = (completed.stderr or "").strip()
+
+    if stdout:
+        payload = _normalize_json_payload(stdout)
+        if completed.returncode != 0:
+            message = _extract_cli_message(payload) or stderr or "Save to Spotify command failed"
+            raise SaveToSpotifyError(_auth_error_from_message(message) or message)
+        return payload
+
+    message = stderr or f"Save to Spotify command failed with exit code {completed.returncode}"
+    raise SaveToSpotifyError(_auth_error_from_message(message) or message)
+
+
+def _ensure_timeline_payload(payload: Any) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise SaveToSpotifyError("timeline must be an object with an `items` array")
+    items = payload.get("items")
+    if not isinstance(items, list):
+        raise SaveToSpotifyError("timeline.items must be a list")
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        spotify_entity = item.get("spotify_entity")
+        if spotify_entity is None:
+            continue
+        if not isinstance(spotify_entity, dict):
+            raise SaveToSpotifyError("timeline spotify_entity entries must be objects")
+        uri = str(spotify_entity.get("uri") or "").strip()
+        if not uri.startswith("spotify:"):
+            raise SaveToSpotifyError(
+                "timeline spotify_entity.uri must use a full `spotify:...` URI"
+            )
+    return payload
+
+
+def _append_flag(cmd: list[str], flag: str, value: Any) -> None:
+    if value in (None, ""):
+        return
+    cmd.extend([flag, str(value)])
+
+
+def handle_save_to_spotify_upload(args: dict, **_: Any) -> str:
+    try:
+        file_path = _validate_existing_file(args.get("file_path"), "file_path")
+        title = str(args.get("title") or "").strip()
+        if not title:
+            raise SaveToSpotifyError("title is required")
+        wait = _coerce_bool(args.get("wait"))
+        wait_timeout = str(args.get("wait_timeout") or "").strip() or None
+
+        cmd = ["upload", file_path, "--title", title]
+        _append_flag(cmd, "--show-id", args.get("show_id"))
+        _append_flag(cmd, "--new-show", args.get("new_show_title"))
+        _append_flag(cmd, "--summary", args.get("summary"))
+        _append_flag(cmd, "--image", _validate_optional_file(args.get("image_path"), "image_path"))
+        _append_flag(cmd, "--language", args.get("language"))
+        if wait:
+            cmd.append("--wait")
+            if wait_timeout:
+                cmd.append(wait_timeout)
+
+        return tool_result(_run_cli(cmd, wait=wait, wait_timeout=wait_timeout))
+    except SaveToSpotifyError as exc:
+        return tool_error(str(exc))
+
+
+def handle_save_to_spotify_shows(args: dict, **_: Any) -> str:
+    action = str(args.get("action") or "list").strip().lower()
+    try:
+        cmd = ["shows"]
+        if action == "list":
+            pass
+        elif action == "get":
+            show_id = str(args.get("show_id") or args.get("id") or "").strip()
+            if not show_id:
+                raise SaveToSpotifyError("show_id is required for action='get'")
+            cmd.extend(["get", show_id])
+        elif action == "create":
+            title = str(args.get("title") or "").strip()
+            if not title:
+                raise SaveToSpotifyError("title is required for action='create'")
+            cmd.extend(["create", "--title", title])
+            _append_flag(cmd, "--summary", args.get("summary"))
+            _append_flag(cmd, "--image", _validate_optional_file(args.get("image_path"), "image_path"))
+            _append_flag(cmd, "--language", args.get("language"))
+        elif action == "delete":
+            show_id = str(args.get("show_id") or args.get("id") or "").strip()
+            if not show_id:
+                raise SaveToSpotifyError("show_id is required for action='delete'")
+            cmd.extend(["delete", show_id])
+        else:
+            raise SaveToSpotifyError(f"Unknown save_to_spotify_shows action: {action}")
+
+        return tool_result(_run_cli(cmd))
+    except SaveToSpotifyError as exc:
+        return tool_error(str(exc))
+
+
+def handle_save_to_spotify_episodes(args: dict, **_: Any) -> str:
+    action = str(args.get("action") or "list").strip().lower()
+    try:
+        cmd = ["episodes"]
+        wait = False
+        wait_timeout = None
+
+        if action == "list":
+            _append_flag(cmd, "--show-id", args.get("show_id"))
+        elif action == "create":
+            title = str(args.get("title") or "").strip()
+            if not title:
+                raise SaveToSpotifyError("title is required for action='create'")
+            file_path = _validate_existing_file(args.get("file_path") or args.get("file"), "file_path")
+            cmd.extend(["create", "--title", title, "--file", file_path])
+            _append_flag(cmd, "--show-id", args.get("show_id"))
+            _append_flag(cmd, "--summary", args.get("summary"))
+            _append_flag(cmd, "--image", _validate_optional_file(args.get("image_path"), "image_path"))
+            _append_flag(cmd, "--language", args.get("language"))
+        elif action == "status":
+            episode_id = str(args.get("episode_id") or args.get("id") or "").strip()
+            if not episode_id:
+                raise SaveToSpotifyError("episode_id is required for action='status'")
+            cmd.extend(["status", episode_id])
+            wait = _coerce_bool(args.get("wait"))
+            wait_timeout = str(args.get("wait_timeout") or "").strip() or None
+            if wait:
+                cmd.append("--wait")
+                if wait_timeout:
+                    cmd.append(wait_timeout)
+        elif action == "delete":
+            episode_id = str(args.get("episode_id") or args.get("id") or "").strip()
+            if not episode_id:
+                raise SaveToSpotifyError("episode_id is required for action='delete'")
+            cmd.extend(["delete", episode_id])
+        else:
+            raise SaveToSpotifyError(f"Unknown save_to_spotify_episodes action: {action}")
+
+        return tool_result(_run_cli(cmd, wait=wait, wait_timeout=wait_timeout))
+    except SaveToSpotifyError as exc:
+        return tool_error(str(exc))
+
+
+def handle_save_to_spotify_timeline(args: dict, **_: Any) -> str:
+    action = str(args.get("action") or "").strip().lower()
+    try:
+        episode_id = str(args.get("episode_id") or args.get("id") or "").strip()
+        if not episode_id:
+            raise SaveToSpotifyError("episode_id is required")
+
+        if action == "get":
+            return tool_result(_run_cli(["timeline", "get", episode_id]))
+        if action == "delete":
+            return tool_result(_run_cli(["timeline", "delete", episode_id]))
+        if action != "set":
+            raise SaveToSpotifyError(f"Unknown save_to_spotify_timeline action: {action}")
+
+        timeline = _ensure_timeline_payload(args.get("timeline"))
+        temp_path: str | None = None
+        try:
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                suffix=".json",
+                delete=False,
+            ) as handle:
+                json.dump(timeline, handle, ensure_ascii=False)
+                temp_path = handle.name
+            return tool_result(
+                _run_cli(
+                    ["timeline", "set", "--episode-id", episode_id, "--from-file", temp_path]
+                )
+            )
+        finally:
+            if temp_path:
+                try:
+                    os.unlink(temp_path)
+                except OSError:
+                    pass
+    except SaveToSpotifyError as exc:
+        return tool_error(str(exc))
+
+
+SAVE_TO_SPOTIFY_UPLOAD_SCHEMA = {
+    "name": "save_to_spotify_upload",
+    "description": "Upload a local audio file to Spotify as a personal podcast episode, optionally creating or targeting a show.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "file_path": COMMON_STRING,
+            "title": COMMON_STRING,
+            "show_id": COMMON_STRING,
+            "new_show_title": COMMON_STRING,
+            "summary": COMMON_STRING,
+            "image_path": COMMON_STRING,
+            "language": COMMON_STRING,
+            "wait": COMMON_BOOL,
+            "wait_timeout": {
+                "type": "string",
+                "description": "Optional readiness timeout passed through to the CLI. Use compact Go-style durations like `90s` or `2m` with no spaces.",
+            },
+        },
+        "required": ["file_path", "title"],
+    },
+}
+
+SAVE_TO_SPOTIFY_SHOWS_SCHEMA = {
+    "name": "save_to_spotify_shows",
+    "description": "List, inspect, create, or delete Save to Spotify shows.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {"type": "string", "enum": ["list", "get", "create", "delete"]},
+            "show_id": COMMON_STRING,
+            "id": COMMON_STRING,
+            "title": COMMON_STRING,
+            "summary": COMMON_STRING,
+            "image_path": COMMON_STRING,
+            "language": COMMON_STRING,
+        },
+        "required": ["action"],
+    },
+}
+
+SAVE_TO_SPOTIFY_EPISODES_SCHEMA = {
+    "name": "save_to_spotify_episodes",
+    "description": "List, create, inspect readiness status for, or delete Save to Spotify episodes.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {"type": "string", "enum": ["list", "create", "status", "delete"]},
+            "show_id": COMMON_STRING,
+            "episode_id": COMMON_STRING,
+            "id": COMMON_STRING,
+            "title": COMMON_STRING,
+            "file_path": COMMON_STRING,
+            "file": COMMON_STRING,
+            "summary": COMMON_STRING,
+            "image_path": COMMON_STRING,
+            "language": COMMON_STRING,
+            "wait": COMMON_BOOL,
+            "wait_timeout": {
+                "type": "string",
+                "description": "Optional readiness timeout passed through to the CLI. Use compact Go-style durations like `90s` or `2m` with no spaces.",
+            },
+        },
+        "required": ["action"],
+    },
+}
+
+SAVE_TO_SPOTIFY_TIMELINE_SCHEMA = {
+    "name": "save_to_spotify_timeline",
+    "description": "Get, replace, or delete episode timeline items like chapters, links, and Spotify-native companion entities.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "action": {"type": "string", "enum": ["get", "set", "delete"]},
+            "episode_id": COMMON_STRING,
+            "id": COMMON_STRING,
+            "timeline": {
+                "type": "object",
+                "properties": {
+                    "items": {"type": "array", "items": {"type": "object"}},
+                },
+            },
+        },
+        "required": ["action", "episode_id"],
+    },
+}

--- a/skills/media/save-to-spotify/SKILL.md
+++ b/skills/media/save-to-spotify/SKILL.md
@@ -1,0 +1,96 @@
+---
+name: save-to-spotify
+description: "Save local or Hermes-generated audio to Spotify as personal podcast episodes."
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+prerequisites:
+  tools: [save_to_spotify_upload, save_to_spotify_shows, save_to_spotify_episodes, save_to_spotify_timeline]
+metadata:
+  hermes:
+    tags: [spotify, audio, podcast, upload, media]
+    related_skills: [spotify]
+---
+
+# Save to Spotify
+
+Upload audio to Spotify as personal podcast content. This toolset saves media you already have; it does not generate audio on its own.
+
+## When to use this skill
+
+The user wants to put a briefing, recap, lesson, memo, or other audio file into Spotify so they can listen from their normal library and devices.
+
+## Core rules
+
+- This capability uploads media; it does not generate audio.
+- Use Hermes TTS or existing local media first, then upload the result.
+- Prefer reusing an existing show before creating a new one.
+- Check `save_to_spotify_episodes` with `action: "status"` before writing timeline items.
+- Only set timeline items after the episode is `READY`.
+- Prefer full `spotify:...` URIs for `spotify_entity`.
+- Do not invent timeline items unless the user explicitly asked for them.
+
+## Typical workflow
+
+1. If the user does not already have a file, generate audio first with Hermes TTS or use an existing local media file.
+2. List shows and reuse one if it already fits the content.
+3. Upload the file with a title and optional show choice.
+4. If timeline/chapter content matters, check episode readiness first.
+5. Only after the episode is `READY`, set timeline items if the user asked for them.
+
+## Minimal patterns
+
+### Upload a file into an existing show
+
+```
+save_to_spotify_shows({"action": "list"})
+save_to_spotify_upload({
+  "file_path": "/path/to/briefing.mp3",
+  "title": "Morning Briefing",
+  "show_id": "spotify:show:abc123"
+})
+```
+
+### Upload and wait until ready
+
+```
+save_to_spotify_upload({
+  "file_path": "/path/to/recap.mp3",
+  "title": "Weekly Recap",
+  "show_id": "spotify:show:abc123",
+  "wait": true
+})
+```
+
+### Create a show only when reuse is not appropriate
+
+```
+save_to_spotify_upload({
+  "file_path": "/path/to/lesson.mp3",
+  "title": "Lesson 12",
+  "new_show_title": "Spanish Practice"
+})
+```
+
+### Timeline write after readiness
+
+```
+save_to_spotify_episodes({"action": "status", "episode_id": "spotify:episode:def456"})
+save_to_spotify_timeline({
+  "action": "set",
+  "episode_id": "spotify:episode:def456",
+  "timeline": {
+    "items": [
+      {"chapter": {"title": "Intro", "start_time_ms": 0}},
+      {"spotify_entity": {"start_time_ms": 60000, "uri": "spotify:track:abc123"}}
+    ]
+  }
+})
+```
+
+## What not to do
+
+- Do not describe this as a Spotify playback or library-saving feature; it is an upload pipeline for personal podcast-style audio.
+- Do not create a new show automatically if an existing one clearly matches and the user did not ask for separation.
+- Do not set timeline data before the episode is `READY`.
+- Do not pass bare IDs or web URLs for `spotify_entity` when a full `spotify:...` URI is available.

--- a/tests/hermes_cli/test_tools_config.py
+++ b/tests/hermes_cli/test_tools_config.py
@@ -86,6 +86,11 @@ def test_configurable_toolsets_include_context_engine():
     assert any(ts_key == "context_engine" for ts_key, _, _ in CONFIGURABLE_TOOLSETS)
 
 
+def test_configurable_toolsets_include_save_to_spotify():
+    assert any(ts_key == "save_to_spotify" for ts_key, _, _ in CONFIGURABLE_TOOLSETS)
+    assert "save_to_spotify" in _DEFAULT_OFF_TOOLSETS
+
+
 def test_get_platform_tools_active_context_engine_is_enabled_for_explicit_config():
     config = {
         "context": {"engine": "lcm"},

--- a/tests/plugins/test_save_to_spotify_plugin.py
+++ b/tests/plugins/test_save_to_spotify_plugin.py
@@ -1,0 +1,354 @@
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+from hermes_cli.plugins import PluginManager
+from plugins.save_to_spotify import tools as save_tools
+
+
+def _completed(stdout: str, *, returncode: int = 0, stderr: str = "") -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(
+        args=["save-to-spotify"],
+        returncode=returncode,
+        stdout=stdout,
+        stderr=stderr,
+    )
+
+
+def test_plugin_manifest_exists_and_is_bundled_backend() -> None:
+    plugin_dir = Path(__file__).resolve().parents[2] / "plugins" / "save_to_spotify"
+    manifest_path = plugin_dir / "plugin.yaml"
+    assert manifest_path.exists()
+
+    data = yaml.safe_load(manifest_path.read_text(encoding="utf-8"))
+    assert data["name"] == "save_to_spotify"
+    assert data["kind"] == "backend"
+    assert data["provides_tools"] == [
+        "save_to_spotify_upload",
+        "save_to_spotify_shows",
+        "save_to_spotify_episodes",
+        "save_to_spotify_timeline",
+    ]
+
+
+def test_plugin_manager_discovers_bundled_save_to_spotify_backend() -> None:
+    mgr = PluginManager()
+    mgr.discover_and_load()
+
+    assert "save_to_spotify" in mgr._plugins
+    loaded = mgr._plugins["save_to_spotify"]
+    assert loaded.manifest.source == "bundled"
+    assert loaded.manifest.kind == "backend"
+    assert loaded.enabled is True, loaded.error
+
+
+def test_missing_binary_returns_install_error(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(save_tools.shutil, "which", lambda _: None)
+
+    payload = json.loads(
+        save_tools.handle_save_to_spotify_shows({"action": "list"})
+    )
+
+    assert "error" in payload
+    assert "not installed" in payload["error"]
+
+
+def test_subprocess_success_parsing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(save_tools.shutil, "which", lambda _: "/usr/local/bin/save-to-spotify")
+    monkeypatch.setattr(
+        save_tools.subprocess,
+        "run",
+        lambda *args, **kwargs: _completed('{"shows":[{"title":"Daily Briefings"}]}'),
+    )
+
+    payload = json.loads(save_tools.handle_save_to_spotify_shows({"action": "list"}))
+
+    assert payload["shows"][0]["title"] == "Daily Briefings"
+
+
+def test_subprocess_json_error_parsing(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(save_tools.shutil, "which", lambda _: "/usr/local/bin/save-to-spotify")
+    monkeypatch.setattr(
+        save_tools.subprocess,
+        "run",
+        lambda *args, **kwargs: _completed('{"error":"show not found"}', returncode=1),
+    )
+
+    payload = json.loads(
+        save_tools.handle_save_to_spotify_shows({"action": "get", "show_id": "spotify:show:abc"})
+    )
+
+    assert payload == {"error": "show not found"}
+
+
+def test_auth_missing_path_maps_to_login_message(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(save_tools.shutil, "which", lambda _: "/usr/local/bin/save-to-spotify")
+    monkeypatch.setattr(
+        save_tools.subprocess,
+        "run",
+        lambda *args, **kwargs: _completed(
+            '{"error":"not authenticated - run save-to-spotify auth login"}',
+            returncode=1,
+        ),
+    )
+
+    payload = json.loads(save_tools.handle_save_to_spotify_shows({"action": "list"}))
+
+    assert payload["error"] == "Save to Spotify is not authenticated. Run `save-to-spotify auth login` first."
+
+
+def test_file_path_validation_failures(tmp_path: Path) -> None:
+    missing = tmp_path / "missing.mp3"
+    payload = json.loads(
+        save_tools.handle_save_to_spotify_upload(
+            {"file_path": str(missing), "title": "Episode"}
+        )
+    )
+    assert "does not exist" in payload["error"]
+
+
+def test_image_path_validation_failures(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    media = tmp_path / "episode.mp3"
+    media.write_bytes(b"audio")
+    payload = json.loads(
+        save_tools.handle_save_to_spotify_upload(
+            {
+                "file_path": str(media),
+                "title": "Episode",
+                "image_path": str(tmp_path / "missing.png"),
+            }
+        )
+    )
+    assert "image_path does not exist" in payload["error"]
+
+
+def test_upload_wait_true_without_wait_timeout_uses_bare_wait(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    media = tmp_path / "episode.mp3"
+    media.write_bytes(b"audio")
+    seen: dict[str, object] = {}
+
+    def fake_run(cmd, **kwargs):
+        seen["cmd"] = cmd
+        seen["timeout"] = kwargs["timeout"]
+        return _completed('{"episode_uri":"spotify:episode:abc"}')
+
+    monkeypatch.setattr(save_tools.shutil, "which", lambda _: "/usr/local/bin/save-to-spotify")
+    monkeypatch.setattr(save_tools.subprocess, "run", fake_run)
+
+    payload = json.loads(
+        save_tools.handle_save_to_spotify_upload(
+            {"file_path": str(media), "title": "Episode", "wait": True}
+        )
+    )
+
+    assert payload["episode_uri"] == "spotify:episode:abc"
+    assert seen["cmd"] == [
+        "/usr/local/bin/save-to-spotify",
+        "--json",
+        "upload",
+        str(media),
+        "--title",
+        "Episode",
+        "--wait",
+    ]
+    assert seen["timeout"] == 330
+
+
+def test_upload_wait_true_with_wait_timeout_passes_duration_and_buffer(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    media = tmp_path / "episode.mp3"
+    media.write_bytes(b"audio")
+    seen: dict[str, object] = {}
+
+    def fake_run(cmd, **kwargs):
+        seen["cmd"] = cmd
+        seen["timeout"] = kwargs["timeout"]
+        return _completed('{"episode_uri":"spotify:episode:abc"}')
+
+    monkeypatch.setattr(save_tools.shutil, "which", lambda _: "/usr/local/bin/save-to-spotify")
+    monkeypatch.setattr(save_tools.subprocess, "run", fake_run)
+
+    json.loads(
+        save_tools.handle_save_to_spotify_upload(
+            {
+                "file_path": str(media),
+                "title": "Episode",
+                "wait": True,
+                "wait_timeout": "2m",
+            }
+        )
+    )
+
+    assert seen["cmd"] == [
+        "/usr/local/bin/save-to-spotify",
+        "--json",
+        "upload",
+        str(media),
+        "--title",
+        "Episode",
+        "--wait",
+        "2m",
+    ]
+    assert seen["timeout"] == 150
+
+
+def test_timeline_temp_file_creation_and_cleanup(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    monkeypatch.setattr(save_tools.shutil, "which", lambda _: "/usr/local/bin/save-to-spotify")
+    seen: dict[str, object] = {}
+
+    def fake_run(cmd, **kwargs):
+        timeline_path = Path(cmd[-1])
+        seen["cmd"] = cmd
+        seen["path"] = timeline_path
+        seen["contents"] = json.loads(timeline_path.read_text(encoding="utf-8"))
+        return _completed('{"ok":true}')
+
+    monkeypatch.setattr(save_tools.subprocess, "run", fake_run)
+
+    payload = json.loads(
+        save_tools.handle_save_to_spotify_timeline(
+            {
+                "action": "set",
+                "episode_id": "spotify:episode:abc",
+                "timeline": {"items": [{"chapter": {"title": "Intro", "start_time_ms": 0}}]},
+            }
+        )
+    )
+
+    assert payload["ok"] is True
+    assert seen["cmd"][:5] == [
+        "/usr/local/bin/save-to-spotify",
+        "--json",
+        "timeline",
+        "set",
+        "--episode-id",
+    ]
+    assert seen["contents"] == {"items": [{"chapter": {"title": "Intro", "start_time_ms": 0}}]}
+    assert not Path(seen["path"]).exists()
+
+
+def test_timeline_spotify_entity_requires_prefix() -> None:
+    payload = json.loads(
+        save_tools.handle_save_to_spotify_timeline(
+            {
+                "action": "set",
+                "episode_id": "spotify:episode:abc",
+                "timeline": {
+                    "items": [
+                        {"spotify_entity": {"start_time_ms": 1000, "uri": "https://open.spotify.com/track/abc"}}
+                    ]
+                },
+            }
+        )
+    )
+
+    assert payload["error"] == "timeline spotify_entity.uri must use a full `spotify:...` URI"
+
+
+def test_representative_command_mapping(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    media = tmp_path / "episode.mp3"
+    media.write_bytes(b"audio")
+    image = tmp_path / "cover.png"
+    image.write_bytes(b"png")
+    seen: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        seen.append(cmd)
+        return _completed('{"ok":true}')
+
+    monkeypatch.setattr(save_tools.shutil, "which", lambda _: "/usr/local/bin/save-to-spotify")
+    monkeypatch.setattr(save_tools.subprocess, "run", fake_run)
+
+    json.loads(
+        save_tools.handle_save_to_spotify_upload(
+            {
+                "file_path": str(media),
+                "title": "Episode",
+                "show_id": "spotify:show:abc",
+                "summary": "sum",
+                "image_path": str(image),
+                "language": "tr",
+            }
+        )
+    )
+    json.loads(save_tools.handle_save_to_spotify_shows({"action": "create", "title": "Show", "summary": "desc"}))
+    json.loads(save_tools.handle_save_to_spotify_episodes({"action": "status", "episode_id": "spotify:episode:def"}))
+    json.loads(save_tools.handle_save_to_spotify_timeline({"action": "get", "episode_id": "spotify:episode:def"}))
+
+    assert seen == [
+        [
+            "/usr/local/bin/save-to-spotify",
+            "--json",
+            "upload",
+            str(media),
+            "--title",
+            "Episode",
+            "--show-id",
+            "spotify:show:abc",
+            "--summary",
+            "sum",
+            "--image",
+            str(image),
+            "--language",
+            "tr",
+        ],
+        [
+            "/usr/local/bin/save-to-spotify",
+            "--json",
+            "shows",
+            "create",
+            "--title",
+            "Show",
+            "--summary",
+            "desc",
+        ],
+        [
+            "/usr/local/bin/save-to-spotify",
+            "--json",
+            "episodes",
+            "status",
+            "spotify:episode:def",
+        ],
+        [
+            "/usr/local/bin/save-to-spotify",
+            "--json",
+            "timeline",
+            "get",
+            "spotify:episode:def",
+        ],
+    ]
+
+
+def test_subprocess_timeout_maps_to_hard_hang_error(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+) -> None:
+    media = tmp_path / "episode.mp3"
+    media.write_bytes(b"audio")
+    monkeypatch.setattr(save_tools.shutil, "which", lambda _: "/usr/local/bin/save-to-spotify")
+
+    def fake_run(*args, **kwargs):
+        raise subprocess.TimeoutExpired(cmd=args[0], timeout=kwargs["timeout"])
+
+    monkeypatch.setattr(save_tools.subprocess, "run", fake_run)
+
+    payload = json.loads(
+        save_tools.handle_save_to_spotify_upload(
+            {"file_path": str(media), "title": "Episode", "wait": True}
+        )
+    )
+
+    assert "system timeout" in payload["error"]

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -46,6 +46,16 @@ class TestGetToolset:
         assert ts is not None
         assert set(ts["tools"]) == {"web_search", "web_extract", "web_search_plus"}
 
+    def test_save_to_spotify_toolset_exists(self):
+        ts = get_toolset("save_to_spotify")
+        assert ts is not None
+        assert ts["tools"] == [
+            "save_to_spotify_upload",
+            "save_to_spotify_shows",
+            "save_to_spotify_episodes",
+            "save_to_spotify_timeline",
+        ]
+
     def test_unknown_returns_none(self):
         assert get_toolset("nonexistent") is None
 
@@ -103,6 +113,18 @@ class TestResolveToolset:
     def test_star_alias(self):
         tools = resolve_toolset("*")
         assert len(tools) > 10
+
+    def test_save_to_spotify_does_not_collide_with_spotify(self):
+        spotify_tools = set(resolve_toolset("spotify"))
+        save_tools = set(resolve_toolset("save_to_spotify"))
+
+        assert save_tools == {
+            "save_to_spotify_upload",
+            "save_to_spotify_shows",
+            "save_to_spotify_episodes",
+            "save_to_spotify_timeline",
+        }
+        assert spotify_tools.isdisjoint(save_tools)
 
 
 class TestResolveMultipleToolsets:

--- a/tests/test_toolsets.py
+++ b/tests/test_toolsets.py
@@ -49,12 +49,12 @@ class TestGetToolset:
     def test_save_to_spotify_toolset_exists(self):
         ts = get_toolset("save_to_spotify")
         assert ts is not None
-        assert ts["tools"] == [
+        assert set(ts["tools"]) == {
             "save_to_spotify_upload",
             "save_to_spotify_shows",
             "save_to_spotify_episodes",
             "save_to_spotify_timeline",
-        ]
+        }
 
     def test_unknown_returns_none(self):
         assert get_toolset("nonexistent") is None

--- a/toolsets.py
+++ b/toolsets.py
@@ -322,6 +322,15 @@ TOOLSETS = {
         "includes": []
     },
 
+    "save_to_spotify": {
+        "description": "Upload personal audio to Spotify and manage shows, episodes, and companion timelines",
+        "tools": [
+            "save_to_spotify_upload", "save_to_spotify_shows",
+            "save_to_spotify_episodes", "save_to_spotify_timeline",
+        ],
+        "includes": []
+    },
+
 
     # Scenario-specific toolsets
     

--- a/website/docs/user-guide/features/built-in-plugins.md
+++ b/website/docs/user-guide/features/built-in-plugins.md
@@ -59,6 +59,7 @@ The repo ships these bundled plugins under `plugins/`. All are opt-in — enable
 | `security-guidance` | hooks | Pattern-match dangerous code on `write_file`/`patch` and append a security warning (or block) — 25 rules (Apache-2.0 fork of Anthropic's `claude-plugins-official` patterns) |
 | `observability/langfuse` | hooks | Trace turns / LLM calls / tools to [Langfuse](https://langfuse.com) |
 | `spotify` | backend (7 tools) | Native Spotify playback, queue, search, playlists, albums, library |
+| `save_to_spotify` | backend (4 tools) | Upload personal audio to Spotify and manage shows, episodes, and companion timelines |
 | `google_meet` | standalone | Join Meet calls, live-caption transcription, optional realtime duplex audio |
 | `image_gen/openai` | image backend | OpenAI `gpt-image-2` image generation backend (alternative to FAL) |
 | `image_gen/openai-codex` | image backend | OpenAI image generation via Codex OAuth |

--- a/website/docs/user-guide/features/save-to-spotify.md
+++ b/website/docs/user-guide/features/save-to-spotify.md
@@ -1,0 +1,168 @@
+---
+title: "Save to Spotify"
+description: "Upload personal audio to Spotify from Hermes using Spotify's official save-to-spotify CLI."
+---
+
+# Save to Spotify
+
+Hermes can upload your existing audio files to Spotify as **personal podcast** content using Spotify's official [`save-to-spotify`](https://github.com/spotify/save-to-spotify) CLI. This is separate from Hermes' regular Spotify playback/search toolset: `save_to_spotify` is for **publishing private audio into your library**, not controlling what's already playing.
+
+## What it does
+
+The `save_to_spotify` toolset exposes four model-visible tools:
+
+- `save_to_spotify_upload`
+- `save_to_spotify_shows`
+- `save_to_spotify_episodes`
+- `save_to_spotify_timeline`
+
+Use them to:
+
+- Upload a local `.mp3`, `.m4a`, `.wav`, or `.ogg` file as a Spotify episode
+- Reuse or create shows to organize your personal audio
+- Check whether an uploaded episode is `READY`
+- Add timeline companions like chapters, links, and `spotify_entity` references after the episode is ready
+
+## Important boundary
+
+This toolset **does not generate audio**. Generate audio first with Hermes TTS or provide an existing local media file, then upload that file to Spotify.
+
+## Setup
+
+### 1. Install the official CLI
+
+Hermes shells out to the official `save-to-spotify` binary in `--json` mode. Install it first:
+
+```bash
+curl -fsSL https://saveto.spotify.com/install.sh | bash
+```
+
+Or follow the manual install steps in the upstream project:
+
+- https://github.com/spotify/save-to-spotify
+
+### 2. Authenticate the CLI once
+
+```bash
+save-to-spotify auth login
+```
+
+To verify:
+
+```bash
+save-to-spotify auth status
+```
+
+### 3. Enable the Hermes toolset
+
+```bash
+hermes tools
+```
+
+Toggle on `🎙️ Save to Spotify` and save. Like `spotify`, this toolset is off by default and only appears to the model after you enable it.
+
+## Chat-first usage
+
+Examples:
+
+```text
+Turn this standup recap audio into a Spotify episode and save it under my existing Meeting Recaps show.
+```
+
+```text
+Generate a morning briefing with TTS, upload it to Spotify, and wait until it's ready.
+```
+
+```text
+Upload this lesson audio to Spotify, then add chapter markers once the episode is ready.
+```
+
+## Recommended workflow
+
+1. Generate or locate the audio file first.
+2. List shows and reuse one when possible.
+3. Upload the episode.
+4. Check readiness with `episodes status`.
+5. Only after the episode is `READY`, set timeline items if the user asked for them.
+
+## Tool behaviors
+
+### `save_to_spotify_upload`
+
+Uploads a local media file and creates an episode in one step.
+
+Key inputs:
+
+- `file_path`
+- `title`
+- optional `show_id`
+- optional `new_show_title`
+- optional `summary`
+- optional `image_path`
+- optional `language`
+- optional `wait`
+- optional `wait_timeout`
+
+If `wait: true`, Hermes passes through the CLI's readiness wait behavior. With no `wait_timeout`, Hermes preserves the CLI default readiness timeout. With `wait_timeout`, Hermes forwards the custom duration.
+
+### `save_to_spotify_shows`
+
+Actions:
+
+- `list`
+- `get`
+- `create`
+- `delete`
+
+### `save_to_spotify_episodes`
+
+Actions:
+
+- `list`
+- `create`
+- `status`
+- `delete`
+
+### `save_to_spotify_timeline`
+
+Actions:
+
+- `get`
+- `set`
+- `delete`
+
+For `action: "set"`, Hermes accepts a structured timeline object and writes the temporary JSON file the CLI expects for `--from-file`.
+
+## Timeline guidance
+
+- Check `episodes status` before timeline writes.
+- Only set timeline items after the episode is `READY`.
+- Prefer full `spotify:...` URIs for `spotify_entity`.
+- Do not invent chapters, links, or companion items unless the user asked for them.
+
+Example timeline payload:
+
+```json
+{
+  "items": [
+    { "chapter": { "title": "Introduction", "start_time_ms": 0 } },
+    { "spotify_entity": { "start_time_ms": 60000, "uri": "spotify:track:abc123" } },
+    { "link": { "start_time_ms": 90000, "duration_ms": 15000, "url": "https://example.com/slides" } }
+  ]
+}
+```
+
+## Failure modes
+
+- If the `save-to-spotify` binary is missing, Hermes returns a clear install error.
+- If the CLI is not authenticated, Hermes returns a clear message telling you to run `save-to-spotify auth login`.
+- If the CLI hangs unexpectedly, Hermes returns a system-timeout error distinct from the CLI's normal readiness timeout handling.
+
+## Relationship to the existing Spotify toolset
+
+These are intentionally separate:
+
+- `spotify`: playback, queue, playlists, albums, library
+- `save_to_spotify`: upload personal audio, manage shows/episodes, set timelines
+
+Hermes does not rename, merge, or replace the existing Spotify plugin when this toolset is enabled.

--- a/website/docs/user-guide/features/tools.md
+++ b/website/docs/user-guide/features/tools.md
@@ -49,7 +49,7 @@ hermes tools
 hermes tools
 ```
 
-Common toolsets include `web`, `search`, `terminal`, `file`, `browser`, `vision`, `image_gen`, `moa`, `skills`, `tts`, `todo`, `memory`, `session_search`, `cronjob`, `code_execution`, `delegation`, `clarify`, `homeassistant`, `messaging`, `spotify`, `discord`, `discord_admin`, `debugging`, `safe`, and `rl`.
+Common toolsets include `web`, `search`, `terminal`, `file`, `browser`, `vision`, `image_gen`, `moa`, `skills`, `tts`, `todo`, `memory`, `session_search`, `cronjob`, `code_execution`, `delegation`, `clarify`, `homeassistant`, `messaging`, `spotify`, `save_to_spotify`, `discord`, `discord_admin`, `debugging`, `safe`, and `rl`.
 
 See [Toolsets Reference](/reference/toolsets-reference) for the full set, including platform presets such as `hermes-cli`, `hermes-telegram`, and dynamic MCP toolsets like `mcp-<server>`.
 


### PR DESCRIPTION
 ## Summary

  This PR adds a new bundled `save_to_spotify` integration to Hermes so users can upload existing audio files to Spotify as personal podcast episodes directly from `hermes chat`.

  This is intentionally additive and separate from the existing `spotify` toolset:
  - `spotify` remains the playback/search/library integration
  - `save_to_spotify` is a new opt-in upload/publishing surface backed by Spotify's official `save-to-spotify` CLI

  ## What Changed

  ### New bundled plugin

  Added a new bundled backend plugin at `plugins/save_to_spotify/` with 4 model-visible tools:

  - `save_to_spotify_upload`
  - `save_to_spotify_shows`
  - `save_to_spotify_episodes`
  - `save_to_spotify_timeline`

  The implementation shells out to the official `save-to-spotify` binary in `--json` mode and does not assume direct native API access.

  ### Toolset wiring

  Added a separate `save_to_spotify` toolset to:
  - `toolsets.py`
  - `hermes_cli/tools_config.py`

  It is default-off, following the same opt-in pattern as `spotify`, and does not share keys or handlers with the existing playback plugin.

  ### Runtime behavior

  Implemented:
  - local `file_path` / `image_path` validation before subprocess calls
  - binary detection via `shutil.which("save-to-spotify")`
  - auth-missing error mapping with guidance to run `save-to-spotify auth login`
  - JSON stdout parsing with Hermes-facing tool errors when the CLI returns `{"error": ...}`
  - separate handling for hard subprocess hangs vs normal readiness waiting
  - `wait=true` passthrough that preserves the CLI's default readiness timeout when no custom duration is supplied
  - timeline `set` via structured input, written to a temp JSON file for the CLI `--from-file` contract
  - guaranteed temp-file cleanup in `finally`

  ### Skill and docs

  Added:
  - bundled skill: `skills/media/save-to-spotify/SKILL.md`
  - feature page: `website/docs/user-guide/features/save-to-spotify.md`

  The skill/docs emphasize:
  - this surface uploads media, it does not generate audio
  - reuse an existing show when possible
  - check episode readiness before timeline writes
  - only set timeline items after `READY`
  - prefer full `spotify:...` URIs for `spotify_entity`

  ## Testing

  Added targeted coverage for:
  - bundled plugin manifest/discovery
  - toolset/config visibility
  - binary missing path
  - subprocess success/error parsing
  - auth-missing mapping
  - file/image validation
  - `wait` command mapping
  - timeline temp-file creation/cleanup
  - `spotify_entity` prefix validation
  - representative upload/shows/episodes/timeline command mapping

  Targeted test slice:
  - `19 passed`

  I also ran a real end-to-end validation through Hermes using the patched checkout:
  - authenticated the official `save-to-spotify` CLI
  - uploaded a real local audio file through Hermes with the `save_to_spotify` toolset
  - confirmed the episode reached `READY`

  Result from the live run:
  - Show URI: `spotify:show:033evUay6YlGmi5yVRC4tq`
  - Episode URI: `spotify:episode:4kuoQPCSeqRf2ljpEJnh9D`

  ## Scope Notes

  This PR does not add Hermes-native auth/setup wrappers for `save-to-spotify`.
  That polish is better handled separately so the core upload capability stays narrow and reviewable.