### PR TITLE
fix: avoid false Web UI build failures on Windows GBK locales

### DIFF
--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -5549,6 +5549,8 @@ def _run_npm_install_deterministic(
             cwd=cwd,
             capture_output=capture_output,
             text=True,
+            encoding="utf-8",
+            errors="replace",
             check=False,
         )
         if ci_result.returncode == 0:
@@ -5561,6 +5563,8 @@ def _run_npm_install_deterministic(
         cwd=cwd,
         capture_output=capture_output,
         text=True,
+        encoding="utf-8",
+        errors="replace",
         check=False,
     )
 
@@ -5597,7 +5601,14 @@ def _build_web_ui(web_dir: Path, *, fatal: bool = False) -> bool:
         if fatal:
             print("  Run manually:  cd web && npm install && npm run build")
         return False
-    r2 = subprocess.run([npm, "run", "build"], cwd=web_dir, capture_output=True)
+    r2 = subprocess.run(
+        [npm, "run", "build"],
+        cwd=web_dir,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+    )
     if r2.returncode != 0:
         print(
             f"  {'✗' if fatal else '⚠'} Web UI build failed"

--- a/tests/hermes_cli/test_web_ui_build.py
+++ b/tests/hermes_cli/test_web_ui_build.py
@@ -13,7 +13,7 @@ from unittest.mock import patch
 
 import pytest
 
-from hermes_cli.main import _web_ui_build_needed, _build_web_ui
+from hermes_cli.main import _web_ui_build_needed, _build_web_ui, _run_npm_install_deterministic
 
 
 def _touch(path: Path, offset: float = 0.0) -> None:
@@ -119,3 +119,31 @@ class TestBuildWebUISkipsWhenFresh:
 
         assert result is True
         assert mock_run.call_count == 2  # npm install + npm run build
+
+    def test_npm_install_uses_utf8_replace_output_decoding(self, tmp_path):
+        web_dir, _ = _make_web_dir(tmp_path)
+        (web_dir / "package-lock.json").write_text("{}", encoding="utf-8")
+
+        mock_cp = __import__("subprocess").CompletedProcess([], 0, stdout="", stderr="")
+        with patch("hermes_cli.main.subprocess.run", return_value=mock_cp) as mock_run:
+            result = _run_npm_install_deterministic("/usr/bin/npm", web_dir)
+
+        assert result.returncode == 0
+        _, kwargs = mock_run.call_args
+        assert kwargs["text"] is True
+        assert kwargs["encoding"] == "utf-8"
+        assert kwargs["errors"] == "replace"
+
+    def test_web_build_uses_utf8_replace_output_decoding(self, tmp_path):
+        web_dir, _ = _make_web_dir(tmp_path)
+
+        mock_cp = __import__("subprocess").CompletedProcess([], 0, stdout="", stderr="")
+        with patch("hermes_cli.main.shutil.which", return_value="/usr/bin/npm"), \
+             patch("hermes_cli.main.subprocess.run", side_effect=[mock_cp, mock_cp]) as mock_run:
+            result = _build_web_ui(web_dir)
+
+        assert result is True
+        _, build_kwargs = mock_run.call_args_list[1]
+        assert build_kwargs["text"] is True
+        assert build_kwargs["encoding"] == "utf-8"
+        assert build_kwargs["errors"] == "replace"


### PR DESCRIPTION
## Summary
- force npm install/npm ci subprocess output to decode as UTF-8 with replacement semantics
- force the Web UI `npm run build` subprocess output to use the same decoding strategy
- add regression coverage for both subprocess paths so Windows locale-dependent decoding does not regress

## Problem
On Windows systems configured with a Chinese GBK locale, `hermes update` could incorrectly report that the Web UI build failed even when the frontend build itself actually succeeded.

The observed failure mode was:
- the update flow printed a background Python traceback from a subprocess reader thread
- the traceback showed `UnicodeDecodeError: 'gbk' codec can't decode byte 0x85 ...`
- Hermes then continued and eventually printed `Web UI build failed (hermes web will not be available)`

This was misleading because running `npm run build` manually in `web/` still succeeded.

## Root cause
The update path captures npm output through Python subprocess APIs. On affected Windows environments, that captured output was being decoded with the process locale instead of a fixed encoding. When npm emitted bytes that are valid in UTF-8 output but invalid under GBK decoding, Python raised `UnicodeDecodeError` inside the background reader thread. That decoding failure then caused Hermes to treat the Web UI build path as failed even though the underlying npm command completed successfully.

## Fix
This patch makes the relevant npm subprocess calls explicit and locale-independent by setting:
- `text=True`
- `encoding="utf-8"`
- `errors="replace"`

The change is applied to:
1. the deterministic npm dependency installation helper (`npm ci` / `npm install`)
2. the Web UI build step (`npm run build`)

Using UTF-8 matches npm's expected output in this workflow, and `errors="replace"` ensures unexpected bytes do not crash output collection.

## Validation
I verified the fix with the following checks:
- `./venv/Scripts/python.exe -m pytest tests/hermes_cli/test_web_ui_build.py -q -o addopts=` → `13 passed`
- direct invocation of the Hermes Web UI build helper returned success
- `npm run build` in `web/` still completed successfully

## Why this approach
This is a narrow, low-risk fix:
- it changes only the npm subprocess calls involved in the failing path
- it avoids depending on the host locale, terminal encoding, or global environment variables
- it preserves existing behavior while preventing false build failures on Windows
