### PR TITLE
fix(auxiliary): support minimax oauth providers

### DIFF
--- a/agent/auxiliary_client.py
+++ b/agent/auxiliary_client.py
@@ -2960,6 +2960,7 @@ def resolve_provider_client(
             PROVIDER_REGISTRY,
             resolve_api_key_provider_credentials,
             resolve_external_process_provider_credentials,
+            resolve_minimax_oauth_runtime_credentials,
         )
     except ImportError:
         logger.debug("hermes_cli.auth not available for provider %s", provider)
@@ -2970,7 +2971,7 @@ def resolve_provider_client(
         logger.warning("resolve_provider_client: unknown provider %r", provider)
         return None, None
 
-    if pconfig.auth_type == "api_key":
+    if pconfig.auth_type in {"api_key", "oauth_minimax"}:
         if provider == "anthropic":
             client, default_model = _try_anthropic(explicit_api_key=explicit_api_key)
             if client is None:
@@ -2979,7 +2980,10 @@ def resolve_provider_client(
             final_model = _normalize_resolved_model(model or default_model, provider)
             return (_to_async_client(client, final_model, is_vision=is_vision) if async_mode else (client, final_model))
 
-        creds = resolve_api_key_provider_credentials(provider)
+        if pconfig.auth_type == "oauth_minimax":
+            creds = resolve_minimax_oauth_runtime_credentials()
+        else:
+            creds = resolve_api_key_provider_credentials(provider)
         api_key = str(creds.get("api_key", "")).strip()
         # Honour an explicit api_key override (e.g. from a fallback_model entry
         # or a custom_providers entry) so callers that pass an explicit

--- a/tests/agent/test_auxiliary_client.py
+++ b/tests/agent/test_auxiliary_client.py
@@ -2497,6 +2497,25 @@ class TestAnthropicExplicitApiKey:
             "resolve_provider_client must forward explicit_api_key to _try_anthropic()"
         )
 
+    def test_resolve_provider_client_supports_minimax_oauth(self):
+        """MiniMax OAuth should resolve via its runtime credential helper."""
+        fake_client = MagicMock()
+        with patch(
+            "hermes_cli.auth.resolve_minimax_oauth_runtime_credentials",
+            return_value={
+                "provider": "minimax-oauth",
+                "api_key": "oauth-token",
+                "base_url": "https://api.minimax.io/anthropic",
+                "source": "oauth",
+            },
+        ), patch("agent.auxiliary_client.OpenAI", return_value=fake_client) as mock_openai:
+            client, model = resolve_provider_client("minimax-oauth")
+
+        assert client is not None
+        assert model == "MiniMax-M2.7-highspeed"
+        assert mock_openai.call_args.kwargs["api_key"] == "oauth-token"
+        assert mock_openai.call_args.kwargs["base_url"] == "https://api.minimax.io/v1"
+
 
 # ── Auxiliary unhealthy-provider TTL cache (issue #23570) ────────────────
 


### PR DESCRIPTION
## What does this PR do?

Supports MiniMax auxiliary providers that authenticate with `oauth_minimax` by resolving runtime OAuth credentials instead of treating them as unsupported non-API-key providers.

## Related Issue

Fixes #21521

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- update `agent/auxiliary_client.py` so `resolve_provider_client()` accepts `oauth_minimax`
- resolve MiniMax OAuth credentials via `resolve_minimax_oauth_runtime_credentials()` instead of the generic API-key helper
- add a regression test in `tests/agent/test_auxiliary_client.py` covering the MiniMax OAuth path

## How to Test

1. `uv run --frozen --extra dev pytest -q -o addopts='' tests/agent/test_auxiliary_client.py -k minimax_oauth`
2. `uv run --frozen ruff check agent/auxiliary_client.py tests/agent/test_auxiliary_client.py`
3. confirm `resolve_provider_client("minimax-oauth")` builds the OpenAI-compatible client with the OAuth-derived token and base URL

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- targeted pytest: `1 passed, 154 deselected`
- `ruff check` passed
