### PR TITLE
fix(dingtalk): support native local media replies

### DIFF
--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -29,6 +29,7 @@ Configuration in config.yaml:
 import asyncio
 import json
 import logging
+import mimetypes
 import os
 import re
 import traceback
@@ -894,20 +895,30 @@ class DingTalkAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        """Send an image via DingTalk markdown.
-
-        DingTalk's session webhook only supports text/markdown payloads, not
-        native image/file attachments. For remote image URLs, render the image
-        inline with markdown so the user still sees the image. Local files need
-        OpenAPI media upload and are handled separately.
-        """
-        image_block = f"![image]({image_url})"
-        content = f"{caption}\n\n{image_block}" if caption else image_block
-        return await self.send(
+        """Send a remote image via DingTalk's native image payload."""
+        session_webhook = self._resolve_session_webhook(chat_id, metadata)
+        if not session_webhook:
+            return SendResult(
+                success=False,
+                error="No valid session_webhook available. Reply must follow an incoming message.",
+            )
+        payload = {"msgtype": "image", "image": {"picURL": image_url}}
+        if caption:
+            # DingTalk's native image payload has no caption field. Send a
+            # short preface first so callers still get the expected context.
+            caption_result = await self.send(
+                chat_id=chat_id,
+                content=caption,
+                reply_to=None,
+                metadata=metadata,
+            )
+            if not caption_result.success:
+                return caption_result
+        return await self._send_webhook_json(
             chat_id=chat_id,
-            content=content,
+            session_webhook=session_webhook,
+            payload=payload,
             reply_to=reply_to,
-            metadata=metadata,
         )
 
     async def send_image_file(
@@ -919,13 +930,27 @@ class DingTalkAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
-        """DingTalk webhook replies cannot send local image files directly."""
-        return SendResult(
-            success=False,
-            error=(
-                "DingTalk session webhook replies do not support local image uploads. "
-                "Only markdown/text replies are supported without OpenAPI media upload."
-            ),
+        """Upload a local image, then send it as markdown via media_id."""
+        session_webhook = self._resolve_session_webhook(chat_id, metadata)
+        if not session_webhook:
+            return SendResult(
+                success=False,
+                error="No valid session_webhook available. Reply must follow an incoming message.",
+            )
+        media_id = await self._upload_media(image_path, media_type="image")
+        if not media_id:
+            return SendResult(success=False, error="Failed to upload DingTalk image media")
+        image_block = f"![image]({media_id})"
+        content = f"{caption}\n\n{image_block}" if caption else image_block
+        payload = {
+            "msgtype": "markdown",
+            "markdown": {"title": "Hermes", "text": self._normalize_markdown(content)},
+        }
+        return await self._send_webhook_json(
+            chat_id=chat_id,
+            session_webhook=session_webhook,
+            payload=payload,
+            reply_to=reply_to,
         )
 
     async def send_document(
@@ -938,13 +963,41 @@ class DingTalkAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
-        """DingTalk webhook replies cannot send local file attachments directly."""
-        return SendResult(
-            success=False,
-            error=(
-                "DingTalk session webhook replies do not support local file attachments. "
-                "Only markdown/text replies are supported without OpenAPI message send."
-            ),
+        """Upload a local file, then send it as a DingTalk file attachment."""
+        session_webhook = self._resolve_session_webhook(chat_id, metadata)
+        if not session_webhook:
+            return SendResult(
+                success=False,
+                error="No valid session_webhook available. Reply must follow an incoming message.",
+            )
+        media_id = await self._upload_media(file_path, media_type="file")
+        if not media_id:
+            return SendResult(success=False, error="Failed to upload DingTalk file media")
+
+        effective_name = file_name or os.path.basename(file_path)
+        file_type = self._guess_file_type(effective_name)
+        if caption:
+            caption_result = await self.send(
+                chat_id=chat_id,
+                content=caption,
+                reply_to=None,
+                metadata=metadata,
+            )
+            if not caption_result.success:
+                return caption_result
+        payload = {
+            "msgtype": "file",
+            "file": {
+                "mediaId": media_id,
+                "fileName": effective_name,
+                "fileType": file_type,
+            },
+        }
+        return await self._send_webhook_json(
+            chat_id=chat_id,
+            session_webhook=session_webhook,
+            payload=payload,
+            reply_to=reply_to,
         )
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
@@ -969,6 +1022,112 @@ class DingTalkAdapter(BasePlatformAdapter):
                 self._session_webhooks.pop(chat_id, None)
                 return None
         return info
+
+    def _resolve_session_webhook(
+        self, chat_id: str, metadata: Optional[Dict[str, Any]]
+    ) -> Optional[str]:
+        metadata = metadata or {}
+        session_webhook = metadata.get("session_webhook")
+        if session_webhook:
+            return session_webhook
+        webhook_info = self._get_valid_webhook(chat_id)
+        if not webhook_info:
+            logger.warning(
+                "[%s] No valid session_webhook for chat_id=%s",
+                self.name,
+                chat_id,
+            )
+            return None
+        session_webhook, _ = webhook_info
+        return session_webhook
+
+    async def _send_webhook_json(
+        self,
+        *,
+        chat_id: str,
+        session_webhook: str,
+        payload: Dict[str, Any],
+        reply_to: Optional[str],
+    ) -> SendResult:
+        if not self._http_client:
+            return SendResult(success=False, error="HTTP client not initialized")
+        is_final_reply = reply_to is not None
+        try:
+            resp = await self._http_client.post(
+                session_webhook, json=payload, timeout=15.0
+            )
+            if resp.status_code < 300:
+                if is_final_reply:
+                    self._fire_done_reaction(chat_id)
+                return SendResult(success=True, message_id=uuid.uuid4().hex[:12])
+            body = resp.text
+            logger.warning(
+                "[%s] Send failed HTTP %d: %s", self.name, resp.status_code, body[:200]
+            )
+            return SendResult(
+                success=False, error=f"HTTP {resp.status_code}: {body[:200]}"
+            )
+        except httpx.TimeoutException:
+            return SendResult(
+                success=False, error="Timeout sending message to DingTalk"
+            )
+        except Exception as e:
+            logger.error("[%s] Send error: %s", self.name, e)
+            return SendResult(success=False, error=str(e))
+
+    async def _upload_media(self, path: str, *, media_type: str) -> Optional[str]:
+        if media_type not in {"image", "file"}:
+            raise ValueError(f"unsupported DingTalk media type: {media_type}")
+        token = await self._get_access_token()
+        if not token:
+            return None
+        if not self._http_client:
+            return None
+
+        mime_type, _ = mimetypes.guess_type(path)
+        filename = os.path.basename(path)
+        upload_url = (
+            f"https://oapi.dingtalk.com/media/upload?access_token={token}&type={media_type}"
+        )
+        try:
+            with open(path, "rb") as fh:
+                files = {
+                    "media": (
+                        filename,
+                        fh,
+                        mime_type or "application/octet-stream",
+                    )
+                }
+                resp = await self._http_client.post(
+                    upload_url, files=files, timeout=60.0
+                )
+        except OSError as exc:
+            logger.warning("[%s] Failed to read media file %s: %s", self.name, path, exc)
+            return None
+        except Exception as exc:
+            logger.warning("[%s] DingTalk media upload failed for %s: %s", self.name, path, exc)
+            return None
+
+        try:
+            body = resp.json()
+        except Exception:
+            body = {}
+        if resp.status_code >= 300 or body.get("errcode") not in (0, "0"):
+            logger.warning(
+                "[%s] DingTalk media upload failed HTTP %s body=%s",
+                self.name,
+                resp.status_code,
+                resp.text[:300],
+            )
+            return None
+        media_id = str(body.get("media_id") or "").strip()
+        return media_id or None
+
+    @staticmethod
+    def _guess_file_type(path_or_name: str) -> str:
+        _, ext = os.path.splitext(path_or_name)
+        ext = ext.lstrip(".").lower()
+        return ext or "bin"
 
     async def _create_and_stream_card(
         self,

--- a/plugins/platforms/dingtalk/adapter.py
+++ b/plugins/platforms/dingtalk/adapter.py
@@ -29,6 +29,7 @@ Configuration in config.yaml:
 import asyncio
 import json
 import logging
+import mimetypes
 import os
 import re
 import traceback
@@ -1097,30 +1098,12 @@ class DingTalkAdapter(BasePlatformAdapter):
             "markdown": {"title": "Hermes", "text": normalized},
         }
 
-        try:
-            resp = await self._http_client.post(
-                session_webhook, json=payload, timeout=15.0
-            )
-            if resp.status_code < 300:
-                # Webhook path: fire Done only for final replies, same as
-                # the card path.
-                if is_final_reply:
-                    self._fire_done_reaction(chat_id)
-                return SendResult(success=True, message_id=uuid.uuid4().hex[:12])
-            body = resp.text
-            logger.warning(
-                "[%s] Send failed HTTP %d: %s", self.name, resp.status_code, body[:200]
-            )
-            return SendResult(
-                success=False, error=f"HTTP {resp.status_code}: {body[:200]}"
-            )
-        except httpx.TimeoutException:
-            return SendResult(
-                success=False, error="Timeout sending message to DingTalk"
-            )
-        except Exception as e:
-            logger.error("[%s] Send error: %s", self.name, e)
-            return SendResult(success=False, error=str(e))
+        return await self._send_webhook_json(
+            chat_id=chat_id,
+            session_webhook=session_webhook,
+            payload=payload,
+            reply_to=reply_to,
+        )
 
     async def send_typing(self, chat_id: str, metadata=None) -> None:
         """DingTalk does not support typing indicators."""
@@ -1134,20 +1117,28 @@ class DingTalkAdapter(BasePlatformAdapter):
         reply_to: Optional[str] = None,
         metadata: Optional[Dict[str, Any]] = None,
     ) -> SendResult:
-        """Send an image via DingTalk markdown.
-
-        DingTalk's session webhook only supports text/markdown payloads, not
-        native image/file attachments. For remote image URLs, render the image
-        inline with markdown so the user still sees the image. Local files need
-        OpenAPI media upload and are handled separately.
-        """
-        image_block = f"![image]({image_url})"
-        content = f"{caption}\n\n{image_block}" if caption else image_block
-        return await self.send(
+        """Send a remote image using DingTalk's native image payload."""
+        session_webhook = self._resolve_session_webhook(chat_id, metadata)
+        if not session_webhook:
+            return SendResult(
+                success=False,
+                error="No valid session_webhook available. Reply must follow an incoming message.",
+            )
+        payload = {"msgtype": "image", "image": {"picURL": image_url}}
+        if caption:
+            caption_result = await self.send(
+                chat_id=chat_id,
+                content=caption,
+                reply_to=None,
+                metadata=metadata,
+            )
+            if not caption_result.success:
+                return caption_result
+        return await self._send_webhook_json(
             chat_id=chat_id,
-            content=content,
+            session_webhook=session_webhook,
+            payload=payload,
             reply_to=reply_to,
-            metadata=metadata,
         )
 
     async def send_image_file(
@@ -1159,13 +1150,27 @@ class DingTalkAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
-        """DingTalk webhook replies cannot send local image files directly."""
-        return SendResult(
-            success=False,
-            error=(
-                "DingTalk session webhook replies do not support local image uploads. "
-                "Only markdown/text replies are supported without OpenAPI media upload."
-            ),
+        """Upload a local image, then send it as markdown via media_id."""
+        session_webhook = self._resolve_session_webhook(chat_id, metadata)
+        if not session_webhook:
+            return SendResult(
+                success=False,
+                error="No valid session_webhook available. Reply must follow an incoming message.",
+            )
+        media_id = await self._upload_media(image_path, media_type="image")
+        if not media_id:
+            return SendResult(success=False, error="Failed to upload DingTalk image media")
+        image_block = f"![image]({media_id})"
+        content = f"{caption}\n\n{image_block}" if caption else image_block
+        payload = {
+            "msgtype": "markdown",
+            "markdown": {"title": "Hermes", "text": self._normalize_markdown(content)},
+        }
+        return await self._send_webhook_json(
+            chat_id=chat_id,
+            session_webhook=session_webhook,
+            payload=payload,
+            reply_to=reply_to,
         )
 
     async def send_document(
@@ -1178,13 +1183,40 @@ class DingTalkAdapter(BasePlatformAdapter):
         metadata: Optional[Dict[str, Any]] = None,
         **kwargs,
     ) -> SendResult:
-        """DingTalk webhook replies cannot send local file attachments directly."""
-        return SendResult(
-            success=False,
-            error=(
-                "DingTalk session webhook replies do not support local file attachments. "
-                "Only markdown/text replies are supported without OpenAPI message send."
-            ),
+        """Upload a local file, then send it as a DingTalk file attachment."""
+        session_webhook = self._resolve_session_webhook(chat_id, metadata)
+        if not session_webhook:
+            return SendResult(
+                success=False,
+                error="No valid session_webhook available. Reply must follow an incoming message.",
+            )
+        media_id = await self._upload_media(file_path, media_type="file")
+        if not media_id:
+            return SendResult(success=False, error="Failed to upload DingTalk file media")
+
+        effective_name = file_name or os.path.basename(file_path)
+        payload = {
+            "msgtype": "file",
+            "file": {
+                "mediaId": media_id,
+                "fileName": effective_name,
+                "fileType": self._guess_file_type(effective_name),
+            },
+        }
+        if caption:
+            caption_result = await self.send(
+                chat_id=chat_id,
+                content=caption,
+                reply_to=None,
+                metadata=metadata,
+            )
+            if not caption_result.success:
+                return caption_result
+        return await self._send_webhook_json(
+            chat_id=chat_id,
+            session_webhook=session_webhook,
+            payload=payload,
+            reply_to=reply_to,
         )
 
     async def get_chat_info(self, chat_id: str) -> Dict[str, Any]:
@@ -1209,6 +1241,121 @@ class DingTalkAdapter(BasePlatformAdapter):
                 self._session_webhooks.pop(chat_id, None)
                 return None
         return info
+
+    def _resolve_session_webhook(
+        self, chat_id: str, metadata: Optional[Dict[str, Any]]
+    ) -> Optional[str]:
+        metadata = metadata or {}
+        session_webhook = metadata.get("session_webhook")
+        if session_webhook:
+            return session_webhook
+        webhook_info = self._get_valid_webhook(chat_id)
+        if not webhook_info:
+            logger.warning(
+                "[%s] No valid session_webhook for chat_id=%s",
+                self.name,
+                chat_id,
+            )
+            return None
+        session_webhook, _ = webhook_info
+        return session_webhook
+
+    async def _send_webhook_json(
+        self,
+        *,
+        chat_id: str,
+        session_webhook: str,
+        payload: Dict[str, Any],
+        reply_to: Optional[str],
+    ) -> SendResult:
+        """Send a webhook payload and treat DingTalk API errors as failures."""
+        if not self._http_client:
+            return SendResult(success=False, error="HTTP client not initialized")
+        try:
+            resp = await self._http_client.post(
+                session_webhook, json=payload, timeout=15.0
+            )
+            if resp.status_code < 300:
+                try:
+                    body = resp.json()
+                except Exception:
+                    body = None
+                if isinstance(body, dict) and body.get("errcode") not in (None, 0, "0"):
+                    error = str(body.get("errmsg") or body.get("message") or "DingTalk rejected the request")
+                    logger.warning(
+                        "[%s] DingTalk webhook rejected payload: errcode=%s errmsg=%s",
+                        self.name,
+                        body.get("errcode"),
+                        error[:200],
+                    )
+                    return SendResult(success=False, error=error[:200])
+                if reply_to is not None:
+                    self._fire_done_reaction(chat_id)
+                return SendResult(success=True, message_id=uuid.uuid4().hex[:12])
+            body_text = str(getattr(resp, "text", ""))
+            logger.warning(
+                "[%s] Send failed HTTP %d: %s",
+                self.name,
+                resp.status_code,
+                body_text[:200],
+            )
+            return SendResult(
+                success=False, error=f"HTTP {resp.status_code}: {body_text[:200]}"
+            )
+        except httpx.TimeoutException:
+            return SendResult(success=False, error="Timeout sending message to DingTalk")
+        except Exception as exc:
+            logger.error("[%s] Send error: %s", self.name, exc)
+            return SendResult(success=False, error=str(exc))
+
+    async def _upload_media(self, path: str, *, media_type: str) -> Optional[str]:
+        if media_type not in {"image", "file"}:
+            raise ValueError(f"unsupported DingTalk media type: {media_type}")
+        token = await self._get_access_token()
+        if not token or not self._http_client:
+            return None
+
+        mime_type, _ = mimetypes.guess_type(path)
+        filename = os.path.basename(path)
+        upload_url = (
+            "https://oapi.dingtalk.com/media/upload"
+            f"?access_token={token}&type={media_type}"
+        )
+        try:
+            with open(path, "rb") as fh:
+                response = await self._http_client.post(
+                    upload_url,
+                    files={"media": (filename, fh, mime_type or "application/octet-stream")},
+                    timeout=60.0,
+                )
+        except Exception as exc:
+            logger.warning(
+                "[%s] DingTalk media upload failed for %s: %s",
+                self.name,
+                path,
+                exc,
+            )
+            return None
+
+        try:
+            body = response.json()
+        except Exception:
+            body = {}
+        if response.status_code >= 300 or not isinstance(body, dict) or body.get("errcode") not in (0, "0"):
+            logger.warning(
+                "[%s] DingTalk media upload failed HTTP %s body=%s",
+                self.name,
+                response.status_code,
+                str(getattr(response, "text", ""))[:300],
+            )
+            return None
+        media_id = str(body.get("media_id") or "").strip()
+        return media_id or None
+
+    @staticmethod
+    def _guess_file_type(path_or_name: str) -> str:
+        _, ext = os.path.splitext(path_or_name)
+        return ext.lstrip(".").lower() or "bin"
 
     async def _create_and_stream_card(
         self,

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -245,28 +245,85 @@ class TestSend:
 
         assert result.success is True
         payload = mock_client.post.call_args.kwargs["json"]
-        assert payload["msgtype"] == "markdown"
-        assert payload["markdown"]["text"] == "Screenshot\n\n![image](https://example.com/demo.png)"
+        assert payload["msgtype"] == "image"
+        assert payload["image"]["picURL"] == "https://example.com/demo.png"
 
     @pytest.mark.asyncio
-    async def test_send_image_file_returns_explicit_unsupported_error(self):
+    async def test_send_image_file_uploads_and_sends_markdown_media_id(self):
         from gateway.platforms.dingtalk import DingTalkAdapter
         adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        adapter._http_client = AsyncMock()
+        adapter._send_webhook_json = AsyncMock(return_value=MagicMock(success=True))
+        adapter._upload_media = AsyncMock(return_value="@image-media")
 
-        result = await adapter.send_image_file("chat-123", "/tmp/demo.png")
+        result = await adapter.send_image_file(
+            "chat-123",
+            "/tmp/demo.png",
+            caption="Preview",
+            metadata={"session_webhook": "https://dingtalk.example/webhook"},
+        )
 
-        assert result.success is False
-        assert result.error and "do not support local image uploads" in result.error
+        assert result.success is True
+        adapter._upload_media.assert_awaited_once_with("/tmp/demo.png", media_type="image")
+        payload = adapter._send_webhook_json.await_args.kwargs["payload"]
+        assert payload["msgtype"] == "markdown"
+        assert "Preview" in payload["markdown"]["text"]
+        assert "![image](@image-media)" in payload["markdown"]["text"]
 
     @pytest.mark.asyncio
-    async def test_send_document_returns_explicit_unsupported_error(self):
+    async def test_send_document_uploads_and_sends_file_attachment(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        adapter._http_client = AsyncMock()
+        adapter._send_webhook_json = AsyncMock(return_value=MagicMock(success=True))
+        adapter._upload_media = AsyncMock(return_value="@file-media")
+
+        result = await adapter.send_document(
+            "chat-123",
+            "/tmp/demo.pdf",
+            file_name="report.pdf",
+            metadata={"session_webhook": "https://dingtalk.example/webhook"},
+        )
+
+        assert result.success is True
+        adapter._upload_media.assert_awaited_once_with("/tmp/demo.pdf", media_type="file")
+        payload = adapter._send_webhook_json.await_args.kwargs["payload"]
+        assert payload["msgtype"] == "file"
+        assert payload["file"]["mediaId"] == "@file-media"
+        assert payload["file"]["fileName"] == "report.pdf"
+        assert payload["file"]["fileType"] == "pdf"
+
+    @pytest.mark.asyncio
+    async def test_send_document_fails_without_webhook(self):
         from gateway.platforms.dingtalk import DingTalkAdapter
         adapter = DingTalkAdapter(PlatformConfig(enabled=True))
 
         result = await adapter.send_document("chat-123", "/tmp/demo.pdf")
 
         assert result.success is False
-        assert result.error and "do not support local file attachments" in result.error
+        assert "session_webhook" in result.error
+
+    @pytest.mark.asyncio
+    async def test_send_image_file_stops_when_upload_fails(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        adapter._http_client = AsyncMock()
+        adapter._send_webhook_json = AsyncMock()
+        adapter._upload_media = AsyncMock(return_value=None)
+
+        result = await adapter.send_image_file(
+            "chat-123",
+            "/tmp/demo.png",
+            metadata={"session_webhook": "https://dingtalk.example/webhook"},
+        )
+
+        assert result.success is False
+        adapter._send_webhook_json.assert_not_awaited()
+
+    def test_guess_file_type_defaults_to_bin(self):
+        from gateway.platforms.dingtalk import DingTalkAdapter
+
+        assert DingTalkAdapter._guess_file_type("README") == "bin"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/gateway/test_dingtalk.py
+++ b/tests/gateway/test_dingtalk.py
@@ -190,13 +190,80 @@ class TestSend:
 
         assert result.success is True
         payload = mock_client.post.call_args.kwargs["json"]
+        assert payload["msgtype"] == "image"
+        assert payload["image"]["picURL"] == "https://example.com/demo.png"
+
+
+    @pytest.mark.asyncio
+    async def test_send_image_file_uploads_and_sends_media_id(self):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        adapter._upload_media = AsyncMock(return_value="@image-media")
+        adapter._send_webhook_json = AsyncMock(return_value=MagicMock(success=True))
+
+        result = await adapter.send_image_file(
+            "chat-123",
+            "/tmp/demo.png",
+            caption="Preview",
+            metadata={"session_webhook": "https://dingtalk.example/webhook"},
+        )
+
+        assert result.success is True
+        adapter._upload_media.assert_awaited_once_with("/tmp/demo.png", media_type="image")
+        payload = adapter._send_webhook_json.await_args.kwargs["payload"]
         assert payload["msgtype"] == "markdown"
-        assert payload["markdown"]["text"] == "Screenshot\n\n![image](https://example.com/demo.png)"
+        assert "Preview" in payload["markdown"]["text"]
+        assert "![image](@image-media)" in payload["markdown"]["text"]
 
 
-# ---------------------------------------------------------------------------
-# Connect / disconnect
-# ---------------------------------------------------------------------------
+    @pytest.mark.asyncio
+    async def test_send_document_uploads_and_sends_file(self):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        adapter._upload_media = AsyncMock(return_value="@file-media")
+        adapter._send_webhook_json = AsyncMock(return_value=MagicMock(success=True))
+
+        result = await adapter.send_document(
+            "chat-123",
+            "/tmp/demo.pdf",
+            file_name="report.pdf",
+            metadata={"session_webhook": "https://dingtalk.example/webhook"},
+        )
+
+        assert result.success is True
+        adapter._upload_media.assert_awaited_once_with("/tmp/demo.pdf", media_type="file")
+        payload = adapter._send_webhook_json.await_args.kwargs["payload"]
+        assert payload["msgtype"] == "file"
+        assert payload["file"] == {
+            "mediaId": "@file-media",
+            "fileName": "report.pdf",
+            "fileType": "pdf",
+        }
+
+
+    @pytest.mark.asyncio
+    async def test_http_200_nonzero_errcode_is_failure(self):
+        from plugins.platforms.dingtalk.adapter import DingTalkAdapter
+
+        adapter = DingTalkAdapter(PlatformConfig(enabled=True))
+        response = MagicMock(status_code=200, text='{"errcode": 400}',
+                             json=lambda: {"errcode": 400, "errmsg": "rejected"})
+        client = AsyncMock()
+        client.post = AsyncMock(return_value=response)
+        adapter._http_client = client
+
+        result = await adapter.send(
+            "chat-123",
+            "Hello",
+            metadata={"session_webhook": "https://dingtalk.example/webhook"},
+        )
+
+        assert result.success is False
+        assert "rejected" in result.error
+
+
 
 
 class TestConnect:


### PR DESCRIPTION
## What does this PR do?

This PR is a focused follow-up to the earlier DingTalk webhook-media fix that
landed upstream as commit `c705c7ac9` (`fix(dingtalk): clarify webhook media behavior`).

It fixes the remaining real delivery gap from [#22487](/mnt/d/hermes-agent/.git):
DingTalk gateway sessions could send text, but local images and local files
still were not delivered through the real DingTalk reply path.

Before this patch:

- remote images were always downgraded to markdown image links
- local images returned an unsupported error
- local files returned an unsupported error

After this patch:

- remote image URLs are sent as native `image.picURL` messages
- local images are uploaded via DingTalk media upload and then sent through
  markdown using the returned `@media_id`
- local files are uploaded via DingTalk media upload and then sent as native
  `file` attachments

The upload + send flow stays internal to the DingTalk adapter, so Hermes still
exposes a single send operation to callers.

That atomicity point is important here: DingTalk's local-image delivery path is
inherently a two-step platform interaction (`media/upload(type=image)` first,
then webhook send), but Hermes must not expose that split to the agent layer.
From the agent's point of view, `send_image_file(...)` is still one operation
with one success/failure result. The adapter owns the internal upload + send
sequence and keeps partial platform state out of the generic gateway contract.

This PR uses the real DingTalk behavior that was verified end-to-end against a
live bot:

- remote images: native webhook `image.picURL`
- local images: `media/upload?type=image` -> markdown `![image](@media_id)`
- local files: `media/upload?type=file` -> native webhook `file.mediaId`

## Related Issue

Fixes #22487

Follow-up to the earlier merged DingTalk webhook-media fix that landed as
`c705c7ac9` (`fix(dingtalk): clarify webhook media behavior`).

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change)

## Changes Made

- Updated [gateway/platforms/dingtalk.py](/mnt/d/hermes-agent/gateway/platforms/dingtalk.py)
  so remote images use the native DingTalk `image.picURL` webhook payload.
- Added an internal DingTalk media upload helper that calls
  `oapi.dingtalk.com/media/upload` and returns the `media_id`.
- Updated local-image sending to upload the image and then send markdown with
  `![image](@media_id)`, which matches the real DingTalk rendering behavior for
  local image replies.
- Updated local-document sending to upload the file and then send a native
  DingTalk `file` payload with `mediaId`, `fileName`, and `fileType`.
- Kept the upload + send flow adapter-internal so callers still see a single
  `send_image_file(...)` / `send_document(...)` operation rather than a manual
  two-step upload/send protocol.
- Explicitly preserved agent-facing atomicity for local-image sends even though
  the underlying DingTalk platform requires two HTTP steps.
- Added focused tests in
  [tests/gateway/test_dingtalk.py](/mnt/d/hermes-agent/tests/gateway/test_dingtalk.py)
  covering:
  - native remote image payloads
  - local image upload + markdown media rendering
  - local file upload + native file attachment payloads
  - failure behavior when media upload fails
  - file type fallback behavior

## How to Test

1. Run:
   `python3 -m pytest -q tests/gateway/test_dingtalk.py`
2. Verify the focused DingTalk adapter suite passes locally.
3. Real DingTalk E2E verification:
   use a live DingTalk bot + live session webhook and verify:
   - remote image delivery through native `image.picURL`
   - local image delivery through `media/upload(type=image)` +
     markdown `![image](@media_id)`
   - local file delivery through `media/upload(type=file)` +
     native `file.mediaId`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 / WSL

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Local verification:

```text
$ python3 -m pytest -q tests/gateway/test_dingtalk.py
68 passed in 37.55s
```

Live DingTalk smoke with the updated adapter:

```text
CONNECT= True
REMOTE_IMAGE= True None
DOCUMENT= True None
LOCAL_IMAGE= True None
```

The implementation path above was also validated manually against a live
DingTalk bot before landing:

- local image uploaded with `media/upload?type=image` and rendered in chat via
  markdown `![image](@media_id)`
- local PNG uploaded with `media/upload?type=file` and delivered as a real file
  attachment
- local text file uploaded with `media/upload?type=file` and delivered as a
  real file attachment
