### PR TITLE
fix(run-agent): rebuild anthropic client on stream retry

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -7137,6 +7137,25 @@ class AIAgent:
             self._try_refresh_anthropic_client_credentials()
         return self._anthropic_client.messages.create(**api_kwargs)
 
+    def _refresh_primary_stream_retry_client(self, *, reason: str) -> None:
+        """Reset the shared provider client used to seed future stream retries.
+
+        Anthropic-wire providers (including DeepSeek's ``/anthropic`` path)
+        stream through ``self._anthropic_client`` and often leave
+        ``self._client_kwargs`` empty. Rebuilding the OpenAI client in that
+        mode can emit misleading "Missing credentials" warnings and skip the
+        real transport reset we need.
+        """
+        if self.api_mode == "anthropic_messages":
+            try:
+                self._anthropic_client.close()
+            except Exception:
+                pass
+            self._rebuild_anthropic_client()
+            return
+
+        self._replace_primary_openai_client(reason=reason)
+
     def _rebuild_anthropic_client(self) -> None:
         """Rebuild the Anthropic client after an interrupt or stale call.
 
@@ -8092,7 +8111,7 @@ class AIAgent:
                                 )
                                 request_client_holder["client"] = None
                             try:
-                                self._replace_primary_openai_client(
+                                self._refresh_primary_stream_retry_client(
                                     reason="stream_mid_tool_retry_pool_cleanup"
                                 )
                             except Exception:
@@ -8150,7 +8169,7 @@ class AIAgent:
                                 # Also rebuild the primary client to purge
                                 # any dead connections from the pool.
                                 try:
-                                    self._replace_primary_openai_client(
+                                    self._refresh_primary_stream_retry_client(
                                         reason="stream_retry_pool_cleanup"
                                     )
                                 except Exception:

--- a/tests/run_agent/test_streaming.py
+++ b/tests/run_agent/test_streaming.py
@@ -1000,6 +1000,92 @@ class TestAnthropicStreamCallbacks:
         assert touch_calls.count("receiving stream response") == len(events)
 
 
+class TestAnthropicStreamRetryCleanup:
+    """Anthropic-wire stream retries must rebuild the Anthropic client, not the
+    OpenAI shared client. Third-party /anthropic providers often leave
+    ``_client_kwargs`` empty, so OpenAI-client rebuilds can fail with
+    misleading credential errors during DeepSeek/Kimi retry cleanup.
+    """
+
+    def test_anthropic_stream_retry_rebuilds_anthropic_client(self):
+        from run_agent import AIAgent
+        import httpx as _httpx
+
+        class _FailingStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            @property
+            def response(self):
+                return None
+
+            def __iter__(self):
+                raise _httpx.RemoteProtocolError("peer closed connection")
+                yield  # pragma: no cover
+
+            def get_final_message(self):
+                raise AssertionError("final message should not be requested")
+
+        class _SuccessfulStream:
+            def __enter__(self):
+                return self
+
+            def __exit__(self, exc_type, exc, tb):
+                return False
+
+            @property
+            def response(self):
+                return None
+
+            def __iter__(self):
+                return iter([])
+
+            def get_final_message(self):
+                return SimpleNamespace(content=[], stop_reason="end_turn")
+
+        agent = AIAgent(
+            api_key="test-key",
+            base_url="https://api.deepseek.com/anthropic",
+            model="deepseek-v4",
+            quiet_mode=True,
+            skip_context_files=True,
+            skip_memory=True,
+        )
+        agent.api_mode = "anthropic_messages"
+        agent.provider = "deepseek"
+        agent._interrupt_requested = False
+        agent._client_kwargs = {}
+        agent._anthropic_api_key = "deepseek-key"
+        agent._anthropic_base_url = "https://api.deepseek.com/anthropic"
+
+        stream_client = MagicMock()
+        stream_client.messages.stream.side_effect = [
+            _FailingStream(),
+            _SuccessfulStream(),
+        ]
+        stream_client.close = MagicMock()
+        agent._anthropic_client = stream_client
+
+        with (
+            patch.object(agent, "_try_refresh_anthropic_client_credentials", return_value=False),
+            patch.object(agent, "_rebuild_anthropic_client") as rebuild,
+            patch.object(
+                agent,
+                "_replace_primary_openai_client",
+                side_effect=AssertionError("openai client rebuild should not run"),
+            ),
+        ):
+            response = agent._interruptible_streaming_api_call({"model": "deepseek-v4"})
+
+        assert stream_client.messages.stream.call_count == 2
+        assert stream_client.close.call_count == 1
+        rebuild.assert_called_once()
+        assert response.stop_reason == "end_turn"
+
+
 class TestPartialToolCallWarning:
     """Regression: when a stream dies mid tool-call argument generation after
     text was already delivered, the partial-stream stub at run_agent.py
@@ -1504,4 +1590,3 @@ class TestCopilotACPStreamingDecision:
             _use_streaming = False
 
         assert _use_streaming is True
-


### PR DESCRIPTION
## What does this PR do?

Fixes the credential-loss half of #23286 for Anthropic-wire providers like DeepSeek's `/anthropic` endpoint.

When a streaming retry is triggered after a transient stream drop, the retry cleanup path currently rebuilds the shared OpenAI client unconditionally. In `api_mode == "anthropic_messages"`, that is the wrong transport: these providers stream through `self._anthropic_client`, and third-party Anthropic endpoints often leave `self._client_kwargs` empty. The result is a misleading `Missing credentials` rebuild failure during retry cleanup.

This change routes stream-retry cleanup through the Anthropic client when the active transport is `anthropic_messages`, so retries reset the correct client instead of trying to rebuild an unused OpenAI one.

It does **not** claim to solve DeepSeek's upstream ~600s server-side stream limit; it only fixes the retry-side credential loss / wrong-client rebuild.

## Related Issue

Related to #23286

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `AIAgent._refresh_primary_stream_retry_client()` in `/run_agent.py` to branch retry cleanup by active transport.
- Reused the existing Anthropic client rebuild path for `api_mode == "anthropic_messages"` instead of calling `_replace_primary_openai_client()`.
- Updated both transient stream retry cleanup sites (`stream_retry_pool_cleanup` and `stream_mid_tool_retry_pool_cleanup`) to use the new helper.
- Added a regression test in `/tests/run_agent/test_streaming.py` that proves Anthropic stream retries rebuild the Anthropic client and do not try to rebuild the OpenAI client.

## How to Test

1. Run:
   `uv run --frozen pytest -q -o addopts='' tests/run_agent/test_streaming.py -k 'AnthropicStreamRetryCleanup or test_anthropic_stream_refreshes_activity_on_every_event'`
2. Run:
   `uv run --frozen ruff check run_agent.py tests/run_agent/test_streaming.py`
3. Optionally reproduce the original issue on a DeepSeek Anthropic endpoint and confirm stream retry cleanup no longer logs `Failed to rebuild shared OpenAI client ... Missing credentials`.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

Targeted regression test:
- `2 passed, 33 deselected`

Repo smoke:
- `uv run --frozen pytest -q -o addopts='' --collect-only tests/run_agent/test_streaming.py`
- `35 tests collected`
