### PR TITLE
fix(cli): remove return from voice finally block

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9293,30 +9293,31 @@ class HermesCLI:
             except Exception:
                 pass
 
-            # Track consecutive no-speech cycles to avoid infinite restart loops.
-            if not submitted:
-                self._no_speech_count = getattr(self, '_no_speech_count', 0) + 1
-                if self._no_speech_count >= 3:
-                    self._voice_continuous = False
-                    self._no_speech_count = 0
-                    _cprint(f"{_DIM}No speech detected 3 times, continuous mode stopped.{_RST}")
-                    return
-            else:
+        # Track consecutive no-speech cycles to avoid infinite restart loops.
+        stop_continuous = False
+        if not submitted:
+            self._no_speech_count = getattr(self, '_no_speech_count', 0) + 1
+            if self._no_speech_count >= 3:
+                self._voice_continuous = False
                 self._no_speech_count = 0
+                stop_continuous = True
+                _cprint(f"{_DIM}No speech detected 3 times, continuous mode stopped.{_RST}")
+        else:
+            self._no_speech_count = 0
 
-            # If no transcript was submitted but continuous mode is active,
-            # restart recording so the user can keep talking.
-            # (When transcript IS submitted, process_loop handles restart
-            # after chat() completes.)
-            if self._voice_continuous and not submitted and not self._voice_recording:
-                def _restart_recording():
-                    try:
-                        self._voice_start_recording()
-                        if hasattr(self, '_app') and self._app:
-                            self._app.invalidate()
-                    except Exception as e:
-                        _cprint(f"{_DIM}Voice auto-restart failed: {e}{_RST}")
-                threading.Thread(target=_restart_recording, daemon=True).start()
+        # If no transcript was submitted but continuous mode is active,
+        # restart recording so the user can keep talking.
+        # (When transcript IS submitted, process_loop handles restart
+        # after chat() completes.)
+        if not stop_continuous and self._voice_continuous and not submitted and not self._voice_recording:
+            def _restart_recording():
+                try:
+                    self._voice_start_recording()
+                    if hasattr(self, '_app') and self._app:
+                        self._app.invalidate()
+                except Exception as e:
+                    _cprint(f"{_DIM}Voice auto-restart failed: {e}{_RST}")
+            threading.Thread(target=_restart_recording, daemon=True).start()
 
     def _voice_speak_response_async(self, text: str) -> None:
         """Schedule TTS and mark it pending before continuous recording can restart."""

--- a/tests/tools/test_voice_cli_integration.py
+++ b/tests/tools/test_voice_cli_integration.py
@@ -2,9 +2,11 @@
 state management, streaming TTS activation, voice message prefix, _vprint."""
 
 import ast
+import inspect
 import os
 import queue
 import threading
+import textwrap
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -1035,6 +1037,26 @@ class TestDisableVoiceModeReal:
         cli = _make_voice_cli(_voice_mode=True)
         cli._disable_voice_mode()
         assert cli._voice_mode is False
+
+
+class TestVoiceProcessingStructure:
+    def test_voice_stop_and_transcribe_has_no_return_in_finally(self):
+        """Python 3.14 warns when a finally block contains a return."""
+        from cli import HermesCLI
+
+        source = textwrap.dedent(inspect.getsource(HermesCLI._voice_stop_and_transcribe))
+        tree = ast.parse(source)
+        fn = next(node for node in tree.body if isinstance(node, ast.FunctionDef))
+
+        returns_in_finally = []
+        for node in ast.walk(fn):
+            if isinstance(node, ast.Try):
+                for final_node in node.finalbody:
+                    for inner in ast.walk(final_node):
+                        if isinstance(inner, ast.Return):
+                            returns_in_finally.append(inner)
+
+        assert not returns_in_finally
 
 
 class TestVoiceSpeakResponseReal:


### PR DESCRIPTION
## What does this PR do?

Removes the `return` from the `finally` block in Hermes voice cleanup so Python 3.14+ no longer emits a `SyntaxWarning`, while preserving the existing continuous-voice restart behavior.

## Related Issue

Fixes #21088

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- restructure `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/hermes-21088-voice-finally/cli.py` so post-cleanup voice restart logic runs after `finally`
- replace the `return` in `_voice_stop_and_transcribe` with a `stop_continuous` flag that preserves the 3x no-speech stop rule
- add an AST-based regression test in `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/hermes-21088-voice-finally/tests/tools/test_voice_cli_integration.py` to assert the `finally` block no longer contains a `return`

## How to Test

1. `uv run --frozen --extra dev pytest -q -o addopts='' tests/tools/test_voice_cli_integration.py -k 'voice_stop_and_transcribe_has_no_return_in_finally'`
2. `PYTHONWARNINGS='error::SyntaxWarning' uv run --frozen python -m py_compile cli.py`
3. `uv run --frozen ruff check cli.py tests/tools/test_voice_cli_integration.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

- `uv run --frozen --extra dev pytest -q -o addopts='' tests/tools/test_voice_cli_integration.py -k 'voice_stop_and_transcribe_has_no_return_in_finally'` -> `1 passed`
- `PYTHONWARNINGS='error::SyntaxWarning' uv run --frozen python -m py_compile cli.py` -> passed
- `uv run --frozen ruff check cli.py tests/tools/test_voice_cli_integration.py` -> `All checks passed!`
