### PR TITLE
fix(feishu): keep group replies in group chats

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -81,8 +81,14 @@ def _reply_anchor_for_event(event) -> str | None:
         return getattr(event, "message_id", None) or getattr(event, "reply_to_message_id", None)
     if platform == "telegram" and thread_id:
         return None
-    if platform == "feishu" and thread_id and getattr(event, "reply_to_message_id", None):
-        return getattr(event, "reply_to_message_id", None)
+    if platform == "feishu":
+        # Feishu topic replies must use reply semantics to stay inside the
+        # topic, but ordinary group messages should be sent directly to the
+        # group chat. Replying to a non-topic group mention can route the
+        # response into the sender's DM instead of the group.
+        if thread_id and getattr(event, "reply_to_message_id", None):
+            return getattr(event, "reply_to_message_id", None)
+        return None
     return getattr(event, "message_id", None)
 
 

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -2002,6 +2002,71 @@ class TestAdapterBehavior(unittest.TestCase):
         self.assertTrue(captured["request"].request_body.reply_in_thread)
 
     @patch.dict(os.environ, {}, clear=True)
+    def test_send_without_topic_metadata_creates_group_message(self):
+        from gateway.config import PlatformConfig
+        from gateway.platforms.feishu import FeishuAdapter
+
+        adapter = FeishuAdapter(PlatformConfig())
+        captured = {}
+
+        class _MessageAPI:
+            def create(self, request):
+                captured["request"] = request
+                return SimpleNamespace(
+                    success=lambda: True,
+                    data=SimpleNamespace(message_id="om_group_send"),
+                )
+
+            def reply(self, request):  # pragma: no cover - defensive assertion path
+                raise AssertionError("group sends should not use reply API outside Feishu topics")
+
+        adapter._client = SimpleNamespace(
+            im=SimpleNamespace(v1=SimpleNamespace(message=_MessageAPI()))
+        )
+
+        async def _direct(func, *args, **kwargs):
+            return func(*args, **kwargs)
+
+        with patch("gateway.platforms.feishu.asyncio.to_thread", side_effect=_direct):
+            result = asyncio.run(
+                adapter.send(
+                    chat_id="oc_group",
+                    content="hello group",
+                    reply_to=None,
+                    metadata=None,
+                )
+            )
+
+        self.assertTrue(result.success)
+        self.assertEqual(result.message_id, "om_group_send")
+        self.assertEqual(captured["request"].receive_id_type, "chat_id")
+        self.assertEqual(captured["request"].request_body.receive_id, "oc_group")
+
+    @patch.dict(os.environ, {}, clear=True)
+    def test_feishu_group_events_do_not_request_reply_anchor(self):
+        from gateway.config import Platform
+        from gateway.platforms.base import _reply_anchor_for_event
+        from gateway.platforms.base import MessageEvent, MessageType
+        from gateway.session import SessionSource
+
+        event = MessageEvent(
+            text="hello",
+            message_type=MessageType.TEXT,
+            source=SessionSource(
+                platform=Platform.FEISHU,
+                chat_id="oc_group",
+                chat_name="Group",
+                chat_type="group",
+                user_id="ou_user",
+                user_name="Alice",
+                thread_id=None,
+            ),
+            message_id="om_group_message",
+        )
+
+        self.assertIsNone(_reply_anchor_for_event(event))
+
+    @patch.dict(os.environ, {}, clear=True)
     def test_send_retries_transient_failure(self):
         from gateway.config import PlatformConfig
         from gateway.platforms.feishu import FeishuAdapter


### PR DESCRIPTION
## What does this PR do?

Fixes Feishu group replies being routed through the reply API even when the inbound message was a normal group @mention rather than a Feishu topic/thread reply.

The root cause was `_reply_anchor_for_event()` falling back to `event.message_id` for ordinary Feishu group messages. That caused the adapter to call `message.reply(...)`, which Feishu routes back to the sender DM in this scenario. This change keeps reply semantics only for true Feishu thread/topic replies and lets ordinary group responses go out through the normal group send path.

## Related Issue

Fixes #23698

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `gateway/platforms/base.py` so Feishu only returns a reply anchor for actual thread/topic replies
- Added a regression test proving non-topic Feishu group sends use the normal group create path instead of `message.reply(...)`
- Added a regression test proving ordinary Feishu group events do not request a reply anchor

## How to Test

1. Run `uv run --frozen pytest -q -o addopts='' tests/gateway/test_feishu.py`
2. Confirm `test_send_without_topic_metadata_creates_group_message` passes
3. Confirm `test_feishu_group_events_do_not_request_reply_anchor` passes

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Targeted verification run: `uv run --frozen pytest -q -o addopts='' tests/gateway/test_feishu.py`
- Focused regression subset: `uv run --frozen pytest -q -o addopts='' tests/gateway/test_feishu.py -k 'topic or group_message or reply_anchor or send_without_topic_metadata'`
