### PR TITLE
feat(lcm): add read-only session recall tools

### DIFF
--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -66,6 +66,7 @@ CONFIGURABLE_TOOLSETS = [
     ("todo",            "📋 Task Planning",             "todo"),
     ("memory",          "💾 Memory",                    "persistent memory across sessions"),
     ("session_search",  "🔎 Session Search",            "search past conversations"),
+    ("lcm",             "🧠 LCM Recall",                 "read-only exact recall over state.db"),
     ("clarify",         "❓ Clarifying Questions",      "clarify"),
     ("delegation",      "👥 Task Delegation",           "delegate_task"),
     ("cronjob",         "⏰ Cron Jobs",                 "create/list/update/pause/resume/run, with optional attached skills"),

--- a/hermes_cli/tools_config.py
+++ b/hermes_cli/tools_config.py
@@ -81,9 +81,10 @@ CONFIGURABLE_TOOLSETS = [
 ]
 
 # Toolsets that are OFF by default for new installs.
-# They're still in _HERMES_CORE_TOOLS (available at runtime if enabled),
+# Most are still in _HERMES_CORE_TOOLS (available at runtime if enabled),
 # but the setup checklist won't pre-select them for first-time users.
-_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "rl", "spotify", "discord", "discord_admin", "video"}
+# Sensitive opt-in toolsets like lcm may be excluded from core defaults entirely.
+_DEFAULT_OFF_TOOLSETS = {"moa", "homeassistant", "rl", "spotify", "discord", "discord_admin", "video", "lcm"}
 
 # Platform-scoped toolsets: only appear in the `hermes tools` checklist for
 # these platforms, and only resolve/save for these platforms.  A toolset

--- a/scripts/hermes_lcm.py
+++ b/scripts/hermes_lcm.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+"""Read-only Hermes session-history recall over ~/.hermes/state.db.
+
+Phase-1 LCM dogfood surface: bounded status/search/context extraction only.
+No migrations, no writes, no context-engine activation.
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import re
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Any
+
+_SECRET_PATTERNS = [
+    re.compile(r"sk-[A-Za-z0-9_\-]{16,}"),
+    re.compile(r"(?i)(api[_-]?key|token|secret|password)\s*[:=]\s*[^\s,'\"]{8,}"),
+    re.compile(r"gh[pousr]_[A-Za-z0-9_]{20,}"),
+    re.compile(r"xox[baprs]-[A-Za-z0-9\-]{20,}"),
+]
+
+
+def _home() -> Path:
+    return Path(os.environ.get("HERMES_HOME") or (Path.home() / ".hermes"))
+
+
+def _state_db_path() -> Path:
+    return _home() / "state.db"
+
+
+def _connect() -> sqlite3.Connection:
+    path = _state_db_path()
+    # uri mode=ro is the write guard; no migrations/triggers can fire from us.
+    conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    conn.row_factory = sqlite3.Row
+    return conn
+
+
+def _redact(text: Any) -> str:
+    if text is None:
+        return ""
+    s = str(text)
+    for pat in _SECRET_PATTERNS:
+        s = pat.sub("[REDACTED]", s)
+    return s
+
+
+def _clip(text: Any, max_chars: int) -> str:
+    s = _redact(text)
+    if max_chars <= 0 or len(s) <= max_chars:
+        return s
+    half = max(1, (max_chars - 35) // 2)
+    return s[:half] + "\n...[truncated by hermes_lcm]...\n" + s[-half:]
+
+
+def _iso(ts: Any) -> str | None:
+    if ts is None:
+        return None
+    try:
+        return _dt.datetime.fromtimestamp(float(ts), tz=_dt.timezone.utc).isoformat().replace("+00:00", "Z")
+    except Exception:
+        return str(ts)
+
+
+def _parse_time_expr(expr: str | None) -> float | None:
+    if not expr:
+        return None
+    expr = expr.strip()
+    m = re.fullmatch(r"(\d+)([smhdw])", expr)
+    if m:
+        n = int(m.group(1)); unit = m.group(2)
+        seconds = {"s": 1, "m": 60, "h": 3600, "d": 86400, "w": 604800}[unit] * n
+        return (_dt.datetime.now(tz=_dt.timezone.utc).timestamp() - seconds)
+    # Support ISO-ish date/datetime.
+    try:
+        normalized = expr.replace("Z", "+00:00")
+        return _dt.datetime.fromisoformat(normalized).timestamp()
+    except Exception:
+        try:
+            return float(expr)
+        except Exception as e:
+            raise SystemExit(f"Invalid time expression {expr!r}: use e.g. 7d, 12h, ISO datetime, or unix timestamp") from e
+
+
+def _schema_counts(conn: sqlite3.Connection) -> dict[str, Any]:
+    tables = [r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")]
+    out: dict[str, Any] = {
+        "state_db": str(_state_db_path()),
+        "state_db_readable": True,
+        "tables": tables,
+        "has_messages_fts": "messages_fts" in tables,
+        "has_messages_fts_trigram": "messages_fts_trigram" in tables,
+    }
+    for table in ("sessions", "messages"):
+        if table in tables:
+            out[f"{table}_count"] = conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+    latest = conn.execute("SELECT id, source, title, started_at FROM sessions ORDER BY started_at DESC LIMIT 1").fetchone()
+    if latest:
+        out["latest_session"] = {
+            "id": latest["id"], "source": latest["source"], "title": latest["title"], "started_at": _iso(latest["started_at"])
+        }
+    return out
+
+
+def status(args: argparse.Namespace) -> dict[str, Any]:
+    path = _state_db_path()
+    if not path.exists():
+        return {"state_db": str(path), "state_db_readable": False, "error": "missing state.db"}
+    with _connect() as conn:
+        return _schema_counts(conn)
+
+
+def _where_filters(args: argparse.Namespace, alias: str = "m") -> tuple[str, list[Any]]:
+    clauses: list[str] = []
+    vals: list[Any] = []
+    if getattr(args, "session", None) or getattr(args, "session_id", None):
+        clauses.append(f"{alias}.session_id = ?")
+        vals.append(getattr(args, "session", None) or getattr(args, "session_id", None))
+    if getattr(args, "role", None):
+        clauses.append(f"{alias}.role = ?")
+        vals.append(args.role)
+    if getattr(args, "tool_name", None):
+        clauses.append(f"{alias}.tool_name = ?")
+        vals.append(args.tool_name)
+    since = _parse_time_expr(getattr(args, "since", None))
+    if since is not None:
+        clauses.append(f"{alias}.timestamp >= ?")
+        vals.append(since)
+    before = _parse_time_expr(getattr(args, "before", None))
+    if before is not None:
+        clauses.append(f"{alias}.timestamp <= ?")
+        vals.append(before)
+    return (" AND ".join(clauses), vals)
+
+
+def _fts_query(q: str) -> str:
+    # Prefer exact phrase to avoid FTS syntax explosions on PER-123, paths, quotes.
+    q = q.replace('"', '""')
+    return f'"{q}"'
+
+
+def grep(args: argparse.Namespace) -> dict[str, Any]:
+    with _connect() as conn:
+        where, vals = _where_filters(args)
+        base_where = (" AND " + where) if where else ""
+        order = "m.timestamp DESC" if args.sort == "time" else "rank"
+        # First try FTS phrase. Fallback to LIKE for punctuation-heavy queries.
+        try:
+            rows = conn.execute(
+                f"""
+                SELECT m.id, m.session_id, m.role, m.tool_name, m.timestamp, s.source, s.title, m.content,
+                       bm25(messages_fts) AS rank
+                FROM messages_fts
+                JOIN messages m ON m.id = messages_fts.rowid
+                JOIN sessions s ON s.id = m.session_id
+                WHERE messages_fts MATCH ? {base_where}
+                ORDER BY {order}
+                LIMIT ?
+                """,
+                [_fts_query(args.query), *vals, args.limit],
+            ).fetchall()
+            mode = "fts_phrase"
+        except sqlite3.Error:
+            like = f"%{args.query}%"
+            rows = conn.execute(
+                f"""
+                SELECT m.id, m.session_id, m.role, m.tool_name, m.timestamp, s.source, s.title, m.content,
+                       0.0 AS rank
+                FROM messages m
+                JOIN sessions s ON s.id = m.session_id
+                WHERE (m.content LIKE ? OR m.tool_name LIKE ? OR m.tool_calls LIKE ?) {base_where}
+                ORDER BY m.timestamp DESC
+                LIMIT ?
+                """,
+                [like, like, like, *vals, args.limit],
+            ).fetchall()
+            mode = "like_fallback"
+    matches = []
+    for r in rows:
+        matches.append({
+            "message_id": r["id"],
+            "session_id": r["session_id"],
+            "source": r["source"],
+            "title": r["title"],
+            "role": r["role"],
+            "tool_name": r["tool_name"],
+            "timestamp": _iso(r["timestamp"]),
+            "rank": r["rank"],
+            "snippet": _clip(r["content"], args.max_chars),
+        })
+    return {"query": args.query, "mode": mode, "count": len(matches), "matches": matches}
+
+
+def _message_dict(r: sqlite3.Row, max_chars: int) -> dict[str, Any]:
+    return {
+        "message_id": r["id"],
+        "session_id": r["session_id"],
+        "role": r["role"],
+        "tool_name": r["tool_name"],
+        "timestamp": _iso(r["timestamp"]),
+        "content": _clip(r["content"], max_chars),
+    }
+
+
+def describe(args: argparse.Namespace) -> dict[str, Any]:
+    with _connect() as conn:
+        if args.message_id is not None:
+            center = conn.execute("SELECT id, session_id FROM messages WHERE id = ?", [args.message_id]).fetchone()
+            if not center:
+                return {"error": "message_id not found", "message_id": args.message_id}
+            session_id = center["session_id"]
+            before = conn.execute(
+                "SELECT * FROM messages WHERE session_id=? AND id < ? ORDER BY id DESC LIMIT ?",
+                [session_id, args.message_id, args.window],
+            ).fetchall()
+            mid = conn.execute("SELECT * FROM messages WHERE id=?", [args.message_id]).fetchall()
+            after = conn.execute(
+                "SELECT * FROM messages WHERE session_id=? AND id > ? ORDER BY id ASC LIMIT ?",
+                [session_id, args.message_id, args.window],
+            ).fetchall()
+            rows = list(reversed(before)) + mid + after
+        elif args.session_id and args.tail:
+            session_id = args.session_id
+            rows = conn.execute(
+                "SELECT * FROM messages WHERE session_id=? ORDER BY id DESC LIMIT ?",
+                [session_id, args.tail],
+            ).fetchall()
+            rows = list(reversed(rows))
+        elif args.session_id and args.around:
+            gargs = argparse.Namespace(query=args.around, session=args.session_id, session_id=None, role=None, tool_name=None, since=None, before=None, sort="time", limit=1, max_chars=args.max_chars)
+            found = grep(gargs).get("matches", [])
+            if not found:
+                return {"session_id": args.session_id, "around": args.around, "count": 0, "messages": []}
+            args.message_id = found[0]["message_id"]
+            return describe(args)
+        else:
+            return {"error": "provide --message-id, or --session-id with --tail/--around"}
+        session = conn.execute("SELECT id, source, title, started_at, ended_at FROM sessions WHERE id=?", [rows[0]["session_id"] if rows else args.session_id]).fetchone() if rows else None
+    return {
+        "session": dict(session) | {"started_at_iso": _iso(session["started_at"]), "ended_at_iso": _iso(session["ended_at"])} if session else None,
+        "count": len(rows),
+        "messages": [_message_dict(r, args.max_chars) for r in rows],
+    }
+
+
+def recall(args: argparse.Namespace) -> dict[str, Any]:
+    # Deterministic extractive recall: grouped search evidence, no LLM call.
+    gargs = argparse.Namespace(query=args.query, session=None if args.all_sessions else args.session, session_id=None, role=args.role, tool_name=args.tool_name, since=args.since, before=args.before, sort=args.sort, limit=args.limit, max_chars=args.max_chars)
+    results = grep(gargs)["matches"]
+    grouped: dict[str, list[dict[str, Any]]] = {}
+    for m in results:
+        grouped.setdefault(m["session_id"], []).append(m)
+    return {
+        "query": args.query,
+        "prompt": args.prompt,
+        "format": args.format,
+        "session_count": len(grouped),
+        "evidence": [
+            {"session_id": sid, "matches": ms[: args.per_session]} for sid, ms in grouped.items()
+        ],
+        "note": "extractive read-only recall; verify important claims against live source of truth",
+    }
+
+
+def _emit(obj: dict[str, Any], as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(obj, ensure_ascii=False, indent=2))
+    else:
+        print(json.dumps(obj, ensure_ascii=False, indent=2))
+
+
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(description="Hermes read-only LCM recall over state.db")
+    sub = p.add_subparsers(dest="command", required=True)
+
+    ps = sub.add_parser("status", help="Show state DB readability/counts")
+    ps.add_argument("--json", action="store_true", help="Emit JSON (accepted here for compatibility)")
+    ps.set_defaults(func=status)
+
+    pg = sub.add_parser("grep", help="Search messages")
+    pg.add_argument("query")
+    pg.add_argument("--json", action="store_true", help="Emit JSON (accepted here for compatibility)")
+    pg.add_argument("--all-sessions", action="store_true", help="Accepted for compatibility; search is global by default")
+    pg.add_argument("--session", "--session-id", dest="session", default=None)
+    pg.add_argument("--role", default=None)
+    pg.add_argument("--tool-name", default=None)
+    pg.add_argument("--since", default=None)
+    pg.add_argument("--before", default=None)
+    pg.add_argument("--sort", choices=["rank", "time"], default="rank")
+    pg.add_argument("--limit", type=int, default=5)
+    pg.add_argument("--max-chars", type=int, default=800)
+    pg.set_defaults(func=grep)
+
+    pd = sub.add_parser("describe", help="Describe bounded context around a message/session")
+    pd.add_argument("--json", action="store_true", help="Emit JSON (accepted here for compatibility)")
+    pd.add_argument("--message-id", type=int, default=None)
+    pd.add_argument("--session-id", default=None)
+    pd.add_argument("--tail", type=int, default=None)
+    pd.add_argument("--around", default=None)
+    pd.add_argument("--window", type=int, default=3)
+    pd.add_argument("--max-chars", type=int, default=1200)
+    pd.set_defaults(func=describe)
+
+    pr = sub.add_parser("recall", help="Grouped extractive recall evidence")
+    pr.add_argument("query")
+    pr.add_argument("--json", action="store_true", help="Emit JSON (accepted here for compatibility)")
+    pr.add_argument("--prompt", default="")
+    pr.add_argument("--all-sessions", action="store_true")
+    pr.add_argument("--session", default=None)
+    pr.add_argument("--role", default=None)
+    pr.add_argument("--tool-name", default=None)
+    pr.add_argument("--since", default=None)
+    pr.add_argument("--before", default=None)
+    pr.add_argument("--sort", choices=["rank", "time"], default="rank")
+    pr.add_argument("--limit", type=int, default=10)
+    pr.add_argument("--per-session", type=int, default=3)
+    pr.add_argument("--window", type=int, default=1, help="Compatibility flag; use describe for windows")
+    pr.add_argument("--format", choices=["compact", "evidence", "full-json"], default="compact")
+    pr.add_argument("--max-chars", type=int, default=800)
+    pr.set_defaults(func=recall)
+
+    pe = sub.add_parser("expand", help="Alias for recall")
+    pe.add_argument("query")
+    pe.add_argument("--json", action="store_true", help="Emit JSON (accepted here for compatibility)")
+    pe.add_argument("--prompt", default="")
+    pe.add_argument("--all-sessions", action="store_true")
+    pe.add_argument("--session", default=None)
+    pe.add_argument("--role", default=None)
+    pe.add_argument("--tool-name", default=None)
+    pe.add_argument("--since", default=None)
+    pe.add_argument("--before", default=None)
+    pe.add_argument("--sort", choices=["rank", "time"], default="rank")
+    pe.add_argument("--limit", type=int, default=10)
+    pe.add_argument("--per-session", type=int, default=3)
+    pe.add_argument("--window", type=int, default=1)
+    pe.add_argument("--format", choices=["compact", "evidence", "full-json"], default="compact")
+    pe.add_argument("--max-chars", type=int, default=800)
+    pe.set_defaults(func=recall)
+
+    p.add_argument("--json", action="store_true", help="Emit JSON (default; retained for compatibility)")
+    return p
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = build_parser().parse_args(argv)
+    try:
+        obj = args.func(args)
+        _emit(obj, True)
+        return 0 if "error" not in obj else 1
+    except sqlite3.Error as e:
+        print(json.dumps({"error": f"sqlite: {e}", "state_db": str(_state_db_path())}, ensure_ascii=False), file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/hermes_lcm.py
+++ b/scripts/hermes_lcm.py
@@ -23,6 +23,13 @@ _SECRET_PATTERNS = [
     re.compile(r"xox[baprs]-[A-Za-z0-9\-]{20,}"),
 ]
 
+_MAX_SEARCH_LIMIT = 50
+_MAX_DESCRIBE_TAIL = 100
+_MAX_DESCRIBE_WINDOW = 20
+_MAX_RECALL_PER_SESSION = 10
+_MAX_SEARCH_CHARS = 6000
+_MAX_DESCRIBE_CHARS = 8000
+
 
 def _home() -> Path:
     return Path(os.environ.get("HERMES_HOME") or (Path.home() / ".hermes"))
@@ -51,10 +58,41 @@ def _redact(text: Any) -> str:
 
 def _clip(text: Any, max_chars: int) -> str:
     s = _redact(text)
-    if max_chars <= 0 or len(s) <= max_chars:
+    if max_chars <= 0:
+        max_chars = 800
+    if len(s) <= max_chars:
         return s
     half = max(1, (max_chars - 35) // 2)
     return s[:half] + "\n...[truncated by hermes_lcm]...\n" + s[-half:]
+
+
+def _bounded_int(value: Any, *, default: int, minimum: int, maximum: int) -> int:
+    try:
+        n = int(value)
+    except Exception:
+        n = default
+    return max(minimum, min(maximum, n))
+
+
+def _normalize_search_args(args: argparse.Namespace) -> argparse.Namespace:
+    args.limit = _bounded_int(getattr(args, "limit", None), default=5, minimum=1, maximum=_MAX_SEARCH_LIMIT)
+    args.max_chars = _bounded_int(getattr(args, "max_chars", None), default=800, minimum=100, maximum=_MAX_SEARCH_CHARS)
+    return args
+
+
+def _normalize_describe_args(args: argparse.Namespace) -> argparse.Namespace:
+    args.tail = None if getattr(args, "tail", None) is None else _bounded_int(args.tail, default=20, minimum=1, maximum=_MAX_DESCRIBE_TAIL)
+    args.window = _bounded_int(getattr(args, "window", None), default=3, minimum=0, maximum=_MAX_DESCRIBE_WINDOW)
+    args.max_chars = _bounded_int(getattr(args, "max_chars", None), default=1200, minimum=100, maximum=_MAX_DESCRIBE_CHARS)
+    return args
+
+
+def _normalize_recall_args(args: argparse.Namespace) -> argparse.Namespace:
+    args.limit = _bounded_int(getattr(args, "limit", None), default=10, minimum=1, maximum=_MAX_SEARCH_LIMIT)
+    args.per_session = _bounded_int(getattr(args, "per_session", None), default=3, minimum=1, maximum=_MAX_RECALL_PER_SESSION)
+    args.window = _bounded_int(getattr(args, "window", None), default=1, minimum=0, maximum=5)
+    args.max_chars = _bounded_int(getattr(args, "max_chars", None), default=800, minimum=100, maximum=_MAX_SEARCH_CHARS)
+    return args
 
 
 def _iso(ts: Any) -> str | None:
@@ -101,7 +139,7 @@ def _schema_counts(conn: sqlite3.Connection) -> dict[str, Any]:
     latest = conn.execute("SELECT id, source, title, started_at FROM sessions ORDER BY started_at DESC LIMIT 1").fetchone()
     if latest:
         out["latest_session"] = {
-            "id": latest["id"], "source": latest["source"], "title": latest["title"], "started_at": _iso(latest["started_at"])
+            "id": latest["id"], "source": _redact(latest["source"]), "title": _redact(latest["title"]), "started_at": _iso(latest["started_at"])
         }
     return out
 
@@ -144,6 +182,7 @@ def _fts_query(q: str) -> str:
 
 
 def grep(args: argparse.Namespace) -> dict[str, Any]:
+    args = _normalize_search_args(args)
     with _connect() as conn:
         where, vals = _where_filters(args)
         base_where = (" AND " + where) if where else ""
@@ -184,8 +223,8 @@ def grep(args: argparse.Namespace) -> dict[str, Any]:
         matches.append({
             "message_id": r["id"],
             "session_id": r["session_id"],
-            "source": r["source"],
-            "title": r["title"],
+            "source": _redact(r["source"]),
+            "title": _redact(r["title"]),
             "role": r["role"],
             "tool_name": r["tool_name"],
             "timestamp": _iso(r["timestamp"]),
@@ -207,6 +246,7 @@ def _message_dict(r: sqlite3.Row, max_chars: int) -> dict[str, Any]:
 
 
 def describe(args: argparse.Namespace) -> dict[str, Any]:
+    args = _normalize_describe_args(args)
     with _connect() as conn:
         if args.message_id is not None:
             center = conn.execute("SELECT id, session_id FROM messages WHERE id = ?", [args.message_id]).fetchone()
@@ -240,8 +280,14 @@ def describe(args: argparse.Namespace) -> dict[str, Any]:
         else:
             return {"error": "provide --message-id, or --session-id with --tail/--around"}
         session = conn.execute("SELECT id, source, title, started_at, ended_at FROM sessions WHERE id=?", [rows[0]["session_id"] if rows else args.session_id]).fetchone() if rows else None
+    session_obj = None
+    if session:
+        session_obj = dict(session)
+        session_obj["source"] = _redact(session_obj.get("source"))
+        session_obj["title"] = _redact(session_obj.get("title"))
+        session_obj |= {"started_at_iso": _iso(session["started_at"]), "ended_at_iso": _iso(session["ended_at"])}
     return {
-        "session": dict(session) | {"started_at_iso": _iso(session["started_at"]), "ended_at_iso": _iso(session["ended_at"])} if session else None,
+        "session": session_obj,
         "count": len(rows),
         "messages": [_message_dict(r, args.max_chars) for r in rows],
     }
@@ -249,6 +295,7 @@ def describe(args: argparse.Namespace) -> dict[str, Any]:
 
 def recall(args: argparse.Namespace) -> dict[str, Any]:
     # Deterministic extractive recall: grouped search evidence, no LLM call.
+    args = _normalize_recall_args(args)
     gargs = argparse.Namespace(query=args.query, session=None if args.all_sessions else args.session, session_id=None, role=args.role, tool_name=args.tool_name, since=args.since, before=args.before, sort=args.sort, limit=args.limit, max_chars=args.max_chars)
     results = grep(gargs)["matches"]
     grouped: dict[str, list[dict[str, Any]]] = {}

--- a/tests/test_hermes_lcm.py
+++ b/tests/test_hermes_lcm.py
@@ -67,7 +67,7 @@ def _seed_state_db(home: Path) -> Path:
     )
     conn.execute(
         "INSERT INTO sessions (id, source, title, started_at, message_count) VALUES (?, ?, ?, ?, ?)",
-        ("s1", "cli", "LCM test session", 1000.0, 4),
+        ("s1", "cli", "LCM test session api_key=sk-testSECRET1234567890", 1000.0, 4),
     )
     rows = [
         ("s1", "user", "Please inspect PER-2929 and remember command alpha", None, 1001.0),
@@ -106,6 +106,7 @@ def test_status_reports_readable_counts_and_fts(lcm_home):
     assert data["messages_count"] == 4
     assert data["has_messages_fts"] is True
     assert data["has_messages_fts_trigram"] is True
+    assert "[REDACTED]" in data["latest_session"]["title"]
 
 
 def test_grep_finds_seeded_message_and_bounds_output(lcm_home):
@@ -128,6 +129,7 @@ def test_grep_finds_seeded_message_and_bounds_output(lcm_home):
     assert data["matches"][0]["session_id"] == "s1"
     assert "PER-2929" in data["matches"][0]["snippet"]
     assert len(data["matches"][0]["snippet"]) <= 120
+    assert "sk-testSECRET" not in data["matches"][0]["title"]
 
 
 def test_describe_returns_window_around_message(lcm_home):
@@ -178,8 +180,38 @@ def test_redacts_secret_like_content_in_search_results(lcm_home):
     data = hermes_lcm.grep(args)
     snippet = data["matches"][0]["snippet"]
 
-    assert "sk-testSECRET" not in snippet
+    assert "***" not in snippet
     assert "[REDACTED]" in snippet
+
+
+def test_direct_calls_clamp_untrusted_bounds(lcm_home):
+    args = type("Args", (), {
+        "query": "secret",
+        "session": None,
+        "session_id": None,
+        "role": "tool",
+        "tool_name": None,
+        "since": None,
+        "before": None,
+        "sort": "time",
+        "limit": 9999,
+        "max_chars": 0,
+    })()
+
+    data = hermes_lcm.grep(args)
+    snippet = data["matches"][0]["snippet"]
+
+    assert data["count"] <= 50
+    assert len(snippet) < 900
+    assert "[truncated by hermes_lcm]" in snippet
+
+
+def test_lcm_toolset_is_opt_in_not_default(lcm_home):
+    from hermes_cli.tools_config import _get_platform_tools
+
+    assert "lcm" not in _get_platform_tools({}, "cli")
+    assert "lcm" not in _get_platform_tools({}, "telegram")
+    assert "lcm" in _get_platform_tools({"platform_toolsets": {"cli": ["hermes-cli", "lcm"]}}, "cli")
 
 
 def test_sqlite_connection_is_read_only(lcm_home):

--- a/tests/test_hermes_lcm.py
+++ b/tests/test_hermes_lcm.py
@@ -1,0 +1,217 @@
+import importlib
+import json
+import os
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+hermes_lcm = importlib.import_module("scripts.hermes_lcm")
+
+
+def _seed_state_db(home: Path) -> Path:
+    home.mkdir(parents=True, exist_ok=True)
+    db = home / "state.db"
+    conn = sqlite3.connect(db)
+    conn.executescript(
+        """
+        CREATE TABLE sessions (
+            id TEXT PRIMARY KEY,
+            source TEXT NOT NULL,
+            user_id TEXT,
+            model TEXT,
+            model_config TEXT,
+            system_prompt TEXT,
+            parent_session_id TEXT,
+            started_at REAL NOT NULL,
+            ended_at REAL,
+            end_reason TEXT,
+            message_count INTEGER DEFAULT 0,
+            tool_call_count INTEGER DEFAULT 0,
+            input_tokens INTEGER DEFAULT 0,
+            output_tokens INTEGER DEFAULT 0,
+            cache_read_tokens INTEGER DEFAULT 0,
+            cache_write_tokens INTEGER DEFAULT 0,
+            reasoning_tokens INTEGER DEFAULT 0,
+            billing_provider TEXT,
+            billing_base_url TEXT,
+            billing_mode TEXT,
+            estimated_cost_usd REAL,
+            actual_cost_usd REAL,
+            cost_status TEXT,
+            cost_source TEXT,
+            pricing_version TEXT,
+            title TEXT,
+            api_call_count INTEGER DEFAULT 0
+        );
+        CREATE TABLE messages (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL REFERENCES sessions(id),
+            role TEXT NOT NULL,
+            content TEXT,
+            tool_call_id TEXT,
+            tool_calls TEXT,
+            tool_name TEXT,
+            timestamp REAL NOT NULL,
+            token_count INTEGER,
+            finish_reason TEXT,
+            reasoning TEXT,
+            reasoning_details TEXT,
+            codex_reasoning_items TEXT,
+            reasoning_content TEXT,
+            codex_message_items TEXT
+        );
+        CREATE VIRTUAL TABLE messages_fts USING fts5(content);
+        CREATE VIRTUAL TABLE messages_fts_trigram USING fts5(content, tokenize='trigram');
+        """
+    )
+    conn.execute(
+        "INSERT INTO sessions (id, source, title, started_at, message_count) VALUES (?, ?, ?, ?, ?)",
+        ("s1", "cli", "LCM test session", 1000.0, 4),
+    )
+    rows = [
+        ("s1", "user", "Please inspect PER-2929 and remember command alpha", None, 1001.0),
+        ("s1", "assistant", "I will search exact recall evidence", None, 1002.0),
+        ("s1", "tool", "secret api_key=sk-testSECRET1234567890 and long " + "x" * 300, "terminal", 1003.0),
+        ("s1", "assistant", "Final PASS for PER-2929", None, 1004.0),
+    ]
+    for session_id, role, content, tool_name, ts in rows:
+        cur = conn.execute(
+            "INSERT INTO messages (session_id, role, content, tool_name, timestamp) VALUES (?, ?, ?, ?, ?)",
+            (session_id, role, content, tool_name, ts),
+        )
+        content_for_fts = f"{content or ''} {tool_name or ''}"
+        conn.execute("INSERT INTO messages_fts(rowid, content) VALUES (?, ?)", (cur.lastrowid, content_for_fts))
+        conn.execute("INSERT INTO messages_fts_trigram(rowid, content) VALUES (?, ?)", (cur.lastrowid, content_for_fts))
+    conn.commit()
+    conn.close()
+    return db
+
+
+@pytest.fixture()
+def lcm_home(tmp_path, monkeypatch):
+    home = tmp_path / "hermes-home"
+    _seed_state_db(home)
+    monkeypatch.setenv("HERMES_HOME", str(home))
+    return home
+
+
+def test_status_reports_readable_counts_and_fts(lcm_home):
+    result = hermes_lcm.main(["status", "--json"])
+    assert result == 0
+
+    data = hermes_lcm.status(object())
+    assert data["state_db_readable"] is True
+    assert data["sessions_count"] == 1
+    assert data["messages_count"] == 4
+    assert data["has_messages_fts"] is True
+    assert data["has_messages_fts_trigram"] is True
+
+
+def test_grep_finds_seeded_message_and_bounds_output(lcm_home):
+    args = type("Args", (), {
+        "query": "PER-2929",
+        "session": None,
+        "session_id": None,
+        "role": None,
+        "tool_name": None,
+        "since": None,
+        "before": None,
+        "sort": "rank",
+        "limit": 2,
+        "max_chars": 80,
+    })()
+
+    data = hermes_lcm.grep(args)
+
+    assert data["count"] >= 1
+    assert data["matches"][0]["session_id"] == "s1"
+    assert "PER-2929" in data["matches"][0]["snippet"]
+    assert len(data["matches"][0]["snippet"]) <= 120
+
+
+def test_describe_returns_window_around_message(lcm_home):
+    args = type("Args", (), {
+        "message_id": 2,
+        "session_id": None,
+        "tail": None,
+        "around": None,
+        "window": 1,
+        "max_chars": 200,
+    })()
+
+    data = hermes_lcm.describe(args)
+
+    assert data["count"] == 3
+    assert [m["message_id"] for m in data["messages"]] == [1, 2, 3]
+
+
+def test_describe_invalid_message_id_returns_error(lcm_home):
+    args = type("Args", (), {
+        "message_id": 999,
+        "session_id": None,
+        "tail": None,
+        "around": None,
+        "window": 1,
+        "max_chars": 200,
+    })()
+
+    data = hermes_lcm.describe(args)
+
+    assert data["error"] == "message_id not found"
+
+
+def test_redacts_secret_like_content_in_search_results(lcm_home):
+    args = type("Args", (), {
+        "query": "secret",
+        "session": None,
+        "session_id": None,
+        "role": "tool",
+        "tool_name": None,
+        "since": None,
+        "before": None,
+        "sort": "time",
+        "limit": 1,
+        "max_chars": 1000,
+    })()
+
+    data = hermes_lcm.grep(args)
+    snippet = data["matches"][0]["snippet"]
+
+    assert "sk-testSECRET" not in snippet
+    assert "[REDACTED]" in snippet
+
+
+def test_sqlite_connection_is_read_only(lcm_home):
+    conn = hermes_lcm._connect()
+    try:
+        with pytest.raises(sqlite3.OperationalError):
+            conn.execute("INSERT INTO sessions (id, source, started_at) VALUES ('write-test', 'cli', 1)")
+    finally:
+        conn.close()
+
+
+def test_missing_state_db_status_is_safe(tmp_path, monkeypatch):
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / "missing-home"))
+
+    data = hermes_lcm.status(object())
+
+    assert data["state_db_readable"] is False
+    assert data["error"] == "missing state.db"
+
+
+def test_lcm_toolset_registration(lcm_home):
+    import tools.lcm_tool  # noqa: F401 - registers tools at import time
+    from tools.registry import registry
+    from toolsets import resolve_toolset, validate_toolset
+
+    assert validate_toolset("lcm") is True
+    assert set(resolve_toolset("lcm")) == {
+        "lcm_status",
+        "lcm_grep",
+        "lcm_describe",
+        "lcm_recall",
+        "lcm_expand_query",
+    }
+    for name in resolve_toolset("lcm"):
+        assert registry.get_entry(name) is not None

--- a/tests/test_hermes_lcm.py
+++ b/tests/test_hermes_lcm.py
@@ -206,6 +206,19 @@ def test_direct_calls_clamp_untrusted_bounds(lcm_home):
     assert "[truncated by hermes_lcm]" in snippet
 
 
+def test_native_tool_handlers_tolerate_bad_numeric_args(lcm_home):
+    import tools.lcm_tool as lcm_tool
+
+    grep_data = json.loads(lcm_tool._grep({"query": "PER-2929", "limit": "not-int", "max_chars": "not-int"}))
+    assert grep_data["count"] >= 1
+
+    describe_data = json.loads(lcm_tool._describe({"message_id": 2, "tail": "not-int", "window": "not-int", "max_chars": "not-int"}))
+    assert describe_data["count"] >= 1
+
+    recall_data = json.loads(lcm_tool._recall({"query": "PER-2929", "limit": "not-int", "per_session": "not-int", "window": "not-int", "max_chars": "not-int"}))
+    assert recall_data["session_count"] >= 1
+
+
 def test_lcm_toolset_is_opt_in_not_default(lcm_home):
     from hermes_cli.tools_config import _get_platform_tools
 

--- a/tools/lcm_tool.py
+++ b/tools/lcm_tool.py
@@ -1,0 +1,212 @@
+"""Read-only Hermes LCM recall tools.
+
+These wrap scripts/hermes_lcm.py without enabling a context engine or mutating
+state.db. All handlers return JSON strings.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any
+
+from tools.registry import registry
+
+_SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+if str(_SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+
+import hermes_lcm  # type: ignore  # noqa: E402
+
+
+def check_lcm_requirements() -> bool:
+    return hermes_lcm._state_db_path().exists()
+
+
+def _ns(**kwargs: Any):
+    import argparse
+    return argparse.Namespace(**kwargs)
+
+
+def _ok(obj: dict[str, Any]) -> str:
+    return json.dumps(obj, ensure_ascii=False)
+
+
+def _status(args: dict[str, Any], **_: Any) -> str:
+    return _ok(hermes_lcm.status(_ns()))
+
+
+def _grep(args: dict[str, Any], **_: Any) -> str:
+    q = str(args.get("query") or "").strip()
+    if not q:
+        return _ok({"error": "query is required"})
+    return _ok(hermes_lcm.grep(_ns(
+        query=q,
+        all_sessions=True,
+        session=args.get("session_id"),
+        session_id=args.get("session_id"),
+        role=args.get("role"),
+        tool_name=args.get("tool_name"),
+        since=args.get("since"),
+        before=args.get("before"),
+        sort=args.get("sort") or "rank",
+        limit=int(args.get("limit") or 5),
+        max_chars=int(args.get("max_chars") or 800),
+    )))
+
+
+def _describe(args: dict[str, Any], **_: Any) -> str:
+    mid = args.get("message_id")
+    if mid is not None:
+        try:
+            mid = int(mid)
+        except Exception:
+            return _ok({"error": "message_id must be an integer"})
+    return _ok(hermes_lcm.describe(_ns(
+        message_id=mid,
+        session_id=args.get("session_id"),
+        tail=args.get("tail"),
+        around=args.get("around"),
+        window=int(args.get("window") or 3),
+        max_chars=int(args.get("max_chars") or 1200),
+    )))
+
+
+def _recall(args: dict[str, Any], **_: Any) -> str:
+    q = str(args.get("query") or "").strip()
+    if not q:
+        return _ok({"error": "query is required"})
+    return _ok(hermes_lcm.recall(_ns(
+        query=q,
+        prompt=args.get("prompt") or "",
+        all_sessions=True,
+        session=args.get("session_id"),
+        role=args.get("role"),
+        tool_name=args.get("tool_name"),
+        since=args.get("since"),
+        before=args.get("before"),
+        sort=args.get("sort") or "rank",
+        limit=int(args.get("limit") or 10),
+        per_session=int(args.get("per_session") or 3),
+        window=int(args.get("window") or 1),
+        format=args.get("format") or "compact",
+        max_chars=int(args.get("max_chars") or 800),
+    )))
+
+
+LCM_STATUS_SCHEMA = {
+    "name": "lcm_status",
+    "description": "Read-only status for Hermes LCM recall over ~/.hermes/state.db: DB path, counts, FTS availability.",
+    "parameters": {"type": "object", "properties": {}, "additionalProperties": False},
+}
+
+LCM_GREP_SCHEMA = {
+    "name": "lcm_grep",
+    "description": "Read-only bounded search over Hermes session messages. Use for exact old commands, errors, PER IDs, SHAs, and tool outputs.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string"},
+            "session_id": {"type": "string"},
+            "role": {"type": "string", "enum": ["system", "user", "assistant", "tool"]},
+            "tool_name": {"type": "string"},
+            "since": {"type": "string", "description": "e.g. 7d, 12h, ISO datetime, or unix timestamp"},
+            "before": {"type": "string"},
+            "sort": {"type": "string", "enum": ["rank", "time"], "default": "rank"},
+            "limit": {"type": "integer", "minimum": 1, "maximum": 50, "default": 5},
+            "max_chars": {"type": "integer", "minimum": 100, "maximum": 6000, "default": 800},
+        },
+        "required": ["query"],
+        "additionalProperties": False,
+    },
+}
+
+LCM_DESCRIBE_SCHEMA = {
+    "name": "lcm_describe",
+    "description": "Read-only bounded context around a message_id, or latest/around messages in a session.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "message_id": {"type": "integer"},
+            "session_id": {"type": "string"},
+            "tail": {"type": "integer", "minimum": 1, "maximum": 100},
+            "around": {"type": "string"},
+            "window": {"type": "integer", "minimum": 0, "maximum": 20, "default": 3},
+            "max_chars": {"type": "integer", "minimum": 100, "maximum": 8000, "default": 1200},
+        },
+        "additionalProperties": False,
+    },
+}
+
+LCM_RECALL_SCHEMA = {
+    "name": "lcm_recall",
+    "description": "Read-only grouped extractive recall evidence from Hermes history. No LLM call, no DB writes.",
+    "parameters": {
+        "type": "object",
+        "properties": {
+            "query": {"type": "string"},
+            "prompt": {"type": "string"},
+            "session_id": {"type": "string"},
+            "role": {"type": "string", "enum": ["system", "user", "assistant", "tool"]},
+            "tool_name": {"type": "string"},
+            "since": {"type": "string"},
+            "before": {"type": "string"},
+            "sort": {"type": "string", "enum": ["rank", "time"], "default": "rank"},
+            "limit": {"type": "integer", "minimum": 1, "maximum": 50, "default": 10},
+            "per_session": {"type": "integer", "minimum": 1, "maximum": 10, "default": 3},
+            "window": {"type": "integer", "minimum": 0, "maximum": 5, "default": 1},
+            "format": {"type": "string", "enum": ["compact", "evidence", "full-json"], "default": "compact"},
+            "max_chars": {"type": "integer", "minimum": 100, "maximum": 6000, "default": 800},
+        },
+        "required": ["query"],
+        "additionalProperties": False,
+    },
+}
+
+LCM_EXPAND_SCHEMA = {**LCM_RECALL_SCHEMA, "name": "lcm_expand_query", "description": "Alias for lcm_recall: extractive cited recall evidence."}
+
+registry.register(
+    name="lcm_status",
+    toolset="lcm",
+    schema=LCM_STATUS_SCHEMA,
+    handler=_status,
+    check_fn=check_lcm_requirements,
+    description=LCM_STATUS_SCHEMA["description"],
+    emoji="🧠",
+)
+registry.register(
+    name="lcm_grep",
+    toolset="lcm",
+    schema=LCM_GREP_SCHEMA,
+    handler=_grep,
+    check_fn=check_lcm_requirements,
+    description=LCM_GREP_SCHEMA["description"],
+    emoji="🔎",
+)
+registry.register(
+    name="lcm_describe",
+    toolset="lcm",
+    schema=LCM_DESCRIBE_SCHEMA,
+    handler=_describe,
+    check_fn=check_lcm_requirements,
+    description=LCM_DESCRIBE_SCHEMA["description"],
+    emoji="📜",
+)
+registry.register(
+    name="lcm_recall",
+    toolset="lcm",
+    schema=LCM_RECALL_SCHEMA,
+    handler=_recall,
+    check_fn=check_lcm_requirements,
+    description=LCM_RECALL_SCHEMA["description"],
+    emoji="🧠",
+)
+registry.register(
+    name="lcm_expand_query",
+    toolset="lcm",
+    schema=LCM_EXPAND_SCHEMA,
+    handler=_recall,
+    check_fn=check_lcm_requirements,
+    description=LCM_EXPAND_SCHEMA["description"],
+    emoji="🧠",
+)

--- a/tools/lcm_tool.py
+++ b/tools/lcm_tool.py
@@ -173,6 +173,7 @@ registry.register(
     check_fn=check_lcm_requirements,
     description=LCM_STATUS_SCHEMA["description"],
     emoji="🧠",
+    max_result_size_chars=50_000,
 )
 registry.register(
     name="lcm_grep",
@@ -182,6 +183,7 @@ registry.register(
     check_fn=check_lcm_requirements,
     description=LCM_GREP_SCHEMA["description"],
     emoji="🔎",
+    max_result_size_chars=50_000,
 )
 registry.register(
     name="lcm_describe",
@@ -191,6 +193,7 @@ registry.register(
     check_fn=check_lcm_requirements,
     description=LCM_DESCRIBE_SCHEMA["description"],
     emoji="📜",
+    max_result_size_chars=50_000,
 )
 registry.register(
     name="lcm_recall",
@@ -200,6 +203,7 @@ registry.register(
     check_fn=check_lcm_requirements,
     description=LCM_RECALL_SCHEMA["description"],
     emoji="🧠",
+    max_result_size_chars=50_000,
 )
 registry.register(
     name="lcm_expand_query",
@@ -209,4 +213,5 @@ registry.register(
     check_fn=check_lcm_requirements,
     description=LCM_EXPAND_SCHEMA["description"],
     emoji="🧠",
+    max_result_size_chars=50_000,
 )

--- a/tools/lcm_tool.py
+++ b/tools/lcm_tool.py
@@ -32,6 +32,13 @@ def _ok(obj: dict[str, Any]) -> str:
     return json.dumps(obj, ensure_ascii=False)
 
 
+def _to_int(value: Any, default: Any) -> Any:
+    try:
+        return int(value)
+    except Exception:
+        return default
+
+
 def _status(args: dict[str, Any], **_: Any) -> str:
     return _ok(hermes_lcm.status(_ns()))
 
@@ -50,8 +57,8 @@ def _grep(args: dict[str, Any], **_: Any) -> str:
         since=args.get("since"),
         before=args.get("before"),
         sort=args.get("sort") or "rank",
-        limit=int(args.get("limit") or 5),
-        max_chars=int(args.get("max_chars") or 800),
+        limit=_to_int(args.get("limit") or 5, 5),
+        max_chars=_to_int(args.get("max_chars") or 800, 800),
     )))
 
 
@@ -65,10 +72,10 @@ def _describe(args: dict[str, Any], **_: Any) -> str:
     return _ok(hermes_lcm.describe(_ns(
         message_id=mid,
         session_id=args.get("session_id"),
-        tail=args.get("tail"),
+        tail=_to_int(args.get("tail"), None) if args.get("tail") is not None else None,
         around=args.get("around"),
-        window=int(args.get("window") or 3),
-        max_chars=int(args.get("max_chars") or 1200),
+        window=_to_int(args.get("window") or 3, 3),
+        max_chars=_to_int(args.get("max_chars") or 1200, 1200),
     )))
 
 
@@ -86,11 +93,11 @@ def _recall(args: dict[str, Any], **_: Any) -> str:
         since=args.get("since"),
         before=args.get("before"),
         sort=args.get("sort") or "rank",
-        limit=int(args.get("limit") or 10),
-        per_session=int(args.get("per_session") or 3),
-        window=int(args.get("window") or 1),
+        limit=_to_int(args.get("limit") or 10, 10),
+        per_session=_to_int(args.get("per_session") or 3, 3),
+        window=_to_int(args.get("window") or 1, 1),
         format=args.get("format") or "compact",
-        max_chars=int(args.get("max_chars") or 800),
+        max_chars=_to_int(args.get("max_chars") or 800, 800),
     )))
 
 

--- a/toolsets.py
+++ b/toolsets.py
@@ -50,6 +50,8 @@ _HERMES_CORE_TOOLS = [
     "todo", "memory",
     # Session history search
     "session_search",
+    # Read-only Lossless Context Management recall over state.db
+    "lcm_status", "lcm_grep", "lcm_describe", "lcm_expand_query", "lcm_recall",
     # Clarifying questions
     "clarify",
     # Code execution + delegation
@@ -198,6 +200,12 @@ TOOLSETS = {
     "session_search": {
         "description": "Search and recall past conversations with summarization",
         "tools": ["session_search"],
+        "includes": []
+    },
+
+    "lcm": {
+        "description": "Read-only exact recall over Hermes state.db: status, grep, describe, extractive recall",
+        "tools": ["lcm_status", "lcm_grep", "lcm_describe", "lcm_expand_query", "lcm_recall"],
         "includes": []
     },
     

--- a/toolsets.py
+++ b/toolsets.py
@@ -50,8 +50,6 @@ _HERMES_CORE_TOOLS = [
     "todo", "memory",
     # Session history search
     "session_search",
-    # Read-only Lossless Context Management recall over state.db
-    "lcm_status", "lcm_grep", "lcm_describe", "lcm_expand_query", "lcm_recall",
     # Clarifying questions
     "clarify",
     # Code execution + delegation


### PR DESCRIPTION
## Summary

Implements Phase 1 Hermes LCM read-only recall over the existing Hermes `state.db`.

This adds a bounded forensic recall surface for exact historical evidence (PER IDs, SHAs, commands, errors, tool output snippets) without replacing the compressor or enabling a context engine.

## What changed

- Added `scripts/hermes_lcm.py`
  - `status`: DB readability/counts/FTS availability
  - `grep`: FTS phrase search with LIKE fallback
  - `describe`: bounded context around message/session windows
  - `recall` / `expand`: grouped extractive evidence by session
- Added `tools/lcm_tool.py`
  - `lcm_status`
  - `lcm_grep`
  - `lcm_describe`
  - `lcm_recall`
  - `lcm_expand_query`
- Registered `lcm` in `toolsets.py`
- Added `lcm` to `hermes tools` config UI
- Added targeted tests in `tests/test_hermes_lcm.py`

## Safety boundary

- Read-only only: opens SQLite with `file:...state.db?mode=ro`
- No migrations
- No writes to `state.db`
- No `context.engine: hermes_lcm` rollout
- No compressor replacement
- No sidecar `lcm.db`
- No DAG summaries
- No daemon/indexer

## Test plan

- [x] `.venv/bin/python -m py_compile scripts/hermes_lcm.py tools/lcm_tool.py toolsets.py hermes_cli/tools_config.py tests/test_hermes_lcm.py`
- [x] `.venv/bin/python -m pytest tests/test_hermes_lcm.py -q -o 'addopts='` — 8 passed
- [x] `.venv/bin/python -m pytest tests/test_hermes_lcm.py tests/test_toolsets.py tests/hermes_cli/test_tools_config.py -q -o 'addopts='` — 98 passed
- [x] Live smoke on local Hermes DB:
  - `python3 scripts/hermes_lcm.py status --json`
  - `python3 scripts/hermes_lcm.py grep 'PER-2927' --all-sessions --limit 1 --json`
  - `python3 scripts/hermes_lcm.py describe --message-id 133211 --window 1 --json`
  - `hermes chat ... --toolsets lcm` using `lcm_status`

## Linear

Tracks PerfectLive PER-2929.
