### PR TITLE
fix(mattermost): support send_message attachments

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -25,6 +25,7 @@ from tools.send_message_tool import (
     _derive_forum_thread_name,
     _parse_target_ref,
     _send_discord,
+    _send_mattermost_via_adapter,
     _send_matrix_via_adapter,
     _send_signal,
     _send_telegram,
@@ -1242,6 +1243,124 @@ class TestSendToPlatformDiscordMedia:
         send_mock.assert_awaited_once()
         call_kwargs = send_mock.await_args.kwargs
         assert call_kwargs["media_files"] == [("/fake/img.png", False)]
+
+
+class TestSendToPlatformMattermostMedia:
+    """_send_to_platform routes Mattermost media correctly."""
+
+    def test_media_files_passed_on_last_chunk_only(self):
+        call_log = []
+
+        async def mock_send_mattermost(pconfig, chat_id, message, media_files=None, thread_id=None):
+            call_log.append({"message": message, "media_files": media_files or []})
+            return {"success": True, "platform": "mattermost", "chat_id": chat_id, "message_id": "1"}
+
+        from gateway.platform_registry import PlatformEntry, platform_registry
+
+        long_msg = "A" * 7000 + " " + "B" * 7000
+        platform_registry.register(
+            PlatformEntry(
+                name="mattermost",
+                label="Mattermost",
+                adapter_factory=lambda cfg: None,
+                check_fn=lambda: True,
+                max_message_length=12000,
+            )
+        )
+
+        try:
+            with patch("tools.send_message_tool._send_mattermost_via_adapter", side_effect=mock_send_mattermost):
+                result = asyncio.run(
+                    _send_to_platform(
+                        Platform.MATTERMOST,
+                        SimpleNamespace(enabled=True, token="tok", extra={}),
+                        "mm-channel",
+                        long_msg,
+                        media_files=[("/fake/img.png", False)],
+                    )
+                )
+        finally:
+            platform_registry.unregister("mattermost")
+
+        assert result["success"] is True
+        assert len(call_log) == 2
+        assert call_log[0]["media_files"] == []
+        assert call_log[1]["media_files"] == [("/fake/img.png", False)]
+
+    def test_media_only_message_uses_native_mattermost_delivery(self):
+        helper = AsyncMock(return_value={"success": True, "platform": "mattermost", "chat_id": "mm", "message_id": "2"})
+
+        with patch("tools.send_message_tool._send_mattermost_via_adapter", helper), \
+             patch("tools.send_message_tool._send_mattermost", AsyncMock(side_effect=AssertionError("fallback sender should not be used"))):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.MATTERMOST,
+                    SimpleNamespace(enabled=True, token="tok", extra={}),
+                    "mm",
+                    "",
+                    media_files=[("/fake/doc.pdf", False)],
+                )
+            )
+
+        assert result["success"] is True
+        helper.assert_awaited_once()
+
+
+class TestSendMattermostViaAdapter:
+    def test_sends_document(self, tmp_path):
+        doc = tmp_path / "notes.txt"
+        doc.write_text("hello")
+
+        adapter = MagicMock()
+        adapter.connect = AsyncMock(return_value=True)
+        adapter.disconnect = AsyncMock()
+        adapter.send = AsyncMock(return_value=SimpleNamespace(success=True, message_id="text1"))
+        adapter.send_image_file = AsyncMock()
+        adapter.send_video = AsyncMock()
+        adapter.send_voice = AsyncMock()
+        adapter.send_document = AsyncMock(return_value=SimpleNamespace(success=True, message_id="doc1"))
+
+        with patch("gateway.platforms.mattermost.MattermostAdapter", new=MagicMock(return_value=adapter)):
+            result = asyncio.run(
+                _send_mattermost_via_adapter(
+                    SimpleNamespace(enabled=True, token="tok", extra={}),
+                    "mm-channel",
+                    "caption",
+                    media_files=[(str(doc), False)],
+                )
+            )
+
+        assert result["success"] is True
+        adapter.connect.assert_awaited_once()
+        adapter.send.assert_awaited_once()
+        adapter.send_document.assert_awaited_once()
+        adapter.send_image_file.assert_not_awaited()
+        adapter.send_video.assert_not_awaited()
+        adapter.disconnect.assert_awaited_once()
+
+    def test_missing_media_returns_error(self):
+        adapter = MagicMock()
+        adapter.connect = AsyncMock(return_value=True)
+        adapter.disconnect = AsyncMock()
+        adapter.send = AsyncMock()
+        adapter.send_image_file = AsyncMock()
+        adapter.send_video = AsyncMock()
+        adapter.send_voice = AsyncMock()
+        adapter.send_document = AsyncMock()
+
+        with patch("gateway.platforms.mattermost.MattermostAdapter", new=MagicMock(return_value=adapter)):
+            result = asyncio.run(
+                _send_mattermost_via_adapter(
+                    SimpleNamespace(enabled=True, token="tok", extra={}),
+                    "mm-channel",
+                    "",
+                    media_files=[("/nonexistent/file.png", False)],
+                )
+            )
+
+        assert "error" in result
+        assert "Media file not found" in result["error"]
+        adapter.disconnect.assert_awaited_once()
 
 
 class TestSendMatrixUrlEncoding:

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -664,6 +664,23 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
             last_result = result
         return last_result
 
+    # --- Mattermost: native media attachment support via adapter ---
+    if platform == Platform.MATTERMOST and media_files:
+        last_result = None
+        for i, chunk in enumerate(chunks):
+            is_last = (i == len(chunks) - 1)
+            result = await _send_mattermost_via_adapter(
+                pconfig,
+                chat_id,
+                chunk,
+                media_files=media_files if is_last else [],
+                thread_id=thread_id,
+            )
+            if isinstance(result, dict) and result.get("error"):
+                return result
+            last_result = result
+        return last_result
+
     # --- Feishu: native media attachment support via adapter ---
     if platform == Platform.FEISHU and media_files:
         last_result = None
@@ -685,7 +702,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files and not message.strip():
         return {
             "error": (
-                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu; "
+                f"send_message MEDIA delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, mattermost and feishu; "
                 f"target {platform.value} had only media attachments"
             )
         }
@@ -693,7 +710,7 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
     if media_files:
         warning = (
             f"MEDIA attachments were omitted for {platform.value}; "
-            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao and feishu"
+            "native send_message media delivery is currently only supported for telegram, discord, matrix, weixin, signal, yuanbao, mattermost and feishu"
         )
 
     last_result = None
@@ -1563,6 +1580,66 @@ async def _send_matrix_via_adapter(pconfig, chat_id, message, media_files=None, 
         }
     except Exception as e:
         return _error(f"Matrix send failed: {e}")
+    finally:
+        try:
+            await adapter.disconnect()
+        except Exception:
+            pass
+
+
+async def _send_mattermost_via_adapter(pconfig, chat_id, message, media_files=None, thread_id=None):
+    """Send via the Mattermost adapter so native file uploads are preserved."""
+    try:
+        from gateway.platforms.mattermost import MattermostAdapter
+    except ImportError:
+        return {"error": "Mattermost adapter not available."}
+
+    media_files = media_files or []
+
+    try:
+        adapter = MattermostAdapter(pconfig)
+        connected = await adapter.connect()
+        if not connected:
+            return _error("Mattermost connect failed")
+
+        metadata = {"thread_id": thread_id} if thread_id else None
+        last_result = None
+
+        if message.strip():
+            last_result = await adapter.send(chat_id, message, metadata=metadata)
+            if not last_result.success:
+                return _error(f"Mattermost send failed: {last_result.error}")
+
+        for media_path, is_voice in media_files:
+            if not os.path.exists(media_path):
+                return _error(f"Media file not found: {media_path}")
+
+            ext = os.path.splitext(media_path)[1].lower()
+            if ext in _IMAGE_EXTS:
+                last_result = await adapter.send_image_file(chat_id, media_path, metadata=metadata)
+            elif ext in _VIDEO_EXTS:
+                last_result = await adapter.send_video(chat_id, media_path, metadata=metadata)
+            elif ext in _VOICE_EXTS and is_voice:
+                last_result = await adapter.send_voice(chat_id, media_path, metadata=metadata)
+            elif ext in _AUDIO_EXTS:
+                last_result = await adapter.send_voice(chat_id, media_path, metadata=metadata)
+            else:
+                last_result = await adapter.send_document(chat_id, media_path, metadata=metadata)
+
+            if not last_result.success:
+                return _error(f"Mattermost media send failed: {last_result.error}")
+
+        if last_result is None:
+            return {"error": "No deliverable text or media remained after processing MEDIA tags"}
+
+        return {
+            "success": True,
+            "platform": "mattermost",
+            "chat_id": chat_id,
+            "message_id": last_result.message_id,
+        }
+    except Exception as e:
+        return _error(f"Mattermost send failed: {e}")
     finally:
         try:
             await adapter.disconnect()


### PR DESCRIPTION
## What does this PR do?

Adds native Mattermost attachment delivery to `send_message` so file uploads are no longer dropped at the tool layer. Mattermost's gateway adapter already supports file uploads, but `tools/send_message_tool.py` only enabled native media delivery for telegram/discord/matrix/weixin/signal/yuanbao/feishu, so Mattermost requests either lost attachments or errored on media-only sends.

## Related Issue

Fixes #23704

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- add a Mattermost native-media branch in `/tools/send_message_tool.py` so `send_message` routes attachments through the adapter instead of the text-only fallback
- add `_send_mattermost_via_adapter(...)` to preserve existing Mattermost upload behavior for images, video, voice/audio, and documents
- update the fallback error/warning strings so the supported-platform list includes Mattermost
- add regression tests in `/tests/tools/test_send_message_tool.py` covering chunked delivery, media-only delivery, document upload routing, and missing-file errors

## How to Test

1. Run `uv run --frozen pytest -q -o addopts='' tests/tools/test_send_message_tool.py -k 'mattermost'`
2. Run `env -i PATH="$PATH" HOME="$HOME" TERM="${TERM:-xterm-256color}" uv run --frozen pytest --collect-only -q -o addopts='' tests/tools/test_send_message_tool.py -k 'mattermost'`
3. Run `uv run --frozen ruff check tools/send_message_tool.py tests/tools/test_send_message_tool.py scripts/lint_diff.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.x

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `4 passed, 104 deselected in 0.66s`
- `4/108 tests collected (104 deselected)`
- `ruff check` passed on the touched files
