### PR TITLE
Support Claude Code proxy session thinking replay

### DIFF
--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -1475,9 +1475,9 @@ def convert_messages_to_anthropic(
     system_prompt is a string or list of content blocks (when cache_control present).
 
     When *base_url* is provided and points to a third-party Anthropic-compatible
-    endpoint, all thinking block signatures are stripped.  Signatures are
-    Anthropic-proprietary — third-party endpoints cannot validate them and will
-    reject them with HTTP 400 "Invalid signature in thinking block".
+    endpoint, Hermes now uses the same signed-thinking replay strategy as the
+    native Anthropic provider: preserve the latest signed thinking or valid
+    redacted_thinking block, strip older turns, and downgrade unsigned blocks.
 
     When *model* is provided and matches the Kimi / Moonshot family (or
     *base_url* is a Kimi / Moonshot host), unsigned thinking blocks
@@ -1893,7 +1893,8 @@ def build_anthropic_kwargs(
     (for Alibaba/DashScope anthropic-compatible endpoints: qwen3.5-plus).
 
     When *base_url* points to a third-party Anthropic-compatible endpoint,
-    thinking block signatures are stripped (they are Anthropic-proprietary).
+    signed thinking replay follows the same latest-turn strategy as the native
+    Anthropic provider.
 
     When *fast_mode* is True, adds ``extra_body["speed"] = "fast"`` and the
     fast-mode beta header for ~2.5x faster output throughput on Opus 4.6.

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -17,8 +17,6 @@ import os
 import platform
 import subprocess
 from pathlib import Path
-from urllib.parse import urlparse
-
 from hermes_constants import get_hermes_home
 from typing import Any, Dict, List, Optional, Tuple
 from utils import base_url_host_matches, normalize_proxy_env_vars
@@ -370,19 +368,14 @@ def _is_third_party_anthropic_endpoint(base_url: str | None) -> bool:
     return True  # Any other endpoint is a third-party proxy
 
 
-def _is_claude_code_proxy_endpoint(base_url: str | None) -> bool:
-    """Return True for local Anthropic proxies that emulate Claude Code traffic."""
-    normalized = _normalize_base_url_text(base_url)
-    if not normalized:
-        return False
-    parsed = urlparse(normalized if "://" in normalized else f"//{normalized}")
-    host = (parsed.hostname or "").lower()
-    return (
-        host == "localhost"
-        or host == "::1"
-        or host == "0.0.0.0"
-        or host.startswith("127.")
-    )
+def _uses_claude_code_proxy_shape(base_url: str | None) -> bool:
+    """Return True for Anthropic-compatible proxy endpoints.
+
+    Hermes uses the Claude Code wire shape for non-native Anthropic Messages
+    endpoints: Bearer auth, session header, and latest signed thinking replay.
+    Native Anthropic keeps its existing API-key/OAuth handling.
+    """
+    return _is_third_party_anthropic_endpoint(base_url)
 
 
 def _is_kimi_coding_endpoint(base_url: str | None) -> bool:
@@ -582,21 +575,21 @@ def build_anthropic_client(
         drop_context_1m_beta=drop_context_1m_beta,
     )
 
-    if _is_claude_code_proxy_endpoint(base_url):
-        # Local Claude-Code-compatible gateways expect bearer auth, matching
-        # Claude Code's POST /v1/messages shape.
-        kwargs["auth_token"] = api_key
-        if common_betas:
-            kwargs["default_headers"] = {"anthropic-beta": ",".join(common_betas)}
-    elif _is_kimi_coding_endpoint(base_url):
+    if _is_kimi_coding_endpoint(base_url):
         # Kimi's /coding endpoint requires User-Agent: claude-code/0.1.0
         # to be recognized as a valid Coding Agent. Without it, returns 403.
-        # Check this BEFORE _requires_bearer_auth since both match api.kimi.com/coding.
+        # Check this BEFORE the generic Claude Code proxy shape.
         kwargs["api_key"] = api_key
         kwargs["default_headers"] = {
             "User-Agent": "claude-code/0.1.0",
             **( {"anthropic-beta": ",".join(common_betas)} if common_betas else {} )
         }
+    elif _uses_claude_code_proxy_shape(base_url):
+        # Anthropic-compatible gateways expect bearer auth, matching Claude
+        # Code's POST /v1/messages shape.
+        kwargs["auth_token"] = api_key
+        if common_betas:
+            kwargs["default_headers"] = {"anthropic-beta": ",".join(common_betas)}
     elif _requires_bearer_auth(normalized_base_url):
         # Some Anthropic-compatible providers (e.g. MiniMax) expect the API key in
         # Authorization: Bearer *** for regular API keys. Route those endpoints
@@ -1735,14 +1728,7 @@ def convert_messages_to_anthropic(
     # orphan stripping, message merging) invalidates the signature,
     # causing HTTP 400 "Invalid signature in thinking block".
     #
-    # Signatures are Anthropic-proprietary.  Third-party endpoints
-    # (MiniMax, Azure AI Foundry, self-hosted proxies) cannot validate
-    # them and will reject them outright.  When targeting a third-party
-    # endpoint, strip ALL thinking/redacted_thinking blocks from every
-    # assistant message — the third-party will generate its own
-    # thinking blocks if it supports extended thinking.
-    #
-    # For direct Anthropic (strategy following clawdbot/OpenClaw):
+    # Strategy following clawdbot/OpenClaw:
     # 1. Strip thinking/redacted_thinking from all assistant messages
     #    EXCEPT the last one — preserves reasoning continuity on the
     #    current tool-use chain while avoiding stale signature errors.
@@ -1751,10 +1737,6 @@ def convert_messages_to_anthropic(
     # 3. Strip cache_control from thinking/redacted_thinking blocks —
     #    cache markers can interfere with signature validation.
     _THINKING_TYPES = frozenset(("thinking", "redacted_thinking"))
-    _is_third_party = _is_third_party_anthropic_endpoint(base_url)
-    _strip_all_thinking = (
-        _is_third_party and not _is_claude_code_proxy_endpoint(base_url)
-    )
     # Kimi /coding and DeepSeek /anthropic share a contract: both speak the
     # Anthropic Messages protocol upstream but require that thinking blocks
     # synthesised from reasoning_content round-trip on subsequent turns when
@@ -1794,10 +1776,8 @@ def convert_messages_to_anthropic(
                 # keep it: the upstream needs it for message-history validation.
                 new_content.append(b)
             m["content"] = new_content or [{"type": "text", "text": "(empty)"}]
-        elif _strip_all_thinking or idx != last_assistant_idx:
-            # Third-party endpoint: strip ALL thinking blocks from every
-            # assistant message — signatures are Anthropic-proprietary.
-            # Direct Anthropic: strip from non-latest assistant messages only.
+        elif idx != last_assistant_idx:
+            # Strip thinking from non-latest assistant messages only.
             stripped = [
                 b for b in m["content"]
                 if not (isinstance(b, dict) and b.get("type") in _THINKING_TYPES)
@@ -2085,4 +2065,3 @@ def build_anthropic_kwargs(
         kwargs["extra_headers"] = {"anthropic-beta": ",".join(betas)}
 
     return kwargs
-

--- a/agent/anthropic_adapter.py
+++ b/agent/anthropic_adapter.py
@@ -17,6 +17,7 @@ import os
 import platform
 import subprocess
 from pathlib import Path
+from urllib.parse import urlparse
 
 from hermes_constants import get_hermes_home
 from typing import Any, Dict, List, Optional, Tuple
@@ -369,6 +370,21 @@ def _is_third_party_anthropic_endpoint(base_url: str | None) -> bool:
     return True  # Any other endpoint is a third-party proxy
 
 
+def _is_claude_code_proxy_endpoint(base_url: str | None) -> bool:
+    """Return True for local Anthropic proxies that emulate Claude Code traffic."""
+    normalized = _normalize_base_url_text(base_url)
+    if not normalized:
+        return False
+    parsed = urlparse(normalized if "://" in normalized else f"//{normalized}")
+    host = (parsed.hostname or "").lower()
+    return (
+        host == "localhost"
+        or host == "::1"
+        or host == "0.0.0.0"
+        or host.startswith("127.")
+    )
+
+
 def _is_kimi_coding_endpoint(base_url: str | None) -> bool:
     """Return True for Kimi's /coding endpoint that requires claude-code UA."""
     normalized = _normalize_base_url_text(base_url)
@@ -566,7 +582,13 @@ def build_anthropic_client(
         drop_context_1m_beta=drop_context_1m_beta,
     )
 
-    if _is_kimi_coding_endpoint(base_url):
+    if _is_claude_code_proxy_endpoint(base_url):
+        # Local Claude-Code-compatible gateways expect bearer auth, matching
+        # Claude Code's POST /v1/messages shape.
+        kwargs["auth_token"] = api_key
+        if common_betas:
+            kwargs["default_headers"] = {"anthropic-beta": ",".join(common_betas)}
+    elif _is_kimi_coding_endpoint(base_url):
         # Kimi's /coding endpoint requires User-Agent: claude-code/0.1.0
         # to be recognized as a valid Coding Agent. Without it, returns 403.
         # Check this BEFORE _requires_bearer_auth since both match api.kimi.com/coding.
@@ -1730,6 +1752,9 @@ def convert_messages_to_anthropic(
     #    cache markers can interfere with signature validation.
     _THINKING_TYPES = frozenset(("thinking", "redacted_thinking"))
     _is_third_party = _is_third_party_anthropic_endpoint(base_url)
+    _strip_all_thinking = (
+        _is_third_party and not _is_claude_code_proxy_endpoint(base_url)
+    )
     # Kimi /coding and DeepSeek /anthropic share a contract: both speak the
     # Anthropic Messages protocol upstream but require that thinking blocks
     # synthesised from reasoning_content round-trip on subsequent turns when
@@ -1769,7 +1794,7 @@ def convert_messages_to_anthropic(
                 # keep it: the upstream needs it for message-history validation.
                 new_content.append(b)
             m["content"] = new_content or [{"type": "text", "text": "(empty)"}]
-        elif _is_third_party or idx != last_assistant_idx:
+        elif _strip_all_thinking or idx != last_assistant_idx:
             # Third-party endpoint: strip ALL thinking blocks from every
             # assistant message — signatures are Anthropic-proprietary.
             # Direct Anthropic: strip from non-latest assistant messages only.
@@ -2060,5 +2085,4 @@ def build_anthropic_kwargs(
         kwargs["extra_headers"] = {"anthropic-beta": ",".join(betas)}
 
     return kwargs
-
 

--- a/agent/transports/anthropic.py
+++ b/agent/transports/anthropic.py
@@ -80,8 +80,9 @@ class AnthropicTransport(ProviderTransport):
     def normalize_response(self, response: Any, **kwargs) -> NormalizedResponse:
         """Normalize Anthropic response to NormalizedResponse.
 
-        Parses content blocks (text, thinking, tool_use), maps stop_reason
-        to OpenAI finish_reason, and collects reasoning_details in provider_data.
+        Parses content blocks (text, thinking, redacted_thinking, tool_use),
+        maps stop_reason to OpenAI finish_reason, and collects
+        reasoning_details in provider_data.
         """
         import json
         from agent.anthropic_adapter import _to_plain_data
@@ -100,6 +101,10 @@ class AnthropicTransport(ProviderTransport):
                 text_parts.append(block.text)
             elif block.type == "thinking":
                 reasoning_parts.append(block.thinking)
+                block_dict = _to_plain_data(block)
+                if isinstance(block_dict, dict):
+                    reasoning_details.append(block_dict)
+            elif block.type == "redacted_thinking":
                 block_dict = _to_plain_data(block)
                 if isinstance(block_dict, dict):
                     reasoning_details.append(block_dict)

--- a/hermes_cli/__init__.py
+++ b/hermes_cli/__init__.py
@@ -14,7 +14,7 @@ Provides subcommands for:
 import os
 import sys
 
-__version__ = "0.13.0"
+__version__ = "0.13.0_sx"
 __release_date__ = "2026.5.7"
 
 

--- a/readme_sx.md
+++ b/readme_sx.md
@@ -30,6 +30,7 @@ diff --git a/hermes_cli/__init__.py b/hermes_cli/__init__.py
 - 对非 `anthropic.com` 的 `anthropic_messages` endpoint 使用 `Authorization: Bearer <key>`。
 - 在 Anthropic Messages 请求中加入 `X-Hermes-Code-Session-Id`，用于 gateway 侧聚合同一个 Hermes 会话。
 - 后续 request 会保留并回传最新 assistant turn 的 signed `thinking` 和合法 `redacted_thinking`。
+- response normalize 阶段会把 `redacted_thinking.data` 保存进 `reasoning_details`，确保下一轮 request 有可回传的 redacted block。
 - 旧 assistant turn 的 thinking 仍会移除，避免历史 thinking 无限累积。
 - unsigned thinking 仍不会作为 Anthropic signed thinking 回传。
 - 官方 Anthropic endpoint 仍保持原 API key / OAuth 行为。
@@ -182,4 +183,3 @@ diff --git a/tests/run_agent/test_run_agent.py b/tests/run_agent/test_run_agent.
 
 git diff --check
 ```
-

--- a/readme_sx.md
+++ b/readme_sx.md
@@ -1,0 +1,185 @@
+# Hermes SX 修改说明
+
+## 版本标识
+
+本分支把 Hermes CLI 的可见版本号改为：
+
+```text
+0.13.0_sx
+```
+
+修改位置：
+
+```diff
+diff --git a/hermes_cli/__init__.py b/hermes_cli/__init__.py
+--- a/hermes_cli/__init__.py
++++ b/hermes_cli/__init__.py
+@@
+-__version__ = "0.13.0"
++__version__ = "0.13.0_sx"
+```
+
+说明：没有修改 `pyproject.toml` 的包版本，因为 Python packaging 版本号不适合使用 `0.13.0_sx` 这种格式。这里改的是 Hermes 自己展示在 `hermes --version` 和启动 banner 中的版本字符串。
+
+## 功能修改概述
+
+本分支修改 Anthropic Messages 路径，让非官方 Anthropic endpoint 走 Claude Code proxy 风格的请求形态。
+
+主要行为：
+
+- 对非 `anthropic.com` 的 `anthropic_messages` endpoint 使用 `Authorization: Bearer <key>`。
+- 在 Anthropic Messages 请求中加入 `X-Hermes-Code-Session-Id`，用于 gateway 侧聚合同一个 Hermes 会话。
+- 后续 request 会保留并回传最新 assistant turn 的 signed `thinking` 和合法 `redacted_thinking`。
+- 旧 assistant turn 的 thinking 仍会移除，避免历史 thinking 无限累积。
+- unsigned thinking 仍不会作为 Anthropic signed thinking 回传。
+- 官方 Anthropic endpoint 仍保持原 API key / OAuth 行为。
+- Kimi `/coding` 特例优先级保留，继续使用它需要的 `User-Agent: claude-code/0.1.0`。
+
+## 核心 Diff
+
+### 1. 非官方 Anthropic endpoint 统一识别为 Claude Code proxy shape
+
+```diff
+diff --git a/agent/anthropic_adapter.py b/agent/anthropic_adapter.py
+@@
++def _uses_claude_code_proxy_shape(base_url: str | None) -> bool:
++    """Return True for Anthropic-compatible proxy endpoints.
++
++    Hermes uses the Claude Code wire shape for non-native Anthropic Messages
++    endpoints: Bearer auth, session header, and latest signed thinking replay.
++    Native Anthropic keeps its existing API-key/OAuth handling.
++    """
++    return _is_third_party_anthropic_endpoint(base_url)
+```
+
+### 2. Anthropic-compatible gateway 使用 Bearer Auth
+
+```diff
+diff --git a/agent/anthropic_adapter.py b/agent/anthropic_adapter.py
+@@
+     if _is_kimi_coding_endpoint(base_url):
+         # Kimi's /coding endpoint requires User-Agent: claude-code/0.1.0
+         # to be recognized as a valid Coding Agent. Without it, returns 403.
+-        # Check this BEFORE _requires_bearer_auth since both match api.kimi.com/coding.
++        # Check this BEFORE the generic Claude Code proxy shape.
+         kwargs["api_key"] = api_key
+         kwargs["default_headers"] = {
+             "User-Agent": "claude-code/0.1.0",
+             **( {"anthropic-beta": ",".join(common_betas)} if common_betas else {} )
+         }
++    elif _uses_claude_code_proxy_shape(base_url):
++        # Anthropic-compatible gateways expect bearer auth, matching Claude
++        # Code's POST /v1/messages shape.
++        kwargs["auth_token"] = api_key
++        if common_betas:
++            kwargs["default_headers"] = {"anthropic-beta": ",".join(common_betas)}
+```
+
+### 3. 非官方 Anthropic endpoint 保留最新 signed thinking
+
+```diff
+diff --git a/agent/anthropic_adapter.py b/agent/anthropic_adapter.py
+@@
+-    # Signatures are Anthropic-proprietary.  Third-party endpoints
+-    # (MiniMax, Azure AI Foundry, self-hosted proxies) cannot validate
+-    # them and will reject them outright.  When targeting a third-party
+-    # endpoint, strip ALL thinking/redacted_thinking blocks from every
+-    # assistant message — the third-party will generate its own
+-    # thinking blocks if it supports extended thinking.
+-    #
+-    # For direct Anthropic (strategy following clawdbot/OpenClaw):
++    # Strategy following clawdbot/OpenClaw:
+@@
+-    _is_third_party = _is_third_party_anthropic_endpoint(base_url)
+-    _strip_all_thinking = (
+-        _is_third_party and not _is_claude_code_proxy_endpoint(base_url)
+-    )
+@@
+-        elif _strip_all_thinking or idx != last_assistant_idx:
+-            # Third-party endpoint: strip ALL thinking blocks from every
+-            # assistant message — signatures are Anthropic-proprietary.
+-            # Direct Anthropic: strip from non-latest assistant messages only.
++        elif idx != last_assistant_idx:
++            # Strip thinking from non-latest assistant messages only.
+```
+
+### 4. Anthropic Messages 请求增加 Hermes session header
+
+```diff
+diff --git a/run_agent.py b/run_agent.py
+@@
+             api_kwargs = _transport.build_kwargs(
+                 model=self.model,
+                 messages=anthropic_messages,
+@@
+                 drop_context_1m_beta=bool(getattr(self, "_oauth_1m_beta_disabled", False)),
+             )
++            from agent.anthropic_adapter import _uses_claude_code_proxy_shape
++            if (
++                getattr(self, "session_id", None)
++                and _uses_claude_code_proxy_shape(getattr(self, "_anthropic_base_url", None))
++            ):
++                extra_headers = dict(api_kwargs.get("extra_headers") or {})
++                extra_headers["X-Hermes-Code-Session-Id"] = self.session_id
++                api_kwargs["extra_headers"] = extra_headers
+             return api_kwargs
+```
+
+### 5. 测试覆盖
+
+```diff
+diff --git a/tests/agent/test_anthropic_adapter.py b/tests/agent/test_anthropic_adapter.py
+@@
++    def test_third_party_anthropic_messages_uses_bearer_auth(self):
++        ...
++        assert kwargs["auth_token"] == "gateway-key"
++        assert "api_key" not in kwargs
++
++    def test_kimi_coding_endpoint_keeps_user_agent_auth_shape(self):
++        ...
++        assert kwargs["api_key"] == "kimi-key"
++        assert "auth_token" not in kwargs
++        assert kwargs["default_headers"]["User-Agent"] == "claude-code/0.1.0"
+@@
++    def test_third_party_preserves_latest_signed_thinking(self):
++        ...
++        assert any(
++            block.get("type") == "thinking" and block.get("signature") == "sig_valid"
++            for block in blocks
++        )
++        assert any(block.get("type") == "redacted_thinking" for block in blocks)
++
++    def test_remote_proxy_preserves_latest_signed_thinking(self):
++        ...
++        assert len(latest_thinking) == 1
++        assert latest_thinking[0]["signature"] == "sig_new"
+```
+
+```diff
+diff --git a/tests/run_agent/test_run_agent.py b/tests/run_agent/test_run_agent.py
+@@
++    def test_anthropic_messages_adds_hermes_session_header(self):
++        ...
++        assert kwargs["extra_headers"]["X-Hermes-Code-Session-Id"] == "test-session-123"
+```
+
+## 验证命令
+
+```bash
+.venv/bin/python -m pytest -o addopts='' \
+  tests/agent/test_anthropic_adapter.py::TestBuildAnthropicClient \
+  tests/agent/test_anthropic_adapter.py::TestThinkingBlockSignatureManagement \
+  tests/agent/test_kimi_coding_anthropic_thinking.py \
+  tests/agent/test_deepseek_anthropic_thinking.py \
+  tests/agent/test_minimax_provider.py \
+  tests/run_agent/test_run_agent.py::TestBuildApiKwargs::test_anthropic_messages_adds_hermes_session_header -q
+
+.venv/bin/python -m py_compile \
+  agent/anthropic_adapter.py \
+  run_agent.py \
+  tests/agent/test_anthropic_adapter.py \
+  tests/run_agent/test_run_agent.py
+
+git diff --check
+```
+

--- a/run_agent.py
+++ b/run_agent.py
@@ -9212,7 +9212,7 @@ class AIAgent:
             ephemeral_out = getattr(self, "_ephemeral_max_output_tokens", None)
             if ephemeral_out is not None:
                 self._ephemeral_max_output_tokens = None  # consume immediately
-            return _transport.build_kwargs(
+            api_kwargs = _transport.build_kwargs(
                 model=self.model,
                 messages=anthropic_messages,
                 tools=self.tools,
@@ -9225,6 +9225,15 @@ class AIAgent:
                 fast_mode=(self.request_overrides or {}).get("speed") == "fast",
                 drop_context_1m_beta=bool(getattr(self, "_oauth_1m_beta_disabled", False)),
             )
+            from agent.anthropic_adapter import _is_claude_code_proxy_endpoint
+            if (
+                getattr(self, "session_id", None)
+                and _is_claude_code_proxy_endpoint(getattr(self, "_anthropic_base_url", None))
+            ):
+                extra_headers = dict(api_kwargs.get("extra_headers") or {})
+                extra_headers["X-Hermes-Code-Session-Id"] = self.session_id
+                api_kwargs["extra_headers"] = extra_headers
+            return api_kwargs
 
         # AWS Bedrock native Converse API — bypasses the OpenAI client entirely.
         # The adapter handles message/tool conversion and boto3 calls directly.

--- a/run_agent.py
+++ b/run_agent.py
@@ -9225,10 +9225,10 @@ class AIAgent:
                 fast_mode=(self.request_overrides or {}).get("speed") == "fast",
                 drop_context_1m_beta=bool(getattr(self, "_oauth_1m_beta_disabled", False)),
             )
-            from agent.anthropic_adapter import _is_claude_code_proxy_endpoint
+            from agent.anthropic_adapter import _uses_claude_code_proxy_shape
             if (
                 getattr(self, "session_id", None)
-                and _is_claude_code_proxy_endpoint(getattr(self, "_anthropic_base_url", None))
+                and _uses_claude_code_proxy_shape(getattr(self, "_anthropic_base_url", None))
             ):
                 extra_headers = dict(api_kwargs.get("extra_headers") or {})
                 extra_headers["X-Hermes-Code-Session-Id"] = self.session_id

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -111,13 +111,27 @@ class TestBuildAnthropicClient:
                 "anthropic-beta": "interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14"
             }
 
-    def test_loopback_anthropic_proxy_uses_bearer_auth(self):
+    def test_third_party_anthropic_messages_uses_bearer_auth(self):
         with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
-            build_anthropic_client("gateway-key", base_url="http://127.0.0.1:4000")
+            build_anthropic_client(
+                "gateway-key",
+                base_url="https://gateway.example.com/anthropic",
+            )
             kwargs = mock_sdk.Anthropic.call_args[1]
-            assert kwargs["base_url"] == "http://127.0.0.1:4000"
+            assert kwargs["base_url"] == "https://gateway.example.com/anthropic"
             assert kwargs["auth_token"] == "gateway-key"
             assert "api_key" not in kwargs
+
+    def test_kimi_coding_endpoint_keeps_user_agent_auth_shape(self):
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client(
+                "kimi-key",
+                base_url="https://api.kimi.com/coding",
+            )
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            assert kwargs["api_key"] == "kimi-key"
+            assert "auth_token" not in kwargs
+            assert kwargs["default_headers"]["User-Agent"] == "claude-code/0.1.0"
 
     def test_azure_anthropic_endpoint_keeps_context_1m_beta(self):
         with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
@@ -1636,7 +1650,7 @@ class TestThinkingBlockSignatureManagement:
         blocks = result[0]["content"]
         assert not any(b.get("type") == "redacted_thinking" for b in blocks)
 
-    def test_third_party_thinking_stripped_by_default(self):
+    def test_third_party_preserves_latest_signed_thinking(self):
         messages = [
             {
                 "role": "assistant",
@@ -1653,9 +1667,13 @@ class TestThinkingBlockSignatureManagement:
         )
         blocks = result[0]["content"]
 
-        assert not any(block.get("type") in {"thinking", "redacted_thinking"} for block in blocks)
+        assert any(
+            block.get("type") == "thinking" and block.get("signature") == "sig_valid"
+            for block in blocks
+        )
+        assert any(block.get("type") == "redacted_thinking" for block in blocks)
 
-    def test_loopback_proxy_preserves_latest_signed_thinking(self):
+    def test_remote_proxy_preserves_latest_signed_thinking(self):
         messages = [
             {
                 "role": "assistant",
@@ -1678,7 +1696,7 @@ class TestThinkingBlockSignatureManagement:
         ]
         _, result = convert_messages_to_anthropic(
             messages,
-            base_url="http://127.0.0.1:4000",
+            base_url="https://gateway.example.com/anthropic",
         )
 
         assistants = [m for m in result if m["role"] == "assistant"]

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1456,6 +1456,22 @@ class TestNormalizeResponse:
         assert nr.provider_data["reasoning_details"][0]["signature"] == "opaque_signature"
         assert nr.provider_data["reasoning_details"][0]["thinking"] == "Let me reason about this..."
 
+    def test_redacted_thinking_response_preserves_data(self):
+        blocks = [
+            SimpleNamespace(
+                type="redacted_thinking",
+                data="opaque_redacted_payload",
+            ),
+            SimpleNamespace(type="text", text="The answer is 42."),
+        ]
+        nr = get_transport("anthropic_messages").normalize_response(self._make_response(blocks))
+
+        assert nr.content == "The answer is 42."
+        assert nr.reasoning is None
+        assert nr.provider_data["reasoning_details"] == [
+            {"type": "redacted_thinking", "data": "opaque_redacted_payload"}
+        ]
+
     def test_stop_reason_mapping(self):
         block = SimpleNamespace(type="text", text="x")
         nr1 = get_transport("anthropic_messages").normalize_response(

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -111,6 +111,14 @@ class TestBuildAnthropicClient:
                 "anthropic-beta": "interleaved-thinking-2025-05-14,fine-grained-tool-streaming-2025-05-14"
             }
 
+    def test_loopback_anthropic_proxy_uses_bearer_auth(self):
+        with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
+            build_anthropic_client("gateway-key", base_url="http://127.0.0.1:4000")
+            kwargs = mock_sdk.Anthropic.call_args[1]
+            assert kwargs["base_url"] == "http://127.0.0.1:4000"
+            assert kwargs["auth_token"] == "gateway-key"
+            assert "api_key" not in kwargs
+
     def test_azure_anthropic_endpoint_keeps_context_1m_beta(self):
         with patch("agent.anthropic_adapter._anthropic_sdk") as mock_sdk:
             build_anthropic_client(
@@ -1627,6 +1635,59 @@ class TestThinkingBlockSignatureManagement:
         _, result = convert_messages_to_anthropic(messages)
         blocks = result[0]["content"]
         assert not any(b.get("type") == "redacted_thinking" for b in blocks)
+
+    def test_third_party_thinking_stripped_by_default(self):
+        messages = [
+            {
+                "role": "assistant",
+                "content": "Response.",
+                "reasoning_details": [
+                    {"type": "thinking", "thinking": "Private reasoning.", "signature": "sig_valid"},
+                    {"type": "redacted_thinking", "data": "opaque_signature_data"},
+                ],
+            },
+        ]
+        _, result = convert_messages_to_anthropic(
+            messages,
+            base_url="https://proxy.example.com/anthropic",
+        )
+        blocks = result[0]["content"]
+
+        assert not any(block.get("type") in {"thinking", "redacted_thinking"} for block in blocks)
+
+    def test_loopback_proxy_preserves_latest_signed_thinking(self):
+        messages = [
+            {
+                "role": "assistant",
+                "content": "",
+                "tool_calls": [
+                    {"id": "tc_old", "function": {"name": "tool1", "arguments": "{}"}},
+                ],
+                "reasoning_details": [
+                    {"type": "thinking", "thinking": "Old reasoning.", "signature": "sig_old"},
+                ],
+            },
+            {"role": "tool", "tool_call_id": "tc_old", "content": "old result"},
+            {
+                "role": "assistant",
+                "content": "Latest answer.",
+                "reasoning_details": [
+                    {"type": "thinking", "thinking": "Latest reasoning.", "signature": "sig_new"},
+                ],
+            },
+        ]
+        _, result = convert_messages_to_anthropic(
+            messages,
+            base_url="http://127.0.0.1:4000",
+        )
+
+        assistants = [m for m in result if m["role"] == "assistant"]
+        assert not any(b.get("type") == "thinking" for b in assistants[0]["content"])
+        latest_thinking = [
+            b for b in assistants[-1]["content"] if b.get("type") == "thinking"
+        ]
+        assert len(latest_thinking) == 1
+        assert latest_thinking[0]["signature"] == "sig_new"
 
     def test_cache_control_stripped_from_thinking_blocks(self):
         """cache_control markers are removed from thinking/redacted_thinking blocks."""

--- a/tests/agent/test_anthropic_adapter.py
+++ b/tests/agent/test_anthropic_adapter.py
@@ -1723,6 +1723,35 @@ class TestThinkingBlockSignatureManagement:
         assert len(latest_thinking) == 1
         assert latest_thinking[0]["signature"] == "sig_new"
 
+    def test_third_party_replay_matches_native_anthropic_strategy(self):
+        messages = [
+            {
+                "role": "assistant",
+                "content": "Old answer.",
+                "reasoning_details": [
+                    {"type": "thinking", "thinking": "Old reasoning.", "signature": "sig_old"},
+                    {"type": "redacted_thinking", "data": "old_redacted"},
+                ],
+            },
+            {"role": "user", "content": "Next question"},
+            {
+                "role": "assistant",
+                "content": "Latest answer.",
+                "reasoning_details": [
+                    {"type": "thinking", "thinking": "Latest reasoning.", "signature": "sig_new"},
+                    {"type": "redacted_thinking", "data": "latest_redacted"},
+                ],
+            },
+        ]
+
+        _, native_result = convert_messages_to_anthropic(messages, base_url=None)
+        _, third_party_result = convert_messages_to_anthropic(
+            messages,
+            base_url="https://gateway.example.com/anthropic",
+        )
+
+        assert third_party_result == native_result
+
     def test_cache_control_stripped_from_thinking_blocks(self):
         """cache_control markers are removed from thinking/redacted_thinking blocks."""
         messages = [

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1178,6 +1178,29 @@ class TestBuildApiKwargs:
         assert kwargs["messages"] is messages
         assert kwargs["timeout"] == 1800.0
 
+    def test_anthropic_messages_adds_hermes_session_header(self):
+        agent = object.__new__(AIAgent)
+        agent.api_mode = "anthropic_messages"
+        agent.model = "claude-opus-4-7"
+        agent.tools = []
+        agent.max_tokens = 1024
+        agent.reasoning_config = None
+        agent._is_anthropic_oauth = False
+        agent._ephemeral_max_output_tokens = None
+        agent.context_compressor = None
+        agent._prepare_anthropic_messages_for_api = MagicMock(
+            return_value=[{"role": "user", "content": "hi"}]
+        )
+        agent._anthropic_preserve_dots = MagicMock(return_value=False)
+        agent._anthropic_base_url = "http://127.0.0.1:4000"
+        agent.request_overrides = {}
+        agent._oauth_1m_beta_disabled = False
+        agent.session_id = "test-session-123"
+
+        kwargs = agent._build_api_kwargs([{"role": "user", "content": "hi"}])
+
+        assert kwargs["extra_headers"]["X-Hermes-Code-Session-Id"] == "test-session-123"
+
     def test_public_moonshot_kimi_k2_5_omits_temperature(self, agent):
         """Kimi models should NOT have client-side temperature overrides.
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -1192,7 +1192,7 @@ class TestBuildApiKwargs:
             return_value=[{"role": "user", "content": "hi"}]
         )
         agent._anthropic_preserve_dots = MagicMock(return_value=False)
-        agent._anthropic_base_url = "http://127.0.0.1:4000"
+        agent._anthropic_base_url = "https://gateway.example.com/anthropic"
         agent.request_overrides = {}
         agent._oauth_1m_beta_disabled = False
         agent.session_id = "test-session-123"


### PR DESCRIPTION
## Summary

- Treat loopback Anthropic-compatible endpoints (`localhost`, `127.*`, `::1`, `0.0.0.0`) as local Claude-Code-compatible proxies.
- Use Anthropic SDK `auth_token` for those local proxies so requests send `Authorization: Bearer <gateway-key>` instead of `x-api-key`.
- Preserve latest signed Anthropic `thinking` / valid `redacted_thinking` blocks for local proxy replay, while keeping normal third-party endpoints on the existing strip-all-thinking behavior.
- Add `X-Hermes-Code-Session-Id` to Anthropic Messages requests sent to local Claude-Code-compatible proxies.

## Verification

- RED first: the new focused tests failed before implementation for bearer auth, loopback thinking replay, and session header injection.
- `.venv/bin/python -m pytest -o addopts='' tests/agent/test_anthropic_adapter.py::TestBuildAnthropicClient tests/agent/test_anthropic_adapter.py::TestThinkingBlockSignatureManagement tests/agent/test_kimi_coding_anthropic_thinking.py tests/agent/test_deepseek_anthropic_thinking.py tests/agent/test_minimax_provider.py tests/run_agent/test_run_agent.py::TestBuildApiKwargs::test_anthropic_messages_adds_hermes_session_header -q`
- `.venv/bin/python -m py_compile agent/anthropic_adapter.py run_agent.py tests/agent/test_anthropic_adapter.py tests/run_agent/test_run_agent.py`
- `git diff --check`

## Local endpoint check

Against `http://127.0.0.1:4000` with session id `hermes-cc-proxy-test-20260511`:

- First request extra headers included `X-Hermes-Code-Session-Id: hermes-cc-proxy-test-20260511`.
- First response returned signed `thinking` plus `text: OK`.
- Second request assistant history preserved signed `thinking` plus `text: OK`.
- Second response returned signed `thinking` plus `text: DONE`.

This PR supersedes #23264 with a narrower no-config implementation.
