### PR TITLE
fix(gateway): honor proxy env vars in DingTalk, WeCom, and BlueBubbles adapters

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -29,6 +29,7 @@ from gateway.platforms.base import (
     cache_image_from_bytes,
     cache_audio_from_bytes,
     cache_document_from_bytes,
+    resolve_proxy_url,
 )
 from gateway.platforms.helpers import strip_markdown
 
@@ -124,6 +125,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         if not str(self.webhook_path).startswith("/"):
             self.webhook_path = f"/{self.webhook_path}"
         self.send_read_receipts = bool(extra.get("send_read_receipts", True))
+        self._proxy_url: Optional[str] = resolve_proxy_url(platform_env_var="BLUEBUBBLES_PROXY")
         self.client: Optional[httpx.AsyncClient] = None
         self._runner = None
         self._private_api_enabled: Optional[bool] = None
@@ -164,7 +166,10 @@ class BlueBubblesAdapter(BasePlatformAdapter):
 
         # Tighter keepalive so idle CLOSE_WAIT drains promptly (#18451).
         from gateway.platforms._http_client_limits import platform_httpx_limits
-        self.client = httpx.AsyncClient(timeout=30.0, limits=platform_httpx_limits())
+        _httpx_kw: dict = {}
+        if self._proxy_url:
+            _httpx_kw["proxy"] = self._proxy_url
+        self.client = httpx.AsyncClient(timeout=30.0, limits=platform_httpx_limits(), **_httpx_kw)
         try:
             await self._api_get("/api/v1/ping")
             info = await self._api_get("/api/v1/server/info")

--- a/gateway/platforms/dingtalk.py
+++ b/gateway/platforms/dingtalk.py
@@ -94,6 +94,7 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     SendResult,
+    resolve_proxy_url,
 )
 
 logger = logging.getLogger(__name__)
@@ -172,6 +173,8 @@ class DingTalkAdapter(BasePlatformAdapter):
         self._mention_patterns: List[re.Pattern] = self._compile_mention_patterns()
         self._allowed_users: Set[str] = self._load_allowed_users()
 
+        self._proxy_url: Optional[str] = resolve_proxy_url(platform_env_var="DINGTALK_PROXY")
+
         self._stream_client: Any = None
         self._stream_task: Optional[asyncio.Task] = None
         self._http_client: Optional["httpx.AsyncClient"] = None
@@ -230,8 +233,11 @@ class DingTalkAdapter(BasePlatformAdapter):
         try:
             # Tighter keepalive so idle CLOSE_WAIT drains promptly (#18451).
             from gateway.platforms._http_client_limits import platform_httpx_limits
+            _httpx_kw: dict = {}
+            if self._proxy_url:
+                _httpx_kw["proxy"] = self._proxy_url
             self._http_client = httpx.AsyncClient(
-                timeout=30.0, limits=platform_httpx_limits(),
+                timeout=30.0, limits=platform_httpx_limits(), **_httpx_kw
             )
 
             credential = dingtalk_stream.Credential(

--- a/gateway/platforms/wecom.py
+++ b/gateway/platforms/wecom.py
@@ -67,6 +67,8 @@ from gateway.platforms.base import (
     SendResult,
     cache_document_from_bytes,
     cache_image_from_bytes,
+    proxy_kwargs_for_aiohttp,
+    resolve_proxy_url,
 )
 
 logger = logging.getLogger(__name__)
@@ -167,6 +169,8 @@ class WeComAdapter(BasePlatformAdapter):
         self._group_allow_from = _coerce_list(extra.get("group_allow_from") or extra.get("groupAllowFrom"))
         self._groups = extra.get("groups") if isinstance(extra.get("groups"), dict) else {}
 
+        self._proxy_url: str | None = resolve_proxy_url(platform_env_var="WECOM_PROXY")
+
         self._session: Optional["aiohttp.ClientSession"] = None
         self._ws: Optional["aiohttp.ClientWebSocketResponse"] = None
         self._http_client: Optional["httpx.AsyncClient"] = None
@@ -210,8 +214,12 @@ class WeComAdapter(BasePlatformAdapter):
         try:
             # Tighter keepalive so idle CLOSE_WAIT drains promptly (#18451).
             from gateway.platforms._http_client_limits import platform_httpx_limits
+            _httpx_kw: dict = {}
+            if self._proxy_url:
+                _httpx_kw["proxy"] = self._proxy_url
             self._http_client = httpx.AsyncClient(
                 timeout=30.0, follow_redirects=True, limits=platform_httpx_limits(),
+                **_httpx_kw,
             )
             await self._open_connection()
             self._mark_connected()
@@ -273,11 +281,15 @@ class WeComAdapter(BasePlatformAdapter):
     async def _open_connection(self) -> None:
         """Open and authenticate a websocket connection."""
         await self._cleanup_ws()
-        self._session = aiohttp.ClientSession(trust_env=True)
+        sess_kw, req_kw = proxy_kwargs_for_aiohttp(self._proxy_url)
+        self._session = aiohttp.ClientSession(
+            trust_env=(not self._proxy_url), **sess_kw
+        )
         self._ws = await self._session.ws_connect(
             self._ws_url,
             heartbeat=HEARTBEAT_INTERVAL_SECONDS * 2,
             timeout=CONNECT_TIMEOUT_SECONDS,
+            **req_kw,
         )
 
         req_id = self._new_req_id("subscribe")


### PR DESCRIPTION
## Problem

Three platform adapters create their HTTP/WebSocket clients without
consulting proxy configuration:

**DingTalk** (`dingtalk.py`):
```python
self._http_client = httpx.AsyncClient(timeout=30.0, limits=platform_httpx_limits())
# no proxy — HTTPS_PROXY / DINGTALK_PROXY silently ignored
```

**WeCom** (`wecom.py`):
```python
self._http_client = httpx.AsyncClient(timeout=30.0, ...)
# no proxy for HTTP client

self._session = aiohttp.ClientSession(trust_env=True)
self._ws = await self._session.ws_connect(self._ws_url, ...)
# trust_env reads standard env vars but misses macOS system proxy
# and the platform-specific WECOM_PROXY env var
```

**BlueBubbles** (`bluebubbles.py`):
```python
self.client = httpx.AsyncClient(timeout=30.0, limits=platform_httpx_limits())
# no proxy — HTTPS_PROXY / BLUEBUBBLES_PROXY silently ignored
```

Users behind corporate firewalls, GFW, or with macOS system proxies
get no proxy coverage on these platforms even when `HTTPS_PROXY` or a
platform-specific env var is set. DingTalk and WeCom are particularly
affected as they connect to remote Chinese APIs where proxies are
commonly required.

## Fix

Apply `resolve_proxy_url()` from `gateway.platforms.base` in each
adapter's `__init__`, then forward the result to the HTTP/WebSocket
client at connect time — the same pattern used by Telegram, Discord,
Matrix, and Slack.

**DingTalk / BlueBubbles** (httpx only):
```python
self._proxy_url = resolve_proxy_url(platform_env_var="DINGTALK_PROXY")

# in connect():
_httpx_kw: dict = {}
if self._proxy_url:
    _httpx_kw["proxy"] = self._proxy_url
self._http_client = httpx.AsyncClient(..., **_httpx_kw)
```

**WeCom** (httpx + aiohttp WebSocket):
```python
self._proxy_url = resolve_proxy_url(platform_env_var="WECOM_PROXY")

# httpx client — same as above
# aiohttp WebSocket:
sess_kw, req_kw = proxy_kwargs_for_aiohttp(self._proxy_url)
self._session = aiohttp.ClientSession(trust_env=(not self._proxy_url), **sess_kw)
self._ws = await self._session.ws_connect(self._ws_url, ..., **req_kw)
```

`proxy_kwargs_for_aiohttp` returns a `ProxyConnector` for SOCKS proxies
(via aiohttp-socks) or a per-request `proxy=` kwarg for HTTP proxies.
`trust_env` is preserved when no explicit proxy is configured to keep
the existing env-var fall-through behaviour unchanged.

## Proxy env var resolution order (via `resolve_proxy_url`)

1. Platform-specific: `DINGTALK_PROXY` / `WECOM_PROXY` / `BLUEBUBBLES_PROXY`
2. Standard: `HTTPS_PROXY`, `HTTP_PROXY`, `ALL_PROXY` (and lowercase)
3. macOS system proxy (auto-detect via `scutil --proxy`)
4. Bypass if `NO_PROXY` matches the target host

## Out of scope

- **Signal** — `http_url` defaults to `127.0.0.1:8080` (local daemon); proxy for localhost is not useful.
- **WhatsApp** — always connects to `127.0.0.1:{port}` (local bridge process); proxy for localhost is not useful.

## Checklist

- [x] `resolve_proxy_url` and `proxy_kwargs_for_aiohttp` are already exported from `gateway.platforms.base`
- [x] Annotation style matches each file's existing convention (`Optional[str]` for DingTalk/BlueBubbles, `str | None` for WeCom which has `from __future__ import annotations`)
- [x] No proxy configured → zero behavior change (no-op empty kwargs)
- [x] WeCom `trust_env` preserved when no explicit proxy is set