### PR TITLE
fix(dashboard): repair sidebar menus and achievements tab

### DIFF
--- a/plugins/hermes-achievements/dashboard/dist/index.js
+++ b/plugins/hermes-achievements/dashboard/dist/index.js
@@ -50,17 +50,7 @@
 
   async function api(path, options) {
     const url = "/api/plugins/hermes-achievements" + path;
-    const res = await fetch(url, options || {});
-    if (!res.ok) {
-      const text = await res.text().catch(function () { return res.statusText; });
-      throw new Error(res.status + ": " + text);
-    }
-    const text = await res.text();
-    try {
-      return JSON.parse(text);
-    } catch (_) {
-      return null;
-    }
+    return SDK.fetchJSON(url, options || {});
   }
 
   function AchievementIcon({ icon }) {

--- a/tests/hermes_cli/test_dashboard_language_switcher.py
+++ b/tests/hermes_cli/test_dashboard_language_switcher.py
@@ -1,4 +1,4 @@
-"""Static dashboard tests for the language switcher placement."""
+"""Static dashboard tests for dashboard plugin and language switcher regressions."""
 from pathlib import Path
 
 
@@ -21,3 +21,14 @@ def test_language_switcher_supports_drop_up_positioning():
 
     assert "dropUp" in content
     assert 'dropUp ? "left-0 bottom-full mb-1" : "right-0 top-full mt-1"' in content
+
+
+def test_achievements_plugin_uses_dashboard_fetch_client_for_auth():
+    """Plugin API calls must include the dashboard session token via SDK.fetchJSON."""
+    bundle = ROOT / "plugins" / "hermes-achievements" / "dashboard" / "dist" / "index.js"
+
+    content = bundle.read_text(encoding="utf-8")
+
+    assert "async function api(path, options)" in content
+    assert "return SDK.fetchJSON(url, options || {});" in content
+    assert "const res = await fetch(url, options || {});" not in content

--- a/tests/hermes_cli/test_dashboard_language_switcher.py
+++ b/tests/hermes_cli/test_dashboard_language_switcher.py
@@ -1,0 +1,23 @@
+"""Static dashboard tests for the language switcher placement."""
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_sidebar_language_switcher_opens_upward_like_theme_switcher():
+    app_tsx = ROOT / "web" / "src" / "App.tsx"
+
+    content = app_tsx.read_text(encoding="utf-8")
+
+    assert "<ThemeSwitcher dropUp />" in content
+    assert "<LanguageSwitcher dropUp />" in content
+
+
+def test_language_switcher_supports_drop_up_positioning():
+    switcher_tsx = ROOT / "web" / "src" / "components" / "LanguageSwitcher.tsx"
+
+    content = switcher_tsx.read_text(encoding="utf-8")
+
+    assert "dropUp" in content
+    assert 'dropUp ? "left-0 bottom-full mb-1" : "right-0 top-full mt-1"' in content

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -558,7 +558,7 @@ export default function App() {
               <div className="flex min-w-0 items-center gap-2">
                 <PluginSlot name="header-right" />
                 <ThemeSwitcher dropUp />
-                <LanguageSwitcher />
+                <LanguageSwitcher dropUp />
               </div>
             </div>
 

--- a/web/src/components/LanguageSwitcher.tsx
+++ b/web/src/components/LanguageSwitcher.tsx
@@ -4,16 +4,20 @@ import { Typography } from "@/components/NouiTypography";
 import { useI18n } from "@/i18n/context";
 import { LOCALE_META } from "@/i18n";
 import type { Locale } from "@/i18n";
+import { cn } from "@/lib/utils";
 
 /**
  * Language picker — shows the current language's flag + endonym, opens a
  * dropdown of all supported locales when clicked.  Persists choice to
  * localStorage via the I18n context.
  *
+ * When placed near the bottom of the sidebar, pass `dropUp` so the menu
+ * opens above the trigger instead of rendering below the viewport.
+ *
  * Replaces the older two-state EN↔ZH toggle now that we ship 16 locales
  * (en, zh, zh-hant, ja, de, es, fr, tr, uk, af, ko, it, ga, pt, ru, hu).
  */
-export function LanguageSwitcher() {
+export function LanguageSwitcher({ dropUp = false }: LanguageSwitcherProps) {
   const { locale, setLocale, t } = useI18n();
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -69,7 +73,10 @@ export function LanguageSwitcher() {
         <div
           role="listbox"
           aria-label={t.language.switchTo}
-          className="absolute right-0 top-full mt-1 z-50 min-w-[10rem] rounded-md border border-border bg-popover shadow-md py-1 max-h-80 overflow-y-auto"
+          className={cn(
+            "absolute z-50 min-w-[10rem] rounded-md border border-border bg-popover shadow-md py-1 max-h-80 overflow-y-auto",
+            dropUp ? "left-0 bottom-full mb-1" : "right-0 top-full mt-1",
+          )}
         >
           {allLocales.map(([code, meta]) => {
             const selected = code === locale;
@@ -97,4 +104,8 @@ export function LanguageSwitcher() {
       )}
     </div>
   );
+}
+
+interface LanguageSwitcherProps {
+  dropUp?: boolean;
 }


### PR DESCRIPTION
## Summary
- Add a `dropUp` placement option to the dashboard `LanguageSwitcher`.
- Use `dropUp` where the language switcher is mounted in the bottom sidebar controls, matching `ThemeSwitcher` behavior.
- Route bundled `hermes-achievements` dashboard API calls through `SDK.fetchJSON` so the dashboard session token is attached.
- Add static regression coverage for both the sidebar language menu and achievements plugin auth fetch path.

## Why
The language dropdown is mounted near the bottom of the sidebar. It always opened with `top-full`, so on small/short viewports it rendered into the clipped/off-screen area below the dashboard shell. The adjacent `ThemeSwitcher` already has a `dropUp` prop for this exact placement.

The achievements tab calls protected `/api/plugins/hermes-achievements/...` endpoints. The bundle used bare `fetch()`, which omitted `X-Hermes-Session-Token` and produced `401 Unauthorized` from the local dashboard. `SDK.fetchJSON` is the dashboard fetch client used by other bundled plugins and injects the session token.

## Test Plan
- [x] `python -m pytest tests/hermes_cli/test_dashboard_language_switcher.py -q -o 'addopts='`
- [x] `cd web && npm run build`
- [x] `cd web && npx eslint src/components/LanguageSwitcher.tsx src/App.tsx`
- [x] Served bundle smoke test: `/dashboard-plugins/hermes-achievements/dist/index.js` contains `SDK.fetchJSON`; achievements API returns `401` without token and `200` with injected token.

Note: `cd web && npm run lint` still reports existing unrelated lint errors on current `origin/main` in files such as `OAuthProvidersCard.tsx`, `Toast.tsx`, `i18n/context.tsx`, and several pages. The changed files pass eslint directly.