### PR TITLE
fix(memory): keep provider plugin commands and skills

### DIFF
--- a/plugins/memory/__init__.py
+++ b/plugins/memory/__init__.py
@@ -263,7 +263,7 @@ def _load_provider_from_dir(provider_dir: Path) -> Optional["MemoryProvider"]:
 
     # Try register(ctx) pattern first (how our plugins are written)
     if hasattr(mod, "register"):
-        collector = _ProviderCollector()
+        collector = _ProviderCollector(name)
         try:
             mod.register(collector)
             if collector.provider:
@@ -286,13 +286,37 @@ def _load_provider_from_dir(provider_dir: Path) -> Optional["MemoryProvider"]:
 
 
 class _ProviderCollector:
-    """Fake plugin context that captures register_memory_provider calls."""
+    """Plugin context for memory providers loaded outside PluginManager."""
 
-    def __init__(self):
+    def __init__(self, plugin_name: str = ""):
         self.provider = None
+        self.plugin_name = plugin_name
+        self._plugin_context = None
 
     def register_memory_provider(self, provider):
         self.provider = provider
+
+    def _context(self):
+        if self._plugin_context is None:
+            from hermes_cli.plugins import (
+                PluginContext,
+                PluginManifest,
+                get_plugin_manager,
+            )
+
+            manifest = PluginManifest(
+                name=self.plugin_name,
+                source="memory",
+                kind="exclusive",
+            )
+            self._plugin_context = PluginContext(manifest, get_plugin_manager())
+        return self._plugin_context
+
+    def register_command(self, *args, **kwargs):
+        return self._context().register_command(*args, **kwargs)
+
+    def register_skill(self, *args, **kwargs):
+        return self._context().register_skill(*args, **kwargs)
 
     # No-op for other registration methods
     def register_tool(self, *args, **kwargs):

--- a/tests/hermes_cli/test_plugin_cli_registration.py
+++ b/tests/hermes_cli/test_plugin_cli_registration.py
@@ -187,3 +187,56 @@ class TestProviderCollectorCliNoop:
         )
         # Should not store anything — CLI is discovered via file convention
         assert not hasattr(collector, "_cli_commands")
+
+
+class TestMemoryProviderPluginRegistrations:
+    def test_provider_loader_keeps_plugin_commands_and_skills(
+        self, tmp_path, monkeypatch
+    ):
+        """Memory provider plugins can expose slash commands and explicit skills."""
+        from hermes_cli import plugins as plugins_mod
+        from plugins.memory import _load_provider_from_dir
+
+        manager = PluginManager()
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", manager)
+
+        provider_dir = tmp_path / "basic-memory"
+        provider_dir.mkdir()
+        skill_md = provider_dir / "SKILL.md"
+        skill_md.write_text("---\nname: basic-memory\n---\nUse basic memory.\n")
+        (provider_dir / "__init__.py").write_text(
+            "def _bm_status(args):\n"
+            "    return f'status:{args}'\n"
+            "\n"
+            "def register(ctx):\n"
+            "    ctx.register_memory_provider('provider-instance')\n"
+            "    ctx.register_command('/bm-status', _bm_status,\n"
+            "        description='Show Basic Memory status', args_hint='<scope>')\n"
+            "    ctx.register_skill('basic-memory', __import__('pathlib').Path(__file__).parent / 'SKILL.md',\n"
+            "        description='Basic Memory workflow')\n"
+        )
+
+        provider = _load_provider_from_dir(provider_dir)
+
+        assert provider == "provider-instance"
+        command = manager._plugin_commands["bm-status"]
+        assert command["handler"]("all") == "status:all"
+        assert command["description"] == "Show Basic Memory status"
+        assert command["plugin"] == "basic-memory"
+        assert command["args_hint"] == "<scope>"
+        assert manager.find_plugin_skill("basic-memory:basic-memory") == skill_md
+
+    def test_provider_collector_rejects_builtin_command_conflicts(
+        self, monkeypatch
+    ):
+        """Memory provider slash commands use the same conflict checks as plugins."""
+        from hermes_cli import plugins as plugins_mod
+        from plugins.memory import _ProviderCollector
+
+        manager = PluginManager()
+        monkeypatch.setattr(plugins_mod, "_plugin_manager", manager)
+
+        collector = _ProviderCollector("basic-memory")
+        collector.register_command("help", lambda args: args)
+
+        assert "help" not in manager._plugin_commands


### PR DESCRIPTION
Summary
This PR fixes #23603 by letting memory-provider plugins register the same in-session commands and explicit skills that regular plugins can already expose.

Why this matters
Memory-provider plugins are loaded through plugins/memory instead of the general PluginManager path. That loader passed register(ctx) a _ProviderCollector that only captured register_memory_provider, so plugins that also called ctx.register_command(...) or ctx.register_skill(...) either lost those registrations or failed before the provider could be returned.

The underlying registries and validation already exist in PluginContext. This change keeps the memory-provider loader small by giving _ProviderCollector a plugin identity and delegating command/skill registration through the standard PluginContext path. Existing no-op behaviour for register_tool, register_hook, and register_cli_command is preserved.

Duplicate check
Before opening this PR I searched open PRs for #23603, _ProviderCollector, register_command, register_skill, and memory provider registration. I did not find an existing open PR for this issue.

Tests
- .venv/bin/python -m pytest tests/hermes_cli/test_plugin_cli_registration.py -q
- .venv/bin/python -m pytest tests/test_plugin_skills.py -q
- .venv/bin/ruff check plugins/memory/__init__.py tests/hermes_cli/test_plugin_cli_registration.py
- git diff --check

Closes #23603