### PR TITLE
fix: add Telegram model picker text search

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -1931,6 +1931,17 @@ class TelegramAdapter(BasePlatformAdapter):
 
     _MODEL_PAGE_SIZE = 8
 
+    def _filter_model_picker_models(self, models: list, query: str) -> list:
+        """Return model ids matching a Telegram picker text query."""
+        terms = [term for term in re.split(r"\s+", (query or "").strip().lower()) if term]
+        if not terms:
+            return list(models)
+        return [
+            model_id
+            for model_id in models
+            if all(term in str(model_id).lower() for term in terms)
+        ]
+
     def _build_model_keyboard(self, models: list, page: int) -> tuple:
         """Build paginated model buttons. Returns (keyboard, page_info_text)."""
         page_size = self._MODEL_PAGE_SIZE
@@ -1971,6 +1982,75 @@ class TelegramAdapter(BasePlatformAdapter):
 
         page_info = f" ({start + 1}–{end} of {total})" if total_pages > 1 else ""
         return InlineKeyboardMarkup(rows), page_info
+
+    async def _handle_model_picker_text_query(self, message: Message) -> bool:
+        """Filter the active model picker when the user types a search query."""
+        chat_id = str(getattr(getattr(message, "chat", None), "id", ""))
+        state = self._model_picker_state.get(chat_id)
+        if not state:
+            return False
+
+        query = (getattr(message, "text", "") or "").strip()
+        if not query:
+            return False
+
+        providers = state.get("providers", [])
+        matches: list = []
+        matched_provider: Optional[Dict[str, Any]] = None
+        for provider in providers:
+            provider_matches = self._filter_model_picker_models(
+                provider.get("models", []), query
+            )
+            if provider_matches and matched_provider is None:
+                matched_provider = provider
+                matches = provider_matches
+
+        if not matched_provider:
+            keyboard = InlineKeyboardMarkup([
+                [InlineKeyboardButton("◀ Back", callback_data="mb")],
+                [InlineKeyboardButton("✗ Cancel", callback_data="mx")],
+            ])
+            text = (
+                f"⚙ *Model Configuration*\n\n"
+                f"No models found for `{query}`.\n"
+                f"Type another search query, or go back to providers."
+            )
+        else:
+            provider_slug = matched_provider.get("slug", "")
+            state["selected_provider"] = provider_slug
+            state["selected_provider_name"] = matched_provider.get("name", provider_slug)
+            state["model_list"] = matches
+            state["model_page"] = 0
+            keyboard, page_info = self._build_model_keyboard(matches, 0)
+            text = (
+                f"⚙ *Model Configuration*\n\n"
+                f"Search: `{query}` — {len(matches)} matches\n"
+                f"Provider: *{state['selected_provider_name']}*{page_info}\n"
+                f"Select a model:"
+            )
+
+        msg_id = state.get("msg_id")
+        try:
+            if msg_id and self._bot:
+                await self._bot.edit_message_text(
+                    chat_id=int(chat_id),
+                    message_id=int(msg_id),
+                    text=text,
+                    parse_mode=ParseMode.MARKDOWN,
+                    reply_markup=keyboard,
+                )
+            elif hasattr(message, "edit_text"):
+                await message.edit_text(
+                    text=text,
+                    parse_mode=ParseMode.MARKDOWN,
+                    reply_markup=keyboard,
+                )
+            else:
+                return False
+        except Exception as exc:
+            logger.warning("[%s] Failed to filter model picker: %s", self.name, exc)
+            return False
+        return True
 
     async def _handle_model_picker_callback(
         self, query, data: str, chat_id: str
@@ -3437,6 +3517,8 @@ class TelegramAdapter(BasePlatformAdapter):
         them into a single MessageEvent before dispatching.
         """
         if not update.message or not update.message.text:
+            return
+        if await self._handle_model_picker_text_query(update.message):
             return
         if not self._should_process_message(update.message):
             return

--- a/tests/gateway/test_telegram_thread_fallback.py
+++ b/tests/gateway/test_telegram_thread_fallback.py
@@ -130,6 +130,11 @@ def _make_adapter():
     adapter._polling_conflict_count = 0
     adapter._polling_network_error_count = 0
     adapter._polling_error_callback_ref = None
+    adapter._pending_text_batches = {}
+    adapter._pending_text_batch_tasks = {}
+    adapter._model_picker_state = {}
+    adapter._text_batch_delay_seconds = 0
+    adapter._text_batch_split_delay_seconds = 0
     adapter.platform = Platform.TELEGRAM
     return adapter
 
@@ -527,6 +532,66 @@ async def test_send_model_picker_uses_metadata_reply_fallback_for_dm_topics():
     assert call_log[0]["reply_to_message_id"] == 462
     assert call_log[0]["message_thread_id"] == 20197
     assert "direct_messages_topic_id" not in call_log[0]
+
+
+@pytest.mark.asyncio
+async def test_model_picker_text_query_filters_models_before_dispatch():
+    """A text reply after /model should filter picker results instead of reaching the agent."""
+    adapter = _make_adapter()
+    edit_calls = []
+    dispatched = []
+
+    adapter._bot = SimpleNamespace()
+    adapter.handle_message = lambda event: dispatched.append(event)
+    adapter._model_picker_state = {
+        "123": {
+            "providers": [
+                {
+                    "name": "Nvidia",
+                    "slug": "nvidia",
+                    "models": [
+                        "nvidia/llama-3.1-nemotron-ultra-253b-v1",
+                        "nvidia/llama-3.3-nemotron-super-49b-v1",
+                        "nvidia/mistral-nemo-12b",
+                        "meta/llama-3.1-8b-instruct",
+                    ],
+                    "total_models": 4,
+                }
+            ],
+            "session_key": "telegram:123",
+            "on_model_selected": lambda *_: None,
+            "current_model": "old-model",
+            "current_provider": "openrouter",
+        }
+    }
+
+    async def mock_edit_message_text(**kwargs):
+        edit_calls.append(dict(kwargs))
+
+    message = SimpleNamespace(
+        text="nemotron",
+        caption=None,
+        chat=SimpleNamespace(id=123, type="private", is_forum=False, title=None, full_name="Alice"),
+        from_user=SimpleNamespace(id=456, full_name="Alice"),
+        message_thread_id=None,
+        reply_to_message=None,
+        message_id=10,
+        date=None,
+        edit_text=mock_edit_message_text,
+    )
+    update = SimpleNamespace(message=message, update_id=99)
+
+    await adapter._handle_text_message(update, SimpleNamespace())
+
+    assert dispatched == []
+    assert edit_calls
+    assert "nemotron" in edit_calls[0]["text"]
+    assert "2 matches" in edit_calls[0]["text"]
+    keyboard = edit_calls[0]["reply_markup"].inline_keyboard
+    buttons = [button for row in keyboard for button in row]
+    model_buttons = [button for button in buttons if button.callback_data.startswith("mm:")]
+    assert [button.callback_data for button in model_buttons] == ["mm:0", "mm:1"]
+    assert all("nemotron" in button.text.lower() for button in model_buttons)
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Add Telegram model picker text search handling for active picker sessions
- Filter matching models before dispatching typed search text to the agent
- Add regression coverage for typed model search results

## Test Plan
- `git diff --check`
- `pytest -n0 tests/gateway/test_telegram_thread_fallback.py -q`

Fixes #23610
/claim #23610
