### PR TITLE
fix(agent): avoid Codex stream for compression summaries

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -43,6 +43,7 @@ Payment / credit exhaustion fallback:
 import json
 import logging
 import os
+import queue
 import threading
 import time
 from pathlib import Path  # noqa: F401 — used by test mocks
@@ -719,7 +720,7 @@ class _CodexCompletionsAdapter:
 
         def _check_cancelled() -> None:
             if deadline is not None and time.monotonic() >= deadline:
-                timed_out.set()
+                _close_client_on_timeout()
                 raise TimeoutError(_timeout_message())
             try:
                 from tools.interrupt import is_interrupted
@@ -743,9 +744,43 @@ class _CodexCompletionsAdapter:
                 timeout_timer = threading.Timer(float(total_timeout), _close_client_on_timeout)
                 timeout_timer.daemon = True
                 timeout_timer.start()
+            def _iter_stream_events(stream: Any):
+                if deadline is None:
+                    yield from stream
+                    return
+
+                event_queue: "queue.Queue[tuple[str, Any]]" = queue.Queue()
+
+                def _consume_stream() -> None:
+                    try:
+                        for event in stream:
+                            event_queue.put(("event", event))
+                        event_queue.put(("done", None))
+                    except BaseException as exc:  # pragma: no cover - defensive for SDK stream errors
+                        event_queue.put(("error", exc))
+
+                threading.Thread(target=_consume_stream, daemon=True).start()
+                while True:
+                    _check_cancelled()
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        _close_client_on_timeout()
+                        raise TimeoutError(_timeout_message())
+                    try:
+                        kind, payload = event_queue.get(timeout=remaining)
+                    except queue.Empty as exc:
+                        _close_client_on_timeout()
+                        raise TimeoutError(_timeout_message()) from exc
+                    if kind == "event":
+                        yield payload
+                    elif kind == "done":
+                        break
+                    else:
+                        raise payload
+
             _check_cancelled()
             with self._client.responses.stream(**resp_kwargs) as stream:
-                for _event in stream:
+                for _event in _iter_stream_events(stream):
                     _check_cancelled()
                     _etype = getattr(_event, "type", "")
                     if _etype == "response.output_item.done":
@@ -2255,6 +2290,7 @@ def _retry_same_provider_sync(
             api_key=resolved_api_key,
             api_mode=resolved_api_mode,
             main_runtime=main_runtime,
+            task=task,
         )
     if retry_client is None:
         raise RuntimeError(
@@ -2312,6 +2348,7 @@ async def _retry_same_provider_async(
             base_url=resolved_base_url,
             api_key=resolved_api_key,
             api_mode=resolved_api_mode,
+            task=task,
         )
     if retry_client is None:
         raise RuntimeError(
@@ -2429,19 +2466,29 @@ def _try_payment_fallback(
     return None, None, ""
 
 
-def _resolve_auto(main_runtime: Optional[Dict[str, Any]] = None) -> Tuple[Optional[OpenAI], Optional[str]]:
+def _resolve_auto(
+    main_runtime: Optional[Dict[str, Any]] = None,
+    *,
+    task: Optional[str] = None,
+) -> Tuple[Optional[OpenAI], Optional[str]]:
     """Full auto-detection chain.
 
     Priority:
       1. User's main provider + main model, regardless of provider type.
-         This means auxiliary tasks (compression, vision, web extraction,
-         session search, etc.) use the same model the user configured for
-         chat.  Users on OpenRouter/Nous get their chosen chat model; users
-         on DeepSeek/ZAI/Alibaba get theirs; etc.  Running aux tasks on the
-         user's picked model keeps behavior predictable — no surprise
-         switches to a cheap fallback model for side tasks.
-      2. OpenRouter → Nous → custom → Codex → API-key providers (fallback
-         chain, only used when the main provider has no working client).
+         This means auxiliary tasks (vision, web extraction, session search,
+         etc.) usually use the same model the user configured for chat. Users
+         on OpenRouter/Nous get their chosen chat model; users on DeepSeek/ZAI/
+         Alibaba get theirs; etc. Running aux tasks on the user's picked model
+         keeps behavior predictable — no surprise switches to a cheap fallback
+         model for side tasks.
+      2. Compression exception: when the main provider is OpenAI Codex, prefer
+         the normal auxiliary fallback chain first. Codex Responses streams are
+         comparatively slow and have caused 120s compression timeouts that drop
+         context, while OpenRouter/Nous/local aux models can summarize quickly.
+         If no other auxiliary backend exists, fall back to main Codex.
+      3. OpenRouter → Nous → custom → API-key providers (fallback chain, only
+         used when the main provider has no working client, or before Codex for
+         compression as described above).
     """
     global auxiliary_is_nous, _stale_base_url_warned
     auxiliary_is_nous = False  # Reset — _try_nous() will set True if it wins
@@ -2480,6 +2527,32 @@ def _resolve_auto(main_runtime: Optional[Dict[str, Any]] = None) -> Tuple[Option
     # config.yaml (auxiliary.<task>.provider) still win over this.
     main_provider = runtime_provider or _read_main_provider()
     main_model = runtime_model or _read_main_model()
+    prefer_fallback_chain = (
+        (task or "").strip().lower() == "compression"
+        and _normalize_aux_provider(main_provider) == "openai-codex"
+    )
+
+    if prefer_fallback_chain:
+        tried_preferred = []
+        for label, try_fn in _get_provider_chain():
+            client, model = try_fn()
+            if client is not None:
+                if tried_preferred:
+                    logger.info(
+                        "Auxiliary auto-detect: compression on Codex main using %s (%s) — skipped: %s",
+                        label, model or "default", ", ".join(tried_preferred),
+                    )
+                else:
+                    logger.info(
+                        "Auxiliary auto-detect: compression on Codex main using %s (%s)",
+                        label, model or "default",
+                    )
+                return client, model
+            tried_preferred.append(label)
+        logger.info(
+            "Auxiliary auto-detect: compression on Codex main found no faster auxiliary backend; falling back to Codex"
+        )
+
     if (main_provider and main_model
             and main_provider not in ("auto", "")):
         resolved_provider = main_provider
@@ -2626,6 +2699,7 @@ def resolve_provider_client(
     api_mode: str = None,
     main_runtime: Optional[Dict[str, Any]] = None,
     is_vision: bool = False,
+    task: Optional[str] = None,
 ) -> Tuple[Optional[Any], Optional[str]]:
     """Central router: given a provider name and optional model, return a
     configured client with the correct auth, base URL, and API format.
@@ -2718,7 +2792,7 @@ def resolve_provider_client(
 
     # ── Auto: try all providers in priority order ────────────────────
     if provider == "auto":
-        client, resolved = _resolve_auto(main_runtime=main_runtime)
+        client, resolved = _resolve_auto(main_runtime=main_runtime, task=task)
         if client is None:
             return None, None
         # When auto-detection lands on a non-OpenRouter provider (e.g. a
@@ -3182,6 +3256,7 @@ def get_text_auxiliary_client(
         explicit_api_key=api_key,
         api_mode=api_mode,
         main_runtime=main_runtime,
+        task=task,
     )
 
 
@@ -3201,6 +3276,7 @@ def get_async_text_auxiliary_client(task: str = "", *, main_runtime: Optional[Di
         explicit_api_key=api_key,
         api_mode=api_mode,
         main_runtime=main_runtime,
+        task=task,
     )
 
 
@@ -3476,11 +3552,20 @@ def _client_cache_key(
     api_mode: Optional[str] = None,
     main_runtime: Optional[Dict[str, Any]] = None,
     is_vision: bool = False,
+    task: Optional[str] = None,
 ) -> tuple:
     runtime = _normalize_main_runtime(main_runtime)
     runtime_key = tuple(runtime.get(field, "") for field in _MAIN_RUNTIME_FIELDS) if provider == "auto" else ()
     pool_hint = _pool_cache_hint(provider, main_runtime=main_runtime)
-    return (provider, async_mode, base_url or "", api_key or "", api_mode or "", runtime_key, is_vision, pool_hint)
+    # Some auto-routing decisions are task-specific (notably compression on
+    # Codex main sessions), so keep separate cache entries only for auto
+    # clients that actually supply a task. Preserve the upstream key shape
+    # otherwise so tests/manual cache cleanup that use explicit providers keep
+    # working.
+    base_key = (provider, async_mode, base_url or "", api_key or "", api_mode or "", runtime_key, is_vision)
+    if pool_hint:
+        base_key = (*base_key, pool_hint)
+    return (*base_key, task) if provider == "auto" and task else base_key
 
 
 def _store_cached_client(cache_key: tuple, client: Any, default_model: Optional[str], *, bound_loop: Any = None) -> None:
@@ -3507,6 +3592,7 @@ def _refresh_nous_auxiliary_client(
     api_mode: Optional[str] = None,
     main_runtime: Optional[Dict[str, Any]] = None,
     is_vision: bool = False,
+    task: Optional[str] = None,
 ) -> Tuple[Optional[Any], Optional[str]]:
     """Refresh Nous runtime creds, rebuild the client, and replace the cache entry."""
     runtime = _resolve_nous_runtime_api(force_refresh=True)
@@ -3536,6 +3622,7 @@ def _refresh_nous_auxiliary_client(
         api_mode=api_mode,
         main_runtime=main_runtime,
         is_vision=is_vision,
+        task=task,
     )
     _store_cached_client(cache_key, client, final_model, bound_loop=current_loop)
     return client, final_model
@@ -3673,6 +3760,7 @@ def _get_cached_client(
     api_mode: str = None,
     main_runtime: Optional[Dict[str, Any]] = None,
     is_vision: bool = False,
+    task: Optional[str] = None,
 ) -> Tuple[Optional[Any], Optional[str]]:
     """Get or create a cached client for the given provider.
 
@@ -3710,6 +3798,7 @@ def _get_cached_client(
         api_mode=api_mode,
         main_runtime=main_runtime,
         is_vision=is_vision,
+        task=task,
     )
     with _client_cache_lock:
         if cache_key in _client_cache:
@@ -3742,6 +3831,7 @@ def _get_cached_client(
         api_mode=api_mode,
         main_runtime=runtime,
         is_vision=is_vision,
+        task=task,
     )
     if client is not None:
         # For async clients, remember which loop they were created on so we
@@ -4125,6 +4215,7 @@ def call_llm(
             api_key=resolved_api_key,
             api_mode=resolved_api_mode,
             main_runtime=main_runtime,
+            task=task,
         )
         if client is None:
             # When the user explicitly chose a non-OpenRouter provider but no
@@ -4145,7 +4236,7 @@ def call_llm(
             if not resolved_base_url:
                 logger.info("Auxiliary %s: provider %s unavailable, trying auto-detection chain",
                             task or "call", resolved_provider)
-                client, final_model = _get_cached_client("auto", main_runtime=main_runtime)
+                client, final_model = _get_cached_client("auto", main_runtime=main_runtime, task=task)
         if client is None:
             raise RuntimeError(
                 f"No LLM provider configured for task={task} provider={resolved_provider}. "
@@ -4497,6 +4588,7 @@ async def async_call_llm(
             base_url=resolved_base_url,
             api_key=resolved_api_key,
             api_mode=resolved_api_mode,
+            task=task,
         )
         if client is None:
             _explicit = (resolved_provider or "").strip().lower()
@@ -4509,7 +4601,7 @@ async def async_call_llm(
             if not resolved_base_url:
                 logger.info("Auxiliary %s: provider %s unavailable, trying auto-detection chain",
                             task or "call", resolved_provider)
-                client, final_model = _get_cached_client("auto", async_mode=True)
+                client, final_model = _get_cached_client("auto", async_mode=True, task=task)
         if client is None:
             raise RuntimeError(
                 f"No LLM provider configured for task={task} provider={resolved_provider}. "

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2093,7 +2093,7 @@ class TestCodexAuxiliaryAdapterTimeout:
                 return False
 
             def __iter__(self):
-                for _ in range(5):
+                for _ in range(20):
                     time.sleep(0.03)
                     yield SimpleNamespace(type="response.in_progress")
 
@@ -2120,7 +2120,7 @@ class TestCodexAuxiliaryAdapterTimeout:
                 timeout=0.05,
             )
 
-        assert time.monotonic() - started < 0.14
+        assert time.monotonic() - started < 0.25
 
 
 # ---------------------------------------------------------------------------

--- a/tests/agent/test_auxiliary_main_first.py
+++ b/tests/agent/test_auxiliary_main_first.py
@@ -5,10 +5,12 @@ tasks routed through a cheap provider-side default (Gemini Flash) while
 non-aggregator users got their main model.  This made behavior inconsistent
 and surprising — users picked Claude but got Gemini Flash summaries.
 
-The current policy: ``auto`` means "use my main chat model" for every user,
+The current policy: ``auto`` means "use my main chat model" for most tasks,
 regardless of provider type.  Explicit per-task overrides in ``config.yaml``
 (``auxiliary.<task>.provider``) still win.  The cheap fallback chain only
-runs when the main provider has no working client.
+runs when the main provider has no working client, except compression on a
+Codex main session, which tries the faster auxiliary chain before falling back
+to Codex to avoid slow Responses streams dropping context after timeout.
 """
 
 from __future__ import annotations
@@ -161,6 +163,81 @@ class TestResolveAutoMainFirst:
         # Runtime override wins
         assert mock_resolve.call_args.args[0] == "anthropic"
         assert mock_resolve.call_args.args[1] == "runtime-model"
+
+    def test_compression_on_codex_main_prefers_aux_chain(self):
+        """Compression should avoid Codex Responses when a faster aux backend exists."""
+        chain_client = MagicMock()
+        codex_client = MagicMock()
+
+        with patch(
+            "agent.auxiliary_client._read_main_provider", return_value="openai-codex",
+        ), patch(
+            "agent.auxiliary_client._read_main_model", return_value="gpt-5.5",
+        ), patch(
+            "agent.auxiliary_client._try_openrouter",
+            return_value=(chain_client, "google/gemini-3-flash-preview"),
+        ), patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(codex_client, "gpt-5.5"),
+        ) as mock_resolve:
+            from agent.auxiliary_client import _resolve_auto
+
+            client, model = _resolve_auto(task="compression")
+
+        assert client is chain_client
+        assert model == "google/gemini-3-flash-preview"
+        mock_resolve.assert_not_called()
+
+    def test_non_compression_on_codex_main_still_uses_main(self):
+        """Only compression gets the Codex avoidance; other aux tasks keep main-first."""
+        codex_client = MagicMock()
+
+        with patch(
+            "agent.auxiliary_client._read_main_provider", return_value="openai-codex",
+        ), patch(
+            "agent.auxiliary_client._read_main_model", return_value="gpt-5.5",
+        ), patch(
+            "agent.auxiliary_client._try_openrouter",
+        ) as mock_try_openrouter, patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(codex_client, "gpt-5.5"),
+        ) as mock_resolve:
+            from agent.auxiliary_client import _resolve_auto
+
+            client, model = _resolve_auto(task="session_search")
+
+        assert client is codex_client
+        assert model == "gpt-5.5"
+        mock_try_openrouter.assert_not_called()
+        mock_resolve.assert_called_once()
+
+    def test_compression_on_codex_main_falls_back_to_codex_when_no_aux_chain(self):
+        """Codex-only users should still have compression instead of no provider."""
+        codex_client = MagicMock()
+
+        with patch(
+            "agent.auxiliary_client._read_main_provider", return_value="openai-codex",
+        ), patch(
+            "agent.auxiliary_client._read_main_model", return_value="gpt-5.5",
+        ), patch(
+            "agent.auxiliary_client._try_openrouter", return_value=(None, None),
+        ), patch(
+            "agent.auxiliary_client._try_nous", return_value=(None, None),
+        ), patch(
+            "agent.auxiliary_client._try_custom_endpoint", return_value=(None, None),
+        ), patch(
+            "agent.auxiliary_client._resolve_api_key_provider", return_value=(None, None),
+        ), patch(
+            "agent.auxiliary_client.resolve_provider_client",
+            return_value=(codex_client, "gpt-5.5"),
+        ) as mock_resolve:
+            from agent.auxiliary_client import _resolve_auto
+
+            client, model = _resolve_auto(task="compression")
+
+        assert client is codex_client
+        assert model == "gpt-5.5"
+        mock_resolve.assert_called_once()
 
 
 # ── Vision — resolve_vision_provider_client ─────────────────────────────────


### PR DESCRIPTION
## What does this PR do?

Fixes a compression-summary failure mode for sessions whose main provider is Codex. Compression uses the text auxiliary `auto` provider path; with Codex as the main provider, `auto` was main-first and routed compression through the Codex Responses stream. If that stream stays alive but emits too slowly, compression can exceed its total timeout and fall back to a context marker instead of a summary.

This PR keeps the existing main-model-first behavior for normal auxiliary tasks, but adds a targeted exception for `task == "compression"` on Codex main sessions: try the faster auxiliary fallback chain first, then fall back to Codex if no auxiliary backend is available. It also makes `auto` client caching task-aware only when a task is supplied, so compression and non-compression routes do not reuse the wrong cached client.

While validating the timeout path, this also tightens Codex stream total-timeout enforcement so blocking/slow stream iteration can be interrupted by the configured total timeout and still evicts the poisoned cached client.

## Related Issue

No issue filed yet.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `agent/auxiliary_client.py`
  - Thread `task` through auxiliary provider resolution and cached-client construction.
  - Preserve explicit auxiliary provider overrides as highest priority.
  - Preserve main-first `auto` routing for non-compression tasks.
  - Prefer the non-Codex auxiliary fallback chain for compression when the main provider is Codex, with Codex fallback if no aux backend is available.
  - Keep cache keys task-aware only for `provider == "auto"` with a supplied task.
  - Enforce Codex auxiliary Responses stream total timeout even when stream iteration blocks between events.
- `tests/agent/test_auxiliary_main_first.py`
  - Add regression coverage for the Codex/compression routing exception and non-compression main-first behavior.
- `tests/agent/test_auxiliary_client.py`
  - Stabilize and cover Codex total timeout behavior while the stream keeps emitting slow progress events.

## How to Test

1. Configure Hermes with Codex as the main provider and a faster auxiliary backend available (for example OpenRouter/Nous).
2. Trigger context compression, or call the text auxiliary path with `task="compression"` and `provider="auto"`.
3. Verify compression chooses the auxiliary fallback chain before Codex, while a non-compression task such as `session_search` still resolves to the Codex main provider.

Automated checks run locally on macOS 15.7.2:

```bash
python scripts/check-windows-footguns.py --diff HEAD~1
python -m pytest tests/agent/test_auxiliary_main_first.py tests/agent/test_auxiliary_client.py tests/run_agent/test_provider_parity.py::TestAuxiliaryClientProviderPriority tests/run_agent/test_async_httpx_del_neuter.py tests/run_agent/test_compression_feasibility.py -q -o 'addopts='
scripts/run_tests.sh tests/agent/test_auxiliary_main_first.py tests/agent/test_auxiliary_client.py tests/run_agent/test_provider_parity.py::TestAuxiliaryClientProviderPriority tests/run_agent/test_async_httpx_del_neuter.py tests/run_agent/test_compression_feasibility.py
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.7.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted CI-parity subset:

```text
201 passed in 3.05s
```

Note: `scripts/run_tests.sh` without arguments currently exits early with `ARGS[@]: unbound variable` on this checkout. Running the full suite as `scripts/run_tests.sh tests/` executed but failed broadly outside this change area in this local environment; the focused affected suites above pass under the wrapper.
