### PR TITLE
fix(weixin): propagate asyncio.TimeoutError from _get_updates to prevent zombie connections

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -414,17 +414,14 @@ async def _get_updates(
     sync_buf: str,
     timeout_ms: int,
 ) -> Dict[str, Any]:
-    try:
-        return await _api_post(
-            session,
-            base_url=base_url,
-            endpoint=EP_GET_UPDATES,
-            payload={"get_updates_buf": sync_buf},
-            token=token,
-            timeout_ms=timeout_ms,
-        )
-    except asyncio.TimeoutError:
-        return {"ret": 0, "msgs": [], "get_updates_buf": sync_buf}
+    return await _api_post(
+        session,
+        base_url=base_url,
+        endpoint=EP_GET_UPDATES,
+        payload={"get_updates_buf": sync_buf},
+        token=token,
+        timeout_ms=timeout_ms,
+    )
 
 
 async def _send_message(

--- a/tests/gateway/test_weixin.py
+++ b/tests/gateway/test_weixin.py
@@ -883,3 +883,22 @@ class TestWeixinContentDedup:
         assert adapter.handle_message.await_count == 0
         # is_duplicate should only be called for message_id, never for content
         assert all("content:" not in str(call) for call in adapter._dedup.is_duplicate.call_args_list)
+
+
+class TestWeixinTimeoutHandling:
+    """Regression test for Issue #23523: _get_updates should not swallow asyncio.TimeoutError."""
+    
+    @patch.object(weixin, "_api_post", new_callable=AsyncMock)
+    def test_get_updates_propagates_timeout_error(self, api_post_mock):
+        """_get_updates should raise asyncio.TimeoutError, not return empty success."""
+        api_post_mock.side_effect = asyncio.TimeoutError()
+        
+        with pytest.raises(asyncio.TimeoutError):
+            asyncio.run(weixin._get_updates(
+                session=None,
+                base_url="https://example.com",
+                token="test-token",
+                sync_buf="",
+                timeout_ms=35000,
+            ))
+


### PR DESCRIPTION
## What does this PR do?

Fixes WeChat gateway zombie connection issue where network drops (WiFi reconnect, macOS sleep/wake) cause the adapter to report "connected" indefinitely but no messages can be sent or received.


### Root Cause

`_get_updates()` caught `asyncio.TimeoutError` and returned an empty success response (`ret=0`). This caused the poll loop to:
1. Reset `consecutive_failures` to 0
2. Continue polling on a dead network connection
3. Never detect the connection was lost
4. Report `weixin.state=connected` forever in `/health/detailed`

The connection was dead, but the gateway never detected it.

## Related Issue

N/A

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- See commit messages for detailed changes

## How to Test

1. Run `pytest tests/ -q` — all tests should pass
2. Verify the specific scenario described above is resolved

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture and workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A