### PR TITLE
fix(auxiliary): guard extract_content_or_reasoning against empty choices

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -4403,6 +4403,9 @@ def extract_content_or_reasoning(response) -> str:
     """
     import re
 
+    if not getattr(response, "choices", None):
+        return ""
+
     msg = response.choices[0].message
     content = (msg.content or "").strip()
 

--- a/tests/tools/test_llm_content_none_guard.py
+++ b/tests/tools/test_llm_content_none_guard.py
@@ -292,3 +292,18 @@ class TestExtractContentOrReasoning:
         """When both content and reasoning exist, content wins."""
         response = _make_response("Actual answer", reasoning="Internal reasoning")
         assert extract_content_or_reasoning(response) == "Actual answer"
+
+    def test_empty_choices_returns_empty(self):
+        """Empty choices list (content filtering, provider error) must not crash."""
+        response = types.SimpleNamespace(choices=[])
+        assert extract_content_or_reasoning(response) == ""
+
+    def test_none_choices_returns_empty(self):
+        """None choices attribute must not crash."""
+        response = types.SimpleNamespace(choices=None)
+        assert extract_content_or_reasoning(response) == ""
+
+    def test_missing_choices_attr_returns_empty(self):
+        """Response without choices attribute must not crash."""
+        response = types.SimpleNamespace()
+        assert extract_content_or_reasoning(response) == ""


### PR DESCRIPTION
## Problem

`extract_content_or_reasoning()` in `agent/auxiliary_client.py` crashes with `IndexError` when an LLM provider returns an empty `choices` list.

This happens when:
- Content filtering removes all choices
- Provider errors produce a structurally valid response with no choices
- Rate limiting returns an empty response body

The function is called from **10+ sites** across vision_tools, web_tools, session_search_tool, mixture_of_agents_tool, and teams_pipeline.

## Fix

```python
if not getattr(response, "choices", None):
    return ""
```

Matches the defensive pattern in `tools/mcp_tool.py:909` and `tools/browser_camofox.py:571`.

## Tests

3 new regression tests (empty choices, None choices, missing attribute). All 34 tests pass.
