### PR TITLE
Hide memory tool progress from public gateway streams

### DIFF
--- a/agent/display.py
+++ b/agent/display.py
@@ -162,6 +162,14 @@ def get_tool_emoji(tool_name: str, default: str = "⚡") -> str:
 # Tool preview (one-line summary of a tool call's primary argument)
 # =========================================================================
 
+_PUBLIC_SILENT_TOOL_PROGRESS = frozenset({"memory"})
+
+
+def should_hide_public_tool_progress(tool_name: str | None) -> bool:
+    """Return True when a tool's lifecycle should stay out of public progress UI."""
+    return str(tool_name or "") in _PUBLIC_SILENT_TOOL_PROGRESS
+
+
 def _oneline(text: str) -> str:
     """Collapse whitespace (including newlines) to single spaces."""
     return " ".join(text.split())
@@ -1004,5 +1012,4 @@ def get_cute_tool_message(
 # =========================================================================
 # Honcho session line (one-liner with clickable OSC 8 hyperlink)
 # =========================================================================
-
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -1121,8 +1121,14 @@ class APIServerAdapter(BasePlatformAdapter):
                 """
                 if not tool_call_id or function_name.startswith("_"):
                     return
+                from agent.display import (
+                    build_tool_preview,
+                    get_tool_emoji,
+                    should_hide_public_tool_progress,
+                )
+                if should_hide_public_tool_progress(function_name):
+                    return
                 _started_tool_call_ids.add(tool_call_id)
-                from agent.display import build_tool_preview, get_tool_emoji
                 label = build_tool_preview(function_name, function_args) or function_name
                 _stream_q.put(("__tool_progress__", {
                     "tool": function_name,
@@ -2169,6 +2175,9 @@ class APIServerAdapter(BasePlatformAdapter):
 
             def _on_tool_start(tool_call_id, function_name, function_args):
                 """Queue a started tool for live function_call streaming."""
+                from agent.display import should_hide_public_tool_progress
+                if should_hide_public_tool_progress(function_name):
+                    return
                 _stream_q.put(("__tool_started__", {
                     "tool_call_id": tool_call_id,
                     "name": function_name,
@@ -2177,6 +2186,9 @@ class APIServerAdapter(BasePlatformAdapter):
 
             def _on_tool_complete(tool_call_id, function_name, function_args, function_result):
                 """Queue a completed tool result for live function_call_output streaming."""
+                from agent.display import should_hide_public_tool_progress
+                if should_hide_public_tool_progress(function_name):
+                    return
                 _stream_q.put(("__tool_completed__", {
                     "tool_call_id": tool_call_id,
                     "name": function_name,
@@ -2771,6 +2783,10 @@ class APIServerAdapter(BasePlatformAdapter):
                 pass
 
         def _callback(event_type: str, tool_name: str = None, preview: str = None, args=None, **kwargs):
+            from agent.display import should_hide_public_tool_progress
+            if should_hide_public_tool_progress(tool_name):
+                return
+
             ts = time.time()
             if event_type == "tool.started":
                 _push({

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -14178,6 +14178,10 @@ class GatewayRunner:
             if not progress_queue or not _run_still_current():
                 return
 
+            from agent.display import should_hide_public_tool_progress
+            if should_hide_public_tool_progress(tool_name):
+                return
+
             # First-touch onboarding: the first time a tool takes longer than
             # _LONG_TOOL_THRESHOLD_S during a run that's streaming every tool
             # (progress_mode == "all"), append a one-time hint suggesting

--- a/tests/agent/test_display.py
+++ b/tests/agent/test_display.py
@@ -10,6 +10,7 @@ from agent.display import (
     extract_edit_diff,
     get_cute_tool_message,
     set_tool_preview_max_len,
+    should_hide_public_tool_progress,
     _render_inline_unified_diff,
     _summarize_rendered_diff_sections,
     render_edit_diff_with_delta,
@@ -109,6 +110,18 @@ class TestBuildToolPreview:
         assert build_tool_preview("terminal", 0) is None
         assert build_tool_preview("terminal", "") is None
         assert build_tool_preview("terminal", []) is None
+
+
+class TestPublicToolProgressPolicy:
+    def test_builtin_memory_tool_is_hidden_from_public_progress(self):
+        assert should_hide_public_tool_progress("memory") is True
+
+    def test_regular_tools_remain_visible_in_public_progress(self):
+        assert should_hide_public_tool_progress("terminal") is False
+        assert should_hide_public_tool_progress("web_search") is False
+
+    def test_missing_tool_name_is_visible_by_default(self):
+        assert should_hide_public_tool_progress(None) is False
 
 
 class TestCuteToolMessagePreviewLength:

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -872,6 +872,70 @@ class TestChatCompletionsEndpoint:
                 assert '"toolCallId": "call_search_1"' in body
 
     @pytest.mark.asyncio
+    async def test_stream_tool_progress_skips_memory_events(self, adapter):
+        """Built-in memory tool calls stay out of public SSE progress."""
+        import asyncio
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                cb = kwargs.get("stream_delta_callback")
+                ts_cb = kwargs.get("tool_start_callback")
+                tc_cb = kwargs.get("tool_complete_callback")
+                if ts_cb:
+                    ts_cb(
+                        "call_memory_1",
+                        "memory",
+                        {
+                            "action": "add",
+                            "target": "memory",
+                            "content": "private memory payload",
+                        },
+                    )
+                    ts_cb("call_search_1", "web_search", {"query": "Python docs"})
+                if tc_cb:
+                    tc_cb(
+                        "call_memory_1",
+                        "memory",
+                        {
+                            "action": "add",
+                            "target": "memory",
+                            "content": "private memory payload",
+                        },
+                        '{"success": true}',
+                    )
+                    tc_cb("call_search_1", "web_search", {"query": "Python docs"}, "ok")
+                if cb:
+                    await asyncio.sleep(0.05)
+                    cb("Found it.")
+                return (
+                    {"final_response": "Found it.", "messages": [], "api_calls": 1},
+                    {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/chat/completions",
+                    json={
+                        "model": "test",
+                        "messages": [{"role": "user", "content": "search"}],
+                        "stream": True,
+                    },
+                )
+                assert resp.status == 200
+                body = await resp.text()
+                assert "event: hermes.tool.progress" in body
+                assert '"tool": "web_search"' in body
+                assert '"toolCallId": "call_search_1"' in body
+                assert '"tool": "memory"' not in body
+                assert "call_memory_1" not in body
+                assert "private memory payload" not in body
+                assert "old_text" not in body
+                assert "+memory" not in body
+                assert "~memory" not in body
+                assert "-memory" not in body
+
+    @pytest.mark.asyncio
     async def test_stream_emits_tool_lifecycle_with_call_id(self, adapter):
         """Regression for #16588.
 
@@ -1732,6 +1796,60 @@ class TestResponsesStreaming:
                 assert '"call_id": "call_123"' in body
                 assert '"name": "read_file"' in body
                 assert '"output": [{"type": "input_text", "text": "{\\"content\\":\\"hello\\"}"}]' in body
+
+    @pytest.mark.asyncio
+    async def test_stream_function_call_items_skip_memory_tool(self, adapter):
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            async def _mock_run_agent(**kwargs):
+                start_cb = kwargs.get("tool_start_callback")
+                complete_cb = kwargs.get("tool_complete_callback")
+                text_cb = kwargs.get("stream_delta_callback")
+                if start_cb:
+                    start_cb(
+                        "call_memory_1",
+                        "memory",
+                        {
+                            "action": "add",
+                            "target": "memory",
+                            "content": "private memory payload",
+                        },
+                    )
+                    start_cb("call_search_1", "web_search", {"query": "Python docs"})
+                if complete_cb:
+                    complete_cb(
+                        "call_memory_1",
+                        "memory",
+                        {
+                            "action": "add",
+                            "target": "memory",
+                            "content": "private memory payload",
+                        },
+                        '{"success": true}',
+                    )
+                    complete_cb("call_search_1", "web_search", {"query": "Python docs"}, "ok")
+                if text_cb:
+                    text_cb("Done.")
+                return (
+                    {"final_response": "Done.", "messages": [], "api_calls": 1},
+                    {"input_tokens": 10, "output_tokens": 5, "total_tokens": 15},
+                )
+
+            with patch.object(adapter, "_run_agent", side_effect=_mock_run_agent):
+                resp = await cli.post(
+                    "/v1/responses",
+                    json={"model": "hermes-agent", "input": "search", "stream": True},
+                )
+                assert resp.status == 200
+                body = await resp.text()
+                assert '"name": "web_search"' in body
+                assert '"call_id": "call_search_1"' in body
+                assert '"name": "memory"' not in body
+                assert "call_memory_1" not in body
+                assert "private memory payload" not in body
+                assert "+memory" not in body
+                assert "~memory" not in body
+                assert "-memory" not in body
 
     @pytest.mark.asyncio
     async def test_streamed_response_is_stored_for_get(self, adapter):
@@ -2776,6 +2894,43 @@ class TestConversationParameter:
 
 
 # ---------------------------------------------------------------------------
+# /v1/runs structured tool progress
+# ---------------------------------------------------------------------------
+
+
+class TestRunStructuredEvents:
+    @pytest.mark.asyncio
+    async def test_run_event_callback_skips_memory_tool_progress(self, adapter):
+        run_id = "run_memory_privacy"
+        queue = asyncio.Queue()
+        adapter._run_streams[run_id] = queue
+        adapter._run_statuses[run_id] = {"status": "running"}
+
+        callback = adapter._make_run_event_callback(run_id, asyncio.get_running_loop())
+        callback(
+            "tool.started",
+            "memory",
+            '+memory: "private memory payload"',
+            {
+                "action": "add",
+                "target": "memory",
+                "content": "private memory payload",
+            },
+        )
+        callback("tool.completed", "memory", None, None, duration=31)
+        callback("tool.started", "web_search", "Python docs", {"query": "Python docs"})
+
+        await asyncio.sleep(0)
+        event = await asyncio.wait_for(queue.get(), timeout=0.5)
+        assert event["event"] == "tool.started"
+        assert event["tool"] == "web_search"
+        assert event["preview"] == "Python docs"
+        assert queue.empty()
+        assert "private memory payload" not in json.dumps(adapter._run_statuses[run_id])
+        assert adapter._run_statuses[run_id]["last_event"] == "tool.started"
+
+
+# ---------------------------------------------------------------------------
 # X-Hermes-Session-Id header (session continuity)
 # ---------------------------------------------------------------------------
 
@@ -3061,4 +3216,3 @@ class TestSessionKeyHeader:
             assert resp.status == 200
             data = await resp.json()
             assert data["features"]["session_key_header"] == "X-Hermes-Session-Key"
-

--- a/tests/gateway/test_memory_tool_progress_privacy.py
+++ b/tests/gateway/test_memory_tool_progress_privacy.py
@@ -1,0 +1,226 @@
+"""Regression tests for memory-tool privacy in public gateway progress."""
+
+import importlib
+import sys
+import time
+import types
+from types import SimpleNamespace
+
+import pytest
+
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.session import SessionSource
+
+
+class ProgressCaptureAdapter(BasePlatformAdapter):
+    def __init__(self, platform=Platform.TELEGRAM):
+        super().__init__(PlatformConfig(enabled=True, token="***"), platform)
+        self.sent = []
+        self.edits = []
+        self.typing = []
+
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        return None
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None) -> SendResult:
+        self.sent.append({"chat_id": chat_id, "content": content, "metadata": metadata})
+        return SendResult(success=True, message_id="progress-1")
+
+    async def edit_message(self, chat_id, message_id, content) -> SendResult:
+        self.edits.append({"message_id": message_id, "content": content})
+        return SendResult(success=True, message_id=message_id)
+
+    async def send_typing(self, chat_id, metadata=None) -> None:
+        self.typing.append(chat_id)
+
+    async def stop_typing(self, chat_id) -> None:
+        return None
+
+    async def get_chat_info(self, chat_id: str):
+        return {"id": chat_id}
+
+
+class MemoryAddThenTerminalAgent:
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        cb = self.tool_progress_callback
+        if cb is not None:
+            cb(
+                "tool.started",
+                "memory",
+                '+memory: "private memory payload"',
+                {
+                    "action": "add",
+                    "target": "memory",
+                    "content": "private memory payload",
+                },
+            )
+            time.sleep(0.2)
+            cb("tool.started", "terminal", "pwd", {"command": "pwd"})
+            time.sleep(0.35)
+        return {"final_response": "done", "messages": [], "api_calls": 1}
+
+
+class MemoryVerboseThenTerminalAgent:
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        cb = self.tool_progress_callback
+        if cb is not None:
+            cb(
+                "tool.started",
+                "memory",
+                '~memory: "private old text"',
+                {
+                    "action": "replace",
+                    "target": "memory",
+                    "old_text": "private old text",
+                    "content": "new private replacement",
+                },
+            )
+            time.sleep(0.2)
+            cb("tool.started", "terminal", "pwd", {"command": "pwd"})
+            time.sleep(0.35)
+        return {"final_response": "done", "messages": [], "api_calls": 1}
+
+
+class MemoryCompletionOnlyAgent:
+    def __init__(self, **kwargs):
+        self.tool_progress_callback = kwargs.get("tool_progress_callback")
+        self.tools = []
+
+    def run_conversation(self, message, conversation_history=None, task_id=None):
+        cb = self.tool_progress_callback
+        if cb is not None:
+            cb("tool.completed", "memory", None, None, duration=31)
+            time.sleep(0.35)
+        return {"final_response": "done", "messages": [], "api_calls": 1}
+
+
+def _make_runner(adapter):
+    gateway_run = importlib.import_module("gateway.run")
+    runner = object.__new__(gateway_run.GatewayRunner)
+    runner.adapters = {adapter.platform: adapter}
+    runner._voice_mode = {}
+    runner._prefill_messages = []
+    runner._ephemeral_system_prompt = ""
+    runner._reasoning_config = None
+    runner._provider_routing = {}
+    runner._fallback_model = None
+    runner._session_db = None
+    runner._running_agents = {}
+    runner._session_run_generation = {}
+    runner.hooks = SimpleNamespace(loaded_hooks=False)
+    runner.config = SimpleNamespace(
+        thread_sessions_per_user=False,
+        group_sessions_per_user=False,
+        stt_enabled=False,
+    )
+    return runner
+
+
+async def _run_once(monkeypatch, tmp_path, agent_cls, *, progress_mode="all", config=None):
+    monkeypatch.setenv("HERMES_TOOL_PROGRESS_MODE", progress_mode)
+
+    fake_dotenv = types.ModuleType("dotenv")
+    fake_dotenv.load_dotenv = lambda *args, **kwargs: None
+    monkeypatch.setitem(sys.modules, "dotenv", fake_dotenv)
+
+    fake_run_agent = types.ModuleType("run_agent")
+    fake_run_agent.AIAgent = agent_cls
+    monkeypatch.setitem(sys.modules, "run_agent", fake_run_agent)
+    import tools.terminal_tool  # noqa: F401 - register terminal emoji
+
+    adapter = ProgressCaptureAdapter()
+    runner = _make_runner(adapter)
+    gateway_run = importlib.import_module("gateway.run")
+    monkeypatch.setattr(gateway_run, "_hermes_home", tmp_path)
+    monkeypatch.setattr(
+        gateway_run,
+        "_resolve_runtime_agent_kwargs",
+        lambda: {"api_key": "fake"},
+    )
+    monkeypatch.setattr(gateway_run, "_load_gateway_config", lambda: config or {})
+
+    source = SessionSource(
+        platform=Platform.TELEGRAM,
+        chat_id="-1001",
+        chat_type="group",
+        thread_id="17585",
+    )
+    result = await runner._run_agent(
+        message="hi",
+        context_prompt="",
+        history=[],
+        source=source,
+        session_id="sess-memory-progress",
+        session_key="agent:main:telegram:group:-1001:17585",
+    )
+    rendered = " ".join(c["content"] for c in adapter.sent) + " " + " ".join(
+        c["content"] for c in adapter.edits
+    )
+    return adapter, result, rendered
+
+
+@pytest.mark.asyncio
+async def test_memory_progress_is_suppressed_in_telegram_all_mode(monkeypatch, tmp_path):
+    adapter, result, rendered = await _run_once(
+        monkeypatch,
+        tmp_path,
+        MemoryAddThenTerminalAgent,
+        progress_mode="all",
+    )
+
+    assert result["final_response"] == "done"
+    assert "terminal" in rendered
+    assert "pwd" in rendered
+    assert "private memory payload" not in rendered
+    assert "+memory" not in rendered
+    assert '"content"' not in rendered
+    assert all("memory" not in call["content"] for call in adapter.sent + adapter.edits)
+
+
+@pytest.mark.asyncio
+async def test_memory_progress_is_suppressed_in_telegram_verbose_mode(monkeypatch, tmp_path):
+    adapter, result, rendered = await _run_once(
+        monkeypatch,
+        tmp_path,
+        MemoryVerboseThenTerminalAgent,
+        progress_mode="verbose",
+    )
+
+    assert result["final_response"] == "done"
+    assert "terminal" in rendered
+    assert "pwd" in rendered
+    assert "private old text" not in rendered
+    assert "new private replacement" not in rendered
+    assert "old_text" not in rendered
+    assert "~memory" not in rendered
+    assert all("memory" not in call["content"] for call in adapter.sent + adapter.edits)
+
+
+@pytest.mark.asyncio
+async def test_memory_completed_event_does_not_emit_long_tool_hint(monkeypatch, tmp_path):
+    config = {"display": {"tool_progress_command": True}, "onboarding": {"seen": {}}}
+    adapter, result, rendered = await _run_once(
+        monkeypatch,
+        tmp_path,
+        MemoryCompletionOnlyAgent,
+        progress_mode="all",
+        config=config,
+    )
+
+    assert result["final_response"] == "done"
+    assert adapter.sent == []
+    assert adapter.edits == []
+    assert "First-time tip" not in rendered
+    assert "/verbose" not in rendered


### PR DESCRIPTION
## Summary

Fixes #6316 by keeping built-in `memory` tool lifecycle previews out of public gateway progress surfaces while preserving normal tool execution and private model-visible tool results.

## Root Cause

The memory tool already generated concise previews such as `+memory`, `~memory`, and `-memory`. Those previews are useful internally, but gateway progress renderers treated them like ordinary tool progress and forwarded them to public-facing chat surfaces, including Telegram and API streaming clients.

## Changes

- Add a shared `should_hide_public_tool_progress()` policy in `agent.display`.
- Suppress `memory` progress before Telegram/gateway progress messages are rendered, including verbose argument rendering and long-tool onboarding hints.
- Suppress `memory` lifecycle events in OpenAI-compatible chat-completions SSE progress.
- Apply the same privacy rule to Responses API function-call streaming and `/v1/runs` structured progress events.
- Add regression tests covering Telegram all/verbose modes, memory completion-only hints, chat SSE, Responses SSE, and run progress callbacks.

## Validation

- `uv run --extra dev --extra messaging pytest tests/agent/test_display.py tests/gateway/test_memory_tool_progress_privacy.py tests/gateway/test_api_server.py::TestChatCompletionsEndpoint::test_stream_tool_progress_skips_memory_events tests/gateway/test_api_server.py::TestResponsesStreaming::test_stream_function_call_items_skip_memory_tool tests/gateway/test_api_server.py::TestRunStructuredEvents::test_run_event_callback_skips_memory_tool_progress -q`
- `uv run --extra dev ruff check agent/display.py gateway/run.py gateway/platforms/api_server.py tests/agent/test_display.py tests/gateway/test_api_server.py tests/gateway/test_memory_tool_progress_privacy.py`
- `git diff --check HEAD`
