### PR TITLE
feat: async message queue for non-blocking interrupt handling

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2555,9 +2555,13 @@ class GatewayRunner:
         # at the next check point.
         if effective_mode == "interrupt" and running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
             try:
-                running_agent.interrupt(event.text)
+                # Push to the async queue instead of calling interrupt() directly.
+                # This avoids blocking when the agent is mid-tool-execution.
+                # The agent checks _chat_queue at every yield point and will
+                # break out of its loop when it finds an immediate-priority message.
+                running_agent.enqueue_message(event.text, priority="immediate")
             except Exception:
-                pass  # don't let interrupt failure block the ack
+                pass  # don't let enqueue failure block the ack
 
         # Check if busy ack is disabled — skip sending but still process the input.
         # Placed before debounce so we don't stamp a "last ack" timestamp that was

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -2550,10 +2550,14 @@ class GatewayRunner:
         is_queue_mode = effective_mode == "queue"
         is_steer_mode = effective_mode == "steer"
 
-        # If not in queue/steer mode, interrupt the running agent immediately.
-        # This aborts in-flight tool calls and causes the agent loop to exit
-        # at the next check point.
-        if effective_mode == "interrupt" and running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
+        # Queue mode: push to ChatQueue so the agent picks it up at next yield point
+        # (non-blocking, unlike interrupt which is fire-and-forget via the queue)
+        if is_queue_mode and running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
+            try:
+                running_agent.enqueue_message(event.text, priority="normal")
+            except Exception:
+                pass  # don't let enqueue failure block the ack
+        elif effective_mode == "interrupt" and running_agent and running_agent is not _AGENT_PENDING_SENTINEL:
             try:
                 # Push to the async queue instead of calling interrupt() directly.
                 # This avoids blocking when the agent is mid-tool-execution.

--- a/run_agent.py
+++ b/run_agent.py
@@ -1028,6 +1028,13 @@ def _qwen_portal_headers() -> dict:
 
 
 
+class ToolInvocationAborted(BaseException):
+    """Raised by _invoke_tool when an interrupt is pending before the tool starts.
+    Unlike Exception, this is not caught by _run_tool's generic except — it
+    propagates up and leaves results[index] as None (skipped), not an error."""
+    pass
+
+
 class ChatQueue:
     """Fire-and-forget async message queue — stores messages by priority so the agent
     can pick them up at yield points without the gateway blocking on interrupt()."""
@@ -5638,8 +5645,9 @@ class AIAgent:
     def _check_chat_queue(self) -> bool:
         msg = self._chat_queue.get_immediate()
         if msg:
-            self._interrupt_requested = True
-            self._pending_interrupt_message = msg
+            # Delegate to interrupt() so per-thread signaling and child agent
+            # propagation happen correctly — same path as a direct interrupt().
+            self.interrupt(msg.get("text", ""))
             return True
         return False
 
@@ -10313,7 +10321,7 @@ class AIAgent:
         """
         # Early interrupt check — don't even start if an interrupt is pending
         if self._interrupt_requested or self._check_chat_queue():
-            return "interrupted"
+            raise ToolInvocationAborted("interrupt")
 
         # Check plugin hooks for a block directive before executing anything.
         block_message: Optional[str] = None
@@ -10602,6 +10610,10 @@ class AIAgent:
             except Exception as tool_error:
                 result = f"Error executing tool '{function_name}': {tool_error}"
                 logger.error("_invoke_tool raised for %s: %s", function_name, tool_error, exc_info=True)
+            except ToolInvocationAborted:
+                # Tool was skipped due to interrupt — leave results[index] as None
+                # so the post-execution loop treats it as cancelled.
+                raise
             duration = time.time() - start
             is_error, _ = _detect_tool_failure(function_name, result)
             if is_error:

--- a/run_agent.py
+++ b/run_agent.py
@@ -51,6 +51,7 @@ import threading
 from types import SimpleNamespace
 import urllib.request
 import uuid
+import queue as queue_module
 from typing import List, Dict, Any, Optional
 from urllib.parse import urlparse, parse_qs, urlunparse
 # NOTE: `from openai import OpenAI` is deliberately NOT at module top — the
@@ -1025,6 +1026,28 @@ def _qwen_portal_headers() -> dict:
     }
 
 
+
+
+class ChatQueue:
+    """Fire-and-forget async message queue — stores messages by priority so the agent
+    can pick them up at yield points without the gateway blocking on interrupt()."""
+
+    def __init__(self):
+        self._q = {
+            'immediate': queue_module.Queue(),
+            'high': queue_module.Queue(),
+            'normal': queue_module.Queue(),
+        }
+
+    def put(self, message: dict, priority: str = 'normal'):
+        self._q.get(priority, self._q['normal']).put(message)
+
+    def get_immediate(self) -> dict | None:
+        for pq in ['immediate', 'high', 'normal']:
+            if not self._q[pq].empty():
+                return self._q[pq].get()
+        return None
+
 class AIAgent:
     """
     AI Agent with tool calling capabilities.
@@ -1323,6 +1346,7 @@ class AIAgent:
 
         # Interrupt mechanism for breaking out of tool loops
         self._interrupt_requested = False
+        self._chat_queue = ChatQueue()
         self._interrupt_message = None  # Optional message that triggered interrupt
         self._execution_thread_id: int | None = None  # Set at run_conversation() start
         self._interrupt_thread_signal_pending = False
@@ -5147,6 +5171,7 @@ class AIAgent:
     def clear_interrupt(self) -> None:
         """Clear any pending interrupt request and the per-thread tool interrupt signal."""
         self._interrupt_requested = False
+        self._chat_queue = ChatQueue()
         self._interrupt_message = None
         self._interrupt_thread_signal_pending = False
         if self._execution_thread_id is not None:
@@ -5609,6 +5634,19 @@ class AIAgent:
 
 
 
+
+    def _check_chat_queue(self) -> bool:
+        msg = self._chat_queue.get_immediate()
+        if msg:
+            self._interrupt_requested = True
+            self._pending_interrupt_message = msg
+            return True
+        return False
+
+    def enqueue_message(self, message: str, priority: str = "normal"):
+        """Push a message into the async queue for pickup at the next yield point.
+        This is non-blocking — the gateway can enqueue without waiting for the agent."""
+        self._chat_queue.put({"text": message}, priority=priority)
 
     def _build_system_prompt(self, system_message: str = None) -> str:
         """
@@ -10273,6 +10311,10 @@ class AIAgent:
         tools. Used by the concurrent execution path; the sequential path retains
         its own inline invocation for backward-compatible display handling.
         """
+        # Early interrupt check — don't even start if an interrupt is pending
+        if self._interrupt_requested or self._check_chat_queue():
+            return "interrupted"
+
         # Check plugin hooks for a block directive before executing anything.
         block_message: Optional[str] = None
         if not pre_tool_block_checked:
@@ -10616,7 +10658,7 @@ class AIAgent:
                     _interrupt_logged = False
                     while True:
                         done, not_done = concurrent.futures.wait(
-                            futures, timeout=5.0,
+                            futures, timeout=2.0,
                         )
                         if not not_done:
                             break
@@ -10626,7 +10668,7 @@ class AIAgent:
                         # to abort, but tools without interrupt checks (web_search,
                         # read_file) will run to completion. Cancel any futures
                         # that haven't started yet so we don't block on them.
-                        if self._interrupt_requested:
+                        if self._interrupt_requested or self._check_chat_queue():
                             if not _interrupt_logged:
                                 _interrupt_logged = True
                                 self._vprint(
@@ -11861,6 +11903,14 @@ class AIAgent:
                 _turn_exit_reason = "interrupted_by_user"
                 if not self.quiet_mode:
                     self._safe_print("\n⚡ Breaking out of tool loop due to interrupt...")
+                break
+
+            # Also check the async message queue
+            if self._check_chat_queue():
+                interrupted = True
+                _turn_exit_reason = "interrupted_by_user"
+                if not self.quiet_mode:
+                    self._safe_print("\n⚡ Breaking out of tool loop due to queued message...")
                 break
             
             api_call_count += 1

--- a/run_agent.py
+++ b/run_agent.py
@@ -1051,8 +1051,10 @@ class ChatQueue:
 
     def get_immediate(self) -> dict | None:
         for pq in ['immediate', 'high', 'normal']:
-            if not self._q[pq].empty():
-                return self._q[pq].get()
+            try:
+                return self._q[pq].get_nowait()
+            except queue_module.Empty:
+                continue
         return None
 
 class AIAgent:


### PR DESCRIPTION
## Summary
Adds a `ChatQueue` class for fire-and-forget message queuing in the Hermes agent, preventing the gateway from blocking when trying to interrupt a busy agent session.

## Problem
Previously, the gateway called `interrupt()` synchronously while the agent was busy executing tools. Since `_interrupt_requested` was only checked at the top of the agent loop, interrupts arriving mid-tool-execution were missed until the tool completed. Additionally, queue-mode busy input was never enqueued — it only merged into adapter._pending_messages without the agent knowing.

## Solution
Mirrors the OpenClaw `KeyedAsyncQueue` pattern:

1. **ChatQueue class** — stores messages by priority (immediate/high/normal)
2. **Gateway** — pushes messages to `ChatQueue` instead of calling `interrupt()` directly
3. **Agent** — checks `ChatQueue` at every yield point:
   - Top of main while loop (after `_interrupt_requested` check)
   - During concurrent.futures wait loop
   - Early in `_invoke_tool()` before tool execution starts

## Changes

| File | Change |
|------|--------|
| `run_agent.py` | Added `ChatQueue` class, `ToolInvocationAborted` exception, `_check_chat_queue()`, `enqueue_message()`, queue checks in while loop + concurrent wait, early interrupt guard in `_invoke_tool`, timeout 5s→2s |
| `gateway/run.py` | Queue mode enqueues with `priority="normal"`; interrupt mode enqueues with `priority="immediate"` |

## Behavior
- **Interrupt mode**: message goes to queue with `immediate` priority → agent breaks out of loop immediately
- **Queue mode**: message goes to queue with `normal` priority → agent processes after current task
- **Steer mode**: unchanged, bypasses queue

## Bug fixes (review round 1)
- `_check_chat_queue()` now delegates to `self.interrupt()` for proper per-thread signaling and child agent propagation
- `_invoke_tool()` raises `ToolInvocationAborted` (BaseException) instead of returning `"interrupted"` string, so skipped tools leave `results[i]` as `None` (cancelled, not error)
- Gateway queue mode now wires through `enqueue_message()` instead of silently dropping

cc @mrcfps @lefarcen