### PR TITLE
fix(browser): pass sandbox flags via AGENT_BROWSER_ARGS

### DIFF
--- a/tests/tools/test_browser_homebrew_paths.py
+++ b/tests/tools/test_browser_homebrew_paths.py
@@ -512,3 +512,81 @@ class TestRunBrowserCommandPathConstruction:
         result_path = captured_env.get("PATH", "")
         assert "/data/data/com.termux/files/usr/bin" in result_path
         assert "/data/data/com.termux/files/usr/sbin" in result_path
+
+    def test_injects_agent_browser_args_for_root_sandbox_bypass(self, tmp_path):
+        """Root launches should pass --no-sandbox through AGENT_BROWSER_ARGS."""
+        captured_env = {}
+
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.wait.return_value = 0
+
+        def capture_popen(cmd, **kwargs):
+            captured_env.update(kwargs.get("env", {}))
+            return mock_proc
+
+        fake_session = {
+            "session_name": "test-session",
+            "session_id": "test-id",
+            "cdp_url": None,
+        }
+        fake_json = json.dumps({"success": True})
+
+        with patch("tools.browser_tool._find_agent_browser", return_value="/usr/local/bin/agent-browser"), \
+             patch("tools.browser_tool._chromium_installed", return_value=True), \
+             patch("tools.browser_tool._get_session_info", return_value=fake_session), \
+             patch("tools.browser_tool._socket_safe_tmpdir", return_value=str(tmp_path)), \
+             patch("tools.browser_tool._discover_homebrew_node_dirs", return_value=[]), \
+             patch("subprocess.Popen", side_effect=capture_popen), \
+             patch("os.open", return_value=99), \
+             patch("os.close"), \
+             patch("os.geteuid", return_value=0), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch.dict(os.environ, {"PATH": "/usr/bin:/bin", "HOME": "/home/test"}, clear=True):
+            with patch("builtins.open", mock_open(read_data=fake_json)):
+                _run_browser_command("test-task", "navigate", ["https://example.com"])
+
+        assert captured_env["AGENT_BROWSER_ARGS"] == "--no-sandbox --disable-dev-shm-usage"
+        assert "AGENT_BROWSER_CHROME_FLAGS" not in captured_env
+
+    def test_injects_agent_browser_args_for_apparmor_restrictions(self, tmp_path):
+        """AppArmor userns restrictions should also flow through AGENT_BROWSER_ARGS."""
+        captured_env = {}
+
+        mock_proc = MagicMock()
+        mock_proc.returncode = 0
+        mock_proc.wait.return_value = 0
+
+        def capture_popen(cmd, **kwargs):
+            captured_env.update(kwargs.get("env", {}))
+            return mock_proc
+
+        fake_session = {
+            "session_name": "test-session",
+            "session_id": "test-id",
+            "cdp_url": None,
+        }
+        fake_json = json.dumps({"success": True})
+        userns_path = "/proc/sys/kernel/apparmor_restrict_unprivileged_userns"
+
+        def selective_open(path, *args, **kwargs):
+            if path == userns_path:
+                return mock_open(read_data="1")()
+            return mock_open(read_data=fake_json)()
+
+        with patch("tools.browser_tool._find_agent_browser", return_value="/usr/local/bin/agent-browser"), \
+             patch("tools.browser_tool._chromium_installed", return_value=True), \
+             patch("tools.browser_tool._get_session_info", return_value=fake_session), \
+             patch("tools.browser_tool._socket_safe_tmpdir", return_value=str(tmp_path)), \
+             patch("tools.browser_tool._discover_homebrew_node_dirs", return_value=[]), \
+             patch("subprocess.Popen", side_effect=capture_popen), \
+             patch("os.open", return_value=99), \
+             patch("os.close"), \
+             patch("os.geteuid", return_value=1000), \
+             patch("tools.interrupt.is_interrupted", return_value=False), \
+             patch.dict(os.environ, {"PATH": "/usr/bin:/bin", "HOME": "/home/test"}, clear=True), \
+             patch("builtins.open", side_effect=selective_open):
+            _run_browser_command("test-task", "navigate", ["https://example.com"])
+
+        assert captured_env["AGENT_BROWSER_ARGS"] == "--no-sandbox --disable-dev-shm-usage"
+        assert "AGENT_BROWSER_CHROME_FLAGS" not in captured_env

--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1873,7 +1873,7 @@ def _run_browser_command(
         # - Ubuntu 23.10+ / AppArmor systems: unprivileged user namespaces
         #   are restricted, causing Chromium to exit with "No usable sandbox"
         #   even for non-root users running under systemd or containers.
-        if "AGENT_BROWSER_CHROME_FLAGS" not in browser_env:
+        if "AGENT_BROWSER_ARGS" not in browser_env:
             _needs_sandbox_bypass = False
             if hasattr(os, "geteuid") and os.geteuid() == 0:
                 _needs_sandbox_bypass = True
@@ -1892,7 +1892,7 @@ def _run_browser_command(
                 except OSError:
                     pass
             if _needs_sandbox_bypass:
-                browser_env["AGENT_BROWSER_CHROME_FLAGS"] = (
+                browser_env["AGENT_BROWSER_ARGS"] = (
                     "--no-sandbox --disable-dev-shm-usage"
                 )
 


### PR DESCRIPTION
## What does this PR do?

Fixes the sandbox-bypass env handoff in `tools/browser_tool.py` so local browser launches pass Chromium flags through the env var that `agent-browser` actually reads.

Today Hermes detects when `--no-sandbox --disable-dev-shm-usage` is needed, but writes those flags to `AGENT_BROWSER_CHROME_FLAGS`. `agent-browser` expects `AGENT_BROWSER_ARGS`, so the bypass never reaches Chrome and headless launches still fail on root/AppArmor-restricted hosts.

## Related Issue

Fixes #23496

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- switch the sandbox bypass env injection from `AGENT_BROWSER_CHROME_FLAGS` to `AGENT_BROWSER_ARGS` in `tools/browser_tool.py`
- add regression coverage in `tests/tools/test_browser_homebrew_paths.py` for both root and AppArmor-restricted launches
- assert we no longer emit the stale `AGENT_BROWSER_CHROME_FLAGS` env var in the launch path

## How to Test

1. Run `uv run --frozen pytest -q -o addopts='' tests/tools/test_browser_homebrew_paths.py`
2. Confirm the new tests cover root sandbox bypass and AppArmor userns restriction detection
3. Optionally reproduce on a Linux/AppArmor host and verify browser commands now launch with `AGENT_BROWSER_ARGS=--no-sandbox --disable-dev-shm-usage`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `uv run --frozen pytest -q -o addopts='' tests/tools/test_browser_homebrew_paths.py` -> `24 passed`
- `uv run --frozen ruff check tools/browser_tool.py tests/tools/test_browser_homebrew_paths.py` -> passed
