### PR TITLE
Fix interrupted tool-call transcript persistence

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -4309,9 +4309,101 @@ class AIAgent:
         """
         self._drop_trailing_empty_response_scaffolding(messages)
         self._apply_persist_user_message_override(messages)
+        inserted = self._sanitize_unanswered_tool_calls(messages)
+        if inserted:
+            logger.warning(
+                "Backfilled %d unanswered tool call(s) before session persistence "
+                "(session=%s)",
+                inserted,
+                self.session_id or "-",
+            )
         self._session_messages = messages
         self._save_session_log(messages)
         self._flush_messages_to_session_db(messages, conversation_history)
+
+    def _sanitize_unanswered_tool_calls(
+        self,
+        messages: List[Dict[str, Any]],
+        *,
+        content: Optional[str] = None,
+    ) -> int:
+        """Insert synthetic tool results for assistant tool calls missing answers.
+
+        Providers require every assistant ``tool_call_id`` to be followed by a
+        matching ``role="tool"`` response before any later user/assistant turn.
+        Interrupts and error exits can leave the canonical transcript with a
+        partially answered tool-call group. Repair that persistence-time shape
+        by adding honest cancellation results next to the owning assistant
+        message, without dropping or reordering existing transcript entries.
+
+        Returns the number of synthetic tool messages inserted.
+        """
+        if not isinstance(messages, list) or not messages:
+            return 0
+
+        synthetic_content = (
+            content
+            if content is not None
+            else "[Tool execution interrupted before Hermes recorded a result for this call.]"
+        )
+        inserted = 0
+        idx = 0
+
+        while idx < len(messages):
+            msg = messages[idx]
+            if not isinstance(msg, dict) or msg.get("role") != "assistant":
+                idx += 1
+                continue
+
+            tool_calls = msg.get("tool_calls")
+            if not isinstance(tool_calls, list) or not tool_calls:
+                idx += 1
+                continue
+
+            expected: List[tuple[str, str]] = []
+            seen_expected: set[str] = set()
+            for tc in tool_calls:
+                call_id = AIAgent._get_tool_call_id_static(tc)
+                if not call_id or call_id in seen_expected:
+                    continue
+                seen_expected.add(call_id)
+                expected.append((call_id, AIAgent._get_tool_call_name_static(tc)))
+
+            if not expected:
+                idx += 1
+                continue
+
+            insert_at = idx + 1
+            answered_ids: set[str] = set()
+            while (
+                insert_at < len(messages)
+                and isinstance(messages[insert_at], dict)
+                and messages[insert_at].get("role") == "tool"
+            ):
+                answered_id = messages[insert_at].get("tool_call_id")
+                if answered_id:
+                    answered_ids.add(answered_id)
+                insert_at += 1
+
+            missing = [
+                {
+                    "role": "tool",
+                    "name": name,
+                    "tool_call_id": call_id,
+                    "content": synthetic_content,
+                }
+                for call_id, name in expected
+                if call_id not in answered_ids
+            ]
+
+            if missing:
+                messages[insert_at:insert_at] = missing
+                inserted += len(missing)
+                insert_at += len(missing)
+
+            idx = insert_at
+
+        return inserted
 
     def _drop_trailing_empty_response_scaffolding(self, messages: List[Dict]) -> None:
         """Remove private empty-response retry/failure scaffolding from transcript tails.
@@ -14902,29 +14994,10 @@ class AIAgent:
                 # If an assistant message with tool_calls was already appended,
                 # the API expects a role="tool" result for every tool_call_id.
                 # Fill in error results for any that weren't answered yet.
-                for idx in range(len(messages) - 1, -1, -1):
-                    msg = messages[idx]
-                    if not isinstance(msg, dict):
-                        break
-                    if msg.get("role") == "tool":
-                        continue
-                    if msg.get("role") == "assistant" and msg.get("tool_calls"):
-                        answered_ids = {
-                            m["tool_call_id"]
-                            for m in messages[idx + 1:]
-                            if isinstance(m, dict) and m.get("role") == "tool"
-                        }
-                        for tc in msg["tool_calls"]:
-                            if not tc or not isinstance(tc, dict): continue
-                            if tc["id"] not in answered_ids:
-                                err_msg = {
-                                    "role": "tool",
-                                    "name": AIAgent._get_tool_call_name_static(tc),
-                                    "tool_call_id": tc["id"],
-                                    "content": f"Error executing tool: {error_msg}",
-                                }
-                                messages.append(err_msg)
-                    break
+                self._sanitize_unanswered_tool_calls(
+                    messages,
+                    content=f"Error executing tool: {error_msg}",
+                )
                 
                 # Non-tool errors don't need a synthetic message injected.
                 # The error is already printed to the user (line above), and

--- a/tests/run_agent/test_unanswered_tool_call_persistence.py
+++ b/tests/run_agent/test_unanswered_tool_call_persistence.py
@@ -1,0 +1,247 @@
+"""Regression tests for persistence-time unanswered tool-call backfill."""
+
+from copy import deepcopy
+
+from run_agent import AIAgent
+
+
+def _agent():
+    agent = AIAgent.__new__(AIAgent)
+    agent.session_id = "test-session"
+    return agent
+
+
+def _tool_call(raw_id: str, name: str = "terminal", **extra):
+    return {
+        "id": raw_id,
+        "type": "function",
+        "function": {"name": name, "arguments": "{}"},
+        **extra,
+    }
+
+
+def _assistant_with_tools(*call_ids: str):
+    return {
+        "role": "assistant",
+        "content": "",
+        "tool_calls": [_tool_call(call_id) for call_id in call_ids],
+    }
+
+
+def _tool_result(call_id: str, content: str = "ok"):
+    return {"role": "tool", "tool_call_id": call_id, "content": content}
+
+
+def _agent_with_stubbed_persistence():
+    agent = _agent()
+    agent._persist_user_message_idx = None
+    agent._persist_user_message_override = None
+    agent._session_messages = []
+    agent.saved_session_logs = []
+    agent.flushed_session_db_messages = []
+    agent._save_session_log = lambda messages: agent.saved_session_logs.append(
+        [m.copy() for m in messages]
+    )
+    agent._flush_messages_to_session_db = lambda messages, conversation_history=None: (
+        agent.flushed_session_db_messages.append([m.copy() for m in messages])
+    )
+    return agent
+
+
+class _RecordingSessionDB:
+    def __init__(self):
+        self.appended = []
+
+    def append_message(self, **kwargs):
+        self.appended.append(kwargs)
+
+
+def _agent_with_recording_db():
+    agent = _agent()
+    agent._persist_user_message_idx = None
+    agent._persist_user_message_override = None
+    agent._session_messages = []
+    agent._session_db = _RecordingSessionDB()
+    agent._session_db_created = True
+    agent._last_flushed_db_idx = 0
+    agent._save_session_log = lambda messages: None
+    return agent
+
+
+def test_sanitize_unanswered_tool_calls_inserts_tail_stubs():
+    agent = _agent()
+    messages = [
+        {"role": "user", "content": "run two things"},
+        _assistant_with_tools("c1", "c2"),
+    ]
+
+    inserted = agent._sanitize_unanswered_tool_calls(messages)
+
+    assert inserted == 2
+    assert [m.get("role") for m in messages] == ["user", "assistant", "tool", "tool"]
+    assert [m.get("tool_call_id") for m in messages[2:]] == ["c1", "c2"]
+    assert all("interrupted" in m["content"] for m in messages[2:])
+
+
+def test_sanitize_unanswered_tool_calls_fills_only_missing_parallel_result():
+    agent = _agent()
+    messages = [
+        _assistant_with_tools("c1", "c2"),
+        _tool_result("c1", "real result"),
+    ]
+
+    inserted = agent._sanitize_unanswered_tool_calls(messages)
+
+    assert inserted == 1
+    assert messages[1] == _tool_result("c1", "real result")
+    assert messages[2]["role"] == "tool"
+    assert messages[2]["tool_call_id"] == "c2"
+
+
+def test_sanitize_unanswered_tool_calls_inserts_before_next_user():
+    agent = _agent()
+    messages = [
+        _assistant_with_tools("c1"),
+        {"role": "user", "content": "interrupt follow-up"},
+    ]
+
+    inserted = agent._sanitize_unanswered_tool_calls(messages)
+
+    assert inserted == 1
+    assert [m.get("role") for m in messages] == ["assistant", "tool", "user"]
+    assert messages[1]["tool_call_id"] == "c1"
+    assert messages[2]["content"] == "interrupt follow-up"
+
+
+def test_sanitize_unanswered_tool_calls_is_idempotent():
+    agent = _agent()
+    messages = [_assistant_with_tools("c1", "c2")]
+
+    first = agent._sanitize_unanswered_tool_calls(messages)
+    second = agent._sanitize_unanswered_tool_calls(messages)
+
+    assert first == 2
+    assert second == 0
+    assert [m.get("tool_call_id") for m in messages if m.get("role") == "tool"] == [
+        "c1",
+        "c2",
+    ]
+
+
+def test_sanitize_unanswered_tool_calls_uses_call_id_over_id():
+    agent = _agent()
+    messages = [
+        {
+            "role": "assistant",
+            "content": "",
+            "tool_calls": [
+                _tool_call(
+                    "fc_123",
+                    call_id="call_123",
+                    response_item_id="fc_123",
+                )
+            ],
+        }
+    ]
+
+    inserted = agent._sanitize_unanswered_tool_calls(messages)
+
+    assert inserted == 1
+    assert messages[1]["tool_call_id"] == "call_123"
+
+
+def test_sanitize_unanswered_tool_calls_preserves_complete_turn():
+    agent = _agent()
+    messages = [
+        _assistant_with_tools("c1"),
+        _tool_result("c1"),
+        {"role": "assistant", "content": "done"},
+    ]
+    original = deepcopy(messages)
+
+    inserted = agent._sanitize_unanswered_tool_calls(messages)
+
+    assert inserted == 0
+    assert messages == original
+
+
+def test_sanitize_unanswered_tool_calls_uses_custom_error_content():
+    agent = _agent()
+    messages = [_assistant_with_tools("c1")]
+
+    inserted = agent._sanitize_unanswered_tool_calls(
+        messages,
+        content="Error executing tool: boom",
+    )
+
+    assert inserted == 1
+    assert messages[1]["content"] == "Error executing tool: boom"
+
+
+def test_persist_session_backfills_before_log_and_db_flush():
+    agent = _agent_with_stubbed_persistence()
+    messages = [
+        {"role": "user", "content": "run two things"},
+        _assistant_with_tools("c1", "c2"),
+        _tool_result("c1", "real result"),
+    ]
+
+    agent._persist_session(messages, conversation_history=[])
+
+    assert [m.get("tool_call_id") for m in messages if m.get("role") == "tool"] == [
+        "c1",
+        "c2",
+    ]
+    assert agent.saved_session_logs[-1] == messages
+    assert agent.flushed_session_db_messages[-1] == messages
+
+
+def test_persist_session_flushes_backfill_after_conversation_history_boundary():
+    agent = _agent_with_recording_db()
+    conversation_history = [{"role": "user", "content": "old"}]
+    messages = [
+        *conversation_history,
+        {"role": "user", "content": "run"},
+        _assistant_with_tools("c1"),
+    ]
+
+    agent._persist_session(messages, conversation_history=conversation_history)
+
+    assert [m["role"] for m in agent._session_db.appended] == [
+        "user",
+        "assistant",
+        "tool",
+    ]
+    assert agent._session_db.appended[-1]["tool_call_id"] == "c1"
+    assert "interrupted" in agent._session_db.appended[-1]["content"]
+
+
+def test_persist_session_strips_empty_scaffolding_before_backfill():
+    agent = _agent_with_stubbed_persistence()
+    messages = [
+        {"role": "user", "content": "run the task"},
+        _assistant_with_tools("c1"),
+        {"role": "assistant", "content": "(empty)", "_empty_terminal_sentinel": True},
+    ]
+
+    agent._persist_session(messages, conversation_history=[])
+
+    assert messages == [{"role": "user", "content": "run the task"}]
+    assert agent.saved_session_logs[-1] == messages
+    assert agent.flushed_session_db_messages[-1] == messages
+
+
+def test_persist_session_applies_user_override_before_backfill_shifts_indices():
+    agent = _agent_with_stubbed_persistence()
+    agent._persist_user_message_idx = 1
+    agent._persist_user_message_override = "clean user text"
+    messages = [
+        _assistant_with_tools("c1"),
+        {"role": "user", "content": "api-only user text"},
+    ]
+
+    agent._persist_session(messages, conversation_history=[])
+
+    assert [m.get("role") for m in messages] == ["assistant", "tool", "user"]
+    assert messages[2]["content"] == "clean user text"
+    assert agent.saved_session_logs[-1] == messages


### PR DESCRIPTION
## Summary

Fixes #11351 by making session persistence repair unanswered assistant tool calls before writing the transcript to disk or SQLite.

When a user interrupts the agent while tool calls are pending, Hermes can have an assistant message with `tool_calls` but no matching `role="tool"` result for every emitted `tool_call_id`. Providers reject that transcript on the next turn, so the saved session becomes effectively corrupted.

## What Changed

- Adds `AIAgent._sanitize_unanswered_tool_calls(...)` as the single helper for backfilling missing tool responses.
- Calls the helper from `_persist_session()` so interrupt, error, gateway-kill, and normal exit paths all persist an API-valid transcript.
- Replaces the duplicated outer-loop error-handler backfill logic with the shared helper.
- Preserves existing real tool results and inserts only missing synthetic results next to the assistant message that owns the tool calls.
- Handles parallel tool calls, Responses-style `call_id` vs `id`, and idempotent repeated persistence.

## Validation

- `scripts/run_tests.sh tests/run_agent/test_unanswered_tool_call_persistence.py`
- `HERMES_HOME=/private/tmp/hermes-agent-issue-11351/.hermes-test scripts/run_tests.sh tests/run_agent/test_agent_guardrails.py tests/run_agent/test_empty_response_recovery_persistence.py tests/run_agent/test_message_sequence_repair.py tests/run_agent/test_concurrent_interrupt.py tests/run_agent/test_stream_interrupt_retry.py`
- `.venv/bin/ruff check run_agent.py tests/run_agent/test_unanswered_tool_call_persistence.py`
- `.venv/bin/python -m py_compile run_agent.py tests/run_agent/test_unanswered_tool_call_persistence.py`
- `git diff --check`

## Notes

The synthetic tool result is explicit about the interruption instead of pretending the tool succeeded. This keeps the transcript provider-valid while preserving the fact that the tool result was not actually produced.
