### PR TITLE
fix(tui): hydrate /agents from delegation status

### DIFF
--- a/ui-tui/src/__tests__/turnStore.test.ts
+++ b/ui-tui/src/__tests__/turnStore.test.ts
@@ -4,6 +4,7 @@ import {
   archiveDoneTodos,
   archiveTodosAtTurnEnd,
   getTurnState,
+  hydrateDelegationActiveSubagents,
   patchTurnState,
   resetTurnState,
   toggleTodoCollapsed
@@ -62,5 +63,91 @@ describe('turnStore live progress helpers', () => {
 
     toggleTodoCollapsed()
     expect(getTurnState().todoCollapsed).toBe(false)
+  })
+
+  it('hydrates active delegation rows into the live subagent list', () => {
+    hydrateDelegationActiveSubagents([
+      {
+        depth: 1,
+        goal: 'inspect delegate_task',
+        model: 'openai/gpt-5.4',
+        parent_id: 'root-agent',
+        started_at: 1715400000,
+        status: 'running',
+        subagent_id: 'sa-live-1',
+        tool_count: 3
+      }
+    ])
+
+    expect(getTurnState().subagents).toEqual([
+      {
+        depth: 1,
+        goal: 'inspect delegate_task',
+        id: 'sa-live-1',
+        index: 0,
+        model: 'openai/gpt-5.4',
+        notes: [],
+        parentId: 'root-agent',
+        startedAt: 1715400000 * 1000,
+        status: 'running',
+        taskCount: 1,
+        thinking: [],
+        toolCount: 3,
+        tools: []
+      }
+    ])
+  })
+
+  it('preserves richer local subagent details when delegation.status only refreshes activity metadata', () => {
+    patchTurnState({
+      subagents: [
+        {
+          depth: 1,
+          goal: 'inspect delegate_task',
+          id: 'sa-live-1',
+          index: 7,
+          model: 'openai/gpt-5.4',
+          notes: ['tool batch ready'],
+          parentId: 'root-agent',
+          startedAt: 1715400000 * 1000,
+          status: 'running',
+          summary: 'kept locally',
+          taskCount: 1,
+          thinking: ['reading source'],
+          toolCount: 1,
+          tools: ['read cli.py']
+        }
+      ]
+    })
+
+    hydrateDelegationActiveSubagents([
+      {
+        depth: 1,
+        goal: 'inspect delegate_task',
+        started_at: 1715400005,
+        status: 'running',
+        subagent_id: 'sa-live-1',
+        tool_count: 4
+      }
+    ])
+
+    expect(getTurnState().subagents).toEqual([
+      {
+        depth: 1,
+        goal: 'inspect delegate_task',
+        id: 'sa-live-1',
+        index: 7,
+        model: 'openai/gpt-5.4',
+        notes: ['tool batch ready'],
+        parentId: 'root-agent',
+        startedAt: 1715400005 * 1000,
+        status: 'running',
+        summary: 'kept locally',
+        taskCount: 1,
+        thinking: ['reading source'],
+        toolCount: 4,
+        tools: ['read cli.py']
+      }
+    ])
   })
 })

--- a/ui-tui/src/app/createGatewayEventHandler.ts
+++ b/ui-tui/src/app/createGatewayEventHandler.ts
@@ -1,6 +1,6 @@
 import { STARTUP_IMAGE, STARTUP_QUERY } from '../config/env.js'
 import { STREAM_BATCH_MS } from '../config/timing.js'
-import { SETUP_REQUIRED_TITLE, buildSetupRequiredSections } from '../content/setup.js'
+import { buildSetupRequiredSections, SETUP_REQUIRED_TITLE } from '../content/setup.js'
 import type {
   CommandsCatalogResponse,
   ConfigFullResponse,
@@ -19,6 +19,7 @@ import { applyDelegationStatus, getDelegationState } from './delegationStore.js'
 import type { GatewayEventHandlerContext } from './interfaces.js'
 import { patchOverlayState } from './overlayStore.js'
 import { turnController } from './turnController.js'
+import { hydrateDelegationActiveSubagents } from './turnStore.js'
 import { getUiState, patchUiState } from './uiStore.js'
 
 const NO_PROVIDER_RE = /\bNo (?:LLM|inference) provider configured\b/i
@@ -112,7 +113,10 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
     lastDelegationFetchAt = now
     rpc<DelegationStatusResponse>('delegation.status', {})
-      .then(r => applyDelegationStatus(r))
+      .then(r => {
+        applyDelegationStatus(r)
+        hydrateDelegationActiveSubagents(r?.active)
+      })
       .catch(() => {})
   }
 
@@ -321,11 +325,13 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
 
         if (p.kind === 'compressing') {
           sys(p.text)
+
           return
         }
 
         if (p.kind === 'goal') {
           sys(p.text)
+
           return
         }
 
@@ -551,7 +557,6 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         sys(`[bg ${ev.payload.task_id}] ${ev.payload.text}`)
 
         return
-
       case 'review.summary': {
         // Self-improvement background review emitted a persistent summary
         // of what it saved to memory/skills. Surface it as a system line
@@ -559,6 +564,7 @@ export function createGatewayEventHandler(ctx: GatewayEventHandlerContext): (ev:
         // flash. Python-side already formats it as "💾 Self-improvement
         // review: …".
         const text = String(ev.payload?.text ?? '').trim()
+
         if (text) {
           sys(text)
         }

--- a/ui-tui/src/app/turnStore.ts
+++ b/ui-tui/src/app/turnStore.ts
@@ -1,6 +1,7 @@
 import { atom } from 'nanostores'
 import { useSyncExternalStore } from 'react'
 
+import type { DelegationStatusResponse } from '../gatewayTypes.js'
 import { isTodoDone } from '../lib/liveProgress.js'
 import type { ActiveTool, ActivityItem, Msg, SubagentProgress, TodoItem } from '../types.js'
 
@@ -65,6 +66,123 @@ export const archiveTodosAtTurnEnd = () => {
 }
 
 export const resetTurnState = () => $turnState.set(buildTurnState())
+
+const ACTIVE_STATUS = new Set<SubagentProgress['status']>(['queued', 'running'])
+
+const normalizeDelegationStartedAt = (value: unknown): number | undefined => {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return undefined
+  }
+
+  // Gateway payloads use UNIX seconds; the TUI stores ms timestamps.
+  return value < 1e12 ? value * 1000 : value
+}
+
+const normalizeDelegationStatus = (value: unknown, fallback: SubagentProgress['status']): SubagentProgress['status'] => {
+  switch (value) {
+    case 'completed':
+
+    case 'failed':
+
+    case 'interrupted':
+
+    case 'queued':
+
+    case 'running':
+      return value
+
+    default:
+      return fallback
+  }
+}
+
+export const hydrateDelegationActiveSubagents = (
+  active: DelegationStatusResponse['active'] | null | undefined
+) => {
+  if (!Array.isArray(active) || active.length === 0) {
+    return
+  }
+
+  patchTurnState(state => {
+    let changed = false
+    let next = state.subagents
+
+    for (const [index, raw] of active.entries()) {
+      const id = typeof raw?.subagent_id === 'string' ? raw.subagent_id.trim() : ''
+
+      if (!id) {
+        continue
+      }
+
+      const existing = next.find(item => item.id === id)
+
+      const base: SubagentProgress =
+        existing ?? {
+          depth: typeof raw?.depth === 'number' ? raw.depth : 0,
+          goal: typeof raw?.goal === 'string' && raw.goal.trim() ? raw.goal : 'subagent',
+          id,
+          index,
+          notes: [],
+          parentId: typeof raw?.parent_id === 'string' ? raw.parent_id : null,
+          startedAt: normalizeDelegationStartedAt(raw?.started_at) ?? Date.now(),
+          status: normalizeDelegationStatus(raw?.status, 'running'),
+          taskCount: 1,
+          thinking: [],
+          toolCount: typeof raw?.tool_count === 'number' ? raw.tool_count : 0,
+          tools: []
+        }
+
+      const nextItem: SubagentProgress = {
+        ...base,
+        depth: typeof raw?.depth === 'number' ? raw.depth : base.depth,
+        goal: typeof raw?.goal === 'string' && raw.goal.trim() ? raw.goal : base.goal,
+        index: existing?.index ?? base.index,
+        model: typeof raw?.model === 'string' && raw.model.trim() ? raw.model : base.model,
+        parentId: typeof raw?.parent_id === 'string' ? raw.parent_id : base.parentId,
+        startedAt: normalizeDelegationStartedAt(raw?.started_at) ?? base.startedAt,
+        status: normalizeDelegationStatus(raw?.status, ACTIVE_STATUS.has(base.status) ? base.status : 'running'),
+        toolCount: typeof raw?.tool_count === 'number' ? raw.tool_count : base.toolCount
+      }
+
+      const same =
+        existing &&
+        existing.depth === nextItem.depth &&
+        existing.goal === nextItem.goal &&
+        existing.index === nextItem.index &&
+        existing.model === nextItem.model &&
+        existing.parentId === nextItem.parentId &&
+        existing.startedAt === nextItem.startedAt &&
+        existing.status === nextItem.status &&
+        existing.toolCount === nextItem.toolCount
+
+      if (same) {
+        continue
+      }
+
+      if (next === state.subagents) {
+        next = [...state.subagents]
+      }
+
+      changed = true
+
+      if (existing) {
+        const existingIndex = next.findIndex(item => item.id === id)
+
+        next[existingIndex] = nextItem
+      } else {
+        next.push(nextItem)
+      }
+    }
+
+    if (!changed) {
+      return state
+    }
+
+    next.sort((a, b) => a.depth - b.depth || a.index - b.index)
+
+    return { ...state, subagents: next }
+  })
+}
 
 export interface TurnState {
   activity: ActivityItem[]

--- a/ui-tui/src/components/agentsOverlay.tsx
+++ b/ui-tui/src/components/agentsOverlay.tsx
@@ -10,7 +10,7 @@ import {
 } from '../app/delegationStore.js'
 import { patchOverlayState } from '../app/overlayStore.js'
 import { $spawnDiff, $spawnHistory, clearDiffPair, type SpawnSnapshot } from '../app/spawnHistoryStore.js'
-import { useTurnSelector } from '../app/turnStore.js'
+import { hydrateDelegationActiveSubagents, useTurnSelector } from '../app/turnStore.js'
 import type { GatewayClient } from '../gatewayClient.js'
 import type { DelegationPauseResponse, DelegationStatusResponse, SubagentInterruptResponse } from '../gatewayTypes.js'
 import { asRpcResult } from '../lib/rpc.js'
@@ -768,7 +768,11 @@ export function AgentsOverlay({ gw, initialHistoryIndex = 0, onClose, t }: Agent
   useEffect(() => {
     // Warm caps + paused flag on open.
     gw.request<DelegationStatusResponse>('delegation.status', {})
-      .then(r => applyDelegationStatus(asRpcResult<DelegationStatusResponse>(r)))
+      .then(r => {
+        const status = asRpcResult<DelegationStatusResponse>(r)
+        applyDelegationStatus(status)
+        hydrateDelegationActiveSubagents(status?.active)
+      })
       .catch(() => {})
   }, [gw])
 


### PR DESCRIPTION
## What does this PR do?

When the TUI misses live `subagent.*` events, `/agents` and `/tasks` can still show "No subagents this turn" even though `delegate_task` children are active and `delegation.status` already knows about them.

This change hydrates the live TUI subagent list from `delegation.status.active` so the overlays can recover the current child-agent tree from the gateway status snapshot instead of relying only on event timing.

## Related Issue

Fixes #22729

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- hydrate `TurnState.subagents` from `delegation.status.active` in `ui-tui/src/app/turnStore.ts`
- refresh that hydration both during the periodic gateway status fetch and when `/agents` opens
- preserve richer locally collected subagent details when the status snapshot only refreshes activity metadata
- add regression tests in `ui-tui/src/__tests__/turnStore.test.ts`

## How to Test

1. Run `cd ui-tui && npm test -- --run src/__tests__/turnStore.test.ts`
2. Run `uv run --frozen pytest -q -o addopts='' tests/gateway/test_status_command.py tests/gateway/test_command_bypass_active_session.py`
3. In the TUI, start a delegated task, drop or miss a live `subagent.*` event, then open `/agents` or `/tasks` and confirm active subagents are reconstructed from `delegation.status` instead of showing an empty state.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `cd ui-tui && npm test -- --run src/__tests__/turnStore.test.ts` -> `6 passed`
- `uv run --frozen pytest -q -o addopts='' tests/gateway/test_status_command.py tests/gateway/test_command_bypass_active_session.py` -> `54 passed`
- `env -i PATH="$PATH" HOME="$HOME" TERM="${TERM:-xterm-256color}" uv run --frozen pytest --collect-only -q -o addopts='' tests/gateway/test_status_command.py tests/gateway/test_command_bypass_active_session.py` -> `54 tests collected`
