### PR TITLE
fix(discord): split-and-deliver oversized edits instead of silent truncation

### DIFF
--- a/gateway/platforms/discord.py
+++ b/gateway/platforms/discord.py
@@ -1577,12 +1577,75 @@ class DiscordAdapter(BasePlatformAdapter):
             msg = await channel.fetch_message(int(message_id))
             formatted = self.format_message(content)
             if len(formatted) > self.MAX_MESSAGE_LENGTH:
-                formatted = formatted[:self.MAX_MESSAGE_LENGTH - 3] + "..."
+                return await self._edit_overflow_split(
+                    channel, msg, formatted, message_id
+                )
             await msg.edit(content=formatted)
             return SendResult(success=True, message_id=message_id)
         except Exception as e:  # pragma: no cover - defensive logging
             logger.error("[%s] Failed to edit Discord message %s: %s", self.name, message_id, e, exc_info=True)
             return SendResult(success=False, error=str(e))
+
+    async def _edit_overflow_split(
+        self,
+        channel: Any,
+        msg: Any,
+        content: str,
+        message_id: str,
+    ) -> SendResult:
+        """Split an oversized edit across the existing message + new continuations.
+
+        Edits the original message with the first chunk, then sends the
+        remaining chunks as replies to each preceding chunk so the user sees
+        a contiguous block.  Returns ``SendResult(success=True,
+        message_id=<last-chunk-id>, continuation_message_ids=(...))`` so
+        ``stream_consumer`` can keep editing the most recent visible message.
+        """
+        chunks = self.truncate_message(content, self.MAX_MESSAGE_LENGTH)
+        if len(chunks) <= 1:
+            chunks = [content]
+
+        # Edit the existing message with the first chunk.
+        try:
+            await msg.edit(content=chunks[0])
+        except Exception as e:
+            if "not modified" not in str(e).lower():
+                logger.error(
+                    "[%s] Overflow split: first-chunk edit failed: %s",
+                    self.name, e, exc_info=True,
+                )
+                return SendResult(success=False, error=str(e))
+
+        # Send remaining chunks as threaded continuations.
+        continuation_ids: List[str] = []
+        prev_msg = msg
+        for chunk in chunks[1:]:
+            try:
+                reference = (
+                    prev_msg.to_reference(fail_if_not_exists=False)
+                    if hasattr(prev_msg, "to_reference")
+                    else prev_msg
+                )
+                sent = await channel.send(content=chunk, reference=reference)
+            except Exception as send_err:
+                logger.warning(
+                    "[%s] Overflow split: continuation send failed: %s",
+                    self.name, send_err,
+                )
+                break
+            continuation_ids.append(str(sent.id))
+            prev_msg = sent
+
+        last_id = continuation_ids[-1] if continuation_ids else message_id
+        logger.debug(
+            "[%s] edit_message overflow split: %d/%d chunks delivered; last_id=%s",
+            self.name, 1 + len(continuation_ids), len(chunks), last_id,
+        )
+        return SendResult(
+            success=True,
+            message_id=last_id,
+            continuation_message_ids=tuple(continuation_ids),
+        )
 
     async def _send_file_attachment(
         self,


### PR DESCRIPTION
## Problem

`DiscordAdapter.edit_message` silently truncated messages that exceeded
the 2000-character limit:

```python
if len(formatted) > self.MAX_MESSAGE_LENGTH:
    formatted = formatted[:self.MAX_MESSAGE_LENGTH - 3] + "..."
await msg.edit(content=formatted)
return SendResult(success=True, message_id=message_id)  # lies: tail was dropped
```

`stream_consumer` received `success=True` and assumed the full content
was on screen. Any streaming response that grew past 2000 chars had its
tail permanently dropped with no error surfaced to the user or the
gateway.

## Fix

Replace the truncation with `_edit_overflow_split()`, mirroring the
same contract Telegram's overflow split established in PR #23576:

1. Edit the **original message** with chunk 1 (so the message stays
   in-thread and doesn't flash as "deleted + new").
2. Send remaining chunks as **reply continuations** to the previous
   chunk, so the user sees a contiguous threaded block.
3. Return `SendResult(success=True, message_id=<last-chunk-id>,
   continuation_message_ids=(...))`.

`stream_consumer` already handles `continuation_message_ids`
(line 1172) — it updates `_message_id` to the last continuation so
subsequent edits target the most recent visible message.

## Behavior

| Scenario | Before | After |
|---|---|---|
| Edit ≤ 2000 chars | Edit in place ✅ | Edit in place ✅ |
| Edit > 2000 chars | Silent truncation with `"..."` ❌ | Split and deliver all chunks ✅ |
| First-chunk edit fails (real error) | Logged, `success=False` | Logged, `success=False` ✅ |
| First-chunk "not modified" | N/A | Continue to send continuations ✅ |
| Continuation send fails | N/A | Best-effort: deliver what succeeded, log warning ✅ |

## Checklist

- [x] No new imports required (`List`, `Any` already imported from `typing`)
- [x] `truncate_message` inherited from `BasePlatformAdapter` (same as `send_message` uses)
- [x] `to_reference(fail_if_not_exists=False)` — same pattern as `send_message`'s reply threading
- [x] `stream_consumer` already consumes `continuation_message_ids` — no consumer changes needed
- [x] No competitor PRs targeting this path