### PR TITLE
fix(cli): route interactive slash commands inline to prevent CLI freeze

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6428,6 +6428,29 @@ class HermesCLI:
         except Exception:
             return False
 
+    # Commands that call _prompt_text_input — must run on the UI thread so
+    # run_in_terminal works instead of falling back to a daemon-thread
+    # input() that races with prompt_toolkit for stdin.
+    _INTERACTIVE_SLASH_COMMANDS: frozenset[str] = frozenset({
+        "model", "new", "clear", "undo", "reset", "reload-mcp",
+    })
+
+    def _should_handle_interactive_slash_inline(
+        self, text: str, has_images: bool = False
+    ) -> bool:
+        """Return True for slash commands that need the UI thread (model picker,
+        destructive confirm prompts, etc.) so they can use prompt_toolkit's
+        ``run_in_terminal`` instead of a daemon-thread ``input()`` fallback."""
+        if not text or has_images or not _looks_like_slash_command(text):
+            return False
+        try:
+            from hermes_cli.commands import resolve_command
+            base = text.split(None, 1)[0].lower().lstrip('/')
+            cmd = resolve_command(base)
+            return bool(cmd and cmd.name in self._INTERACTIVE_SLASH_COMMANDS)
+        except Exception:
+            return False
+
     def _should_handle_steer_command_inline(self, text: str, has_images: bool = False) -> bool:
         """Return True when /steer should be dispatched immediately while the agent is running.
 
@@ -11071,9 +11094,11 @@ class HermesCLI:
             text = event.app.current_buffer.text.strip()
             has_images = bool(self._attached_images)
             if text or has_images:
-                # Handle /model directly on the UI thread so interactive pickers
-                # can safely use prompt_toolkit terminal handoff helpers.
-                if self._should_handle_model_command_inline(text, has_images=has_images):
+                # Handle interactive slash commands (/model, /new, /clear,
+                # /undo, /reset) directly on the UI thread so they can safely
+                # use prompt_toolkit terminal handoff helpers (run_in_terminal)
+                # instead of a daemon-thread input() that races with stdin.
+                if self._should_handle_interactive_slash_inline(text, has_images=has_images):
                     if not self.process_command(text):
                         self._should_exit = True
                         if event.app.is_running:

--- a/tests/cli/test_interactive_slash_inline_routing.py
+++ b/tests/cli/test_interactive_slash_inline_routing.py
@@ -1,0 +1,79 @@
+"""Tests that destructive/interactive slash commands are routed inline on the
+UI thread so _prompt_text_input uses run_in_terminal instead of a daemon-thread
+input() that races with prompt_toolkit for stdin."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+
+def _make_cli():
+    """Build a minimal HermesCLI-like stand-in for gate checks."""
+    from cli import HermesCLI
+
+    cli = HermesCLI.__new__(HermesCLI)
+    cli._app = MagicMock()  # truthy so the inline path is active
+    return cli
+
+
+def test_model_commands_routed_inline():
+    """/model still routes inline."""
+    cli = _make_cli()
+    assert cli._should_handle_interactive_slash_inline("/model") is True
+    assert cli._should_handle_interactive_slash_inline("/model gpt-5") is True
+
+
+def test_new_routed_inline():
+    cli = _make_cli()
+    assert cli._should_handle_interactive_slash_inline("/new") is True
+    assert cli._should_handle_interactive_slash_inline("/new my session") is True
+
+
+def test_clear_routed_inline():
+    cli = _make_cli()
+    assert cli._should_handle_interactive_slash_inline("/clear") is True
+
+
+def test_undo_routed_inline():
+    cli = _make_cli()
+    assert cli._should_handle_interactive_slash_inline("/undo") is True
+
+
+def test_reset_routed_inline():
+    cli = _make_cli()
+    assert cli._should_handle_interactive_slash_inline("/reset") is True
+
+
+def test_non_interactive_commands_not_routed_inline():
+    """Non-interactive slash commands (no _prompt_text_input) should NOT
+    route inline — they work fine through the process_loop daemon thread."""
+    cli = _make_cli()
+    assert cli._should_handle_interactive_slash_inline("/help") is False
+    assert cli._should_handle_interactive_slash_inline("/status") is False
+    assert cli._should_handle_interactive_slash_inline("/stop") is False
+    assert cli._should_handle_interactive_slash_inline("/title") is False
+
+
+def test_non_slash_input_not_routed_inline():
+    cli = _make_cli()
+    assert cli._should_handle_interactive_slash_inline("hello") is False
+    assert cli._should_handle_interactive_slash_inline("") is False
+
+
+def test_images_attached_not_routed_inline():
+    """When images are attached, the inline path is skipped — the command
+    can't be handled reliably inline with image data pending."""
+    cli = _make_cli()
+    assert cli._should_handle_interactive_slash_inline("/new", has_images=True) is False
+
+
+def test_reload_mcp_routed_inline():
+    cli = _make_cli()
+    assert cli._should_handle_interactive_slash_inline("/reload-mcp") is True
+
+
+def test_old_gate_still_works():
+    """_should_handle_model_command_inline still works (backward compat)."""
+    cli = _make_cli()
+    assert cli._should_handle_model_command_inline("/model") is True
+    assert cli._should_handle_model_command_inline("/new") is False  # old gate excludes non-model


### PR DESCRIPTION
## Problem

`/new`, `/clear`, `/undo`, `/reset`, and `/reload-mcp` call `_confirm_destructive_slash` which calls `_prompt_text_input` to ask the user for confirmation. These commands are dispatched from the `process_loop` daemon thread where `_prompt_text_input` falls back to a bare `input()` call — but prompt_toolkit owns stdin in raw mode on the main thread, causing a stdin race that freezes the terminal.

This is identical to the deadlock fixed for `tools/approval.py` in PR #16477.

## Root cause

Commit `b9c001116` introduced `_confirm_destructive_slash` using the `_prompt_text_input` pattern from `_confirm_and_reload_mcp`. Commit `c5f1f863a` added the daemon-thread `input()` fallback to `_prompt_text_input` which inadvertently enabled this race condition for destructive slash commands.

## Fix

Route interactive slash commands inline on the UI thread — exactly like `/model` already does. This lets `_prompt_text_input` use `run_in_terminal` instead of the broken daemon-thread `input()` fallback.

- New `_INTERACTIVE_SLASH_COMMANDS` frozenset with the 6 commands that call `_prompt_text_input`: `model`, `new`, `clear`, `undo`, `reset`, `reload-mcp`
- New `_should_handle_interactive_slash_inline()` gate method
- Accept handler updated to use the new gate

## Testing

- All 28 existing CLI tests pass (destructive slash confirm, prompt_text_input thread safety, new session, steer busy path)
- 10 new tests in `tests/cli/test_interactive_slash_inline_routing.py` verify each command routes inline and non-interactive commands do not

Closes the freeze regression from PR #22687 / issue #4069.