### PR TITLE
fix(feishu): avoid creating incorrect thread to msg referenced by user

### DIFF
--- a/gateway/platforms/feishu.py
+++ b/gateway/platforms/feishu.py
@@ -2930,7 +2930,7 @@ class FeishuAdapter(BasePlatformAdapter):
             if hint:
                 text = f"{hint}\n\n{text}" if text else hint
 
-        thread_id = getattr(message, "thread_id", None) or getattr(message, "root_id", None) or None
+        thread_id = getattr(message, "thread_id", None) or None
         reply_to_message_id = (
             getattr(message, "parent_id", None)
             or getattr(message, "upper_message_id", None)

--- a/tests/gateway/test_feishu.py
+++ b/tests/gateway/test_feishu.py
@@ -4534,6 +4534,59 @@ class TestFeishuProcessInboundMessage(unittest.TestCase):
         )
         adapter._dispatch_inbound_event.assert_not_called()
 
+    def test_root_id_not_used_as_thread_id(self):
+        """When a message has root_id but no thread_id, thread_id must be None.
+
+        Feishu sets root_id when a user replies-to/references another message.
+        That root_id points to the referenced message's thread, not the
+        current conversation thread. Using it as thread_id would cause the
+        bot to reply in the wrong message.
+        """
+        adapter = self._build_adapter()
+        message = SimpleNamespace(
+            content=json.dumps({"text": "hello"}),
+            message_type="text",
+            message_id="m6",
+            mentions=[],
+            chat_id="oc_chat",
+            parent_id=None,
+            upper_message_id=None,
+            root_id="omt_root_123",
+            thread_id=None,
+        )
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message, message=message, sender_id=None,
+                chat_type="group", message_id="m6",
+            )
+        )
+        adapter.build_source.assert_called_once()
+        _, kwargs = adapter.build_source.call_args
+        self.assertIsNone(kwargs["thread_id"])
+
+    def test_thread_id_passed_when_set(self):
+        """When a message has thread_id set, it is passed through to build_source."""
+        adapter = self._build_adapter()
+        message = SimpleNamespace(
+            content=json.dumps({"text": "hello in thread"}),
+            message_type="text",
+            message_id="m7",
+            mentions=[],
+            chat_id="oc_chat",
+            parent_id=None,
+            upper_message_id=None,
+            thread_id="omt_thread_456",
+        )
+        asyncio.run(
+            adapter._process_inbound_message(
+                data=message, message=message, sender_id=None,
+                chat_type="group", message_id="m7",
+            )
+        )
+        adapter.build_source.assert_called_once()
+        _, kwargs = adapter.build_source.call_args
+        self.assertEqual(kwargs["thread_id"], "omt_thread_456")
+
 
 class TestFeishuFetchMessageText(unittest.TestCase):
     def _build_adapter(self):


### PR DESCRIPTION


## What does this PR do?

<!-- Describe the change clearly. What problem does it solve? Why is this approach the right one? -->

avoid creating incorrect thread to referenced msg refered by user

reply to user's message instead

避免错误**创建话题**在用户所引用的消息上
改为直接回复用户的消息

## Related Issue

Fixes #20548

## Type of Change

<!-- Check the one that applies. -->

- [*] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [*] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- `gateway/platforms/feishu.py`
  removed incorrect `or getattr(message, "root_id", None)` fallback condition from the `thread_id` assignment in `_process_inbound_message`, so `root_id` no longer leaks into `thread_id`
- `tests/gateway/test_feishu.py` — Added two tests to `TestFeishuProcessInboundMessage`:
  - `test_root_id_not_used_as_thread_id` — verifies `thread_id` is `None` when only `root_id` is set
  - `test_thread_id_passed_when_set` — verifies `thread_id` is passed through correctly when explicitly set

## How to Test

1. send a direct message with reference **replying** to another message in Feishu, not reply in a thread or create thread.
   在飞书私聊发送一条**回复**所引用消息的消息，不要在话题中回复或者创建话题。
2. check replied messag by Hermes Agent.
   检查Hermes对刚才发的消息的回复。
3. Hermes' reply should shown in chat history of main dialog, not in a new separate thread of the referenced message.
   Hermes的回复应该出现在主对话聊天记录中，而非出现在单独的新话题中。

## Checklist

### Code

- [*] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [*] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [*] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [*] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [*] I've run `pytest tests/ -q` and all tests pass
- [*] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [*] I've tested on my platform: Termux 0.116 beta on Android 15 

### Documentation & Housekeeping

- [N/A] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [N/A] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [N/A] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [N/A] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

<img width="1206" height="2622" alt="IMG_5161" src="https://github.com/user-attachments/assets/d548c5b1-9d82-4fee-9726-112a282db4f4" />

