### PR TITLE
fix(packaging): ship dashboard plugin assets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,6 +186,11 @@ py-modules = ["run_agent", "model_tools", "toolsets", "batch_runner", "trajector
 [tool.setuptools.package-data]
 hermes_cli = ["web_dist/**/*"]
 gateway = ["assets/**/*"]
+plugins = [
+  "*/dashboard/manifest.json",
+  "*/dashboard/dist/*",
+  "*/dashboard/dist/**/*",
+]
 
 [tool.setuptools.packages.find]
 include = ["agent", "agent.*", "tools", "tools.*", "hermes_cli", "gateway", "gateway.*", "tui_gateway", "tui_gateway.*", "cron", "acp_adapter", "plugins", "plugins.*", "providers", "providers.*"]

--- a/tests/test_project_metadata.py
+++ b/tests/test_project_metadata.py
@@ -11,6 +11,13 @@ def _load_optional_dependencies():
     return project["optional-dependencies"]
 
 
+def _load_package_data():
+    pyproject_path = Path(__file__).resolve().parents[1] / "pyproject.toml"
+    with pyproject_path.open("rb") as handle:
+        tool = tomllib.load(handle)["tool"]
+    return tool["setuptools"]["package-data"]
+
+
 def test_matrix_extra_linux_only_in_all():
     """mautrix[encryption] depends on python-olm which is upstream-broken on
     modern macOS (archived libolm, C++ errors with Clang 21+).  The [matrix]
@@ -52,3 +59,15 @@ def test_feishu_extra_includes_qrcode_for_qr_login():
 
     feishu_extra = optional_dependencies["feishu"]
     assert any(dep.startswith("qrcode") for dep in feishu_extra)
+
+
+def test_dashboard_plugin_manifests_and_assets_are_packaged():
+    """Bundled dashboard plugins need their manifests and built assets in
+    wheel installs so /api/dashboard/plugins can discover them outside a
+    source checkout."""
+    package_data = _load_package_data()
+    plugin_data = package_data["plugins"]
+
+    assert "*/dashboard/manifest.json" in plugin_data
+    assert "*/dashboard/dist/*" in plugin_data
+    assert "*/dashboard/dist/**/*" in plugin_data


### PR DESCRIPTION
## Summary
- include dashboard manifest and dist assets in plugin package data
- cover both kanban and hermes-achievements dashboard bundles
- add packaging regression coverage for bundled dashboard plugin assets

## Verification
- uv run --extra dev python -m pytest -q -o addopts="" tests/test_project_metadata.py
- uv run --extra dev --extra web python -m pytest -q -o addopts="" tests/hermes_cli/test_web_server.py -k "DashboardPluginManifestExtensions"

Fixes #23727