### PR TITLE
fix(auxiliary): fall back to env when openrouter pool is exhausted

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -1364,12 +1364,11 @@ def _try_openrouter(explicit_api_key: str = None) -> Tuple[Optional[OpenAI], Opt
     pool_present, entry = _select_pool_entry("openrouter")
     if pool_present:
         or_key = explicit_api_key or _pool_runtime_api_key(entry)
-        if not or_key:
-            return None, None
-        base_url = _pool_runtime_base_url(entry, OPENROUTER_BASE_URL) or OPENROUTER_BASE_URL
-        logger.debug("Auxiliary client: OpenRouter via pool")
-        return OpenAI(api_key=or_key, base_url=base_url,
-                       default_headers=build_or_headers()), _OPENROUTER_MODEL
+        if or_key:
+            base_url = _pool_runtime_base_url(entry, OPENROUTER_BASE_URL) or OPENROUTER_BASE_URL
+            logger.debug("Auxiliary client: OpenRouter via pool")
+            return OpenAI(api_key=or_key, base_url=base_url,
+                           default_headers=build_or_headers()), _OPENROUTER_MODEL
 
     or_key = explicit_api_key or os.getenv("OPENROUTER_API_KEY")
     if not or_key:

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -24,7 +24,10 @@ from agent.auxiliary_client import (
     _is_payment_error,
     _is_rate_limit_error,
     _normalize_aux_provider,
+    _OPENROUTER_MODEL,
+    OPENROUTER_BASE_URL,
     _try_payment_fallback,
+    _try_openrouter,
     _resolve_auto,
     _CodexCompletionsAdapter,
 )
@@ -557,6 +560,21 @@ class TestExplicitProviderRouting:
             "OPENROUTER_API_KEY not set" in record.message
             for record in caplog.records
         )
+
+    def test_try_openrouter_pool_exhausted_falls_back_to_env(self, monkeypatch):
+        monkeypatch.setenv("OPENROUTER_API_KEY", "sk-or-env-fallback")
+        with patch("agent.auxiliary_client._select_pool_entry", return_value=(True, None)), \
+             patch("agent.auxiliary_client.OpenAI") as mock_openai:
+            mock_client = MagicMock(name="openrouter_client")
+            mock_openai.return_value = mock_client
+
+            client, model = _try_openrouter()
+
+        assert client is mock_client
+        assert model == _OPENROUTER_MODEL
+        mock_openai.assert_called_once()
+        assert mock_openai.call_args.kwargs["api_key"] == "sk-or-env-fallback"
+        assert mock_openai.call_args.kwargs["base_url"] == OPENROUTER_BASE_URL
 
 class TestGetTextAuxiliaryClient:
     """Test the full resolution chain for get_text_auxiliary_client."""


### PR DESCRIPTION
## What does this PR do?

Fixes the OpenRouter auxiliary client fallback path so a cooled-down/exhausted credential pool no longer blocks `OPENROUTER_API_KEY` from being used. This keeps auxiliary tasks on the expected env-var fallback path instead of returning `(None, None)` early.

## Related Issue

Fixes #23452

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- update `agent/auxiliary_client.py` so `_try_openrouter()` only returns the pool-backed client when a usable pooled key exists
- fall through to `OPENROUTER_API_KEY` env lookup when the pool exists but currently has no selectable entry
- add a regression test in `tests/agent/test_auxiliary_client.py` covering the exhausted-pool + env-fallback case

## How to Test

1. `uv run --frozen pytest -q -o addopts='' tests/agent/test_auxiliary_client.py -k 'openrouter and (pool_exhausted or env_keeps_not_set_warning or falls_back_to_env)'`
2. `uv run --frozen ruff check agent/auxiliary_client.py tests/agent/test_auxiliary_client.py`
3. `env -i HOME="$HOME" PATH="$PATH" TERM="${TERM:-xterm-256color}" UV_CACHE_DIR="$HOME/.cache/uv" uv run --frozen pytest -q -o addopts='' --collect-only tests/agent/test_auxiliary_client.py -k 'openrouter and (pool_exhausted or env_keeps_not_set_warning or falls_back_to_env)'`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- targeted pytest: `4 passed, 138 deselected`
- `ruff check`: passed
- collect-only smoke: `4 tests collected`
- repo-wide `pytest tests/ -q` was not used as the merge gate here because the same clean `origin/main` baseline currently shows unrelated collection failures outside this change scope
