### PR TITLE
fix(kanban): use colLabel instead of undefined COLUMN_LABEL

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -1898,7 +1898,7 @@
           type: "checkbox",
           className: "hermes-kanban-col-check",
           title: "Select all tasks in this column",
-          "aria-label": `Select all tasks in ${COLUMN_LABEL[props.column.name] || props.column.name}`,
+          "aria-label": `Select all tasks in ${colLabel || props.column.name}`,
           checked: props.column.tasks.length > 0 && props.column.tasks.every(function (t) { return props.selectedIds.has(t.id); }),
           onChange: function (e) {
             e.stopPropagation();


### PR DESCRIPTION
## Summary

The column select-all checkbox in the kanban dashboard crashes with:

```
ReferenceError: COLUMN_LABEL is not defined
```

This is because the aria-label references the undefined `COLUMN_LABEL` map instead of the already-computed `colLabel` local variable.

## Fix

Replace:
```js
`Select all tasks in ${COLUMN_LABEL[props.column.name] || props.column.name}`
```

With:
```js
`Select all tasks in ${colLabel || props.column.name}`
```

## Root cause

Commit 3df7e3024 introduced the column select-all checkbox but used the wrong variable name. The `colLabel` local (computed via `getColumnLabel(t, props.column.name)`) was already available and correct — it just wasn't used.