### PR TITLE
fix(terminal): strip VIRTUAL_ENV from agent subprocess envs

### DIFF
--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -299,6 +299,49 @@ class TestBlocklistCoverage:
         assert extras.issubset(_HERMES_PROVIDER_ENV_BLOCKLIST)
 
 
+class TestVirtualEnvIsBlocked:
+    """VIRTUAL_ENV and friends must be stripped from subprocess envs.
+
+    Regression test for the gateway-clobbering bug: if Hermes' VIRTUAL_ENV
+    leaks into a terminal subprocess that runs ``uv sync`` / ``poetry install``
+    / ``pip install`` in some other project, those tools treat Hermes' venv as
+    the implicit install target and rebuild it against the wrong
+    pyproject.toml — wiping every Hermes runtime dependency and bricking the
+    gateway. The gateway systemd unit deliberately sets VIRTUAL_ENV for its
+    own use; the blocklist makes sure it stops there.
+    """
+
+    def test_virtual_env_is_blocked(self):
+        assert "VIRTUAL_ENV" in _HERMES_PROVIDER_ENV_BLOCKLIST
+
+    def test_related_venv_markers_are_blocked(self):
+        for name in (
+            "VIRTUAL_ENV_PROMPT",
+            "UV_PROJECT_ENVIRONMENT",
+            "POETRY_ACTIVE",
+            "PIPENV_ACTIVE",
+            "CONDA_PREFIX",
+            "CONDA_DEFAULT_ENV",
+        ):
+            assert name in _HERMES_PROVIDER_ENV_BLOCKLIST, (
+                f"{name} should be in the blocklist so package managers "
+                f"don't treat Hermes' venv as the active environment"
+            )
+
+    def test_sanitize_strips_virtual_env(self):
+        from tools.environments.local import _sanitize_subprocess_env
+
+        env = {
+            "PATH": "/usr/bin",
+            "VIRTUAL_ENV": "/home/user/.hermes/hermes-agent/venv",
+            "VIRTUAL_ENV_PROMPT": "hermes-agent",
+        }
+        result = _sanitize_subprocess_env(env)
+        assert "VIRTUAL_ENV" not in result
+        assert "VIRTUAL_ENV_PROMPT" not in result
+        assert result["PATH"] == "/usr/bin"
+
+
 class TestSanePathIncludesHomebrew:
     """Verify _SANE_PATH includes macOS Homebrew directories."""
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -137,6 +137,21 @@ def _build_provider_env_blocklist() -> frozenset:
         "VERCEL_TOKEN",
         "VERCEL_PROJECT_ID",
         "VERCEL_TEAM_ID",
+        # Hermes' own Python virtualenv must NOT leak into agent subprocesses.
+        # If it does, tools like `uv sync` / `uv pip install` / `poetry install`
+        # treat Hermes' venv as the implicit install target for the user's
+        # project and rebuild it against the wrong pyproject.toml, wiping every
+        # Hermes runtime dependency. Users who genuinely want their tools to
+        # run inside Hermes' venv can opt back in via tools.env_passthrough.
+        # See: gateway systemd unit emits Environment="VIRTUAL_ENV=..." for
+        # its own use; this blocklist makes sure it stops at the gateway.
+        "VIRTUAL_ENV",
+        "VIRTUAL_ENV_PROMPT",
+        "UV_PROJECT_ENVIRONMENT",
+        "POETRY_ACTIVE",
+        "PIPENV_ACTIVE",
+        "CONDA_PREFIX",
+        "CONDA_DEFAULT_ENV",
     })
     return frozenset(blocked)
 


### PR DESCRIPTION
Fixes #23473.

## Problem

The gateway systemd unit sets `VIRTUAL_ENV=<hermes-venv>` so the gateway process can find its own `.venv`. That variable then leaks into every terminal subprocess Hermes spawns.

If the agent runs `uv sync`, `uv pip install`, `poetry install`, or `pip install` in any project directory other than Hermes' own, those tools see `VIRTUAL_ENV` pointing at Hermes' venv and treat it as the active install target. They rebuild it against the user's `pyproject.toml`, wipe every Hermes runtime dependency, and the gateway fails on the next restart.

Reproduced in the wild: `cd ~/code/some-project && uv sync` wiped `~/.hermes/hermes-agent/venv` (Python 3.11 → 3.12, every dep gone) mid-conversation. Full repro and root-cause analysis in #23473.

## Fix

Scrub at the subprocess-env boundary in `tools/environments/local.py`. Add `VIRTUAL_ENV` and the related package-manager activation markers to `_HERMES_PROVIDER_ENV_BLOCKLIST`:

- `VIRTUAL_ENV`
- `VIRTUAL_ENV_PROMPT`
- `UV_PROJECT_ENVIRONMENT`
- `POETRY_ACTIVE`
- `PIPENV_ACTIVE`
- `CONDA_PREFIX`
- `CONDA_DEFAULT_ENV`

The gateway still receives `VIRTUAL_ENV` from its unit file — it just stops there.

## Why not `UnsetEnvironment=` in the systemd unit?

That removes `VIRTUAL_ENV` from the gateway's own environment, which the unit specifically sets for the gateway process. We need it set for the gateway and unset for *children of the gateway*. The subprocess-env scrub is the right layer.

## Opt-out

Users who genuinely want their terminal tools to run inside Hermes' venv can add `VIRTUAL_ENV` to `tools.env_passthrough` in `config.yaml`. The existing passthrough mechanism in `tools/env_passthrough.py` already handles this — no new plumbing needed.

## Tests

Added a `TestVirtualEnvIsBlocked` class in `tests/tools/test_local_env_blocklist.py`:

- `test_virtual_env_is_blocked` — membership in the blocklist
- `test_related_venv_markers_are_blocked` — covers the full set of package-manager markers
- `test_sanitize_strips_virtual_env` — end-to-end: `_sanitize_subprocess_env` strips the var

All 38 tests in `tests/tools/test_local_env_blocklist.py` + `tests/tools/test_env_passthrough.py` pass locally.

## Out of scope (deferred)

- Startup `sys.prefix` / `VIRTUAL_ENV` self-check in the gateway — would catch leftover broken venvs from earlier clobbering. Belongs on the `hermes doctor` work in #8946.
- Touching the systemd / launchd unit templates in `hermes_cli/gateway.py` — not needed once the subprocess scrub is in place.
