### PR TITLE
fix(kanban): auto-unblock dependency-blocked children when parents complete

### DIFF
--- a/hermes_cli/kanban_db.py
+++ b/hermes_cli/kanban_db.py
@@ -1525,6 +1525,12 @@ def link_tasks(conn: sqlite3.Connection, parent_id: str, child_id: str) -> None:
             conn, child_id, "linked",
             {"parent": parent_id, "child": child_id},
         )
+    # Re-evaluate readiness after linking — handles two late-link cases:
+    # (1) child was 'ready' and we just linked an unfinished parent → demoted
+    #     above; recompute is a no-op for that path.
+    # (2) child is 'blocked' with a reason referencing this parent, and the
+    #     parent is already 'done' → auto-unblock now that the link exists.
+    recompute_ready(conn)
 
 
 def _would_cycle(conn: sqlite3.Connection, parent_id: str, child_id: str) -> bool:
@@ -1813,10 +1819,19 @@ def _synthesize_ended_run(
 # ---------------------------------------------------------------------------
 
 def recompute_ready(conn: sqlite3.Connection) -> int:
-    """Promote ``todo`` tasks to ``ready`` when all parents are ``done``.
+    """Promote ``todo`` tasks to ``ready`` when all parents are ``done``,
+    and auto-unblock dependency-blocked tasks when their parents complete.
 
-    Returns the number of tasks promoted.  Safe to call inside or outside
-    an existing transaction; it opens its own IMMEDIATE txn.
+    Returns the number of tasks promoted or auto-unblocked.  Safe to call
+    inside or outside an existing transaction; it opens its own IMMEDIATE
+    txn.
+
+    A blocked task is treated as dependency-blocked (and therefore eligible
+    for auto-unblock when all its parents are ``done``) iff the most recent
+    ``blocked`` event's ``reason`` references one of its parent task ids by
+    literal ``t_<hex>`` substring. This preserves manual-block semantics
+    (e.g. a worker pausing for an out-of-band human approval): those blocks
+    don't mention a parent id and stay blocked until human intervention.
     """
     promoted = 0
     with write_txn(conn):
@@ -1837,6 +1852,71 @@ def recompute_ready(conn: sqlite3.Connection) -> int:
                     (task_id,),
                 )
                 _append_event(conn, task_id, "promoted", None)
+                promoted += 1
+        # Auto-unblock dependency-blocked tasks whose parents all completed.
+        blocked_rows = conn.execute(
+            "SELECT id, current_run_id FROM tasks WHERE status = 'blocked'"
+        ).fetchall()
+        for row in blocked_rows:
+            task_id = row["id"]
+            parent_rows = conn.execute(
+                "SELECT t.id AS pid, t.status AS pstatus FROM tasks t "
+                "JOIN task_links l ON l.parent_id = t.id "
+                "WHERE l.child_id = ?",
+                (task_id,),
+            ).fetchall()
+            if not parent_rows:
+                continue
+            if not all(p["pstatus"] == "done" for p in parent_rows):
+                continue
+            parent_ids = {p["pid"] for p in parent_rows}
+            ev_row = conn.execute(
+                "SELECT payload FROM task_events "
+                "WHERE task_id = ? AND kind = 'blocked' "
+                "ORDER BY id DESC LIMIT 1",
+                (task_id,),
+            ).fetchone()
+            if not ev_row:
+                continue
+            try:
+                payload = json.loads(ev_row["payload"] or "{}")
+            except (ValueError, TypeError):
+                payload = {}
+            reason_text = str(payload.get("reason") or "")
+            if not any(pid in reason_text for pid in parent_ids):
+                # Manual block (waiting on human approval, etc.) — leave it.
+                continue
+            now_ts = int(time.time())
+            if row["current_run_id"]:
+                conn.execute(
+                    """
+                    UPDATE task_runs
+                       SET status = 'reclaimed', outcome = 'reclaimed',
+                           summary = COALESCE(
+                               summary,
+                               'invariant recovery on auto-unblock'
+                           ),
+                           ended_at = ?,
+                           claim_lock = NULL, claim_expires = NULL,
+                           worker_pid = NULL
+                     WHERE id = ? AND ended_at IS NULL
+                    """,
+                    (now_ts, int(row["current_run_id"])),
+                )
+            cur = conn.execute(
+                "UPDATE tasks SET status = 'ready', current_run_id = NULL "
+                "WHERE id = ? AND status = 'blocked'",
+                (task_id,),
+            )
+            if cur.rowcount == 1:
+                _append_event(
+                    conn, task_id, "unblocked",
+                    {
+                        "auto": True,
+                        "reason": "all parents complete",
+                        "parents_done": sorted(parent_ids),
+                    },
+                )
                 promoted += 1
     return promoted
 

--- a/tests/hermes_cli/test_kanban_db.py
+++ b/tests/hermes_cli/test_kanban_db.py
@@ -145,6 +145,128 @@ def test_recompute_ready_fan_in_waits_for_all_parents(kanban_home):
         assert kb.get_task(conn, c).status == "ready"
 
 
+def test_recompute_ready_auto_unblocks_dependency_blocked_child(kanban_home):
+    """A child blocked while waiting on a parent should auto-unblock
+    when that parent completes — the bug behind real-world stuck tasks."""
+    with kb.connect() as conn:
+        p = kb.create_task(conn, title="parent")
+        c = kb.create_task(conn, title="child", parents=[p])
+        # Worker tried to run child, found it needed the parent, blocked
+        # itself with a reason that references the parent id.
+        kb.claim_task(conn, c)  # ready -> running (parent already done? no — c is todo)
+    # c is in 'todo' (parent not done), so claim above returned None. Fix by
+    # completing parent first to put c in 'ready', then claiming.
+    with kb.connect() as conn:
+        kb.complete_task(conn, p)
+        assert kb.get_task(conn, c).status == "ready"
+        # Re-create the dependency scenario: link a NEW parent that's not done.
+        p2 = kb.create_task(conn, title="parent2")
+        kb.link_tasks(conn, p2, c)
+        assert kb.get_task(conn, c).status == "todo"
+        # Promote back to ready and claim, then block referencing p2.
+        kb.complete_task(conn, p2)
+        assert kb.get_task(conn, c).status == "ready"
+    # Simpler scenario for the test: brand-new parent+child, block child
+    # mentioning parent id, then complete parent.
+    with kb.connect() as conn:
+        pp = kb.create_task(conn, title="real-parent")
+        cc = kb.create_task(conn, title="real-child")
+        # Block child manually-but-with-parent-reason BEFORE linking; link
+        # after so the block reason references a real parent id.
+        kb.claim_task(conn, cc)
+        kb.block_task(
+            conn, cc,
+            reason=f"waiting on parent {pp}; please complete and resume",
+        )
+        kb.link_tasks(conn, pp, cc)
+        assert kb.get_task(conn, cc).status == "blocked"
+        kb.complete_task(conn, pp)
+        # complete_task calls recompute_ready, which should auto-unblock cc.
+        assert kb.get_task(conn, cc).status == "ready"
+        # Audit trail: an 'unblocked' event with auto=True should exist.
+        ev = conn.execute(
+            "SELECT payload FROM task_events "
+            "WHERE task_id = ? AND kind = 'unblocked' "
+            "ORDER BY id DESC LIMIT 1",
+            (cc,),
+        ).fetchone()
+        assert ev is not None
+        import json
+        payload = json.loads(ev["payload"])
+        assert payload.get("auto") is True
+        assert pp in payload.get("parents_done", [])
+
+
+def test_recompute_ready_preserves_manual_blocks(kanban_home):
+    """A block reason that does NOT mention any parent id should stay
+    blocked even when all parents complete — manual blocks (e.g. waiting
+    on human approval) must not be auto-cleared."""
+    with kb.connect() as conn:
+        p = kb.create_task(conn, title="parent")
+        c = kb.create_task(conn, title="child")
+        kb.link_tasks(conn, p, c)
+        kb.complete_task(conn, p)
+        assert kb.get_task(conn, c).status == "ready"
+        kb.claim_task(conn, c)
+        # Manual block — reason mentions no parent id; this is a human-gated
+        # pause (force-push approval, credential rotation, etc.).
+        kb.block_task(
+            conn, c,
+            reason="need approval to force-push to main",
+        )
+        assert kb.get_task(conn, c).status == "blocked"
+        # All parents are already done. Recompute should NOT touch this.
+        kb.recompute_ready(conn)
+        assert kb.get_task(conn, c).status == "blocked"
+
+
+def test_recompute_ready_auto_unblock_only_when_all_parents_done(kanban_home):
+    """When a dependency-blocked child has multiple parents, partial
+    completion should NOT auto-unblock; all parents must be done."""
+    with kb.connect() as conn:
+        p1 = kb.create_task(conn, title="p1")
+        p2 = kb.create_task(conn, title="p2")
+        c = kb.create_task(conn, title="c", parents=[p1, p2])
+        # Worker claims after both parents promoted? They aren't yet — c is
+        # 'todo'. Promote p1 first; c stays todo because p2 isn't done.
+        kb.complete_task(conn, p1)
+        assert kb.get_task(conn, c).status == "todo"
+        # Complete p2 to get c to ready, then claim+block referencing p2.
+        kb.complete_task(conn, p2)
+        # Re-block c to simulate a worker pause that mentioned p2.
+        kb.claim_task(conn, c)
+        # Add a NEW parent that's not done; the auto-unblock check requires
+        # ALL parents done.
+        p3 = kb.create_task(conn, title="p3")
+        kb.block_task(conn, c, reason=f"blocked on {p3}")
+        kb.link_tasks(conn, p3, c)
+        assert kb.get_task(conn, c).status == "blocked"
+        # p3 still in flight — recompute should leave c blocked.
+        kb.recompute_ready(conn)
+        assert kb.get_task(conn, c).status == "blocked"
+        # Finish p3 → auto-unblock fires.
+        kb.complete_task(conn, p3)
+        assert kb.get_task(conn, c).status == "ready"
+
+
+def test_link_tasks_auto_unblocks_when_late_linked_parent_is_done(kanban_home):
+    """If a worker blocks referencing a parent id and the link is created
+    AFTER the parent has already completed, linking should re-evaluate
+    readiness and auto-unblock the child."""
+    with kb.connect() as conn:
+        p = kb.create_task(conn, title="parent")
+        c = kb.create_task(conn, title="child")
+        kb.claim_task(conn, c)
+        kb.block_task(conn, c, reason=f"need {p} to finish first")
+        # Parent completes BEFORE the link exists.
+        kb.complete_task(conn, p)
+        assert kb.get_task(conn, c).status == "blocked"
+        # Now the orchestrator (or human) belatedly links the dependency.
+        kb.link_tasks(conn, p, c)
+        # link_tasks should call recompute_ready and auto-unblock c.
+        assert kb.get_task(conn, c).status == "ready"
+
+
 # ---------------------------------------------------------------------------
 # Atomic claim (CAS)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

When a kanban worker blocks a task with a reason that references a parent task id (e.g. `waiting on parent t_abc123 to finish`) and that parent later completes, the child stays blocked forever. `recompute_ready` only promoted `todo → ready`, never touching `blocked`. This is the most common cause of stuck tasks in production: the orchestrator links the dependency, the parent finishes, and the child is silently stranded until a human notices.

Concrete real-world repro from my board today: `t_be29f448` (docfiller POC) blocked at 16:13 with reason referencing infra parent `t_9fca002b`; parent completed at 16:16; child stayed blocked for hours until a manual sweep.

## Fix

- **`recompute_ready`** now also auto-unblocks blocked children whose latest `blocked` event's reason text contains a parent task id substring AND whose parents are all `done`. The parent-id reference is the discriminator: manual blocks (waiting on human approval, credential rotation, force-push sign-off, etc.) don't mention a parent id and are preserved.
- **`link_tasks`** now calls `recompute_ready` after the link write so late-linked dependencies (parent already done at link time, common when orchestrators belatedly wire up a dep graph) re-evaluate child readiness and clear the block immediately.
- Auto-unblock events are auditable: the `unblocked` event carries `auto=True` plus the `parents_done` list, so dashboards and digests can surface the cascade.

## Why this discriminator (parent-id substring) is right

The block-reason text is the most reliable signal we have without a schema change. A worker that says `waiting on t_9fca002b` is unambiguously a dependency-block. A worker that says `need approval to force-push to main` is unambiguously human-gated. Worker prompts in the kanban-worker skill already encourage referencing the parent id when blocking on a dependency, so this matches existing convention.

A schema-flag alternative (`blocked_kind: dependency | manual`) would be cleaner long-term but requires a migration and updates to every `block_task` call site. The substring check is a zero-migration fix that solves the production pain immediately. If the project wants to add the flag later, recompute_ready can be tightened to prefer it and fall back to substring.

## Tests

4 new tests in `tests/hermes_cli/test_kanban_db.py`:

- `test_recompute_ready_auto_unblocks_dependency_blocked_child` — happy path: block referencing parent, parent completes, child auto-unblocks with audit-trail event.
- `test_recompute_ready_preserves_manual_blocks` — manual block ("need approval to force-push to main") stays blocked even when all parents are done.
- `test_recompute_ready_auto_unblock_only_when_all_parents_done` — partial parent completion does NOT auto-unblock; all parents must be done.
- `test_link_tasks_auto_unblocks_when_late_linked_parent_is_done` — late-link case: parent finishes before the link is created, then linking the parent auto-unblocks the child.

`pytest tests/hermes_cli/test_kanban_db.py` passes 85/86 on this branch (1 pre-existing failure: `test_max_runtime_uses_current_run_start_after_retry` hits the live-system PID-kill guard — confirmed pre-existing by stashing and re-running on `main`).

`ruff check` clean on touched files.