### PR TITLE
feat(plugins): add gateway:startup hook for plugin system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 __pycache__/
 .venv/
 .vscode/
+.claude/
 .env
 .env.local
 .env.development.local

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3595,6 +3595,11 @@ class GatewayRunner:
         await self.hooks.emit("gateway:startup", {
             "platforms": [p.value for p in self.adapters.keys()],
         })
+        from hermes_cli.plugins import invoke_hook as _invoke_hook
+        _invoke_hook(
+            "gateway:startup",
+            platforms=[p.value for p in self.adapters.keys()],
+        )
         
         if connected_count > 0:
             logger.info("Gateway running with %s platform(s)", connected_count)

--- a/hermes_cli/plugins.py
+++ b/hermes_cli/plugins.py
@@ -150,6 +150,7 @@ VALID_HOOKS: Set[str] = {
     #   {"action": "rewrite", "text": "..."}    -> replace event.text, continue
     #   {"action": "allow"}  /  None             -> normal dispatch
     # Kwargs: event: MessageEvent, gateway: GatewayRunner, session_store.
+    "gateway:startup",
     "pre_gateway_dispatch",
     # Approval lifecycle hooks. Fired by tools/approval.py when a dangerous
     # command needs user approval -- fires BOTH for CLI-interactive prompts


### PR DESCRIPTION
Fire after gateway finishes booting, so shell hooks and Python plugins in config.yaml can react to gateway startup, matching the existing HookRegistry event.
Closes #23747