### PR TITLE
feat(google-workspace): add gmail attachment list/get CLI verbs (#22872)

### DIFF
--- a/skills/productivity/google-workspace/SKILL.md
+++ b/skills/productivity/google-workspace/SKILL.md
@@ -196,6 +196,13 @@ $GAPI gmail reply MESSAGE_ID --from '"Support Bot" <user@example.com>' --body "T
 $GAPI gmail labels
 $GAPI gmail modify MESSAGE_ID --add-labels LABEL_ID
 $GAPI gmail modify MESSAGE_ID --remove-labels UNREAD
+
+# Attachments
+# List attachments in a message (returns JSON with attachment_id, filename, mime_type, size_bytes)
+$GAPI gmail attachment list MESSAGE_ID
+
+# Download a single attachment to a local path
+$GAPI gmail attachment get MESSAGE_ID ATTACHMENT_ID --output /tmp/report.pdf
 ```
 
 ### Calendar

--- a/skills/productivity/google-workspace/scripts/google_api.py
+++ b/skills/productivity/google-workspace/scripts/google_api.py
@@ -10,6 +10,8 @@ Usage:
   python google_api.py gmail get MESSAGE_ID
   python google_api.py gmail send --to user@example.com --subject "Hi" --body "Hello"
   python google_api.py gmail reply MESSAGE_ID --body "Thanks"
+  python google_api.py gmail attachment list MESSAGE_ID
+  python google_api.py gmail attachment get MESSAGE_ID ATTACHMENT_ID --output /path/to/file.pdf
   python google_api.py calendar list [--from DATE] [--to DATE] [--calendar primary]
   python google_api.py calendar create --summary "Meeting" --start DATETIME --end DATETIME
   python google_api.py drive search "budget report" [--max 10]
@@ -450,6 +452,82 @@ def gmail_modify(args):
     service = build_service("gmail", "v1")
     result = service.users().messages().modify(userId="me", id=args.message_id, body=body).execute()
     print(json.dumps({"id": result["id"], "labels": result.get("labelIds", [])}, indent=2))
+
+
+def _walk_attachments(payload: dict, path: str = "") -> list[dict]:
+    """Recursively collect attachment metadata from a Gmail message payload.
+
+    Returns a list of {attachment_id, filename, mime_type, size_bytes, part_id}
+    for every part whose body has an attachmentId.
+    """
+    found: list[dict] = []
+    part_id = payload.get("partId") or path or "root"
+    body = payload.get("body") if isinstance(payload.get("body"), dict) else None
+    attachment_id = body.get("attachmentId") if body else None
+    if attachment_id:
+        found.append({
+            "attachment_id": attachment_id,
+            "filename": payload.get("filename") or "",
+            "mime_type": payload.get("mimeType") or "",
+            "size_bytes": int(body.get("size") or 0),
+            "part_id": part_id,
+        })
+    parts = payload.get("parts")
+    if isinstance(parts, list):
+        for idx, part in enumerate(parts):
+            child_path = f"{part_id}.{idx}"
+            found.extend(_walk_attachments(part, child_path))
+    return found
+
+
+def gmail_attachment_list(args):
+    if _gws_binary():
+        msg = _run_gws(
+            ["gmail", "users", "messages", "get"],
+            params={"userId": "me", "id": args.message_id, "format": "full"},
+        )
+    else:
+        service = build_service("gmail", "v1")
+        msg = service.users().messages().get(
+            userId="me", id=args.message_id, format="full"
+        ).execute()
+
+    payload = msg.get("payload") if isinstance(msg, dict) else None
+    attachments = _walk_attachments(payload) if isinstance(payload, dict) else []
+    print(json.dumps(attachments, indent=2, ensure_ascii=False))
+
+
+def gmail_attachment_get(args):
+    if _gws_binary():
+        att = _run_gws(
+            ["gmail", "users", "messages", "attachments", "get"],
+            params={
+                "userId": "me",
+                "messageId": args.message_id,
+                "id": args.attachment_id,
+            },
+        )
+    else:
+        service = build_service("gmail", "v1")
+        att = service.users().messages().attachments().get(
+            userId="me", messageId=args.message_id, id=args.attachment_id
+        ).execute()
+
+    data = att.get("data") if isinstance(att, dict) else None
+    if not data:
+        print("ERROR: Attachment payload missing 'data' field.", file=sys.stderr)
+        sys.exit(1)
+
+    raw = base64.urlsafe_b64decode(data)
+    output_path = Path(args.output)
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    output_path.write_bytes(raw)
+
+    print(json.dumps({
+        "status": "saved",
+        "path": str(output_path),
+        "size_bytes": len(raw),
+    }, indent=2))
 
 
 # =========================================================================
@@ -1088,6 +1166,19 @@ def main():
     p.add_argument("--add-labels", default="", help="Comma-separated label IDs to add")
     p.add_argument("--remove-labels", default="", help="Comma-separated label IDs to remove")
     p.set_defaults(func=gmail_modify)
+
+    att = gmail_sub.add_parser("attachment", help="Inspect or download message attachments")
+    att_sub = att.add_subparsers(dest="att_action", required=True)
+
+    p = att_sub.add_parser("list", help="List attachments in a message")
+    p.add_argument("message_id")
+    p.set_defaults(func=gmail_attachment_list)
+
+    p = att_sub.add_parser("get", help="Download a single attachment by ID")
+    p.add_argument("message_id")
+    p.add_argument("attachment_id")
+    p.add_argument("--output", required=True, help="Local output path for attachment bytes")
+    p.set_defaults(func=gmail_attachment_get)
 
     # --- Calendar ---
     cal = sub.add_parser("calendar")

--- a/tests/skills/test_google_workspace_api.py
+++ b/tests/skills/test_google_workspace_api.py
@@ -1,5 +1,6 @@
 """Tests for Google Workspace gws bridge and CLI wrapper."""
 
+import base64
 import importlib.util
 import json
 import subprocess
@@ -278,3 +279,157 @@ def test_api_get_credentials_refresh_persists_authorized_user_type(api_module, m
     assert isinstance(creds, FakeCredentials)
     assert saved["token"] == "ya29.refreshed"
     assert saved["type"] == "authorized_user"
+
+
+def test_walk_attachments_finds_nested_parts(api_module):
+    """_walk_attachments surfaces attachments from multi-level multipart payloads."""
+    payload = {
+        "partId": "0",
+        "mimeType": "multipart/mixed",
+        "parts": [
+            {
+                "partId": "0.0",
+                "mimeType": "text/plain",
+                "body": {"size": 12, "data": "aGVsbG8gd29ybGQ="},
+            },
+            {
+                "partId": "0.1",
+                "mimeType": "multipart/related",
+                "parts": [
+                    {
+                        "partId": "0.1.0",
+                        "mimeType": "application/pdf",
+                        "filename": "report.pdf",
+                        "body": {"size": 4096, "attachmentId": "att-1"},
+                    },
+                ],
+            },
+            {
+                "partId": "0.2",
+                "mimeType": "image/png",
+                "filename": "logo.png",
+                "body": {"size": 2048, "attachmentId": "att-2"},
+            },
+        ],
+    }
+
+    found = api_module._walk_attachments(payload)
+
+    assert len(found) == 2
+    assert {a["attachment_id"] for a in found} == {"att-1", "att-2"}
+    pdf = next(a for a in found if a["attachment_id"] == "att-1")
+    assert pdf["filename"] == "report.pdf"
+    assert pdf["mime_type"] == "application/pdf"
+    assert pdf["size_bytes"] == 4096
+    png = next(a for a in found if a["attachment_id"] == "att-2")
+    assert png["filename"] == "logo.png"
+    assert png["size_bytes"] == 2048
+
+
+def test_walk_attachments_empty_when_no_attachments(api_module):
+    """A plain text-only payload returns an empty list."""
+    payload = {
+        "mimeType": "text/plain",
+        "body": {"size": 5, "data": "aGVsbG8="},
+    }
+    assert api_module._walk_attachments(payload) == []
+
+
+def test_api_gmail_attachment_list_uses_messages_get(api_module, capsys):
+    """gmail attachment list reads the full message and surfaces attachments."""
+    payload = {
+        "parts": [
+            {
+                "partId": "1",
+                "mimeType": "application/pdf",
+                "filename": "invoice.pdf",
+                "body": {"size": 1234, "attachmentId": "att-xyz"},
+            },
+        ],
+    }
+    captured = {}
+
+    def capture_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return MagicMock(returncode=0, stdout=json.dumps({"payload": payload}), stderr="")
+
+    args = api_module.argparse.Namespace(
+        message_id="msg-1", func=api_module.gmail_attachment_list,
+    )
+
+    with patch.object(api_module.subprocess, "run", side_effect=capture_run):
+        api_module.gmail_attachment_list(args)
+
+    cmd = captured["cmd"]
+    assert cmd[0] == "/usr/bin/gws"
+    assert cmd[1:5] == ["gmail", "users", "messages", "get"]
+    params = json.loads(cmd[cmd.index("--params") + 1])
+    assert params["userId"] == "me"
+    assert params["id"] == "msg-1"
+    assert params["format"] == "full"
+
+    out = json.loads(capsys.readouterr().out)
+    assert len(out) == 1
+    assert out[0]["attachment_id"] == "att-xyz"
+    assert out[0]["filename"] == "invoice.pdf"
+    assert out[0]["size_bytes"] == 1234
+
+
+def test_api_gmail_attachment_get_decodes_and_writes(api_module, tmp_path, capsys):
+    """gmail attachment get base64url-decodes the payload and writes it to disk."""
+    raw_bytes = b"%PDF-1.4 fake content\x00\xff"
+    encoded = base64.urlsafe_b64encode(raw_bytes).decode()
+
+    captured = {}
+
+    def capture_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return MagicMock(returncode=0, stdout=json.dumps({"size": len(raw_bytes), "data": encoded}), stderr="")
+
+    output = tmp_path / "out" / "doc.pdf"
+    args = api_module.argparse.Namespace(
+        message_id="msg-1",
+        attachment_id="att-xyz",
+        output=str(output),
+        func=api_module.gmail_attachment_get,
+    )
+
+    with patch.object(api_module.subprocess, "run", side_effect=capture_run):
+        api_module.gmail_attachment_get(args)
+
+    cmd = captured["cmd"]
+    assert cmd[1:6] == ["gmail", "users", "messages", "attachments", "get"]
+    params = json.loads(cmd[cmd.index("--params") + 1])
+    assert params["userId"] == "me"
+    assert params["messageId"] == "msg-1"
+    assert params["id"] == "att-xyz"
+
+    assert output.read_bytes() == raw_bytes
+    out = json.loads(capsys.readouterr().out)
+    assert out["status"] == "saved"
+    assert out["path"] == str(output)
+    assert out["size_bytes"] == len(raw_bytes)
+
+
+def test_api_gmail_attachment_get_errors_on_missing_data(api_module, tmp_path, capsys):
+    """gmail attachment get surfaces a clear error when the API response has no 'data'."""
+    captured = {}
+
+    def capture_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return MagicMock(returncode=0, stdout=json.dumps({"size": 0}), stderr="")
+
+    output = tmp_path / "doc.pdf"
+    args = api_module.argparse.Namespace(
+        message_id="msg-1",
+        attachment_id="att-xyz",
+        output=str(output),
+        func=api_module.gmail_attachment_get,
+    )
+
+    with patch.object(api_module.subprocess, "run", side_effect=capture_run):
+        with pytest.raises(SystemExit) as excinfo:
+            api_module.gmail_attachment_get(args)
+
+    assert excinfo.value.code == 1
+    assert not output.exists()


### PR DESCRIPTION
## Summary

The bundled `productivity/google-workspace` skill ships a CLI wrapper for
Gmail (`search`, `get`, `send`, `reply`, `labels`, `modify`) but exposes no
surface for downloading attachments. When the agent surfaces emails matching
the SKILL.md example `has:attachment filename:pdf newer_than:7d`, it then
has no skill-supported way to fetch them — it falls back to ad-hoc Python
or asks the user to download manually.

This adds two subcommands under `gmail attachment`.

## The gap

`skills/productivity/google-workspace/scripts/google_api.py` has full
plumbing for `users.messages.get`, `send`, `reply`, `labels`, `modify` —
but never wires `users.messages.attachments.get`. The Gmail message
payload references attachments by `body.attachmentId`, which is opaque
without a second API call to resolve to bytes.

## The fix

Two new subcommands following the existing `_run_gws` / `build_service`
dual-path pattern:

```bash
$GAPI gmail attachment list MESSAGE_ID
# → [{"attachment_id": "...", "filename": "...", "mime_type": "...", "size_bytes": N, "part_id": "..."}]

$GAPI gmail attachment get MESSAGE_ID ATTACHMENT_ID --output /tmp/file.pdf
# → {"status": "saved", "path": "/tmp/file.pdf", "size_bytes": N}
```

- `gmail attachment list` walks the message payload via a new
  `_walk_attachments()` helper that handles nested `multipart/*` parts
  (cover letter + signed/encrypted wrappers).
- `gmail attachment get` base64url-decodes the payload and writes bytes
  to disk, creating parent directories as needed.
- Both go through `_run_gws` when the gws binary is available and fall
  back to `googleapiclient` otherwise, matching every other verb in the
  file.
- No new OAuth scopes — `gmail.readonly` already covers
  `attachments.get`.

## Test plan

- [x] Focused: `tests/skills/test_google_workspace_api.py` — 5 new tests
  (12 total, all pass):
  - `_walk_attachments` finds attachments across nested multipart
  - `_walk_attachments` returns empty for text-only payloads
  - `gmail attachment list` issues the expected `messages.get` call and
    emits the JSON shape
  - `gmail attachment get` decodes base64url and writes the raw bytes
    to the output path, creating parent directories
  - `gmail attachment get` surfaces a clear stderr error and exits 1
    when the API response omits `data`
- [x] Adjacent suite: `tests/skills/` (164 passed) — no regressions in
  bridge / OAuth / sibling skills tests.

## Related

- Fixes #22872
- Same skill area as previously salvaged PR #19886 (#16470 → #19886);
  no overlap with that diff.