### PR TITLE
fix(hindsight): repair embedded daemon PATH lookup

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -35,6 +35,8 @@ import json
 import logging
 import os
 import queue
+import shutil
+import sys
 import threading
 
 from datetime import datetime, timezone
@@ -97,6 +99,56 @@ def _check_local_runtime() -> tuple[bool, str | None]:
         return True, None
     except Exception as exc:
         return False, str(exc)
+
+
+def _ensure_hindsight_embed_on_path(env: dict[str, str] | None = None) -> str | None:
+    """Best-effort PATH repair for ``hindsight-embed`` in minimal runtimes.
+
+    Some dashboard/plugin entrypoints run with a stripped PATH that omits the
+    active venv or uv tool bin directory. When local_embedded mode starts the
+    daemon manager, it shells out to ``hindsight-embed`` and fails even though
+    the package is installed. Patch the PATH in-process with the most likely
+    Hermes install locations before starting the daemon.
+    """
+    from pathlib import Path
+
+    target = "hindsight-embed.exe" if os.name == "nt" else "hindsight-embed"
+    target_env = os.environ if env is None else env
+    current_path = target_env.get("PATH", "")
+    resolved = shutil.which(target, path=current_path)
+    if resolved:
+        return resolved
+
+    candidates: list[str] = []
+    seen: set[str] = set()
+
+    def add_dir(path_like: os.PathLike[str] | str | None) -> None:
+        if not path_like:
+            return
+        path = Path(path_like).expanduser()
+        try:
+            normalized = str(path.resolve())
+        except OSError:
+            normalized = str(path)
+        if normalized in seen or not path.is_dir():
+            return
+        seen.add(normalized)
+        candidates.append(normalized)
+
+    add_dir(Path(sys.executable).resolve().parent)
+    venv = target_env.get("VIRTUAL_ENV", "").strip()
+    if venv:
+        add_dir(Path(venv) / ("Scripts" if os.name == "nt" else "bin"))
+    add_dir(target_env.get("UV_TOOL_BIN_DIR", "").strip() or None)
+    add_dir(Path.home() / ".local" / "bin")
+
+    if not candidates:
+        return None
+
+    existing_parts = [part for part in current_path.split(os.pathsep) if part]
+    merged_parts = [*candidates, *[part for part in existing_parts if part not in seen]]
+    target_env["PATH"] = os.pathsep.join(merged_parts)
+    return shutil.which(target, path=target_env.get("PATH", ""))
 
 
 # ---------------------------------------------------------------------------
@@ -1210,6 +1262,13 @@ class HindsightMemoryProvider(MemoryProvider):
                 log_dir.mkdir(parents=True, exist_ok=True)
                 log_path = log_dir / "hindsight-embed.log"
                 try:
+                    embed_bin = _ensure_hindsight_embed_on_path()
+                    if not embed_bin:
+                        with open(log_path, "a", encoding="utf-8") as f:
+                            f.write(
+                                "\n=== hindsight-embed not found on current PATH; "
+                                "daemon start will rely on downstream resolution ===\n"
+                            )
                     # Redirect the daemon manager's Rich console to our log file
                     # instead of stderr. This avoids global fd redirects that
                     # would capture output from other threads.

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -6,6 +6,7 @@ turn counting, tags), and schema completeness.
 """
 
 import json
+import os
 import re
 import sys
 from types import SimpleNamespace
@@ -20,6 +21,7 @@ from plugins.memory.hindsight import (
     RETAIN_SCHEMA,
     _load_config,
     _build_embedded_profile_env,
+    _ensure_hindsight_embed_on_path,
     _normalize_retain_tags,
     _resolve_bank_id_template,
     _sanitize_bank_segment,
@@ -149,6 +151,45 @@ def test_normalize_retain_tags_accepts_csv_and_dedupes():
 def test_normalize_retain_tags_accepts_json_array_string():
     value = json.dumps(["agent:fakeassistantname", "source_system:hermes-agent"])
     assert _normalize_retain_tags(value) == ["agent:fakeassistantname", "source_system:hermes-agent"]
+
+
+def test_ensure_hindsight_embed_on_path_adds_sys_executable_dir(tmp_path, monkeypatch):
+    bin_dir = tmp_path / "venv" / "bin"
+    bin_dir.mkdir(parents=True)
+    embed_name = "hindsight-embed.exe" if os.name == "nt" else "hindsight-embed"
+    python_name = "python.exe" if os.name == "nt" else "python3"
+    embed = bin_dir / embed_name
+    embed.write_text("@echo off\n" if os.name == "nt" else "#!/bin/sh\nexit 0\n", encoding="utf-8")
+    embed.chmod(0o755)
+    python_bin = bin_dir / python_name
+    python_bin.write_text("", encoding="utf-8")
+
+    monkeypatch.setattr("plugins.memory.hindsight.sys.executable", str(python_bin))
+    env = {"PATH": os.pathsep.join(["/usr/bin", "/bin"])}
+
+    resolved = _ensure_hindsight_embed_on_path(env)
+
+    assert resolved == str(embed)
+    assert str(bin_dir) in env["PATH"].split(os.pathsep)
+
+
+def test_ensure_hindsight_embed_on_path_keeps_existing_lookup(monkeypatch):
+    env = {"PATH": os.pathsep.join(["/custom/bin", "/usr/bin"])}
+    target = "hindsight-embed.exe" if os.name == "nt" else "hindsight-embed"
+    resolved_path = str((os.pathsep.join(["/custom/bin", target])).replace(os.pathsep, "/"))
+
+    def fake_which(name, path=None):
+        assert name == target
+        if path == env["PATH"]:
+            return resolved_path
+        raise AssertionError("helper should not rebuild PATH when lookup already works")
+
+    monkeypatch.setattr("plugins.memory.hindsight.shutil.which", fake_which)
+
+    resolved = _ensure_hindsight_embed_on_path(env)
+
+    assert resolved == resolved_path
+    assert env["PATH"] == os.pathsep.join(["/custom/bin", "/usr/bin"])
 
 
 # ---------------------------------------------------------------------------
@@ -1548,4 +1589,3 @@ class TestShutdown:
         embedded.close.assert_called_once()
         assert embedded._client is None
         assert provider._client is None
-


### PR DESCRIPTION
## What does this PR do?

Repairs local_embedded Hindsight startup when the dashboard/plugin runtime inherits a minimal `PATH`. Hermes now prepends likely install locations for `hindsight-embed` before the daemon manager shells out, so an installed embedded daemon can still auto-start even when the current process PATH omits the active venv or uv tool bin directory.

## Related Issue

Fixes #23202

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `_ensure_hindsight_embed_on_path()` in `plugins/memory/hindsight/__init__.py` to repair `PATH` with common Hermes install locations before local_embedded daemon startup.
- Called the helper at embedded-daemon boot time and added a log breadcrumb when `hindsight-embed` still cannot be resolved.
- Added regression tests in `tests/plugins/memory/test_hindsight_provider.py` covering both PATH repair and the no-op path when lookup already works.

## How to Test

1. Run `uv run --frozen pytest -q -o addopts='' tests/plugins/memory/test_hindsight_provider.py`.
2. Run `uv run --frozen ruff check plugins/memory/hindsight/__init__.py tests/plugins/memory/test_hindsight_provider.py`.
3. In a minimal-PATH environment, initialize local_embedded Hindsight and confirm Hermes can still resolve `hindsight-embed` from the active venv/bin or uv tool bin.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `98 passed in 13.33s`
- `All checks passed!` from targeted `ruff check`
