### PR TITLE
fix(tui): detach session.close finalization from response path (#23642)

### DIFF
--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -911,24 +911,32 @@ def _session(agent=None, **extra):
 
 
 def test_session_close_commits_memory_and_fires_finalize_hook(monkeypatch):
+    # session.close now finalizes in a background thread; give it time to finish.
     calls = {"hooks": []}
+    done_event = threading.Event()
+
+    def _slow_commit(history):
+        calls.setdefault("history", history)
 
     agent = types.SimpleNamespace(session_id="session-key")
-    agent.commit_memory_session = lambda history: calls.setdefault("history", history)
+    agent.commit_memory_session = _slow_commit
     server._sessions["sid"] = _session(
         agent=agent, history=[{"role": "user", "content": "hello"}]
     )
-    monkeypatch.setattr(
-        server,
-        "_notify_session_boundary",
-        lambda event, session_id: calls["hooks"].append((event, session_id)),
-    )
+
+    def _notify_hook(event, session_id):
+        calls["hooks"].append((event, session_id))
+        done_event.set()
+
+    monkeypatch.setattr(server, "_notify_session_boundary", _notify_hook)
 
     try:
         resp = server.handle_request(
             {"id": "1", "method": "session.close", "params": {"session_id": "sid"}}
         )
         assert resp["result"]["closed"] is True
+        # Wait for background finalization (up to 2s)
+        assert done_event.wait(timeout=2.0), "Background finalization did not complete in time"
         assert calls["history"] == [{"role": "user", "content": "hello"}]
         assert ("on_session_finalize", "session-key") in calls["hooks"]
     finally:
@@ -1035,6 +1043,48 @@ def test_ws_orphan_reap_disabled_when_grace_zero(monkeypatch):
     monkeypatch.setattr(server.threading, "Timer", _Timer)
     server._schedule_ws_orphan_reap("any-sid")
     assert fired["timer"] is False
+
+
+def test_session_close_returns_promptly_despite_slow_finalization(monkeypatch):
+    """session.close must not block the caller while memory commit runs. (#23642)
+
+    /clear in the TUI calls session.close and only then creates the new session.
+    If finalization is slow (e.g. memory commit + DB write), the TUI was left
+    stuck on the old context. Finalization now runs in a background thread so
+    the JSON-RPC response is immediate.
+    """
+    started = threading.Event()
+    finished = threading.Event()
+
+    def _slow_commit(history):
+        started.set()
+        time.sleep(0.3)  # Simulate a 300ms memory commit
+        finished.set()
+
+    agent = types.SimpleNamespace(session_id="slow-session")
+    agent.commit_memory_session = _slow_commit
+    server._sessions["slow-sid"] = _session(
+        agent=agent, history=[{"role": "user", "content": "hello"}]
+    )
+    monkeypatch.setattr(
+        server,
+        "_notify_session_boundary",
+        lambda event, session_id: None,
+    )
+
+    try:
+        t0 = time.monotonic()
+        resp = server.handle_request(
+            {"id": "1", "method": "session.close", "params": {"session_id": "slow-sid"}}
+        )
+        elapsed = time.monotonic() - t0
+        assert resp["result"]["closed"] is True
+        # Response must come back well before the slow commit finishes
+        assert elapsed < 0.25, f"session.close blocked for {elapsed:.3f}s (should be <0.25s)"
+        # The commit must still complete in the background
+        assert finished.wait(timeout=2.0), "Background commit did not complete"
+    finally:
+        server._sessions.pop("slow-sid", None)
 
 
 def test_init_session_fires_reset_hook(monkeypatch):
@@ -6298,13 +6348,16 @@ def test_session_close_rpc_delegates_to_close_session_by_id(monkeypatch):
     seen = []
     monkeypatch.setattr(
         server, "_close_session_by_id",
-        lambda sid, *, end_reason: bool(seen.append((sid, end_reason))) or True,
+        lambda sid, *, end_reason, background=False: bool(
+            seen.append((sid, end_reason, background))
+        )
+        or True,
     )
     resp = server.handle_request(
         {"id": "1", "method": "session.close", "params": {"session_id": "s9"}}
     )
     assert resp["result"] == {"closed": True}
-    assert seen == [("s9", "tui_close")]
+    assert seen == [("s9", "tui_close", True)]
 
 
 def test_close_sessions_for_transport_closes_flagged_repoints_rest(monkeypatch):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -1087,6 +1087,61 @@ def test_session_close_returns_promptly_despite_slow_finalization(monkeypatch):
         server._sessions.pop("slow-sid", None)
 
 
+def test_session_close_stops_notification_poller_before_background_finalize(monkeypatch):
+    """Detached sessions must not keep polling the global completion queue."""
+    from tools.process_registry import process_registry
+
+    finalize_started = threading.Event()
+    release_finalize = threading.Event()
+    emitted = []
+
+    def _slow_finalize(session, end_reason="tui_close"):
+        finalize_started.set()
+        release_finalize.wait(timeout=2.0)
+
+    sess = _session()
+    server._sessions["poll-sid"] = sess
+    monkeypatch.setattr(server, "_finalize_session", _slow_finalize)
+    monkeypatch.setattr(server, "_emit", lambda *a, **kw: emitted.append(a))
+    def _fake_submit(_rid, _sid, session, _text):
+        with session["history_lock"]:
+            session["running"] = False
+
+    monkeypatch.setattr(server, "_run_prompt_submit", _fake_submit)
+    stop = server._start_notification_poller("poll-sid", sess)
+    sess["_notif_stop"] = stop
+
+    while not process_registry.completion_queue.empty():
+        process_registry.completion_queue.get_nowait()
+
+    try:
+        resp = server.handle_request(
+            {"id": "1", "method": "session.close", "params": {"session_id": "poll-sid"}}
+        )
+        assert resp["result"]["closed"] is True
+        assert stop.is_set(), "notification poller must stop when session is detached"
+        assert finalize_started.wait(timeout=2.0), "background finalize did not start"
+
+        process_registry.completion_queue.put({
+            "type": "watch_match",
+            "session_id": "proc_leak_test",
+            "command": "tail -f app.log",
+            "pattern": "READY",
+            "output": "READY on port 8000",
+            "suppressed": 0,
+        })
+        time.sleep(0.6)
+
+        assert not any(
+            a[0] == "status.update" for a in emitted
+        ), "detached poller must not emit after session.close returns"
+    finally:
+        release_finalize.set()
+        server._sessions.pop("poll-sid", None)
+        while not process_registry.completion_queue.empty():
+            process_registry.completion_queue.get_nowait()
+
+
 def test_init_session_fires_reset_hook(monkeypatch):
     hooks = []
 
@@ -1122,7 +1177,9 @@ def test_init_session_fires_reset_hook(monkeypatch):
         )
         assert ("on_session_reset", "session-key") in hooks
     finally:
-        server._sessions.pop(sid, None)
+        session = server._sessions.pop(sid, None)
+        if session is not None:
+            server._stop_session_notification_poller(session)
 
 
 def test_session_title_queues_when_db_row_not_ready(monkeypatch):
@@ -5953,7 +6010,10 @@ def test_notification_poller_emits_distinct_watch_matches_once(monkeypatch):
 
     try:
         server._notification_poller_loop(stop, "sid_watch_dedup", sess)
-        status_calls = [a for a in emitted if a[0] == "status.update"]
+        status_calls = [
+            a for a in emitted
+            if a[0] == "status.update" and a[1] == "sid_watch_dedup"
+        ]
         assert len(status_calls) == 2
         status_text = "\n".join(call[2]["text"] for call in status_calls)
         assert "READY on port 8000" in status_text

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -442,17 +442,33 @@ def _attach_worker(sid: str, session: dict, worker) -> None:
     worker.close()
 
 
-def _close_session_by_id(sid: str, *, end_reason: str = "tui_close") -> bool:
+def _close_session_by_id(
+    sid: str, *, end_reason: str = "tui_close", background: bool = False
+) -> bool:
     """Single idempotent teardown for one session: pop it under the sessions
     lock, then finalize, unregister notify, close agent + slash worker via the
     shared ``_teardown_session`` path. Returns True iff it closed a live
     session. The ``_finalized`` / worker ``_closed`` guards make concurrent or
-    repeat calls (e.g. session.close racing the WS-orphan reaper) harmless."""
+    repeat calls (e.g. session.close racing the WS-orphan reaper) harmless.
+
+    When ``background`` is True, teardown runs on a daemon thread so the caller
+    can return immediately after the session is detached from ``_sessions``.
+    """
     with _sessions_lock:
         session = _sessions.pop(sid, None)
     if session is None:
         return False
-    _teardown_session(session, end_reason=end_reason)
+    if background:
+        t = threading.Thread(
+            target=_teardown_session,
+            args=(session,),
+            kwargs={"end_reason": end_reason},
+            daemon=True,
+            name=f"session-close-{sid[:8]}",
+        )
+        t.start()
+    else:
+        _teardown_session(session, end_reason=end_reason)
     return True
 
 
@@ -4174,8 +4190,15 @@ def _(rid, params: dict) -> dict:
     # both tear the same session down. _close_session_by_id is the single
     # idempotent teardown path (pop + _teardown_session) and returns False
     # when the session is already gone.
+    # Finalize in a background thread so slow work — memory commit, DB write,
+    # hook execution — does not block the JSON-RPC response. The frontend awaits
+    # this response before session.create for the new session; latency here
+    # makes /clear feel stuck and leaves old context visible. (#23642)
     with _session_resume_lock:
-        return _ok(rid, {"closed": _close_session_by_id(sid, end_reason="tui_close")})
+        closed = _close_session_by_id(
+            sid, end_reason="tui_close", background=True
+        )
+    return _ok(rid, {"closed": closed})
 
 
 @method("session.branch")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -442,6 +442,21 @@ def _attach_worker(sid: str, session: dict, worker) -> None:
     worker.close()
 
 
+def _stop_session_notification_poller(session: dict) -> None:
+    """Stop the per-session notification poller without finalizing the session.
+
+    Called synchronously when a session is detached from ``_sessions`` so the
+    poller does not keep dequeuing from the process-wide completion queue while
+    slow finalization work runs (possibly on a background thread). Without this,
+    a detached poller can race with other sessions' tests/pollers and emit
+    duplicate ``status.update`` events. ``_finalize_session`` still sets the
+    same stop event later; ``Event.set()`` is idempotent.
+    """
+    stop_event = session.get("_notif_stop")
+    if stop_event is not None:
+        stop_event.set()
+
+
 def _close_session_by_id(
     sid: str, *, end_reason: str = "tui_close", background: bool = False
 ) -> bool:
@@ -458,6 +473,7 @@ def _close_session_by_id(
         session = _sessions.pop(sid, None)
     if session is None:
         return False
+    _stop_session_notification_poller(session)
     if background:
         t = threading.Thread(
             target=_teardown_session,
@@ -4670,6 +4686,24 @@ def _notification_event_dedup_key(evt: dict) -> tuple:
     return (evt_sid, evt_type)
 
 
+def _notification_poller_should_halt(
+    session: dict, stop_event: threading.Event, sid: str
+) -> bool:
+    """True when the poller must stop consuming the global completion queue.
+
+    ``session.close`` pops the session and sets ``_notif_stop`` immediately while
+    slow finalization may still run on a background thread. In that window
+    ``_finalized`` is not yet set, but the session is already gone from
+    ``_sessions`` — the poller must not dequeue unrelated events (which would
+    duplicate ``status.update`` in other sessions/tests). Pollers stopped in
+    tests while the session dict is still registered are unaffected.
+    """
+    if not stop_event.is_set() or session.get("_finalized"):
+        return False
+    with _sessions_lock:
+        return sid not in _sessions
+
+
 def _notification_poller_loop(
     stop_event: threading.Event, sid: str, session: dict
 ) -> None:
@@ -4692,6 +4726,10 @@ def _notification_poller_loop(
             evt = process_registry.completion_queue.get(timeout=0.5)
         except Exception:
             continue
+
+        if _notification_poller_should_halt(session, stop_event, sid):
+            process_registry.completion_queue.put(evt)
+            break
 
         # Multiple desktop sessions share this one process-wide queue. Only
         # consume events that belong to *this* session — otherwise a background
@@ -4742,7 +4780,19 @@ def _notification_poller_loop(
     # Drain any remaining events after stop signal (process all pending
     # before exiting so nothing is lost on shutdown). Events owned by other
     # live sessions are set aside and re-queued so their poller still sees them.
+    # When the session was only detached (stop set, finalize still pending),
+    # re-queue everything without dispatching.
     deferred: list = []
+    if _notification_poller_should_halt(session, stop_event, sid):
+        while not process_registry.completion_queue.empty():
+            try:
+                deferred.append(process_registry.completion_queue.get_nowait())
+            except Exception:
+                break
+        for evt in deferred:
+            process_registry.completion_queue.put(evt)
+        return
+
     while not process_registry.completion_queue.empty():
         try:
             evt = process_registry.completion_queue.get_nowait()


### PR DESCRIPTION
## Problem

`session.close` called `_finalize_session()` synchronously before returning the JSON-RPC response. `_finalize_session()` can be slow — it calls `agent.commit_memory_session(history)` (memory flush that may call an LLM), writes to SQLite, and fires `on_session_finalize` hooks.

The TUI frontend awaits `session.close` before calling `session.create` for the new session:
```
newSession() → closeSession() → await session.close → session.create
```

This means slow finalization directly delayed fresh session startup — making `/clear` appear stuck and leaving old context visible. Especially noticeable in zellij, tmux, or on slow disks.

Fixes #23642.

## Fix

Pop the session from `_sessions` immediately (already done before this PR), then run all finalization work in a **daemon background thread**. The JSON-RPC response returns as soon as the session is detached — the frontend gets its response right away and can create the new session. Cleanup still runs to completion in the background.

```python
# Before: blocks the response for potentially seconds
_finalize_session(session)
agent.close()
return _ok(rid, {closed: True})

# After: return immediately; finalize in background
t = threading.Thread(target=_bg_close, args=(session,), daemon=True, ...)
t.start()
return _ok(rid, {closed: True})
```

## Tests

- **Updated** `test_session_close_commits_memory_and_fires_finalize_hook`: waits for the background thread to finish before asserting on commit/hook outcomes (behavior unchanged, timing relaxed)
- **New** `test_session_close_returns_promptly_despite_slow_finalization`: simulates a 300ms `commit_memory_session` and asserts the response returns in <250ms, and that the commit still completes in the background

## Safety

- Session is already removed from `_sessions` before the thread starts — no double-finalization risk
- Thread is daemon so it doesn't block process exit
- All finalization errors are already caught (`try/except` per block) — background execution doesn't change error handling