### PR TITLE
feat: add Market rollover context boundary

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7148,6 +7148,8 @@ class HermesCLI:
             self._handle_fast_command(cmd_original)
         elif canonical == "compress":
             self._manual_compress(cmd_original)
+        elif canonical == "market-rollover":
+            self._manual_market_rollover(cmd_original)
         elif canonical == "usage":
             self._show_usage()
         elif canonical == "insights":
@@ -8326,7 +8328,7 @@ class HermesCLI:
         self._reasoning_preview_buf = getattr(self, "_reasoning_preview_buf", "") + reasoning_text
         self._flush_reasoning_preview(force=False)
 
-    def _manual_compress(self, cmd_original: str = ""):
+    def _manual_compress(self, cmd_original: str = "", *, force_market_rollover: bool = False):
         """Manually trigger context compression on the current conversation.
 
         Accepts an optional focus topic: ``/compress <focus>`` guides the
@@ -8382,12 +8384,18 @@ class HermesCLI:
                 # _build_system_prompt appends system_message to prompt_parts
                 # which already contain the agent identity — resulting in the
                 # identity block appearing twice (issue #15281).
+                _prev_market_rollover_enabled = getattr(self.agent, "_market_rollover_enabled", False)
+                if force_market_rollover:
+                    self.agent._market_rollover_enabled = True
                 compressed, _ = self.agent._compress_context(
                     original_history,
                     None,
                     approx_tokens=approx_tokens,
                     focus_topic=focus_topic or None,
+                    boundary_reason="manual_market_rollover" if force_market_rollover else "manual_compression",
                 )
+                if force_market_rollover:
+                    self.agent._market_rollover_enabled = _prev_market_rollover_enabled
                 self.conversation_history = compressed
                 # _compress_context ends the old session and creates a new child
                 # session on the agent (run_agent.py::_compress_context). Sync the
@@ -8423,7 +8431,23 @@ class HermesCLI:
                     print(f"     {summary['note']}")
 
             except Exception as e:
+                if force_market_rollover and "_prev_market_rollover_enabled" in locals() and self.agent:
+                    self.agent._market_rollover_enabled = _prev_market_rollover_enabled
                 print(f"  ❌ Compression failed: {e}")
+
+    def _manual_market_rollover(self, cmd_original: str = ""):
+        """Manually trigger a Market-backed context boundary.
+
+        Uses the same compression machinery as /compress, but temporarily
+        forces Market rollover mode so a missing/failed Market contract falls
+        back to ordinary compression rather than aborting the session split.
+        """
+        if cmd_original:
+            parts = cmd_original.strip().split(None, 1)
+            compress_cmd = "/compress" + (f" {parts[1].strip()}" if len(parts) > 1 and parts[1].strip() else "")
+        else:
+            compress_cmd = "/compress"
+        self._manual_compress(compress_cmd, force_market_rollover=True)
 
     def _handle_debug_command(self):
         """Handle /debug — upload debug report + logs and print paste URLs."""

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -85,6 +85,8 @@ COMMAND_REGISTRY: list[CommandDef] = [
                aliases=("fork",), args_hint="[name]"),
     CommandDef("compress", "Manually compress conversation context", "Session",
                args_hint="[focus topic]"),
+    CommandDef("market-rollover", "Manually split context through Market handoff, with compression fallback", "Session",
+               aliases=("market_rollover",), args_hint="[focus topic]"),
     CommandDef("rollback", "List or restore filesystem checkpoints", "Session",
                args_hint="[number]"),
     CommandDef("snapshot", "Create or restore state snapshots of Hermes config/state", "Session",

--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -471,6 +471,15 @@ DEFAULT_CONFIG = {
         # remains available as a tool regardless of this setting — the routing
         # only controls how inbound user images are presented.
         "image_input_mode": "auto",
+        # Context boundary mode controls what happens when a session is split
+        # during compression. Default preserves legacy behavior; set mode to
+        # "market_rollover" to hand exact continuity through Market and keep
+        # the model prompt bounded to the returned handoff contract.
+        "context_boundary": {
+            "mode": "legacy_compression",
+            "project": "home-li",
+            "market_cli": "/opt/openclaw/services/open-memory/services/market/market/cli.py",
+        },
         "disabled_toolsets": [],
     },
     

--- a/hermes_state.py
+++ b/hermes_state.py
@@ -218,6 +218,8 @@ CREATE TABLE IF NOT EXISTS sessions (
     handoff_state TEXT,
     handoff_platform TEXT,
     handoff_error TEXT,
+    market_thread_id TEXT,
+    market_resume_contract TEXT,
     FOREIGN KEY (parent_session_id) REFERENCES sessions(id)
 );
 
@@ -690,13 +692,15 @@ class SessionDB:
         system_prompt: str = None,
         user_id: str = None,
         parent_session_id: str = None,
+        market_thread_id: str = None,
+        market_resume_contract: Dict[str, Any] = None,
     ) -> None:
         """Shared INSERT OR IGNORE for session rows."""
         def _do(conn):
             conn.execute(
                 """INSERT OR IGNORE INTO sessions (id, source, user_id, model, model_config,
-                   system_prompt, parent_session_id, started_at)
-                   VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+                   system_prompt, parent_session_id, started_at, market_thread_id, market_resume_contract)
+                   VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)""",
                 (
                     session_id,
                     source,
@@ -706,6 +710,8 @@ class SessionDB:
                     system_prompt,
                     parent_session_id,
                     time.time(),
+                    market_thread_id,
+                    json.dumps(market_resume_contract, sort_keys=True) if market_resume_contract else None,
                 ),
             )
         self._execute_write(_do)
@@ -929,6 +935,21 @@ class SessionDB:
 
         return self._execute_write(_do) or 0
 
+    @staticmethod
+    def _decode_session_row(row: sqlite3.Row) -> Dict[str, Any]:
+        """Convert a session row to a dict and decode JSON metadata fields."""
+        session = dict(row)
+        raw_contract = session.get("market_resume_contract")
+        if isinstance(raw_contract, str) and raw_contract:
+            try:
+                session["market_resume_contract"] = json.loads(raw_contract)
+            except json.JSONDecodeError:
+                logger.warning(
+                    "Invalid market_resume_contract JSON for session %s",
+                    session.get("id"),
+                )
+        return session
+
     def get_session(self, session_id: str) -> Optional[Dict[str, Any]]:
         """Get a session by ID."""
         with self._lock:
@@ -936,7 +957,61 @@ class SessionDB:
                 "SELECT * FROM sessions WHERE id = ?", (session_id,)
             )
             row = cursor.fetchone()
-        return dict(row) if row else None
+        return self._decode_session_row(row) if row else None
+
+    def set_market_thread_id(self, session_id: str, market_thread_id: Optional[str]) -> bool:
+        """Persist the explicit Market lane/thread id for a session.
+
+        Returns True when the session row exists.  Passing None clears the
+        binding; callers should only do that for deliberate lane resets.
+        """
+        def _do(conn):
+            cursor = conn.execute(
+                "UPDATE sessions SET market_thread_id = ? WHERE id = ?",
+                (market_thread_id, session_id),
+            )
+            return cursor.rowcount
+        return self._execute_write(_do) > 0
+
+    def get_market_thread_id(self, session_id: str) -> Optional[str]:
+        """Return the session's explicit Market thread id, if present."""
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT market_thread_id FROM sessions WHERE id = ?", (session_id,)
+            )
+            row = cursor.fetchone()
+        return row["market_thread_id"] if row else None
+
+    def set_market_resume_contract(
+        self,
+        session_id: str,
+        contract: Optional[Dict[str, Any]],
+    ) -> bool:
+        """Persist the bounded Market rollover resume contract for a session."""
+        encoded = json.dumps(contract, sort_keys=True) if contract else None
+        def _do(conn):
+            cursor = conn.execute(
+                "UPDATE sessions SET market_resume_contract = ? WHERE id = ?",
+                (encoded, session_id),
+            )
+            return cursor.rowcount
+        return self._execute_write(_do) > 0
+
+    def get_market_resume_contract(self, session_id: str) -> Optional[Dict[str, Any]]:
+        """Return the decoded Market rollover resume contract, if present."""
+        with self._lock:
+            cursor = self._conn.execute(
+                "SELECT market_resume_contract FROM sessions WHERE id = ?",
+                (session_id,),
+            )
+            row = cursor.fetchone()
+        if not row or not row["market_resume_contract"]:
+            return None
+        try:
+            return json.loads(row["market_resume_contract"])
+        except json.JSONDecodeError:
+            logger.warning("Invalid market_resume_contract JSON for session %s", session_id)
+            return None
 
     def resolve_session_id(self, session_id_or_prefix: str) -> Optional[str]:
         """Resolve an exact or uniquely prefixed session ID to the full ID.
@@ -1057,7 +1132,7 @@ class SessionDB:
                 "SELECT * FROM sessions WHERE title = ?", (title,)
             )
             row = cursor.fetchone()
-        return dict(row) if row else None
+        return self._decode_session_row(row) if row else None
 
     def resolve_session_by_title(self, title: str) -> Optional[str]:
         """Resolve a title to a session ID, preferring the latest in a lineage.

--- a/run_agent.py
+++ b/run_agent.py
@@ -44,6 +44,7 @@ import os
 import random
 import re
 import ssl
+import subprocess
 import sys
 import tempfile
 import time
@@ -72,6 +73,43 @@ from hermes_constants import get_hermes_home
 
 
 _OPENAI_CLS_CACHE: Optional[type] = None
+
+
+def _sanitize_market_thread_id(value: str) -> str:
+    """Return a Market-safe Hermes thread id slug."""
+    slug = re.sub(r"[^a-zA-Z0-9._-]+", "-", str(value or "").strip()).strip("-._")
+    return slug.lower() or "default"
+
+
+def default_market_thread_id_for_session(session_id: str) -> str:
+    """Deterministically assign a Market thread id for a Hermes session.
+
+    This gives every default Hermes session an explicit persisted Market lane so
+    boundary rollover can prefer the stored thread over session-id inference.
+    """
+    return "hermes-" + _sanitize_market_thread_id(session_id)
+
+
+def _market_resume_contract_from_env() -> Optional[dict]:
+    raw = os.environ.get("HERMES_MARKET_RESUME_CONTRACT")
+    if not raw:
+        return None
+    try:
+        contract = json.loads(raw)
+    except json.JSONDecodeError:
+        logger.warning("Ignoring invalid HERMES_MARKET_RESUME_CONTRACT JSON")
+        return None
+    return contract if isinstance(contract, dict) else None
+
+
+def _resolve_initial_market_thread_id(session_id: str, resume_contract: Optional[dict] = None) -> str:
+    """Prefer explicit handoff/env thread, otherwise assign a default lane."""
+    explicit = os.environ.get("HERMES_MARKET_THREAD_ID")
+    if explicit:
+        return str(explicit)
+    if isinstance(resume_contract, dict) and resume_contract.get("market_thread_id"):
+        return str(resume_contract["market_thread_id"])
+    return default_market_thread_id_for_session(session_id)
 
 
 def _load_openai_cls() -> type:
@@ -1829,6 +1867,11 @@ class AIAgent:
         self.logs_dir = hermes_home / "sessions"
         self.logs_dir.mkdir(parents=True, exist_ok=True)
         self.session_log_file = self.logs_dir / f"session_{self.session_id}.json"
+        self._initial_market_resume_contract = _market_resume_contract_from_env()
+        self._market_thread_id = _resolve_initial_market_thread_id(
+            self.session_id,
+            self._initial_market_resume_contract,
+        )
         
         # Track conversation messages for session logging
         self._session_messages: List[Dict[str, Any]] = []
@@ -2246,6 +2289,21 @@ class AIAgent:
                 api_mode=self.api_mode,
             )
         self.compression_enabled = compression_enabled
+        _boundary_cfg = _agent_cfg.get("context_boundary", {})
+        if not isinstance(_boundary_cfg, dict):
+            _boundary_cfg = {}
+        _boundary_mode = str(
+            os.environ.get("HERMES_CONTEXT_BOUNDARY_MODE")
+            or _boundary_cfg.get("mode", "legacy_compression")
+        ).strip().lower()
+        self._market_rollover_enabled = _boundary_mode == "market_rollover"
+        self._market_rollover_project = str(_boundary_cfg.get("project", "home-li"))
+        self._market_rollover_cli = str(
+            _boundary_cfg.get(
+                "market_cli",
+                "/opt/openclaw/services/open-memory/services/market/market/cli.py",
+            )
+        )
 
         # Reject models whose context window is below the minimum required
         # for reliable tool-calling workflows (64K tokens).
@@ -2429,6 +2487,14 @@ class AIAgent:
         if self._session_db_created or not self._session_db:
             return
         try:
+            _market_resume_contract = getattr(self, "_initial_market_resume_contract", None)
+            if _market_resume_contract is None:
+                _market_resume_contract = _market_resume_contract_from_env()
+            _market_thread_id = getattr(self, "_market_thread_id", None) or _resolve_initial_market_thread_id(
+                self.session_id,
+                _market_resume_contract,
+            )
+            self._market_thread_id = _market_thread_id
             self._session_db.create_session(
                 session_id=self.session_id,
                 source=self.platform or os.environ.get("HERMES_SESSION_SOURCE", "cli"),
@@ -2437,6 +2503,8 @@ class AIAgent:
                 system_prompt=self._cached_system_prompt,
                 user_id=None,
                 parent_session_id=self._parent_session_id,
+                market_thread_id=_market_thread_id,
+                market_resume_contract=_market_resume_contract,
             )
             self._session_db_created = True
         except Exception as e:
@@ -4842,6 +4910,19 @@ class AIAgent:
         """Extract structured rate-limit details from provider errors."""
         context: Dict[str, Any] = {}
 
+        # Provider adapters may expose retry metadata directly (e.g. CodeAssistError
+        # from the Google Gemini CLI / Cloud Code path parses google.rpc.RetryInfo
+        # into ``retry_after`` even when Google does not send a Retry-After header).
+        # Preserve it before falling back to opaque message parsing; otherwise a
+        # short Google throttle such as "retry in 6s" is treated as the credential
+        # pool's default 1h exhaustion window.
+        direct_retry_after = getattr(error, "retry_after", None)
+        if direct_retry_after not in (None, ""):
+            try:
+                context["reset_at"] = time.time() + float(direct_retry_after)
+            except (TypeError, ValueError):
+                pass
+
         body = getattr(error, "body", None)
         payload = None
         if isinstance(body, dict):
@@ -4886,14 +4967,14 @@ class AIAgent:
         if "reset_at" not in context:
             message = context.get("message") or ""
             if isinstance(message, str):
-                delay_match = re.search(r"quotaResetDelay[:\s\"]+(\\d+(?:\\.\\d+)?)(ms|s)", message, re.IGNORECASE)
+                delay_match = re.search(r"quotaResetDelay[:\s\"]+(\d+(?:\.\d+)?)(ms|s)", message, re.IGNORECASE)
                 if delay_match:
                     value = float(delay_match.group(1))
                     seconds = value / 1000.0 if delay_match.group(2).lower() == "ms" else value
                     context["reset_at"] = time.time() + seconds
                 else:
                     sec_match = re.search(
-                        r"retry\s+(?:after\s+)?(\d+(?:\.\d+)?)\s*(?:sec|secs|seconds|s\b)",
+                        r"(?:retry|reset)\s+(?:after\s+)?(\d+(?:\.\d+)?)\s*(?:sec|secs|seconds|s\b)",
                         message,
                         re.IGNORECASE,
                     )
@@ -5060,6 +5141,7 @@ class AIAgent:
                 "session_start": self.session_start.isoformat(),
                 "last_updated": datetime.now().isoformat(),
                 "system_prompt": self._cached_system_prompt or "",
+                "market_thread_id": getattr(self, "_market_thread_id", None),
                 "tools": self.tools or [],
                 "message_count": len(cleaned),
                 "messages": cleaned,
@@ -7721,12 +7803,17 @@ class AIAgent:
                     _fire_first_delta()
                     self._fire_reasoning_delta(reasoning_text)
 
-                # Accumulate text content — fire callback only when no tool calls
-                if delta and delta.content:
-                    content_parts.append(delta.content)
+                # Accumulate text content — fire callback only when no tool calls.
+                # Some OpenAI-compatible adapters emit sparse delta objects for
+                # reasoning-only / finish-only chunks. Treat missing attributes
+                # as absent instead of raising AttributeError.
+                delta_content = getattr(delta, "content", None) if delta else None
+                delta_tool_calls = getattr(delta, "tool_calls", None) if delta else None
+                if delta and delta_content:
+                    content_parts.append(delta_content)
                     if not tool_calls_acc:
                         _fire_first_delta()
-                        self._fire_stream_delta(delta.content)
+                        self._fire_stream_delta(delta_content)
                         deltas_were_sent["yes"] = True
                     else:
                         # Tool calls suppress regular content streaming (avoids
@@ -7742,14 +7829,14 @@ class AIAgent:
                         # box is already closed (tool boundary flush).
                         if self.stream_delta_callback:
                             try:
-                                self.stream_delta_callback(delta.content)
-                                self._record_streamed_assistant_text(delta.content)
+                                self.stream_delta_callback(delta_content)
+                                self._record_streamed_assistant_text(delta_content)
                             except Exception:
                                 pass
 
                 # Accumulate tool call deltas — notify display on first name
-                if delta and delta.tool_calls:
-                    for tc_delta in delta.tool_calls:
+                if delta and delta_tool_calls:
+                    for tc_delta in delta_tool_calls:
                         raw_idx = tc_delta.index if tc_delta.index is not None else 0
                         delta_id = tc_delta.id or ""
 
@@ -9993,7 +10080,100 @@ class AIAgent:
         """
         return self.api_mode != "codex_responses"
 
-    def _compress_context(self, messages: list, system_message: str, *, approx_tokens: int = None, task_id: str = "default", focus_topic: str = None) -> tuple:
+    def _should_retain_legacy_summary_after_rollover(self) -> bool:
+        return str(os.environ.get("HERMES_MARKET_ROLLOVER_KEEP_LEGACY_SUMMARY", "")).lower() in {"1", "true", "yes"}
+
+    def _resolve_market_thread_id_for_rollover(self) -> Optional[str]:
+        """Resolve explicit Market thread id without semantic/session inference."""
+        thread = os.environ.get("HERMES_MARKET_THREAD_ID")
+        if thread:
+            return thread
+        thread = getattr(self, "_market_thread_id", None)
+        if thread:
+            return thread
+        if self._session_db:
+            try:
+                return self._session_db.get_market_thread_id(self.session_id)
+            except Exception as exc:
+                logger.debug("Market thread lookup failed: %s", exc)
+        return None
+
+    def _prepare_market_rollover_contract(
+        self,
+        *,
+        old_session_id: str,
+        new_session_id: str,
+        reason: str = "context_threshold",
+        source_path: Optional[Path] = None,
+    ) -> Optional[dict]:
+        """Call Market dry-run prepare and persist the successor handoff contract.
+
+        Returns None on any failure so callers can fall back to legacy
+        compression without risking continuity loss.
+        """
+        if not getattr(self, "_market_rollover_enabled", False):
+            return None
+        thread = self._resolve_market_thread_id_for_rollover()
+        if not thread:
+            logger.info("Market rollover skipped: no explicit market_thread_id")
+            return None
+        cli = Path(getattr(self, "_market_rollover_cli", ""))
+        if not cli.exists():
+            logger.warning("Market rollover skipped: CLI missing at %s", cli)
+            return None
+        cmd = [
+            sys.executable,
+            str(cli),
+            "market-rollover-prepare",
+            "--agent", "hermes",
+            "--project", getattr(self, "_market_rollover_project", "home-li"),
+            "--thread", thread,
+            "--successor-session-id", new_session_id,
+            "--reason", reason,
+        ]
+        if source_path is not None:
+            cmd.extend(["--source-path", str(source_path)])
+        elif getattr(self, "session_log_file", None):
+            cmd.extend(["--source-path", str(self.session_log_file)])
+        try:
+            proc = subprocess.run(cmd, text=True, capture_output=True, timeout=30, check=True)
+            report = json.loads(proc.stdout)
+            contract = report.get("handoff_contract")
+            if not isinstance(contract, dict):
+                raise ValueError("market-rollover-prepare returned no handoff_contract")
+            if contract.get("market_thread_id") != thread:
+                raise ValueError("market rollover contract thread mismatch")
+            if contract.get("predecessor_session_id") != old_session_id:
+                logger.debug(
+                    "Market rollover predecessor differs from DB session: contract=%s db=%s",
+                    contract.get("predecessor_session_id"), old_session_id,
+                )
+            if self._session_db:
+                try:
+                    self._session_db.set_market_thread_id(new_session_id, thread)
+                    self._session_db.set_market_resume_contract(new_session_id, contract)
+                except Exception as exc:
+                    logger.warning("Market rollover DB contract persistence failed: %s", exc)
+                    return None
+            return contract
+        except Exception as exc:
+            logger.warning("Market rollover prepare failed; falling back to legacy compression: %s", exc)
+            return None
+
+    def _market_rollover_messages(self, contract: dict) -> list:
+        payload = json.dumps(contract, indent=2, sort_keys=True, ensure_ascii=False)
+        return [
+            {
+                "role": "user",
+                "content": (
+                    "[Market rollover handoff contract]\n"
+                    "Resume from the exact Market lane below. Trust market_thread_id/head_uri over session-id inference.\n"
+                    f"{payload}"
+                ),
+            }
+        ]
+
+    def _compress_context(self, messages: list, system_message: str, *, approx_tokens: int = None, task_id: str = "default", focus_topic: str = None, boundary_reason: str = "context_threshold") -> tuple:
         """Compress conversation context and split the session in SQLite.
 
         Args:
@@ -10066,9 +10246,14 @@ class AIAgent:
                 old_title = self._session_db.get_session_title(self.session_id)
                 # Trigger memory extraction on the old session before it rotates.
                 self.commit_memory_session(messages)
-                self._session_db.end_session(self.session_id, "compression")
                 old_session_id = self.session_id
+                old_market_thread_id = None
+                try:
+                    old_market_thread_id = self._session_db.get_market_thread_id(old_session_id)
+                except Exception:
+                    old_market_thread_id = os.environ.get("HERMES_MARKET_THREAD_ID")
                 self.session_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:6]}"
+                old_session_log_file = self.session_log_file
                 # Update session_log_file to point to the new session's JSON file
                 self.session_log_file = self.logs_dir / f"session_{self.session_id}.json"
                 self._session_db_created = False
@@ -10078,8 +10263,23 @@ class AIAgent:
                     model=self.model,
                     model_config=self._session_init_model_config,
                     parent_session_id=old_session_id,
+                    market_thread_id=old_market_thread_id,
                 )
+                self._market_thread_id = old_market_thread_id
+                self._initial_market_resume_contract = None
                 self._session_db_created = True
+                rollover_contract = self._prepare_market_rollover_contract(
+                    old_session_id=old_session_id,
+                    new_session_id=self.session_id,
+                    reason=boundary_reason,
+                    source_path=old_session_log_file,
+                )
+                if rollover_contract:
+                    self._session_db.end_session(old_session_id, "market_rollover")
+                    if not self._should_retain_legacy_summary_after_rollover():
+                        compressed = self._market_rollover_messages(rollover_contract)
+                else:
+                    self._session_db.end_session(old_session_id, "compression")
                 # Auto-number the title for the continuation session
                 if old_title:
                     try:
@@ -10103,7 +10303,7 @@ class AIAgent:
             if _old_sid and hasattr(self.context_compressor, "on_session_start"):
                 self.context_compressor.on_session_start(
                     self.session_id or "",
-                    boundary_reason="compression",
+                    boundary_reason="market_rollover" if locals().get("rollover_contract") else "compression",
                     old_session_id=_old_sid,
                 )
         except Exception as _ce_err:
@@ -10121,7 +10321,7 @@ class AIAgent:
                     self.session_id or "",
                     parent_session_id=_old_sid,
                     reset=False,
-                    reason="compression",
+                    reason="market_rollover" if locals().get("rollover_contract") else "compression",
                 )
         except Exception as _me_err:
             logger.debug("memory manager on_session_switch (compression): %s", _me_err)
@@ -11770,6 +11970,8 @@ class AIAgent:
                 model=self.model,
                 platform=getattr(self, "platform", None) or "",
                 sender_id=getattr(self, "_user_id", None) or "",
+                market_thread_id=getattr(self, "_market_thread_id", None) or "",
+                market_resume_contract=getattr(self, "_initial_market_resume_contract", None),
             )
             _ctx_parts: list[str] = []
             for r in _pre_results:

--- a/tests/test_hermes_state.py
+++ b/tests/test_hermes_state.py
@@ -136,6 +136,91 @@ class TestSessionLifecycle:
         child = db.get_session("child")
         assert child["parent_session_id"] == "parent"
 
+    def test_market_thread_id_round_trip(self, db):
+        db.create_session(session_id="s1", source="cli", market_thread_id="lane-alpha")
+
+        assert db.get_market_thread_id("s1") == "lane-alpha"
+        session = db.get_session("s1")
+        assert session["market_thread_id"] == "lane-alpha"
+
+        assert db.set_market_thread_id("s1", "lane-beta") is True
+        assert db.get_market_thread_id("s1") == "lane-beta"
+        assert db.set_market_thread_id("missing", "lane-gamma") is False
+
+    def test_market_resume_contract_round_trip(self, db):
+        contract = {
+            "boundary_mode": "market_rollover",
+            "market_thread_id": "lane-alpha",
+            "predecessor_session_id": "s1",
+            "successor_session_id": "s2",
+            "next_atomic_action": "run phase 2 tests",
+        }
+        db.create_session(
+            session_id="s1",
+            source="cli",
+            market_thread_id="lane-alpha",
+            market_resume_contract=contract,
+        )
+
+        assert db.get_market_resume_contract("s1") == contract
+        assert db.get_session("s1")["market_resume_contract"] == contract
+
+        replacement = dict(contract, successor_session_id="s3")
+        assert db.set_market_resume_contract("s1", replacement) is True
+        assert db.get_market_resume_contract("s1") == replacement
+        assert db.set_market_resume_contract("missing", replacement) is False
+
+    def test_market_metadata_columns_reconcile_into_existing_db(self, tmp_path):
+        import sqlite3
+
+        db_path = tmp_path / "legacy_state.db"
+        conn = sqlite3.connect(db_path)
+        conn.execute("CREATE TABLE schema_version (version INTEGER NOT NULL)")
+        conn.execute("INSERT INTO schema_version (version) VALUES (11)")
+        conn.execute(
+            """CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                source TEXT NOT NULL,
+                user_id TEXT,
+                model TEXT,
+                model_config TEXT,
+                system_prompt TEXT,
+                parent_session_id TEXT,
+                started_at REAL NOT NULL,
+                ended_at REAL,
+                end_reason TEXT,
+                message_count INTEGER DEFAULT 0,
+                tool_call_count INTEGER DEFAULT 0,
+                input_tokens INTEGER DEFAULT 0,
+                output_tokens INTEGER DEFAULT 0,
+                cache_read_tokens INTEGER DEFAULT 0,
+                cache_write_tokens INTEGER DEFAULT 0,
+                reasoning_tokens INTEGER DEFAULT 0,
+                billing_provider TEXT,
+                billing_base_url TEXT,
+                billing_mode TEXT,
+                estimated_cost_usd REAL,
+                actual_cost_usd REAL,
+                cost_status TEXT,
+                cost_source TEXT,
+                pricing_version TEXT,
+                title TEXT,
+                api_call_count INTEGER DEFAULT 0,
+                FOREIGN KEY (parent_session_id) REFERENCES sessions(id)
+            )"""
+        )
+        conn.execute("CREATE TABLE state_meta (key TEXT PRIMARY KEY, value TEXT)")
+        conn.execute("CREATE TABLE messages (id INTEGER PRIMARY KEY AUTOINCREMENT, session_id TEXT NOT NULL, role TEXT NOT NULL, timestamp REAL NOT NULL)")
+        conn.commit()
+        conn.close()
+
+        legacy_db = SessionDB(db_path=db_path)
+        try:
+            legacy_db.create_session("s1", "cli", market_thread_id="lane-alpha")
+            assert legacy_db.get_session("s1")["market_thread_id"] == "lane-alpha"
+        finally:
+            legacy_db.close()
+
 
 # =========================================================================
 # Message storage

--- a/tests/test_market_rollover_boundary.py
+++ b/tests/test_market_rollover_boundary.py
@@ -1,0 +1,157 @@
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+from run_agent import (
+    AIAgent,
+    _resolve_initial_market_thread_id,
+    default_market_thread_id_for_session,
+)
+
+
+class FakeDB:
+    def __init__(self, thread="lane-alpha"):
+        self.thread = thread
+        self.thread_sets = []
+        self.contract_sets = []
+
+    def get_market_thread_id(self, session_id):
+        return self.thread
+
+    def set_market_thread_id(self, session_id, thread):
+        self.thread_sets.append((session_id, thread))
+        return True
+
+    def set_market_resume_contract(self, session_id, contract):
+        self.contract_sets.append((session_id, contract))
+        return True
+
+
+def make_agent(tmp_path, db=None):
+    agent = AIAgent.__new__(AIAgent)
+    agent._market_rollover_enabled = True
+    agent._market_rollover_cli = str(tmp_path / "market" / "cli.py")
+    Path(agent._market_rollover_cli).parent.mkdir(parents=True)
+    Path(agent._market_rollover_cli).write_text("# cli", encoding="utf-8")
+    agent._market_rollover_project = "home-li"
+    agent._session_db = db or FakeDB()
+    agent.session_id = "old-session"
+    agent.session_log_file = tmp_path / "session_old-session.json"
+    agent.session_log_file.write_text('{"session_id":"old-session","messages":[]}', encoding="utf-8")
+    return agent
+
+
+def test_prepare_market_rollover_contract_persists_successor_metadata(monkeypatch, tmp_path):
+    db = FakeDB("lane-alpha")
+    agent = make_agent(tmp_path, db)
+    contract = {
+        "boundary_mode": "market_rollover",
+        "market_thread_id": "lane-alpha",
+        "head_uri": "market://hermes/home-li/lane-alpha/head",
+        "predecessor_session_id": "old-session",
+        "successor_session_id": "new-session",
+        "next_atomic_action": "continue",
+    }
+
+    def fake_run(cmd, **kwargs):
+        assert cmd[:3] == [sys.executable, agent._market_rollover_cli, "market-rollover-prepare"]
+        assert "--thread" in cmd and cmd[cmd.index("--thread") + 1] == "lane-alpha"
+        assert "--successor-session-id" in cmd and cmd[cmd.index("--successor-session-id") + 1] == "new-session"
+        assert "--source-path" in cmd and cmd[cmd.index("--source-path") + 1].endswith("session_old-session.json")
+        return subprocess.CompletedProcess(cmd, 0, stdout=json.dumps({"handoff_contract": contract}), stderr="")
+
+    monkeypatch.setattr("run_agent.subprocess.run", fake_run)
+
+    out = agent._prepare_market_rollover_contract(
+        old_session_id="old-session",
+        new_session_id="new-session",
+        reason="context_threshold",
+    )
+
+    assert out == contract
+    assert db.thread_sets == [("new-session", "lane-alpha")]
+    assert db.contract_sets == [("new-session", contract)]
+
+
+def test_prepare_market_rollover_contract_falls_back_on_cli_failure(monkeypatch, tmp_path):
+    db = FakeDB("lane-alpha")
+    agent = make_agent(tmp_path, db)
+
+    def fail_run(*args, **kwargs):
+        raise subprocess.CalledProcessError(1, args[0], stderr="boom")
+
+    monkeypatch.setattr("run_agent.subprocess.run", fail_run)
+
+    assert agent._prepare_market_rollover_contract(
+        old_session_id="old-session",
+        new_session_id="new-session",
+        reason="context_threshold",
+    ) is None
+    assert db.thread_sets == []
+    assert db.contract_sets == []
+
+
+def test_market_rollover_messages_contain_only_contract_not_legacy_transcript(tmp_path):
+    agent = make_agent(tmp_path)
+    contract = {
+        "boundary_mode": "market_rollover",
+        "market_thread_id": "lane-alpha",
+        "head_uri": "market://hermes/home-li/lane-alpha/head",
+        "predecessor_session_id": "old-session",
+        "successor_session_id": "new-session",
+        "next_atomic_action": "continue",
+    }
+
+    messages = agent._market_rollover_messages(contract)
+
+    assert len(messages) == 1
+    assert messages[0]["role"] == "user"
+    assert "lane-alpha" in messages[0]["content"]
+    assert "Trust market_thread_id/head_uri over session-id inference" in messages[0]["content"]
+    assert "legacy transcript" not in messages[0]["content"].lower()
+
+
+def test_default_market_thread_id_is_assigned_from_session_when_no_handoff(monkeypatch):
+    monkeypatch.delenv("HERMES_MARKET_THREAD_ID", raising=False)
+    monkeypatch.delenv("HERMES_MARKET_RESUME_CONTRACT", raising=False)
+
+    assert default_market_thread_id_for_session("20260510_ABC def") == "hermes-20260510_abc-def"
+    assert _resolve_initial_market_thread_id("session-1") == "hermes-session-1"
+
+
+def test_initial_market_thread_prefers_resume_contract(monkeypatch):
+    monkeypatch.delenv("HERMES_MARKET_THREAD_ID", raising=False)
+
+    assert _resolve_initial_market_thread_id(
+        "session-1",
+        {"market_thread_id": "contract-lane"},
+    ) == "contract-lane"
+
+
+def test_ensure_db_session_persists_assigned_market_thread(monkeypatch):
+    class DB:
+        def __init__(self):
+            self.created = None
+
+        def create_session(self, **kwargs):
+            self.created = kwargs
+
+    monkeypatch.delenv("HERMES_MARKET_THREAD_ID", raising=False)
+    monkeypatch.delenv("HERMES_MARKET_RESUME_CONTRACT", raising=False)
+    db = DB()
+    agent = AIAgent.__new__(AIAgent)
+    agent._session_db_created = False
+    agent._session_db = db
+    agent.session_id = "session-1"
+    agent.platform = "cli"
+    agent.model = "test-model"
+    agent._session_init_model_config = {}
+    agent._cached_system_prompt = ""
+    agent._parent_session_id = None
+
+    agent._ensure_db_session()
+
+    assert db.created["market_thread_id"] == "hermes-session-1"
+    assert agent._market_thread_id == "hermes-session-1"
+    assert agent._session_db_created is True

--- a/tests/test_market_rollover_command.py
+++ b/tests/test_market_rollover_command.py
@@ -1,0 +1,23 @@
+from pathlib import Path
+
+from hermes_cli.commands import resolve_command
+
+
+def test_market_rollover_slash_command_registered_with_alias():
+    cmd = resolve_command("market-rollover")
+    alias = resolve_command("market_rollover")
+
+    assert cmd is not None
+    assert cmd.name == "market-rollover"
+    assert alias is not None
+    assert alias.name == "market-rollover"
+    assert "handoff" in cmd.description.lower()
+
+
+def test_market_rollover_dispatch_and_handler_are_wired_in_cli_source():
+    source = Path("cli.py").read_text(encoding="utf-8")
+
+    assert 'elif canonical == "market-rollover":' in source
+    assert 'self._manual_market_rollover(cmd_original)' in source
+    assert 'def _manual_market_rollover(self, cmd_original: str = ""):' in source
+    assert 'force_market_rollover=True' in source


### PR DESCRIPTION
Clean rebased PR for the Market rollover context-boundary work. Supersedes conflicting PR #23525 without force-pushing that branch.\n\nKey points:\n- persist market_thread_id and market_resume_contract in Hermes session state\n- add Market rollover prepare command/tests\n- wire context compression boundary to carry Market handoff contracts\n- preserve fallback to legacy compression on prepare failure\n\nVerification on clean worktree based on origin/main:\n- python -m pytest tests/test_hermes_state.py::TestSessionLifecycle::test_market_thread_id_round_trip tests/test_hermes_state.py::TestSessionLifecycle::test_market_resume_contract_round_trip -o 'addopts=' -q