### PR TITLE
fix(tools): redact secrets in persisted tool-result preview

### DIFF
--- a/tests/tools/test_tool_result_storage.py
+++ b/tests/tools/test_tool_result_storage.py
@@ -422,6 +422,85 @@ class TestMaybePersistToolResult:
         assert PERSISTED_OUTPUT_TAG in result
 
 
+# ── preview redaction ─────────────────────────────────────────────────
+
+class TestPreviewRedaction:
+    """Inline previews embedded in <persisted-output> blocks must be scrubbed
+    of obvious secrets before they land in durable session/transcript state.
+    The full content written to the sandbox file stays untouched so the model
+    can still read_file the original."""
+
+    def test_canary_secret_redacted_in_preview(self):
+        env = MagicMock()
+        env.execute.return_value = {"output": "", "returncode": 0}
+        # Synthetic canary: an OpenAI-style key prefix followed by enough
+        # filler to push past the persistence threshold.
+        secret = "sk-CANARYabcdefghijklmnopqrstuv"
+        content = f"line 0 {secret}\n" + "filler line\n" * 5_000
+        result = maybe_persist_tool_result(
+            content=content,
+            tool_name="terminal",
+            tool_use_id="tc_redact",
+            env=env,
+            threshold=30_000,
+        )
+        assert PERSISTED_OUTPUT_TAG in result
+        # Raw secret must not survive into the in-context preview.
+        assert secret not in result
+
+    def test_full_content_to_sandbox_is_not_redacted(self):
+        """The on-disk copy stays verbatim — only the preview is scrubbed."""
+        env = MagicMock()
+        env.execute.return_value = {"output": "", "returncode": 0}
+        secret = "sk-CANARYabcdefghijklmnopqrstuv"
+        content = f"{secret}\n" + "x" * 60_000
+        maybe_persist_tool_result(
+            content=content,
+            tool_name="terminal",
+            tool_use_id="tc_disk",
+            env=env,
+            threshold=30_000,
+        )
+        # stdin payload must be byte-exact — the model needs to recover the
+        # original via read_file.
+        assert env.execute.call_args[1]["stdin_data"] == content
+
+    def test_redaction_failure_falls_back_to_raw_preview(self):
+        """If redact_sensitive_text raises, persistence still succeeds with
+        the un-redacted preview rather than breaking tool execution."""
+        env = MagicMock()
+        env.execute.return_value = {"output": "", "returncode": 0}
+        content = "DISTINCTIVE_PREVIEW_TOKEN " + "x" * 60_000
+        with patch(
+            "agent.redact.redact_sensitive_text",
+            side_effect=RuntimeError("regex engine exploded"),
+        ):
+            result = maybe_persist_tool_result(
+                content=content,
+                tool_name="terminal",
+                tool_use_id="tc_fallback",
+                env=env,
+                threshold=30_000,
+            )
+        assert PERSISTED_OUTPUT_TAG in result
+        assert "DISTINCTIVE_PREVIEW_TOKEN" in result
+
+    def test_inline_truncation_path_also_redacts(self):
+        """The no-env / write-failed fallback also has to scrub the preview —
+        it's the same persistence boundary."""
+        secret = "ghp_CANARYabcdefghijklmnop"
+        content = f"{secret}\n" + "y" * 60_000
+        result = maybe_persist_tool_result(
+            content=content,
+            tool_name="terminal",
+            tool_use_id="tc_inline_redact",
+            env=None,
+            threshold=30_000,
+        )
+        assert "Truncated" in result
+        assert secret not in result
+
+
 # ── enforce_turn_budget ───────────────────────────────────────────────
 
 class TestEnforceTurnBudget:

--- a/tools/tool_result_storage.py
+++ b/tools/tool_result_storage.py
@@ -68,6 +68,26 @@ def generate_preview(content: str, max_chars: int = DEFAULT_PREVIEW_SIZE_CHARS) 
     return truncated, True
 
 
+def _redact_preview(preview: str) -> str:
+    """Apply secret redaction to a persisted-output preview.
+
+    The full content written to the sandbox file is untouched (the model can
+    still read_file the original); only the bounded preview that lands in
+    durable session/transcript state is scrubbed. ``force=True`` because this
+    is a privacy boundary that should fire regardless of the operator's
+    global ``security.redact_secrets`` setting. Any exception falls back to
+    the un-redacted preview rather than breaking tool execution.
+    """
+    if not preview:
+        return preview
+    try:
+        from agent.redact import redact_sensitive_text
+        return redact_sensitive_text(preview, force=True)
+    except Exception as exc:
+        logger.warning("Preview redaction failed, using raw preview: %s", exc)
+        return preview
+
+
 def _heredoc_marker(content: str) -> str:
     """Return a heredoc delimiter that doesn't collide with content."""
     if HEREDOC_MARKER not in content:
@@ -155,6 +175,7 @@ def maybe_persist_tool_result(
     storage_dir = _resolve_storage_dir(env)
     remote_path = f"{storage_dir}/{tool_use_id}.txt"
     preview, has_more = generate_preview(content, max_chars=config.preview_size)
+    redacted_preview = _redact_preview(preview)
 
     if env is not None:
         try:
@@ -163,7 +184,7 @@ def maybe_persist_tool_result(
                     "Persisted large tool result: %s (%s, %d chars -> %s)",
                     tool_name, tool_use_id, len(content), remote_path,
                 )
-                return _build_persisted_message(preview, has_more, len(content), remote_path)
+                return _build_persisted_message(redacted_preview, has_more, len(content), remote_path)
         except Exception as exc:
             logger.warning("Sandbox write failed for %s: %s", tool_use_id, exc)
 
@@ -172,7 +193,7 @@ def maybe_persist_tool_result(
         tool_name, len(content),
     )
     return (
-        f"{preview}\n\n"
+        f"{redacted_preview}\n\n"
         f"[Truncated: tool response was {len(content):,} chars. "
         f"Full output could not be saved to sandbox.]"
     )


### PR DESCRIPTION
Apply secret redaction to the bounded preview that lands in durable session/transcript state when a large tool result is spilled to the sandbox.

## What changed and why
- `tools/tool_result_storage.py`: new `_redact_preview()` helper that calls `agent.redact.redact_sensitive_text(preview, force=True)` and falls back to the raw preview on any exception; wired into `maybe_persist_tool_result` so both the `<persisted-output>` block and the no-env / write-failed inline-truncation fallback receive the scrubbed preview. The full content written to the sandbox file is untouched — the model can still recover the original via `read_file`.
- `force=True` because this is a privacy boundary and should fire regardless of the operator's global `security.redact_secrets` setting (matches how `send_message_tool.py` and `code_execution_tool.py` already use the same helper for output that crosses a trust boundary).
- `tests/tools/test_tool_result_storage.py`: 4 new tests in a `TestPreviewRedaction` class — canary `sk-…` token in preview is masked, full stdin payload to sandbox stays byte-exact, redaction-helper failure falls back to the raw preview rather than breaking tool execution, and the no-env truncation path also redacts.

Scope is intentionally narrow (item 3 of the issue). Items 1, 2, 4, 5, and 6 the issue lists were already implemented in the file (stdin-based sandbox writes via `env.execute(..., stdin_data=...)`, aggregate `enforce_turn_budget` that skips already-persisted blocks via the `PERSISTED_OUTPUT_TAG` check, and existing test coverage for those mechanics). Touching SQLite `append_message` to redact tool-role content before insert would also affect FTS5 indexing and message replay; that belongs in a separate PR if maintainers want it.

## How to test
- `pytest tests/tools/test_tool_result_storage.py -q --timeout=60` — 53 tests pass (49 existing + 4 new).
- Manual smoke: `python -c "from tools.tool_result_storage import _redact_preview; print(_redact_preview('sk-CANARYabcdefghijklmnopqrstuv inside'))"` returns `sk-CAN...stuv inside`.

## What platforms tested on
- macOS on darwin-arm64 (local)

Fixes #23200

<!-- autocontrib:worker-id=issue-new-13296801 kind=pr-open -->