### PR TITLE
fix: remove redundant return in finally block (voice processing)

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -9300,7 +9300,6 @@ class HermesCLI:
                     self._voice_continuous = False
                     self._no_speech_count = 0
                     _cprint(f"{_DIM}No speech detected 3 times, continuous mode stopped.{_RST}")
-                    return
             else:
                 self._no_speech_count = 0
 


### PR DESCRIPTION
## Problem

`_voice_stop_and_transcribe()` in `cli.py` has a `return` statement inside a `finally` block (line 9303). In Python, `return` in `finally` silently swallows any exception being propagated — the exception is discarded and the function returns normally.

Python 3.14 will emit `SyntaxWarning` for this pattern:
> `SyntaxWarning: 'return' in a 'finally' block`

## Fix

Remove the redundant `return` statement. The `return` was intended to prevent voice auto-restart when the no-speech limit (3 consecutive) is reached, but this guard is already redundant:

```python
# Two lines before the removed return:
self._voice_continuous = False  # ← disables continuous mode

# The auto-restart condition checks this flag:
if self._voice_continuous and not submitted and not self._voice_recording:
    # This block is unreachable when _voice_continuous is False
```

Setting `_voice_continuous = False` already makes the subsequent auto-restart condition evaluate to `False`, so the `return` was unnecessary. Removing it preserves identical control flow while eliminating the exception-swallowing bug.

## Before vs After

| Aspect | Before | After |
|--------|--------|-------|
| Exception in try/except | Silently swallowed by `return` in `finally` | Propagated normally |
| Auto-restart when no-speech limit reached | Blocked by `return` | Blocked by `_voice_continuous = False` |
| Python 3.14 compatibility | SyntaxWarning | No warning |

## Tests
- Verified syntax with `ast.parse()`
- AST scanner confirms no `return` in `finally` remains
- 1 line removed, 0 lines added