### PR TITLE
chore: prefer gpt-5.5 across model catalogs

### DIFF
--- a/cli-config.yaml.example
+++ b/cli-config.yaml.example
@@ -92,7 +92,7 @@ model:
 #         timeout_seconds: 600       # Longer timeout for extended-thinking Opus calls
 #   openai-codex:
 #     models:
-#       gpt-5.4:
+#       gpt-5.5:
 #         stale_timeout_seconds: 1800  # Longer non-stream stale timeout for slow large-context turns
 
 # =============================================================================

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -3467,7 +3467,7 @@ def _model_flow_azure_foundry(config, current_model=""):
     else:
         try:
             model_name = input(
-                f"Model / deployment name [{current_model or 'e.g. gpt-5.4, claude-sonnet-4-6'}]: "
+                f"Model / deployment name [{current_model or 'e.g. gpt-5.5, claude-sonnet-4-6'}]: "
             ).strip()
         except (KeyboardInterrupt, EOFError):
             print("\nCancelled.")

--- a/hermes_cli/models.py
+++ b/hermes_cli/models.py
@@ -82,6 +82,7 @@ VERCEL_AI_GATEWAY_MODELS: list[tuple[str, str]] = [
     ("anthropic/claude-opus-4.7",            ""),
     ("anthropic/claude-opus-4.6",            ""),
     ("anthropic/claude-haiku-4.5",           ""),
+    ("openai/gpt-5.5",                       ""),
     ("openai/gpt-5.4",                       ""),
     ("openai/gpt-5.4-mini",                  ""),
     ("openai/gpt-5.3-codex",                 ""),
@@ -180,6 +181,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     # Native OpenAI Chat Completions (api.openai.com). Used by /model counts and
     # provider_model_ids fallback when /v1/models is unavailable.
     "openai": [
+        "gpt-5.5",
         "gpt-5.4",
         "gpt-5.4-mini",
         "gpt-5-mini",
@@ -194,6 +196,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "copilot-acp",
     ],
     "copilot": [
+        "gpt-5.5",
         "gpt-5.4",
         "gpt-5.4-mini",
         "gpt-5-mini",
@@ -326,9 +329,11 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
         "moonshotai/Kimi-K2.5",
         "google/gemini-3.1-flash-lite-preview",
         "anthropic/claude-sonnet-4.6",
+        "openai/gpt-5.5",
         "openai/gpt-5.4",
     ],
     "opencode-zen": [
+        "gpt-5.5",
         "kimi-k2.5",
         "gpt-5.4-pro",
         "gpt-5.4",
@@ -382,6 +387,7 @@ _PROVIDER_MODELS: dict[str, list[str]] = {
     "kilocode": [
         "anthropic/claude-opus-4.6",
         "anthropic/claude-sonnet-4.6",
+        "openai/gpt-5.5",
         "openai/gpt-5.4",
         "google/gemini-3-pro-preview",
         "google/gemini-3-flash-preview",

--- a/hermes_cli/setup.py
+++ b/hermes_cli/setup.py
@@ -76,6 +76,7 @@ _DEFAULT_PROVIDER_MODELS = {
         "copilot-acp",
     ],
     "copilot": [
+        "gpt-5.5",
         "gpt-5.4",
         "gpt-5.4-mini",
         "gpt-5-mini",
@@ -101,9 +102,9 @@ _DEFAULT_PROVIDER_MODELS = {
     "arcee": ["trinity-large-thinking", "trinity-large-preview", "trinity-mini"],
     "minimax": ["MiniMax-M2.7", "MiniMax-M2.5", "MiniMax-M2.1", "MiniMax-M2"],
     "minimax-cn": ["MiniMax-M2.7", "MiniMax-M2.5", "MiniMax-M2.1", "MiniMax-M2"],
-    "ai-gateway": ["anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5", "google/gemini-3-flash"],
-    "kilocode": ["anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5.4", "google/gemini-3-pro-preview", "google/gemini-3-flash-preview"],
-    "opencode-zen": ["gpt-5.4", "gpt-5.3-codex", "claude-sonnet-4-6", "gemini-3-flash", "glm-5", "kimi-k2.5", "minimax-m2.7"],
+    "ai-gateway": ["anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5.5", "openai/gpt-5.4", "google/gemini-3-flash"],
+    "kilocode": ["anthropic/claude-opus-4.6", "anthropic/claude-sonnet-4.6", "openai/gpt-5.5", "openai/gpt-5.4", "google/gemini-3-pro-preview", "google/gemini-3-flash-preview"],
+    "opencode-zen": ["gpt-5.5", "gpt-5.4", "gpt-5.3-codex", "claude-sonnet-4-6", "gemini-3-flash", "glm-5", "kimi-k2.5", "minimax-m2.7"],
     "opencode-go": ["kimi-k2.6", "kimi-k2.5", "glm-5.1", "glm-5", "mimo-v2.5-pro", "mimo-v2.5", "mimo-v2-pro", "mimo-v2-omni", "minimax-m2.7", "minimax-m2.5", "qwen3.6-plus", "qwen3.5-plus"],
     "huggingface": [
         "Qwen/Qwen3.5-397B-A17B", "Qwen/Qwen3-235B-A22B-Thinking-2507",

--- a/plugins/image_gen/openai-codex/__init__.py
+++ b/plugins/image_gen/openai-codex/__init__.py
@@ -72,7 +72,7 @@ _SIZES = {
 # Codex Responses surface used for the request. The chat model itself is only
 # the host that calls the ``image_generation`` tool; the actual image work is
 # done by ``API_MODEL``.
-_CODEX_CHAT_MODEL = "gpt-5.4"
+_CODEX_CHAT_MODEL = "gpt-5.5"
 _CODEX_BASE_URL = "https://chatgpt.com/backend-api/codex"
 _CODEX_INSTRUCTIONS = (
     "You are an assistant that must fulfill image generation requests by "

--- a/plugins/model-providers/gmi/__init__.py
+++ b/plugins/model-providers/gmi/__init__.py
@@ -24,6 +24,7 @@ gmi = ProviderProfile(
         "moonshotai/Kimi-K2.5",
         "google/gemini-3.1-flash-lite-preview",
         "anthropic/claude-sonnet-4.6",
+        "openai/gpt-5.5",
         "openai/gpt-5.4",
     ),
 )

--- a/plugins/model-providers/openrouter/__init__.py
+++ b/plugins/model-providers/openrouter/__init__.py
@@ -105,6 +105,7 @@ openrouter = OpenRouterProfile(
     models_url="https://openrouter.ai/api/v1/models",
     fallback_models=(
         "anthropic/claude-sonnet-4.6",
+        "openai/gpt-5.5",
         "openai/gpt-5.4",
         "deepseek/deepseek-chat",
         "google/gemini-3-flash-preview",

--- a/tests/hermes_cli/test_ai_gateway_models.py
+++ b/tests/hermes_cli/test_ai_gateway_models.py
@@ -159,3 +159,6 @@ def test_fetch_ai_gateway_models_falls_back_on_error():
     with patch("urllib.request.urlopen", side_effect=OSError("network")):
         result = fetch_ai_gateway_models(force_refresh=True)
     assert result == list(VERCEL_AI_GATEWAY_MODELS)
+    ids = [mid for mid, _ in result]
+    assert "openai/gpt-5.5" in ids
+    assert ids.index("openai/gpt-5.5") < ids.index("openai/gpt-5.4")

--- a/tests/hermes_cli/test_copilot_in_model_list.py
+++ b/tests/hermes_cli/test_copilot_in_model_list.py
@@ -16,6 +16,8 @@ def test_copilot_picker_keeps_curated_copilot_models_when_live_catalog_unavailab
     copilot = next((p for p in providers if p["slug"] == "copilot"), None)
 
     assert copilot is not None
+    assert copilot["models"][0] == "gpt-5.5"
+    assert "gpt-5.5" in copilot["models"]
     assert "gpt-5.4" in copilot["models"]
     assert "claude-sonnet-4.6" in copilot["models"]
     assert "claude-sonnet-4" in copilot["models"]

--- a/tests/hermes_cli/test_gmi_provider.py
+++ b/tests/hermes_cli/test_gmi_provider.py
@@ -87,6 +87,8 @@ class TestGmiModelCatalog:
         assert "deepseek-ai/DeepSeek-V3.2" in models
         assert "moonshotai/Kimi-K2.5" in models
         assert "anthropic/claude-sonnet-4.6" in models
+        assert "openai/gpt-5.5" in models
+        assert models.index("openai/gpt-5.5") < models.index("openai/gpt-5.4")
 
     def test_canonical_provider_entry(self):
         slugs = [p.slug for p in CANONICAL_PROVIDERS]

--- a/tests/hermes_cli/test_model_validation.py
+++ b/tests/hermes_cli/test_model_validation.py
@@ -227,6 +227,8 @@ class TestProviderModelIds:
              patch("hermes_cli.models._fetch_github_models", return_value=None):
             ids = provider_model_ids("copilot")
 
+        assert ids[0] == "gpt-5.5"
+        assert "gpt-5.5" in ids
         assert "gpt-5.4" in ids
         assert "claude-sonnet-4.6" in ids
         assert "claude-sonnet-4" in ids
@@ -240,6 +242,8 @@ class TestProviderModelIds:
              patch("hermes_cli.models._fetch_github_models", return_value=None):
             ids = provider_model_ids("copilot-acp")
 
+        assert ids[0] == "gpt-5.5"
+        assert "gpt-5.5" in ids
         assert "gpt-5.4" in ids
         assert "claude-sonnet-4.6" in ids
         assert "claude-sonnet-4" in ids

--- a/tests/hermes_cli/test_user_providers_model_switch.py
+++ b/tests/hermes_cli/test_user_providers_model_switch.py
@@ -251,6 +251,7 @@ def test_openai_native_curated_catalog_is_non_empty():
     from hermes_cli.models import _PROVIDER_MODELS
 
     assert _PROVIDER_MODELS.get("openai")
+    assert _PROVIDER_MODELS["openai"][0] == "gpt-5.5"
     assert len(_PROVIDER_MODELS["openai"]) >= 4
 
 

--- a/tests/plugins/image_gen/test_openai_codex_provider.py
+++ b/tests/plugins/image_gen/test_openai_codex_provider.py
@@ -181,7 +181,7 @@ class TestGenerate:
         result = provider.generate("a cat", aspect_ratio="portrait")
         assert result["success"] is True
 
-        assert captured["model"] == "gpt-5.4"
+        assert captured["model"] == "gpt-5.5"
         assert captured["store"] is False
         assert captured["input"][0]["type"] == "message"
         assert captured["input"][0]["role"] == "user"

--- a/tools/mixture_of_agents_tool.py
+++ b/tools/mixture_of_agents_tool.py
@@ -25,7 +25,7 @@ Architecture:
 3. Multiple layers can be used for iterative refinement (future enhancement)
 
 Models Used (via OpenRouter):
-- Reference Models: claude-opus-4.6, gemini-3-pro-preview, gpt-5.4-pro, deepseek-v3.2
+- Reference Models: claude-opus-4.6, gemini-3-pro-preview, gpt-5.5, deepseek-v3.2
 - Aggregator Model: claude-opus-4.6 (highest capability for synthesis)
 
 Configuration:
@@ -63,7 +63,7 @@ logger = logging.getLogger(__name__)
 REFERENCE_MODELS = [
     "anthropic/claude-opus-4.6",
     "google/gemini-2.5-pro",
-    "openai/gpt-5.4-pro",
+    "openai/gpt-5.5",
     "deepseek/deepseek-v3.2",
 ]
 

--- a/website/docs/guides/azure-foundry.md
+++ b/website/docs/guides/azure-foundry.md
@@ -48,8 +48,8 @@ model:
   provider: azure-foundry
   base_url: https://my-resource.openai.azure.com/openai/v1
   api_mode: chat_completions         # or "anthropic_messages"
-  default: gpt-5.4-mini              # your deployment / model name
-  context_length: 400000             # auto-detected
+  default: gpt-5.5                   # your deployment / model name
+  context_length: 1050000            # auto-detected
 ```
 
 And in `~/.hermes/.env`:
@@ -67,7 +67,7 @@ model:
   provider: azure-foundry
   base_url: https://my-resource.openai.azure.com/openai/v1
   api_mode: chat_completions
-  default: gpt-5.4
+  default: gpt-5.5
 ```
 
 Important behaviour:

--- a/website/docs/integrations/providers.md
+++ b/website/docs/integrations/providers.md
@@ -204,7 +204,7 @@ Hermes supports GitHub Copilot as a first-class provider with two modes:
 **`copilot` — Direct Copilot API** (recommended). Uses your GitHub Copilot subscription to access GPT-5.x, Claude, Gemini, and other models through the Copilot API.
 
 ```bash
-hermes chat --provider copilot --model gpt-5.4
+hermes chat --provider copilot --model gpt-5.5
 ```
 
 **Authentication options** (checked in this order):
@@ -253,7 +253,7 @@ hermes chat --provider copilot-acp --model copilot-acp
 ```yaml
 model:
   provider: "copilot"
-  default: "gpt-5.4"
+  default: "gpt-5.5"
 ```
 
 | Environment variable | Description |

--- a/website/docs/reference/faq.md
+++ b/website/docs/reference/faq.md
@@ -18,7 +18,7 @@ Hermes Agent works with any OpenAI-compatible API. Supported providers include:
 
 - **[OpenRouter](https://openrouter.ai/)** — access hundreds of models through one API key (recommended for flexibility)
 - **Nous Portal** — Nous Research's own inference endpoint
-- **OpenAI** — GPT-5.4, GPT-5-codex, GPT-4.1, GPT-4o, etc.
+- **OpenAI** — GPT-5.5, GPT-5-codex, GPT-4.1, GPT-4o, etc.
 - **Anthropic** — Claude models (direct API, OAuth via `hermes login anthropic`, OpenRouter, or any compatible proxy)
 - **Google** — Gemini models (direct API via `gemini` provider, the `google-gemini-cli` OAuth provider, OpenRouter, or compatible proxy)
 - **z.ai / ZhipuAI** — GLM models
@@ -643,7 +643,7 @@ There is no hard limit. Each profile is just a directory under `~/.hermes/profil
 
 ### Using different models for different tasks (multi-model workflows)
 
-**Scenario:** You use GPT-5.4 as your daily driver, but Gemini or Grok writes better social media content. Manually switching models every time is tedious.
+**Scenario:** You use GPT-5.5 as your daily driver, but Gemini or Grok writes better social media content. Manually switching models every time is tedious.
 
 **Solution: Delegation config.** Hermes can route subagents to a different model automatically. Set this in `~/.hermes/config.yaml`:
 
@@ -653,7 +653,7 @@ delegation:
   provider: "openrouter"                    # provider for subagents
 ```
 
-Now when you tell Hermes "write me a Twitter thread about X" and it spawns a `delegate_task` subagent, that subagent runs on Gemini instead of your main model. Your primary conversation stays on GPT-5.4.
+Now when you tell Hermes "write me a Twitter thread about X" and it spawns a `delegate_task` subagent, that subagent runs on Gemini instead of your main model. Your primary conversation stays on GPT-5.5.
 
 You can also be explicit in your prompt: *"Delegate a task to write social media posts about our product launch. Use your subagent for the actual writing."* The agent will use `delegate_task`, which automatically picks up the delegation config.
 
@@ -662,7 +662,7 @@ For one-off model switches without delegation, use `/model` in the CLI:
 ```bash
 /model google/gemini-3-flash-preview    # switch for this session
 # ... write your content ...
-/model openai/gpt-5.4                   # switch back
+/model openai/gpt-5.5                   # switch back
 ```
 
 See [Subagent Delegation](../user-guide/features/delegation.md) for more on how delegation works.

--- a/website/docs/reference/model-catalog.md
+++ b/website/docs/reference/model-catalog.md
@@ -30,7 +30,7 @@ Published on every merge to `main` via the existing `deploy-site.yml` GitHub Pag
       "metadata": {},
       "models": [
         {"id": "moonshotai/kimi-k2.6", "description": "recommended", "metadata": {}},
-        {"id": "openai/gpt-5.4",       "description": ""}
+        {"id": "openai/gpt-5.5",       "description": ""}
       ]
     },
     "nous": {

--- a/website/docs/user-guide/configuring-models.md
+++ b/website/docs/user-guide/configuring-models.md
@@ -155,8 +155,8 @@ On OpenRouter (or any aggregator), bare model names resolve *within* the aggrega
 Inside any `hermes chat` session:
 
 ```
-/model gpt-5.4 --provider openrouter             # session-only
-/model gpt-5.4 --provider openrouter --global    # also persists to config.yaml
+/model gpt-5.5 --provider openrouter             # session-only
+/model gpt-5.5 --provider openrouter --global    # also persists to config.yaml
 ```
 
 `--global` does the same thing the dashboard's **Change** button does, plus it switches the running session in-place.


### PR DESCRIPTION
## Summary
- Prefer GPT-5.5 across curated Hermes model catalogs and setup fallbacks
- Update OpenRouter/GMI/Codex image-gen/MoA defaults and examples to use GPT-5.5
- Refresh docs and focused assertions so fallback ordering stays covered

## Test Plan
- `python -m pytest tests/hermes_cli/test_ai_gateway_models.py tests/hermes_cli/test_copilot_in_model_list.py tests/hermes_cli/test_gmi_provider.py tests/hermes_cli/test_model_validation.py tests/hermes_cli/test_user_providers_model_switch.py tests/plugins/image_gen/test_openai_codex_provider.py tests/tools/test_mixture_of_agents_tool.py -o 'addopts=' -q`
- `python -m pytest tests/hermes_cli/test_models.py -o 'addopts=' -q`

## Review Notes
- Subagent implementation was used.
- Independent spec review passed.
- Independent quality review requested docs consistency fixes, which were applied before commit.
