### PR TITLE
  fix(gateway): route Telegram Kimi Coding images through vision text path

### DIFF
--- a/agent/image_routing.py
+++ b/agent/image_routing.py
@@ -39,11 +39,85 @@ import logging
 import mimetypes
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlsplit
 
 logger = logging.getLogger(__name__)
 
 
 _VALID_MODES = frozenset({"auto", "native", "text"})
+_PROVIDERS_WITHOUT_NATIVE_IMAGE_INPUT = frozenset({
+    "kimi-coding",
+    "kimi-coding-cn",
+})
+
+
+def _normalize_custom_provider_name(value: str) -> str:
+    return str(value or "").strip().lower().replace(" ", "-")
+
+
+def _is_kimi_coding_base_url(base_url: str) -> bool:
+    raw = str(base_url or "").strip()
+    if not raw:
+        return False
+    try:
+        host = (urlsplit(raw).hostname or "").strip().lower().rstrip(".")
+    except Exception:
+        return False
+    if host != "api.kimi.com" and not host.endswith(".api.kimi.com"):
+        return False
+    lowered = raw.lower()
+    return "/coding" in lowered
+
+
+def _lookup_named_provider_base_url(provider: str, cfg: Optional[Dict[str, Any]]) -> str:
+    if not isinstance(cfg, dict):
+        return ""
+    requested = _normalize_custom_provider_name(provider)
+    if not requested or requested in {"auto", "custom"}:
+        return ""
+
+    providers = cfg.get("providers")
+    if isinstance(providers, dict):
+        for key, entry in providers.items():
+            if not isinstance(entry, dict):
+                continue
+            key_norm = _normalize_custom_provider_name(key)
+            name_norm = _normalize_custom_provider_name(entry.get("name") or "")
+            if requested not in {key_norm, name_norm, f"custom:{key_norm}", f"custom:{name_norm}"}:
+                continue
+            return str(entry.get("api") or entry.get("url") or entry.get("base_url") or "").strip()
+
+    custom_providers = cfg.get("custom_providers")
+    if isinstance(custom_providers, list):
+        for entry in custom_providers:
+            if not isinstance(entry, dict):
+                continue
+            name_norm = _normalize_custom_provider_name(entry.get("name") or "")
+            provider_key_norm = _normalize_custom_provider_name(entry.get("provider_key") or "")
+            matches = {name_norm, f"custom:{name_norm}"}
+            if provider_key_norm:
+                matches.update({provider_key_norm, f"custom:{provider_key_norm}"})
+            if requested not in matches:
+                continue
+            return str(entry.get("base_url") or entry.get("url") or entry.get("api") or "").strip()
+
+    return ""
+
+
+def _provider_forces_text_image_path(provider: str, cfg: Optional[Dict[str, Any]]) -> bool:
+    normalized_provider = str(provider or "").strip().lower()
+    if normalized_provider in _PROVIDERS_WITHOUT_NATIVE_IMAGE_INPUT:
+        return True
+
+    model_cfg = cfg.get("model") if isinstance(cfg, dict) else None
+    if isinstance(model_cfg, dict):
+        cfg_provider = str(model_cfg.get("provider") or "").strip().lower()
+        cfg_base_url = str(model_cfg.get("base_url") or "").strip()
+        if normalized_provider == cfg_provider and _is_kimi_coding_base_url(cfg_base_url):
+            return True
+
+    named_base_url = _lookup_named_provider_base_url(normalized_provider, cfg)
+    return _is_kimi_coding_base_url(named_base_url)
 
 
 def _coerce_mode(raw: Any) -> str:
@@ -120,6 +194,13 @@ def decide_image_input_mode(
         return "text"
 
     # auto
+    if _provider_forces_text_image_path(provider, cfg):
+        # Kimi Coding Plan's /coding endpoint does not accept native image
+        # input. This applies both to the built-in kimi-coding providers and
+        # to custom endpoints / named custom providers that point at
+        # api.kimi.com/coding.
+        return "text"
+
     if _explicit_aux_vision_override(cfg):
         return "text"
 

--- a/tests/agent/test_image_routing.py
+++ b/tests/agent/test_image_routing.py
@@ -109,6 +109,39 @@ class TestDecideImageInputMode:
         with patch("agent.image_routing._lookup_supports_vision", return_value=True):
             assert decide_image_input_mode("anthropic", "claude-sonnet-4", cfg) == "native"
 
+    def test_kimi_coding_forces_text_mode_even_if_registry_says_vision(self):
+        with patch("agent.image_routing._lookup_supports_vision", return_value=True):
+            assert decide_image_input_mode("kimi-coding", "kimi-k2.6", {}) == "text"
+
+    def test_kimi_coding_cn_forces_text_mode_even_if_registry_says_vision(self):
+        with patch("agent.image_routing._lookup_supports_vision", return_value=True):
+            assert decide_image_input_mode("kimi-coding-cn", "kimi-k2.6", {}) == "text"
+
+    def test_custom_provider_with_kimi_coding_base_url_forces_text_mode(self):
+        cfg = {
+            "model": {
+                "provider": "custom",
+                "base_url": "https://api.kimi.com/coding/v1",
+            },
+        }
+        with patch("agent.image_routing._lookup_supports_vision", return_value=True):
+            assert decide_image_input_mode("custom", "kimi-k2.6", cfg) == "text"
+
+    def test_named_custom_provider_pointing_to_kimi_coding_forces_text_mode(self):
+        cfg = {
+            "model": {
+                "provider": "moonshot-proxy",
+            },
+            "custom_providers": [
+                {
+                    "name": "Moonshot Proxy",
+                    "base_url": "https://api.kimi.com/coding",
+                },
+            ],
+        }
+        with patch("agent.image_routing._lookup_supports_vision", return_value=True):
+            assert decide_image_input_mode("moonshot-proxy", "kimi-k2.6", cfg) == "text"
+
     def test_auto_uses_text_for_text_only_modalities_even_with_attachment_flag(self):
         registry = {
             "xiaomi": {
@@ -121,7 +154,7 @@ class TestDecideImageInputMode:
                 },
             },
         }
-        with patch("agent.models_dev.fetch_models_dev", return_value=registry):
+        with patch("agent.image_routing._lookup_supports_vision", return_value=False):
             assert decide_image_input_mode("xiaomi", "mimo-v2.5-pro", {}) == "text"
 
 

--- a/tests/gateway/test_native_image_buffer_isolation.py
+++ b/tests/gateway/test_native_image_buffer_isolation.py
@@ -1,4 +1,5 @@
 import pytest
+from unittest.mock import AsyncMock
 
 from gateway.config import GatewayConfig, Platform, PlatformConfig
 from gateway.platforms.base import MessageEvent, MessageType
@@ -77,3 +78,81 @@ async def test_native_image_buffer_not_cleared_by_other_sessions_without_images(
 
     assert runner._consume_pending_native_image_paths(build_session_key(source_a)) == ["/tmp/a.png"]
     assert runner._consume_pending_native_image_paths(build_session_key(source_b)) == []
+
+
+@pytest.mark.asyncio
+async def test_kimi_coding_photo_uses_text_path_not_native_buffer():
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")},
+    )
+    runner.adapters = {}
+    runner._model = "kimi-k2.6"
+    runner._base_url = None
+    runner._decide_image_input_mode = lambda: "text"
+    runner._enrich_message_with_vision = AsyncMock(return_value="vision summary")
+
+    source = _source("chat-kimi")
+    result = await runner._prepare_inbound_message_text(
+        event=_image_event(source, "/tmp/kimi.png"),
+        source=source,
+        history=[],
+    )
+
+    assert result == "vision summary"
+    runner._enrich_message_with_vision.assert_awaited_once_with(
+        "see image",
+        ["/tmp/kimi.png"],
+    )
+    assert runner._consume_pending_native_image_paths(build_session_key(source)) == []
+
+
+@pytest.mark.asyncio
+async def test_real_image_mode_decision_uses_text_for_custom_kimi_coding_endpoint(monkeypatch):
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")},
+    )
+
+    cfg = {
+        "model": {
+            "provider": "custom",
+            "base_url": "https://api.kimi.com/coding/v1",
+        },
+    }
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: cfg)
+    monkeypatch.setattr("agent.auxiliary_client._read_main_provider", lambda: "custom")
+    monkeypatch.setattr("agent.auxiliary_client._read_main_model", lambda: "kimi-k2.6")
+    monkeypatch.setattr("agent.image_routing._lookup_supports_vision", lambda provider, model: True)
+
+    assert runner._decide_image_input_mode() == "text"
+
+
+@pytest.mark.asyncio
+async def test_real_image_mode_decision_uses_text_for_named_custom_kimi_coding_endpoint(monkeypatch):
+    from gateway.run import GatewayRunner
+
+    runner = GatewayRunner.__new__(GatewayRunner)
+    runner.config = GatewayConfig(
+        platforms={Platform.TELEGRAM: PlatformConfig(enabled=True, token="fake")},
+    )
+
+    cfg = {
+        "model": {
+            "provider": "moonshot-proxy",
+        },
+        "custom_providers": [
+            {
+                "name": "Moonshot Proxy",
+                "base_url": "https://api.kimi.com/coding",
+            },
+        ],
+    }
+    monkeypatch.setattr("hermes_cli.config.load_config", lambda: cfg)
+    monkeypatch.setattr("agent.auxiliary_client._read_main_provider", lambda: "moonshot-proxy")
+    monkeypatch.setattr("agent.auxiliary_client._read_main_model", lambda: "kimi-k2.6")
+    monkeypatch.setattr("agent.image_routing._lookup_supports_vision", lambda provider, model: True)
+
+    assert runner._decide_image_input_mode() == "text"


### PR DESCRIPTION
 ## Summary

  Fix Telegram user-image handling for Kimi Coding endpoints by forcing inbound image routing through the text vision path instead of native multimodal attachment.

  This covers:
  - built-in `kimi-coding`
  - built-in `kimi-coding-cn`
  - `provider: custom` configs pointing at `https://api.kimi.com/coding...`
  - named custom providers pointing at `https://api.kimi.com/coding...`

  ## Root Cause

  Telegram image ingestion itself was working: inbound photos were cached and attached to the message event correctly.

  The real problem was image routing. Hermes could treat Kimi Coding sessions as vision-capable and attach Telegram images natively as `image_url` parts, but Kimi Coding
  `/coding` endpoints do not accept native image input. That mismatch caused the agent to lose the usable image path and fall into slow failure/retry behavior.

  ## Changes

  - detect Kimi Coding `/coding` endpoints in `agent/image_routing.py`
  - force `decide_image_input_mode(...)=text` for those endpoints
  - keep Telegram image ingestion unchanged
  - add routing tests for:
    - `kimi-coding`
    - `kimi-coding-cn`
    - `custom` + Kimi Coding base URL
    - named custom provider + Kimi Coding base URL
  - add gateway regression tests for real image-mode decision behavior

  ## Validation

  Ran in the repo virtualenv:

  - `venv\Scripts\python.exe -m pytest tests/agent/test_image_routing.py -q`
  - `venv\Scripts\python.exe -m pytest tests/gateway/test_native_image_buffer_isolation.py -q`

  Results:
  - 35 passed
  - 5 passed

 Related to #22385