### PR TITLE
fix: eager fallback on billing 402

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -978,7 +978,11 @@ def _routermint_headers() -> dict:
 
 
 def _pool_may_recover_from_rate_limit(
-    pool, *, provider: str | None = None, base_url: str | None = None
+    pool,
+    *,
+    provider: str | None = None,
+    base_url: str | None = None,
+    reason=None,
 ) -> bool:
     """Decide whether to wait for credential-pool rotation instead of falling back.
 
@@ -996,14 +1000,20 @@ def _pool_may_recover_from_rate_limit(
     throttles — even a multi-entry pool shares the same quota window, so
     rotation won't recover.  Skip straight to the fallback for those (#13636).
 
+    Billing exhaustion is different again: even when a credential pool has
+    multiple entries, a 402 typically reflects account-level depletion, so
+    rotation should not block eager fallback.
+
     In those cases we must fall back to the configured ``fallback_model``
-    instead.  Returns True only when rotation has somewhere to go.
+    instead. Returns True only when rotation has somewhere to go.
 
     See issues #11314 and #13636.
     """
     if pool is None:
         return False
     if not pool.has_available():
+        return False
+    if reason == FailoverReason.billing:
         return False
     # CloudCode / Gemini CLI quotas are account-wide — all pool entries share
     # the same throttle window, so rotation can't recover.  Prefer fallback.
@@ -13545,6 +13555,7 @@ class AIAgent:
                             self._credential_pool,
                             provider=self.provider,
                             base_url=getattr(self, "base_url", None),
+                            reason=classified.reason,
                         )
                         if not pool_may_recover:
                             self._emit_status("⚠️ Rate limited — switching to fallback provider...")

--- a/tests/agent/test_credential_pool_routing.py
+++ b/tests/agent/test_credential_pool_routing.py
@@ -133,6 +133,29 @@ class TestEagerFallbackWithPool:
 
         agent._try_activate_fallback.assert_called_once()
 
+    def test_billing_fires_eager_fallback_even_with_multi_entry_pool(self):
+        """402 billing must not be blocked by a multi-entry credential pool."""
+        from agent.error_classifier import FailoverReason
+        from run_agent import _pool_may_recover_from_rate_limit
+
+        agent = self._make_agent(has_pool=True, pool_has_creds=True, has_fallback=True)
+        agent._credential_pool.entries.return_value = [MagicMock(), MagicMock()]
+        agent.provider = "deepseek"
+        agent.base_url = "https://api.deepseek.com/v1"
+
+        is_rate_limited = True
+        if is_rate_limited and agent._fallback_index < len(agent._fallback_chain):
+            pool_may_recover = _pool_may_recover_from_rate_limit(
+                agent._credential_pool,
+                provider=agent.provider,
+                base_url=agent.base_url,
+                reason=FailoverReason.billing,
+            )
+            if not pool_may_recover:
+                agent._try_activate_fallback()
+
+        agent._try_activate_fallback.assert_called_once()
+
 
 # ---------------------------------------------------------------------------
 # 5. Full 429 rotation cycle via _recover_with_credential_pool

--- a/tests/run_agent/test_provider_fallback.py
+++ b/tests/run_agent/test_provider_fallback.py
@@ -221,6 +221,20 @@ class TestPoolRotationRoom:
     def test_many_credentials_available_returns_true(self):
         assert _pool_may_recover_from_rate_limit(_pool(10)) is True
 
+    def test_billing_reason_never_waits_for_pool_rotation(self):
+        """402 billing exhaustion should prefer eager fallback even with a
+        multi-entry pool; account-level depletion is not recoverable by
+        rotating credentials.
+        """
+        from agent.error_classifier import FailoverReason
+
+        assert _pool_may_recover_from_rate_limit(
+            _pool(10),
+            provider="deepseek",
+            base_url="https://api.deepseek.com/v1",
+            reason=FailoverReason.billing,
+        ) is False
+
 
 # ── Skip-self dedup (#22548) ───────────────────────────────────────────────
 

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -2812,6 +2812,53 @@ class TestRunConversation:
         failure_msgs = [m for m in status_messages if "no content" in m.lower() or "no fallback" in m.lower()]
         assert len(failure_msgs) >= 1, f"Expected at least 1 failure status, got: {status_messages}"
 
+    def test_billing_error_triggers_eager_fallback_before_retry_budget(self, agent):
+        """A primary HTTP 402 should switch to fallback immediately."""
+        self._setup_agent(agent)
+        agent.provider = "deepseek"
+        agent.model = "deepseek-v4-pro"
+        agent.base_url = "https://api.deepseek.com/v1"
+        agent._fallback_chain = [{"provider": "openrouter", "model": "openai/gpt-oss-120b:free"}]
+        agent._fallback_index = 0
+        agent._fallback_activated = False
+
+        billing_error = RuntimeError("HTTP 402: Insufficient Balance")
+        billing_error.status_code = 402
+        billing_error.body = {"error": {"message": "Insufficient Balance"}}
+
+        success_resp = _mock_response(
+            content="Fallback recovered the request.",
+            finish_reason="stop",
+        )
+        agent.client.chat.completions.create.side_effect = [
+            billing_error,
+            success_resp,
+        ]
+
+        fallback_called = {"count": 0}
+
+        def _mock_fallback(reason=None):
+            fallback_called["count"] += 1
+            assert reason == FailoverReason.billing
+            agent._fallback_index = 1
+            agent._fallback_activated = True
+            agent.provider = "openrouter"
+            agent.model = "openai/gpt-oss-120b:free"
+            return True
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+            patch.object(agent, "_emit_status"),
+            patch.object(agent, "_try_activate_fallback", side_effect=_mock_fallback),
+        ):
+            result = agent.run_conversation("answer me")
+
+        assert fallback_called["count"] == 1
+        assert result["completed"] is True
+        assert result["final_response"] == "Fallback recovered the request."
+
     def test_partial_stream_recovery_uses_streamed_content(self, agent):
         """When streaming fails after partial delivery, recovered partial content becomes final response."""
         self._setup_agent(agent)


### PR DESCRIPTION
 ## Summary

  Fix eager fallback when the primary provider returns HTTP 402 / `FailoverReason.billing`.

  The real bug was not in cron wiring. `cron/scheduler.py` already passes both
  `fallback_model` and `credential_pool` into `AIAgent`. The failure was in the
  eager-fallback guard: billing exhaustion was grouped with rate limits, then
  `_pool_may_recover_from_rate_limit()` could still block fallback while waiting
  for credential-pool rotation.

  That is wrong for billing/account exhaustion. Rotating credentials should not
  delay fallback for `FailoverReason.billing`.

  Fixes #23138.

  ## Changes

  - teach `_pool_may_recover_from_rate_limit()` about the failover reason
  - force it to return `False` for `FailoverReason.billing`
  - pass `classified.reason` into the eager-fallback guard in `run_conversation()`
  - add regression tests for:
    - helper-level billing/pool behavior
    - eager fallback with a multi-entry credential pool
    - run-level `HTTP 402 -> immediate fallback`

  ## Why this fixes the issue

  Before this change, a primary `402 Insufficient Balance` could be treated as
  "maybe credential rotation can recover", which prevented eager fallback from
  activating even though `fallback_providers` was configured.

  After this change, `402 -> FailoverReason.billing` skips pool-rotation gating
  and switches to the fallback provider immediately.

  ## Validation

  Passed:

  - `venv\Scripts\python.exe -m pytest tests/run_agent/test_run_agent.py -k billing_error_triggers_eager_fallback_before_retry_budget -q`
  - `venv\Scripts\python.exe -m pytest tests/run_agent/test_provider_fallback.py tests/agent/test_credential_pool_routing.py tests/agent/test_error_classifier.py -q`