### PR TITLE
feat(skill_manager): honor metadata.hermes.locked frontmatter flag

### DIFF
--- a/tests/tools/test_skill_manager_tool.py
+++ b/tests/tools/test_skill_manager_tool.py
@@ -943,3 +943,161 @@ class TestPinnedGuard:
                        side_effect=RuntimeError("sidecar broken")):
                 result = _delete_skill("my-skill")
         assert result["success"] is True
+
+
+# ---------------------------------------------------------------------------
+# Locked-skill guard — skill_manage refuses ALL write actions on skills whose
+# SKILL.md frontmatter sets `metadata.hermes.locked: true`. Lock is the
+# edit-side counterpart to pin: pin guards delete, lock guards everything.
+# Read actions (skill_view, skills_list) are unaffected — locked skills are
+# still discoverable and loadable, just not writable.
+# ---------------------------------------------------------------------------
+
+LOCKED_SKILL_CONTENT = """\
+---
+name: locked-skill
+description: A skill that opts out of agent modification via the locked flag.
+metadata:
+  hermes:
+    locked: true
+---
+
+# Locked Skill
+
+This skill gates a real-world side effect; agents must not edit it.
+"""
+
+
+class TestLockedGuard:
+    """All write actions refuse on locked skills; create is exempt (no target yet)."""
+
+    def test_edit_refuses_locked(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("locked-skill", LOCKED_SKILL_CONTENT)
+            result = json.loads(skill_manage("edit", "locked-skill", content=VALID_SKILL_CONTENT_2))
+        assert result["success"] is False
+        assert "locked" in result["error"].lower()
+        assert "metadata.hermes.locked" in result["error"]
+        # Content unchanged
+        content = (tmp_path / "locked-skill" / "SKILL.md").read_text()
+        assert "Updated description" not in content
+        assert "locked: true" in content
+
+    def test_patch_refuses_locked(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("locked-skill", LOCKED_SKILL_CONTENT)
+            result = json.loads(skill_manage(
+                "patch", "locked-skill",
+                old_string="gates a real-world",
+                new_string="patched",
+            ))
+        assert result["success"] is False
+        assert "locked" in result["error"].lower()
+        content = (tmp_path / "locked-skill" / "SKILL.md").read_text()
+        assert "patched" not in content
+
+    def test_delete_refuses_locked(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("locked-skill", LOCKED_SKILL_CONTENT)
+            result = json.loads(skill_manage("delete", "locked-skill"))
+        assert result["success"] is False
+        assert "locked" in result["error"].lower()
+        assert (tmp_path / "locked-skill" / "SKILL.md").exists()
+
+    def test_write_file_refuses_locked(self, tmp_path):
+        with _skill_dir(tmp_path):
+            _create_skill("locked-skill", LOCKED_SKILL_CONTENT)
+            result = json.loads(skill_manage(
+                "write_file", "locked-skill",
+                file_path="references/api.md",
+                file_content="content",
+            ))
+        assert result["success"] is False
+        assert "locked" in result["error"].lower()
+        assert not (tmp_path / "locked-skill" / "references" / "api.md").exists()
+
+    def test_remove_file_refuses_locked(self, tmp_path):
+        """Lock blocks remove_file too — even supporting files of a locked skill
+        require the user to lift the lock before they can be deleted."""
+        with _skill_dir(tmp_path):
+            # Create unlocked first so write_file goes through, then upgrade
+            # to locked by editing the frontmatter directly on disk.
+            _create_skill("locked-skill", VALID_SKILL_CONTENT)
+            _write_file("locked-skill", "references/api.md", "content")
+            (tmp_path / "locked-skill" / "SKILL.md").write_text(LOCKED_SKILL_CONTENT)
+            result = json.loads(skill_manage(
+                "remove_file", "locked-skill",
+                file_path="references/api.md",
+            ))
+        assert result["success"] is False
+        assert "locked" in result["error"].lower()
+        assert (tmp_path / "locked-skill" / "references" / "api.md").exists()
+
+    def test_unlocked_skills_still_editable(self, tmp_path):
+        """Sanity check: only the explicitly-locked skill is refused; siblings work."""
+        with _skill_dir(tmp_path):
+            _create_skill("locked-one", LOCKED_SKILL_CONTENT)
+            _create_skill("free-one", VALID_SKILL_CONTENT)
+            blocked = json.loads(skill_manage("edit", "locked-one", content=VALID_SKILL_CONTENT_2))
+            allowed = json.loads(skill_manage("edit", "free-one", content=VALID_SKILL_CONTENT_2))
+        assert blocked["success"] is False
+        assert allowed["success"] is True
+
+    def test_locked_false_does_not_block(self, tmp_path):
+        """Explicit `locked: false` behaves the same as omitting the flag."""
+        content = """\
+---
+name: unlocked-skill
+description: Locked flag explicitly set to false.
+metadata:
+  hermes:
+    locked: false
+---
+
+# Unlocked Skill
+
+Step 1: Do the thing.
+"""
+        with _skill_dir(tmp_path):
+            _create_skill("unlocked-skill", content)
+            result = json.loads(skill_manage(
+                "patch", "unlocked-skill",
+                old_string="Do the thing.",
+                new_string="Do the new thing.",
+            ))
+        assert result["success"] is True, result
+
+    def test_create_is_exempt_but_subsequent_edits_blocked(self, tmp_path):
+        """`create` is bypassed by the lock guard — it cannot target an existing
+        skill so there is nothing to protect at create-time. But the newly-created
+        skill IS locked, so any subsequent edit fails."""
+        with _skill_dir(tmp_path):
+            result = json.loads(skill_manage("create", "new-skill", content=LOCKED_SKILL_CONTENT))
+            assert result["success"] is True, result
+            edit_result = json.loads(skill_manage("edit", "new-skill", content=VALID_SKILL_CONTENT_2))
+        assert edit_result["success"] is False
+        assert "locked" in edit_result["error"].lower()
+
+    def test_broken_frontmatter_fails_open(self, tmp_path):
+        """If SKILL.md is unparseable, the lock guard does not fire.
+
+        Rationale (matches `_pinned_guard`'s broken-sidecar behaviour): a
+        malformed file shouldn't lock the agent out of fixing it. The lock
+        is opt-in for *valid* skills; corruption is a separate concern.
+        """
+        with _skill_dir(tmp_path):
+            _create_skill("my-skill", VALID_SKILL_CONTENT)
+            # Corrupt the frontmatter so YAML parsing finds no `locked` flag.
+            (tmp_path / "my-skill" / "SKILL.md").write_text(
+                "---\nname: my-skill\n: : : invalid yaml\n---\n\nbody\n"
+            )
+            result = json.loads(skill_manage(
+                "patch", "my-skill",
+                old_string="body",
+                new_string="patched",
+            ))
+        # The lock guard MUST NOT block on missing/unparseable frontmatter.
+        # (The patch itself may fail for an unrelated reason — e.g. the
+        # frontmatter validator — but not because of locked.)
+        if not result["success"]:
+            assert "locked" not in result["error"].lower(), result

--- a/tools/skill_manager_tool.py
+++ b/tools/skill_manager_tool.py
@@ -161,6 +161,61 @@ def _pinned_guard(name: str) -> Optional[str]:
     return None
 
 
+def _locked_guard(name: str) -> Optional[str]:
+    """Return a refusal message if *name* is locked, else None.
+
+    Lock protects a skill from **modification** by ``skill_manage`` — its
+    SKILL.md and supporting files cannot be edited, patched, deleted, or
+    overwritten while the lock is in effect.
+
+    A skill opts in by setting ``metadata.hermes.locked: true`` in its
+    SKILL.md frontmatter. The default (no flag, or ``locked: false``)
+    preserves existing behaviour — agents can freely edit user skills.
+
+    Lock is the edit-side counterpart to ``_pinned_guard`` (which guards
+    delete only):
+
+        ``_pinned_guard``  blocks: delete
+                           opt-in:  ``hermes curator pin <name>``
+        ``_locked_guard``  blocks: edit, patch, delete, write_file, remove_file
+                           opt-in:  ``metadata.hermes.locked: true`` in SKILL.md
+
+    Use case: skills that gate real-world side effects (financial transfers,
+    device control, message dispatch) where silent drift via the background
+    self-improvement loop or an in-conversation patch is unacceptable. The
+    skill author sets the flag once; subsequent ``skill_manage`` writes are
+    refused with a message instructing the user (not the agent) to lift the
+    lock by hand.
+
+    Best-effort: if SKILL.md is missing or its frontmatter is unparseable
+    the write is allowed through, mirroring the resilient fallback in
+    ``_pinned_guard``. The lock should fail open rather than break the
+    agent on a malformed file.
+    """
+    try:
+        existing = _find_skill(name)
+        if not existing:
+            return None
+        skill_md = existing["path"] / "SKILL.md"
+        if not skill_md.exists():
+            return None
+        from agent.skill_utils import parse_frontmatter
+        fm, _body = parse_frontmatter(skill_md.read_text(encoding="utf-8"))
+        hermes_meta = (fm.get("metadata") or {}).get("hermes") or {}
+        if hermes_meta.get("locked") is True:
+            return (
+                f"Skill '{name}' is locked (metadata.hermes.locked: true) "
+                f"and cannot be modified by skill_manage. The lock prevents "
+                f"silent drift in skills that gate real-world side effects. "
+                f"To change it, ask the user to edit SKILL.md directly, or "
+                f"to set `metadata.hermes.locked: false` in its frontmatter "
+                f"first."
+            )
+    except Exception:
+        logger.debug("locked-guard lookup failed for %s", name, exc_info=True)
+    return None
+
+
 MAX_SKILL_CONTENT_CHARS = 100_000   # ~36k tokens at 2.75 chars/token
 MAX_SKILL_FILE_BYTES = 1_048_576    # 1 MiB per supporting file
 
@@ -727,6 +782,14 @@ def skill_manage(
 
     Returns JSON string with results.
     """
+    # Lock guard — any write action against a locked skill is refused.
+    # `create` is exempt because it cannot target an existing skill (it
+    # would error in _create_skill anyway if the name was already taken).
+    if action in ("edit", "patch", "delete", "write_file", "remove_file"):
+        locked_err = _locked_guard(name)
+        if locked_err:
+            return tool_error(locked_err, success=False)
+
     if action == "create":
         if not content:
             return tool_error("content is required for 'create'. Provide the full SKILL.md text (frontmatter + body).", success=False)
@@ -824,7 +887,14 @@ SKILL_MANAGE_SCHEMA = {
         "Pinned skills are protected from deletion only — skill_manage(action='delete') "
         "will refuse with a message pointing the user to `hermes curator unpin <name>`. "
         "Patches and edits go through on pinned skills so you can still improve them as "
-        "pitfalls come up; pin only guards against irrecoverable loss."
+        "pitfalls come up; pin only guards against irrecoverable loss.\n\n"
+        "Locked skills (frontmatter `metadata.hermes.locked: true`) are protected from "
+        "all modification — edit, patch, delete, write_file, and remove_file all refuse. "
+        "Lock is the edit-side counterpart to pin: pin guards against accidental deletion, "
+        "lock guards against drift. Use locks for skills that gate real-world side effects "
+        "(financial transfers, device control, message dispatch) where silent agent edits "
+        "are unsafe. To modify a locked skill, the user must edit SKILL.md by hand or "
+        "remove the flag from the frontmatter first — never attempt to bypass it."
     ),
     "parameters": {
         "type": "object",


### PR DESCRIPTION
## Summary

Adds `_locked_guard()` as the **edit-side counterpart to `_pinned_guard()`**. A skill opts in by setting `metadata.hermes.locked: true` in its SKILL.md frontmatter; subsequent `skill_manage` write actions (`edit`, `patch`, `delete`, `write_file`, `remove_file`) are refused with a message instructing the user — not the agent — to lift the lock by hand. Read actions are unaffected.

The default behaviour (no flag, or `locked: false`) is preserved exactly.

```
_pinned_guard  blocks: delete
               opt-in: `hermes curator pin <name>`
_locked_guard  blocks: edit, patch, delete, write_file, remove_file
               opt-in: `metadata.hermes.locked: true` in SKILL.md
```

## Motivation

The background self-improvement loop (`_spawn_background_review`) plus the in-conversation `skill_manage` schema (which actively encourages patching during the run) can silently rewrite *any* user skill. For skills that gate real-world side effects — financial transfers, device control, message dispatch — silent drift is unsafe. This was filed previously as #20273 (background-review + curator overwriting bundled/hub skills) and the user-facing concern is the same as in #17583 (no distinction between *"user authored, do not touch"* and *"agent generated, fair game"*).

A concrete failure mode I hit while building a Mode-B style stub skill: between two runs, the SKILL.md was rewritten by the agent to match the latest cron prompt's overrides — the city changed, the data source changed, the deterministic side-effect script was deleted from the workflow, and a new hard rule *"no device control, ever, in this skill version"* appeared. Nothing was logged beyond a single `💾 Skill patched` line. The next run executed the rewritten version as if it were the user's design.

That is exactly the drift pattern this flag prevents.

## Why this PR is compatible with the wontfix reasoning on #21315

#21315 proposed `skills.evolution_mode = auto|confirm|readonly`. It was closed (NOT_PLANNED) on three grounds:

1. **No new UX surface needed** — every mutation already goes through `skills_guard` and the curator takes snapshots that can be rolled back from.
2. **`readonly` disables a headline feature** — making self-improvement gateable globally is *"fighting the product, not extending it."*
3. **Precision over gating** — bad patches should be fixed by improving the reviewer's heuristics, not by asking the user to triage every patch.

This PR is deliberately a much smaller change shaped to fit those constraints:

- **No new UX surface.** No pending queue, no `/skills review` slash command, no diff prompts, no platform confirm/reject flow. The lock is a single frontmatter boolean checked at the existing tool boundary.
- **Does not disable the self-improvement loop.** The default behaviour is unchanged; 99% of skills remain mutable. Lock is *opt-in per skill*, intended for the rare ones that gate side effects the user cannot afford to have rewritten.
- **Does not ask the user to triage every patch.** The user authors the lock once when they create the sensitive skill. There is no per-run interaction, no notification queue, no review backlog.
- **Symmetric with an existing mechanism.** `_pinned_guard` already guards deletes via the same shape (advisory check, opt-in per skill, fails open on broken metadata). This adds the missing edit-side counterpart that #18354 essentially argued for ("two different concerns that should not be conflated"). Where #18354 wanted pin split into delete-protection + edit-protection, this PR keeps pin as-is and introduces lock as the separate edit-protection axis.

It also addresses #20273's narrower bug surface for user-authored skills: a locked skill cannot be silently rewritten by the background-review agent even when it passes the security guard. (Bundled-skill protection per PR #19379 is orthogonal; this PR does not touch that path.)

## What this PR deliberately does NOT do

- Does not add a config-level kill switch for the background reviewer (per #21315's #2).
- Does not add cryptographic provenance for skill mutations (out of scope; see #11692 for that conversation).
- Does not change pin semantics. Pin still means delete-protection only.
- Does not change `_create_skill`. `create` cannot target an existing skill so there is nothing to protect at create-time; the newly-created skill IS subject to the lock once it exists.

## Implementation

1. New `_locked_guard(name)` in `tools/skill_manager_tool.py`, placed next to `_pinned_guard` for visible symmetry. Reads the target skill's `SKILL.md` frontmatter via the existing `agent.skill_utils.parse_frontmatter` helper; checks `metadata.hermes.locked is True`.
2. One dispatch hook in `skill_manage()` before the action handlers run, gating the five write actions.
3. Schema docstring updated alongside the existing "Pinned skills are protected from deletion" paragraph so the agent knows what to expect when a write is refused.
4. Fails open on missing or unparseable frontmatter — mirrors `_pinned_guard`'s broken-sidecar handling. A corrupted file should never trap the agent.

Net diff: +229 / -1 across two files. The non-test portion is +72 / -1 in `skill_manager_tool.py`: the function (~40 lines), the dispatch hook (5 lines), the schema-doc update (8 lines), plus blank lines.

## Tests

`tests/tools/test_skill_manager_tool.py::TestLockedGuard` — 9 cases mirroring `TestPinnedGuard`'s structure:

- One refusal test per blocked action (`edit`, `patch`, `delete`, `write_file`, `remove_file`).
- `test_unlocked_skills_still_editable` — sanity check that only the explicitly-locked skill is refused; siblings work.
- `test_locked_false_does_not_block` — explicit `locked: false` behaves identically to omitting the flag.
- `test_create_is_exempt_but_subsequent_edits_blocked` — create-time bypass + post-create lock enforcement.
- `test_broken_frontmatter_fails_open` — unparseable YAML does not falsely trigger the lock.

All 95 tests in `test_skill_manager_tool.py` pass locally (8 existing pin tests + 9 new lock tests + 78 unrelated). No existing test was modified.

## Related

- #21315 — RFC (closed wontfix). Same concern, larger surface. This PR is the smallest change I could shape to address the underlying problem while staying compatible with the maintainers' three objections.
- #20273 — Bug report on background-review writing bundled skills. Lock addresses the user-authored-skill side of the same surface (bundled is PR #19379's territory).
- #17583 — Earlier RFC for user-locked vs self-improving tiers. Same conceptual split; this PR implements only the per-skill opt-in lock, no global tier system.
- #18354 — Argued pin should split into delete-protection + edit-protection. This PR resolves the underlying tension by adding lock as the edit-protection axis rather than splitting pin.

## Test plan

- [x] `pytest tests/tools/test_skill_manager_tool.py::TestLockedGuard` passes (9/9).
- [x] `pytest tests/tools/test_skill_manager_tool.py::TestPinnedGuard` still passes (8/8) — no regression in the existing guard.
- [x] `pytest tests/tools/test_skill_manager_tool.py` full file passes (95/95).
- [ ] Manual smoke test: add `metadata.hermes.locked: true` to a real skill and attempt patch from a chat session — expect refusal.