### PR TITLE
fix(local-env): block virtualenv activation leaks

### DIFF
--- a/tests/tools/test_local_env_blocklist.py
+++ b/tests/tools/test_local_env_blocklist.py
@@ -295,6 +295,13 @@ class TestBlocklistCoverage:
             "VERCEL_TOKEN",
             "VERCEL_PROJECT_ID",
             "VERCEL_TEAM_ID",
+            "VIRTUAL_ENV",
+            "VIRTUAL_ENV_PROMPT",
+            "UV_PROJECT_ENVIRONMENT",
+            "POETRY_ACTIVE",
+            "PIPENV_ACTIVE",
+            "CONDA_PREFIX",
+            "CONDA_DEFAULT_ENV",
         }
         assert extras.issubset(_HERMES_PROVIDER_ENV_BLOCKLIST)
 

--- a/tools/environments/local.py
+++ b/tools/environments/local.py
@@ -137,6 +137,13 @@ def _build_provider_env_blocklist() -> frozenset:
         "VERCEL_TOKEN",
         "VERCEL_PROJECT_ID",
         "VERCEL_TEAM_ID",
+        "VIRTUAL_ENV",
+        "VIRTUAL_ENV_PROMPT",
+        "UV_PROJECT_ENVIRONMENT",
+        "POETRY_ACTIVE",
+        "PIPENV_ACTIVE",
+        "CONDA_PREFIX",
+        "CONDA_DEFAULT_ENV",
     })
     return frozenset(blocked)
 


### PR DESCRIPTION
## What does this PR do?

Stops Hermes from leaking Python environment activation markers into local subprocesses, so package-manager commands run by the agent do not accidentally mutate Hermes' own runtime environment.

This change adds virtualenv and package-manager activation variables to the local environment blocklist used when Hermes prepares subprocess envs. That keeps project-local `uv`, `poetry`, `pipenv`, or conda commands from inheriting Hermes' active runtime markers.

## Related Issue

Fixes #23473

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `VIRTUAL_ENV`, `VIRTUAL_ENV_PROMPT`, `UV_PROJECT_ENVIRONMENT`, `POETRY_ACTIVE`, `PIPENV_ACTIVE`, `CONDA_PREFIX`, and `CONDA_DEFAULT_ENV` to `_HERMES_PROVIDER_ENV_BLOCKLIST` in `tools/environments/local.py`
- Extended `tests/tools/test_local_env_blocklist.py` to cover the newly blocked activation markers

## How to Test

1. Run `uv run --frozen --extra dev pytest -q -o addopts='' tests/tools/test_local_env_blocklist.py tests/tools/test_env_passthrough.py`
2. Run `uv run --frozen ruff check tools/environments/local.py tests/tools/test_local_env_blocklist.py tests/tools/test_env_passthrough.py`
3. Confirm the new activation variables are scrubbed from the sanitized local subprocess environment

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `35 passed, 8 warnings in 7.61s`
