### PR TITLE
fix: align auxiliary defaults and timeout handling

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -720,7 +720,7 @@ class _CodexCompletionsAdapter:
 
         def _check_cancelled() -> None:
             if deadline is not None and time.monotonic() >= deadline:
-                timed_out.set()
+                _close_client_on_timeout()
                 raise TimeoutError(_timeout_message())
             try:
                 from tools.interrupt import is_interrupted

--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -43,6 +43,7 @@ Payment / credit exhaustion fallback:
 import json
 import logging
 import os
+import queue
 import threading
 import time
 from pathlib import Path  # noqa: F401 — used by test mocks
@@ -744,20 +745,73 @@ class _CodexCompletionsAdapter:
                 timeout_timer.daemon = True
                 timeout_timer.start()
             _check_cancelled()
+            def _collect_stream_event(_event: Any) -> None:
+                nonlocal has_function_calls
+                _check_cancelled()
+                _etype = getattr(_event, "type", "")
+                if _etype == "response.output_item.done":
+                    _done = getattr(_event, "item", None)
+                    if _done is not None:
+                        collected_output_items.append(_done)
+                elif "output_text.delta" in _etype:
+                    _delta = getattr(_event, "delta", "")
+                    if _delta:
+                        collected_text_deltas.append(_delta)
+                elif "function_call" in _etype:
+                    has_function_calls = True
+
             with self._client.responses.stream(**resp_kwargs) as stream:
-                for _event in stream:
-                    _check_cancelled()
-                    _etype = getattr(_event, "type", "")
-                    if _etype == "response.output_item.done":
-                        _done = getattr(_event, "item", None)
-                        if _done is not None:
-                            collected_output_items.append(_done)
-                    elif "output_text.delta" in _etype:
-                        _delta = getattr(_event, "delta", "")
-                        if _delta:
-                            collected_text_deltas.append(_delta)
-                    elif "function_call" in _etype:
-                        has_function_calls = True
+                if deadline is None:
+                    for _event in stream:
+                        _collect_stream_event(_event)
+                else:
+                    # A sync streaming iterator can keep yielding keepalive
+                    # events without letting the SDK's per-request timeout fire.
+                    # Consume it in a daemon thread so this adapter can enforce
+                    # the caller's *total* auxiliary timeout even while next()
+                    # is sleeping or waiting for the next event.
+                    event_queue: "queue.Queue[Tuple[str, Any]]" = queue.Queue()
+
+                    def _pump_stream() -> None:
+                        try:
+                            for _event in stream:
+                                event_queue.put(("event", _event))
+                                if timed_out.is_set():
+                                    break
+                            event_queue.put(("done", None))
+                        except BaseException as exc:  # propagate SDK/iterator errors
+                            event_queue.put(("error", exc))
+
+                    pump_thread = threading.Thread(target=_pump_stream, daemon=True)
+                    pump_thread.start()
+                    while True:
+                        _check_cancelled()
+                        try:
+                            _kind, _payload = event_queue.get_nowait()
+                        except queue.Empty as exc:
+                            # On some macOS/CI runtimes, Condition.wait(timeout)
+                            # and even tiny sleeps can overshoot short deadlines by
+                            # >100 ms. For the final small window, poll monotonic
+                            # directly so a 50 ms auxiliary timeout is enforced as
+                            # a total deadline rather than "next scheduler wakeup".
+                            remaining = float(deadline - time.monotonic())
+                            if remaining <= 0:
+                                timed_out.set()
+                                _close_client_on_timeout()
+                                raise TimeoutError(_timeout_message()) from exc
+                            if remaining > 0.2:
+                                try:
+                                    _kind, _payload = event_queue.get(timeout=min(0.1, remaining - 0.1))
+                                except queue.Empty:
+                                    continue
+                            else:
+                                continue
+                        if _kind == "event":
+                            _collect_stream_event(_payload)
+                        elif _kind == "done":
+                            break
+                        elif _kind == "error":
+                            raise _payload
                 _check_cancelled()
                 final = stream.get_final_response()
 

--- a/agent/title_generator.py
+++ b/agent/title_generator.py
@@ -58,7 +58,11 @@ def generate_title(
             task="title_generation",
             messages=messages,
             max_tokens=500,
-            temperature=0.3,
+            # Title generation is a background convenience task. Azure/OpenAI
+            # reasoning models can reject non-default temperature values, and
+            # surfacing that retry as a Telegram warning is noisier than using
+            # the provider default. Keep this call provider-neutral.
+            temperature=None,
             timeout=timeout,
             main_runtime=main_runtime,
         )

--- a/gateway/shutdown_forensics.py
+++ b/gateway/shutdown_forensics.py
@@ -229,24 +229,34 @@ def spawn_async_diagnostic(
     script = (
         f"echo '=== shutdown diagnostic @ {signal_name} ==='; "
         "echo '--- date ---'; date -u +%Y-%m-%dT%H:%M:%SZ; "
-        "echo '--- ps auxf (top 60 by cpu) ---'; "
-        "ps auxf --sort=-pcpu 2>/dev/null | head -60; "
+        "echo '--- ps snapshot (top 60 by cpu when supported) ---'; "
+        "ps auxf --sort=-pcpu 2>/dev/null | head -60 || ps aux 2>/dev/null | head -60 || true; "
         "echo '--- pstree of self ---'; "
         f"pstree -plau {os.getpid()} 2>/dev/null | head -40 || true; "
-        "echo '--- /proc/loadavg ---'; "
-        "cat /proc/loadavg 2>/dev/null || true; "
-        "echo '--- recent dmesg (oom/killed) ---'; "
+        "echo '--- loadavg ---'; "
+        "cat /proc/loadavg 2>/dev/null || uptime 2>/dev/null || true; "
+        "echo '--- recent dmesg/journal (oom/killed) ---'; "
         "dmesg -T 2>/dev/null | tail -20 || journalctl --user -n 20 --no-pager 2>/dev/null | tail -20 || true; "
         "echo '=== end ==='"
     )
 
-    try:
-        # Open the log file in append mode and let the subprocess inherit.
-        # We use os.O_APPEND so concurrent diagnostics from rapid signals
-        # don't trample each other.
-        fd = os.open(str(log_path), os.O_WRONLY | os.O_CREAT | os.O_APPEND, 0o644)
-    except OSError:
-        return None
+    # Use a tiny Python wrapper instead of the GNU `timeout` binary.  macOS
+    # does not ship `timeout`, and returning None there would silently disable
+    # the diagnostic exactly where Dynaev development commonly runs.
+    child_code = (
+        "import subprocess, sys\n"
+        f"log_path = {str(log_path)!r}\n"
+        f"script = {script!r}\n"
+        f"timeout_seconds = {float(timeout_seconds)!r}\n"
+        "try:\n"
+        "    with open(log_path, 'ab', buffering=0) as fh:\n"
+        "        try:\n"
+        "            subprocess.run(['bash', '-c', script], stdout=fh, stderr=subprocess.STDOUT, stdin=subprocess.DEVNULL, timeout=timeout_seconds, check=False)\n"
+        "        except subprocess.TimeoutExpired:\n"
+        "            fh.write(f'=== diagnostic timed out after {timeout_seconds:.0f}s ===\\n'.encode())\n"
+        "except Exception:\n"
+        "    sys.exit(0)\n"
+    )
 
     try:
         # Detach from our process group so the subprocess survives even
@@ -255,25 +265,15 @@ def spawn_async_diagnostic(
         # start_new_session, a SIGKILL on our cgroup takes the diag down
         # before it can flush.
         proc = subprocess.Popen(
-            ["timeout", f"{timeout_seconds:.0f}", "bash", "-c", script],
-            stdout=fd,
-            stderr=subprocess.STDOUT,
+            [sys.executable, "-c", child_code],
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
             stdin=subprocess.DEVNULL,
             start_new_session=True,
             close_fds=True,
         )
     except (FileNotFoundError, OSError):
-        try:
-            os.close(fd)
-        except OSError:
-            pass
         return None
-    finally:
-        # Subprocess inherited the fd; we can drop our handle.
-        try:
-            os.close(fd)
-        except OSError:
-            pass
 
     return proc.pid
 

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2085,6 +2085,8 @@ class TestCodexAuxiliaryAdapterTimeout:
         assert response.choices[0].message.content == "summary"
 
     def test_enforces_total_timeout_while_stream_keeps_emitting_events(self):
+        close_calls = []
+
         class SlowAliveStream:
             def __enter__(self):
                 return self
@@ -2110,7 +2112,10 @@ class TestCodexAuxiliaryAdapterTimeout:
             def stream(self, **kwargs):
                 return SlowAliveStream()
 
-        fake_client = SimpleNamespace(responses=FakeResponses(), close=lambda: None)
+        fake_client = SimpleNamespace(
+            responses=FakeResponses(),
+            close=lambda: close_calls.append(True),
+        )
         adapter = _CodexCompletionsAdapter(fake_client, "gpt-5.5")
 
         started = time.monotonic()
@@ -2121,6 +2126,7 @@ class TestCodexAuxiliaryAdapterTimeout:
             )
 
         assert time.monotonic() - started < 0.14
+        assert close_calls, "total timeout should close the underlying stream client"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_title_generator.py
+++ b/tests/agent/test_title_generator.py
@@ -113,6 +113,23 @@ class TestGenerateTitle:
         user_content = captured_kwargs["messages"][1]["content"]
         assert len(user_content) < 1100  # 500 + 500 + formatting
 
+    def test_uses_provider_default_temperature(self):
+        """Title generation must not send non-default temperature to Azure reasoning models."""
+        captured_kwargs = {}
+
+        def mock_call_llm(**kwargs):
+            captured_kwargs.update(kwargs)
+            resp = MagicMock()
+            resp.choices = [MagicMock()]
+            resp.choices[0].message.content = "Short Title"
+            return resp
+
+        with patch("agent.title_generator.call_llm", side_effect=mock_call_llm):
+            assert generate_title("question", "answer") == "Short Title"
+
+        assert captured_kwargs["task"] == "title_generation"
+        assert captured_kwargs["temperature"] is None
+
 
 class TestAutoTitleSession:
     """Tests for auto_title_session() — the sync worker function."""

--- a/tests/gateway/test_shutdown_forensics.py
+++ b/tests/gateway/test_shutdown_forensics.py
@@ -202,6 +202,40 @@ class TestSpawnAsyncDiagnostic:
         # is plenty of headroom and proves we're not waiting on it.
         assert elapsed < 1.0, f"spawn blocked for {elapsed:.2f}s"
 
+    @pytest.mark.skipif(sys.platform == "win32", reason="POSIX-only diagnostic")
+    def test_uses_python_timeout_wrapper_not_platform_timeout_binary(self, tmp_path, monkeypatch):
+        """Regression: macOS does not ship GNU ``timeout``.
+
+        The detached diagnostic must spawn a Python wrapper that calls
+        ``subprocess.run(..., timeout=timeout_seconds)`` instead of shelling
+        out through a platform-specific ``timeout`` command.
+        """
+        popen_calls = []
+
+        class FakeProc:
+            pid = 4242
+
+        def fake_popen(args, **kwargs):
+            popen_calls.append((args, kwargs))
+            return FakeProc()
+
+        monkeypatch.setattr(sf.subprocess, "Popen", fake_popen)
+
+        result = sf.spawn_async_diagnostic(
+            tmp_path / "diag.log", "SIGTERM", timeout_seconds=1.25
+        )
+
+        assert result == 4242
+        assert len(popen_calls) == 1
+        args, kwargs = popen_calls[0]
+        assert args[0] == sys.executable
+        assert args[1] == "-c"
+        child_code = args[2]
+        assert "subprocess.run(['bash', '-c', script]" in child_code
+        assert "timeout=timeout_seconds" in child_code
+        assert "['timeout'" not in child_code
+        assert kwargs["start_new_session"] is True
+
 
 # ---------------------------------------------------------------------------
 # _parse_systemd_duration_to_us


### PR DESCRIPTION
## Summary
- Align auxiliary provider defaults so title generation uses the default model/provider path consistently.
- Add total-timeout enforcement for Codex Responses streaming and close the underlying client on timeout.
- Replace the shutdown diagnostic dependency on GNU `timeout` with a portable Python subprocess timeout wrapper for macOS.

## Test Plan
- `venv/bin/python -m pytest tests/agent/test_auxiliary_client.py tests/agent/test_title_generator.py tests/gateway/test_shutdown_forensics.py -q -o 'addopts='`

## Notes
- Draft PR for review only.
- No runtime/profile/gateway/provider configuration changes are included.
