### PR TITLE
fix(cli): preserve Ctrl-J newline on macOS

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1865,18 +1865,18 @@ _TERMINAL_INPUT_MODE_RESET_SEQ = (
 
 
 def _preserve_ctrl_enter_newline() -> bool:
-    """Detect environments where Ctrl+Enter must produce a newline, not submit.
+    """Detect environments where Ctrl+Enter/Ctrl+J must newline, not submit.
 
-    Native Windows, WSL, SSH sessions, and Windows Terminal all send Ctrl+Enter
-    as bare LF (c-j). On those terminals c-j must NOT be bound to submit;
-    binding it to submit makes Ctrl+Enter (intended as 'newline like Alt+Enter')
-    submit instead. Local POSIX TTYs that deliver Enter as LF (docker exec,
-    some thin PTYs without SSH) still need c-j bound to submit, so we keep
-    that binding for those.
+    Native Windows, macOS, WSL, SSH sessions, and Windows Terminal all need
+    bare LF (c-j) preserved for multiline input. On those terminals c-j must
+    NOT be bound to submit; binding it to submit makes Ctrl+Enter/Ctrl+J
+    (intended as 'newline like Alt+Enter') submit instead. Bare local Linux
+    TTYs that deliver Enter as LF (docker exec, some thin PTYs without SSH)
+    still need c-j bound to submit, so we keep that binding for those.
 
     See issue #22379.
     """
-    if sys.platform == "win32":
+    if sys.platform in {"win32", "darwin"}:
         return True
     if any(os.environ.get(v) for v in ("SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY")):
         return True
@@ -1898,16 +1898,17 @@ def _preserve_ctrl_enter_newline() -> bool:
 def _bind_prompt_submit_keys(kb, handler) -> None:
     """Bind terminal Enter forms to the submit handler.
 
-    Enter is always submit. On POSIX we also bind c-j (LF) to submit because
-    some thin PTYs (docker exec, certain SSH flavors) deliver Enter as LF
-    instead of CR — without this, Enter appears dead on those terminals.
+    Enter is always submit. On bare local Linux/POSIX we also bind c-j (LF)
+    to submit because some thin PTYs (docker exec, certain SSH flavors) deliver
+    Enter as LF instead of CR — without this, Enter appears dead on those
+    terminals.
 
-    Exception: on Windows, WSL, SSH sessions, and Windows Terminal,
-    c-j is the wire encoding of Ctrl+Enter (a distinct keystroke from
-    plain Enter / c-m). We leave c-j unbound there so the c-j newline
-    handler registered separately can fire — giving the user an
-    Enter-involving newline keystroke without terminal settings changes.
-    See _preserve_ctrl_enter_newline() and issue #22379.
+    Exception: on macOS, Windows, WSL, SSH sessions, and Windows Terminal,
+    c-j is reserved for the newline binding registered separately. On Windows
+    Terminal it is the wire encoding of Ctrl+Enter; on macOS it is the user's
+    Ctrl+J newline shortcut. Leaving it unbound here lets the multiline handler
+    fire without conflicting with submit. See _preserve_ctrl_enter_newline()
+    and issue #22379.
     """
     kb.add("enter")(handler)
     if sys.platform != "win32" and not _preserve_ctrl_enter_newline():
@@ -5035,7 +5036,7 @@ class HermesCLI:
                 )
 
         _cprint(f"\n  {_DIM}Tip: Just type your message to chat with Hermes!{_RST}")
-        _cprint(f"  {_DIM}Multi-line: Alt+Enter for a new line{_RST}")
+        _cprint(f"  {_DIM}Multi-line: Ctrl+J or Alt+Enter for a new line{_RST}")
         _cprint(f"  {_DIM}Draft editor: Ctrl+G (Alt+G in VSCode/Cursor){_RST}")
         if _is_termux_environment():
             _cprint(f"  {_DIM}Attach image: /image {_termux_example_image_path()} or start your prompt with a local image path{_RST}\n")
@@ -11041,26 +11042,22 @@ class HermesCLI:
         def handle_alt_enter(event):
             """Alt+Enter inserts a newline for multi-line input.
 
-            Works on mac/Linux/WSL. On Windows Terminal this keystroke is
-            intercepted at the terminal layer (toggles fullscreen) and never
-            reaches here — Windows users get newline via Ctrl+Enter instead
-            (bound below as c-j, since WT delivers Ctrl+Enter as LF).
+            Works on mac/Linux/WSL. Ctrl+J is also reserved for the same
+            newline handler on macOS, Windows Terminal, WSL, and SSH sessions
+            where c-j should not submit the prompt.
             """
             event.current_buffer.insert_text('\n')
 
         if _preserve_ctrl_enter_newline():
             @kb.add('c-j')
             def handle_ctrl_enter_newline(event):
-                """Ctrl+Enter inserts a newline on Windows, WSL, SSH, and WT.
+                """Ctrl+J/Ctrl+Enter inserts a newline in preserved environments.
 
                 Windows Terminal (incl. WSL/SSH sessions through it) delivers
-                Ctrl+Enter as LF (c-j), distinct from plain Enter (c-m). This
-                binding makes Ctrl+Enter the equivalent of Alt+Enter on those
-                terminals, giving an Enter-involving newline keystroke
-                without requiring terminal settings changes. Ctrl+J (the raw
-                LF keystroke) also triggers this by virtue of being the same
-                key code — a harmless side effect since Ctrl+J has no
-                conflicting Hermes binding. See issue #22379.
+                Ctrl+Enter as LF (c-j), distinct from plain Enter (c-m). macOS
+                users can press Ctrl+J directly for a newline. This binding
+                makes those keystrokes the equivalent of Alt+Enter without
+                requiring terminal settings changes. See issue #22379.
                 """
                 event.current_buffer.insert_text('\n')
 

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -168,9 +168,9 @@ class TestPromptToolkitTerminalCompatibility:
 
         On a bare local POSIX TTY (no SSH/WSL/WT) we keep c-j → submit so
         Enter works on thin PTYs (docker exec, certain ssh configurations).
-        On Windows, WSL, SSH sessions, and Windows Terminal we leave c-j
-        unbound here so it can be used as the Ctrl+Enter newline keystroke
-        without conflicting with submit. See issue #22379.
+        On macOS, Windows, WSL, SSH sessions, and Windows Terminal we leave
+        c-j unbound here so it can be used as the Ctrl+J/Ctrl+Enter newline
+        keystroke without conflicting with submit. See issue #22379.
         """
         import sys as _sys
         import os as _os
@@ -197,6 +197,15 @@ class TestPromptToolkitTerminalCompatibility:
         with _patch.object(_sys, "platform", "linux"), \
              _patch.dict(_os.environ, {"SSH_CONNECTION": "1.2.3.4 5 6.7.8.9 22"}, clear=True), \
              _patch("builtins.open", side_effect=OSError("no /proc")):
+            kb = KeyBindings()
+            _bind_prompt_submit_keys(kb, submit_handler)
+            bindings = {tuple(key.value for key in binding.keys): binding.handler for binding in kb.bindings}
+            assert bindings[("c-m",)] is submit_handler
+            assert ("c-j",) not in bindings
+
+        # macOS: Ctrl+J is a distinct newline shortcut, not submit.
+        with _patch.object(_sys, "platform", "darwin"), \
+             _patch.dict(_os.environ, {}, clear=True):
             kb = KeyBindings()
             _bind_prompt_submit_keys(kb, submit_handler)
             bindings = {tuple(key.value for key in binding.keys): binding.handler for binding in kb.bindings}

--- a/tests/cli/test_ctrl_enter_newline.py
+++ b/tests/cli/test_ctrl_enter_newline.py
@@ -22,6 +22,13 @@ def test_native_windows_preserves_newline():
         assert cli_mod._preserve_ctrl_enter_newline() is True
 
 
+def test_macos_preserves_ctrl_j_newline():
+    import cli as cli_mod
+    with patch.object(sys, "platform", "darwin"):
+        with patch.dict(os.environ, {}, clear=True):
+            assert cli_mod._preserve_ctrl_enter_newline() is True
+
+
 def test_ssh_session_preserves_newline_on_linux():
     import cli as cli_mod
     with patch.object(sys, "platform", "linux"):


### PR DESCRIPTION
## Summary
- preserve c-j/Ctrl-J as a multiline newline shortcut on macOS instead of binding it to submit
- keep bare local Linux c-j submit fallback unchanged
- update CLI help text and focused tests

## Verification
- python -m pytest -q -n 0 tests/cli/test_ctrl_enter_newline.py tests/cli/test_cli_init.py::TestPromptToolkitTerminalCompatibility::test_lf_enter_binds_to_submit_handler_posix
