### PR TITLE
fix(gateway/weixin): return error code on long-poll timeout instead of masking as success

### DIFF
--- a/gateway/platforms/weixin.py
+++ b/gateway/platforms/weixin.py
@@ -424,7 +424,7 @@ async def _get_updates(
             timeout_ms=timeout_ms,
         )
     except asyncio.TimeoutError:
-        return {"ret": 0, "msgs": [], "get_updates_buf": sync_buf}
+        return {"ret": -3, "errcode": -3, "errmsg": "connection timeout"}
 
 
 async def _send_message(


### PR DESCRIPTION
## Summary

`_get_updates()` in `gateway/platforms/weixin.py` swallows `asyncio.TimeoutError` as a success response `{"ret": 0}`, causing the long-poll loop to silently spin forever when the network drops.

## Root Cause

When the iLink long-poll socket times out (35s), `_get_updates()` currently returns `{"ret": 0}` — identical to a successful empty-poll response. The `_poll_loop` receives `ret=0`, resets `consecutive_failures`, and immediately starts the next poll. This creates an infinite silent loop with no error logged and the health endpoint permanently reporting `weixin.state: connected`.

## Fix

Return a distinct error code on `asyncio.TimeoutError`:

```python
except asyncio.TimeoutError:
    return {"ret": -3, "errcode": -3, "errmsg": "connection timeout"}
```

The `_poll_loop` already handles `ret != 0` as a failure condition — it increments `consecutive_failures`, logs a warning, and applies retry backoff. After `MAX_CONSECUTIVE_FAILURES` (3), it sleeps for `BACKOFF_DELAY_SECONDS` (30s) before continuing. This is a significant improvement over the current silent infinite loop.

The error code `-3` is unused by the existing protocol (only `-14` and `-2` are defined), making it safe and unambiguous.

## Verification

- Syntax validated: `python3 -m py_compile gateway/platforms/weixin.py` ✓
- All 53 related tests pass (1 pre-existing failure due to missing pytest-asyncio plugin in this environment, unrelated to this change)
- Backward compatible: only the timeout path changes behavior; successful polls are unaffected

Closes #23523
