### PR TITLE
fix(cron): normalize no_agent boolean inputs for create and update paths

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -22,7 +22,7 @@ from typing import Optional, Dict, List, Any, Union
 logger = logging.getLogger(__name__)
 
 from hermes_time import now as _hermes_now
-from utils import atomic_replace
+from utils import atomic_replace, is_truthy_value
 
 try:
     from croniter import croniter
@@ -573,7 +573,7 @@ def create_job(
     normalized_toolsets = [str(t).strip() for t in enabled_toolsets if str(t).strip()] if enabled_toolsets else None
     normalized_toolsets = normalized_toolsets or None
     normalized_workdir = _normalize_workdir(workdir)
-    normalized_no_agent = bool(no_agent)
+    normalized_no_agent = is_truthy_value(no_agent, default=False)
 
     # no_agent jobs are meaningless without a script — the script IS the job.
     # Surface this as a clear ValueError at create time so bad configs never
@@ -668,6 +668,9 @@ def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]
                 updates["workdir"] = None
             else:
                 updates["workdir"] = _normalize_workdir(_wd)
+
+        if "no_agent" in updates:
+            updates["no_agent"] = is_truthy_value(updates.get("no_agent"), default=False)
 
         updated = _apply_skill_fields({**job, **updates})
         schedule_changed = "schedule" in updates

--- a/tests/cron/test_cron_no_agent.py
+++ b/tests/cron/test_cron_no_agent.py
@@ -78,6 +78,18 @@ def test_create_job_default_is_not_no_agent(hermes_env):
     assert job.get("no_agent") is False
 
 
+def test_create_job_string_false_does_not_enable_no_agent(hermes_env):
+    from cron.jobs import create_job
+
+    job = create_job(
+        prompt="say hi",
+        schedule="every 5m",
+        no_agent="false",
+        deliver="local",
+    )
+    assert job["no_agent"] is False
+
+
 def test_update_job_roundtrips_no_agent_flag(hermes_env):
     from cron.jobs import create_job, update_job, get_job
 
@@ -92,6 +104,18 @@ def test_update_job_roundtrips_no_agent_flag(hermes_env):
     update_job(job["id"], {"no_agent": True})
     reloaded = get_job(job["id"])
     assert reloaded["no_agent"] is True
+
+
+def test_update_job_string_false_disables_no_agent(hermes_env):
+    from cron.jobs import create_job, update_job, get_job
+
+    script_path = hermes_env / "scripts" / "w.sh"
+    script_path.write_text("echo hi\n")
+    job = create_job(prompt=None, schedule="every 5m", script="w.sh", no_agent=True, deliver="local")
+
+    update_job(job["id"], {"no_agent": "false"})
+    reloaded = get_job(job["id"])
+    assert reloaded["no_agent"] is False
 
 
 # ---------------------------------------------------------------------------
@@ -129,6 +153,22 @@ def test_cronjob_tool_create_no_agent_with_script_succeeds(hermes_env):
     assert result["job"]["script"] == "alert.sh"
 
 
+def test_cronjob_tool_create_string_false_keeps_agent_mode(hermes_env):
+    from tools.cronjob_tools import cronjob
+
+    result = json.loads(
+        cronjob(
+            action="create",
+            schedule="every 5m",
+            prompt="ping",
+            no_agent="false",
+            deliver="local",
+        )
+    )
+    assert result.get("success") is True
+    assert result["job"].get("no_agent") in (False, None)
+
+
 def test_cronjob_tool_update_toggles_no_agent(hermes_env):
     from tools.cronjob_tools import cronjob
 
@@ -153,6 +193,28 @@ def test_cronjob_tool_update_toggles_no_agent(hermes_env):
     on = json.loads(cronjob(action="update", job_id=job_id, no_agent=True))
     assert on["success"] is True
     assert on["job"]["no_agent"] is True
+
+
+def test_cronjob_tool_update_string_false_disables_no_agent(hermes_env):
+    from tools.cronjob_tools import cronjob
+
+    script_path = hermes_env / "scripts" / "w.sh"
+    script_path.write_text("echo hi\n")
+
+    created = json.loads(
+        cronjob(
+            action="create",
+            schedule="every 5m",
+            script="w.sh",
+            no_agent=True,
+            deliver="local",
+        )
+    )
+    job_id = created["job_id"]
+
+    off = json.loads(cronjob(action="update", job_id=job_id, no_agent="false", prompt="run"))
+    assert off["success"] is True
+    assert off["job"].get("no_agent") in (False, None)
 
 
 def test_cronjob_tool_update_no_agent_without_script_errors(hermes_env):

--- a/tools/cronjob_tools.py
+++ b/tools/cronjob_tools.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional, Union
 
 from hermes_constants import display_hermes_home
+from utils import is_truthy_value
 
 logger = logging.getLogger(__name__)
 
@@ -314,7 +315,7 @@ def cronjob(
             if not schedule:
                 return tool_error("schedule is required for create", success=False)
             canonical_skills = _canonical_skills(skill, skills)
-            _no_agent = bool(no_agent)
+            _no_agent = is_truthy_value(no_agent, default=False)
             # Job-shape validation differs by mode:
             #   - no_agent=True → script is the job; prompt/skills are optional
             #     (and irrelevant to execution).
@@ -486,7 +487,7 @@ def cronjob(
                 # Toggling no_agent on/off at update time. If flipping to True,
                 # we need a script to already exist on the job (or be part of
                 # the same update) — otherwise the next tick would error out.
-                target_no_agent = bool(no_agent)
+                target_no_agent = is_truthy_value(no_agent, default=False)
                 if target_no_agent:
                     effective_script = updates.get("script") if "script" in updates else job.get("script")
                     if not effective_script:


### PR DESCRIPTION
## What does this PR do?

Fixes a boolean coercion bug in cron `no_agent` handling.

Before this change, `create_job()`, `update_job()`, and the `cronjob` tool used Python truthiness for `no_agent`. That meant string inputs like `"false"` were treated as truthy, which could incorrectly flip jobs into script-only mode or trigger the misleading `no_agent=True requires a script` validation error.

This patch switches those paths to explicit boolean coercion using the shared `is_truthy_value()` helper so quoted config/tool inputs behave as intended.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `cron/jobs.py` to explicitly coerce `no_agent` during job creation and update.
- Updated `tools/cronjob_tools.py` to explicitly coerce `no_agent` in the tool-layer create/update paths.
- Added regression coverage in `tests/cron/test_cron_no_agent.py` for `"false"` string inputs in both data-layer and tool-layer flows.

## How to Test

1. Reproduce the old bug:
   - Call `cronjob(action="create", schedule="every 5m", prompt="ping", no_agent="false", deliver="local")`
   - Before this fix, `"false"` could be treated as truthy and incorrectly route through `no_agent=True` validation/behavior.

2. Verify the fix:
   - The same call should now succeed as a normal agent-backed cron job.
   - Updating an existing `no_agent=True` job with `no_agent="false"` should disable script-only mode instead of preserving it.

3. Run the targeted regression tests:

        $env:TMP="$PWD/.pytest-tmp"
        $env:TEMP=$env:TMP
        python -m pytest tests/cron/test_cron_no_agent.py -q -n0 -k "string_false or test_create_job_default_is_not_no_agent or test_update_job_roundtrips_no_agent_flag or test_cronjob_tool_update_toggles_no_agent"

   Expected result:
   - `7 passed, 15 deselected`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)


### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted regression command passed locally:

    7 passed, 15 deselected

