### PR TITLE
feat: extend  to accept bare GitHub user/repo shorthand

### DIFF
--- a/hermes_cli/profile_distribution.py
+++ b/hermes_cli/profile_distribution.py
@@ -354,6 +354,8 @@ def _env_template_from_manifest(manifest: DistributionManifest) -> str:
 # ---------------------------------------------------------------------------
 
 
+_BARE_USER_REPO_RE = re.compile(r"^[\w.-]+/[\w.-]+")
+
 def _looks_like_git_url(s: str) -> bool:
     s = s.strip()
     if s.endswith(".git"):
@@ -367,6 +369,9 @@ def _looks_like_git_url(s: str) -> bool:
     # Bare github.com/user/repo shorthand
     if re.match(r"^github\.com/[\w.-]+/[\w.-]+/?$", s):
         return True
+    # Bare GitHub shorthand: user/repo (e.g. SouthpawIN/senter)
+    if _BARE_USER_REPO_RE.match(s) and "/" in s and not s.startswith((".", "/", "~")):
+        return True
     return False
 
 
@@ -374,6 +379,9 @@ def _git_clone(url: str, dest: Path) -> None:
     # Normalize github.com/user/repo shorthand
     if re.match(r"^github\.com/[\w.-]+/[\w.-]+/?$", url):
         url = f"https://{url.rstrip('/')}"
+    # Normalize bare user/repo shorthand
+    elif _BARE_USER_REPO_RE.match(url) and "/" in url and not url.startswith((".", "/", "~")):
+        url = f"https://github.com/{url.strip('/')}"
     try:
         subprocess.run(
             ["git", "clone", "--depth", "1", url, str(dest)],

--- a/tests/hermes_cli/test_profile_distribution.py
+++ b/tests/hermes_cli/test_profile_distribution.py
@@ -247,6 +247,11 @@ class TestLooksLikeGitUrl:
         "git@github.com:user/repo.git",
         "ssh://git@example.com/repo.git",
         "git://example.com/repo.git",
+        # Bare GitHub user/repo shorthand
+        "SouthpawIN/senter",
+        "SouthpawIN/nous-girl",
+        "nousresearch/hermes-agent",
+        "user-name/repo_name",
     ])
     def test_accepts_git_sources(self, src):
         assert _looks_like_git_url(src)
@@ -256,6 +261,11 @@ class TestLooksLikeGitUrl:
         "./relative/dir",
         "~/profile",
         "some-random-string",
+        # Shorthand that looks like local paths
+        "./user/repo",
+        "../user/repo",
+        "/user/repo",
+        "~/myprofiles/senter",
     ])
     def test_rejects_non_git(self, src):
         assert not _looks_like_git_url(src)


### PR DESCRIPTION
## What

Extends `hermes profile install` to recognise bare GitHub `user/repo` shorthand (e.g. `SouthpawIN/senter`) and normalise it to `https://github.com/user/repo` automatically. No new subcommand — `hermes profile install` handles it natively.

```bash
# Before: only these worked
hermes profile install github.com/SouthpawIN/senter
hermes profile install https://github.com/SouthpawIN/senter.git

# After: these also work
hermes profile install SouthpawIN/senter
hermes profile install SouthpawIN/nous-girl
hermes profile install SouthpawIN/chizul
```

## Changes

- **`profile_distribution.py`**: `_looks_like_git_url()` and `_git_clone()` now detect bare `user/repo` patterns and normalise them to `https://github.com/user/repo`. Local paths (`./`, `../`, `/`, `~/`) are excluded to avoid false positives.
- **`test_profile_distribution.py`**: 4 new test cases in `TestLooksLikeGitUrl` for bare shorthand acceptance + 4 for local-path rejection.

## Design

- 18 lines total, zero new subcommands or APIs
- Falls through to the existing `plan_install()` / `install_distribution()` engine
- Same safety guarantees: credentials excluded, user data preserved on update