### PR TITLE
fix(gateway): guide around unsupported launchd domains

### DIFF
--- a/hermes_cli/gateway.py
+++ b/hermes_cli/gateway.py
@@ -2740,6 +2740,37 @@ def _launchd_domain() -> str:
     return f"gui/{os.getuid()}"  # windows-footgun: ok — POSIX launchd (macOS) helper, never invoked on Windows
 
 
+def _launchd_domain_is_unsupported(exc: subprocess.CalledProcessError) -> bool:
+    """Return True when launchd rejects gui/<uid> management operations outright."""
+    stderr = ((exc.stderr or "") + " " + (exc.stdout or "")).lower()
+    return exc.returncode in (5, 125) or (
+        "domain does not support specified action" in stderr
+        or "input/output error" in stderr
+    )
+
+
+def _exit_unsupported_launchd_action(
+    action: str,
+    exc: subprocess.CalledProcessError,
+    *,
+    plist_written: bool = False,
+) -> None:
+    """Print a clear fallback path when launchd rejects service management."""
+    from hermes_constants import display_hermes_home as _dhh
+
+    print_error(f"launchd could not {action} the Hermes gateway on this macOS release.")
+    detail = (exc.stderr or exc.stdout or str(exc)).strip()
+    if detail:
+        print_info(f"  launchctl said: {detail}")
+    if plist_written:
+        print_info("  The launchd plist was written, but launchd refused to load or start it.")
+    print_info("  This macOS launchd domain appears to reject gui/<uid> bootstrap/kickstart operations.")
+    print_info("  Run the gateway directly instead:")
+    print_info("    hermes gateway run")
+    print_info(f"    nohup hermes gateway run >{_dhh()}/logs/gateway.log 2>&1 &")
+    raise SystemExit(1)
+
+
 def generate_launchd_plist() -> str:
     python_path = get_python_path()
     working_dir = str(PROJECT_ROOT)
@@ -2875,8 +2906,13 @@ def launchd_install(force: bool = False):
     plist_path.parent.mkdir(parents=True, exist_ok=True)
     print(f"Installing launchd service to: {plist_path}")
     plist_path.write_text(generate_launchd_plist())
-    
-    subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=True, timeout=30)
+
+    try:
+        subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=True, timeout=30)
+    except subprocess.CalledProcessError as exc:
+        if _launchd_domain_is_unsupported(exc):
+            _exit_unsupported_launchd_action("install", exc, plist_written=True)
+        raise
     
     print()
     print("✓ Service installed and loaded!")
@@ -2906,8 +2942,13 @@ def launchd_start():
         print("↻ launchd plist missing; regenerating service definition")
         plist_path.parent.mkdir(parents=True, exist_ok=True)
         plist_path.write_text(generate_launchd_plist(), encoding="utf-8")
-        subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=True, timeout=30)
-        subprocess.run(["launchctl", "kickstart", f"{_launchd_domain()}/{label}"], check=True, timeout=30)
+        try:
+            subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=True, timeout=30)
+            subprocess.run(["launchctl", "kickstart", f"{_launchd_domain()}/{label}"], check=True, timeout=30)
+        except subprocess.CalledProcessError as exc:
+            if _launchd_domain_is_unsupported(exc):
+                _exit_unsupported_launchd_action("start", exc, plist_written=True)
+            raise
         print("✓ Service started")
         return
 
@@ -2915,11 +2956,18 @@ def launchd_start():
     try:
         subprocess.run(["launchctl", "kickstart", f"{_launchd_domain()}/{label}"], check=True, timeout=30)
     except subprocess.CalledProcessError as e:
+        if _launchd_domain_is_unsupported(e):
+            _exit_unsupported_launchd_action("start", e)
         if e.returncode not in (3, 113):
             raise
         print("↻ launchd job was unloaded; reloading service definition")
-        subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=True, timeout=30)
-        subprocess.run(["launchctl", "kickstart", f"{_launchd_domain()}/{label}"], check=True, timeout=30)
+        try:
+            subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=True, timeout=30)
+            subprocess.run(["launchctl", "kickstart", f"{_launchd_domain()}/{label}"], check=True, timeout=30)
+        except subprocess.CalledProcessError as exc:
+            if _launchd_domain_is_unsupported(exc):
+                _exit_unsupported_launchd_action("start", exc)
+            raise
     print("✓ Service started")
 
 def launchd_stop():
@@ -3011,13 +3059,20 @@ def launchd_restart():
         subprocess.run(["launchctl", "kickstart", "-k", target], check=True, timeout=90)
         print("✓ Service restarted")
     except subprocess.CalledProcessError as e:
+        if _launchd_domain_is_unsupported(e):
+            _exit_unsupported_launchd_action("restart", e)
         if e.returncode not in (3, 113):
             raise
         # Job not loaded — bootstrap and start fresh
         print("↻ launchd job was unloaded; reloading")
         plist_path = get_launchd_plist_path()
-        subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=True, timeout=30)
-        subprocess.run(["launchctl", "kickstart", target], check=True, timeout=30)
+        try:
+            subprocess.run(["launchctl", "bootstrap", _launchd_domain(), str(plist_path)], check=True, timeout=30)
+            subprocess.run(["launchctl", "kickstart", target], check=True, timeout=30)
+        except subprocess.CalledProcessError as exc:
+            if _launchd_domain_is_unsupported(exc):
+                _exit_unsupported_launchd_action("restart", exc)
+            raise
         print("✓ Service restarted")
 
 def launchd_status(deep: bool = False):

--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -554,6 +554,54 @@ class TestLaunchdServiceRecovery:
             ["launchctl", "kickstart", target],
         ]
 
+    def test_launchd_install_exits_cleanly_when_gui_domain_rejects_bootstrap(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+
+        def fake_run(cmd, check=False, **kwargs):
+            raise gateway_cli.subprocess.CalledProcessError(
+                5, cmd, stderr="Input/output error"
+            )
+
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with pytest.raises(SystemExit) as excinfo:
+            gateway_cli.launchd_install()
+
+        assert excinfo.value.code == 1
+        output = capsys.readouterr().out
+        assert "nohup hermes gateway run" in output
+        assert "launchd plist was written" in output
+        assert plist_path.exists()
+
+    def test_launchd_start_exits_cleanly_when_gui_domain_rejects_kickstart(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        plist_path = tmp_path / "ai.hermes.gateway.plist"
+        plist_path.write_text(gateway_cli.generate_launchd_plist(), encoding="utf-8")
+        label = gateway_cli.get_launchd_label()
+        target = f"{gateway_cli._launchd_domain()}/{label}"
+
+        def fake_run(cmd, check=False, **kwargs):
+            if cmd == ["launchctl", "kickstart", target]:
+                raise gateway_cli.subprocess.CalledProcessError(
+                    125, cmd, stderr="Domain does not support specified action"
+                )
+            return SimpleNamespace(returncode=0, stdout="", stderr="")
+
+        monkeypatch.setattr(gateway_cli, "get_launchd_plist_path", lambda: plist_path)
+        monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+
+        with pytest.raises(SystemExit) as excinfo:
+            gateway_cli.launchd_start()
+
+        assert excinfo.value.code == 1
+        output = capsys.readouterr().out
+        assert "Domain does not support specified action" in output
+        assert "hermes gateway run" in output
+
     def test_launchd_restart_drains_running_gateway_before_kickstart(self, monkeypatch):
         calls = []
         target = f"{gateway_cli._launchd_domain()}/{gateway_cli.get_launchd_label()}"


### PR DESCRIPTION
## What does this PR do?
- turns unsupported macOS launchd gui-domain failures into actionable fallback guidance instead of surfacing a raw `launchctl` traceback
- covers install/start/restart flows that currently fail with `Input/output error` or `Domain does not support specified action`
- adds regression tests for bootstrap and kickstart failure handling

## Related Issue
Fixes #23387

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / chore

## Changes Made
- added launchd unsupported-domain detection helpers in `hermes_cli/gateway.py`
- convert launchd bootstrap/kickstart failures for unsupported domains into a clean `SystemExit(1)` with explicit foreground/background fallback commands
- added regression coverage in `tests/hermes_cli/test_gateway_service.py`

## How to Test
- `uv run --frozen pytest -q -o addopts='' tests/hermes_cli/test_gateway_service.py -k launchd`
- `uv run --frozen ruff check hermes_cli/gateway.py tests/hermes_cli/test_gateway_service.py`
- `env -i HOME="$HOME" PATH="$PATH" TERM="${TERM:-xterm-256color}" bash -lc 'cd /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/hermes-23387-launchd-guidance && uv run --frozen pytest --collect-only -q -o addopts="" tests/hermes_cli/test_gateway_service.py -k launchd'`

## Checklist
- [x] I have linked the related issue (or explained why not)
- [x] I added or updated tests for the change
- [x] I ran relevant local verification
- [x] I kept the scope focused
- [ ] I ran the full repo test suite

## For New Skills
- Not applicable

## Screenshots / Logs
- Not applicable