### PR TITLE
fix(achievements): send session token on plugin API calls (closes #23238 #23304)

### DIFF
--- a/plugins/hermes-achievements/dashboard/dist/index.js
+++ b/plugins/hermes-achievements/dashboard/dist/index.js
@@ -51,8 +51,9 @@
   async function api(path, options) {
     const url = "/api/plugins/hermes-achievements" + path;
     const token = window.__HERMES_SESSION_TOKEN__ || "";
-    const headers = { ...(options?.headers || {}), Authorization: `Bearer ${token}` };
-    const res = await fetch(url, { ...options, headers });
+    const headers = { ...((options && options.headers) || {}) };
+    if (token) headers["X-Hermes-Session-Token"] = token;
+    const res = await fetch(url, { ...(options || {}), headers });
     if (!res.ok) {
       const text = await res.text().catch(function () { return res.statusText; });
       throw new Error(res.status + ": " + text);

--- a/plugins/hermes-achievements/dashboard/dist/index.js
+++ b/plugins/hermes-achievements/dashboard/dist/index.js
@@ -50,7 +50,9 @@
 
   async function api(path, options) {
     const url = "/api/plugins/hermes-achievements" + path;
-    const res = await fetch(url, options || {});
+    const token = window.__HERMES_SESSION_TOKEN__ || "";
+    const headers = { ...(options?.headers || {}), Authorization: `Bearer ${token}` };
+    const res = await fetch(url, { ...options, headers });
     if (!res.ok) {
       const text = await res.text().catch(function () { return res.statusText; });
       throw new Error(res.status + ": " + text);

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -54,6 +54,7 @@ AUTHOR_MAP = {
     "cleo@edaphic.xyz": "curiouscleo",
     "hirokazu.ogawa@kwansei.ac.jp": "hrkzogw",
     "datapod.k@gmail.com": "dandacompany",
+    "treydong.zh@gmail.com": "TreyDong",
     "127238744+teknium1@users.noreply.github.com": "teknium1",
     "128259593+Gutslabs@users.noreply.github.com": "Gutslabs",
     "50326054+nocturnum91@users.noreply.github.com": "nocturnum91",


### PR DESCRIPTION
## Summary
Achievements dashboard tab works again. Commit `ec9329ec4` (fix(security): require dashboard auth for plugin API routes, May 4) closed the `/api/plugins/*` auth-middleware bypass — correct fix for #19533, but the achievements plugin's `api()` in `dist/index.js` calls `fetch()` without sending the session token, so every request to the achievements page returns `401 Unauthorized` since that commit landed.

## Changes
- `plugins/hermes-achievements/dashboard/dist/index.js`: `api()` now reads `window.__HERMES_SESSION_TOKEN__` (already injected into the SPA HTML by the dashboard server) and attaches it as `X-Hermes-Session-Token` on every plugin API call. Same pattern as `web/src/lib/api.ts` `fetchJSON()`.
- `scripts/release.py`: AUTHOR_MAP entry for treydong.zh@gmail.com → TreyDong.

## Validation
End-to-end test against a live dashboard (real `hermes_cli.web_server.app`, isolated `HERMES_HOME`, ASGI server on a random loopback port):

| Case | Status |
|---|---|
| no token | 401 `{"detail":"Unauthorized"}` |
| `X-Hermes-Session-Token` (the patched path) | 200, 60 achievements returned |
| `Authorization: Bearer` (also accepted server-side) | 200 |
| bad token | 401 |
| `/scan-status` GET | 200 |
| `/rescan` POST | 200 |

`tests/hermes_cli/test_web_server.py`: 143/144 passing — same one pre-existing failure (`TestPluginAPIAuth::test_plugin_route_allows_auth`, unrelated, fails on `origin/main` too because the `example-dashboard` plugin isn't mounted in the test fixture).

## Credit
- @TreyDong opened #23238 with the original fix — cherry-picked here, authorship preserved.
- @Eji4h independently submitted the same fix in #23304 a couple hours later — closed by the author as a duplicate of #23238.

The follow-up commit on top of TreyDong's switches the header from `Authorization: Bearer` to `X-Hermes-Session-Token` so it matches the canonical pattern in `web/src/lib/api.ts`. The server accepts both schemes, so functionally either works; this is a cosmetic alignment to keep all dashboard fetches consistent.

Closes #23238
Closes #23304
