### PR TITLE
fix(cli): recursively expand nested paste references

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -3350,6 +3350,7 @@ class HermesCLI:
         if not isinstance(text, str) or "[Pasted text #" not in text:
             return text or ""
         paste_ref_re = re.compile(r'\[Pasted text #\d+: \d+ lines \u2192 (.+?)\]')
+        max_passes = 32
 
         def _expand_ref(match):
             path = Path(match.group(1))
@@ -3362,7 +3363,15 @@ class HermesCLI:
                 logger.warning("Paste file gone or unreadable, returning placeholder: %s", path)
                 return match.group(0)
 
-        return paste_ref_re.sub(_expand_ref, text)
+        expanded = text
+        for _ in range(max_passes):
+            next_expanded = paste_ref_re.sub(_expand_ref, expanded)
+            if next_expanded == expanded or "[Pasted text #" not in next_expanded:
+                return next_expanded
+            expanded = next_expanded
+
+        logger.warning("Paste reference expansion hit recursion limit; returning partially expanded text")
+        return expanded
 
     def _print_user_message_preview(self, user_input: str) -> None:
         """Render a user message using the normal chat scrollback style."""

--- a/tests/cli/test_cli_external_editor.py
+++ b/tests/cli/test_cli_external_editor.py
@@ -80,6 +80,42 @@ def test_expand_paste_references_replaces_placeholder_with_file_contents(tmp_pat
     assert expanded == "before line one\nline two after"
 
 
+def test_expand_paste_references_recursively_expands_nested_placeholders(tmp_path):
+    cli_obj = _make_cli()
+    paste_a = tmp_path / "paste_a.txt"
+    paste_b = tmp_path / "paste_b.txt"
+    paste_c = tmp_path / "paste_c.txt"
+    paste_a.write_text("alpha", encoding="utf-8")
+    paste_b.write_text(
+        f"[Pasted text #1: 1 lines → {paste_a}]\nbeta",
+        encoding="utf-8",
+    )
+    paste_c.write_text(
+        f"[Pasted text #2: 2 lines → {paste_b}]\ngamma",
+        encoding="utf-8",
+    )
+
+    text = f"before [Pasted text #3: 3 lines → {paste_c}] after"
+    expanded = cli_obj._expand_paste_references(text)
+
+    assert expanded == "before alpha\nbeta\ngamma after"
+
+
+def test_expand_paste_references_stops_on_self_referential_placeholder(tmp_path):
+    cli_obj = _make_cli()
+    paste_file = tmp_path / "self.txt"
+    paste_file.write_text(
+        f"[Pasted text #1: 1 lines → {paste_file}]",
+        encoding="utf-8",
+    )
+
+    expanded = cli_obj._expand_paste_references(
+        f"before [Pasted text #1: 1 lines → {paste_file}] after"
+    )
+
+    assert expanded == f"before [Pasted text #1: 1 lines → {paste_file}] after"
+
+
 def test_open_external_editor_expands_paste_placeholders_before_open(tmp_path):
     cli_obj = _make_cli()
     paste_file = tmp_path / "paste.txt"


### PR DESCRIPTION
## What does this PR do?

Fixes chained paste expansion in the interactive CLI.

Today `_expand_paste_references()` only runs a single `re.sub()` pass, so if a pasted file contains another `[Pasted text #N: ... → file]` placeholder, only the top-level reference is expanded and nested placeholders are left behind in the final message.

This patch makes paste expansion recursive so chained paste files are fully expanded before the message is sent to the agent. It also adds a bounded pass limit so self-referential or cyclic placeholders do not loop forever.

## Related Issue

Fixes #23430.

## Type of Change

- [x] Bug fix
- [x] Tests

## Changes Made

- Update `HermesCLI._expand_paste_references()` to repeatedly expand paste placeholders until the text stabilizes or no placeholders remain
- Add a recursion/pass limit to avoid infinite expansion on self-referential placeholders
- Add regression tests for:
  - nested/chained paste expansion
  - self-referential placeholders stopping safely
  - existing single-level expansion behavior remaining intact

## How to Test

```bash
pytest -q tests/cli/test_cli_external_editor.py
pytest -q tests/cli/test_cli_external_editor.py -k paste
```

Local result:

- `9 passed in 24.62s`
- `4 passed in 37.37s`

## Checklist

- [x] I have tested these changes locally
- [x] I have added or updated tests where needed
- [x] This PR is scoped to a single bugfix

## Screenshots / Logs

N/A
