### PR TITLE
fix(hindsight): clear _session_turns after sync_turn to send only deltas on append mode

### DIFF
--- a/plugins/memory/hindsight/__init__.py
+++ b/plugins/memory/hindsight/__init__.py
@@ -1453,6 +1453,19 @@ class HindsightMemoryProvider(MemoryProvider):
         retain_async_flag = self._retain_async
         retain_context = self._retain_context
 
+        # On the modern API (update_mode='append'), the server preserves
+        # prior document content across retains, so the next retain only
+        # needs to ship NEW turns. Without this clear, every retain would
+        # re-append the full growing transcript and the document would
+        # accumulate duplicates of every earlier turn (#23724).
+        #
+        # On the legacy path (update_mode is None, per-process document_id,
+        # replace semantics), each retain overwrites the document, so we
+        # MUST keep the full session buffer to avoid losing earlier turns
+        # on the next retain. Leave _session_turns intact in that case.
+        if update_mode == "append":
+            self._session_turns = []
+
         def _do_retain() -> None:
             item = self._build_retain_kwargs(
                 content,

--- a/tests/plugins/memory/test_hindsight_provider.py
+++ b/tests/plugins/memory/test_hindsight_provider.py
@@ -1117,6 +1117,74 @@ class TestUpdateModeAppendCapability:
         item = kw["items"][0]
         assert item["update_mode"] == "append"
 
+    def test_modern_api_sends_only_new_turns_on_subsequent_retain(
+        self, provider_with_config, monkeypatch
+    ):
+        """With update_mode='append' the server preserves prior content,
+        so each retain must ship ONLY the turns accumulated since the last
+        retain. Resending the full growing transcript would duplicate
+        every earlier turn on the server (#23724)."""
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_version",
+            lambda *a, **kw: "0.5.6",
+        )
+        p = provider_with_config(retain_every_n_turns=2)
+
+        # First retain batch: turns 1-2 should be shipped.
+        p.sync_turn("turn1-user", "turn1-asst")
+        p.sync_turn("turn2-user", "turn2-asst")
+        p._retain_queue.join()
+        first_content = p._client.aretain_batch.call_args.kwargs["items"][0]["content"]
+        assert "turn1-user" in first_content
+        assert "turn2-user" in first_content
+
+        p._client.aretain_batch.reset_mock()
+
+        # Second retain batch: only turns 3-4 should be shipped — the
+        # server already has turns 1-2 from the previous append.
+        p.sync_turn("turn3-user", "turn3-asst")
+        p.sync_turn("turn4-user", "turn4-asst")
+        p._retain_queue.join()
+        second_content = p._client.aretain_batch.call_args.kwargs["items"][0]["content"]
+        assert "turn3-user" in second_content
+        assert "turn4-user" in second_content
+        assert "turn1-user" not in second_content
+        assert "turn2-user" not in second_content
+
+    def test_legacy_api_still_sends_full_session_on_each_retain(
+        self, provider_with_config, monkeypatch
+    ):
+        """On legacy servers (no update_mode support) each retain replaces
+        the per-process document, so we MUST keep resending the full
+        accumulated session. Otherwise the second retain would overwrite
+        the document with only the new turns and lose earlier content."""
+        self._clear_capability_cache()
+        monkeypatch.setattr(
+            "plugins.memory.hindsight._fetch_hindsight_api_version",
+            lambda *a, **kw: None,
+        )
+        p = provider_with_config(retain_every_n_turns=2)
+
+        p.sync_turn("turn1-user", "turn1-asst")
+        p.sync_turn("turn2-user", "turn2-asst")
+        p._retain_queue.join()
+
+        p._client.aretain_batch.reset_mock()
+
+        p.sync_turn("turn3-user", "turn3-asst")
+        p.sync_turn("turn4-user", "turn4-asst")
+        p._retain_queue.join()
+
+        kw = p._client.aretain_batch.call_args.kwargs
+        content = kw["items"][0]["content"]
+        # Legacy path: no update_mode, replace-on-write, full session each time.
+        assert "update_mode" not in kw["items"][0]
+        assert "turn1-user" in content
+        assert "turn2-user" in content
+        assert "turn3-user" in content
+        assert "turn4-user" in content
+
     def test_capability_cached_per_url(self, provider, monkeypatch):
         """The /version probe must run at most once per (process, api_url)."""
         self._clear_capability_cache()


### PR DESCRIPTION
## Summary

Fixes #23724.

On the modern Hindsight API (≥ 0.5.0) `sync_turn()` uses `update_mode='append'`
against a stable session-scoped `document_id`, so the server preserves prior
document content across retains. However, `_session_turns` was never cleared
after a successful retain enqueue, so every subsequent retain re-shipped the
full growing transcript instead of just the new turns.

With `retain_every_n_turns=N`, retain #k sends turns 1..k·N, so turn `i` ends
up appended to the document `⌈(total_turns − i + 1)/N⌉` times. The downstream
chunker/extractor then produces 3-4× duplicate facts per session and burns
~80% extra extraction tokens (see issue for measurements on a live document).

## Fix

After building `content` in `sync_turn()`, clear `_session_turns` iff we used
`update_mode='append'`:

```python
document_id, update_mode = self._resolve_retain_target(self._document_id)
...
if update_mode == "append":
    self._session_turns = []
```

That's the entire behavior change. The next retain starts with an empty buffer
and ships only the turns accumulated since the last successful enqueue.

## Why conditional on `update_mode == "append"`

`_resolve_retain_target` returns `update_mode=None` on the legacy path
(Hindsight < 0.5.0). There the per-process `document_id` is unique per
process lifecycle and each retain *replaces* the document (preserving the
`#6654` resume-overwrite fix). On that path we MUST keep resending the full
session — clearing the buffer would make the next retain overwrite the
document with only the new turns and silently lose earlier content.

The session-switch flush path (`on_session_switch`, `c38dac74`) already
snapshots `_session_turns` and clears it explicitly after enqueueing the
flush, so it's unaffected.

## Relationship to #20664

I'm aware #20664 is open and addresses the same bug. Its approach is to
switch the modern path from `update_mode='append'` on the session document
back to `update_mode='replace'` on the per-process document.

This PR takes the opposite, minimal approach: keep append semantics (which
is the documented direction of travel — see `3082fa0` and
vectorize-io/hindsight#932 / #1303), and instead fix the client to actually
honor them by only sending deltas.

Reasons to prefer this approach:

- **One line of behavior change.** No rollback of the append-mode work in
  `3082fa0`, no changes to capability probing, no changes to `document_id`
  selection.
- **Preserves the cross-process dedup property** that `update_mode='append'`
  on a stable session-scoped `document_id` was introduced to enable. Going
  back to per-process `replace` documents loses that.
- **Smaller request payloads** — each retain now ships only the new turns
  (`retain_every_n_turns` turns), not the entire growing session. This is
  the original motivation for batching.
- **Symmetric with the existing session-switch flush**, which already does
  exactly this: build content from the buffered turns, then clear the
  buffer. `sync_turn()` was the asymmetric outlier.

Happy to defer to #20664 if maintainers prefer the replace-semantics
direction; flagging here so the choice is explicit.

## Testing

```
$ scripts/run_tests.sh tests/plugins/memory/test_hindsight_provider.py
98 passed
```

Two new tests added under `TestUpdateModeAppendCapability`:

- `test_modern_api_sends_only_new_turns_on_subsequent_retain` — with the
  /version probe stubbed to `0.5.6`, verifies that the second retain batch
  contains turns 3-4 only, NOT turns 1-2 (which the server already has).
- `test_legacy_api_still_sends_full_session_on_each_retain` — with /version
  stubbed to `None` (legacy server), verifies that the second retain still
  contains the full session 1-4 AND has no `update_mode` key, so the
  resume-overwrite fix keeps working on older Hindsight deployments.

The existing `test_sync_turn_accumulates_full_session` still passes — it
runs without monkeypatching the probe, falls back to legacy mode, and
exercises the same full-session-resend behavior the new legacy-API test
codifies explicitly.

Full memory plugin suite and session-switch tests also green:

```
$ pytest tests/plugins/memory/ tests/agent/test_memory_session_switch.py \
         tests/agent/test_memory_provider.py tests/run_agent/test_memory_sync_interrupted.py
252 passed
```

Tested on macOS 14 / Python 3.11.

## Risk

- The fix only affects the modern (`update_mode='append'`) path. Legacy
  servers are untouched and covered by the new explicit test.
- No public API or schema change.
- `on_session_switch` already uses the same content/clear pattern, so the
  semantics are now symmetric across the two retain entry points instead of
  asymmetric.
