### PR TITLE
fix(agent): preserve multiline truncation boundaries

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -11820,6 +11820,17 @@ class AIAgent:
         truncated_response_prefix = ""
         compression_attempts = 0
         _turn_exit_reason = "unknown"  # Diagnostic: why the loop ended
+
+        def _join_truncated_continuation(prefix: str, continuation: str) -> str:
+            if not prefix:
+                return continuation
+            if not continuation:
+                return prefix
+            if prefix[-1].isspace() or continuation[0].isspace():
+                return prefix + continuation
+            if "\n" in prefix:
+                return prefix + "\n" + continuation
+            return prefix + continuation
         
         # Record the execution thread so interrupt()/clear_interrupt() can
         # scope the tool-level interrupt signal to THIS agent's thread only.
@@ -14888,7 +14899,10 @@ class AIAgent:
                     codex_ack_continuations = 0
 
                     if truncated_response_prefix:
-                        final_response = truncated_response_prefix + final_response
+                        final_response = _join_truncated_continuation(
+                            truncated_response_prefix,
+                            final_response,
+                        )
                         truncated_response_prefix = ""
                         length_continue_retries = 0
                     

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -3100,6 +3100,24 @@ class TestRunConversation:
         assert second_call_messages[-1]["role"] == "user"
         assert "truncated by the output length limit" in second_call_messages[-1]["content"]
 
+    def test_length_continuation_preserves_newline_for_multiline_output(self, agent):
+        """Multiline truncation should not merge the continuation into the last line."""
+        self._setup_agent(agent)
+        first = _mock_response(content="Done:\n✅ Update DC", finish_reason="length")
+        second = _mock_response(content="⬜ Bugs high", finish_reason="stop")
+        agent.client.chat.completions.create.side_effect = [first, second]
+
+        with (
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello")
+
+        assert result["completed"] is True
+        assert result["api_calls"] == 2
+        assert result["final_response"] == "Done:\n✅ Update DC\n⬜ Bugs high"
+
     def test_ollama_glm_stop_after_tools_without_terminal_boundary_requests_continuation(self, agent):
         """Ollama-hosted GLM responses can misreport truncated output as stop."""
         self._setup_agent(agent)


### PR DESCRIPTION
## What does this PR do?

Fixes a truncation-continuation formatting bug where Hermes could merge the next continuation directly into the final line of a multiline partial response.

The root cause was the final response join path: after a `finish_reason='length'` retry, Hermes concatenated the stored partial prefix and the continuation text with no boundary logic. For multiline output, that could collapse the next checklist/item line into the previous line.

## Related Issue

Fixes #23696

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- add a small truncation-join helper in `run_agent.py`
- preserve existing inline continuation behavior when whitespace already provides a boundary
- insert a newline boundary for multiline partial responses when the continuation would otherwise merge into the last visible line
- add a regression test covering multiline checklist-style continuation joins

## How to Test

1. Run `uv run --frozen pytest -q -o addopts='' tests/run_agent/test_run_agent.py -k 'length_finish_reason_requests_continuation or length_continuation_preserves_newline_for_multiline_output'`
2. Run `uv run --frozen ruff check run_agent.py tests/run_agent/test_run_agent.py`
3. Reproduce a `finish_reason='length'` continuation on multiline output and confirm the continuation starts on the next line instead of merging into the previous item.

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `uv run --frozen pytest -q -o addopts='' tests/run_agent/test_run_agent.py -k 'length_finish_reason_requests_continuation or length_continuation_preserves_newline_for_multiline_output'` -> `2 passed`
- `env -i PATH="$PATH" HOME="$HOME" TERM="${TERM:-xterm-256color}" uv run --frozen pytest --collect-only -q -o addopts='' tests/run_agent/test_run_agent.py -k 'length_finish_reason_requests_continuation or length_continuation_preserves_newline_for_multiline_output'` -> `2/324 tests collected`
- `uv run --frozen ruff check run_agent.py tests/run_agent/test_run_agent.py` -> `All checks passed!`
