### PR TITLE
fix: allow Mattermost approval aliases

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -998,17 +998,45 @@ _PLAINTEXT_GATEWAY_RESTART_PATTERNS: tuple[re.Pattern[str], ...] = (
     re.compile(r"^(?:please\s+)?restart\s+hermes[.!?\s]*$", re.IGNORECASE),
 )
 
+_PLAINTEXT_MATTERMOST_APPROVAL_WORDS = frozenset({"approve", "deny"})
+_PLAINTEXT_MATTERMOST_APPROVAL_ARGS = frozenset({
+    "all",
+    "session",
+    "ses",
+    "always",
+    "permanent",
+    "permanently",
+})
 
-def coerce_plaintext_gateway_command(event: "MessageEvent") -> None:
-    """Rewrite a tiny set of DM plaintext admin phrases into slash commands.
+
+def _mattermost_plaintext_approval_alias(text: str) -> str | None:
+    """Return a slash-command equivalent for safe Mattermost approval aliases."""
+    raw = (text or "").strip().lower()
+    if not raw or raw.startswith("/"):
+        return None
+    parts = raw.split()
+    if not parts or parts[0] not in _PLAINTEXT_MATTERMOST_APPROVAL_WORDS:
+        return None
+    if any(part not in _PLAINTEXT_MATTERMOST_APPROVAL_ARGS for part in parts[1:]):
+        return None
+    if parts[0] == "deny" and any(part != "all" for part in parts[1:]):
+        return None
+    return "/" + " ".join(parts)
+
+
+def coerce_plaintext_gateway_command(event: "MessageEvent", session_key: str | None = None) -> None:
+    """Rewrite a tiny set of plaintext control phrases into slash commands.
 
     This keeps high-impact operational phrases like ``restart gateway`` out of
     the LLM/tool path, where they can trigger a self-restart from inside the
     currently running agent and leave the gateway stuck in ``draining`` while it
     waits for that same agent to finish.
 
-    Scope is intentionally narrow: DM text messages only, exact restart-style
-    phrases only. Group chats keep natural-language semantics.
+    Mattermost has one additional safety-scoped rewrite: during a live
+    dangerous-command approval, explicit bare replies like ``approve`` or
+    ``deny`` are rewritten to ``/approve``/``/deny``.  This must happen in the
+    base adapter before the active-session guard; otherwise the guard treats the
+    reply as normal user text and queues it for the next turn.
     """
     try:
         if event is None or event.message_type != MessageType.TEXT:
@@ -1017,6 +1045,20 @@ def coerce_plaintext_gateway_command(event: "MessageEvent") -> None:
         if not text or text.startswith("/"):
             return
         source = getattr(event, "source", None)
+
+        if session_key and _platform_name(getattr(source, "platform", None)) == "mattermost":
+            approval_alias = _mattermost_plaintext_approval_alias(text)
+            if approval_alias:
+                try:
+                    from tools.approval import has_blocking_approval
+                    approval_live = has_blocking_approval(session_key)
+                except Exception:
+                    approval_live = False
+                if approval_live:
+                    event.text = approval_alias
+                    event.message_type = MessageType.COMMAND
+                    return
+
         if getattr(source, "chat_type", None) != "dm":
             return
         for pattern in _PLAINTEXT_GATEWAY_RESTART_PATTERNS:
@@ -2675,6 +2717,7 @@ class BasePlatformAdapter(ABC):
             group_sessions_per_user=self.config.extra.get("group_sessions_per_user", True),
             thread_sessions_per_user=self.config.extra.get("thread_sessions_per_user", False),
         )
+        coerce_plaintext_gateway_command(event, session_key=session_key)
 
         # On-entry self-heal: if the adapter still has an _active_sessions
         # entry for this key but the owner task has already exited (done or

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -63,6 +63,43 @@ _AGENT_CACHE_IDLE_TTL_SECS = 3600.0  # evict agents idle for >1h
 _PLATFORM_CONNECT_TIMEOUT_SECS_DEFAULT = 30.0
 _ADAPTER_DISCONNECT_TIMEOUT_SECS_DEFAULT = 5.0
 _TELEGRAM_COMMAND_MENTION_RE = re.compile(r"(?<![\w:/])/([A-Za-z0-9][A-Za-z0-9_-]*)")
+_MATTERMOST_PLAINTEXT_APPROVAL_WORDS = frozenset({
+    "approve",
+    "deny",
+})
+_MATTERMOST_PLAINTEXT_APPROVAL_ARGS = frozenset({
+    "all",
+    "session",
+    "ses",
+    "always",
+    "permanent",
+    "permanently",
+})
+
+
+def _mattermost_plaintext_approval_alias(text: str) -> Optional[str]:
+    """Return a slash-command equivalent for safe Mattermost approval aliases.
+
+    Mattermost consumes unregistered slash commands client/server-side, so a
+    user typing ``/approve`` may never produce a normal post that Hermes can see.
+    During a live dangerous-command approval, accept an intentionally tiny set
+    of bare-text aliases (``approve``, ``approve session``, ``deny all``, …)
+    and rewrite them to the existing gateway slash-command handlers.
+
+    We deliberately do *not* accept conversational words like ``yes`` or ``ok``:
+    approving a shell command must still require an explicit approval word.
+    """
+    raw = (text or "").strip().lower()
+    if not raw or raw.startswith("/"):
+        return None
+    parts = raw.split()
+    if not parts or parts[0] not in _MATTERMOST_PLAINTEXT_APPROVAL_WORDS:
+        return None
+    if any(part not in _MATTERMOST_PLAINTEXT_APPROVAL_ARGS for part in parts[1:]):
+        return None
+    if parts[0] == "deny" and any(part != "all" for part in parts[1:]):
+        return None
+    return "/" + " ".join(parts)
 
 
 def _telegramize_command_mentions(text: str, platform: Any) -> str:
@@ -5311,6 +5348,35 @@ class GatewayRunner:
         # Otherwise control/session commands like /new or /help get silently
         # consumed as update answers instead of being dispatched normally.
         _quick_key = self._session_key_for_source(source)
+
+        # Mattermost intercepts unregistered slash commands before they become
+        # normal posts, so `/approve` may never reach Hermes.  While a
+        # dangerous-command approval is actively blocking this session, accept
+        # explicit bare aliases (`approve`, `approve session`, `deny all`, ...)
+        # and route them through the normal /approve|/deny handlers.  This is
+        # scoped to Mattermost + live approval state and intentionally excludes
+        # ambiguous replies like "yes".
+        if source.platform == Platform.MATTERMOST and not event.is_command():
+            _approval_alias = _mattermost_plaintext_approval_alias(event.text)
+            if _approval_alias:
+                try:
+                    from tools.approval import has_blocking_approval as _has_mm_blocking_approval
+                    _mm_approval_live = _has_mm_blocking_approval(_quick_key)
+                except Exception:
+                    _mm_approval_live = False
+                if _mm_approval_live:
+                    logger.info(
+                        "Mattermost plaintext approval alias %r rewritten to %s for %s",
+                        event.text,
+                        _approval_alias,
+                        _quick_key,
+                    )
+                    event = dataclasses.replace(
+                        event,
+                        text=_approval_alias,
+                        message_type=MessageType.COMMAND,
+                    )
+
         _update_prompts = getattr(self, "_update_prompt_pending", {})
         if _update_prompts.get(_quick_key):
             raw = (event.text or "").strip()
@@ -6138,8 +6204,9 @@ class GatewayRunner:
                 logger.debug("Skill command check failed (non-fatal): %s", e)
         
         # Pending exec approvals are handled by /approve and /deny commands above.
-        # No bare text matching — "yes" in normal conversation must not trigger
-        # execution of a dangerous command.
+        # Mattermost has an earlier, narrowly-scoped bare `approve`/`deny` shim
+        # because that client consumes unregistered slash commands.  We still do
+        # not accept conversational replies like "yes" for dangerous commands.
 
         if self._is_telegram_topic_root_lobby(source):
             # Debounce the lobby reminder so a user who forgets about
@@ -14564,12 +14631,24 @@ class GatewayRunner:
 
                 # Fallback: plain text approval prompt
                 cmd_preview = cmd[:200] + "..." if len(cmd) > 200 else cmd
+                if source.platform == Platform.MATTERMOST:
+                    # Mattermost eats unknown slash commands before Hermes can
+                    # see them.  The gateway rewrites these explicit bare
+                    # aliases to the same handlers while an approval is live.
+                    approval_instructions = (
+                        "Reply `approve` to execute, `approve session` to approve this pattern "
+                        "for the session, `approve always` to approve permanently, or `deny` to cancel."
+                    )
+                else:
+                    approval_instructions = (
+                        "Reply `/approve` to execute, `/approve session` to approve this pattern "
+                        "for the session, `/approve always` to approve permanently, or `/deny` to cancel."
+                    )
                 msg = (
                     f"⚠️ **Dangerous command requires approval:**\n"
                     f"```\n{cmd_preview}\n```\n"
                     f"Reason: {desc}\n\n"
-                    f"Reply `/approve` to execute, `/approve session` to approve this pattern "
-                    f"for the session, `/approve always` to approve permanently, or `/deny` to cancel."
+                    f"{approval_instructions}"
                 )
                 try:
                     asyncio.run_coroutine_threadsafe(

--- a/tests/gateway/test_approve_deny_commands.py
+++ b/tests/gateway/test_approve_deny_commands.py
@@ -352,6 +352,51 @@ class TestBareTextNoLongerApproves:
         assert not entry.event.is_set()
 
 
+class TestMattermostPlaintextApprovalAliases:
+    """Mattermost-safe aliases for approval prompts.
+
+    Mattermost consumes unregistered slash commands like /approve before the
+    gateway can see them, so the adapter prompt tells users to type explicit
+    bare aliases during a live approval.  Keep this alias surface tiny: no
+    conversational yes/ok matching.
+    """
+
+    @pytest.mark.parametrize(
+        ("text", "expected"),
+        [
+            ("approve", "/approve"),
+            ("approve all", "/approve all"),
+            ("approve session", "/approve session"),
+            ("approve all session", "/approve all session"),
+            ("approve always", "/approve always"),
+            ("deny", "/deny"),
+            ("deny all", "/deny all"),
+            ("  APPROVE SESSION  ", "/approve session"),
+        ],
+    )
+    def test_supported_aliases_rewrite_to_slash_commands(self, text, expected):
+        from gateway.run import _mattermost_plaintext_approval_alias
+
+        assert _mattermost_plaintext_approval_alias(text) == expected
+
+    @pytest.mark.parametrize(
+        "text",
+        [
+            "yes",
+            "ok",
+            "confirm",
+            "approve this please",
+            "deny session",
+            "/approve",
+            "normal conversation",
+        ],
+    )
+    def test_ambiguous_or_regular_text_does_not_rewrite(self, text):
+        from gateway.run import _mattermost_plaintext_approval_alias
+
+        assert _mattermost_plaintext_approval_alias(text) is None
+
+
 # ------------------------------------------------------------------
 # End-to-end blocking flow
 # ------------------------------------------------------------------

--- a/tests/gateway/test_command_bypass_active_session.py
+++ b/tests/gateway/test_command_bypass_active_session.py
@@ -43,10 +43,10 @@ class _StubAdapter(BasePlatformAdapter):
         return {}
 
 
-def _make_adapter():
+def _make_adapter(platform=Platform.TELEGRAM):
     """Create a minimal adapter for testing the active-session guard."""
     config = PlatformConfig(enabled=True, token="test-token")
-    adapter = _StubAdapter(config, Platform.TELEGRAM)
+    adapter = _StubAdapter(config, platform)
     adapter.sent_responses = []
 
     async def _mock_handler(event):
@@ -62,16 +62,16 @@ def _make_adapter():
     return adapter
 
 
-def _make_event(text="/stop", chat_id="12345"):
+def _make_event(text="/stop", chat_id="12345", platform=Platform.TELEGRAM):
     source = SessionSource(
-        platform=Platform.TELEGRAM, chat_id=chat_id, chat_type="dm"
+        platform=platform, chat_id=chat_id, chat_type="dm"
     )
     return MessageEvent(text=text, message_type=MessageType.TEXT, source=source)
 
 
-def _session_key(chat_id="12345"):
+def _session_key(chat_id="12345", platform=Platform.TELEGRAM):
     source = SessionSource(
-        platform=Platform.TELEGRAM, chat_id=chat_id, chat_type="dm"
+        platform=platform, chat_id=chat_id, chat_type="dm"
     )
     return build_session_key(source)
 
@@ -135,6 +135,35 @@ class TestCommandBypassActiveSession:
 
         assert sk not in adapter._pending_messages
         assert any("handled:approve" in r for r in adapter.sent_responses)
+
+    @pytest.mark.asyncio
+    async def test_mattermost_plaintext_approve_bypasses_guard_when_approval_pending(self):
+        """Mattermost bare `approve` must bypass the active-session guard.
+
+        Mattermost may reject unknown slash commands before Hermes sees them,
+        so the approval prompt tells users to type `approve` without a slash.
+        The base adapter's active-session guard runs before GatewayRunner's
+        message handler; it must rewrite this alias early enough to avoid the
+        generic busy/queue path.
+        """
+        from tools.approval import _ApprovalEntry, _gateway_queues
+
+        adapter = _make_adapter(Platform.MATTERMOST)
+        sk = _session_key(platform=Platform.MATTERMOST)
+        adapter._active_sessions[sk] = asyncio.Event()
+        _gateway_queues[sk] = [_ApprovalEntry({"command": "rm -rf /tmp/x"})]
+
+        try:
+            await adapter.handle_message(_make_event("approve", platform=Platform.MATTERMOST))
+        finally:
+            _gateway_queues.pop(sk, None)
+
+        assert sk not in adapter._pending_messages, (
+            "Mattermost plaintext approve was queued instead of dispatched"
+        )
+        assert any("handled:approve" in r for r in adapter.sent_responses), (
+            "Mattermost plaintext approve did not reach the /approve handler"
+        )
 
     @pytest.mark.asyncio
     async def test_deny_bypasses_guard(self):

--- a/website/docs/user-guide/messaging/mattermost.md
+++ b/website/docs/user-guide/messaging/mattermost.md
@@ -227,6 +227,20 @@ When the bot is `@mentioned`, the mention is automatically stripped from the mes
 
 ## Troubleshooting
 
+### `/approve` says the slash command is not registered
+
+Mattermost intercepts unknown slash commands before bots can see them. If a
+dangerous-command approval prompt appears in Mattermost, reply without the
+slash:
+
+- `approve` — approve once
+- `approve session` — approve the same pattern for this session
+- `approve always` — approve the same pattern permanently
+- `deny` — cancel
+
+Hermes only accepts these bare aliases while a command approval is actively
+pending, so regular conversation text such as "yes" does not execute anything.
+
 ### Bot is not responding to messages
 
 **Cause**: The bot is not a member of the channel, or `MATTERMOST_ALLOWED_USERS` doesn't include your User ID.


### PR DESCRIPTION
## Summary
- accept explicit bare approval aliases in Mattermost while a dangerous-command approval is pending
- show Mattermost-specific approval instructions without slash commands
- document the Mattermost /approve interception behavior

## Test Plan
- .venv/bin/python -m pytest tests/gateway/test_approve_deny_commands.py tests/gateway/test_mattermost.py -q -o 'addopts='