### PR TITLE
fix(e2e): disable destructive-slash confirm in test fixtures

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -216,6 +216,9 @@ def make_runner(platform: Platform, session_entry: SessionEntry = None) -> "Gate
 
     runner._is_user_authorized = lambda _source: True
     runner._set_session_env = lambda _context: None
+    # Disable destructive-slash confirmation so tests exercise the actual
+    # command-execution path without needing to simulate button clicks.
+    runner._read_user_config = lambda: {"approvals": {"destructive_slash_confirm": False}}
     runner._handle_message_with_agent = AsyncMock(return_value="agent-handled-default")
     runner._should_send_voice_reply = lambda *_a, **_kw: False
     runner._send_voice_reply = AsyncMock()


### PR DESCRIPTION
## Summary

`tests/e2e/test_platform_commands.py` e2e tests for `/new`, `/clear`, etc. fail because the test fixture (`object.__new__(GatewayRunner)`) bypasses `__init__`, so `confirm_required` defaults to `True`. This causes `_maybe_confirm_destructive_slash` to route through the confirmation flow rather than directly executing `execute()`.

Root cause: bare-runner fixtures never set `_read_user_config`, and `send_slash_confirm` was never mocked to return `"once"`, so `_on_confirm` (which calls `execute()`) is never reached.

## Fix

In `make_runner()` fixture, add:
```python
runner._read_user_config = lambda: {"approvals": {"destructive_slash_confirm": False}}
```

This disables the confirmation gate so tests exercise the actual command-execution path.

## Testing

```
pytest tests/e2e/test_platform_commands.py -v
# Before: 9 failed, 41 passed, 4 skipped
# After:  50 passed, 4 skipped (all /new tests pass)
```

Verified on `upstream/main` — same 9 failures there, confirming this is an upstream bug not introduced by any local change.

## Classification

- **Type**: Bug (test design flaw)
- **Impact**: All 9 `/new`-related e2e tests fail deterministically; no production impact
