### PR TITLE
feat: add cron run history and status summary

### DIFF
--- a/cron/jobs.py
+++ b/cron/jobs.py
@@ -43,6 +43,8 @@ JOBS_FILE = CRON_DIR / "jobs.json"
 # concurrent mark_job_run / advance_next_run calls can clobber each other.
 _jobs_file_lock = threading.Lock()
 OUTPUT_DIR = CRON_DIR / "output"
+RUNS_FILE = CRON_DIR / "runs.jsonl"
+_runs_file_lock = threading.Lock()
 ONESHOT_GRACE_SECONDS = 120
 
 
@@ -995,6 +997,76 @@ def save_job_output(job_id: str, output: str):
         raise
     
     return output_file
+
+
+def append_run_history(record: Dict[str, Any]) -> None:
+    """Append one structured cron run-history row to runs.jsonl."""
+    ensure_dirs()
+    row = dict(record)
+    row.setdefault("schema_version", 1)
+    row.setdefault("event_type", "run_attempt")
+    line = json.dumps(row, ensure_ascii=False, sort_keys=True) + "\n"
+
+    with _runs_file_lock:
+        with open(RUNS_FILE, "a", encoding="utf-8") as f:
+            f.write(line)
+            f.flush()
+            os.fsync(f.fileno())
+        _secure_file(RUNS_FILE)
+
+
+def list_run_history(
+    job_id: Optional[str] = None,
+    limit: int = 50,
+    since: Optional[str] = None,
+    until: Optional[str] = None,
+    status: Optional[Union[str, List[str]]] = None,
+) -> List[Dict[str, Any]]:
+    """Return recent cron run-history rows, newest first.
+
+    Readers intentionally tolerate malformed/partial JSONL lines so a torn
+    final append never prevents the CLI/dashboard from reading older rows.
+    """
+    ensure_dirs()
+    if limit <= 0:
+        return []
+    if not RUNS_FILE.exists():
+        return []
+
+    statuses = None
+    if status is not None:
+        if isinstance(status, str):
+            statuses = {status}
+        else:
+            statuses = {str(item) for item in status}
+
+    rows: List[Dict[str, Any]] = []
+    with _runs_file_lock:
+        with open(RUNS_FILE, "r", encoding="utf-8") as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    row = json.loads(line)
+                except json.JSONDecodeError:
+                    logger.warning("Skipping malformed cron run-history row")
+                    continue
+                if not isinstance(row, dict):
+                    continue
+                row_started = str(row.get("started_at") or "")
+                if job_id and row.get("job_id") != job_id:
+                    continue
+                if statuses is not None and row.get("status") not in statuses:
+                    continue
+                if since and row_started and row_started < since:
+                    continue
+                if until and row_started and row_started > until:
+                    continue
+                rows.append(row)
+
+    rows.sort(key=lambda r: str(r.get("started_at") or ""), reverse=True)
+    return rows[:limit]
 
 
 # =============================================================================

--- a/cron/scheduler.py
+++ b/cron/scheduler.py
@@ -11,12 +11,16 @@ runs at a time if multiple processes overlap.
 import asyncio
 import concurrent.futures
 import contextvars
+import hashlib
 import json
 import logging
 import os
+import re
 import shutil
 import subprocess
 import sys
+import time
+import uuid
 
 # fcntl is Unix-only; on Windows use msvcrt for file locking
 try:
@@ -121,12 +125,325 @@ _LEGACY_HOME_TARGET_ENV_VARS = {
     "QQBOT_HOME_CHANNEL": "QQ_HOME_CHANNEL",
 }
 
-from cron.jobs import get_due_jobs, mark_job_run, save_job_output, advance_next_run
+from cron.jobs import (
+    advance_next_run,
+    append_run_history,
+    get_due_jobs,
+    get_job,
+    mark_job_run,
+    save_job_output,
+)
 
 # Sentinel: when a cron agent has nothing new to report, it can start its
 # response with this marker to suppress delivery.  Output is still saved
 # locally for audit.
 SILENT_MARKER = "[SILENT]"
+
+
+def _job_mode(job: dict) -> str:
+    return "no_agent" if job.get("no_agent") else "agent"
+
+
+def _schedule_kind(job: dict) -> str:
+    schedule = job.get("schedule")
+    if isinstance(schedule, dict):
+        return str(schedule.get("kind") or "unknown")
+    return "unknown"
+
+
+def _normalize_history_skills(job: dict) -> list[str]:
+    raw = job.get("skills")
+    if raw is None:
+        raw_items = [job.get("skill")] if job.get("skill") else []
+    elif isinstance(raw, str):
+        raw_items = [raw]
+    else:
+        raw_items = list(raw)
+    normalized: list[str] = []
+    for item in raw_items:
+        text = str(item or "").strip()
+        if text and text not in normalized:
+            normalized.append(text)
+    return normalized
+
+
+def _error_type(error: str | None) -> str | None:
+    if not error:
+        return None
+    text = str(error).strip()
+    if not text:
+        return None
+    first = text.splitlines()[0].strip()
+    match = re.match(r"^([A-Za-z_][\w.]*?(?:Error|Exception|Timeout|Failure|Blocked)?)(?::|\s-)", first)
+    if match:
+        return match.group(1)[:120]
+    if "blocked" in text.lower():
+        return "blocked"
+    return first[:120]
+
+
+def _normalize_error_text(error: str | None) -> str:
+    text = str(error or "").strip().lower()
+    text = re.sub(r"\d+", "#", text)
+    text = re.sub(r"\s+", " ", text)
+    return text
+
+
+def _error_fingerprint(error: str | None) -> str | None:
+    normalized = _normalize_error_text(error)
+    if not normalized:
+        return None
+    return hashlib.sha256(normalized.encode("utf-8")).hexdigest()[:16]
+
+
+def _sanitize_history_error(error: str | None, *, max_len: int = 500) -> str | None:
+    """Return a concise, non-identifying error summary for run history rows.
+
+    Full script stdout/stderr and raw delivery target IDs belong in the saved
+    output file/logs, not the structured history row that dashboards and CLIs
+    read by default.
+    """
+    if not error:
+        return None
+    text = str(error).strip()
+    if not text:
+        return None
+
+    # Redact platform:chat/thread targets while preserving the platform label.
+    platform_pattern = r"\b(telegram|discord|slack|matrix|mattermost|signal|sms|email|whatsapp|webhook|feishu|wecom|weixin|qqbot|yuanbao|bluebubbles):[^\s,)]+"
+    text = re.sub(platform_pattern, r"\1:<redacted>", text, flags=re.IGNORECASE)
+
+    lines = [line.strip() for line in text.splitlines() if line.strip()]
+    if not lines:
+        return None
+    summary = lines[0]
+    if len(lines) > 1:
+        summary = f"{summary} (details saved in output_path)"
+    if len(summary) > max_len:
+        summary = summary[: max_len - 1].rstrip() + "…"
+    return summary
+
+
+def _delivery_targets(deliver) -> list[str]:
+    if deliver is None:
+        raw_items = ["local"]
+    elif isinstance(deliver, str):
+        raw_items = [deliver]
+    else:
+        raw_items = list(deliver)
+    targets: list[str] = []
+    for item in raw_items:
+        text = str(item or "").strip()
+        if not text:
+            continue
+        label = text.split(":", 1)[0].strip().lower() or text.lower()
+        if label and label not in targets:
+            targets.append(label)
+    return targets
+
+
+def _external_delivery_expected(job: dict, should_deliver: bool) -> bool:
+    if not should_deliver:
+        return False
+    targets = _delivery_targets(job.get("deliver"))
+    if not targets:
+        return False
+    return any(target not in {"local", "log"} for target in targets)
+
+
+def _parse_iso_datetime(value: str | None):
+    if not value:
+        return None
+    try:
+        from datetime import datetime
+        return datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except Exception:
+        return None
+
+
+def _compute_due_lag_ms(scheduled_for: str | None, started_at: str | None) -> int | None:
+    scheduled = _parse_iso_datetime(scheduled_for)
+    started = _parse_iso_datetime(started_at)
+    if not scheduled or not started:
+        return None
+    try:
+        return max(0, int((started - scheduled).total_seconds() * 1000))
+    except Exception:
+        return None
+
+
+def _rollup_cron_run_status(
+    *,
+    processing_error: bool,
+    success: bool,
+    silent: bool,
+    external_delivery_expected: bool,
+    delivery_error: str | None,
+) -> str:
+    if processing_error:
+        return "processing_error"
+    if not success:
+        return "error"
+    if delivery_error and external_delivery_expected:
+        return "delivery_error"
+    if silent:
+        return "silent"
+    return "ok"
+
+
+def _response_status(success: bool, final_response: str | None, silent: bool, empty_final_response: bool, job: dict) -> str:
+    text = str(final_response or "")
+    if not success and final_response:
+        return "failure_alert"
+    if silent and SILENT_MARKER in text.strip().upper():
+        if job.get("no_agent") and not text.strip().replace(SILENT_MARKER, "").strip():
+            return "no_agent_empty"
+        return "silent_marker"
+    if empty_final_response or not text:
+        return "empty"
+    return "non_empty"
+
+
+def _delivery_status(
+    *,
+    success: bool,
+    should_deliver: bool,
+    silent: bool,
+    delivery_error: str | None,
+    external_delivery_expected: bool,
+    job: dict,
+    final_response: str | None,
+) -> str:
+    if delivery_error:
+        return "delivery_error"
+    if silent:
+        return "skipped_silent"
+    if not should_deliver:
+        if not final_response:
+            return "skipped_no_content"
+        return "skipped_no_target"
+    if not success and not should_deliver:
+        return "not_attempted_error"
+    if not external_delivery_expected and "local" in _delivery_targets(job.get("deliver")):
+        return "skipped_local"
+    return "delivered"
+
+
+def _file_sha256(path) -> str | None:
+    if not path:
+        return None
+    try:
+        h = hashlib.sha256()
+        with open(path, "rb") as f:
+            for chunk in iter(lambda: f.read(1024 * 1024), b""):
+                h.update(chunk)
+        return h.hexdigest()
+    except Exception:
+        return None
+
+
+def _build_cron_run_record(
+    *,
+    job: dict,
+    run_id: str,
+    tick_id: str,
+    scheduled_for: str | None,
+    started_at: str,
+    ended_at: str,
+    duration_ms: int,
+    success: bool,
+    output: str | None,
+    final_response: str | None,
+    error: str | None,
+    delivery_error: str | None,
+    should_deliver: bool,
+    external_delivery_expected: bool,
+    silent: bool,
+    empty_final_response: bool,
+    processing_error: bool,
+    output_file=None,
+    session_id: str | None = None,
+) -> dict:
+    output_path = str(output_file) if output_file else None
+    try:
+        output_bytes = Path(output_file).stat().st_size if output_file else None
+    except Exception:
+        output_bytes = len((output or "").encode("utf-8")) if output is not None else None
+    final_response_bytes = len((final_response or "").encode("utf-8")) if final_response is not None else 0
+    current_job = None
+    try:
+        current_job = get_job(job.get("id"))
+    except Exception:
+        current_job = None
+    next_run_at_after = (current_job or {}).get("next_run_at")
+    exec_status = "processing_error" if processing_error else ("failed" if not success else "succeeded")
+    if error and "blocked" in str(error).lower():
+        exec_status = "blocked"
+    response_status = _response_status(success, final_response, silent, empty_final_response, job)
+    delivery_status = _delivery_status(
+        success=success,
+        should_deliver=should_deliver,
+        silent=silent,
+        delivery_error=delivery_error,
+        external_delivery_expected=external_delivery_expected,
+        job=job,
+        final_response=final_response,
+    )
+    status = _rollup_cron_run_status(
+        processing_error=processing_error,
+        success=success,
+        silent=silent,
+        external_delivery_expected=external_delivery_expected,
+        delivery_error=delivery_error,
+    )
+    history_error = _sanitize_history_error(error)
+    history_delivery_error = _sanitize_history_error(delivery_error)
+    return {
+        "schema_version": 1,
+        "event_type": "run_attempt",
+        "run_id": run_id,
+        "tick_id": tick_id,
+        "job_id": job.get("id"),
+        "job_name": job.get("name"),
+        "schedule_kind": _schedule_kind(job),
+        "schedule_display": job.get("schedule_display"),
+        "scheduled_for": scheduled_for,
+        "started_at": started_at,
+        "ended_at": ended_at,
+        "duration_ms": max(0, int(duration_ms or 0)),
+        "due_lag_ms": _compute_due_lag_ms(scheduled_for, started_at),
+        "next_run_at_after": next_run_at_after,
+        "mode": _job_mode(job),
+        "success": bool(success),
+        "status": status,
+        "execution_status": exec_status,
+        "response_status": response_status,
+        "delivery_status": delivery_status,
+        "error": history_error,
+        "error_type": _error_type(history_error),
+        "error_fingerprint": _error_fingerprint(error),
+        "delivery_error": history_delivery_error,
+        "delivery_error_type": _error_type(history_delivery_error),
+        "delivery_error_fingerprint": _error_fingerprint(delivery_error),
+        "should_deliver": bool(should_deliver),
+        "external_delivery_expected": bool(external_delivery_expected),
+        "silent": bool(silent),
+        "empty_final_response": bool(empty_final_response),
+        "output_path": output_path,
+        "output_bytes": output_bytes,
+        "output_sha256": _file_sha256(output_file),
+        "final_response_bytes": final_response_bytes,
+        "deliver": ",".join(_delivery_targets(job.get("deliver"))),
+        "delivery_targets": _delivery_targets(job.get("deliver")),
+        "session_id": session_id,
+        "model": job.get("model"),
+        "provider": job.get("provider"),
+        "no_agent": bool(job.get("no_agent")),
+        "script": job.get("script"),
+        "workdir": job.get("workdir"),
+        "toolsets": job.get("enabled_toolsets"),
+        "skills": _normalize_history_skills(job),
+    }
 
 # Backward-compatible module override used by tests and emergency monkeypatches.
 _hermes_home: Path | None = None
@@ -1688,6 +2005,8 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
 
     try:
         due_jobs = get_due_jobs()
+        tick_id = uuid.uuid4().hex
+        scheduled_for_by_job_id = {job.get("id"): job.get("next_run_at") for job in due_jobs}
 
         if verbose and not due_jobs:
             logger.info("%s - No jobs due", _hermes_now().strftime('%H:%M:%S'))
@@ -1730,6 +2049,24 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
 
         def _process_job(job: dict) -> bool:
             """Run one due job end-to-end: execute, save, deliver, mark."""
+            run_id = uuid.uuid4().hex
+            scheduled_for = scheduled_for_by_job_id.get(job.get("id"))
+            started = _hermes_now()
+            started_at = started.isoformat()
+            monotonic_start = time.monotonic()
+
+            success = False
+            output = ""
+            final_response = ""
+            error = None
+            delivery_error = None
+            output_file = None
+            should_deliver = False
+            external_expected = False
+            silent = False
+            empty_final_response = False
+            processing_error = False
+
             try:
                 success, output, final_response, error = run_job(job)
 
@@ -1742,11 +2079,12 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
                 # output is already saved above).  Failed jobs always deliver.
                 deliver_content = final_response if success else f"⚠️ Cron job '{job.get('name', job['id'])}' failed:\n{error}"
                 should_deliver = bool(deliver_content)
-                if should_deliver and success and SILENT_MARKER in deliver_content.strip().upper():
+                silent = bool(should_deliver and success and SILENT_MARKER in deliver_content.strip().upper())
+                if silent:
                     logger.info("Job '%s': agent returned %s — skipping delivery", job["id"], SILENT_MARKER)
                     should_deliver = False
 
-                delivery_error = None
+                external_expected = _external_delivery_expected(job, should_deliver)
                 if should_deliver:
                     try:
                         delivery_error = _deliver_result(job, deliver_content, adapters=adapters, loop=loop)
@@ -1759,15 +2097,49 @@ def tick(verbose: bool = True, adapters=None, loop=None) -> int:
                 # (issue #8585)
                 if success and not final_response:
                     success = False
+                    empty_final_response = True
                     error = "Agent completed but produced empty response (model error, timeout, or misconfiguration)"
 
                 mark_job_run(job["id"], success, error, delivery_error=delivery_error)
                 return True
 
             except Exception as e:
+                processing_error = True
+                success = False
+                error = str(e)
                 logger.error("Error processing job %s: %s", job['id'], e)
-                mark_job_run(job["id"], False, str(e))
+                try:
+                    mark_job_run(job["id"], False, str(e))
+                except Exception as mark_exc:
+                    logger.warning("Failed to mark cron job %s failed: %s", job.get("id"), mark_exc)
                 return False
+            finally:
+                ended_at = _hermes_now().isoformat()
+                duration_ms = int((time.monotonic() - monotonic_start) * 1000)
+                try:
+                    record = _build_cron_run_record(
+                        job=job,
+                        run_id=run_id,
+                        tick_id=tick_id,
+                        scheduled_for=scheduled_for,
+                        started_at=started_at,
+                        ended_at=ended_at,
+                        duration_ms=duration_ms,
+                        success=success,
+                        output=output,
+                        final_response=final_response,
+                        error=error,
+                        delivery_error=delivery_error,
+                        should_deliver=should_deliver,
+                        external_delivery_expected=external_expected,
+                        silent=silent,
+                        empty_final_response=empty_final_response,
+                        processing_error=processing_error,
+                        output_file=output_file,
+                    )
+                    append_run_history(record)
+                except Exception as hist_exc:
+                    logger.warning("Failed to append cron run history for job %s: %s", job.get("id"), hist_exc)
 
         # Partition due jobs: those with a per-job workdir mutate
         # os.environ["TERMINAL_CWD"] inside run_job, which is process-global —

--- a/hermes_cli/cron.py
+++ b/hermes_cli/cron.py
@@ -129,14 +129,95 @@ def cron_tick():
     tick(verbose=True)
 
 
-def cron_status():
-    """Show cron execution status."""
-    from cron.jobs import list_jobs
+def _is_failure_status(status: str) -> bool:
+    return status not in {"ok", "silent"}
+
+
+def _build_cron_status_snapshot(jobs, rows, pids):
+    """Build a compact cron reliability snapshot from job metadata + run history."""
+    active_jobs = [job for job in jobs if job.get("state") not in {"paused", "completed"} and job.get("enabled", True)]
+    next_runs = [job.get("next_run_at") for job in active_jobs if job.get("next_run_at")]
+
+    status_counts = {}
+    rows_by_job = {}
+    for row in sorted(rows, key=lambda r: str(r.get("started_at") or ""), reverse=True):
+        status = str(row.get("status") or "unknown")
+        status_counts[status] = status_counts.get(status, 0) + 1
+        job_id = row.get("job_id")
+        if job_id:
+            rows_by_job.setdefault(job_id, []).append(row)
+
+    job_summaries = []
+    for job in sorted(jobs, key=lambda j: (str(j.get("name") or ""), str(j.get("id") or ""))):
+        job_rows = rows_by_job.get(job.get("id"), [])
+        last_row = job_rows[0] if job_rows else None
+        last_success = next((row for row in job_rows if not _is_failure_status(str(row.get("status") or ""))), None)
+        last_failure = next((row for row in job_rows if _is_failure_status(str(row.get("status") or ""))), None)
+        consecutive_failures = 0
+        for row in job_rows:
+            if _is_failure_status(str(row.get("status") or "")):
+                consecutive_failures += 1
+            else:
+                break
+        durations = [int(row.get("duration_ms") or 0) for row in job_rows if row.get("duration_ms") is not None]
+        job_summaries.append(
+            {
+                "job_id": job.get("id"),
+                "name": job.get("name"),
+                "state": job.get("state", "scheduled" if job.get("enabled", True) else "paused"),
+                "next_run_at": job.get("next_run_at"),
+                "history_count": len(job_rows),
+                "last_run_at": last_row.get("started_at") if last_row else job.get("last_run_at"),
+                "last_status": last_row.get("status") if last_row else job.get("last_status"),
+                "last_success_at": last_success.get("started_at") if last_success else None,
+                "last_failure_at": last_failure.get("started_at") if last_failure else None,
+                "consecutive_failures": consecutive_failures,
+                "avg_duration_ms": int(sum(durations) / len(durations)) if durations else None,
+                "last_duration_ms": last_row.get("duration_ms") if last_row else None,
+                "last_output_bytes": last_row.get("output_bytes") if last_row else None,
+                "delivery_failures": sum(1 for row in job_rows if row.get("status") == "delivery_error"),
+                "silent_runs": sum(1 for row in job_rows if row.get("status") == "silent"),
+                "empty_response_runs": sum(1 for row in job_rows if row.get("response_status") == "empty"),
+            }
+        )
+
+    return {
+        "gateway_running": bool(pids),
+        "gateway_pids": list(pids),
+        "active_jobs": len(active_jobs),
+        "total_jobs": len(jobs),
+        "next_run_at": min(next_runs) if next_runs else None,
+        "history_count": len(rows),
+        "status_counts": status_counts,
+        "jobs": job_summaries,
+    }
+
+
+def _status_color(status: str):
+    if status in {"ok", "silent"}:
+        return Colors.GREEN if status == "ok" else Colors.DIM
+    if status == "delivery_error":
+        return Colors.YELLOW
+    return Colors.RED
+
+
+def cron_status(args=None):
+    """Show cron scheduler and recent execution health."""
+    from cron.jobs import list_jobs, list_run_history
     from hermes_cli.gateway import find_gateway_pids
+
+    limit = int(getattr(args, "history_limit", 500) or 500)
+    pids = find_gateway_pids()
+    jobs = list_jobs(include_disabled=True)
+    rows = list_run_history(limit=limit)
+    snapshot = _build_cron_status_snapshot(jobs, rows, pids)
+
+    if getattr(args, "json", False):
+        print(json.dumps(snapshot, ensure_ascii=False, indent=2))
+        return 0
 
     print()
 
-    pids = find_gateway_pids()
     if pids:
         print(color("✓ Gateway is running — cron jobs will fire automatically", Colors.GREEN))
         print(f"  PID: {', '.join(map(str, pids))}")
@@ -149,17 +230,46 @@ def cron_status():
         print("    hermes gateway            # Or run in foreground")
 
     print()
+    print(f"  {snapshot['active_jobs']} active job(s), {snapshot['total_jobs']} total job(s)")
+    if snapshot.get("next_run_at"):
+        print(f"  Next run: {snapshot['next_run_at']}")
+    print(f"  Recent run rows sampled: {snapshot['history_count']}")
+    if snapshot["status_counts"]:
+        counts = ", ".join(f"{status}={count}" for status, count in sorted(snapshot["status_counts"].items()))
+        print(f"  Recent statuses: {counts}")
 
-    jobs = list_jobs(include_disabled=False)
-    if jobs:
-        next_runs = [j.get("next_run_at") for j in jobs if j.get("next_run_at")]
-        print(f"  {len(jobs)} active job(s)")
-        if next_runs:
-            print(f"  Next run: {min(next_runs)}")
+    if snapshot["jobs"]:
+        print()
+        print(color("  Job health", Colors.CYAN))
+        for summary in snapshot["jobs"]:
+            status = str(summary.get("last_status") or "never")
+            status_display = color(status, _status_color(status)) if status != "never" else color(status, Colors.DIM)
+            failures = summary.get("consecutive_failures") or 0
+            failure_text = f", consecutive failures: {failures}" if failures else ""
+            print(f"  - {summary.get('name') or summary.get('job_id')} ({summary.get('job_id')})")
+            print(f"      state={summary.get('state')} last={status_display} at {summary.get('last_run_at') or '-'}{failure_text}")
+            if summary.get("last_success_at"):
+                print(f"      last success: {summary.get('last_success_at')}")
+            if summary.get("last_failure_at"):
+                print(f"      last failure: {summary.get('last_failure_at')}")
+            if summary.get("avg_duration_ms") is not None:
+                print(
+                    f"      avg duration: {_fmt_duration_ms(summary.get('avg_duration_ms'))}; "
+                    f"last output: {summary.get('last_output_bytes') if summary.get('last_output_bytes') is not None else '-'} bytes"
+                )
+            if summary.get("delivery_failures") or summary.get("silent_runs") or summary.get("empty_response_runs"):
+                print(
+                    "      flags: "
+                    f"delivery_failures={summary.get('delivery_failures')}, "
+                    f"silent={summary.get('silent_runs')}, "
+                    f"empty_response={summary.get('empty_response_runs')}"
+                )
     else:
-        print("  No active jobs")
+        print()
+        print("  No configured jobs")
 
     print()
+    return 0
 
 
 def cron_create(args):
@@ -267,6 +377,76 @@ def _job_action(action: str, job_id: str, success_verb: str) -> int:
     return 0
 
 
+def _fmt_duration_ms(ms) -> str:
+    try:
+        ms = int(ms or 0)
+    except (TypeError, ValueError):
+        return "-"
+    if ms < 1000:
+        return f"{ms}ms"
+    return f"{ms / 1000:.1f}s"
+
+
+def cron_history(args):
+    """Show recent cron run history."""
+    from datetime import timedelta
+    from hermes_time import now as _hermes_now
+    from cron.jobs import list_run_history
+
+    limit = getattr(args, "limit", 20) or 20
+    job_id = getattr(args, "job_id", None)
+    status = getattr(args, "status", None)
+    since = getattr(args, "since", None)
+    days = getattr(args, "days", None)
+    if days and not since:
+        since = (_hermes_now() - timedelta(days=int(days))).isoformat()
+
+    rows = list_run_history(job_id=job_id, limit=limit, since=since, status=status)
+
+    if getattr(args, "json", False):
+        print(json.dumps(rows, ensure_ascii=False, indent=2))
+        return 0
+
+    print()
+    print(color("┌─────────────────────────────────────────────────────────────────────────┐", Colors.CYAN))
+    print(color("│                         Cron Run History                                │", Colors.CYAN))
+    print(color("└─────────────────────────────────────────────────────────────────────────┘", Colors.CYAN))
+    print()
+
+    if not rows:
+        print(color("No cron run history yet.", Colors.DIM))
+        print()
+        return 0
+
+    for row in rows:
+        status_value = str(row.get("status") or "?")
+        if status_value == "ok":
+            status_display = color(status_value, Colors.GREEN)
+        elif status_value == "silent":
+            status_display = color(status_value, Colors.DIM)
+        elif status_value == "delivery_error":
+            status_display = color(status_value, Colors.YELLOW)
+        else:
+            status_display = color(status_value, Colors.RED)
+        print(f"  {row.get('started_at', '-')}  {status_display}  {row.get('job_name') or row.get('job_id', '?')}")
+        print(f"    Job:        {row.get('job_id', '-')}")
+        if row.get("scheduled_for"):
+            print(f"    Scheduled:  {row.get('scheduled_for')}")
+        if row.get("due_lag_ms") is not None:
+            print(f"    Due lag:    {_fmt_duration_ms(row.get('due_lag_ms'))}")
+        print(f"    Duration:   {_fmt_duration_ms(row.get('duration_ms'))}")
+        print(f"    Execution:  {row.get('execution_status', '-')}")
+        print(f"    Response:   {row.get('response_status', '-')}")
+        print(f"    Delivery:   {row.get('delivery_status', '-')}")
+        print(f"    Output:     {row.get('output_bytes', 0)} bytes  {row.get('output_path') or '-'}")
+        if row.get("error"):
+            print(f"    Error:      {row.get('error')}")
+        if row.get("delivery_error"):
+            print(f"    Delivery error: {row.get('delivery_error')}")
+        print()
+    return 0
+
+
 def cron_command(args):
     """Handle cron subcommands."""
     subcmd = getattr(args, 'cron_command', None)
@@ -277,12 +457,14 @@ def cron_command(args):
         return 0
 
     if subcmd == "status":
-        cron_status()
-        return 0
+        return cron_status(args)
 
     if subcmd == "tick":
         cron_tick()
         return 0
+
+    if subcmd == "history":
+        return cron_history(args)
 
     if subcmd in {"create", "add"}:
         return cron_create(args)
@@ -303,5 +485,5 @@ def cron_command(args):
         return _job_action("remove", args.job_id, "Removed")
 
     print(f"Unknown cron command: {subcmd}")
-    print("Usage: hermes cron [list|create|edit|pause|resume|run|remove|status|tick]")
+    print("Usage: hermes cron [list|create|edit|pause|resume|run|remove|status|tick|history]")
     sys.exit(1)

--- a/hermes_cli/main.py
+++ b/hermes_cli/main.py
@@ -9905,7 +9905,18 @@ def main():
     cron_remove.add_argument("job_id", help="Job ID to remove")
 
     # cron status
-    cron_subparsers.add_parser("status", help="Check if cron scheduler is running")
+    cron_status = cron_subparsers.add_parser("status", help="Show cron scheduler and recent run health")
+    cron_status.add_argument("--history-limit", type=int, default=500, help="Number of recent run-history rows to analyze")
+    cron_status.add_argument("--json", action="store_true", help="Print machine-readable JSON")
+
+    # cron history
+    cron_history = cron_subparsers.add_parser("history", help="Show recent cron run history")
+    cron_history.add_argument("job_id", nargs="?", help="Optional job ID to filter")
+    cron_history.add_argument("--limit", type=int, default=20, help="Number of recent runs to show")
+    cron_history.add_argument("--status", help="Filter by rollup status")
+    cron_history.add_argument("--days", type=int, help="Only show runs from the last N days")
+    cron_history.add_argument("--since", help="Only show runs at or after this ISO timestamp")
+    cron_history.add_argument("--json", action="store_true", help="Print machine-readable JSON")
 
     # cron tick (mostly for debugging)
     cron_tick = cron_subparsers.add_parser("tick", help="Run due jobs once and exit")

--- a/tests/cron/test_cron_run_history.py
+++ b/tests/cron/test_cron_run_history.py
@@ -1,0 +1,154 @@
+"""Tests for cron run-history storage and status summarization."""
+
+import json
+from argparse import Namespace
+
+import pytest
+
+
+@pytest.fixture()
+def tmp_cron_dir(tmp_path, monkeypatch):
+    cron_dir = tmp_path / "cron"
+    monkeypatch.setattr("cron.jobs.CRON_DIR", cron_dir)
+    monkeypatch.setattr("cron.jobs.JOBS_FILE", cron_dir / "jobs.json")
+    monkeypatch.setattr("cron.jobs.OUTPUT_DIR", cron_dir / "output")
+    monkeypatch.setattr("cron.jobs.RUNS_FILE", cron_dir / "runs.jsonl")
+    return cron_dir
+
+
+def test_append_and_list_run_history_filters_newest_first(tmp_cron_dir):
+    from cron.jobs import RUNS_FILE, append_run_history, list_run_history
+
+    append_run_history({"job_id": "job-a", "status": "ok", "started_at": "2026-05-11T01:00:00"})
+    append_run_history({"job_id": "job-b", "status": "error", "started_at": "2026-05-11T02:00:00"})
+    append_run_history({"job_id": "job-a", "status": "silent", "started_at": "2026-05-11T03:00:00"})
+
+    assert RUNS_FILE.exists()
+    assert oct(RUNS_FILE.stat().st_mode & 0o777) == "0o600"
+
+    rows = list_run_history(limit=2)
+    assert [row["started_at"] for row in rows] == ["2026-05-11T03:00:00", "2026-05-11T02:00:00"]
+    assert rows[0]["schema_version"] == 1
+    assert rows[0]["event_type"] == "run_attempt"
+
+    assert [row["status"] for row in list_run_history(job_id="job-a")] == ["silent", "ok"]
+    assert [row["job_id"] for row in list_run_history(status="error")] == ["job-b"]
+    assert [row["job_id"] for row in list_run_history(since="2026-05-11T02:30:00")] == ["job-a"]
+
+
+def test_list_run_history_skips_malformed_rows(tmp_cron_dir):
+    from cron.jobs import RUNS_FILE, append_run_history, list_run_history
+
+    append_run_history({"job_id": "good", "status": "ok", "started_at": "2026-05-11T01:00:00"})
+    with RUNS_FILE.open("a", encoding="utf-8") as f:
+        f.write("{not-json\n")
+        f.write(json.dumps(["not", "an", "object"]) + "\n")
+
+    rows = list_run_history()
+    assert len(rows) == 1
+    assert rows[0]["job_id"] == "good"
+
+
+def test_build_cron_run_record_sanitizes_errors_and_body_metadata(tmp_path, monkeypatch):
+    from cron.scheduler import _build_cron_run_record
+
+    output_file = tmp_path / "output.txt"
+    output_file.write_text("full body stays in output file", encoding="utf-8")
+    monkeypatch.setattr("cron.scheduler.get_job", lambda job_id: {"next_run_at": "2026-05-11T04:00:00"})
+
+    record = _build_cron_run_record(
+        job={
+            "id": "job-1",
+            "name": "Nightly",
+            "schedule": {"kind": "interval"},
+            "schedule_display": "every 1h",
+            "deliver": "telegram:-100123:456",
+            "skills": ["maps", "maps", "qmd"],
+            "no_agent": True,
+            "script": "watchdog.py",
+        },
+        run_id="run-1",
+        tick_id="tick-1",
+        scheduled_for="2026-05-11T00:00:00",
+        started_at="2026-05-11T00:00:02",
+        ended_at="2026-05-11T00:00:03",
+        duration_ms=1000,
+        success=False,
+        output="full body stays in output file",
+        final_response="failure alert",
+        error="RuntimeError: script failed\nstdout secret body\nstderr secret body",
+        delivery_error="Failed to send to telegram:-100123:456",
+        should_deliver=True,
+        external_delivery_expected=True,
+        silent=False,
+        empty_final_response=False,
+        processing_error=False,
+        output_file=output_file,
+    )
+
+    assert record["status"] == "error"
+    assert record["delivery_targets"] == ["telegram"]
+    assert record["skills"] == ["maps", "qmd"]
+    assert record["output_bytes"] == output_file.stat().st_size
+    assert record["output_sha256"]
+    assert "stdout secret body" not in record["error"]
+    assert "stderr secret body" not in record["error"]
+    assert "telegram:-100123:456" not in record["delivery_error"]
+    assert "telegram:<redacted>" in record["delivery_error"]
+
+
+def test_cron_status_snapshot_summarizes_job_health():
+    from hermes_cli.cron import _build_cron_status_snapshot
+
+    jobs = [
+        {"id": "job-a", "name": "A", "state": "scheduled", "enabled": True, "next_run_at": "2026-05-11T04:00:00"},
+        {"id": "job-b", "name": "B", "state": "paused", "enabled": True},
+    ]
+    rows = [
+        {"job_id": "job-a", "status": "error", "started_at": "2026-05-11T03:00:00", "duration_ms": 300, "output_bytes": 10, "response_status": "empty"},
+        {"job_id": "job-a", "status": "delivery_error", "started_at": "2026-05-11T02:00:00", "duration_ms": 200, "output_bytes": 20},
+        {"job_id": "job-a", "status": "ok", "started_at": "2026-05-11T01:00:00", "duration_ms": 100, "output_bytes": 30},
+    ]
+
+    snapshot = _build_cron_status_snapshot(jobs, rows, [123])
+
+    assert snapshot["gateway_running"] is True
+    assert snapshot["active_jobs"] == 1
+    assert snapshot["total_jobs"] == 2
+    assert snapshot["next_run_at"] == "2026-05-11T04:00:00"
+    assert snapshot["status_counts"] == {"error": 1, "delivery_error": 1, "ok": 1}
+    job_a = next(job for job in snapshot["jobs"] if job["job_id"] == "job-a")
+    assert job_a["last_status"] == "error"
+    assert job_a["last_success_at"] == "2026-05-11T01:00:00"
+    assert job_a["last_failure_at"] == "2026-05-11T03:00:00"
+    assert job_a["consecutive_failures"] == 2
+    assert job_a["avg_duration_ms"] == 200
+    assert job_a["delivery_failures"] == 1
+    assert job_a["empty_response_runs"] == 1
+
+
+def test_cron_history_cli_json(tmp_cron_dir, capsys):
+    from cron.jobs import append_run_history
+    from hermes_cli.cron import cron_history
+
+    append_run_history({"job_id": "job-a", "status": "ok", "started_at": "2026-05-11T01:00:00"})
+
+    assert cron_history(Namespace(job_id=None, limit=10, status=None, since=None, days=None, json=True)) == 0
+    rows = json.loads(capsys.readouterr().out)
+    assert rows[0]["job_id"] == "job-a"
+
+
+def test_cron_status_cli_json(tmp_cron_dir, monkeypatch, capsys):
+    from cron.jobs import append_run_history, create_job
+    from hermes_cli.cron import cron_status
+
+    job = create_job(prompt="Check", schedule="every 1h", name="Check")
+    append_run_history({"job_id": job["id"], "status": "ok", "started_at": "2026-05-11T01:00:00", "duration_ms": 50})
+    monkeypatch.setattr("hermes_cli.gateway.find_gateway_pids", lambda: [999])
+
+    assert cron_status(Namespace(history_limit=10, json=True)) == 0
+    snapshot = json.loads(capsys.readouterr().out)
+    assert snapshot["gateway_running"] is True
+    assert snapshot["active_jobs"] == 1
+    assert snapshot["status_counts"] == {"ok": 1}
+    assert snapshot["jobs"][0]["last_status"] == "ok"


### PR DESCRIPTION
## Summary

- Add a local JSONL cron run-history store at `~/.hermes/cron/runs.jsonl`
- Instrument cron scheduler job attempts with structured execution, response, delivery, timing, and output metadata
- Add `hermes cron history` for recent run inspection and `hermes cron status --json` / expanded human status for local reliability summaries
- Sanitize structured history rows so raw delivery chat/thread IDs and script stdout/stderr bodies are not copied into dashboard-facing metadata

## Why

Cron jobs are becoming a reliability-critical part of Hermes. This gives local/private visibility into:

- which jobs ran or failed
- whether failures were execution, response, or delivery related
- which jobs are repeatedly silent or empty
- rough timing/output-size trends
- where full output is saved for audit

This is intentionally a local substrate before adding heavier observability backends.

## Test Plan

```bash
/Users/danielrahal/.hermes/hermes-agent/venv/bin/python -m py_compile cron/jobs.py cron/scheduler.py hermes_cli/cron.py hermes_cli/main.py tests/cron/test_cron_run_history.py
/Users/danielrahal/.hermes/hermes-agent/venv/bin/python -m pytest -o addopts='' tests/cron/test_cron_run_history.py tests/hermes_cli/test_cron.py tests/cron/test_cron_no_agent.py tests/cron/test_cron_script.py -q
git diff --check
```

Result: `63 passed`.
