### PR TITLE
fix: stabilize TUI approvals and Node 18 launch path

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6428,6 +6428,26 @@ class HermesCLI:
         except Exception:
             return False
 
+    def _should_handle_prompting_command_inline(self, text: str, has_images: bool = False) -> bool:
+        """Return True for slash commands whose handlers synchronously prompt.
+
+        The prompt_toolkit input loop normally queues slash commands to the
+        process_loop worker thread.  That is fine for non-interactive commands,
+        but commands that call ``_prompt_text_input()`` must run on the UI
+        thread.  Otherwise the worker prints ``Choice [1/2/3]:`` while the
+        prompt_toolkit composer still owns stdin, so the user's ``1``/``2``/``3``
+        is submitted as the next chat message instead of answering the prompt.
+        """
+        if not text or has_images or not _looks_like_slash_command(text):
+            return False
+        try:
+            from hermes_cli.commands import resolve_command
+            base = text.split(None, 1)[0].lower().lstrip('/')
+            cmd = resolve_command(base)
+            return bool(cmd and cmd.name in {"clear", "new", "undo", "reload-mcp"})
+        except Exception:
+            return False
+
     def _should_handle_steer_command_inline(self, text: str, has_images: bool = False) -> bool:
         """Return True when /steer should be dispatched immediately while the agent is running.
 
@@ -11074,6 +11094,18 @@ class HermesCLI:
                 # Handle /model directly on the UI thread so interactive pickers
                 # can safely use prompt_toolkit terminal handoff helpers.
                 if self._should_handle_model_command_inline(text, has_images=has_images):
+                    if not self.process_command(text):
+                        self._should_exit = True
+                        if event.app.is_running:
+                            event.app.exit()
+                    event.app.current_buffer.reset(append_to_history=True)
+                    return
+
+                # Handle slash commands that synchronously prompt directly on
+                # the UI thread.  If these are queued to process_loop, the
+                # prompt_toolkit composer keeps owning stdin and the user's
+                # choice (e.g. "1" for /clear) becomes a normal chat message.
+                if self._should_handle_prompting_command_inline(text, has_images=has_images):
                     if not self.process_command(text):
                         self._should_exit = True
                         if event.app.is_running:

--- a/cli.py
+++ b/cli.py
@@ -6429,24 +6429,16 @@ class HermesCLI:
             return False
 
     def _should_handle_prompting_command_inline(self, text: str, has_images: bool = False) -> bool:
-        """Return True for slash commands whose handlers synchronously prompt.
+        """Return True for legacy slash handlers that must run inline.
 
-        The prompt_toolkit input loop normally queues slash commands to the
-        process_loop worker thread.  That is fine for non-interactive commands,
-        but commands that call ``_prompt_text_input()`` must run on the UI
-        thread.  Otherwise the worker prints ``Choice [1/2/3]:`` while the
-        prompt_toolkit composer still owns stdin, so the user's ``1``/``2``/``3``
-        is submitted as the next chat message instead of answering the prompt.
+        Destructive session commands used to run inline because their old
+        ``input()`` confirmation prompt could not safely read from the worker
+        thread while prompt_toolkit owned stdin.  They now use the native TUI
+        approval panel when the app is live, so they should stay on the normal
+        worker queue: the UI thread remains free to handle the numbered
+        approve/deny keystrokes, and the worker blocks on a response queue.
         """
-        if not text or has_images or not _looks_like_slash_command(text):
-            return False
-        try:
-            from hermes_cli.commands import resolve_command
-            base = text.split(None, 1)[0].lower().lstrip('/')
-            cmd = resolve_command(base)
-            return bool(cmd and cmd.name in {"clear", "new", "undo", "reload-mcp"})
-        except Exception:
-            return False
+        return False
 
     def _should_handle_steer_command_inline(self, text: str, has_images: bool = False) -> bool:
         """Return True when /steer should be dispatched immediately while the agent is running.
@@ -8692,6 +8684,45 @@ class HermesCLI:
         if not confirm_required:
             return "once"
 
+        # When the prompt_toolkit app is active and this command is being
+        # processed on the worker thread, use the existing native approval
+        # panel instead of a blocking ``input()`` prompt.  The UI thread stays
+        # free to handle 1/2/3 keystrokes, while this worker waits on the
+        # panel's response queue.  Calling ``_prompt_text_input`` from the UI
+        # thread used to depend on prompt_toolkit's ``run_in_terminal`` being
+        # effectively synchronous; newer prompt_toolkit returns an awaitable,
+        # which made /clear render the warning as plain text and then submit
+        # the user's choice as the next chat message.
+        try:
+            app_active = bool(getattr(self, "_app", None))
+            in_main_thread = threading.current_thread() is threading.main_thread()
+        except Exception:
+            app_active = False
+            in_main_thread = True
+
+        if app_active and not in_main_thread:
+            verdict = self._approval_callback(
+                f"/{command}",
+                detail,
+                allow_permanent=True,
+                choices=["once", "always", "deny"],
+            )
+            if verdict == "deny":
+                return None
+            # The generic command-approval panel has a session-scoped option;
+            # destructive slash confirmations only need one-shot vs permanent
+            # opt-out, so treat session approval as proceed-once.
+            if verdict == "session":
+                return "once"
+            if verdict == "always":
+                if save_config_value("approvals.destructive_slash_confirm", False):
+                    _cprint("🔒 Future /clear, /new, /reset, and /undo will run without confirmation.")
+                    _cprint("   Re-enable via `approvals.destructive_slash_confirm: true` in config.yaml.")
+                else:
+                    _cprint("⚠️  Couldn't persist opt-out — proceeding once.")
+                return "always"
+            return "once"
+
         # Render warning + prompt — single-line composer prompt, mirrors
         # ``_confirm_and_reload_mcp``.
         print()
@@ -8756,6 +8787,33 @@ class HermesCLI:
             confirm_required = True
 
         if not confirm_required:
+            with self._busy_command(self._slow_command_status(cmd_original)):
+                self._reload_mcp()
+            return
+
+        try:
+            app_active = bool(getattr(self, "_app", None))
+            in_main_thread = threading.current_thread() is threading.main_thread()
+        except Exception:
+            app_active = False
+            in_main_thread = True
+
+        if app_active and not in_main_thread:
+            verdict = self._approval_callback(
+                "/reload-mcp",
+                "Reloading MCP servers rebuilds the tool set for this session and invalidates the provider prompt cache. The next message will re-send full input tokens (can be expensive on long-context or high-reasoning models).",
+                allow_permanent=True,
+                choices=["once", "always", "deny"],
+            )
+            if verdict == "deny":
+                _cprint("🟡 /reload-mcp cancelled. MCP tools unchanged.")
+                return
+            if verdict == "always":
+                if save_config_value("approvals.mcp_reload_confirm", False):
+                    _cprint("🔒 Future /reload-mcp commands will run without confirmation.")
+                    _cprint("   Re-enable via `approvals.mcp_reload_confirm: true` in config.yaml.")
+                else:
+                    _cprint("⚠️  Couldn't persist opt-out — reloading once.")
             with self._busy_command(self._slow_command_status(cmd_original)):
                 self._reload_mcp()
             return
@@ -9669,7 +9727,8 @@ class HermesCLI:
         return ""
 
     def _approval_callback(self, command: str, description: str,
-                           *, allow_permanent: bool = True) -> str:
+                           *, allow_permanent: bool = True,
+                           choices: list[str] | None = None) -> str:
         """
         Prompt for dangerous command approval through the prompt_toolkit UI.
 
@@ -9692,7 +9751,7 @@ class HermesCLI:
             self._approval_state = {
                 "command": command,
                 "description": description,
-                "choices": self._approval_choices(command, allow_permanent=allow_permanent),
+                "choices": choices if choices is not None else self._approval_choices(command, allow_permanent=allow_permanent),
                 "selected": 0,
                 "response_queue": response_queue,
             }

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -1164,6 +1164,22 @@ def _make_tui_argv(tui_dir: Path, tui_dev: bool) -> tuple[list[str], Path]:
     return [node, str(root / "dist" / "entry.js")], root
 
 
+def _tui_argv_uses_node(argv: list[str]) -> bool:
+    """Return true when the TUI argv directly invokes the node binary."""
+
+    if not argv:
+        return False
+    return Path(argv[0]).name == "node"
+
+
+def _add_tui_node_argv_flags(argv: list[str]) -> list[str]:
+    """Add Node-only flags that are rejected when passed via NODE_OPTIONS."""
+
+    if not _tui_argv_uses_node(argv) or "--expose-gc" in argv:
+        return argv
+    return [argv[0], "--expose-gc", *argv[1:]]
+
+
 def _normalize_tui_toolsets(toolsets: object) -> list[str]:
     """Normalize argparse/Fire-style toolset input for the TUI subprocess."""
     try:
@@ -1283,21 +1299,22 @@ def _launch_tui(
         env["HERMES_TUI_TOOL_PROGRESS"] = "off"
     if accept_hooks:
         env["HERMES_ACCEPT_HOOKS"] = "1"
+    argv, cwd = _make_tui_argv(tui_dir, tui_dev)
+
     # Guarantee an 8GB V8 heap + exposed GC for the TUI. Default node cap is
     # ~1.5–4GB depending on version and can fatal-OOM on long sessions with
-    # large transcripts / reasoning blobs. Token-level merge: respect any
-    # user-supplied --max-old-space-size (they may have set it higher) and
-    # avoid duplicating --expose-gc.
-    _tokens = env.get("NODE_OPTIONS", "").split()
+    # large transcripts / reasoning blobs. Keep heap sizing in NODE_OPTIONS,
+    # but never put --expose-gc there: modern Node rejects that flag from the
+    # environment before the TUI can start. If the caller already exported it,
+    # strip it and pass it directly to node argv when we invoke node ourselves.
+    _tokens = [t for t in env.get("NODE_OPTIONS", "").split() if t != "--expose-gc"]
     if not any(t.startswith("--max-old-space-size=") for t in _tokens):
         _tokens.append("--max-old-space-size=8192")
-    if "--expose-gc" not in _tokens:
-        _tokens.append("--expose-gc")
     env["NODE_OPTIONS"] = " ".join(_tokens)
+    argv = _add_tui_node_argv_flags(argv)
     if resume_session_id:
         env["HERMES_TUI_RESUME"] = resume_session_id
 
-    argv, cwd = _make_tui_argv(tui_dir, tui_dev)
     code: Optional[int] = None
     try:
         try:

--- a/tests/cli/test_destructive_slash_confirm.py
+++ b/tests/cli/test_destructive_slash_confirm.py
@@ -6,6 +6,7 @@ don't have to construct a full HermesCLI (which requires extensive setup).
 
 from __future__ import annotations
 
+import threading
 from types import SimpleNamespace
 from unittest.mock import patch
 
@@ -152,22 +153,23 @@ def test_gate_default_true_when_config_missing():
     assert result is None
 
 
-def test_prompting_slash_commands_are_handled_inline():
-    """Commands that prompt must bypass the worker queue in prompt_toolkit mode.
+def test_prompting_slash_commands_use_worker_queue():
+    """Destructive slash commands should not run inline in prompt_toolkit mode.
 
-    If /clear is processed by the background process_loop, the regular composer
-    still owns stdin and the user's "1" is submitted as a normal chat message.
+    The worker path now uses the native approval panel, leaving the UI thread
+    free to capture numbered approval keystrokes.  Running inline regressed on
+    newer prompt_toolkit because run_in_terminal returns an awaitable.
     """
     from cli import HermesCLI
 
     self_ = SimpleNamespace()
     should_inline = _bound(HermesCLI._should_handle_prompting_command_inline, self_)
 
-    assert should_inline("/clear") is True
-    assert should_inline("/new") is True
-    assert should_inline("/reset") is True
-    assert should_inline("/undo") is True
-    assert should_inline("/reload-mcp") is True
+    assert should_inline("/clear") is False
+    assert should_inline("/new") is False
+    assert should_inline("/reset") is False
+    assert should_inline("/undo") is False
+    assert should_inline("/reload-mcp") is False
 
 
 def test_non_prompting_slash_commands_still_use_normal_queue():
@@ -180,3 +182,42 @@ def test_non_prompting_slash_commands_still_use_normal_queue():
     assert should_inline("/model") is False
     assert should_inline("hello") is False
     assert should_inline("/clear", has_images=True) is False
+
+
+def test_prompt_toolkit_worker_uses_approval_panel_for_clear():
+    """When a TUI app is active on the worker thread, use approval UI.
+
+    This is the regression path for /clear: process_loop runs on a daemon
+    thread, and the main prompt_toolkit thread must remain available to handle
+    the user's 1/2/3 selection.
+    """
+    from cli import HermesCLI
+
+    calls = []
+    self_ = SimpleNamespace(
+        _app=object(),
+        _approval_callback=lambda command, detail, allow_permanent=True, choices=None: calls.append(
+            (command, detail, allow_permanent, choices)
+        ) or "once",
+        _prompt_text_input=lambda _prompt: (_ for _ in ()).throw(
+            AssertionError("legacy input prompt should not run in TUI worker path")
+        ),
+    )
+    result_holder = []
+
+    def _run():
+        with patch(
+            "cli.load_cli_config",
+            return_value={"approvals": {"destructive_slash_confirm": True}},
+        ):
+            result_holder.append(
+                _bound(HermesCLI._confirm_destructive_slash, self_)("clear", "detail")
+            )
+
+    t = threading.Thread(target=_run)
+    t.start()
+    t.join(timeout=2)
+
+    assert not t.is_alive()
+    assert result_holder == ["once"]
+    assert calls == [("/clear", "detail", True, ["once", "always", "deny"])]

--- a/tests/cli/test_destructive_slash_confirm.py
+++ b/tests/cli/test_destructive_slash_confirm.py
@@ -150,3 +150,33 @@ def test_gate_default_true_when_config_missing():
     # treated as on despite the config error.  If the gate had been off
     # this would have returned 'once' without consulting the prompt.
     assert result is None
+
+
+def test_prompting_slash_commands_are_handled_inline():
+    """Commands that prompt must bypass the worker queue in prompt_toolkit mode.
+
+    If /clear is processed by the background process_loop, the regular composer
+    still owns stdin and the user's "1" is submitted as a normal chat message.
+    """
+    from cli import HermesCLI
+
+    self_ = SimpleNamespace()
+    should_inline = _bound(HermesCLI._should_handle_prompting_command_inline, self_)
+
+    assert should_inline("/clear") is True
+    assert should_inline("/new") is True
+    assert should_inline("/reset") is True
+    assert should_inline("/undo") is True
+    assert should_inline("/reload-mcp") is True
+
+
+def test_non_prompting_slash_commands_still_use_normal_queue():
+    from cli import HermesCLI
+
+    self_ = SimpleNamespace()
+    should_inline = _bound(HermesCLI._should_handle_prompting_command_inline, self_)
+
+    assert should_inline("/help") is False
+    assert should_inline("/model") is False
+    assert should_inline("hello") is False
+    assert should_inline("/clear", has_images=True) is False

--- a/tests/hermes_cli/test_tui_resume_flow.py
+++ b/tests/hermes_cli/test_tui_resume_flow.py
@@ -521,6 +521,54 @@ def test_launch_tui_exports_model_provider_and_toolsets(monkeypatch, main_mod):
     assert active_path_during_call == active_path
     assert not active_path.exists()
     assert env["NODE_ENV"] == "production"
+    assert env["NODE_OPTIONS"] == "--max-old-space-size=8192"
+    assert captured["argv"] == ["node", "--expose-gc", "dist/entry.js"]
+
+
+def test_launch_tui_strips_expose_gc_from_existing_node_options(monkeypatch, main_mod):
+    captured = {}
+
+    monkeypatch.setenv("NODE_OPTIONS", "--trace-warnings --expose-gc --max-old-space-size=16384")
+    monkeypatch.setattr(
+        main_mod,
+        "_make_tui_argv",
+        lambda tui_dir, tui_dev: (["/usr/local/bin/node", "dist/entry.js"], Path(".")),
+    )
+
+    def fake_call(argv, cwd=None, env=None):
+        captured.update({"argv": argv, "env": env})
+        return 1
+
+    monkeypatch.setattr(main_mod.subprocess, "call", fake_call)
+
+    with pytest.raises(SystemExit):
+        main_mod._launch_tui()
+
+    assert captured["env"]["NODE_OPTIONS"] == "--trace-warnings --max-old-space-size=16384"
+    assert captured["argv"] == ["/usr/local/bin/node", "--expose-gc", "dist/entry.js"]
+
+
+def test_launch_tui_does_not_add_expose_gc_to_non_node_argv(monkeypatch, main_mod):
+    captured = {}
+
+    monkeypatch.setenv("NODE_OPTIONS", "--expose-gc")
+    monkeypatch.setattr(
+        main_mod,
+        "_make_tui_argv",
+        lambda tui_dir, tui_dev: (["npm", "start"], Path(".")),
+    )
+
+    def fake_call(argv, cwd=None, env=None):
+        captured.update({"argv": argv, "env": env})
+        return 1
+
+    monkeypatch.setattr(main_mod.subprocess, "call", fake_call)
+
+    with pytest.raises(SystemExit):
+        main_mod._launch_tui()
+
+    assert captured["env"]["NODE_OPTIONS"] == "--max-old-space-size=8192"
+    assert captured["argv"] == ["npm", "start"]
 
 
 def test_print_tui_exit_summary_includes_resume_and_token_totals(monkeypatch, capsys):

--- a/tests/tools/test_approval.py
+++ b/tests/tools/test_approval.py
@@ -943,7 +943,7 @@ class TestFailClosedUnderPromptToolkit:
                 "prompt_dangerous_approval deadlocked under prompt_toolkit "
                 "with no callback -- fail-closed guard is broken"
             )
-            assert result == ["deny"]
+            assert result == ["unavailable"]
         finally:
             ptc.get_app_or_none = orig
 
@@ -965,3 +965,113 @@ class TestFailClosedUnderPromptToolkit:
             assert result == "once"
         finally:
             ptc.get_app_or_none = orig
+
+
+class TestApprovalUnavailableMessaging:
+    """Regression tests for no-callback approval failures.
+
+    A prompt that cannot be presented is not the same as an explicit user
+    denial. The tool result must say approval was unavailable so the agent
+    can rewrite the command instead of telling the user they denied it.
+    """
+
+    def _with_prompt_toolkit_active(self, fn):
+        import prompt_toolkit.application.current as ptc
+
+        orig = ptc.get_app_or_none
+        ptc.get_app_or_none = lambda: object()
+        try:
+            return fn()
+        finally:
+            ptc.get_app_or_none = orig
+
+    def test_combined_guard_python_c_no_callback_does_not_claim_user_denied(self):
+        def run():
+            with mock_patch.dict("os.environ", {"HERMES_INTERACTIVE": "1"}, clear=False):
+                with mock_patch("tools.approval._get_approval_mode", return_value="manual"):
+                    with mock_patch(
+                        "tools.tirith_security.check_command_security",
+                        return_value={"action": "allow", "findings": [], "summary": ""},
+                    ):
+                        return approval_module.check_all_command_guards(
+                            "python3 -c 'print(123)'",
+                            "local",
+                            approval_callback=None,
+                        )
+
+        result = self._with_prompt_toolkit_active(run)
+
+        assert result["approved"] is False
+        assert "no approval UI was available" in result["message"]
+        assert "The user did not deny" in result["message"]
+        assert "User denied" not in result["message"]
+        assert "Do NOT retry" not in result["message"]
+
+    def test_tirith_variation_selector_no_callback_does_not_claim_user_denied(self):
+        findings = [
+            {
+                "rule_id": "unicode_variation_selector",
+                "severity": "warning",
+                "title": "Unicode variation selector",
+                "description": "Variation selector characters can hide text differences.",
+            }
+        ]
+
+        def run():
+            with mock_patch.dict("os.environ", {"HERMES_INTERACTIVE": "1"}, clear=False):
+                with mock_patch("tools.approval._get_approval_mode", return_value="manual"):
+                    with mock_patch(
+                        "tools.tirith_security.check_command_security",
+                        return_value={
+                            "action": "warn",
+                            "findings": findings,
+                            "summary": "variation selector warning",
+                        },
+                    ):
+                        return approval_module.check_all_command_guards(
+                            "printf 'Waiting For ⏱️'",
+                            "local",
+                            approval_callback=None,
+                        )
+
+        result = self._with_prompt_toolkit_active(run)
+
+        assert result["approved"] is False
+        assert "no approval UI was available" in result["message"]
+        assert "The user did not deny" in result["message"]
+        assert "User denied" not in result["message"]
+        assert "Do NOT retry" not in result["message"]
+
+    def test_explicit_deny_still_reports_user_denied(self):
+        with mock_patch.dict("os.environ", {"HERMES_INTERACTIVE": "1"}, clear=False):
+            with mock_patch("tools.approval._get_approval_mode", return_value="manual"):
+                with mock_patch(
+                    "tools.tirith_security.check_command_security",
+                    return_value={"action": "allow", "findings": [], "summary": ""},
+                ):
+                    result = approval_module.check_all_command_guards(
+                        "python3 -c 'print(123)'",
+                        "local",
+                        approval_callback=lambda *args, **kwargs: "deny",
+                    )
+
+        assert result["approved"] is False
+        assert result["message"] == "BLOCKED: User denied. Do NOT retry."
+
+    def test_timeout_has_distinct_message(self):
+        with mock_patch.dict("os.environ", {"HERMES_INTERACTIVE": "1"}, clear=False):
+            with mock_patch("tools.approval._get_approval_mode", return_value="manual"):
+                with mock_patch(
+                    "tools.tirith_security.check_command_security",
+                    return_value={"action": "allow", "findings": [], "summary": ""},
+                ):
+                    result = approval_module.check_all_command_guards(
+                        "python3 -c 'print(123)'",
+                        "local",
+                        approval_callback=lambda *args, **kwargs: "timeout",
+                    )
+
+        assert result["approved"] is False
+        assert "approval request timed out" in result["message"]
+        assert "User denied" not in result["message"]
+        assert "user denied" not in result["message"].lower()

--- a/tools/approval.py
+++ b/tools/approval.py
@@ -617,7 +617,11 @@ def prompt_dangerous_approval(command: str, description: str,
             prompt_toolkit integration. Signature:
             (command, description, *, allow_permanent=True) -> str.
 
-    Returns: 'once', 'session', 'always', or 'deny'
+    Returns: 'once', 'session', 'always', 'deny', 'timeout', or 'unavailable'
+
+    'deny' means the user explicitly rejected the command. 'timeout' means
+    no response arrived before the approval deadline. 'unavailable' means an
+    approval prompt could not be presented in the current execution context.
     """
     if timeout_seconds is None:
         timeout_seconds = _get_approval_timeout()
@@ -628,14 +632,14 @@ def prompt_dangerous_approval(command: str, description: str,
                                      allow_permanent=allow_permanent)
         except Exception as e:
             logger.error("Approval callback failed: %s", e, exc_info=True)
-            return "deny"
+            return "unavailable"
 
     # Fail-closed guard: if prompt_toolkit owns the terminal (interactive
     # CLI session) and no approval callback is registered on this thread,
     # the input() fallback below would spawn a daemon thread whose read
     # can never see Enter -- the user's keystrokes go to prompt_toolkit,
     # not input(), producing an invisible 60s deadlock (issue #15216).
-    # Deny fast and log loudly instead so the caller can surface a real
+    # Fail fast and log loudly instead so the caller can surface a real
     # error to the agent. Any thread that needs interactive approval must
     # install a callback via tools.terminal_tool.set_approval_callback()
     # before reaching this point (see delegate_tool.py, run_agent.py
@@ -646,11 +650,12 @@ def prompt_dangerous_approval(command: str, description: str,
         if get_app_or_none() is not None:
             logger.warning(
                 "Dangerous-command approval requested on a thread with no "
-                "approval callback while prompt_toolkit is active; denying "
-                "to avoid stdin deadlock. command=%r description=%r",
+                "approval callback while prompt_toolkit is active; approval "
+                "is unavailable in this execution context. command=%r "
+                "description=%r",
                 command, description,
             )
-            return "deny"
+            return "unavailable"
     except Exception:
         # prompt_toolkit not installed, or detection failed -- fall through
         # to the legacy input() path (safe in non-TUI contexts: scripts,
@@ -689,7 +694,7 @@ def prompt_dangerous_approval(command: str, description: str,
 
             if thread.is_alive():
                 print("\n" + t("approval.timeout"))
-                return "deny"
+                return "timeout"
 
             choice = result["choice"]
             if choice in ('o', 'once'):
@@ -769,6 +774,25 @@ def _get_cron_approval_mode() -> str:
         return "deny"
     except Exception:
         return "deny"
+
+
+def _approval_unavailable_message(description: str) -> str:
+    return (
+        f"BLOCKED: Command required approval ({description}), but no approval "
+        "UI was available in this execution context. The user did not deny "
+        "the command. Rewrite the command to avoid the approval trigger, run "
+        "it interactively where approval prompts are available, or explicitly "
+        "use --yolo / approvals.mode=off if you accept the risk."
+    )
+
+
+def _approval_timeout_message(description: str) -> str:
+    return (
+        f"BLOCKED: Command required approval ({description}), but the approval "
+        "request timed out. This was not an explicit denial. Ask again only if "
+        "the user wants to retry or rewrite the command to avoid the approval "
+        "trigger."
+    )
 
 
 def _smart_approve(command: str, description: str) -> str:
@@ -903,6 +927,22 @@ def check_dangerous_command(command: str, env_type: str,
         return {
             "approved": False,
             "message": f"BLOCKED: User denied this potentially dangerous command (matched '{description}' pattern). Do NOT retry this command - the user has explicitly rejected it.",
+            "pattern_key": pattern_key,
+            "description": description,
+        }
+
+    if choice == "timeout":
+        return {
+            "approved": False,
+            "message": _approval_timeout_message(description),
+            "pattern_key": pattern_key,
+            "description": description,
+        }
+
+    if choice == "unavailable":
+        return {
+            "approved": False,
+            "message": _approval_unavailable_message(description),
             "pattern_key": pattern_key,
             "description": description,
         }
@@ -1266,6 +1306,22 @@ def check_all_command_guards(command: str, env_type: str,
         return {
             "approved": False,
             "message": "BLOCKED: User denied. Do NOT retry.",
+            "pattern_key": primary_key,
+            "description": combined_desc,
+        }
+
+    if choice == "timeout":
+        return {
+            "approved": False,
+            "message": _approval_timeout_message(combined_desc),
+            "pattern_key": primary_key,
+            "description": combined_desc,
+        }
+
+    if choice == "unavailable":
+        return {
+            "approved": False,
+            "message": _approval_unavailable_message(combined_desc),
             "pattern_key": primary_key,
             "description": combined_desc,
         }

--- a/ui-tui/package-lock.json
+++ b/ui-tui/package-lock.json
@@ -2674,6 +2674,22 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/code-excerpt": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/code-excerpt/-/code-excerpt-4.0.0.tgz",
@@ -4301,6 +4317,22 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/ink/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/internal-slot": {
@@ -6319,22 +6351,6 @@
         "node": ">= 0.4"
       }
     },
-    "node_modules/string-width": {
-      "version": "8.2.0",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.0.tgz",
-      "integrity": "sha512-6hJPQ8N0V0P3SNmP6h2J99RLuzrWz2gvT7VnK5tKvrNqJoyS9W4/Fb8mo31UiPvy00z7DQXkP2hnKBVav76thw==",
-      "license": "MIT",
-      "dependencies": {
-        "get-east-asian-width": "^1.5.0",
-        "strip-ansi": "^7.1.2"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/string.prototype.matchall": {
       "version": "4.0.12",
       "resolved": "https://registry.npmjs.org/string.prototype.matchall/-/string.prototype.matchall-4.0.12.tgz",
@@ -7140,6 +7156,22 @@
       },
       "engines": {
         "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/widest-line/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"

--- a/ui-tui/package.json
+++ b/ui-tui/package.json
@@ -46,5 +46,8 @@
     "tsx": "^4.19.0",
     "typescript": "^5.7.0",
     "vitest": "^4.1.3"
+  },
+  "overrides": {
+    "string-width": "7.2.0"
   }
 }

--- a/ui-tui/src/entry.tsx
+++ b/ui-tui/src/entry.tsx
@@ -36,9 +36,9 @@ setupGracefulExit({
     }
   ],
   onError: (scope, err) => {
-    const message = err instanceof Error ? `${err.name}: ${err.message}` : String(err)
+    const message = err instanceof Error ? (err.stack || `${err.name}: ${err.message}`) : String(err)
 
-    process.stderr.write(`hermes-tui ${scope}: ${message.slice(0, 2000)}\n`)
+    process.stderr.write(`hermes-tui ${scope}: ${message.slice(0, 4000)}\n`)
   },
   onSignal: signal => {
     resetTerminalModes()

--- a/ui-tui/src/gatewayClient.ts
+++ b/ui-tui/src/gatewayClient.ts
@@ -1,8 +1,9 @@
 import { type ChildProcess, spawn } from 'node:child_process'
 import { EventEmitter } from 'node:events'
 import { existsSync } from 'node:fs'
-import { delimiter, resolve } from 'node:path'
+import { delimiter, dirname, resolve } from 'node:path'
 import { createInterface } from 'node:readline'
+import { fileURLToPath } from 'node:url'
 
 import type { GatewayEvent } from './gatewayTypes.js'
 import { CircularBuffer } from './lib/circularBuffer.js'
@@ -17,6 +18,7 @@ const WS_CONNECTING = 0
 const WS_OPEN = 1
 const WS_CLOSING = 2
 const WS_CLOSED = 3
+const _moduleDir = dirname(fileURLToPath(import.meta.url))
 
 const truncateLine = (line: string) =>
   line.length > MAX_LOG_LINE_BYTES ? `${line.slice(0, MAX_LOG_LINE_BYTES)}… [truncated ${line.length} bytes]` : line
@@ -474,7 +476,7 @@ export class GatewayClient extends EventEmitter {
   }
 
   start() {
-    const root = process.env.HERMES_PYTHON_SRC_ROOT ?? resolve(import.meta.dirname, '../../')
+    const root = process.env.HERMES_PYTHON_SRC_ROOT ?? resolve(_moduleDir, '../../')
     const attachUrl = resolveGatewayAttachUrl()
     const sidecarUrl = resolveSidecarUrl()
 


### PR DESCRIPTION
## Summary

This PR bundles a set of related fixes from debugging the Hermes dashboard/TUI flow on a local macOS setup using Node 18:

- distinguish unavailable approval transport from an explicit user denial
- route destructive slash-command confirmations through the native TUI approval panel instead of legacy stdin prompting
- keep the TUI dependency tree compatible with Node 18 by pinning `string-width` away from the Node 20-only major
- avoid `import.meta.dirname` in the TUI gateway client so the built TUI starts on Node 18
- pass `--expose-gc` directly to the Node argv instead of via `NODE_OPTIONS`, which Node rejects
- include longer TUI startup stack traces for easier diagnosis

## Why

While validating Discord/dashboard/TUI usage, several approval and launch-path failures showed up as user-facing breakage:

- destructive slash-command choices could be consumed as normal chat messages instead of approval input
- unavailable approval plumbing could be conflated with an explicit denial
- the TUI could fail under Node 18 because of dependency/runtime compatibility issues
- Node rejects `--expose-gc` in `NODE_OPTIONS`, preventing the TUI from launching in that configuration

## Test plan

Ran locally after rebasing on latest `origin/main`:

- `venv/bin/python -m pytest -o addopts='' tests/tools/test_approval.py tests/cli/test_destructive_slash_confirm.py tests/hermes_cli/test_tui_resume_flow.py`
  - 167 passed
- `cd ui-tui && npm run type-check`
- `cd ui-tui && npm run build`
- `git diff --check origin/main..HEAD`

Manual validation:

- confirmed the TUI approval panel works for destructive slash-command confirmation
