### PR TITLE
feat: add SearXNG search backend and auto-resume builtin hook

### DIFF
--- a/gateway/builtin_hooks/auto_resume.py
+++ b/gateway/builtin_hooks/auto_resume.py
@@ -1,0 +1,108 @@
+"""Auto-resume: resume interrupted sessions on gateway restart.
+
+When the gateway restarts (crash, update, deploy), this hook scans for
+sessions that were interrupted mid-turn (last message was a tool result
+or a user message that never got a response) and triggers the agent to
+pick up where it left off.
+"""
+import asyncio
+import json
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+async def handle(event_type: str, context: dict) -> None:
+    if event_type != "gateway:startup":
+        return
+
+    logger.info("Checking for interrupted sessions to auto-resume...")
+    await asyncio.sleep(8)  # Wait for platform adapters to connect
+
+    try:
+        from hermes_cli.config import get_hermes_home
+        from hermes_state import SessionDB
+        from gateway.run import _gateway_runner_ref
+        from gateway.platforms.base import Platform, MessageEvent, MessageType
+        from gateway.session import SessionSource
+
+        path = get_hermes_home() / "sessions" / "sessions.json"
+        if not path.exists():
+            logger.info("No sessions.json found — skipping auto-resume")
+            return
+
+        with open(path) as f:
+            sessions = json.load(f)
+
+        db = SessionDB()
+        runner = _gateway_runner_ref()
+        if not runner:
+            logger.warning("No gateway runner available — skipping auto-resume")
+            return
+
+        resumed = 0
+        for key, entry in sessions.items():
+            if not isinstance(entry, dict) or entry.get("suspended"):
+                continue
+
+            sid = entry.get("session_id")
+            if not sid:
+                continue
+
+            # Check if the session was interrupted mid-turn:
+            #   role=tool → tool result was pending → agent should continue
+            #   role=user → user message was unanswered → agent should reply
+            try:
+                msgs = db.get_messages(sid)
+            except Exception:
+                continue
+            if not msgs:
+                continue
+            last_role = msgs[-1].get("role", "")
+            if last_role not in ("tool", "user"):
+                continue
+
+            origin = entry.get("origin", {})
+            pn = origin.get("platform", "")
+            if not pn:
+                continue
+            try:
+                plat = Platform(pn)
+            except ValueError:
+                continue
+            if plat not in runner.adapters:
+                continue
+
+            # Mark session for resume — the gateway injects a
+            # "[System note: Your previous turn was interrupted...]"
+            # prefix so the agent knows to continue rather than start fresh.
+            runner.session_store.mark_resume_pending(key, reason="gateway_restart")
+
+            source = SessionSource(
+                platform=plat,
+                chat_id=origin.get("chat_id", ""),
+                chat_name=origin.get("chat_name", ""),
+                chat_type=origin.get("chat_type", "dm"),
+                user_id=origin.get("user_id", ""),
+                user_name=origin.get("user_name", ""),
+                thread_id=origin.get("thread_id"),
+            )
+
+            # Fire a synthetic internal event to trigger agent resume.
+            # The text is "." — the gateway overrides it with the resume prefix.
+            ev = MessageEvent(
+                text=".",
+                message_type=MessageType.TEXT,
+                source=source,
+                internal=True,
+            )
+
+            logger.info("Auto-resuming session %s (%s)", key, plat.value)
+            asyncio.create_task(runner._handle_message(ev))
+            resumed += 1
+
+        if resumed:
+            logger.info("Auto-resumed %d interrupted session(s)", resumed)
+
+    except Exception:
+        logger.exception("auto-resume hook failed")

--- a/gateway/hooks.py
+++ b/gateway/hooks.py
@@ -55,11 +55,21 @@ class HookRegistry:
     def _register_builtin_hooks(self) -> None:
         """Register built-in hooks that are always active.
 
-        Currently empty — no shipped built-in hooks. Kept as the extension
-        point for future always-on gateway hooks so they drop in without
-        re-plumbing discover_and_load().
+        These fire on every gateway startup without requiring a user-created
+        hook directory under ~/.hermes/hooks/.
         """
-        return
+        try:
+            from gateway.builtin_hooks.auto_resume import handle as auto_resume_handle
+            self._handlers.setdefault("gateway:startup", []).append(auto_resume_handle)
+            self._loaded_hooks.append({
+                "name": "auto-resume",
+                "description": "Resume interrupted sessions after gateway restart",
+                "events": ["gateway:startup"],
+                "path": "builtin",
+            })
+        except Exception:
+            logger = logging.getLogger(__name__)
+            logger.warning("Failed to register builtin auto-resume hook", exc_info=True)
 
     def discover_and_load(self) -> None:
         """

--- a/tools/web_tools.py
+++ b/tools/web_tools.py
@@ -126,7 +126,7 @@ def _get_backend() -> str:
     keys manually without running setup.
     """
     configured = (_load_web_config().get("backend") or "").lower().strip()
-    if configured in ("parallel", "firecrawl", "tavily", "exa"):
+    if configured in ("parallel", "firecrawl", "tavily", "exa", "searxng"):
         return configured
 
     # Fallback for manual / legacy config — pick the highest-priority
@@ -155,6 +155,8 @@ def _is_backend_available(backend: str) -> bool:
         return check_firecrawl_api_key()
     if backend == "tavily":
         return _has_env("TAVILY_API_KEY")
+    if backend == "searxng":
+        return _has_env("SEARXNG_URL")
     return False
 
 # ─── Firecrawl Client ────────────────────────────────────────────────────────
@@ -1071,6 +1073,112 @@ async def _parallel_extract(urls: List[str]) -> List[Dict[str, Any]]:
     return results
 
 
+# ─── SearXNG Search & Extract Helpers ─────────────────────────────────────────
+
+def _searxng_base_url() -> str:
+    """Return the configured SearXNG base URL, or empty string if not set."""
+    return os.getenv("SEARXNG_URL", "").strip().rstrip("/")
+
+
+def _searxng_search(query: str, limit: int = 10) -> dict:
+    """Search using a self-hosted SearXNG instance and return results as a dict."""
+    from tools.interrupt import is_interrupted
+    if is_interrupted():
+        return {"error": "Interrupted", "success": False}
+
+    base = _searxng_base_url()
+    if not base:
+        return {"error": "SEARXNG_URL environment variable is not set. "
+                         "Configure a self-hosted SearXNG instance to use this backend.", "success": False}
+
+    params = {
+        "q": query,
+        "format": "json",
+        "limit": min(limit, 20),
+    }
+    logger.info("SearXNG search: '%s' (base=%s, limit=%d)", query, base, limit)
+
+    response = httpx.get(
+        f"{base}/search",
+        params=params,
+        timeout=30,
+        follow_redirects=True,
+    )
+    response.raise_for_status()
+    data = response.json()
+
+    web_results = []
+    for i, result in enumerate(data.get("results", [])[:limit]):
+        web_results.append({
+            "title": result.get("title", ""),
+            "url": result.get("url", ""),
+            "description": result.get("content", "") or result.get("description", ""),
+            "position": i + 1,
+        })
+
+    return {"success": True, "data": {"web": web_results}}
+
+
+async def _searxng_extract(urls: List[str]) -> List[Dict[str, Any]]:
+    """Extract content from URLs using direct HTTP fetch via httpx.
+
+    Returns a list of result dicts matching the structure expected by the
+    LLM post-processing pipeline (url, title, content, metadata).
+    """
+    from tools.interrupt import is_interrupted
+    if is_interrupted():
+        return [{"url": u, "error": "Interrupted", "title": ""} for u in urls]
+
+    results: List[Dict[str, Any]] = []
+    async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+        for url in urls:
+            if is_interrupted():
+                results.append({"url": url, "error": "Interrupted", "title": ""})
+                continue
+
+            try:
+                logger.info("SearXNG extract: %s", url)
+                resp = await client.get(url, headers={
+                    "User-Agent": "Mozilla/5.0 (compatible; Hermes/1.0; +http://hermes-agent.ai)",
+                    "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8",
+                    "Accept-Language": "en-US,en;q=0.5",
+                })
+                resp.raise_for_status()
+                html = resp.text
+
+                # Basic title extraction
+                title = ""
+                title_match = re.search(r"<title[^>]*>([^<]+)</title>", html, re.IGNORECASE)
+                if title_match:
+                    title = title_match.group(1).strip()
+
+                # Strip HTML tags for plain-text content (simple approach)
+                content = re.sub(r"<script[^>]*>.*?</script>", "", html, flags=re.DOTALL | re.IGNORECASE)
+                content = re.sub(r"<style[^>]*>.*?</style>", "", content, flags=re.DOTALL | re.IGNORECASE)
+                content = re.sub(r"<[^>]+>", " ", content)
+                content = re.sub(r"&\w+?;", " ", content)  # decode common HTML entities
+                content = re.sub(r"\s{2,}", " ", content).strip()
+
+                results.append({
+                    "url": url,
+                    "title": title,
+                    "content": content,
+                    "raw_content": content,
+                    "metadata": {"sourceURL": url, "title": title},
+                })
+            except Exception as exc:
+                logger.debug("SearXNG extract failed for %s: %s", url, exc)
+                results.append({
+                    "url": url,
+                    "title": "",
+                    "content": "",
+                    "raw_content": "",
+                    "error": str(exc),
+                })
+
+    return results
+
+
 def web_search_tool(query: str, limit: int = 5) -> str:
     """
     Search the web for information using available search API backend.
@@ -1140,6 +1248,15 @@ def web_search_tool(query: str, limit: int = 5) -> str:
 
         if backend == "exa":
             response_data = _exa_search(query, limit)
+            debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
+            result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
+            debug_call_data["final_response_size"] = len(result_json)
+            _debug.log_call("web_search_tool", debug_call_data)
+            _debug.save()
+            return result_json
+
+        if backend == "searxng":
+            response_data = _searxng_search(query, limit)
             debug_call_data["results_count"] = len(response_data.get("data", {}).get("web", []))
             result_json = json.dumps(response_data, indent=2, ensure_ascii=False)
             debug_call_data["final_response_size"] = len(result_json)
@@ -1297,6 +1414,8 @@ async def web_extract_tool(
                     "include_images": False,
                 })
                 results = _normalize_tavily_documents(raw, fallback_url=safe_urls[0] if safe_urls else "")
+            elif backend == "searxng":
+                results = await _searxng_extract(safe_urls)
             else:
                 # ── Firecrawl extraction ──
                 # Determine requested formats for Firecrawl v2


### PR DESCRIPTION
## Summary

Two features in one PR:

### 1. SearXNG Search Backend
Adds a self-hosted SearXNG backend for  and  tools, filling the gap for zero-cost self-hosted search.

- **Config-driven only** (no auto-detect) — set  in config or  env var
- Uses SearXNG JSON API () for search
- HTTP extract for full-text page content
- Graceful fallback to firecrawl (default unchanged) for backward compatibility
- Removed hardcoded search engine list — users control that via their SearXNG instance

### 2. Auto-Resume Builtin Hook
Gateway restarts break active sessions silently. This builtin hook fixes that.

- Scans  on gateway startup
- Waits 8 seconds for platforms to connect
- Finds sessions where the last message role is  or  (i.e., the user was waiting for a response)
- Auto-marks them as  and triggers resume via the standard gateway API
- No user configuration required — builtin hook, always active

## Files Changed
| File | Change |
|------|--------|
|  | +121 lines — SearXNG search/extract backend |
|  | +108 lines — new builtin hook |
|  | +18/-5 — registers auto_resume via  |