### PR TITLE
fix(telegram): use thread fallback helper in slash-confirm result send

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -2645,7 +2645,7 @@ class TelegramAdapter(BasePlatformAdapter):
                                     {"thread_id": str(thread_id)},
                                 )
                             )
-                        await self._bot.send_message(**send_kwargs)
+                        await self._send_message_with_thread_fallback(**send_kwargs)
                 except Exception as exc:
                     logger.error("[%s] slash-confirm callback failed: %s", self.name, exc, exc_info=True)
             return


### PR DESCRIPTION
## Summary

PR #23458 introduced `_send_message_with_thread_fallback()` and wired it into all control-style sends (`send_update_prompt`, `send_approval_request`, `send_model_picker_prompt`), but the follow-up result message in the `sc:` callback branch of `handle_callback_query` still called `self._bot.send_message` directly.

In supergroups where the callback's parent message carries a stale `message_thread_id` (e.g. a DM reply chain), this raises `"Message thread not found"` and the result text is silently dropped — the user clicks Approve / Once / Cancel but receives no confirmation message.

## Change

Replace the bare `self._bot.send_message(**send_kwargs)` call at the end of the `sc:` branch with `self._send_message_with_thread_fallback(**send_kwargs)`, so the existing retry-without-`message_thread_id` logic applies here too.

**1 line changed** in `gateway/platforms/telegram.py`.

## Test plan

- [ ] Trigger a slash-confirm prompt inside a Telegram supergroup topic thread
- [ ] Click an approval button — confirm the result message is delivered
- [ ] Verify no regression on regular (non-thread) chats