### PR TITLE
Add native MLX local client

### DIFF
--- a/agent/mlx_local_client.py
+++ b/agent/mlx_local_client.py
@@ -1,0 +1,458 @@
+"""OpenAI-compatible client facade for local MLX models.
+
+The adapter lets Hermes use ``mlx_lm.generate`` without starting a localhost
+HTTP server. It intentionally looks like the small subset of the OpenAI SDK
+that ``run_agent.py`` consumes: ``client.chat.completions.create(...)`` returns
+objects with ``choices[*].message``/``delta``/``usage`` attributes, and supports
+both non-streaming and streaming calls.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import shlex
+import shutil
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Iterable
+
+MLX_LOCAL_MARKER_BASE_URL = "mlx://local"
+_DEFAULT_TIMEOUT_SECONDS = 900.0
+_TOOL_CALL_BLOCK_RE = re.compile(r"<tool_call>\s*(\{.*?\})\s*</tool_call>", re.DOTALL)
+
+
+def _resolve_command(command: str | None = None) -> str:
+    explicit = (
+        command
+        or os.getenv("HERMES_MLX_LOCAL_COMMAND", "").strip()
+        or os.getenv("MLX_LM_GENERATE_PATH", "").strip()
+    )
+    if explicit:
+        return explicit
+
+    discovered = shutil.which("mlx_lm.generate")
+    if discovered:
+        return discovered
+
+    for candidate in (
+        Path.home() / ".local/bin/mlx_lm.generate",
+        Path("/opt/homebrew/bin/mlx_lm.generate"),
+        Path("/usr/local/bin/mlx_lm.generate"),
+    ):
+        if candidate.exists() and os.access(candidate, os.X_OK):
+            return str(candidate)
+
+    return "mlx_lm.generate"
+
+
+def _subprocess_env() -> dict[str, str]:
+    env = os.environ.copy()
+    path_parts = [
+        str(Path.home() / ".local/bin"),
+        "/opt/homebrew/bin",
+        "/usr/local/bin",
+        env.get("PATH", ""),
+    ]
+    env["PATH"] = os.pathsep.join(part for part in path_parts if part)
+    return env
+
+
+def _timeout_seconds(timeout: Any) -> float:
+    if timeout is None:
+        return _DEFAULT_TIMEOUT_SECONDS
+    if isinstance(timeout, (int, float)):
+        return float(timeout)
+    candidates = [getattr(timeout, attr, None) for attr in ("read", "write", "connect", "pool", "timeout")]
+    numeric = [float(value) for value in candidates if isinstance(value, (int, float))]
+    return max(numeric) if numeric else _DEFAULT_TIMEOUT_SECONDS
+
+
+def _render_content(content: Any) -> str:
+    if content is None:
+        return ""
+    if isinstance(content, str):
+        return content.strip()
+    if isinstance(content, dict):
+        text = content.get("text")
+        if isinstance(text, str):
+            return text.strip()
+        return json.dumps(content, ensure_ascii=False)
+    if isinstance(content, list):
+        parts: list[str] = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+            elif isinstance(item, dict):
+                text = item.get("text")
+                if isinstance(text, str) and text.strip():
+                    parts.append(text.strip())
+        return "\n".join(parts).strip()
+    return str(content).strip()
+
+
+def _render_tool_calls(tool_calls: Any) -> str:
+    if not isinstance(tool_calls, list):
+        return ""
+    rendered: list[str] = []
+    for index, tool_call in enumerate(tool_calls, start=1):
+        if hasattr(tool_call, "function"):
+            call_id = getattr(tool_call, "id", None) or getattr(tool_call, "call_id", None)
+            function = getattr(tool_call, "function", None)
+            name = getattr(function, "name", None)
+            arguments = getattr(function, "arguments", "{}")
+        elif isinstance(tool_call, dict):
+            call_id = tool_call.get("id") or tool_call.get("call_id")
+            function = tool_call.get("function") or {}
+            name = function.get("name") if isinstance(function, dict) else None
+            arguments = function.get("arguments", "{}") if isinstance(function, dict) else "{}"
+        else:
+            continue
+        if not isinstance(name, str) or not name.strip():
+            continue
+        if not isinstance(arguments, str):
+            arguments = json.dumps(arguments, ensure_ascii=False)
+        call_id = call_id if isinstance(call_id, str) and call_id.strip() else f"mlx_call_{index}"
+        rendered.append(
+            "<tool_call>"
+            + json.dumps(
+                {
+                    "id": call_id,
+                    "type": "function",
+                    "function": {"name": name.strip(), "arguments": arguments},
+                },
+                ensure_ascii=False,
+            )
+            + "</tool_call>"
+        )
+    return "\n".join(rendered)
+
+
+def _format_messages(
+    messages: list[dict[str, Any]],
+    *,
+    tools: list[dict[str, Any]] | None = None,
+    tool_choice: Any = None,
+) -> tuple[str | None, str]:
+    system_parts: list[str] = []
+    transcript: list[str] = []
+
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        role = str(message.get("role") or "user").strip().lower()
+        rendered = _render_content(message.get("content"))
+        if role == "assistant":
+            tool_call_text = _render_tool_calls(message.get("tool_calls"))
+            if tool_call_text:
+                rendered = "\n".join(part for part in (rendered, tool_call_text) if part)
+        elif role == "tool":
+            call_id = message.get("tool_call_id")
+            name = message.get("name") or message.get("tool_name")
+            prefix_parts = []
+            if isinstance(name, str) and name.strip():
+                prefix_parts.append(f"name={name.strip()}")
+            if isinstance(call_id, str) and call_id.strip():
+                prefix_parts.append(f"tool_call_id={call_id.strip()}")
+            if prefix_parts and rendered:
+                rendered = f"({' '.join(prefix_parts)})\n{rendered}"
+        if not rendered:
+            continue
+        if role == "system":
+            system_parts.append(rendered)
+        else:
+            label = {
+                "user": "User",
+                "assistant": "Assistant",
+                "tool": "Tool",
+            }.get(role, role.title())
+            transcript.append(f"{label}:\n{rendered}")
+
+    prompt_sections: list[str] = []
+    if tools:
+        tool_specs: list[dict[str, Any]] = []
+        for tool in tools:
+            if not isinstance(tool, dict):
+                continue
+            function = tool.get("function") or {}
+            if not isinstance(function, dict):
+                continue
+            name = function.get("name")
+            if not isinstance(name, str) or not name.strip():
+                continue
+            tool_specs.append(
+                {
+                    "name": name.strip(),
+                    "description": function.get("description", ""),
+                    "parameters": function.get("parameters", {}),
+                }
+            )
+        if tool_specs:
+            prompt_sections.append(
+                "Available tools are listed as OpenAI function schemas. "
+                "When using a tool, emit only <tool_call>{...}</tool_call> "
+                "with one JSON object shaped as {id,type,function:{name,arguments}}. "
+                "The function.arguments value must be a JSON string.\n"
+                + json.dumps(tool_specs, ensure_ascii=False)
+            )
+
+    if tool_choice is not None:
+        prompt_sections.append(f"Tool choice hint: {json.dumps(tool_choice, ensure_ascii=False)}")
+
+    if transcript:
+        prompt_sections.append("Conversation transcript:\n\n" + "\n\n".join(transcript))
+    prompt_sections.append("Continue from the latest user request.")
+
+    system_prompt = "\n\n".join(system_parts).strip() or None
+    return system_prompt, "\n\n".join(section.strip() for section in prompt_sections if section.strip())
+
+
+def _usage() -> SimpleNamespace:
+    return SimpleNamespace(
+        prompt_tokens=0,
+        completion_tokens=0,
+        total_tokens=0,
+        prompt_tokens_details=SimpleNamespace(cached_tokens=0),
+    )
+
+
+def _parse_tool_calls(text: str) -> tuple[list[SimpleNamespace] | None, str | None]:
+    if not text:
+        return None, None
+
+    calls: list[SimpleNamespace] = []
+    consumed: list[tuple[int, int]] = []
+    for match in _TOOL_CALL_BLOCK_RE.finditer(text):
+        try:
+            obj = json.loads(match.group(1))
+        except Exception:
+            continue
+        function = obj.get("function") if isinstance(obj, dict) else None
+        if not isinstance(function, dict):
+            continue
+        name = function.get("name")
+        if not isinstance(name, str) or not name.strip():
+            continue
+        arguments = function.get("arguments", "{}")
+        if not isinstance(arguments, str):
+            arguments = json.dumps(arguments, ensure_ascii=False)
+        call_id = obj.get("id")
+        if not isinstance(call_id, str) or not call_id.strip():
+            call_id = f"mlx_call_{len(calls) + 1}"
+        calls.append(
+            SimpleNamespace(
+                id=call_id,
+                call_id=call_id,
+                type="function",
+                function=SimpleNamespace(name=name.strip(), arguments=arguments),
+            )
+        )
+        consumed.append((match.start(), match.end()))
+
+    cleaned = text.strip()
+    if consumed:
+        parts: list[str] = []
+        cursor = 0
+        for start, end in consumed:
+            if cursor < start:
+                parts.append(text[cursor:start])
+            cursor = end
+        if cursor < len(text):
+            parts.append(text[cursor:])
+        cleaned = "\n".join(part.strip() for part in parts if part.strip()).strip()
+
+    return calls or None, cleaned or None
+
+
+class _MLXChatCompletions:
+    def __init__(self, client: "MLXLocalClient"):
+        self._client = client
+
+    def create(self, **kwargs: Any) -> Any:
+        return self._client._create_chat_completion(**kwargs)
+
+
+class _MLXChatNamespace:
+    def __init__(self, client: "MLXLocalClient"):
+        self.completions = _MLXChatCompletions(client)
+
+
+class MLXLocalClient:
+    """Minimal OpenAI-client-compatible facade for ``mlx_lm.generate``."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str | None = None,
+        base_url: str | None = None,
+        default_headers: dict[str, str] | None = None,
+        timeout: Any = None,
+        command: str | None = None,
+        **_: Any,
+    ):
+        self.api_key = api_key or "mlx-local"
+        self.base_url = base_url or MLX_LOCAL_MARKER_BASE_URL
+        self._default_headers = dict(default_headers or {})
+        self._timeout = timeout
+        self._command = _resolve_command(command)
+        self.chat = _MLXChatNamespace(self)
+        self.is_closed = False
+
+    def close(self) -> None:
+        self.is_closed = True
+
+    def _create_chat_completion(
+        self,
+        *,
+        model: str | None = None,
+        messages: list[dict[str, Any]] | None = None,
+        tools: list[dict[str, Any]] | None = None,
+        tool_choice: Any = None,
+        max_tokens: int | None = None,
+        temperature: float | None = None,
+        timeout: Any = None,
+        stream: bool = False,
+        stream_options: dict[str, Any] | None = None,
+        **_: Any,
+    ) -> Any:
+        response_text = self._run_generate(
+            model=model,
+            messages=messages or [],
+            tools=tools,
+            tool_choice=tool_choice,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            timeout=timeout,
+        )
+        tool_calls, content = _parse_tool_calls(response_text)
+        finish_reason = "tool_calls" if tool_calls else "stop"
+        if stream:
+            return self._stream_chunks(
+                model=model,
+                content=content,
+                tool_calls=tool_calls,
+                finish_reason=finish_reason,
+                include_usage=bool((stream_options or {}).get("include_usage")),
+            )
+
+        message = SimpleNamespace(
+            role="assistant",
+            content=content,
+            tool_calls=tool_calls,
+            reasoning=None,
+            reasoning_content=None,
+            reasoning_details=None,
+        )
+        return SimpleNamespace(
+            model=model or "mlx-local",
+            choices=[SimpleNamespace(index=0, message=message, finish_reason=finish_reason)],
+            usage=_usage(),
+        )
+
+    def _run_generate(
+        self,
+        *,
+        model: str | None,
+        messages: list[dict[str, Any]],
+        tools: list[dict[str, Any]] | None,
+        tool_choice: Any,
+        max_tokens: int | None,
+        temperature: float | None,
+        timeout: Any,
+    ) -> str:
+        if not model:
+            raise ValueError("MLX local client requires a local model path as the model name.")
+
+        system_prompt, prompt = _format_messages(messages, tools=tools, tool_choice=tool_choice)
+        argv = shlex.split(self._command)
+        argv += ["--model", model, "--prompt", "-", "--verbose", "False"]
+        if system_prompt:
+            argv += ["--system-prompt", system_prompt]
+        if max_tokens is not None:
+            argv += ["--max-tokens", str(max_tokens)]
+        if temperature is not None:
+            argv += ["--temp", str(temperature)]
+
+        try:
+            completed = subprocess.run(
+                argv,
+                input=prompt,
+                text=True,
+                capture_output=True,
+                timeout=_timeout_seconds(timeout or self._timeout),
+                env=_subprocess_env(),
+                check=False,
+            )
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                "Could not start mlx_lm.generate. Install mlx-lm or set "
+                "HERMES_MLX_LOCAL_COMMAND/MLX_LM_GENERATE_PATH."
+            ) from exc
+
+        if completed.returncode != 0:
+            stderr = (completed.stderr or "").strip()
+            raise RuntimeError(f"mlx_lm.generate failed with exit code {completed.returncode}: {stderr}")
+        return (completed.stdout or "").strip()
+
+    def _stream_chunks(
+        self,
+        *,
+        model: str | None,
+        content: str | None,
+        tool_calls: list[SimpleNamespace] | None,
+        finish_reason: str,
+        include_usage: bool,
+    ) -> Iterable[SimpleNamespace]:
+        if tool_calls:
+            deltas: list[SimpleNamespace] = []
+            for index, call in enumerate(tool_calls):
+                deltas.append(
+                    SimpleNamespace(
+                        index=index,
+                        id=call.id,
+                        type="function",
+                        function=SimpleNamespace(
+                            name=call.function.name,
+                            arguments=call.function.arguments,
+                        ),
+                    )
+                )
+            yield SimpleNamespace(
+                model=model or "mlx-local",
+                choices=[
+                    SimpleNamespace(
+                        index=0,
+                        delta=SimpleNamespace(content=None, tool_calls=deltas),
+                        finish_reason=None,
+                    )
+                ],
+                usage=None,
+            )
+        elif content:
+            yield SimpleNamespace(
+                model=model or "mlx-local",
+                choices=[
+                    SimpleNamespace(
+                        index=0,
+                        delta=SimpleNamespace(content=content, tool_calls=None),
+                        finish_reason=None,
+                    )
+                ],
+                usage=None,
+            )
+
+        yield SimpleNamespace(
+            model=model or "mlx-local",
+            choices=[
+                SimpleNamespace(
+                    index=0,
+                    delta=SimpleNamespace(content=None, tool_calls=None),
+                    finish_reason=finish_reason,
+                )
+            ],
+            usage=None,
+        )
+        if include_usage:
+            yield SimpleNamespace(model=model or "mlx-local", choices=[], usage=_usage())

--- a/run_agent.py
+++ b/run_agent.py
@@ -1199,6 +1199,11 @@ class AIAgent:
         self.base_url = base_url or ""
         provider_name = provider.strip().lower() if isinstance(provider, str) and provider.strip() else None
         self.provider = provider_name or ""
+        if self.provider == "mlx-local" and not self.base_url:
+            self.base_url = "mlx://local"
+            base_url = self.base_url
+        if self.base_url.startswith("mlx://local") and not api_key:
+            api_key = "mlx-local"
         self.acp_command = acp_command or command
         self.acp_args = list(acp_args or args or [])
         if api_mode in {"chat_completions", "codex_responses", "anthropic_messages", "bedrock_converse"}:
@@ -6284,9 +6289,25 @@ class AIAgent:
         # copy locks the contract so future transport/keepalive work can't reintroduce
         # the same class of bug.
         client_kwargs = dict(client_kwargs)
+        base_url = str(client_kwargs.get("base_url", "") or "")
+        if self.provider == "mlx-local" or base_url.startswith("mlx://local"):
+            from agent.mlx_local_client import MLXLocalClient
+
+            safe_kwargs = {
+                k: v for k, v in client_kwargs.items()
+                if k in {"api_key", "base_url", "default_headers", "timeout", "command"}
+            }
+            client = MLXLocalClient(**safe_kwargs)
+            logger.info(
+                "MLX local client created (%s, shared=%s) %s",
+                reason,
+                shared,
+                self._client_log_context(),
+            )
+            return client
         _validate_proxy_env_urls()
         _validate_base_url(client_kwargs.get("base_url"))
-        if self.provider == "copilot-acp" or str(client_kwargs.get("base_url", "")).startswith("acp://copilot"):
+        if self.provider == "copilot-acp" or base_url.startswith("acp://copilot"):
             from agent.copilot_acp_client import CopilotACPClient
 
             client = CopilotACPClient(**client_kwargs)

--- a/tests/run_agent/test_mlx_local_client.py
+++ b/tests/run_agent/test_mlx_local_client.py
@@ -1,0 +1,173 @@
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+
+def _minimal_agent(provider="custom"):
+    from run_agent import AIAgent
+
+    agent = object.__new__(AIAgent)
+    agent.provider = provider
+    agent.model = "/tmp/qwen-mlx"
+    agent.base_url = "mlx://local"
+    agent._client_log_context = lambda: "test-context"
+    return agent
+
+
+def test_create_openai_client_routes_mlx_local_before_url_validation():
+    agent = _minimal_agent()
+    client_kwargs = {
+        "api_key": "no-key-required",
+        "base_url": "mlx://local",
+        "default_headers": {"x-test": "1"},
+        "timeout": 123,
+        "http_client": object(),  # OpenAI-specific; must not leak into local shim
+    }
+
+    client = agent._create_openai_client(
+        client_kwargs,
+        reason="unit-test",
+        shared=False,
+    )
+
+    from agent.mlx_local_client import MLXLocalClient
+
+    assert isinstance(client, MLXLocalClient)
+    assert client.base_url == "mlx://local"
+    assert client.api_key == "no-key-required"
+    assert "http_client" not in client_kwargs or client_kwargs["http_client"] is not None
+
+
+def test_provider_mlx_local_initializes_without_api_key_or_base_url():
+    from agent.mlx_local_client import MLXLocalClient
+    from run_agent import AIAgent
+
+    agent = AIAgent(
+        provider="mlx-local",
+        model="/models/qwen",
+        quiet_mode=True,
+        skip_memory=True,
+        enabled_toolsets=[],
+    )
+
+    assert agent.provider == "mlx-local"
+    assert agent.base_url == "mlx://local"
+    assert agent.api_key == "mlx-local"
+    assert isinstance(agent.client, MLXLocalClient)
+
+
+def test_mlx_local_client_non_streaming_invokes_mlx_generate(monkeypatch):
+    from agent.mlx_local_client import MLXLocalClient
+
+    completed = SimpleNamespace(stdout="local qwen ok\n", stderr="", returncode=0)
+    run = Mock(return_value=completed)
+    monkeypatch.setattr("agent.mlx_local_client.subprocess.run", run)
+
+    client = MLXLocalClient(command="mlx_lm.generate")
+    response = client.chat.completions.create(
+        model="/models/qwen",
+        messages=[
+            {"role": "system", "content": "Be terse."},
+            {"role": "user", "content": "Say ok"},
+        ],
+        max_tokens=20,
+        temperature=0,
+    )
+
+    assert response.choices[0].message.content == "local qwen ok"
+    assert response.choices[0].message.tool_calls is None
+    assert response.choices[0].finish_reason == "stop"
+    argv = run.call_args.args[0]
+    assert argv[:2] == ["mlx_lm.generate", "--model"]
+    assert "/models/qwen" in argv
+    assert "--prompt" in argv
+    assert argv[argv.index("--prompt") + 1] == "-"
+    assert "Say ok" in run.call_args.kwargs["input"]
+    assert "--max-tokens" in argv
+    assert "--temp" in argv
+
+
+def test_mlx_local_client_streaming_returns_openai_shaped_chunks(monkeypatch):
+    from agent.mlx_local_client import MLXLocalClient
+
+    monkeypatch.setattr(
+        "agent.mlx_local_client.subprocess.run",
+        Mock(return_value=SimpleNamespace(stdout="streamed ok", stderr="", returncode=0)),
+    )
+
+    client = MLXLocalClient(command="mlx_lm.generate")
+    chunks = list(
+        client.chat.completions.create(
+            model="/models/qwen",
+            messages=[{"role": "user", "content": "Say ok"}],
+            stream=True,
+            stream_options={"include_usage": True},
+        )
+    )
+
+    assert chunks[0].choices[0].delta.content == "streamed ok"
+    assert chunks[0].choices[0].finish_reason is None
+    assert chunks[1].choices[0].finish_reason == "stop"
+    assert chunks[2].choices == []
+    assert chunks[2].usage.total_tokens == 0
+
+
+def test_mlx_local_client_extracts_tool_call_blocks(monkeypatch):
+    from agent.mlx_local_client import MLXLocalClient
+
+    raw = '<tool_call>{"id":"call_1","type":"function","function":{"name":"read_file","arguments":"{\\"path\\":\\"/tmp/a\\"}"}}</tool_call>'
+    monkeypatch.setattr(
+        "agent.mlx_local_client.subprocess.run",
+        Mock(return_value=SimpleNamespace(stdout=raw, stderr="", returncode=0)),
+    )
+
+    client = MLXLocalClient(command="mlx_lm.generate")
+    response = client.chat.completions.create(
+        model="/models/qwen",
+        messages=[{"role": "user", "content": "Read file"}],
+        tools=[{"type": "function", "function": {"name": "read_file", "parameters": {}}}],
+    )
+
+    tool_call = response.choices[0].message.tool_calls[0]
+    assert response.choices[0].finish_reason == "tool_calls"
+    assert response.choices[0].message.content is None
+    assert tool_call.id == "call_1"
+    assert tool_call.function.name == "read_file"
+    assert tool_call.function.arguments == '{"path":"/tmp/a"}'
+
+
+def test_mlx_local_client_preserves_tool_turn_context(monkeypatch):
+    from agent.mlx_local_client import MLXLocalClient
+
+    run = Mock(return_value=SimpleNamespace(stdout="done", stderr="", returncode=0))
+    monkeypatch.setattr("agent.mlx_local_client.subprocess.run", run)
+
+    client = MLXLocalClient(command="mlx_lm.generate")
+    client.chat.completions.create(
+        model="/models/qwen",
+        messages=[
+            {"role": "user", "content": "Read the file"},
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "call_1",
+                        "type": "function",
+                        "function": {"name": "read_file", "arguments": '{"path":"/tmp/a"}'},
+                    }
+                ],
+            },
+            {
+                "role": "tool",
+                "tool_call_id": "call_1",
+                "name": "read_file",
+                "content": "file contents",
+            },
+        ],
+    )
+
+    prompt = run.call_args.kwargs["input"]
+    assert "<tool_call>" in prompt
+    assert "read_file" in prompt
+    assert "tool_call_id=call_1" in prompt
+    assert "file contents" in prompt


### PR DESCRIPTION
Summary
- Add a native mlx://local chat-completions-compatible client backed by mlx_lm.generate.
- Route mlx://local before OpenAI URL validation so Hermes can use local MLX models without an OpenAI-compatible HTTP server.
- Add tests for routing, provider initialization, non-streaming/streaming response shapes, tool-call parsing, and tool-turn context preservation.

Security / architecture rationale
- This intentionally avoids binding the model to a persistent localhost service or websocket/HTTP listener.
- Avoiding a local network listener lowers attack surface and is more consistent with enterprise security policies for local model execution.
- The model is invoked as a local subprocess on demand, matching the local-process pattern used by Codex/Claude-style local integrations rather than requiring port binding.

Validation
- /opt/homebrew/bin/uv run --python 3.13 --no-project --with '.[dev]' python -m pytest tests/run_agent/test_mlx_local_client.py tests/run_agent/test_run_agent.py -q -o 'addopts='
  - 329 passed
- /opt/homebrew/bin/uv run --python 3.13 --no-project --with '.[dev]' python -m ruff check agent/mlx_local_client.py run_agent.py tests/run_agent/test_mlx_local_client.py
  - All checks passed
- Manual smoke test:
  - hermes --profile local-qwen chat -Q -q "Reply exactly: local mlx shim ok"
  - session_id: 20260510_213524_75e8fa
  - session/logs confirmed model=/Users/jody/Models/LLM/Qwen3-Coder-30B-A3B-Instruct-MLX-4bit and base_url=mlx://local, with MLX local client used and no fallback.
  - lsof -nP -iTCP:8080 -sTCP:LISTEN returned no listener.

Note
- A full default pytest run under uv's default Python selected Python 3.14 and produced unrelated repository-wide failures. The targeted verification above was re-run with the project-configured Python 3.13.