### PR TITLE
fix(agent): pass custom providers to aux context checks

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2165,6 +2165,7 @@ class AIAgent:
 
         # Persist for reuse on switch_model / fallback activation. Must come
         # AFTER the custom_providers branch so per-model overrides aren't lost.
+        self._custom_providers = _custom_providers
         self._config_context_length = _config_context_length
 
         self._ensure_lmstudio_runtime_loaded(_config_context_length)
@@ -3151,6 +3152,7 @@ class AIAgent:
                 # provider-specific paths (e.g. Bedrock static table, OpenRouter API)
                 # are invoked for the correct client, not inherited from the main model.
                 provider=(_aux_cfg_provider if _aux_cfg_provider and _aux_cfg_provider != "auto" else getattr(self, "provider", "")),
+                custom_providers=getattr(self, "_custom_providers", None),
             )
 
             # Hard floor: the auxiliary compression model must have at least

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -182,6 +182,37 @@ def test_feasibility_check_passes_config_context_length(mock_get_client, mock_ct
         api_key="sk-custom",
         config_context_length=1_000_000,
         provider="openrouter",
+        custom_providers=None,
+    )
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=1_000_000)
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_feasibility_check_passes_custom_providers(mock_get_client, mock_ctx_len):
+    """Aux compression feasibility should honor custom_providers context overrides."""
+    agent = _make_agent(main_context=200_000, threshold_percent=0.85)
+    agent._custom_providers = [
+        {
+            "provider": "custom-openai",
+            "base_url": "http://custom-endpoint:8080/v1",
+            "models": {"custom/big-model": {"context_length": 1_000_000}},
+        }
+    ]
+    mock_client = MagicMock()
+    mock_client.base_url = "http://custom-endpoint:8080/v1"
+    mock_client.api_key = "sk-custom"
+    mock_get_client.return_value = (mock_client, "custom/big-model")
+
+    agent._emit_status = lambda msg: None
+    agent._check_compression_model_feasibility()
+
+    mock_ctx_len.assert_called_once_with(
+        "custom/big-model",
+        base_url="http://custom-endpoint:8080/v1",
+        api_key="sk-custom",
+        config_context_length=None,
+        provider="openrouter",
+        custom_providers=agent._custom_providers,
     )
 
 
@@ -205,6 +236,7 @@ def test_feasibility_check_ignores_invalid_context_length(mock_get_client, mock_
         api_key="sk-test",
         config_context_length=None,
         provider="openrouter",
+        custom_providers=None,
     )
 
 
@@ -258,6 +290,7 @@ def test_init_feasibility_check_uses_aux_context_override_from_config():
         api_key="sk-custom",
         config_context_length=1_000_000,
         provider="",
+        custom_providers=[],
     )
 
 


### PR DESCRIPTION
## What does this PR do?

Fixes auxiliary compression feasibility checks so they pass through configured custom providers when checking the available context window, which keeps custom-model auxiliary setups from being misclassified.

## Related Issue

Fixes #21947

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

- Persisted custom providers during agent initialization in `run_agent.py`
- Passed custom providers into the compression feasibility check
- Added regression coverage in `tests/run_agent/test_compression_feasibility.py`

## How to Test

1. Run `uv run --frozen pytest -q -o addopts='' tests/run_agent/test_compression_feasibility.py`
2. Run `uv run --frozen ruff check run_agent.py tests/run_agent/test_compression_feasibility.py`
3. Confirm both commands pass

## Checklist

### Code

- [ ] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [ ] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [ ] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [ ] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [ ] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `uv run --frozen pytest -q -o addopts='' tests/run_agent/test_compression_feasibility.py` -> `17 passed`
