### PR TITLE
fix(homebrew): update in-repo formula URL/version/SHA and remove placeholder (#19690)

### DIFF
--- a/packaging/homebrew/hermes-agent.rb
+++ b/packaging/homebrew/hermes-agent.rb
@@ -3,10 +3,11 @@ class HermesAgent < Formula
 
   desc "Self-improving AI agent that creates skills from experience"
   homepage "https://hermes-agent.nousresearch.com"
-  # Stable source should point at the semver-named sdist asset attached by
-  # scripts/release.py, not the CalVer tag tarball.
-  url "https://github.com/NousResearch/hermes-agent/releases/download/v2026.3.30/hermes_agent-0.6.0.tar.gz"
-  sha256 "<replace-with-release-asset-sha256>"
+  # Use the tagged source archive so this formula remains installable even when
+  # semver-named release assets are missing from GitHub releases.
+  url "https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.5.7.tar.gz"
+  sha256 "75b629e787a68164713b66d1dd163c65f853474c9c775cd6f206797a629aa2c0"
+  version "0.13.0"
   license "MIT"
 
   depends_on "certifi" => :no_linkage


### PR DESCRIPTION
## Summary
Fixes the checked-in Homebrew formula so it is installable and aligned with current release state.

Changes in `packaging/homebrew/hermes-agent.rb`:
- Replace stale URL (`hermes_agent-0.6.0.tar.gz`) with current source archive tag URL (`v2026.5.7`).
- Replace placeholder SHA with the real SHA256 for that archive.
- Set explicit formula `version "0.13.0"` to match the package/CLI version.
- Update comment to reflect why the tagged archive is used.

Closes #19690.

## Evidence
- Old release-asset URL currently returns `HTTP/2 404`.
- New archive URL resolves and checksum matches:
  - URL: `https://github.com/NousResearch/hermes-agent/archive/refs/tags/v2026.5.7.tar.gz`
  - SHA256: `75b629e787a68164713b66d1dd163c65f853474c9c775cd6f206797a629aa2c0`

## Validation
- `ruby -c packaging/homebrew/hermes-agent.rb` → `Syntax OK`

Note: Homebrew local audit/style commands reject in-repo formula paths unless the formula is in a tap context, so this PR validates syntax + URL/checksum correctness directly.
