### PR TITLE
feat(agent): allow pre_llm_call runtime overrides

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -2707,6 +2707,146 @@ class AIAgent:
             old_model, old_provider, new_model, new_provider,
         )
 
+    @staticmethod
+    def _collect_pre_llm_hook_result(result: Any) -> tuple[str | None, dict]:
+        """Normalize one ``pre_llm_call`` hook result.
+
+        Backward compatible behavior is preserved: strings and ``context``
+        entries become ephemeral user-message context. New runtime override
+        keys are collected separately so the caller can apply them before the
+        LLM request is built.
+        """
+        if isinstance(result, str):
+            text = result.strip()
+            return (result if text else None), {}
+
+        if not isinstance(result, dict):
+            return None, {}
+
+        context = str(result["context"]) if result.get("context") else None
+        override: dict[str, Any] = {}
+
+        nested = result.get("runtime_override")
+        if isinstance(nested, dict):
+            override.update(nested)
+
+        allowed_direct = {
+            "model",
+            "provider",
+            "base_url",
+            "api_key",
+            "api_mode",
+            "system_prompt",
+            "restore_main",
+        }
+        for key in allowed_direct:
+            if key in result:
+                override[key] = result[key]
+
+        return context, override
+
+    def _apply_pre_llm_runtime_override(
+        self,
+        runtime_override: dict,
+        active_system_prompt: str | None,
+    ) -> str | None:
+        """Apply runtime overrides returned by ``pre_llm_call`` hooks.
+
+        This is intentionally additive: hooks that only return context keep the
+        old behavior. Model/provider overrides reuse ``switch_model()`` so the
+        normal client rebuild, API mode detection, prompt-cache policy, and
+        context-compressor updates stay centralized.
+        """
+        if not isinstance(runtime_override, dict) or not runtime_override:
+            return active_system_prompt
+
+        if not hasattr(self, "_pre_llm_base_runtime"):
+            self._pre_llm_base_runtime = {
+                "model": getattr(self, "model", ""),
+                "provider": getattr(self, "provider", ""),
+                "base_url": getattr(self, "base_url", ""),
+                "api_key": getattr(self, "api_key", ""),
+                "api_mode": getattr(self, "api_mode", ""),
+            }
+
+        try:
+            if runtime_override.get("restore_main"):
+                base = getattr(self, "_pre_llm_base_runtime", {}) or {}
+                base_model = base.get("model")
+                base_provider = base.get("provider")
+                if base_model and base_provider:
+                    self.switch_model(
+                        base_model,
+                        base_provider,
+                        api_key=base.get("api_key", ""),
+                        base_url=base.get("base_url", ""),
+                        api_mode=base.get("api_mode", ""),
+                    )
+                    logger.info(
+                        "pre_llm_call runtime override restored main provider=%s model=%s",
+                        getattr(self, "provider", ""),
+                        getattr(self, "model", ""),
+                    )
+            else:
+                model = runtime_override.get("model")
+                provider = runtime_override.get("provider")
+                base_url = runtime_override.get("base_url") or ""
+                api_key = runtime_override.get("api_key") or ""
+                api_mode = runtime_override.get("api_mode") or ""
+
+                if model or provider or base_url or api_key or api_mode:
+                    target_model = str(model or getattr(self, "model", ""))
+                    target_provider = str(provider or getattr(self, "provider", "") or "auto")
+                    resolved_model = target_model
+                    resolved_api_key = str(api_key or "")
+                    resolved_base_url = str(base_url or "")
+                    resolved_api_mode = str(api_mode or "")
+
+                    try:
+                        from agent.auxiliary_client import resolve_provider_client
+
+                        resolved_client, resolved_client_model = resolve_provider_client(
+                            target_provider,
+                            model=target_model,
+                            raw_codex=True,
+                            explicit_base_url=resolved_base_url or None,
+                            explicit_api_key=resolved_api_key or None,
+                            api_mode=resolved_api_mode or None,
+                            main_runtime=getattr(self, "_primary_runtime", None),
+                        )
+                        if resolved_client is not None:
+                            resolved_model = str(resolved_client_model or target_model)
+                            resolved_api_key = str(getattr(resolved_client, "api_key", "") or resolved_api_key)
+                            resolved_base_url = str(getattr(resolved_client, "base_url", "") or resolved_base_url).rstrip("/")
+                    except Exception as exc:
+                        logger.debug("pre_llm_call provider resolution skipped: %s", exc)
+
+                    self.switch_model(
+                        resolved_model,
+                        target_provider,
+                        api_key=resolved_api_key,
+                        base_url=resolved_base_url,
+                        api_mode=resolved_api_mode,
+                    )
+                    logger.info(
+                        "pre_llm_call runtime override applied provider=%s model=%s api_mode=%s",
+                        getattr(self, "provider", ""),
+                        getattr(self, "model", ""),
+                        getattr(self, "api_mode", ""),
+                    )
+        except Exception as exc:
+            logger.warning("pre_llm_call runtime override failed: %s", exc)
+
+        system_prompt = runtime_override.get("system_prompt")
+        if system_prompt:
+            overlay = str(system_prompt).strip()
+            if overlay:
+                active_system_prompt = (
+                    ((active_system_prompt or "") + "\n\n" + overlay).strip()
+                )
+
+        return active_system_prompt
+
     def _safe_print(self, *args, **kwargs):
         """Print that silently handles broken pipes / closed stdout.
 
@@ -11775,15 +11915,15 @@ class AIAgent:
                         break  # Under threshold
 
         # Plugin hook: pre_llm_call
-        # Fired once per turn before the tool-calling loop.  Plugins can
+        # Fired once per turn before the tool-calling loop. Plugins can
         # return a dict with a ``context`` key (or a plain string) whose
         # value is appended to the current turn's user message.
         #
-        # Context is ALWAYS injected into the user message, never the
-        # system prompt.  This preserves the prompt cache prefix — the
-        # system prompt stays identical across turns so cached tokens
-        # are reused.  The system prompt is Hermes's territory; plugins
-        # contribute context alongside the user's input.
+        # Plugins may also return runtime overrides via
+        # ``{"runtime_override": {...}}`` (or direct model/provider keys)
+        # to switch model/provider/client settings before the LLM request is
+        # built. Context injection stays ephemeral and system prompt overlays
+        # are request-scoped by modifying ``active_system_prompt`` for this turn.
         #
         # All injected context is ephemeral (not persisted to session DB).
         _plugin_user_context = ""
@@ -11800,13 +11940,20 @@ class AIAgent:
                 sender_id=getattr(self, "_user_id", None) or "",
             )
             _ctx_parts: list[str] = []
+            _runtime_override: dict[str, Any] = {}
             for r in _pre_results:
-                if isinstance(r, dict) and r.get("context"):
-                    _ctx_parts.append(str(r["context"]))
-                elif isinstance(r, str) and r.strip():
-                    _ctx_parts.append(r)
+                _context, _override = self._collect_pre_llm_hook_result(r)
+                if _context:
+                    _ctx_parts.append(_context)
+                if _override:
+                    _runtime_override.update(_override)
             if _ctx_parts:
                 _plugin_user_context = "\n\n".join(_ctx_parts)
+            if _runtime_override:
+                active_system_prompt = self._apply_pre_llm_runtime_override(
+                    _runtime_override,
+                    active_system_prompt,
+                )
         except Exception as exc:
             logger.warning("pre_llm_call hook failed: %s", exc)
 

--- a/tests/agent/test_pre_llm_runtime_override.py
+++ b/tests/agent/test_pre_llm_runtime_override.py
@@ -1,0 +1,145 @@
+from types import SimpleNamespace
+
+from run_agent import AIAgent
+
+
+def test_collect_pre_llm_hook_result_preserves_context_only_returns():
+    assert AIAgent._collect_pre_llm_hook_result("memory note") == ("memory note", {})
+    assert AIAgent._collect_pre_llm_hook_result({"context": "memory note"}) == (
+        "memory note",
+        {},
+    )
+    assert AIAgent._collect_pre_llm_hook_result(None) == (None, {})
+
+
+def test_collect_pre_llm_hook_result_extracts_runtime_override():
+    context, override = AIAgent._collect_pre_llm_hook_result(
+        {
+            "context": "route note",
+            "runtime_override": {
+                "provider": "openrouter",
+                "model": "openrouter/example-specialist",
+            },
+        }
+    )
+
+    assert context == "route note"
+    assert override == {
+        "provider": "openrouter",
+        "model": "openrouter/example-specialist",
+    }
+
+
+def test_collect_pre_llm_hook_result_accepts_direct_override_keys():
+    context, override = AIAgent._collect_pre_llm_hook_result(
+        {
+            "model": "openrouter/example-specialist",
+            "provider": "openrouter",
+            "system_prompt": "Use the specialist rubric.",
+            "ignored": "value",
+        }
+    )
+
+    assert context is None
+    assert override == {
+        "model": "openrouter/example-specialist",
+        "provider": "openrouter",
+        "system_prompt": "Use the specialist rubric.",
+    }
+
+
+def _agent_for_runtime_override():
+    agent = object.__new__(AIAgent)
+    agent.model = "openrouter/main"
+    agent.provider = "openrouter"
+    agent.base_url = "https://openrouter.ai/api/v1"
+    agent.api_key = "main-key"
+    agent.api_mode = "chat_completions"
+    agent._primary_runtime = {
+        "model": agent.model,
+        "provider": agent.provider,
+        "base_url": agent.base_url,
+        "api_key": agent.api_key,
+        "api_mode": agent.api_mode,
+    }
+    agent.switch_calls = []
+
+    def fake_switch_model(new_model, new_provider, api_key="", base_url="", api_mode=""):
+        agent.switch_calls.append(
+            {
+                "model": new_model,
+                "provider": new_provider,
+                "api_key": api_key,
+                "base_url": base_url,
+                "api_mode": api_mode,
+            }
+        )
+        agent.model = new_model
+        agent.provider = new_provider
+        if api_key:
+            agent.api_key = api_key
+        if base_url:
+            agent.base_url = base_url
+        if api_mode:
+            agent.api_mode = api_mode
+
+    agent.switch_model = fake_switch_model
+    return agent
+
+
+def test_apply_pre_llm_runtime_override_switches_model_and_system_prompt(monkeypatch):
+    agent = _agent_for_runtime_override()
+
+    def fake_resolve_provider_client(*args, **kwargs):
+        return (
+            SimpleNamespace(
+                api_key="specialist-key",
+                base_url="https://openrouter.ai/api/v1",
+            ),
+            "openrouter/specialist-resolved",
+        )
+
+    monkeypatch.setattr(
+        "agent.auxiliary_client.resolve_provider_client",
+        fake_resolve_provider_client,
+    )
+
+    active_system_prompt = agent._apply_pre_llm_runtime_override(
+        {
+            "provider": "openrouter",
+            "model": "openrouter/specialist",
+            "system_prompt": "Use the specialist rubric.",
+        },
+        "Base system prompt.",
+    )
+
+    assert agent.switch_calls == [
+        {
+            "model": "openrouter/specialist-resolved",
+            "provider": "openrouter",
+            "api_key": "specialist-key",
+            "base_url": "https://openrouter.ai/api/v1",
+            "api_mode": "",
+        }
+    ]
+    assert agent.model == "openrouter/specialist-resolved"
+    assert active_system_prompt == "Base system prompt.\n\nUse the specialist rubric."
+
+
+def test_apply_pre_llm_runtime_override_can_restore_main_model():
+    agent = _agent_for_runtime_override()
+    agent._apply_pre_llm_runtime_override(
+        {"provider": "openrouter", "model": "openrouter/specialist"},
+        "Base system prompt.",
+    )
+
+    agent._apply_pre_llm_runtime_override({"restore_main": True}, "Base system prompt.")
+
+    assert agent.switch_calls[-1] == {
+        "model": "openrouter/main",
+        "provider": "openrouter",
+        "api_key": "main-key",
+        "base_url": "https://openrouter.ai/api/v1",
+        "api_mode": "chat_completions",
+    }
+    assert agent.model == "openrouter/main"

--- a/website/docs/user-guide/features/hooks.md
+++ b/website/docs/user-guide/features/hooks.md
@@ -367,7 +367,7 @@ def register(ctx):
 
 - Callbacks receive **keyword arguments**. Always accept `**kwargs` for forward compatibility — new parameters may be added in future versions without breaking your plugin.
 - If a callback **crashes**, it's logged and skipped. Other hooks and the agent continue normally. A misbehaving plugin can never break the agent.
-- Two hooks' return values affect behavior: [`pre_tool_call`](#pre_tool_call) can **block** the tool, and [`pre_llm_call`](#pre_llm_call) can **inject context** into the LLM call. All other hooks are fire-and-forget observers.
+- Two hooks' return values affect behavior: [`pre_tool_call`](#pre_tool_call) can **block** the tool, and [`pre_llm_call`](#pre_llm_call) can **inject context** or apply runtime model/provider/system-prompt overrides before the LLM call. All other hooks are fire-and-forget observers.
 
 ### Quick reference
 
@@ -375,7 +375,7 @@ def register(ctx):
 |------|-----------|---------|
 | [`pre_tool_call`](#pre_tool_call) | Before any tool executes | `{"action": "block", "message": str}` to veto the call |
 | [`post_tool_call`](#post_tool_call) | After any tool returns | ignored |
-| [`pre_llm_call`](#pre_llm_call) | Once per turn, before the tool-calling loop | `{"context": str}` to prepend context to the user message |
+| [`pre_llm_call`](#pre_llm_call) | Once per turn, before the tool-calling loop | `{"context": str}` to prepend context, or `{"runtime_override": {...}}` to override model/provider/system prompt |
 | [`post_llm_call`](#post_llm_call) | Once per turn, after the tool-calling loop | ignored |
 | [`on_session_start`](#on_session_start) | New session created (first turn only) | ignored |
 | [`on_session_end`](#on_session_end) | Session ends | ignored |
@@ -503,7 +503,7 @@ def register(ctx):
 
 ### `pre_llm_call`
 
-Fires **once per turn**, before the tool-calling loop begins. This is the **only hook whose return value is used** — it can inject context into the current turn's user message.
+Fires **once per turn**, before the tool-calling loop begins. This hook can inject context into the current turn's user message and can apply runtime overrides before the LLM request is built.
 
 **Callback signature:**
 
@@ -525,6 +525,16 @@ def my_callback(session_id: str, user_message: str, conversation_history: list,
 
 **Return value:** If the callback returns a dict with a `"context"` key, or a plain non-empty string, the text is appended to the current turn's user message. Return `None` for no injection.
 
+A callback may also return runtime overrides either under `"runtime_override"` or as direct keys. Supported override keys are:
+
+- `"provider"`: target provider name, for example `"openrouter"`
+- `"model"`: target model identifier
+- `"base_url"`, `"api_key"`, `"api_mode"`: optional transport overrides
+- `"system_prompt"`: request-scoped system-prompt overlay appended to the active system prompt
+- `"restore_main"`: restore the session's original main runtime after a previous override
+
+If multiple plugins return overrides, later plugin results win for duplicate keys. Model/provider overrides use the same runtime switching path as `/model`; return `restore_main` when a router wants to move back to the original main runtime.
+
 ```python
 # Inject context
 return {"context": "Recalled memories:\n- User likes Python\n- Working on hermes-agent"}
@@ -534,9 +544,21 @@ return "Recalled memories:\n- User likes Python"
 
 # No injection
 return None
+
+# Route this turn to a specialist model
+return {
+    "runtime_override": {
+        "provider": "openrouter",
+        "model": "openrouter/example-specialist",
+        "system_prompt": "Use the specialist rubric for this turn.",
+    }
+}
+
+# Restore the original main runtime on a later turn
+return {"runtime_override": {"restore_main": True}}
 ```
 
-**Where context is injected:** Always the **user message**, never the system prompt. This preserves the prompt cache — the system prompt stays identical across turns, so cached tokens are reused. The system prompt is Hermes's territory (model guidance, tool enforcement, personality, skills). Plugins contribute context alongside the user's input.
+**Where context is injected:** Always the **user message**, never the system prompt. This preserves the prompt cache — the system prompt stays identical across turns, so cached tokens are reused. Plugin-provided `"system_prompt"` is treated as an explicit request-scoped overlay for plugins that need model-routing or specialist behavior.
 
 All injected context is **ephemeral** — added at API call time only. The original user message in the conversation history is never mutated, and nothing is persisted to the session database.
 

--- a/website/docs/user-guide/features/plugins.md
+++ b/website/docs/user-guide/features/plugins.md
@@ -192,7 +192,7 @@ Plugins can register callbacks for these lifecycle events. See the **[Event Hook
 |------|-----------|
 | [`pre_tool_call`](/docs/user-guide/features/hooks#pre_tool_call) | Before any tool executes |
 | [`post_tool_call`](/docs/user-guide/features/hooks#post_tool_call) | After any tool returns |
-| [`pre_llm_call`](/docs/user-guide/features/hooks#pre_llm_call) | Once per turn, before the LLM loop — can return `{"context": "..."}` to [inject context into the user message](/docs/user-guide/features/hooks#pre_llm_call) |
+| [`pre_llm_call`](/docs/user-guide/features/hooks#pre_llm_call) | Once per turn, before the LLM loop — can return `{"context": "..."}` to [inject context into the user message](/docs/user-guide/features/hooks#pre_llm_call), or `{"runtime_override": {...}}` to override model/provider/system prompt at runtime |
 | [`post_llm_call`](/docs/user-guide/features/hooks#post_llm_call) | Once per turn, after the LLM loop (successful turns only) |
 | [`on_session_start`](/docs/user-guide/features/hooks#on_session_start) | New session created (first turn only) |
 | [`on_session_end`](/docs/user-guide/features/hooks#on_session_end) | End of every `run_conversation` call + CLI exit handler |


### PR DESCRIPTION
## Summary

Closes #23739.

This PR extends the existing `pre_llm_call` hook so plugins can apply runtime LLM overrides before the agent builds/sends the request.

Supported return shapes are backward compatible:

```python
# Existing behavior still works
return {"context": "extra context"}
return "extra context"

# New runtime override shape
return {
    "runtime_override": {
        "provider": "openrouter",
        "model": "openrouter/example-specialist",
        "system_prompt": "Use the specialist rubric for this turn.",
    }
}

# Restore the original main runtime after a previous routing override
return {"runtime_override": {"restore_main": True}}
```

Direct keys (`model`, `provider`, `base_url`, `api_key`, `api_mode`, `system_prompt`, `restore_main`) are also accepted for convenience.

## Why

`pre_llm_call` already fires at the right point in `AIAgent.run_conversation()`, but until now its return value could only inject user-message context. Plugins that need to route a turn to a specialist model/provider have to monkey-patch `_run_agent_loop` / `run_conversation` internals.

A concrete reference implementation is `topic_detect` / Hermes ARC:

- https://github.com/ShockShoot/hermes-arc

That plugin currently carries a monkey patch only because the core hook cannot apply model/provider/system-prompt overrides.

## Implementation notes

- Adds `_collect_pre_llm_hook_result()` to preserve existing context-return behavior and collect runtime override keys.
- Adds `_apply_pre_llm_runtime_override()` to apply model/provider overrides through the existing `switch_model()` path, so client rebuilds, API mode detection, prompt-cache policy, and context-compressor updates remain centralized.
- Supports optional provider credential/base URL resolution through `resolve_provider_client()`.
- Applies `system_prompt` as a request-scoped overlay on `active_system_prompt`.
- Allows routers to restore the original main runtime with `restore_main`.
- Keeps hook failures non-fatal and logged, matching existing hook behavior.

## Tests

```bash
python3 -m py_compile run_agent.py
python3 -m pytest tests/agent/test_pre_llm_runtime_override.py tests/agent/test_shell_hooks.py::TestCallbackSubprocess::test_pre_llm_call_context_flows_through -q
```

Result:

```text
6 passed
```

## Documentation

Updated:

- `website/docs/user-guide/features/hooks.md`
- `website/docs/user-guide/features/plugins.md`
