### PR TITLE
fix(update): show pending commit list in --check output and banner

### DIFF
--- a/hermes_cli/banner.py
+++ b/hermes_cli/banner.py
@@ -213,8 +213,31 @@ def check_for_updates() -> Optional[int]:
             return None
         behind = _check_via_local_git(repo_dir)
 
+    # Also cache the pending commit list so callers can show it without
+    # re-running git log (issue #23681).
+    pending_commits = []
     try:
-        cache_file.write_text(json.dumps({"ts": now, "behind": behind, "rev": embedded_rev}))
+        repo_dir = _resolve_repo_dir()
+        if repo_dir and isinstance(behind, int) and behind > 0:
+            log_result = subprocess.run(
+                ["git", "log", "HEAD..origin/main",
+                 "--oneline", "--no-decorate",
+                 f"--max-count={min(behind, 10)}"],
+                cwd=str(repo_dir),
+                capture_output=True, text=True, timeout=5,
+            )
+            if log_result.returncode == 0 and log_result.stdout.strip():
+                pending_commits = log_result.stdout.strip().splitlines()
+    except Exception:
+        pass
+
+    try:
+        cache_file.write_text(json.dumps({
+            "ts": now,
+            "behind": behind,
+            "rev": embedded_rev,
+            "commits": pending_commits,
+        }))
     except Exception:
         pass
 
@@ -595,6 +618,15 @@ def build_welcome_banner(console: Console, model: str, cwd: str,
                     f"[bold yellow]⚠ {behind} {commits_word} behind[/]"
                     f"[dim yellow] — run [bold]{recommended_update_command()}[/bold] to update[/]"
                 )
+                # Show cached commit list if available (issue #23681)
+                try:
+                    cached = json.loads((get_hermes_home() / ".update_check").read_text())
+                    for commit_line in cached.get("commits", [])[:5]:
+                        right_lines.append(f"[dim yellow]  {commit_line}[/]")
+                    if behind > 5:
+                        right_lines.append(f"[dim yellow]  ... and {behind - 5} more[/]")
+                except Exception:
+                    pass
             else:
                 # UPDATE_AVAILABLE_NO_COUNT: nix-built hermes; we know an update
                 # exists but not by how much, and we don't know how the user

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -6358,6 +6358,27 @@ def _cmd_update_check():
         from hermes_cli.config import recommended_update_command
         print(f"  Run '{recommended_update_command()}' to install.")
 
+        # Show the pending commit list so users can see what changed
+        # without needing to delete ~/.hermes/.update_check (issue #23681)
+        try:
+            log_result = subprocess.run(
+                git_cmd + ["log", "HEAD..origin/main",
+                           "--oneline", "--no-decorate",
+                           f"--max-count={min(behind, 10)}"],
+                cwd=PROJECT_ROOT,
+                capture_output=True,
+                text=True,
+            )
+            if log_result.returncode == 0 and log_result.stdout.strip():
+                print()
+                print("  Pending commits:")
+                for line in log_result.stdout.strip().splitlines():
+                    print(f"    {line}")
+                if behind > 10:
+                    print(f"    ... and {behind - 10} more")
+        except Exception:
+            pass
+
 
 def _ensure_fhs_path_guard() -> None:
     """Ensure /usr/local/bin is on PATH for RHEL-family root non-login shells.


### PR DESCRIPTION
## Problem

After hermes update --check, users had to delete ~/.hermes/.update_check to see the commit list again.

## Fix

1. hermes update --check now prints pending commits (up to 10)
2. Cache stores commit list alongside behind count
3. Banner shows top 5 pending commits in update warning

Fixes #23681