### PR TITLE
feat(tui): add selection foreground highlight

### DIFF
--- a/ui-tui/packages/hermes-ink/src/ink/hooks/use-selection.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/hooks/use-selection.ts
@@ -35,6 +35,10 @@ export function useSelection(): {
    *  replaces the old SGR-7 inverse so syntax highlighting stays readable
    *  under selection). Call once on mount + whenever theme changes. */
   setSelectionBgColor: (color: string) => void
+  /** Set the selection highlight fg color. When set, selected text
+   *  renders with a uniform foreground instead of preserving syntax colors.
+   *  Call once on mount + whenever theme changes. */
+  setSelectionFgColor: (color: string) => void
   /** Monotonic counter incremented on every selection mutation. */
   version: () => number
 } {
@@ -61,6 +65,7 @@ export function useSelection(): {
         moveFocus: () => {},
         captureScrolledRows: () => {},
         setSelectionBgColor: () => {},
+        setSelectionFgColor: () => {},
         version: () => 0
       }
     }
@@ -77,6 +82,7 @@ export function useSelection(): {
       moveFocus: (move: FocusMove) => ink.moveSelectionFocus(move),
       captureScrolledRows: (firstRow, lastRow, side) => ink.captureScrolledRows(firstRow, lastRow, side),
       setSelectionBgColor: (color: string) => ink.setSelectionBgColor(color),
+      setSelectionFgColor: (color: string) => ink.setSelectionFgColor(color),
       version: () => ink.getSelectionVersion()
     }
   }, [ink])

--- a/ui-tui/packages/hermes-ink/src/ink/ink.tsx
+++ b/ui-tui/packages/hermes-ink/src/ink/ink.tsx
@@ -1560,6 +1560,23 @@ export default class Ink {
     // selection exists (which itself triggers a full-damage frame).
   }
 
+  setSelectionFgColor(color: string): void {
+    const wrapped = colorize('\0', color, 'foreground')
+    const nul = wrapped.indexOf('\0')
+
+    if (nul <= 0 || nul === wrapped.length - 1) {
+      this.stylePool.setSelectionFg(null)
+
+      return
+    }
+
+    this.stylePool.setSelectionFg({
+      type: 'ansi',
+      code: wrapped.slice(0, nul),
+      endCode: wrapped.slice(nul + 1) // always \x1b[39m for fg
+    })
+  }
+
   /**
    * Capture text from rows about to scroll out of the viewport during
    * drag-to-scroll. Must be called BEFORE the ScrollBox scrolls so the

--- a/ui-tui/packages/hermes-ink/src/ink/screen.ts
+++ b/ui-tui/packages/hermes-ink/src/ink/screen.ts
@@ -272,32 +272,52 @@ export class StylePool {
    * Cache is keyed by baseId only — setSelectionBg() clears it on change.
    */
   private selectionBgCode: AnsiCode | null = null
-  private selectionBgCache = new Map<number, number>()
+  private selectionFgCode: AnsiCode | null = null
+  private selectionOverlayCache = new Map<number, number>()
   setSelectionBg(bg: AnsiCode | null): void {
     if (this.selectionBgCode?.code === bg?.code) {
       return
     }
 
     this.selectionBgCode = bg
-    this.selectionBgCache.clear()
+    this.selectionOverlayCache.clear()
+  }
+  setSelectionFg(fg: AnsiCode | null): void {
+    if (this.selectionFgCode?.code === fg?.code) {
+      return
+    }
+
+    this.selectionFgCode = fg
+    this.selectionOverlayCache.clear()
   }
   withSelectionBg(baseId: number): number {
     const bg = this.selectionBgCode
+    const fg = this.selectionFgCode
 
-    if (bg === null) {
+    if (bg === null && fg === null) {
       return this.withInverse(baseId)
     }
 
-    let id = this.selectionBgCache.get(baseId)
+    let id = this.selectionOverlayCache.get(baseId)
 
     if (id === undefined) {
-      // Keep everything except bg (49m) and inverse (27m). Fg, bold, dim,
-      // italic, underline, strikethrough all preserved.
-      const kept = this.get(baseId).filter(c => c.endCode !== '\x1b[49m' && c.endCode !== '\x1b[27m')
+      // Keep everything except bg (49m), inverse (27m), and fg (39m) when a
+      // selection foreground is configured. Bold, italic, underline etc. are
+      // preserved so the text keeps its visual weight under selection.
+      const kept = this.get(baseId).filter(
+        c => c.endCode !== '\x1b[49m' && c.endCode !== '\x1b[27m' && (fg !== null ? c.endCode !== '\x1b[39m' : true)
+      )
 
-      kept.push(bg)
+      if (fg !== null) {
+        kept.push(fg)
+      }
+
+      if (bg !== null) {
+        kept.push(bg)
+      }
+
       id = this.intern(kept)
-      this.selectionBgCache.set(baseId, id)
+      this.selectionOverlayCache.set(baseId, id)
     }
 
     return id

--- a/ui-tui/src/__tests__/theme.test.ts
+++ b/ui-tui/src/__tests__/theme.test.ts
@@ -237,6 +237,22 @@ describe('fromSkin', () => {
     expect(theme.color.selectionBg).toBe('#654321')
   })
 
+  it('maps selection_fg from skins', async () => {
+    const { fromSkin } = await importThemeWithCleanEnv()
+
+    const theme = fromSkin({ selection_fg: '#abcdef' }, {})
+
+    expect(theme.color.selectionFg).toBe('#abcdef')
+  })
+
+  it('falls back to theme default when selection_fg is not in skin', async () => {
+    const { DEFAULT_THEME, fromSkin } = await importThemeWithCleanEnv()
+
+    const theme = fromSkin({}, {})
+
+    expect(theme.color.selectionFg).toBe(DEFAULT_THEME.color.selectionFg)
+  })
+
   it('overrides branding', async () => {
     const { fromSkin } = await importThemeWithCleanEnv()
     const { brand } = fromSkin({}, { agent_name: 'TestBot', prompt_symbol: '$' })

--- a/ui-tui/src/app/useMainApp.ts
+++ b/ui-tui/src/app/useMainApp.ts
@@ -152,6 +152,10 @@ export function useMainApp(gw: GatewayClient) {
     selection.setSelectionBgColor(ui.theme.color.selectionBg)
   }, [selection, ui.theme.color.selectionBg])
 
+  useEffect(() => {
+    selection.setSelectionFgColor(ui.theme.color.selectionFg)
+  }, [selection, ui.theme.color.selectionFg])
+
   // macOS Terminal.app does not forward Cmd+C to fullscreen TUIs that enable
   // mouse tracking, so the only reliable native-feeling path is iTerm-style
   // copy-on-select: once a drag creates a stable TUI selection, write it to

--- a/ui-tui/src/theme.ts
+++ b/ui-tui/src/theme.ts
@@ -25,6 +25,7 @@ export interface ThemeColors {
   statusBad: string
   statusCritical: string
   selectionBg: string
+  selectionFg: string
 
   diffAdded: string
   diffRemoved: string
@@ -290,6 +291,7 @@ export const DARK_THEME: Theme = {
     statusBad: '#FF8C00',
     statusCritical: '#FF6B6B',
     selectionBg: '#3a3a55',
+    selectionFg: '#FFF8DC',
 
     diffAdded: 'rgb(220,255,220)',
     diffRemoved: 'rgb(255,220,220)',
@@ -335,6 +337,7 @@ export const LIGHT_THEME: Theme = {
     statusBad: '#D84315',
     statusCritical: '#B71C1C',
     selectionBg: '#D4E4F7',
+    selectionFg: '#3D2F13',
 
     diffAdded: 'rgb(200,240,200)',
     diffRemoved: 'rgb(240,200,200)',
@@ -565,6 +568,7 @@ export function fromSkin(
       statusBad: d.color.statusBad,
       statusCritical: d.color.statusCritical,
       selectionBg: c('selection_bg') ?? c('completion_menu_current_bg') ?? (hasSkinColors ? completionCurrentBg : d.color.selectionBg),
+      selectionFg: c('selection_fg') ?? d.color.selectionFg,
 
       diffAdded: d.color.diffAdded,
       diffRemoved: d.color.diffRemoved,

--- a/ui-tui/src/types/hermes-ink.d.ts
+++ b/ui-tui/src/types/hermes-ink.d.ts
@@ -153,6 +153,7 @@ declare module '@hermes/ink' {
     readonly moveFocus: (move: unknown) => void
     readonly captureScrolledRows: (firstRow: number, lastRow: number, side: 'above' | 'below') => void
     readonly setSelectionBgColor: (color: string) => void
+    readonly setSelectionFgColor: (color: string) => void
   }
   export function useHasSelection(): boolean
   export function useStdout(): { readonly stdout?: NodeJS.WriteStream }


### PR DESCRIPTION
## Summary
Adds OpenCode-style selection foreground color (`selectionFg`) to the Hermes Ink TUI, complementing the existing `selectionBg`. Selected text now renders with a uniform foreground color instead of preserving syntax-highlighted colors, matching the behavior of OpenCode / @opentui/core.

## Changes
- `ui-tui/src/theme.ts`: add `selectionFg` to `ThemeColors`, default values for dark/light themes, and `selection_fg` skin mapping in `fromSkin()`
- `ui-tui/packages/hermes-ink/src/ink/screen.ts`: extend `StylePool` with `setSelectionFg()` and unified `selectionOverlayCache`; `withSelectionBg` now composes both bg and fg overlays
- `ui-tui/packages/hermes-ink/src/ink/ink.tsx`: add `setSelectionFgColor()` method
- `ui-tui/packages/hermes-ink/src/ink/hooks/use-selection.ts`: expose `setSelectionFgColor` in `useSelection` hook
- `ui-tui/src/app/useMainApp.ts`: wire `selection.setSelectionFgColor()` from active theme
- `ui-tui/src/types/hermes-ink.d.ts`: update type definitions
- `ui-tui/src/__tests__/theme.test.ts`: add tests for `selection_fg` skin mapping and fallback

## Validation
```bash
cd ui-tui && npx vitest run
# Result: 62 test files, 656 tests passed
```

Credential scan: clean

---

**Archival note:** This PR is closed and not part of the active toast/selectioncopy stack (#24596 / #24585).
