### PR TITLE
feat: fallback to OpenRouter API for unknown model pricing

### DIFF
--- a/agent/usage_pricing.py
+++ b/agent/usage_pricing.py
@@ -655,7 +655,18 @@ def get_pricing_entry(
         )
         if entry:
             return entry
-    return _lookup_official_docs_pricing(route)
+    entry = _lookup_official_docs_pricing(route)
+    if entry:
+        return entry
+    # Fallback: try OpenRouter's model API as a generic pricing source.
+    # OpenRouter's /v1/models endpoint returns pricing for almost every
+    # publicly-routed model, so this covers models not in our hardcoded
+    # lookup — e.g. deepseek-v4-flash, gpt-5.x, date-suffixed variants.
+    try:
+        return _openrouter_pricing_entry(route)
+    except Exception:
+        pass
+    return None
 
 
 def normalize_usage(


### PR DESCRIPTION
When `get_pricing_entry()` cannot find pricing in the hardcoded `_OFFICIAL_DOCS_PRICING` dict or from the endpoints own `/v1/models` response, fall back to querying OpenRouters model pricing API.

This solves several real problems:
- **New model IDs missing from the hardcoded snapshot**: e.g. `deepseek-v4-flash`, `deepseek-v4-pro`, `gpt-5.4`, `gpt-5.5` — the dict only has legacy aliases like `deepseek-chat`
- **Date-suffixed model variants**: `gpt-4o-2025-08-06`, `claude-opus-4-7-20250507` etc. that dont match the canonical names
- **Any provider routed through a non-OpenRouter base URL**: after failing endpoint metadata and hardcoded lookup, we still try OpenRouter as a fallback pricing source

OpenRouters `GET /v1/models` returns pricing data for virtually every publicly-routed model, and no API key is required to read it. This removes the need to maintain a complete offline pricing catalog.

**Testing:** All 315 related tests pass (test_usage_pricing.py + test_model_metadata.py + test_hermes_state.py).