### PR TITLE
fix(delegate): honor per-call and per-task model overrides

### DIFF
--- a/tests/tools/test_delegate.py
+++ b/tests/tools/test_delegate.py
@@ -69,6 +69,8 @@ class TestDelegateRequirements(unittest.TestCase):
         self.assertIn("tasks", props)
         self.assertIn("context", props)
         self.assertIn("toolsets", props)
+        self.assertIn("model", props)
+        self.assertIn("model", props["tasks"]["items"]["properties"])
         # max_iterations is intentionally NOT exposed to the model — it's
         # config-authoritative via delegation.max_iterations so users get
         # predictable budgets.
@@ -384,6 +386,7 @@ class TestDelegateTask(unittest.TestCase):
                 context=None,
                 toolsets=None,
                 model=None,
+                explicit_model_override=False,
                 max_iterations=10,
                 parent_agent=parent,
                 task_count=1,
@@ -405,6 +408,7 @@ class TestDelegateTask(unittest.TestCase):
                 context=None,
                 toolsets=None,
                 model=None,
+                explicit_model_override=False,
                 max_iterations=10,
                 parent_agent=parent,
                 task_count=1,
@@ -1264,6 +1268,127 @@ class TestDelegationProviderIntegration(unittest.TestCase):
             # But provider/base_url/api_key should inherit from parent
             self.assertEqual(kwargs["provider"], parent.provider)
             self.assertEqual(kwargs["base_url"], parent.base_url)
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_top_level_model_override_reaches_child_agent(self, mock_creds, mock_cfg):
+        mock_cfg.return_value = {"max_iterations": 45}
+        mock_creds.return_value = {
+            "model": "configured-subagent-model",
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+        }
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done", "completed": True, "api_calls": 1
+            }
+            MockAgent.return_value = mock_child
+
+            delegate_task(
+                goal="Use explicit child model",
+                model="explicit-call-model",
+                parent_agent=parent,
+            )
+
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["model"], "explicit-call-model")
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_batch_task_model_beats_top_level_model(self, mock_creds, mock_cfg):
+        mock_cfg.return_value = {"max_iterations": 45}
+        mock_creds.return_value = {
+            "model": "configured-subagent-model",
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+        }
+        parent = _make_mock_parent(depth=0)
+
+        with patch("tools.delegate_tool._build_child_agent") as mock_build, \
+             patch("tools.delegate_tool._run_single_child") as mock_run:
+            mock_child = MagicMock()
+            mock_build.return_value = mock_child
+            mock_run.return_value = {
+                "task_index": 0, "status": "completed",
+                "summary": "Done", "api_calls": 1, "duration_seconds": 1.0
+            }
+
+            delegate_task(
+                model="default-child-model",
+                tasks=[
+                    {"goal": "Task A", "model": "task-a-model"},
+                    {"goal": "Task B"},
+                ],
+                parent_agent=parent,
+            )
+
+            self.assertEqual(mock_build.call_args_list[0].kwargs["model"], "task-a-model")
+            self.assertEqual(
+                mock_build.call_args_list[1].kwargs["model"],
+                "default-child-model",
+            )
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_per_call_model_beats_delegation_config_model(self, mock_creds, mock_cfg):
+        mock_cfg.return_value = {"max_iterations": 45, "model": "configured-subagent-model"}
+        mock_creds.return_value = {
+            "model": "configured-subagent-model",
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+        }
+        parent = _make_mock_parent(depth=0)
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done", "completed": True, "api_calls": 1
+            }
+            MockAgent.return_value = mock_child
+
+            delegate_task(
+                goal="Override configured delegation model",
+                model="explicit-call-model",
+                parent_agent=parent,
+            )
+
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["model"], "explicit-call-model")
+
+    @patch("tools.delegate_tool._load_config")
+    @patch("tools.delegate_tool._resolve_delegation_credentials")
+    def test_delegation_config_model_still_applies_without_override(self, mock_creds, mock_cfg):
+        mock_cfg.return_value = {"max_iterations": 45, "model": "configured-subagent-model"}
+        mock_creds.return_value = {
+            "model": "configured-subagent-model",
+            "provider": None,
+            "base_url": None,
+            "api_key": None,
+            "api_mode": None,
+        }
+        parent = _make_mock_parent(depth=0)
+        parent.model = "parent-model"
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            mock_child = MagicMock()
+            mock_child.run_conversation.return_value = {
+                "final_response": "done", "completed": True, "api_calls": 1
+            }
+            MockAgent.return_value = mock_child
+
+            delegate_task(goal="Use configured model", parent_agent=parent)
+
+            _, kwargs = MockAgent.call_args
+            self.assertEqual(kwargs["model"], "configured-subagent-model")
 
 
 class TestChildCredentialPoolResolution(unittest.TestCase):
@@ -2497,6 +2622,7 @@ class TestFallbackModelInheritance(unittest.TestCase):
                 context=None,
                 toolsets=None,
                 model=None,
+                explicit_model_override=False,
                 max_iterations=10,
                 parent_agent=parent,
                 task_count=1,
@@ -2518,12 +2644,36 @@ class TestFallbackModelInheritance(unittest.TestCase):
                 context=None,
                 toolsets=None,
                 model=None,
+                explicit_model_override=False,
                 max_iterations=10,
                 parent_agent=parent,
                 task_count=1,
             )
 
         _, kwargs = MockAgent.call_args
+        self.assertIsNone(kwargs["fallback_model"])
+
+    def test_explicit_model_override_does_not_inherit_parent_fallback(self):
+        parent = _make_mock_parent(depth=0)
+        fallback_entry = {"provider": "openrouter", "model": "gpt-4o-mini", "api_key": "sk-or-x"}
+        parent._fallback_chain = [fallback_entry]
+
+        with patch("run_agent.AIAgent") as MockAgent:
+            MockAgent.return_value = MagicMock()
+            _build_child_agent(
+                task_index=0,
+                goal="test explicit model override",
+                context=None,
+                toolsets=None,
+                model="explicit-model",
+                explicit_model_override=True,
+                max_iterations=10,
+                parent_agent=parent,
+                task_count=1,
+            )
+
+        _, kwargs = MockAgent.call_args
+        self.assertEqual(kwargs["model"], "explicit-model")
         self.assertIsNone(kwargs["fallback_model"])
 
 

--- a/tools/delegate_tool.py
+++ b/tools/delegate_tool.py
@@ -321,6 +321,16 @@ def _normalize_role(r: Optional[str]) -> str:
     return "leaf"
 
 
+def _normalize_model_override(value: Any) -> Optional[str]:
+    """Normalize a caller-provided model override to a non-empty string."""
+    if value is None:
+        return None
+    if isinstance(value, str):
+        value = value.strip()
+        return value or None
+    return None
+
+
 def _get_max_concurrent_children() -> int:
     """Read delegation.max_concurrent_children from config, falling back to
     DELEGATION_MAX_CONCURRENT_CHILDREN env var, then the default (3).
@@ -883,6 +893,7 @@ def _build_child_agent(
     # 'leaf' (default) cannot; 'orchestrator' retains the delegation
     # toolset subject to depth/kill-switch bounds applied below.
     role: str = "leaf",
+    explicit_model_override: bool = False,
 ):
     """
     Build a child AIAgent on the main thread (thread-safe construction).
@@ -1064,7 +1075,9 @@ def _build_child_agent(
     # from rate-limits and credential exhaustion exactly like the top-level
     # agent does.  _fallback_chain is a list accepted by AIAgent's
     # fallback_model parameter (which handles both list and dict forms).
-    parent_fallback = getattr(parent_agent, "_fallback_chain", None) or None
+    parent_fallback = None if explicit_model_override else (
+        getattr(parent_agent, "_fallback_chain", None) or None
+    )
 
     # Inherit the parent's OpenRouter provider-preference filters by default
     # (so subagents routed to the same provider honour the same routing
@@ -1904,19 +1917,23 @@ def delegate_task(
     acp_command: Optional[str] = None,
     acp_args: Optional[List[str]] = None,
     role: Optional[str] = None,
+    model: Optional[str] = None,
     parent_agent=None,
 ) -> str:
     """
     Spawn one or more child agents to handle delegated tasks.
 
     Supports two modes:
-      - Single: provide goal (+ optional context, toolsets, role)
-      - Batch:  provide tasks array [{goal, context, toolsets, role}, ...]
+      - Single: provide goal (+ optional context, toolsets, role, model)
+      - Batch:  provide tasks array [{goal, context, toolsets, role, model}, ...]
 
     The 'role' parameter controls whether a child can further delegate:
     'leaf' (default) cannot; 'orchestrator' retains the delegation
     toolset and can spawn its own workers, bounded by
     delegation.max_spawn_depth.  Per-task role beats the top-level one.
+
+    Model precedence is:
+      tasks[].model > delegate_task(model=...) > delegation.model > parent.model
 
     Returns JSON with results array, one entry per task.
     """
@@ -1934,6 +1951,7 @@ def delegate_task(
 
     # Normalise the top-level role once; per-task overrides re-normalise.
     top_role = _normalize_role(role)
+    top_model = _normalize_model_override(model)
 
     # Depth limit — configurable via delegation.max_spawn_depth,
     # default 2 for parity with the original MAX_DEPTH constant.
@@ -1997,7 +2015,13 @@ def delegate_task(
         task_list = tasks
     elif goal and isinstance(goal, str) and goal.strip():
         task_list = [
-            {"goal": goal, "context": context, "toolsets": toolsets, "role": top_role}
+            {
+                "goal": goal,
+                "context": context,
+                "toolsets": toolsets,
+                "role": top_role,
+                "model": top_model,
+            }
         ]
     else:
         return tool_error("Provide either 'goal' (single task) or 'tasks' (batch).")
@@ -2038,12 +2062,16 @@ def delegate_task(
             # Per-task role beats top-level; normalise again so unknown
             # per-task values warn and degrade to leaf uniformly.
             effective_role = _normalize_role(t.get("role") or top_role)
+            task_model = _normalize_model_override(t.get("model"))
+            child_model = task_model or top_model or creds["model"]
+            explicit_model_override = task_model is not None or top_model is not None
             child = _build_child_agent(
                 task_index=i,
                 goal=t["goal"],
                 context=t.get("context"),
                 toolsets=t.get("toolsets") or toolsets,
-                model=creds["model"],
+                model=child_model,
+                explicit_model_override=explicit_model_override,
                 max_iterations=effective_max_iter,
                 task_count=n_tasks,
                 parent_agent=parent_agent,
@@ -2669,6 +2697,13 @@ DELEGATE_TASK_SCHEMA = {
                     "['terminal', 'file', 'web'] for full-stack tasks."
                 ),
             },
+            "model": {
+                "type": "string",
+                "description": (
+                    "Optional model override for child agents in this delegation call. "
+                    "Per-task tasks[].model overrides this top-level value."
+                ),
+            },
             "tasks": {
                 "type": "array",
                 "items": {
@@ -2683,6 +2718,13 @@ DELEGATE_TASK_SCHEMA = {
                             "type": "array",
                             "items": {"type": "string"},
                             "description": f"Toolsets for this specific task. Available: {_TOOLSET_LIST_STR}. Use 'web' for network access, 'terminal' for shell, 'browser' for web interaction.",
+                        },
+                        "model": {
+                            "type": "string",
+                            "description": (
+                                "Model override for this specific task. "
+                                "Overrides the top-level model for this task only."
+                            ),
                         },
                         "acp_command": {
                             "type": "string",
@@ -2759,6 +2801,7 @@ registry.register(
         acp_command=args.get("acp_command"),
         acp_args=args.get("acp_args"),
         role=args.get("role"),
+        model=args.get("model"),
         parent_agent=kw.get("parent_agent"),
     ),
     check_fn=check_delegate_requirements,


### PR DESCRIPTION
## What does this PR do?

Fixes a delegation wiring gap: `delegate_task()` could only route child models
through `delegation.model` config or by inheriting the parent model. A single
delegation call could not explicitly choose a child model, and batch mode could
not route different sub-tasks to different models.

This PR adds per-call and per-task model overrides for delegation without
expanding the provider/credential system.

Model selection precedence is now:

- `tasks[].model`
- `delegate_task(model=...)`
- `delegation.model`
- `parent_agent.model`

It also keeps explicit model overrides from silently inheriting the parent's
fallback model chain, so a child that was explicitly routed to another model
does not fail back onto the parent model behind the caller's back.

This PR intentionally does **not** add per-task provider overrides. Provider,
base URL, API mode, and credential resolution remain controlled by existing
delegation config and parent runtime state.

## Related Issue

Fixes the `delegate_task` per-call / per-task model override gap described in
the delegation model routing discussion.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- Added top-level `model` support to [`tools/delegate_tool.py`](../tools/delegate_tool.py)
  `delegate_task(...)`.
- Added per-task `tasks[].model` support to the delegate tool schema.
- Threaded model override precedence through child construction:
  - `tasks[].model > delegate_task(model=...) > delegation.model > parent.model`
- Added `_normalize_model_override(...)` helper to keep override parsing narrow
  and explicit.
- Prevented explicit model overrides from inheriting the parent's fallback chain.
- Added regression coverage in [`tests/tools/test_delegate.py`](../tests/tools/test_delegate.py) for:
  - schema exposure of `model`
  - top-level model override
  - per-task model override beating top-level
  - per-call override beating `delegation.model`
  - config model still applying without override
  - explicit model override clearing inherited fallback

## How to Test

1. Run the delegate tool test suite:
   ```bash
   python3 -m pytest -q -n 0 tests/tools/test_delegate.py
   ```
2. Confirm the suite passes.
3. Verify the new behaviors covered by tests:
   - schema exposes top-level `model` and `tasks[].model`
   - single-call override reaches child `AIAgent(model=...)`
   - `tasks[].model` beats top-level `model`
   - explicit override beats `delegation.model`
   - no override keeps current `delegation.model` behavior
   - explicit override does not inherit parent fallback chain

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: WSL / Linux `python3 -m pytest`

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Focused verification passed locally:

```text
132 passed in 15.34s
```
