### PR TITLE
fix(kimi-coding): preserve trailing slash and guard against stale api_mode

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -285,6 +285,14 @@ def _resolve_runtime_from_pool_entry(
     if api_mode == "anthropic_messages" and provider in ("opencode-zen", "opencode-go"):
         base_url = re.sub(r"/v1/?$", "", base_url)
 
+    # Kimi Code Anthropic-compatible endpoint requires a trailing slash.
+    if (
+        provider in ("kimi-coding", "kimi-coding-cn")
+        and api_mode == "anthropic_messages"
+        and base_url.rstrip("/") == "https://api.kimi.com/coding"
+    ):
+        base_url = "https://api.kimi.com/coding/"
+
     return {
         "provider": provider,
         "api_mode": api_mode,
@@ -862,6 +870,9 @@ def _resolve_explicit_runtime(
             if provider in ("kimi-coding", "kimi-coding-cn"):
                 creds = resolve_api_key_provider_credentials(provider)
                 base_url = creds.get("base_url", "").rstrip("/")
+                # Kimi Code Anthropic-compatible endpoint requires trailing slash.
+                if base_url == "https://api.kimi.com/coding":
+                    base_url = "https://api.kimi.com/coding/"
             else:
                 base_url = env_url or pconfig.inference_base_url
 
@@ -879,7 +890,10 @@ def _resolve_explicit_runtime(
             api_mode = "codex_responses"
         else:
             configured_mode = _parse_api_mode(model_cfg.get("api_mode"))
-            if configured_mode:
+            if configured_mode and _provider_supports_explicit_api_mode(
+                provider,
+                configured_provider=str(model_cfg.get("provider") or "").strip().lower(),
+            ):
                 api_mode = configured_mode
             else:
                 # Auto-detect from URL (Anthropic /anthropic suffix,
@@ -891,7 +905,12 @@ def _resolve_explicit_runtime(
         return {
             "provider": provider,
             "api_mode": api_mode,
-            "base_url": base_url.rstrip("/"),
+            "base_url": (
+                "https://api.kimi.com/coding/"
+                if provider in ("kimi-coding", "kimi-coding-cn")
+                and base_url.rstrip("/") == "https://api.kimi.com/coding"
+                else base_url.rstrip("/")
+            ),
             "api_key": api_key,
             "source": "explicit",
             "requested_provider": requested_provider,


### PR DESCRIPTION
## Problem

Two bugs in `runtime_provider.py` cause `kimi-for-coding` HTTP 404:

### Bug 1: Trailing-slash stripped (3 sites)
The Anthropic SDK appends `/v1/messages` to the configured `base_url`. Without a trailing slash on `https://api.kimi.com/coding`, the SDK constructs `/codingv1/messages` instead of `/coding/v1/messages` → 404.

Three `.rstrip("/")` calls in `_resolve_explicit_runtime` and `_resolve_runtime_from_pool_entry` strip the slash. All three now detect the stripped Kimi URL and restore it.

### Bug 2: Stale api_mode leak
`_resolve_explicit_runtime` unconditionally honors `model_cfg.api_mode` from `config.yaml`, which may contain a different provider's api_mode (e.g. `chat_completions` for opencode-go). After a `/model kimi-for-coding` switch, this overrides URL-based auto-detection that would correctly return `anthropic_messages`.

The credential pool path (`_resolve_runtime_from_pool_entry`) already handles this via `_provider_supports_explicit_api_mode`. This PR adds the same guard to `_resolve_explicit_runtime`.

## Changes

`hermes_cli/runtime_provider.py` — 21 insertions, 2 deletions across 4 sites:
- Site 1: trailing slash after credential lookup
- Site 2: trailing slash in return dict
- Site 3: trailing slash before pool entry return
- Site 4: `_provider_supports_explicit_api_mode` guard on configured api_mode

## Verification

All three code paths return correct values:

| Path | `api_mode` | `base_url` |
|------|-------------|-------------|
| Explicit credentials (simulates `/model` switch) | `anthropic_messages` | `https://api.kimi.com/coding/` |
| Pool path (fresh agent start) | `anthropic_messages` | `https://api.kimi.com/coding/` |
| CLI inference test | ✅ Returns `OK` | |

```python
from hermes_cli.runtime_provider import resolve_runtime_provider

# Explicit credentials (like _ensure_runtime_credentials after /model)
r = resolve_runtime_provider(requested='kimi-coding', explicit_api_key='...', explicit_base_url='https://api.kimi.com/coding/')
assert r['api_mode'] == 'anthropic_messages'
assert r['base_url'] == 'https://api.kimi.com/coding/'

# Pool path (fresh agent)
r2 = resolve_runtime_provider(requested='kimi-coding')
assert r2['api_mode'] == 'anthropic_messages'
assert r2['base_url'] == 'https://api.kimi.com/coding/'
```

The trailing-slash fix on its own was necessary but not sufficient — the api_mode leak is why `/model` switch still 404ed even with the correct URL.