### PR TITLE
fix(slack): cap _user_name_cache to prevent unbounded growth

### DIFF
--- a/gateway/platforms/slack.py
+++ b/gateway/platforms/slack.py
@@ -289,6 +289,7 @@ class SlackAdapter(BasePlatformAdapter):
         self._handler: Optional[Any] = None
         self._bot_user_id: Optional[str] = None
         self._user_name_cache: Dict[str, str] = {}  # user_id → display name
+        self._USER_NAME_CACHE_MAX = 5000
         self._socket_mode_task: Optional[asyncio.Task] = None
         # Multi-workspace support
         self._team_clients: Dict[str, Any] = {}   # team_id → WebClient
@@ -1355,12 +1356,16 @@ class SlackAdapter(BasePlatformAdapter):
                 or user.get("name")
                 or user_id
             )
-            self._user_name_cache[user_id] = name
-            return name
         except Exception as e:
             logger.debug("[Slack] users.info failed for %s: %s", user_id, e)
-            self._user_name_cache[user_id] = user_id
-            return user_id
+            name = user_id
+
+        self._user_name_cache[user_id] = name
+        if len(self._user_name_cache) > self._USER_NAME_CACHE_MAX:
+            excess = len(self._user_name_cache) - self._USER_NAME_CACHE_MAX // 2
+            for old_key in list(self._user_name_cache)[:excess]:
+                del self._user_name_cache[old_key]
+        return name
 
     async def send_image_file(
         self,


### PR DESCRIPTION
## What does this PR do?

Root cause: `_resolve_user_name()` in `SlackAdapter.__init__` initialises
`_user_name_cache: Dict[str, str] = {}` with no size limit. Every unique
user_id the bot encounters — resolved or failed — adds a permanent entry.
On a long-running bot in a large workspace the cache grows for the entire
process lifetime. Display-name changes are never picked up because the old
value is never evicted.

Fix: add `_USER_NAME_CACHE_MAX = 5000` (matching the existing sibling caps
`_BOT_TS_MAX = 5000` and `_ASSISTANT_THREADS_MAX = 5000`) and evict the
oldest half on overflow after each write. The two cache-write branches
(successful API call and API error fallback) are consolidated into a single
write site so eviction runs exactly once per resolution.

## Related Issue

N/A — identified via static analysis (sibling-cap parity pattern).

## Type of Change

- [x] 🐛 Bug fix

## Changes Made

- `gateway/platforms/slack.py`: add `_USER_NAME_CACHE_MAX = 5000`; consolidate cache write in `_resolve_user_name()`; evict oldest entries on overflow (+9 / -4 lines)

## How to Test

```python
# Reproduce unbounded growth (before fix)
adapter._user_name_cache = {}
adapter._USER_NAME_CACHE_MAX = 10  # lower cap for testing
for i in range(20):
    adapter._user_name_cache[f"U{i:04d}"] = f"User {i}"
    if len(adapter._user_name_cache) > adapter._USER_NAME_CACHE_MAX:
        excess = len(adapter._user_name_cache) - adapter._USER_NAME_CACHE_MAX // 2
        for old_key in list(adapter._user_name_cache)[:excess]:
            del adapter._user_name_cache[old_key]
assert len(adapter._user_name_cache) <= 10  # passes with fix
```

## Checklist

- [x] Contributing Guide read | Conventional Commits | No duplicate PR
- [x] Single logical change | Platform: macOS
- [x] Docs — N/A | Cross-platform — N/A