### PR TITLE
feat: add local artifacts presentation MVP

### DIFF
--- a/agent/artifacts.py
+++ b/agent/artifacts.py
@@ -1,0 +1,115 @@
+"""Structured artifact event helpers.
+
+This module defines a small, backwards-compatible event envelope for Hermes
+Canvas/Artifacts. It deliberately does not wire events into every runtime stream;
+callers can opt in by converting an ``artifact_present`` result into this shape
+and sending the fallback text to clients that do not understand structured
+artifact events.
+"""
+from __future__ import annotations
+
+import json
+import re
+from copy import deepcopy
+from typing import Any
+
+
+_ARTIFACT_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_.-]{0,127}$")
+_PREVIEW_URL_PREFIX = "/api/plugins/artifacts/preview/"
+_REQUIRED_FIELDS = ("id", "version", "title", "contentType", "path", "url")
+_FORBIDDEN_FIELDS = {"content", "html", "source", "sourceContent", "raw", "body"}
+
+
+class ArtifactEventError(ValueError):
+    """Raised when artifact metadata is incomplete or unsafe for event output."""
+
+
+def _validate_artifact_metadata(artifact: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(artifact, dict):
+        raise ArtifactEventError("artifact metadata must be an object")
+
+    forbidden = _FORBIDDEN_FIELDS.intersection(artifact)
+    if forbidden:
+        raise ArtifactEventError(f"artifact metadata includes raw content fields: {sorted(forbidden)}")
+
+    missing = [field for field in _REQUIRED_FIELDS if field not in artifact]
+    if missing:
+        raise ArtifactEventError(f"artifact metadata missing required fields: {missing}")
+
+    artifact_id = artifact.get("id")
+    if not isinstance(artifact_id, str) or not _ARTIFACT_ID_RE.fullmatch(artifact_id):
+        raise ArtifactEventError("invalid artifact id")
+
+    try:
+        version = int(artifact.get("version"))
+    except (TypeError, ValueError) as exc:
+        raise ArtifactEventError("invalid artifact version") from exc
+    if version < 1:
+        raise ArtifactEventError("artifact version must be >= 1")
+
+    for field in ("title", "contentType", "path", "url"):
+        value = artifact.get(field)
+        if not isinstance(value, str) or not value.strip():
+            raise ArtifactEventError(f"artifact field {field!r} must be a non-empty string")
+
+    url = artifact["url"]
+    if not url.startswith(_PREVIEW_URL_PREFIX):
+        raise ArtifactEventError("artifact url must use the local artifacts preview API")
+
+    safe = deepcopy(artifact)
+    safe["version"] = version
+    return safe
+
+
+def build_artifact_event(artifact: dict[str, Any]) -> dict[str, Any]:
+    """Build a stable structured event for rich clients.
+
+    The event is intentionally tiny:
+
+    ``{"type": "artifact", "artifact": {...metadata...}}``
+
+    It carries preview metadata only, never raw artifact contents. Clients that do
+    not understand the event can ignore it and render ``render_artifact_fallback_text``.
+    """
+
+    return {"type": "artifact", "artifact": _validate_artifact_metadata(artifact)}
+
+
+def artifact_event_from_tool_result(raw_result: str | dict[str, Any]) -> dict[str, Any] | None:
+    """Convert a successful ``artifact_present`` result into an artifact event.
+
+    Returns ``None`` for non-JSON, unsuccessful, or non-artifact tool results so
+    callers can use it opportunistically without changing existing tool handling.
+    Invalid artifact metadata still raises ``ArtifactEventError`` because that is
+    a producer bug, not a normal non-artifact result.
+    """
+
+    if isinstance(raw_result, str):
+        try:
+            data = json.loads(raw_result)
+        except json.JSONDecodeError:
+            return None
+    elif isinstance(raw_result, dict):
+        data = raw_result
+    else:
+        return None
+
+    if not isinstance(data, dict) or data.get("success") is not True:
+        return None
+    artifact = data.get("artifact")
+    if not isinstance(artifact, dict):
+        return None
+    return build_artifact_event(artifact)
+
+
+def render_artifact_fallback_text(event: dict[str, Any]) -> str:
+    """Render a compact plain-text fallback for clients that ignore events."""
+
+    if not isinstance(event, dict) or event.get("type") != "artifact":
+        raise ArtifactEventError("event must be an artifact event")
+    artifact = _validate_artifact_metadata(event.get("artifact", {}))
+    return (
+        f"Artifact ready: {artifact['title']} "
+        f"({artifact['contentType']}, v{artifact['version']})\n"
+        f"Preview: {artifact['url']}"
+    )

--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -109,6 +109,15 @@ _PUBLIC_API_PATHS: frozenset = frozenset({
     "/api/dashboard/plugins/rescan",
 })
 
+# Artifact preview files are intentionally renderable in sandboxed iframes.
+# Iframes cannot attach the ephemeral dashboard session header, so the preview
+# route is public while list/detail/control APIs remain protected. The plugin
+# store still validates artifact IDs, version paths, traversal attempts, and
+# secret-looking filenames before serving a file.
+_PUBLIC_API_PREFIXES: tuple[str, ...] = (
+    "/api/plugins/artifacts/preview/",
+)
+
 
 def _has_valid_session_token(request: Request) -> bool:
     """True if the request carries a valid dashboard session token.
@@ -225,7 +234,7 @@ async def host_header_middleware(request: Request, call_next):
 async def auth_middleware(request: Request, call_next):
     """Require the session token on all /api/ routes except the public list."""
     path = request.url.path
-    if path.startswith("/api/") and path not in _PUBLIC_API_PATHS:
+    if path.startswith("/api/") and path not in _PUBLIC_API_PATHS and not path.startswith(_PUBLIC_API_PREFIXES):
         if not _has_valid_session_token(request):
             return JSONResponse(
                 status_code=401,

--- a/plugins/artifacts/__init__.py
+++ b/plugins/artifacts/__init__.py
@@ -1,0 +1,4 @@
+"""Hermes Artifacts plugin.
+
+Read-only Dashboard viewer for immutable local artifacts.
+"""

--- a/plugins/artifacts/dashboard/dist/index.js
+++ b/plugins/artifacts/dashboard/dist/index.js
@@ -1,0 +1,155 @@
+(function () {
+  "use strict";
+
+  const SDK = window.__HERMES_PLUGIN_SDK__;
+  if (!SDK) return;
+
+  const React = SDK.React;
+  const h = React.createElement;
+  const C = SDK.components || {};
+  const hooks = SDK.hooks || React;
+  const Card = C.Card || "div";
+  const CardContent = C.CardContent || "div";
+  const Button = C.Button || "button";
+  const Badge = C.Badge || "span";
+  const useState = hooks.useState || React.useState;
+  const useEffect = hooks.useEffect || React.useEffect;
+
+  const API_BASE = "/api/plugins/artifacts";
+
+  function api(path) {
+    return fetch(API_BASE + path).then(function (res) {
+      if (!res.ok) {
+        return res.text().then(function (text) {
+          throw new Error(res.status + ": " + (text || res.statusText));
+        });
+      }
+      return res.json();
+    });
+  }
+
+  function ArtifactCard(props) {
+    const artifact = props.artifact;
+    const selected = props.selected && props.selected.id === artifact.id;
+    return h(Card, {
+      className: "hermes-artifact-card" + (selected ? " hermes-artifact-card-selected" : ""),
+      onClick: function () { props.onSelect(artifact); },
+      role: "button",
+      tabIndex: 0,
+      onKeyDown: function (event) {
+        if (event.key === "Enter" || event.key === " ") props.onSelect(artifact);
+      }
+    },
+      h(CardContent, { className: "hermes-artifact-card-content" },
+        h("div", { className: "hermes-artifact-card-title" }, artifact.title || artifact.id),
+        h("div", { className: "hermes-artifact-card-meta" },
+          h(Badge, null, artifact.contentType || "unknown"),
+          h("span", null, "v" + (artifact.latestVersion || 1))
+        ),
+        artifact.description ? h("p", { className: "hermes-artifact-card-description" }, artifact.description) : null
+      )
+    );
+  }
+
+  function EmptyState() {
+    return h("div", { className: "hermes-artifacts-empty" },
+      h("h3", null, "No artifacts yet"),
+      h("p", null, "Artifacts will appear here once a builder or tool registers manifests under HERMES_HOME/artifacts.")
+    );
+  }
+
+  function Preview(props) {
+    const artifact = props.artifact;
+    if (!artifact) {
+      return h("section", { className: "hermes-artifact-preview hermes-artifact-preview-empty" },
+        h("h3", null, "Select an artifact"),
+        h("p", null, "Preview runs in a sandboxed iframe. No same-origin bridge. No tiny browser demon gets dashboard cookies.")
+      );
+    }
+    return h("section", { className: "hermes-artifact-preview" },
+      h("div", { className: "hermes-artifact-preview-header" },
+        h("div", null,
+          h("h2", null, artifact.title || artifact.id),
+          h("p", null, artifact.id + " · " + (artifact.contentType || "unknown"))
+        ),
+        h(Button, {
+          type: "button",
+          onClick: function () { window.open(artifact.previewUrl, "_blank", "noopener,noreferrer"); }
+        }, "Open raw")
+      ),
+      h("iframe", {
+        title: "Artifact preview: " + (artifact.title || artifact.id),
+        className: "hermes-artifact-iframe",
+        sandbox: "allow-scripts",
+        referrerPolicy: "no-referrer",
+        src: artifact.previewUrl
+      })
+    );
+  }
+
+  function ArtifactsPage() {
+    const _state = useState([]);
+    const artifacts = _state[0];
+    const setArtifacts = _state[1];
+    const _selected = useState(null);
+    const selected = _selected[0];
+    const setSelected = _selected[1];
+    const _loading = useState(true);
+    const loading = _loading[0];
+    const setLoading = _loading[1];
+    const _error = useState(null);
+    const error = _error[0];
+    const setError = _error[1];
+
+    function load() {
+      setLoading(true);
+      setError(null);
+      return api("/list")
+        .then(function (data) {
+          const list = data.artifacts || [];
+          setArtifacts(list);
+          setSelected(function (current) {
+            if (current && list.some(function (item) { return item.id === current.id; })) return current;
+            return list[0] || null;
+          });
+        })
+        .catch(function (err) { setError(err.message || String(err)); })
+        .finally(function () { setLoading(false); });
+    }
+
+    useEffect(function () { load(); }, []);
+
+    return h("div", { className: "hermes-artifacts-page" },
+      h("header", { className: "hermes-artifacts-header" },
+        h("div", null,
+          h("h1", null, "Artifacts"),
+          h("p", null, "Local immutable artifact previews rendered in a sandboxed iframe.")
+        ),
+        h(Button, { type: "button", onClick: load, disabled: loading }, loading ? "Loading…" : "Refresh")
+      ),
+      error ? h("div", { className: "hermes-artifacts-error" }, error) : null,
+      h("main", { className: "hermes-artifacts-layout" },
+        h("aside", { className: "hermes-artifacts-list" },
+          loading ? h("p", { className: "hermes-artifacts-muted" }, "Loading artifacts…") : null,
+          !loading && artifacts.length === 0 ? h(EmptyState) : null,
+          artifacts.map(function (artifact) {
+            return h(ArtifactCard, {
+              key: artifact.id,
+              artifact: artifact,
+              selected: selected,
+              onSelect: setSelected
+            });
+          })
+        ),
+        h(Preview, { artifact: selected })
+      )
+    );
+  }
+
+  SDK.registerPage({
+    path: "/artifacts",
+    name: "artifacts",
+    label: "Artifacts",
+    component: ArtifactsPage
+  });
+})();

--- a/plugins/artifacts/dashboard/dist/index.js
+++ b/plugins/artifacts/dashboard/dist/index.js
@@ -2,7 +2,8 @@
   "use strict";
 
   const SDK = window.__HERMES_PLUGIN_SDK__;
-  if (!SDK) return;
+  const REGISTRY = window.__HERMES_PLUGINS__;
+  if (!SDK || !REGISTRY || typeof REGISTRY.register !== "function") return;
 
   const React = SDK.React;
   const h = React.createElement;
@@ -18,6 +19,9 @@
   const API_BASE = "/api/plugins/artifacts";
 
   function api(path) {
+    if (typeof SDK.fetchJSON === "function") {
+      return SDK.fetchJSON(API_BASE + path);
+    }
     return fetch(API_BASE + path).then(function (res) {
       if (!res.ok) {
         return res.text().then(function (text) {
@@ -146,10 +150,5 @@
     );
   }
 
-  SDK.registerPage({
-    path: "/artifacts",
-    name: "artifacts",
-    label: "Artifacts",
-    component: ArtifactsPage
-  });
+  REGISTRY.register("artifacts", ArtifactsPage);
 })();

--- a/plugins/artifacts/dashboard/dist/style.css
+++ b/plugins/artifacts/dashboard/dist/style.css
@@ -1,0 +1,114 @@
+.hermes-artifacts-page {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  height: 100%;
+  min-height: 0;
+}
+
+.hermes-artifacts-header,
+.hermes-artifact-preview-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.hermes-artifacts-header h1,
+.hermes-artifact-preview-header h2 {
+  margin: 0;
+}
+
+.hermes-artifacts-header p,
+.hermes-artifact-preview-header p,
+.hermes-artifact-card-description,
+.hermes-artifacts-muted {
+  color: hsl(var(--muted-foreground, 215 16% 47%));
+  margin: 0.25rem 0 0;
+}
+
+.hermes-artifacts-layout {
+  display: grid;
+  grid-template-columns: minmax(16rem, 22rem) minmax(0, 1fr);
+  gap: 1rem;
+  min-height: 32rem;
+  flex: 1;
+}
+
+.hermes-artifacts-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  overflow: auto;
+  min-height: 0;
+}
+
+.hermes-artifact-card {
+  cursor: pointer;
+  border: 1px solid hsl(var(--border, 214 32% 91%));
+  transition: border-color 120ms ease, transform 120ms ease;
+}
+
+.hermes-artifact-card:hover,
+.hermes-artifact-card:focus {
+  border-color: hsl(var(--primary, 221 83% 53%));
+  transform: translateY(-1px);
+  outline: none;
+}
+
+.hermes-artifact-card-selected {
+  border-color: hsl(var(--primary, 221 83% 53%));
+  box-shadow: 0 0 0 1px hsl(var(--primary, 221 83% 53%) / 0.25);
+}
+
+.hermes-artifact-card-content {
+  padding: 0.9rem;
+}
+
+.hermes-artifact-card-title {
+  font-weight: 650;
+}
+
+.hermes-artifact-card-meta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.4rem;
+  font-size: 0.8rem;
+}
+
+.hermes-artifact-preview {
+  min-width: 0;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.hermes-artifact-preview-empty,
+.hermes-artifacts-empty,
+.hermes-artifacts-error {
+  border: 1px dashed hsl(var(--border, 214 32% 91%));
+  border-radius: 0.75rem;
+  padding: 1rem;
+}
+
+.hermes-artifacts-error {
+  border-color: hsl(var(--destructive, 0 84% 60%));
+  color: hsl(var(--destructive, 0 84% 60%));
+}
+
+.hermes-artifact-iframe {
+  width: 100%;
+  min-height: 28rem;
+  flex: 1;
+  border: 1px solid hsl(var(--border, 214 32% 91%));
+  border-radius: 0.75rem;
+  background: white;
+}
+
+@media (max-width: 900px) {
+  .hermes-artifacts-layout {
+    grid-template-columns: 1fr;
+  }
+}

--- a/plugins/artifacts/dashboard/manifest.json
+++ b/plugins/artifacts/dashboard/manifest.json
@@ -1,0 +1,14 @@
+{
+  "name": "artifacts",
+  "label": "Artifacts",
+  "description": "Read-only local artifact gallery with sandboxed previews",
+  "icon": "PanelRight",
+  "version": "0.1.0",
+  "tab": {
+    "path": "/artifacts",
+    "position": "after:kanban"
+  },
+  "entry": "dist/index.js",
+  "css": "dist/style.css",
+  "api": "plugin_api.py"
+}

--- a/plugins/artifacts/dashboard/plugin_api.py
+++ b/plugins/artifacts/dashboard/plugin_api.py
@@ -1,0 +1,78 @@
+"""Artifacts dashboard plugin backend routes.
+
+Mounted at /api/plugins/artifacts/ by the Dashboard plugin loader.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException, Response
+from fastapi.responses import FileResponse
+
+try:
+    from plugins.artifacts import store
+except Exception:  # pragma: no cover - supports direct file loading in tests
+    import importlib.util
+    import sys
+
+    _store_path = Path(__file__).resolve().parents[1] / "store.py"
+    _spec = importlib.util.spec_from_file_location("hermes_artifacts_store_runtime", _store_path)
+    if _spec is None or _spec.loader is None:
+        raise
+    store = importlib.util.module_from_spec(_spec)  # type: ignore[assignment]
+    sys.modules[_spec.name] = store
+    _spec.loader.exec_module(store)
+
+
+router = APIRouter()
+
+
+def _security_headers(content_type: str | None = None) -> dict[str, str]:
+    headers = {
+        "X-Content-Type-Options": "nosniff",
+        "Referrer-Policy": "no-referrer",
+        "Content-Security-Policy": store.DEFAULT_CSP,
+        "Cache-Control": "private, max-age=60",
+    }
+    if content_type:
+        headers["Content-Type"] = content_type
+    return headers
+
+
+@router.get("/list")
+def list_artifacts() -> dict[str, object]:
+    artifacts = store.list_artifacts()
+    return {"artifacts": artifacts, "count": len(artifacts)}
+
+
+@router.get("/{artifact_id}")
+def get_artifact(artifact_id: str) -> dict[str, object]:
+    try:
+        artifact = store.get_artifact(artifact_id)
+    except store.ArtifactStoreError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="artifact not found") from exc
+    return {"artifact": artifact}
+
+
+@router.head("/preview/{artifact_id}/versions/{version}/{file_path:path}")
+def head_preview(artifact_id: str, version: int, file_path: str) -> Response:
+    try:
+        path = store.resolve_preview_path(artifact_id, version, file_path)
+    except store.ArtifactStoreError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="preview file not found") from exc
+    return Response(headers=_security_headers(store.content_type_for(path)))
+
+
+@router.get("/preview/{artifact_id}/versions/{version}/{file_path:path}")
+def get_preview(artifact_id: str, version: int, file_path: str) -> FileResponse:
+    try:
+        path = store.resolve_preview_path(artifact_id, version, file_path)
+    except store.ArtifactStoreError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except FileNotFoundError as exc:
+        raise HTTPException(status_code=404, detail="preview file not found") from exc
+    return FileResponse(path, media_type=store.content_type_for(path), headers=_security_headers())

--- a/plugins/artifacts/store.py
+++ b/plugins/artifacts/store.py
@@ -1,0 +1,206 @@
+"""Filesystem store for Hermes Dashboard artifacts.
+
+Phase 1 is intentionally read-only: it discovers artifact manifests under a
+Hermes-controlled root and resolves preview file paths without allowing path
+traversal, symlink escapes, or dotfile/secret exposure.
+"""
+from __future__ import annotations
+
+import json
+import mimetypes
+import re
+from pathlib import Path
+from typing import Any
+from urllib.parse import unquote
+
+try:
+    from hermes_constants import get_hermes_home
+except Exception:  # pragma: no cover - defensive fallback for isolated tests
+    import os as _os
+
+    def get_hermes_home() -> Path:  # type: ignore[misc]
+        val = (_os.environ.get("HERMES_HOME") or "").strip()
+        return Path(val) if val else Path.home() / ".hermes"
+
+
+ARTIFACT_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,127}$")
+DEFAULT_CSP = (
+    "default-src 'none'; "
+    "script-src 'unsafe-inline' 'unsafe-eval' data: blob:; "
+    "style-src 'unsafe-inline' data:; "
+    "img-src data: blob:; "
+    "font-src data:; "
+    "connect-src 'none'; "
+    "media-src data: blob:; "
+    "object-src 'none'; "
+    "base-uri 'none'; "
+    "form-action 'none'; "
+    "frame-ancestors 'self'"
+)
+
+
+class ArtifactStoreError(ValueError):
+    """Raised when an artifact manifest or path is unsafe/invalid."""
+
+
+def artifact_root() -> Path:
+    """Return the profile-aware artifact root."""
+
+    return get_hermes_home() / "artifacts"
+
+
+def _safe_artifact_id(artifact_id: str) -> str:
+    if not ARTIFACT_ID_RE.fullmatch(artifact_id or ""):
+        raise ArtifactStoreError("invalid artifact id")
+    return artifact_id
+
+
+def _read_manifest(manifest_path: Path) -> dict[str, Any] | None:
+    try:
+        data = json.loads(manifest_path.read_text(encoding="utf-8"))
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+        return None
+    if not isinstance(data, dict):
+        return None
+    artifact_id = data.get("id")
+    if not isinstance(artifact_id, str):
+        artifact_id = manifest_path.parent.name
+    try:
+        _safe_artifact_id(artifact_id)
+    except ArtifactStoreError:
+        return None
+    data["id"] = artifact_id
+    return data
+
+
+def _version_entry(manifest: dict[str, Any], version: int | None = None) -> dict[str, Any]:
+    versions = manifest.get("versions")
+    if not isinstance(versions, list):
+        versions = []
+    if version is None:
+        latest = manifest.get("latestVersion") or manifest.get("latest_version") or 1
+        try:
+            version = int(latest)
+        except (TypeError, ValueError):
+            version = 1
+    for row in versions:
+        if not isinstance(row, dict):
+            continue
+        try:
+            if int(row.get("version", -1)) == version:
+                return row
+        except (TypeError, ValueError):
+            continue
+    return {"version": version, "entrypoint": "index.html", "contentType": manifest.get("contentType", "text/html")}
+
+
+def _public_manifest(manifest: dict[str, Any]) -> dict[str, Any]:
+    artifact_id = _safe_artifact_id(str(manifest.get("id", "")))
+    latest = _version_entry(manifest)
+    version = int(latest.get("version", manifest.get("latestVersion") or 1))
+    entrypoint = str(latest.get("entrypoint") or "index.html")
+    content_type = str(latest.get("contentType") or manifest.get("contentType") or "text/html")
+    return {
+        "id": artifact_id,
+        "title": manifest.get("title") or artifact_id,
+        "description": manifest.get("description") or "",
+        "contentType": content_type,
+        "latestVersion": version,
+        "createdAt": manifest.get("createdAt"),
+        "updatedAt": manifest.get("updatedAt"),
+        "versions": manifest.get("versions") if isinstance(manifest.get("versions"), list) else [latest],
+        "previewUrl": f"/api/plugins/artifacts/preview/{artifact_id}/versions/{version}/{entrypoint}",
+    }
+
+
+def list_artifacts(root: Path | None = None) -> list[dict[str, Any]]:
+    """List public artifact manifest summaries from the controlled root."""
+
+    root = root or artifact_root()
+    if not root.exists():
+        return []
+    out: list[dict[str, Any]] = []
+    for child in sorted(root.iterdir(), key=lambda p: p.name.lower()):
+        if not child.is_dir() or child.name.startswith("."):
+            continue
+        try:
+            _safe_artifact_id(child.name)
+        except ArtifactStoreError:
+            continue
+        manifest = _read_manifest(child / "manifest.json")
+        if not manifest:
+            continue
+        if manifest["id"] != child.name:
+            # Keep ids directory-scoped; no alias tricks through manifests.
+            continue
+        try:
+            out.append(_public_manifest(manifest))
+        except (ArtifactStoreError, TypeError, ValueError):
+            continue
+    return out
+
+
+def get_artifact(artifact_id: str, root: Path | None = None) -> dict[str, Any]:
+    root = root or artifact_root()
+    safe_id = _safe_artifact_id(artifact_id)
+    manifest = _read_manifest(root / safe_id / "manifest.json")
+    if not manifest or manifest.get("id") != safe_id:
+        raise FileNotFoundError(safe_id)
+    return _public_manifest(manifest)
+
+
+def _decode_path(value: str) -> str:
+    decoded = value or ""
+    # Decode repeatedly enough to catch common double-encoding, without a cute
+    # infinite loop. Cute infinite loops are still infinite loops.
+    for _ in range(3):
+        nxt = unquote(decoded)
+        if nxt == decoded:
+            break
+        decoded = nxt
+    return decoded.replace("\\", "/")
+
+
+def _reject_unsafe_parts(decoded_path: str) -> None:
+    if decoded_path.startswith("/") or decoded_path.startswith("~"):
+        raise ArtifactStoreError("absolute preview paths are not allowed")
+    parts = [part for part in decoded_path.split("/") if part not in {"", "."}]
+    if not parts:
+        raise ArtifactStoreError("empty preview path")
+    for part in parts:
+        if part == "..":
+            raise ArtifactStoreError("path traversal is not allowed")
+        if part.startswith("."):
+            raise ArtifactStoreError("dotfiles are not served")
+        lowered = part.lower()
+        if lowered in {".env", "id_rsa", "id_ed25519"} or lowered.endswith((".pem", ".key")):
+            raise ArtifactStoreError("secret-looking files are not served")
+
+
+def resolve_preview_path(artifact_id: str, version: int, file_path: str, root: Path | None = None) -> Path:
+    """Resolve a preview file path and prove it stays inside the version dir."""
+
+    if version < 1:
+        raise ArtifactStoreError("invalid artifact version")
+    root = (root or artifact_root()).resolve()
+    safe_id = _safe_artifact_id(artifact_id)
+    decoded = _decode_path(file_path)
+    _reject_unsafe_parts(decoded)
+
+    base = (root / safe_id / "versions" / str(version)).resolve()
+    candidate = (base / decoded).resolve()
+    try:
+        candidate.relative_to(base)
+        base.relative_to(root)
+    except ValueError as exc:
+        raise ArtifactStoreError("preview path escapes artifact root") from exc
+    if not candidate.exists() or not candidate.is_file():
+        raise FileNotFoundError(decoded)
+    # If candidate was a symlink to inside base, resolve() above has normalized it.
+    # If it pointed outside, relative_to(base) already rejected it.
+    return candidate
+
+
+def content_type_for(path: Path) -> str:
+    guessed, _ = mimetypes.guess_type(str(path))
+    return guessed or "application/octet-stream"

--- a/skills/creative/artifact-builder/SKILL.md
+++ b/skills/creative/artifact-builder/SKILL.md
@@ -1,0 +1,171 @@
+---
+name: artifact-builder
+description: Use when building Hermes Canvas/Artifacts deliverables out-of-band, especially HTML/SVG/Markdown/Mermaid artifacts that should be registered with artifact_present instead of pasted into main chat.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [artifacts, canvas, html, svg, mermaid, dashboard, preview, design, sandbox]
+    related_skills: [claude-design, sketch, popular-web-designs, architecture-diagram, excalidraw, verification-before-completion]
+---
+
+# Artifact Builder
+
+## Overview
+
+Use this skill to act as a focused artifact builder for Hermes Canvas/Artifacts. The builder creates a concrete artifact file or generated content, registers it through `artifact_present`, and returns only structured artifact metadata plus a short human note.
+
+This is the Hermes-native version of the useful part of OpenClaw Canvas: build something visual or reusable, put it into a controlled artifact store, and let the Dashboard render it in a sandboxed preview. It is not a browser bridge, not a native WebView controller, and not a permission slip for tiny browser demons to touch the agent runtime.
+
+## When to Use
+
+Use this skill when the user asks for:
+
+- a rendered HTML artifact, dashboard, prototype, report, slide/deck, or component board;
+- an SVG, Mermaid, Markdown, JSON, or text artifact that should be browsed later;
+- a Canvas/Artifacts-style deliverable rather than prose in chat;
+- multiple visual variants where the final output should be previewable in the Artifacts Dashboard;
+- a subagent/profile that builds artifacts while the main chat stays compact.
+
+Do not use this skill for:
+
+- ordinary prose answers that fit in chat;
+- production app changes in an existing repo, unless the artifact is a separate preview/report;
+- bidirectional UI bridges or agent-control surfaces;
+- `canvas.eval`, arbitrary iframe JS control, or raw HTML injection into Dashboard DOM.
+
+## Contract
+
+Main chat never receives raw HTML dumps by default. The builder writes or generates the artifact out-of-band and calls `artifact_present`. Return structured artifact metadata, not the whole file body.
+
+Minimum success payload after `artifact_present`:
+
+```json
+{
+  "success": true,
+  "artifact": {
+    "id": "revenue-dashboard",
+    "version": 1,
+    "title": "Revenue Dashboard",
+    "contentType": "text/html",
+    "path": "$HERMES_HOME/artifacts/revenue-dashboard/versions/1/index.html",
+    "url": "/api/plugins/artifacts/preview/revenue-dashboard/versions/1/index.html"
+  }
+}
+```
+
+If registration fails, return a concise timeout/failure object or note with:
+
+- what was attempted;
+- the exact failed check or tool error;
+- whether a local source file exists;
+- the safe next action.
+
+Do not silently fall back to pasting the artifact into chat. That defeats the point and makes token budgets cry quietly in a corner.
+
+## Workflow
+
+1. **Intake**
+   - Identify artifact type: `text/html`, `image/svg+xml`, `text/markdown`, `application/vnd.mermaid`, `application/json`, or `text/plain`.
+   - Decide whether the artifact is generated from `content` or first written as a local `source_path`.
+   - Pick a stable, lowercase artifact id when persistence/versioning matters.
+
+2. **Build**
+   - Prefer a complete, portable file with local CSS/JS for HTML artifacts.
+   - Keep assets under the artifact source directory before registration.
+   - For standalone HTML, use semantic markup, accessible contrast, responsive layout, and no secrets or private env data.
+   - For Mermaid/Markdown/SVG, ensure the content is valid enough for preview/download.
+
+3. **Verify before registration**
+   - Confirm the source file exists and has substantive content.
+   - For HTML/SVG/JSON/Mermaid, run a cheap syntax or structural check where available.
+   - For visual artifacts, use browser/snapshot/vision verification when available.
+   - Fix visible broken layout, console errors, or missing data before presentation.
+
+4. **Register**
+   - Call `artifact_present` with exactly one of `content` or `source_path`.
+   - Pass `title`, optional `artifact_id`, `content_type`, and a safe `filename`.
+   - Let the tool copy the file into `$HERMES_HOME/artifacts/<id>/versions/<n>/` and create the manifest.
+
+5. **Return**
+   - Return the JSON metadata or its key fields: id, version, title, contentType, path, url.
+   - Add one short note about what was built and any caveat.
+   - Do not include raw HTML/CSS/JS unless the user explicitly asks for source.
+
+## Tool Use Pattern
+
+For generated content:
+
+```python
+artifact_present(
+    title="Revenue Dashboard",
+    artifact_id="revenue-dashboard",
+    content=html,
+    filename="index.html",
+    content_type="text/html",
+    description="Interactive revenue dashboard prototype"
+)
+```
+
+For an existing file:
+
+```python
+artifact_present(
+    title="Architecture Diagram",
+    artifact_id="architecture-diagram",
+    source_path="/absolute/path/to/diagram.svg",
+    content_type="image/svg+xml",
+    description="System architecture diagram"
+)
+```
+
+Use `source_path` for anything large, multi-step, or visually verified from disk. Use `content` for small generated artifacts where keeping a separate source file adds no value.
+
+## Runtime and Safety Constraints
+
+- Preview must use the Artifacts Dashboard sandboxed preview path.
+- No `allow-same-origin` by default.
+- No `canvas.eval`.
+- No direct JS bridge from artifact iframe to agent runtime.
+- No rendering generated HTML directly in Dashboard DOM.
+- No LAN exposure or public bind changes.
+- No copying dotfiles, `.env`, private keys, tokens, or secret-looking files.
+- No symlink tricks, path traversal, or absolute output filenames.
+- Avoid external CDNs unless the user explicitly accepts network dependencies; default to local/self-contained artifacts.
+
+## Design Quality Bar
+
+For HTML and visual artifacts:
+
+- Use real copy and realistic data, not lorem ipsum confetti.
+- Make layout responsive enough for desktop and narrow viewports.
+- Include meaningful empty/error/loading states when the artifact represents a product UI.
+- Prefer a coherent visual stance over generic gradient-card soup.
+- Keep JavaScript minimal and local to the artifact.
+
+When the assignment is primarily design, combine this with `claude-design`, `sketch`, or `popular-web-designs`. Those skills drive taste; this one drives artifact lifecycle and registration.
+
+## Verification Checklist
+
+- [ ] Artifact type and filename are explicit.
+- [ ] Source file or generated content exists and is substantive.
+- [ ] Visual/syntax verification ran where practical.
+- [ ] `artifact_present` returned `success: true`.
+- [ ] Returned metadata includes `id`, `version`, `title`, `contentType`, `path`, and `url`.
+- [ ] Preview URL starts with `/api/plugins/artifacts/preview/`.
+- [ ] Main response does not paste raw HTML by default.
+- [ ] No secrets, dotfiles, symlinks, path traversal, or unsafe iframe privileges are involved.
+
+## Common Pitfalls
+
+1. **Pasting the full artifact into chat.** Use `artifact_present`; chat gets the handle.
+2. **Skipping visual verification.** HTML that technically exists can still look like a ransom note generated by CSS.
+3. **Using unsafe iframe privileges.** `allow-same-origin` and bridges are later-phase decisions, not MVP defaults.
+4. **Treating OpenClaw Canvas SKILL.md as the implementation.** OpenClaw relies on a broader Canvas plugin/host/native surface. Hermes needs plugin + store + sandbox + tool.
+5. **Registering secrets by accident.** Never pass `.env`, keys, cookies, token dumps, or hidden files as source artifacts.
+
+## Reference
+
+See `references/artifact-runtime-api.md` for the current `artifact_present` payload shape, supported content types, preview URLs, and failure contract.

--- a/skills/creative/artifact-builder/references/artifact-runtime-api.md
+++ b/skills/creative/artifact-builder/references/artifact-runtime-api.md
@@ -1,0 +1,142 @@
+# Artifact Runtime API
+
+Current Hermes Canvas/Artifacts runtime surface for the `artifact-builder` skill.
+
+## Tool: `artifact_present`
+
+Registers generated content or an existing local file as a versioned Hermes artifact under `$HERMES_HOME/artifacts` and returns structured metadata for the Artifacts Dashboard.
+
+Call with exactly one of:
+
+- `content`: string content to write into the artifact version directory.
+- `source_path`: existing local regular file to copy into the artifact version directory.
+
+Common arguments:
+
+```json
+{
+  "title": "Revenue Dashboard",
+  "artifact_id": "revenue-dashboard",
+  "content": "<html>...</html>",
+  "filename": "index.html",
+  "content_type": "text/html",
+  "description": "Interactive revenue dashboard prototype"
+}
+```
+
+Successful result:
+
+```json
+{
+  "success": true,
+  "artifact": {
+    "id": "revenue-dashboard",
+    "version": 1,
+    "title": "Revenue Dashboard",
+    "contentType": "text/html",
+    "path": "$HERMES_HOME/artifacts/revenue-dashboard/versions/1/index.html",
+    "url": "/api/plugins/artifacts/preview/revenue-dashboard/versions/1/index.html",
+    "createdAt": "2026-05-11T00:00:00Z"
+  }
+}
+```
+
+Failure result:
+
+```json
+{
+  "success": false,
+  "error": "Provide exactly one of content or source_path"
+}
+```
+
+Failures must be reported as structured error notes. Do not paste the artifact source into chat as a fallback unless the user explicitly asks for source.
+
+## Structured artifact event
+
+Rich clients can render artifact cards from this optional event envelope:
+
+```json
+{
+  "type": "artifact",
+  "artifact": {
+    "id": "revenue-dashboard",
+    "version": 1,
+    "title": "Revenue Dashboard",
+    "contentType": "text/html",
+    "path": "$HERMES_HOME/artifacts/revenue-dashboard/versions/1/index.html",
+    "url": "/api/plugins/artifacts/preview/revenue-dashboard/versions/1/index.html"
+  }
+}
+```
+
+Use `agent.artifacts.artifact_event_from_tool_result(...)` to convert a successful `artifact_present` JSON result into this envelope. Plain clients can ignore the event and render `agent.artifacts.render_artifact_fallback_text(...)`, e.g. `Artifact ready: Revenue Dashboard (text/html, v1)` plus the preview URL. This keeps the response backward compatible while avoiding prose scraping.
+
+The event carries preview metadata only. It must not contain raw HTML/source content, external preview URLs, dotfile/secret fields, or bridge instructions.
+
+## Supported content types
+
+The current tool accepts caller-provided MIME/content types. Preferred types for Dashboard artifacts:
+
+| Type | Filename | Use |
+| --- | --- | --- |
+| `text/html` | `index.html` | Standalone HTML artifact, prototype, dashboard, deck |
+| `image/svg+xml` | `index.svg` or source filename | SVG diagrams and visualizations |
+| `text/markdown` | `index.md` or source filename | Markdown reports and docs |
+| `application/vnd.mermaid` | `diagram.mmd` | Mermaid diagrams |
+| `application/json` | `data.json` | JSON data artifacts |
+| `text/plain` | `artifact.txt` | Plain text outputs |
+
+If `filename` is omitted for generated `content`, the tool chooses defaults such as `index.html`, `index.svg`, `index.md`, `diagram.mmd`, `data.json`, or `artifact.txt` based on `content_type`.
+
+## Preview URLs
+
+Artifacts are previewed through the Dashboard plugin API:
+
+```text
+/api/plugins/artifacts/preview/<artifact_id>/versions/<version>/<filename>
+```
+
+Example:
+
+```text
+/api/plugins/artifacts/preview/revenue-dashboard/versions/1/index.html
+```
+
+The Dashboard viewer should load preview URLs in a sandboxed iframe. The MVP default is `sandbox="allow-scripts"` without `allow-same-origin`.
+
+## Storage layout
+
+```text
+$HERMES_HOME/artifacts/
+└── revenue-dashboard/
+    ├── manifest.json
+    └── versions/
+        └── 1/
+            └── index.html
+```
+
+The manifest tracks `id`, `title`, `description`, `contentType`, `latestVersion`, timestamps, and version entries.
+
+## Safety constraints
+
+`artifact_present` rejects or should reject:
+
+- calls with both `content` and `source_path`, or neither;
+- unsafe output filenames such as absolute paths, `..`, dotfiles, and secret-looking names;
+- source files that are dotfiles, symlinks, non-regular files, or secret-looking files;
+- attempts to expose `.env`, keys, PEM files, or token dumps.
+
+The preview resolver separately blocks traversal, dotfiles, secret-looking files, invalid artifact ids, and path escapes from the artifact root.
+
+## Builder responsibilities
+
+Before calling `artifact_present`, the builder should:
+
+1. choose the content type and filename;
+2. produce substantive content or a source file;
+3. run syntax/visual checks where practical;
+4. register the artifact;
+5. return only structured artifact metadata and a short summary.
+
+Main chat never receives raw HTML dumps by default.

--- a/tests/agent/test_artifact_events.py
+++ b/tests/agent/test_artifact_events.py
@@ -1,0 +1,77 @@
+"""Contract tests for structured artifact events."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agent.artifacts import (
+    ArtifactEventError,
+    artifact_event_from_tool_result,
+    build_artifact_event,
+    render_artifact_fallback_text,
+)
+
+
+ARTIFACT = {
+    "id": "revenue-dashboard",
+    "version": 1,
+    "title": "Revenue Dashboard",
+    "contentType": "text/html",
+    "path": "/tmp/.hermes/artifacts/revenue-dashboard/versions/1/index.html",
+    "url": "/api/plugins/artifacts/preview/revenue-dashboard/versions/1/index.html",
+}
+
+
+def test_build_artifact_event_returns_stable_envelope_without_raw_content():
+    event = build_artifact_event(ARTIFACT)
+
+    assert event == {
+        "type": "artifact",
+        "artifact": ARTIFACT,
+    }
+    assert "content" not in event["artifact"]
+    assert "<html" not in json.dumps(event).lower()
+
+
+def test_artifact_event_from_tool_result_converts_artifact_present_json():
+    raw = json.dumps({"success": True, "artifact": ARTIFACT})
+
+    event = artifact_event_from_tool_result(raw)
+
+    assert event["type"] == "artifact"
+    assert event["artifact"]["id"] == "revenue-dashboard"
+    assert event["artifact"]["url"].startswith("/api/plugins/artifacts/preview/")
+
+
+def test_render_artifact_fallback_text_keeps_plain_clients_backward_compatible():
+    event = build_artifact_event(ARTIFACT)
+
+    text = render_artifact_fallback_text(event)
+
+    assert "Revenue Dashboard" in text
+    assert "text/html" in text
+    assert "/api/plugins/artifacts/preview/revenue-dashboard/versions/1/index.html" in text
+    assert "<html" not in text.lower()
+
+
+@pytest.mark.parametrize(
+    "artifact",
+    [
+        {**ARTIFACT, "id": "../bad"},
+        {**ARTIFACT, "version": 0},
+        {**ARTIFACT, "contentType": ""},
+        {**ARTIFACT, "url": "https://example.com/remote"},
+        {**ARTIFACT, "content": "<html>do not leak</html>"},
+    ],
+)
+def test_build_artifact_event_rejects_unsafe_or_incomplete_metadata(artifact):
+    with pytest.raises(ArtifactEventError):
+        build_artifact_event(artifact)
+
+
+def test_artifact_event_from_tool_result_returns_none_for_non_artifact_results():
+    assert artifact_event_from_tool_result(json.dumps({"success": True, "output": "ok"})) is None
+    assert artifact_event_from_tool_result("not json") is None
+    assert artifact_event_from_tool_result(json.dumps({"success": False, "error": "bad"})) is None

--- a/tests/plugins/test_artifacts_dashboard_plugin.py
+++ b/tests/plugins/test_artifacts_dashboard_plugin.py
@@ -1,0 +1,215 @@
+"""Tests for the Artifacts dashboard plugin MVP.
+
+The plugin mounts as /api/plugins/artifacts/ inside the dashboard. These tests
+attach the router to a bare FastAPI app and use an isolated HERMES_HOME so the
+artifact store can be exercised without running the full dashboard.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+PLUGIN_FILE = REPO_ROOT / "plugins" / "artifacts" / "dashboard" / "plugin_api.py"
+STORE_FILE = REPO_ROOT / "plugins" / "artifacts" / "store.py"
+BUNDLE_FILE = REPO_ROOT / "plugins" / "artifacts" / "dashboard" / "dist" / "index.js"
+MANIFEST_FILE = REPO_ROOT / "plugins" / "artifacts" / "dashboard" / "manifest.json"
+
+
+def _load_module(name: str, path: Path):
+    assert path.exists(), f"missing module: {path}"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _load_plugin_router():
+    return _load_module("hermes_dashboard_plugin_artifacts_test", PLUGIN_FILE).router
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    return home
+
+
+@pytest.fixture
+def artifact_root(hermes_home):
+    root = hermes_home / "artifacts"
+    root.mkdir()
+    return root
+
+
+def write_artifact(
+    root: Path,
+    artifact_id: str = "hello-card",
+    *,
+    version: int = 1,
+    title: str = "Hello Card",
+    content_type: str = "text/html",
+    entrypoint: str = "index.html",
+    body: str = "<html><body>Hello artifact</body></html>",
+):
+    version_dir = root / artifact_id / "versions" / str(version)
+    version_dir.mkdir(parents=True)
+    (version_dir / entrypoint).write_text(body, encoding="utf-8")
+    manifest = {
+        "id": artifact_id,
+        "title": title,
+        "description": "Fixture artifact",
+        "contentType": content_type,
+        "latestVersion": version,
+        "createdAt": "2026-05-10T12:00:00Z",
+        "updatedAt": "2026-05-10T12:00:00Z",
+        "versions": [
+            {
+                "version": version,
+                "entrypoint": entrypoint,
+                "contentType": content_type,
+                "createdAt": "2026-05-10T12:00:00Z",
+            }
+        ],
+    }
+    (root / artifact_id / "manifest.json").write_text(json.dumps(manifest), encoding="utf-8")
+    return manifest
+
+
+@pytest.fixture
+def client(artifact_root):
+    app = FastAPI()
+    app.include_router(_load_plugin_router(), prefix="/api/plugins/artifacts")
+    return TestClient(app)
+
+
+# ---------------------------------------------------------------------------
+# Store/API happy path
+# ---------------------------------------------------------------------------
+
+
+def test_store_lists_manifests_from_controlled_hermes_root(artifact_root):
+    write_artifact(artifact_root, "hello-card")
+    store = _load_module("hermes_artifacts_store_test", STORE_FILE)
+
+    artifacts = store.list_artifacts()
+
+    assert [a["id"] for a in artifacts] == ["hello-card"]
+    assert artifacts[0]["title"] == "Hello Card"
+    assert artifacts[0]["latestVersion"] == 1
+    assert artifacts[0]["previewUrl"] == "/api/plugins/artifacts/preview/hello-card/versions/1/index.html"
+
+
+def test_api_lists_artifacts_and_serves_preview(client, artifact_root):
+    write_artifact(artifact_root, "hello-card")
+
+    listing = client.get("/api/plugins/artifacts/list")
+    assert listing.status_code == 200, listing.text
+    assert listing.json()["artifacts"][0]["id"] == "hello-card"
+
+    preview = client.get("/api/plugins/artifacts/preview/hello-card/versions/1/index.html")
+    assert preview.status_code == 200, preview.text
+    assert "Hello artifact" in preview.text
+    assert preview.headers["content-type"].startswith("text/html")
+    assert preview.headers["x-content-type-options"] == "nosniff"
+    assert "default-src 'none'" in preview.headers["content-security-policy"]
+
+
+# ---------------------------------------------------------------------------
+# Path safety
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad_path",
+    [
+        "../manifest.json",
+        "..%2Fmanifest.json",
+        "%2e%2e/manifest.json",
+        "/etc/passwd",
+        "assets/../../manifest.json",
+        "assets\\..\\..\\manifest.json",
+    ],
+)
+def test_preview_rejects_traversal_and_absolute_paths(client, artifact_root, bad_path):
+    write_artifact(artifact_root, "hello-card")
+
+    r = client.get(f"/api/plugins/artifacts/preview/hello-card/versions/1/{bad_path}")
+
+    assert r.status_code in {400, 404, 422}
+    assert "Hello artifact" not in r.text
+
+
+def test_preview_rejects_symlink_escape(client, artifact_root, tmp_path):
+    write_artifact(artifact_root, "hello-card")
+    outside_secret = tmp_path / "outside.env"
+    outside_secret.write_text("TOKEN=do-not-serve", encoding="utf-8")
+    link = artifact_root / "hello-card" / "versions" / "1" / "leak.env"
+    link.symlink_to(outside_secret)
+
+    r = client.get("/api/plugins/artifacts/preview/hello-card/versions/1/leak.env")
+
+    assert r.status_code in {400, 403, 404}
+    assert "do-not-serve" not in r.text
+
+
+@pytest.mark.parametrize("dotfile", [".env", ".secret", "assets/.env"])
+def test_preview_rejects_dotfiles(client, artifact_root, dotfile):
+    write_artifact(artifact_root, "hello-card")
+    target = artifact_root / "hello-card" / "versions" / "1" / dotfile
+    target.parent.mkdir(parents=True, exist_ok=True)
+    target.write_text("SECRET=do-not-serve", encoding="utf-8")
+
+    r = client.get(f"/api/plugins/artifacts/preview/hello-card/versions/1/{dotfile}")
+
+    assert r.status_code in {400, 403, 404}
+    assert "do-not-serve" not in r.text
+
+
+def test_preview_rejects_invalid_artifact_id(client, artifact_root):
+    write_artifact(artifact_root, "hello-card")
+
+    r = client.get("/api/plugins/artifacts/preview/../../bad/versions/1/index.html")
+
+    assert r.status_code in {400, 404}
+
+
+# ---------------------------------------------------------------------------
+# Dashboard bundle invariants
+# ---------------------------------------------------------------------------
+
+
+def test_dashboard_manifest_declares_artifacts_tab_and_api():
+    data = json.loads(MANIFEST_FILE.read_text(encoding="utf-8"))
+
+    assert data["name"] == "artifacts"
+    assert data["tab"]["path"] == "/artifacts"
+    assert data["entry"] == "dist/index.js"
+    assert data["css"] == "dist/style.css"
+    assert data["api"] == "plugin_api.py"
+
+
+def test_dashboard_bundle_uses_sandboxed_iframe_not_inner_html():
+    js = BUNDLE_FILE.read_text(encoding="utf-8")
+
+    assert 'API_BASE = "/api/plugins/artifacts"' in js
+    assert 'api("/list")' in js
+    assert "iframe" in js
+    assert "sandbox" in js
+    assert "allow-scripts" in js
+    assert "allow-same-origin" not in js
+    assert "dangerouslySetInnerHTML" not in js
+    assert "referrerPolicy" in js
+    assert "no-referrer" in js

--- a/tests/plugins/test_artifacts_dashboard_plugin.py
+++ b/tests/plugins/test_artifacts_dashboard_plugin.py
@@ -201,6 +201,15 @@ def test_dashboard_manifest_declares_artifacts_tab_and_api():
     assert data["api"] == "plugin_api.py"
 
 
+def test_dashboard_bundle_uses_real_plugin_registry_and_sdk_fetch_client():
+    js = BUNDLE_FILE.read_text(encoding="utf-8")
+
+    assert "window.__HERMES_PLUGINS__" in js
+    assert 'REGISTRY.register("artifacts", ArtifactsPage)' in js
+    assert "registerPage" not in js
+    assert "SDK.fetchJSON(API_BASE + path)" in js
+
+
 def test_dashboard_bundle_uses_sandboxed_iframe_not_inner_html():
     js = BUNDLE_FILE.read_text(encoding="utf-8")
 
@@ -213,3 +222,11 @@ def test_dashboard_bundle_uses_sandboxed_iframe_not_inner_html():
     assert "dangerouslySetInnerHTML" not in js
     assert "referrerPolicy" in js
     assert "no-referrer" in js
+
+
+def test_dashboard_auth_middleware_allows_artifact_preview_prefix_only():
+    source = (REPO_ROOT / "hermes_cli" / "web_server.py").read_text(encoding="utf-8")
+
+    assert '"/api/plugins/artifacts/preview/"' in source
+    assert "path.startswith(_PUBLIC_API_PREFIXES)" in source
+    assert '"/api/plugins/artifacts/list"' not in source

--- a/tests/skills/test_artifact_builder_skill.py
+++ b/tests/skills/test_artifact_builder_skill.py
@@ -1,0 +1,53 @@
+"""Contract tests for the artifact-builder skill."""
+
+from pathlib import Path
+
+from tools.skill_manager_tool import _validate_frontmatter
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SKILL_PATH = ROOT / "skills" / "creative" / "artifact-builder" / "SKILL.md"
+RUNTIME_REF_PATH = ROOT / "skills" / "creative" / "artifact-builder" / "references" / "artifact-runtime-api.md"
+
+
+def _skill_content() -> str:
+    return SKILL_PATH.read_text(encoding="utf-8")
+
+
+def test_artifact_builder_skill_exists_with_valid_frontmatter():
+    assert SKILL_PATH.exists()
+    content = _skill_content()
+    assert _validate_frontmatter(content) is None
+    assert "name: artifact-builder" in content
+    assert "description: Use when" in content
+
+
+def test_artifact_builder_skill_enforces_out_of_band_registration_contract():
+    content = _skill_content()
+    required_phrases = [
+        "artifact_present",
+        "Main chat never receives raw HTML dumps by default",
+        "Return structured artifact metadata",
+        "sandboxed preview",
+        "No `canvas.eval`",
+        "No `allow-same-origin` by default",
+        "timeout/failure",
+    ]
+    for phrase in required_phrases:
+        assert phrase in content
+
+
+def test_artifact_builder_skill_documents_runtime_api_reference():
+    assert RUNTIME_REF_PATH.exists()
+    reference = RUNTIME_REF_PATH.read_text(encoding="utf-8")
+    required_phrases = [
+        "artifact_present",
+        "contentType",
+        "url",
+        "/api/plugins/artifacts/preview/",
+        "text/html",
+        "image/svg+xml",
+        "application/vnd.mermaid",
+    ]
+    for phrase in required_phrases:
+        assert phrase in reference

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -401,10 +401,10 @@ def test_load_enabled_toolsets_rejects_disabled_mcp_env(monkeypatch, capsys):
         config_mod, "load_config", lambda: {"platform_toolsets": {"cli": ["memory"]}}
     )
 
-    # Sorted: ["kanban", "memory"]. `kanban` is auto-recovered by
+    # Sorted: ["artifacts", "kanban", "memory"]. `artifacts` and `kanban` are auto-recovered by
     # _get_platform_tools because it's a non-configurable platform toolset
     # whose tools live in hermes-cli's universe (see toolsets.py).
-    assert server._load_enabled_toolsets() == ["kanban", "memory"]
+    assert server._load_enabled_toolsets() == ["artifacts", "kanban", "memory"]
     err = capsys.readouterr().err
     assert "ignoring disabled MCP servers" in err
     assert "mcp-off" in err
@@ -425,7 +425,7 @@ def test_load_enabled_toolsets_falls_back_when_tui_env_invalid(monkeypatch, caps
         config_mod, "load_config", lambda: {"platform_toolsets": {"cli": ["memory"]}}
     )
 
-    assert server._load_enabled_toolsets() == ["kanban", "memory"]
+    assert server._load_enabled_toolsets() == ["artifacts", "kanban", "memory"]
     assert "using configured CLI toolsets" in capsys.readouterr().err
 
 

--- a/tests/tools/test_artifact_tool.py
+++ b/tests/tools/test_artifact_tool.py
@@ -1,0 +1,208 @@
+"""Tests for the artifact_present agent tool."""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _reset_artifact_tool_modules():
+    for name in list(sys.modules):
+        if name in {"tools.artifact_tool", "plugins.artifacts.store"}:
+            sys.modules.pop(name, None)
+
+
+@pytest.fixture
+def hermes_home(tmp_path, monkeypatch):
+    home = tmp_path / ".hermes"
+    home.mkdir()
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    monkeypatch.setenv("TERMINAL_CWD", str(tmp_path))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path)
+    _reset_artifact_tool_modules()
+    return home
+
+
+@pytest.fixture
+def artifact_tool(hermes_home):
+    return importlib.import_module("tools.artifact_tool")
+
+
+def _json(raw: str) -> dict:
+    data = json.loads(raw)
+    assert isinstance(data, dict)
+    return data
+
+
+# ---------------------------------------------------------------------------
+# Content registration
+# ---------------------------------------------------------------------------
+
+
+def test_artifact_present_registers_content_under_hermes_artifacts(artifact_tool, hermes_home):
+    raw = artifact_tool.artifact_present(
+        title="Revenue Dashboard",
+        content="<html><body>Revenue</body></html>",
+        filename="index.html",
+        content_type="text/html",
+    )
+
+    data = _json(raw)
+    assert data["success"] is True
+    artifact = data["artifact"]
+    assert artifact["id"] == "revenue-dashboard"
+    assert artifact["version"] == 1
+    assert artifact["title"] == "Revenue Dashboard"
+    assert artifact["contentType"] == "text/html"
+    assert artifact["url"] == "/api/plugins/artifacts/preview/revenue-dashboard/versions/1/index.html"
+
+    path = Path(artifact["path"])
+    assert path == hermes_home / "artifacts" / "revenue-dashboard" / "versions" / "1" / "index.html"
+    assert path.read_text(encoding="utf-8") == "<html><body>Revenue</body></html>"
+
+    manifest = json.loads((hermes_home / "artifacts" / "revenue-dashboard" / "manifest.json").read_text())
+    assert manifest["id"] == "revenue-dashboard"
+    assert manifest["latestVersion"] == 1
+    assert manifest["versions"][0]["entrypoint"] == "index.html"
+
+
+def test_artifact_present_increments_version_for_existing_artifact(artifact_tool, hermes_home):
+    first = _json(artifact_tool.artifact_present(
+        artifact_id="daily-report",
+        title="Daily Report",
+        content="one",
+        filename="index.html",
+    ))
+    second = _json(artifact_tool.artifact_present(
+        artifact_id="daily-report",
+        title="Daily Report",
+        content="two",
+        filename="index.html",
+    ))
+
+    assert first["artifact"]["version"] == 1
+    assert second["artifact"]["version"] == 2
+    assert Path(second["artifact"]["path"]).read_text(encoding="utf-8") == "two"
+    manifest = json.loads((hermes_home / "artifacts" / "daily-report" / "manifest.json").read_text())
+    assert manifest["latestVersion"] == 2
+    assert [v["version"] for v in manifest["versions"]] == [1, 2]
+
+
+# ---------------------------------------------------------------------------
+# Source file registration
+# ---------------------------------------------------------------------------
+
+
+def test_artifact_present_copies_existing_source_file(artifact_tool, hermes_home, tmp_path):
+    source = tmp_path / "chart.svg"
+    source.write_text("<svg><text>ok</text></svg>", encoding="utf-8")
+
+    data = _json(artifact_tool.artifact_present(
+        title="Chart",
+        source_path=str(source),
+        content_type="image/svg+xml",
+    ))
+
+    artifact = data["artifact"]
+    assert artifact["id"] == "chart"
+    assert artifact["contentType"] == "image/svg+xml"
+    assert artifact["path"].endswith("/chart/versions/1/chart.svg")
+    assert Path(artifact["path"]).read_text(encoding="utf-8") == "<svg><text>ok</text></svg>"
+    assert Path(artifact["path"]).resolve() != source.resolve()
+
+
+def test_artifact_present_relative_source_path_resolves_from_terminal_cwd(artifact_tool, hermes_home, tmp_path, monkeypatch):
+    source = tmp_path / "report.md"
+    source.write_text("# Report", encoding="utf-8")
+    monkeypatch.chdir(REPO_ROOT)  # prove cwd is not the resolver
+
+    data = _json(artifact_tool.artifact_present(title="Report", source_path="report.md"))
+
+    artifact = data["artifact"]
+    assert artifact["contentType"] == "text/markdown"
+    assert Path(artifact["path"]).read_text(encoding="utf-8") == "# Report"
+
+
+def test_artifact_present_allows_sources_under_hidden_hermes_workspace_parent(artifact_tool, hermes_home):
+    workspace = hermes_home / "workspace"
+    workspace.mkdir()
+    source = workspace / "demo.html"
+    source.write_text("<html>workspace</html>", encoding="utf-8")
+
+    data = _json(artifact_tool.artifact_present(title="Workspace Demo", source_path=str(source)))
+
+    assert data["success"] is True
+    assert Path(data["artifact"]["path"]).read_text(encoding="utf-8") == "<html>workspace</html>"
+
+
+# ---------------------------------------------------------------------------
+# Safety / validation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("filename", ["../index.html", "/tmp/index.html", "assets/../../x.html", ".env"])
+def test_artifact_present_rejects_unsafe_output_filenames(artifact_tool, filename):
+    data = _json(artifact_tool.artifact_present(title="Bad", content="x", filename=filename))
+
+    assert data["success"] is False
+    assert "artifact" not in data
+
+
+@pytest.mark.parametrize("source_name", [".env", "token.key", "private.pem", "id_rsa"])
+def test_artifact_present_rejects_secret_like_source_files(artifact_tool, tmp_path, source_name):
+    source = tmp_path / source_name
+    source.write_text("SECRET=do-not-copy", encoding="utf-8")
+
+    data = _json(artifact_tool.artifact_present(title="Secret", source_path=str(source)))
+
+    assert data["success"] is False
+    assert "do-not-copy" not in json.dumps(data)
+
+
+def test_artifact_present_rejects_symlink_source_escape(artifact_tool, tmp_path):
+    outside = tmp_path / "outside.html"
+    outside.write_text("outside", encoding="utf-8")
+    link = tmp_path / "link.html"
+    link.symlink_to(outside)
+
+    data = _json(artifact_tool.artifact_present(title="Link", source_path=str(link)))
+
+    assert data["success"] is False
+    assert "outside" not in json.dumps(data)
+
+
+def test_artifact_present_requires_exactly_one_input_mode(artifact_tool, tmp_path):
+    source = tmp_path / "x.html"
+    source.write_text("x", encoding="utf-8")
+
+    both = _json(artifact_tool.artifact_present(title="Both", content="x", source_path=str(source)))
+    neither = _json(artifact_tool.artifact_present(title="Neither"))
+
+    assert both["success"] is False
+    assert neither["success"] is False
+
+
+# ---------------------------------------------------------------------------
+# Registry/toolset integration
+# ---------------------------------------------------------------------------
+
+
+def test_artifact_present_registers_tool_and_toolset(hermes_home):
+    from tools.registry import registry
+    import toolsets
+
+    importlib.import_module("tools.artifact_tool")
+    names = {entry.name for entry in registry._snapshot_entries()}
+
+    assert "artifact_present" in names
+    assert "artifacts" in toolsets.TOOLSETS
+    assert "artifact_present" in toolsets.TOOLSETS["artifacts"]["tools"]
+    assert "artifact_present" in toolsets._HERMES_CORE_TOOLS

--- a/tests/tools/test_registry.py
+++ b/tests/tools/test_registry.py
@@ -291,6 +291,7 @@ class TestCheckFnExceptionHandling:
 class TestBuiltinDiscovery:
     def test_matches_previous_manual_builtin_tool_set(self):
         expected = {
+            "tools.artifact_tool",
             "tools.browser_cdp_tool",
             "tools.browser_dialog_tool",
             "tools.browser_tool",

--- a/tools/artifact_tool.py
+++ b/tools/artifact_tool.py
@@ -1,0 +1,320 @@
+"""Artifact presentation tool.
+
+Registers generated content or a local file as an immutable Dashboard artifact
+under HERMES_HOME/artifacts and returns structured metadata for the Artifacts
+viewer.
+"""
+from __future__ import annotations
+
+import json
+import mimetypes
+import os
+import re
+import shutil
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.parse import unquote
+
+from tools.registry import registry, tool_error
+
+try:
+    from hermes_constants import get_hermes_home
+except Exception:  # pragma: no cover - isolated import fallback
+    def get_hermes_home() -> Path:  # type: ignore[misc]
+        val = (os.environ.get("HERMES_HOME") or "").strip()
+        return Path(val) if val else Path.home() / ".hermes"
+
+
+ARTIFACT_ID_RE = re.compile(r"^[a-z0-9][a-z0-9_.-]{0,127}$")
+_SECRET_FILENAMES = {".env", ".secret", "id_rsa", "id_ed25519", "known_hosts"}
+_SECRET_SUFFIXES = {".pem", ".key", ".p12", ".pfx"}
+_DEFAULT_FILENAME_BY_TYPE = {
+    "text/html": "index.html",
+    "image/svg+xml": "index.svg",
+    "text/markdown": "index.md",
+    "application/vnd.mermaid": "diagram.mmd",
+    "application/json": "data.json",
+    "text/plain": "artifact.txt",
+}
+
+
+ARTIFACT_PRESENT_SCHEMA = {
+    "name": "artifact_present",
+    "description": (
+        "Register generated content or an existing local file as a local Hermes artifact. "
+        "Writes under HERMES_HOME/artifacts, creates a versioned manifest, and returns "
+        "structured metadata including preview URL for the Artifacts dashboard."
+    ),
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "title": {"type": "string", "description": "Human-readable artifact title"},
+            "artifact_id": {"type": "string", "description": "Optional stable id; generated from title when omitted"},
+            "content": {"type": "string", "description": "Generated content to store. Mutually exclusive with source_path."},
+            "source_path": {"type": "string", "description": "Existing local file to copy. Mutually exclusive with content."},
+            "filename": {"type": "string", "description": "Output filename inside the artifact version directory"},
+            "content_type": {"type": "string", "description": "MIME/content type, e.g. text/html or image/svg+xml"},
+            "description": {"type": "string", "description": "Optional artifact description"},
+        },
+        "required": [],
+    },
+}
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds").replace("+00:00", "Z")
+
+
+def _ok(payload: dict[str, Any]) -> str:
+    return json.dumps({"success": True, **payload}, ensure_ascii=False)
+
+
+def _err(message: str) -> str:
+    return json.dumps({"success": False, "error": message}, ensure_ascii=False)
+
+
+def _slugify(value: str) -> str:
+    value = (value or "").strip().lower()
+    value = re.sub(r"[^a-z0-9_.-]+", "-", value)
+    value = re.sub(r"[-_.]{2,}", "-", value).strip("-_.")
+    return value or "artifact"
+
+
+def _artifact_id(title: str | None, artifact_id: str | None) -> str:
+    candidate = _slugify(artifact_id or title or "artifact")
+    if not ARTIFACT_ID_RE.fullmatch(candidate):
+        raise ValueError("invalid artifact_id")
+    return candidate
+
+
+def _decode_path(value: str) -> str:
+    decoded = value or ""
+    for _ in range(3):
+        nxt = unquote(decoded)
+        if nxt == decoded:
+            break
+        decoded = nxt
+    return decoded.replace("\\", "/")
+
+
+def _is_secret_name(name: str) -> bool:
+    lowered = name.lower()
+    return lowered in _SECRET_FILENAMES or any(lowered.endswith(suffix) for suffix in _SECRET_SUFFIXES)
+
+
+def _safe_filename(filename: str) -> str:
+    decoded = _decode_path(filename).strip()
+    if not decoded:
+        raise ValueError("filename cannot be empty")
+    if decoded.startswith("/") or decoded.startswith("~"):
+        raise ValueError("absolute filenames are not allowed")
+    parts = [part for part in decoded.split("/") if part not in {"", "."}]
+    if not parts:
+        raise ValueError("filename cannot be empty")
+    for part in parts:
+        if part == "..":
+            raise ValueError("filename traversal is not allowed")
+        if part.startswith("."):
+            raise ValueError("dotfiles are not allowed")
+        if _is_secret_name(part):
+            raise ValueError("secret-looking filenames are not allowed")
+    return "/".join(parts)
+
+
+def _resolve_source_path(source_path: str, task_id: str = "default") -> Path:
+    raw = Path(source_path).expanduser()
+    if not raw.is_absolute():
+        base = os.environ.get("TERMINAL_CWD") or os.getcwd()
+        raw = Path(base) / raw
+    # Reject symlink inputs even if they resolve inside the same tree. The tool
+    # should copy exactly the file the user names, not follow surprise portals.
+    if raw.is_symlink():
+        raise ValueError("symlink sources are not allowed")
+    resolved = raw.resolve()
+    if not resolved.exists():
+        raise FileNotFoundError(str(source_path))
+    if not resolved.is_file():
+        raise ValueError("source_path must be a regular file")
+    if resolved.name.startswith("."):
+        raise ValueError("dotfile sources are not allowed")
+    if _is_secret_name(resolved.name):
+        raise ValueError("secret-looking source files are not allowed")
+    return resolved
+
+
+def _guess_content_type(filename: str, content_type: str | None = None) -> str:
+    if content_type:
+        return content_type
+    guessed, _ = mimetypes.guess_type(filename)
+    if filename.endswith(".md"):
+        return "text/markdown"
+    return guessed or "text/plain"
+
+
+def _default_filename(content_type: str | None, source: Path | None = None) -> str:
+    if source is not None:
+        return source.name
+    return _DEFAULT_FILENAME_BY_TYPE.get(content_type or "", "index.html")
+
+
+def _artifact_root() -> Path:
+    return get_hermes_home() / "artifacts"
+
+
+def _load_manifest(manifest_path: Path, artifact_id: str, title: str, description: str, content_type: str) -> dict[str, Any]:
+    if manifest_path.exists():
+        try:
+            data = json.loads(manifest_path.read_text(encoding="utf-8"))
+            if isinstance(data, dict) and data.get("id") == artifact_id:
+                data.setdefault("versions", [])
+                return data
+        except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+            pass
+    now = _now()
+    return {
+        "id": artifact_id,
+        "title": title,
+        "description": description,
+        "contentType": content_type,
+        "latestVersion": 0,
+        "createdAt": now,
+        "updatedAt": now,
+        "versions": [],
+    }
+
+
+def _next_version(manifest: dict[str, Any]) -> int:
+    versions = manifest.get("versions") if isinstance(manifest.get("versions"), list) else []
+    nums: list[int] = []
+    for row in versions:
+        if isinstance(row, dict):
+            try:
+                nums.append(int(row.get("version", 0)))
+            except (TypeError, ValueError):
+                pass
+    try:
+        nums.append(int(manifest.get("latestVersion", 0)))
+    except (TypeError, ValueError):
+        pass
+    return max(nums or [0]) + 1
+
+
+def _write_manifest(manifest_path: Path, manifest: dict[str, Any]) -> None:
+    manifest_path.write_text(json.dumps(manifest, ensure_ascii=False, indent=2) + "\n", encoding="utf-8")
+
+
+def artifact_present(
+    *,
+    title: str | None = None,
+    artifact_id: str | None = None,
+    content: str | None = None,
+    source_path: str | None = None,
+    filename: str | None = None,
+    content_type: str | None = None,
+    description: str | None = None,
+    task_id: str = "default",
+) -> str:
+    """Register content or a source file as a versioned Hermes artifact."""
+
+    try:
+        has_content = content is not None
+        has_source = bool(source_path)
+        if has_content == has_source:
+            return _err("Provide exactly one of content or source_path")
+        resolved_source: Path | None = None
+        if has_source:
+            resolved_source = _resolve_source_path(str(source_path), task_id=task_id)
+        effective_content_type = _guess_content_type(
+            filename or (resolved_source.name if resolved_source else ""),
+            content_type,
+        )
+        effective_filename = _safe_filename(filename or _default_filename(effective_content_type, resolved_source))
+        aid = _artifact_id(title, artifact_id)
+        effective_title = title or aid
+        effective_description = description or ""
+
+        root = _artifact_root()
+        artifact_dir = root / aid
+        manifest_path = artifact_dir / "manifest.json"
+        manifest = _load_manifest(manifest_path, aid, effective_title, effective_description, effective_content_type)
+        version = _next_version(manifest)
+        version_dir = artifact_dir / "versions" / str(version)
+        target = version_dir / effective_filename
+        resolved_version_dir = version_dir.resolve(strict=False)
+        resolved_target = target.resolve(strict=False)
+        try:
+            resolved_target.relative_to(resolved_version_dir)
+        except ValueError as exc:
+            raise ValueError("target path escapes artifact version directory") from exc
+
+        version_dir.mkdir(parents=True, exist_ok=False)
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if resolved_source is not None:
+            shutil.copyfile(resolved_source, target)
+        else:
+            target.write_text(content or "", encoding="utf-8")
+
+        now = _now()
+        manifest["title"] = effective_title
+        manifest["description"] = effective_description
+        manifest["contentType"] = effective_content_type
+        manifest["latestVersion"] = version
+        manifest["updatedAt"] = now
+        versions = manifest.setdefault("versions", [])
+        if not isinstance(versions, list):
+            versions = []
+            manifest["versions"] = versions
+        versions.append({
+            "version": version,
+            "entrypoint": effective_filename,
+            "contentType": effective_content_type,
+            "createdAt": now,
+            "source": "file" if resolved_source is not None else "content",
+        })
+        artifact_dir.mkdir(parents=True, exist_ok=True)
+        _write_manifest(manifest_path, manifest)
+
+        url = f"/api/plugins/artifacts/preview/{aid}/versions/{version}/{effective_filename}"
+        artifact = {
+            "id": aid,
+            "version": version,
+            "title": effective_title,
+            "description": effective_description,
+            "contentType": effective_content_type,
+            "path": str(target),
+            "manifestPath": str(manifest_path),
+            "url": url,
+        }
+        return _ok({"artifact": artifact})
+    except Exception as exc:
+        return _err(str(exc))
+
+
+def _handle_artifact_present(args, **kw):
+    tid = kw.get("task_id") or "default"
+    return artifact_present(
+        title=args.get("title"),
+        artifact_id=args.get("artifact_id"),
+        content=args.get("content") if "content" in args else None,
+        source_path=args.get("source_path"),
+        filename=args.get("filename"),
+        content_type=args.get("content_type"),
+        description=args.get("description"),
+        task_id=tid,
+    )
+
+
+def _check_artifact_reqs() -> bool:
+    return True
+
+
+registry.register(
+    name="artifact_present",
+    toolset="artifacts",
+    schema=ARTIFACT_PRESENT_SCHEMA,
+    handler=_handle_artifact_present,
+    check_fn=_check_artifact_reqs,
+    emoji="🖼️",
+    max_result_size_chars=20_000,
+)

--- a/toolsets.py
+++ b/toolsets.py
@@ -35,6 +35,8 @@ _HERMES_CORE_TOOLS = [
     "terminal", "process",
     # File manipulation
     "read_file", "write_file", "patch", "search_files",
+    # Artifacts / Canvas
+    "artifact_present",
     # Vision + image generation
     "vision_analyze", "image_generate",
     # Skills
@@ -172,8 +174,14 @@ TOOLSETS = {
     },
     
     "file": {
-        "description": "File manipulation tools: read, write, patch (with fuzzy matching), and search (content + files)",
+        "description": "File system operations: read, write, edit, and search files",
         "tools": ["read_file", "write_file", "patch", "search_files"],
+        "includes": []
+    },
+
+    "artifacts": {
+        "description": "Register local generated content or files as Hermes dashboard artifacts",
+        "tools": ["artifact_present"],
         "includes": []
     },
     

--- a/website/docs/reference/tools-reference.md
+++ b/website/docs/reference/tools-reference.md
@@ -8,11 +8,17 @@ description: "Authoritative reference for Hermes built-in tools, grouped by tool
 
 This page documents Hermes' built-in tools, grouped by toolset. Availability varies by platform, credentials, and enabled toolsets.
 
-**Quick counts (current registry):** ~70 tools — 10 browser tools (core) + 2 CDP-gated browser tools, 4 file tools, 10 RL tools, 4 Home Assistant tools, 2 terminal tools, 2 web tools, 5 Feishu tools, 7 Spotify tools (registered by the bundled `spotify` plugin), 5 Yuanbao tools, 7 kanban tools (registered when the kanban dispatcher spawns the agent), 2 Discord tools, and a handful of standalone tools (`memory`, `clarify`, `delegate_task`, `execute_code`, `cronjob`, `session_search`, `skill_view`/`skill_manage`/`skills_list`, `text_to_speech`, `image_generate`, `vision_analyze`, `video_analyze`, `mixture_of_agents`, `send_message`, `todo`, `computer_use`, `process`).
+**Quick counts (current registry):** ~71 tools — 10 browser tools (core) + 2 CDP-gated browser tools, 4 file tools, 1 artifacts tool, 10 RL tools, 4 Home Assistant tools, 2 terminal tools, 2 web tools, 5 Feishu tools, 7 Spotify tools (registered by the bundled `spotify` plugin), 5 Yuanbao tools, 7 kanban tools (registered when the kanban dispatcher spawns the agent), 2 Discord tools, and a handful of standalone tools (`memory`, `clarify`, `delegate_task`, `execute_code`, `cronjob`, `session_search`, `skill_view`/`skill_manage`/`skills_list`, `text_to_speech`, `image_generate`, `vision_analyze`, `video_analyze`, `mixture_of_agents`, `send_message`, `todo`, `computer_use`, `process`).
 
 :::tip MCP Tools
 In addition to built-in tools, Hermes can load tools dynamically from MCP servers. MCP tools appear with the prefix `mcp_<server>_` (e.g., `mcp_github_create_issue` for the `github` MCP server). See [MCP Integration](/docs/user-guide/features/mcp) for configuration.
 :::
+
+## `artifacts` toolset
+
+| Tool | Description | Requires environment |
+|------|-------------|----------------------|
+| `artifact_present` | Register generated content or an existing local file as a local Hermes artifact under `HERMES_HOME/artifacts`. Creates an immutable version directory plus manifest metadata and returns a dashboard preview URL. | — |
 
 ## `browser` toolset
 

--- a/website/docs/reference/toolsets-reference.md
+++ b/website/docs/reference/toolsets-reference.md
@@ -53,6 +53,7 @@ Or in-session:
 | Toolset | Tools | Purpose |
 |---------|-------|---------|
 | `browser` | `browser_back`, `browser_cdp`, `browser_click`, `browser_console`, `browser_dialog`, `browser_get_images`, `browser_navigate`, `browser_press`, `browser_scroll`, `browser_snapshot`, `browser_type`, `browser_vision`, `web_search` | Core browser automation. Includes `web_search` as a fallback for quick lookups. `browser_cdp` and `browser_dialog` are gated at runtime — registered only when a CDP endpoint is reachable at session start (via `/browser connect`, `browser.cdp_url` config, Browserbase, or Camofox). `browser_dialog` works together with the `pending_dialogs` and `frame_tree` fields that `browser_snapshot` adds when a CDP supervisor is attached. |
+| `artifacts` | `artifact_present` | Register generated content or existing local files as immutable Dashboard artifacts under `HERMES_HOME/artifacts`. |
 | `clarify` | `clarify` | Ask the user a question when the agent needs clarification. |
 | `code_execution` | `execute_code` | Run Python scripts that call Hermes tools programmatically. |
 | `cronjob` | `cronjob` | Schedule and manage recurring tasks. |


### PR DESCRIPTION
## Summary
- add a local `artifact_present` tool that registers immutable generated content/files under `HERMES_HOME/artifacts`
- add structured artifact event helpers plus an Artifacts dashboard plugin with sandboxed previews
- document the artifact runtime API and add an `artifact-builder` skill for generating HTML/SVG/Markdown-style presentation artifacts

## Security model
- preview URLs are intentionally reachable without auth headers so sandboxed iframe previews can load them
- preview serving is constrained to validated artifact IDs/version paths, rejects traversal/secret-looking paths, rejects symlinks, and serves from the controlled artifact root only
- rendered previews use iframe sandboxing and a preview-specific CSP rather than injecting artifact HTML into the dashboard DOM

## Test plan
- `git diff --check origin/main...HEAD`
- static added-line scan for secrets/eval/shell/SQL/innerHTML patterns
- independent blocker review pass: no blockers; noted public preview/CSP trade-off as intentional
- `uv run --with pytest --with pyyaml --with fastapi --with httpx --with aiohttp python -m pytest -o addopts='' tests/agent/test_artifact_events.py tests/tools/test_artifact_tool.py tests/plugins/test_artifacts_dashboard_plugin.py tests/skills/test_artifact_builder_skill.py -q` -> 45 passed
- `python3 -m py_compile agent/artifacts.py tools/artifact_tool.py plugins/artifacts/store.py plugins/artifacts/dashboard/plugin_api.py`
- registry smoke: `artifact_present` registers under the `artifacts` toolset and `resolve_toolset('artifacts')` includes it

## Notes
This is intentionally a minimal Canvas/Artifacts-style MVP for Hermes: it stores and previews local artifacts without introducing remote publishing or multi-user collaboration semantics.
