### PR TITLE
fix(cli): restore local shift-enter newline

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -1865,17 +1865,19 @@ _TERMINAL_INPUT_MODE_RESET_SEQ = (
 
 
 def _preserve_ctrl_enter_newline() -> bool:
-    """Detect environments where Ctrl+Enter must produce a newline, not submit.
+    """Detect environments where LF/c-j should produce a newline, not submit.
 
-    Native Windows, WSL, SSH sessions, and Windows Terminal all send Ctrl+Enter
-    as bare LF (c-j). On those terminals c-j must NOT be bound to submit;
-    binding it to submit makes Ctrl+Enter (intended as 'newline like Alt+Enter')
-    submit instead. Local POSIX TTYs that deliver Enter as LF (docker exec,
-    some thin PTYs without SSH) still need c-j bound to submit, so we keep
-    that binding for those.
+    The classic CLI uses Enter (c-m) for submit. Some terminals deliver
+    Shift+Enter / Ctrl+Enter as bare LF (c-j), and those should keep working as
+    multiline newlines by default. Thin PTYs that really need LF submit can opt
+    back in with ``HERMES_CLI_SUBMIT_ON_LF=1``.
 
-    See issue #22379.
+    This preserves the pre-regression local multiline behavior on macOS while
+    keeping an explicit escape hatch for thin PTYs. See issues #22379 and
+    #22908.
     """
+    if str(os.environ.get("HERMES_CLI_SUBMIT_ON_LF", "")).strip().lower() in {"1", "true", "yes", "on"}:
+        return False
     if sys.platform == "win32":
         return True
     if any(os.environ.get(v) for v in ("SSH_CONNECTION", "SSH_CLIENT", "SSH_TTY")):
@@ -1883,6 +1885,8 @@ def _preserve_ctrl_enter_newline() -> bool:
     if os.environ.get("WT_SESSION"):
         return True
     if "microsoft" in os.environ.get("WSL_DISTRO_NAME", "").lower():
+        return True
+    if sys.platform != "win32":
         return True
     # WSL detection — env vars can be scrubbed under sudo, also peek /proc.
     for p in ("/proc/version", "/proc/sys/kernel/osrelease"):
@@ -1898,16 +1902,9 @@ def _preserve_ctrl_enter_newline() -> bool:
 def _bind_prompt_submit_keys(kb, handler) -> None:
     """Bind terminal Enter forms to the submit handler.
 
-    Enter is always submit. On POSIX we also bind c-j (LF) to submit because
-    some thin PTYs (docker exec, certain SSH flavors) deliver Enter as LF
-    instead of CR — without this, Enter appears dead on those terminals.
-
-    Exception: on Windows, WSL, SSH sessions, and Windows Terminal,
-    c-j is the wire encoding of Ctrl+Enter (a distinct keystroke from
-    plain Enter / c-m). We leave c-j unbound there so the c-j newline
-    handler registered separately can fire — giving the user an
-    Enter-involving newline keystroke without terminal settings changes.
-    See _preserve_ctrl_enter_newline() and issue #22379.
+    Enter is always submit. LF/c-j is reserved for newline by default so local
+    multiline composition keeps working. Thin PTYs that need LF submit can opt
+    back in with ``HERMES_CLI_SUBMIT_ON_LF=1``.
     """
     kb.add("enter")(handler)
     if sys.platform != "win32" and not _preserve_ctrl_enter_newline():
@@ -11184,16 +11181,15 @@ class HermesCLI:
         if _preserve_ctrl_enter_newline():
             @kb.add('c-j')
             def handle_ctrl_enter_newline(event):
-                """Ctrl+Enter inserts a newline on Windows, WSL, SSH, and WT.
+                """LF/c-j inserts a newline whenever submit-on-LF is disabled.
 
-                Windows Terminal (incl. WSL/SSH sessions through it) delivers
-                Ctrl+Enter as LF (c-j), distinct from plain Enter (c-m). This
-                binding makes Ctrl+Enter the equivalent of Alt+Enter on those
-                terminals, giving an Enter-involving newline keystroke
-                without requiring terminal settings changes. Ctrl+J (the raw
-                LF keystroke) also triggers this by virtue of being the same
-                key code — a harmless side effect since Ctrl+J has no
-                conflicting Hermes binding. See issue #22379.
+                This keeps Shift+Enter / Ctrl+Enter working on terminals that
+                deliver those keys as LF (c-j), and restores the local macOS
+                multiline behavior from before the LF-submit regression. Thin
+                PTYs can still opt back into LF submit via
+                ``HERMES_CLI_SUBMIT_ON_LF=1``. Ctrl+J also triggers this
+                binding because it shares the same key code, which is harmless
+                because Hermes does not reserve Ctrl+J for anything else.
                 """
                 event.current_buffer.insert_text('\n')
 

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -164,14 +164,7 @@ class TestBusyInputMode:
 
 class TestPromptToolkitTerminalCompatibility:
     def test_lf_enter_binds_to_submit_handler_posix(self):
-        """Some thin PTYs deliver Enter as LF/c-j instead of CR/enter.
-
-        On a bare local POSIX TTY (no SSH/WSL/WT) we keep c-j → submit so
-        Enter works on thin PTYs (docker exec, certain ssh configurations).
-        On Windows, WSL, SSH sessions, and Windows Terminal we leave c-j
-        unbound here so it can be used as the Ctrl+Enter newline keystroke
-        without conflicting with submit. See issue #22379.
-        """
+        """Enter always submits; LF/c-j only submits when explicitly opted in."""
         import sys as _sys
         import os as _os
         from unittest.mock import patch as _patch
@@ -182,7 +175,8 @@ class TestPromptToolkitTerminalCompatibility:
         def submit_handler(event):
             return None
 
-        # Bare local POSIX (no SSH/WSL markers): both enter and c-j submit.
+        # Bare local POSIX: c-j stays free so Shift+Enter/Ctrl+Enter style
+        # LF terminals keep multiline composition by default.
         with _patch.object(_sys, "platform", "linux"), \
              _patch.dict(_os.environ, {}, clear=True), \
              _patch("builtins.open", side_effect=OSError("no /proc")):
@@ -190,10 +184,9 @@ class TestPromptToolkitTerminalCompatibility:
             _bind_prompt_submit_keys(kb, submit_handler)
             bindings = {tuple(key.value for key in binding.keys): binding.handler for binding in kb.bindings}
             assert bindings[("c-m",)] is submit_handler
-            assert bindings[("c-j",)] is submit_handler
+            assert ("c-j",) not in bindings
 
-        # POSIX over SSH: c-j stays free so Ctrl+Enter (sent as LF by
-        # Windows Terminal / Kitty / mintty over SSH) inserts a newline.
+        # POSIX over SSH: c-j still stays free for newline.
         with _patch.object(_sys, "platform", "linux"), \
              _patch.dict(_os.environ, {"SSH_CONNECTION": "1.2.3.4 5 6.7.8.9 22"}, clear=True), \
              _patch("builtins.open", side_effect=OSError("no /proc")):
@@ -211,6 +204,17 @@ class TestPromptToolkitTerminalCompatibility:
             bindings = {tuple(key.value for key in binding.keys): binding.handler for binding in kb.bindings}
             assert bindings[("c-m",)] is submit_handler
             assert ("c-j",) not in bindings
+
+        # Thin PTY compatibility can be restored explicitly when LF must
+        # submit instead of inserting a newline.
+        with _patch.object(_sys, "platform", "linux"), \
+             _patch.dict(_os.environ, {"HERMES_CLI_SUBMIT_ON_LF": "1"}, clear=True), \
+             _patch("builtins.open", side_effect=OSError("no /proc")):
+            kb = KeyBindings()
+            _bind_prompt_submit_keys(kb, submit_handler)
+            bindings = {tuple(key.value for key in binding.keys): binding.handler for binding in kb.bindings}
+            assert bindings[("c-m",)] is submit_handler
+            assert bindings[("c-j",)] is submit_handler
 
     def test_cpr_warning_callback_is_disabled(self):
         from cli import _disable_prompt_toolkit_cpr_warning

--- a/tests/cli/test_ctrl_enter_newline.py
+++ b/tests/cli/test_ctrl_enter_newline.py
@@ -52,14 +52,20 @@ def test_windows_terminal_session_preserves_newline():
 
 
 def test_pure_local_linux_does_not_preserve():
-    """A bare local Linux TTY (no SSH/WSL/WT) keeps c-j → submit so docker exec
-    style Enter-as-LF stays usable."""
+    """A bare local Linux TTY now preserves LF/c-j for multiline composition."""
     import cli as cli_mod
     # Stub out /proc reads — those are the WSL fallback signal.
     with patch.object(sys, "platform", "linux"):
         with patch.dict(os.environ, {}, clear=True):
             with patch("builtins.open", side_effect=OSError("no /proc")):
-                assert cli_mod._preserve_ctrl_enter_newline() is False
+                assert cli_mod._preserve_ctrl_enter_newline() is True
+
+
+def test_submit_on_lf_env_disables_newline_preservation():
+    import cli as cli_mod
+    with patch.object(sys, "platform", "linux"):
+        with patch.dict(os.environ, {"HERMES_CLI_SUBMIT_ON_LF": "1"}, clear=True):
+            assert cli_mod._preserve_ctrl_enter_newline() is False
 
 
 def test_proc_version_microsoft_marker_preserves_newline():


### PR DESCRIPTION
## What does this PR do?

Restores local Shift+Enter newline behavior in the classic CLI while keeping an explicit opt-in for thin PTY setups that want LF/Ctrl-J to submit.

## Related Issue

Fixes #22908

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- restored newline-preserving behavior for local classic CLI sessions in `cli.py`
- added `HERMES_CLI_SUBMIT_ON_LF=1` as the explicit opt-in that re-enables LF/Ctrl-J submit behavior when needed
- updated targeted CLI tests in `tests/cli/test_ctrl_enter_newline.py` and `tests/cli/test_cli_init.py`

## How to Test

1. `uv run --frozen --extra dev pytest -q -o addopts='' tests/cli/test_ctrl_enter_newline.py tests/cli/test_cli_shift_enter_newline.py tests/cli/test_cli_init.py -k 'ctrl_enter or shift_enter or lf_enter_binds'`
2. `uv run --frozen ruff check cli.py tests/cli/test_ctrl_enter_newline.py tests/cli/test_cli_shift_enter_newline.py tests/cli/test_cli_init.py`
3. confirm local sessions preserve Shift+Enter newline by default, and set `HERMES_CLI_SUBMIT_ON_LF=1` to get LF/Ctrl-J submit in thin PTYs

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `17 passed, 33 deselected` from the targeted CLI pytest verification above
