### PR TITLE
fix(daytona): sync sandbox files back after each command

### DIFF
--- a/tools/environments/base.py
+++ b/tools/environments/base.py
@@ -769,6 +769,16 @@ class BaseEnvironment(ABC):
         """
         pass
 
+    def _after_execute(self) -> None:
+        """Hook called after each command execution.
+
+        Remote backends override this to pull agent-generated files
+        back from the sandbox to the host so the gateway can attach
+        them mid-turn (e.g. ``MEDIA:~/.hermes/cache/images/foo.png``).
+        Bind-mount and local backends don't need it.
+        """
+        pass
+
     # ------------------------------------------------------------------
     # Unified execute()
     # ------------------------------------------------------------------
@@ -818,6 +828,7 @@ class BaseEnvironment(ABC):
         )
         result = self._wait_for_process(proc, timeout=effective_timeout)
         self._update_cwd(result)
+        self._after_execute()
 
         return result
 

--- a/tools/environments/daytona.py
+++ b/tools/environments/daytona.py
@@ -230,6 +230,49 @@ class DaytonaEnvironment(BaseEnvironment):
 
         return _ThreadedProcessHandle(exec_fn, cancel_fn=cancel)
 
+    _SYNC_BACK_MARKER = "/tmp/.hermes_cache_sync_marker"
+
+    def _after_execute(self) -> None:
+        """Pull agent-generated files under ``~/.hermes/cache/`` back to host.
+
+        ``sync_back`` tars the full ``.hermes/`` subtree, so we gate it on a
+        cheap probe: ``find`` exits at the first cache file newer than the
+        marker. When nothing was written we skip the round trip entirely.
+        On the first call the marker doesn't exist, so we treat the tree
+        as dirty and sync.
+        """
+        if self._sandbox is None or self._sync_manager is None:
+            return
+
+        marker = shlex.quote(self._SYNC_BACK_MARKER)
+        cache_dir = shlex.quote(f"{self._remote_home}/.hermes/cache")
+        probe = (
+            f"if [ ! -e {marker} ]; then echo dirty; exit 0; fi; "
+            f"[ -d {cache_dir} ] || exit 0; "
+            f"find {cache_dir} -type f ! -name .keep -newer {marker} "
+            f"-print -quit 2>/dev/null"
+        )
+        try:
+            res = self._sandbox.process.exec(f"bash -c {shlex.quote(probe)}", timeout=10)
+            dirty = bool((res.result or "").strip())
+        except Exception as e:
+            logger.debug("Daytona: post-execute probe failed (%s) — syncing anyway", e)
+            dirty = True
+
+        if not dirty:
+            return
+
+        try:
+            self._sync_manager.sync_back()
+        except Exception as e:
+            logger.warning("Daytona: post-execute sync_back failed: %s", e)
+            return
+
+        try:
+            self._sandbox.process.exec(f"touch {marker}", timeout=5)
+        except Exception as e:
+            logger.debug("Daytona: marker refresh failed: %s", e)
+
     def cleanup(self):
         with self._lock:
             if self._sandbox is None:


### PR DESCRIPTION
## Problem

On Daytona, `sync_back` only runs at sandbox cleanup (idle ≥ `terminal.lifetime_seconds`, default 300s). Files the agent writes mid-turn under `~/.hermes/cache/` therefore don't reach the host before the gateway processes its reply, so Slack/Telegram `MEDIA:` attachments referencing host paths silently fail with `[Slack] Skipping missing image: ...` / `Failed to send media: File not found: ...`.

Reproduction in a real session:

```
17:20:36  tools.vision_tools: Analyzing image: /root/.hermes/cache/images/foo.png
17:21:00  [Slack] Skipping missing image: /Users/hemezh/.hermes/cache/images/foo.png
```

The agent generated the image, vision-analyzed it inside the sandbox, then referenced `MEDIA:~/.hermes/cache/images/foo.png` in its Slack reply. The gateway resolved `~` against the host home, found no file (because `sync_back` had not yet fired), and dropped the attachment without surfacing it to the user.

## Fix

- Add an `_after_execute()` hook on `BaseEnvironment` (no-op by default).
- `BaseEnvironment.execute()` calls it once `_run_bash` + `_wait_for_process` complete and `_update_cwd` has run.
- `DaytonaEnvironment` overrides it: probe `~/.hermes/cache/` with `find -newer <marker> -print -quit`; if anything changed (or the marker is missing on first run), call `self._sync_manager.sync_back()` and `touch` the marker.

The probe is a single bounded `find` over `~/.hermes/cache/`, so commands that don't write into the cache pay only one cheap sandbox-side round trip — no tar, no download.

## Verification

```
hermes chat -Q --yolo -q 'python3 -c "...write /root/.hermes/cache/images/foo.png..."; say SAVED'
# agent log:
sync_back: applied 1 changed file(s)
# host:
ls ~/.hermes/cache/images/foo.png  → present
```

Same flow then works from Slack: the `MEDIA:` resolver sees the file the moment the gateway processes the reply.

## Scope

- No behavior change for `local`, `docker`, or `singularity` — bind-mount / host-visible backends keep the no-op `_after_execute`.
- Other pull-style remote backends (`SSH`, `Modal`) similarly unaffected unless they choose to override the hook. Left as a follow-up to keep this change minimal.
- Marker lives at `/tmp/.hermes_cache_sync_marker` inside the sandbox; resets naturally on sandbox restart (which is fine — first call treats the tree as dirty and resyncs).