### PR TITLE
fix(commands): make /sessions CLI-only and functional

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7036,6 +7036,9 @@ class HermesCLI:
                     pass
         elif canonical == "history":
             self.show_history()
+        elif canonical == "sessions":
+            if not self._show_recent_sessions(reason="command"):
+                print("(._.) No recent sessions available.")
         elif canonical == "title":
             parts = cmd_original.split(maxsplit=1)
             if len(parts) > 1:

--- a/hermes_cli/commands.py
+++ b/hermes_cli/commands.py
@@ -115,7 +115,7 @@ COMMAND_REGISTRY: list[CommandDef] = [
                args_hint="[name]"),
 
     # Configuration
-    CommandDef("sessions", "Browse and resume previous sessions", "Session"),
+    CommandDef("sessions", "Browse and resume previous sessions", "Session", cli_only=True),
 
     # Configuration
     CommandDef("config", "Show current configuration", "Configuration",

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -319,6 +319,32 @@ class TestHistoryDisplay:
         assert "Checking Running Hermes Agent" in output
         assert "Use /resume <session id or title> to continue" in output
 
+    def test_sessions_command_lists_recent_sessions(self, capsys):
+        cli = _make_cli()
+        cli.session_id = "current"
+        cli._session_db = MagicMock()
+        cli._session_db.list_sessions_rich.return_value = [
+            {
+                "id": "current",
+                "title": "Current",
+                "preview": "Current preview",
+                "last_active": 0,
+            },
+            {
+                "id": "20260401_201329_d85961",
+                "title": "Checking Running Hermes Agent",
+                "preview": "check running gateways for hermes agent",
+                "last_active": 0,
+            },
+        ]
+
+        assert cli.process_command("/sessions") is True
+        output = capsys.readouterr().out
+
+        assert "Recent sessions" in output
+        assert "Checking Running Hermes Agent" in output
+        assert "Use /resume <session id or title> to continue" in output
+
 
 class TestRootLevelProviderOverride:
     """Root-level provider/base_url in config.yaml must NOT override model.provider."""

--- a/tests/hermes_cli/test_commands.py
+++ b/tests/hermes_cli/test_commands.py
@@ -115,6 +115,13 @@ class TestResolveCommand:
         assert topic.name == "topic"
         assert "topic" in GATEWAY_KNOWN_COMMANDS
 
+    def test_sessions_is_cli_only(self):
+        sessions = resolve_command("sessions")
+        assert sessions is not None
+        assert sessions.name == "sessions"
+        assert sessions.cli_only is True
+        assert "sessions" not in GATEWAY_KNOWN_COMMANDS
+
     def test_leading_slash_stripped(self):
         assert resolve_command("/help").name == "help"
         assert resolve_command("/bg").name == "background"


### PR DESCRIPTION
## Summary
- mark `/sessions` as CLI-only so gateway platforms no longer advertise or silently swallow it
- wire the classic CLI slash dispatcher to show recent sessions inline when `/sessions` is used
- add regression tests for command registration and CLI slash handling

## Verification
- `scripts/run_tests.sh tests/hermes_cli/test_commands.py tests/cli/test_cli_init.py`
- independent delegated code review: passed

## Notes
- Existing authored PR #18315 was inspected first; its current red checks reproduce on `upstream/main` and were not actionable in this run.
- Codex was attempted first, but it failed with the known sandbox / CA-bundle permission errors and a usage-limit stop, so Hermes handled the fallback implementation.

Closes #23533
