### PR TITLE
fix(cron): add whatsapp to _HOME_TARGET_ENV_VARS

### DIFF
--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -111,6 +111,7 @@ _HOME_TARGET_ENV_VARS = {
     "weixin": "WEIXIN_HOME_CHANNEL",
     "bluebubbles": "BLUEBUBBLES_HOME_CHANNEL",
     "qqbot": "QQBOT_HOME_CHANNEL",
+    "whatsapp": "WHATSAPP_HOME_CHANNEL",
 }
 
 # Legacy env var names kept for back-compat.  Each entry is the current


### PR DESCRIPTION
## Summary

`deliver: whatsapp` cron jobs are silently dropped because `whatsapp` is absent from `_HOME_TARGET_ENV_VARS` in `cron/scheduler.py`. The resolver returns an empty list, which the caller treats as a no-op.

## Root Cause

`_HOME_TARGET_ENV_VARS` maps platform names to their home-channel env vars. Every messaging platform is present except `whatsapp`. Since `_resolve_delivery_targets({"deliver": "whatsapp"})` finds no env var, it returns `[]` and the message is never sent.

## Fix

Add `whatsapp` to `_HOME_TARGET_ENV_VARS` pointing to `WHATSAPP_HOME_CHANNEL`, which is already used by the gateway adapter and tests.

## Verification

```python
from cron.scheduler import _resolve_delivery_targets
job = {"id": "x", "name": "x", "deliver": "whatsapp"}
assert _resolve_delivery_targets(job) != []  # was: [], now: resolves correctly
```

All 121 cron scheduler tests pass.

Closes #22997
