### PR TITLE
fix(model-picker): use live catalogs for api-key providers

### DIFF
--- a/hermes_cli/model_switch.py
+++ b/hermes_cli/model_switch.py
@@ -1360,12 +1360,16 @@ def list_authenticated_providers(
                 model_ids = _ids if _ids is not None else (curated.get(hermes_slug, []) or curated.get(pid, []))
             except Exception:
                 model_ids = curated.get(hermes_slug, []) or curated.get(pid, [])
+        elif overlay.auth_type == "api_key":
+            # For simple API-key providers, reuse the shared live discovery
+            # path so `/model` stays aligned with `/v1/models` when the
+            # provider exposes fresh inventory, while still falling back to
+            # curated + models.dev entries when the endpoint is unavailable.
+            model_ids = provider_model_ids(hermes_slug)
         else:
-            # Use curated list — look up by Hermes slug, fall back to overlay key
+            # OAuth/external-process providers without a dedicated live path
+            # keep the curated floor so the picker stays populated offline.
             model_ids = curated.get(hermes_slug, []) or curated.get(pid, [])
-            # Merge with models.dev for preferred providers (same rationale as above).
-            if hermes_slug in _MODELS_DEV_PREFERRED:
-                model_ids = _merge_with_models_dev(hermes_slug, model_ids)
         total = len(model_ids)
         top = model_ids[:max_models]
 

--- a/tests/hermes_cli/test_api_key_provider_model_list.py
+++ b/tests/hermes_cli/test_api_key_provider_model_list.py
@@ -1,0 +1,25 @@
+"""Regression tests for live model discovery in the /model picker."""
+
+import os
+from unittest.mock import patch
+
+from hermes_cli.model_switch import list_authenticated_providers
+
+
+@patch.dict(os.environ, {"NVIDIA_API_KEY": "test-key"}, clear=True)
+def test_api_key_provider_picker_uses_live_models_when_available():
+    live_models = [
+        "nvidia/nemotron-ultra-253b-v1",
+        "meta/llama-4-maverick-17b-128e-instruct",
+    ]
+
+    with patch("agent.models_dev.fetch_models_dev", return_value={}), \
+         patch("hermes_cli.models.provider_model_ids", return_value=live_models) as provider_ids:
+        providers = list_authenticated_providers(current_provider="openrouter", max_models=50)
+
+    nvidia = next((p for p in providers if p["slug"] == "nvidia"), None)
+
+    assert nvidia is not None
+    assert nvidia["models"] == live_models
+    assert nvidia["total_models"] == len(live_models)
+    provider_ids.assert_any_call("nvidia")


### PR DESCRIPTION
## What does this PR do?

Makes the gateway `/model` picker reuse `provider_model_ids()` for built-in API-key providers instead of staying stuck on the curated static table. That lets providers like NVIDIA, StepFun, GMI, and Z.AI surface their live `/v1/models` catalogs when credentials are present, while keeping the existing fallback chain if the endpoint is unavailable.

## Related Issue

Fixes #23609

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- route built-in `api_key` provider rows in `list_authenticated_providers()` through `provider_model_ids()`
- keep the dedicated aws-sdk path intact for Bedrock and curated fallback for non-api-key providers
- add a regression test proving the picker uses live inventory for an NVIDIA credentialed row

## How to Test

1. `uv run --frozen --extra dev pytest -q -o addopts='' tests/hermes_cli/test_api_key_provider_model_list.py tests/hermes_cli/test_copilot_in_model_list.py`
2. `uv run --frozen ruff check hermes_cli/model_switch.py tests/hermes_cli/test_api_key_provider_model_list.py tests/hermes_cli/test_copilot_in_model_list.py`
3. With `NVIDIA_API_KEY` set, verify the `/model` picker row is populated from the live catalog path instead of the curated floor only

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `3 passed in 2.08s`
