### PR TITLE
fix(docker): repair dashboard runtime perms for remapped uid

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -41,6 +41,31 @@ if [ "$(id -u)" = "0" ]; then
             echo "Warning: chown failed (rootless container?) — continuing anyway"
     fi
 
+    # Runtime dashboard/TUI startup can still need write access inside the
+    # install tree (for example packages/hermes-ink/dist and npm-managed
+    # node_modules caches). When HERMES_UID remaps the hermes user, those
+    # paths remain owned by the image's original uid unless we re-chown them
+    # here. Keep the scope narrow to the runtime-mutable trees under
+    # /opt/hermes rather than recursively chowning the whole install dir.
+    runtime_mutable_paths=(
+        "$INSTALL_DIR/ui-tui"
+        "$INSTALL_DIR/node_modules"
+    )
+    for runtime_path in "${runtime_mutable_paths[@]}"; do
+        [ -e "$runtime_path" ] || continue
+        runtime_needs_chown=false
+        if [ -n "$HERMES_UID" ] && [ "$HERMES_UID" != "10000" ]; then
+            runtime_needs_chown=true
+        elif [ "$(stat -c %u "$runtime_path" 2>/dev/null)" != "$actual_hermes_uid" ]; then
+            runtime_needs_chown=true
+        fi
+        if [ "$runtime_needs_chown" = true ]; then
+            echo "Fixing ownership of $runtime_path to hermes ($actual_hermes_uid)"
+            chown -R hermes:hermes "$runtime_path" 2>/dev/null || \
+                echo "Warning: chown failed for $runtime_path (rootless container?) — continuing anyway"
+        fi
+    done
+
     # Ensure config.yaml is readable by the hermes runtime user even if it was
     # edited on the host after initial ownership setup. Must run here (as root)
     # rather than after the gosu drop, otherwise a non-root caller like

--- a/tests/tools/test_docker_entrypoint_runtime_perms.py
+++ b/tests/tools/test_docker_entrypoint_runtime_perms.py
@@ -1,0 +1,31 @@
+"""contract test: docker entrypoint repairs runtime-writable install dirs
+
+regression guard for #23402. remapping the hermes uid/gid at container start
+must also fix the runtime-mutable install-tree paths that the dashboard/TUI may
+write into, otherwise chat startup can fail with EACCES under custom
+HERMES_UID/HERMES_GID deployments.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+ENTRYPOINT = REPO_ROOT / "docker" / "entrypoint.sh"
+
+
+def test_entrypoint_chowns_runtime_mutable_install_dirs_for_remapped_uid() -> None:
+    text = ENTRYPOINT.read_text()
+
+    assert "runtime_mutable_paths=(" in text
+    assert 'if [ -n "$HERMES_UID" ] && [ "$HERMES_UID" != "10000" ]; then' in text
+
+    for required_path in ('"$INSTALL_DIR/ui-tui"', '"$INSTALL_DIR/node_modules"'):
+        assert required_path in text, (
+            f"{required_path} must be included in the runtime install-tree chown "
+            "list for custom HERMES_UID deployments; see #23402"
+        )
+
+    assert 'chown -R hermes:hermes "$runtime_path"' in text, (
+        "entrypoint must recursively repair ownership on runtime-mutable "
+        "install dirs before dropping privileges"
+    )


### PR DESCRIPTION
## What does this PR do?

Fixes the Docker entrypoint so remapping the runtime user with `HERMES_UID` / `HERMES_GID` also repairs ownership on the install-tree directories that the dashboard/TUI still needs to write into at runtime. Without this, dashboard chat startup can fail with `permission denied` under `/opt/hermes/ui-tui/...` even though `HERMES_HOME` itself is writable.

## Related Issue

Fixes #23402

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- extend `docker/entrypoint.sh` to repair ownership on the runtime-mutable install dirs under `/opt/hermes` before dropping privileges
- keep the repair scope narrow to `ui-tui` and `node_modules` instead of recursively chowning the entire install tree
- add `tests/tools/test_docker_entrypoint_runtime_perms.py` as a regression guard for custom `HERMES_UID` deployments

## How to Test

1. `uv run --frozen pytest -q -o addopts='' tests/tools/test_docker_entrypoint_runtime_perms.py tests/tools/test_dockerfile_node_modules_perms.py`
2. `uv run --frozen ruff check tests/tools/test_docker_entrypoint_runtime_perms.py tests/tools/test_dockerfile_node_modules_perms.py`
3. `bash -n docker/entrypoint.sh`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- targeted pytest: `2 passed`
- `ruff check`: passed
- `bash -n docker/entrypoint.sh`: passed
- collect-only smoke: `2 tests collected`
- repo-wide `pytest tests/ -q` was not used as the merge gate here; this PR is scoped to the Docker entrypoint + regression contract tests
