### PR TITLE
feat(telegram): native draft streaming via sendMessageDraft (Bot API 9.5+) (salvage of #3412)

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -321,7 +321,15 @@ class PlatformConfig:
 class StreamingConfig:
     """Configuration for real-time token streaming to messaging platforms."""
     enabled: bool = False
-    transport: str = "edit"       # "edit" (progressive editMessageText) or "off"
+    # Transport selection:
+    #   "auto"  — prefer native streaming-draft updates when the platform
+    #             supports them (Telegram sendMessageDraft, Bot API 9.5+);
+    #             fall back to edit-based when not.  Recommended.
+    #   "draft" — explicitly request native drafts; falls back to edit when
+    #             the platform/chat doesn't support them.
+    #   "edit"  — progressive editMessageText only (legacy behaviour).
+    #   "off"   — disable streaming entirely.
+    transport: str = "auto"
     edit_interval: float = 1.0    # Seconds between message edits (Telegram rate-limits at ~1/s)
     buffer_threshold: int = 40    # Chars before forcing an edit
     cursor: str = " ▉"           # Cursor shown during streaming
@@ -350,7 +358,7 @@ class StreamingConfig:
             return cls()
         return cls(
             enabled=_coerce_bool(data.get("enabled"), False),
-            transport=data.get("transport", "edit"),
+            transport=data.get("transport", "auto"),
             edit_interval=_coerce_float(data.get("edit_interval"), 1.0),
             buffer_threshold=_coerce_int(data.get("buffer_threshold"), 40),
             cursor=data.get("cursor", " ▉"),

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -1320,6 +1320,52 @@ class BasePlatformAdapter(ABC):
         """
         return len
 
+    def supports_draft_streaming(
+        self,
+        chat_type: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """Whether this adapter supports native streaming-draft updates.
+
+        Telegram Bot API 9.5 introduced ``sendMessageDraft``, which renders an
+        animated streaming preview as the bot calls it repeatedly with the
+        same ``draft_id`` and growing text.  Adapters that implement
+        ``send_draft`` should return True here for the chat types where the
+        platform supports it (Telegram restricts drafts to private DMs).
+
+        Default implementation returns False.  Stream consumers fall back to
+        the edit-based path (``send`` + ``edit_message``) when this returns
+        False or when ``send_draft`` raises.
+        """
+        return False
+
+    async def send_draft(
+        self,
+        chat_id: str,
+        draft_id: int,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Send or update an animated streaming-draft preview.
+
+        Reuse the same ``draft_id`` (any non-zero int) across consecutive
+        calls within a single response so the platform animates the preview
+        rather than re-creating it.  Different responses must use different
+        ``draft_id`` values within the same chat to avoid animating over a
+        prior bubble.
+
+        Drafts have no message_id and cannot be edited, replied to, or
+        deleted via normal message APIs.  When the response finishes, the
+        caller delivers the final answer as a regular ``send`` and the
+        draft preview clears naturally on the client.
+
+        Default implementation raises NotImplementedError; adapters that
+        also return True from :meth:`supports_draft_streaming` must override.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not implement send_draft"
+        )
+
     @property
     def has_fatal_error(self) -> bool:
         return self._fatal_error_message is not None

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1686,6 +1686,77 @@ class TelegramAdapter(BasePlatformAdapter):
             )
             return False
 
+    def supports_draft_streaming(
+        self,
+        chat_type: Optional[str] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> bool:
+        """Telegram supports sendMessageDraft for private chats only.
+
+        Bot API 9.5 (March 2026) opened ``sendMessageDraft`` to all bots
+        unconditionally for private (DM) chats.  Groups, supergroups, and
+        channels still rely on the edit-based path.
+
+        We additionally require ``self._bot`` to expose ``send_message_draft``
+        (added to python-telegram-bot in 22.6); older PTB installs gracefully
+        fall back to the edit path even on DMs.
+        """
+        if not self._bot or not hasattr(self._bot, "send_message_draft"):
+            return False
+        return (chat_type or "").lower() in ("dm", "private")
+
+    async def send_draft(
+        self,
+        chat_id: str,
+        draft_id: int,
+        content: str,
+        metadata: Optional[Dict[str, Any]] = None,
+    ) -> SendResult:
+        """Stream a partial message via Telegram's native sendMessageDraft.
+
+        The Bot API animates the preview when the same ``draft_id`` is reused
+        across consecutive calls in the same chat.  When the response
+        finishes, the caller sends the final text via the normal ``send``
+        path; the draft preview clears naturally on the client (Telegram has
+        no Bot API to "promote" a draft to a real message — the final
+        ``sendMessage`` is what the user receives in their history).
+        """
+        if not self._bot:
+            return SendResult(success=False, error="not_connected")
+        if not hasattr(self._bot, "send_message_draft"):
+            return SendResult(success=False, error="api_unavailable")
+
+        # Trim to the same UTF-16 budget the platform enforces on regular
+        # sends.  Drafts have the same length contract as messages.
+        text = content if len(content) <= self.MAX_MESSAGE_LENGTH else \
+            self.truncate_message(content, self.MAX_MESSAGE_LENGTH, len_fn=utf16_len)[0]
+
+        kwargs: Dict[str, Any] = {
+            "chat_id": int(chat_id),
+            "draft_id": int(draft_id),
+            "text": text,
+        }
+        thread_id = self._metadata_thread_id(metadata)
+        if thread_id is not None:
+            kwargs["message_thread_id"] = thread_id
+
+        try:
+            ok = await self._bot.send_message_draft(**kwargs)
+            if ok:
+                # Drafts have no message_id; we report success without one
+                # so the caller knows the animation frame landed.
+                return SendResult(success=True, message_id=None)
+            return SendResult(success=False, error="draft_rejected")
+        except Exception as e:
+            # Most likely: BadRequest because this bot/chat doesn't allow
+            # drafts, or a transient server hiccup.  The caller treats any
+            # failure as "fall back to edit-based for this response".
+            logger.debug(
+                "[%s] sendMessageDraft failed (chat=%s draft_id=%s): %s",
+                self.name, chat_id, draft_id, e,
+            )
+            return SendResult(success=False, error=str(e))
+
     async def _send_message_with_thread_fallback(self, **kwargs):
         """Send a Telegram message, retrying once without message_thread_id
         if Telegram returns 'Message thread not found'.

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -13984,6 +13984,8 @@ class GatewayRunner:
                         cursor=_effective_cursor,
                         buffer_only=_buffer_only,
                         fresh_final_after_seconds=_fresh_final_secs,
+                        transport=_scfg.transport or "auto",
+                        chat_type=getattr(source, "chat_type", "") or "",
                     )
                     _stream_consumer = GatewayStreamConsumer(
                         adapter=_adapter,
@@ -14805,6 +14807,8 @@ class GatewayRunner:
                             cursor=_effective_cursor,
                             buffer_only=_buffer_only,
                             fresh_final_after_seconds=_fresh_final_secs,
+                            transport=_scfg.transport or "auto",
+                            chat_type=getattr(source, "chat_type", "") or "",
                         )
                         _stream_consumer = GatewayStreamConsumer(
                             adapter=_adapter,

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -55,6 +55,18 @@ class StreamConsumerConfig:
     # openclaw/openclaw#72038.  Default 0 = always edit in place (legacy
     # behavior).  The gateway enables this selectively per-platform.
     fresh_final_after_seconds: float = 0.0
+    # Streaming transport selection:
+    #   "auto"  — prefer native draft streaming (e.g. Telegram sendMessageDraft)
+    #             when the adapter + chat supports it; fall back to edit.
+    #   "draft" — explicitly request native draft streaming; fall back to
+    #             edit when unsupported.
+    #   "edit"  — progressive editMessageText (legacy behavior).
+    #   "off"   — handled by the gateway before the consumer is even built.
+    transport: str = "auto"
+    # Hint for the consumer about the originating chat type (e.g. "dm",
+    # "group", "supergroup", "forum").  Used to gate native draft streaming,
+    # which is platform-specific (Telegram drafts are DM-only).
+    chat_type: str = ""
 
 
 class GatewayStreamConsumer:
@@ -87,6 +99,11 @@ class GatewayStreamConsumer:
         "</REASONING_SCRATCHPAD>", "</think>", "</reasoning>",
         "</THINKING>", "</thinking>", "</thought>",
     )
+
+    # Class-wide monotonic counter for native-streaming draft ids.  Telegram
+    # animates a draft when the same draft_id is reused across consecutive
+    # calls in the same chat, so we need a fresh non-zero id per response.
+    _draft_id_counter: int = 0
 
     def __init__(
         self,
@@ -141,6 +158,20 @@ class GatewayStreamConsumer:
         self._in_think_block = False
         self._think_buffer = ""
 
+        # Native draft-streaming state.  Resolved at the start of run() based
+        # on cfg.transport, cfg.chat_type, and the adapter's
+        # supports_draft_streaming() probe.  When True, the consumer emits
+        # animated draft frames via adapter.send_draft instead of progressive
+        # edits via adapter.edit_message.  The final answer still goes
+        # through the normal first-send path so the user gets a real message
+        # in their chat history (drafts have no message_id).
+        self._use_draft_streaming = False
+        self._draft_id: Optional[int] = None
+        # Cumulative draft-frame failure count for this consumer.  After the
+        # first failure we permanently disable drafts for the remainder of
+        # this response and route through edit-based for graceful degradation.
+        self._draft_failures = 0
+
     @property
     def already_sent(self) -> bool:
         """True if at least one message was sent or edited during the run."""
@@ -179,6 +210,16 @@ class GatewayStreamConsumer:
         self._last_sent_text = ""
         self._fallback_final_send = False
         self._fallback_prefix = ""
+        # Native draft streaming: bump the draft_id so the next text segment
+        # animates as a fresh preview below the tool-progress bubbles, not
+        # over the prior segment's already-finalized draft.  This is how
+        # we avoid the "inter-tool-call text leak" failure mode openclaw
+        # documented in their issue #32535 — each text block becomes its
+        # own visible message via the finalize, then a new draft animates
+        # for the next one.
+        if self._use_draft_streaming:
+            type(self)._draft_id_counter += 1
+            self._draft_id = type(self)._draft_id_counter
 
     def on_delta(self, text: str) -> None:
         """Thread-safe callback — called from the agent's worker thread.
@@ -316,6 +357,20 @@ class GatewayStreamConsumer:
         )
         _raw_limit = getattr(self.adapter, "MAX_MESSAGE_LENGTH", 4096)
         _safe_limit = max(500, _raw_limit - _len_fn(self.cfg.cursor) - 100)
+
+        # Resolve native draft streaming once per run.  When enabled the
+        # consumer routes mid-stream frames through adapter.send_draft and
+        # leaves _message_id=None so the existing got_done path delivers the
+        # final answer as a regular sendMessage (drafts have no message_id
+        # to edit).
+        self._use_draft_streaming = self._resolve_draft_streaming()
+        if self._use_draft_streaming:
+            type(self)._draft_id_counter += 1
+            self._draft_id = type(self)._draft_id_counter
+            logger.debug(
+                "Stream consumer using native-draft transport (chat=%s draft_id=%s)",
+                self.chat_id, self._draft_id,
+            )
 
         try:
             while True:
@@ -754,6 +809,89 @@ class GatewayStreamConsumer:
         err_lower = err.lower()
         return "flood" in err_lower or "retry after" in err_lower or "rate" in err_lower
 
+    def _resolve_draft_streaming(self) -> bool:
+        """Decide whether this run should use native draft streaming.
+
+        Honors ``cfg.transport``:
+          * ``"edit"``  → never use drafts (legacy progressive-edit path).
+          * ``"draft"`` → require draft support; gracefully fall back to edit
+            when the adapter declines.  Logs the downgrade at debug.
+          * ``"auto"``  → use drafts when the adapter supports them for this
+            chat type; otherwise edit.
+
+        Adapter eligibility is checked via
+        :meth:`BasePlatformAdapter.supports_draft_streaming`, which considers
+        the chat type (e.g. Telegram drafts are DM-only) and platform-version
+        gates (e.g. python-telegram-bot 22.6+).
+        """
+        transport = (self.cfg.transport or "auto").lower()
+        if transport == "edit":
+            return False
+        # "off" is filtered upstream by the gateway; treat as edit defensively.
+        if transport == "off":
+            return False
+        # Test adapters are MagicMocks that don't subclass BasePlatformAdapter;
+        # default them to edit so existing test behaviour is preserved.
+        if not isinstance(self.adapter, _BasePlatformAdapter):
+            return False
+        try:
+            supported = self.adapter.supports_draft_streaming(
+                chat_type=self.cfg.chat_type or None,
+                metadata=self.metadata,
+            )
+        except Exception:
+            logger.debug("supports_draft_streaming probe raised", exc_info=True)
+            supported = False
+        if not supported:
+            if transport == "draft":
+                logger.debug(
+                    "Draft streaming requested but unsupported (chat=%s, type=%r) — "
+                    "falling back to edit",
+                    self.chat_id, self.cfg.chat_type,
+                )
+            return False
+        return True
+
+    async def _send_draft_frame(self, text: str) -> bool:
+        """Emit a single animated draft frame for the current accumulated text.
+
+        Returns True when the frame landed.  On any failure, permanently
+        disables drafts for the remainder of this run so subsequent frames
+        flow through the edit-based path (which can adapt with flood-control
+        backoff, etc.).  Drafts have no message_id and clear naturally on
+        the client when the response finalizes via a regular sendMessage.
+        """
+        if self._draft_id is None:
+            # Defensive: should never happen — _use_draft_streaming gate is
+            # set in tandem with _draft_id in run().  Disable to be safe.
+            self._use_draft_streaming = False
+            return False
+        try:
+            result = await self.adapter.send_draft(
+                chat_id=self.chat_id,
+                draft_id=self._draft_id,
+                content=text,
+                metadata=self.metadata,
+            )
+        except Exception as e:
+            logger.debug(
+                "send_draft raised, disabling draft transport for this run: %s", e,
+            )
+            self._draft_failures += 1
+            self._use_draft_streaming = False
+            return False
+        if not getattr(result, "success", False):
+            logger.debug(
+                "send_draft returned success=False, disabling draft transport: %s",
+                getattr(result, "error", "unknown"),
+            )
+            self._draft_failures += 1
+            self._use_draft_streaming = False
+            return False
+        # Frame delivered.  Track text for parity with edit-based no-op skip.
+        self._last_sent_text = text
+        return True
+
     async def _flush_segment_tail_on_edit_failure(self) -> None:
         """Deliver un-sent tail content before a segment-break reset.
 
@@ -948,6 +1086,35 @@ class GatewayStreamConsumer:
                 and self.cfg.cursor in text
                 and len(_visible_stripped) < _MIN_NEW_MSG_CHARS):
             return True  # too short for a standalone message — accumulate more
+
+        # Native draft streaming: route mid-stream frames through send_draft.
+        # The final answer is delivered via the regular sendMessage path
+        # below — drafts have no message_id so we can't finalize them
+        # in-place; the regular sendMessage clears the draft naturally on
+        # the client and gives the user a real message in their history.
+        # Skip when:
+        #   * finalize=True (this is the final answer; needs to be a real message)
+        #   * an edit path is already established (message_id is set, e.g. after
+        #     a tool-boundary segment break where the prior text was finalized
+        #     as a real sendMessage and the next text segment continues editing
+        #     that one — staying on edit-based for that segment is correct).
+        if (
+            self._use_draft_streaming
+            and not finalize
+            and self._message_id is None
+        ):
+            # No-op skip: identical to the last frame we sent.
+            if text == self._last_sent_text:
+                return True
+            ok = await self._send_draft_frame(text)
+            if ok:
+                # Drafts mark "we put something on screen" but DO NOT set
+                # _already_sent — that flag gates the gateway's fallback
+                # final-send path and we still need that to fire so the
+                # user gets a real message (drafts have no message_id).
+                return True
+            # Failure already disabled drafts for this run; fall through to
+            # the regular edit/send path below.
         try:
             if self._message_id is not None:
                 if self._edit_supported:

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -64,6 +64,8 @@ AUTHOR_MAP = {
     "aubrey@freeman-wisco.com": "Freeman-Consulting",
     "don.rhm@gmail.com": "rahimsais",
     "40222899+rahimsais@users.noreply.github.com": "rahimsais",
+    "alfred@Alfreds-Mac-mini.local": "NivOO5",
+    "231191380+NivOO5@users.noreply.github.com": "NivOO5",
     "ra2157218@gmail.com": "Abd0r",
     "abdielv@proton.me": "AJV20",
     "mason@growagainorchids.com": "masonjames",

--- a/tests/gateway/test_stream_consumer_draft.py
+++ b/tests/gateway/test_stream_consumer_draft.py
@@ -1,0 +1,318 @@
+"""Tests for native draft streaming in GatewayStreamConsumer.
+
+Telegram Bot API 9.5 (March 2026) introduced sendMessageDraft for native
+animated streaming previews in private chats.  This test suite covers the
+consumer's transport-selection, fallback, and tool-boundary handling for
+that path.
+
+Adapter under test is a runtime subclass of BasePlatformAdapter that
+overrides supports_draft_streaming + send_draft, since the consumer's
+isinstance(BasePlatformAdapter) gate excludes plain MagicMocks.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gateway.stream_consumer import (
+    GatewayStreamConsumer,
+    StreamConsumerConfig,
+)
+
+
+def _make_draft_capable_adapter(
+    *, supports_draft: bool = True, draft_succeeds: bool = True,
+):
+    """Build a minimal BasePlatformAdapter subclass with draft support.
+
+    The runtime subclass + cleared __abstractmethods__ pattern lets us
+    construct an adapter without hauling in any platform's heavy state
+    (Telegram bot, Discord client, etc.) while still satisfying the
+    consumer's isinstance(BasePlatformAdapter) gate.
+    """
+    from gateway.platforms.base import BasePlatformAdapter, SendResult
+
+    DraftCapableAdapter = type(
+        "DraftCapableAdapter",
+        (BasePlatformAdapter,),
+        {"MAX_MESSAGE_LENGTH": 4096},
+    )
+    DraftCapableAdapter.__abstractmethods__ = frozenset()
+    adapter = DraftCapableAdapter.__new__(DraftCapableAdapter)
+    adapter._typing_paused = set()
+    adapter._fatal_error_message = None
+
+    # Track every send_draft call for assertions.
+    adapter.draft_calls = []
+
+    def _supports(chat_type=None, metadata=None):
+        return bool(supports_draft) and (chat_type or "").lower() == "dm"
+    adapter.supports_draft_streaming = _supports
+
+    async def _send_draft(*, chat_id, draft_id, content, metadata=None):
+        adapter.draft_calls.append({
+            "chat_id": chat_id,
+            "draft_id": draft_id,
+            "content": content,
+            "metadata": metadata,
+        })
+        if draft_succeeds:
+            return SendResult(success=True, message_id=None)
+        return SendResult(success=False, error="draft_rejected")
+    adapter.send_draft = _send_draft
+
+    # send / edit_message: count and return canned successes so the
+    # consumer's first-send + finalize paths work when drafts fall back
+    # or when delivering the final message.
+    adapter.send = AsyncMock(
+        return_value=SimpleNamespace(success=True, message_id="msg_real"),
+    )
+    adapter.edit_message = AsyncMock(
+        return_value=SimpleNamespace(success=True),
+    )
+    return adapter
+
+
+class TestDraftTransportSelection:
+    """Verify _resolve_draft_streaming picks the right transport."""
+
+    def test_auto_dm_with_draft_capable_adapter_picks_draft(self):
+        adapter = _make_draft_capable_adapter()
+        cfg = StreamConsumerConfig(transport="auto", chat_type="dm")
+        consumer = GatewayStreamConsumer(adapter, "12345", cfg)
+        assert consumer._resolve_draft_streaming() is True
+
+    def test_auto_group_falls_back_to_edit(self):
+        adapter = _make_draft_capable_adapter()
+        cfg = StreamConsumerConfig(transport="auto", chat_type="group")
+        consumer = GatewayStreamConsumer(adapter, "12345", cfg)
+        assert consumer._resolve_draft_streaming() is False
+
+    def test_explicit_edit_never_uses_drafts(self):
+        adapter = _make_draft_capable_adapter()
+        cfg = StreamConsumerConfig(transport="edit", chat_type="dm")
+        consumer = GatewayStreamConsumer(adapter, "12345", cfg)
+        assert consumer._resolve_draft_streaming() is False
+
+    def test_explicit_draft_unsupported_falls_back(self):
+        adapter = _make_draft_capable_adapter(supports_draft=False)
+        cfg = StreamConsumerConfig(transport="draft", chat_type="dm")
+        consumer = GatewayStreamConsumer(adapter, "12345", cfg)
+        assert consumer._resolve_draft_streaming() is False
+
+    def test_magicmock_adapter_falls_back_to_edit(self):
+        """MagicMock adapters (used in many existing tests) must default to
+        edit-based since their auto-attributes aren't real callables."""
+        adapter = MagicMock()
+        cfg = StreamConsumerConfig(transport="auto", chat_type="dm")
+        consumer = GatewayStreamConsumer(adapter, "12345", cfg)
+        assert consumer._resolve_draft_streaming() is False
+
+
+class TestDraftStreamingHappyPath:
+    """End-to-end: stream a few deltas in a DM, verify drafts animated and
+    the final message was delivered as a real sendMessage."""
+
+    @pytest.mark.asyncio
+    async def test_dm_stream_animates_draft_then_finalizes_with_send(self):
+        adapter = _make_draft_capable_adapter()
+        cfg = StreamConsumerConfig(
+            transport="auto", chat_type="dm",
+            edit_interval=0.01, buffer_threshold=5, cursor="",
+        )
+        consumer = GatewayStreamConsumer(adapter, "12345", cfg)
+
+        consumer.on_delta("Hello ")
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.05)
+        consumer.on_delta("world!")
+        await asyncio.sleep(0.05)
+        consumer.finish()
+        await task
+
+        # At least one draft frame landed.
+        assert len(adapter.draft_calls) >= 1, (
+            "expected at least one send_draft frame"
+        )
+        # Final draft frame held the full accumulated text.
+        assert adapter.draft_calls[-1]["content"] == "Hello world!"
+        # All draft frames in this run shared a single draft_id (animation).
+        draft_ids = {c["draft_id"] for c in adapter.draft_calls}
+        assert len(draft_ids) == 1
+        # Final answer was delivered as a regular sendMessage so the user
+        # sees a real message in their history (drafts have no message_id).
+        adapter.send.assert_awaited()
+        # And the final send carried the complete reply.
+        final_call = adapter.send.call_args
+        sent_content = (
+            final_call.kwargs.get("content")
+            if "content" in final_call.kwargs
+            else final_call.args[1] if len(final_call.args) > 1 else None
+        )
+        assert sent_content == "Hello world!"
+
+    @pytest.mark.asyncio
+    async def test_group_chat_skips_draft_path(self):
+        adapter = _make_draft_capable_adapter()
+        cfg = StreamConsumerConfig(
+            transport="auto", chat_type="group",
+            edit_interval=0.01, buffer_threshold=5, cursor="",
+        )
+        consumer = GatewayStreamConsumer(adapter, "67890", cfg)
+
+        consumer.on_delta("Group message")
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.05)
+        consumer.finish()
+        await task
+
+        # Group chats skip drafts entirely — no send_draft calls at all.
+        assert adapter.draft_calls == []
+        # Edit-based path delivered via send (first message).
+        adapter.send.assert_awaited()
+
+
+class TestDraftFallbackOnFailure:
+    """When a draft frame fails, the consumer disables drafts for the rest
+    of the response and continues via the edit-based path."""
+
+    @pytest.mark.asyncio
+    async def test_first_draft_failure_disables_drafts_for_run(self):
+        adapter = _make_draft_capable_adapter(draft_succeeds=False)
+        cfg = StreamConsumerConfig(
+            transport="auto", chat_type="dm",
+            edit_interval=0.01, buffer_threshold=5, cursor="",
+        )
+        consumer = GatewayStreamConsumer(adapter, "12345", cfg)
+
+        consumer.on_delta("Hello ")
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.05)
+        consumer.on_delta("world!")
+        await asyncio.sleep(0.05)
+        consumer.finish()
+        await task
+
+        # The consumer attempted draft, hit failure, disabled drafts.
+        assert consumer._draft_failures >= 1
+        assert consumer._use_draft_streaming is False
+        # Final message delivered via the regular send path.
+        adapter.send.assert_awaited()
+
+
+class TestDraftIdLifecycle:
+    """Each response gets its own draft_id (no animation collision across
+    consecutive responses to the same chat)."""
+
+    @pytest.mark.asyncio
+    async def test_consecutive_responses_use_distinct_draft_ids(self):
+        adapter = _make_draft_capable_adapter()
+        cfg1 = StreamConsumerConfig(
+            transport="auto", chat_type="dm",
+            edit_interval=0.01, buffer_threshold=5, cursor="",
+        )
+        consumer1 = GatewayStreamConsumer(adapter, "12345", cfg1)
+        consumer1.on_delta("First reply")
+        task1 = asyncio.create_task(consumer1.run())
+        await asyncio.sleep(0.05)
+        consumer1.finish()
+        await task1
+
+        cfg2 = StreamConsumerConfig(
+            transport="auto", chat_type="dm",
+            edit_interval=0.01, buffer_threshold=5, cursor="",
+        )
+        consumer2 = GatewayStreamConsumer(adapter, "12345", cfg2)
+        consumer2.on_delta("Second reply")
+        task2 = asyncio.create_task(consumer2.run())
+        await asyncio.sleep(0.05)
+        consumer2.finish()
+        await task2
+
+        # Two responses → two distinct draft_ids.
+        all_ids = {c["draft_id"] for c in adapter.draft_calls}
+        assert len(all_ids) >= 2, (
+            f"expected distinct draft_ids across responses; got {all_ids}"
+        )
+        # Every draft_id must be non-zero (Telegram's contract).
+        assert all(did != 0 for did in all_ids)
+
+    @pytest.mark.asyncio
+    async def test_tool_boundary_bumps_draft_id(self):
+        """After a segment break (tool boundary), the next text segment
+        animates via a new draft_id so it appears below the tool-progress
+        bubble rather than overwriting the prior segment's preview."""
+        adapter = _make_draft_capable_adapter()
+        cfg = StreamConsumerConfig(
+            transport="auto", chat_type="dm",
+            edit_interval=0.01, buffer_threshold=5, cursor="",
+        )
+        consumer = GatewayStreamConsumer(adapter, "12345", cfg)
+
+        consumer.on_delta("Pre-tool ")
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.05)
+        # Tool boundary
+        consumer.on_segment_break()
+        await asyncio.sleep(0.05)
+        consumer.on_delta("Post-tool")
+        await asyncio.sleep(0.05)
+        consumer.finish()
+        await task
+
+        # Pre-tool and post-tool segments must use different draft_ids.
+        draft_ids = [c["draft_id"] for c in adapter.draft_calls]
+        if len(draft_ids) >= 2:
+            # Find pre-tool and post-tool calls by content
+            pre_ids = {
+                c["draft_id"] for c in adapter.draft_calls
+                if "Pre-tool" in c["content"] and "Post-tool" not in c["content"]
+            }
+            post_ids = {
+                c["draft_id"] for c in adapter.draft_calls
+                if "Post-tool" in c["content"]
+            }
+            if pre_ids and post_ids:
+                assert pre_ids.isdisjoint(post_ids), (
+                    f"pre-tool and post-tool segments must use distinct "
+                    f"draft_ids; got pre={pre_ids} post={post_ids}"
+                )
+
+
+class TestAlreadySentInDraftMode:
+    """Drafts must NOT mark _already_sent — that flag gates the gateway's
+    fallback final-send path, which we still need to fire so the user gets
+    a real message in their history (drafts have no message_id)."""
+
+    @pytest.mark.asyncio
+    async def test_drafts_do_not_set_already_sent_until_real_message(self):
+        adapter = _make_draft_capable_adapter()
+        cfg = StreamConsumerConfig(
+            transport="auto", chat_type="dm",
+            edit_interval=0.01, buffer_threshold=5, cursor="",
+        )
+        consumer = GatewayStreamConsumer(adapter, "12345", cfg)
+
+        consumer.on_delta("Hello")
+        # Drive the consumer for a bit but DON'T finish — only drafts have
+        # been sent.
+        task = asyncio.create_task(consumer.run())
+        await asyncio.sleep(0.05)
+        # At this point drafts may have fired but we haven't finalized.
+        # _already_sent must still be False so a downstream fallback would
+        # know it needs to deliver the final answer.
+        if adapter.draft_calls:
+            assert consumer._already_sent is False, (
+                "drafts wrongly marked _already_sent — "
+                "would suppress gateway fallback delivery"
+            )
+
+        consumer.finish()
+        await task
+
+        # After the regular sendMessage finalize, _already_sent is True.
+        assert consumer._already_sent is True

--- a/website/docs/user-guide/messaging/telegram.md
+++ b/website/docs/user-guide/messaging/telegram.md
@@ -611,7 +611,33 @@ To find a topic's `thread_id`, open the topic in Telegram Web or Desktop and loo
 
 - **Bot API 9.4 (Feb 2026):** Private Chat Topics — bots can create forum topics in 1-on-1 DM chats via `createForumTopic`. Hermes uses this for two distinct features: operator-curated [Private Chat Topics](#private-chat-topics-bot-api-94) (config-driven, fixed topic list) and user-driven [Multi-session DM mode](#multi-session-dm-mode-topic) (activated by `/topic`, unlimited user-created topics).
 - **Privacy policy:** Telegram now requires bots to have a privacy policy. Set one via BotFather with `/setprivacy_policy`, or Telegram may auto-generate a placeholder. This is particularly important if your bot is public-facing.
-- **Message streaming:** Bot API 9.x added support for streaming long responses, which can improve perceived latency for lengthy agent replies.
+- **Bot API 9.5 (Mar 2026): Native streaming via `sendMessageDraft`.** Hermes uses Telegram's native streaming-draft API to render an animated preview of the agent's reply as tokens arrive in private chats. Drops the per-edit jitter you used to see with the legacy `editMessageText` polling path on slow models.
+
+### Streaming transport (`gateway.streaming.transport`)
+
+When streaming is enabled (`gateway.streaming.enabled: true`), Hermes picks one of four transports:
+
+| Value | Behaviour |
+|---|---|
+| `auto` (default) | Native draft streaming on supported chats (currently Telegram DMs); legacy edit-based path otherwise. Falls back gracefully if a draft frame fails. |
+| `draft` | Force native drafts. Logs a downgrade and falls back to edit if the chat doesn't support drafts (e.g. groups/topics). |
+| `edit` | Legacy progressive `editMessageText` polling for every chat type. |
+| `off` | Disable streaming entirely (final reply only, no progressive updates). |
+
+In `~/.hermes/config.yaml`:
+
+```yaml
+gateway:
+  streaming:
+    enabled: true
+    transport: auto    # auto | draft | edit | off
+```
+
+**What you'll see in DMs with `auto` (default)** — when the agent generates a reply, Telegram shows an animated draft preview that updates token-by-token. When the reply finishes, it's delivered as a regular message and the draft preview clears naturally on the client. Drafts have no message id, so the final answer is what stays in your chat history.
+
+**What about groups, supergroups, forum topics?** Telegram restricts `sendMessageDraft` to private chats (DMs). The gateway transparently falls back to the edit-based path for everything else — same UX as before.
+
+**What if a draft frame fails?** Any failure (transient network error, server-side rejection, older python-telegram-bot install) flips that response back to the edit-based path for the rest of the stream. The next response gets a fresh attempt.
 
 ## Rendering: Tables and Link Previews
 


### PR DESCRIPTION
## Summary

Telegram DMs now stream the agent's reply token-by-token using Telegram's native `sendMessageDraft` API (Bot API 9.5, March 2026). Smooth animated previews replace the per-second `editMessageText` polling that made slow models (o1, deepseek-r1) feel sluggish in the bot UI.

Default streaming transport flips `edit` → `auto`. Groups, supergroups, forum topics, and every non-Telegram platform continue using the edit-based path with no behaviour change.

## How it works

```
DM stream begins  → sendMessageDraft(draft_id=N, text="")    starts the bubble
deltas arrive     → sendMessageDraft(draft_id=N, text=...)   animates the preview
turn ends         → sendMessage(text=final)                  draft clears naturally
                                                             user sees the real answer
tool boundary     → finalize current text as a real send +   no inter-tool leak
                    bump draft_id for the next text segment
group / topic     → adapter.supports_draft_streaming = False → edit-based path
draft frame fails → disable drafts for the rest of the run  → edit-based fallback
```

## Changes

| Area | What |
|---|---|
| `gateway/platforms/base.py` | New adapter contract: `supports_draft_streaming(chat_type, metadata)` and `send_draft(...)`. Default impls return False / NotImplementedError so existing adapters are unaffected. |
| `gateway/platforms/telegram.py` | Telegram override: gates drafts on DM chat type AND PTB 22.6+ capability, routes `send_draft` to PTB's `Bot.send_message_draft` with UTF-16 length trimming, returns `SendResult(success=False, error=...)` on any failure for the consumer to handle. |
| `gateway/stream_consumer.py` | `StreamConsumerConfig.transport` (`auto\|draft\|edit\|off`) and `chat_type`. Resolves `_use_draft_streaming` once per run, allocates a class-wide monotonic `draft_id`, and routes mid-stream frames through `_send_draft_frame` instead of `edit_message`. Per-response fallback on any draft failure. Tool-boundary `_reset_segment_state` bumps `draft_id` for the next segment. Drafts intentionally do NOT set `_already_sent` so the gateway's final-send path still fires (drafts have no `message_id`). |
| `gateway/config.py` | `StreamingConfig.transport` default `edit` → `auto`. Documented all four options. |
| `gateway/run.py` | Both `GatewayStreamConsumer` construction sites now pass `transport` and `chat_type` through. |
| `tests/gateway/test_stream_consumer_draft.py` | 11 new tests covering transport selection, happy path, group fallback, draft-failure fallback, draft_id lifecycle (per-response distinct, tool-boundary bump), and the `_already_sent` invariant. |
| `website/docs/user-guide/messaging/telegram.md` | New `Streaming transport` section explaining the four options, the DM-only constraint, and per-response fallback behaviour. |

## Salvage notes

PR #3412 by @NivOO5 was branched against a March 27 base. Current `stream_consumer.py` is ~4× larger and has a different state machine (`_NEW_SEGMENT`, `_COMMENTARY`, `finalize`, `_on_new_message`, fresh-final logic). A direct cherry-pick was infeasible.

This PR re-authors the feature against current main with @NivOO5's substantive commit attribution preserved (re-attributed from `Alfred <alfred@Alfreds-Mac-mini.local>`, the contributor's local hostname-derived git config). The design call is faithful to the original proposal — DM-only, edit-fallback, transport=`auto|draft|edit|off` — with two improvements baked in based on the openclaw rollout experience:

1. **Per-response monotonic `draft_id` counter** instead of a `time.monotonic()*1e6` hash. The original PR's hash had a small but real collision risk across consecutive responses to the same chat. The counter is collision-free and easier to reason about in tests.
2. **Tool-boundary `draft_id` bump.** When the agent does `text → tool → text`, naive draft handling produces visible bleed-through across tool calls — openclaw documented this as their issue #32535 after they shipped. Bumping `draft_id` on segment break makes each text segment animate as its own preview below the tool-progress bubble. The pre-tool text is finalized as a real `sendMessage` (existing first-send path); the post-tool text starts a fresh draft.

The exception-catch in the helper is also tightened — the original PR caught bare `Exception` inside the helper; the salvage uses the consumer's `_draft_failures` counter and disables drafts for the rest of the run on any non-success result, with debug-level logging.

## Validation

- `tests/gateway/test_stream_consumer*` + `test_telegram_thread_fallback.py` + `test_dm_topics.py` + `test_telegram_approval_buttons.py` + `test_telegram_model_picker.py`: **190/190 pass.**
- Full `tests/gateway/` (excluding 4 pre-existing failures unrelated to this PR — `test_tts_media_routing.py` and `test_update_streaming.py::test_recognized_slash_command_bypasses_pending_update_prompt`, all confirmed present on `origin/main` without this PR): **5203/5203 pass.**

## Compatibility

- **Default transport `auto` is backwards-compatible.** It routes to `draft` only when the adapter declares support for the specific chat type — Telegram only declares support for DMs. Every other chat type (groups, supergroups, forum topics) and every other platform continues to use the edit-based path.
- **PTB 22.6+ is required** for drafts. Older installs cause `supports_draft_streaming` to return False, falling back to edit. No deployment hard requirement to upgrade.
- **No new env vars.** Configuration lives in `~/.hermes/config.yaml` under `gateway.streaming.transport`.

## Closes

- #21439 (duplicate feature request for `sendMessageDraft` support)

Inspired by PR #3412 by @NivOO5; re-authored against current main with attribution preserved on the substantive commit.
