### PR TITLE
fix(cli): mark sessions command as cli_only

### DIFF
--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -114,10 +114,9 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("resume", "Resume a previously-named session", "Session",
                args_hint="[name]"),
 
-    # Configuration
-    CommandDef("sessions", "Browse and resume previous sessions", "Session"),
-
-    # Configuration
+    # Session
+    CommandDef("sessions", "Browse and resume previous sessions", "Session",
+               cli_only=True),
     CommandDef("config", "Show current configuration", "Configuration",
                cli_only=True),
     CommandDef("model", "Switch model for this session", "Configuration",


### PR DESCRIPTION
## Summary

The `/sessions` slash command is registered in `COMMAND_REGISTRY` but has **no handler** in either the gateway dispatcher or the CLI dispatcher. It results in a silent no-op — the user sends `/sessions` and gets zero response.

## Fix

Mark `sessions` as `cli_only=True` so it is excluded from `GATEWAY_KNOWN_COMMANDS`. The interactive session browser requires keyboard navigation and is not feasible in messaging gateways.

## Changes

- `hermes_cli/commands.py`: Added `cli_only=True` to `sessions` command definition

## Testing

- `hermes sessions browse` continues to work in CLI mode
- Gateway now properly rejects `/sessions` with unknown command handling

Closes #23533