### PR TITLE
feat(gateway): async message queue for interrupt handling

### DIFF
--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1481,3 +1481,29 @@ def estimate_request_tokens_rough(
     if tools:
         total_chars += len(str(tools))
     return (total_chars + 3) // 4
+
+
+def model_requires_max_completion_tokens(model: str) -> bool:
+    """Return True when a model requires max_completion_tokens instead of max_tokens.
+
+    OpenAI's newer model families (gpt-4o, gpt-4.1, gpt-5, o1/o3/o4) only accept
+    ``max_completion_tokens``.  This matters for custom OpenAI-compatible endpoints
+    (OpenRouter, self-hosted, proxies) that sit behind non-api.openai.com hosts —
+    the URL-based check alone is insufficient for those.
+
+    Provider-prefixed model names such as "openai/gpt-4o" or "anthropic/claude-3-5"
+    are handled by stripping the prefix before matching.
+    """
+    if not model:
+        return False
+    m = model.strip().lower()
+    if "/" in m:
+        m = m.rsplit("/", 1)[-1]
+    return (
+        m.startswith("gpt-4o")
+        or m.startswith("gpt-4.1")
+        or m.startswith("gpt-5")
+        or m.startswith("o1")
+        or m.startswith("o3")
+        or m.startswith("o4")
+    )

--- a/agent/model_metadata.py
+++ b/agent/model_metadata.py
@@ -1483,7 +1483,7 @@ def estimate_request_tokens_rough(
     return (total_chars + 3) // 4
 
 
-def model_requires_max_completion_tokens(model: str) -> bool:
+def model_requires_max_completion_tokens(model: str | None) -> bool:
     """Return True when a model requires max_completion_tokens instead of max_tokens.
 
     OpenAI's newer model families (gpt-4o, gpt-4.1, gpt-5, o1/o3/o4) only accept

--- a/agent/nous_rate_guard.py
+++ b/agent/nous_rate_guard.py
@@ -186,7 +186,9 @@ def format_remaining(seconds: float) -> str:
 # Buckets with reset windows shorter than this are treated as transient
 # (upstream jitter, secondary throttling) rather than a genuine quota
 # exhaustion worth a cross-session breaker trip.
-_MIN_RESET_FOR_BREAKER_SECONDS = 60.0
+# 30s captures per-minute RPM limits that genuinely reset in ~60s or less
+# while still filtering out very short upstream blips.
+_MIN_RESET_FOR_BREAKER_SECONDS = 30.0
 
 
 def is_genuine_nous_rate_limit(
@@ -216,12 +218,12 @@ def is_genuine_nous_rate_limit(
 
       1. The 429 response's own ``x-ratelimit-*`` headers.  Nous emits
          the full suite on every response including 429s.  An exhausted
-         bucket (``remaining == 0`` with a reset window >= 60s) is
+         bucket (``remaining == 0`` with a reset window >= 30s) is
          proof of (a).
       2. The last-known-good rate-limit state captured by
          ``_capture_rate_limits()`` on the previous successful
          response.  If any bucket there was already near-exhausted with
-         a substantial reset window, the current 429 is almost
+         a reset window of 30s or more, the current 429 is almost
          certainly (a) continuing from that condition.
 
     If neither signal fires, we treat the 429 as (b): fail the single

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2254,12 +2254,17 @@ class GatewayRunner:
         is_queue_mode = effective_mode == "queue"
         is_steer_mode = effective_mode == "steer"
 
-        # If not in queue/steer mode, interrupt the running agent immediately.
-        # This aborts in-flight tool calls and causes the agent loop to exit
-        # at the next check point.
+        # If not in queue/steer mode, push to the async chat queue.
+        # The queue is checked at every yield point in the agent loop,
+        # so the interrupt is processed reliably regardless of where
+        # the agent is in its execution (even mid-tool).
         if effective_mode == "interrupt" and running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
             try:
-                running_agent.interrupt(event.text)
+                if hasattr(running_agent, "_chat_queue"):
+                    running_agent._chat_queue.push(event, priority="immediate")
+                else:
+                    # Fallback for agents that don't have _chat_queue yet
+                    running_agent.interrupt(event.text)
             except Exception:
                 pass  # don't let interrupt failure block the ack
 

--- a/run_agent.py
+++ b/run_agent.py
@@ -36,6 +36,7 @@ import ssl
 import sys
 import tempfile
 import time
+import queue
 import threading
 from types import SimpleNamespace
 import urllib.request
@@ -883,6 +884,102 @@ def _qwen_portal_headers() -> dict:
     }
 
 
+# ─── Async Message Queue ────────────────────────────────────────────────────
+#
+# Inspired by OpenClaw's KeyedAsyncQueue.
+# Decouples message ingestion (gateway) from message processing (agent).
+# This allows the gateway to accept messages instantly without blocking,
+# while the agent processes them at natural yield points in its loop.
+#
+# Priority levels:
+#   immediate (0) → interrupt the agent immediately, break the loop
+#   high    (1) → steer injection mid-run (non-blocking)
+#   normal  (2) → queue for next turn (append as user message)
+#
+class ChatQueue:
+    """
+    Thread-safe async message queue for gateway → agent communication.
+
+    Messages are stored with a priority. The agent checks the queue at
+    natural yield points:
+      - Before each API call (top of while loop)
+      - After tool execution completes
+      - During concurrent tool wait loops (every 2s poll)
+
+    This replaces the old approach where the gateway called agent.interrupt()
+    directly, which only worked when the agent was at a specific checkpoint.
+    With ChatQueue, messages are ALWAYS processed — even if the agent is in
+    the middle of a long-running tool (the interrupt check happens at the
+    next yield point).
+    """
+
+    def __init__(self):
+        self._queue = queue.PriorityQueue()
+        self._lock = threading.Lock()
+        self._steer_pending = None   # non-None = there's a steer waiting
+
+    def push(self, event, priority: str = "normal") -> None:
+        """
+        Push a message event into the queue.
+
+        Args:
+            event: MessageEvent or similar object with .text attribute
+            priority: "immediate" | "high" | "normal"
+        """
+        priority_map = {"immediate": 0, "high": 1, "normal": 2}
+        p = priority_map.get(priority, 2)
+        self._queue.put((p, event))
+        if priority == "high":
+            # Steer messages are stored separately so the agent can retrieve
+            # them without needing to drain the full queue
+            with self._lock:
+                self._steer_pending = event
+
+    def pop_immediate(self):
+        """Pop the highest-priority immediate message if one exists. Non-blocking."""
+        try:
+            p, event = self._queue.get_nowait()
+            if p == 0:
+                return event
+            else:
+                # Put it back if it's not immediate
+                self._queue.put((p, event))
+                return None
+        except queue.Empty:
+            return None
+
+    def pop_all_normal(self):
+        """Pop all normal-priority messages. Returns list of events."""
+        results = []
+        while True:
+            try:
+                p, event = self._queue.get_nowait()
+                if p == 2:
+                    results.append(event)
+                else:
+                    # Re-queue non-normal
+                    self._queue.put((p, event))
+                    break
+            except queue.Empty:
+                break
+        return results
+
+    def get_steer(self):
+        """Atomically pop and return any pending steer message."""
+        with self._lock:
+            s = self._steer_pending
+            self._steer_pending = None
+            return s
+
+    def has_messages(self):
+        """Return True if any messages are queued."""
+        return not self._queue.empty()
+
+    def is_empty(self):
+        """Return True if the queue is empty."""
+        return self._queue.empty()
+
+
 class AIAgent:
     """
     AI Agent with tool calling capabilities.
@@ -1180,6 +1277,9 @@ class AIAgent:
         self._interrupt_message = None  # Optional message that triggered interrupt
         self._execution_thread_id: int | None = None  # Set at run_conversation() start
         self._interrupt_thread_signal_pending = False
+        # Async message queue: decouples gateway message ingestion from agent processing.
+        # See ChatQueue class docstring for details. Replaces direct interrupt() calls.
+        self._chat_queue = ChatQueue()
         self._client_lock = threading.RLock()
 
         # /steer mechanism — inject a user note into the next tool result
@@ -4509,6 +4609,51 @@ class AIAgent:
         if _steer_lock is not None:
             with _steer_lock:
                 self._pending_steer = None
+
+    def _check_chat_queue(self) -> bool:
+        """
+        Check the async message queue for pending gateway messages.
+
+        Called at natural yield points in the agent loop:
+          - Top of the main while loop (before each API call)
+          - After tool execution completes
+          - During concurrent tool wait loops
+
+        Returns True if an immediate interrupt was found (caller should
+        break out of the loop immediately). Returns False if the queue
+        is empty or only contained normal/steer messages.
+
+        This is the core of the async message queue design: messages sent
+        by the gateway during agent execution are stored in the queue and
+        processed at the NEXT yield point, rather than requiring the agent
+        to be at a specific checkpoint when the message arrives.
+        """
+        # Fast path: if the queue is empty, do nothing
+        if self._chat_queue.is_empty():
+            return False
+
+        # Priority 0 (immediate): interrupt immediately
+        immediate_event = self._chat_queue.pop_immediate()
+        if immediate_event is not None:
+            event_text = getattr(immediate_event, "text", None) or ""
+            self.interrupt(event_text)
+            return True
+
+        # Priority 1 (high/steer): inject via steer() — non-blocking
+        steer_event = self._chat_queue.get_steer()
+        if steer_event is not None:
+            steer_text = getattr(steer_event, "text", None) or ""
+            if steer_text.strip():
+                try:
+                    self.steer(steer_text)
+                except Exception:
+                    pass
+
+        # Priority 2 (normal): messages will be picked up as part of the
+        # normal turn flow via _pending_messages in the gateway session.
+        # No action needed here — the gateway's merge_pending_message_event
+        # already handled this at queue insertion time.
+        return False
 
     def steer(self, text: str) -> bool:
         """
@@ -9499,6 +9644,14 @@ class AIAgent:
         tools. Used by the concurrent execution path; the sequential path retains
         its own inline invocation for backward-compatible display handling.
         """
+        # Early interrupt check: abort before starting any tool. This ensures
+        # even tools without their own interrupt checks (web_search, read_file,
+        # etc.) can be stopped quickly when the user sends /stop or a new message.
+        if self._interrupt_requested:
+            return json.dumps({
+                "error": f"[Tool execution cancelled — {function_name} was skipped due to user interrupt]"
+            }, ensure_ascii=False)
+
         # Check plugin hooks for a block directive before executing anything.
         block_message: Optional[str] = None
         if not pre_tool_block_checked:
@@ -9840,7 +9993,7 @@ class AIAgent:
                     _interrupt_logged = False
                     while True:
                         done, not_done = concurrent.futures.wait(
-                            futures, timeout=5.0,
+                            futures, timeout=2.0,
                         )
                         if not not_done:
                             break
@@ -9863,6 +10016,15 @@ class AIAgent:
                             # Give already-running tools a moment to notice the
                             # per-thread interrupt signal and exit gracefully.
                             concurrent.futures.wait(not_done, timeout=3.0)
+                            break
+
+                        # Also check the async message queue during concurrent wait.
+                        # This ensures immediate messages can stop a long batch
+                        # even when individual tools don't have their own interrupt checks.
+                        if self._check_chat_queue():
+                            for f in not_done:
+                                f.cancel()
+                            concurrent.futures.wait(not_done, timeout=1.0)
                             break
 
                         _conc_elapsed = int(time.time() - _conc_start)
@@ -10977,6 +11139,13 @@ class AIAgent:
         while (api_call_count < self.max_iterations and self.iteration_budget.remaining > 0) or self._budget_grace_call:
             # Reset per-turn checkpoint dedup so each iteration can take one snapshot
             self._checkpoint_mgr.new_turn()
+
+            # Check async message queue — processes gateway messages that arrived
+            # during tool execution. This is the core of the async queue design:
+            # messages are stored and processed at the next yield point, rather
+            # than requiring the agent to be at a specific checkpoint.
+            if self._check_chat_queue():
+                break
 
             # Check for interrupt request (e.g., user sent new message)
             if self._interrupt_requested:

--- a/run_agent.py
+++ b/run_agent.py
@@ -3043,10 +3043,10 @@ class AIAgent:
         """Return the correct max tokens kwarg for the current provider.
 
         OpenAI's newer models (gpt-4o, o-series, gpt-5+) require
-        'max_completion_tokens'. Azure OpenAI also requires
-        'max_completion_tokens' for gpt-5.x models served via the
-        OpenAI-compatible endpoint. OpenRouter, local models, and older
-        OpenAI models use 'max_tokens'.
+        'max_completion_tokens' on api.openai.com, Azure, and any
+        OpenAI-compatible endpoint (OpenRouter, self-hosted, proxies).
+        Older OpenAI models (gpt-4-turbo, gpt-3.5-turbo, etc.) use
+        'max_tokens' on all endpoints.
         """
         if (self._is_direct_openai_url()
                 or self._is_azure_openai_url()

--- a/run_agent.py
+++ b/run_agent.py
@@ -1866,6 +1866,23 @@ class AIAgent:
             _api_retries = 3
         self._api_max_retries = _api_retries
 
+        # API retry backoff tuning.  Defaults target rate-limit scenarios
+        # (short resets) with sensible growth.  Overridable via config.yaml:
+        #   agent.api_retry_base_delay  (default 2.0 seconds)
+        #   agent.api_retry_max_delay  (default 60.0 seconds)
+        try:
+            self._api_retry_base_delay = float(_agent_section.get("api_retry_base_delay", 2.0))
+            if self._api_retry_base_delay <= 0:
+                self._api_retry_base_delay = 2.0
+        except (TypeError, ValueError):
+            self._api_retry_base_delay = 2.0
+        try:
+            self._api_retry_max_delay = float(_agent_section.get("api_retry_max_delay", 60.0))
+            if self._api_retry_max_delay <= 0:
+                self._api_retry_max_delay = 60.0
+        except (TypeError, ValueError):
+            self._api_retry_max_delay = 60.0
+
         # Initialize context compressor for automatic context management
         # Compresses conversation when approaching model's context limit
         # Configuration via config.yaml (compression section)
@@ -11605,8 +11622,8 @@ class AIAgent:
                                 "failed": True  # Mark as failure for filtering
                             }
                         
-                        # Backoff before retry — jittered exponential: 5s base, 120s cap
-                        wait_time = jittered_backoff(retry_count, base_delay=5.0, max_delay=120.0)
+                        # Backoff before retry — jittered exponential, config-driven
+                        wait_time = jittered_backoff(retry_count, base_delay=self._api_retry_base_delay, max_delay=self._api_retry_max_delay)
                         self._vprint(f"{self.log_prefix}⏳ Retrying in {wait_time:.1f}s ({_failure_hint})...", force=True)
                         logging.warning(f"Invalid API response (retry {retry_count}/{max_retries}): {', '.join(error_details)} | Provider: {provider_name}")
                         
@@ -13030,7 +13047,7 @@ class AIAgent:
                                     _retry_after = min(int(_ra_raw), 120)  # Cap at 2 minutes
                                 except (TypeError, ValueError):
                                     pass
-                    wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=2.0, max_delay=60.0)
+                    wait_time = _retry_after if _retry_after else jittered_backoff(retry_count, base_delay=self._api_retry_base_delay, max_delay=self._api_retry_max_delay)
                     if is_rate_limited:
                         self._emit_status(f"⏱️ Rate limited. Waiting {wait_time:.1f}s (attempt {retry_count + 1}/{max_retries})...")
                     else:

--- a/run_agent.py
+++ b/run_agent.py
@@ -145,6 +145,7 @@ from agent.model_metadata import (
     parse_available_output_tokens_from_error,
     save_context_length, is_local_endpoint,
     query_ollama_num_ctx,
+    model_requires_max_completion_tokens,
 )
 from agent.context_compressor import ContextCompressor
 from agent.subdirectory_hints import SubdirectoryHintTracker
@@ -3047,7 +3048,9 @@ class AIAgent:
         OpenAI-compatible endpoint. OpenRouter, local models, and older
         OpenAI models use 'max_tokens'.
         """
-        if self._is_direct_openai_url() or self._is_azure_openai_url():
+        if (self._is_direct_openai_url()
+                or self._is_azure_openai_url()
+                or model_requires_max_completion_tokens(self.model)):
             return {"max_completion_tokens": value}
         return {"max_tokens": value}
 

--- a/tests/agent/test_model_metadata.py
+++ b/tests/agent/test_model_metadata.py
@@ -1022,3 +1022,69 @@ class TestContextLengthCache:
         with patch("agent.model_metadata._get_context_cache_path", return_value=cache_file):
             save_context_length(model, url, 200000)
             assert get_cached_context_length(model, url) == 200000
+
+
+class TestModelRequiresMaxCompletionTokens:
+    """Tests for model_requires_max_completion_tokens()."""
+
+    def test_gpt_4o_family(self):
+        from agent.model_metadata import model_requires_max_completion_tokens
+        assert model_requires_max_completion_tokens("gpt-4o") is True
+        assert model_requires_max_completion_tokens("gpt-4o-mini") is True
+        assert model_requires_max_completion_tokens("gpt-4o-2024-08-06") is True
+
+    def test_gpt_4_1_family(self):
+        from agent.model_metadata import model_requires_max_completion_tokens
+        assert model_requires_max_completion_tokens("gpt-4.1") is True
+        assert model_requires_max_completion_tokens("gpt-4.1-mini") is True
+        assert model_requires_max_completion_tokens("gpt-4.1-nano") is True
+
+    def test_gpt_5_family(self):
+        from agent.model_metadata import model_requires_max_completion_tokens
+        assert model_requires_max_completion_tokens("gpt-5") is True
+        assert model_requires_max_completion_tokens("gpt-5.4") is True
+        assert model_requires_max_completion_tokens("gpt-5.4-mini") is True
+        assert model_requires_max_completion_tokens("gpt-5.4-nano") is True
+        assert model_requires_max_completion_tokens("gpt-5.1-chat") is True
+
+    def test_o_series(self):
+        from agent.model_metadata import model_requires_max_completion_tokens
+        assert model_requires_max_completion_tokens("o1") is True
+        assert model_requires_max_completion_tokens("o1-mini") is True
+        assert model_requires_max_completion_tokens("o1-preview") is True
+        assert model_requires_max_completion_tokens("o3") is True
+        assert model_requires_max_completion_tokens("o3-mini") is True
+        assert model_requires_max_completion_tokens("o3-mini-high") is True
+        assert model_requires_max_completion_tokens("o4") is True
+        assert model_requires_max_completion_tokens("o4-mini") is True
+
+    def test_prefixed_model_names(self):
+        from agent.model_metadata import model_requires_max_completion_tokens
+        assert model_requires_max_completion_tokens("openai/gpt-4o-mini") is True
+        assert model_requires_max_completion_tokens("openai/gpt-5.4") is True
+        assert model_requires_max_completion_tokens("anthropic/claude-sonnet-4") is False
+        assert model_requires_max_completion_tokens("openai/gpt-4o") is True
+
+    def test_older_models_use_max_tokens(self):
+        from agent.model_metadata import model_requires_max_completion_tokens
+        assert model_requires_max_completion_tokens("gpt-4-turbo") is False
+        assert model_requires_max_completion_tokens("gpt-3.5-turbo") is False
+        assert model_requires_max_completion_tokens("claude-3-5-sonnet-20240620") is False
+        assert model_requires_max_completion_tokens("llama3.1-8b") is False
+        assert model_requires_max_completion_tokens("mixtral-8x7b") is False
+
+    def test_empty_and_none(self):
+        from agent.model_metadata import model_requires_max_completion_tokens
+        assert model_requires_max_completion_tokens("") is False
+        assert model_requires_max_completion_tokens(None) is False
+
+    def test_whitespace_handling(self):
+        from agent.model_metadata import model_requires_max_completion_tokens
+        assert model_requires_max_completion_tokens("  gpt-4o-mini  ") is True
+        assert model_requires_max_completion_tokens("gpt-5.4") is True
+
+    def test_case_insensitive(self):
+        from agent.model_metadata import model_requires_max_completion_tokens
+        assert model_requires_max_completion_tokens("GPT-4O-MINI") is True
+        assert model_requires_max_completion_tokens("Gpt-5.4") is True
+        assert model_requires_max_completion_tokens("O3-MINI") is True


### PR DESCRIPTION
## Summary

Inspired by OpenClaw's . This change decouples message ingestion (gateway) from message processing (agent), replacing the old approach where the gateway called  directly.

## Problem

When a user sends a message while the agent is mid-task (e.g., running semgrep), the old approach relied on the agent being at a specific checkpoint to receive the interrupt. If the agent was inside a long-running tool call (without its own interrupt checks), the message would queue until that tool finished.

## Solution

**run_agent.py:**
- Added  class: thread-safe priority queue with  levels
- Added  attribute to 
- Added  method: called at every yield point, processes queued messages and triggers interrupt/steer
- Call  at top of main while loop (before each API call)
- Call  during concurrent tool wait loop (every ~2s poll)
- Add early interrupt check in : aborts tool before starting any tool
- Reduce  timeout from 5s to 2s for faster interrupt detection

**gateway/run.py:**
- : push to  (priority=immediate) instead of calling  directly
- Fallback to old  for agents without 

## Backward Compatibility

The old  call path is kept as fallback for agents that don't have  yet.

## Testing

Manual testing: send a message during a long-running kanban worker task. The interrupt should be processed within 2 seconds at the next yield point.