### PR TITLE
fix(model-switch): mark bare custom provider as current

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1697,7 +1697,10 @@ def list_authenticated_providers(
             results.append({
                 "slug": slug,
                 "name": grp["name"],
-                "is_current": slug == current_provider,
+                "is_current": slug == current_provider or (
+                    bool(current_base_url)
+                    and _grp_url_norm == current_base_url.strip().rstrip("/").lower()
+                ),
                 "is_user_defined": True,
                 "models": grp["models"],
                 "total_models": len(grp["models"]),

--- a/tests/hermes_cli/test_model_switch_custom_providers.py
+++ b/tests/hermes_cli/test_model_switch_custom_providers.py
@@ -343,6 +343,7 @@ def test_list_authenticated_providers_bare_custom_slug_recovers(monkeypatch):
     group = matches[0]
     # Canonical slug, NOT the bare "custom" that caused #17478
     assert group["slug"] == "custom:ollama"
+    assert group["is_current"] is True
 
 
 def test_list_authenticated_providers_distinct_endpoints_stay_separate(monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Fixes custom-provider selection state when the current provider slug is the bare `custom` bucket, so the authenticated provider group is still marked current when the active base URL matches.

## Related Issue

Fixes #20811

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Updated `hermes_cli/model_switch.py` to compare the current base URL for grouped custom providers
- Tightened the existing custom-provider regression coverage in `tests/hermes_cli/test_model_switch_custom_providers.py`

## How to Test

1. Run `uv run --frozen pytest -q -o addopts='' tests/hermes_cli/test_model_switch_custom_providers.py -k 'current_endpoint_uses_current_slug or bare_custom_slug_recovers'`
2. Run `uv run --frozen ruff check hermes_cli/model_switch.py tests/hermes_cli/test_model_switch_custom_providers.py`
3. Confirm both commands pass

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `uv run --frozen pytest -q -o addopts='' tests/hermes_cli/test_model_switch_custom_providers.py -k 'current_endpoint_uses_current_slug or bare_custom_slug_recovers'` -> `2 passed`
