### PR TITLE
fix(gateway): warn before DingTalk session_webhook expires in long-lived stream

### DIFF
--- a/plugins/platforms/dingtalk/adapter.py
+++ b/plugins/platforms/dingtalk/adapter.py
@@ -109,6 +109,14 @@ MAX_MESSAGE_LENGTH = 20000
 RECONNECT_BACKOFF = [2, 5, 10, 30, 60]
 _SESSION_WEBHOOKS_MAX = 500
 _DINGTALK_WEBHOOK_RE = re.compile(r'^https://(?:api|oapi)\.dingtalk\.com/')
+# Within a long-lived Stream Mode WebSocket the cached session_webhook can
+# only be refreshed by a new inbound message.  If a webhook crosses into
+# this window without being refreshed, we log a warning so operators see
+# the imminent failure before sends start silently dropping.  Larger than
+# the 5-min eviction safety margin in _get_valid_webhook so the warning
+# fires before eviction.
+_WEBHOOK_NEAR_EXPIRY_WINDOW_MS = 10 * 60 * 1000  # 10 minutes
+_WEBHOOK_WATCHER_INTERVAL_SEC = 60.0
 
 # DingTalk message type → runtime content type
 DINGTALK_TYPE_MAPPING = {
@@ -214,6 +222,11 @@ class DingTalkAdapter(BasePlatformAdapter):
         self._dedup = MessageDeduplicator(max_size=1000)
         # Map chat_id -> (session_webhook, expired_time_ms) for reply routing
         self._session_webhooks: Dict[str, tuple[str, int]] = {}
+        # chat_id -> expired_time_ms we've already logged a near-expiry
+        # warning for.  Stored per-expiry so a refreshed webhook (new
+        # expired_time_ms) re-arms the warning.
+        self._webhook_expiry_warned: Dict[str, int] = {}
+        self._webhook_watch_task: Optional[asyncio.Task] = None
         # Map chat_id -> last inbound ChatbotMessage. Keyed by chat_id instead
         # of a single class attribute to avoid cross-message clobbering when
         # multiple conversations run concurrently.
@@ -239,7 +252,7 @@ class DingTalkAdapter(BasePlatformAdapter):
 
     # -- Connection lifecycle -----------------------------------------------
 
-    async def connect(self) -> bool:
+    async def connect(self, *, is_reconnect: bool = False) -> bool:
         """Connect to DingTalk via Stream Mode."""
         if not DINGTALK_STREAM_AVAILABLE:
             logger.warning(
@@ -298,6 +311,7 @@ class DingTalkAdapter(BasePlatformAdapter):
             )
 
             self._stream_task = asyncio.create_task(self._run_stream())
+            self._webhook_watch_task = asyncio.create_task(self._watch_webhook_expiry())
             self._mark_connected()
             logger.info("[%s] Connected via Stream Mode", self.name)
             return True
@@ -358,6 +372,14 @@ class DingTalkAdapter(BasePlatformAdapter):
                 logger.debug("[%s] stream task did not exit cleanly during disconnect", self.name)
             self._stream_task = None
 
+        if self._webhook_watch_task:
+            self._webhook_watch_task.cancel()
+            try:
+                await asyncio.wait_for(self._webhook_watch_task, timeout=5.0)
+            except (asyncio.CancelledError, asyncio.TimeoutError):
+                pass
+            self._webhook_watch_task = None
+
         # Cancel any in-flight background tasks (emoji reactions, etc.)
         if self._bg_tasks:
             for task in list(self._bg_tasks):
@@ -384,6 +406,7 @@ class DingTalkAdapter(BasePlatformAdapter):
 
         self._stream_client = None
         self._session_webhooks.clear()
+        self._webhook_expiry_warned.clear()
         self._message_contexts.clear()
         self._streaming_cards.clear()
         self._done_emoji_fired.clear()
@@ -1018,8 +1041,72 @@ class DingTalkAdapter(BasePlatformAdapter):
             if now_ms + safety_margin_ms >= expired_time_ms:
                 # Expired, remove from cache
                 self._session_webhooks.pop(chat_id, None)
+                self._webhook_expiry_warned.pop(chat_id, None)
                 return None
         return info
+
+    async def _watch_webhook_expiry(self) -> None:
+        """Proactively warn when a cached session_webhook is about to expire.
+
+        Within a long-lived Stream Mode WebSocket, a session_webhook can
+        only be refreshed when a new inbound message arrives in the same
+        chat.  If no one sends a message before its TTL, replies (cron
+        jobs, proactive messages) fail silently.  This watcher logs a
+        warning while the webhook is still valid so operators can spot
+        the imminent outage and prompt a fresh inbound message.
+        """
+        try:
+            while self._running:
+                try:
+                    await asyncio.sleep(_WEBHOOK_WATCHER_INTERVAL_SEC)
+                except asyncio.CancelledError:
+                    return
+                if not self._running:
+                    return
+                try:
+                    self._scan_webhooks_for_near_expiry()
+                except Exception:
+                    logger.error(
+                        "[%s] webhook-expiry watcher iteration failed",
+                        self.name, exc_info=True,
+                    )
+        except asyncio.CancelledError:
+            return
+
+    def _scan_webhooks_for_near_expiry(self) -> None:
+        """Emit a one-shot warning for each webhook entering the near-expiry window."""
+        if not self._session_webhooks:
+            if self._webhook_expiry_warned:
+                self._webhook_expiry_warned.clear()
+            return
+        now_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
+        live_chat_ids: Set[str] = set()
+        for chat_id, (_webhook, expired_time_ms) in list(
+            self._session_webhooks.items()
+        ):
+            live_chat_ids.add(chat_id)
+            if not expired_time_ms or expired_time_ms <= 0:
+                continue
+            remaining_ms = expired_time_ms - now_ms
+            if not 0 < remaining_ms <= _WEBHOOK_NEAR_EXPIRY_WINDOW_MS:
+                continue
+            # Re-warn if the webhook was refreshed (different expired_time_ms)
+            # since the last warning.
+            if self._webhook_expiry_warned.get(chat_id) == expired_time_ms:
+                continue
+            self._webhook_expiry_warned[chat_id] = expired_time_ms
+            logger.warning(
+                "[%s] session_webhook for chat_id=%s expires in %ds; replies "
+                "will fail until a new inbound message refreshes it. Stream "
+                "Mode only refreshes webhooks on incoming messages — proactive "
+                "sends to this chat may start failing silently.",
+                self.name, chat_id, max(0, remaining_ms // 1000),
+            )
+        # Drop warned entries for webhooks that have been evicted or refreshed
+        # outside the warning window so future expiries get warned again.
+        stale = [cid for cid in self._webhook_expiry_warned if cid not in live_chat_ids]
+        for cid in stale:
+            self._webhook_expiry_warned.pop(cid, None)
 
     async def _create_and_stream_card(
         self,

--- a/plugins/platforms/dingtalk/adapter.py
+++ b/plugins/platforms/dingtalk/adapter.py
@@ -59,6 +59,10 @@ MAX_MESSAGE_LENGTH = 20000
 RECONNECT_BACKOFF = [2, 5, 10, 30, 60]
 _SESSION_WEBHOOKS_MAX = 500
 _DINGTALK_WEBHOOK_RE = re.compile(r'^https://(?:api|oapi)\.dingtalk\.com/')
+# A session webhook can only be refreshed by a new inbound message. Warn before
+# the five-minute send-time safety margin in ``_get_valid_webhook`` evicts it.
+_WEBHOOK_NEAR_EXPIRY_WINDOW_MS = 10 * 60 * 1000
+_WEBHOOK_WATCHER_INTERVAL_SEC = 60.0
 _TRUTHY = {"true", "1", "yes", "on"}
 _EMOTION_ID = "2659900"
 _EMOTION_BG = "im_bg_1"
@@ -147,6 +151,8 @@ class DingTalkAdapter(BasePlatformAdapter):
         self._robot_code: str = extra.get("robot_code") or self._client_id
         self._dedup = MessageDeduplicator(max_size=1000)
         self._session_webhooks: Dict[str, tuple[str, int]] = {}  # chat_id -> (webhook, expired_time_ms)
+        self._webhook_expiry_warned: Dict[str, int] = {}
+        self._webhook_watch_task: Optional[asyncio.Task] = None
         self._message_contexts: Dict[str, Any] = {}  # chat_id -> last inbound ChatbotMessage (per-chat: no clobber)
         self._card_template_id: Optional[str] = extra.get("card_template_id")
         self._done_emoji_fired: Set[str] = set()  # chats whose Done reaction fired this turn; reset per inbound
@@ -179,6 +185,7 @@ class DingTalkAdapter(BasePlatformAdapter):
                     logger.info("[%s] Robot SDK initialized (media download)", self.name)
             self._stream_client.register_callback_handler(dingtalk_stream.ChatbotMessage.TOPIC, _IncomingHandler(self, asyncio.get_running_loop()))
             self._stream_task = asyncio.create_task(self._run_stream())
+            self._webhook_watch_task = asyncio.create_task(self._watch_webhook_expiry())
             self._mark_connected()
             logger.info("[%s] Connected via Stream Mode", self.name)
             self._wire_plugin_handlers(self._stream_client)  # plugin-registered native handlers
@@ -231,6 +238,13 @@ class DingTalkAdapter(BasePlatformAdapter):
             except (asyncio.CancelledError, asyncio.TimeoutError):
                 logger.debug("[%s] stream task did not exit cleanly during disconnect", self.name)
             self._stream_task = None
+        if self._webhook_watch_task:
+            self._webhook_watch_task.cancel()
+            try:
+                await asyncio.wait_for(self._webhook_watch_task, timeout=5.0)
+            except (asyncio.CancelledError, asyncio.TimeoutError):
+                pass
+            self._webhook_watch_task = None
         for task in list(self._bg_tasks):
             task.cancel()
         if self._bg_tasks:
@@ -242,7 +256,7 @@ class DingTalkAdapter(BasePlatformAdapter):
         if self._http_client:
             await self._http_client.aclose()
         self._http_client = self._stream_client = None
-        for store in (self._session_webhooks, self._message_contexts, self._streaming_cards, self._done_emoji_fired, self._dedup, self._bg_tasks):
+        for store in (self._session_webhooks, self._webhook_expiry_warned, self._message_contexts, self._streaming_cards, self._done_emoji_fired, self._dedup, self._bg_tasks):
             store.clear()
         logger.info("[%s] Disconnected", self.name)
 
@@ -441,8 +455,41 @@ class DingTalkAdapter(BasePlatformAdapter):
         expired_time_ms = info[1] if info else 0
         if expired_time_ms and expired_time_ms > 0 and int(datetime.now(tz=timezone.utc).timestamp() * 1000) + 5 * 60 * 1000 >= expired_time_ms:
             self._session_webhooks.pop(chat_id, None)
+            self._webhook_expiry_warned.pop(chat_id, None)
             return None
         return info or None
+
+    async def _watch_webhook_expiry(self) -> None:
+        """Warn while cached session webhooks can still be refreshed."""
+        try:
+            while self._running:
+                self._scan_webhooks_for_near_expiry()
+                await asyncio.sleep(_WEBHOOK_WATCHER_INTERVAL_SEC)
+        except asyncio.CancelledError:
+            return
+
+    def _scan_webhooks_for_near_expiry(self) -> None:
+        """Log one warning per cached webhook expiry within the warning window."""
+        for chat_id, warned_expiry in list(self._webhook_expiry_warned.items()):
+            webhook = self._session_webhooks.get(chat_id)
+            if webhook is None or webhook[1] != warned_expiry:
+                self._webhook_expiry_warned.pop(chat_id, None)
+
+        now_ms = int(datetime.now(tz=timezone.utc).timestamp() * 1000)
+        for chat_id, (_, expired_time_ms) in self._session_webhooks.items():
+            expires_in_ms = expired_time_ms - now_ms
+            if not 0 < expires_in_ms <= _WEBHOOK_NEAR_EXPIRY_WINDOW_MS:
+                continue
+            if self._webhook_expiry_warned.get(chat_id) == expired_time_ms:
+                continue
+            logger.warning(
+                "[%s] DingTalk session_webhook for chat_id=%s expires in %.1f minutes; "
+                "it can only be refreshed by a new inbound message.",
+                self.name,
+                chat_id,
+                expires_in_ms / 60_000,
+            )
+            self._webhook_expiry_warned[chat_id] = expired_time_ms
 
     async def _create_and_stream_card(self, chat_id: str, message: Any, content: str, *, finalize: bool = True) -> Optional[SendResult]:
         """Create, deliver and stream an AI Card; ``finalize=False`` leaves it open for ``edit_message`` by out_track_id."""

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -407,6 +407,21 @@ class TestConnect:
         assert adapter._http_client is None
 
     @pytest.mark.asyncio
+    async def test_disconnect_cancels_webhook_expiry_watcher(self):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        adapter._running = True
+        watcher = asyncio.create_task(adapter._watch_webhook_expiry())
+        adapter._webhook_watch_task = watcher
+        await asyncio.sleep(0)
+
+        await adapter.disconnect()
+
+        assert watcher.done()
+        assert adapter._webhook_watch_task is None
+
+    @pytest.mark.asyncio
     async def test_disconnect_finalizes_open_streaming_cards(self):
         """Streaming cards must be finalized before HTTP client closes."""
         from unittest.mock import AsyncMock, patch
@@ -435,6 +450,127 @@ class TestConnect:
         assert set(close_calls) == {"chat-1", "chat-2"}
         assert adapter._streaming_cards == {}
         assert adapter._http_client is None
+
+
+# ---------------------------------------------------------------------------
+# Session webhook near-expiry watcher
+# ---------------------------------------------------------------------------
+
+
+class TestWebhookNearExpiryWatcher:
+    """Proactive warning for session_webhooks approaching their TTL inside a
+    long-lived Stream Mode connection (issue #23513).  Without an inbound
+    message to refresh the cached webhook, the only signal to operators
+    used to be a send-time failure.  The watcher emits a one-shot warning
+    while the webhook is still valid so the imminent silent failure is
+    visible.
+    """
+
+    def _now_ms(self) -> int:
+        return int(datetime.now(tz=timezone.utc).timestamp() * 1000)
+
+    def test_warns_when_webhook_enters_near_expiry_window(self, caplog):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        # 7 minutes from now — inside the 10-min warning window.
+        expired_time_ms = self._now_ms() + 7 * 60 * 1000
+        adapter._session_webhooks["chat-1"] = (
+            "https://api.dingtalk.com/x", expired_time_ms,
+        )
+
+        with caplog.at_level("WARNING", logger="plugins.platforms.dingtalk.adapter"):
+            adapter._scan_webhooks_for_near_expiry()
+
+        assert any(
+            "expires in" in rec.message and "chat-1" in rec.message
+            for rec in caplog.records
+        )
+        assert adapter._webhook_expiry_warned.get("chat-1") == expired_time_ms
+
+    def test_no_warning_for_fresh_webhook(self, caplog):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        # 30 minutes from now — outside the 10-min warning window.
+        adapter._session_webhooks["chat-1"] = (
+            "https://api.dingtalk.com/x", self._now_ms() + 30 * 60 * 1000,
+        )
+
+        with caplog.at_level("WARNING", logger="plugins.platforms.dingtalk.adapter"):
+            adapter._scan_webhooks_for_near_expiry()
+
+        assert not any("expires in" in rec.message for rec in caplog.records)
+        assert "chat-1" not in adapter._webhook_expiry_warned
+
+    def test_no_duplicate_warning_for_same_expiry(self, caplog):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        expired_time_ms = self._now_ms() + 7 * 60 * 1000
+        adapter._session_webhooks["chat-1"] = (
+            "https://api.dingtalk.com/x", expired_time_ms,
+        )
+
+        with caplog.at_level("WARNING", logger="plugins.platforms.dingtalk.adapter"):
+            adapter._scan_webhooks_for_near_expiry()
+            adapter._scan_webhooks_for_near_expiry()
+
+        warns = [r for r in caplog.records if "expires in" in r.message]
+        assert len(warns) == 1
+
+    def test_refreshed_webhook_rearms_warning(self, caplog):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        first_expiry = self._now_ms() + 7 * 60 * 1000
+        adapter._session_webhooks["chat-1"] = (
+            "https://api.dingtalk.com/x", first_expiry,
+        )
+
+        with caplog.at_level("WARNING", logger="plugins.platforms.dingtalk.adapter"):
+            adapter._scan_webhooks_for_near_expiry()
+            second_expiry = self._now_ms() + 8 * 60 * 1000
+            adapter._session_webhooks["chat-1"] = (
+                "https://api.dingtalk.com/x", second_expiry,
+            )
+            adapter._scan_webhooks_for_near_expiry()
+
+        warns = [r for r in caplog.records if "expires in" in r.message]
+        assert len(warns) == 2
+        assert adapter._webhook_expiry_warned["chat-1"] == second_expiry
+
+    def test_already_expired_webhook_skipped(self, caplog):
+        """Already-expired webhooks are evicted by _get_valid_webhook; the
+        watcher must not double-warn."""
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        adapter._session_webhooks["chat-1"] = (
+            "https://api.dingtalk.com/x", self._now_ms() - 60 * 1000,
+        )
+
+        with caplog.at_level("WARNING", logger="plugins.platforms.dingtalk.adapter"):
+            adapter._scan_webhooks_for_near_expiry()
+
+        assert not any("expires in" in rec.message for rec in caplog.records)
+
+    def test_eviction_clears_warned_marker(self):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        past = self._now_ms() - 60 * 1000
+        adapter._session_webhooks["chat-1"] = (
+            "https://api.dingtalk.com/x", past,
+        )
+        adapter._webhook_expiry_warned["chat-1"] = past
+
+        assert adapter._get_valid_webhook("chat-1") is None
+        assert "chat-1" not in adapter._webhook_expiry_warned
+        assert "chat-1" not in adapter._session_webhooks
+
+    def test_stale_warned_entries_pruned(self):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        adapter._webhook_expiry_warned["gone-chat"] = self._now_ms() + 1000
+
+        adapter._scan_webhooks_for_near_expiry()
+
+        assert "gone-chat" not in adapter._webhook_expiry_warned
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -214,6 +214,21 @@ class TestConnect:
 
 
     @pytest.mark.asyncio
+    async def test_disconnect_cancels_webhook_expiry_watcher(self):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        adapter._running = True
+        watcher = asyncio.create_task(adapter._watch_webhook_expiry())
+        adapter._webhook_watch_task = watcher
+        await asyncio.sleep(0)
+
+        await adapter.disconnect()
+
+        assert watcher.done()
+        assert adapter._webhook_watch_task is None
+
+    @pytest.mark.asyncio
     async def test_disconnect_finalizes_open_streaming_cards(self):
         """Streaming cards must be finalized before HTTP client closes."""
         from unittest.mock import AsyncMock, patch
@@ -242,6 +257,127 @@ class TestConnect:
         assert set(close_calls) == {"chat-1", "chat-2"}
         assert adapter._streaming_cards == {}
         assert adapter._http_client is None
+
+
+# ---------------------------------------------------------------------------
+# Session webhook near-expiry watcher
+# ---------------------------------------------------------------------------
+
+
+class TestWebhookNearExpiryWatcher:
+    """Proactive warning for session_webhooks approaching their TTL inside a
+    long-lived Stream Mode connection (issue #23513).  Without an inbound
+    message to refresh the cached webhook, the only signal to operators
+    used to be a send-time failure.  The watcher emits a one-shot warning
+    while the webhook is still valid so the imminent silent failure is
+    visible.
+    """
+
+    def _now_ms(self) -> int:
+        return int(datetime.now(tz=timezone.utc).timestamp() * 1000)
+
+    def test_warns_when_webhook_enters_near_expiry_window(self, caplog):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        # 7 minutes from now — inside the 10-min warning window.
+        expired_time_ms = self._now_ms() + 7 * 60 * 1000
+        adapter._session_webhooks["chat-1"] = (
+            "https://api.dingtalk.com/x", expired_time_ms,
+        )
+
+        with caplog.at_level("WARNING", logger="plugins.platforms.dingtalk.adapter"):
+            adapter._scan_webhooks_for_near_expiry()
+
+        assert any(
+            "expires in" in rec.message and "chat-1" in rec.message
+            for rec in caplog.records
+        )
+        assert adapter._webhook_expiry_warned.get("chat-1") == expired_time_ms
+
+    def test_no_warning_for_fresh_webhook(self, caplog):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        # 30 minutes from now — outside the 10-min warning window.
+        adapter._session_webhooks["chat-1"] = (
+            "https://api.dingtalk.com/x", self._now_ms() + 30 * 60 * 1000,
+        )
+
+        with caplog.at_level("WARNING", logger="plugins.platforms.dingtalk.adapter"):
+            adapter._scan_webhooks_for_near_expiry()
+
+        assert not any("expires in" in rec.message for rec in caplog.records)
+        assert "chat-1" not in adapter._webhook_expiry_warned
+
+    def test_no_duplicate_warning_for_same_expiry(self, caplog):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        expired_time_ms = self._now_ms() + 7 * 60 * 1000
+        adapter._session_webhooks["chat-1"] = (
+            "https://api.dingtalk.com/x", expired_time_ms,
+        )
+
+        with caplog.at_level("WARNING", logger="plugins.platforms.dingtalk.adapter"):
+            adapter._scan_webhooks_for_near_expiry()
+            adapter._scan_webhooks_for_near_expiry()
+
+        warns = [r for r in caplog.records if "expires in" in r.message]
+        assert len(warns) == 1
+
+    def test_refreshed_webhook_rearms_warning(self, caplog):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        first_expiry = self._now_ms() + 7 * 60 * 1000
+        adapter._session_webhooks["chat-1"] = (
+            "https://api.dingtalk.com/x", first_expiry,
+        )
+
+        with caplog.at_level("WARNING", logger="plugins.platforms.dingtalk.adapter"):
+            adapter._scan_webhooks_for_near_expiry()
+            second_expiry = self._now_ms() + 8 * 60 * 1000
+            adapter._session_webhooks["chat-1"] = (
+                "https://api.dingtalk.com/x", second_expiry,
+            )
+            adapter._scan_webhooks_for_near_expiry()
+
+        warns = [r for r in caplog.records if "expires in" in r.message]
+        assert len(warns) == 2
+        assert adapter._webhook_expiry_warned["chat-1"] == second_expiry
+
+    def test_already_expired_webhook_skipped(self, caplog):
+        """Already-expired webhooks are evicted by _get_valid_webhook; the
+        watcher must not double-warn."""
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        adapter._session_webhooks["chat-1"] = (
+            "https://api.dingtalk.com/x", self._now_ms() - 60 * 1000,
+        )
+
+        with caplog.at_level("WARNING", logger="plugins.platforms.dingtalk.adapter"):
+            adapter._scan_webhooks_for_near_expiry()
+
+        assert not any("expires in" in rec.message for rec in caplog.records)
+
+    def test_eviction_clears_warned_marker(self):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        past = self._now_ms() - 60 * 1000
+        adapter._session_webhooks["chat-1"] = (
+            "https://api.dingtalk.com/x", past,
+        )
+        adapter._webhook_expiry_warned["chat-1"] = past
+
+        assert adapter._get_valid_webhook("chat-1") is None
+        assert "chat-1" not in adapter._webhook_expiry_warned
+        assert "chat-1" not in adapter._session_webhooks
+
+    def test_stale_warned_entries_pruned(self):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        adapter._webhook_expiry_warned["gone-chat"] = self._now_ms() + 1000
+
+        adapter._scan_webhooks_for_near_expiry()
+
+        assert "gone-chat" not in adapter._webhook_expiry_warned
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Add a proactive near-expiry warning for cached DingTalk session_webhooks so long-lived Stream Mode connections don't silently fail proactive sends.

## What changed and why
- A new background task `_watch_webhook_expiry` starts in `connect()` and is cancelled in `disconnect()`. It wakes every 60s and scans `_session_webhooks` for entries whose remaining TTL is `(0, 10 min]` and logs a `warning` once per (chat_id, expired_time_ms).
- Warning window (10 min) is wider than the existing 5-min eviction safety margin in `_get_valid_webhook` so the warning fires while the webhook is still usable — operators get advance notice instead of a post-mortem after the silent failure.
- The warning marker is keyed on `expired_time_ms`, so an inbound message that refreshes the webhook with a new expiry re-arms the warning. Stale markers (cache eviction, reconnect) are pruned each scan and cleared in `disconnect()`.
- Addresses the *Minimum* expected behaviour in #23513 ("adapter should log a clear warning before the webhook expires"). The *Better* (proactive refresh via keepalives) and *Best* (Robot OpenAPI fallback) options are larger surface changes — already tracked in the related issues #17370 / #14336 — and intentionally left out of this PR to keep the change focused.

## How to test
- `pytest tests/gateway/test_dingtalk.py -q` — 72 tests pass, including the new `TestWebhookNearExpiryWatcher` class covering warn-on-near-expiry, no-warn-for-fresh-webhook, no-duplicate-warning, re-arm-on-refresh, skip-already-expired, eviction-clears-marker, and prune-stale-warned-entries.
- `ruff check gateway/platforms/dingtalk.py tests/gateway/test_dingtalk.py` — clean.
- Manual: with the gateway running on Stream Mode, an idle chat whose webhook is within 10 minutes of `session_webhook_expired_time` will produce a single `[Dingtalk] session_webhook for chat_id=... expires in Ns; replies will fail until a new inbound message refreshes it.` warning in the gateway log, rather than the previous silent-failure-then-warning-at-send-time pattern.

## What platforms tested on
- macOS on darwin-arm64 (local)

Fixes #23513

<!-- autocontrib:worker-id=issue-new-3f199f91 kind=pr-open -->