### PR TITLE
fix(cli): hermes memory status now reads actual config instead of hardcoded 'always active'

### DIFF
--- a/hermes_cli/memory_setup.py
+++ b/hermes_cli/memory_setup.py
@@ -392,8 +392,28 @@ def cmd_status(args) -> None:
     mem_config = config.get("memory", {})
     provider_name = mem_config.get("provider", "")
 
+    memory_enabled = mem_config.get("memory_enabled", True)
+    user_profile_enabled = mem_config.get("user_profile_enabled", True)
+
+    mem_mark = "enabled ✓" if memory_enabled else "disabled ✗"
+    user_mark = "enabled ✓" if user_profile_enabled else "disabled ✗"
+
+    # Check if the memory toolset is enabled for the CLI platform
+    # platform_toolsets.cli is either None (default = all enabled) or
+    # an explicit list of enabled toolset names.
+    platform_toolsets = config.get("platform_toolsets", {}) or {}
+    cli_toolsets = platform_toolsets.get("cli")
+    memory_tool_enabled = (
+        cli_toolsets is None
+        or (isinstance(cli_toolsets, list) and "memory" in cli_toolsets)
+    )
+    tool_mark = "enabled ✓" if memory_tool_enabled else "disabled ✗"
+
     print(f"\nMemory status\n" + "─" * 40)
-    print(f"  Built-in:  always active")
+    print(f"  Built-in (MEMORY.md / USER.md):")
+    print(f"    Memory injection:   {mem_mark}")
+    print(f"    User profile:       {user_mark}")
+    print(f"    Memory tool:        {tool_mark}")
     print(f"  Provider:  {provider_name or '(none — built-in only)'}")
 
     if provider_name:


### PR DESCRIPTION
## What changed

Replaced the hardcoded `"Built-in:  always active"` label in `hermes memory status` with three config-aware indicators that each read from the actual source of truth in config.yaml.

Before:
```
  Built-in:  always active
```

After:
```
  Built-in (MEMORY.md / USER.md):
    Memory injection:   disabled ✗
    User profile:       disabled ✗
    Memory tool:        disabled ✗
```

## Why

The 'always active' label was a hardcoded string that never reflected the user's actual configuration. This was misleading — users who had disabled built-in memory (via `memory_enabled: false`, `user_profile_enabled: false`, or `hermes tools disable memory`) would still see 'always active' and be confused.

## How to test

1. Run `hermes memory status` with various `memory.memory_enabled` and `memory.user_profile_enabled` settings
2. Verify the output matches the config
3. Run `hermes tools disable memory` then `hermes memory status` — the tool line should show disabled

## Files changed

- `hermes_cli/memory_setup.py`: cmd_status() now reads memory_enabled, user_profile_enabled, and platform_toolsets instead of printing a hardcoded string

## Platforms tested

Linux