### PR TITLE
fix(cli): schedule destructive prompts on app loop

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -6018,13 +6018,10 @@ class HermesCLI:
     def _prompt_text_input(self, prompt_text: str) -> str | None:
         """Prompt for free-text input safely inside or outside prompt_toolkit.
 
-        Mirrors the thread-aware guard in ``_run_curses_picker``: ``run_in_terminal``
-        returns a coroutine that must be awaited by the prompt_toolkit event loop,
-        which only exists on the main thread.  Slash commands are dispatched from
-        the ``process_loop`` daemon thread (see issue #23185), so calling
-        ``run_in_terminal`` from there orphans the coroutine — ``_ask`` never runs,
-        and user keystrokes leak into the composer instead.  Fall back to a direct
-        ``input()`` when we're off the main thread.
+        Slash commands are dispatched from the ``process_loop`` daemon thread,
+        but ``run_in_terminal`` must execute on the prompt_toolkit app loop to
+        safely own stdin. Schedule the prompt back onto that loop when we have
+        an active app; otherwise fall back to direct ``input()``.
         """
         import threading
         result = [None]
@@ -6036,26 +6033,55 @@ class HermesCLI:
                 pass
 
         in_main_thread = threading.current_thread() is threading.main_thread()
+        app = self._app
 
-        if self._app and in_main_thread:
-            from prompt_toolkit.application import run_in_terminal
-            was_visible = self._status_bar_visible
-            self._status_bar_visible = False
-            self._app.invalidate()
+        def _run_prompt_via_app() -> bool:
+            if not app:
+                return False
             try:
-                run_in_terminal(_ask)
+                loop = app.loop  # type: ignore[attr-defined]
             except Exception:
-                # WSL / Warp / certain terminal emulators silently drop the
-                # scheduled coroutine.  Fall back to a direct input() so the
-                # user's keystrokes don't leak into the agent buffer.
+                loop = None
+            if loop is None:
+                return False
+
+            response_queue = queue.Queue(maxsize=1)
+
+            def _dispatch():
+                was_visible = self._status_bar_visible
+                self._status_bar_visible = False
                 try:
-                    _ask()
+                    app.invalidate()
                 except Exception:
                     pass
-            finally:
-                self._status_bar_visible = was_visible
-                self._app.invalidate()
-        else:
+                try:
+                    from prompt_toolkit.application import run_in_terminal
+                    run_in_terminal(_ask)
+                    response_queue.put(("ok", result[0]))
+                except Exception as exc:
+                    response_queue.put(("err", exc))
+                finally:
+                    self._status_bar_visible = was_visible
+                    try:
+                        app.invalidate()
+                    except Exception:
+                        pass
+
+            try:
+                if in_main_thread:
+                    _dispatch()
+                else:
+                    loop.call_soon_threadsafe(_dispatch)
+                status, payload = response_queue.get(timeout=60)
+            except Exception:
+                return False
+
+            if status == "ok":
+                result[0] = payload
+                return True
+            return False
+
+        if not _run_prompt_via_app():
             _ask()
         return result[0]
 

--- a/tests/cli/test_prompt_text_input_thread_safety.py
+++ b/tests/cli/test_prompt_text_input_thread_safety.py
@@ -1,16 +1,4 @@
-"""Tests for ``HermesCLI._prompt_text_input`` thread-safe input dispatch.
-
-Slash commands (``/clear``, ``/new``, ``/undo``, ``/reload-mcp``) are dispatched
-from the ``process_loop`` daemon thread.  ``prompt_toolkit.run_in_terminal``
-returns a coroutine that only the main-thread event loop can drive; calling it
-from a daemon thread orphans the coroutine, ``_ask`` never runs, and user
-keystrokes leak into the composer instead of the confirmation prompt
-(see issue #23185).
-
-The fix mirrors ``_run_curses_picker``: when off the main thread, fall back to
-a direct ``input()`` call so the prompt actually renders and consumes
-keystrokes.
-"""
+"""Tests for ``HermesCLI._prompt_text_input`` thread-safe input dispatch."""
 
 import threading
 from unittest.mock import MagicMock, patch
@@ -22,6 +10,7 @@ def _make_cli():
 
     obj = object.__new__(cli_mod.HermesCLI)
     obj._app = MagicMock()
+    obj._app._is_running = True
     obj._status_bar_visible = True
     return obj
 
@@ -40,16 +29,18 @@ class TestPromptTextInputThreadSafety:
         # not the orphaned-coroutine result.
         assert mock_rit.called
 
-    def test_background_thread_falls_back_to_direct_input(self):
-        """On a daemon thread, skip run_in_terminal and call input() directly.
-
-        This is the bug from issue #23185: process_loop dispatches slash
-        commands on a daemon thread, so run_in_terminal's coroutine is
-        orphaned.  The fallback must drive input() itself so user keystrokes
-        don't leak into the agent buffer.
-        """
+    def test_background_thread_schedules_prompt_back_to_app_loop(self):
+        """On a daemon thread, schedule the prompt on the app loop."""
         cli = _make_cli()
         captured = {}
+        scheduled = {}
+
+        class _FakeLoop:
+            def call_soon_threadsafe(self, callback):
+                scheduled["called"] = True
+                callback()
+
+        cli._app.loop = _FakeLoop()
 
         def fake_input(prompt):
             captured["prompt"] = prompt
@@ -58,7 +49,7 @@ class TestPromptTextInputThreadSafety:
         result_holder = {}
 
         def run_on_daemon():
-            with patch("prompt_toolkit.application.run_in_terminal") as mock_rit, \
+            with patch("prompt_toolkit.application.run_in_terminal", side_effect=lambda fn: fn()) as mock_rit, \
                  patch("builtins.input", side_effect=fake_input):
                 result_holder["value"] = cli._prompt_text_input("Choice [1/2/3]: ")
                 result_holder["rit_called"] = mock_rit.called
@@ -66,11 +57,9 @@ class TestPromptTextInputThreadSafety:
         t = threading.Thread(target=run_on_daemon, daemon=True)
         t.start()
         t.join(timeout=2.0)
-        assert not t.is_alive(), "daemon thread hung — input() was not driven"
-
-        # run_in_terminal was bypassed entirely on the background thread.
-        assert result_holder["rit_called"] is False
-        # input() was invoked with the prompt and its return value was captured.
+        assert not t.is_alive(), "daemon thread hung — prompt was not scheduled"
+        assert scheduled.get("called") is True
+        assert result_holder["rit_called"] is True
         assert captured.get("prompt") == "Choice [1/2/3]: "
         assert result_holder["value"] == "1"
 


### PR DESCRIPTION
## What does this PR do?

Fixes the destructive slash confirmation prompt so `/new`, `/clear`, and similar commands no longer call raw `input()` from the `process_loop` daemon thread when prompt_toolkit owns stdin. Instead, the prompt is scheduled back onto the app loop and executed via `run_in_terminal`, which avoids the terminal hang reported on Windows and Linux terminals.

## Related Issue

Fixes #23694

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- updated `/cli.py` so `_prompt_text_input(...)` routes background-thread prompts onto the prompt_toolkit app loop with `call_soon_threadsafe(...)`
- kept direct `input()` only as the fallback when there is no active app loop to own stdin safely
- updated `/tests/cli/test_prompt_text_input_thread_safety.py` to assert background-thread prompts are scheduled back to the app loop instead of bypassing `run_in_terminal`

## How to Test

1. `uv run --frozen ruff check cli.py tests/cli/test_prompt_text_input_thread_safety.py tests/cli/test_destructive_slash_confirm.py`
2. `uv run --frozen pytest -q -o addopts='' tests/cli/test_prompt_text_input_thread_safety.py tests/cli/test_destructive_slash_confirm.py`
3. `env -i PATH=/Library/Frameworks/Python.framework/Versions/3.10/bin:/usr/bin:/bin:/usr/sbin:/sbin:/opt/homebrew/bin HOME=/Users/leongong TMPDIR=$TMPDIR /Library/Frameworks/Python.framework/Versions/3.10/bin/uv run --frozen pytest --collect-only -q -o addopts='' tests/cli/test_prompt_text_input_thread_safety.py tests/cli/test_destructive_slash_confirm.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Thread-safety + destructive-confirm suites: `12 passed`
- Clean-env collect-only smoke: `12 tests collected`
