### PR TITLE
fix(auxiliary): evict async wrappers on poisoned client (follow-up to #23482)

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -900,6 +900,14 @@ class AsyncCodexAuxiliaryClient:
         self.chat = _AsyncCodexChatShim(async_adapter)
         self.api_key = sync_wrapper.api_key
         self.base_url = sync_wrapper.base_url
+        # Mirror the sync wrapper's _real_client so cache eviction by leaf
+        # OpenAI client (e.g. _close_client_on_timeout in #23482) drops
+        # this async entry too. Without this, sync and async cache entries
+        # diverge on poisoning: the sync entry is evicted but the async
+        # entry keeps reusing the closed transport, failing every
+        # subsequent async aux call with 'Connection error' until the
+        # gateway restarts.
+        self._real_client = sync_wrapper._real_client
 
 
 class _AnthropicCompletionsAdapter:
@@ -1035,6 +1043,9 @@ class AsyncAnthropicAuxiliaryClient:
         self.chat = _AsyncAnthropicChatShim(async_adapter)
         self.api_key = sync_wrapper.api_key
         self.base_url = sync_wrapper.base_url
+        # See AsyncCodexAuxiliaryClient: mirror _real_client so cache
+        # eviction on a poisoned underlying client also drops this entry.
+        self._real_client = sync_wrapper._real_client
 
 
 def _endpoint_speaks_anthropic_messages(base_url: str) -> bool:
@@ -2001,9 +2012,13 @@ def _evict_cached_client_instance(target: Any) -> bool:
     transport after a timeout, broken streaming session, etc.) so the next
     auxiliary call rebuilds rather than reusing the dead instance.
 
-    Walks ``CodexAuxiliaryClient`` wrappers via their ``_real_client`` so a
-    timeout that closes the underlying ``OpenAI`` client also evicts the
-    Codex shim that exposed it.
+    Walks both sync and async wrappers (``CodexAuxiliaryClient``,
+    ``AnthropicAuxiliaryClient``, ``AsyncCodexAuxiliaryClient``, etc.) via
+    their ``_real_client`` attribute so a timeout that closes the underlying
+    ``OpenAI`` (or native provider) client evicts every cached shim that
+    exposed it. Async wrappers must mirror their sync sibling's
+    ``_real_client`` for this to work — otherwise the sync entry is evicted
+    but the async entry survives and keeps reusing the dead transport.
 
     Returns True when at least one entry was evicted.
     """

--- a/agent/gemini_native_adapter.py
+++ b/agent/gemini_native_adapter.py
@@ -945,6 +945,12 @@ class AsyncGeminiNativeClient:
         self.api_key = sync_client.api_key
         self.base_url = sync_client.base_url
         self.chat = _AsyncGeminiChatNamespace(self)
+        # Expose the underlying sync client as _real_client so the auxiliary
+        # cache's eviction-by-leaf-client helper (#23482) can find and drop
+        # this async entry when the sync GeminiNativeClient is poisoned.
+        # GeminiNativeClient is itself the leaf (no OpenAI client beneath
+        # it), so we point at the sync_client directly.
+        self._real_client = sync_client
 
     async def _create_chat_completion(self, **kwargs: Any) -> Any:
         stream = bool(kwargs.get("stream"))

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2183,6 +2183,42 @@ class TestAuxiliaryClientPoisonedCacheEviction:
         assert _evict_cached_client_instance(None) is False
         assert _evict_cached_client_instance(MagicMock()) is False
 
+    def test_evict_cached_client_instance_walks_async_wrapper(self):
+        """async_mode is part of the cache key so sync and async share the same
+        underlying OpenAI client across two distinct cache entries. A single
+        timeout that closes the leaf must evict BOTH — otherwise the async
+        entry survives, keeps reusing the dead transport, and every async
+        aux call (compression, vision, session_search) fails fast with
+        'Connection error' until gateway restart even while the sync route
+        recovers.
+
+        Regression for the async-side gap left by #23482, which fixed the
+        sync wrapper's _real_client walk but missed the async wrappers.
+        """
+        from agent.auxiliary_client import (
+            _client_cache, _client_cache_lock, _evict_cached_client_instance,
+            CodexAuxiliaryClient, AsyncCodexAuxiliaryClient,
+        )
+
+        real = SimpleNamespace(api_key="k", base_url="https://chatgpt.com/backend-api/codex",
+                               responses=SimpleNamespace(stream=lambda **k: None),
+                               close=lambda: None)
+        sync_wrapper = CodexAuxiliaryClient(real, "gpt-5.5")
+        async_wrapper = AsyncCodexAuxiliaryClient(sync_wrapper)
+        with _client_cache_lock:
+            _client_cache.clear()
+            _client_cache[("openai-codex", False, None, None, None)] = (sync_wrapper, "gpt-5.5", None)
+            _client_cache[("openai-codex", True, None, None, None)] = (async_wrapper, "gpt-5.5", None)
+        try:
+            assert _evict_cached_client_instance(real) is True
+            assert ("openai-codex", False, None, None, None) not in _client_cache
+            assert ("openai-codex", True, None, None, None) not in _client_cache, (
+                "async cache entry survived eviction — wrapper is missing _real_client"
+            )
+        finally:
+            with _client_cache_lock:
+                _client_cache.clear()
+
     def test_codex_timeout_evicts_cached_wrapper(self):
         """The timeout closer evicts the cache entry that wraps the closed client."""
         from agent.auxiliary_client import (


### PR DESCRIPTION
## What does this PR do?

  Closes the **async-side gap** left by #23482. That fix solved cache poisoning on the sync auxiliary path — which is what the original #23432 reporter reproduced via `context_compressor.py` → `call_llm`. The async side has the identical bug class
   but was not covered.

  The cache key includes `async_mode` (see `_client_cache_key`), so the **sync and async clients for the same provider live in two distinct cache entries pointing at the same underlying transport**. The #23482 fix walked the sync wrapper's
  `_real_client` correctly, but the async wrappers — `AsyncCodexAuxiliaryClient`, `AsyncAnthropicAuxiliaryClient`, `AsyncGeminiNativeClient` — never exposed `_real_client`, so the async entry survived eviction and kept handing out the poisoned
  client.

  **Async-only callers that are NOT covered by #23482:**
  
  | Code path | Affected feature |
  |---|---| 
  | `tools/vision_tools.py` (5 call sites) | `vision_analyze` for image inputs |
  | `tools/session_search_tool.py` | `session_search` over chat history |
  | `tools/web_tools.py` | LLM-backed web tools |
  | `agent/plugin_llm.py` | Any plugin that delegates to an aux LLM |
  | `plugins/teams_pipeline/pipeline.py` | Teams gateway pipeline |
  | `trajectory_compressor.py` | Trajectory compression (separate from `context_compressor`) |

  For any of these, **one timeout permanently poisons every subsequent async aux call** with `Connection error` until gateway restart — even while the sync route recovered as designed in #23482.

  ## Fix

  Mirror the sync wrapper's `_real_client` onto each async wrapper so the existing eviction helper finds them. Three lines, one per wrapper:
  
  | Wrapper | Added | Note |
  |---|---|---|
  | `AsyncCodexAuxiliaryClient` | `self._real_client = sync_wrapper._real_client` | Underlying OpenAI client |
  | `AsyncAnthropicAuxiliaryClient` | same shape | Underlying native Anthropic client |
  | `AsyncGeminiNativeClient` | `self._real_client = sync_client` | Gemini's native facade is itself the leaf — no OpenAI client beneath it, so we point at the sync `GeminiNativeClient` directly |

  Plus a one-line docstring update on `_evict_cached_client_instance` to reflect that it now covers both sync and async wrappers via the same attribute walk.

  ## Why this approach (vs. modifying the eviction helper)
  
  The async wrappers already store enough to reach the leaf (via `self._sync.chat.completions._sync._client` or similar). I considered teaching `_evict_cached_client_instance` to walk those chains, but mirroring `_real_client` is:
  
  - **Symmetric with the sync wrappers** — same attribute, same semantics
  - **Smaller diff** — 3 one-line additions vs. a multi-branch helper
  - **Self-documenting** — the attribute name signals the contract this class participates in
  - **Future-proof** — any new helper that uses `_real_client` (e.g. a future "is this client healthy?" probe) automatically covers async too

  ## Related Issue

  Refs #23482 (parent fix), #23432 (original issue — closed by #23482; sync side fully resolved, this PR addresses the parallel bug class on the async side).
  
  ## Type of Change

  - [x] 🐛 Bug fix (non-breaking change that fixes an issue)
  - [ ] ✨ New feature
  - [ ] 🔒 Security fix
  - [ ] 📝 Documentation update 
  - [ ] ✅ Tests (adding or improving test coverage)
  - [ ] ♻️  Refactor (no behavior change)
  - [ ] 🎯 New skill (bundled or hub)

  ## Changes Made

  - `agent/auxiliary_client.py` (+18 / -3)
    - `AsyncCodexAuxiliaryClient.__init__`: mirror `_real_client` (with explanatory comment)
    - `AsyncAnthropicAuxiliaryClient.__init__`: same
    - `_evict_cached_client_instance` docstring: now covers async wrappers
  - `agent/gemini_native_adapter.py` (+6)
    - `AsyncGeminiNativeClient.__init__`: mirror `_real_client` pointing at sync_client
  - `tests/agent/test_auxiliary_client.py` (+36)
    - New `test_evict_cached_client_instance_walks_async_wrapper`: seeds both sync and async cache entries pointing at the same leaf, asserts a single eviction call drops both. Without the wrapper changes the test fails with the assertion message
  `"async cache entry survived eviction — wrapper is missing _real_client"`.
  
  ## How to Test

  ```bash
  # 1. New test passes on this branch
  pytest 'tests/agent/test_auxiliary_client.py::TestAuxiliaryClientPoisonedCacheEviction' -v
  # → 8 passed

  # 2. Regression discipline — revert the wrapper changes only:
  git stash push -- agent/auxiliary_client.py agent/gemini_native_adapter.py
  pytest 'tests/agent/test_auxiliary_client.py::TestAuxiliaryClientPoisonedCacheEviction::test_evict_cached_client_instance_walks_async_wrapper' -v
  # → FAIL: "async cache entry survived eviction — wrapper is missing _real_client"
  git stash pop
  pytest 'tests/agent/test_auxiliary_client.py::TestAuxiliaryClientPoisonedCacheEviction::test_evict_cached_client_instance_walks_async_wrapper' -v
  # → PASS again

  # 3. Full file: 147/148 pass; the one pre-existing failure
  #    (test_async_call_llm_retries_nous_after_401) is environmental
  #    (httpx rejecting socks:// proxy URLs from local env), unrelated to this change.
  ```

  ## Checklist

  ### Code
  
  - [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
  - [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(auxiliary): ...`)
  - [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls?q=23482+OR+23432) — no PR addresses the async-side gap
  - [x] My PR contains **only** changes related to this fix — single commit, `+60 / -3` across 3 files
  - [ ] I've run `pytest tests/ -q` and all tests pass — ran `tests/agent/test_auxiliary_client.py` (147/148 pass; the one pre-existing failure is environmental and present on `main`); did not run the full repository suite locally. Relying on CI
  to validate the full suite.
  - [x] I've added tests for my changes — 1 new regression test with verified discipline
  - [x] I've tested on my platform: Ubuntu 24.04 (kernel 6.8), Python 3.13.5

  ### Documentation & Housekeeping

  - [x] I've updated relevant documentation — `_evict_cached_client_instance` docstring updated to cover async wrappers
  - [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
  - [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
  - [x] I've considered cross-platform impact (Windows, macOS) — purely Python attribute additions; platform-agnostic
  - [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A (internal cache plumbing only; no tool-facing schema change)

  ---

