### PR TITLE
fix(website): preserve filter bar visibility when clicking skills category

### DIFF
--- a/website/src/pages/skills/index.tsx
+++ b/website/src/pages/skills/index.tsx
@@ -290,6 +290,7 @@ export default function SkillsDashboard() {
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const searchRef = useRef<HTMLInputElement>(null);
   const gridRef = useRef<HTMLDivElement>(null);
+  const controlsBarRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -367,7 +368,15 @@ export default function SkillsDashboard() {
 
   const handleCategoryClick = useCallback((cat: string) => {
     setCategoryFilter(cat);
-    gridRef.current?.scrollIntoView({ behavior: "smooth", block: "start" });
+    const main = gridRef.current;
+    if (main) {
+      const navbar = document.querySelector<HTMLElement>(".navbar");
+      const navbarH = navbar?.offsetHeight ?? 60;
+      const controlsH = controlsBarRef.current?.offsetHeight ?? 0;
+      const target =
+        main.getBoundingClientRect().top + window.scrollY - navbarH - controlsH - 16;
+      window.scrollTo({ top: Math.max(0, target), behavior: "smooth" });
+    }
     setSidebarOpen(false);
   }, []);
 
@@ -428,7 +437,7 @@ export default function SkillsDashboard() {
           </div>
         </header>
 
-        <div className={styles.controlsBar}>
+        <div className={styles.controlsBar} ref={controlsBarRef}>
           <div className={styles.searchWrap}>
             <svg className={styles.searchIcon} viewBox="0 0 20 20" fill="currentColor" width="18" height="18">
               <path


### PR DESCRIPTION
## Summary

- On the Skills Hub page (`/docs/skills`), clicking a category in the sidebar called `scrollIntoView({ block: "start" })` on the `<main>` grid. This aligned the grid's top edge with the viewport top, which is occluded by the fixed Docusaurus navbar (~60px) and the sticky `.controlsBar` (search + source pills, ~120-200px depending on viewport). Result: the filter summary row (`N results · <Category> ×  …  Clear all`) and frequently the first row of cards were cropped behind the sticky chrome.
- Replace with an explicit `window.scrollTo`, subtracting the live-measured navbar height (`.navbar.offsetHeight`) and `.controlsBar.offsetHeight` plus a 16px gap. The grid now lands flush below the sticky chrome on every viewport, keeping the filter summary and first card row in view.
- One-file change in `website/src/pages/skills/index.tsx`; no styling, no behavior change beyond the scroll target math.

## Test plan

- [x] `npm start` in `website/`, open `http://localhost:3000/docs/skills`
- [x] Click sidebar categories (Translation, Creative, Other, Finance, …) — filter summary chip + first card row visible directly under the controls bar
- [x] Click a category pill inside a card (e.g. the `Creative` chip) — same path through `handleCategoryClick`, same outcome
- [x] Verify on light theme and dark theme
- [x] Verify with browser-zoom 100% and 125%