### PR TITLE
fix(cli): CJK/fullwidth alignment — replace f-string :<N with _pad_display

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -5410,7 +5410,7 @@ class HermesCLI:
         if not sessions:
             return False
 
-        from hermes_cli.main import _relative_time
+        from hermes_cli.main import _pad_display, _relative_time
 
         print()
         if reason == "history":
@@ -5421,10 +5421,14 @@ class HermesCLI:
         print(f"  {'Title':<32} {'Preview':<40} {'Last Active':<13} {'ID'}")
         print(f"  {'─' * 32} {'─' * 40} {'─' * 13} {'─' * 24}")
         for session in sessions:
-            title = (session.get("title") or "—")[:30]
-            preview = (session.get("preview") or "")[:38]
+            title = session.get("title") or "—"
+            preview = session.get("preview") or ""
             last_active = _relative_time(session.get("last_active"))
-            print(f"  {title:<32} {preview:<40} {last_active:<13} {session['id']}")
+            print(
+                f"  {_pad_display(title, 32)} "
+                f"{_pad_display(preview, 40)} "
+                f"{_pad_display(last_active, 13)} {session['id']}"
+            )
         print()
         print("  Use /resume <session id or title> to continue where you left off.")
         print()

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -70,6 +70,8 @@ import sys
 from pathlib import Path
 from typing import Optional
 
+from rich.cells import cell_len
+
 
 def _add_accept_hooks_flag(parser) -> None:
     """Attach the ``--accept-hooks`` flag.  Shared across every agent
@@ -284,6 +286,23 @@ def _relative_time(ts) -> str:
     return datetime.fromtimestamp(ts).strftime("%Y-%m-%d")
 
 
+def _pad_display(s: str, width: int) -> str:
+    """Pad/truncate *s* to exactly *width* terminal columns, respecting
+    full-width (CJK, emoji) characters that occupy 2 columns.
+
+    Uses ``rich.cells.cell_len`` which accounts for Unicode East Asian
+    Width.  Truncates from the right if the string is wider than *width*.
+    """
+    cur = cell_len(s)
+    if cur == width:
+        return s
+    if cur > width:
+        while s and cell_len(s) > width:
+            s = s[:-1]
+        cur = cell_len(s)
+    return s + " " * (width - cur)
+
+
 def _has_any_provider_configured() -> bool:
     """Check if at least one inference provider is usable."""
     from hermes_cli.config import get_env_path, get_hermes_home, load_config
@@ -429,13 +448,13 @@ def _session_browse_picker(sessions: list) -> Optional[str]:
             name_width = max(20, max_x - fixed_cols)
 
             if title:
-                name = title[:name_width]
+                name = title
             elif preview:
-                name = preview[:name_width]
+                name = preview
             else:
                 name = sid
 
-            return f"{name:<{name_width}}  {last_active:<10}  {source:<5} {sid}"
+            return f"{_pad_display(name, name_width)}  {_pad_display(last_active, 10)}  {_pad_display(source, 5)} {sid}"
 
         def _match(s, query):
             """Check if a session matches the search query (case-insensitive)."""
@@ -11062,18 +11081,22 @@ Examples:
                 print("─" * 95)
             for s in sessions:
                 last_active = _relative_time(s.get("last_active"))
-                preview = (
-                    s.get("preview", "")[:38]
-                    if has_titles
-                    else s.get("preview", "")[:48]
-                )
+                sid = s["id"]
                 if has_titles:
-                    title = (s.get("title") or "—")[:30]
-                    sid = s["id"]
-                    print(f"{title:<32} {preview:<40} {last_active:<13} {sid}")
+                    title = s.get("title") or "—"
+                    preview = s.get("preview", "")
+                    print(
+                        f"{_pad_display(title, 32)} "
+                        f"{_pad_display(preview, 40)} "
+                        f"{_pad_display(last_active, 13)} {sid}"
+                    )
                 else:
-                    sid = s["id"]
-                    print(f"{preview:<50} {last_active:<13} {s['source']:<6} {sid}")
+                    preview = s.get("preview", "")
+                    print(
+                        f"{_pad_display(preview, 50)} "
+                        f"{_pad_display(last_active, 13)} "
+                        f"{_pad_display(s['source'], 6)} {sid}"
+                    )
 
         elif action == "export":
             if args.session_id:

--- a/hermes_cli/pairing.py
+++ b/hermes_cli/pairing.py
@@ -30,6 +30,8 @@ def pairing_command(args):
 
 def _cmd_list(store):
     """List all pending and approved users."""
+    from hermes_cli.main import _pad_display
+
     pending = store.list_pending()
     approved = store.list_approved()
 
@@ -43,8 +45,11 @@ def _cmd_list(store):
         print(f"  {'--------':<12} {'----':<10} {'-------':<20} {'----':<20} {'---'}")
         for p in pending:
             print(
-                f"  {p['platform']:<12} {p['code']:<10} {p['user_id']:<20} "
-                f"{(p.get('user_name') or ''):<20} {p['age_minutes']}m ago"
+                f"  {_pad_display(p['platform'], 12)} "
+                f"{_pad_display(p['code'], 10)} "
+                f"{_pad_display(p['user_id'], 20)} "
+                f"{_pad_display(p.get('user_name') or '', 20)} "
+                f"{p['age_minutes']}m ago"
             )
     else:
         print("\n  No pending pairing requests.")
@@ -54,7 +59,11 @@ def _cmd_list(store):
         print(f"  {'Platform':<12} {'User ID':<20} {'Name':<20}")
         print(f"  {'--------':<12} {'-------':<20} {'----':<20}")
         for a in approved:
-            print(f"  {a['platform']:<12} {a['user_id']:<20} {(a.get('user_name') or ''):<20}")
+            print(
+                f"  {_pad_display(a['platform'], 12)} "
+                f"{_pad_display(a['user_id'], 20)} "
+                f"{_pad_display(a.get('user_name') or '', 20)}"
+            )
     else:
         print("\n  No approved users.")
 

--- a/tests/hermes_cli/test_pad_display.py
+++ b/tests/hermes_cli/test_pad_display.py
@@ -1,0 +1,79 @@
+"""Tests for _pad_display — CJK-aware column padding."""
+
+import pytest
+
+from hermes_cli.main import _pad_display
+
+
+def test_pad_display_ascii_exact():
+    """ASCII string at exact width — no padding or truncation."""
+    assert _pad_display("Hello", 5) == "Hello"
+
+
+def test_pad_display_ascii_needs_padding():
+    """ASCII string shorter than width — right-padded with spaces."""
+    assert _pad_display("Hi", 10) == "Hi        "
+
+
+def test_pad_display_ascii_needs_truncation():
+    """ASCII string longer than width — truncated."""
+    assert _pad_display("Hello World!", 5) == "Hello"
+
+
+def test_pad_display_cjk_exact():
+    """CJK-only string at exact display width (2 per char)."""
+    # "中文" = 4 display columns
+    assert _pad_display("中文", 4) == "中文"
+
+
+def test_pad_display_cjk_needs_padding():
+    """CJK string shorter than width — padded with spaces by display width."""
+    result = _pad_display("中文", 8)
+    assert result == "中文    "  # 4 display cols of chars + 4 space padding
+
+
+def test_pad_display_cjk_needs_truncation():
+    """CJK string truncated by display width (preserves whole characters)."""
+    result = _pad_display("中文测试", 6)
+    # "中" (2) + "文" (2) + "测" (2) = 6, "试" would make 8
+    assert result == "中文测"
+
+
+def test_pad_display_mixed_cjk_ascii():
+    """Mixed CJK+ASCII — correct display width accounting."""
+    # "Hi中文" = 2 + 4 = 6 display columns
+    result = _pad_display("Hi中文", 10)
+    assert result == "Hi中文    "  # 6 chars + 4 spaces
+
+
+def test_pad_display_emoji_padding():
+    """Emoji (typically 2-column) handled correctly."""
+    assert _pad_display("😀", 4) == "😀  "  # emoji = 2 cols, pad 2
+
+
+def test_pad_display_empty_string():
+    """Empty string is padded to full width."""
+    assert _pad_display("", 10) == "          "
+    assert _pad_display("", 0) == ""
+
+
+def test_pad_display_wide_edge():
+    """Edge: char-by-char truncation lands at the right spot."""
+    # "测试" = 4 cols, need 3 cols — must drop last char entirely
+    result = _pad_display("测试", 3)
+    # "测" = 2 cols, leaving 1 col — can't fit another full-width char
+    # So result should be "测 " (2 cols + 1 space) or just "测" if we then pad
+    # Actually: cur=4, width=3. cur>width, so loop: cell_len("测试")=4>3 → s="测", cell_len("测")=2 <= 3 → stop. Then width-cur=1, so add 1 space.
+    assert result == "测 "
+
+
+def test_pad_display_zero_width():
+    """Zero-width target."""
+    assert _pad_display("abc", 0) == ""
+    assert _pad_display("中文", 0) == ""
+
+
+def test_pad_display_negative_becomes_zero():
+    """Negative width behaves like zero (guard in caller)."""
+    # _pad_display handles this gracefully via range
+    assert _pad_display("abc", -1) == ""


### PR DESCRIPTION
## What changed

Replaced f-string `:<N` padding and `.ljust(N)` with `_pad_display()` using `rich.cells.cell_len` to measure display width instead of Python's code-point counting across all session list renderings.

## Why

Fullwidth characters (CJK, emoji) render at 2 terminal columns but Python `len()` counts them as 1, causing subsequent columns to misalign in session listings.

## How to test

1. Create a few sessions with CJK or emoji in their titles
2. Run `hermes sessions list` and `/resume` (or `hermes --resume` with no arg)
3. Confirm columns are aligned

## Files changed

- `hermes_cli/main.py`: cmd_sessions, _session_browse_picker, added _pad_display utility + cell_len import
- `cli.py`: _show_recent_sessions
- `hermes_cli/pairing.py`: _cmd_list
- Added `tests/hermes_cli/test_pad_display.py`

## Platforms tested

Linux