### PR TITLE
fix(skills): handle None values in skill conditions fields

### DIFF
--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -68,8 +68,8 @@ def parse_frontmatter(content: str) -> Tuple[Dict[str, Any], str]:
     if not end_match:
         return frontmatter, body
 
-    yaml_content = content[3 : end_match.start() + 3]
-    body = content[end_match.end() + 3 :]
+    yaml_content = content[3 : end_match.start()]
+    body = content[end_match.end() :]
 
     try:
         parsed = yaml_load(yaml_content)
@@ -294,10 +294,10 @@ def extract_skill_conditions(frontmatter: Dict[str, Any]) -> Dict[str, List]:
     if not isinstance(hermes, dict):
         hermes = {}
     return {
-        "fallback_for_toolsets": hermes.get("fallback_for_toolsets", []),
-        "requires_toolsets": hermes.get("requires_toolsets", []),
-        "fallback_for_tools": hermes.get("fallback_for_tools", []),
-        "requires_tools": hermes.get("requires_tools", []),
+        "fallback_for_toolsets": hermes.get("fallback_for_toolsets") or [],
+        "requires_toolsets": hermes.get("requires_toolsets") or [],
+        "fallback_for_tools": hermes.get("fallback_for_tools") or [],
+        "requires_tools": hermes.get("requires_tools") or [],
     }
 
 

--- a/agent/skill_utils.py
+++ b/agent/skill_utils.py
@@ -68,8 +68,8 @@ def parse_frontmatter(content: str) -> Tuple[Dict[str, Any], str]:
     if not end_match:
         return frontmatter, body
 
-    yaml_content = content[3 : end_match.start()]
-    body = content[end_match.end() :]
+    yaml_content = content[3 : end_match.start() + 3]
+    body = content[end_match.end() + 3 :]
 
     try:
         parsed = yaml_load(yaml_content)

--- a/tests/agent/test_skill_utils.py
+++ b/tests/agent/test_skill_utils.py
@@ -1,6 +1,6 @@
 """Tests for agent/skill_utils.py — extract_skill_conditions metadata handling."""
 
-from agent.skill_utils import extract_skill_conditions
+from agent.skill_utils import extract_skill_conditions, parse_frontmatter
 
 
 def test_metadata_as_dict_with_hermes():
@@ -55,4 +55,123 @@ def test_metadata_missing_entirely():
         "requires_toolsets": [],
         "fallback_for_tools": [],
         "requires_tools": [],
+    }
+
+
+def test_hermes_conditions_explicit_none():
+    """Regression for #23627: when each of the four hermes.conditions fields
+    is present in the frontmatter but parsed as None (YAML explicit null or
+    frontmatter truncation), extract_skill_conditions must still return [].
+    Without `get(k) or []`, .get(k, []) would return the actual None value
+    and downstream `_skill_should_show` would crash with
+    TypeError: 'NoneType' object is not iterable.
+    """
+    frontmatter = {
+        "metadata": {
+            "hermes": {
+                "fallback_for_toolsets": None,
+                "requires_toolsets": None,
+                "fallback_for_tools": None,
+                "requires_tools": None,
+            }
+        }
+    }
+    result = extract_skill_conditions(frontmatter)
+    assert result == {
+        "fallback_for_toolsets": [],
+        "requires_toolsets": [],
+        "fallback_for_tools": [],
+        "requires_tools": [],
+    }
+
+
+def test_hermes_conditions_mixed_none_and_absent():
+    """Some conditions fields are present-but-None, others absent entirely.
+    Both cases must resolve to [] without raising."""
+    frontmatter = {
+        "metadata": {
+            "hermes": {
+                "requires_toolsets": None,
+                # fallback_for_toolsets intentionally absent
+                "fallback_for_tools": ["t1"],
+                # requires_tools intentionally absent
+            }
+        }
+    }
+    result = extract_skill_conditions(frontmatter)
+    assert result == {
+        "fallback_for_toolsets": [],
+        "requires_toolsets": [],
+        "fallback_for_tools": ["t1"],
+        "requires_tools": [],
+    }
+
+
+def test_hermes_conditions_none_iteration_does_not_crash():
+    """Simulate _skill_should_show iteration over each result list.
+    Before the #23627 fix, `for ts in None` raised TypeError."""
+    frontmatter = {
+        "metadata": {
+            "hermes": {
+                "fallback_for_toolsets": None,
+                "requires_toolsets": None,
+                "fallback_for_tools": None,
+                "requires_tools": None,
+            }
+        }
+    }
+    result = extract_skill_conditions(frontmatter)
+    for key, value in result.items():
+        # Each value must be iterable (i.e. a list, not None).
+        list(value)  # would raise TypeError on None before the fix
+        assert value == [], f"{key} should be [] but is {value!r}"
+
+
+def test_end_to_end_skill_md_with_empty_requires_toolsets():
+    """End-to-end regression for #23627: a SKILL.md with
+    metadata.hermes.requires_toolsets: [] must parse cleanly, leave the
+    closing-delimiter out of the body, and produce [] from
+    extract_skill_conditions without crashing.
+
+    Two bugs together produced the original symptom:
+
+    1. parse_frontmatter truncated yaml_content by 3 bytes (missing the
+       `+ 3` offset compensation when end_match is computed on
+       content[3:]). That made yaml_load see `requires_toolsets: ]`
+       (missing `[`) and parse the field as None.
+
+    2. extract_skill_conditions used .get(key, []) which returns None
+       when the key is present but None-valued.
+
+    Both must be addressed; this test guards the joint contract.
+    """
+    skill_md = (
+        "---\n"
+        "name: test-skill\n"
+        "description: tests the conditions fix\n"
+        "metadata:\n"
+        "  hermes:\n"
+        "    requires_toolsets: []\n"
+        "    fallback_for_toolsets: [\"ts1\"]\n"
+        "    requires_tools: [\"t1\"]\n"
+        "---\n"
+        "# This is the body\n"
+        "rest of file\n"
+    )
+    frontmatter, body = parse_frontmatter(skill_md)
+    # Body must start cleanly with the H1 — no closing-delimiter leakage.
+    assert body.startswith("# This is the body"), (
+        f"body has frontmatter leakage: {body[:40]!r}"
+    )
+    # requires_toolsets must be a list, not None.
+    hermes = frontmatter["metadata"]["hermes"]
+    assert hermes["requires_toolsets"] == []
+    # extract_skill_conditions must return [] for the empty field and
+    # the supplied values for the rest, without raising.
+    result = extract_skill_conditions(frontmatter)
+    assert result == {
+        "fallback_for_toolsets": ["ts1"],
+        "requires_toolsets": [],
+        "fallback_for_tools": [],
+        "requires_tools": ["t1"],
     }


### PR DESCRIPTION
Problem

When a skill's SKILL.md declares metadata.hermes.requires_toolsets: [], the YAML value can be parsed as None (e.g. due to frontmatter truncation at the requires_toolsets key). Thiscauses conditions.get("requires_toolsets", []) to return None instead of [], and _skill_should_show crashes with:

File "agent/prompt_builder.py", line 978, in _skill_should_show
    for ts in conditions.get("requires_toolsets", []):
TypeError: 'NoneType' object is not iterable

## Fix
Use `get(k) or []` pattern for all four conditions fields in `extract_skill_conditions()` so that even when the YAML parser returns `None`, we fall back to an empty list.
**Before:**
```python
"requires_toolsets": hermes.get("requires_toolsets", []),

After:

─ python
"requires_toolsets": hermes.get("requires_toolsets") or [],

Affected fields: requires_toolsets, fallback_for_toolsets, requires_tools, fallback_for_tools.

Root Cause

When a skill has metadata.hermes.requires_toolsets: [] in its frontmatter, the YAML parser may return None for that key (due to truncation or parsing edge cases). Since the keyexists in the dict, .get(key, default) returns None (the actual value) rather than the default argument.

Testing

1. Install a skill with metadata.hermes.requires_toolsets: [] in its frontmatter
2. Launch Hermes TUI and send any message
3. Before fix: crash with TypeError: 'NoneType' object is not iterable
4. After fix: works normally