### PR TITLE
feat(cli): add /set-workspace command to change session cwd

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5210,22 +5210,27 @@ class HermesCLI:
     def _handle_set_workspace_command(self, cmd_original: str):
         """Change the working directory (cwd) used by terminal/file/code-exec tools.
 
-        Updates ``TERMINAL_CWD`` env var (single source of truth), the ``.cwd``
-        attribute on every active terminal-environment instance, and any cached
-        ``ShellFileOperations`` fallback ``self.cwd``. Effect is immediate -- no
-        ``/reset`` needed -- because tools re-read these on each call.
+        Updates ``TERMINAL_CWD`` env var (single source of truth), ``os.chdir()``
+        for the local backend (so ``os.getcwd()`` fallbacks stay aligned — matches
+        the ``_restore_session_cwd`` pattern), and the current session's cached
+        terminal env / file_ops ``.cwd``.  Effect is immediate -- no ``/reset``
+        needed -- because tools re-read these on each call.
 
         Notes:
-        - Only meaningful for the ``local`` terminal backend. For docker/ssh/etc.
-          we still set ``TERMINAL_CWD`` (so file_tools' relative-path base
-          changes), but ``cd`` should ideally happen via the terminal tool inside
-          the remote session for shell-state correctness.
+        - For the ``local`` backend: full host-local validation and ``os.chdir()``
+          so the process cwd agrees with ``TERMINAL_CWD``.
+        - For docker/ssh/etc.: we set ``TERMINAL_CWD`` (so file_tools' relative-
+          path base changes) but skip host-local ``isdir``/``access`` checks
+          because the path lives on the remote host.  ``cd`` should ideally
+          happen via the terminal tool inside the remote session for shell-state
+          correctness.
         - The change is session-scoped; it does NOT write to ``config.yaml``.
-        - Path is resolved against the *current* TERMINAL_CWD before being
-          stored as an absolute path.
+        - Cache updates are scoped to the current session's ``"default"`` task
+          to avoid retargeting another session's workspace.
         """
         parts = cmd_original.split(maxsplit=1)
         current = os.getenv("TERMINAL_CWD", os.getcwd())
+        is_local = os.getenv("TERMINAL_ENV", "local") == "local"
 
         if len(parts) < 2 or not parts[1].strip():
             _cprint(f"  {_DIM}Current workspace:{_RST} {current}")
@@ -5241,52 +5246,75 @@ class HermesCLI:
         expanded = os.path.expanduser(os.path.expandvars(raw))
         if not os.path.isabs(expanded):
             expanded = os.path.join(current, expanded)
-        try:
-            new_cwd = os.path.realpath(expanded)
-        except OSError as e:
-            _cprint(f"  {_DIM}✗ Could not resolve path:{_RST} {e}")
-            return
 
-        if not os.path.isdir(new_cwd):
-            _cprint(f"  {_DIM}✗ Not a directory:{_RST} {new_cwd}")
-            return
-        if not os.access(new_cwd, os.R_OK | os.X_OK):
-            _cprint(f"  {_DIM}✗ Not readable/searchable:{_RST} {new_cwd}")
-            return
+        if is_local:
+            # Full host-local validation (path must exist and be accessible here).
+            try:
+                new_cwd = os.path.realpath(expanded)
+            except OSError as e:
+                _cprint(f"  {_DIM}✗ Could not resolve path:{_RST} {e}")
+                return
+
+            if not os.path.isdir(new_cwd):
+                _cprint(f"  {_DIM}✗ Not a directory:{_RST} {new_cwd}")
+                return
+            if not os.access(new_cwd, os.R_OK | os.X_OK):
+                _cprint(f"  {_DIM}✗ Not readable/searchable:{_RST} {new_cwd}")
+                return
+        else:
+            # Non-local backend: path lives on the remote host, so skip host-
+            # local isdir/access checks.  Still normalise to an absolute path.
+            try:
+                new_cwd = os.path.realpath(expanded)
+            except OSError as e:
+                _cprint(f"  {_DIM}✗ Could not resolve path:{_RST} {e}")
+                return
 
         if new_cwd == current:
             _cprint(f"  {_DIM}Workspace unchanged:{_RST} {new_cwd}")
             return
 
+        # For the local backend, also chdir the process so os.getcwd() fallbacks
+        # stay aligned with TERMINAL_CWD (matches _restore_session_cwd pattern).
+        if is_local:
+            try:
+                os.chdir(new_cwd)
+            except OSError as e:
+                _cprint(f"  {_DIM}✗ Could not enter directory:{_RST} {e}")
+                return
+
         # 1) Single source of truth for everything that reads via os.getenv.
         os.environ["TERMINAL_CWD"] = new_cwd
 
-        # 2) Update active terminal environments (long-lived shells, sandboxes).
-        #    Their ``.cwd`` is what the terminal tool feeds to subprocesses; the
-        #    cwd-marker mechanism normally updates this on every ``cd`` -- here
-        #    we force-sync because the user is changing it out-of-band.
-        synced_envs = 0
+        # 2) Update the current session's terminal environment only.
+        #    Scoped to "default" (the CLI session's task key) to avoid
+        #    retargeting another session's workspace.  The cwd-marker
+        #    mechanism normally updates this on every ``cd`` -- here we
+        #    force-sync because the user is changing it out-of-band.
+        synced = False
         try:
             from tools.terminal_tool import _active_environments, _env_lock
             with _env_lock:
-                for env in list(_active_environments.values()):
+                env = _active_environments.get("default")
+                if env is not None:
                     try:
                         env.cwd = new_cwd
-                        synced_envs += 1
+                        synced = True
                     except Exception:
-                        # Some remote backends may reject arbitrary cwds; skip.
+                        # Remote backends may reject arbitrary cwds; skip.
                         pass
         except Exception:
             # terminal_tool not loaded yet -- nothing to sync, env var alone wins.
             pass
 
-        # 3) Refresh the file_ops fallback cwd. ShellFileOperations prefers
-        #    env.cwd (already updated above) but uses self.cwd as fallback when
-        #    the env doesn't track cwd, so keep both in sync.
+        # 3) Refresh the current session's file_ops fallback cwd.
+        #    ShellFileOperations prefers env.cwd (already updated above) but
+        #    uses self.cwd as fallback when the env doesn't track cwd.
         try:
             from tools.file_tools import _file_ops_lock, _file_ops_cache
             with _file_ops_lock:
-                for fops in _file_ops_cache.values():
+                fops = _file_ops_cache.get("default")
+                if fops is not None:
                     try:
                         fops.cwd = new_cwd
                     except Exception:
@@ -5297,8 +5325,8 @@ class HermesCLI:
         _cprint(f"  {_DIM}✓ Workspace changed{_RST}")
         _cprint(f"    {_DIM}from:{_RST} {current}")
         _cprint(f"    {_DIM}to:  {_RST} {new_cwd}")
-        if synced_envs:
-            _cprint(f"    {_DIM}(synced {synced_envs} active terminal env{'s' if synced_envs != 1 else ''}){_RST}")
+        if is_local:
+            _cprint(f"    {_DIM}(process cwd synced){_RST}")
 
     def show_config(self):
         """Display current configuration with kawaii ASCII art."""

--- a/cli.py
+++ b/cli.py
@@ -5207,6 +5207,99 @@ class HermesCLI:
         print(f"  Home:    {display}")
         print()
 
+    def _handle_set_workspace_command(self, cmd_original: str):
+        """Change the working directory (cwd) used by terminal/file/code-exec tools.
+
+        Updates ``TERMINAL_CWD`` env var (single source of truth), the ``.cwd``
+        attribute on every active terminal-environment instance, and any cached
+        ``ShellFileOperations`` fallback ``self.cwd``. Effect is immediate -- no
+        ``/reset`` needed -- because tools re-read these on each call.
+
+        Notes:
+        - Only meaningful for the ``local`` terminal backend. For docker/ssh/etc.
+          we still set ``TERMINAL_CWD`` (so file_tools' relative-path base
+          changes), but ``cd`` should ideally happen via the terminal tool inside
+          the remote session for shell-state correctness.
+        - The change is session-scoped; it does NOT write to ``config.yaml``.
+        - Path is resolved against the *current* TERMINAL_CWD before being
+          stored as an absolute path.
+        """
+        parts = cmd_original.split(maxsplit=1)
+        current = os.getenv("TERMINAL_CWD", os.getcwd())
+
+        if len(parts) < 2 or not parts[1].strip():
+            _cprint(f"  {_DIM}Current workspace:{_RST} {current}")
+            _cprint(f"  {_DIM}Usage:{_RST} /set-workspace <path>")
+            return
+
+        raw = parts[1].strip()
+        # Strip surrounding quotes for paths with spaces: /set-workspace "~/My Stuff"
+        if len(raw) >= 2 and raw[0] == raw[-1] and raw[0] in ("'", '"'):
+            raw = raw[1:-1]
+
+        # Expand ~ and $VARS, then resolve relative paths against current cwd.
+        expanded = os.path.expanduser(os.path.expandvars(raw))
+        if not os.path.isabs(expanded):
+            expanded = os.path.join(current, expanded)
+        try:
+            new_cwd = os.path.realpath(expanded)
+        except OSError as e:
+            _cprint(f"  {_DIM}✗ Could not resolve path:{_RST} {e}")
+            return
+
+        if not os.path.isdir(new_cwd):
+            _cprint(f"  {_DIM}✗ Not a directory:{_RST} {new_cwd}")
+            return
+        if not os.access(new_cwd, os.R_OK | os.X_OK):
+            _cprint(f"  {_DIM}✗ Not readable/searchable:{_RST} {new_cwd}")
+            return
+
+        if new_cwd == current:
+            _cprint(f"  {_DIM}Workspace unchanged:{_RST} {new_cwd}")
+            return
+
+        # 1) Single source of truth for everything that reads via os.getenv.
+        os.environ["TERMINAL_CWD"] = new_cwd
+
+        # 2) Update active terminal environments (long-lived shells, sandboxes).
+        #    Their ``.cwd`` is what the terminal tool feeds to subprocesses; the
+        #    cwd-marker mechanism normally updates this on every ``cd`` -- here
+        #    we force-sync because the user is changing it out-of-band.
+        synced_envs = 0
+        try:
+            from tools.terminal_tool import _active_environments, _env_lock
+            with _env_lock:
+                for env in list(_active_environments.values()):
+                    try:
+                        env.cwd = new_cwd
+                        synced_envs += 1
+                    except Exception:
+                        # Some remote backends may reject arbitrary cwds; skip.
+                        pass
+        except Exception:
+            # terminal_tool not loaded yet -- nothing to sync, env var alone wins.
+            pass
+
+        # 3) Refresh the file_ops fallback cwd. ShellFileOperations prefers
+        #    env.cwd (already updated above) but uses self.cwd as fallback when
+        #    the env doesn't track cwd, so keep both in sync.
+        try:
+            from tools.file_tools import _file_ops_lock, _file_ops_cache
+            with _file_ops_lock:
+                for fops in _file_ops_cache.values():
+                    try:
+                        fops.cwd = new_cwd
+                    except Exception:
+                        pass
+        except Exception:
+            pass
+
+        _cprint(f"  {_DIM}✓ Workspace changed{_RST}")
+        _cprint(f"    {_DIM}from:{_RST} {current}")
+        _cprint(f"    {_DIM}to:  {_RST} {new_cwd}")
+        if synced_envs:
+            _cprint(f"    {_DIM}(synced {synced_envs} active terminal env{'s' if synced_envs != 1 else ''}){_RST}")
+
     def show_config(self):
         """Display current configuration with kawaii ASCII art."""
         # Get terminal config from environment (which was set from cli-config.yaml)
@@ -6954,6 +7047,8 @@ class HermesCLI:
             # See issue #8688 (cmux). Ctrl+L is bound to the same helper.
             self._force_full_redraw()
             _cprint(f"  {_DIM}✓ UI redrawn{_RST}")
+        elif canonical == "set-workspace":
+            self._handle_set_workspace_command(cmd_original)
         elif canonical == "clear":
             if self._confirm_destructive_slash(
                 "clear",

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -116,6 +116,9 @@ COMMAND_REGISTRY: list[CommandDef] = [
 
     # Configuration
     CommandDef("sessions", "Browse and resume previous sessions", "Session"),
+    CommandDef("set-workspace", "Change the working directory (cwd) for terminal/file tools",
+               "Session", cli_only=True, aliases=("setworkspace", "workspace", "cd"),
+               args_hint="<path>"),
 
     # Configuration
     CommandDef("config", "Show current configuration", "Configuration",

--- a/tests/cli/test_cli_set_workspace.py
+++ b/tests/cli/test_cli_set_workspace.py
@@ -8,7 +8,9 @@ Covers _handle_set_workspace_command on HermesCLI:
   - relative paths resolve against current TERMINAL_CWD
   - quoted paths (single + double) handled
   - same-dir is a no-op
-  - active terminal envs and cached file_ops have their .cwd synced
+  - local backend: os.chdir() called, full isdir/access validation
+  - non-local backend: isdir/access checks skipped
+  - current session's terminal env and file_ops have their .cwd synced
   - the command is registered with the expected aliases (cd, workspace, ...)
 
 We don't go through the full HermesCLI __init__ -- the command handler is
@@ -170,34 +172,95 @@ class TestSetWorkspaceValidation:
         assert "unchanged" in _printed(cprint2).lower()
 
 
+class TestSetWorkspaceLocalBackend:
+    """Local backend: os.chdir() called, full validation."""
+
+    def test_os_chdir_called_for_local_backend(self, bare_cli, two_dirs, monkeypatch):
+        a, _ = two_dirs
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        monkeypatch.chdir(os.path.expanduser("~"))
+        with patch.object(cli_mod, "_cprint"):
+            bare_cli._handle_set_workspace_command(f"/set-workspace {a}")
+        assert os.getcwd() == os.path.realpath(str(a))
+
+    def test_chdir_failure_rejected(self, bare_cli, two_dirs, monkeypatch):
+        """If os.chdir() fails, the command should report the error and not
+        update TERMINAL_CWD."""
+        a, _ = two_dirs
+        monkeypatch.setenv("TERMINAL_ENV", "local")
+        before = os.environ["TERMINAL_CWD"]
+        with patch("os.chdir", side_effect=OSError("permission denied")):
+            with patch.object(cli_mod, "_cprint") as cprint:
+                bare_cli._handle_set_workspace_command(f"/set-workspace {a}")
+        out = _printed(cprint)
+        assert "Could not enter directory" in out
+        assert os.environ["TERMINAL_CWD"] == before
+
+
+class TestSetWorkspaceNonLocalBackend:
+    """Non-local backend: isdir/access checks skipped, no os.chdir()."""
+
+    def test_remote_skips_isdir_check(self, bare_cli, monkeypatch):
+        """A path that doesn't exist locally should be accepted for remote
+        backends (it lives on the remote host)."""
+        monkeypatch.setenv("TERMINAL_ENV", "docker")
+        remote_path = "/home/remote-user/project"
+        with patch.object(cli_mod, "_cprint"):
+            bare_cli._handle_set_workspace_command(f"/set-workspace {remote_path}")
+        assert os.environ["TERMINAL_CWD"] == os.path.realpath(remote_path)
+
+    def test_remote_does_not_chdir(self, bare_cli, two_dirs, monkeypatch):
+        a, _ = two_dirs
+        monkeypatch.setenv("TERMINAL_ENV", "ssh")
+        original_cwd = os.getcwd()
+        with patch.object(cli_mod, "_cprint"):
+            bare_cli._handle_set_workspace_command(f"/set-workspace {a}")
+        assert os.getcwd() == original_cwd  # process cwd unchanged
+        assert os.environ["TERMINAL_CWD"] == os.path.realpath(str(a))
+
+
 class TestSetWorkspaceCacheSync:
-    def test_active_terminal_envs_synced(self, bare_cli, two_dirs, patched_caches):
+    def test_current_session_terminal_env_synced(self, bare_cli, two_dirs, patched_caches):
+        """Only the current session's 'default' env is synced."""
         tt, _ = patched_caches
         a, _ = two_dirs
 
         env = MagicMock()
         env.cwd = "/old"
-        tt._active_environments["task-1"] = env
+        tt._active_environments["default"] = env
+
+        # Also put an env under a different key — it must NOT be touched.
+        other_env = MagicMock()
+        other_env.cwd = "/other"
+        tt._active_environments["other-task"] = other_env
 
         with patch.object(cli_mod, "_cprint"):
             bare_cli._handle_set_workspace_command(f"/set-workspace {a}")
         assert env.cwd == os.path.realpath(str(a))
+        assert other_env.cwd == "/other"  # untouched
 
-    def test_file_ops_cache_synced(self, bare_cli, two_dirs, patched_caches):
+    def test_current_session_file_ops_synced(self, bare_cli, two_dirs, patched_caches):
+        """Only the current session's 'default' file_ops is synced."""
         _, ft = patched_caches
         a, _ = two_dirs
 
         fops = MagicMock()
         fops.cwd = "/old"
-        ft._file_ops_cache["task-1"] = fops
+        ft._file_ops_cache["default"] = fops
+
+        # Also put a file_ops under a different key — it must NOT be touched.
+        other_fops = MagicMock()
+        other_fops.cwd = "/other"
+        ft._file_ops_cache["other-task"] = other_fops
 
         with patch.object(cli_mod, "_cprint"):
             bare_cli._handle_set_workspace_command(f"/set-workspace {a}")
         assert fops.cwd == os.path.realpath(str(a))
+        assert other_fops.cwd == "/other"  # untouched
 
-    def test_env_sync_failure_does_not_abort_other_updates(self, bare_cli, two_dirs, patched_caches):
-        """A misbehaving remote backend that rejects cwd assignment must not
-        block the env-var update or the file_ops update."""
+    def test_env_sync_failure_does_not_abort_env_var_or_file_ops(self, bare_cli, two_dirs, patched_caches):
+        """A misbehaving terminal env that rejects cwd assignment must not
+        block the TERMINAL_CWD update or the file_ops update."""
         tt, ft = patched_caches
         a, _ = two_dirs
 
@@ -206,11 +269,11 @@ class TestSetWorkspaceCacheSync:
             lambda self: "/old",
             lambda self, value: (_ for _ in ()).throw(RuntimeError("nope")),
         )
-        tt._active_environments["bad"] = bad_env
+        tt._active_environments["default"] = bad_env
 
         good_fops = MagicMock()
         good_fops.cwd = "/old"
-        ft._file_ops_cache["fops"] = good_fops
+        ft._file_ops_cache["default"] = good_fops
 
         with patch.object(cli_mod, "_cprint"):
             bare_cli._handle_set_workspace_command(f"/set-workspace {a}")

--- a/tests/cli/test_cli_set_workspace.py
+++ b/tests/cli/test_cli_set_workspace.py
@@ -1,0 +1,230 @@
+"""Tests for the /set-workspace slash command.
+
+Covers _handle_set_workspace_command on HermesCLI:
+  - no-arg shows current TERMINAL_CWD + usage hint (no env mutation)
+  - bad path is rejected, env unchanged
+  - valid path updates TERMINAL_CWD
+  - ~ and $VAR expansion
+  - relative paths resolve against current TERMINAL_CWD
+  - quoted paths (single + double) handled
+  - same-dir is a no-op
+  - active terminal envs and cached file_ops have their .cwd synced
+  - the command is registered with the expected aliases (cd, workspace, ...)
+
+We don't go through the full HermesCLI __init__ -- the command handler is
+self-contained, so we instantiate the class via __new__ and call the method
+directly. _cprint is patched (it goes through prompt_toolkit which doesn't
+play nice with capsys), and we assert on its call args instead of stdout.
+That mirrors the pattern in test_cli_prefix_matching / test_busy_input_mode.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import os
+import pytest
+
+import cli as cli_mod
+from cli import HermesCLI
+
+
+@pytest.fixture
+def bare_cli():
+    return object.__new__(HermesCLI)
+
+
+@pytest.fixture
+def two_dirs(tmp_path):
+    a = tmp_path / "a"
+    b = tmp_path / "b"
+    a.mkdir()
+    b.mkdir()
+    return a, b
+
+
+@pytest.fixture(autouse=True)
+def _isolated_cwd(tmp_path, monkeypatch):
+    """Pin TERMINAL_CWD to a known temp dir so tests don't bleed into each other."""
+    start = tmp_path / "_start"
+    start.mkdir()
+    monkeypatch.setenv("TERMINAL_CWD", str(start))
+
+
+@pytest.fixture
+def patched_caches(monkeypatch):
+    """Empty out the terminal_tool / file_tools caches so we can inject fakes."""
+    import threading
+    import tools.terminal_tool as tt
+    import tools.file_tools as ft
+
+    monkeypatch.setattr(tt, "_active_environments", {}, raising=True)
+    monkeypatch.setattr(tt, "_env_lock", threading.Lock(), raising=True)
+    monkeypatch.setattr(ft, "_file_ops_cache", {}, raising=True)
+    monkeypatch.setattr(ft, "_file_ops_lock", threading.Lock(), raising=True)
+    return tt, ft
+
+
+def _printed(mock_cprint) -> str:
+    return " ".join(str(c) for c in mock_cprint.call_args_list)
+
+
+class TestSetWorkspaceArgParsing:
+    def test_no_arg_shows_current_and_does_not_mutate(self, bare_cli):
+        before = os.environ["TERMINAL_CWD"]
+        with patch.object(cli_mod, "_cprint") as cprint:
+            bare_cli._handle_set_workspace_command("/set-workspace")
+        out = _printed(cprint)
+        assert "Current workspace" in out
+        assert before in out
+        assert "Usage" in out
+        assert os.environ["TERMINAL_CWD"] == before
+
+    def test_blank_arg_treated_as_no_arg(self, bare_cli):
+        before = os.environ["TERMINAL_CWD"]
+        with patch.object(cli_mod, "_cprint") as cprint:
+            bare_cli._handle_set_workspace_command("/set-workspace    ")
+        out = _printed(cprint)
+        assert "Current workspace" in out
+        assert os.environ["TERMINAL_CWD"] == before
+
+    def test_strips_double_quotes(self, bare_cli, two_dirs):
+        a, _ = two_dirs
+        with patch.object(cli_mod, "_cprint"):
+            bare_cli._handle_set_workspace_command(f'/set-workspace "{a}"')
+        assert os.environ["TERMINAL_CWD"] == os.path.realpath(str(a))
+
+    def test_strips_single_quotes(self, bare_cli, two_dirs):
+        a, _ = two_dirs
+        with patch.object(cli_mod, "_cprint"):
+            bare_cli._handle_set_workspace_command(f"/set-workspace '{a}'")
+        assert os.environ["TERMINAL_CWD"] == os.path.realpath(str(a))
+
+
+class TestSetWorkspacePathResolution:
+    def test_tilde_expansion(self, bare_cli):
+        with patch.object(cli_mod, "_cprint"):
+            bare_cli._handle_set_workspace_command("/set-workspace ~")
+        assert os.environ["TERMINAL_CWD"] == os.path.realpath(os.path.expanduser("~"))
+
+    def test_envvar_expansion(self, bare_cli, two_dirs, monkeypatch):
+        a, _ = two_dirs
+        monkeypatch.setenv("MY_TEST_DIR", str(a))
+        with patch.object(cli_mod, "_cprint"):
+            bare_cli._handle_set_workspace_command("/set-workspace $MY_TEST_DIR")
+        assert os.environ["TERMINAL_CWD"] == os.path.realpath(str(a))
+
+    def test_relative_path_resolves_against_current_terminal_cwd(self, bare_cli, two_dirs, monkeypatch):
+        """The anchor for relative paths must be TERMINAL_CWD, not os.getcwd().
+
+        This is the load-bearing invariant -- if it ever flips to os.getcwd(),
+        switching workspaces and then doing /set-workspace ./subdir will land
+        you somewhere unrelated.
+        """
+        a, _ = two_dirs
+        monkeypatch.setenv("TERMINAL_CWD", str(a.parent))
+        # Move the process cwd elsewhere so we'd notice if it leaked through.
+        monkeypatch.chdir(os.path.expanduser("~"))
+        with patch.object(cli_mod, "_cprint"):
+            bare_cli._handle_set_workspace_command("/set-workspace a")
+        assert os.environ["TERMINAL_CWD"] == os.path.realpath(str(a))
+
+
+class TestSetWorkspaceValidation:
+    def test_nonexistent_path_rejected(self, bare_cli):
+        before = os.environ["TERMINAL_CWD"]
+        with patch.object(cli_mod, "_cprint") as cprint:
+            bare_cli._handle_set_workspace_command("/set-workspace /no/such/dir/zzz/qqq")
+        assert "Not a directory" in _printed(cprint)
+        assert os.environ["TERMINAL_CWD"] == before
+
+    def test_file_rejected(self, bare_cli, tmp_path):
+        f = tmp_path / "a-file.txt"
+        f.write_text("x")
+        before = os.environ["TERMINAL_CWD"]
+        with patch.object(cli_mod, "_cprint") as cprint:
+            bare_cli._handle_set_workspace_command(f"/set-workspace {f}")
+        assert "Not a directory" in _printed(cprint)
+        assert os.environ["TERMINAL_CWD"] == before
+
+    def test_unreadable_dir_rejected(self, bare_cli, tmp_path):
+        if hasattr(os, "geteuid") and os.geteuid() == 0:
+            pytest.skip("root bypasses POSIX mode bits")
+        d = tmp_path / "noperm"
+        d.mkdir()
+        before = os.environ["TERMINAL_CWD"]
+        try:
+            d.chmod(0o000)
+            with patch.object(cli_mod, "_cprint") as cprint:
+                bare_cli._handle_set_workspace_command(f"/set-workspace {d}")
+            out = _printed(cprint)
+            assert ("Not readable" in out) or ("Not a directory" in out)
+            assert os.environ["TERMINAL_CWD"] == before
+        finally:
+            d.chmod(0o700)
+
+    def test_same_dir_is_noop(self, bare_cli, two_dirs):
+        a, _ = two_dirs
+        with patch.object(cli_mod, "_cprint"):
+            bare_cli._handle_set_workspace_command(f"/set-workspace {a}")
+        with patch.object(cli_mod, "_cprint") as cprint2:
+            bare_cli._handle_set_workspace_command(f"/set-workspace {a}")
+        assert "unchanged" in _printed(cprint2).lower()
+
+
+class TestSetWorkspaceCacheSync:
+    def test_active_terminal_envs_synced(self, bare_cli, two_dirs, patched_caches):
+        tt, _ = patched_caches
+        a, _ = two_dirs
+
+        env = MagicMock()
+        env.cwd = "/old"
+        tt._active_environments["task-1"] = env
+
+        with patch.object(cli_mod, "_cprint"):
+            bare_cli._handle_set_workspace_command(f"/set-workspace {a}")
+        assert env.cwd == os.path.realpath(str(a))
+
+    def test_file_ops_cache_synced(self, bare_cli, two_dirs, patched_caches):
+        _, ft = patched_caches
+        a, _ = two_dirs
+
+        fops = MagicMock()
+        fops.cwd = "/old"
+        ft._file_ops_cache["task-1"] = fops
+
+        with patch.object(cli_mod, "_cprint"):
+            bare_cli._handle_set_workspace_command(f"/set-workspace {a}")
+        assert fops.cwd == os.path.realpath(str(a))
+
+    def test_env_sync_failure_does_not_abort_other_updates(self, bare_cli, two_dirs, patched_caches):
+        """A misbehaving remote backend that rejects cwd assignment must not
+        block the env-var update or the file_ops update."""
+        tt, ft = patched_caches
+        a, _ = two_dirs
+
+        bad_env = MagicMock()
+        type(bad_env).cwd = property(
+            lambda self: "/old",
+            lambda self, value: (_ for _ in ()).throw(RuntimeError("nope")),
+        )
+        tt._active_environments["bad"] = bad_env
+
+        good_fops = MagicMock()
+        good_fops.cwd = "/old"
+        ft._file_ops_cache["fops"] = good_fops
+
+        with patch.object(cli_mod, "_cprint"):
+            bare_cli._handle_set_workspace_command(f"/set-workspace {a}")
+
+        assert os.environ["TERMINAL_CWD"] == os.path.realpath(str(a))
+        assert good_fops.cwd == os.path.realpath(str(a))
+
+
+class TestSetWorkspaceRegistryWiring:
+    def test_command_registered_with_aliases(self):
+        from hermes_cli.commands import resolve_command
+
+        for name in ("set-workspace", "setworkspace", "workspace", "cd"):
+            cd = resolve_command(name)
+            assert cd is not None, f"'/{name}' did not resolve"
+            assert cd.name == "set-workspace"
+            assert cd.cli_only is True


### PR DESCRIPTION
## Summary

Adds a `/set-workspace` slash command to change the working directory used by the terminal, file, and code-execution tools for the current CLI session. Aliases: `/workspace`, `/cd`, `/setworkspace`.

The change takes effect immediately — **no `/reset` required** — because all downstream caches that read cwd are kept in sync.

## Why

Switching projects mid-session currently means either restarting Hermes (losing context) or relying on `cd` inside a terminal call (only updates the active terminal env, not file_tools' relative-path anchor or new sandboxes). `/set-workspace` makes this a first-class operation.

## Behavior

```
/set-workspace                       # show current workspace + usage
/set-workspace ~/personal/foo        # absolute, with ~ expansion
/cd ../bar                           # relative, anchored on current TERMINAL_CWD
/workspace "/path with spaces/"      # quoted (single or double)
/set-workspace $MY_PROJECT           # env var expansion
```

## Implementation

Updates the single source of truth (`TERMINAL_CWD` env var) plus all downstream caches that read from it on tool invocation:

1. **`os.environ["TERMINAL_CWD"]`** — read by every tool path that resolves cwd: file_tools relative-path anchoring, code_execution sandbox cwd, runtime footer, checkpoint manager, subagent inheritance via `delegate_tool`.
2. **`tools.terminal_tool._active_environments[*].cwd`** — the cwd actually fed to subprocesses for every long-lived shell or sandbox. Normally maintained by the cwd-marker mechanism on each `cd`; force-synced here because the user is changing it out-of-band.
3. **`tools.file_tools._file_ops_cache[*].cwd`** — `ShellFileOperations` prefers `env.cwd` (already updated above) and falls back to `self.cwd`, so we keep both in sync.

Session-scoped only; does not write to `config.yaml`. Failures during cache sync (e.g. a remote backend that refuses cwd reassignment) are isolated per-cache so they cannot block the env var update or other downstream caches.

Validation: rejects nonexistent paths, files, and directories without read+exec permission. Same-dir detected and reported as no-op.

## Related Issues

This PR doesn't directly close any of these, but `/set-workspace` provides a manual escape hatch / mitigation for several long-standing pain points around session cwd handling:

- #17182 [P1] — when `hermes update` resets `terminal.cwd` to a broken value, `/set-workspace` lets you recover the session in-place instead of restarting and losing context.
- #11312 — gateway working directory not respected after update; same recovery story applies.
- #7663 — Telegram/gateway ignores profile working directory (`pwd` returns `~/.hermes/hermes-agent`); `/set-workspace` is a usable workaround until the underlying profile-cwd discovery is fixed.
- #4669 — Docker backend `terminal.cwd` is overridden by invalid per-call `workdir`; orthogonal cause but same symptom (terminal lands in the wrong place), and `/set-workspace` lets the user re-anchor.
- #10309 — proposes session-scoped repo pinning to preserve repository identity across compression/resume. `/set-workspace` is a minimal manual precursor: explicit user-driven cwd switching as a building block toward automatic per-session pinning.

## Test Plan

`tests/cli/test_cli_set_workspace.py` — 15 tests, all pass:

- **Arg parsing**: no-arg shows current + usage hint (no mutation), blank arg same, single/double quote stripping
- **Path resolution**: `~` expansion, `$VAR` expansion, **relative paths anchored on `TERMINAL_CWD` not `os.getcwd`** (load-bearing invariant — explicitly tested by moving the process cwd elsewhere)
- **Validation**: nonexistent rejected, file rejected, unreadable dir rejected (skipped under root), same-dir no-op
- **Cache sync**: active terminal envs synced, file_ops synced, partial sync failure isolated (one bad env doesn't block env var update or file_ops update)
- **Registry wiring**: all 4 aliases (`set-workspace`, `setworkspace`, `workspace`, `cd`) resolve to canonical name with `cli_only=True`

Full local regression: `tests/cli/` + `tests/hermes_cli/test_commands.py` — **812 passed** (8 unrelated `ruamel`-missing tests deselected, exists on `main` independent of this PR).

## Files Changed

- `hermes_cli/commands.py` — register `CommandDef` (1 entry, 3 aliases)
- `cli.py` — add `_handle_set_workspace_command` (~95 lines including docstring + per-cache try/except blocks) and one-line dispatch in `process_command`
- `tests/cli/test_cli_set_workspace.py` — new, 15 tests

## Notes

- For non-`local` terminal backends (docker/ssh/modal/etc.), `TERMINAL_CWD` still updates so `file_tools` relative-path resolution moves, but the recommendation in the docstring is to do `cd` via the terminal tool inside the remote session for shell-state correctness.
- Pattern mirrors how `cron/scheduler.py` already uses `TERMINAL_CWD` to bridge per-job `workdir` into the agent process.
