### PR TITLE
feat(skills): add rss-feed skill for stateless daily news crawls

### DIFF
--- a/skills/research/rss-feed/SKILL.md
+++ b/skills/research/rss-feed/SKILL.md
@@ -1,0 +1,125 @@
+---
+name: rss-feed
+description: "Fetch and digest RSS/Atom feeds with a stateless shell pipeline — curl + xmlstarlet + pandoc. Use whenever the user asks to crawl, read, digest, or summarize a feed, get a daily news brief, or set up a cron-driven RSS cron job. Prefer this over blogwatcher when no subscription state is needed."
+version: 1.0.0
+license: MIT
+platforms: [linux, macos]
+metadata:
+  hermes:
+    tags: [RSS, Atom, Feed-Reader, News, Cron, Summarization]
+    related_skills: [blogwatcher]
+prerequisites:
+  commands: [curl, xmlstarlet, pandoc]
+---
+
+# RSS Feed
+
+Stateless RSS/Atom digest workflow built from standard *nix tools: `curl` fetches, `xmlstarlet` parses, `pandoc` cleans item HTML into plain text. Nothing is persisted — every run is fetch, parse, render, discard. Designed for a daily cron that produces a markdown digest the agent then summarizes, with an optional interactive `fzf` picker for ad-hoc reading.
+
+## When to use
+
+- User pastes one or more feed URLs and wants a digest.
+- User asks for a "daily news brief" or "what's new on [blog]".
+- User wants a cron job that crawls news and dumps a file for the agent to read.
+- User wants to skim today's headlines from a list of feeds without setting up a managed reader.
+
+Do NOT use this skill when:
+
+- The user wants persistent read/unread state, OPML import, or managed subscriptions — use `blogwatcher` instead.
+
+## Installation
+
+Only `curl`, `xmlstarlet`, and `pandoc` are required. `fzf` is optional and only needed for the interactive picker.
+
+- Debian/Ubuntu: `apt install xmlstarlet pandoc fzf`
+- macOS: `brew install xmlstarlet pandoc fzf`
+- Arch: `pacman -S xmlstarlet pandoc fzf`
+
+## feeds.txt format
+
+One URL per line. Blank lines and `#` comments are ignored.
+
+```
+# Anthropic news
+https://www.anthropic.com/news/rss.xml
+https://hnrss.org/frontpage
+# comments and blank lines OK
+```
+
+A starter file lives at `feeds.example.txt` next to this SKILL.md.
+
+## Workflow — cron / non-interactive
+
+The main path. `crawl.sh` is non-interactive and writes a markdown digest to stdout.
+
+1. Run the crawler against a feeds file or a single URL.
+2. Read the markdown digest from stdout.
+3. Summarize, group, or reformat as the user asked.
+
+Example:
+
+```bash
+bash skills/research/rss-feed/scripts/crawl.sh ~/.hermes/feeds.txt --limit 10
+```
+
+Single-feed form (no feeds.txt needed):
+
+```bash
+bash skills/research/rss-feed/scripts/crawl.sh https://hnrss.org/frontpage --limit 5
+```
+
+`--limit N` caps items per feed. Omit it to take whatever the feed serves.
+
+## Workflow — interactive picker
+
+```bash
+bash skills/research/rss-feed/scripts/pick.sh ~/.hermes/feeds.txt
+```
+
+Opens `fzf` with item previews. On select, the article URL is fetched with `curl` and rendered through `pandoc` (falling back to `w3m` if available). Requires a TTY and will not work inside a non-interactive agent run — only suggest this when the user is at a shell.
+
+## Cron wiring
+
+Sample crontab line: crawl daily at 07:00 and drop a dated digest the agent can read on demand.
+
+```
+0 7 * * * bash $HOME/.hermes/skills/research/rss-feed/scripts/crawl.sh $HOME/.hermes/feeds.txt --limit 15 > $HOME/.hermes/news/$(date +\%Y-\%m-\%d).md
+```
+
+The `%` characters must be escaped as `\%` in crontab. Make sure `$HOME/.hermes/news/` exists.
+
+You can also wire this through hermes's built-in scheduler instead of system `cron` — see `cron/jobs.py` in the repo for the job definition format. That route is preferable when the digest should trigger an agent run rather than just write a file.
+
+## Output format
+
+`crawl.sh` emits one `##` section per feed, then a bullet per item. Parse this directly:
+
+```
+## Hacker News — https://hnrss.org/frontpage
+- **Show HN: foo** — 2026-05-11
+  <one-line summary, cleaned via pandoc>
+  https://news.ycombinator.com/item?id=...
+- **Ask HN: bar** — 2026-05-11
+  <one-line summary>
+  https://news.ycombinator.com/item?id=...
+
+## Anthropic — https://www.anthropic.com/news/rss.xml
+- **Claude 4.7 released** — 2026-05-10
+  <one-line summary>
+  https://www.anthropic.com/news/claude-4-7
+```
+
+Fields per item: title (bold), publish date, single-line summary, canonical URL.
+
+## Tips
+
+- Feed autodiscovery: if the user gives a homepage URL and not a feed URL, fetch the page first and grep for `<link rel="alternate" type="application/rss+xml" href="...">` to find the real feed before adding it to `feeds.txt`.
+- Paywalled or summary-only feeds: the digest only carries what the publisher exposed in the feed body. Surface that limitation to the user rather than fabricating article detail.
+- Some feeds are unreliable about `pubDate` (missing, malformed, or all set to the fetch time). When dates look wrong, fall back to source order (feed order in `feeds.txt`, item order within a feed) and tell the user.
+- Pipe the digest into the agent context as-is — it is already markdown and does not need preprocessing.
+
+## Differences from blogwatcher
+
+- No external binary install needed; uses standard *nix tools only (`curl`, `xmlstarlet`, `pandoc`).
+- Stateless — no read/unread tracking, no SQLite, no OPML. Designed for cron-driven digests, not interactive reading sessions.
+- Output is plain markdown the agent consumes directly, instead of a CLI with subcommands and a managed database.

--- a/skills/research/rss-feed/feeds.example.txt
+++ b/skills/research/rss-feed/feeds.example.txt
@@ -1,0 +1,12 @@
+# Example feeds file for the rss-feed skill.
+# One URL per line. Lines starting with `#` are comments.
+# Blank lines are ignored.
+
+# Hacker News front page
+https://hnrss.org/frontpage
+
+# Anthropic news
+https://www.anthropic.com/news/rss.xml
+
+# LWN headlines
+https://lwn.net/headlines/rss

--- a/skills/research/rss-feed/scripts/crawl.sh
+++ b/skills/research/rss-feed/scripts/crawl.sh
@@ -1,0 +1,270 @@
+#!/usr/bin/env bash
+# crawl.sh — stateless RSS/Atom crawler; emits a markdown digest to stdout. Deps: curl, xmlstarlet, pandoc.
+set -euo pipefail
+IFS=$'\n\t'
+
+DEFAULT_UA='hermes-rss-feed/1.0 (+https://github.com/NousResearch/hermes-agent)'
+LIMIT=10
+UA="$DEFAULT_UA"
+DEBUG=0
+POSITIONAL=()
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: crawl.sh <feed-url-or-feeds-file> [--limit N] [--user-agent UA] [--debug]
+  <feed-url-or-feeds-file>  http(s) URL, or path to a file with one URL per line ('#' comments ok)
+  --limit N                 cap items per feed (default 10)
+  --user-agent UA           override the HTTP User-Agent
+  --debug                   set -x (verbose tracing)
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --limit)
+            if [ "$#" -lt 2 ]; then echo "crawl.sh: --limit requires an argument" >&2; exit 2; fi
+            LIMIT="$2"
+            shift 2
+            ;;
+        --user-agent)
+            if [ "$#" -lt 2 ]; then echo "crawl.sh: --user-agent requires an argument" >&2; exit 2; fi
+            UA="$2"
+            shift 2
+            ;;
+        --debug)
+            DEBUG=1
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --)
+            shift
+            while [ "$#" -gt 0 ]; do POSITIONAL+=("$1"); shift; done
+            ;;
+        -*)
+            echo "crawl.sh: unknown flag: $1" >&2
+            usage
+            exit 2
+            ;;
+        *)
+            POSITIONAL+=("$1")
+            shift
+            ;;
+    esac
+done
+
+if [ "$DEBUG" -eq 1 ]; then
+    set -x
+fi
+
+if [ "${#POSITIONAL[@]}" -lt 1 ]; then
+    usage
+    exit 2
+fi
+
+TARGET="${POSITIONAL[0]}"
+
+# Pre-flight: required tools.
+missing=()
+for cmd in curl xmlstarlet pandoc; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        missing+=("$cmd")
+    fi
+done
+if [ "${#missing[@]}" -gt 0 ]; then
+    os="$(uname -s 2>/dev/null || echo unknown)"
+    case "$os" in
+        Linux)  echo "crawl.sh: missing required tool(s): ${missing[*]} — try: sudo apt install xmlstarlet pandoc curl" >&2 ;;
+        Darwin) echo "crawl.sh: missing required tool(s): ${missing[*]} — try: brew install xmlstarlet pandoc curl" >&2 ;;
+        *)      echo "crawl.sh: missing required tool(s): ${missing[*]} — install xmlstarlet, pandoc, and curl" >&2 ;;
+    esac
+    exit 127
+fi
+
+# Temp file management.
+TMPDIR_LOCAL="$(mktemp -d 2>/dev/null || mktemp -d -t 'crawl')"
+cleanup() {
+    if [ -n "${TMPDIR_LOCAL:-}" ] && [ -d "$TMPDIR_LOCAL" ]; then
+        rm -rf "$TMPDIR_LOCAL"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+# Build the list of feed URLs to crawl.
+FEEDS=()
+if [[ "$TARGET" == http://* || "$TARGET" == https://* ]]; then
+    FEEDS+=("$TARGET")
+else
+    if [ ! -r "$TARGET" ]; then
+        echo "crawl.sh: feeds file not readable: $TARGET" >&2
+        exit 2
+    fi
+    while IFS= read -r line || [ -n "$line" ]; do
+        # Strip CR (Windows line endings) and leading/trailing whitespace.
+        line="${line%$'\r'}"
+        # Trim leading whitespace.
+        line="${line#"${line%%[![:space:]]*}"}"
+        # Trim trailing whitespace.
+        line="${line%"${line##*[![:space:]]}"}"
+        if [ -z "$line" ]; then continue; fi
+        case "$line" in
+            \#*) continue ;;
+        esac
+        FEEDS+=("$line")
+    done < "$TARGET"
+fi
+
+if [ "${#FEEDS[@]}" -eq 0 ]; then
+    echo "crawl.sh: no feeds to crawl" >&2
+    exit 0
+fi
+
+# Clean a piece of text: HTML -> plain via pandoc, strip CR, collapse whitespace, cap at 400 chars.
+clean_text() {
+    # Reads from stdin, writes one cleaned line to stdout.
+    pandoc -f html -t plain --wrap=none 2>/dev/null \
+        | tr -d '\r' \
+        | tr '\n\t' '  ' \
+        | tr -s ' ' \
+        | sed -e 's/^ //' -e 's/ $//' \
+        | head -c 400
+}
+
+# Process one feed URL. All output to stdout; warnings to stderr.
+process_feed() {
+    local url="$1"
+    local body status http_code root title items_xpath feed_kind
+    body="$TMPDIR_LOCAL/body.xml"
+
+    # Fetch. Capture http code separately. --fail-with-body returns non-zero on >=400 but still gives the body.
+    set +e
+    http_code="$(curl --silent --location --compressed --max-time 30 \
+        --user-agent "$UA" \
+        --write-out '%{http_code}' \
+        --output "$body" \
+        "$url")"
+    status="$?"
+    set -e
+
+    if [ "$status" -ne 0 ]; then
+        echo "crawl.sh: curl exit $status for $url — skipping" >&2
+        return 0
+    fi
+    case "$http_code" in
+        2*|000) : ;;
+        *)
+            echo "crawl.sh: HTTP $http_code for $url — skipping" >&2
+            return 0
+            ;;
+    esac
+
+    if [ ! -s "$body" ]; then
+        echo "crawl.sh: empty body for $url — skipping" >&2
+        return 0
+    fi
+
+    # Detect root element.
+    if ! root="$(xmlstarlet sel -t -v 'name(/*)' "$body" 2>/dev/null)"; then
+        echo "crawl.sh: not valid XML: $url — skipping" >&2
+        return 0
+    fi
+
+    case "$root" in
+        rss)
+            feed_kind=rss
+            title="$(xmlstarlet sel -t -v '/rss/channel/title' "$body" 2>/dev/null || true)"
+            items_xpath='/rss/channel/item'
+            ;;
+        feed)
+            # Atom 1.0 uses xmlns="http://www.w3.org/2005/Atom" by default.
+            # XPath 1.0 unqualified names only match the empty namespace, so we register a prefix.
+            feed_kind=atom
+            title="$(xmlstarlet sel -N a=http://www.w3.org/2005/Atom -t -v '/a:feed/a:title' "$body" 2>/dev/null || true)"
+            items_xpath='/a:feed/a:entry'
+            ;;
+        *)
+            echo "crawl.sh: unrecognized root element '$root' for $url — skipping" >&2
+            return 0
+            ;;
+    esac
+
+    if [ -z "$title" ]; then
+        title="(untitled feed)"
+    fi
+    # Collapse whitespace in the feed title.
+    title="$(printf '%s' "$title" | tr '\r\n\t' '   ' | tr -s ' ' | sed -e 's/^ //' -e 's/ $//')"
+
+    printf '## %s — %s\n' "$title" "$url"
+
+    # Extract items. Use tab as field delimiter, newline as record delimiter.
+    # Fields: 1=title, 2=link, 3=date, 4=summary-html
+    local items_tsv="$TMPDIR_LOCAL/items.tsv"
+    if [ "$feed_kind" = rss ]; then
+        # description first; if empty we'll still get one. content:encoded is in a namespace; xmlstarlet handles it via local-name.
+        xmlstarlet sel -T -t \
+            -m "$items_xpath" \
+                -v 'normalize-space(title)' -o $'\t' \
+                -v 'normalize-space(link)' -o $'\t' \
+                -v 'normalize-space(pubDate)' -o $'\t' \
+                -v "normalize-space((description | *[local-name()='encoded'])[1])" \
+                -n \
+            "$body" 2>/dev/null > "$items_tsv" || true
+    else
+        # Atom: prefer link[@rel='alternate']/@href, else first link/@href.
+        # Summary: summary text, else content text.
+        # All element names need the 'a:' prefix because of the default Atom namespace.
+        xmlstarlet sel -N a=http://www.w3.org/2005/Atom -T -t \
+            -m "$items_xpath" \
+                -v 'normalize-space(a:title)' -o $'\t' \
+                -v "normalize-space((a:link[@rel='alternate']/@href | a:link/@href)[1])" -o $'\t' \
+                -v 'normalize-space((a:published | a:updated)[1])' -o $'\t' \
+                -v 'normalize-space((a:summary | a:content)[1])' \
+                -n \
+            "$body" 2>/dev/null > "$items_tsv" || true
+    fi
+
+    if [ ! -s "$items_tsv" ]; then
+        printf '(no items)\n\n'
+        return 0
+    fi
+
+    # Apply per-feed limit.
+    local limited="$TMPDIR_LOCAL/items.limited.tsv"
+    head -n "$LIMIT" "$items_tsv" > "$limited"
+
+    local any=0
+    local item_title item_link item_date item_summary cleaned
+    while IFS=$'\t' read -r item_title item_link item_date item_summary; do
+        if [ -z "$item_title" ] && [ -z "$item_link" ]; then
+            continue
+        fi
+        any=1
+        [ -z "$item_title" ] && item_title="(untitled)"
+        [ -z "$item_date" ]  && item_date="(no date)"
+
+        if [ -n "$item_summary" ]; then
+            cleaned="$(printf '%s' "$item_summary" | clean_text)"
+        else
+            cleaned=""
+        fi
+
+        printf -- '- **%s** — %s\n' "$item_title" "$item_date"
+        if [ -n "$cleaned" ]; then
+            printf '  %s\n' "$cleaned"
+        fi
+        if [ -n "$item_link" ]; then
+            printf '  %s\n' "$item_link"
+        fi
+    done < "$limited"
+
+    if [ "$any" -eq 0 ]; then
+        printf '(no items)\n'
+    fi
+    printf '\n'
+}
+
+for feed_url in "${FEEDS[@]}"; do
+    process_feed "$feed_url"
+done

--- a/skills/research/rss-feed/scripts/pick.sh
+++ b/skills/research/rss-feed/scripts/pick.sh
@@ -1,0 +1,262 @@
+#!/usr/bin/env bash
+# pick.sh — interactive fzf picker over one or many RSS/Atom feeds. Deps: curl, xmlstarlet, pandoc, fzf (w3m optional).
+set -euo pipefail
+IFS=$'\n\t'
+
+DEFAULT_UA='hermes-rss-feed/1.0 (+https://github.com/NousResearch/hermes-agent)'
+LIMIT=25
+UA="$DEFAULT_UA"
+POSITIONAL=()
+
+usage() {
+    cat >&2 <<'EOF'
+Usage: pick.sh <feed-url-or-feeds-file> [--limit N] [--user-agent UA]
+  Interactive picker; uses fzf. Non-interactive contexts should use crawl.sh.
+EOF
+}
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --limit)
+            if [ "$#" -lt 2 ]; then echo "pick.sh: --limit requires an argument" >&2; exit 2; fi
+            LIMIT="$2"
+            shift 2
+            ;;
+        --user-agent)
+            if [ "$#" -lt 2 ]; then echo "pick.sh: --user-agent requires an argument" >&2; exit 2; fi
+            UA="$2"
+            shift 2
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        --)
+            shift
+            while [ "$#" -gt 0 ]; do POSITIONAL+=("$1"); shift; done
+            ;;
+        -*)
+            echo "pick.sh: unknown flag: $1" >&2
+            usage
+            exit 2
+            ;;
+        *)
+            POSITIONAL+=("$1")
+            shift
+            ;;
+    esac
+done
+
+if [ "${#POSITIONAL[@]}" -lt 1 ]; then
+    usage
+    exit 2
+fi
+
+# TTY check — picker requires an interactive terminal.
+if [ ! -t 1 ] || [ ! -t 0 ]; then
+    echo "pick.sh: not a TTY — use scripts/crawl.sh for non-interactive contexts." >&2
+    exit 0
+fi
+
+TARGET="${POSITIONAL[0]}"
+
+# Pre-flight: required tools.
+missing=()
+for cmd in curl xmlstarlet pandoc fzf; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        missing+=("$cmd")
+    fi
+done
+if [ "${#missing[@]}" -gt 0 ]; then
+    os="$(uname -s 2>/dev/null || echo unknown)"
+    case "$os" in
+        Linux)  echo "pick.sh: missing required tool(s): ${missing[*]} — try: sudo apt install xmlstarlet pandoc curl fzf" >&2 ;;
+        Darwin) echo "pick.sh: missing required tool(s): ${missing[*]} — try: brew install xmlstarlet pandoc curl fzf" >&2 ;;
+        *)      echo "pick.sh: missing required tool(s): ${missing[*]} — install xmlstarlet, pandoc, curl, and fzf" >&2 ;;
+    esac
+    exit 127
+fi
+
+TMPDIR_LOCAL="$(mktemp -d 2>/dev/null || mktemp -d -t 'pick')"
+cleanup() {
+    if [ -n "${TMPDIR_LOCAL:-}" ] && [ -d "$TMPDIR_LOCAL" ]; then
+        rm -rf "$TMPDIR_LOCAL"
+    fi
+}
+trap cleanup EXIT INT TERM
+
+# Build feed list.
+FEEDS=()
+if [[ "$TARGET" == http://* || "$TARGET" == https://* ]]; then
+    FEEDS+=("$TARGET")
+else
+    if [ ! -r "$TARGET" ]; then
+        echo "pick.sh: feeds file not readable: $TARGET" >&2
+        exit 2
+    fi
+    while IFS= read -r line || [ -n "$line" ]; do
+        line="${line%$'\r'}"
+        line="${line#"${line%%[![:space:]]*}"}"
+        line="${line%"${line##*[![:space:]]}"}"
+        if [ -z "$line" ]; then continue; fi
+        case "$line" in
+            \#*) continue ;;
+        esac
+        FEEDS+=("$line")
+    done < "$TARGET"
+fi
+
+if [ "${#FEEDS[@]}" -eq 0 ]; then
+    echo "pick.sh: no feeds to fetch" >&2
+    exit 0
+fi
+
+# Collect items from one feed into the merged TSV.
+# Output fields per row: title <TAB> link <TAB> source <TAB> date
+collect_feed() {
+    local url="$1"
+    local body http_code status root source items_xpath feed_kind
+    body="$TMPDIR_LOCAL/body.xml"
+
+    set +e
+    http_code="$(curl --silent --location --compressed --max-time 30 \
+        --user-agent "$UA" \
+        --write-out '%{http_code}' \
+        --output "$body" \
+        "$url")"
+    status="$?"
+    set -e
+
+    if [ "$status" -ne 0 ]; then
+        echo "pick.sh: curl exit $status for $url — skipping" >&2
+        return 0
+    fi
+    case "$http_code" in
+        2*|000) : ;;
+        *)
+            echo "pick.sh: HTTP $http_code for $url — skipping" >&2
+            return 0
+            ;;
+    esac
+
+    if [ ! -s "$body" ]; then
+        echo "pick.sh: empty body for $url — skipping" >&2
+        return 0
+    fi
+
+    if ! root="$(xmlstarlet sel -t -v 'name(/*)' "$body" 2>/dev/null)"; then
+        echo "pick.sh: not valid XML: $url — skipping" >&2
+        return 0
+    fi
+
+    case "$root" in
+        rss)
+            feed_kind=rss
+            source="$(xmlstarlet sel -t -v '/rss/channel/title' "$body" 2>/dev/null || true)"
+            items_xpath='/rss/channel/item'
+            ;;
+        feed)
+            # Atom 1.0: default namespace requires xmlstarlet -N prefix mapping.
+            feed_kind=atom
+            source="$(xmlstarlet sel -N a=http://www.w3.org/2005/Atom -t -v '/a:feed/a:title' "$body" 2>/dev/null || true)"
+            items_xpath='/a:feed/a:entry'
+            ;;
+        *)
+            echo "pick.sh: unrecognized root element '$root' for $url — skipping" >&2
+            return 0
+            ;;
+    esac
+
+    if [ -z "$source" ]; then
+        source="$url"
+    fi
+    source="$(printf '%s' "$source" | tr '\r\n\t' '   ' | tr -s ' ' | sed -e 's/^ //' -e 's/ $//')"
+
+    local raw="$TMPDIR_LOCAL/raw.tsv"
+    if [ "$feed_kind" = rss ]; then
+        xmlstarlet sel -T -t \
+            -m "$items_xpath" \
+                -v 'normalize-space(title)' -o $'\t' \
+                -v 'normalize-space(link)' -o $'\t' \
+                -v 'normalize-space(pubDate)' \
+                -n \
+            "$body" 2>/dev/null > "$raw" || true
+    else
+        xmlstarlet sel -N a=http://www.w3.org/2005/Atom -T -t \
+            -m "$items_xpath" \
+                -v 'normalize-space(a:title)' -o $'\t' \
+                -v "normalize-space((a:link[@rel='alternate']/@href | a:link/@href)[1])" -o $'\t' \
+                -v 'normalize-space((a:published | a:updated)[1])' \
+                -n \
+            "$body" 2>/dev/null > "$raw" || true
+    fi
+
+    if [ ! -s "$raw" ]; then
+        return 0
+    fi
+
+    head -n "$LIMIT" "$raw" | while IFS=$'\t' read -r t l d; do
+        if [ -z "$t" ] && [ -z "$l" ]; then continue; fi
+        [ -z "$t" ] && t="(untitled)"
+        [ -z "$d" ] && d="(no date)"
+        printf '%s\t%s\t%s\t%s\n' "$t" "$l" "$source" "$d"
+    done
+}
+
+ALL="$TMPDIR_LOCAL/all.tsv"
+: > "$ALL"
+for feed_url in "${FEEDS[@]}"; do
+    collect_feed "$feed_url" >> "$ALL"
+done
+
+if [ ! -s "$ALL" ]; then
+    echo "pick.sh: no items collected" >&2
+    exit 0
+fi
+
+# fzf: show title (col 1) + date (col 4); preview shows the link (col 2).
+selection="$(fzf --delimiter=$'\t' --with-nth=1,4 --preview 'echo {2}' --prompt='item> ' < "$ALL" || true)"
+if [ -z "$selection" ]; then
+    exit 0
+fi
+
+# Extract the link (field 2).
+url="$(printf '%s' "$selection" | awk -F '\t' '{print $2}')"
+if [ -z "$url" ]; then
+    echo "pick.sh: selected item has no link" >&2
+    exit 0
+fi
+
+printf '%s\n' "$url"
+
+# Render the article: prefer curl + pandoc -> less; fall back to w3m; else just print the URL.
+page_output() {
+    if command -v less >/dev/null 2>&1; then
+        less -R
+    else
+        cat
+    fi
+}
+
+render_with_pandoc() {
+    local html
+    html="$TMPDIR_LOCAL/article.html"
+    if ! curl --silent --location --compressed --max-time 30 --user-agent "$UA" --output "$html" "$url"; then
+        return 1
+    fi
+    if [ ! -s "$html" ]; then
+        return 1
+    fi
+    if ! pandoc -f html -t plain --wrap=none "$html" 2>/dev/null | page_output; then
+        return 1
+    fi
+    return 0
+}
+
+if ! render_with_pandoc; then
+    if command -v w3m >/dev/null 2>&1; then
+        w3m -dump "$url" | page_output || printf '%s\n' "$url"
+    else
+        printf '%s\n' "$url"
+    fi
+fi

--- a/tests/skills/fixtures/rss/sample_atom1.xml
+++ b/tests/skills/fixtures/rss/sample_atom1.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<feed xmlns="http://www.w3.org/2005/Atom">
+  <title>Sample Atom Feed</title>
+  <subtitle>A sample Atom 1.0 feed used for testing the rss-feed skill.</subtitle>
+  <link rel="alternate" type="text/html" href="https://example.org/"/>
+  <link rel="self" type="application/atom+xml" href="https://example.org/atom.xml"/>
+  <id>urn:uuid:8f3a1a5e-2c4b-4f6d-9a7e-1234567890ab</id>
+  <updated>2026-05-05T12:00:00Z</updated>
+  <author>
+    <name>Sample Author</name>
+    <email>author@example.org</email>
+  </author>
+  <entry>
+    <id>urn:uuid:11111111-aaaa-bbbb-cccc-111111111111</id>
+    <title>Atom Entry Alpha</title>
+    <link rel="alternate" type="text/html" href="https://example.org/atom/alpha"/>
+    <published>2026-05-05T09:30:00Z</published>
+    <updated>2026-05-05T09:45:00Z</updated>
+    <summary type="html">&lt;p&gt;Alpha entry summary with &lt;em&gt;emphasis&lt;/em&gt;.&lt;/p&gt;</summary>
+    <content type="html">&lt;p&gt;Full alpha content with a &lt;a href="https://example.org/ref"&gt;link&lt;/a&gt; inside.&lt;/p&gt;</content>
+  </entry>
+  <entry>
+    <id>urn:uuid:22222222-aaaa-bbbb-cccc-222222222222</id>
+    <title>Atom Entry Beta</title>
+    <link rel="alternate" type="text/html" href="https://example.org/atom/beta"/>
+    <published>2026-05-04T14:15:00Z</published>
+    <updated>2026-05-04T14:20:00Z</updated>
+    <summary type="html">&lt;p&gt;Beta entry summary, &lt;strong&gt;short&lt;/strong&gt; and sweet.&lt;/p&gt;</summary>
+    <content type="html">&lt;p&gt;Beta full content body for entry two.&lt;/p&gt;</content>
+  </entry>
+  <entry>
+    <id>urn:uuid:33333333-aaaa-bbbb-cccc-333333333333</id>
+    <title>Atom Entry Gamma</title>
+    <link rel="alternate" type="text/html" href="https://example.org/atom/gamma"/>
+    <published>2026-05-03T22:00:00Z</published>
+    <updated>2026-05-03T22:05:00Z</updated>
+    <summary type="html">&lt;p&gt;Gamma summary with ampersands &amp;amp; quotes &amp;quot;ok&amp;quot;.&lt;/p&gt;</summary>
+    <content type="html">&lt;p&gt;Gamma full content with special chars handled.&lt;/p&gt;</content>
+  </entry>
+</feed>

--- a/tests/skills/fixtures/rss/sample_rss2.xml
+++ b/tests/skills/fixtures/rss/sample_rss2.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Sample Test Blog</title>
+    <link>https://example.com/</link>
+    <description>A sample RSS 2.0 feed used for testing the rss-feed skill.</description>
+    <language>en-us</language>
+    <pubDate>Mon, 05 May 2026 12:00:00 GMT</pubDate>
+    <lastBuildDate>Mon, 05 May 2026 12:00:00 GMT</lastBuildDate>
+    <item>
+      <title>First Post Title</title>
+      <link>https://example.com/posts/first</link>
+      <guid isPermaLink="true">https://example.com/posts/first</guid>
+      <pubDate>Mon, 05 May 2026 09:30:00 GMT</pubDate>
+      <description>&lt;p&gt;Some text with &lt;em&gt;emphasis&lt;/em&gt; about the first post.&lt;/p&gt;</description>
+    </item>
+    <item>
+      <title>Second Post Title</title>
+      <link>https://example.com/posts/second</link>
+      <guid isPermaLink="true">https://example.com/posts/second</guid>
+      <pubDate>Sun, 04 May 2026 14:15:00 GMT</pubDate>
+      <description>&lt;p&gt;The &lt;strong&gt;second&lt;/strong&gt; entry, with a &lt;a href="https://example.com/ref"&gt;link&lt;/a&gt;.&lt;/p&gt;</description>
+    </item>
+    <item>
+      <title>Third Post Title &#8212; Has Special Chars &amp; Stuff</title>
+      <link>https://example.com/posts/third</link>
+      <guid isPermaLink="true">https://example.com/posts/third</guid>
+      <pubDate>Sat, 03 May 2026 22:00:00 GMT</pubDate>
+      <description>&lt;p&gt;Third post with ampersands &amp;amp; quotes &amp;quot;like this&amp;quot;.&lt;/p&gt;</description>
+    </item>
+    <item>
+      <title>Fourth Post</title>
+      <link>https://example.com/posts/fourth</link>
+      <guid isPermaLink="true">https://example.com/posts/fourth</guid>
+      <pubDate>Fri, 02 May 2026 08:45:00 GMT</pubDate>
+      <description>&lt;p&gt;A &lt;em&gt;short&lt;/em&gt; fourth post for testing limits.&lt;/p&gt;</description>
+    </item>
+  </channel>
+</rss>

--- a/tests/skills/test_rss_feed.py
+++ b/tests/skills/test_rss_feed.py
@@ -1,0 +1,88 @@
+"""Tests for the rss-feed skill's crawl.sh script."""
+import os
+import shutil
+import subprocess
+from pathlib import Path
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]  # repo root
+CRAWL = ROOT / "skills/research/rss-feed/scripts/crawl.sh"
+FIX = Path(__file__).parent / "fixtures/rss"
+RSS2 = FIX / "sample_rss2.xml"
+ATOM1 = FIX / "sample_atom1.xml"
+
+REQUIRES_TOOLS = pytest.mark.skipif(
+    not (shutil.which("xmlstarlet") and shutil.which("pandoc") and shutil.which("curl")),
+    reason="rss-feed skill requires xmlstarlet, pandoc, and curl on PATH",
+)
+
+
+def _run(*args, expect_zero=True):
+    result = subprocess.run(
+        ["bash", str(CRAWL), *args],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    if expect_zero:
+        assert result.returncode == 0, f"crawl.sh exited {result.returncode}\nstderr: {result.stderr}"
+    return result
+
+
+@REQUIRES_TOOLS
+def test_rss2_extracts_items():
+    out = _run(f"file://{RSS2}").stdout
+    # feed title header
+    assert "## " in out
+    # at least 3 items rendered as bullet lines
+    assert out.count("\n- **") >= 3
+    # one of the known fixture titles appears
+    assert "First Post Title" in out
+    # links from the fixture appear in the output
+    assert "https://example.com/posts/first" in out
+
+
+@REQUIRES_TOOLS
+def test_atom1_extracts_entries():
+    out = _run(f"file://{ATOM1}").stdout
+    assert "## " in out
+    assert out.count("\n- **") >= 3
+    assert "Atom Entry Alpha" in out
+    assert "https://example.org/atom/alpha" in out
+
+
+@REQUIRES_TOOLS
+def test_limit_caps_items(tmp_path):
+    out = _run(f"file://{RSS2}", "--limit", "2").stdout
+    # exactly 2 items rendered
+    assert out.count("\n- **") == 2
+
+
+@REQUIRES_TOOLS
+def test_feeds_file(tmp_path):
+    feeds = tmp_path / "feeds.txt"
+    feeds.write_text(
+        f"# a comment\n\nfile://{RSS2}\nfile://{ATOM1}\n"
+    )
+    out = _run(str(feeds)).stdout
+    # Both feed headers present
+    assert out.count("## ") == 2
+    # Both fixtures' marker titles present
+    assert "First Post Title" in out
+    assert "Atom Entry Alpha" in out
+
+
+@REQUIRES_TOOLS
+def test_invalid_url_does_not_crash(tmp_path):
+    # crawl.sh should warn to stderr and exit 0
+    feeds = tmp_path / "feeds.txt"
+    feeds.write_text("https://invalid-host-that-does-not-exist.example/\n")
+    # We don't assert zero — we only assert it doesn't blow up the runner.
+    result = subprocess.run(
+        ["bash", str(CRAWL), str(feeds)],
+        capture_output=True,
+        text=True,
+        timeout=30,
+    )
+    # Either exits 0 with empty/warning output, or non-zero but doesn't crash with a python-style traceback.
+    assert "Traceback" not in result.stderr


### PR DESCRIPTION
## Summary

Adds a new `rss-feed` skill under `skills/research/rss-feed/` for stateless RSS/Atom digesting. Uses standard *nix tools (`curl` + `xmlstarlet` + `pandoc`, optional `fzf`) — no SQLite, no managed subscriptions, no extra binary to install. Designed for a daily cron job that emits a markdown digest the agent then summarizes.

- `scripts/crawl.sh` — non-interactive crawler. Accepts a single feed URL or a `feeds.txt` path. Detects RSS 2.0 vs Atom 1.0 (registers the Atom namespace explicitly so XPath 1.0 actually matches), pipes summaries through `pandoc -f html -t plain`, caps each at 400 chars, prints a markdown digest to stdout.
- `scripts/pick.sh` — `fzf`-based interactive picker with article rendering via `pandoc` (falls back to `w3m -dump`). Silently no-ops when not run from a TTY.
- `feeds.example.txt` — starter feeds file.
- `tests/skills/test_rss_feed.py` + `tests/skills/fixtures/rss/{sample_rss2.xml,sample_atom1.xml}` — exercises `crawl.sh` against on-disk fixtures via `curl`'s `file://` scheme. `pytest.skipif` gates the suite on `xmlstarlet`/`pandoc`/`curl` being on PATH so it skips cleanly on CI hosts without the tools.

Frontmatter follows the hermes skill convention (`platforms`, `metadata.hermes.tags`, `prerequisites.commands`) so the web dashboard can toggle it.

### Why this is distinct from `blogwatcher`

- No external binary install (`blogwatcher-cli` not required).
- Stateless — no read/unread, no OPML, no DB. Designed for cron digests rather than interactive subscription management.
- Output is plain markdown that the agent consumes directly.

The two skills are complementary; `related_skills: [blogwatcher]` is declared in the frontmatter.

## Test plan

- [ ] On a host with `xmlstarlet` + `pandoc` + `curl` installed: `pytest tests/skills/test_rss_feed.py -v` — all 5 tests pass against the bundled fixtures.
- [ ] Manual: `bash skills/research/rss-feed/scripts/crawl.sh https://hnrss.org/frontpage --limit 5` — emits a digest with 5 items, each with title, date, summary, and link.
- [ ] Manual: drop a `feeds.txt`, wire the sample crontab line from SKILL.md, confirm the dated digest file lands in `~/.hermes/news/`.
- [ ] Without the tools installed: `pytest tests/skills/test_rss_feed.py` — all 5 tests skip with the documented reason, no crashes.