### PR TITLE
fix(packaging): ship bundled skills in wheel

### DIFF
--- a/hermes_constants.py
+++ b/hermes_constants.py
@@ -5,10 +5,24 @@ without risk of circular imports.
 """
 
 import os
+import sysconfig
 from pathlib import Path
 
 
 _profile_fallback_warned: bool = False
+
+
+def _get_packaged_data_dir(name: str) -> Path | None:
+    """Return an installed data-files directory if one exists."""
+    candidates = []
+    for scheme in ("data", "purelib", "platlib"):
+        raw = sysconfig.get_path(scheme)
+        if raw:
+            candidates.append(Path(raw) / name)
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return None
 
 
 def get_hermes_home() -> Path:
@@ -116,9 +130,25 @@ def get_optional_skills_dir(default: Path | None = None) -> Path:
     override = os.getenv("HERMES_OPTIONAL_SKILLS", "").strip()
     if override:
         return Path(override)
+    packaged = _get_packaged_data_dir("optional-skills")
+    if packaged is not None:
+        return packaged
     if default is not None:
         return default
     return get_hermes_home() / "optional-skills"
+
+
+def get_bundled_skills_dir(default: Path | None = None) -> Path:
+    """Return the bundled skills directory for source and packaged installs."""
+    override = os.getenv("HERMES_BUNDLED_SKILLS", "").strip()
+    if override:
+        return Path(override)
+    packaged = _get_packaged_data_dir("skills")
+    if packaged is not None:
+        return packaged
+    if default is not None:
+        return default
+    return get_hermes_home() / "skills"
 
 
 def get_hermes_dir(new_subpath: str, old_name: str) -> Path:

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+from collections import defaultdict
+from pathlib import Path
+
+from setuptools import setup
+
+
+REPO_ROOT = Path(__file__).parent.resolve()
+
+
+def _data_file_tree(root_name: str) -> list[tuple[str, list[str]]]:
+    root = REPO_ROOT / root_name
+    grouped: defaultdict[str, list[str]] = defaultdict(list)
+    for path in sorted(root.rglob("*")):
+        if not path.is_file():
+            continue
+        rel_path = path.relative_to(REPO_ROOT)
+        grouped[str(rel_path.parent)].append(str(rel_path))
+    return sorted(grouped.items())
+
+
+setup(
+    data_files=[
+        *_data_file_tree("skills"),
+        *_data_file_tree("optional-skills"),
+    ]
+)

--- a/tests/test_packaging_metadata.py
+++ b/tests/test_packaging_metadata.py
@@ -1,5 +1,9 @@
 from pathlib import Path
+import subprocess
 import tomllib
+import zipfile
+
+from hermes_constants import get_bundled_skills_dir, get_optional_skills_dir
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
@@ -20,3 +24,44 @@ def test_manifest_includes_bundled_skills():
 
     assert "graft skills" in manifest
     assert "graft optional-skills" in manifest
+
+
+def test_wheel_includes_bundled_skills(tmp_path):
+    dist_dir = tmp_path / "dist"
+    subprocess.run(
+        ["uv", "build", "--wheel", "--out-dir", str(dist_dir)],
+        cwd=REPO_ROOT,
+        check=True,
+    )
+
+    wheels = sorted(dist_dir.glob("*.whl"))
+    assert wheels, "expected a built wheel artifact"
+
+    with zipfile.ZipFile(wheels[-1]) as wheel:
+        names = set(wheel.namelist())
+
+    assert any(name.startswith("hermes_agent-0.13.0.data/data/skills/") for name in names)
+    assert any(
+        name.startswith("hermes_agent-0.13.0.data/data/skills/devops/kanban-worker/")
+        for name in names
+    )
+    assert any(name.startswith("hermes_agent-0.13.0.data/data/optional-skills/") for name in names)
+
+
+def test_packaged_data_dirs_are_discoverable(tmp_path, monkeypatch):
+    packaged_root = tmp_path / "venv"
+    (packaged_root / "skills" / "devops" / "kanban-worker").mkdir(parents=True)
+    (packaged_root / "optional-skills" / "creative").mkdir(parents=True)
+
+    monkeypatch.delenv("HERMES_BUNDLED_SKILLS", raising=False)
+    monkeypatch.delenv("HERMES_OPTIONAL_SKILLS", raising=False)
+    monkeypatch.setattr(
+        "hermes_constants.sysconfig.get_path",
+        lambda scheme: str(packaged_root) if scheme == "data" else "",
+    )
+
+    bundled = get_bundled_skills_dir(Path("/fallback/skills"))
+    optional_dir = get_optional_skills_dir(Path("/fallback/optional-skills"))
+
+    assert bundled == packaged_root / "skills"
+    assert optional_dir == packaged_root / "optional-skills"

--- a/tools/skills_sync.py
+++ b/tools/skills_sync.py
@@ -26,7 +26,7 @@ import logging
 import os
 import shutil
 from pathlib import Path
-from hermes_constants import get_hermes_home
+from hermes_constants import get_bundled_skills_dir, get_hermes_home
 from typing import Dict, List, Tuple
 from utils import atomic_replace
 
@@ -44,10 +44,7 @@ def _get_bundled_dir() -> Path:
     Checks HERMES_BUNDLED_SKILLS env var first (set by Nix wrapper),
     then falls back to the relative path from this source file.
     """
-    env_override = os.getenv("HERMES_BUNDLED_SKILLS")
-    if env_override:
-        return Path(env_override)
-    return Path(__file__).parent.parent / "skills"
+    return get_bundled_skills_dir(Path(__file__).parent.parent / "skills")
 
 
 def _read_manifest() -> Dict[str, str]:


### PR DESCRIPTION
## What does this PR do?

Fixes the pip/wheel packaging gap behind `#23725` by shipping the bundled `skills/` and `optional-skills/` trees inside the built wheel, then teaching runtime skill lookup to discover those packaged data directories. With this change, fresh installs and `hermes update` can seed `kanban-worker` from an installed wheel instead of only from a source checkout.

## Related Issue

Fixes #23725

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Added `setup.py` `data_files` packaging so wheel builds include the full `skills/` and `optional-skills/` trees.
- Added packaged-data discovery helpers in `hermes_constants.py` so installed wheels resolve bundled skill roots before falling back to source-tree paths.
- Updated `tools/skills_sync.py` to use the shared bundled-skills resolver instead of assuming a source checkout.
- Added packaging regression tests in `tests/test_packaging_metadata.py` covering wheel contents and packaged data discovery.

## How to Test

1. Build a wheel and confirm it now contains `.data/data/skills/devops/kanban-worker/...` and `.data/data/optional-skills/...`:
   `uv build --wheel --out-dir /tmp/hermes-23725-wheelcheck`
2. Run the targeted regression suite:
   `uv run --frozen pytest -q tests/test_packaging_metadata.py tests/hermes_cli/test_profiles.py tests/hermes_cli/test_managed_installs.py tests/hermes_cli/test_cmd_update.py tests/tools/test_skills_sync.py`
3. Confirm the packaging and lookup paths are lint-clean:
   `uv run --frozen ruff check setup.py hermes_constants.py tools/skills_sync.py tests/test_packaging_metadata.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `uv build --wheel --out-dir /tmp/hermes-23725-wheelcheck` now includes bundled skill paths under `hermes_agent-0.13.0.data/data/skills/...` and `.../optional-skills/...`.
- The broad local `pytest tests/ -x --ignore=tests/integration --ignore=tests/e2e --tb=short` check fails on both this branch and clean `origin/main` at `tests/acp/test_entry.py` with `ModuleNotFoundError: No module named 'acp'`, so I used targeted proof for this packaging fix.
