### PR TITLE
fix(cli): wire /sessions slash command to recent-session list

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -7103,6 +7103,12 @@ class HermesCLI:
             self.new_session(title=title)
         elif canonical == "resume":
             self._handle_resume_command(cmd_original)
+        elif canonical == "sessions":
+            # /sessions: show recent sessions + usage; identical UX to bare /resume.
+            # Registered in commands.py but no dispatcher existed, so autocomplete
+            # advertised it as "Browse and resume previous sessions" while typing
+            # it produced "Unknown command: /sessions".
+            self._handle_resume_command("/resume")
         elif canonical == "model":
             self._handle_model_switch(cmd_original)
         elif canonical == "gquota":

--- a/tests/cli/test_cli_init.py
+++ b/tests/cli/test_cli_init.py
@@ -319,6 +319,33 @@ class TestHistoryDisplay:
         assert "Checking Running Hermes Agent" in output
         assert "Use /resume <session id or title> to continue" in output
 
+    def test_sessions_slash_command_lists_recent_sessions(self, capsys):
+        """/sessions is registered in commands.py and must be dispatched, not "Unknown command"."""
+        cli = _make_cli()
+        cli.session_id = "current"
+        cli._session_db = MagicMock()
+        cli._session_db.list_sessions_rich.return_value = [
+            {
+                "id": "current",
+                "title": "Current",
+                "preview": "Current preview",
+                "last_active": 0,
+            },
+            {
+                "id": "20260401_201329_d85961",
+                "title": "Checking Running Hermes Agent",
+                "preview": "check running gateways for hermes agent",
+                "last_active": 0,
+            },
+        ]
+
+        cli.process_command("/sessions")
+        output = capsys.readouterr().out
+
+        assert "Unknown command" not in output
+        assert "Recent sessions" in output
+        assert "Checking Running Hermes Agent" in output
+
 
 class TestRootLevelProviderOverride:
     """Root-level provider/base_url in config.yaml must NOT override model.provider."""


### PR DESCRIPTION
## Problem

`/sessions` is registered in `hermes_cli/commands.py` (line 118):

```python
CommandDef("sessions", "Browse and resume previous sessions", "Session"),
```

…so autocomplete advertises it as **"Browse and resume previous sessions"**. But `cli.py`'s `process_command()` has no `elif canonical == "sessions"` branch. Typing `/sessions` falls through to the catch-all and prints `Unknown command: /sessions` — directly contradicting the advertised help text.

## Fix

Dispatch `/sessions` to `_handle_resume_command("/resume")`, which already prints the recent-sessions table and the `/resume <id|title>` usage hint when invoked with no target. This matches the registered description and reuses the existing handler instead of adding a parallel code path.

```python
elif canonical == "sessions":
    self._handle_resume_command("/resume")
```

## Test

Added `test_sessions_slash_command_lists_recent_sessions` in `tests/cli/test_cli_init.py`, mirroring the existing `test_resume_without_target_lists_recent_sessions` pattern. Asserts that `/sessions`:

- does NOT produce `Unknown command`
- prints the `Recent sessions` table
- includes a known session title from the mocked DB

Local run:

```
$ python -m pytest tests/cli/test_cli_init.py -k "resume or sessions" -q
...                                                                      [100%]
3 passed, 32 deselected in 1.61s
```

## Alternative considered

Removing the `CommandDef` entry to silence autocomplete. Rejected: `/sessions` is the most discoverable name for the action and several other tools (Claude Code, Codex CLI) bind a similar verb. Dispatching is the better fix.

Closes #23741