### PR TITLE
fix(gateway): strip markdown wrappers from media paths

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2064,13 +2064,13 @@ class BasePlatformAdapter(ABC):
         # Extract MEDIA:<path> tags, allowing optional whitespace after the colon
         # and quoted/backticked paths for LLM-formatted outputs.
         media_pattern = re.compile(
-            r'''[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}]|$)|\S+)[`"']?'''
+            r'''(?:\*\*|__|\*|_)?[`"']?MEDIA:\s*(?P<path>`[^`\n]+`|"[^"\n]+"|'[^'\n]+'|(?:~/|/)\S+(?:[^\S\n]+\S+)*?\.(?:png|jpe?g|gif|webp|mp4|mov|avi|mkv|webm|ogg|opus|mp3|wav|m4a|flac|epub|pdf|zip|rar|7z|docx?|xlsx?|pptx?|txt|csv|apk|ipa)(?=[\s`"',;:)\]}*_]|$)|\S+)[`"']?(?:\*\*|__|\*|_)?'''
         )
         for match in media_pattern.finditer(content):
             path = match.group("path").strip()
             if len(path) >= 2 and path[0] == path[-1] and path[0] in "`\"'":
                 path = path[1:-1].strip()
-            path = path.lstrip("`\"'").rstrip("`\"',.;:)}]")
+            path = path.lstrip("`\"'*_").rstrip("`\"',.;:)}]*_")
             if path:
                 media.append((os.path.expanduser(path), has_voice_tag))
 

--- a/tests/gateway/test_platform_base.py
+++ b/tests/gateway/test_platform_base.py
@@ -323,6 +323,15 @@ class TestExtractMedia:
         assert "Here" in cleaned
         assert "After" in cleaned
 
+    def test_media_tag_strips_markdown_emphasis_wrappers(self):
+        content = "Here\n**MEDIA:/tmp/report.docx**\nAfter"
+        media, cleaned = BasePlatformAdapter.extract_media(content)
+        assert media == [("/tmp/report.docx", False)]
+        assert "MEDIA:" not in cleaned
+        assert "**" not in cleaned
+        assert "Here" in cleaned
+        assert "After" in cleaned
+
     def test_media_tag_supports_unquoted_flac_paths_with_spaces(self):
         content = "MEDIA:/tmp/Jane Doe/speech.flac"
         media, cleaned = BasePlatformAdapter.extract_media(content)
@@ -728,4 +737,3 @@ class TestProxyKwargsForAiohttp:
             sess_kw, req_kw = proxy_kwargs_for_aiohttp("http://proxy:8080")
             assert sess_kw == {}
             assert req_kw == {"proxy": "http://proxy:8080"}
-


### PR DESCRIPTION
## What does this PR do?
- strips markdown emphasis wrappers around `MEDIA:` paths before gateway adapters resolve files
- prevents `**MEDIA:/tmp/report.docx**` from becoming `/tmp/report.docx**`
- keeps the cleaned user-visible text from leaking raw emphasis markers after media extraction

## Related Issue
Fixes #23759

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactor / chore

## Changes Made
- expanded `BasePlatformAdapter.extract_media()` to tolerate markdown emphasis wrappers around `MEDIA:` directives
- strips trailing `*` / `_` markers from extracted paths as a safety net
- added a regression test covering bold-wrapped media paths

## How to Test
- `uv run --frozen pytest -q -o addopts='' tests/gateway/test_platform_base.py tests/gateway/test_send_image_file.py -k 'media'`
- `uv run --frozen ruff check gateway/platforms/base.py tests/gateway/test_platform_base.py`
- `env -i HOME="$HOME" PATH="$PATH" TERM="${TERM:-xterm-256color}" bash -lc 'cd /Users/leongong/Desktop/LeonProjects/worktrees/hermes-agent/hermes-23759-media-bold-path && uv run --frozen pytest --collect-only -q -o addopts="" tests/gateway/test_platform_base.py tests/gateway/test_send_image_file.py -k media'`

## Checklist
- [x] I have linked the related issue (or explained why not)
- [x] I added or updated tests for the change
- [x] I ran relevant local verification
- [x] I kept the scope focused
- [ ] I ran the full repo test suite

## For New Skills
- Not applicable

## Screenshots / Logs
- Not applicable