### PR TITLE
fix(scripts): tolerate empty run_tests args on bash 3.2

### DIFF
--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -120,10 +120,17 @@ echo "▶ running pytest with $WORKERS workers, hermetic env, in $REPO_ROOT"
 echo "  (TZ=UTC LANG=C.UTF-8 PYTHONHASHSEED=0; all credential env vars unset)"
 
 # -o "addopts=" clears pyproject.toml's `-n auto` so our -n wins.
-exec "$PYTHON" -m pytest \
-  -o "addopts=" \
-  -n "$WORKERS" \
-  --ignore=tests/integration \
-  --ignore=tests/e2e \
-  -m "not integration" \
-  "${ARGS[@]}"
+PYTEST_CMD=(
+  "$PYTHON" -m pytest
+  -o "addopts="
+  -n "$WORKERS"
+  --ignore=tests/integration
+  --ignore=tests/e2e
+  -m "not integration"
+)
+
+if [ "$#" -gt 0 ]; then
+  PYTEST_CMD+=("${ARGS[@]}")
+fi
+
+exec "${PYTEST_CMD[@]}"


### PR DESCRIPTION
## What does this PR do?

Fixes `scripts/run_tests.sh` on Bash 3.2 when no extra args are provided, so the script no longer trips over empty-array expansion and still executes the default pytest command correctly.

## Related Issue

Fixes #22011

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Switched `scripts/run_tests.sh` to build the pytest command in an array
- Only append extra args when they exist
- Preserved the existing default split-test invocation

## How to Test

1. Run `bash -n scripts/run_tests.sh`
2. Run `/bin/bash scripts/run_tests.sh` in a Bash 3.2-compatible shell with a fake `.venv` test harness
3. Confirm the script executes the default pytest command without empty-args errors

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Verified the no-arg path now expands to the expected default pytest command on Bash 3.2
