### PR TITLE
Docs/contributing multi fixes

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -264,7 +264,34 @@ User message → AIAgent._run_agent_loop()
 
 Before writing a tool, ask: [should this be a skill instead?](#should-it-be-a-skill-or-a-tool)
 
-Tools self-register with the central registry. Each tool file co-locates its schema, handler, and registration:
+### Plugin route (default for custom or local-only tools)
+
+For most custom or local-only tools, **do not edit Hermes core.** Drop a
+plugin into `~/.hermes/plugins/<name>/` (or ship it via a pip entry
+point) and register tools from its `register(ctx)` hook:
+
+```python
+# ~/.hermes/plugins/my_plugin/__init__.py
+def register(ctx):
+    ctx.register_tool(
+        name="my_tool",
+        toolset="my_plugin",
+        schema={...},
+        handler=lambda args, **kw: ...,
+    )
+```
+
+Plugin toolsets are auto-discovered and can be enabled or disabled
+without touching `tools/` or `toolsets.py`. See `AGENTS.md` (section
+**Plugins**) for the full plugin surface (lifecycle hooks, CLI
+subcommands, model-provider plugins, memory plugins).
+
+### Built-in / core tool route (only for tools that should ship in base)
+
+Use this route only when the tool is being contributed to Hermes itself
+and should be available out of the box on every install. Built-in tools
+self-register with the central registry. Each tool file co-locates its
+schema, handler, and registration:
 
 ```python
 """my_tool — Brief description of what this tool does."""

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,8 +169,11 @@ hermes-agent/
 │   ├── run.py                    # GatewayRunner — platform lifecycle, message routing, cron
 │   ├── config.py                 # Platform configuration resolution
 │   ├── session.py                # Session store, context prompts, reset policies
-│   └── platforms/                # Platform adapters
-│       ├── telegram.py, discord_adapter.py, slack.py, whatsapp.py
+│   └── platforms/                # Platform adapters — telegram, discord, slack,
+│                                 #   whatsapp, signal, matrix, mattermost, email,
+│                                 #   sms, dingtalk, wecom, weixin, feishu, bluebubbles,
+│                                 #   yuanbao, webhook, api_server, msgraph_webhook, …
+│                                 #   See gateway/platforms/ADDING_A_PLATFORM.md.
 │
 ├── scripts/                  # Installer and bridge scripts
 │   ├── install.sh                # Linux/macOS installer

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -106,14 +106,29 @@ hermes chat -q "Hello"
 
 ### Run tests
 
-```bash
-# Preferred — matches CI (hermetic env, 4 xdist workers); see AGENTS.md
-scripts/run_tests.sh
+Always use the wrapper — it pins the hermetic env (unset provider keys,
+temp `HERMES_HOME`, `TZ=UTC`, `LANG=C.UTF-8`, 4 xdist workers) that
+GitHub Actions uses, and `tests/conftest.py` enforces the same
+invariants for any pytest invocation. Calling `pytest` directly on a
+workstation with provider keys set or `-n auto` workers has caused
+multiple "passes locally, fails in CI" incidents (and the reverse).
 
-# Alternative (activate the venv first). The wrapper is still recommended
-# for parity with GitHub Actions before you open a PR:
-pytest tests/ -v
+```bash
+scripts/run_tests.sh                                  # full suite, CI-parity
+scripts/run_tests.sh tests/test_hermes_constants.py   # one file
+scripts/run_tests.sh -v --tb=long                     # extra pytest flags
 ```
+
+If you genuinely cannot use the wrapper (e.g. on Windows or inside an
+IDE that shells `pytest` directly), activate the venv and pin the
+worker count to 4 so you don't surface ordering flakes CI never sees:
+
+```bash
+source .venv/bin/activate
+python -m pytest tests/ -q -n 4
+```
+
+See `AGENTS.md` (section **Testing**) for the full rationale.
 
 ---
 
@@ -754,7 +769,7 @@ refactor/description   # Code restructuring
 
 ### Before submitting
 
-1. **Run tests**: `scripts/run_tests.sh` (recommended; same as CI) or `pytest tests/ -v` with the project venv activated
+1. **Run tests**: `scripts/run_tests.sh` — the canonical CI-parity runner. Direct `pytest` is a fallback only; see [Run tests](#run-tests) for the venv + `-n 4` recipe and why the wrapper exists.
 2. **Test manually**: Run `hermes` and exercise the code path you changed
 3. **Check cross-platform impact**: If you touch file I/O, process management, or terminal handling, consider macOS, Linux, and WSL2
 4. **Keep PRs focused**: One logical change per PR. Don't mix a bug fix with a refactor with a new feature.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,9 +66,10 @@ If your skill is specialized, community-contributed, or niche, it's better suite
 git clone --recurse-submodules https://github.com/NousResearch/hermes-agent.git
 cd hermes-agent
 
-# Create venv with Python 3.11
-uv venv venv --python 3.11
-export VIRTUAL_ENV="$(pwd)/venv"
+# Create venv with Python 3.11. Use `.venv` to match AGENTS.md and the
+# scripts/run_tests.sh probe order (`.venv` → `venv` → fallback).
+uv venv .venv --python 3.11
+export VIRTUAL_ENV="$(pwd)/.venv"
 
 # Install with all extras (messaging, cron, CLI menus, dev tools)
 uv pip install -e ".[all,dev]"
@@ -96,7 +97,7 @@ echo "OPENROUTER_API_KEY=***" >> ~/.hermes/.env
 ```bash
 # Symlink for global access
 mkdir -p ~/.local/bin
-ln -sf "$(pwd)/venv/bin/hermes" ~/.local/bin/hermes
+ln -sf "$(pwd)/.venv/bin/hermes" ~/.local/bin/hermes
 
 # Verify
 hermes doctor


### PR DESCRIPTION
## What does this PR do?

Aligns four spots in `CONTRIBUTING.md` with the rest of the documentation
and tooling that have drifted ahead of it:

- **`venv` vs `.venv` path drift** — `AGENTS.md` and `scripts/run_tests.sh`
  both treat `.venv` as the canonical layout (the wrapper probes `.venv`
  first, then `venv`, then `$HOME/.hermes/hermes-agent/venv`). `README.md`
  was updated to match, but the "Clone and install" + "Run" sections in
  `CONTRIBUTING.md` still create and symlink a plain `venv/`.
- **Stale `gateway/platforms/` tree entry** — references `discord_adapter.py`
  (renamed to `discord.py`) and lists only 4 of the 30+ platform adapters
  that ship today.
- **Sanctioning bare `pytest tests/ -v`** — `AGENTS.md` is unambiguous
  ("ALWAYS use `scripts/run_tests.sh` — do not call `pytest` directly")
  because the wrapper unsets provider keys, redirects `HERMES_HOME`, pins
  `TZ=UTC` + `LANG=C.UTF-8`, and forces 4 xdist workers to mirror CI.
  `CONTRIBUTING.md` still pitched `pytest tests/ -v` as an equal alternative
  in two places, without `-n 4` or the venv-activation reminder.
- **No mention of the plugin route in "Adding a New Tool"** — `AGENTS.md`
  is explicit: "For most custom or local-only tools, do not edit Hermes
  core. Use the plugin route instead." The current section jumps straight
  into editing `tools/` + `toolsets.py`, which sends new contributors
  patching core for work that was never meant to live in the repo.

Each fix is a standalone commit so it can be reviewed (or reverted) on its
own. No production code is touched.

## Related Issue

N/A — proactive documentation alignment, no open issue.

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [x] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

`CONTRIBUTING.md` only — 4 commits, +59 / −13:

1. **`docs(contributing): align venv path with AGENTS.md and run_tests.sh`** —
   switch the three `venv` callsites in "Clone and install" + "Run" to
   `.venv` so the documented layout matches what `scripts/run_tests.sh`
   probes first.
2. **`docs(contributing): refresh gateway/platforms/ list to match reality`** —
   rename `discord_adapter.py` → `discord.py` in the project-structure
   tree, expand the adapter list (signal, matrix, mattermost, email, sms,
   dingtalk, wecom, weixin, feishu, bluebubbles, yuanbao, webhook,
   api_server, msgraph_webhook, …), and point at
   `gateway/platforms/ADDING_A_PLATFORM.md`.
3. **`docs(contributing): drop bare 'pytest tests/ -v' as a sanctioned alternative`** —
   rewrite the "Run tests" section to lead with the wrapper rationale
   (matches `AGENTS.md`'s **Testing** section), demote direct-pytest to
   a fallback that pins `-n 4` and activates `.venv` first, and tighten
   the "Before submitting" bullet to point at the new section.
4. **`docs(contributing): point custom tools to the plugin route before editing core`** —
   add a "Plugin route (default for custom or local-only tools)"
   subsection at the top of "Adding a New Tool" with a minimal
   `register(ctx)` example + a pointer to `AGENTS.md`'s **Plugins**
   section, and reframe the existing self-registration / `toolsets.py`
   instructions as the built-in route reserved for tools being
   contributed to Hermes itself.

## How to Test

1. **Render the doc** in GitHub's web preview (or `mdcat CONTRIBUTING.md`)
   and walk the four affected sections — "Clone and install" / "Run"
   (commit 1), "Project Structure" `gateway/platforms/` entry (commit 2),
   "Run tests" + "Before submitting" (commit 3), "Adding a New Tool"
   (commit 4).
2. **Cross-check against the source of truth** in each case:
   ```bash
   # commit 1: wrapper probes .venv first
   sed -n '1,40p' scripts/run_tests.sh
   grep -n '\.venv\|^source venv' AGENTS.md

   # commit 2: actual platform adapters
   ls gateway/platforms/*.py | wc -l
   ls gateway/platforms/discord*.py

   # commit 3: AGENTS.md "Testing" section
   sed -n '/^## Testing$/,/^## /p' AGENTS.md | head -40

   # commit 4: AGENTS.md "Adding New Tools" / "Plugins" sections
   sed -n '/^## Adding New Tools$/,/^## /p' AGENTS.md
   sed -n '/^## Plugins$/,/^## /p' AGENTS.md | head -30
   ```
3. **No code paths exercised** — `CONTRIBUTING.md` is the only file
   modified. Existing tests are unaffected; running them is optional but
   confirms the branch is clean:
   ```bash
   scripts/run_tests.sh tests/test_hermes_constants.py
   ```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`docs(contributing): ...` for all four commits)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `scripts/run_tests.sh` and the suite is unaffected (docs-only change, no production code touched)
- [x] I've added tests for my changes — N/A (documentation-only, no behavior change to test)
- [x] I've tested on my platform: macOS 15.6 (Darwin 24.6.0), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — `CONTRIBUTING.md` is itself the change
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A (this PR aligns `CONTRIBUTING.md` *to* the existing `AGENTS.md`; no architecture or workflow change)
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — N/A (docs-only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ git log upstream/main..HEAD --oneline
7b01179af  docs(contributing): point custom tools to the plugin route before editing core
9de78c66a  docs(contributing): drop bare 'pytest tests/ -v' as a sanctioned alternative
35cf79dad  docs(contributing): refresh gateway/platforms/ list to match reality
fbd241943  docs(contributing): align venv path with AGENTS.md and run_tests.sh

$ git diff --stat upstream/main..HEAD
 CONTRIBUTING.md | 72 ++++++++++++++++++++++++++++++++++++++++++++++-----------
 1 file changed, 59 insertions(+), 13 deletions(-)
```
