### PR TITLE
Recover inline XML tool calls from chat-completion content

### DIFF
--- a/agent/inline_tool_calls.py
+++ b/agent/inline_tool_calls.py
@@ -1,0 +1,226 @@
+"""JSON-aware extraction for inline XML-wrapped tool calls."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from typing import Any
+
+from agent.transports.types import ToolCall
+
+
+_START_TAG_RE = re.compile(
+    r"<(tool_use|tool_call|tool_calls|function_call|function_calls)\b[^>]*>",
+    re.IGNORECASE,
+)
+_JSON_DECODER = json.JSONDecoder()
+_BOUNDARY_CHARS = set(" \t\r\n([{,:;.!?")
+
+
+@dataclass(frozen=True)
+class InlineToolExtraction:
+    tool_calls: list[ToolCall]
+    content: str | None
+    parsed_spans: list[tuple[int, int]]
+
+
+def extract_inline_tool_calls(text: str | None) -> InlineToolExtraction:
+    """Extract valid inline XML tool calls from assistant text.
+
+    This intentionally recognizes only JSON payloads wrapped in known tool-call
+    tags. The JSON parser determines the payload boundary, so nested objects and
+    strings containing text like ``</tool_use>`` are handled safely.
+    """
+    if not isinstance(text, str) or "<" not in text:
+        return InlineToolExtraction([], text, [])
+
+    tool_calls: list[ToolCall] = []
+    spans: list[tuple[int, int]] = []
+    lower_text = text.lower()
+    pos = 0
+
+    while True:
+        match = _START_TAG_RE.search(text, pos)
+        if match is None:
+            break
+
+        if not _has_safe_boundary(text, match.start()):
+            pos = match.end()
+            continue
+
+        tag = match.group(1).lower()
+        json_start = _skip_ws(text, match.end())
+        try:
+            payload, json_end = _JSON_DECODER.raw_decode(text, json_start)
+        except (json.JSONDecodeError, TypeError, ValueError):
+            pos = match.end()
+            continue
+
+        close_start = _skip_ws(text, json_end)
+        close_tag = f"</{tag}>"
+        if not lower_text.startswith(close_tag, close_start):
+            pos = match.end()
+            continue
+
+        span_end = close_start + len(close_tag)
+        raw_payload = text[json_start:json_end]
+        recovered = _payload_to_tool_calls(
+            payload,
+            raw_payload=raw_payload,
+            start_offset=match.start(),
+            first_sequence=len(tool_calls),
+        )
+        if recovered:
+            tool_calls.extend(recovered)
+            spans.append((match.start(), span_end))
+            pos = span_end
+        else:
+            pos = match.end()
+
+    cleaned = _remove_spans(text, spans)
+    content = (cleaned if cleaned.strip() else None) if spans else text
+    return InlineToolExtraction(
+        tool_calls=tool_calls,
+        content=content,
+        parsed_spans=spans,
+    )
+
+
+def strip_inline_tool_call_blocks(text: str | None) -> str:
+    """Remove valid inline XML tool-call blocks without executing them."""
+    if not isinstance(text, str) or "<" not in text:
+        return text or ""
+    extracted = extract_inline_tool_calls(text)
+    if not extracted.parsed_spans:
+        return text
+    return extracted.content or ""
+
+
+def _has_safe_boundary(text: str, start: int) -> bool:
+    if start <= 0:
+        return True
+    return text[start - 1] in _BOUNDARY_CHARS
+
+
+def _skip_ws(text: str, pos: int) -> int:
+    while pos < len(text) and text[pos].isspace():
+        pos += 1
+    return pos
+
+
+def _remove_spans(text: str, spans: list[tuple[int, int]]) -> str:
+    if not spans:
+        return text
+
+    parts: list[str] = []
+    cursor = 0
+    for start, end in spans:
+        if cursor < start:
+            parts.append(text[cursor:start])
+        cursor = max(cursor, end)
+    if cursor < len(text):
+        parts.append(text[cursor:])
+    return "".join(parts)
+
+
+def _payload_to_tool_calls(
+    payload: Any,
+    *,
+    raw_payload: str,
+    start_offset: int,
+    first_sequence: int,
+) -> list[ToolCall]:
+    entries = payload if isinstance(payload, list) else [payload]
+    tool_calls: list[ToolCall] = []
+    for offset, entry in enumerate(entries):
+        if not isinstance(entry, dict):
+            continue
+        tool_call = _entry_to_tool_call(
+            entry,
+            raw_payload=raw_payload,
+            start_offset=start_offset,
+            sequence=first_sequence + offset,
+        )
+        if tool_call is not None:
+            tool_calls.append(tool_call)
+    return tool_calls
+
+
+def _entry_to_tool_call(
+    entry: dict[str, Any],
+    *,
+    raw_payload: str,
+    start_offset: int,
+    sequence: int,
+) -> ToolCall | None:
+    function = entry.get("function")
+    if not isinstance(function, dict):
+        function = {}
+
+    name = entry.get("name")
+    if not isinstance(name, str) or not name.strip():
+        name = function.get("name")
+    if not isinstance(name, str) or not name.strip():
+        return None
+
+    arguments, ok = _normalize_arguments(entry, function)
+    if not ok:
+        return None
+
+    call_id = _first_nonempty_string(
+        entry.get("id"),
+        entry.get("tool_call_id"),
+        entry.get("tool_use_id"),
+        entry.get("call_id"),
+    )
+    if call_id is None:
+        call_id = _stable_call_id(raw_payload, start_offset, sequence)
+
+    return ToolCall(id=call_id, name=name.strip(), arguments=arguments)
+
+
+def _normalize_arguments(
+    entry: dict[str, Any],
+    function: dict[str, Any],
+) -> tuple[str, bool]:
+    sentinel = object()
+    raw_args = entry.get("arguments", sentinel)
+    if raw_args is sentinel:
+        raw_args = entry.get("input", sentinel)
+    if raw_args is sentinel:
+        raw_args = function.get("arguments", sentinel)
+    if raw_args is sentinel or raw_args is None:
+        return "{}", True
+
+    if isinstance(raw_args, dict):
+        return json.dumps(raw_args, ensure_ascii=False), True
+
+    if isinstance(raw_args, str):
+        stripped = raw_args.strip()
+        if not stripped:
+            return "{}", True
+        try:
+            parsed = json.loads(stripped)
+        except (json.JSONDecodeError, TypeError, ValueError):
+            return "", False
+        if not isinstance(parsed, dict):
+            return "", False
+        return json.dumps(parsed, ensure_ascii=False), True
+
+    return "", False
+
+
+def _first_nonempty_string(*values: Any) -> str | None:
+    for value in values:
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    return None
+
+
+def _stable_call_id(raw_payload: str, start_offset: int, sequence: int) -> str:
+    digest = hashlib.sha1(
+        f"{raw_payload}\0{start_offset}\0{sequence}".encode("utf-8")
+    ).hexdigest()
+    return f"call_inline_{digest[:16]}"

--- a/agent/transports/chat_completions.py
+++ b/agent/transports/chat_completions.py
@@ -12,6 +12,7 @@ reasoning configuration, temperature handling, and extra_body assembly.
 import copy
 from typing import Any, Dict, List, Optional
 
+from agent.inline_tool_calls import extract_inline_tool_calls
 from agent.lmstudio_reasoning import resolve_lmstudio_effort
 from agent.moonshot_schema import is_moonshot_model, sanitize_moonshot_tools
 from agent.prompt_builder import DEVELOPER_ROLE_MODELS
@@ -518,6 +519,7 @@ class ChatCompletionsTransport(ProviderTransport):
         choice = response.choices[0]
         msg = choice.message
         finish_reason = choice.finish_reason or "stop"
+        content = msg.content
 
         tool_calls = None
         if msg.tool_calls:
@@ -546,6 +548,13 @@ class ChatCompletionsTransport(ProviderTransport):
                         provider_data=tc_provider_data or None,
                     )
                 )
+        elif isinstance(content, str):
+            inline = extract_inline_tool_calls(content)
+            if inline.tool_calls:
+                tool_calls = inline.tool_calls
+                content = inline.content
+                if finish_reason == "stop":
+                    finish_reason = "tool_calls"
 
         usage = None
         if hasattr(response, "usage") and response.usage:
@@ -575,7 +584,7 @@ class ChatCompletionsTransport(ProviderTransport):
             provider_data["reasoning_details"] = rd
 
         return NormalizedResponse(
-            content=msg.content,
+            content=content,
             tool_calls=tool_calls,
             finish_reason=finish_reason,
             reasoning=reasoning,

--- a/run_agent.py
+++ b/run_agent.py
@@ -138,6 +138,7 @@ from tools.browser_tool import cleanup_browser
 
 
 # Agent internals extracted to agent/ package for modularity
+from agent.inline_tool_calls import strip_inline_tool_call_blocks
 from agent.memory_manager import StreamingContextScrubber, build_memory_context_block, sanitize_context
 from agent.think_scrubber import StreamingThinkScrubber
 from agent.retry_utils import jittered_backoff
@@ -3556,6 +3557,7 @@ class AIAgent:
         Additionally strips standalone tool-call XML blocks that some open
         models (notably Gemma variants on OpenRouter) emit inside assistant
         content instead of via the structured ``tool_calls`` field:
+          * ``<tool_use>…</tool_use>``
           * ``<tool_call>…</tool_call>``
           * ``<tool_calls>…</tool_calls>``
           * ``<tool_result>…</tool_result>``
@@ -3577,18 +3579,20 @@ class AIAgent:
         content = re.sub(r'<reasoning>.*?</reasoning>', '', content, flags=re.DOTALL | re.IGNORECASE)
         content = re.sub(r'<REASONING_SCRATCHPAD>.*?</REASONING_SCRATCHPAD>', '', content, flags=re.DOTALL | re.IGNORECASE)
         content = re.sub(r'<thought>.*?</thought>', '', content, flags=re.DOTALL | re.IGNORECASE)
-        # 1b. Tool-call XML blocks (openclaw/openclaw#67318). Handle the
-        #     generic tag names first — they have no attribute gating since
-        #     a literal <tool_call> in prose is already vanishingly rare.
-        for _tc_name in ("tool_call", "tool_calls", "tool_result",
-                          "function_call", "function_calls"):
-            content = re.sub(
-                rf'<{_tc_name}\b[^>]*>.*?</{_tc_name}>',
-                '',
-                content,
-                flags=re.DOTALL | re.IGNORECASE,
-            )
-        # 1c. <function name="...">...</function> — Gemma-style standalone
+        # 1b. JSON-bearing tool-call XML blocks (openclaw/openclaw#67318).
+        #     Use JSON-aware span removal so closing tag text inside JSON
+        #     strings (for example a write_file payload containing
+        #     "</tool_call>") does not terminate the block early.
+        content = strip_inline_tool_call_blocks(content)
+        # 1c. Tool-result XML blocks are cleanup-only; never turn these into
+        #     executable calls.
+        content = re.sub(
+            r'<tool_result\b[^>]*>.*?</tool_result>',
+            '',
+            content,
+            flags=re.DOTALL | re.IGNORECASE,
+        )
+        # 1d. <function name="...">...</function> — Gemma-style standalone
         #     tool call. Only strip when the tag sits at a block boundary
         #     (start of text, after a newline, or after sentence-ending
         #     punctuation) AND carries a name="..." attribute. This keeps
@@ -3623,7 +3627,7 @@ class AIAgent:
         #     during streaming may still be valuable to the user; matches
         #     OpenClaw's intentional asymmetry.)
         content = re.sub(
-            r'</(?:tool_call|tool_calls|tool_result|function_call|function_calls|function)>\s*',
+            r'</(?:tool_use|tool_call|tool_calls|tool_result|function_call|function_calls|function)>\s*',
             '',
             content,
             flags=re.IGNORECASE,

--- a/tests/agent/test_inline_tool_calls.py
+++ b/tests/agent/test_inline_tool_calls.py
@@ -1,0 +1,170 @@
+"""Tests for JSON-aware inline XML tool-call extraction."""
+
+import json
+
+from agent.inline_tool_calls import (
+    extract_inline_tool_calls,
+    strip_inline_tool_call_blocks,
+)
+
+
+def test_extracts_tool_use_with_nested_input_object():
+    text = (
+        '<tool_use>{"id":"t1","name":"terminal",'
+        '"input":{"command":"ls","timeout":300}}</tool_use>'
+    )
+
+    result = extract_inline_tool_calls(text)
+
+    assert result.content is None
+    assert result.parsed_spans == [(0, len(text))]
+    assert len(result.tool_calls) == 1
+    call = result.tool_calls[0]
+    assert call.id == "t1"
+    assert call.name == "terminal"
+    assert json.loads(call.arguments) == {"command": "ls", "timeout": 300}
+
+
+def test_extracts_tool_use_with_closing_tag_inside_json_string():
+    text = (
+        '<tool_use>{"id":"t1","name":"write_file",'
+        '"input":{"content":"</tool_use>"}}</tool_use>'
+    )
+
+    result = extract_inline_tool_calls(text)
+
+    assert result.content is None
+    assert len(result.tool_calls) == 1
+    assert result.tool_calls[0].name == "write_file"
+    assert json.loads(result.tool_calls[0].arguments) == {
+        "content": "</tool_use>",
+    }
+
+
+def test_strips_tool_call_with_closing_tag_inside_json_string():
+    text = (
+        'before <tool_call>{"name":"write_file",'
+        '"arguments":{"content":"</tool_call>"}}</tool_call> after'
+    )
+
+    result = strip_inline_tool_call_blocks(text)
+
+    assert result == "before  after"
+    assert "</tool_call>" not in result
+    assert '"}}' not in result
+
+
+def test_extracts_function_call_shape():
+    text = (
+        '<function_call>{"function":{"name":"read_file",'
+        '"arguments":{"path":"README.md"}}}</function_call>'
+    )
+
+    result = extract_inline_tool_calls(text)
+
+    assert len(result.tool_calls) == 1
+    assert result.tool_calls[0].name == "read_file"
+    assert json.loads(result.tool_calls[0].arguments) == {"path": "README.md"}
+
+
+def test_extracts_plural_tool_calls_array_and_preserves_surrounding_text():
+    text = (
+        'before <tool_calls>[{"id":"a","name":"read_file",'
+        '"arguments":{"path":"a.md"}},{"id":"b","name":"terminal",'
+        '"arguments":{"command":"pwd"}}]</tool_calls> after'
+    )
+
+    result = extract_inline_tool_calls(text)
+
+    assert result.content == "before  after"
+    assert [call.id for call in result.tool_calls] == ["a", "b"]
+    assert [call.name for call in result.tool_calls] == ["read_file", "terminal"]
+
+
+def test_prose_mention_is_not_extracted():
+    text = "Use <tool_use> in docs when describing Anthropic blocks."
+
+    result = extract_inline_tool_calls(text)
+
+    assert result.tool_calls == []
+    assert result.parsed_spans == []
+    assert result.content == text
+
+
+def test_prose_mention_before_actual_tool_use_is_skipped():
+    text = (
+        "Use <tool_use> in docs first.\n"
+        '<tool_use>{"id":"t1","name":"terminal","input":{"command":"pwd"}}</tool_use>'
+    )
+
+    result = extract_inline_tool_calls(text)
+
+    assert len(result.tool_calls) == 1
+    assert result.tool_calls[0].id == "t1"
+    assert result.content == "Use <tool_use> in docs first.\n"
+
+
+def test_quoted_tool_use_example_is_not_extracted():
+    text = (
+        'Example: "<tool_use>{"name":"read_file",'
+        '"input":{"path":"README.md"}}</tool_use>"'
+    )
+
+    result = extract_inline_tool_calls(text)
+
+    assert result.tool_calls == []
+    assert result.parsed_spans == []
+    assert result.content == text
+
+
+def test_backticked_tool_use_example_is_not_extracted():
+    text = '`<tool_use>{"name":"read_file","input":{"path":"README.md"}}</tool_use>`'
+
+    result = extract_inline_tool_calls(text)
+
+    assert result.tool_calls == []
+    assert result.parsed_spans == []
+    assert result.content == text
+
+
+def test_surrounding_whitespace_is_preserved():
+    text = (
+        '  before <tool_use>{"name":"terminal",'
+        '"input":{"command":"pwd"}}</tool_use> after  '
+    )
+
+    result = extract_inline_tool_calls(text)
+
+    assert len(result.tool_calls) == 1
+    assert result.content == "  before  after  "
+
+
+def test_malformed_json_is_not_extracted():
+    text = '<tool_use>{"name": </tool_use>'
+
+    result = extract_inline_tool_calls(text)
+
+    assert result.tool_calls == []
+    assert result.parsed_spans == []
+    assert result.content == text
+
+
+def test_missing_name_is_not_extracted():
+    text = '<tool_use>{"arguments":{"path":"README.md"}}</tool_use>'
+
+    result = extract_inline_tool_calls(text)
+
+    assert result.tool_calls == []
+    assert result.parsed_spans == []
+    assert result.content == text
+
+
+def test_missing_id_gets_stable_generated_id():
+    text = '<tool_use>{"name":"read_file","arguments":{"path":"README.md"}}</tool_use>'
+
+    first = extract_inline_tool_calls(text)
+    second = extract_inline_tool_calls(text)
+
+    assert len(first.tool_calls) == 1
+    assert first.tool_calls[0].id.startswith("call_inline_")
+    assert first.tool_calls[0].id == second.tool_calls[0].id

--- a/tests/agent/transports/test_chat_completions.py
+++ b/tests/agent/transports/test_chat_completions.py
@@ -1,5 +1,7 @@
 """Tests for the ChatCompletionsTransport."""
 
+import json
+
 import pytest
 from types import SimpleNamespace
 
@@ -675,6 +677,100 @@ class TestChatCompletionsNormalize:
         assert len(nr.tool_calls) == 1
         assert nr.tool_calls[0].name == "terminal"
         assert nr.tool_calls[0].id == "call_123"
+
+    def test_inline_tool_use_response(self, transport):
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(
+                    content=(
+                        '<tool_use>{"id":"t1","name":"terminal",'
+                        '"input":{"command":"pwd"}}</tool_use>'
+                    ),
+                    tool_calls=None,
+                    reasoning_content=None,
+                ),
+                finish_reason="stop",
+            )],
+            usage=SimpleNamespace(prompt_tokens=10, completion_tokens=20, total_tokens=30),
+        )
+
+        nr = transport.normalize_response(r)
+
+        assert nr.content is None
+        assert nr.finish_reason == "tool_calls"
+        assert len(nr.tool_calls) == 1
+        assert nr.tool_calls[0].id == "t1"
+        assert nr.tool_calls[0].name == "terminal"
+        assert json.loads(nr.tool_calls[0].arguments) == {"command": "pwd"}
+        assert nr.usage.total_tokens == 30
+
+    def test_inline_tool_use_preserves_length_finish_reason(self, transport):
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(
+                    content='<tool_use>{"name":"terminal","input":{}}</tool_use>',
+                    tool_calls=None,
+                    reasoning_content=None,
+                ),
+                finish_reason="length",
+            )],
+            usage=None,
+        )
+
+        nr = transport.normalize_response(r)
+
+        assert nr.finish_reason == "length"
+        assert len(nr.tool_calls) == 1
+
+    def test_inline_tool_use_preserves_surrounding_text_and_reasoning(self, transport):
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(
+                    content=(
+                        'I will check. <tool_use>{"id":"t1","name":"terminal",'
+                        '"input":{"command":"pwd"}}</tool_use> Done.'
+                    ),
+                    tool_calls=None,
+                    reasoning="summary text",
+                    reasoning_content="scratchpad",
+                ),
+                finish_reason="stop",
+            )],
+            usage=None,
+        )
+
+        nr = transport.normalize_response(r)
+
+        assert nr.content == "I will check.  Done."
+        assert nr.finish_reason == "tool_calls"
+        assert nr.reasoning == "summary text"
+        assert nr.reasoning_content == "scratchpad"
+        assert len(nr.tool_calls) == 1
+
+    def test_structured_tool_calls_take_precedence_over_inline_text(self, transport):
+        tc = SimpleNamespace(
+            id="call_123",
+            function=SimpleNamespace(name="terminal", arguments='{"command": "ls"}'),
+        )
+        content = '<tool_use>{"id":"inline","name":"read_file","input":{}}</tool_use>'
+        r = SimpleNamespace(
+            choices=[SimpleNamespace(
+                message=SimpleNamespace(
+                    content=content,
+                    tool_calls=[tc],
+                    reasoning_content=None,
+                ),
+                finish_reason="tool_calls",
+            )],
+            usage=None,
+        )
+
+        nr = transport.normalize_response(r)
+
+        assert nr.content == content
+        assert len(nr.tool_calls) == 1
+        assert nr.tool_calls[0].id == "call_123"
+        assert nr.tool_calls[0].name == "terminal"
 
     def test_tool_call_extra_content_preserved(self, transport):
         """Gemini 3 thinking models attach extra_content with thought_signature

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -393,6 +393,25 @@ class TestStripThinkBlocks:
         assert "read_file" not in result
         assert "done" in result
 
+    def test_tool_use_block_stripped(self, agent):
+        text = '<tool_use>{"name":"read_file","input":{"path":"/tmp/x"}}</tool_use> done'
+        result = agent._strip_think_blocks(text)
+        assert "<tool_use>" not in result
+        assert "read_file" not in result
+        assert "done" in result
+
+    def test_tool_call_closing_tag_inside_json_string_stripped(self, agent):
+        text = (
+            'before <tool_call>{"name":"write_file",'
+            '"arguments":{"content":"</tool_call>"}}</tool_call> after'
+        )
+        result = agent._strip_think_blocks(text)
+        assert "<tool_call>" not in result
+        assert "</tool_call>" not in result
+        assert '"}}' not in result
+        assert "before" in result
+        assert "after" in result
+
     def test_function_calls_block_stripped(self, agent):
         text = '<function_calls>[{"name":"x"}]</function_calls>after'
         result = agent._strip_think_blocks(text)
@@ -2493,6 +2512,34 @@ class TestRunConversation:
         assert result["api_calls"] == 2
         assert mock_handle_function_call.call_args.kwargs["tool_call_id"] == "c1"
         assert mock_handle_function_call.call_args.kwargs["session_id"] == agent.session_id
+
+    def test_inline_tool_use_content_then_stop(self, agent):
+        self._setup_agent(agent)
+        resp1 = _mock_response(
+            content=(
+                '<tool_use>{"id":"c1","name":"web_search",'
+                '"input":{"query":"hermes"}}</tool_use>'
+            ),
+            finish_reason="stop",
+        )
+        resp2 = _mock_response(content="Done searching", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [resp1, resp2]
+
+        with (
+            patch("run_agent.handle_function_call", return_value="search result") as mock_handle_function_call,
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("search something")
+
+        assert result["final_response"] == "Done searching"
+        assert result["api_calls"] == 2
+        assert mock_handle_function_call.call_args.args[:2] == (
+            "web_search",
+            {"query": "hermes"},
+        )
+        assert mock_handle_function_call.call_args.kwargs["tool_call_id"] == "c1"
 
     def test_request_scoped_api_hooks_fire_for_each_api_call(self, agent):
         self._setup_agent(agent)


### PR DESCRIPTION
## Summary

Fixes #22696.

Some OpenAI-compatible chat-completions providers can emit tool calls as inline XML-wrapped JSON in the assistant `content` field, especially `<tool_use>{...}</tool_use>`, instead of returning structured `tool_calls`. The previous cleanup path was regex-oriented and could be tripped up when JSON string values themselves contained text such as `</tool_use>` or `</tool_call>`.

This PR adds a small JSON-aware inline tool-call extractor and wires it into the chat-completions response normalization path so Hermes can recover those calls before the main agent loop decides whether to execute tools.

## What Changed

- Added `agent/inline_tool_calls.py` with a JSON-boundary scanner for inline XML tool-call blocks.
- Supports `<tool_use>`, `<tool_call>`, `<tool_calls>`, `<function_call>`, and `<function_calls>` payloads.
- Handles nested JSON and string values containing closing-tag text without prematurely terminating the block.
- Converts valid inline payloads into normalized `ToolCall` objects.
- Leaves malformed blocks and plain prose mentions alone instead of guessing.
- Preserves structured provider `tool_calls` precedence when they are present.
- Keeps `<tool_result>` cleanup-only in `run_agent.py`; tool results are never treated as executable calls.
- Adds focused tests for helper behavior, chat-completions normalization, final-content cleanup, and the mocked agent loop.

## Design Notes

The extractor intentionally only executes known XML tags with valid JSON payloads and a tool name. It does not try to parse arbitrary XML or repair malformed payloads, which keeps the behavior predictable and avoids turning documentation examples or broken content into accidental tool calls.

When inline calls are recovered from a normal `stop` response, the normalized finish reason is upgraded to `tool_calls`. Other finish reasons, such as `length`, are preserved so truncation handling still works as before.

## Validation

- `HERMES_HOME=/private/tmp/hermes-agent-issue-22696/.test-hermes scripts/run_tests.sh tests/agent/test_inline_tool_calls.py tests/agent/transports/test_chat_completions.py tests/run_agent/test_run_agent.py`
  - `409 passed`
- `.venv/bin/ruff check agent/inline_tool_calls.py agent/transports/chat_completions.py run_agent.py tests/agent/test_inline_tool_calls.py tests/agent/transports/test_chat_completions.py tests/run_agent/test_run_agent.py`
  - passed
- `git diff --check`
  - passed
- `.venv/bin/ruff format --check agent/inline_tool_calls.py tests/agent/test_inline_tool_calls.py`
  - passed
