### PR TITLE
fix(cli): propagate fallback_providers to AIAgent in oneshot mode

### DIFF
--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -302,6 +302,10 @@ def _run_agent(
 
     session_db = _create_session_db_for_oneshot()
 
+    # Load fallback provider chain from config.yaml so oneshot mode can
+    # survive 429 rate-limits on the primary provider (parity with gateway).
+    fallback_model = cfg.get("fallback_providers") or cfg.get("fallback_model") or None
+
     agent = AIAgent(
         api_key=runtime.get("api_key"),
         base_url=runtime.get("base_url"),
@@ -313,6 +317,7 @@ def _run_agent(
         platform="cli",
         session_db=session_db,
         credential_pool=runtime.get("credential_pool"),
+        fallback_model=fallback_model,
         # Interactive callbacks are intentionally NOT wired beyond this
         # one.  In oneshot mode there's no user sitting at a terminal:
         #   - clarify  → returns a synthetic "pick a default" instruction


### PR DESCRIPTION
## Summary

Fixes #18961 — `--oneshot` CLI mode now respects the configured `fallback_providers` chain, bringing it to parity with gateway mode.

This PR **supersedes #18962** which fell 86 commits behind `main` and shows `DIRTY` merge state.

## Problem

When the primary provider returns HTTP 429 (rate-limit) in `--oneshot` mode, the agent hard-fails instead of falling back through the `fallback_providers` chain. Gateway mode already handles this correctly.

## Root Cause

`hermes_cli/oneshot.py` loads `cfg = load_config()` but never extracts `fallback_providers` / `fallback_model`, and the `AIAgent(...)` call is missing the `fallback_model=` parameter.

## Fix (2 lines)

1. After the existing `toolsets_list` block, extract fallback config:
   ```python
   fallback_model = cfg.get("fallback_providers") or cfg.get("fallback_model") or None
   ```
2. Pass it to `AIAgent(...)`:
   ```python
   fallback_model=fallback_model,
   ```

`AIAgent.__init__` already normalizes both list (`fallback_providers`) and legacy dict (`fallback_model`) formats, so this works with either config style.

## Conflict Resolution

`origin/main` added `session_db = _create_session_db_for_oneshot()` and `clarify_callback=_oneshot_clarify_callback` in the same block as the old PR. This branch is rebased onto current `origin/main` and inserts the fallback extraction between those two new lines.

## Testing

- `hermes_cli/oneshot.py` is valid Python (no syntax errors).
- `AIAgent.__init__` already accepts `fallback_model` (line ~954 in `run_agent.py`).
