### PR TITLE
fix(session-search): read content from matched session

### DIFF
--- a/tests/tools/test_session_search.py
+++ b/tests/tools/test_session_search.py
@@ -572,7 +572,63 @@ class TestSessionSearch:
         assert result["success"] is True
         assert result["count"] == 1
         entry = result["results"][0]
-        assert entry["session_id"] == "parent_sid", "should report resolved parent session ID"
+        assert entry["session_id"] == "child_sid", "should preserve the matched child session ID"
+        assert entry["resolved_session_id"] == "parent_sid"
         assert entry["source"] == "api_server", (
             f"source should be parent's 'api_server', got {entry['source']!r}"
         )
+
+    def test_uses_original_session_for_content_retrieval(self):
+        """Regression for #22150: fetch transcript from the matched child
+        session even when dedup metadata resolves to the parent."""
+        from unittest.mock import MagicMock, AsyncMock, patch as _patch
+        from tools.session_search_tool import session_search
+
+        mock_db = MagicMock()
+        mock_db.search_messages.return_value = [
+            {
+                "session_id": "child_sid",
+                "content": "headless-chatgpt",
+                "source": "telegram",
+                "session_started": 1709400000,
+                "model": "gpt-4o-mini",
+            },
+        ]
+
+        def _get_session(session_id):
+            if session_id == "child_sid":
+                return {
+                    "id": "child_sid",
+                    "parent_session_id": "parent_sid",
+                    "source": "telegram",
+                    "started_at": 1709400000,
+                    "model": "gpt-4o-mini",
+                }
+            if session_id == "parent_sid":
+                return {
+                    "id": "parent_sid",
+                    "parent_session_id": None,
+                    "source": "api_server",
+                    "started_at": 1709300000,
+                    "model": "gpt-4o-mini",
+                }
+            return None
+
+        mock_db.get_session.side_effect = _get_session
+        mock_db.get_messages_as_conversation.side_effect = lambda sid: [
+            {"role": "user", "content": f"message from {sid}"},
+            {"role": "assistant", "content": "response"},
+        ]
+
+        with _patch(
+            "tools.session_search_tool.async_call_llm",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("no provider"),
+        ):
+            result = json.loads(session_search(query="headless-chatgpt", db=mock_db))
+
+        assert result["success"] is True
+        mock_db.get_messages_as_conversation.assert_called_once_with("child_sid")
+        entry = result["results"][0]
+        assert entry["session_id"] == "child_sid"
+        assert entry["resolved_session_id"] == "parent_sid"

--- a/tools/session_search_tool.py
+++ b/tools/session_search_tool.py
@@ -433,26 +433,36 @@ def session_search(
                 continue
             if resolved_sid not in seen_sessions:
                 result = dict(result)
-                result["session_id"] = resolved_sid
+                if resolved_sid != raw_sid:
+                    result["resolved_session_id"] = resolved_sid
                 seen_sessions[resolved_sid] = result
             if len(seen_sessions) >= limit:
                 break
 
         # Prepare all sessions for parallel summarization
         tasks = []
-        for session_id, match_info in seen_sessions.items():
+        for resolved_session_id, match_info in seen_sessions.items():
             try:
-                messages = db.get_messages_as_conversation(session_id)
+                message_session_id = match_info["session_id"]
+                messages = db.get_messages_as_conversation(message_session_id)
                 if not messages:
                     continue
-                session_meta = db.get_session(session_id) or {}
+                session_meta = db.get_session(resolved_session_id) or {}
                 conversation_text = _format_conversation(messages)
                 conversation_text = _truncate_around_matches(conversation_text, query)
-                tasks.append((session_id, match_info, conversation_text, session_meta))
+                tasks.append(
+                    (
+                        resolved_session_id,
+                        message_session_id,
+                        match_info,
+                        conversation_text,
+                        session_meta,
+                    )
+                )
             except Exception as e:
                 logging.warning(
                     "Failed to prepare session %s: %s",
-                    session_id,
+                    resolved_session_id,
                     e,
                     exc_info=True,
                 )
@@ -469,7 +479,7 @@ def session_search(
 
             coros = [
                 _bounded_summary(text, meta)
-                for _, _, text, meta in tasks
+                for _, _, _, text, meta in tasks
             ]
             return await asyncio.gather(*coros, return_exceptions=True)
 
@@ -493,11 +503,19 @@ def session_search(
             }, ensure_ascii=False)
 
         summaries = []
-        for (session_id, match_info, conversation_text, session_meta), result in zip(tasks, results):
+        for (
+            resolved_session_id,
+            message_session_id,
+            match_info,
+            conversation_text,
+            session_meta,
+        ), result in zip(tasks, results):
             if isinstance(result, Exception):
                 logging.warning(
                     "Failed to summarize session %s: %s",
-                    session_id, result, exc_info=True,
+                    resolved_session_id,
+                    result,
+                    exc_info=True,
                 )
                 result = None
 
@@ -507,13 +525,15 @@ def session_search(
             # root, so session_meta has the authoritative platform/source for the
             # session the user actually cares about (#15909).
             entry = {
-                "session_id": session_id,
+                "session_id": message_session_id,
                 "when": _format_timestamp(
                     session_meta.get("started_at") or match_info.get("session_started")
                 ),
                 "source": session_meta.get("source") or match_info.get("source", "unknown"),
                 "model": session_meta.get("model") or match_info.get("model"),
             }
+            if resolved_session_id != message_session_id:
+                entry["resolved_session_id"] = resolved_session_id
 
             if result:
                 entry["summary"] = result


### PR DESCRIPTION
## What does this PR do?

Fixes session search content retrieval so matched content is read from the original matched session instead of always switching content lookups to the resolved parent/root session.

## Related Issue

Fixes #22150

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Preserved original matched session IDs in `tools/session_search_tool.py`
- Added regression coverage for content retrieval behavior in `tests/tools/test_session_search.py`

## How to Test

1. Run `uv run --frozen pytest -q -o addopts='' tests/tools/test_session_search.py`
2. Run `uv run --frozen ruff check tools/session_search_tool.py tests/tools/test_session_search.py`
3. Confirm both commands pass

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `uv run --frozen pytest -q -o addopts='' tests/tools/test_session_search.py` -> `39 passed`
