### PR TITLE
fix(nix): container entrypoint chown -R strips setgid, breaking hostUsers group access

### DIFF
--- a/nix/nixosModules.nix
+++ b/nix/nixosModules.nix
@@ -115,9 +115,13 @@
       chown "$HERMES_UID:$HERMES_GID" "$TARGET_HOME"
       chmod 0750 "$TARGET_HOME"
 
-      # Ensure HERMES_HOME is owned by the target user
+      # Ensure HERMES_HOME is owned by the target user.
+      # Use find instead of chown -R: chown strips the setgid bit (kernel
+      # behavior), destroying the 2770 permissions the NixOS activation
+      # script sets for group access by hostUsers.  Only touch files with
+      # wrong ownership so correctly-owned dirs keep their permission bits.
       if [ -n "''${HERMES_HOME:-}" ] && [ -d "$HERMES_HOME" ]; then
-        chown -R "$HERMES_UID:$HERMES_GID" "$HERMES_HOME"
+        find "$HERMES_HOME" \! -user "$HERMES_UID" -exec chown "$HERMES_UID:$HERMES_GID" {} +
       fi
 
       # ── Provision apt packages (first boot only, cached in writable layer) ──


### PR DESCRIPTION
## Summary

The NixOS container entrypoint runs `chown -R $UID:$GID $HERMES_HOME` on every container start. Because `HERMES_HOME` is a bind-mounted host directory, this affects host filesystem permissions. The Linux kernel strips the setgid bit on any `chown` call (security behavior), so the `2770` permissions the NixOS activation script sets on `HERMES_HOME` get destroyed on every container restart.

This causes `PermissionError` for interactive CLI users listed in `container.hostUsers` — they're in the `hermes` group but can't enter the `0700` directory.

**Affected config:** `container.enable = true` + `container.hostUsers` + `addToSystemPackages = true`

## Fix

Replace `chown -R` with `find $HERMES_HOME ! -user $UID -exec chown $UID:$GID {} +`. This only touches files with wrong ownership, leaving correctly-owned directories and their setgid/permission bits intact.

## Related issues

- #19795 / #19788 — same `chown -R` bug in Docker `entrypoint.sh`
- #9383 — `_secure_dir()` hardcodes `0700` in managed mode (same class of bug, different code path)
- #14181 — atomic writes recreate files as `0600` (same class)

## Test plan

- [ ] `nix flake check --no-build` passes
- [ ] `nixos-rebuild switch` with `container.enable + hostUsers + addToSystemPackages`
- [ ] After container restart, verify `/var/lib/hermes/.hermes` retains `2770`
- [ ] Interactive `hermes --tui` works as a hostUser without `sudo chmod` workaround