### PR TITLE
fix(auxiliary): prefer direct providers over aggregators in auto-detect chain

### DIFF
--- a/scripts/release.py
+++ b/scripts/release.py
@@ -39,6 +39,7 @@ PYPROJECT_FILE = REPO_ROOT / "pyproject.toml"
 
 # Auto-extracted from noreply emails + manual overrides
 AUTHOR_MAP = {
+    "bartok9@users.noreply.github.com": "Bartok9",
     # teknium (multiple emails)
     "teknium1@gmail.com": "teknium1",
     "0x.badfriend@gmail.com": "discodirector",

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -731,28 +731,78 @@ def _session(agent=None, **extra):
 
 
 def test_session_close_commits_memory_and_fires_finalize_hook(monkeypatch):
+    # session.close now finalizes in a background thread; give it time to finish.
     calls = {"hooks": []}
+    done_event = threading.Event()
+
+    def _slow_commit(history):
+        calls.setdefault("history", history)
 
     agent = types.SimpleNamespace(session_id="session-key")
-    agent.commit_memory_session = lambda history: calls.setdefault("history", history)
+    agent.commit_memory_session = _slow_commit
     server._sessions["sid"] = _session(
         agent=agent, history=[{"role": "user", "content": "hello"}]
     )
-    monkeypatch.setattr(
-        server,
-        "_notify_session_boundary",
-        lambda event, session_id: calls["hooks"].append((event, session_id)),
-    )
+
+    def _notify_hook(event, session_id):
+        calls["hooks"].append((event, session_id))
+        done_event.set()
+
+    monkeypatch.setattr(server, "_notify_session_boundary", _notify_hook)
 
     try:
         resp = server.handle_request(
             {"id": "1", "method": "session.close", "params": {"session_id": "sid"}}
         )
         assert resp["result"]["closed"] is True
+        # Wait for background finalization (up to 2s)
+        assert done_event.wait(timeout=2.0), "Background finalization did not complete in time"
         assert calls["history"] == [{"role": "user", "content": "hello"}]
         assert ("on_session_finalize", "session-key") in calls["hooks"]
     finally:
         server._sessions.pop("sid", None)
+
+
+def test_session_close_returns_promptly_despite_slow_finalization(monkeypatch):
+    """session.close must not block the caller while memory commit runs. (#23642)
+
+    /clear in the TUI calls session.close and only then creates the new session.
+    If finalization is slow (e.g. memory commit + DB write), the TUI was left
+    stuck on the old context. Finalization now runs in a background thread so
+    the JSON-RPC response is immediate.
+    """
+    started = threading.Event()
+    finished = threading.Event()
+
+    def _slow_commit(history):
+        started.set()
+        time.sleep(0.3)  # Simulate a 300ms memory commit
+        finished.set()
+
+    agent = types.SimpleNamespace(session_id="slow-session")
+    agent.commit_memory_session = _slow_commit
+    server._sessions["slow-sid"] = _session(
+        agent=agent, history=[{"role": "user", "content": "hello"}]
+    )
+    monkeypatch.setattr(
+        server,
+        "_notify_session_boundary",
+        lambda event, session_id: None,
+    )
+
+    try:
+        t0 = time.monotonic()
+        resp = server.handle_request(
+            {"id": "1", "method": "session.close", "params": {"session_id": "slow-sid"}}
+        )
+        elapsed = time.monotonic() - t0
+        assert resp["result"]["closed"] is True
+        # Response must come back well before the slow commit finishes
+        assert elapsed < 0.25, f"session.close blocked for {elapsed:.3f}s (should be <0.25s)"
+        # The commit must still complete in the background
+        assert finished.wait(timeout=2.0), "Background commit did not complete"
+    finally:
+        server._sessions.pop("slow-sid", None)
 
 
 def test_init_session_fires_reset_hook(monkeypatch):

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -2635,25 +2635,35 @@ def _(rid, params: dict) -> dict:
     session = _sessions.pop(sid, None)
     if not session:
         return _ok(rid, {"closed": False})
-    _finalize_session(session)
-    try:
-        from tools.approval import unregister_gateway_notify
 
-        unregister_gateway_notify(session["session_key"])
-    except Exception:
-        pass
-    try:
-        agent = session.get("agent")
-        if agent and hasattr(agent, "close"):
-            agent.close()
-    except Exception:
-        pass
-    try:
-        worker = session.get("slash_worker")
-        if worker:
-            worker.close()
-    except Exception:
-        pass
+    # Detach from _sessions (already done above) then finalize in a background
+    # thread so that slow work — memory commit, DB write, hook execution — does
+    # not block the JSON-RPC response.  The frontend is waiting on this response
+    # before it can call session.create for the new session; any latency here
+    # makes /clear feel stuck and leaves old context visible. (#23642)
+    def _bg_close(s: dict) -> None:
+        _finalize_session(s)
+        try:
+            from tools.approval import unregister_gateway_notify
+            unregister_gateway_notify(s["session_key"])
+        except Exception:
+            pass
+        try:
+            a = s.get("agent")
+            if a and hasattr(a, "close"):
+                a.close()
+        except Exception:
+            pass
+        try:
+            w = s.get("slash_worker")
+            if w:
+                w.close()
+        except Exception:
+            pass
+
+    t = threading.Thread(target=_bg_close, args=(session,), daemon=True,
+                         name=f"session-close-{sid[:8]}")
+    t.start()
     return _ok(rid, {"closed": True})
 
 


### PR DESCRIPTION
## Summary

When `_resolve_auto()` falls through to Step 2 (the provider chain walk), the previous order tried `openrouter` **before** any `local/custom` or direct `api-key` providers. On long sessions with a depleted OpenRouter account, this produced a wave of doomed HTTP 402s before finally reaching MiniMax, DeepSeek, or any other direct provider the user had configured.

Reported in #23570 — the user's auxiliary fallback kept routing to OpenRouter despite having MiniMax configured as a direct api-key provider. The user fixed it locally by manually reordering the chain.

## New order: local/custom → api-key → nous → openrouter

| Position | Provider | Rationale |
|---|---|---|
| 1 | `local/custom` | Zero network latency, zero credit cost — always try first |
| 2 | `api-key` | Direct first-party credentials the user explicitly set up; avoids aggregator markup and credit burn |
| 3 | `nous` | Free-tier aggregator, but rate-limited per account |
| 4 | `openrouter` | Metered; if balance is exhausted, should not shadow direct providers that are still healthy |

## Interaction with the 402 unhealthy cache

The 402 unhealthy cache (added in #23597) already prevents a depleted OpenRouter entry from being retried within its TTL window. This reorder is complementary: OpenRouter is never the *first* Step-2 candidate to begin with, so a new session that hasn't yet observed a 402 doesn't needlessly try OpenRouter before a local Ollama or a direct DeepSeek endpoint.

## How to test

1. Configure a direct api-key provider (e.g. DeepSeek) in `config.yaml`.
2. Set `OPENROUTER_API_KEY` to a depleted or invalid key.
3. Start a session and trigger an auxiliary task (e.g. let context compress).
4. Observe that auxiliary uses DeepSeek directly instead of hitting OpenRouter 402 first.

## Changes

- `agent/auxiliary_client.py`: reorder `_get_provider_chain()` + expand docstring with rationale
- `tests/agent/test_auxiliary_client.py`: update `TestGetProviderChain` to assert the new canonical order

Fixes part of #23570