### PR TITLE
fix(dashboard): follow active profile gateway state

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -513,9 +513,13 @@ def write_runtime_status(
     _write_json_file(path, payload)
 
 
-def read_runtime_status() -> Optional[dict[str, Any]]:
-    """Read the persisted gateway runtime health/status information."""
-    return _read_json_file(_get_runtime_status_path())
+def read_runtime_status(path: Optional[Path] = None) -> Optional[dict[str, Any]]:
+    """Read persisted gateway runtime health/status information.
+
+    ``path`` is optional so callers like the dashboard can inspect a different
+    profile's state file without mutating ``HERMES_HOME`` in-process.
+    """
+    return _read_json_file(path or _get_runtime_status_path())
 
 
 def remove_pid_file() -> None:

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -520,15 +520,42 @@ def _probe_gateway_health() -> tuple[bool, dict | None]:
     return False, None
 
 
+def _resolve_status_home() -> Path:
+    """Return the Hermes home whose gateway state the dashboard should show.
+
+    The dashboard process can outlive profile switches, especially in Docker
+    where PID 1 booted it with the root ``HERMES_HOME`` and users later switch
+    into ``profiles/<name>`` before starting the gateway. Re-read the sticky
+    active profile on each status request so we inspect the same runtime files
+    the active gateway is currently updating.
+    """
+    home = get_hermes_home()
+    try:
+        from hermes_cli.profiles import get_active_profile, get_profile_dir
+
+        active = get_active_profile()
+        if active and active != "default":
+            profile_dir = get_profile_dir(active)
+            if profile_dir.is_dir():
+                return profile_dir
+    except Exception:
+        pass
+    return home
+
+
 @app.get("/api/status")
 async def get_status():
     current_ver, latest_ver = check_config_version()
+    status_home = _resolve_status_home()
+    current_home = get_hermes_home()
+    status_pid_path = status_home / "gateway.pid"
+    status_runtime_path = status_home / "gateway_state.json"
 
     # --- Gateway liveness detection ---
     # Try local PID check first (same-host).  If that fails and a remote
     # GATEWAY_HEALTH_URL is configured, probe the gateway over HTTP so the
     # dashboard works when the gateway runs in a separate container.
-    gateway_pid = get_running_pid()
+    gateway_pid = get_running_pid(status_pid_path)
     gateway_running = gateway_pid is not None
     remote_health_body: dict | None = None
 
@@ -551,16 +578,17 @@ async def get_status():
     try:
         from gateway.config import load_gateway_config
 
-        gateway_config = load_gateway_config()
-        configured_gateway_platforms = {
-            platform.value for platform in gateway_config.get_connected_platforms()
-        }
+        if status_home == current_home:
+            gateway_config = load_gateway_config()
+            configured_gateway_platforms = {
+                platform.value for platform in gateway_config.get_connected_platforms()
+            }
     except Exception:
         configured_gateway_platforms = None
 
     # Prefer the detailed health endpoint response (has full state) when the
     # local runtime status file is absent or stale (cross-container).
-    runtime = read_runtime_status()
+    runtime = read_runtime_status(status_runtime_path)
     if runtime is None and remote_health_body and remote_health_body.get("gateway_state"):
         runtime = remote_health_body
 
@@ -593,7 +621,7 @@ async def get_status():
     active_sessions = 0
     try:
         from hermes_state import SessionDB
-        db = SessionDB()
+        db = SessionDB(db_path=status_home / "state.db")
         try:
             sessions = db.list_sessions_rich(limit=50)
             now = time.time()
@@ -610,9 +638,9 @@ async def get_status():
     return {
         "version": __version__,
         "release_date": __release_date__,
-        "hermes_home": str(get_hermes_home()),
-        "config_path": str(get_config_path()),
-        "env_path": str(get_env_path()),
+        "hermes_home": str(status_home),
+        "config_path": str(status_home / "config.yaml"),
+        "env_path": str(status_home / ".env"),
         "config_version": current_ver,
         "latest_config_version": latest_ver,
         "gateway_running": gateway_running,

--- a/tests/hermes_cli/test_web_server.py
+++ b/tests/hermes_cli/test_web_server.py
@@ -137,11 +137,11 @@ class TestWebServerEndpoints:
             def get_connected_platforms(self):
                 return [_Platform("telegram")]
 
-        monkeypatch.setattr(web_server, "get_running_pid", lambda: 1234)
+        monkeypatch.setattr(web_server, "get_running_pid", lambda *args, **kwargs: 1234)
         monkeypatch.setattr(
             web_server,
             "read_runtime_status",
-            lambda: {
+            lambda *args, **kwargs: {
                 "gateway_state": "running",
                 "updated_at": "2026-04-12T00:00:00+00:00",
                 "platforms": {
@@ -169,11 +169,11 @@ class TestWebServerEndpoints:
             def get_connected_platforms(self):
                 return []
 
-        monkeypatch.setattr(web_server, "get_running_pid", lambda: None)
+        monkeypatch.setattr(web_server, "get_running_pid", lambda *args, **kwargs: None)
         monkeypatch.setattr(
             web_server,
             "read_runtime_status",
-            lambda: {
+            lambda *args, **kwargs: {
                 "gateway_state": "startup_failed",
                 "updated_at": "2026-04-12T00:00:00+00:00",
                 "platforms": {
@@ -1439,8 +1439,8 @@ class TestStatusRemoteGateway:
         """When local PID check fails and remote probe succeeds, gateway shows running."""
         import hermes_cli.web_server as ws
 
-        monkeypatch.setattr(ws, "get_running_pid", lambda: None)
-        monkeypatch.setattr(ws, "read_runtime_status", lambda: None)
+        monkeypatch.setattr(ws, "get_running_pid", lambda *args, **kwargs: None)
+        monkeypatch.setattr(ws, "read_runtime_status", lambda *args, **kwargs: None)
         monkeypatch.setattr(ws, "_GATEWAY_HEALTH_URL", "http://gw:8642")
         monkeypatch.setattr(ws, "_probe_gateway_health", lambda: (True, {
             "status": "ok",
@@ -1461,8 +1461,8 @@ class TestStatusRemoteGateway:
         """When local PID check succeeds, the remote probe is never called."""
         import hermes_cli.web_server as ws
 
-        monkeypatch.setattr(ws, "get_running_pid", lambda: 1234)
-        monkeypatch.setattr(ws, "read_runtime_status", lambda: {
+        monkeypatch.setattr(ws, "get_running_pid", lambda *args, **kwargs: 1234)
+        monkeypatch.setattr(ws, "read_runtime_status", lambda *args, **kwargs: {
             "gateway_state": "running",
             "platforms": {},
         })
@@ -1484,8 +1484,8 @@ class TestStatusRemoteGateway:
         """When GATEWAY_HEALTH_URL is unset, no probe is attempted."""
         import hermes_cli.web_server as ws
 
-        monkeypatch.setattr(ws, "get_running_pid", lambda: None)
-        monkeypatch.setattr(ws, "read_runtime_status", lambda: None)
+        monkeypatch.setattr(ws, "get_running_pid", lambda *args, **kwargs: None)
+        monkeypatch.setattr(ws, "read_runtime_status", lambda *args, **kwargs: None)
         monkeypatch.setattr(ws, "_GATEWAY_HEALTH_URL", None)
 
         resp = self.client.get("/api/status")
@@ -1498,8 +1498,8 @@ class TestStatusRemoteGateway:
         """Remote gateway running but PID not in response — pid should be None."""
         import hermes_cli.web_server as ws
 
-        monkeypatch.setattr(ws, "get_running_pid", lambda: None)
-        monkeypatch.setattr(ws, "read_runtime_status", lambda: None)
+        monkeypatch.setattr(ws, "get_running_pid", lambda *args, **kwargs: None)
+        monkeypatch.setattr(ws, "read_runtime_status", lambda *args, **kwargs: None)
         monkeypatch.setattr(ws, "_GATEWAY_HEALTH_URL", "http://gw:8642")
         monkeypatch.setattr(ws, "_probe_gateway_health", lambda: (True, {
             "status": "ok",
@@ -1511,6 +1511,63 @@ class TestStatusRemoteGateway:
         assert data["gateway_running"] is True
         assert data["gateway_pid"] is None
         assert data["gateway_state"] == "running"
+
+    def test_status_uses_active_profile_runtime_paths(self, monkeypatch, tmp_path):
+        """Dashboard status should follow the sticky active profile at request time."""
+        import hermes_cli.web_server as ws
+        import hermes_state
+
+        docker_home = tmp_path / "opt" / "data"
+        profile_home = docker_home / "profiles" / "hermes-main"
+        profile_home.mkdir(parents=True)
+        (docker_home / "active_profile").write_text("hermes-main\n")
+
+        monkeypatch.setattr(Path, "home", lambda: tmp_path)
+        monkeypatch.setenv("HERMES_HOME", str(docker_home))
+        monkeypatch.setattr(ws, "_GATEWAY_HEALTH_URL", None)
+        monkeypatch.setattr(ws, "check_config_version", lambda: (1, 1))
+
+        seen: dict[str, Path | None] = {"pid_path": None, "status_path": None, "db_path": None}
+
+        def fake_get_running_pid(pid_path=None, cleanup_stale=True):
+            seen["pid_path"] = pid_path
+            return 4321
+
+        def fake_read_runtime_status(path=None):
+            seen["status_path"] = path
+            return {
+                "gateway_state": "running",
+                "platforms": {"telegram": {"state": "connected"}},
+            }
+
+        class FakeSessionDB:
+            def __init__(self, db_path=None):
+                seen["db_path"] = db_path
+
+            def list_sessions_rich(self, limit=50):
+                now = time.time()
+                return [{"ended_at": None, "last_active": now, "started_at": now}]
+
+            def close(self):
+                pass
+
+        monkeypatch.setattr(ws, "get_running_pid", fake_get_running_pid)
+        monkeypatch.setattr(ws, "read_runtime_status", fake_read_runtime_status)
+        monkeypatch.setattr(hermes_state, "SessionDB", FakeSessionDB)
+
+        resp = self.client.get("/api/status")
+
+        assert resp.status_code == 200
+        data = resp.json()
+        assert seen["pid_path"] == profile_home / "gateway.pid"
+        assert seen["status_path"] == profile_home / "gateway_state.json"
+        assert seen["db_path"] == profile_home / "state.db"
+        assert data["gateway_running"] is True
+        assert data["gateway_pid"] == 4321
+        assert data["gateway_state"] == "running"
+        assert data["hermes_home"] == str(profile_home)
+        assert data["config_path"] == str(profile_home / "config.yaml")
+        assert data["env_path"] == str(profile_home / ".env")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What does this PR do?

Fixes dashboard status lookups when Hermes is running under a non-default sticky profile in Docker or other custom `HERMES_HOME` layouts.

Today the dashboard process can keep reading `gateway.pid`, `gateway_state.json`, and `state.db` from the root Hermes home it booted with, even after users switch the active profile and start the gateway from `profiles/<name>`. That makes the dashboard show `STOPPED` and `0` active sessions while the gateway is actually running in the profile directory.

This patch makes `/api/status` re-read the sticky active profile on each request and inspect that profile's runtime files instead of the dashboard process's boot-time home.

## Related Issue

Fixes #23457

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added an optional explicit-path parameter to `gateway.status.read_runtime_status()` so callers can inspect another profile's runtime state file without mutating `HERMES_HOME`
- Added `_resolve_status_home()` in `hermes_cli/web_server.py` to follow the sticky active profile on each `/api/status` request
- Updated `/api/status` to read `gateway.pid`, `gateway_state.json`, and `state.db` from the resolved active-profile home
- Returned profile-specific `hermes_home`, `config_path`, and `env_path` values in the status payload
- Added a regression test covering the Docker/profile-switch case and updated existing status tests to accept explicit-path lookup arguments

## How to Test

1. Run `uv run --frozen pytest -q -o addopts='' tests/hermes_cli/test_web_server.py -k 'status and not plugin'`
2. Run `uv run --frozen ruff check hermes_cli/web_server.py gateway/status.py tests/hermes_cli/test_web_server.py`
3. In a Docker/custom-home setup, boot the dashboard with root `HERMES_HOME`, switch to a non-default profile, start the gateway there, and confirm `/api/status` now reports the profile runtime instead of the boot-time root

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 / local uv env

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Targeted status regression tests: `8 passed, 137 deselected`
- `ruff check` passed
- Local repo-wide `uv run --frozen pytest tests/ -q --ignore=tests/integration --ignore=tests/e2e --tb=short -o addopts=''` still hits the same pre-existing collection errors on both this branch and a clean `origin/main` worktree (`tomllib`, `acp`, `websockets.asyncio`, `StrEnum` under the local Python 3.10 environment)
