### PR TITLE
fix(whatsapp): match allowlist against LID aliases

### DIFF
--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from typing import Dict, Optional, Any
 
 from hermes_constants import get_hermes_dir
+from gateway.whatsapp_identity import expand_whatsapp_aliases, normalize_whatsapp_identifier
 
 logger = logging.getLogger(__name__)
 
@@ -261,7 +262,10 @@ class WhatsAppAdapter(BasePlatformAdapter):
         ))
         self._reply_prefix: Optional[str] = config.extra.get("reply_prefix")
         self._dm_policy = str(config.extra.get("dm_policy") or os.getenv("WHATSAPP_DM_POLICY", "open")).strip().lower()
-        self._allow_from = self._coerce_allow_list(config.extra.get("allow_from") or config.extra.get("allowFrom"))
+        self._allow_from = self._coerce_allow_list(
+            config.extra.get("allow_from") or config.extra.get("allowFrom"),
+            normalize_whatsapp_ids=True,
+        )
         self._group_policy = str(config.extra.get("group_policy") or os.getenv("WHATSAPP_GROUP_POLICY", "open")).strip().lower()
         self._group_allow_from = self._coerce_allow_list(config.extra.get("group_allow_from") or config.extra.get("groupAllowFrom"))
         self._mention_patterns = self._compile_mention_patterns()
@@ -314,20 +318,32 @@ class WhatsAppAdapter(BasePlatformAdapter):
         return {part.strip() for part in str(raw).split(",") if part.strip()}
 
     @staticmethod
-    def _coerce_allow_list(raw) -> set[str]:
+    def _coerce_allow_list(raw, *, normalize_whatsapp_ids: bool = False) -> set[str]:
         """Parse allow_from / group_allow_from from config or env var."""
+        def coerce_part(part: Any) -> str:
+            value = str(part).strip()
+            if not value:
+                return ""
+            if normalize_whatsapp_ids:
+                if value == "*":
+                    return value
+                return normalize_whatsapp_identifier(value)
+            return value
+
         if raw is None:
             return set()
         if isinstance(raw, list):
-            return {str(part).strip() for part in raw if str(part).strip()}
-        return {part.strip() for part in str(raw).split(",") if part.strip()}
+            return {value for part in raw if (value := coerce_part(part))}
+        return {value for part in str(raw).split(",") if (value := coerce_part(part))}
 
     def _is_dm_allowed(self, sender_id: str) -> bool:
         """Check whether a DM from the given sender should be processed."""
         if self._dm_policy == "disabled":
             return False
         if self._dm_policy == "allowlist":
-            return sender_id in self._allow_from
+            if "*" in self._allow_from:
+                return True
+            return bool(expand_whatsapp_aliases(sender_id) & self._allow_from)
         # "open" — all DMs allowed
         return True
 

--- a/tests/gateway/test_whatsapp_group_gating.py
+++ b/tests/gateway/test_whatsapp_group_gating.py
@@ -29,7 +29,10 @@ def _make_adapter(require_mention=None, mention_patterns=None, free_response_cha
     adapter.config = PlatformConfig(enabled=True, extra=extra)
     adapter._message_handler = AsyncMock()
     adapter._dm_policy = str(extra.get("dm_policy", "open")).strip().lower()
-    adapter._allow_from = WhatsAppAdapter._coerce_allow_list(extra.get("allow_from"))
+    adapter._allow_from = WhatsAppAdapter._coerce_allow_list(
+        extra.get("allow_from"),
+        normalize_whatsapp_ids=True,
+    )
     adapter._group_policy = str(extra.get("group_policy", "open")).strip().lower()
     adapter._group_allow_from = WhatsAppAdapter._coerce_allow_list(extra.get("group_allow_from"))
     adapter._mention_patterns = adapter._compile_mention_patterns()
@@ -195,6 +198,44 @@ def test_dm_policy_allowlist_allows_listed_sender():
     adapter = _make_adapter(dm_policy="allowlist", allow_from=["6281234567890@s.whatsapp.net"])
 
     assert adapter._should_process_message(_dm_message("hello")) is True
+
+
+def test_dm_policy_allowlist_allows_sender_lid_alias(monkeypatch, tmp_path):
+    session_dir = tmp_path / "whatsapp" / "session"
+    session_dir.mkdir(parents=True)
+    (session_dir / "lid-mapping-123456789012345_reverse.json").write_text(
+        json.dumps("6281234567890"),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    adapter = _make_adapter(dm_policy="allowlist", allow_from=["+6281234567890"])
+
+    assert adapter._should_process_message(
+        _dm_message(
+            "hello",
+            senderId="123456789012345@lid",
+            **{"from": "123456789012345@lid"},
+        )
+    ) is True
+
+
+def test_dm_policy_allowlist_blocks_unlisted_sender_lid_alias(monkeypatch, tmp_path):
+    session_dir = tmp_path / "whatsapp" / "session"
+    session_dir.mkdir(parents=True)
+    (session_dir / "lid-mapping-123456789012345_reverse.json").write_text(
+        json.dumps("6281234567890"),
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    adapter = _make_adapter(dm_policy="allowlist", allow_from=["+6289999999999"])
+
+    assert adapter._should_process_message(
+        _dm_message(
+            "hello",
+            senderId="123456789012345@lid",
+            **{"from": "123456789012345@lid"},
+        )
+    ) is False
 
 
 def test_dm_policy_open_allows_all_dms():


### PR DESCRIPTION
## Summary
- normalize WhatsApp DM `allow_from` values before matching
- resolve incoming sender IDs through existing WhatsApp LID alias mappings
- keep group allowlist matching exact chat IDs
- add regression tests for allowed and blocked LID senders

## Why
WhatsApp can deliver the same sender as a phone JID or as an `@lid` ID. The bridge already knows how to map those identities, but the Python WhatsApp adapter was checking DM allowlists with an exact string match.

That made `dm_policy: allowlist` silently drop valid DMs when the user configured a phone number and Baileys emitted the sender as a LID.

## Tests
- `python3 -m py_compile gateway/platforms/whatsapp.py tests/gateway/test_whatsapp_group_gating.py`
- `python3 -m pytest -o addopts= tests/gateway/test_whatsapp_group_gating.py -q`
- `python3 -m pytest -o addopts= tests/gateway/test_whatsapp_group_gating.py tests/gateway/test_session.py -q`

Note: `scripts/run_tests.sh tests/gateway/test_whatsapp_group_gating.py -q` could not run in this temporary worktree because no local repo venv exists. I used the same focused pytest targets directly.

## Real-world validation
I hit this on my VPS with a WhatsApp gateway using `dm_policy: allowlist`. The bridge received the DM, but Hermes did not process it until the adapter used the existing LID alias mapping. After this patch, the same deployment accepted the DM and returned a WhatsApp response.

## Issue
No duplicate issue or PR found while searching for WhatsApp LID allowlist handling.