### PR TITLE
Honor model.base_url for bare provider: custom main models

### DIFF
--- a/hermes_cli/runtime_provider.py
+++ b/hermes_cli/runtime_provider.py
@@ -956,12 +956,44 @@ def resolve_runtime_provider(
         custom_runtime["requested_provider"] = requested_provider
         return custom_runtime
 
+    model_cfg = _get_model_config()
+
+    # Bare top-level custom provider configured via model.provider + model.base_url
+    # should resolve directly from config, even when the caller did not pass an
+    # explicit_base_url. Without this, gateway/cron startup falls through to the
+    # generic openrouter/custom path and can lose the configured Anthropic-style
+    # endpoint, causing provider/base_url mismatches for custom main models.
+    if requested_provider == "custom":
+        cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
+        cfg_base_url = str(model_cfg.get("base_url") or "").strip().rstrip("/")
+        if cfg_provider == "custom" and cfg_base_url:
+            cfg_api_key = str(model_cfg.get("api_key") or "").strip()
+            api_key_candidates = [
+                (explicit_api_key or "").strip(),
+                cfg_api_key,
+                os.getenv("OPENAI_API_KEY", "").strip(),
+                os.getenv("OPENROUTER_API_KEY", "").strip(),
+            ]
+            api_key = next(
+                (candidate for candidate in api_key_candidates if has_usable_secret(candidate)),
+                "",
+            ) or "no-key-required"
+            return {
+                "provider": "custom",
+                "api_mode": _parse_api_mode(model_cfg.get("api_mode"))
+                or _detect_api_mode_for_url(cfg_base_url)
+                or "chat_completions",
+                "base_url": cfg_base_url,
+                "api_key": api_key,
+                "source": "config",
+                "requested_provider": requested_provider,
+            }
+
     provider = resolve_provider(
         requested_provider,
         explicit_api_key=explicit_api_key,
         explicit_base_url=explicit_base_url,
     )
-    model_cfg = _get_model_config()
     explicit_runtime = _resolve_explicit_runtime(
         provider=provider,
         requested_provider=requested_provider,

--- a/tests/hermes_cli/test_runtime_provider_resolution.py
+++ b/tests/hermes_cli/test_runtime_provider_resolution.py
@@ -95,6 +95,37 @@ def test_resolve_runtime_provider_anthropic_explicit_override_skips_pool(monkeyp
     assert resolved.get("credential_pool") is None
 
 
+def test_resolve_runtime_provider_bare_custom_uses_model_config_base_url(monkeypatch):
+    def _unexpected_resolve_provider(*args, **kwargs):
+        raise AssertionError("resolve_provider should not be called for bare custom config runtime")
+
+    def _unexpected_load_pool(provider):
+        raise AssertionError(f"load_pool should not be called for {provider}")
+
+    monkeypatch.setattr(rp, "resolve_provider", _unexpected_resolve_provider)
+    monkeypatch.setattr(rp, "load_pool", _unexpected_load_pool)
+    monkeypatch.setattr(
+        rp,
+        "_get_model_config",
+        lambda: {
+            "provider": "custom",
+            "default": "MiniMax-M2.7",
+            "base_url": "https://api.minimaxi.com/anthropic",
+            "api_key": "test-minimax-key",
+            "api_mode": "anthropic_messages",
+        },
+    )
+
+    resolved = rp.resolve_runtime_provider(requested="custom")
+
+    assert resolved["provider"] == "custom"
+    assert resolved["api_mode"] == "anthropic_messages"
+    assert resolved["base_url"] == "https://api.minimaxi.com/anthropic"
+    assert resolved["api_key"] == "test-minimax-key"
+    assert resolved["source"] == "config"
+    assert resolved["requested_provider"] == "custom"
+
+
 def test_resolve_runtime_provider_falls_back_when_pool_empty(monkeypatch):
     class _Pool:
         def has_credentials(self):


### PR DESCRIPTION
## Summary

This fixes runtime resolution for top-level custom main models configured via `config.yaml`, for example:

```yaml
model:
  default: MiniMax-M2.7
  provider: custom
  base_url: https://api.minimaxi.com/anthropic
  api_key: ${MINIMAX_CN_API_KEY}
  api_mode: anthropic_messages
```

Previously, bare `provider: custom` only short-circuited when an explicit
`base_url` was passed at runtime. When the custom endpoint was configured only
in `model.base_url`, `resolve_runtime_provider()` fell through to the generic
openrouter/custom path, which could lose the configured Anthropic-style
endpoint and re-resolve the runtime incorrectly.

## Fix

Add a direct config-based runtime resolution branch for:

- `requested_provider == "custom"`
- `model.provider == "custom"`
- `model.base_url` present

This returns a first-class custom runtime using:

- `provider: custom`
- `base_url: model.base_url`
- `api_mode: model.api_mode` (or URL detection fallback)
- config/env API key fallback

before the generic provider resolution path runs.

## Tests

Added coverage for bare custom main-model resolution from config:

- `test_resolve_runtime_provider_bare_custom_uses_model_config_base_url`

## Verified locally

- `resolve_runtime_provider(requested="custom")` now returns:
  - `provider = custom`
  - `api_mode = anthropic_messages`
  - `base_url = https://api.minimaxi.com/anthropic`

- local Hermes oneshot invocation succeeds with:
  - `--provider custom --model MiniMax-M2.7`
