### PR TITLE
fix(cli,tui-gateway): sanitize env and redact output in exec quick commands

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7271,12 +7271,19 @@ class HermesCLI:
                     exec_cmd = qcmd.get("command", "")
                     if exec_cmd:
                         try:
+                            # Sanitize env to prevent credential leakage —
+                            # quick commands run in the CLI process which
+                            # has all API keys in os.environ.
+                            from tools.environments.local import _sanitize_subprocess_env
+                            sanitized_env = _sanitize_subprocess_env(os.environ.copy())
                             result = subprocess.run(
                                 exec_cmd, shell=True, capture_output=True,
-                                text=True, timeout=30
+                                text=True, timeout=30, env=sanitized_env
                             )
                             output = result.stdout.strip() or result.stderr.strip()
                             if output:
+                                from agent.redact import redact_sensitive_text
+                                output = redact_sensitive_text(output)
                                 self._console_print(_rich_text_from_ansi(output))
                             else:
                                 self._console_print("[dim]Command returned no output[/]")

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -4456,18 +4456,27 @@ def _(rid, params: dict) -> dict:
     if name in qcmds:
         qc = qcmds[name]
         if qc.get("type") == "exec":
+            # Sanitize env to prevent credential leakage —
+            # quick commands run in the TUI server process which
+            # has all API keys in os.environ.
+            from tools.environments.local import _sanitize_subprocess_env
+            sanitized_env = _sanitize_subprocess_env(os.environ.copy())
             r = subprocess.run(
                 qc.get("command", ""),
                 shell=True,
                 capture_output=True,
                 text=True,
                 timeout=30,
+                env=sanitized_env,
             )
             output = (
                 (r.stdout or "")
                 + ("\n" if r.stdout and r.stderr else "")
                 + (r.stderr or "")
             ).strip()[:4000]
+            if output:
+                from agent.redact import redact_sensitive_text
+                output = redact_sensitive_text(output)
             if r.returncode != 0:
                 return _err(
                     rid,


### PR DESCRIPTION
## What does this PR do?

**Root cause:** `HermesCLI.process_command()` (`cli.py:7274`) and `tui_gateway/server.py` (`command.dispatch`, line 4459) both handle `type: exec` quick commands via `subprocess.run(shell=True)` with no `env=` parameter. The child process inherits the full parent environment — every API key and bot token in `os.environ` is visible to the script. Output is returned raw to the terminal or web-UI client with no redaction applied.

**Fix:** Mirror the approach applied to `gateway/run.py` in #23584:
- Call `_sanitize_subprocess_env(os.environ.copy())` before spawning the subprocess to strip provider credentials from the child env.
- Call `redact_sensitive_text()` on the collected output before display to catch any remaining sensitive patterns.

All three `type: exec` quick-command paths now apply identical env sanitization and output redaction.

## Related Issue

Parity with #23584 (closes #1806), which applied the same fix to `gateway/run.py` but left the CLI and TUI-gateway paths unpatched.

## Type of Change

- [x] 🔒 Security fix

## Changes Made

- `cli.py`: add `_sanitize_subprocess_env` + `env=sanitized_env` + `redact_sensitive_text` in the `type: exec` quick-command branch (+9 lines)
- `tui_gateway/server.py`: same fix in `command.dispatch` (+8 lines)

## How to Test

```
python3.11 -m pytest tests/test_tui_gateway_server.py -v --override-ini="addopts="
```

Manual verification: configure a `type: exec` quick command with `command: env`, trigger it — `ANTHROPIC_API_KEY`, `OPENROUTER_API_KEY` and other provider secrets must not appear in the output.

## Checklist

- [x] Contributing Guide read | Conventional Commits | No duplicate PR
- [x] Single logical change | Symmetric across all three exec quick-command paths
- [x] Tests pass (pre-existing failures on main unrelated to this change)
- [x] Docs — N/A | Cross-platform — N/A