### PR TITLE
fix(browser): use AGENT_BROWSER_ARGS instead of AGENT_BROWSER_CHROME_FLAGS

### DIFF
--- a/tools/browser_tool.py
+++ b/tools/browser_tool.py
@@ -1873,7 +1873,7 @@ def _run_browser_command(
         # - Ubuntu 23.10+ / AppArmor systems: unprivileged user namespaces
         #   are restricted, causing Chromium to exit with "No usable sandbox"
         #   even for non-root users running under systemd or containers.
-        if "AGENT_BROWSER_CHROME_FLAGS" not in browser_env:
+        if "AGENT_BROWSER_ARGS" not in browser_env:
             _needs_sandbox_bypass = False
             if hasattr(os, "geteuid") and os.geteuid() == 0:
                 _needs_sandbox_bypass = True
@@ -1892,7 +1892,7 @@ def _run_browser_command(
                 except OSError:
                     pass
             if _needs_sandbox_bypass:
-                browser_env["AGENT_BROWSER_CHROME_FLAGS"] = (
+                browser_env["AGENT_BROWSER_ARGS"] = (
                     "--no-sandbox --disable-dev-shm-usage"
                 )
 


### PR DESCRIPTION
## Summary

- Fix env var name mismatch between `browser_tool.py` and `agent-browser` package
- `browser_tool.py` wrote sandbox-bypass flags into `AGENT_BROWSER_CHROME_FLAGS`, but `agent-browser` only reads `AGENT_BROWSER_ARGS`
- This caused `--no-sandbox` injection to silently fail on headless VMs, root containers, and AppArmor-restricted systems (Ubuntu 23.10+), breaking all browser tool usage

## Changes

- Renamed 2 occurrences of `AGENT_BROWSER_CHROME_FLAGS` → `AGENT_BROWSER_ARGS` in `tools/browser_tool.py`

## Test Plan

- [x] Verified no remaining references to `AGENT_BROWSER_CHROME_FLAGS` in Python files
- [ ] Confirm browser tool launches correctly on headless VM with AppArmor restrictions

Fixes #23496