### PR TITLE
fix(gateway): unload default gateway before bootstrapping profile-spe…

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2736,6 +2736,28 @@ def get_launchd_label() -> str:
     return f"ai.hermes.gateway-{suffix}" if suffix else "ai.hermes.gateway"
 
 
+def _unload_conflicting_gateway(current_label: str) -> None:
+    """Unload any conflicting gateway launchd service before bootstrapping a new one.
+
+    When switching from the default ``ai.hermes.gateway`` to a profile-specific
+    label (e.g. ``ai.hermes.gateway-deepseek-pro``), the old default service
+    must be removed first.  Otherwise two gateways fight for the same ports
+    and KeepAlive causes an endless crash-restart loop.
+    """
+    if current_label == "ai.hermes.gateway":
+        return  # Already the default — nothing to conflict with
+    domain = _launchd_domain()
+    generic = "ai.hermes.gateway"
+    # bootout is idempotent — fails silently if the service isn't loaded
+    subprocess.run(["launchctl", "bootout", f"{domain}/{generic}"], check=False, timeout=90)
+    # Remove the old plist so it doesn't get reloaded on next login
+    generic_plist = _launchd_user_home() / "Library" / "LaunchAgents" / f"{generic}.plist"
+    try:
+        generic_plist.unlink()
+    except FileNotFoundError:
+        pass
+
+
 def _launchd_domain() -> str:
     return f"gui/{os.getuid()}"  # windows-footgun: ok — POSIX launchd (macOS) helper, never invoked on Windows
 
@@ -2850,8 +2872,10 @@ def refresh_launchd_plist_if_needed() -> bool:
     if not plist_path.exists() or launchd_plist_is_current():
         return False
 
-    plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
     label = get_launchd_label()
+    _unload_conflicting_gateway(label)
+
+    plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
     # Bootout/bootstrap so launchd picks up the new definition
     subprocess.run(["launchctl", "bootout", f"{_launchd_domain()}/{label}"], check=False, timeout=90)
     subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=False, timeout=30)


### PR DESCRIPTION
…cific one

When a profile-aware gateway (e.g. --profile deepseek-pro) refreshes its LaunchAgent plist, it now unloads and removes the default ai.hermes.gateway service first.  Without this, two gateway services fight for the same ports and KeepAlive produces an endless crash-restart loop.

The fix adds _unload_conflicting_gateway(), called from refresh_launchd_plist_if_needed() before writing the new plist. When the new service label is profile-specific, it bootouts the default ai.hermes.gateway (idempotent) and removes its plist to prevent reload on next login.

## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->



## Related Issue

<!-- Link the issue this PR addresses. If no issue exists, consider creating one first. -->

Fixes #

## Type of Change

<!-- Check the one that applies. -->

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

<!-- List the specific changes. Include file paths for code changes. -->

- 

## How to Test

<!-- Steps to verify this change works. For bugs: reproduction steps + proof that the fix works. -->

1. 
2. 
3. 

## Checklist

<!-- Complete these before requesting review. -->

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [ ] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [ ] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [ ] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [ ] I've tested on my platform: <!-- e.g. Ubuntu 24.04, macOS 15.2, Windows 11 -->

### Documentation & Housekeeping

<!-- Check all that apply. It's OK to check "N/A" if a category doesn't apply to your change. -->

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [ ] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

<!-- Only fill this out if you're adding a skill. Delete this section otherwise. -->

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

<!-- If applicable, add screenshots or log output showing the fix/feature in action. -->

