### PR TITLE
fix(line): use build_source instead of nonexistent create_source

### DIFF
--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -959,7 +959,7 @@ class LineAdapter(BasePlatformAdapter):
         if chat_type == "dm" and self._client:
             asyncio.create_task(self._client.loading(chat_id))
 
-        source_obj = self.create_source(
+        source_obj = self.build_source(
             chat_id=chat_id,
             chat_type=chat_type,
             user_id=user_id,


### PR DESCRIPTION
## Summary

- `LineAdapter._handle_message_event` calls `self.create_source(...)`, which raises `AttributeError` on every inbound LINE message — the base `PlatformAdapter` exposes this factory as `build_source(...)` (used by the IRC and Teams adapters).
- One-line rename to `build_source` makes the LINE adapter functional.

## Fixes

#23728

## Test plan

- [x] Reproduced the crash on `nousresearch/hermes-agent:latest` (built from main): every webhook returned 200 but the agent never replied; logs showed the stack trace from #23728.
- [x] Applied the patch in the running container; restarted the gateway; sent text / sticker messages from LINE → adapter dispatched them, agent replied via the LINE channel as expected.
- [ ] Maintainers: please confirm there is no out-of-tree `create_source` override I missed — `grep -rn "def create_source" plugins/` returns no hits.