### PR TITLE
fix(slash-access): distinguish unset DM allowlist from explicit empty list

### DIFF
--- a/gateway/slash_access.py
+++ b/gateway/slash_access.py
@@ -178,9 +178,10 @@ def policy_from_extra(extra: dict, scope: str) -> SlashAccessPolicy:
     """
     admin_key, cmd_key = _keys_for_scope(scope)
     admin_ids = _coerce_id_list(extra.get(admin_key))
+    dm_cmds_configured = cmd_key in extra
     cmds = _coerce_command_list(extra.get(cmd_key))
 
-    if scope == "dm" and not cmds:
+    if scope == "dm" and not dm_cmds_configured:
         # DM didn't specify — let group's user_allowed_commands fall through
         # so operators only need to list it once if it's the same.
         cmds = _coerce_command_list(extra.get("group_user_allowed_commands"))

--- a/tests/gateway/test_slash_access_dispatch.py
+++ b/tests/gateway/test_slash_access_dispatch.py
@@ -269,6 +269,23 @@ async def test_group_only_gating_leaves_dm_unrestricted():
     assert "Tier: unrestricted" in result
 
 
+@pytest.mark.asyncio
+async def test_explicit_empty_dm_allowlist_does_not_fall_back_to_group_commands():
+    runner = _make_runner(
+        platform_extra={
+            "allow_admin_from": ["111"],
+            "user_allowed_commands": [],
+            "group_user_allowed_commands": ["model"],
+        }
+    )
+    result = await runner._handle_message(
+        _make_event("/model", _make_source(user_id="999", chat_type="dm"))
+    )
+    assert "⛔" in result
+    assert "/model is admin-only here" in result
+    assert "No slash commands are enabled for non-admins" in result
+
+
 # ---------------------------------------------------------------------------
 # Plugin-registered slash commands are gated through the same path
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes a slash-access policy bug in gateway DM scopes.

Before this change, an explicit DM config of:

    user_allowed_commands: []

was treated the same as "unset", so the DM policy incorrectly fell back to `group_user_allowed_commands`. That made it impossible for operators to intentionally disable non-admin slash commands in DMs while still allowing a separate command set in groups.

This patch preserves the distinction between:
- DM allowlist not configured at all
- DM allowlist explicitly configured as an empty list

Fallback from DM to `group_user_allowed_commands` now happens only when the DM key is absent.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)
- [ ] 📝 Documentation update
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `gateway/slash_access.py` so DM command fallback only applies when `user_allowed_commands` is not configured for the DM scope
- Added a regression test in `tests/gateway/test_slash_access_dispatch.py` covering the explicit-empty DM allowlist case
- Verified the full `test_slash_access_dispatch.py` file still passes after the change

## How to Test

1. Reproduce the pre-fix case by configuring:

       allow_admin_from: ["111"]
       user_allowed_commands: []
       group_user_allowed_commands: ["model"]

2. In a DM as a non-admin user, run `/model`
3. Confirm it is denied instead of inheriting the group allowlist

Validation run for this patch:

    python -m pytest -n 0 --basetemp .pytest-tmp tests/gateway/test_slash_access_dispatch.py

Result: `19 passed`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)


### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

N/A

## Screenshots / Logs

Targeted test output:

    ============================= test session starts =============================
    Python 3.12.13, pytest-9.0.3, pluggy-1.6.0
    collected 19 items

    tests/gateway/test_slash_access_dispatch.py ...................          [100%]

    ============================= 19 passed in 1.88s ==============================
