### PR TITLE
feat(clarify): add multi-select (checkbox) support to clarify tool

### DIFF
--- a/cli.py
+++ b/cli.py
@@ -2552,6 +2552,7 @@ class HermesCLI:
         self._clarify_state = None
         self._clarify_freetext = False
         self._clarify_deadline = 0
+        self._clarify_multi_base = None
         self._sudo_state = None
         self._sudo_deadline = 0
         self._modal_input_snapshot = None
@@ -9543,7 +9544,7 @@ class HermesCLI:
         for line in reqs["details"].split("\n"):
             _cprint(f"    {line}")
 
-    def _clarify_callback(self, question, choices):
+    def _clarify_callback(self, question, choices, multi_select=False):
         """
         Platform callback for the clarify tool. Called from the agent thread.
 
@@ -9551,22 +9552,31 @@ class HermesCLI:
         questions), then blocks until the user responds via the prompt_toolkit
         key bindings.  If no response arrives within the configured timeout the
         question is dismissed and the agent is told to decide on its own.
+
+        When ``multi_select`` is True, shows checkboxes and the user can
+        select multiple options with Space, confirming with Enter.
         """
         import time as _time
 
         timeout = CLI_CONFIG.get("clarify", {}).get("timeout", 120)
         response_queue = queue.Queue()
         is_open_ended = not choices
+        # multi-select support: only active when multi_select is True and choices exist
+        effective_multi = multi_select and not is_open_ended
 
         self._clarify_state = {
             "question": question,
             "choices": choices if not is_open_ended else [],
             "selected": 0,
+            # multi-select support
+            "multi_select": effective_multi,
+            "selected_indices": set() if effective_multi else None,
             "response_queue": response_queue,
         }
         self._clarify_deadline = _time.monotonic() + timeout
         # Open-ended questions skip straight to freetext input
         self._clarify_freetext = is_open_ended
+        self._clarify_multi_base = None
 
         # Trigger prompt_toolkit repaint from this (non-main) thread
         self._invalidate()
@@ -9603,6 +9613,7 @@ class HermesCLI:
         self._clarify_state = None
         self._clarify_freetext = False
         self._clarify_deadline = 0
+        self._clarify_multi_base = None
         self._invalidate()
         _cprint(f"\n{_DIM}(clarify timed out after {timeout}s — agent will decide){_RST}")
         return (
@@ -11055,6 +11066,11 @@ class HermesCLI:
             if self._clarify_freetext and self._clarify_state:
                 text = event.app.current_buffer.text.strip()
                 if text:
+                    # multi-select: prepend previously checked real choices
+                    base = getattr(self, '_clarify_multi_base', None)
+                    if base:
+                        text = ", ".join(base) + ", " + text
+                        self._clarify_multi_base = None
                     self._clarify_state["response_queue"].put(text)
                     self._clarify_state = None
                     self._clarify_freetext = False
@@ -11067,6 +11083,35 @@ class HermesCLI:
                 state = self._clarify_state
                 selected = state["selected"]
                 choices = state.get("choices") or []
+                # multi-select support: submit comma-joined list of checked choices
+                if state.get("multi_select"):
+                    indices = state.get("selected_indices")
+                    if not indices:
+                        # Nothing checked → submit empty string (parses to [])
+                        state["response_queue"].put("")
+                        self._clarify_state = None
+                        event.app.invalidate()
+                        return
+                    sorted_idx = sorted(indices)
+                    selected_choices = [choices[i] for i in sorted_idx if i < len(choices)]
+                    other_checked = len(choices) in sorted_idx
+                    if other_checked and selected_choices:
+                        # "Other" + real choices: store base choices, switch to freetext
+                        # so the user can type a custom answer that gets appended
+                        self._clarify_multi_base = selected_choices
+                        self._clarify_freetext = True
+                        event.app.invalidate()
+                        return
+                    if selected_choices:
+                        state["response_queue"].put(", ".join(selected_choices))
+                        self._clarify_state = None
+                        event.app.invalidate()
+                        return
+                    # Only "Other" was checked → switch to freetext
+                    self._clarify_freetext = True
+                    event.app.invalidate()
+                    return
+                # Original single-select behavior: submit the highlighted choice
                 if selected < len(choices):
                     state["response_queue"].put(choices[selected])
                     self._clarify_state = None
@@ -11262,11 +11307,42 @@ class HermesCLI:
                 self._clarify_state["selected"] = min(max_idx, self._clarify_state["selected"] + 1)
                 event.app.invalidate()
 
+        # multi-select support: Space toggles the checkbox at the current cursor position
+        @kb.add('space', filter=Condition(lambda: bool(self._clarify_state) and not self._clarify_freetext and self._clarify_state.get("multi_select")))
+        def clarify_toggle(event):
+            if self._clarify_state:
+                selected = self._clarify_state["selected"]
+                indices = self._clarify_state.get("selected_indices", set())
+                if selected in indices:
+                    indices.discard(selected)
+                else:
+                    indices.add(selected)
+                event.app.invalidate()
+
         # Number keys for quick clarify selection (1-9, 0 for 10th item)
         def _make_clarify_number_handler(idx):
             def handler(event):
                 if self._clarify_state and not self._clarify_freetext:
                     choices = self._clarify_state.get("choices") or []
+                    # multi-select support: number keys toggle checkboxes instead of submitting
+                    if self._clarify_state.get("multi_select"):
+                        if idx < len(choices):
+                            indices = self._clarify_state.get("selected_indices", set())
+                            if idx in indices:
+                                indices.discard(idx)
+                            else:
+                                indices.add(idx)
+                            event.app.invalidate()
+                        elif idx == len(choices):
+                            # Toggle "Other" in multi-select mode
+                            indices = self._clarify_state.get("selected_indices", set())
+                            if idx in indices:
+                                indices.discard(idx)
+                            else:
+                                indices.add(idx)
+                            event.app.invalidate()
+                        return
+                    # Original single-select: number keys submit directly
                     # Map index to choice (treating "Other" as the last option)
                     if idx < len(choices):
                         # Select a numbered choice
@@ -11435,6 +11511,7 @@ class HermesCLI:
                 )
                 self._clarify_state = None
                 self._clarify_freetext = False
+                self._clarify_multi_base = None
                 event.app.current_buffer.reset()
                 event.app.invalidate()
                 return
@@ -11529,6 +11606,7 @@ class HermesCLI:
                 )
                 self._clarify_state = None
                 self._clarify_freetext = False
+                self._clarify_multi_base = None
                 event.app.current_buffer.reset()
                 event.app.invalidate()
                 return
@@ -12081,6 +12159,9 @@ class HermesCLI:
             question = state["question"]
             choices = state.get("choices") or []
             selected = state.get("selected", 0)
+            # multi-select support
+            multi_select = state.get("multi_select", False)
+            selected_indices = state.get("selected_indices", set()) if multi_select else set()
             preview_lines = _wrap_panel_text(question, 60)
             for i, choice in enumerate(choices):
                 # Show number prefix for quick selection (1-9 for items 1-9, 0 for 10th item)
@@ -12090,7 +12171,13 @@ class HermesCLI:
                     num_prefix = '0'
                 else:
                     num_prefix = ' '
-                if i == selected and not cli_ref._clarify_freetext:
+                if multi_select:
+                    cb = "[x]" if i in selected_indices else "[ ]"
+                    if i == selected and not cli_ref._clarify_freetext:
+                        prefix = f"❯ {cb} {num_prefix}. "
+                    else:
+                        prefix = f"  {cb} {num_prefix}. "
+                elif i == selected and not cli_ref._clarify_freetext:
                     prefix = f"❯ {num_prefix}. "
                 else:
                     prefix = f"  {num_prefix}. "
@@ -12103,11 +12190,20 @@ class HermesCLI:
                 other_num_prefix = '0'
             else:
                 other_num_prefix = ' '
-            other_label = (
-                f"❯ {other_num_prefix}. Other (type below)" if cli_ref._clarify_freetext
-                else f"❯ {other_num_prefix}. Other (type your answer)" if selected == len(choices)
-                else f"  {other_num_prefix}. Other (type your answer)"
-            )
+            other_idx_val = len(choices)
+            if multi_select:
+                cb = "[x]" if other_idx_val in selected_indices else "[ ]"
+                other_label = (
+                    f"❯ {cb} {other_num_prefix}. Other (type below)" if cli_ref._clarify_freetext
+                    else f"❯ {cb} {other_num_prefix}. Other (type your answer)" if selected == other_idx_val
+                    else f"  {cb} {other_num_prefix}. Other (type your answer)"
+                )
+            else:
+                other_label = (
+                    f"❯ {other_num_prefix}. Other (type below)" if cli_ref._clarify_freetext
+                    else f"❯ {other_num_prefix}. Other (type your answer)" if selected == len(choices)
+                    else f"  {other_num_prefix}. Other (type your answer)"
+                )
             preview_lines.extend(_wrap_panel_text(other_label, 60, subsequent_indent="    "))
             box_width = _panel_box_width("Hermes needs your input", preview_lines)
             inner_text_width = max(8, box_width - 2)
@@ -12123,7 +12219,14 @@ class HermesCLI:
                         num_prefix = '0'
                     else:
                         num_prefix = ' '
-                    if i == selected and not cli_ref._clarify_freetext:
+                    # multi-select support: add checkbox after cursor indicator
+                    if multi_select:
+                        cb = "[x]" if i in selected_indices else "[ ]"
+                        if i == selected and not cli_ref._clarify_freetext:
+                            prefix = f'❯ {cb} {num_prefix}. '
+                        else:
+                            prefix = f'  {cb} {num_prefix}. '
+                    elif i == selected and not cli_ref._clarify_freetext:
                         prefix = f'❯ {num_prefix}. '
                     else:
                         prefix = f'  {num_prefix}. '
@@ -12138,12 +12241,22 @@ class HermesCLI:
                     other_num_prefix = '0'
                 else:
                     other_num_prefix = ' '
-                if selected == other_idx and not cli_ref._clarify_freetext:
-                    other_label_mand = f'❯ {other_num_prefix}. Other (type your answer)'
-                elif cli_ref._clarify_freetext:
-                    other_label_mand = f'❯ {other_num_prefix}. Other (type below)'
+                # multi-select support: add checkbox to Other option
+                if multi_select:
+                    cb = "[x]" if other_idx in selected_indices else "[ ]"
+                    if selected == other_idx and not cli_ref._clarify_freetext:
+                        other_label_mand = f'❯ {cb} {other_num_prefix}. Other (type your answer)'
+                    elif cli_ref._clarify_freetext:
+                        other_label_mand = f'❯ {cb} {other_num_prefix}. Other (type below)'
+                    else:
+                        other_label_mand = f'  {cb} {other_num_prefix}. Other (type your answer)'
                 else:
-                    other_label_mand = f'  {other_num_prefix}. Other (type your answer)'
+                    if selected == other_idx and not cli_ref._clarify_freetext:
+                        other_label_mand = f'❯ {other_num_prefix}. Other (type your answer)'
+                    elif cli_ref._clarify_freetext:
+                        other_label_mand = f'❯ {other_num_prefix}. Other (type below)'
+                    else:
+                        other_label_mand = f'  {other_num_prefix}. Other (type your answer)'
                 other_wrapped = _wrap_panel_text(other_label_mand, inner_text_width, subsequent_indent="    ")
             elif cli_ref._clarify_freetext:
                 # Freetext-only mode: the guidance line takes the place of choices.

--- a/hermes_cli/callbacks.py
+++ b/hermes_cli/callbacks.py
@@ -15,22 +15,28 @@ from hermes_cli.config import save_env_value_secure
 from hermes_constants import display_hermes_home
 
 
-def clarify_callback(cli, question, choices):
+def clarify_callback(cli, question, choices, multi_select=False):
     """Prompt for clarifying question through the TUI.
 
     Sets up the interactive selection UI, then blocks until the user
     responds. Returns the user's choice or a timeout message.
+
+    When ``multi_select`` is True, shows checkboxes and the user can
+    select multiple options with Space, confirming with Enter.
     """
     from cli import CLI_CONFIG
 
     timeout = CLI_CONFIG.get("clarify", {}).get("timeout", 120)
     response_queue = queue.Queue()
     is_open_ended = not choices
+    effective_multi = multi_select and not is_open_ended
 
     cli._clarify_state = {
         "question": question,
         "choices": choices if not is_open_ended else [],
         "selected": 0,
+        "multi_select": effective_multi,
+        "selected_indices": set() if effective_multi else None,
         "response_queue": response_queue,
     }
     cli._clarify_deadline = _time.monotonic() + timeout

--- a/hermes_cli/oneshot.py
+++ b/hermes_cli/oneshot.py
@@ -336,10 +336,15 @@ def _run_agent(
     return agent.chat(prompt) or ""
 
 
-def _oneshot_clarify_callback(question: str, choices=None) -> str:
+def _oneshot_clarify_callback(question: str, choices=None, multi_select=False) -> str:
     """Clarify is disabled in oneshot mode — tell the agent to pick a
     default and proceed instead of stalling or erroring."""
     if choices:
+        if multi_select:
+            return (
+                f"[oneshot mode: no user available. Pick the best subset from "
+                f"{choices} using your own judgment and continue.]"
+            )
         return (
             f"[oneshot mode: no user available. Pick the best option from "
             f"{choices} using your own judgment and continue.]"

--- a/run_agent.py
+++ b/run_agent.py
@@ -1143,7 +1143,7 @@ class AIAgent:
                 None or empty = let OpenRouter pick the strongest available coder.
             session_id (str): Pre-generated session ID for logging (optional, auto-generated if not provided)
             tool_progress_callback (callable): Callback function(tool_name, args_preview) for progress notifications
-            clarify_callback (callable): Callback function(question, choices) -> str for interactive user questions.
+            clarify_callback (callable): Callback function(question, choices, multi_select=False) -> str for interactive user questions.
                 Provided by the platform layer (CLI or gateway). If None, the clarify tool returns an error.
             max_tokens (int): Maximum tokens for model responses (optional, uses model default if not set)
             reasoning_config (Dict): OpenRouter reasoning configuration override (e.g. {"effort": "none"} to disable thinking).
@@ -10347,6 +10347,7 @@ class AIAgent:
             return _clarify_tool(
                 question=function_args.get("question", ""),
                 choices=function_args.get("choices"),
+                multi_select=function_args.get("multi_select", False),
                 callback=self.clarify_callback,
             )
         elif function_name == "delegate_task":
@@ -10976,6 +10977,7 @@ class AIAgent:
                 function_result = _clarify_tool(
                     question=function_args.get("question", ""),
                     choices=function_args.get("choices"),
+                    multi_select=function_args.get("multi_select", False),
                     callback=self.clarify_callback,
                 )
                 tool_duration = time.time() - tool_start_time

--- a/tests/tools/test_clarify_tool.py
+++ b/tests/tools/test_clarify_tool.py
@@ -193,3 +193,189 @@ class TestClarifySchema:
     def test_max_choices_is_four(self):
         """MAX_CHOICES constant should be 4."""
         assert MAX_CHOICES == 4
+
+    def test_schema_multi_select_optional(self):
+        """multi_select should not be in required list."""
+        assert "multi_select" not in CLARIFY_SCHEMA["parameters"]["required"]
+
+    def test_schema_multi_select_is_boolean(self):
+        """multi_select should be a boolean parameter."""
+        ms_spec = CLARIFY_SCHEMA["parameters"]["properties"].get("multi_select")
+        assert ms_spec is not None
+        assert ms_spec["type"] == "boolean"
+
+    def test_schema_multi_select_default_false(self):
+        """multi_select should default to false (not in required)."""
+        # The model should treat it as false when omitted
+        assert "multi_select" not in CLARIFY_SCHEMA["parameters"]["required"]
+
+
+class TestClarifyToolMultiSelect:
+    """Tests for multi_select (checkbox) support added to clarify_tool."""
+
+    def test_multi_select_false_keeps_existing_behavior(self):
+        """When multi_select=False, user_response should be a single string."""
+        def mock_callback(question, choices):
+            return "blue"
+
+        result = json.loads(clarify_tool(
+            "What color?",
+            choices=["red", "blue", "green"],
+            multi_select=False,
+            callback=mock_callback,
+        ))
+        assert result["user_response"] == "blue"
+        assert isinstance(result["user_response"], str)
+
+    def test_multi_select_true_returns_list(self):
+        """When multi_select=True, user_response should be a list of strings."""
+        def mock_callback(question, choices):
+            return "red, blue"
+
+        result = json.loads(clarify_tool(
+            "Which colors?",
+            choices=["red", "blue", "green"],
+            multi_select=True,
+            callback=mock_callback,
+        ))
+        assert result["user_response"] == ["red", "blue"]
+        assert isinstance(result["user_response"], list)
+
+    def test_multi_select_single_choice_still_list(self):
+        """Even a single selection should be a list when multi_select=True."""
+        def mock_callback(question, choices):
+            return "red"
+
+        result = json.loads(clarify_tool(
+            "Which color?",
+            choices=["red", "blue"],
+            multi_select=True,
+            callback=mock_callback,
+        ))
+        assert result["user_response"] == ["red"]
+        assert isinstance(result["user_response"], list)
+
+    def test_multi_select_with_json_array_response(self):
+        """Callback can return a JSON array string for multi-select."""
+        def mock_callback(question, choices):
+            return '["red", "blue"]'
+
+        result = json.loads(clarify_tool(
+            "Which colors?",
+            choices=["red", "blue", "green"],
+            multi_select=True,
+            callback=mock_callback,
+        ))
+        assert result["user_response"] == ["red", "blue"]
+
+    def test_multi_select_no_choices_falls_back_to_single_string(self):
+        """When choices is None, multi_select has no effect on response type."""
+        def mock_callback(question, choices):
+            return "free form answer"
+
+        result = json.loads(clarify_tool(
+            "What do you think?",
+            multi_select=True,
+            callback=mock_callback,
+        ))
+        # Without choices, falls back to single string response
+        assert result["user_response"] == "free form answer"
+        assert isinstance(result["user_response"], str)
+
+    def test_multi_select_default_is_false(self):
+        """Default multi_select should be False (backward compatible)."""
+        def mock_callback(question, choices):
+            return "picked"
+
+        result = json.loads(clarify_tool(
+            "Pick one",
+            choices=["a", "b"],
+            callback=mock_callback,
+        ))
+        assert result["user_response"] == "picked"
+        assert isinstance(result["user_response"], str)
+
+    def test_multi_select_callback_receives_flag(self):
+        """Callback should receive multi_select keyword argument when supported."""
+        received_flag = []
+
+        def mock_callback(question, choices, **kwargs):
+            received_flag.append(kwargs.get("multi_select"))
+            return "a, b"
+
+        clarify_tool(
+            "Pick",
+            choices=["a", "b", "c"],
+            multi_select=True,
+            callback=mock_callback,
+        )
+        assert received_flag == [True]
+
+    def test_multi_select_backward_compatible_callback(self):
+        """Callback that does not accept multi_select keyword should still work."""
+        def mock_callback(question, choices):
+            return "a, b"
+
+        result = json.loads(clarify_tool(
+            "Pick",
+            choices=["a", "b", "c"],
+            multi_select=True,
+            callback=mock_callback,
+        ))
+        assert result["user_response"] == ["a", "b"]
+
+    def test_multi_select_empty_selection_returns_empty_list(self):
+        """Empty response should produce empty list when multi_select=True."""
+        def mock_callback(question, choices):
+            return ""
+
+        result = json.loads(clarify_tool(
+            "Which?",
+            choices=["a", "b"],
+            multi_select=True,
+            callback=mock_callback,
+        ))
+        assert result["user_response"] == []
+
+    def test_multi_select_whitespace_choices_stripped(self):
+        """Individual selections should be stripped of whitespace."""
+        def mock_callback(question, choices):
+            return "  a , b ,  c  "
+
+        result = json.loads(clarify_tool(
+            "Which?",
+            choices=["a", "b", "c"],
+            multi_select=True,
+            callback=mock_callback,
+        ))
+        assert result["user_response"] == ["a", "b", "c"]
+
+    def test_multi_select_choices_offered_preserved(self):
+        """choices_offered should match what was passed in, not the response."""
+        def mock_callback(question, choices):
+            return "red, blue"
+
+        result = json.loads(clarify_tool(
+            "Which?",
+            choices=["red", "blue", "green"],
+            multi_select=True,
+            callback=mock_callback,
+        ))
+        assert result["choices_offered"] == ["red", "blue", "green"]
+
+    def test_multi_select_max_choices_enforced(self):
+        """MAX_CHOICES enforcement should still work with multi_select."""
+        choices_passed = []
+
+        def mock_callback(question, choices):
+            choices_passed.extend(choices or [])
+            return "a, b, c, d"
+
+        many_choices = ["a", "b", "c", "d", "e", "f"]
+        clarify_tool(
+            "Pick some",
+            choices=many_choices,
+            multi_select=True,
+            callback=mock_callback,
+        )
+        assert len(choices_passed) == MAX_CHOICES

--- a/tools/clarify_tool.py
+++ b/tools/clarify_tool.py
@@ -6,6 +6,9 @@ Allows the agent to present structured multiple-choice questions or open-ended
 prompts to the user. In CLI mode, choices are navigable with arrow keys. On
 messaging platforms, choices are rendered as a numbered list.
 
+Supports both single-select (radio) and multi-select (checkbox) modes via the
+``multi_select`` parameter.
+
 The actual user-interaction logic lives in the platform layer (cli.py for CLI,
 gateway/run.py for messaging). This module defines the schema, validation, and
 a thin dispatcher that delegates to a platform-provided callback.
@@ -20,21 +23,64 @@ from typing import List, Optional, Callable
 MAX_CHOICES = 4
 
 
+def _invoke_callback(callback, question, choices, multi_select):
+    """Invoke the platform callback, passing multi_select if supported."""
+    try:
+        return callback(question, choices, multi_select=multi_select)
+    except TypeError:
+        # Callback does not accept the multi_select keyword; fall back
+        return callback(question, choices)
+
+
+def _parse_multi_select_response(raw_response) -> List[str]:
+    """Parse a multi-select response into a list of cleaned choice strings.
+
+    Handles three forms:
+      - Already a list  →  stringify + strip each element
+      - JSON array      →  parse and strip
+      - Comma-separated →  split, strip, drop empties
+    """
+    if isinstance(raw_response, list):
+        return [str(r).strip() for r in raw_response if str(r).strip()]
+
+    raw = str(raw_response).strip()
+
+    # Try JSON array
+    if raw.startswith("["):
+        try:
+            parsed = json.loads(raw)
+            if isinstance(parsed, list):
+                return [str(p).strip() for p in parsed if str(p).strip()]
+        except json.JSONDecodeError:
+            pass
+
+    # Fall back to comma-separated
+    return [s.strip() for s in raw.split(",") if s.strip()]
+
+
 def clarify_tool(
     question: str,
     choices: Optional[List[str]] = None,
+    multi_select: bool = False,
     callback: Optional[Callable] = None,
 ) -> str:
     """
     Ask the user a question, optionally with multiple-choice options.
 
     Args:
-        question: The question text to present.
-        choices:  Up to 4 predefined answer choices. When omitted the
-                  question is purely open-ended.
-        callback: Platform-provided function that handles the actual UI
-                  interaction. Signature: callback(question, choices) -> str.
-                  Injected by the agent runner (cli.py / gateway).
+        question:     The question text to present.
+        choices:      Up to 4 predefined answer choices. When omitted the
+                      question is purely open-ended.
+        multi_select: When True, the user can select multiple choices
+                      (checkboxes).  The ``user_response`` in the output JSON
+                      will be a list of strings instead of a single string.
+                      Has no effect when ``choices`` is omitted.
+        callback:     Platform-provided function that handles the actual UI
+                      interaction.  Signature:
+                      ``callback(question, choices, multi_select=False) -> str``.
+                      The optional ``multi_select`` keyword is passed so the
+                      platform can render checkboxes instead of radio buttons.
+                      Injected by the agent runner (cli.py / gateway).
 
     Returns:
         JSON string with the user's response.
@@ -61,17 +107,22 @@ def clarify_tool(
         )
 
     try:
-        user_response = callback(question, choices)
+        raw_response = _invoke_callback(callback, question, choices, multi_select)
     except Exception as exc:
         return json.dumps(
             {"error": f"Failed to get user input: {exc}"},
             ensure_ascii=False,
         )
 
+    if multi_select and choices is not None:
+        user_response = _parse_multi_select_response(raw_response)
+    else:
+        user_response = str(raw_response).strip()
+
     return json.dumps({
         "question": question,
         "choices_offered": choices,
-        "user_response": str(user_response).strip(),
+        "user_response": user_response,
     }, ensure_ascii=False)
 
 
@@ -88,10 +139,12 @@ CLARIFY_SCHEMA = {
     "name": "clarify",
     "description": (
         "Ask the user a question when you need clarification, feedback, or a "
-        "decision before proceeding. Supports two modes:\n\n"
-        "1. **Multiple choice** — provide up to 4 choices. The user picks one "
+        "decision before proceeding. Supports three modes:\n\n"
+        "1. **Single-select multiple choice** — provide up to 4 choices. The user picks one "
         "or types their own answer via a 5th 'Other' option.\n"
-        "2. **Open-ended** — omit choices entirely. The user types a free-form "
+        "2. **Multi-select multiple choice** — set multi_select=true. The user can select "
+        "multiple options via checkboxes. user_response will be a list of selected choices.\n"
+        "3. **Open-ended** — omit choices entirely. The user types a free-form "
         "response.\n\n"
         "Use this tool when:\n"
         "- The task is ambiguous and you need the user to choose an approach\n"
@@ -119,6 +172,15 @@ CLARIFY_SCHEMA = {
                     "automatically appends an 'Other (type your answer)' option."
                 ),
             },
+            "multi_select": {
+                "type": "boolean",
+                "description": (
+                    "When true, the user can select MULTIPLE options (like checkboxes). "
+                    "The user_response will be a list of selected choices. "
+                    "When false (default), single selection (radio). "
+                    "Has no effect when choices is omitted (open-ended question)."
+                ),
+            },
         },
         "required": ["question"],
     },
@@ -135,6 +197,7 @@ registry.register(
     handler=lambda args, **kw: clarify_tool(
         question=args.get("question", ""),
         choices=args.get("choices"),
+        multi_select=args.get("multi_select", False),
         callback=kw.get("callback")),
     check_fn=check_clarify_requirements,
     emoji="❓",


### PR DESCRIPTION
## Summary

Adds a `multi_select` boolean parameter to the `clarify` tool, enabling checkbox-style multi-choice questions where users can select multiple options (Space to toggle, Enter to confirm). Fully backward compatible — `multi_select=False` (default) preserves existing single-select behavior.

## Changes

**6 files modified — 402 insertions (+), 27 deletions (-)**

| File | Changes |
|------|---------|
| `tools/clarify_tool.py` | +85/−17 — Add `multi_select` to `CLARIFY_SCHEMA`. `_invoke_callback()` with TypeError fallback. `_parse_multi_select_response()` supporting list, JSON array, comma-separated. |
| `run_agent.py` | +2/−2 — Both dispatch points pass `multi_select`. |
| `cli.py` | +139/−10 — Checkbox UI, Space toggle, Enter handler, number keys, `_clarify_multi_base` reset in all exit paths. |
| `hermes_cli/callbacks.py` | +4/−2 — TUI fallback accepts `multi_select`. |
| `hermes_cli/oneshot.py` | +5/−2 — Oneshot multi-select message. |
| `tests/tools/test_clarify_tool.py` | +186/−0 — 12 new tests (35 total, all passing). |

## Edge Cases

- Empty selection -> `[]` (not highlighted item as string)
- "Other" + real choices -> freetext, base choices prepended to typed answer
- Only "Other" -> freetext
- `_clarify_multi_base` reset in all exit paths (timeout, cancel, normal)
- Multi-select + no choices -> falls back to single string (open-ended)

## Backward Compatibility

- `multi_select` defaults to `False` everywhere
- `_invoke_callback` catches `TypeError` for old 2-arg lambdas (TUI gateway)
- Oneshot mode returns appropriate fallback message

## Verification

```
$ python -m pytest tests/tools/test_clarify_tool.py -v
35 passed in 0.62s
```