### PR TITLE
fix(kanban): use localized column label in select-all aria label

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -1898,7 +1898,7 @@
           type: "checkbox",
           className: "hermes-kanban-col-check",
           title: "Select all tasks in this column",
-          "aria-label": `Select all tasks in ${COLUMN_LABEL[props.column.name] || props.column.name}`,
+          "aria-label": `Select all tasks in ${colLabel || props.column.name}`,
           checked: props.column.tasks.length > 0 && props.column.tasks.every(function (t) { return props.selectedIds.has(t.id); }),
           onChange: function (e) {
             e.stopPropagation();


### PR DESCRIPTION
## What does this PR do?

Fixes a Kanban dashboard render crash caused by a stale `COLUMN_LABEL` reference in the column select-all checkbox aria label.

The dashboard now computes `colLabel` through `getColumnLabel(t, props.column.name)`, which supports the current i18n fallback path. Reusing that value avoids referencing the removed `COLUMN_LABEL` object and keeps the accessible label aligned with the rendered column title.

Before this change, opening the Kanban dashboard could fail with:

```text
ReferenceError: COLUMN_LABEL is not defined
```

## Related Issue

Fixes #23620.

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `plugins/kanban/dashboard/dist/index.js`
  - Replaces the stale `COLUMN_LABEL[props.column.name]` lookup with the already computed `colLabel` fallback for the select-all checkbox `aria-label`.

## How to Test

1. Start the dashboard and open the Kanban tab.
2. Confirm the board renders instead of showing the plugin render error.
3. Confirm the column select-all checkboxes have accessible labels such as `Select all tasks in Triage`.
4. Run validation commands:

```bash
node --check plugins/kanban/dashboard/dist/index.js
python -m pytest tests/plugins/test_kanban_dashboard_plugin.py -q -o 'addopts='
```

Validated locally:

```text
node --check plugins/kanban/dashboard/dist/index.js
# no output, exit code 0

python -m pytest tests/plugins/test_kanban_dashboard_plugin.py -q -o 'addopts='
# 81 passed
```

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [ ] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04 / Linux, dashboard served locally

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Before:

```text
KANBAN TAB HIT A RENDERING ERROR
COLUMN_LABEL is not defined
```

After:

- Kanban tab renders successfully.
- Browser console shows no JavaScript errors.
- Column select-all checkbox labels render from the localized/fallback column label.

