### PR TITLE
fix(skills): create new skills in external skill dir

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -699,6 +699,7 @@ def _two_roots(local_dir: Path, external_dir: Path):
     """Patch the skill manager so local SKILLS_DIR = local_dir and
     get_all_skills_dirs() returns [local_dir, external_dir] in order."""
     with patch("tools.skill_manager_tool.SKILLS_DIR", local_dir), \
+         patch("agent.skill_utils.get_external_skills_dirs", return_value=[external_dir]), \
          patch("agent.skill_utils.get_all_skills_dirs",
                return_value=[local_dir, external_dir]):
         yield
@@ -820,9 +821,8 @@ class TestExternalSkillMutations:
         assert not cat_dir.exists()  # empty category cleaned up
         assert external.exists()     # but never the external root
 
-    def test_create_still_writes_to_local_root(self, tmp_path):
-        """Creating a new skill always lands in local SKILLS_DIR, never
-        external_dirs — create is unchanged by this PR."""
+    def test_create_defaults_to_first_external_root(self, tmp_path):
+        """Creating a new skill should honor the first configured external root."""
         local = tmp_path / "local"
         external = tmp_path / "vault"
         local.mkdir(); external.mkdir()
@@ -832,8 +832,8 @@ class TestExternalSkillMutations:
                 "name: test-skill", "name: fresh-skill"))
 
         assert result["success"] is True, result
-        assert (local / "fresh-skill" / "SKILL.md").exists()
-        assert not (external / "fresh-skill").exists()
+        assert (external / "fresh-skill" / "SKILL.md").exists()
+        assert not (local / "fresh-skill").exists()
 
 
 

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -270,9 +270,17 @@ def _validate_content_size(content: str, label: str = "SKILL.md") -> Optional[st
 
 def _resolve_skill_dir(name: str, category: str = None) -> Path:
     """Build the directory path for a new skill, optionally under a category."""
+    try:
+        from agent.skill_utils import get_external_skills_dirs
+
+        external_dirs = get_external_skills_dirs()
+    except Exception:
+        external_dirs = []
+
+    target_root = external_dirs[0] if external_dirs else SKILLS_DIR
     if category:
-        return SKILLS_DIR / category / name
-    return SKILLS_DIR / name
+        return target_root / category / name
+    return target_root / name
 
 
 def _find_skill(name: str) -> Optional[Dict[str, Any]]:
@@ -415,7 +423,7 @@ def _create_skill(name: str, content: str, category: str = None) -> Dict[str, An
     result = {
         "success": True,
         "message": f"Skill '{name}' created.",
-        "path": str(skill_dir.relative_to(SKILLS_DIR)),
+        "path": str(skill_dir.relative_to(_containing_skills_root(skill_dir))),
         "skill_md": str(skill_md),
     }
     if category:


### PR DESCRIPTION
## What does this PR do?

Fixes `skill_manage(action='create')` so new skills are created in the configured external skill directory when one is available, instead of always forcing creation into the local bundled skills path.

## Related Issue

Fixes #21810

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Updated `tools/skill_manager_tool.py` to consult external skill roots before falling back to `SKILLS_DIR`
- Added regression coverage in `tests/tools/test_skill_manager_tool.py`

## How to Test

1. Run `uv run --frozen pytest -q -o addopts='' tests/tools/test_skill_manager_tool.py`
2. Run `uv run --frozen ruff check tools/skill_manager_tool.py tests/tools/test_skill_manager_tool.py`
3. Confirm both commands pass

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `uv run --frozen pytest -q -o addopts='' tests/tools/test_skill_manager_tool.py` -> `86 passed`
