### PR TITLE
fix: don't cache failed update checks; sync cache on explicit --check

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -216,10 +216,14 @@ def check_for_updates() -> Optional[int]:
             return None
         behind = _check_via_local_git(repo_dir)
 
-    try:
-        cache_file.write_text(json.dumps({"ts": now, "behind": behind, "rev": embedded_rev}))
-    except Exception:
-        pass
+    # Only cache successful results — a None (check failed) should not be
+    # persisted for 6 hours, otherwise the banner stays silent even after
+    # the network recovers.  See #23681.
+    if behind is not None:
+        try:
+            cache_file.write_text(json.dumps({"ts": now, "behind": behind, "rev": embedded_rev}))
+        except Exception:
+            pass
 
     return behind
 

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -7101,6 +7101,21 @@ def _cmd_update_check():
     )
     behind = int(rev_result.stdout.strip())
 
+    # Update the banner cache so the next ``hermes`` launch also shows the
+    # commit count without re-fetching.  See #23681.
+    try:
+        import time as _time, json as _json
+        from hermes_cli.banner import get_hermes_home
+        _cache_file = get_hermes_home() / ".update_check"
+        _embedded_rev = os.environ.get("HERMES_REVISION") or None
+        _cache_file.write_text(_json.dumps({
+            "ts": _time.time(),
+            "behind": behind,
+            "rev": _embedded_rev,
+        }))
+    except Exception:
+        pass
+
     if behind == 0:
         print("✓ Already up to date.")
     else:


### PR DESCRIPTION
## Fixes #23681

### Problem
The update-check cache (`~/.hermes/.update_check`) has two issues:

1. **Failed checks are cached for 6 hours**: `check_for_updates()` caches ALL results, including `None` (check failed). When the check fails (network timeout, stale git refs), `None` is persisted. Subsequent launches read the fresh cache, get `None`, and the banner shows nothing — even though the user may have seen "3 commits behind" from a prior `hermes update --check`.

2. **`hermes update --check` doesn't update the cache**: The explicit `--check` command fetches and displays the commit count but does NOT write to the cache file. The banner's `check_for_updates()` has to do its own separate check (possibly against different refs), which could return a different result or fail entirely.

### Fix
**In `hermes_cli/banner.py`** — Only cache successful results:
```python
# Before — caches None for 6 hours
cache_file.write_text(json.dumps({"ts": now, "behind": behind, "rev": embedded_rev}))

# After — only cache when check succeeded
if behind is not None:
    cache_file.write_text(json.dumps({"ts": now, "behind": behind, "rev": embedded_rev}))
```

**In `hermes_cli/main.py`** — Write cache after explicit `--check`:
After a successful `hermes update --check`, write the result to the same cache file so the banner uses the same fresh data on next launch.

### Before vs After
| Scenario | Before | After |
|----------|--------|-------|
| Check fails (network) | Cached `None` for 6h, banner silent | Not cached, retries next launch |
| `hermes update --check` shows 3 behind | Banner may show different count or nothing | Banner shows same 3 behind |
| Cache exists with valid data | Works correctly | Works correctly (no change) |

### Tests
- Verified syntax with `ast.parse()` on both changed files
- Fix is minimal (4 lines removed, 23 added) and backward compatible