### PR TITLE
fix(kanban): use FALLBACK_COLUMN_LABEL in column select-all aria-label

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -1898,7 +1898,7 @@
           type: "checkbox",
           className: "hermes-kanban-col-check",
           title: "Select all tasks in this column",
-          "aria-label": `Select all tasks in ${COLUMN_LABEL[props.column.name] || props.column.name}`,
+          "aria-label": `Select all tasks in ${FALLBACK_COLUMN_LABEL[props.column.name] || props.column.name}`,
           checked: props.column.tasks.length > 0 && props.column.tasks.every(function (t) { return props.selectedIds.has(t.id); }),
           onChange: function (e) {
             e.stopPropagation();


### PR DESCRIPTION
## Summary

Fixes `ReferenceError: COLUMN_LABEL is not defined` in the Kanban dashboard's column select-all checkbox.

## Root Cause

The i18n refactor in commit `c39168453` renamed `COLUMN_LABEL` to `FALLBACK_COLUMN_LABEL` but missed one reference at line 1901 of `plugins/kanban/dashboard/dist/index.js` — the `aria-label` attribute of the column header checkbox.

## Fix

Changed `COLUMN_LABEL` → `FALLBACK_COLUMN_LABEL` on the single affected line. All other references (lines 59, 97) already use the correct name.

## Testing

- Verified all `COLUMN_LABEL` references now use `FALLBACK_COLUMN_LABEL`
- Ran kanban Python tests: 168 passed
- No frontend test framework exists for the dashboard; change is a single variable rename in a template literal

Fixes #23620