### PR TITLE
Add find-doctors skill

### DIFF
--- a/skills/find-doctors/SKILL.md
+++ b/skills/find-doctors/SKILL.md
@@ -1,0 +1,135 @@
+---
+name: find-doctors
+slug: find-doctors
+version: 0.1.0
+description: Find the strongest mainland China doctors and hospitals for a specific disease using evidence-based medical source triangulation. Use when a patient or family member asks “这个病找哪个医生/医院最好”, “中国大陆哪里看这个病最强”, “帮我按病种找专家”, “想挂名医/会诊/二诊”, or needs a ranked shortlist of doctors, hospitals, departments, and appointment paths.
+tags: [find-doctors, find-dcotors, doctors, hospitals, China, mainland China, 医生, 医院, 找医生, 名医, 专家, 挂号, 二诊]
+license: MIT
+metadata:
+  openclaw:
+    emoji: "🏥"
+    requires:
+      bins: []
+    os: ["linux", "darwin", "win32"]
+  hermes:
+    tags: [find-doctors, find-dcotors, 医生推荐, 医院推荐, 中国大陆, 就医导航]
+related_skills: [health-checkup-report]
+---
+
+# Find Doctors
+
+Use this skill to help patients identify the best-fit mainland China doctors and hospitals for a named disease, suspected disease, or treatment need.
+
+Treat `find-dcotors`, `找医生`, `找专家`, and `医院推荐` as aliases.
+
+This skill is a medical navigation and research workflow. It does not diagnose, prescribe, guarantee outcomes, or replace an in-person clinician.
+
+## Required Research Posture
+
+Because hospital rankings, doctor rosters, outpatient schedules, platform reviews, and official pages change frequently, use live search or browser tools whenever available.
+
+If live search is unavailable, say that the ranking is provisional and ask the user to enable browsing or provide sources/screenshots.
+
+Read `references/methodology.md` before producing a ranked doctor shortlist.
+
+## Intake
+
+Collect only details that materially change the search:
+
+- disease name, suspected disease, or procedure/treatment needed
+- confirmed diagnosis vs symptoms only
+- adult, pediatric, pregnancy, rare disease, oncology stage, emergency status, or recurrent/refractory case if relevant
+- current city/province and whether the patient can travel to Beijing, Shanghai, Guangzhou, Chengdu, Wuhan, Hangzhou, Nanjing, Xi'an, etc.
+- preference for public tertiary hospital, international department, specialist outpatient, multidisciplinary clinic, second opinion, surgery, medication, radiotherapy, interventional treatment, rehab, or chronic follow-up
+- insurance/self-pay constraints and urgency
+
+If the user only gives symptoms, first help them choose the likely first department and ask them to seek a proper diagnosis. Do not rank disease specialists as if the diagnosis is confirmed.
+
+## Safety First
+
+Start with urgent escalation if the user mentions red flags such as:
+
+- chest pain, stroke-like symptoms, severe breathing difficulty, fainting, confusion
+- severe bleeding, vomiting blood, black stool, major trauma, severe abdominal pain
+- infant/child high fever with lethargy, seizure, dehydration, or breathing difficulty
+- cancer treatment complications, severe infection signs, post-operative acute symptoms
+- suicidal thoughts or acute psychiatric danger
+
+For red flags, advise immediate emergency care or local urgent evaluation before specialist ranking.
+
+## Evidence Workflow
+
+1. Normalize the disease.
+   - Identify the Chinese disease name, common synonyms, subspecialty, and first-choice department.
+   - Separate diagnosis, staging, and treatment mode. Example: `肺癌` is not enough; `早期肺结节手术`, `EGFR阳性晚期肺癌靶向治疗`, and `放疗` point to different teams.
+
+2. Build a hospital shortlist.
+   - Use disease-relevant specialty rankings, not overall hospital fame.
+   - Cross-check at least two classes of evidence when possible:
+     - Fudan hospital specialty reputation / specialty comprehensive rankings
+     - Chinese Academy of Medical Sciences STEM/ASTEM or discipline-level hospital science metrics
+     - National clinical key specialties or national/provincial medical centers
+     - disease-specific centers, MDTs, national quality-control centers, registries, or official hospital specialty pages
+   - Prefer public tertiary hospitals for complex cases unless the user explicitly wants private care or convenience.
+
+3. Discover doctor candidates.
+   - Start from official hospital department/team pages and official appointment pages.
+   - Add doctors from guideline/consensus authorship, academic society roles, clinical trial principal investigators, specialty committee roles, and major disease-center leadership.
+   - Use patient platforms such as 好大夫在线, 微医, 名医汇, 京东健康, or hospital mini-programs as secondary evidence for accessibility, case volume signals, patient language, and recent appointment availability.
+   - Verify doctor identity and practice location when possible with official hospital pages or national physician registration query.
+
+4. Score fit, not celebrity.
+   - Disease/procedure fit and case experience: 40
+   - Hospital/department strength: 25
+   - Individual doctor evidence: 20
+   - Accessibility and logistics: 10
+   - Source reliability and recency: 5
+   - Penalize sponsored rankings, miracle claims, unverifiable titles, stale pages, and doctors whose expertise does not match the exact disease subtype.
+
+5. Output a useful shortlist.
+   - Provide `全国优先`, `区域优先`, and `更容易挂到/先看` tiers when appropriate.
+   - For each candidate include doctor, hospital, department, why this match is strong, evidence used, appointment path, and caveats.
+   - Keep the tone practical: `我找到的证据支持优先考虑`, not `绝对最好`.
+
+## Output Contract
+
+Use Chinese by default unless the user asks otherwise.
+
+For a full answer:
+
+```text
+一句话建议：
+<best practical path>
+
+先确认：
+- <diagnosis/stage/treatment details that would change ranking>
+
+全国优先候选：
+1. <医生>｜<医院>｜<科室>
+   为什么：<disease-specific reason>
+   证据：<ranking/official page/guideline/society/platform signals>
+   怎么挂：<official appointment path or platform>
+   注意：<availability/logistics/caveat>
+
+区域/可及性候选：
+...
+
+选择策略：
+- <when to choose top national center>
+- <when to choose local tertiary hospital first>
+- <when second opinion or MDT is worth it>
+
+来源与不确定性：
+- <list source types and dates>
+- <state missing info or stale pages>
+```
+
+For a quick answer, return the top 3 hospitals/doctor directions and one next step.
+
+## Boundaries
+
+- Do not claim that a doctor is the “best” without explaining the evidence and uncertainty.
+- Do not use a single platform score, ad list, or comment count as the ranking basis.
+- Do not recommend medicine, dose, stopping treatment, or bypassing emergency care.
+- Do not expose personal identifiers. Ask users to redact names, ID numbers, phone numbers, medical record numbers, and exact addresses from uploaded records.
+- Do not fabricate appointment availability, pricing, surgery volume, titles, or hospital affiliations.

--- a/skills/find-doctors/agents/openai.yaml
+++ b/skills/find-doctors/agents/openai.yaml
@@ -1,0 +1,4 @@
+interface:
+  display_name: "Find Doctors"
+  short_description: "Finds best-fit mainland China doctors and hospitals for a disease"
+  default_prompt: "Use $find-doctors with a disease name, diagnosis stage, city, and travel preference to build an evidence-based shortlist of mainland China doctors, hospitals, departments, and appointment paths."

--- a/skills/find-doctors/clawhub.json
+++ b/skills/find-doctors/clawhub.json
@@ -1,0 +1,19 @@
+{
+  "name": "find-doctors",
+  "version": "0.1.0",
+  "description": "Evidence-based mainland China doctor and hospital finder for a specific disease, using specialty rankings, official hospital pages, clinical-key-specialty signals, doctor-level evidence, and appointment practicality.",
+  "keywords": [
+    "find-doctors",
+    "find-dcotors",
+    "doctor-finder",
+    "hospital-ranking",
+    "medical-navigation",
+    "China",
+    "mainland-China",
+    "医生推荐",
+    "医院推荐",
+    "挂号",
+    "名医",
+    "专家"
+  ]
+}

--- a/skills/find-doctors/references/methodology.md
+++ b/skills/find-doctors/references/methodology.md
@@ -1,0 +1,241 @@
+# Mainland China Doctor-Finding Methodology
+
+Use this reference when ranking mainland China doctors and hospitals by disease.
+
+## Core Idea
+
+There is no single official, disease-level “best doctor” list for mainland China. A reliable recommendation must triangulate:
+
+1. disease-to-specialty fit
+2. hospital and department strength
+3. doctor-level subspecialty evidence
+4. official identity/appointment verification
+5. practical access for the patient
+
+The answer should help the patient choose a path, not merely display a popularity list.
+
+## Source Priority
+
+### Tier A: Official and institutional evidence
+
+- Official hospital department pages and doctor profiles
+- Official outpatient registration pages, hospital app/mini-program pages, or provincial appointment platforms
+- National Health Commission / government pages for clinical key specialties, clinical guidelines, and physician registration
+- National or regional medical centers and official disease-center pages
+- National clinical quality-control centers when disease-relevant
+
+Use these for identity, affiliation, department, outpatient availability, specialty focus, and institutional capabilities.
+
+### Tier B: Specialty strength rankings
+
+- Fudan University Hospital Management Institute rankings:
+  - specialty reputation
+  - specialty comprehensive rankings
+  - regional rankings
+  - useful for department reputation and referral center discovery
+- Chinese Academy of Medical Sciences hospital science metrics:
+  - STEM / ASTEM
+  - useful for research strength and discipline output
+- National clinical key specialty project lists:
+  - useful as a government-recognized specialty-strength signal
+
+Do not use overall hospital ranking when a specialty ranking exists.
+
+### Tier C: Doctor-level professional evidence
+
+- guideline or expert consensus authorship
+- Chinese Medical Association / Chinese Medical Doctor Association / disease-specific society committee roles
+- clinical trial principal investigator or sub-center PI
+- PubMed, CNKI, Wanfang, hospital news, awards, grants, and major lecture/academic conference roles
+- disease-center or MDT leadership
+- high-volume surgical/procedure responsibility when officially stated
+
+Academic output alone is not enough. Check whether the doctor actually treats the specific disease subtype and patient group.
+
+### Tier D: Patient-facing platforms
+
+- 好大夫在线
+- 微医
+- 名医汇
+- 京东健康 / 百度健康 / 支付宝医疗 / hospital mini-programs
+
+Use these for:
+
+- recent online activity
+- patient language and service style
+- appointment/contact paths
+- rough disease-tag/case-volume signals
+- review patterns
+
+Do not treat platform rankings, paid placement, or review counts as clinical proof.
+
+## Useful Public Source Starting Points
+
+- Fudan hospital ranking portal: https://www.fdygs.com/news222.aspx
+- 健康界 ranking portal mirror/entry: https://rank.cn-healthcare.com/
+- Chinese hospital science metrics portal: https://stem.pumc.edu.cn/2024/STEM/index.htm
+- 2023 STEM/ASTEM discipline entry: https://stem.pumc.edu.cn/2024/STEM/5d09f62775b74c76a1a8014f3dbe74cc.html
+- National clinical key specialty policy example: https://www.nhc.gov.cn/yzygj/c100068/201312/9ff67986ccdf421ab9760cc462eec6ce.shtml
+- 国家临床重点专科能力建设项目 coverage: https://www.gov.cn/xinwen/2021-10/18/content_5643483.htm
+- NHC clinical guidelines / diagnosis and treatment specifications section examples: https://www.nhc.gov.cn/yzygj/c100068/202204/0c1f7d3aca0545abbeb02030ce255930.shtml
+- National physician registration query entry: https://app.gjzwfw.gov.cn/jmopen/webapp/html5/zwfwdoctorsearch/index.html
+- 好大夫在线: https://www.haodf.com/
+
+When answering, cite the specific pages actually used, not only this generic source list.
+
+## Search Recipes
+
+Use combinations like:
+
+- `<疾病> 最好 医生 医院 中国`
+- `<疾病> 专科排名 复旦 医院`
+- `<疾病> 国家临床重点专科 医院`
+- `<疾病> MDT 中心 医院`
+- `<疾病> 指南 专家共识 <医生名>`
+- `<疾病> 临床试验 PI <医院>`
+- `<医院> <科室> <疾病> 专家`
+- `<医生名> <医院> <疾病> 擅长`
+- `<医生名> 主任医师 <疾病> 指南`
+- `site:<hospital-domain> <疾病> <医生名>`
+
+For oncology, refine by tumor type, stage, molecular subtype, and treatment mode:
+
+- `肺癌 EGFR 靶向 医生`
+- `肺结节 微创手术 专家`
+- `乳腺癌 保乳 放疗 专家`
+- `肝癌 介入 MDT 专家`
+
+For pediatrics, add `儿童`, `儿科`, `小儿`, or `儿童医院`.
+
+For rare diseases, add `罕见病`, `诊疗协作网`, `遗传`, `多学科`, or the gene/syndrome name.
+
+## Scoring Rubric
+
+Use this rubric transparently. Adjust weights only when the user's context requires it.
+
+### Disease/procedure fit: 40
+
+High score:
+
+- doctor profile explicitly names the disease/subtype/procedure
+- doctor leads a relevant disease group, MDT, ward, or procedure team
+- evidence of high case exposure or procedure volume from official source
+- patient group matches: adult/pediatric, pregnancy, geriatric, recurrent/refractory, rare disease
+
+Low score:
+
+- only broad department match
+- disease is mentioned only in generic keyword lists
+- doctor focuses on a different subtype or treatment mode
+
+### Hospital/department strength: 25
+
+High score:
+
+- top specialty ranking or strong regional specialty ranking
+- national clinical key specialty or national/provincial medical center
+- official disease center, MDT, or specialized ward
+
+Low score:
+
+- famous hospital but weak/irrelevant department evidence
+- private or online-only source with little official specialty backing
+
+### Doctor-level evidence: 20
+
+High score:
+
+- guideline/consensus author
+- society committee role relevant to the disease
+- clinical trial PI or major research record in the exact domain
+- official leadership role in disease center or specialty group
+
+Low score:
+
+- title only, no disease-specific proof
+- platform popularity without official corroboration
+
+### Accessibility/logistics: 10
+
+High score:
+
+- clear outpatient path
+- reasonable travel fit
+- teleconsult/online follow-up available when appropriate
+- expert clinic, special needs clinic, international department, or MDT path visible
+
+Low score:
+
+- no current appointment path found
+- only historical affiliation
+- impractical travel for non-complex care
+
+### Reliability/recency: 5
+
+High score:
+
+- official or primary sources
+- current year schedules or recently updated pages
+- multiple independent sources agree
+
+Low score:
+
+- stale pages
+- sponsored content
+- copied bios without source
+
+## Ranking Pattern
+
+Prefer this structure:
+
+- `全国优先`: best evidence if the patient can travel and the case is complex
+- `区域优先`: strong options near the patient
+- `先看/更容易挂到`: good triage or first-visit options when the top expert is hard to access
+
+Always explain what changes the recommendation:
+
+- confirmed diagnosis vs suspected disease
+- disease stage/severity
+- treatment mode
+- whether surgery or medication is the main decision
+- pediatric/adult distinction
+- need for second opinion vs first diagnosis
+
+## Red Flags in Doctor-Finding
+
+Be skeptical when:
+
+- the page is marked sponsored, advertorial, or paid ranking
+- claims include “包治”, “根治”, “唯一”, “祖传秘方”, or “不用手术/不用化疗一定治好”
+- hospital or doctor affiliation cannot be verified
+- the doctor appears on many content farms but not on the hospital site
+- review text is repetitive, generic, or promotional
+- a private clinic claims to be the best but has no public tertiary referral or specialist evidence
+
+## Patient-Friendly Decision Advice
+
+Use these practical rules:
+
+- For mild/common diseases, local top tertiary hospital may be better than waiting months for a national celebrity doctor.
+- For complex, rare, recurrent, multi-treatment, surgical, pediatric, or oncology cases, a national/regional specialty center is worth considering.
+- If the diagnosis is uncertain, first choose a strong diagnostic department rather than the most famous treatment specialist.
+- If surgery is possible, prioritize a team with disease-specific procedure experience and multidisciplinary backup.
+- If treatment plans conflict, consider a second opinion from a disease center or MDT clinic.
+- If top doctors are hard to book, first see a strong team member in the same department; many centers operate team-based care.
+
+## Source Citation Standard
+
+In final answers, cite:
+
+- source name
+- page type
+- date accessed or page date when visible
+- what the source proves
+
+Example:
+
+```text
+证据：复旦专科声誉榜支持该院呼吸专科实力；医院官网医生页显示该医生长期负责肺癌/肺结节方向；好大夫页面只作为近期出诊和患者可及性参考。
+```
+
+Do not cite a source for a claim it does not actually prove.


### PR DESCRIPTION
Adds the `find-doctors` skill for evidence-based mainland China doctor and hospital navigation.\n\nThis includes OpenClaw/ClawHub metadata, Hermes tags, and a methodology reference for source triangulation across specialty rankings, official hospital pages, doctor-level evidence, and appointment practicality.