### PR TITLE
feat(spotify): switch playlist get action to paginated items endpoint

### DIFF
--- a/plugins/spotify/client.py
+++ b/plugins/spotify/client.py
@@ -222,6 +222,21 @@ class SpotifyClient:
     def get_playlist(self, *, playlist_id: str, market: Optional[str] = None) -> Any:
         return self.request("GET", f"/playlists/{playlist_id}", params={"market": market})
 
+    def get_playlist_items(
+        self,
+        *,
+        playlist_id: str,
+        limit: int = 20,
+        offset: int = 0,
+        market: Optional[str] = None,
+    ) -> Any:
+        """Fetch playlist tracks via the modern paginated endpoint."""
+        return self.request("GET", f"/playlists/{playlist_id}/items", params={
+            "limit": limit,
+            "offset": offset,
+            "market": market,
+        })
+
     def create_playlist(
         self,
         *,

--- a/plugins/spotify/tools.py
+++ b/plugins/spotify/tools.py
@@ -232,7 +232,12 @@ def _handle_spotify_playlists(args: dict, **kw) -> str:
             ))
         if action == "get":
             playlist_id = normalize_spotify_id(str(args.get("playlist_id") or ""), "playlist")
-            return tool_result(client.get_playlist(playlist_id=playlist_id, market=args.get("market")))
+            return tool_result(client.get_playlist_items(
+                playlist_id=playlist_id,
+                limit=_coerce_limit(args.get("limit"), default=20),
+                offset=max(0, int(args.get("offset") or 0)),
+                market=args.get("market"),
+            ))
         if action == "create":
             name = str(args.get("name") or "").strip()
             if not name:


### PR DESCRIPTION
## Summary

Fixes the `spotify_playlists` tool to support paginated playlist retrieval for large playlists.

### Problem
The `get` action was hitting the deprecated `GET /playlists/{id}` endpoint, which embeds tracks inline and ignores pagination parameters (`limit`/`offset`). This made it impossible to retrieve full playlists larger than ~100 tracks — the response was always truncated.

### Solution
- Added `get_playlist_items()` method to `client.py` using the modern `GET /playlists/{playlist_id}/items` endpoint which supports proper `limit`/`offset` pagination.
- Updated `tools.py` `_handle_spotify_playlists` to use `get_playlist_items()` for the `get` action instead of the deprecated `get_playlist()`.

### Changes
- `plugins/spotify/client.py`: +15 lines (new `get_playlist_items` method)
- `plugins/spotify/tools.py`: +7/-1 lines (switch to paginated endpoint)

### Test Plan
- [x] Verified playlist pagination with a 359-track playlist (8 pages of 50)
- [x] Successfully retrieved all 359 tracks across multiple paginated calls
- [x] Limit/offset parameters respected properly