### PR TITLE
fix(status): detect ZAI env vars in hermes status

### DIFF
--- a/hermes_cli/status.py
+++ b/hermes_cli/status.py
@@ -131,7 +131,7 @@ def show_status(args):
         "DeepSeek": "DEEPSEEK_API_KEY",
         "xAI / Grok": "XAI_API_KEY",
         "NVIDIA NIM": "NVIDIA_API_KEY",
-        "Z.AI / GLM": "GLM_API_KEY",
+        "Z.AI / GLM": ("GLM_API_KEY", "ZAI_API_KEY", "Z_AI_API_KEY"),
         "Kimi": "KIMI_API_KEY",
         "StepFun Step Plan": "STEPFUN_API_KEY",
         "MiniMax": "MINIMAX_API_KEY",

--- a/tests/hermes_cli/test_status.py
+++ b/tests/hermes_cli/test_status.py
@@ -109,3 +109,14 @@ def test_show_status_reports_vercel_backend_contract(monkeypatch, capsys, tmp_pa
     assert "oidc-token" not in output
     assert "snapshot filesystem" in output
     assert "live processes do not survive" in output
+
+
+def test_show_status_accepts_zai_api_key(monkeypatch, capsys, tmp_path):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+    monkeypatch.setenv("ZAI_API_KEY", "zai-secret-1234")
+
+    show_status(SimpleNamespace(all=False, deep=False))
+
+    output = capsys.readouterr().out
+    line = next(line for line in output.splitlines() if "Z.AI / GLM" in line)
+    assert "(not set)" not in line


### PR DESCRIPTION
## What does this PR do?

Makes `hermes status` recognize `ZAI_API_KEY` and `Z_AI_API_KEY` in addition to the existing GLM env name, so authenticated Z.AI / GLM setups show up correctly in status output.

## Related Issue

Fixes #21990

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Updated provider env detection in `hermes_cli/status.py`
- Added a regression test covering `ZAI_API_KEY` in `tests/hermes_cli/test_status.py`

## How to Test

1. Run `uv run --frozen pytest -q -o addopts='' tests/hermes_cli/test_status.py`
2. Run `uv run --frozen ruff check hermes_cli/status.py tests/hermes_cli/test_status.py`
3. Confirm both commands pass

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `uv run --frozen pytest -q -o addopts='' tests/hermes_cli/test_status.py` -> `5 passed`
