### PR TITLE
fix(auxiliary): raise default compression timeout

### DIFF
--- a/hermes_cli/config.py
+++ b/hermes_cli/config.py
@@ -817,7 +817,7 @@ DEFAULT_CONFIG = {
             "model": "",
             "base_url": "",
             "api_key": "",
-            "timeout": 120,        # seconds — compression summarises large contexts; increase for local models
+            "timeout": 300,        # seconds — compression often runs over large contexts and slower OAuth/cloud backends
             "extra_body": {},
         },
         "session_search": {

--- a/tests/hermes_cli/test_aux_config.py
+++ b/tests/hermes_cli/test_aux_config.py
@@ -50,6 +50,12 @@ def test_session_search_defaults_include_extra_body_and_concurrency():
     assert ss["max_concurrency"] == 3
 
 
+def test_compression_default_timeout_is_generous_for_large_sessions():
+    compression = DEFAULT_CONFIG["auxiliary"]["compression"]
+
+    assert compression["timeout"] == 300
+
+
 def test_aux_tasks_keys_all_exist_in_default_config():
     """Every task the menu offers must be defined in DEFAULT_CONFIG."""
     aux_keys = {k for k, _name, _desc in _AUX_TASKS}
@@ -224,7 +230,7 @@ def test_reset_aux_to_auto_clears_routing_preserves_timeouts(tmp_path, monkeypat
     # User-tuned timeout survives reset
     assert cfg["auxiliary"]["vision"]["timeout"] == 300
     # Default compression timeout preserved
-    assert cfg["auxiliary"]["compression"]["timeout"] == 120
+    assert cfg["auxiliary"]["compression"]["timeout"] == 300
 
 
 def test_reset_aux_to_auto_idempotent(tmp_path, monkeypatch):


### PR DESCRIPTION
## What does this PR do?

Raises the default auxiliary compression timeout from 120s to 300s so large Codex/compression passes are less likely to self-timeout and get retried as noisy connection failures.

## Related Issue

Fixes #22986

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- increased `DEFAULT_CONFIG["auxiliary"]["compression"]["timeout"]` from `120` to `300`
- clarified the inline config comment so the longer timeout is explicitly tied to large-context / slower cloud backends
- added a regression assertion for the default timeout in `tests/hermes_cli/test_aux_config.py`
- updated the reset-preserves-timeouts expectation to the new default

## How to Test

1. Run `uv run --frozen pytest -q -o addopts='' tests/hermes_cli/test_aux_config.py`
2. Confirm `DEFAULT_CONFIG["auxiliary"]["compression"]["timeout"] == 300`
3. Run `hermes model` / reset-aux flows and confirm compression timeout stays at the new default unless a user has overridden it

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 / arm64

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `uv run --frozen pytest -q -o addopts='' tests/hermes_cli/test_aux_config.py` → `22 passed`
- `uv run --frozen ruff check hermes_cli/config.py tests/hermes_cli/test_aux_config.py` → passed
