### PR TITLE
chore(ci): pass VERCEL_DEPLOY_HOOK via env block, not inline expression

### DIFF
--- a/.github/workflows/deploy-site.yml
+++ b/.github/workflows/deploy-site.yml
@@ -44,7 +44,9 @@ jobs:
     timeout-minutes: 30
     steps:
       - name: Trigger Vercel Deploy
-        run: curl -fsS --retry 3 --retry-delay 10 -X POST "${{ secrets.VERCEL_DEPLOY_HOOK }}"
+        env:
+          VERCEL_DEPLOY_HOOK: ${{ secrets.VERCEL_DEPLOY_HOOK }}
+        run: curl -fsS --retry 3 --retry-delay 10 -X POST "$VERCEL_DEPLOY_HOOK"
 
   deploy-docs:
     if: github.repository == 'NousResearch/hermes-agent'


### PR DESCRIPTION
## What does this PR do?

Wraps `VERCEL_DEPLOY_HOOK` in an `env:` block instead of expanding the secret directly inside the `run:` command line. Same call, just routed through an environment variable so the secret never appears on the rendered shell command.

GitHub auto-masks secret values in logs either way, but the env-mapping pattern is the [documented hardening](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-secrets) and avoids edge cases (shell `set -x`, custom wrappers, error traces) where the URL could otherwise surface.

## Related Issue

Fixes #23631

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `.github/workflows/deploy-site.yml`: move `${{ secrets.VERCEL_DEPLOY_HOOK }}` into the step's `env:` block; `run:` consumes the env var via `"$VERCEL_DEPLOY_HOOK"`.

## How to Test

The step only runs on a release publish, but the change is a mechanical YAML rewrite. To verify locally:

1. `yq '.jobs.deploy-vercel.steps[0]' .github/workflows/deploy-site.yml` — confirm `env.VERCEL_DEPLOY_HOOK` is now present and `run:` references `$VERCEL_DEPLOY_HOOK`.
2. `actionlint .github/workflows/deploy-site.yml` (if installed) — no lint errors.
3. On the next release, the `deploy-vercel` job continues to fire; secret remains masked in logs.

## Checklist

### Code

- [x] I've read the Contributing Guide
- [x] My commit messages follow Conventional Commits
- [x] I searched for existing PRs to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix
- [x] I've run `pytest tests/ -q` and all tests pass (no test impact — workflow YAML only)
- [ ] I've added tests for my changes — N/A (workflow YAML; behavior is unchanged)
- [x] I've tested on my platform: macOS 15.2

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact — N/A (CI-only)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Notes for reviewer

Operational follow-ups from the issue (rotate the hook, audit deploy logs) are outside the scope of a code change and should be handled by whoever owns the Vercel project.