### PR TITLE
fix(gateway): expose busy command outside cli

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -6097,13 +6097,13 @@ class GatewayRunner:
             # /fast and /reasoning are config-only and take effect next
             # message, so they fall through to the catch-all busy response
             # below — users should wait and set them between turns.
-            if _cmd_def_inner and _cmd_def_inner.name in ("yolo", "verbose"):
+            if _cmd_def_inner and _cmd_def_inner.name in ("yolo", "verbose", "busy"):
                 if _cmd_def_inner.name == "yolo":
                     return await self._handle_yolo_command(event)
                 if _cmd_def_inner.name == "verbose":
                     return await self._handle_verbose_command(event)
-                if _cmd_def_inner.name == "footer":
-                    return await self._handle_footer_command(event)
+                if _cmd_def_inner.name == "busy":
+                    return await self._handle_busy_command(event)
 
             # Gateway-handled info/control commands with dedicated
             # running-agent handlers.
@@ -6374,6 +6374,9 @@ class GatewayRunner:
 
         if canonical == "verbose":
             return await self._handle_verbose_command(event)
+
+        if canonical == "busy":
+            return await self._handle_busy_command(event)
 
         if canonical == "footer":
             return await self._handle_footer_command(event)
@@ -10731,6 +10734,58 @@ class GatewayRunner:
             if preview:
                 example = t("gateway.footer.example_line", preview=preview)
         return t("gateway.footer.saved", state=state, example=example)
+
+    async def _handle_busy_command(self, event: MessageEvent) -> str:
+        """Handle /busy — control how follow-up input behaves while Hermes is running."""
+        config_path = _hermes_home / "config.yaml"
+        raw_arg = (event.get_command_args() or "").strip().lower()
+
+        try:
+            user_config: dict = _load_gateway_config()
+        except Exception as e:
+            return t("gateway.config_read_failed", error=e)
+
+        current_mode = getattr(self, "_busy_input_mode", "interrupt")
+        if current_mode not in {"queue", "steer", "interrupt"}:
+            current_mode = "interrupt"
+
+        if not raw_arg or raw_arg in ("status", "?"):
+            if current_mode == "queue":
+                behavior = "queues your next message for the following turn"
+            elif current_mode == "steer":
+                behavior = "steers your next message into the current run after the next tool call"
+            else:
+                behavior = "interrupts the current run immediately"
+            return (
+                f"Busy input mode: `{current_mode}`\n"
+                f"While Hermes is busy, Enter {behavior}.\n"
+                f"Usage: `/busy [queue|steer|interrupt|status]`"
+            )
+
+        if raw_arg not in {"queue", "interrupt", "steer"}:
+            return f"Usage: `/busy [queue|steer|interrupt|status]`"
+
+        try:
+            if not isinstance(user_config.get("display"), dict):
+                user_config["display"] = {}
+            user_config["display"]["busy_input_mode"] = raw_arg
+            atomic_yaml_write(config_path, user_config)
+        except Exception as e:
+            logger.warning("Failed to save busy_input_mode: %s", e)
+            self._busy_input_mode = raw_arg
+            return (
+                f"Busy input mode set to `{raw_arg}` for this gateway session only.\n"
+                f"(Could not save to config: {e})"
+            )
+
+        self._busy_input_mode = raw_arg
+        if raw_arg == "queue":
+            behavior = "Follow-up messages will queue for the next turn."
+        elif raw_arg == "steer":
+            behavior = "Follow-up messages will steer into the current run after the next tool call."
+        else:
+            behavior = "Follow-up messages will interrupt the current run."
+        return f"Busy input mode set to `{raw_arg}`.\n{behavior}"
 
     async def _handle_compress_command(self, event: MessageEvent) -> str:
         """Handle /compress command -- manually compress conversation context.

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -151,7 +151,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
     CommandDef("voice", "Toggle voice mode", "Configuration",
                args_hint="[on|off|tts|status]", subcommands=("on", "off", "tts", "status")),
     CommandDef("busy", "Control what Enter does while Hermes is working", "Configuration",
-               cli_only=True, args_hint="[queue|steer|interrupt|status]",
+               args_hint="[queue|steer|interrupt|status]",
                subcommands=("queue", "steer", "interrupt", "status")),
 
     # Tools & Skills

--- a/tests/gateway/test_busy_session_ack.py
+++ b/tests/gateway/test_busy_session_ack.py
@@ -552,3 +552,57 @@ class TestBusySessionOnboardingHint:
         assert "/busy interrupt" in content
         # Must NOT tell the user to /busy queue when they're already on queue.
         assert "/busy queue" not in content
+
+
+class TestBusyGatewayCommand:
+    @pytest.mark.asyncio
+    async def test_busy_command_updates_gateway_mode_and_config(self, tmp_path, monkeypatch):
+        from gateway.run import GatewayRunner
+        import gateway.run as run_mod
+
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        event = _make_event(text="/busy queue")
+
+        monkeypatch.setattr(run_mod, "_hermes_home", tmp_path)
+        (tmp_path / "config.yaml").write_text("display:\n  busy_input_mode: interrupt\n", encoding="utf-8")
+
+        reply = await GatewayRunner._handle_busy_command(runner, event)
+
+        assert runner._busy_input_mode == "queue"
+        assert "queue" in reply.lower()
+        saved = (tmp_path / "config.yaml").read_text(encoding="utf-8")
+        assert "busy_input_mode: queue" in saved
+
+    @pytest.mark.asyncio
+    async def test_busy_command_runs_mid_turn_without_interrupting_agent(self, tmp_path, monkeypatch):
+        from gateway.run import GatewayRunner
+        import gateway.run as run_mod
+
+        runner, _sentinel = _make_runner()
+        runner._busy_input_mode = "interrupt"
+        adapter = _make_adapter()
+        event = _make_event(text="/busy steer")
+        sk = build_session_key(event.source)
+        agent = MagicMock()
+        agent.get_activity_summary.return_value = {
+            "api_call_count": 1,
+            "max_iterations": 10,
+            "current_tool": "terminal",
+            "last_activity_ts": time.time(),
+            "last_activity_desc": "terminal",
+            "seconds_since_activity": 1.0,
+        }
+        runner._running_agents[sk] = agent
+        runner._running_agents_ts[sk] = time.time()
+        runner.adapters[event.source.platform] = adapter
+
+        monkeypatch.setattr(run_mod, "_hermes_home", tmp_path)
+        (tmp_path / "config.yaml").write_text("display:\n  busy_input_mode: interrupt\n", encoding="utf-8")
+
+        reply = await GatewayRunner._handle_message(runner, event)
+
+        assert "steer" in str(reply).lower()
+        assert runner._busy_input_mode == "steer"
+        agent.interrupt.assert_not_called()
+        assert sk not in adapter._pending_messages


### PR DESCRIPTION
## What does this PR do?

Makes `/busy` available on gateway platforms so Telegram/Discord/Slack users can inspect or change busy-input behavior without switching back to the local CLI.

## Related Issue

Fixes #18362

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- remove the CLI-only restriction from `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/hermes-18362-gateway-busy-command/hermes_cli/commands.py` so `/busy` is advertised to gateway clients
- add `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/hermes-18362-gateway-busy-command/gateway/run.py::_handle_busy_command()` to read, update, and persist `display.busy_input_mode`
- allow `/busy` to run even while an agent is active, without interrupting that run
- add gateway tests in `/Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/hermes-18362-gateway-busy-command/tests/gateway/test_busy_session_ack.py` covering config writes and mid-turn handling

## How to Test

1. `uv run --frozen --extra dev pytest -q -o addopts='' tests/gateway/test_busy_session_ack.py tests/cli/test_busy_input_mode_command.py`
2. `uv run --frozen ruff check hermes_cli/commands.py gateway/run.py tests/gateway/test_busy_session_ack.py tests/cli/test_busy_input_mode_command.py`
3. In gateway mode, run `/busy`, then `/busy queue` or `/busy steer`, and confirm the mode changes without interrupting an active run

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## For New Skills

- [ ] This skill is **broadly useful** to most users (if bundled) — see [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#should-the-skill-be-bundled)
- [ ] SKILL.md follows the [standard format](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#skillmd-format) (frontmatter, trigger conditions, steps, pitfalls)
- [ ] No external dependencies that aren't already available (prefer stdlib, curl, existing Hermes tools)
- [ ] I've tested the skill end-to-end: `hermes --toolsets skills -q "Use the X skill to do Y"`

## Screenshots / Logs

- `uv run --frozen --extra dev pytest -q -o addopts='' tests/gateway/test_busy_session_ack.py tests/cli/test_busy_input_mode_command.py` -> `25 passed`
- `uv run --frozen ruff check hermes_cli/commands.py gateway/run.py tests/gateway/test_busy_session_ack.py tests/cli/test_busy_input_mode_command.py` -> `All checks passed!`
