### PR TITLE
fix(gateway): keep empty gateway responses silent

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -1079,6 +1079,7 @@ def _normalize_empty_agent_response(
     response: str,
     *,
     history_len: int = 0,
+    allow_user_visible_diagnostics: bool = True,
 ) -> str:
     """Normalize empty/None agent responses into user-facing messages.
 
@@ -1087,6 +1088,9 @@ def _normalize_empty_agent_response(
     Fix for #18765.
     """
     if response:
+        return response
+
+    if not allow_user_visible_diagnostics:
         return response
 
     if agent_result.get("failed"):
@@ -7552,17 +7556,11 @@ class GatewayRunner:
 
             response = agent_result.get("final_response") or ""
 
-            # Convert the agent's internal "(empty)" sentinel into a
-            # user-friendly message.  "(empty)" means the model failed to
-            # produce visible content after exhausting all retries (nudge,
-            # prefill, empty-retry, fallback).  Sending the raw sentinel
-            # looks like a bug; a short explanation is more helpful.
+            # Chat gateways treat silent outcomes as a valid no-op. Keep the
+            # agent's internal empty sentinel out of user-visible channels and
+            # let the adapter no-op on the empty final response.
             if response == "(empty)":
-                response = (
-                    "⚠️ The model returned no response after processing tool "
-                    "results. This can happen with some models — try again or "
-                    "rephrase your question."
-                )
+                response = ""
             agent_messages = agent_result.get("messages", [])
             _response_time = time.time() - _msg_start_time
             _api_calls = agent_result.get("api_calls", 0)
@@ -7594,7 +7592,10 @@ class GatewayRunner:
             # Normalize empty responses: surface errors, partial failures, and
             # the case where agent did work but returned no text. Fix for #18765.
             response = _normalize_empty_agent_response(
-                agent_result, response, history_len=len(history),
+                agent_result,
+                response,
+                history_len=len(history),
+                allow_user_visible_diagnostics=False,
             )
 
             # If the agent's session_id changed during compression, update

--- a/tests/test_lazy_session_regressions.py
+++ b/tests/test_lazy_session_regressions.py
@@ -405,6 +405,49 @@ class TestGatewaySurfacesNullResponse:
         assert "500 Internal Server Error" in response
         assert "/reset" in response
 
+    def test_gateway_mode_keeps_failed_empty_response_silent(self):
+        """Gateway turns should not leak backend failures into chat channels."""
+        from gateway.run import _normalize_empty_agent_response
+
+        agent_result = {
+            "final_response": None,
+            "api_calls": 0,
+            "failed": True,
+            "error": "500 Internal Server Error",
+        }
+
+        response = agent_result.get("final_response") or ""
+        response = _normalize_empty_agent_response(
+            agent_result,
+            response,
+            history_len=5,
+            allow_user_visible_diagnostics=False,
+        )
+
+        assert response == ""
+
+    def test_gateway_mode_keeps_partial_empty_response_silent(self):
+        """Gateway turns should stay silent for empty partial/tool failures."""
+        from gateway.run import _normalize_empty_agent_response
+
+        agent_result = {
+            "final_response": None,
+            "api_calls": 5,
+            "partial": True,
+            "interrupted": False,
+            "error": "Model generated invalid tool call: nonexistent_tool",
+        }
+
+        response = agent_result.get("final_response") or ""
+        response = _normalize_empty_agent_response(
+            agent_result,
+            response,
+            history_len=10,
+            allow_user_visible_diagnostics=False,
+        )
+
+        assert response == ""
+
     def test_nonempty_response_passes_through(self):
         """Non-empty response is returned unchanged."""
         from gateway.run import _normalize_empty_agent_response


### PR DESCRIPTION
## What does this PR do?

Keeps gateway chat channels silent when the agent ends a turn with no user-facing text.

The gateway currently turns empty results into backend-style warning text like `(empty)` fallbacks or synthetic failure messages. That makes valid silent outcomes look broken in shared chats. This change keeps those diagnostics internal for gateway delivery while preserving the existing helper behavior for non-gateway callers.

## Related Issue

Fixes #22712

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- stop converting gateway `(empty)` sentinels into user-visible warning text in `gateway/run.py`
- skip synthetic empty-response diagnostics in the gateway delivery path while keeping `_normalize_empty_agent_response(...)` unchanged by default for other callers
- add regression coverage in `tests/test_lazy_session_regressions.py` for silent gateway-mode failed/partial empty turns

## How to Test

1. `uv run --frozen --extra dev pytest -q -o addopts='' tests/test_lazy_session_regressions.py`
2. `uv run --frozen ruff check gateway/run.py tests/test_lazy_session_regressions.py`
3. Confirm the new gateway-mode tests keep failed/partial empty responses silent while the existing helper tests still surface diagnostics by default.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `uv run --frozen --extra dev pytest -q -o addopts='' tests/test_lazy_session_regressions.py` -> `19 passed`
- `uv run --frozen ruff check gateway/run.py tests/test_lazy_session_regressions.py` -> `All checks passed!`
