### PR TITLE
fix(cron): normalize bash script paths on Windows

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -27,7 +27,7 @@ except ImportError:
         import msvcrt
     except ImportError:
         msvcrt = None
-from pathlib import Path
+from pathlib import Path, PurePath
 from typing import List, Optional
 
 # Add parent directory to path for imports BEFORE repo-level imports.
@@ -693,6 +693,13 @@ def _get_script_timeout() -> int:
     return _DEFAULT_SCRIPT_TIMEOUT
 
 
+def _format_bash_script_path(path: PurePath) -> str:
+    """Return a bash-safe script path for the current platform."""
+    if os.name == "nt":
+        return path.as_posix()
+    return str(path)
+
+
 def _run_job_script(script_path: str) -> tuple[bool, str]:
     """Execute a cron job's data-collection script and capture its output.
 
@@ -769,7 +776,7 @@ def _run_job_script(script_path: str) -> tuple[bool, str]:
                 "On Windows, install Git for Windows (which ships Git Bash) "
                 "or rewrite the script as Python (.py)."
             )
-        argv = [_bash, str(path)]
+        argv = [_bash, _format_bash_script_path(path)]
     else:
         argv = [sys.executable, str(path)]
 

--- a/tests/cron/test_scheduler.py
+++ b/tests/cron/test_scheduler.py
@@ -3,11 +3,12 @@
 import json
 import logging
 import os
+from pathlib import PurePosixPath, PureWindowsPath
 from unittest.mock import AsyncMock, patch, MagicMock
 
 import pytest
 
-from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt
+from cron.scheduler import _resolve_origin, _resolve_delivery_target, _deliver_result, _send_media_via_adapter, run_job, SILENT_MARKER, _build_job_prompt, _format_bash_script_path
 from tools.env_passthrough import clear_env_passthrough
 from tools.credential_files import clear_credential_files
 
@@ -68,6 +69,24 @@ class TestResolveOrigin:
         """
         job = {"origin": non_dict_origin}
         assert _resolve_origin(job) is None
+
+
+class TestFormatBashScriptPath:
+    def test_uses_forward_slashes_on_windows(self):
+        with patch("cron.scheduler.os.name", "nt"):
+            formatted = _format_bash_script_path(
+                PureWindowsPath(r"C:\Users\denis\.hermes\scripts\hermes-backup.sh")
+            )
+
+        assert formatted == "C:/Users/denis/.hermes/scripts/hermes-backup.sh"
+
+    def test_keeps_posix_paths_unchanged(self):
+        path = PurePosixPath("/home/denis/.hermes/scripts/hermes-backup.sh")
+
+        with patch("cron.scheduler.os.name", "posix"):
+            formatted = _format_bash_script_path(path)
+
+        assert formatted == str(path)
 
 
 class TestResolveDeliveryTarget:


### PR DESCRIPTION
## What does this PR do?

Fixes native Windows Git Bash cron `.sh` / `.bash` script execution by normalizing the script argument to a forward-slash path before invoking `bash`.

Without this, `_run_job_script()` passes a native Windows path like `C:\Users\denis\.hermes\scripts\hermes-backup.sh`, and Git Bash treats the backslashes as escape characters, mangling the path into `C:Usersdenis...` and failing with exit code 127.

## Related Issue

Fixes #23404

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `_format_bash_script_path()` in `/cron/scheduler.py` to centralize bash path formatting.
- Switched `.sh` / `.bash` execution in `_run_job_script()` to use a bash-safe path argument on Windows.
- Added regression tests in `/tests/cron/test_scheduler.py` for Windows and POSIX path formatting behavior.

## How to Test

1. Run `uv run --frozen pytest -q -o addopts='' tests/cron/test_scheduler.py`
2. Run `uv run --frozen ruff check cron/scheduler.py tests/cron/test_scheduler.py`
3. On native Windows with Git Bash, configure a cron job using a `.sh` script and verify the script path reaches bash in forward-slash form instead of losing backslashes.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS (targeted regression tests); Windows path behavior covered by explicit unit tests

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `uv run --frozen pytest -q -o addopts='' tests/cron/test_scheduler.py` -> `123 passed`
- `uv run --frozen ruff check cron/scheduler.py tests/cron/test_scheduler.py` -> `All checks passed!`
- The repo-wide local `pytest tests/ -q` entrypoint still fails during collection on both this branch and a clean `origin/main` worktree with the same preexisting environment-level errors (`tomllib`, `acp`, `websockets.asyncio`, `StrEnum`), so I left that checklist item unchecked rather than claiming a false full-green run.
