### PR TITLE
fix(vision): skip ollama-cloud in auto vision routing

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -303,6 +303,7 @@ _PROVIDER_VISION_MODELS: Dict[str, str] = {
 _PROVIDERS_WITHOUT_VISION: frozenset = frozenset({
     "kimi-coding",
     "kimi-coding-cn",
+    "ollama-cloud",
 })
 
 # OpenRouter app attribution headers (base — always sent).

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2035,12 +2035,39 @@ class TestVisionAutoSkipsKimiCoding:
         assert client is fake_kimi_client
         gcc_mock.assert_called_once()
 
+    def test_ollama_cloud_skips_to_aggregator_chain(self, monkeypatch):
+        """Ollama Cloud should fall through to the aggregator chain for vision."""
+        fake_or_client = MagicMock(name="openrouter_client")
+
+        monkeypatch.setattr(
+            "agent.auxiliary_client._read_main_provider", lambda: "ollama-cloud",
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._read_main_model", lambda: "glm-5.1:cloud",
+        )
+        rpc_mock = MagicMock(side_effect=AssertionError(
+            "resolve_provider_client should NOT be called for ollama-cloud"))
+        monkeypatch.setattr(
+            "agent.auxiliary_client.resolve_provider_client", rpc_mock,
+        )
+        monkeypatch.setattr(
+            "agent.auxiliary_client._resolve_strict_vision_backend",
+            lambda p, m=None: (fake_or_client, "gemini")
+            if p == "openrouter"
+            else (None, None),
+        )
+
+        provider, client, _ = resolve_vision_provider_client()
+        assert provider == "openrouter"
+        assert client is fake_or_client
+
     def test_skip_set_covers_exactly_known_entries(self):
         """Guard against accidental widening of the skip list."""
         from agent.auxiliary_client import _PROVIDERS_WITHOUT_VISION
         assert _PROVIDERS_WITHOUT_VISION == frozenset({
             "kimi-coding",
             "kimi-coding-cn",
+            "ollama-cloud",
         })
 
 


### PR DESCRIPTION
## What does this PR do?

Skips `ollama-cloud` in auto vision routing so `vision_analyze` falls through to the aggregator chain instead of trying a provider path that does not accept image input.

## Related Issue

Fixes #23422

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- add `ollama-cloud` to `_PROVIDERS_WITHOUT_VISION` in `agent/auxiliary_client.py`
- add a regression test proving auto vision routing skips `ollama-cloud` and falls through to OpenRouter
- extend the skip-set guard test to cover the new provider

## How to Test

1. `uv run --frozen pytest -q -o addopts='' tests/agent/test_auxiliary_client.py -k 'VisionAutoSkipsKimiCoding or ollama_cloud_skips_to_aggregator_chain'`
2. `uv run --frozen ruff check agent/auxiliary_client.py tests/agent/test_auxiliary_client.py`
3. `env -i HOME="$HOME" PATH="$PATH" TERM="${TERM:-xterm-256color}" UV_CACHE_DIR="$HOME/.cache/uv" uv run --frozen pytest -q -o addopts='' --collect-only tests/agent/test_auxiliary_client.py -k 'VisionAutoSkipsKimiCoding or ollama_cloud_skips_to_aggregator_chain'`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `5 passed, 143 deselected in 1.78s`
- `All checks passed!` from `ruff check`
- collect-only smoke passed with `5/148 tests collected (143 deselected)`
