### PR TITLE
fix(gateway): add chat_id to hook_ctx for message source tracking

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -7462,6 +7462,7 @@ class GatewayRunner:
             hook_ctx = {
                 "platform": source.platform.value if source.platform else "",
                 "user_id": source.user_id,
+                "chat_id": source.chat_id or "",
                 "session_id": session_entry.session_id,
                 "message": message_text[:500],
             }


### PR DESCRIPTION
## Summary
Adds `chat_id` to the `hook_ctx` dictionary passed to gateway hooks, enabling hook implementations to identify the target chat of a message source.

## Change
`gateway/run.py`: One line addition in `hook_ctx`:
```diff
+ "chat_id": source.chat_id or "",
```

## Motivation
Hook extensions currently lack `chat_id` visibility, making it impossible to route or filter hook logic based on the target chat. This change surfaces that field without breaking existing consumers (falls back to empty string if `chat_id` is `None`).