### PR TITLE
fix(telegram): surface reply-to media (text + bytes) to the agent

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -3438,6 +3438,8 @@ class TelegramAdapter(BasePlatformAdapter):
 
         event = self._build_message_event(update.message, MessageType.TEXT, update_id=update.update_id)
         event.text = self._clean_bot_trigger_text(event.text)
+        # Re-fetch reply-to media bytes (no-op for non-replies / text-only replies)
+        await self._hydrate_reply_to_media(event, update.message)
         self._enqueue_text_event(event)
 
     async def _handle_command(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -3448,6 +3450,7 @@ class TelegramAdapter(BasePlatformAdapter):
             return
         
         event = self._build_message_event(update.message, MessageType.COMMAND, update_id=update.update_id)
+        await self._hydrate_reply_to_media(event, update.message)
         await self.handle_message(event)
 
     async def _handle_location_message(self, update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -3485,6 +3488,7 @@ class TelegramAdapter(BasePlatformAdapter):
 
         event = self._build_message_event(msg, MessageType.LOCATION, update_id=update.update_id)
         event.text = "\n".join(parts)
+        await self._hydrate_reply_to_media(event, msg)
         await self.handle_message(event)
 
     # ------------------------------------------------------------------
@@ -3635,11 +3639,18 @@ class TelegramAdapter(BasePlatformAdapter):
             msg_type = MessageType.DOCUMENT
         
         event = self._build_message_event(msg, msg_type, update_id=update.update_id)
-        
+
         # Add caption as text
         if msg.caption:
             event.text = self._clean_bot_trigger_text(msg.caption)
-        
+
+        # Re-fetch reply-to media bytes BEFORE the inbound media is cached
+        # below.  The hydrator appends to ``event.media_urls`` so the order
+        # ends up: [reply-to media, *inbound media] — putting the quoted
+        # context first matches how the agent reads the message ("here's
+        # what was quoted, then here's the new media").
+        await self._hydrate_reply_to_media(event, msg)
+
         # Handle stickers: describe via vision tool with caching
         if msg.sticker:
             await self._handle_sticker(msg, event)
@@ -3664,8 +3675,11 @@ class TelegramAdapter(BasePlatformAdapter):
                             break
                 # Save to local cache (for vision tool access)
                 cached_path = cache_image_from_bytes(bytes(image_bytes), ext=ext)
-                event.media_urls = [cached_path]
-                event.media_types = [f"image/{ext.lstrip('.')}" ]
+                # ``.append`` (vs ``=``) preserves anything the reply-to
+                # hydrator above already appended so a user replying to a
+                # doc with a photo+caption surfaces both files.
+                event.media_urls.append(cached_path)
+                event.media_types.append(f"image/{ext.lstrip('.')}")
                 logger.info("[Telegram] Cached user photo at %s", cached_path)
                 media_group_id = getattr(msg, "media_group_id", None)
                 if media_group_id:
@@ -3684,8 +3698,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 file_obj = await msg.voice.get_file()
                 audio_bytes = await file_obj.download_as_bytearray()
                 cached_path = cache_audio_from_bytes(bytes(audio_bytes), ext=".ogg")
-                event.media_urls = [cached_path]
-                event.media_types = ["audio/ogg"]
+                event.media_urls.append(cached_path)
+                event.media_types.append("audio/ogg")
                 logger.info("[Telegram] Cached user voice at %s", cached_path)
             except Exception as e:
                 logger.warning("[Telegram] Failed to cache voice: %s", e, exc_info=True)
@@ -3694,8 +3708,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 file_obj = await msg.audio.get_file()
                 audio_bytes = await file_obj.download_as_bytearray()
                 cached_path = cache_audio_from_bytes(bytes(audio_bytes), ext=".mp3")
-                event.media_urls = [cached_path]
-                event.media_types = ["audio/mp3"]
+                event.media_urls.append(cached_path)
+                event.media_types.append("audio/mp3")
                 logger.info("[Telegram] Cached user audio at %s", cached_path)
             except Exception as e:
                 logger.warning("[Telegram] Failed to cache audio: %s", e, exc_info=True)
@@ -3711,8 +3725,8 @@ class TelegramAdapter(BasePlatformAdapter):
                             ext = candidate
                             break
                 cached_path = cache_video_from_bytes(bytes(video_bytes), ext=ext)
-                event.media_urls = [cached_path]
-                event.media_types = [SUPPORTED_VIDEO_TYPES.get(ext, "video/mp4")]
+                event.media_urls.append(cached_path)
+                event.media_types.append(SUPPORTED_VIDEO_TYPES.get(ext, "video/mp4"))
                 logger.info("[Telegram] Cached user video at %s", cached_path)
             except Exception as e:
                 logger.warning("[Telegram] Failed to cache video: %s", e, exc_info=True)
@@ -3770,8 +3784,11 @@ class TelegramAdapter(BasePlatformAdapter):
                         return
 
                     event.message_type = MessageType.PHOTO
-                    event.media_urls = [cached_path]
-                    event.media_types = [doc_mime if doc_mime.startswith("image/") else _TELEGRAM_IMAGE_EXT_TO_MIME.get(image_ext, "image/jpeg")]
+                    event.media_urls.append(cached_path)
+                    event.media_types.append(
+                        doc_mime if doc_mime.startswith("image/")
+                        else _TELEGRAM_IMAGE_EXT_TO_MIME.get(image_ext, "image/jpeg")
+                    )
                     logger.info("[Telegram] Cached user image-document at %s", cached_path)
 
                     media_group_id = getattr(msg, "media_group_id", None)
@@ -3790,8 +3807,8 @@ class TelegramAdapter(BasePlatformAdapter):
                     file_obj = await doc.get_file()
                     video_bytes = await file_obj.download_as_bytearray()
                     cached_path = cache_video_from_bytes(bytes(video_bytes), ext=ext)
-                    event.media_urls = [cached_path]
-                    event.media_types = [SUPPORTED_VIDEO_TYPES[ext]]
+                    event.media_urls.append(cached_path)
+                    event.media_types.append(SUPPORTED_VIDEO_TYPES[ext])
                     event.message_type = MessageType.VIDEO
                     logger.info("[Telegram] Cached user video document at %s", cached_path)
                     await self.handle_message(event)
@@ -3814,8 +3831,8 @@ class TelegramAdapter(BasePlatformAdapter):
                 raw_bytes = bytes(doc_bytes)
                 cached_path = cache_document_from_bytes(raw_bytes, original_filename or f"document{ext}")
                 mime_type = SUPPORTED_DOCUMENT_TYPES[ext]
-                event.media_urls = [cached_path]
-                event.media_types = [mime_type]
+                event.media_urls.append(cached_path)
+                event.media_types.append(mime_type)
                 logger.info("[Telegram] Cached user document at %s", cached_path)
 
                 # For text files, inject content into event.text (capped at 100 KB)
@@ -4111,27 +4128,39 @@ class TelegramAdapter(BasePlatformAdapter):
         )
         
         # Extract reply context if this message is a reply.
-        # Prefer Telegram's native partial quote (message.quote, TextQuote)
-        # so a user replying to a single selected substring of a prior
-        # multi-section message doesn't get the whole replied-to message
-        # injected into the agent's context — which can cause the agent
-        # to act on unrelated actionable-looking text the user didn't
-        # quote (#22619). Fall back to the full replied-to message text
-        # / caption when no native quote is present.
+        #
+        # Three layers of fallback for ``reply_to_text``:
+        #
+        # 1. Native partial quote (``message.quote``, TextQuote) — the user
+        #    explicitly selected a substring of the replied-to message via
+        #    Telegram's quote feature.  Most precise signal of intent (#22619).
+        #
+        # 2. Full text/caption of the replied-to message — the legacy path.
+        #
+        # 3. A structured media descriptor — for replies to messages that have
+        #    no text *or* caption (a photo with no caption, a voice note, a
+        #    document, etc.), build a short tag like ``[file: name.pdf]`` or
+        #    ``[photo]`` / ``[voice 7s]``.  Previously this case dropped to
+        #    ``None`` and the agent-visible ``[Replying to: "..."]`` prefix
+        #    was suppressed entirely, leaving the agent guessing what was
+        #    being referenced.  See ``_describe_reply_to_message``.
+        #
+        # The actual media bytes for a media-only reply are re-fetched and
+        # cached by ``_hydrate_reply_to_media``, called from every async
+        # handler (text / command / location / media) so the agent gets the
+        # file path on ``event.media_urls`` too — Telegram only carries
+        # metadata on ``reply_to_message``, not the bytes themselves.
         reply_to_id = None
         reply_to_text = None
         if message.reply_to_message:
-            reply_to_id = str(message.reply_to_message.message_id)
+            rtm = message.reply_to_message
+            reply_to_id = str(rtm.message_id)
             quote = getattr(message, "quote", None)
             quote_text = getattr(quote, "text", None) if quote is not None else None
             if quote_text:
                 reply_to_text = quote_text
             else:
-                reply_to_text = (
-                    message.reply_to_message.text
-                    or message.reply_to_message.caption
-                    or None
-                )
+                reply_to_text = self._describe_reply_to_message(rtm)
 
         # Per-channel/topic ephemeral prompt
         from gateway.platforms.base import resolve_channel_prompt
@@ -4155,6 +4184,183 @@ class TelegramAdapter(BasePlatformAdapter):
             channel_prompt=_channel_prompt,
             timestamp=message.date,
         )
+
+    # ── Reply-to context hydration ────────────────────────────────────────
+
+    @staticmethod
+    def _describe_reply_to_message(rtm: Any) -> Optional[str]:
+        """Build a human-readable description of a replied-to message.
+
+        Always prefers the actual text/caption when present.  For media-only
+        replies (no caption), returns a short ``[file: name.pdf]`` /
+        ``[photo]`` / ``[voice 0:07]`` style tag so downstream context
+        injection has something concrete to show the agent — better than
+        a silent ``None`` that erases the fact a reply happened at all.
+        """
+        text = getattr(rtm, "text", None) or getattr(rtm, "caption", None)
+        # Build a media-tag suffix even when text is present, so the agent
+        # knows the reply targeted a file (not just a copy-pasted caption).
+        tag: Optional[str] = None
+        if getattr(rtm, "document", None):
+            doc = rtm.document
+            name = getattr(doc, "file_name", None) or "file"
+            mime = getattr(doc, "mime_type", None)
+            tag = f"[file: {name}" + (f" ({mime})" if mime else "") + "]"
+        elif getattr(rtm, "photo", None):
+            tag = "[photo]"
+        elif getattr(rtm, "voice", None):
+            dur = getattr(rtm.voice, "duration", None)
+            tag = f"[voice {dur}s]" if dur else "[voice]"
+        elif getattr(rtm, "audio", None):
+            audio = rtm.audio
+            title = getattr(audio, "title", None) or getattr(audio, "file_name", None)
+            tag = f"[audio: {title}]" if title else "[audio]"
+        elif getattr(rtm, "video", None):
+            tag = "[video]"
+        elif getattr(rtm, "video_note", None):
+            tag = "[video note]"
+        elif getattr(rtm, "sticker", None):
+            emoji = getattr(rtm.sticker, "emoji", None) or ""
+            tag = f"[sticker {emoji}]" if emoji else "[sticker]"
+        elif getattr(rtm, "animation", None):
+            tag = "[gif]"
+        elif getattr(rtm, "location", None):
+            tag = "[location]"
+        elif getattr(rtm, "contact", None):
+            tag = "[contact]"
+
+        if text and tag:
+            return f"{tag} {text}"
+        if text:
+            return text
+        return tag  # may be None for purely-empty messages
+
+    async def _hydrate_reply_to_media(self, event: MessageEvent, message: Any) -> None:
+        """Re-fetch + cache any media on the replied-to message.
+
+        Telegram delivers reply context as ``message.reply_to_message`` with
+        the original media's metadata (file_id, file_name, mime_type, etc.)
+        but **does not** re-stream the bytes.  When a user replies to a
+        PDF the bot sent earlier with "send this to user@example.com", the
+        agent only sees a text update — it has no path to the actual file.
+
+        This helper closes that gap: for each supported media type on
+        ``reply_to_message``, it does the same ``get_file()`` →
+        ``download_as_bytearray()`` → ``cache_*_from_bytes()`` round-trip
+        that fresh inbound media uses, then appends the resulting cached
+        path to ``event.media_urls`` / ``event.media_types`` so the agent
+        can operate on the file directly.
+
+        Failures are logged and swallowed — a reply with un-fetchable
+        media still flows through with the structured ``reply_to_text``
+        descriptor, which is strictly better than the prior silent drop.
+        """
+        rtm = getattr(message, "reply_to_message", None)
+        if rtm is None:
+            return
+
+        try:
+            if getattr(rtm, "photo", None):
+                photo = rtm.photo[-1]  # largest PhotoSize
+                file_obj = await photo.get_file()
+                data = await file_obj.download_as_bytearray()
+                ext = ".jpg"
+                fp = getattr(file_obj, "file_path", None)
+                if fp:
+                    for cand in (".png", ".webp", ".gif", ".jpeg", ".jpg"):
+                        if fp.lower().endswith(cand):
+                            ext = cand
+                            break
+                cached = cache_image_from_bytes(bytes(data), ext=ext)
+                event.media_urls.append(cached)
+                event.media_types.append(f"image/{ext.lstrip('.')}")
+                logger.info("[Telegram] Cached reply-to photo at %s", cached)
+
+            elif getattr(rtm, "voice", None):
+                file_obj = await rtm.voice.get_file()
+                data = await file_obj.download_as_bytearray()
+                cached = cache_audio_from_bytes(bytes(data), ext=".ogg")
+                event.media_urls.append(cached)
+                event.media_types.append("audio/ogg")
+                logger.info("[Telegram] Cached reply-to voice at %s", cached)
+
+            elif getattr(rtm, "audio", None):
+                file_obj = await rtm.audio.get_file()
+                data = await file_obj.download_as_bytearray()
+                cached = cache_audio_from_bytes(bytes(data), ext=".mp3")
+                event.media_urls.append(cached)
+                event.media_types.append("audio/mp3")
+                logger.info("[Telegram] Cached reply-to audio at %s", cached)
+
+            elif getattr(rtm, "video", None):
+                file_obj = await rtm.video.get_file()
+                data = await file_obj.download_as_bytearray()
+                ext = ".mp4"
+                fp = getattr(file_obj, "file_path", None)
+                if fp:
+                    for cand in SUPPORTED_VIDEO_TYPES:
+                        if fp.lower().endswith(cand):
+                            ext = cand
+                            break
+                cached = cache_video_from_bytes(bytes(data), ext=ext)
+                event.media_urls.append(cached)
+                event.media_types.append(SUPPORTED_VIDEO_TYPES.get(ext, "video/mp4"))
+                logger.info("[Telegram] Cached reply-to video at %s", cached)
+
+            elif getattr(rtm, "document", None):
+                doc = rtm.document
+                original = getattr(doc, "file_name", None) or "document"
+                _, ext = os.path.splitext(original)
+                ext = ext.lower()
+                # Reverse-lookup MIME → ext if filename had none
+                if not ext and getattr(doc, "mime_type", None):
+                    mime_to_ext = {v: k for k, v in SUPPORTED_DOCUMENT_TYPES.items()}
+                    ext = mime_to_ext.get(doc.mime_type, "")
+                # Fetch + cache the bytes regardless of whether the type is
+                # in SUPPORTED_DOCUMENT_TYPES — the original message already
+                # passed the gate when first delivered, so re-fetching for
+                # reply context shouldn't second-guess it.
+                file_obj = await doc.get_file()
+                data = await file_obj.download_as_bytearray()
+                # Image documents (PNG/JPG sent as "file") → image cache
+                _IMG_EXTS = {".jpg", ".jpeg", ".png", ".webp", ".gif", ".heic", ".heif", ".bmp"}
+                mime = getattr(doc, "mime_type", None) or ""
+                if mime.startswith("image/") or ext in _IMG_EXTS:
+                    if not ext:
+                        ext = ".jpg"
+                    cached = cache_image_from_bytes(bytes(data), ext=ext)
+                    event.media_urls.append(cached)
+                    event.media_types.append(mime or f"image/{ext.lstrip('.')}")
+                elif ext in SUPPORTED_VIDEO_TYPES:
+                    cached = cache_video_from_bytes(bytes(data), ext=ext)
+                    event.media_urls.append(cached)
+                    event.media_types.append(SUPPORTED_VIDEO_TYPES[ext])
+                else:
+                    cached = cache_document_from_bytes(bytes(data), original)
+                    event.media_urls.append(cached)
+                    event.media_types.append(
+                        SUPPORTED_DOCUMENT_TYPES.get(ext, mime or "application/octet-stream")
+                    )
+                logger.info(
+                    "[Telegram] Cached reply-to document %s at %s", original, cached
+                )
+
+            elif getattr(rtm, "sticker", None):
+                # Stickers are typically WebP; reuse the image cache so the
+                # vision tool can see the pixels (matches inbound handling).
+                sticker = rtm.sticker
+                file_obj = await sticker.get_file()
+                data = await file_obj.download_as_bytearray()
+                cached = cache_image_from_bytes(bytes(data), ext=".webp")
+                event.media_urls.append(cached)
+                event.media_types.append("image/webp")
+                logger.info("[Telegram] Cached reply-to sticker at %s", cached)
+        except Exception as e:
+            # Non-fatal: ``reply_to_text`` already carries a textual
+            # descriptor, so the agent still has *some* context.
+            logger.warning(
+                "[Telegram] Failed to cache reply-to media: %s", e, exc_info=True
+            )
 
     # ── Message reactions (processing lifecycle) ──────────────────────────
 

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6747,7 +6747,33 @@ class GatewayRunner:
                         except Exception:
                             pass
 
-        if event.media_urls and event.message_type == MessageType.DOCUMENT:
+        # Inject a context note with the cached file path so the agent can
+        # operate on document/text attachments via the filesystem (e.g.
+        # email send, summarize, hash, re-OCR).  Images / audio / video go
+        # through the native attachment / STT / vision pipelines and don't
+        # need a path injection here — the inner mtype filter skips them.
+        #
+        # Two trigger paths:
+        #
+        #   1. ``message_type == DOCUMENT`` — the user uploaded a file as
+        #      their primary message (e.g. dragged a PDF into Telegram).
+        #
+        #   2. ``reply_to_message_id`` is set AND media_urls is populated —
+        #      the user replied to a previously-sent file.  Platform
+        #      adapters that re-fetch the replied-to bytes (currently the
+        #      Telegram adapter, via ``_hydrate_reply_to_media``) append
+        #      the cached path to ``event.media_urls`` so the agent has
+        #      the same path-level access as if the user had re-uploaded
+        #      the file.  Without this branch, a reply like "send this to
+        #      alice@example.com" while quoting a PDF surfaced only the
+        #      ``[Replying to: ...]`` filename pointer and no path — the
+        #      agent had to guess.
+        is_reply_with_media = bool(
+            event.media_urls and getattr(event, "reply_to_message_id", None)
+        )
+        if event.media_urls and (
+            event.message_type == MessageType.DOCUMENT or is_reply_with_media
+        ):
             import mimetypes as _mimetypes
             from tools.credential_files import to_agent_visible_cache_path
 
@@ -6775,7 +6801,24 @@ class GatewayRunner:
                 # cache directories are auto-mounted at /root/.hermes/cache/* by get_cache_directory_mounts().
                 agent_path = to_agent_visible_cache_path(path)
 
-                if mtype.startswith("text/"):
+                # Phrase the note differently for reply-to context: the
+                # user is REFERENCING a prior file (and presumably already
+                # said what to do with it in the reply text), not
+                # uploading something new and waiting for the agent to ask.
+                if is_reply_with_media:
+                    if mtype.startswith("text/"):
+                        context_note = (
+                            f"[The user is replying to a text document: "
+                            f"'{display_name}'. Its content is included below. "
+                            f"The file is also saved at: {agent_path}]"
+                        )
+                    else:
+                        context_note = (
+                            f"[The user is replying to a document: "
+                            f"'{display_name}'. The file is saved at: {agent_path}. "
+                            f"Use this path with any tool that needs the file.]"
+                        )
+                elif mtype.startswith("text/"):
                     context_note = (
                         f"[The user sent a text document: '{display_name}'. "
                         f"Its content has been included below. "

--- a/tests/gateway/test_reply_to_injection.py
+++ b/tests/gateway/test_reply_to_injection.py
@@ -157,3 +157,140 @@ async def test_reply_snippet_truncated_to_500_chars():
     assert result is not None
     assert result.startswith('[Replying to: "' + "x" * 500 + '"]')
     assert "x" * 501 not in result
+
+
+# ── Reply-with-media path injection ───────────────────────────────────────
+#
+# When a user replies to a media message (PDF / text doc / etc.) with a
+# text message ("send this to alice@example.com"), the Telegram adapter's
+# reply-to hydrator re-fetches the bytes and appends the cached path to
+# ``event.media_urls``. _prepare_inbound_message_text must inject a
+# path-level context note so the agent knows the quoted file is at that
+# path — otherwise the agent only sees ``[Replying to: [file: ...]]``
+# (the filename), which is not enough to operate on.
+
+
+@pytest.mark.asyncio
+async def test_reply_to_pdf_with_text_injects_path():
+    """The agent must learn the cached path of the replied-to file."""
+    from gateway.platforms.base import MessageType
+
+    runner = _make_runner()
+    source = _source()
+    event = MessageEvent(
+        text="send this to alice@example.com",
+        message_type=MessageType.TEXT,  # critical: TEXT, not DOCUMENT
+        source=source,
+        reply_to_message_id="42",
+        reply_to_text="[file: quarterly_report.pdf (application/pdf)]",
+        media_urls=["/cache/doc_abc_quarterly_report.pdf"],
+        media_types=["application/pdf"],
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result is not None
+    # The path-injection block must fire even though message_type is TEXT
+    assert "The user is replying to a document" in result
+    assert "quarterly_report.pdf" in result
+    assert "/cache/doc_abc_quarterly_report.pdf" in result
+    # And the existing reply-to pointer still appears
+    assert "[Replying to:" in result
+    # And the user's original text survives
+    assert "send this to alice@example.com" in result
+
+
+@pytest.mark.asyncio
+async def test_reply_to_text_doc_includes_content_and_path():
+    """Reply-to .txt/.md files should still get the text-document phrasing
+    so the agent knows the content is inlined (vs needing to read the file)."""
+    from gateway.platforms.base import MessageType
+
+    runner = _make_runner()
+    source = _source()
+    event = MessageEvent(
+        text="what's in this?",
+        message_type=MessageType.TEXT,
+        source=source,
+        reply_to_message_id="42",
+        reply_to_text="[file: notes.md]",
+        media_urls=["/cache/doc_xyz_notes.md"],
+        media_types=["text/markdown"],
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result is not None
+    assert "The user is replying to a text document" in result
+    assert "notes.md" in result
+    assert "/cache/doc_xyz_notes.md" in result
+
+
+@pytest.mark.asyncio
+async def test_inbound_document_phrasing_unchanged():
+    """Regression: when the user UPLOADS a doc (not reply), the existing
+    'The user sent a document' phrasing must still fire — not the
+    reply-to phrasing."""
+    from gateway.platforms.base import MessageType
+
+    runner = _make_runner()
+    source = _source()
+    event = MessageEvent(
+        text="here's the file",
+        message_type=MessageType.DOCUMENT,
+        source=source,
+        media_urls=["/cache/doc_def_report.pdf"],
+        media_types=["application/pdf"],
+        # no reply_to fields
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result is not None
+    assert "The user sent a document" in result
+    assert "The user is replying to" not in result
+
+
+@pytest.mark.asyncio
+async def test_reply_to_image_does_not_trigger_path_injection():
+    """Images go through the vision pipeline, not file-path injection.
+    A reply to a photo with a text caption must NOT produce a
+    'The user is replying to a document' note for the image entry."""
+    from gateway.platforms.base import MessageType
+
+    runner = _make_runner()
+    source = _source()
+    event = MessageEvent(
+        text="translate the text in this",
+        message_type=MessageType.TEXT,
+        source=source,
+        reply_to_message_id="42",
+        reply_to_text="[photo]",
+        media_urls=["/cache/img_abc.jpg"],
+        media_types=["image/jpeg"],
+    )
+
+    result = await runner._prepare_inbound_message_text(
+        event=event,
+        source=source,
+        history=[],
+    )
+
+    assert result is not None
+    # Image MIMEs are filtered out by the inner mtype check
+    assert "The user is replying to a document" not in result
+    assert "The user is replying to a text document" not in result
+    # But the reply-to pointer still appears
+    assert "[Replying to:" in result

--- a/tests/gateway/test_telegram_reply_to_media.py
+++ b/tests/gateway/test_telegram_reply_to_media.py
@@ -1,0 +1,299 @@
+"""Tests for Telegram reply-to-media context hydration.
+
+When a user replies to a *media* message (PDF / photo / voice / video /
+sticker), Telegram delivers the metadata on ``msg.reply_to_message`` but
+does NOT re-stream the bytes.  Two layers of behavior are verified:
+
+1. Sync description (`_describe_reply_to_message`) — always produces a
+   non-empty string for non-empty replies, even when there's no
+   text/caption to fall back on.
+
+2. Async hydration (`_hydrate_reply_to_media`) — re-fetches the bytes
+   via Telegram's getFile API and appends to ``event.media_urls`` /
+   ``event.media_types`` using the same cache helpers the inbound
+   media path uses.  Failures are swallowed (non-fatal).
+"""
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+
+def _ensure_telegram_mock():
+    """Mock the telegram package for environments without it installed."""
+    if "telegram" in sys.modules and hasattr(sys.modules["telegram"], "__file__"):
+        return
+    mod = MagicMock()
+    mod.ext.ContextTypes.DEFAULT_TYPE = type(None)
+    mod.constants.ParseMode.MARKDOWN_V2 = "MarkdownV2"
+    mod.constants.ChatType.GROUP = "group"
+    mod.constants.ChatType.SUPERGROUP = "supergroup"
+    mod.constants.ChatType.CHANNEL = "channel"
+    mod.constants.ChatType.PRIVATE = "private"
+    for name in ("telegram", "telegram.ext", "telegram.constants", "telegram.request"):
+        sys.modules.setdefault(name, mod)
+
+
+_ensure_telegram_mock()
+
+from gateway.config import PlatformConfig  # noqa: E402
+from gateway.platforms.base import MessageEvent, MessageType  # noqa: E402
+from gateway.platforms.telegram import TelegramAdapter  # noqa: E402
+
+
+@pytest.fixture()
+def adapter():
+    return TelegramAdapter(PlatformConfig(enabled=True, token="test-token"))
+
+
+def _attrs(**kw):
+    """Build a SimpleNamespace whose missing attrs return None on getattr.
+
+    SimpleNamespace alone raises AttributeError; we need ``getattr(..., default)``
+    semantics so the helpers' ``getattr(rtm, 'photo', None)`` lookups work
+    naturally on a minimal stub.
+    """
+    base = {
+        "text": None,
+        "caption": None,
+        "document": None,
+        "photo": None,
+        "voice": None,
+        "audio": None,
+        "video": None,
+        "video_note": None,
+        "sticker": None,
+        "animation": None,
+        "location": None,
+        "contact": None,
+    }
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+# ── _describe_reply_to_message ────────────────────────────────────────────
+
+class TestDescribeReplyTo:
+    def test_text_returned_verbatim(self, adapter):
+        rtm = _attrs(text="hello world")
+        assert adapter._describe_reply_to_message(rtm) == "hello world"
+
+    def test_caption_used_when_no_text(self, adapter):
+        rtm = _attrs(caption="caption only")
+        assert adapter._describe_reply_to_message(rtm) == "caption only"
+
+    def test_document_only_returns_filename_tag(self, adapter):
+        doc = SimpleNamespace(file_name="quarterly_report.pdf", mime_type="application/pdf")
+        rtm = _attrs(document=doc)
+        out = adapter._describe_reply_to_message(rtm)
+        assert "quarterly_report.pdf" in out
+        assert "application/pdf" in out
+        assert out.startswith("[file:")
+
+    def test_document_with_caption_combines_both(self, adapter):
+        doc = SimpleNamespace(file_name="report.pdf", mime_type="application/pdf")
+        rtm = _attrs(document=doc, caption="Q3 numbers")
+        out = adapter._describe_reply_to_message(rtm)
+        assert "report.pdf" in out
+        assert "Q3 numbers" in out
+
+    def test_document_without_filename_falls_back(self, adapter):
+        doc = SimpleNamespace(file_name=None, mime_type="application/pdf")
+        rtm = _attrs(document=doc)
+        out = adapter._describe_reply_to_message(rtm)
+        assert "[file:" in out
+
+    def test_photo_only(self, adapter):
+        rtm = _attrs(photo=[SimpleNamespace()])
+        assert adapter._describe_reply_to_message(rtm) == "[photo]"
+
+    def test_voice_with_duration(self, adapter):
+        rtm = _attrs(voice=SimpleNamespace(duration=7))
+        assert adapter._describe_reply_to_message(rtm) == "[voice 7s]"
+
+    def test_voice_without_duration(self, adapter):
+        rtm = _attrs(voice=SimpleNamespace(duration=None))
+        assert adapter._describe_reply_to_message(rtm) == "[voice]"
+
+    def test_audio_with_title(self, adapter):
+        rtm = _attrs(audio=SimpleNamespace(title="Song", file_name=None))
+        assert adapter._describe_reply_to_message(rtm) == "[audio: Song]"
+
+    def test_audio_with_filename_only(self, adapter):
+        rtm = _attrs(audio=SimpleNamespace(title=None, file_name="track.mp3"))
+        assert adapter._describe_reply_to_message(rtm) == "[audio: track.mp3]"
+
+    def test_video_only(self, adapter):
+        rtm = _attrs(video=SimpleNamespace())
+        assert adapter._describe_reply_to_message(rtm) == "[video]"
+
+    def test_sticker_with_emoji(self, adapter):
+        rtm = _attrs(sticker=SimpleNamespace(emoji="🐱"))
+        assert adapter._describe_reply_to_message(rtm) == "[sticker 🐱]"
+
+    def test_sticker_without_emoji(self, adapter):
+        rtm = _attrs(sticker=SimpleNamespace(emoji=None))
+        assert adapter._describe_reply_to_message(rtm) == "[sticker]"
+
+    def test_animation_only(self, adapter):
+        rtm = _attrs(animation=SimpleNamespace())
+        assert adapter._describe_reply_to_message(rtm) == "[gif]"
+
+    def test_location_only(self, adapter):
+        rtm = _attrs(location=SimpleNamespace())
+        assert adapter._describe_reply_to_message(rtm) == "[location]"
+
+    def test_empty_returns_none(self, adapter):
+        rtm = _attrs()
+        assert adapter._describe_reply_to_message(rtm) is None
+
+
+# ── _hydrate_reply_to_media ───────────────────────────────────────────────
+
+@pytest.fixture()
+def empty_event():
+    return MessageEvent(text="reply text", message_type=MessageType.TEXT)
+
+
+def _mk_file(file_path: str = "documents/file_0.pdf", payload: bytes = b"PDFDATA"):
+    """Build a mock telegram File whose download returns *payload*."""
+    file_obj = MagicMock()
+    file_obj.file_path = file_path
+    file_obj.download_as_bytearray = AsyncMock(return_value=bytearray(payload))
+    return file_obj
+
+
+class TestHydrateReplyToMedia:
+
+    @pytest.mark.asyncio
+    async def test_no_reply_is_noop(self, adapter, empty_event):
+        msg = SimpleNamespace(reply_to_message=None)
+        await adapter._hydrate_reply_to_media(empty_event, msg)
+        assert empty_event.media_urls == []
+        assert empty_event.media_types == []
+
+    @pytest.mark.asyncio
+    async def test_photo_reply_caches_bytes(self, adapter, empty_event, tmp_path):
+        file_obj = _mk_file(file_path="photos/file_0.png", payload=b"PNGDATA")
+        photo = SimpleNamespace()
+        photo.get_file = AsyncMock(return_value=file_obj)
+        rtm = _attrs(photo=[photo])
+        msg = SimpleNamespace(reply_to_message=rtm)
+
+        with patch(
+            "gateway.platforms.telegram.cache_image_from_bytes",
+            return_value=str(tmp_path / "img.png"),
+        ) as mock_cache:
+            await adapter._hydrate_reply_to_media(empty_event, msg)
+
+        mock_cache.assert_called_once_with(b"PNGDATA", ext=".png")
+        assert empty_event.media_urls == [str(tmp_path / "img.png")]
+        assert empty_event.media_types == ["image/png"]
+
+    @pytest.mark.asyncio
+    async def test_voice_reply_caches_audio(self, adapter, empty_event, tmp_path):
+        file_obj = _mk_file(payload=b"OGG")
+        voice = SimpleNamespace()
+        voice.get_file = AsyncMock(return_value=file_obj)
+        rtm = _attrs(voice=voice)
+        msg = SimpleNamespace(reply_to_message=rtm)
+
+        with patch(
+            "gateway.platforms.telegram.cache_audio_from_bytes",
+            return_value=str(tmp_path / "v.ogg"),
+        ) as mock_cache:
+            await adapter._hydrate_reply_to_media(empty_event, msg)
+
+        mock_cache.assert_called_once_with(b"OGG", ext=".ogg")
+        assert empty_event.media_urls == [str(tmp_path / "v.ogg")]
+        assert empty_event.media_types == ["audio/ogg"]
+
+    @pytest.mark.asyncio
+    async def test_document_reply_caches_pdf(self, adapter, empty_event, tmp_path):
+        file_obj = _mk_file(payload=b"%PDF-1.7")
+        doc = SimpleNamespace(
+            file_name="quarterly_report.pdf",
+            mime_type="application/pdf",
+        )
+        doc.get_file = AsyncMock(return_value=file_obj)
+        rtm = _attrs(document=doc)
+        msg = SimpleNamespace(reply_to_message=rtm)
+
+        with patch(
+            "gateway.platforms.telegram.cache_document_from_bytes",
+            return_value=str(tmp_path / "doc_abc_quarterly_report.pdf"),
+        ) as mock_cache:
+            await adapter._hydrate_reply_to_media(empty_event, msg)
+
+        mock_cache.assert_called_once_with(b"%PDF-1.7", "quarterly_report.pdf")
+        assert empty_event.media_urls == [
+            str(tmp_path / "doc_abc_quarterly_report.pdf")
+        ]
+        assert empty_event.media_types == ["application/pdf"]
+
+    @pytest.mark.asyncio
+    async def test_image_document_reply_routes_to_image_cache(
+        self, adapter, empty_event, tmp_path
+    ):
+        """A PNG sent as 'file' should land in the image cache, not the doc cache."""
+        file_obj = _mk_file(payload=b"PNG")
+        doc = SimpleNamespace(file_name="screenshot.png", mime_type="image/png")
+        doc.get_file = AsyncMock(return_value=file_obj)
+        rtm = _attrs(document=doc)
+        msg = SimpleNamespace(reply_to_message=rtm)
+
+        with patch(
+            "gateway.platforms.telegram.cache_image_from_bytes",
+            return_value=str(tmp_path / "img.png"),
+        ) as mock_img, patch(
+            "gateway.platforms.telegram.cache_document_from_bytes"
+        ) as mock_doc:
+            await adapter._hydrate_reply_to_media(empty_event, msg)
+
+        mock_img.assert_called_once()
+        mock_doc.assert_not_called()
+        assert empty_event.media_urls == [str(tmp_path / "img.png")]
+        assert empty_event.media_types == ["image/png"]
+
+    @pytest.mark.asyncio
+    async def test_fetch_failure_is_non_fatal(self, adapter, empty_event):
+        """A getFile() that raises must NOT crash the message handler."""
+        doc = SimpleNamespace(file_name="report.pdf", mime_type="application/pdf")
+        doc.get_file = AsyncMock(side_effect=RuntimeError("network down"))
+        rtm = _attrs(document=doc)
+        msg = SimpleNamespace(reply_to_message=rtm)
+
+        # Must not raise
+        await adapter._hydrate_reply_to_media(empty_event, msg)
+        assert empty_event.media_urls == []
+        assert empty_event.media_types == []
+
+    @pytest.mark.asyncio
+    async def test_appends_rather_than_replaces(self, adapter, tmp_path):
+        """Hydrator must preserve any media already on the event (e.g. inbound)."""
+        event = MessageEvent(
+            text="reply",
+            message_type=MessageType.TEXT,
+            media_urls=["/tmp/inbound.jpg"],
+            media_types=["image/jpeg"],
+        )
+        file_obj = _mk_file(payload=b"PDF")
+        doc = SimpleNamespace(file_name="quoted.pdf", mime_type="application/pdf")
+        doc.get_file = AsyncMock(return_value=file_obj)
+        rtm = _attrs(document=doc)
+        msg = SimpleNamespace(reply_to_message=rtm)
+
+        with patch(
+            "gateway.platforms.telegram.cache_document_from_bytes",
+            return_value=str(tmp_path / "quoted_cached.pdf"),
+        ):
+            await adapter._hydrate_reply_to_media(event, msg)
+
+        assert event.media_urls == [
+            "/tmp/inbound.jpg",
+            str(tmp_path / "quoted_cached.pdf"),
+        ]
+        assert event.media_types == ["image/jpeg", "application/pdf"]


### PR DESCRIPTION
## Summary

Replying to a media message (PDF / photo / voice / video / sticker / document) in Telegram dropped the file context on the floor. Two gaps combined to break a very common interaction:

1. `_build_message_event` only looked at `reply_to_message.text` / `.caption`. When a user replied to a bot-sent PDF that had no caption, `reply_to_text` was `None` and the agent-visible `[Replying to: "..."]` prefix was suppressed entirely. Same for replies to photos / voice notes / videos / etc.

2. Even if `reply_to_text` had been populated, Telegram does NOT re-stream the bytes on a reply update — only metadata on `reply_to_message`. So a reply like `send this file to alice@example.com` arrived with the filename nowhere visible and the actual file unreachable. The agent could sometimes search prior history and guess, but typically responded "I don't see any file to send."

This change closes both gaps with platform-local helpers; no schema or `MessageEvent` field additions, no behavior changes for non-reply messages.

## `gateway/platforms/telegram.py`

- **`_describe_reply_to_message(rtm)`** (sync, `@staticmethod`) — fallback for `reply_to_text` when there's no `message.quote` partial selection AND no text/caption on the replied-to message. Builds a short tag for any media type:
  - `[file: quarterly_report.pdf (application/pdf)]`
  - `[photo]` / `[voice 7s]` / `[audio: track.mp3]`
  - `[video]` / `[video note]` / `[sticker 🐱]` / `[gif]`
  - `[location]` / `[contact]`
  
  Combines text + tag when both exist (`[file: report.pdf] Q3 numbers`). Returns `None` only for the truly-empty case.

- **`_hydrate_reply_to_media(event, message)`** (async) — re-fetches the replied-to bytes via `get_file()` → `download_as_bytearray()` and caches via the *same* `cache_image_from_bytes` / `cache_audio_from_bytes` / `cache_video_from_bytes` / `cache_document_from_bytes` helpers the inbound-media path uses. Cached path is **appended** to `event.media_urls` / `.media_types` so the downstream image / vision / file pipelines pick it up exactly as if the user had re-uploaded the file. Failures are logged at WARNING and swallowed — `reply_to_text` still flows.

  Wired into all four `_build_message_event` call sites (`_handle_text_message`, `_handle_command`, `_handle_location_message`, `_handle_media_message`).

- The inbound-media handlers in `_handle_media_message` switched from `event.media_urls = [path]` to `.append(path)` so reply-to media already appended by the hydrator survives. Order ends up `[reply-to media, *inbound media]` which matches "here's what was quoted, then here's the new media."

- Composes with #22619's `message.quote` handling: a partial native quote still wins; `_describe_reply_to_message` only runs in the no-quote fallback path.

## `gateway/run.py`

The `[The user sent a document: ... saved at: <path>]` context-note injection in `_prepare_inbound_message_text` was gated on `event.message_type == MessageType.DOCUMENT`. A reply-with-text quoting a PDF has `message_type == TEXT`, so the injection was skipped — the agent saw `[Replying to: [file: foo.pdf]]` (the filename) but no path.

New trigger: when `event.reply_to_message_id` is set AND `event.media_urls` is populated (the post-hydration state), the same injection block fires with reply-specific phrasing:

> `[The user is replying to a document: 'quarterly_report.pdf'. The file is saved at: <path>. Use this path with any tool that needs the file.]`

The phrasing distinction matters: a fresh upload ends with "Ask the user what they'd like you to do with it" (correct because the upload itself doesn't carry instructions), but a reply where the user said "send this to alice@example.com" in the same turn does NOT need that prompt — the instruction is already in the reply text. Image/audio/video media flow through the existing inner mtype filter unchanged (they're handled by the vision/STT/native attach pipelines, not file-path injection).

## Tests

- `tests/gateway/test_telegram_reply_to_media.py` (new, 23 tests): `_describe_reply_to_message` covers every media type + text/caption combinations; `_hydrate_reply_to_media` covers photo / voice / audio / video / document / sticker / image-as-doc, fetch-failure non-fatal behavior, append-vs-replace semantics.

- `tests/gateway/test_reply_to_injection.py` (+4 tests): reply-to PDF + TEXT message → path injected with reply-specific phrasing; reply-to .md → text-doc phrasing with content note; inbound DOCUMENT (no reply) → original phrasing preserved (regression guard); reply-to image → no path injection (inner mtype filter skips images).

## Reproduction

1. Send a PDF (e.g. `quarterly_report.pdf`) to a Telegram chat with the bot (use the document attach path, not photo).
2. Reply to that PDF with text: `send this to alice@example.com`.
3. **Before:** the agent responds `I don't see any file attached` or "could you re-upload?" The reply was a TEXT message and the PDF's bytes weren't re-fetched.
4. **After:** the agent sees the `[Replying to: [file: ...]]` pointer AND the `[The user is replying to a document: ... saved at: /…/doc_…_quarterly_report.pdf]` context note, and can attach the file directly via email_send / vision_analyze / etc. without re-uploading.

## Prior art

- #22251 fixes the photo-only subset of this issue. This PR extends the same approach (re-fetch via getFile, append to `event.media_urls`) to voice / audio / video / document / sticker / image-document, and adds the run.py path-injection trigger that makes non-image media actually actionable.
- #16850 covers a superset (reply media + sender sidecars + multi-sender attribution) with a different design (separate `reply_to_media_urls` field on `MessageEvent`). This PR is intentionally narrower and reuses the existing `media_urls` channel so the change is purely additive.

## Tested on

- macOS 14 (dev) — full `tests/gateway/` run; only the two pre-existing flaky Discord/WhatsApp tests fail (same as a clean `upstream/main` checkout).
- Linux (Docker, vLLM-served Qwen3-VL model) — manual end-to-end: reply-to-PDF triggers email send via tool call; reply-to-photo triggers vision_analyze; reply-to-voice triggers STT.

## Backwards compatibility

Pure additions. Non-reply messages flow unchanged. Replies that already carried text/caption keep the same behavior as today (`reply_to_text` = text/caption). Image-only replies still go through vision; new behavior only kicks in for the previously-broken `reply-to-media-without-caption` and `reply-to-document` cases.