### PR TITLE
fix(utils): restore default mode for new atomic writes

### DIFF
--- a/tests/hermes_cli/test_atomic_json_write.py
+++ b/tests/hermes_cli/test_atomic_json_write.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import stat
 from pathlib import Path
 from unittest.mock import patch
 
@@ -35,6 +36,14 @@ class TestAtomicJsonWrite:
         atomic_json_write(target, {"new": True})
         result = json.loads(target.read_text())
         assert result == {"new": True}
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX file permissions only")
+    def test_new_file_defaults_to_world_readable_mode(self, tmp_path):
+        target = tmp_path / "new.json"
+
+        atomic_json_write(target, {"mode": "default"})
+
+        assert stat.S_IMODE(target.stat().st_mode) == 0o644
 
     def test_preserves_original_on_serialization_error(self, tmp_path):
         target = tmp_path / "data.json"

--- a/tests/hermes_cli/test_atomic_yaml_write.py
+++ b/tests/hermes_cli/test_atomic_yaml_write.py
@@ -1,5 +1,7 @@
 """Tests for utils.atomic_yaml_write — crash-safe YAML file writes."""
 
+import os
+import stat
 from pathlib import Path
 from unittest.mock import patch
 
@@ -42,3 +44,11 @@ class TestAtomicYamlWrite:
         text = target.read_text(encoding="utf-8")
         assert "key: value" in text
         assert "# comment" in text
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX file permissions only")
+    def test_new_file_defaults_to_world_readable_mode(self, tmp_path):
+        target = tmp_path / "data.yaml"
+
+        atomic_yaml_write(target, {"key": "value"})
+
+        assert stat.S_IMODE(target.stat().st_mode) == 0o644

--- a/utils.py
+++ b/utils.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 
 TRUTHY_STRINGS = frozenset({"1", "true", "yes", "on"})
+_DEFAULT_ATOMIC_FILE_MODE = 0o644
 
 
 def is_truthy_value(value: Any, default: bool = False) -> bool:
@@ -51,7 +52,7 @@ def _restore_file_mode(path: Path, mode: "int | None") -> None:
     right after ``os.replace`` restores the original permissions.
     """
     if mode is None:
-        return
+        mode = _DEFAULT_ATOMIC_FILE_MODE
     try:
         os.chmod(path, mode)
     except OSError:


### PR DESCRIPTION
## What does this PR do?

Restores the expected default file mode for new files created through `atomic_json_write()` and `atomic_yaml_write()`. When there was no pre-existing target file, the post-replace mode restore path no-op'd, leaving brand-new files stuck at `0o600` from `mkstemp()`.

## Related Issue

Fixes #23613

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- default `_restore_file_mode()` to `0o644` when an atomic write is creating a brand-new file
- keep existing-file mode preservation behavior unchanged
- add POSIX regression coverage for both JSON and YAML atomic writes

## How to Test

1. `uv run --frozen --extra dev pytest -q -o addopts='' tests/hermes_cli/test_atomic_json_write.py tests/hermes_cli/test_atomic_yaml_write.py`
2. `uv run --frozen ruff check utils.py tests/hermes_cli/test_atomic_json_write.py tests/hermes_cli/test_atomic_yaml_write.py`
3. On POSIX, verify the new-file mode assertions land at `0o644`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `19 passed in 1.34s`
