### PR TITLE
fix(repo): protect workflow paths with codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,3 @@
+# Require maintainer review for workflow and composite action changes.
+.github/workflows/ @NousResearch/hermes-maintainers
+.github/actions/ @NousResearch/hermes-maintainers

--- a/tests/test_codeowners.py
+++ b/tests/test_codeowners.py
@@ -1,0 +1,24 @@
+"""Regression tests for workflow ownership protections."""
+
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_github_codeowners_exists():
+    codeowners_path = REPO_ROOT / ".github" / "CODEOWNERS"
+
+    assert codeowners_path.exists()
+
+
+def test_workflows_and_actions_require_maintainer_review():
+    codeowners_path = REPO_ROOT / ".github" / "CODEOWNERS"
+    lines = {
+        line.strip()
+        for line in codeowners_path.read_text(encoding="utf-8").splitlines()
+        if line.strip() and not line.lstrip().startswith("#")
+    }
+
+    assert ".github/workflows/ @NousResearch/hermes-maintainers" in lines
+    assert ".github/actions/ @NousResearch/hermes-maintainers" in lines


### PR DESCRIPTION
## What does this PR do?

Adds a repo-level `.github/CODEOWNERS` file so workflow and composite action changes require maintainer review, and adds a regression test to keep those protected paths from disappearing again.

## Related Issue

Fixes #23632

## Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- added `.github/CODEOWNERS` to require maintainer review on `.github/workflows/` and `.github/actions/`
- added `tests/test_codeowners.py` to assert the protected paths stay covered

## How to Test

1. Run `uv run --frozen pytest -q -o addopts='' tests/test_codeowners.py`
2. Confirm `.github/CODEOWNERS` exists and contains entries for `.github/workflows/` and `.github/actions/`
3. Optionally open a PR diff touching a workflow file and verify GitHub shows CODEOWNERS review requirements

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 / arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `uv run --frozen pytest -q -o addopts='' tests/test_codeowners.py` → `2 passed`
- `uv run --frozen ruff check tests/test_codeowners.py` → passed
