### PR TITLE
fix(feishu): cap _message_text_cache with LRU eviction to prevent unbounded growth

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -239,6 +239,7 @@ _FEISHU_REACTION_FAILURE = "CrossMark"
 # drain on completion; the cap is a safeguard against unbounded growth from
 # delete-failures, not a capacity plan.
 _FEISHU_PROCESSING_REACTION_CACHE_SIZE = 1024
+_FEISHU_MESSAGE_TEXT_CACHE_SIZE = 512       # LRU cap for reply-context message text lookups
 
 # QR onboarding constants
 _ONBOARD_ACCOUNTS_URLS = {
@@ -1392,7 +1393,7 @@ class FeishuAdapter(BasePlatformAdapter):
         self._sent_message_ids_to_chat: Dict[str, str] = {}  # message_id → chat_id (for reaction routing)
         self._sent_message_id_order: List[str] = []  # LRU order for _sent_message_ids_to_chat
         self._chat_info_cache: Dict[str, Dict[str, Any]] = {}
-        self._message_text_cache: Dict[str, Optional[str]] = {}
+        self._message_text_cache: "OrderedDict[str, Optional[str]]" = OrderedDict()
         self._app_lock_identity: Optional[str] = None
         self._text_batch_state = FeishuBatchState()
         self._pending_text_batches = self._text_batch_state.events
@@ -3830,6 +3831,7 @@ class FeishuAdapter(BasePlatformAdapter):
         if not self._client or not message_id:
             return None
         if message_id in self._message_text_cache:
+            self._message_text_cache.move_to_end(message_id)
             return self._message_text_cache[message_id]
         try:
             request = self._build_get_message_request(message_id)
@@ -3851,6 +3853,9 @@ class FeishuAdapter(BasePlatformAdapter):
                 mentions=parent_mentions,
             )
             self._message_text_cache[message_id] = text
+            self._message_text_cache.move_to_end(message_id)
+            while len(self._message_text_cache) > _FEISHU_MESSAGE_TEXT_CACHE_SIZE:
+                self._message_text_cache.popitem(last=False)
             return text
         except Exception:
             logger.warning("[Feishu] Failed to fetch parent message %s", message_id, exc_info=True)


### PR DESCRIPTION
## Problem

`_message_text_cache` in `FeishuAdapter` is a plain `dict` with no size
limit. It caches the text content of messages fetched for reply-context
lookups (when a user quotes a previous message). Every unique
`message_id` ever looked up stays in memory permanently:

```python
# Before — grows forever
self._message_text_cache: Dict[str, Optional[str]] = {}

# _fetch_message_text — no eviction on write
self._message_text_cache[message_id] = text
return text
```

In active group chats or long-running deployments this is a slow memory
leak: one dict entry per quoted message, accumulating without bound.

## Fix

Replace the plain `dict` with an `OrderedDict` and evict the
least-recently-used entry whenever the cache exceeds
`_FEISHU_MESSAGE_TEXT_CACHE_SIZE` (512). Cache hits call `move_to_end()`
to refresh LRU order.

```python
# After
self._message_text_cache: "OrderedDict[str, Optional[str]]" = OrderedDict()

# on hit
self._message_text_cache.move_to_end(message_id)
return self._message_text_cache[message_id]

# on write
self._message_text_cache[message_id] = text
self._message_text_cache.move_to_end(message_id)
while len(self._message_text_cache) > _FEISHU_MESSAGE_TEXT_CACHE_SIZE:
    self._message_text_cache.popitem(last=False)
```

This is the identical pattern already used by
`_remember_processing_reaction` / `_pending_processing_reactions` in the
same class (`_FEISHU_PROCESSING_REACTION_CACHE_SIZE = 1024`).

## Checklist

- [x] `OrderedDict` already imported (`from collections import OrderedDict`, line 62)
- [x] Naming and constant placement consistent with existing `_FEISHU_*_CACHE_SIZE` constants
- [x] Type annotation uses string form — consistent with sibling `_pending_processing_reactions` declaration
- [x] `None` values handled correctly (`in` checks presence, not truthiness)
- [x] No new imports required