### PR TITLE
test(kanban-dashboard): cover _task_dict task_age fallback

### DIFF
--- a/tests/plugins/test_kanban_dashboard_plugin.py
+++ b/tests/plugins/test_kanban_dashboard_plugin.py
@@ -1102,6 +1102,87 @@ def test_create_task_no_warning_on_triage(client, monkeypatch):
     assert "warning" not in r.json() or not r.json()["warning"]
 
 
+# ---------------------------------------------------------------------------
+# _task_dict — outer try/except fallback when task_age raises
+#
+# Background: kanban_db.task_age was hardened in 061a1830 to return None for
+# corrupt timestamp values via _safe_int. The companion fix added a belt-and-
+# suspenders try/except in plugin_api._task_dict so that *any future* exception
+# from task_age (not just ValueError on '%s') still yields a usable dict
+# instead of 500'ing GET /board for the entire org.
+#
+# kanban_db._safe_int / task_age corruption paths are covered in
+# tests/hermes_cli/test_kanban_db.py. The OUTER fallback here is not, which
+# means a refactor that drops the try/except would not be caught by CI. The
+# tests below pin that contract.
+# ---------------------------------------------------------------------------
+
+
+_FALLBACK_AGE = {
+    "created_age_seconds": None,
+    "started_age_seconds": None,
+    "time_to_complete_seconds": None,
+}
+
+
+def test_board_endpoint_survives_task_age_exception(client, monkeypatch):
+    """If task_age raises for any reason, GET /board must NOT 500.
+
+    Pre-fix behavior (without the try/except in _task_dict): a single corrupt
+    row turned the entire board response into a 500. The fallback dict lets
+    the dashboard render every other card normally.
+    """
+    create = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "doomed", "assignee": "alice"},
+    )
+    assert create.status_code == 200, create.text
+
+    # Force task_age to raise an exception type _safe_int does NOT handle —
+    # simulates a future regression where someone re-introduces an unguarded
+    # operation in task_age. ValueError on '%s' would be absorbed by _safe_int
+    # and never reach the outer try/except, so it would not exercise the
+    # contract this test pins.
+    def _boom(_task):
+        raise RuntimeError("simulated future task_age bug")
+    monkeypatch.setattr("hermes_cli.kanban_db.task_age", _boom)
+
+    r = client.get("/api/plugins/kanban/board")
+    assert r.status_code == 200, r.text
+
+    payload = r.json()
+    # /board returns columns as a list of {name, tasks} — not a dict — so
+    # flatten across all columns to find our seeded task.
+    tasks = [t for col in payload["columns"] for t in col["tasks"]]
+    assert len(tasks) == 1, f"expected exactly the seeded task, got {tasks!r}"
+    # Strict equality: the literal fallback dict from plugin_api._task_dict
+    # is the published contract the dashboard UI relies on. Key renames or
+    # silent additions should fail this test on purpose.
+    assert tasks[0]["age"] == _FALLBACK_AGE
+
+
+def test_single_task_endpoint_survives_task_age_exception(client, monkeypatch):
+    """GET /tasks/:id also calls _task_dict — same fallback should kick in.
+
+    This is the "drawer view" path: the user clicks one card and we serialize
+    just that task. A corrupt timestamp on a single task should not block the
+    user from opening its drawer.
+    """
+    create = client.post(
+        "/api/plugins/kanban/tasks",
+        json={"title": "drawer-target", "assignee": "bob"},
+    )
+    task_id = create.json()["task"]["id"]
+
+    def _boom(_task):
+        raise RuntimeError("simulated future task_age bug")
+    monkeypatch.setattr("hermes_cli.kanban_db.task_age", _boom)
+
+    r = client.get(f"/api/plugins/kanban/tasks/{task_id}")
+    assert r.status_code == 200, r.text
+    assert r.json()["task"]["age"] == _FALLBACK_AGE
+
+
 def test_create_task_probe_error_does_not_break_create(client, monkeypatch):
     """Probe failure must never break task creation."""
     def _raise():


### PR DESCRIPTION
The fix in 061a1830 added an outer try/except in plugin_api._task_dict so that a future failure mode in kanban_db.task_age (anything _safe_int doesn't already absorb) cannot 500 the GET /board response. The _safe_int / task_age corruption paths
  got regression coverage in tests/hermes_cli/test_kanban_db.py, but the OUTER fallback contract remained untested -- meaning a refactor that drops the try/except would not be caught by CI.

  Pin that contract from both consumers of _task_dict:
  - GET /board returns 200 with the literal fallback age dict for the affected card (other cards continue to render via the same path)
  - GET /tasks/:id (drawer view) returns 200 with the same fallback, so a single corrupt task can't block its own drawer

  Both tests force task_age to raise RuntimeError rather than ValueError on '%s', because ValueError is absorbed by _safe_int and never reaches the outer try/except -- testing that path would only re-cover what test_kanban_db.py already pins.

  Manually verified the regression discipline:
    git checkout 061a1830^ -- plugins/kanban/dashboard/plugin_api.py
    pytest -k task_age_exception        # both FAIL with 500
    git checkout HEAD -- plugins/kanban/dashboard/plugin_api.py
    pytest -k task_age_exception        # both PASS

  ## What does this PR do?

  Adds regression coverage for the **outer** `try/except` fallback in `plugins/kanban/dashboard/plugin_api.py::_task_dict`, which was added by PR #23225 (`fix(kanban): guard task_age against corrupt timestamp values`, salvage of #20940).

  That fix is two layers of defense against the "corrupt timestamp 500's the whole board" bug:

  1. **Inner**: `_safe_int()` inside `kanban_db.task_age()` — covered by the test follow-up Teknium added alongside the salvage (`tests/hermes_cli/test_kanban_db.py::test_safe_int_*`, `test_task_age_*`).
  2. **Outer**: a belt-and-suspenders `try/except` in `_task_dict()` that catches *any* future failure mode `_safe_int` doesn't yet absorb — **previously untested at the `_task_dict` boundary**.

  A refactor that drops the outer guard would silently re-introduce the original 500-on-corrupt-row bug without breaking any existing test. This PR closes that gap from both consumers of `_task_dict` (`GET /board` and `GET /tasks/:id`).

  ### Isn't this a duplicate of `test_task_dict_survives_corrupt_created_at`?

  No — that test is misnamed. Its docstring promises to verify "plugin_api must not 500", but the test body only calls `kanban_db.task_age(task)` directly and never invokes `_task_dict`. With a corrupt `created_at='%s'`, `_safe_int` absorbs the
  `ValueError` inside `task_age`, so the outer `try/except` is never reached — and the existing test would still pass even if the outer guard were deleted.

  Empirical proof (run on this branch's HEAD with the outer `try/except` in `_task_dict` removed but `_safe_int` kept intact):

  ```
  test_task_dict_survives_corrupt_created_at                         PASSED  ← does not exercise outer guard
  test_board_endpoint_survives_task_age_exception                    FAILED  ← caught by this PR
  test_single_task_endpoint_survives_task_age_exception              FAILED  ← caught by this PR
  ```

  (Happy to send a separate PR renaming the existing test to something like `test_task_age_returns_none_for_corrupt_created_at` so its name matches its actual scope — kept that out of this PR to keep the diff narrow.)

  ## Related Issue

  No open issue tracked this gap. Follow-up coverage for PR #23225 (salvage of #20940).

  ## Type of Change

  - [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [ ] ✨ New feature (non-breaking change that adds functionality)
  - [ ] 🔒 Security fix
  - [ ] 📝 Documentation update
  - [x] ✅ Tests (adding or improving test coverage)
  - [ ] ♻️  Refactor (no behavior change)
  - [ ] 🎯 New skill (bundled or hub)

  ## Changes Made

  - `tests/plugins/test_kanban_dashboard_plugin.py` (+81 / -0)
    - New section: `_task_dict — outer try/except fallback when task_age raises`
    - `test_board_endpoint_survives_task_age_exception` — pins `GET /board` returns 200 with the literal fallback `age` dict when `task_age` raises an unexpected exception type
    - Module-level `_FALLBACK_AGE` constant mirrors `plugin_api.py:151` so an accidental key rename will fail the test on purpose

  No production code changed.
  
  ## How to Test

  ```bash
  # 1. New tests pass on current main
  pytest tests/plugins/test_kanban_dashboard_plugin.py -k task_age_exception -v
  # → 2 passed
  
  # 2. Confirm they actually pin the contract — drop the outer try/except in
  #    _task_dict (keep _safe_int intact so we isolate the layer this PR covers).
  #    Edit plugins/kanban/dashboard/plugin_api.py:148-151 down to bare:
  #       d["age"] = kanban_db.task_age(task)
  pytest tests/plugins/test_kanban_dashboard_plugin.py -k task_age_exception -v
  # → 2 failed: RuntimeError propagates as 500
  pytest tests/hermes_cli/test_kanban_db.py::test_task_dict_survives_corrupt_created_at -v
  # → 1 passed (confirms the existing test does not exercise the outer guard)
  
  # 3. Restore the fix:
  git checkout HEAD -- plugins/kanban/dashboard/plugin_api.py
  pytest tests/plugins/test_kanban_dashboard_plugin.py -k task_age_exception -v
  # → 2 passed again
  ``` 
  
  Both new tests force `task_age` to raise `RuntimeError` (not `ValueError("%s")`) — `ValueError` is absorbed by `_safe_int` and never reaches the outer `try/except`, so testing the `ValueError` path would only re-cover what `test_kanban_db.py`
  already pins.
  
  ## Checklist
  
  ### Code

  - [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
  - [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`test(kanban-dashboard): ...`)
  - [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) — found #20940 (closed) and #23225 (merged); this PR closes a coverage gap left after the salvage and is non-duplicate (see "Isn't this a duplicate..."
  section above)
  - [x] My PR contains **only** changes related to this fix/feature (no unrelated commits) — single commit, `+81 / -0` in one file
  - [ ] I've run `pytest tests/ -q` and all tests pass — ran the full `tests/plugins/test_kanban_dashboard_plugin.py` (85 tests, all pass) and the targeted regression tests; did not run the full repository suite locally. Relying on CI to validate
  the full suite.
  - [x] I've added tests for my changes — this PR **is** the test addition
  - [x] I've tested on my platform: Ubuntu 24.04 (kernel 6.8), Python 3.13.5

  ### Documentation & Housekeeping
  
  - [x] I've updated relevant documentation (README, `docs/`, docstrings) — N/A (test-only)
  - [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
  - [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
  - [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — uses only `monkeypatch` + FastAPI `TestClient`,
  both platform-agnostic
  - [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

  ## Screenshots / Logs
  
  N/A (test-only change; pytest output included in "How to Test" above).
