### PR TITLE
fix(dashboard): restore plugin tab route on direct URL load

### DIFF
--- a/hermes_cli/web_server.py
+++ b/hermes_cli/web_server.py
@@ -3381,18 +3381,53 @@ def mount_spa(application: FastAPI):
 
     _index_path = WEB_DIST / "index.html"
 
-    def _serve_index(prefix: str = ""):
+    def _serve_index(prefix: str = "", full_path: str = ""):
         """Return index.html with the session token + base-path injected.
 
         ``prefix`` is the normalised ``X-Forwarded-Prefix`` (e.g. ``/hermes``)
         or empty string when served at root.
+        ``full_path`` is the SPA route the browser requested (used to restore
+        the correct route after async plugin registration).
         """
         html = _index_path.read_text()
         chat_js = "true" if _DASHBOARD_EMBEDDED_CHAT_ENABLED else "false"
+        import json as _json
+        plugins = _get_dashboard_plugins()
+        plugin_paths_json = _json.dumps([
+            p["tab"]["path"] for p in plugins if not p.get("tab", {}).get("hidden")
+        ])
+        initial_route = _json.dumps("/" + full_path.lstrip("/")) if full_path else _json.dumps("/")
         token_script = (
             f'<script>window.__HERMES_SESSION_TOKEN__="{_SESSION_TOKEN}";'
             f"window.__HERMES_DASHBOARD_EMBEDDED_CHAT__={chat_js};"
-            f'window.__HERMES_BASE_PATH__="{prefix}";</script>'
+            f'window.__HERMES_BASE_PATH__="{prefix}";'
+            f"window.__HERMES_INITIAL_ROUTE__={initial_route};"
+            f"window.__HERMES_PLUGIN_PATHS__={plugin_paths_json};"
+            f"(function(){{"
+            f"var _target=window.__HERMES_INITIAL_ROUTE__;"
+            f"var _paths=new Set(window.__HERMES_PLUGIN_PATHS__||[]);"
+            f"if(!_paths.has(_target))return;"
+            f"var _done=false;"
+            f"function _installHook(){{"
+            f"var P=window.__HERMES_PLUGINS__;"
+            f"if(!P||typeof P.register!=='function')return false;"
+            f"var _orig=P.register;"
+            f"P.register=function(name,comp){{"
+            f"_orig.call(this,name,comp);"
+            f"if(_done)return;"
+            f"setTimeout(function(){{"
+            f"if(!_done&&window.location.pathname!==_target){{"
+            f"_done=true;"
+            f"window.history.pushState({{}},'',_target);"
+            f"window.dispatchEvent(new PopStateEvent('popstate'));"
+            f"}}}}  ,30);"
+            f"}};"
+            f"return true;"
+            f"}}"
+            f"var _interval=setInterval(function(){{if(_installHook())clearInterval(_interval);}},10);"
+            f"setTimeout(function(){{clearInterval(_interval);}},3000);"
+            f"}})();"
+            f'</script>'
         )
         if prefix:
             # Rewrite absolute asset URLs baked into the Vite build so the
@@ -3446,7 +3481,7 @@ def mount_spa(application: FastAPI):
             and file_path.is_file()
         ):
             return FileResponse(file_path)
-        return _serve_index(prefix)
+        return _serve_index(prefix, full_path=full_path)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

Navigating directly to a plugin tab URL (e.g. `http://127.0.0.1:9119/kanban`) loads the Sessions page instead of the intended tab.

**Root cause:** React Router race condition on cold page load:
1. Browser requests `/kanban` — server returns `index.html`
2. React initializes and the main bundle sets up `window.__HERMES_PLUGINS__`
3. Plugin scripts load asynchronously
4. Router renders immediately — `/kanban` has no registered route yet, so the catch-all `<Navigate to="/sessions" replace />` fires
5. Plugin script loads and registers the kanban route — but router is already at `/sessions`

This affects any plugin tab (Kanban, etc.) when accessed via direct URL or browser refresh.

## Fix

Two changes to `hermes_cli/web_server.py`:

1. Pass `full_path` from `serve_spa()` through to `_serve_index()`
2. Inject an IIFE into `index.html` that:
   - Sets `window.__HERMES_INITIAL_ROUTE__` to the requested path
   - Sets `window.__HERMES_PLUGIN_PATHS__` from the server-known plugin routes
   - Wraps `window.__HERMES_PLUGINS__.register` and on first call fires `history.pushState` back to the original route + `popstate` event to re-trigger routing

The IIFE only activates when the requested path is a known plugin path, so root and built-in routes are unaffected.

## Testing

```bash
hermes dashboard --port 9119
# Open http://127.0.0.1:9119/kanban directly in browser
# Without fix: lands on Sessions page
# With fix: Kanban board renders correctly
```

Also verified: navigating via sidebar links still works, browser refresh on plugin tabs works, root `/` unaffected.