### PR TITLE
fix(discord): classify mixed attachments by supported media

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -4211,27 +4211,31 @@ class DiscordAdapter(BasePlatformAdapter):
                     auto_threaded_channel = thread
                     self._threads.mark(thread_id)
 
-        # Determine message type
+        # Determine message type. Keep a first-pass attachment classification
+        # so document-only messages still dispatch as media even if caching is
+        # skipped, then reconcile against the actual media_types list after
+        # processing to avoid mixed-attachment misclassification.
         msg_type = MessageType.TEXT
         if normalized_content.startswith("/"):
             msg_type = MessageType.COMMAND
         elif message.attachments:
-            # Check attachment types
             for att in message.attachments:
-                if att.content_type:
-                    if att.content_type.startswith("image/"):
-                        msg_type = MessageType.PHOTO
-                    elif att.content_type.startswith("video/"):
-                        msg_type = MessageType.VIDEO
-                    elif att.content_type.startswith("audio/"):
-                        msg_type = MessageType.AUDIO
-                    else:
-                        doc_ext = ""
-                        if att.filename:
-                            _, doc_ext = os.path.splitext(att.filename)
-                            doc_ext = doc_ext.lower()
-                        if doc_ext in SUPPORTED_DOCUMENT_TYPES:
-                            msg_type = MessageType.DOCUMENT
+                content_type = att.content_type or ""
+                if content_type.startswith("image/"):
+                    msg_type = MessageType.PHOTO
+                    break
+                if content_type.startswith("video/"):
+                    msg_type = MessageType.VIDEO
+                    break
+                if content_type.startswith("audio/"):
+                    msg_type = MessageType.AUDIO
+                    break
+                doc_ext = ""
+                if att.filename:
+                    _, doc_ext = os.path.splitext(att.filename)
+                    doc_ext = doc_ext.lower()
+                if doc_ext in SUPPORTED_DOCUMENT_TYPES:
+                    msg_type = MessageType.DOCUMENT
                     break
 
         # When auto-threading kicked in, route responses to the new thread
@@ -4356,6 +4360,17 @@ class DiscordAdapter(BasePlatformAdapter):
                                 "[Discord] Failed to cache document %s: %s",
                                 att.filename, e, exc_info=True,
                             )
+
+        if msg_type != MessageType.COMMAND and media_types:
+            first_type = media_types[0].lower()
+            if first_type.startswith("image/"):
+                msg_type = MessageType.PHOTO
+            elif first_type.startswith("video/"):
+                msg_type = MessageType.VIDEO
+            elif first_type.startswith("audio/"):
+                msg_type = MessageType.AUDIO
+            else:
+                msg_type = MessageType.DOCUMENT
 
         # Use normalized_content (saved before auto-threading) instead of message.content,
         # to detect /slash commands in channel messages.

--- a/tests/gateway/test_discord_document_handling.py
+++ b/tests/gateway/test_discord_document_handling.py
@@ -384,3 +384,24 @@ class TestIncomingDocumentHandling:
         assert event.message_type == MessageType.PHOTO
         assert event.media_urls == ["/tmp/cached_image.png"]
         assert event.media_types == ["image/png"]
+
+    @pytest.mark.asyncio
+    async def test_mixed_unsupported_then_image_uses_media_type(self, adapter):
+        """A later supported attachment must override an earlier unsupported blob."""
+        with patch(
+            "gateway.platforms.discord.cache_image_from_url",
+            new_callable=AsyncMock,
+            return_value="/tmp/mixed_image.png",
+        ):
+            msg = make_message(
+                [
+                    make_attachment(filename="blob.bin", content_type="application/octet-stream"),
+                    make_attachment(filename="photo.png", content_type="image/png"),
+                ]
+            )
+            await adapter._handle_message(msg)
+
+        event = adapter.handle_message.call_args[0][0]
+        assert event.message_type == MessageType.PHOTO
+        assert event.media_urls == ["/tmp/mixed_image.png"]
+        assert event.media_types == ["image/png"]


### PR DESCRIPTION
## What does this PR do?

Fixes Discord mixed-attachment handling so a later supported attachment still determines the incoming Hermes event type. This prevents messages like `blob.bin + photo.png` from being classified as plain text when the first attachment is unsupported.

## Related Issue

Fixes #11771

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- update `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/hermes-11771-discord-mixed-attachments/gateway/platforms/discord.py` to keep first-pass attachment classification and reconcile it with processed `media_types`
- continue scanning attachments until a supported media/document type is found instead of letting an early unsupported blob dominate
- add a regression test in `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/hermes-11771-discord-mixed-attachments/tests/gateway/test_discord_document_handling.py` covering `application/octet-stream` followed by `image/png`

## How to Test

1. `uv run --frozen --extra dev pytest -q -o addopts='' tests/gateway/test_discord_document_handling.py`
2. `uv run --frozen ruff check gateway/platforms/discord.py tests/gateway/test_discord_document_handling.py`
3. Confirm `test_mixed_unsupported_then_image_uses_media_type` keeps the event as `MessageType.PHOTO`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- [x] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [x] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [x] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [x] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

- `uv run --frozen --extra dev pytest -q -o addopts='' tests/gateway/test_discord_document_handling.py` -> `12 passed`
- `uv run --frozen ruff check gateway/platforms/discord.py tests/gateway/test_discord_document_handling.py` -> `All checks passed!`
