### PR TITLE
refactor(platforms): remove redundant sys.path.insert boilerplate

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -479,9 +479,6 @@ from pathlib import Path
 from typing import Dict, List, Optional, Any, Callable, Awaitable, Tuple, Union
 from enum import Enum
 
-from pathlib import Path as _Path
-sys.path.insert(0, str(_Path(__file__).resolve().parents[2]))
-
 from gateway.config import Platform, PlatformConfig
 from gateway.session import SessionSource, build_session_key
 from hermes_constants import get_default_hermes_root, get_hermes_dir, get_hermes_home

--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -31,11 +31,6 @@ except ImportError:
     AsyncSocketModeHandler = Any
     AsyncWebClient = Any
 
-import sys
-from pathlib import Path as _Path
-
-sys.path.insert(0, str(_Path(__file__).resolve().parents[2]))
-
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.helpers import MessageDeduplicator
 from gateway.platforms.base import (

--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -60,10 +60,6 @@ except ImportError:
         DEFAULT_TYPE = Any
     ContextTypes = _MockContextTypes
 
-import sys
-from pathlib import Path as _Path
-sys.path.insert(0, str(_Path(__file__).resolve().parents[2]))
-
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
     BasePlatformAdapter,

--- a/gateway/platforms/whatsapp.py
+++ b/gateway/platforms/whatsapp.py
@@ -176,9 +176,6 @@ def _terminate_bridge_process(proc, *, force: bool = False) -> None:
     except psutil.NoSuchProcess:
         return
 
-import sys
-sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
-
 from gateway.config import Platform, PlatformConfig
 from gateway.platforms.base import (
     BasePlatformAdapter,

--- a/plugins/platforms/discord/adapter.py
+++ b/plugins/platforms/discord/adapter.py
@@ -43,10 +43,6 @@ except ImportError:
     Intents = Any
     commands = None
 
-import sys
-from pathlib import Path as _Path
-sys.path.insert(0, str(_Path(__file__).resolve().parents[2]))
-
 from gateway.config import Platform, PlatformConfig
 import re
 

--- a/scripts/release.py
+++ b/scripts/release.py
@@ -227,6 +227,7 @@ AUTHOR_MAP = {
     "mason@growagainorchids.com": "masonjames",
     "108541149+amethystani@users.noreply.github.com": "amethystani",
     "ytchen0719@gmail.com": "liquidchen",
+    "mehmet.kar@std.yildiz.edu.tr": "mehmetkr-31",
     "am@studio1.tailb672fe.ts.net": "subtract0",
     "mike@grossmann.at": "ReqX",
     "axmaiqiu@gmail.com": "qWaitCrypto",


### PR DESCRIPTION
gateway/run.py already inserts the repo root into sys.path before any adapter is imported. These five adapters (telegram, discord, slack, whatsapp, base) manually repeated the same insert, which is unnecessary and creates import side-effects.

Removes the redundant sys.path.insert from all five files. No behavior change — imports resolve identically because the gateway entry point already sets up the path.