### PR TITLE
fix(api-server): apply non-vision image fallback

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -9356,9 +9356,13 @@ class AIAgent:
             if _ephemeral_out is not None:
                 self._ephemeral_max_output_tokens = None
 
+            # Provider-profile transports still need the shared non-vision
+            # image fallback before chat-completions kwargs are built.
+            _msgs_for_chat = self._prepare_messages_for_non_vision_model(api_messages)
+
             return _ct.build_kwargs(
                 model=self.model,
-                messages=api_messages,
+                messages=_msgs_for_chat,
                 tools=self.tools,
                 base_url=self.base_url,
                 timeout=self._resolved_api_call_timeout(),

--- a/tests/run_agent/test_run_agent.py
+++ b/tests/run_agent/test_run_agent.py
@@ -4086,6 +4086,27 @@ class TestBuildApiKwargsAnthropicMaxTokens:
 
 
 class TestAnthropicImageFallback:
+    def test_build_api_kwargs_provider_profile_applies_non_vision_fallback(self, agent):
+        agent.api_mode = "chat_completions"
+        agent.provider = "openrouter"
+        agent.model = "qwen/qwen3-235b-a22b"
+        agent.reasoning_config = None
+
+        api_messages = [{
+            "role": "user",
+            "content": [
+                {"type": "text", "text": "Describe this image"},
+                {"type": "image_url", "image_url": {"url": "https://example.com/cat.png"}},
+            ],
+        }]
+        transformed = [{"role": "user", "content": "[Image description: a cat] Describe this image"}]
+
+        with patch.object(agent, "_prepare_messages_for_non_vision_model", return_value=transformed) as mock_prepare:
+            kwargs = agent._build_api_kwargs(api_messages)
+
+        mock_prepare.assert_called_once_with(api_messages)
+        assert kwargs["messages"] == transformed
+
     def test_build_api_kwargs_converts_multimodal_user_image_to_text(self, agent):
         agent.api_mode = "anthropic_messages"
         agent.reasoning_config = None


### PR DESCRIPTION
## What does this PR do?

Fixes the provider-profile `chat_completions` path so non-vision models still run Hermes' shared image fallback before transport kwargs are built. Without this, `/v1/chat/completions` can forward raw `image_url` parts to non-vision models and trigger 400s even though the legacy path already strips or describes those images.

## Related Issue

Fixes #23733

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- updated `/run_agent.py` so the provider-profile `chat_completions` branch calls `_prepare_messages_for_non_vision_model(...)` before `build_kwargs(...)`
- added a regression test in `/tests/run_agent/test_run_agent.py` that proves the provider-profile path now forwards transformed non-vision messages instead of raw multimodal payloads
- re-ran `/tests/gateway/test_api_server_multimodal.py` to verify the API server multimodal path still behaves correctly end to end

## How to Test

1. `uv run --frozen ruff check run_agent.py tests/run_agent/test_run_agent.py`
2. `uv run --frozen pytest -q -o addopts='' tests/run_agent/test_run_agent.py -k 'provider_profile_applies_non_vision_fallback or converts_multimodal_user_image_to_text or reuses_cached_image_analysis_for_duplicate_images'`
3. `uv run --frozen pytest -q -o addopts='' tests/gateway/test_api_server_multimodal.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Targeted regression pytest: `3 passed, 321 deselected`
- API server multimodal suite: `23 passed`
- Clean-env collect-only smoke: `347 tests collected`
