### PR TITLE
fix(auxiliary): import DEFAULT_CONFIG from hermes_cli.config

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -100,7 +100,7 @@ class _OpenAIProxy:
 OpenAI = _OpenAIProxy()  # module-level name, resolves lazily on call/isinstance
 
 from agent.credential_pool import load_pool
-from hermes_cli.config import get_hermes_home
+from hermes_cli.config import DEFAULT_CONFIG, get_hermes_home
 from hermes_constants import OPENROUTER_BASE_URL
 from utils import base_url_host_matches, base_url_hostname, normalize_proxy_env_vars
 


### PR DESCRIPTION
## Summary

`agent/auxiliary_client.py` references `DEFAULT_CONFIG.get("auxiliary", {})` at lines 3874 and 4249, but only `get_hermes_home` was imported from `hermes_cli.config`.

This caused `NameError: name 'DEFAULT_CONFIG' is not defined` during context compression when `call_llm()` triggers auxiliary LLM calls.

## Fix

Add `DEFAULT_CONFIG` to the import statement on line 103:

```python
from hermes_cli.config import DEFAULT_CONFIG, get_hermes_home
```

## Testing

- `DEFAULT_CONFIG` is defined in `hermes_cli/config.py` at line 437
- Import now resolves correctly
- Context compression no longer raises NameError

## Fixes

Closes #23542