### PR TITLE
fix(tools): forward media args through live adapter

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -2229,3 +2229,35 @@ class TestSendViaAdapterStandaloneFallback:
         assert result["success"] is True
         assert result["message_id"] == "abc-123"
         assert result["extra_field"] == "preserved"
+
+    @pytest.mark.asyncio
+    async def test_live_adapter_forwards_media_kwargs(self, monkeypatch):
+        """Live in-process adapters receive media_files and force_document."""
+        from tools.send_message_tool import _send_via_adapter
+
+        send_mock = AsyncMock(
+            return_value=SimpleNamespace(success=True, message_id="live-42", error=None)
+        )
+        runner = SimpleNamespace(
+            adapters={_FakePlatform("qqbot"): SimpleNamespace(send=send_mock)}
+        )
+        platform = next(iter(runner.adapters))
+
+        monkeypatch.setattr("gateway.run._gateway_runner_ref", lambda: runner)
+
+        result = await _send_via_adapter(
+            platform,
+            SimpleNamespace(extra={}),
+            "chat-1",
+            "hello",
+            media_files=[("/tmp/report.pdf", False)],
+            force_document=True,
+        )
+
+        assert result == {"success": True, "message_id": "live-42"}
+        send_mock.assert_awaited_once_with(
+            chat_id="chat-1",
+            content="hello",
+            media_files=[("/tmp/report.pdf", False)],
+            force_document=True,
+        )

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -458,7 +458,12 @@ async def _send_via_adapter(
             adapter = None
         if adapter is not None:
             try:
-                result = await adapter.send(chat_id=chat_id, content=chunk)
+                result = await adapter.send(
+                    chat_id=chat_id,
+                    content=chunk,
+                    media_files=media_files,
+                    force_document=force_document,
+                )
             except asyncio.CancelledError:
                 raise
             except Exception as e:


### PR DESCRIPTION
## What does this PR do?

Fixes the live in-process `_send_via_adapter()` path so gateway adapters receive `media_files` and `force_document` just like the existing standalone sender path. Before this change, attachments could silently disappear whenever the gateway runner and adapter lived in the current process.

## Related Issue

Fixes #23760

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Forwarded `media_files` and `force_document` through the live `adapter.send(...)` call in `/tools/send_message_tool.py`
- Added a regression test in `/tests/tools/test_send_message_tool.py` that exercises the live in-process adapter path and asserts both kwargs are preserved

## How to Test

1. Run `uv run --frozen pytest -q -o addopts='' tests/tools/test_send_message_tool.py -k TestSendViaAdapterStandaloneFallback`
2. Confirm the new `test_live_adapter_forwards_media_kwargs` passes
3. Run `uv run --frozen ruff check tools/send_message_tool.py tests/tools/test_send_message_tool.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15 / local targeted pytest and ruff

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `uv run --frozen pytest -q -o addopts='' tests/tools/test_send_message_tool.py -k TestSendViaAdapterStandaloneFallback` -> `6 passed`
- `uv run --frozen ruff check tools/send_message_tool.py tests/tools/test_send_message_tool.py` -> passed
