### PR TITLE
[Security] Encrypt API server response_store.db payloads at rest

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -74,6 +74,7 @@ The following scenarios are **not** considered security breaches:
 ### Credential Storage
 - API keys and tokens belong exclusively in `~/.hermes/.env` — never in `config.yaml` or checked into version control.
 - The credential pool system (`agent/credential_pool.py`) handles key rotation and fallback. Credentials are resolved from environment variables, not stored in plaintext databases.
+- The API server's Responses API stores chaining state in `~/.hermes/response_store.db` when requests use `store: true` (the default). Sensitive response payloads are encrypted at rest when a long, high-entropy `API_SERVER_RESPONSE_STORE_KEY` or `API_SERVER_KEY` is configured; use `response_store_encryption: required` for shared or remote deployments. SQLite metadata such as response IDs, row counts, timestamps, and conversation names may remain visible.
 
 ---
 

--- a/gateway/platforms/api_server.py
+++ b/gateway/platforms/api_server.py
@@ -25,6 +25,7 @@ Requires:
 """
 
 import asyncio
+import base64
 import hashlib
 import hmac
 import json
@@ -35,6 +36,7 @@ import re
 import sqlite3
 import time
 import uuid
+from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 try:
@@ -43,6 +45,14 @@ try:
 except ImportError:
     AIOHTTP_AVAILABLE = False
     web = None  # type: ignore[assignment]
+
+try:
+    from cryptography.fernet import Fernet, InvalidToken
+    CRYPTOGRAPHY_AVAILABLE = True
+except ImportError:
+    CRYPTOGRAPHY_AVAILABLE = False
+    Fernet = None  # type: ignore[assignment,misc]
+    InvalidToken = Exception  # type: ignore[assignment,misc]
 
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
@@ -61,6 +71,10 @@ MAX_REQUEST_BYTES = 10_000_000  # 10 MB — accommodates long agent conversation
 CHAT_COMPLETIONS_SSE_KEEPALIVE_SECONDS = 30.0
 MAX_NORMALIZED_TEXT_LENGTH = 65_536  # 64 KB cap for normalized content parts
 MAX_CONTENT_LIST_SIZE = 1_000  # Max items when content is an array
+RESPONSE_STORE_ENCRYPTED_PREFIX = "enc:v1:"
+RESPONSE_STORE_MIN_SECRET_LENGTH = 16
+_RESPONSE_STORE_KEY_CONTEXT = b"hermes-response-store-v1\0"
+_RESPONSE_STORE_KID_CONTEXT = b"hermes-response-store-kid-v1\0"
 
 
 def _coerce_port(value: Any, default: int = DEFAULT_PORT) -> int:
@@ -288,6 +302,123 @@ def check_api_server_requirements() -> bool:
     return AIOHTTP_AVAILABLE
 
 
+class ResponseStoreCryptoError(RuntimeError):
+    """Raised when encrypted ResponseStore data cannot be read or written."""
+
+
+def _normalize_response_store_encryption_mode(value: Any) -> str:
+    """Normalize ResponseStore encryption mode from config/env-shaped values."""
+    if isinstance(value, bool):
+        return "required" if value else "off"
+    mode = str(value or "auto").strip().lower()
+    if mode in {"", "auto"}:
+        return "auto"
+    if mode in {"off", "false", "no", "0", "plain", "plaintext", "disabled", "disable"}:
+        return "off"
+    if mode in {"required", "require", "on", "true", "yes", "1", "encrypted", "encrypt"}:
+        return "required"
+    logger.warning(
+        "Unknown API response store encryption mode %r; using auto",
+        value,
+    )
+    return "auto"
+
+
+def _has_usable_response_store_secret(value: Optional[str]) -> bool:
+    """Return True when a response-store key is non-placeholder and long enough."""
+    if not isinstance(value, str):
+        return False
+    try:
+        from hermes_cli.auth import has_usable_secret
+        return has_usable_secret(value, min_length=RESPONSE_STORE_MIN_SECRET_LENGTH)
+    except Exception:
+        cleaned = value.strip()
+        if len(cleaned) < RESPONSE_STORE_MIN_SECRET_LENGTH:
+            return False
+        return cleaned.lower() not in {
+            "changeme",
+            "change-me",
+            "change-me-local-dev",
+            "your_api_key_here",
+            "your-api-key",
+            "password",
+            "placeholder",
+            "example",
+            "dummy",
+            "secret",
+            "token",
+            "none",
+            "null",
+        }
+
+
+class _ResponseStoreCrypto:
+    """Small Fernet wrapper for encrypted response-store payloads."""
+
+    def __init__(self, secret: str):
+        if not CRYPTOGRAPHY_AVAILABLE or Fernet is None:
+            raise ResponseStoreCryptoError("cryptography is not installed")
+        if not _has_usable_response_store_secret(secret):
+            raise ResponseStoreCryptoError("response store encryption key is missing or unusable")
+
+        material = secret.strip().encode("utf-8")
+        fernet_key = base64.urlsafe_b64encode(
+            hashlib.sha256(_RESPONSE_STORE_KEY_CONTEXT + material).digest()
+        )
+        self.key_id = hashlib.sha256(
+            _RESPONSE_STORE_KID_CONTEXT + material
+        ).hexdigest()[:12]
+        self._fernet = Fernet(fernet_key)
+
+    def encrypt(self, response_id: str, plaintext_json: str) -> str:
+        envelope = json.dumps(
+            {"response_id": response_id, "data": plaintext_json},
+            separators=(",", ":"),
+        )
+        try:
+            token = self._fernet.encrypt(envelope.encode("utf-8")).decode("ascii")
+        except Exception as exc:
+            raise ResponseStoreCryptoError(
+                f"failed to encrypt response store row {response_id}"
+            ) from exc
+        return f"{RESPONSE_STORE_ENCRYPTED_PREFIX}{self.key_id}:{token}"
+
+    def decrypt(self, response_id: str, raw: str) -> str:
+        rest = raw[len(RESPONSE_STORE_ENCRYPTED_PREFIX):]
+        key_id, separator, token = rest.partition(":")
+        if not separator or not key_id or not token:
+            raise ResponseStoreCryptoError(
+                f"malformed encrypted response store row {response_id}"
+            )
+        if key_id != self.key_id:
+            raise ResponseStoreCryptoError(
+                f"failed to decrypt response store row {response_id} with key {self.key_id}"
+            )
+        try:
+            envelope = json.loads(self._fernet.decrypt(token.encode("ascii")).decode("utf-8"))
+            plaintext_json = envelope.get("data")
+            if envelope.get("response_id") != response_id or not isinstance(plaintext_json, str):
+                raise ValueError("encrypted response store row is bound to a different response_id")
+            return plaintext_json
+        except (InvalidToken, json.JSONDecodeError, UnicodeError, ValueError) as exc:
+            raise ResponseStoreCryptoError(
+                f"failed to decrypt response store row {response_id} with key {self.key_id}"
+            ) from exc
+
+
+def _response_store_crypto_error_response(exc: Exception) -> "web.Response":
+    """Return a safe OpenAI-style error for encrypted response-store failures."""
+    logger.warning("Response store crypto failure: %s", exc)
+    return web.json_response(
+        _openai_error(
+            "Stored response could not be decrypted with the configured response store key.",
+            err_type="server_error",
+            code="response_store_decryption_failed",
+        ),
+        status=500,
+    )
+
+
 class ResponseStore:
     """
     SQLite-backed LRU store for Responses API state.
@@ -300,17 +431,32 @@ class ResponseStore:
     if the on-disk path is unavailable.
     """
 
-    def __init__(self, max_size: int = MAX_STORED_RESPONSES, db_path: str = None):
+    def __init__(
+        self,
+        max_size: int = MAX_STORED_RESPONSES,
+        db_path: str = None,
+        *,
+        encryption_mode: str = "auto",
+        encryption_key: Optional[str] = None,
+    ):
         self._max_size = max_size
+        self._db_path: Optional[Path] = None
+        self._encryption_mode = _normalize_response_store_encryption_mode(encryption_mode)
+        self._crypto: Optional[_ResponseStoreCrypto] = None
+        self._init_crypto(encryption_key)
+
         if db_path is None:
             try:
                 from hermes_cli.config import get_hermes_home
                 db_path = str(get_hermes_home() / "response_store.db")
             except Exception:
                 db_path = ":memory:"
+        db_path = str(db_path)
         try:
+            self._db_path = self._prepare_db_path(db_path)
             self._conn = sqlite3.connect(db_path, check_same_thread=False)
         except Exception:
+            self._db_path = None
             self._conn = sqlite3.connect(":memory:", check_same_thread=False)
         # Use shared WAL-fallback helper so response_store.db degrades
         # gracefully on NFS/SMB/FUSE-mounted HERMES_HOME (same filesystem
@@ -318,6 +464,7 @@ class ResponseStore:
         # hermes_state._WAL_INCOMPAT_MARKERS).
         from hermes_state import apply_wal_with_fallback
         apply_wal_with_fallback(self._conn, db_label="response_store.db")
+        self._conn.execute("PRAGMA secure_delete=ON")
         self._conn.execute(
             """CREATE TABLE IF NOT EXISTS responses (
                 response_id TEXT PRIMARY KEY,
@@ -332,6 +479,136 @@ class ResponseStore:
             )"""
         )
         self._conn.commit()
+        self._secure_db_files()
+        if self._crypto is not None:
+            self._migrate_plaintext_rows()
+
+    @property
+    def encryption_enabled(self) -> bool:
+        return self._crypto is not None
+
+    def _init_crypto(self, encryption_key: Optional[str]) -> None:
+        if self._encryption_mode == "off":
+            return
+        if not encryption_key:
+            if self._encryption_mode == "required":
+                raise ResponseStoreCryptoError(
+                    "response store encryption requires API_SERVER_RESPONSE_STORE_KEY or API_SERVER_KEY"
+                )
+            logger.warning(
+                "API response store encryption is in auto mode, but no usable key is configured; "
+                "response_store.db will remain plaintext. Set API_SERVER_RESPONSE_STORE_KEY "
+                "or API_SERVER_KEY to encrypt stored Responses API state."
+            )
+            return
+        try:
+            self._crypto = _ResponseStoreCrypto(encryption_key)
+            logger.info(
+                "API response store encryption enabled (key id: %s)",
+                self._crypto.key_id,
+            )
+        except ResponseStoreCryptoError:
+            if self._encryption_mode == "required":
+                raise
+            logger.warning(
+                "API response store encryption is in auto mode, but the configured key is unusable "
+                "or cryptography is unavailable; response_store.db will remain plaintext.",
+                exc_info=True,
+            )
+
+    @staticmethod
+    def _chmod_allowed() -> bool:
+        if os.environ.get("HERMES_SKIP_CHMOD"):
+            return False
+        try:
+            from hermes_cli.config import is_managed
+            if is_managed():
+                return False
+        except Exception:
+            pass
+        return os.name != "nt"
+
+    def _prepare_db_path(self, db_path: str) -> Optional[Path]:
+        if db_path == ":memory:" or db_path.startswith("file:"):
+            return None
+        path = Path(db_path)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        fd = os.open(str(path), os.O_RDWR | os.O_CREAT, 0o600)
+        os.close(fd)
+        self._chmod_path(path)
+        return path
+
+    def _chmod_path(self, path: Path) -> None:
+        if not self._chmod_allowed():
+            return
+        try:
+            path.chmod(0o600)
+        except (OSError, NotImplementedError):
+            pass
+
+    def _secure_db_files(self) -> None:
+        if self._db_path is None:
+            return
+        self._chmod_path(self._db_path)
+        self._chmod_path(Path(f"{self._db_path}-wal"))
+        self._chmod_path(Path(f"{self._db_path}-shm"))
+
+    def _decode_response_data(self, response_id: str, raw: str) -> tuple[Dict[str, Any], bool]:
+        if raw.startswith(RESPONSE_STORE_ENCRYPTED_PREFIX):
+            if self._crypto is None:
+                raise ResponseStoreCryptoError(
+                    f"response store row {response_id} is encrypted, but encryption is not configured"
+                )
+            raw = self._crypto.decrypt(response_id, raw)
+            return json.loads(raw), False
+        return json.loads(raw), True
+
+    def _encode_response_data(self, response_id: str, data: Dict[str, Any]) -> str:
+        raw = json.dumps(data, default=str)
+        if self._crypto is None:
+            return raw
+        return self._crypto.encrypt(response_id, raw)
+
+    def _rewrite_response_data(self, response_id: str, data: Dict[str, Any]) -> None:
+        encoded = self._encode_response_data(response_id, data)
+        self._conn.execute(
+            "UPDATE responses SET data = ? WHERE response_id = ?",
+            (encoded, response_id),
+        )
+        self._conn.commit()
+        self._secure_db_files()
+
+    def _migrate_plaintext_rows(self) -> None:
+        rows = self._conn.execute("SELECT response_id, data FROM responses").fetchall()
+        migrated = 0
+        for response_id, raw in rows:
+            if not isinstance(raw, str) or raw.startswith(RESPONSE_STORE_ENCRYPTED_PREFIX):
+                continue
+            try:
+                data = json.loads(raw)
+            except json.JSONDecodeError:
+                logger.warning("Skipping malformed plaintext response store row %s during encryption migration", response_id)
+                continue
+            encoded = self._encode_response_data(response_id, data)
+            self._conn.execute(
+                "UPDATE responses SET data = ? WHERE response_id = ?",
+                (encoded, response_id),
+            )
+            migrated += 1
+        if migrated:
+            self._conn.commit()
+            logger.info("Encrypted %d existing response_store.db row(s)", migrated)
+            self._post_migration_cleanup()
+        self._secure_db_files()
+
+    def _post_migration_cleanup(self) -> None:
+        if self._db_path is None:
+            return
+        for statement in ("PRAGMA wal_checkpoint(TRUNCATE)", "VACUUM"):
+            try:
+                self._conn.execute(statement)
+            except sqlite3.DatabaseError as exc:
+                logger.debug("response_store.db cleanup statement %s failed: %s", statement, exc)
 
     def get(self, response_id: str) -> Optional[Dict[str, Any]]:
         """Retrieve a stored response by ID (updates access time for LRU)."""
@@ -345,13 +622,17 @@ class ResponseStore:
             (time.time(), response_id),
         )
         self._conn.commit()
-        return json.loads(row[0])
+        data, was_plaintext = self._decode_response_data(response_id, row[0])
+        if was_plaintext and self._crypto is not None:
+            self._rewrite_response_data(response_id, data)
+        self._secure_db_files()
+        return data
 
     def put(self, response_id: str, data: Dict[str, Any]) -> None:
         """Store a response, evicting the oldest if at capacity."""
         self._conn.execute(
             "INSERT OR REPLACE INTO responses (response_id, data, accessed_at) VALUES (?, ?, ?)",
-            (response_id, json.dumps(data, default=str), time.time()),
+            (response_id, self._encode_response_data(response_id, data), time.time()),
         )
         # Evict oldest entries beyond max_size
         count = self._conn.execute("SELECT COUNT(*) FROM responses").fetchone()[0]
@@ -362,6 +643,7 @@ class ResponseStore:
                 (count - self._max_size,),
             )
         self._conn.commit()
+        self._secure_db_files()
 
     def delete(self, response_id: str) -> bool:
         """Remove a response from the store. Returns True if found and deleted."""
@@ -369,6 +651,7 @@ class ResponseStore:
             "DELETE FROM responses WHERE response_id = ?", (response_id,)
         )
         self._conn.commit()
+        self._secure_db_files()
         return cursor.rowcount > 0
 
     def get_conversation(self, name: str) -> Optional[str]:
@@ -385,6 +668,7 @@ class ResponseStore:
             (name, response_id),
         )
         self._conn.commit()
+        self._secure_db_files()
 
     def close(self) -> None:
         """Close the database connection."""
@@ -601,7 +885,18 @@ class APIServerAdapter(BasePlatformAdapter):
         self._app: Optional["web.Application"] = None
         self._runner: Optional["web.AppRunner"] = None
         self._site: Optional["web.TCPSite"] = None
-        self._response_store = ResponseStore()
+        response_store_key = os.getenv("API_SERVER_RESPONSE_STORE_KEY", "").strip() or self._api_key
+        self._response_store_init_error: Optional[ResponseStoreCryptoError] = None
+        try:
+            self._response_store = ResponseStore(
+                encryption_mode=extra.get("response_store_encryption", "auto"),
+                encryption_key=response_store_key,
+            )
+        except ResponseStoreCryptoError as exc:
+            self._response_store_init_error = exc
+            # Keep construction non-fatal so gateway startup can report the
+            # platform as failed through the normal connect() path.
+            self._response_store = ResponseStore(db_path=":memory:", encryption_mode="off")
         # Active run streams: run_id -> asyncio.Queue of SSE event dicts
         self._run_streams: Dict[str, "asyncio.Queue[Optional[Dict]]"] = {}
         # Creation timestamps for orphaned-run TTL sweep
@@ -2117,7 +2412,10 @@ class APIServerAdapter(BasePlatformAdapter):
 
         stored_session_id = None
         if not conversation_history and previous_response_id:
-            stored = self._response_store.get(previous_response_id)
+            try:
+                stored = self._response_store.get(previous_response_id)
+            except ResponseStoreCryptoError as exc:
+                return _response_store_crypto_error_response(exc)
             if stored is None:
                 return web.json_response(_openai_error(f"Previous response not found: {previous_response_id}"), status=404)
             conversation_history = list(stored.get("conversation_history", []))
@@ -2294,12 +2592,15 @@ class APIServerAdapter(BasePlatformAdapter):
 
         # Store the complete response object for future chaining / GET retrieval
         if store:
-            self._response_store.put(response_id, {
-                "response": response_data,
-                "conversation_history": full_history,
-                "instructions": instructions,
-                "session_id": session_id,
-            })
+            try:
+                self._response_store.put(response_id, {
+                    "response": response_data,
+                    "conversation_history": full_history,
+                    "instructions": instructions,
+                    "session_id": session_id,
+                })
+            except ResponseStoreCryptoError as exc:
+                return _response_store_crypto_error_response(exc)
             # Update conversation mapping so the next request with the same
             # conversation name automatically chains to this response
             if conversation:
@@ -2321,7 +2622,10 @@ class APIServerAdapter(BasePlatformAdapter):
             return auth_err
 
         response_id = request.match_info["response_id"]
-        stored = self._response_store.get(response_id)
+        try:
+            stored = self._response_store.get(response_id)
+        except ResponseStoreCryptoError as exc:
+            return _response_store_crypto_error_response(exc)
         if stored is None:
             return web.json_response(_openai_error(f"Response not found: {response_id}"), status=404)
 
@@ -2856,7 +3160,10 @@ class APIServerAdapter(BasePlatformAdapter):
 
         stored_session_id = None
         if not conversation_history and previous_response_id:
-            stored = self._response_store.get(previous_response_id)
+            try:
+                stored = self._response_store.get(previous_response_id)
+            except ResponseStoreCryptoError as exc:
+                return _response_store_crypto_error_response(exc)
             if stored:
                 conversation_history = list(stored.get("conversation_history", []))
                 stored_session_id = stored.get("session_id")
@@ -3329,6 +3636,13 @@ class APIServerAdapter(BasePlatformAdapter):
         """Start the aiohttp web server."""
         if not AIOHTTP_AVAILABLE:
             logger.warning("[%s] aiohttp not installed", self.name)
+            return False
+        if self._response_store_init_error is not None:
+            logger.error(
+                "[%s] Refusing to start: response store encryption is required but unavailable: %s",
+                self.name,
+                self._response_store_init_error,
+            )
             return False
 
         try:

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -2411,6 +2411,14 @@ OPTIONAL_ENV_VARS = {
         "category": "messaging",
         "advanced": True,
     },
+    "API_SERVER_RESPONSE_STORE_KEY": {
+        "description": "Dedicated long, high-entropy encryption key for API server response_store.db at-rest encryption. If unset, API_SERVER_KEY is used as a fallback when available.",
+        "prompt": "API response store encryption key",
+        "url": None,
+        "password": True,
+        "category": "messaging",
+        "advanced": True,
+    },
     "API_SERVER_PORT": {
         "description": "Port for the API server (default: 8642).",
         "prompt": "API server port",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,6 +37,8 @@ dependencies = [
   "edge-tts>=7.2.7,<8",
   # Skills Hub (GitHub App JWT auth — optional, only needed for bot identity)
   "PyJWT[crypto]>=2.12.0,<3",  # CVE-2026-32597
+  # Authenticated at-rest encryption for API server response_store.db
+  "cryptography>=46.0.5,<47",
   # Windows has no IANA tzdata shipped with the OS, so Python's ``zoneinfo``
   # (PEP 615) raises ``ZoneInfoNotFoundError`` for every non-UTC timezone
   # out of the box.  ``tzdata`` ships the Olson database as a data package

--- a/tests/gateway/test_api_server.py
+++ b/tests/gateway/test_api_server.py
@@ -14,6 +14,8 @@ Tests cover:
 
 import asyncio
 import json
+import os
+import sqlite3
 import time
 import uuid
 from unittest.mock import AsyncMock, MagicMock, patch
@@ -26,6 +28,7 @@ from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.api_server import (
     APIServerAdapter,
     ResponseStore,
+    ResponseStoreCryptoError,
     _IdempotencyCache,
     _CORS_HEADERS,
     _derive_chat_session_id,
@@ -55,6 +58,18 @@ class TestCheckRequirements:
 
 
 class TestResponseStore:
+    @staticmethod
+    def _raw_response_data(db_path, response_id="resp_1"):
+        conn = sqlite3.connect(str(db_path))
+        try:
+            row = conn.execute(
+                "SELECT data FROM responses WHERE response_id = ?",
+                (response_id,),
+            ).fetchone()
+            return row[0] if row else None
+        finally:
+            conn.close()
+
     def test_put_and_get(self):
         store = ResponseStore(max_size=10)
         store.put("resp_1", {"output": "hello"})
@@ -104,6 +119,201 @@ class TestResponseStore:
     def test_delete_missing(self):
         store = ResponseStore(max_size=10)
         assert store.delete("resp_missing") is False
+
+    def test_auto_without_key_stores_plaintext_and_warns(self, tmp_path, caplog):
+        db_path = tmp_path / "response_store.db"
+        with caplog.at_level("WARNING"):
+            store = ResponseStore(max_size=10, db_path=str(db_path))
+        store.put("resp_1", {"output": "plain sentinel"})
+        assert store.get("resp_1") == {"output": "plain sentinel"}
+        assert "plain sentinel" in self._raw_response_data(db_path)
+        assert "response_store.db will remain plaintext" in caplog.text
+
+    def test_required_without_key_raises(self, tmp_path):
+        with pytest.raises(ResponseStoreCryptoError):
+            ResponseStore(
+                max_size=10,
+                db_path=str(tmp_path / "response_store.db"),
+                encryption_mode="required",
+            )
+
+    def test_required_with_short_key_raises(self, tmp_path):
+        with pytest.raises(ResponseStoreCryptoError):
+            ResponseStore(
+                max_size=10,
+                db_path=str(tmp_path / "response_store.db"),
+                encryption_mode="required",
+                encryption_key="too-short",
+            )
+
+    def test_off_with_key_stores_plaintext(self, tmp_path):
+        db_path = tmp_path / "response_store.db"
+        store = ResponseStore(
+            max_size=10,
+            db_path=str(db_path),
+            encryption_mode="off",
+            encryption_key="very-secret-response-store-key",
+        )
+        store.put("resp_1", {"output": "plaintext despite key"})
+        assert store.get("resp_1") == {"output": "plaintext despite key"}
+        assert "plaintext despite key" in self._raw_response_data(db_path)
+
+    def test_encrypted_store_hides_raw_payload_and_round_trips(self, tmp_path):
+        db_path = tmp_path / "response_store.db"
+        store = ResponseStore(
+            max_size=10,
+            db_path=str(db_path),
+            encryption_mode="required",
+            encryption_key="very-secret-response-store-key",
+        )
+        store.put("resp_1", {"output": "secret sentinel"})
+
+        raw = self._raw_response_data(db_path)
+        assert raw.startswith("enc:v1:")
+        assert "secret sentinel" not in raw
+        assert store.get("resp_1") == {"output": "secret sentinel"}
+
+    def test_encrypted_store_reopens_with_same_key(self, tmp_path):
+        db_path = tmp_path / "response_store.db"
+        key = "very-secret-response-store-key"
+        store = ResponseStore(max_size=10, db_path=str(db_path), encryption_mode="required", encryption_key=key)
+        store.put("resp_1", {"output": "persistent secret"})
+        store.close()
+
+        reopened = ResponseStore(max_size=10, db_path=str(db_path), encryption_mode="required", encryption_key=key)
+        assert reopened.get("resp_1") == {"output": "persistent secret"}
+
+    def test_encrypted_store_wrong_key_raises(self, tmp_path):
+        db_path = tmp_path / "response_store.db"
+        store = ResponseStore(
+            max_size=10,
+            db_path=str(db_path),
+            encryption_mode="required",
+            encryption_key="very-secret-response-store-key",
+        )
+        store.put("resp_1", {"output": "persistent secret"})
+        store.close()
+
+        wrong = ResponseStore(
+            max_size=10,
+            db_path=str(db_path),
+            encryption_mode="required",
+            encryption_key="different-secret-response-store-key",
+        )
+        with pytest.raises(ResponseStoreCryptoError):
+            wrong.get("resp_1")
+
+    def test_encrypted_store_rejects_replayed_row(self, tmp_path):
+        db_path = tmp_path / "response_store.db"
+        store = ResponseStore(
+            max_size=10,
+            db_path=str(db_path),
+            encryption_mode="required",
+            encryption_key="very-secret-response-store-key",
+        )
+        store.put("resp_1", {"output": "first secret"})
+        store.put("resp_2", {"output": "second secret"})
+        store.close()
+
+        conn = sqlite3.connect(str(db_path))
+        try:
+            resp_1_raw = conn.execute(
+                "SELECT data FROM responses WHERE response_id = ?",
+                ("resp_1",),
+            ).fetchone()[0]
+            conn.execute(
+                "UPDATE responses SET data = ? WHERE response_id = ?",
+                (resp_1_raw, "resp_2"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        reopened = ResponseStore(
+            max_size=10,
+            db_path=str(db_path),
+            encryption_mode="required",
+            encryption_key="very-secret-response-store-key",
+        )
+        assert reopened.get("resp_1") == {"output": "first secret"}
+        with pytest.raises(ResponseStoreCryptoError):
+            reopened.get("resp_2")
+
+    def test_malformed_encrypted_row_raises(self, tmp_path):
+        db_path = tmp_path / "response_store.db"
+        store = ResponseStore(
+            max_size=10,
+            db_path=str(db_path),
+            encryption_mode="required",
+            encryption_key="very-secret-response-store-key",
+        )
+        store.put("resp_1", {"output": "persistent secret"})
+        store.close()
+
+        conn = sqlite3.connect(str(db_path))
+        try:
+            conn.execute(
+                "UPDATE responses SET data = ? WHERE response_id = ?",
+                ("enc:v1:missing-token", "resp_1"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+
+        reopened = ResponseStore(
+            max_size=10,
+            db_path=str(db_path),
+            encryption_mode="required",
+            encryption_key="very-secret-response-store-key",
+        )
+        with pytest.raises(ResponseStoreCryptoError):
+            reopened.get("resp_1")
+
+    def test_plaintext_rows_migrate_when_encryption_enabled(self, tmp_path):
+        db_path = tmp_path / "response_store.db"
+        plaintext = ResponseStore(max_size=10, db_path=str(db_path), encryption_mode="off")
+        plaintext.put("resp_1", {"output": "legacy plaintext sentinel"})
+        plaintext.close()
+        assert "legacy plaintext sentinel" in self._raw_response_data(db_path)
+
+        encrypted = ResponseStore(
+            max_size=10,
+            db_path=str(db_path),
+            encryption_mode="required",
+            encryption_key="very-secret-response-store-key",
+        )
+        assert encrypted.get("resp_1") == {"output": "legacy plaintext sentinel"}
+        raw = self._raw_response_data(db_path)
+        assert raw.startswith("enc:v1:")
+        assert "legacy plaintext sentinel" not in raw
+
+    def test_delete_encrypted_row_does_not_require_decrypt(self, tmp_path):
+        db_path = tmp_path / "response_store.db"
+        store = ResponseStore(
+            max_size=10,
+            db_path=str(db_path),
+            encryption_mode="required",
+            encryption_key="very-secret-response-store-key",
+        )
+        store.put("resp_1", {"output": "delete without decrypt"})
+        store.close()
+
+        wrong = ResponseStore(
+            max_size=10,
+            db_path=str(db_path),
+            encryption_mode="required",
+            encryption_key="different-secret-response-store-key",
+        )
+        assert wrong.delete("resp_1") is True
+        assert self._raw_response_data(db_path) is None
+
+    @pytest.mark.skipif(os.name == "nt", reason="POSIX mode assertions do not apply on Windows")
+    def test_on_disk_db_created_owner_only(self, tmp_path):
+        db_path = tmp_path / "response_store.db"
+        store = ResponseStore(max_size=10, db_path=str(db_path), encryption_mode="off")
+        store.put("resp_1", {"output": "hello"})
+        mode = db_path.stat().st_mode & 0o777
+        assert mode == 0o600
 
 
 # ---------------------------------------------------------------------------
@@ -246,6 +456,17 @@ class TestAdapterInit:
         adapter = APIServerAdapter(config)
         assert adapter._port == 8642
 
+    @pytest.mark.asyncio
+    async def test_required_response_store_encryption_blocks_connect_without_key(self):
+        adapter = APIServerAdapter(
+            PlatformConfig(
+                enabled=True,
+                extra={"response_store_encryption": "required"},
+            )
+        )
+        assert adapter._response_store_init_error is not None
+        assert await adapter.connect() is False
+
     def test_create_agent_forwards_config_reasoning_effort(self, monkeypatch):
         captured = {}
 
@@ -336,9 +557,9 @@ class TestAuth:
 # ---------------------------------------------------------------------------
 
 
-def _make_adapter(api_key: str = "", cors_origins=None) -> APIServerAdapter:
+def _make_adapter(api_key: str = "", cors_origins=None, extra=None) -> APIServerAdapter:
     """Create an adapter with optional API key."""
-    extra = {}
+    extra = dict(extra or {})
     if api_key:
         extra["key"] = api_key
     if cors_origins is not None:
@@ -1363,6 +1584,103 @@ class TestResponsesEndpoint:
             call_kwargs = mock_run.call_args.kwargs
             assert len(call_kwargs["conversation_history"]) > 0
             assert call_kwargs["user_message"] == "Now add 1 more"
+
+    @pytest.mark.asyncio
+    async def test_previous_response_id_chaining_with_encrypted_store(self):
+        """Encrypted response rows still support previous_response_id chaining."""
+        api_key = "very-secret-api-server-key"
+        adapter = _make_adapter(api_key=api_key)
+        first_history = [
+            {"role": "user", "content": "secret sentinel question"},
+            {"role": "assistant", "content": "secret sentinel answer"},
+        ]
+
+        app = _create_app(adapter)
+        headers = {"Authorization": f"Bearer {api_key}"}
+        async with TestClient(TestServer(app)) as cli:
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "secret sentinel answer", "messages": list(first_history), "api_calls": 1},
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
+                resp1 = await cli.post(
+                    "/v1/responses",
+                    json={"model": "hermes-agent", "input": "secret sentinel question"},
+                    headers=headers,
+                )
+
+            assert resp1.status == 200
+            data1 = await resp1.json()
+            raw = TestResponseStore._raw_response_data(adapter._response_store._db_path, data1["id"])
+            assert raw.startswith("enc:v1:")
+            assert "secret sentinel" not in raw
+
+            second_history = first_history + [
+                {"role": "user", "content": "follow up"},
+                {"role": "assistant", "content": "done"},
+            ]
+            with patch.object(adapter, "_run_agent", new_callable=AsyncMock) as mock_run:
+                mock_run.return_value = (
+                    {"final_response": "done", "messages": list(second_history), "api_calls": 1},
+                    {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+                )
+                resp2 = await cli.post(
+                    "/v1/responses",
+                    json={
+                        "model": "hermes-agent",
+                        "input": "follow up",
+                        "previous_response_id": data1["id"],
+                    },
+                    headers=headers,
+                )
+
+            assert resp2.status == 200
+            call_kwargs = mock_run.call_args.kwargs
+            assert call_kwargs["conversation_history"] == first_history
+            assert call_kwargs["user_message"] == "follow up"
+
+    @pytest.mark.asyncio
+    async def test_previous_response_id_wrong_store_key_returns_500(self, tmp_path):
+        """Wrong at-rest key is reported as a store error, not as a missing response."""
+        db_path = tmp_path / "response_store.db"
+        writer = ResponseStore(
+            max_size=10,
+            db_path=str(db_path),
+            encryption_mode="required",
+            encryption_key="very-secret-response-store-key",
+        )
+        writer.put("resp_prev", {
+            "response": {"id": "resp_prev", "status": "completed"},
+            "conversation_history": [{"role": "user", "content": "secret"}],
+            "session_id": "api-test-session",
+        })
+        writer.close()
+
+        api_key = "very-secret-api-server-key"
+        adapter = _make_adapter(api_key=api_key)
+        adapter._response_store.close()
+        adapter._response_store = ResponseStore(
+            max_size=10,
+            db_path=str(db_path),
+            encryption_mode="required",
+            encryption_key="different-secret-response-store-key",
+        )
+
+        app = _create_app(adapter)
+        async with TestClient(TestServer(app)) as cli:
+            resp = await cli.post(
+                "/v1/responses",
+                json={
+                    "model": "hermes-agent",
+                    "input": "follow up",
+                    "previous_response_id": "resp_prev",
+                },
+                headers={"Authorization": f"Bearer {api_key}"},
+            )
+            assert resp.status == 500
+            data = await resp.json()
+
+        assert data["error"]["code"] == "response_store_decryption_failed"
 
     @pytest.mark.asyncio
     async def test_previous_response_id_stores_full_agent_transcript_once(self, adapter):
@@ -3061,4 +3379,3 @@ class TestSessionKeyHeader:
             assert resp.status == 200
             data = await resp.json()
             assert data["features"]["session_key_header"] == "X-Hermes-Session-Key"
-

--- a/uv.lock
+++ b/uv.lock
@@ -8,10 +8,6 @@ resolution-markers = [
     "python_full_version < '3.12'",
 ]
 
-[options]
-exclude-newer = "2026-05-01T22:46:56.926194148Z"
-exclude-newer-span = "P7D"
-
 [[package]]
 name = "agent-client-protocol"
 version = "0.9.0"
@@ -1274,6 +1270,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "deprecated"
 version = "1.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -1959,6 +1964,7 @@ source = { editable = "." }
 dependencies = [
     { name = "anthropic" },
     { name = "croniter" },
+    { name = "cryptography" },
     { name = "edge-tts" },
     { name = "exa-py" },
     { name = "fal-client" },
@@ -2014,6 +2020,7 @@ all = [
     { name = "ptyprocess", marker = "sys_platform != 'win32'" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-split" },
     { name = "pytest-xdist" },
     { name = "python-telegram-bot", extra = ["webhooks"] },
     { name = "pywinpty", marker = "sys_platform == 'win32'" },
@@ -2026,6 +2033,7 @@ all = [
     { name = "ty" },
     { name = "uvicorn", extra = ["standard"] },
     { name = "vercel" },
+    { name = "youtube-transcript-api" },
 ]
 bedrock = [
     { name = "boto3" },
@@ -2044,6 +2052,7 @@ dev = [
     { name = "mcp" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "pytest-split" },
     { name = "pytest-xdist" },
     { name = "ruff" },
     { name = "ty" },
@@ -2162,6 +2171,9 @@ web = [
 yc-bench = [
     { name = "yc-bench", marker = "python_full_version >= '3.12'" },
 ]
+youtube = [
+    { name = "youtube-transcript-api" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -2177,6 +2189,7 @@ requires-dist = [
     { name = "atroposlib", marker = "extra == 'rl'", git = "https://github.com/NousResearch/atropos.git?rev=c20c85256e5a45ad31edf8b7276e9c5ee1995a30" },
     { name = "boto3", marker = "extra == 'bedrock'", specifier = ">=1.35.0,<2" },
     { name = "croniter", specifier = ">=6.0.0,<7" },
+    { name = "cryptography", specifier = ">=46.0.5,<47" },
     { name = "daytona", marker = "extra == 'daytona'", specifier = ">=0.148.0,<1" },
     { name = "debugpy", marker = "extra == 'dev'", specifier = ">=1.8.0,<2" },
     { name = "dingtalk-stream", marker = "extra == 'dingtalk'", specifier = ">=0.20,<1" },
@@ -2234,6 +2247,7 @@ requires-dist = [
     { name = "hermes-agent", extras = ["voice"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["web"], marker = "extra == 'all'" },
     { name = "hermes-agent", extras = ["web"], marker = "extra == 'termux-all'" },
+    { name = "hermes-agent", extras = ["youtube"], marker = "extra == 'all'" },
     { name = "honcho-ai", marker = "extra == 'honcho'", specifier = ">=2.0.1,<3" },
     { name = "httpx", extras = ["socks"], specifier = ">=0.28.1,<1" },
     { name = "jinja2", specifier = ">=3.1.5,<4" },
@@ -2255,6 +2269,7 @@ requires-dist = [
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.12.0,<3" },
     { name = "pytest", marker = "extra == 'dev'", specifier = ">=9.0.2,<10" },
     { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=1.3.0,<2" },
+    { name = "pytest-split", marker = "extra == 'dev'", specifier = ">=0.9,<1" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.0,<4" },
     { name = "python-dotenv", specifier = ">=1.2.1,<2" },
     { name = "python-telegram-bot", extras = ["webhooks"], marker = "extra == 'messaging'", specifier = ">=22.6,<23" },
@@ -2283,8 +2298,9 @@ requires-dist = [
     { name = "vercel", marker = "extra == 'vercel'", specifier = ">=0.5.7,<0.6.0" },
     { name = "wandb", marker = "extra == 'rl'", specifier = ">=0.15.0,<1" },
     { name = "yc-bench", marker = "python_full_version >= '3.12' and extra == 'yc-bench'", git = "https://github.com/collinear-ai/yc-bench.git?rev=bfb0c88062450f46341bd9a5298903fc2e952a5c" },
+    { name = "youtube-transcript-api", marker = "extra == 'youtube'", specifier = ">=1.2.0" },
 ]
-provides-extras = ["modal", "daytona", "vercel", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "computer-use", "acp", "mistral", "bedrock", "termux", "termux-all", "dingtalk", "feishu", "google", "web", "rl", "yc-bench", "all"]
+provides-extras = ["modal", "daytona", "vercel", "dev", "messaging", "cron", "slack", "matrix", "cli", "tts-premium", "voice", "pty", "honcho", "mcp", "homeassistant", "sms", "computer-use", "acp", "mistral", "bedrock", "termux", "termux-all", "dingtalk", "feishu", "google", "youtube", "web", "rl", "yc-bench", "all"]
 
 [[package]]
 name = "hf-transfer"
@@ -4440,6 +4456,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pytest-split"
+version = "0.11.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/2f/16/8af4c5f2ceb3640bb1f78dfdf5c184556b10dfe9369feaaad7ff1c13f329/pytest_split-0.11.0.tar.gz", hash = "sha256:8ebdb29cc72cc962e8eb1ec07db1eeb98ab25e215ed8e3216f6b9fc7ce0ec2b5", size = 13421, upload-time = "2026-02-03T09:14:31.469Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ae/a1/d4423657caaa8be9b31e491592b49cebdcfd434d3e74512ce71f6ec39905/pytest_split-0.11.0-py3-none-any.whl", hash = "sha256:899d7c0f5730da91e2daf283860eb73b503259cb416851a65599368849c7f382", size = 11911, upload-time = "2026-02-03T09:14:33.708Z" },
+]
+
+[[package]]
 name = "pytest-xdist"
 version = "3.8.0"
 source = { registry = "https://pypi.org/simple" }
@@ -6163,6 +6191,19 @@ dependencies = [
     { name = "sqlalchemy", marker = "python_full_version >= '3.12'" },
     { name = "streamlit", marker = "python_full_version >= '3.12'" },
     { name = "typer", marker = "python_full_version >= '3.12'" },
+]
+
+[[package]]
+name = "youtube-transcript-api"
+version = "1.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "defusedxml" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/43/4104185a2eaa839daa693b30e15c37e7e58795e8e09ec414f22b3db54bec/youtube_transcript_api-1.2.4.tar.gz", hash = "sha256:b72d0e96a335df599d67cee51d49e143cff4f45b84bcafc202ff51291603ddcd", size = 469839, upload-time = "2026-01-29T09:09:17.088Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/95/129ea37efd6cd6ed00f62baae6543345c677810b8a3bf0026756e1d3cf3c/youtube_transcript_api-1.2.4-py3-none-any.whl", hash = "sha256:03878759356da5caf5edac77431780b91448fb3d8c21d4496015bdc8a7bc43ff", size = 485227, upload-time = "2026-01-29T09:09:15.427Z" },
 ]
 
 [[package]]

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -396,6 +396,7 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `WEBHOOK_SECRET` | Global HMAC secret for webhook signature validation (used as fallback when routes don't specify their own) |
 | `API_SERVER_ENABLED` | Enable the OpenAI-compatible API server (`true`/`false`). Runs alongside other platforms. |
 | `API_SERVER_KEY` | Bearer token for API server authentication. Enforced for non-loopback binding. |
+| `API_SERVER_RESPONSE_STORE_KEY` | Dedicated long, high-entropy encryption key for API server `response_store.db` payloads. If unset, `API_SERVER_KEY` is used as a fallback when available. |
 | `API_SERVER_CORS_ORIGINS` | Comma-separated browser origins allowed to call the API server directly (for example `http://localhost:3000,http://127.0.0.1:3000`). Default: disabled. |
 | `API_SERVER_PORT` | Port for the API server (default: `8642`) |
 | `API_SERVER_HOST` | Host/bind address for the API server (default: `127.0.0.1`). Use `0.0.0.0` for network access — requires `API_SERVER_KEY` and a narrow `API_SERVER_CORS_ORIGINS` allowlist. |

--- a/website/docs/user-guide/features/api-server.md
+++ b/website/docs/user-guide/features/api-server.md
@@ -338,15 +338,33 @@ The default bind address (`127.0.0.1`) is for local-only use. Browser access is 
 | `API_SERVER_PORT` | `8642` | HTTP server port |
 | `API_SERVER_HOST` | `127.0.0.1` | Bind address (localhost only by default) |
 | `API_SERVER_KEY` | _(none)_ | Bearer token for auth |
+| `API_SERVER_RESPONSE_STORE_KEY` | `API_SERVER_KEY` fallback | Dedicated key for encrypting stored Responses API state at rest |
 | `API_SERVER_CORS_ORIGINS` | _(none)_ | Comma-separated allowed browser origins |
 | `API_SERVER_MODEL_NAME` | _(profile name)_ | Model name on `/v1/models`. Defaults to profile name, or `hermes-agent` for default profile. |
 
 ### config.yaml
 
 ```yaml
-# Not yet supported — use environment variables.
-# config.yaml support coming in a future release.
+platforms:
+  api_server:
+    extra:
+      # auto: encrypt response_store.db when API_SERVER_RESPONSE_STORE_KEY
+      # or API_SERVER_KEY is configured; otherwise keep plaintext for
+      # loopback-only local compatibility.
+      # required: refuse to start unless encryption is active.
+      # off: keep legacy plaintext storage.
+      response_store_encryption: auto
 ```
+
+### Responses API storage
+
+When `store` is `true` (the default), `/v1/responses` stores response state in `~/.hermes/response_store.db` so `previous_response_id`, `conversation`, and `GET /v1/responses/{id}` can work across requests and gateway restarts.
+
+By default, Hermes encrypts the sensitive `responses.data` payload when a usable `API_SERVER_RESPONSE_STORE_KEY` or `API_SERVER_KEY` is configured. For shared, remote, or non-loopback deployments, set a dedicated long, high-entropy `API_SERVER_RESPONSE_STORE_KEY` and `response_store_encryption: required`.
+
+Changing the response-store key can make existing encrypted stored responses unreadable. Field-level encryption protects the response payload, but SQLite metadata such as response IDs, row counts, access timestamps, and conversation names may remain visible. Migrating old plaintext rows is best-effort for the live database and is not a forensic wipe of backups, snapshots, or previously copied files.
+
+Set `store: false` on a request if you do not want that response persisted for future chaining.
 
 ## Security Headers
 


### PR DESCRIPTION
## Summary

Fixes NousResearch/hermes-agent#7486.

This PR hardens the API server Responses API state store by encrypting sensitive stored response payloads in `~/.hermes/response_store.db` while preserving the existing `previous_response_id`, named `conversation`, and `GET /v1/responses/{response_id}` behavior.

## What changed

- Adds authenticated field-level encryption for `responses.data` in `ResponseStore` using Fernet.
- Uses a dedicated `API_SERVER_RESPONSE_STORE_KEY` when configured, with `API_SERVER_KEY` as the compatibility fallback.
- Adds `response_store_encryption` modes:
  - `auto`: encrypt when a usable key is available; otherwise preserve existing plaintext local behavior.
  - `required`: refuse API server startup unless encryption is active.
  - `off`: explicitly keep legacy plaintext storage.
- Binds encrypted payloads to their `response_id` so copied/replayed encrypted rows are rejected.
- Migrates existing plaintext rows to encrypted rows when encryption becomes active.
- Sets restrictive `0600` permissions on the response-store SQLite files where supported.
- Enables SQLite `secure_delete` and does best-effort cleanup after plaintext migration.
- Returns a safe OpenAI-style 500 when encrypted stored state cannot be decrypted instead of treating it as a missing response.
- Documents the at-rest data behavior, key configuration, remaining visible metadata, and migration caveats.

## Compatibility and security notes

The default mode is intentionally `auto` so existing loopback-only local API server deployments keep working if no API key is configured. Shared, remote, or non-loopback deployments should set a long high-entropy `API_SERVER_RESPONSE_STORE_KEY` and configure `response_store_encryption: required`.

This encrypts the sensitive JSON payload stored in `responses.data`. SQLite metadata such as response IDs, row counts, timestamps, and conversation names can still be visible. Migrating old plaintext rows is best-effort for the active database and is not a forensic wipe of backups, snapshots, or previously copied files.

## Validation

- `uv lock --check`
- `uv run --extra dev ruff check gateway/platforms/api_server.py tests/gateway/test_api_server.py hermes_cli/config.py`
- `uv run python -m py_compile gateway/platforms/api_server.py tests/gateway/test_api_server.py hermes_cli/config.py`
- `uv run --extra dev pytest tests/gateway/test_api_server*.py tests/gateway/test_weak_credential_guard.py -q` (`292 passed`)

I also ran the full `tests/gateway` suite during review; it surfaced unrelated failures in DingTalk, Google Chat, TTS media routing, shutdown diagnostics, and update streaming tests. The API-server and response-store slices are green.
