### PR TITLE
fix(line): use build_source not create_source so inbound messages dispatch

### DIFF
--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -959,7 +959,7 @@ class LineAdapter(BasePlatformAdapter):
         if chat_type == "dm" and self._client:
             asyncio.create_task(self._client.loading(chat_id))
 
-        source_obj = self.create_source(
+        source_obj = self.build_source(
             chat_id=chat_id,
             chat_type=chat_type,
             user_id=user_id,


### PR DESCRIPTION
## Summary

The LINE Messaging API plugin added in #23197 has a typo that causes **100% of inbound text messages to crash** before they reach the agent. `_handle_message_event` calls `self.create_source(...)` at `plugins/platforms/line/adapter.py:962`, but the base adapter's helper is named `build_source` — every other platform adapter (mattermost, matrix, whatsapp, msgraph_webhook, wecom, feishu, bluebubbles, qqbot) calls `self.build_source(...)`.

Reproduces every time you send any text to a LINE bot configured via this plugin. The webhook is received, signature verified, event dispatched — then dies in `_handle_message_event` with:

```
ERROR hermes_plugins.line_platform.adapter: LINE: dispatch_event failed
  File ".../plugins/platforms/line/adapter.py", line 877, in _handle_webhook
  File ".../plugins/platforms/line/adapter.py", line 910, in _dispatch_event
  File ".../plugins/platforms/line/adapter.py", line 962, in _handle_message_event
AttributeError: 'LineAdapter' object has no attribute 'create_source'
```

The kwargs at the call site (`chat_id`, `chat_type`, `user_id`, `user_name`, `chat_name`) already match `build_source`'s signature exactly — pure rename, zero behavior change. Verified locally: after the one-character fix, inbound messages dispatch normally, agent responds via the free reply token, and the postback fallback path also works.

## Why the test suite didn't catch this

`tests/gateway/test_line_plugin.py` (644 lines) covers signature verification, parsing, the postback state machine, etc., but doesn't appear to exercise the full webhook → `_handle_message_event` → `build_source` → `MessageEvent` path against a real `LineAdapter` instance — so the missing-attribute crash hides behind the unit-test boundary. Worth a follow-up to add an end-to-end smoke test that constructs a real adapter and feeds it a parsed message event.

## Test plan
- [x] Inbound text DM dispatches to agent and gets a reply (verified locally on a real LINE OA + ngrok tunnel)
- [x] Reply token path is used (free; no Push API call)
- [ ] Group / room dispatch (untested locally — same code path, same fix applies)

🤖 Generated with [Claude Code](https://claude.com/claude-code)