### PR TITLE
Add opt-in native vision path hints for image tools

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -129,6 +129,31 @@ def decide_image_input_mode(
     return "text"
 
 
+def native_vision_path_hint_enabled(cfg: Optional[Dict[str, Any]]) -> bool:
+    """Return whether native image turns should expose local path hints.
+
+    This is intentionally opt-in. The path is useful when a tool expects an
+    ``image_url``/path string argument, but local cache paths are dynamic and
+    may reduce prompt-cache reuse or expose host path details to providers.
+    """
+    if not isinstance(cfg, dict):
+        return False
+    agent_cfg = cfg.get("agent") or {}
+    if not isinstance(agent_cfg, dict):
+        return False
+
+    raw = agent_cfg.get("native_vision_path_hint", False)
+    if isinstance(raw, bool):
+        return raw
+    if isinstance(raw, str):
+        val = raw.strip().lower()
+        if val in {"1", "true", "yes", "on"}:
+            return True
+        if val in {"", "0", "false", "no", "off"}:
+            return False
+    return False
+
+
 # Image size handling is REACTIVE rather than proactive: we attempt native
 # attachment at full size regardless of provider, and rely on
 # ``run_agent._try_shrink_image_parts_in_messages`` to shrink + retry if
@@ -230,22 +255,25 @@ def _file_to_data_url(path: Path) -> Optional[str]:
 def build_native_content_parts(
     user_text: str,
     image_paths: List[str],
+    *,
+    include_path_hints: bool = False,
 ) -> Tuple[List[Dict[str, Any]], List[str]]:
     """Build an OpenAI-style ``content`` list for a user turn.
 
     Shape:
-      [{"type": "text", "text": "...\\n\\n[Image attached at: /local/path]"},
+      [{"type": "text", "text": "..."},
        {"type": "image_url", "image_url": {"url": "data:image/png;base64,..."}},
        ...]
 
-    The local path of each successfully attached image is appended to the
-    text part as ``[Image attached at: <path>]``. The model still sees the
-    pixels via the ``image_url`` part (full native vision); the path note
-    just gives it a string handle so MCP/skill tools that take an image
-    path or URL argument can be invoked on the same image without an
-    extra round-trip. This parallels the text-mode hint produced by
-    ``Runner._enrich_message_with_vision`` (``vision_analyze using image_url:
-    <path>``) so behaviour is consistent across both image input modes.
+    When ``include_path_hints`` is true, the local path of each successfully
+    attached image is appended to the text part as
+    ``[Image attached at: <path>]``. The model still sees the pixels via the
+    ``image_url`` part (full native vision); the path note just gives it a
+    string handle so MCP/skill tools that take an image path or URL argument
+    can be invoked on the same image without an extra round-trip. This
+    parallels the text-mode hint produced by ``Runner._enrich_message_with_vision``
+    (``vision_analyze using image_url: <path>``) while remaining opt-in for
+    prompt-cache and local-path privacy reasons.
 
     Images are attached at their native size. If a provider rejects the
     request because an image is too large (e.g. Anthropic's 5 MB per-image
@@ -276,14 +304,17 @@ def build_native_content_parts(
 
     text = (user_text or "").strip()
 
-    # If at least one image attached, build a single text part that combines
-    # the user's caption (or a neutral default) with one path hint per image.
+    # If at least one image attached, build a single text part. If enabled,
+    # append one path hint per image that was actually attached.
     if attached_paths:
         base_text = text or "What do you see in this image?"
-        path_hints = "\n".join(
-            f"[Image attached at: {p}]" for p in attached_paths
-        )
-        combined_text = f"{base_text}\n\n{path_hints}"
+        if include_path_hints:
+            path_hints = "\n".join(
+                f"[Image attached at: {p}]" for p in attached_paths
+            )
+            combined_text = f"{base_text}\n\n{path_hints}"
+        else:
+            combined_text = base_text
         parts: List[Dict[str, Any]] = [{"type": "text", "text": combined_text}]
         parts.extend(image_parts)
         return parts, skipped
@@ -298,4 +329,5 @@ def build_native_content_parts(
 __all__ = [
     "decide_image_input_mode",
     "build_native_content_parts",
+    "native_vision_path_hint_enabled",
 ]

--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -560,6 +560,19 @@ agent:
   # primaries (default 3). The OpenAI SDK does its own low-level retries
   # underneath this wrapper — this is the Hermes-level loop.
   # api_max_retries: 3
+
+  # How user-attached images are presented to the main model.
+  #   auto:   attach natively when the current model supports vision; otherwise
+  #           pre-analyze with vision_analyze and inject a text description.
+  #   native: always attach pixels natively.
+  #   text:   always use vision_analyze text pre-analysis.
+  # image_input_mode: auto
+
+  # Native image turns do not expose local cache paths as text by default.
+  # Enable this when MCP/custom tools need the attached image path as a string
+  # argument. Trade-off: local paths are dynamic and may reduce prompt-cache
+  # reuse or expose host path details to the model provider.
+  # native_vision_path_hint: false
   
   # Enable verbose logging
   verbose: false

--- a/cli.py
+++ b/cli.py
@@ -9904,17 +9904,20 @@ class HermesCLI:
                 from agent.image_routing import (
                     build_native_content_parts,
                     decide_image_input_mode,
+                    native_vision_path_hint_enabled,
                 )
                 from hermes_cli.config import load_config
 
+                _cfg = load_config()
                 _img_mode = decide_image_input_mode(
                     (self.provider or "").strip(),
                     (self.model or "").strip(),
-                    load_config(),
+                    _cfg,
                 )
             except Exception as _img_exc:
                 logging.debug("image_routing decision failed, defaulting to text: %s", _img_exc)
                 _img_mode = "text"
+                _cfg = {}
 
             if _img_mode == "native":
                 try:
@@ -9923,6 +9926,7 @@ class HermesCLI:
                     _parts, _skipped = build_native_content_parts(
                         _text_for_parts,
                         _img_str_paths,
+                        include_path_hints=native_vision_path_hint_enabled(_cfg),
                     )
                     if _skipped:
                         _cprint(

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -15127,10 +15127,26 @@ class GatewayRunner:
                 _native_imgs = self._consume_pending_native_image_paths(session_key)
                 if _native_imgs:
                     try:
-                        from agent.image_routing import build_native_content_parts
+                        from agent.image_routing import (
+                            build_native_content_parts,
+                            native_vision_path_hint_enabled,
+                        )
+                        from hermes_cli.config import load_config as _load_hermes_config
+
+                        try:
+                            _path_hint_cfg = _load_hermes_config()
+                        except Exception as _hint_exc:
+                            logger.debug(
+                                "Native image path-hint config read failed, using default false: %s",
+                                _hint_exc,
+                            )
+                            _path_hint_cfg = None
                         _parts, _skipped = build_native_content_parts(
                             message,
                             _native_imgs,
+                            include_path_hints=native_vision_path_hint_enabled(
+                                _path_hint_cfg
+                            ),
                         )
                         if _skipped:
                             logger.warning(

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -471,6 +471,12 @@ DEFAULT_CONFIG = {
         # remains available as a tool regardless of this setting — the routing
         # only controls how inbound user images are presented.
         "image_input_mode": "auto",
+        # When true, native image turns also append "[Image attached at: <path>]"
+        # to the text part so MCP/skill tools can receive the same local image
+        # path as a string argument. Default false preserves prompt-cache
+        # friendliness and avoids exposing local cache paths unless explicitly
+        # needed.
+        "native_vision_path_hint": False,
         "disabled_toolsets": [],
     },
     

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import ast
 import base64
 from pathlib import Path
 from unittest.mock import patch
@@ -13,6 +14,7 @@ from agent.image_routing import (
     _explicit_aux_vision_override,
     build_native_content_parts,
     decide_image_input_mode,
+    native_vision_path_hint_enabled,
 )
 
 
@@ -125,6 +127,29 @@ class TestDecideImageInputMode:
             assert decide_image_input_mode("xiaomi", "mimo-v2.5-pro", {}) == "text"
 
 
+# ─── native_vision_path_hint_enabled ─────────────────────────────────────────
+
+
+class TestNativeVisionPathHintEnabled:
+    def test_missing_config_is_false(self):
+        assert native_vision_path_hint_enabled(None) is False
+        assert native_vision_path_hint_enabled({}) is False
+
+    def test_boolean_config(self):
+        assert native_vision_path_hint_enabled({"agent": {"native_vision_path_hint": True}}) is True
+        assert native_vision_path_hint_enabled({"agent": {"native_vision_path_hint": False}}) is False
+
+    def test_string_config(self):
+        for value in ("true", "True", "1", "yes", "on"):
+            assert native_vision_path_hint_enabled({"agent": {"native_vision_path_hint": value}}) is True
+        for value in ("false", "False", "0", "no", "off", "", "nonsense"):
+            assert native_vision_path_hint_enabled({"agent": {"native_vision_path_hint": value}}) is False
+
+    def test_non_bool_non_string_is_false(self):
+        assert native_vision_path_hint_enabled({"agent": {"native_vision_path_hint": 1}}) is False
+        assert native_vision_path_hint_enabled({"agent": {"native_vision_path_hint": ["true"]}}) is False
+
+
 # ─── build_native_content_parts ──────────────────────────────────────────────
 
 
@@ -136,31 +161,26 @@ def _png_bytes() -> bytes:
 
 
 class TestBuildNativeContentParts:
-    def test_text_then_image(self, tmp_path: Path):
+    def test_text_then_image_without_path_hint_by_default(self, tmp_path: Path):
         img = tmp_path / "cat.png"
         img.write_bytes(_png_bytes())
         parts, skipped = build_native_content_parts("hello", [str(img)])
         assert skipped == []
         assert len(parts) == 2
         assert parts[0]["type"] == "text"
-        # User caption is preserved and a per-image path hint is appended so
-        # the model can use the local path as a string argument for tools
-        # that take ``image_url: str`` (issue #18960).
-        assert parts[0]["text"] == f"hello\n\n[Image attached at: {img}]"
+        assert parts[0]["text"] == "hello"
         assert parts[1]["type"] == "image_url"
         assert parts[1]["image_url"]["url"].startswith("data:image/png;base64,")
 
-    def test_empty_text_inserts_default_prompt(self, tmp_path: Path):
+    def test_empty_text_inserts_default_prompt_without_path_hint_by_default(self, tmp_path: Path):
         img = tmp_path / "cat.jpg"
         img.write_bytes(_png_bytes())
         parts, skipped = build_native_content_parts("", [str(img)])
         assert skipped == []
         # Even with empty user text, we insert a neutral prompt so the turn
-        # isn't just pixels, and the path hint is appended after.
+        # isn't just pixels.
         assert parts[0]["type"] == "text"
-        assert parts[0]["text"] == (
-            f"What do you see in this image?\n\n[Image attached at: {img}]"
-        )
+        assert parts[0]["text"] == "What do you see in this image?"
         assert parts[1]["type"] == "image_url"
 
     def test_missing_file_is_skipped(self, tmp_path: Path):
@@ -170,7 +190,7 @@ class TestBuildNativeContentParts:
         # would otherwise be told a non-existent file is attached.
         assert parts == [{"type": "text", "text": "hi"}]
 
-    def test_path_hint_appended(self, tmp_path: Path):
+    def test_path_hint_appended_when_enabled(self, tmp_path: Path):
         """The local path of each attached image is appended to the user
         text part so MCP/skill tools that take ``image_url: str`` can be
         invoked on the same image (issue #18960). Mirrors text-mode
@@ -178,14 +198,18 @@ class TestBuildNativeContentParts:
         """
         img = tmp_path / "scan.png"
         img.write_bytes(_png_bytes())
-        parts, _ = build_native_content_parts("attach this", [str(img)])
+        parts, _ = build_native_content_parts(
+            "attach this",
+            [str(img)],
+            include_path_hints=True,
+        )
         text_part = next(p for p in parts if p.get("type") == "text")
         assert "[Image attached at:" in text_part["text"]
         assert str(img) in text_part["text"]
         # User caption is preserved verbatim ahead of the hint.
         assert text_part["text"].startswith("attach this")
 
-    def test_path_hint_one_per_attached_image(self, tmp_path: Path):
+    def test_path_hint_one_per_attached_image_when_enabled(self, tmp_path: Path):
         """Each successfully attached image gets its own path hint line;
         skipped images do NOT appear in the hints.
         """
@@ -193,13 +217,28 @@ class TestBuildNativeContentParts:
         good.write_bytes(_png_bytes())
         missing = tmp_path / "missing.png"  # never created
         parts, skipped = build_native_content_parts(
-            "see attached", [str(good), str(missing)]
+            "see attached",
+            [str(good), str(missing)],
+            include_path_hints=True,
         )
         assert skipped == [str(missing)]
         text_part = next(p for p in parts if p.get("type") == "text")
         assert text_part["text"].count("[Image attached at:") == 1
         assert str(good) in text_part["text"]
         assert str(missing) not in text_part["text"]
+
+    def test_empty_text_path_hint_when_enabled(self, tmp_path: Path):
+        img = tmp_path / "scan.png"
+        img.write_bytes(_png_bytes())
+        parts, skipped = build_native_content_parts(
+            "",
+            [str(img)],
+            include_path_hints=True,
+        )
+        assert skipped == []
+        assert parts[0]["text"] == (
+            f"What do you see in this image?\n\n[Image attached at: {img}]"
+        )
 
     def test_multiple_images(self, tmp_path: Path):
         img1 = tmp_path / "a.png"
@@ -210,7 +249,22 @@ class TestBuildNativeContentParts:
         assert skipped == []
         image_parts = [p for p in parts if p.get("type") == "image_url"]
         assert len(image_parts) == 2
-        # Both paths surface in the text part, one per line.
+        text_part = next(p for p in parts if p.get("type") == "text")
+        assert text_part["text"] == "compare these"
+
+    def test_multiple_images_with_path_hints_enabled(self, tmp_path: Path):
+        img1 = tmp_path / "a.png"
+        img2 = tmp_path / "b.png"
+        img1.write_bytes(_png_bytes())
+        img2.write_bytes(_png_bytes())
+        parts, skipped = build_native_content_parts(
+            "compare these",
+            [str(img1), str(img2)],
+            include_path_hints=True,
+        )
+        assert skipped == []
+        image_parts = [p for p in parts if p.get("type") == "image_url"]
+        assert len(image_parts) == 2
         text_part = next(p for p in parts if p.get("type") == "text")
         assert text_part["text"].count("[Image attached at:") == 2
         assert str(img1) in text_part["text"]
@@ -284,3 +338,30 @@ class TestLargeImageHandling:
         assert len(parts) == 2
         assert parts[0]["type"] == "text"
         assert parts[1]["type"] == "image_url"
+
+
+# ─── Call-site wiring ────────────────────────────────────────────────────────
+
+
+class TestNativeVisionPathHintCallSites:
+    def test_production_call_sites_thread_path_hint_flag(self):
+        repo_root = Path(__file__).resolve().parents[2]
+        files = [
+            repo_root / "cli.py",
+            repo_root / "gateway" / "run.py",
+            repo_root / "tui_gateway" / "server.py",
+        ]
+
+        for file_path in files:
+            tree = ast.parse(file_path.read_text(encoding="utf-8"), filename=str(file_path))
+            calls = [
+                node
+                for node in ast.walk(tree)
+                if isinstance(node, ast.Call)
+                and getattr(node.func, "id", "") == "build_native_content_parts"
+            ]
+            assert calls, f"expected build_native_content_parts call in {file_path}"
+            for call in calls:
+                assert any(kw.arg == "include_path_hints" for kw in call.keywords), (
+                    f"{file_path} calls build_native_content_parts without include_path_hints"
+                )

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -3094,6 +3094,7 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                     from agent.image_routing import (
                         decide_image_input_mode,
                         build_native_content_parts,
+                        native_vision_path_hint_enabled,
                     )
                     from agent.auxiliary_client import (
                         _read_main_model,
@@ -3113,12 +3114,14 @@ def _run_prompt_submit(rid, sid: str, session: dict, text: Any) -> None:
                         file=sys.stderr,
                     )
                     _mode = "text"
+                    _cfg = {}
 
                 if _mode == "native":
                     try:
                         _parts, _skipped = build_native_content_parts(
                             prompt,
                             images,
+                            include_path_hints=native_vision_path_hint_enabled(_cfg),
                         )
                         if _skipped:
                             print(

--- a/website/docs/user-guide/features/vision.md
+++ b/website/docs/user-guide/features/vision.md
@@ -199,6 +199,30 @@ When a user attaches an image — from the CLI clipboard, the gateway (Telegram/
 | **Vision-capable** (GPT-4V, Claude with vision, Gemini, Qwen-VL, MiMo-VL, etc.) | Sent as **real pixels** using the provider's native image content format above. No text summary layer. |
 | **Text-only** (DeepSeek V3, smaller open-source models, older chat-only endpoints) | Routed through the `vision_analyze` auxiliary tool — an auxiliary vision model describes the image, and the text description is injected into the conversation. |
 
-You don't configure this — Hermes looks up your current model's capability in the provider metadata and picks the right path automatically. The practical effect: you can switch between vision and non-vision models mid-session and image handling "just works" without changing your workflow. Text-only models get coherent context about the image rather than a broken multimodal payload they'd have to reject.
+You usually do not need to configure this routing — Hermes looks up your current model's capability in the provider metadata and picks the right path automatically. The practical effect: you can switch between vision and non-vision models mid-session and image handling "just works" without changing your workflow. Text-only models get coherent context about the image rather than a broken multimodal payload they'd have to reject.
+
+### Native Vision Path Hints
+
+Native image routing sends the pixels to the model, but it does not expose your
+local cached image path as text by default. If you use MCP servers or custom
+tools that need the same image as a string argument, enable:
+
+```yaml
+agent:
+  native_vision_path_hint: true
+```
+
+When enabled, Hermes adds one line per attached image to the text part of the
+same native multimodal turn:
+
+```text
+[Image attached at: /path/to/cached-image.png]
+```
+
+This gives the model a path it can pass to tools such as issue trackers, OCR
+endpoints, or image-to-database workflows while preserving native vision
+quality. The setting is off by default because local cache paths are
+message-specific and may reduce prompt-cache reuse or expose host path details
+to the model provider.
 
 Which auxiliary model handles the text-description path is configurable under `auxiliary.vision` — see [Auxiliary Models](/docs/user-guide/configuration#auxiliary-models).


### PR DESCRIPTION
## Summary

Adds an opt-in `agent.native_vision_path_hint` setting for native multimodal image turns.

When the flag is enabled, Hermes keeps sending attached images as native `image_url` content parts and also appends one text line per successfully attached local image:

```text
[Image attached at: /path/to/cached-image.png]
```

This gives the model a string handle it can pass to MCP servers or custom tools that accept `image_url: str`, while preserving native vision quality.

## Why

Fixes #18960.

Native vision mode already lets the main model see the pixels, but it previously withheld the local cached image path from the text context. That makes workflows such as Slack image upload -> MCP issue-tracker attachment awkward: the model can inspect the image but cannot call a tool that needs the same image path as an argument.

The new flag is default-off to preserve existing prompt-cache behavior and avoid exposing host-local cache paths unless the user explicitly needs tool-parameter access.

## Implementation

- Adds `native_vision_path_hint_enabled()` in `agent/image_routing.py`.
- Extends `build_native_content_parts(..., include_path_hints=False)` so default behavior omits path hints and opt-in behavior appends hints only for images that were actually attached.
- Wires the flag through the native image call sites in the classic CLI, gateway runner, and TUI gateway.
- Adds the default config key under `agent` without a config-version bump.
- Documents the setting in the user vision docs and example config.
- Expands image-routing tests to cover default-off behavior, opt-in hints, missing/skipped images, multi-image turns, config coercion, and production call-site wiring.

## Validation

- `scripts/run_tests.sh tests/agent/test_image_routing.py tests/gateway/test_native_image_buffer_isolation.py`
- `uvx ruff check agent/image_routing.py cli.py gateway/run.py tui_gateway/server.py hermes_cli/config.py tests/agent/test_image_routing.py`
- `git diff --check origin/main..HEAD`
- `/Users/vuductai/Documents/Projects/hermes-agent/.venv/bin/python -m py_compile agent/image_routing.py cli.py gateway/run.py tui_gateway/server.py hermes_cli/config.py`
