### PR TITLE
fix(cron): remove output dirs for completed one-shot jobs

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -798,6 +798,9 @@ def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,
                         # Remove the job (limit reached)
                         jobs.pop(i)
                         save_jobs(jobs)
+                        job_output_dir = OUTPUT_DIR / job_id
+                        if job_output_dir.exists():
+                            shutil.rmtree(job_output_dir)
                         return
                 
                 # Compute next run

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -335,6 +335,17 @@ class TestMarkJobRun:
         # Job should be removed after hitting repeat limit
         assert get_job(job["id"]) is None
 
+    def test_repeat_limit_removes_output_dir(self, tmp_cron_dir):
+        job = create_job(prompt="Once", schedule="30m", repeat=1)
+        job_output_dir = tmp_cron_dir / "cron" / "output" / job["id"]
+        job_output_dir.mkdir(parents=True)
+        (job_output_dir / "run.md").write_text("done", encoding="utf-8")
+
+        mark_job_run(job["id"], success=True)
+
+        assert get_job(job["id"]) is None
+        assert not job_output_dir.exists()
+
     def test_repeat_negative_one_is_infinite(self, tmp_cron_dir):
         # LLMs often pass repeat=-1 to mean "infinite/forever".
         # The job must NOT be deleted after runs when repeat <= 0.


### PR DESCRIPTION
## What does this PR do?

Cleans up cron output directories when a completed one-shot job is auto-removed by the repeat-limit path, so stale output folders do not accumulate after the job record is deleted.

## Related Issue

Fixes #22065

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Added output-directory cleanup to the repeat-limit deletion path in `cron/jobs.py`
- Added a regression test in `tests/cron/test_jobs.py`

## How to Test

1. Run `uv run --frozen pytest -q -o addopts='' tests/cron/test_jobs.py -k 'repeat_limit_removes_job or repeat_limit_removes_output_dir'`
2. Run `uv run --frozen ruff check cron/jobs.py tests/cron/test_jobs.py`
3. Confirm both commands pass

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `uv run --frozen pytest -q -o addopts='' tests/cron/test_jobs.py -k 'repeat_limit_removes_job or repeat_limit_removes_output_dir'` -> `2 passed`
