### PR TITLE
fix(utils): support explicit mode for first-time atomic writes

### DIFF
--- a/gateway/status.py
+++ b/gateway/status.py
@@ -39,6 +39,7 @@ _gateway_lock_handle = None
 # past the JSON payload so runtime status / PID readers can still read the file
 # while another process holds the mutual-exclusion lock.
 _WINDOWS_LOCK_OFFSET = 1024 * 1024
+_RUNTIME_METADATA_CREATE_MODE = 0o644
 
 
 def _get_pid_path() -> Path:
@@ -210,7 +211,13 @@ def _read_json_file(path: Path) -> Optional[dict[str, Any]]:
 
 
 def _write_json_file(path: Path, payload: dict[str, Any]) -> None:
-    atomic_json_write(path, payload, indent=None, separators=(",", ":"))
+    atomic_json_write(
+        path,
+        payload,
+        indent=None,
+        separators=(",", ":"),
+        create_mode=_RUNTIME_METADATA_CREATE_MODE,
+    )
 
 
 def _read_pid_record(pid_path: Optional[Path] = None) -> Optional[dict]:

--- a/gateway/status.py
+++ b/gateway/status.py
@@ -46,6 +46,9 @@ _gateway_lock_handle = None
 # past the JSON payload so runtime status / PID readers can still read the file
 # while another process holds the mutual-exclusion lock.
 _WINDOWS_LOCK_OFFSET = 1024 * 1024
+# Runtime metadata is intentionally readable by local supervision/status tools,
+# but only on first creation. Existing permissions remain authoritative.
+_RUNTIME_METADATA_CREATE_MODE = 0o644
 _GATEWAY_RUNNING_PID_CACHE_TTL_SECONDS = 1.0
 _gateway_running_pid_cache_lock = threading.Lock()
 _gateway_running_pid_cache: dict[tuple[str, bool, bool], tuple[float, tuple[Any, ...], Optional[int]]] = {}
@@ -696,7 +699,13 @@ def _read_json_file(path: Path) -> Optional[dict[str, Any]]:
 
 
 def _write_json_file(path: Path, payload: dict[str, Any]) -> None:
-    atomic_json_write(path, payload, indent=None, separators=(",", ":"))
+    atomic_json_write(
+        path,
+        payload,
+        indent=None,
+        separators=(",", ":"),
+        create_mode=_RUNTIME_METADATA_CREATE_MODE,
+    )
 
 
 def _read_pid_record(pid_path: Optional[Path] = None) -> Optional[dict]:

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -263,9 +263,27 @@ class TestGatewayRuntimeStatus:
             (
                 target,
                 payload,
-                {"indent": None, "separators": (",", ":")},
+                {
+                    "indent": None,
+                    "separators": (",", ":"),
+                    "create_mode": status._RUNTIME_METADATA_CREATE_MODE,
+                },
             )
         ]
+
+    def test_write_json_file_first_create_is_world_readable(self, tmp_path, monkeypatch):
+        import stat as _stat
+
+        if os.name != "posix":
+            return
+
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        target = tmp_path / "gateway_state.json"
+
+        status._write_json_file(target, {"gateway_state": "running"})
+
+        mode = _stat.S_IMODE(target.stat().st_mode)
+        assert mode == status._RUNTIME_METADATA_CREATE_MODE
 
     def test_write_runtime_status_overwrites_stale_pid_on_restart(self, tmp_path, monkeypatch):
         """Regression: setdefault() preserved stale PID from previous process (#1631)."""

--- a/tests/gateway/test_status.py
+++ b/tests/gateway/test_status.py
@@ -13,6 +13,28 @@ from gateway import status
 
 
 class TestGatewayPidState:
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX-only mode assertion")
+    def test_runtime_metadata_create_mode_is_applied_before_replace(
+        self, tmp_path, monkeypatch
+    ):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        target = tmp_path / "gateway_state.json"
+
+        status._write_json_file(target, {"gateway_state": "running"})
+
+        assert (target.stat().st_mode & 0o777) == 0o644
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX-only mode assertion")
+    def test_runtime_metadata_preserves_existing_mode(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("HERMES_HOME", str(tmp_path))
+        target = tmp_path / "gateway_state.json"
+        target.write_text("{}", encoding="utf-8")
+        target.chmod(0o600)
+
+        status._write_json_file(target, {"gateway_state": "running"})
+
+        assert (target.stat().st_mode & 0o777) == 0o600
+
     def test_write_pid_file_records_gateway_metadata(self, tmp_path, monkeypatch):
         monkeypatch.setenv("HERMES_HOME", str(tmp_path))
 

--- a/tests/hermes_cli/test_atomic_json_write.py
+++ b/tests/hermes_cli/test_atomic_json_write.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import stat
 from pathlib import Path
 from unittest.mock import patch
 
@@ -157,3 +158,21 @@ class TestAtomicJsonWrite:
         result = json.loads(target.read_text())
         assert "writer" in result
         assert len(result["data"]) == 100
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX-only mode assertion")
+    def test_first_create_keeps_default_temp_permissions_without_create_mode(self, tmp_path):
+        target = tmp_path / "default_mode.json"
+
+        atomic_json_write(target, {"ok": True})
+
+        mode = stat.S_IMODE(target.stat().st_mode)
+        assert mode == 0o600
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX-only mode assertion")
+    def test_first_create_applies_explicit_create_mode(self, tmp_path):
+        target = tmp_path / "explicit_mode.json"
+
+        atomic_json_write(target, {"ok": True}, create_mode=0o644)
+
+        mode = stat.S_IMODE(target.stat().st_mode)
+        assert mode == 0o644

--- a/tests/hermes_cli/test_atomic_json_write.py
+++ b/tests/hermes_cli/test_atomic_json_write.py
@@ -2,6 +2,7 @@
 
 import json
 import os
+import stat
 from pathlib import Path
 from unittest.mock import patch
 
@@ -58,6 +59,42 @@ class TestAtomicJsonWrite:
 
         assert json.loads(target.read_text(encoding="utf-8")) == {"api_key": "secret"}
 
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX-only mode assertion")
+    def test_create_mode_is_set_before_replacement(self, tmp_path, monkeypatch):
+        """A reader must never observe the temp file's restrictive mode."""
+        import utils
+
+        target = tmp_path / "runtime.json"
+        events = []
+        real_fchmod = os.fchmod
+        real_replace = utils.atomic_replace
+
+        def record_fchmod(fd, mode):
+            events.append(("fchmod", mode))
+            return real_fchmod(fd, mode)
+
+        def record_replace(tmp_path_arg, target_arg):
+            events.append(("replace", stat.S_IMODE(Path(tmp_path_arg).stat().st_mode)))
+            return real_replace(tmp_path_arg, target_arg)
+
+        monkeypatch.setattr(utils.os, "fchmod", record_fchmod)
+        monkeypatch.setattr(utils, "atomic_replace", record_replace)
+
+        atomic_json_write(target, {"ok": True}, create_mode=0o644)
+
+        assert events == [("fchmod", 0o644), ("replace", 0o644)]
+        assert stat.S_IMODE(target.stat().st_mode) == 0o644
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX-only mode assertion")
+    def test_create_mode_does_not_change_existing_target_mode(self, tmp_path):
+        target = tmp_path / "existing.json"
+        target.write_text('{"old": true}', encoding="utf-8")
+        target.chmod(0o640)
+
+        atomic_json_write(target, {"new": True}, create_mode=0o644)
+
+        assert stat.S_IMODE(target.stat().st_mode) == 0o640
 
     def test_concurrent_writes_dont_corrupt(self, tmp_path):
         """Multiple rapid writes should each produce valid JSON."""

--- a/tests/hermes_cli/test_atomic_yaml_write.py
+++ b/tests/hermes_cli/test_atomic_yaml_write.py
@@ -1,5 +1,7 @@
 """Tests for utils.atomic_yaml_write — crash-safe YAML file writes."""
 
+import os
+import stat
 from pathlib import Path
 from unittest.mock import patch
 
@@ -42,3 +44,21 @@ class TestAtomicYamlWrite:
         text = target.read_text(encoding="utf-8")
         assert "key: value" in text
         assert "# comment" in text
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX-only mode assertion")
+    def test_first_create_keeps_default_temp_permissions_without_create_mode(self, tmp_path):
+        target = tmp_path / "default_mode.yaml"
+
+        atomic_yaml_write(target, {"ok": True})
+
+        mode = stat.S_IMODE(target.stat().st_mode)
+        assert mode == 0o600
+
+    @pytest.mark.skipif(os.name != "posix", reason="POSIX-only mode assertion")
+    def test_first_create_applies_explicit_create_mode(self, tmp_path):
+        target = tmp_path / "explicit_mode.yaml"
+
+        atomic_yaml_write(target, {"ok": True}, create_mode=0o644)
+
+        mode = stat.S_IMODE(target.stat().st_mode)
+        assert mode == 0o644

--- a/utils.py
+++ b/utils.py
@@ -58,6 +58,23 @@ def _restore_file_mode(path: Path, mode: "int | None") -> None:
         pass
 
 
+def _restore_atomic_write_mode(
+    path: Path,
+    original_mode: "int | None",
+    create_mode: "int | None" = None,
+) -> None:
+    """Restore an existing mode or apply an explicit mode for first creates.
+
+    Atomic writes swap a freshly-created temp file into place. When the target
+    did not exist before the write, there is no preserved mode to restore, so
+    callers that need a specific first-create mode must opt in explicitly.
+    """
+    if original_mode is not None:
+        _restore_file_mode(path, original_mode)
+    elif create_mode is not None:
+        _restore_file_mode(path, create_mode)
+
+
 def atomic_replace(tmp_path: Union[str, Path], target: Union[str, Path]) -> str:
     """Atomically move *tmp_path* onto *target*, preserving symlinks.
 
@@ -87,6 +104,7 @@ def atomic_json_write(
     data: Any,
     *,
     indent: int = 2,
+    create_mode: int | None = None,
     **dump_kwargs: Any,
 ) -> None:
     """Write JSON data to a file atomically.
@@ -99,6 +117,9 @@ def atomic_json_write(
         path: Target file path (will be created or overwritten).
         data: JSON-serializable data to write.
         indent: JSON indentation (default 2).
+        create_mode: Optional permission bits to apply when atomically
+            creating a brand-new target file. Existing files keep their
+            original mode.
         **dump_kwargs: Additional keyword args forwarded to json.dump(), such
             as default=str for non-native types.
     """
@@ -125,7 +146,7 @@ def atomic_json_write(
             os.fsync(f.fileno())
         # Preserve symlinks — swap in-place on the real file (GitHub #16743).
         real_path = atomic_replace(tmp_path, path)
-        _restore_file_mode(real_path, original_mode)
+        _restore_atomic_write_mode(Path(real_path), original_mode, create_mode)
     except BaseException:
         # Intentionally catch BaseException so temp-file cleanup still runs for
         # KeyboardInterrupt/SystemExit before re-raising the original signal.
@@ -143,6 +164,7 @@ def atomic_yaml_write(
     default_flow_style: bool = False,
     sort_keys: bool = False,
     extra_content: str | None = None,
+    create_mode: int | None = None,
 ) -> None:
     """Write YAML data to a file atomically.
 
@@ -157,6 +179,9 @@ def atomic_yaml_write(
         sort_keys: Whether to sort dict keys (default False).
         extra_content: Optional string to append after the YAML dump
             (e.g. commented-out sections for user reference).
+        create_mode: Optional permission bits to apply when atomically
+            creating a brand-new target file. Existing files keep their
+            original mode.
     """
     path = Path(path)
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -177,7 +202,7 @@ def atomic_yaml_write(
             os.fsync(f.fileno())
         # Preserve symlinks — swap in-place on the real file (GitHub #16743).
         real_path = atomic_replace(tmp_path, path)
-        _restore_file_mode(real_path, original_mode)
+        _restore_atomic_write_mode(Path(real_path), original_mode, create_mode)
     except BaseException:
         # Match atomic_json_write: cleanup must also happen for process-level
         # interruptions before we re-raise them.

--- a/utils.py
+++ b/utils.py
@@ -349,6 +349,7 @@ def atomic_json_write(
     *,
     indent: int = 2,
     mode: int | None = None,
+    create_mode: int | None = None,
     **dump_kwargs: Any,
 ) -> None:
     """Write JSON data to a file atomically.
@@ -364,6 +365,10 @@ def atomic_json_write(
         mode: Optional final permission mode. When set, the temp file is
             created and replaced with this mode, avoiding chmod-after-write
             TOCTOU exposure for secret-bearing files.
+        create_mode: Optional permission mode for a brand-new target. Existing
+            targets retain their original mode; the selected mode is applied to
+            the temp file before replacement so readers never observe mkstemp's
+            restrictive default on the new file.
         **dump_kwargs: Additional keyword args forwarded to json.dump(), such
             as default=str for non-native types.
     """
@@ -372,6 +377,9 @@ def atomic_json_write(
 
     original_mode = None if mode is not None else _preserve_file_mode(path)
     original_owner = _preserve_file_owner(path)
+    effective_mode = mode if mode is not None else original_mode
+    if effective_mode is None and create_mode is not None and not path.exists():
+        effective_mode = create_mode
 
     fd, tmp_path = tempfile.mkstemp(
         dir=str(path.parent),
@@ -379,11 +387,11 @@ def atomic_json_write(
         suffix=".tmp",
     )
     try:
-        if mode is not None and hasattr(os, "fchmod"):
-            # fchmod is Unix-only; Windows' os module has no fchmod. Skipping it
-            # here is safe — mkstemp already created the temp file as 0o600, and
-            # the post-replace os.chmod below applies the final mode durably.
-            os.fchmod(fd, mode)
+        if effective_mode is not None and hasattr(os, "fchmod"):
+            # Set the mode on the temp fd BEFORE replacement. This keeps the
+            # first-created file at its requested mode for the entire time it
+            # is visible, rather than exposing mkstemp's 0600 briefly.
+            os.fchmod(fd, effective_mode)
         with os.fdopen(fd, "w", encoding="utf-8") as f:
             json.dump(
                 data,
@@ -398,13 +406,7 @@ def atomic_json_write(
         real_path = atomic_replace(tmp_path, path)
         real_path_obj = Path(real_path)
         _restore_file_owner(real_path_obj, original_owner)
-        if mode is not None:
-            try:
-                os.chmod(real_path_obj, mode)
-            except OSError:
-                pass
-        else:
-            _restore_file_mode(real_path_obj, original_mode)
+        _restore_file_mode(real_path_obj, effective_mode)
     except BaseException:
         # Intentionally catch BaseException so temp-file cleanup still runs for
         # KeyboardInterrupt/SystemExit before re-raising the original signal.


### PR DESCRIPTION
## What does this PR do?

Fixes a real deployment bug behind `#23613` without widening permissions for every
JSON/YAML file Hermes writes.

`atomic_json_write()` and `atomic_yaml_write()` currently write through
`tempfile.mkstemp()`, so first-time creates inherit the temp file's `0o600`
mode. If the target file did not already exist, there is no original mode to
restore after `os.replace()`. That is correct for many files, but it breaks
gateway runtime metadata such as `gateway_state.json` when one process creates
it and another user/process needs to read it later.

This PR keeps the default atomic-writer behavior conservative and adds an
explicit first-create permission hook instead:

- `utils.atomic_json_write(..., create_mode=...)`
- `utils.atomic_yaml_write(..., create_mode=...)`

Then `gateway/status.py` opts in only for gateway runtime metadata, so
`gateway_state.json` is created with a readable mode on first write while the
rest of Hermes' JSON/YAML callsites keep their current default semantics.

## Related Issue

Fixes #23613

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)
- [x] ♻️ Refactor (no behavior change)

## Changes Made

- Added `create_mode` to [`utils.py`](../utils.py) atomic writers so callers can
  explicitly control the permission bits used when atomically creating a
  brand-new file.
- Kept the default behavior unchanged for all existing callsites that do not opt
  in: first-time atomic writes still keep the temp file's restrictive mode.
- Updated [`gateway/status.py`](../gateway/status.py) to pass
  `create_mode=0o644` for runtime metadata JSON writes.
- Added permission-focused regression tests in:
  - [`tests/hermes_cli/test_atomic_json_write.py`](../tests/hermes_cli/test_atomic_json_write.py)
  - [`tests/hermes_cli/test_atomic_yaml_write.py`](../tests/hermes_cli/test_atomic_yaml_write.py)
  - [`tests/gateway/test_status.py`](../tests/gateway/test_status.py)

## How to Test

1. Run the focused atomic writer and gateway status suite:
   ```bash
   python3 -m pytest -q -n 0 \
     tests/hermes_cli/test_atomic_json_write.py \
     tests/hermes_cli/test_atomic_yaml_write.py \
     tests/gateway/test_status.py
   ```
2. Confirm the suite passes.
3. On POSIX, the new assertions verify:
   - default first-create JSON/YAML writes remain `0o600`
   - explicit `create_mode=0o644` is applied when requested
   - `gateway/status.py` opts into `0o644` for `gateway_state.json`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL / Linux `python3 -m pytest`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused verification passed locally:

```text
65 passed in 9.97s
```

Note: a narrower `tests/gateway/test_api_server.py::TestHealthDetailedEndpoint::test_health_detailed_no_runtime_status`
probe hit a sandbox `PermissionError` on local socket creation in this environment,
not an assertion failure in the change under review.
