### PR TITLE
feat(dashboard): show session ID and token counts on sessions page

### DIFF
--- a/web/src/pages/SessionsPage.tsx
+++ b/web/src/pages/SessionsPage.tsx
@@ -274,6 +274,7 @@ function SessionRow({
   const [messages, setMessages] = useState<SessionMessage[] | null>(null);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
   const { t } = useI18n();
   const navigate = useNavigate();
 
@@ -344,8 +345,40 @@ function SessionRow({
                   </span>
                 </>
               )}
+              {(session.input_tokens > 0 || session.output_tokens > 0) && (
+                <>
+                  <span className="text-border">&#183;</span>
+                  <span className="tabular-nums">
+                    {session.input_tokens >= 1000
+                      ? `${(session.input_tokens / 1000).toFixed(1)}K`
+                      : session.input_tokens}{" "}
+                    in
+                  </span>
+                  <span className="text-border">&#183;</span>
+                  <span className="tabular-nums">
+                    {session.output_tokens >= 1000
+                      ? `${(session.output_tokens / 1000).toFixed(1)}K`
+                      : session.output_tokens}{" "}
+                    out
+                  </span>
+                </>
+              )}
               <span className="text-border">&#183;</span>
               <span>{timeAgo(session.last_active)}</span>
+              <span className="text-border">&#183;</span>
+              <button
+                className={`text-[10px] transition-colors ${copied ? "text-success" : "text-muted-foreground/50 hover:text-foreground"}`}
+                title="Click to copy session ID"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  navigator.clipboard.writeText(session.id).then(() => {
+                    setCopied(true);
+                    setTimeout(() => setCopied(false), 1500);
+                  });
+                }}
+              >
+                {copied ? "Copied!" : session.id}
+              </button>
             </div>
             {snippet && <SnippetHighlight snippet={snippet} />}
           </div>


### PR DESCRIPTION
## Summary

The sessions dashboard at /sessions currently shows model, message count, tool calls, and time ago — but omits the session ID and token usage. This PR adds both.

### Changes

- **Session ID** — clickable label at the far right of each row's metadata line. Click copies the full ID to clipboard with a brief "Copied!" confirmation. Default color: muted-foreground/50, turns green (text-success) on copy. Tooltip: "Click to copy session ID".

- **Token counts** — displayed between tool calls and time ago in compact format (e.g. "12.5K in · 3.2K out"). Hidden when both input and output tokens are zero.

### Before / After

**Row before:**
```
deepseek-v4-pro · 5 msgs · 3 tools · 2h ago
```

**Row after:**
```
deepseek-v4-pro · 5 msgs · 3 tools · 12.5K in · 3.2K out · 2h ago · 20260510_193553…
```

### Files changed

- `web/src/pages/SessionsPage.tsx` — 33 insertions in SessionRow component

## How to Test

1. Open dashboard at http://127.0.0.1:9119/sessions
2. Verify each session row shows token counts (when >0) and session ID at far right
3. Click the session ID — clipboard should receive the full ID, text briefly shows "Copied!"
4. Hover over ID — tooltip shows "Click to copy session ID"

## Platform Tested

- Windows 11 (native) with git-bash
- Hermes Agent latest main

## Related

Closes #23461