### PR TITLE
Fix strict gateway fallback routing

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -664,6 +664,91 @@ from gateway.whatsapp_identity import (
 logger = logging.getLogger(__name__)
 
 
+def _runtime_credential_label(runtime: Optional[dict]) -> str:
+    """Best-effort human label for the credential used by a runtime bundle."""
+    if not isinstance(runtime, dict):
+        return ""
+    explicit = runtime.get("credential_label") or runtime.get("credential")
+    if explicit:
+        return str(explicit)
+    pool = runtime.get("credential_pool")
+    if pool is not None:
+        try:
+            current = pool.current()
+            if current is not None and getattr(current, "label", None):
+                return str(current.label)
+        except Exception:
+            pass
+    source = runtime.get("source")
+    return str(source) if source else ""
+
+
+def _gateway_route_policy_for_source(
+    cfg: Optional[dict],
+    source: Any = None,
+    *,
+    provider: Optional[str] = None,
+) -> dict:
+    """Return the first matching gateway credential-routing policy.
+
+    Supported config shape (intentionally small and permissive):
+
+    gateway_credential_routing:
+      rules:
+        - platform: weixin
+          chat_id: ...        # optional
+          user_id: ...        # optional
+          provider: openai-codex
+          exclusive: true     # or strict: true / allow_fallback: false
+          fallback_policy: fail_closed
+          runtime_footer: true
+    """
+    routing = (cfg or {}).get("gateway_credential_routing") or {}
+    rules = routing.get("rules") if isinstance(routing, dict) else None
+    if not isinstance(rules, list):
+        return {}
+
+    def _norm(value: Any) -> str:
+        if value is None:
+            return ""
+        if hasattr(value, "value"):
+            value = getattr(value, "value")
+        return str(value).strip().lower()
+
+    src_platform = _norm(getattr(source, "platform", None))
+    src_chat = str(getattr(source, "chat_id", "") or "")
+    src_user = str(getattr(source, "user_id", "") or "")
+    provider_norm = _norm(provider)
+
+    for rule in rules:
+        if not isinstance(rule, dict):
+            continue
+        if rule.get("platform") and _norm(rule.get("platform")) != src_platform:
+            continue
+        if rule.get("chat_id") and str(rule.get("chat_id")) != src_chat:
+            continue
+        if rule.get("user_id") and str(rule.get("user_id")) != src_user:
+            continue
+        if rule.get("provider") and provider_norm and _norm(rule.get("provider")) != provider_norm:
+            continue
+        return dict(rule)
+    return {}
+
+
+def _gateway_policy_allows_fallback(policy: Optional[dict]) -> bool:
+    """Whether a matching gateway credential policy permits fallback."""
+    if not policy:
+        return True
+    fallback_policy = str(policy.get("fallback_policy") or "").strip().lower().replace("-", "_")
+    if fallback_policy in {"fail_closed", "failclose", "deny", "disabled", "none"}:
+        return False
+    if policy.get("strict") is True or policy.get("exclusive") is True:
+        return False
+    if policy.get("allow_fallback") is False:
+        return False
+    return True
+
+
 # Sentinel placed into _running_agents immediately when a session starts
 # processing, *before* any await.  Prevents a second message for the same
 # session from bypassing the "already running" guard during the async gap
@@ -671,7 +756,7 @@ logger = logging.getLogger(__name__)
 _AGENT_PENDING_SENTINEL = object()
 
 
-def _resolve_runtime_agent_kwargs() -> dict:
+def _resolve_runtime_agent_kwargs(source: Any = None) -> dict:
     """Resolve provider credentials for gateway-created AIAgent instances.
 
     If the primary provider fails with an authentication error, attempt to
@@ -684,22 +769,46 @@ def _resolve_runtime_agent_kwargs() -> dict:
     )
     from hermes_cli.auth import AuthError
 
+    primary_provider = os.getenv("HERMES_INFERENCE_PROVIDER")
     try:
         runtime = resolve_runtime_provider(
-            requested=os.getenv("HERMES_INFERENCE_PROVIDER"),
+            requested=primary_provider,
         )
     except AuthError as auth_exc:
+        try:
+            _cfg = _load_gateway_config()
+        except Exception:
+            _cfg = {}
+        try:
+            _model_cfg = (_cfg or {}).get("model") or {}
+            if not primary_provider and isinstance(_model_cfg, dict):
+                primary_provider = str(_model_cfg.get("provider") or "").strip() or None
+        except Exception:
+            pass
+        policy = _gateway_route_policy_for_source(_cfg, source, provider=primary_provider)
+        if not _gateway_policy_allows_fallback(policy):
+            logger.error(
+                "Gateway credential route fail-closed: platform=%s chat=%s provider=%s reason=%s",
+                getattr(getattr(source, "platform", None), "value", getattr(source, "platform", "")),
+                getattr(source, "chat_id", ""),
+                primary_provider or "auto",
+                auth_exc,
+            )
+            raise RuntimeError(
+                "Configured gateway credential route is unavailable and fallback is disabled: "
+                f"{auth_exc}"
+            ) from auth_exc
         # Primary provider auth failed (expired token, revoked key, etc.).
         # Try the fallback provider chain before raising.
         logger.warning("Primary provider auth failed: %s — trying fallback", auth_exc)
-        fb_config = _try_resolve_fallback_provider()
+        fb_config = _try_resolve_fallback_provider(primary_error=str(auth_exc), primary_provider=primary_provider)
         if fb_config is not None:
             return fb_config
         raise RuntimeError(format_runtime_provider_error(auth_exc)) from auth_exc
     except Exception as exc:
         raise RuntimeError(format_runtime_provider_error(exc)) from exc
 
-    return {
+    result = {
         "api_key": runtime.get("api_key"),
         "base_url": runtime.get("base_url"),
         "provider": runtime.get("provider"),
@@ -707,10 +816,23 @@ def _resolve_runtime_agent_kwargs() -> dict:
         "command": runtime.get("command"),
         "args": list(runtime.get("args") or []),
         "credential_pool": runtime.get("credential_pool"),
+        "credential_label": _runtime_credential_label(runtime),
     }
+    logger.info(
+        "Gateway runtime selected: provider=%s model=%s credential=%s fallback=%s",
+        result.get("provider"),
+        None,
+        result.get("credential_label") or "",
+        False,
+    )
+    return result
 
 
-def _try_resolve_fallback_provider() -> dict | None:
+def _try_resolve_fallback_provider(
+    *,
+    primary_error: str = "",
+    primary_provider: Optional[str] = None,
+) -> dict | None:
     """Attempt to resolve credentials from the fallback_model/fallback_providers config."""
     from hermes_cli.runtime_provider import resolve_runtime_provider
     try:
@@ -747,7 +869,11 @@ def _try_resolve_fallback_provider() -> dict | None:
                     "command": runtime.get("command"),
                     "args": list(runtime.get("args") or []),
                     "credential_pool": runtime.get("credential_pool"),
+                    "credential_label": _runtime_credential_label(runtime),
                     "model": entry.get("model"),
+                    "fallback_used": True,
+                    "fallback_reason": primary_error,
+                    "primary_provider": primary_provider,
                 }
             except Exception as fb_exc:
                 logger.debug("Fallback entry %s failed: %s", entry.get("provider"), fb_exc)
@@ -1831,7 +1957,7 @@ class GatewayRunner:
                 list(self._session_model_overrides.keys())[:5] if self._session_model_overrides else "[]",
             )
 
-        runtime_kwargs = _resolve_runtime_agent_kwargs()
+        runtime_kwargs = _resolve_runtime_agent_kwargs(source=source)
         runtime_model = runtime_kwargs.pop("model", None)
         if runtime_model:
             logger.info(
@@ -1885,6 +2011,14 @@ class GatewayRunner:
         route = {
             "model": model,
             "runtime": runtime,
+            "runtime_metadata": {
+                "provider": runtime.get("provider"),
+                "model": model,
+                "credential_label": runtime_kwargs.get("credential_label") or "",
+                "fallback_used": bool(runtime_kwargs.get("fallback_used")),
+                "fallback_reason": runtime_kwargs.get("fallback_reason") or "",
+                "primary_provider": runtime_kwargs.get("primary_provider") or "",
+            },
             "signature": (
                 model,
                 runtime["provider"],
@@ -1906,6 +2040,35 @@ class GatewayRunner:
             overrides = None
         route["request_overrides"] = overrides or {}
         return route
+
+    def _resolve_turn_fallback_model(
+        self,
+        user_config: Optional[dict],
+        source: Any = None,
+        runtime_kwargs: Optional[dict] = None,
+    ) -> list | dict | None:
+        """Return the AIAgent fallback chain allowed for this gateway turn.
+
+        Strict/exclusive gateway credential routes are fail-closed for both
+        runtime credential resolution and later provider/API-time auth errors.
+        Disabling ``fallback_model`` at AIAgent construction prevents the
+        agent's own fallback machinery from silently bypassing those routes.
+        """
+        runtime_kwargs = runtime_kwargs or {}
+        policy = _gateway_route_policy_for_source(
+            user_config,
+            source,
+            provider=runtime_kwargs.get("provider"),
+        )
+        if not _gateway_policy_allows_fallback(policy):
+            logger.info(
+                "Gateway credential route disables agent fallback: platform=%s chat=%s provider=%s",
+                getattr(getattr(source, "platform", None), "value", getattr(source, "platform", "")),
+                getattr(source, "chat_id", ""),
+                runtime_kwargs.get("provider") or "auto",
+            )
+            return None
+        return self._fallback_model
 
     async def _handle_adapter_fatal_error(self, adapter: BasePlatformAdapter) -> None:
         """React to an adapter failure after startup.
@@ -7632,13 +7795,18 @@ class GatewayRunner:
             _footer_line = ""
             try:
                 from gateway.runtime_footer import build_footer_line as _bfl
+                _runtime_metadata = agent_result.get("runtime_metadata") or {}
                 _footer_line = _bfl(
                     user_config=_load_gateway_config(),
                     platform_key=_platform_config_key(source.platform),
-                    model=agent_result.get("model"),
+                    model=agent_result.get("model") or _runtime_metadata.get("model"),
                     context_tokens=agent_result.get("last_prompt_tokens", 0) or 0,
                     context_length=agent_result.get("context_length") or None,
                     cwd=os.environ.get("TERMINAL_CWD", ""),
+                    provider=_runtime_metadata.get("provider"),
+                    credential_label=_runtime_metadata.get("credential_label"),
+                    fallback_used=bool(_runtime_metadata.get("fallback_used")),
+                    fallback_reason=_runtime_metadata.get("fallback_reason"),
                 )
             except Exception as _footer_err:
                 logger.debug("runtime_footer build failed: %s", _footer_err)
@@ -10294,6 +10462,7 @@ class GatewayRunner:
             self._reasoning_config = reasoning_config
             self._service_tier = self._load_service_tier()
             turn_route = self._resolve_turn_agent_config(prompt, model, runtime_kwargs)
+            fallback_model = self._resolve_turn_fallback_model(user_config, source, runtime_kwargs)
 
             def run_sync():
                 agent = AIAgent(
@@ -10322,7 +10491,7 @@ class GatewayRunner:
                     chat_type=source.chat_type,
                     thread_id=source.thread_id,
                     session_db=self._session_db,
-                    fallback_model=self._fallback_model,
+                    fallback_model=fallback_model,
                 )
                 try:
                     return agent.run_conversation(
@@ -14884,16 +15053,19 @@ class GatewayRunner:
                     logger.debug("interim_assistant_callback error: %s", _e)
 
             turn_route = self._resolve_turn_agent_config(message, model, runtime_kwargs)
+            fallback_model = self._resolve_turn_fallback_model(user_config, source, runtime_kwargs)
 
             # Check agent cache — reuse the AIAgent from the previous message
             # in this session to preserve the frozen system prompt and tool
             # schemas for prompt cache hits.
+            _cache_keys = dict(self._extract_cache_busting_config(user_config) or {})
+            _cache_keys["gateway_fallback_model"] = fallback_model
             _sig = self._agent_config_signature(
                 turn_route["model"],
                 turn_route["runtime"],
                 enabled_toolsets,
                 combined_ephemeral,
-                cache_keys=self._extract_cache_busting_config(user_config),
+                cache_keys=_cache_keys,
             )
             agent = None
             _cache_lock = getattr(self, "_agent_cache_lock", None)
@@ -14944,7 +15116,7 @@ class GatewayRunner:
                     thread_id=source.thread_id,
                     gateway_session_key=session_key,
                     session_db=self._session_db,
-                    fallback_model=self._fallback_model,
+                    fallback_model=fallback_model,
                 )
                 if _cache_lock and _cache is not None:
                     with _cache_lock:
@@ -15285,6 +15457,8 @@ class GatewayRunner:
                     _run_message = message
 
                 result = agent.run_conversation(_run_message, conversation_history=agent_history, task_id=session_id)
+                if isinstance(result, dict):
+                    result["runtime_metadata"] = dict(turn_route.get("runtime_metadata") or {})
             finally:
                 unregister_gateway_notify(_approval_session_key)
                 reset_current_session_key(_approval_session_token)

--- a/gateway/runtime_footer.py
+++ b/gateway/runtime_footer.py
@@ -96,6 +96,10 @@ def format_runtime_footer(
     context_length: Optional[int],
     cwd: Optional[str] = None,
     fields: Iterable[str] = _DEFAULT_FIELDS,
+    provider: Optional[str] = None,
+    credential_label: Optional[str] = None,
+    fallback_used: bool = False,
+    fallback_reason: Optional[str] = None,
 ) -> str:
     """Render the footer line, or return "" if no fields have data.
 
@@ -108,6 +112,12 @@ def format_runtime_footer(
             m = _model_short(model)
             if m:
                 parts.append(m)
+        elif field == "provider":
+            if provider:
+                parts.append(str(provider))
+        elif field in {"credential", "credential_label"}:
+            if credential_label:
+                parts.append(str(credential_label))
         elif field == "context_pct":
             if context_length and context_length > 0 and context_tokens >= 0:
                 pct = max(0, min(100, round((context_tokens / context_length) * 100)))
@@ -120,7 +130,13 @@ def format_runtime_footer(
 
     if not parts:
         return ""
-    return _SEP.join(parts)
+    line = _SEP.join(parts)
+    if fallback_used:
+        reason = str(fallback_reason or "").strip()
+        if reason:
+            reason = f" · {reason}"
+        return f"⚠ fallback: {line}{reason}"
+    return line
 
 
 def build_footer_line(
@@ -131,6 +147,10 @@ def build_footer_line(
     context_tokens: int,
     context_length: Optional[int],
     cwd: Optional[str] = None,
+    provider: Optional[str] = None,
+    credential_label: Optional[str] = None,
+    fallback_used: bool = False,
+    fallback_reason: Optional[str] = None,
 ) -> str:
     """Top-level entry point used by gateway/run.py.
 
@@ -147,4 +167,8 @@ def build_footer_line(
         context_length=context_length,
         cwd=cwd,
         fields=cfg.get("fields") or _DEFAULT_FIELDS,
+        provider=provider,
+        credential_label=credential_label,
+        fallback_used=fallback_used,
+        fallback_reason=fallback_reason,
     )

--- a/tests/gateway/test_runtime_fallback_policy.py
+++ b/tests/gateway/test_runtime_fallback_policy.py
@@ -1,0 +1,210 @@
+"""Focused tests for gateway runtime credential fallback routing."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from hermes_cli.auth import AuthError
+
+
+def _source(platform: str = "weixin", chat_id: str = "chat-1", user_id: str = "user-1"):
+    return SimpleNamespace(
+        platform=platform,
+        chat_id=chat_id,
+        user_id=user_id,
+        user_name="Test User",
+        chat_name="Test Chat",
+        chat_type="group",
+        thread_id=None,
+    )
+
+
+def test_strict_gateway_route_fails_closed_without_fallback(monkeypatch):
+    """A matched strict route must not silently fall back after primary auth failure."""
+    import gateway.run as run
+
+    monkeypatch.setenv("HERMES_INFERENCE_PROVIDER", "openai-codex")
+    cfg = {
+        "gateway_credential_routing": {
+            "rules": [
+                {
+                    "platform": "weixin",
+                    "chat_id": "chat-1",
+                    "provider": "openai-codex",
+                    "exclusive": True,
+                }
+            ]
+        }
+    }
+
+    with patch("hermes_cli.runtime_provider.resolve_runtime_provider", side_effect=AuthError("expired", provider="openai-codex")), \
+        patch.object(run, "_load_gateway_config", return_value=cfg), \
+        patch.object(run, "_try_resolve_fallback_provider") as fallback:
+        with pytest.raises(RuntimeError, match="fallback is disabled"):
+            run._resolve_runtime_agent_kwargs(source=_source())
+
+    fallback.assert_not_called()
+
+
+def test_non_strict_gateway_route_uses_fallback_with_metadata(monkeypatch):
+    """Non-strict routes retain existing fallback behavior and expose fallback metadata."""
+    import gateway.run as run
+
+    monkeypatch.setenv("HERMES_INFERENCE_PROVIDER", "openai-codex")
+    fallback_config = {
+        "api_key": "fb-key",
+        "base_url": "https://fallback.example/v1",
+        "provider": "openrouter",
+        "model": "anthropic/claude-sonnet-4",
+        "fallback_used": True,
+        "fallback_reason": "expired",
+        "primary_provider": "openai-codex",
+    }
+
+    with patch("hermes_cli.runtime_provider.resolve_runtime_provider", side_effect=AuthError("expired", provider="openai-codex")), \
+        patch.object(run, "_load_gateway_config", return_value={}), \
+        patch.object(run, "_try_resolve_fallback_provider", return_value=fallback_config) as fallback:
+        resolved = run._resolve_runtime_agent_kwargs(source=_source())
+
+    assert resolved is fallback_config
+    fallback.assert_called_once_with(primary_error="expired", primary_provider="openai-codex")
+
+
+def test_runtime_footer_shows_fallback_warning_when_enabled():
+    """Footer-enabled gateways should visibly warn when a fallback runtime handled the turn."""
+    from gateway.runtime_footer import build_footer_line
+
+    line = build_footer_line(
+        user_config={
+            "display": {
+                "runtime_footer": {
+                    "enabled": True,
+                    "fields": ["model", "provider", "credential"],
+                }
+            }
+        },
+        platform_key="weixin",
+        model="anthropic/claude-sonnet-4",
+        context_tokens=0,
+        context_length=None,
+        cwd="",
+        provider="openrouter",
+        credential_label="fallback-key",
+        fallback_used=True,
+        fallback_reason="expired primary token",
+    )
+
+    assert line.startswith("⚠ fallback:")
+    assert "claude-sonnet-4" in line
+    assert "openrouter" in line
+    assert "fallback-key" in line
+    assert "expired primary token" in line
+
+
+class _FakeBackgroundAdapter:
+    def __init__(self):
+        self.sent = []
+
+    async def send(self, *args, **kwargs):
+        self.sent.append((args, kwargs))
+
+    def extract_media(self, text):
+        return [], text
+
+    def extract_images(self, text):
+        return [], text
+
+
+async def _inline_executor(func):
+    return func()
+
+
+class _RecordingAgent:
+    constructed_kwargs = []
+
+    def __init__(self, **kwargs):
+        type(self).constructed_kwargs.append(kwargs)
+
+    def run_conversation(self, **kwargs):
+        return {"final_response": "ok", "messages": [], "api_calls": 1, "tools": []}
+
+
+def _runner_for_background(fallback_model):
+    import gateway.run as run
+    from gateway.config import Platform
+
+    runner = run.GatewayRunner.__new__(run.GatewayRunner)
+    runner.adapters = {Platform.WEIXIN: _FakeBackgroundAdapter()}
+    runner._session_db = None
+    runner._provider_routing = {}
+    runner._fallback_model = fallback_model
+    runner._service_tier = None
+    runner._reasoning_config = None
+    runner._thread_metadata_for_source = lambda source, event_message_id=None: {}
+    runner._resolve_session_agent_runtime = lambda *, source, user_config, session_key=None: (
+        "primary/model",
+        {
+            "api_key": "primary-key",
+            "base_url": "https://primary.example/v1",
+            "provider": "openai-codex",
+            "api_mode": "chat_completions",
+        },
+    )
+    runner._resolve_session_reasoning_config = lambda *args, **kwargs: None
+    runner._load_service_tier = lambda: None
+    runner._run_in_executor_with_context = _inline_executor
+    runner._cleanup_agent_resources = lambda agent: None
+    return runner
+
+
+@pytest.mark.asyncio
+async def test_strict_gateway_route_disables_aiagent_fallback_after_runtime_success(monkeypatch):
+    """Strict routes must disable AIAgent fallback for later API-time 401/403s."""
+    import gateway.run as run
+    from gateway.config import Platform
+
+    fallback = {"provider": "openrouter", "model": "anthropic/claude-sonnet-4"}
+    cfg = {
+        "gateway_credential_routing": {
+            "rules": [
+                {
+                    "platform": "weixin",
+                    "chat_id": "chat-1",
+                    "provider": "openai-codex",
+                    "fallback_policy": "fail_closed",
+                }
+            ]
+        }
+    }
+    source = _source(platform=Platform.WEIXIN, chat_id="chat-1")
+    runner = _runner_for_background(fallback)
+    _RecordingAgent.constructed_kwargs = []
+
+    with patch.object(run, "_load_gateway_config", return_value=cfg), \
+        patch("run_agent.AIAgent", _RecordingAgent):
+        await runner._run_background_task("hello", source, "task-1")
+
+    assert _RecordingAgent.constructed_kwargs
+    assert _RecordingAgent.constructed_kwargs[-1]["fallback_model"] is None
+
+
+@pytest.mark.asyncio
+async def test_non_strict_gateway_route_keeps_aiagent_fallback_after_runtime_success(monkeypatch):
+    """Non-strict routes still pass the configured AIAgent fallback chain."""
+    import gateway.run as run
+    from gateway.config import Platform
+
+    fallback = {"provider": "openrouter", "model": "anthropic/claude-sonnet-4"}
+    source = _source(platform=Platform.WEIXIN, chat_id="chat-1")
+    runner = _runner_for_background(fallback)
+    _RecordingAgent.constructed_kwargs = []
+
+    with patch.object(run, "_load_gateway_config", return_value={}), \
+        patch("run_agent.AIAgent", _RecordingAgent):
+        await runner._run_background_task("hello", source, "task-2")
+
+    assert _RecordingAgent.constructed_kwargs
+    assert _RecordingAgent.constructed_kwargs[-1]["fallback_model"] == fallback


### PR DESCRIPTION
## Summary
- Enforce strict gateway fallback routing so explicit provider/model selections are not silently swapped into unintended fallback paths.
- Add runtime footer details for selected/fallback routing so cc-connect/Codex can observe the active runtime decision.
- Add gateway regression tests covering strict fallback policy behavior.

## Validation
- `python -m pytest tests/gateway/test_runtime_fallback_policy.py`
