### PR TITLE
fix(web): drop language picker upward in sidebar to prevent viewport clip

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -558,7 +558,7 @@ export default function App() {
               <div className="flex min-w-0 items-center gap-2">
                 <PluginSlot name="header-right" />
                 <ThemeSwitcher dropUp />
-                <LanguageSwitcher />
+                <LanguageSwitcher dropUp />
               </div>
             </div>
 

--- a/web/src/components/LanguageSwitcher.tsx
+++ b/web/src/components/LanguageSwitcher.tsx
@@ -4,6 +4,7 @@ import { Typography } from "@/components/NouiTypography";
 import { useI18n } from "@/i18n/context";
 import { LOCALE_META } from "@/i18n";
 import type { Locale } from "@/i18n";
+import { cn } from "@/lib/utils";
 
 /**
  * Language picker — shows the current language's flag + endonym, opens a
@@ -12,8 +13,12 @@ import type { Locale } from "@/i18n";
  *
  * Replaces the older two-state EN↔ZH toggle now that we ship 16 locales
  * (en, zh, zh-hant, ja, de, es, fr, tr, uk, af, ko, it, ga, pt, ru, hu).
+ *
+ * When mounted at the bottom of a container (e.g. the sidebar rail), pass
+ * `dropUp` so the menu opens above the trigger instead of clipping below
+ * the viewport.
  */
-export function LanguageSwitcher() {
+export function LanguageSwitcher({ dropUp = false }: LanguageSwitcherProps) {
   const { locale, setLocale, t } = useI18n();
   const [open, setOpen] = useState(false);
   const containerRef = useRef<HTMLDivElement>(null);
@@ -69,7 +74,10 @@ export function LanguageSwitcher() {
         <div
           role="listbox"
           aria-label={t.language.switchTo}
-          className="absolute right-0 top-full mt-1 z-50 min-w-[10rem] rounded-md border border-border bg-popover shadow-md py-1 max-h-80 overflow-y-auto"
+          className={cn(
+            "absolute z-50 min-w-[10rem] rounded-md border border-border bg-popover shadow-md py-1 max-h-80 overflow-y-auto",
+            dropUp ? "left-0 bottom-full mb-1" : "right-0 top-full mt-1",
+          )}
         >
           {allLocales.map(([code, meta]) => {
             const selected = code === locale;
@@ -97,4 +105,8 @@ export function LanguageSwitcher() {
       )}
     </div>
   );
+}
+
+interface LanguageSwitcherProps {
+  dropUp?: boolean;
 }


### PR DESCRIPTION
## Summary
- `LanguageSwitcher` is mounted at the bottom of the sidebar rail next to `ThemeSwitcher`, but its dropdown opened downward (`top-full`), so on shorter viewports the list overflowed past the bottom of the window (visible in the attached repro).
- `ThemeSwitcher` already supports a `dropUp` prop for this exact case — mirror the pattern on `LanguageSwitcher` and pass `dropUp` from the sidebar mount in `App.tsx`.

## Test plan
- [x] `cd web && npm run dev` against a running `hermes dashboard`, click the language picker in the sidebar footer, confirm the listbox now opens above the trigger and no longer clips below the viewport.
- [ ] Type-check + lint in CI.