### PR TITLE
 fix(cron): serialize job file updates and harden jobs.json auto-repair

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -40,8 +40,10 @@ JOBS_FILE = CRON_DIR / "jobs.json"
 
 # In-process lock protecting load_jobs→modify→save_jobs cycles.
 # Required when tick() runs jobs in parallel threads — without this,
-# concurrent mark_job_run / advance_next_run calls can clobber each other.
-_jobs_file_lock = threading.Lock()
+# concurrent create/update/remove/mark_job_run/advance_next_run calls can
+# clobber each other. RLock keeps nested callers safe when a locked path
+# triggers auto-repair and save_jobs() during load_jobs().
+_jobs_file_lock = threading.RLock()
 OUTPUT_DIR = CRON_DIR / "output"
 ONESHOT_GRACE_SECONDS = 120
 
@@ -412,13 +414,15 @@ def load_jobs() -> List[Dict[str, Any]]:
         # Retry with strict=False to handle bare control chars in string values
         try:
             with open(JOBS_FILE, 'r', encoding='utf-8') as f:
-                data = json.loads(f.read(), strict=False)
-                jobs = data.get("jobs", [])
-                if jobs:
-                    # Auto-repair: rewrite with proper escaping
+                raw = f.read()
+            data = json.loads(raw, strict=False)
+            jobs = data.get("jobs", [])
+            if jobs:
+                # Auto-repair: rewrite with proper escaping
+                with _jobs_file_lock:
                     save_jobs(jobs)
-                    logger.warning("Auto-repaired jobs.json (had invalid control characters)")
-                return jobs
+                logger.warning("Auto-repaired jobs.json (had invalid control characters)")
+            return jobs
         except Exception as e:
             logger.error("Failed to auto-repair jobs.json: %s", e)
             raise RuntimeError(f"Cron database corrupted and unrepairable: {e}") from e
@@ -629,9 +633,10 @@ def create_job(
         "workdir": normalized_workdir,
     }
 
-    jobs = load_jobs()
-    jobs.append(job)
-    save_jobs(jobs)
+    with _jobs_file_lock:
+        jobs = load_jobs()
+        jobs.append(job)
+        save_jobs(jobs)
 
     return job
 
@@ -655,50 +660,72 @@ def list_jobs(include_disabled: bool = False) -> List[Dict[str, Any]]:
 
 def update_job(job_id: str, updates: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     """Update a job by ID, refreshing derived schedule fields when needed."""
-    jobs = load_jobs()
-    for i, job in enumerate(jobs):
-        if job["id"] != job_id:
-            continue
+    with _jobs_file_lock:
+        jobs = load_jobs()
+        for i, job in enumerate(jobs):
+            if job["id"] != job_id:
+                continue
 
-        # Validate / normalize workdir if present in updates.  Empty string or
-        # None both mean "clear the field" (restore old behaviour).
-        if "workdir" in updates:
-            _wd = updates["workdir"]
-            if _wd in (None, "", False):
-                updates["workdir"] = None
-            else:
-                updates["workdir"] = _normalize_workdir(_wd)
+            normalized_updates = dict(updates)
 
-        updated = _apply_skill_fields({**job, **updates})
-        schedule_changed = "schedule" in updates
+            if "model" in normalized_updates:
+                _model = normalized_updates["model"]
+                normalized_updates["model"] = str(_model).strip() if isinstance(_model, str) else None
+                normalized_updates["model"] = normalized_updates["model"] or None
 
-        if "skills" in updates or "skill" in updates:
-            normalized_skills = _normalize_skill_list(updated.get("skill"), updated.get("skills"))
-            updated["skills"] = normalized_skills
-            updated["skill"] = normalized_skills[0] if normalized_skills else None
+            if "provider" in normalized_updates:
+                _provider = normalized_updates["provider"]
+                normalized_updates["provider"] = str(_provider).strip() if isinstance(_provider, str) else None
+                normalized_updates["provider"] = normalized_updates["provider"] or None
 
-        if schedule_changed:
-            updated_schedule = updated["schedule"]
-            # The API may pass schedule as a raw string (e.g. "every 10m")
-            # instead of a pre-parsed dict.  Normalize it the same way
-            # create_job() does so downstream code can call .get() safely.
-            if isinstance(updated_schedule, str):
-                updated_schedule = parse_schedule(updated_schedule)
-                updated["schedule"] = updated_schedule
-            updated["schedule_display"] = updates.get(
-                "schedule_display",
-                updated_schedule.get("display", updated.get("schedule_display")),
-            )
-            if updated.get("state") != "paused":
-                updated["next_run_at"] = compute_next_run(updated_schedule)
+            if "base_url" in normalized_updates:
+                _base_url = normalized_updates["base_url"]
+                normalized_updates["base_url"] = (
+                    str(_base_url).strip().rstrip("/")
+                    if isinstance(_base_url, str)
+                    else None
+                )
+                normalized_updates["base_url"] = normalized_updates["base_url"] or None
 
-        if updated.get("enabled", True) and updated.get("state") != "paused" and not updated.get("next_run_at"):
-            updated["next_run_at"] = compute_next_run(updated["schedule"])
+            # Validate / normalize workdir if present in updates.  Empty string or
+            # None both mean "clear the field" (restore old behaviour).
+            if "workdir" in normalized_updates:
+                _wd = normalized_updates["workdir"]
+                if _wd in (None, "", False):
+                    normalized_updates["workdir"] = None
+                else:
+                    normalized_updates["workdir"] = _normalize_workdir(_wd)
 
-        jobs[i] = updated
-        save_jobs(jobs)
-        return _normalize_job_record(jobs[i])
-    return None
+            updated = _apply_skill_fields({**job, **normalized_updates})
+            schedule_changed = "schedule" in normalized_updates
+
+            if "skills" in normalized_updates or "skill" in normalized_updates:
+                normalized_skills = _normalize_skill_list(updated.get("skill"), updated.get("skills"))
+                updated["skills"] = normalized_skills
+                updated["skill"] = normalized_skills[0] if normalized_skills else None
+
+            if schedule_changed:
+                updated_schedule = updated["schedule"]
+                # The API may pass schedule as a raw string (e.g. "every 10m")
+                # instead of a pre-parsed dict.  Normalize it the same way
+                # create_job() does so downstream code can call .get() safely.
+                if isinstance(updated_schedule, str):
+                    updated_schedule = parse_schedule(updated_schedule)
+                    updated["schedule"] = updated_schedule
+                updated["schedule_display"] = normalized_updates.get(
+                    "schedule_display",
+                    updated_schedule.get("display", updated.get("schedule_display")),
+                )
+                if updated.get("state") != "paused":
+                    updated["next_run_at"] = compute_next_run(updated_schedule)
+
+            if updated.get("enabled", True) and updated.get("state") != "paused" and not updated.get("next_run_at"):
+                updated["next_run_at"] = compute_next_run(updated["schedule"])
+
+            jobs[i] = updated
+            save_jobs(jobs)
+            return _normalize_job_record(jobs[i])
+        return None
 
 
 def pause_job(job_id: str, reason: Optional[str] = None) -> Optional[Dict[str, Any]]:
@@ -752,17 +779,18 @@ def trigger_job(job_id: str) -> Optional[Dict[str, Any]]:
 
 def remove_job(job_id: str) -> bool:
     """Remove a job by ID."""
-    jobs = load_jobs()
-    original_len = len(jobs)
-    jobs = [j for j in jobs if j["id"] != job_id]
-    if len(jobs) < original_len:
-        save_jobs(jobs)
-        # Clean up output directory to prevent orphaned dirs accumulating
-        job_output_dir = OUTPUT_DIR / job_id
-        if job_output_dir.exists():
-            shutil.rmtree(job_output_dir)
-        return True
-    return False
+    with _jobs_file_lock:
+        jobs = load_jobs()
+        original_len = len(jobs)
+        jobs = [j for j in jobs if j["id"] != job_id]
+        if len(jobs) < original_len:
+            save_jobs(jobs)
+            # Clean up output directory to prevent orphaned dirs accumulating
+            job_output_dir = OUTPUT_DIR / job_id
+            if job_output_dir.exists():
+                shutil.rmtree(job_output_dir)
+            return True
+        return False
 
 
 def mark_job_run(job_id: str, success: bool, error: Optional[str] = None,

--- a/tests/cron/test_jobs.py
+++ b/tests/cron/test_jobs.py
@@ -227,6 +227,30 @@ class TestJobCRUD:
         assert jobs[0]["schedule_display"] == "every 60m"
         assert jobs[0]["state"] == "scheduled"
 
+    def test_load_jobs_auto_repair_rewrites_invalid_control_chars(self, tmp_cron_dir):
+        raw = (
+            '{\n'
+            '  "jobs": [\n'
+            '    {\n'
+            '      "id": "abc123deadbe",\n'
+            '      "name": "bad job",\n'
+            '      "prompt": "line1\x01line2",\n'
+            '      "schedule": {"kind": "interval", "minutes": 60, "display": "every 60m"},\n'
+            '      "enabled": true\n'
+            '    }\n'
+            '  ]\n'
+            '}\n'
+        )
+        jobs_path = tmp_cron_dir / "cron" / "jobs.json"
+        jobs_path.parent.mkdir(parents=True, exist_ok=True)
+        jobs_path.write_text(raw, encoding="utf-8")
+
+        jobs = load_jobs()
+
+        assert jobs[0]["prompt"] == "line1\x01line2"
+        reloaded = json.loads(jobs_path.read_text(encoding="utf-8"))
+        assert reloaded["jobs"][0]["prompt"] == "line1\u0001line2"
+
     def test_remove_job(self, tmp_cron_dir):
         job = create_job(prompt="Temp job", schedule="30m")
         assert remove_job(job["id"]) is True
@@ -299,6 +323,87 @@ class TestUpdateJob:
     def test_update_nonexistent_returns_none(self, tmp_cron_dir):
         result = update_job("nonexistent_id", {"name": "X"})
         assert result is None
+
+    def test_update_preserves_runtime_overrides_when_not_specified(self, tmp_cron_dir):
+        job = create_job(
+            prompt="Pinned runtime",
+            schedule="every 1h",
+            model="gpt-5.5",
+            provider="openai-codex",
+        )
+
+        updated = update_job(job["id"], {"prompt": "Prompt only update"})
+
+        assert updated is not None
+        assert updated["prompt"] == "Prompt only update"
+        assert updated["model"] == "gpt-5.5"
+        assert updated["provider"] == "openai-codex"
+
+    def test_concurrent_updates_do_not_corrupt_other_jobs(self, tmp_cron_dir):
+        target = create_job(
+            prompt="Target",
+            schedule="every 1h",
+            model="gpt-5.5",
+            provider="openai-codex",
+        )
+        untouched = create_job(
+            prompt="Untouched",
+            schedule="every 2h",
+            model="claude-sonnet-4",
+            provider="openrouter",
+        )
+
+        started = threading.Barrier(3)
+
+        def _run_update(payload):
+            started.wait()
+            update_job(target["id"], payload)
+
+        t1 = threading.Thread(
+            target=_run_update,
+            args=({"skills": ["hermes-memory-compaction"], "prompt": "update-1"},),
+        )
+        t2 = threading.Thread(
+            target=_run_update,
+            args=({"enabled_toolsets": ["terminal", "file", "skills"], "prompt": "update-2"},),
+        )
+
+        t1.start()
+        t2.start()
+        started.wait()
+        t1.join()
+        t2.join()
+
+        reloaded_target = get_job(target["id"])
+        reloaded_untouched = get_job(untouched["id"])
+
+        assert reloaded_target is not None
+        assert reloaded_target["model"] == "gpt-5.5"
+        assert reloaded_target["provider"] == "openai-codex"
+
+        assert reloaded_untouched is not None
+        assert reloaded_untouched["prompt"] == "Untouched"
+        assert reloaded_untouched["model"] == "claude-sonnet-4"
+        assert reloaded_untouched["provider"] == "openrouter"
+
+    def test_update_normalizes_blank_runtime_overrides_to_none(self, tmp_cron_dir):
+        job = create_job(
+            prompt="Pinned runtime",
+            schedule="every 1h",
+            model="gpt-5.5",
+            provider="openai-codex",
+            base_url="https://api.openai.com/v1",
+        )
+
+        updated = update_job(
+            job["id"],
+            {"model": "   ", "provider": "", "base_url": " https://api.openai.com/v1/ "},
+        )
+
+        assert updated is not None
+        assert updated["model"] is None
+        assert updated["provider"] is None
+        assert updated["base_url"] == "https://api.openai.com/v1"
 
 
 class TestPauseResumeJob:

--- a/tests/tools/test_cronjob_tools.py
+++ b/tests/tools/test_cronjob_tools.py
@@ -219,6 +219,29 @@ class TestUnifiedCronjobTool:
         assert updated["job"]["provider"] == "openrouter"
         assert updated["job"]["base_url"] is None
 
+    def test_update_preserves_runtime_overrides_when_not_supplied(self):
+        created = json.loads(
+            cronjob(
+                action="create",
+                prompt="Check",
+                schedule="every 1h",
+                model="gpt-5.5",
+                provider="openai-codex",
+            )
+        )
+
+        updated = json.loads(
+            cronjob(
+                action="update",
+                job_id=created["job_id"],
+                enabled_toolsets=["terminal", "file", "skills"],
+            )
+        )
+
+        assert updated["success"] is True
+        assert updated["job"]["model"] == "gpt-5.5"
+        assert updated["job"]["provider"] == "openai-codex"
+
     def test_create_skill_backed_job(self):
         result = json.loads(
             cronjob(


### PR DESCRIPTION
## Summary

  Fix cron job storage corruption during rapid consecutive updates.

  The main issue was that cron job CRUD paths did not consistently protect the
  `load_jobs() -> modify -> save_jobs()` cycle with `_jobs_file_lock`.

  That left `create_job()`, `update_job()`, and `remove_job()` vulnerable to
  lost-update races against each other and against scheduler-side writes such as
  `mark_job_run()` / `advance_next_run()`. Because the whole `jobs.json` file is
  rewritten each time, one stale writer could silently overwrite unrelated jobs.

  This PR also fixes a second bug in the `load_jobs()` auto-repair path on
  Windows: it attempted to rewrite `jobs.json` while the original file handle was
  still open, causing `PermissionError` during `os.replace()`.

  Fixes #22761.

  ## Changes

  - switch `_jobs_file_lock` from `Lock` to `RLock`
  - protect `create_job()`, `update_job()`, and `remove_job()` with the same file lock
  - ensure `load_jobs()` auto-repair rewrites `jobs.json` only after closing the read handle
  - route auto-repair rewrites through the shared file lock
  - normalize `model`, `provider`, and `base_url` in `update_job()` the same way as `create_job()`

  ## Why this fixes the issue

  Before this change:
  - rapid consecutive updates could race on `jobs.json`
  - stale snapshots could overwrite unrelated jobs
  - runtime override fields like `model` / `provider` were especially easy to lose
    because they are often omitted from partial updates
  - on Windows, the auto-repair path could fail while trying to rewrite an
    invalid `jobs.json`

  After this change:
  - all mutating cron job file operations serialize through the same lock
  - auto-repair no longer rewrites while the source file is still open
  - partial updates preserve existing runtime override fields unless explicitly changed

  ## Tests

  Added regression coverage for:
  - preserving `model/provider` when update payloads do not specify them
  - concurrent updates to one job not corrupting another job
  - blank runtime override values normalizing consistently
  - `cronjob(action="update")` preserving runtime overrides when not supplied
  - `load_jobs()` auto-repair successfully rewriting invalid control characters

  ## Validation

  Passed:

  - `venv\Scripts\python.exe -m pytest tests\cron\test_jobs.py -k auto_repair_rewrites_invalid_control_chars -q`
  - `venv\Scripts\python.exe -m pytest tests\cron\test_jobs.py tests\tools\test_cronjob_tools.py -q