### PR TITLE
feat: add email challenge authentication

### DIFF
--- a/gateway/config.py
+++ b/gateway/config.py
@@ -1352,6 +1352,15 @@ def _apply_env_overrides(config: GatewayConfig) -> None:
             "imap_host": email_imap,
             "smtp_host": email_smtp,
         })
+        email_auth_mode = os.getenv("EMAIL_AUTH_MODE")
+        if email_auth_mode is not None:
+            config.platforms[Platform.EMAIL].extra["auth_mode"] = email_auth_mode
+        email_challenge_ttl = os.getenv("EMAIL_CHALLENGE_TTL_SECONDS")
+        if email_challenge_ttl is not None:
+            config.platforms[Platform.EMAIL].extra["challenge_ttl_seconds"] = email_challenge_ttl
+        email_challenge_store = os.getenv("EMAIL_CHALLENGE_STORE")
+        if email_challenge_store is not None:
+            config.platforms[Platform.EMAIL].extra["challenge_store"] = email_challenge_store
     email_home = os.getenv("EMAIL_HOME_ADDRESS")
     if email_home and Platform.EMAIL in config.platforms:
         config.platforms[Platform.EMAIL].home_channel = HomeChannel(

--- a/gateway/email_challenge.py
+++ b/gateway/email_challenge.py
@@ -1,0 +1,459 @@
+"""Persistent email challenge-response store."""
+
+from __future__ import annotations
+
+import contextlib
+import copy
+import hashlib
+import json
+import logging
+import os
+import secrets
+import time
+from pathlib import Path
+from typing import Any, Dict, Iterator, Optional, Tuple
+
+from hermes_constants import get_hermes_home
+
+
+logger = logging.getLogger(__name__)
+DEFAULT_EMAIL_CHALLENGE_TTL_SECONDS = 900
+MAX_PENDING_CHALLENGES_PER_SENDER = 25
+MAX_PENDING_CHALLENGES_TOTAL = 500
+MAX_PENDING_CHALLENGE_CACHED_ATTACHMENT_BYTES = 25_000_000
+
+_CACHE_PATH_MARKERS = {
+    "audio": "audio_",
+    "documents": "doc_",
+    "images": "img_",
+    "videos": "video_",
+}
+
+
+def cleanup_challenge_cached_attachments(event_data: Dict[str, Any]) -> list[Dict[str, Any]]:
+    """Delete cached local attachment files referenced by challenge-owned event data.
+
+    Returns attachment metadata for files that could not be unlinked so callers
+    that own the persistent store can retain a small cleanup tombstone and retry
+    later without keeping the original body/subject/event payload.
+    """
+    failed: list[Dict[str, Any]] = []
+    attachments = event_data.get("attachments") if isinstance(event_data, dict) else None
+    if not isinstance(attachments, list):
+        return failed
+    for attachment in attachments:
+        if not isinstance(attachment, dict):
+            continue
+        path = _challenge_cached_attachment_path(attachment.get("path"))
+        if path is None:
+            continue
+        try:
+            path.unlink()
+        except FileNotFoundError:
+            continue
+        except OSError as exc:
+            logger.warning("[Email] Could not delete cached challenge attachment %s: %s", path, exc)
+            failed.append({
+                "path": str(path),
+                "type": attachment.get("type"),
+                "media_type": attachment.get("media_type"),
+            })
+    return failed
+
+
+def _challenge_cached_attachment_path(raw_path: Any) -> Optional[Path]:
+    if not isinstance(raw_path, str) or not raw_path:
+        return None
+    path = Path(raw_path)
+    if not path.is_absolute() or path.name in ("", ".", ".."):
+        return None
+    try:
+        resolved_path = path.resolve()
+    except OSError:
+        return None
+    from gateway.platforms import base
+
+    cache_roots = {
+        "audio": base.AUDIO_CACHE_DIR,
+        "documents": base.DOCUMENT_CACHE_DIR,
+        "images": base.IMAGE_CACHE_DIR,
+        "videos": base.VIDEO_CACHE_DIR,
+    }
+    for cache_kind, prefix in _CACHE_PATH_MARKERS.items():
+        if not path.name.startswith(prefix):
+            continue
+        try:
+            root = cache_roots[cache_kind].resolve()
+        except OSError:
+            continue
+        if resolved_path.is_relative_to(root):
+            return path
+    return None
+
+
+class EmailChallengeStore:
+    """Small JSON-backed one-time challenge store for email gateway auth."""
+
+    def __init__(self, path: Optional[str] = None, ttl_seconds: int = DEFAULT_EMAIL_CHALLENGE_TTL_SECONDS):
+        self.path = Path(path) if path else get_hermes_home() / "email_challenges.json"
+        self.ttl_seconds = ttl_seconds
+
+    def create(self, sender: str, subject: str, message_id: str, event_data: Dict[str, Any]) -> Optional[str]:
+        with self._locked_data() as data:
+            self._cleanup_expired_locked(data)
+            sender = sender.lower()
+            self._trim_sender_challenges_locked(data, sender)
+            if self._pending_count_locked(data) >= MAX_PENDING_CHALLENGES_TOTAL:
+                logger.warning("[Email] Email challenge store full; dropping challenge for %s", sender)
+                return None
+            pending_bytes = self._pending_cached_attachment_bytes_locked(data)
+            event_bytes = self._event_cached_attachment_bytes(event_data)
+            if pending_bytes + event_bytes > MAX_PENDING_CHALLENGE_CACHED_ATTACHMENT_BYTES:
+                logger.warning("[Email] Email challenge attachment cache quota full; dropping challenge for %s", sender)
+                cleanup_challenge_cached_attachments(event_data)
+                return None
+            code = self._new_code(data)
+            data["challenges"].append({
+                "code_hash": self._code_hash(code),
+                "sender": sender,
+                "subject": subject,
+                "message_id": message_id,
+                "created_at": time.time(),
+                "used": False,
+                "event": event_data,
+            })
+            return code
+
+    def confirm(self, sender: str, code: str) -> Tuple[str, Optional[Dict[str, Any]]]:
+        with self._locked_data() as data:
+            sender = sender.lower()
+            now = time.time()
+            found = None
+            for challenge in data["challenges"]:
+                if self._challenge_matches_code(challenge, code):
+                    found = challenge
+                    break
+
+            if not found:
+                return "not_found", None
+            if found.get("used"):
+                return "used", None
+            if found.get("sender") != sender:
+                return "sender_mismatch", None
+
+            created_at = self._created_at(found)
+            if created_at is None or now - created_at > self.ttl_seconds:
+                failed_cleanup = cleanup_challenge_cached_attachments(found.get("event") or {})
+                self._record_cleanup_pending_locked(data, failed_cleanup)
+                found["used"] = True
+                self._scrub_sensitive_challenge_locked(found)
+                return "expired", None
+
+            event = copy.deepcopy(found.get("event") or None)
+            found["used"] = True
+            self._scrub_sensitive_challenge_locked(found)
+            return "ok", event
+
+    def remove(self, sender: str, code: str) -> bool:
+        """Remove a pending challenge and delete its cached attachments."""
+        with self._locked_data() as data:
+            sender = sender.lower()
+            retained = []
+            removed = False
+            for challenge in data["challenges"]:
+                if not removed and challenge.get("sender") == sender and self._challenge_matches_code(challenge, code):
+                    failed_cleanup = cleanup_challenge_cached_attachments(challenge.get("event") or {})
+                    self._record_cleanup_pending_locked(data, failed_cleanup)
+                    removed = True
+                    continue
+                retained.append(challenge)
+            data["challenges"] = retained
+            return removed
+
+    def cleanup_expired(self) -> None:
+        if not self.path.exists():
+            return
+        with self._locked_data() as data:
+            self._cleanup_expired_locked(data)
+
+    def _new_code(self, data: Dict[str, Any]) -> str:
+        existing_hashes = {challenge.get("code_hash") for challenge in data["challenges"]}
+        legacy_codes = {challenge.get("code") for challenge in data["challenges"]}
+        while True:
+            code = secrets.token_urlsafe(12)
+            if code not in legacy_codes and self._code_hash(code) not in existing_hashes:
+                return code
+
+    def _challenge_matches_code(self, challenge: Dict[str, Any], code: str) -> bool:
+        code_hash = challenge.get("code_hash")
+        if isinstance(code_hash, str):
+            return secrets.compare_digest(code_hash, self._code_hash(code))
+        legacy_code = challenge.get("code")
+        return isinstance(legacy_code, str) and secrets.compare_digest(legacy_code, code)
+
+    def _code_hash(self, code: str) -> str:
+        return hashlib.sha256(code.encode("utf-8")).hexdigest()
+
+    def _cleanup_expired_locked(self, data: Dict[str, Any]) -> bool:
+        self._retry_cleanup_pending_locked(data)
+        now = time.time()
+        before = len(data["challenges"])
+        retained = []
+        for challenge in data["challenges"]:
+            created_at = self._created_at(challenge)
+            keep = not challenge.get("used") and created_at is not None and now - created_at <= self.ttl_seconds
+            if keep:
+                retained.append(challenge)
+            else:
+                failed_cleanup = cleanup_challenge_cached_attachments(challenge.get("event") or {})
+                self._record_cleanup_pending_locked(data, failed_cleanup)
+                self._scrub_sensitive_challenge_locked(challenge)
+        data["challenges"] = retained
+        return len(data["challenges"]) != before
+
+    def _record_cleanup_pending_locked(self, data: Dict[str, Any], attachments: list[Dict[str, Any]]) -> None:
+        valid = []
+        for attachment in attachments:
+            if not isinstance(attachment, dict):
+                continue
+            path = _challenge_cached_attachment_path(attachment.get("path"))
+            if path is None:
+                continue
+            valid.append({
+                "path": str(path),
+                "type": attachment.get("type"),
+                "media_type": attachment.get("media_type"),
+            })
+        if not valid:
+            return
+        data.setdefault("cleanup_pending", []).append({"attachments": valid})
+
+    def _retry_cleanup_pending_locked(self, data: Dict[str, Any]) -> None:
+        pending = data.get("cleanup_pending")
+        if not isinstance(pending, list) or not pending:
+            data.pop("cleanup_pending", None)
+            return
+        retained = []
+        for item in pending:
+            if not isinstance(item, dict):
+                continue
+            failed_cleanup = cleanup_challenge_cached_attachments(item)
+            if failed_cleanup:
+                retained.append({"attachments": failed_cleanup})
+        if retained:
+            data["cleanup_pending"] = retained
+        else:
+            data.pop("cleanup_pending", None)
+
+    def _scrub_sensitive_challenge_locked(self, challenge: Dict[str, Any]) -> None:
+        challenge.pop("event", None)
+        challenge.pop("subject", None)
+        challenge.pop("message_id", None)
+        challenge.pop("body", None)
+        challenge.pop("attachments", None)
+
+    def _trim_sender_challenges_locked(self, data: Dict[str, Any], sender: str) -> None:
+        pending_for_sender = [
+            challenge
+            for challenge in data["challenges"]
+            if challenge.get("sender") == sender and not challenge.get("used")
+        ]
+        overflow = len(pending_for_sender) - MAX_PENDING_CHALLENGES_PER_SENDER + 1
+        if overflow <= 0:
+            return
+        pending_for_sender.sort(key=lambda challenge: self._created_at(challenge) or 0)
+        to_remove = {id(challenge) for challenge in pending_for_sender[:overflow]}
+        for challenge in pending_for_sender[:overflow]:
+            failed_cleanup = cleanup_challenge_cached_attachments(challenge.get("event") or {})
+            self._record_cleanup_pending_locked(data, failed_cleanup)
+        data["challenges"] = [challenge for challenge in data["challenges"] if id(challenge) not in to_remove]
+
+    def _pending_count_locked(self, data: Dict[str, Any]) -> int:
+        return sum(1 for challenge in data["challenges"] if not challenge.get("used"))
+
+    def _pending_cached_attachment_bytes_locked(self, data: Dict[str, Any]) -> int:
+        return sum(
+            self._event_cached_attachment_bytes(challenge.get("event") or {})
+            for challenge in data["challenges"]
+            if not challenge.get("used")
+        )
+
+    def _event_cached_attachment_bytes(self, event_data: Dict[str, Any]) -> int:
+        attachments = event_data.get("attachments") if isinstance(event_data, dict) else None
+        if not isinstance(attachments, list):
+            return 0
+        total = 0
+        for attachment in attachments:
+            if not isinstance(attachment, dict):
+                continue
+            path = _challenge_cached_attachment_path(attachment.get("path"))
+            if path is None:
+                continue
+            try:
+                total += path.stat().st_size
+            except OSError:
+                continue
+        return total
+
+    def _created_at(self, challenge: Dict[str, Any]) -> Optional[float]:
+        if "created_at" not in challenge:
+            logger.warning("[Email] Ignoring email challenge without timestamp in %s", self.path)
+            return None
+        try:
+            return float(challenge.get("created_at"))
+        except (TypeError, ValueError):
+            logger.warning("[Email] Ignoring malformed email challenge timestamp in %s", self.path)
+            return None
+
+    @contextlib.contextmanager
+    def _locked_data(self) -> Iterator[Dict[str, Any]]:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        lock_path = self.path.with_name(f".{self.path.name}.lock")
+        with lock_path.open("a+") as lock_file:
+            self._lock_file(lock_file)
+            try:
+                self._loaded_store_was_sanitized = False
+                data = self._load()
+                self._harden_permissions()
+                original = self._serialized(data)
+                yield data
+                if self._loaded_store_was_sanitized or self._serialized(data) != original:
+                    self._save(data)
+            finally:
+                self._loaded_store_was_sanitized = False
+                self._unlock_file(lock_file)
+
+    def _serialized(self, data: Dict[str, Any]) -> str:
+        return json.dumps(data, indent=2, sort_keys=True)
+
+    def _load(self) -> Dict[str, Any]:
+        try:
+            raw = json.loads(self.path.read_text(encoding="utf-8"))
+        except FileNotFoundError:
+            return {"challenges": []}
+        except json.JSONDecodeError:
+            logger.warning("[Email] Ignoring corrupt email challenge store: %s", self.path)
+            self._discard_invalid_store()
+            return {"challenges": []}
+        except OSError as exc:
+            logger.warning("[Email] Could not read email challenge store %s: %s", self.path, exc)
+            raise
+        if not isinstance(raw, dict) or not isinstance(raw.get("challenges"), list):
+            logger.warning("[Email] Ignoring invalid email challenge store shape: %s", self.path)
+            self._discard_invalid_store()
+            return {"challenges": []}
+        challenges, challenges_sanitized = self._sanitize_loaded_challenges(raw["challenges"])
+        data = {"challenges": challenges}
+        cleanup_pending = raw.get("cleanup_pending")
+        if isinstance(cleanup_pending, list):
+            data["cleanup_pending"] = cleanup_pending
+        if challenges_sanitized or data != raw:
+            logger.warning("[Email] Sanitizing invalid email challenge store entries: %s", self.path)
+            self._loaded_store_was_sanitized = True
+        return data
+
+    def _sanitize_loaded_challenges(self, raw_challenges: list[Any]) -> tuple[list[Dict[str, Any]], bool]:
+        challenges: list[Dict[str, Any]] = []
+        sanitized = False
+        for raw_challenge in raw_challenges:
+            if not isinstance(raw_challenge, dict):
+                sanitized = True
+                continue
+            challenge = self._sanitize_loaded_challenge(raw_challenge)
+            if challenge is None:
+                sanitized = True
+                continue
+            if challenge != raw_challenge:
+                sanitized = True
+            challenges.append(challenge)
+        return challenges, sanitized
+
+    def _sanitize_loaded_challenge(self, challenge: Dict[str, Any]) -> Optional[Dict[str, Any]]:
+        code_hash = challenge.get("code_hash")
+        legacy_code = challenge.get("code")
+        has_code_hash = isinstance(code_hash, str) and len(code_hash) == 64 and all(
+            char in "0123456789abcdefABCDEF" for char in code_hash
+        )
+        has_legacy_code = isinstance(legacy_code, str) and bool(legacy_code)
+        sender = challenge.get("sender")
+        used = challenge.get("used")
+        if not (has_code_hash or has_legacy_code) or not isinstance(sender, str) or not sender:
+            return None
+        if used not in (True, False):
+            return None
+        has_valid_created_at = self._created_at(challenge) is not None
+        if not has_valid_created_at:
+            return None
+
+        sanitized: Dict[str, Any] = {}
+        if has_code_hash:
+            sanitized["code_hash"] = code_hash
+        if has_legacy_code:
+            sanitized["code"] = legacy_code
+        sanitized["sender"] = sender
+        sanitized["created_at"] = challenge["created_at"]
+        sanitized["used"] = used
+
+        if not used:
+            subject = challenge.get("subject")
+            message_id = challenge.get("message_id")
+            event = challenge.get("event")
+            if not isinstance(subject, str) or not isinstance(message_id, str) or not isinstance(event, dict):
+                return None
+            sanitized["subject"] = subject
+            sanitized["message_id"] = message_id
+            sanitized["event"] = event
+
+        return sanitized
+
+    def _discard_invalid_store(self) -> None:
+        try:
+            self.path.unlink()
+        except FileNotFoundError:
+            return
+        except OSError as exc:
+            logger.warning("[Email] Could not remove invalid email challenge store %s: %s", self.path, exc)
+
+    def _harden_permissions(self) -> None:
+        if os.name == "nt" or not self.path.exists():
+            return
+        try:
+            os.chmod(self.path, 0o600)
+        except OSError as exc:
+            logger.warning("[Email] Could not harden email challenge store permissions %s: %s", self.path, exc)
+
+    def _save(self, data: Dict[str, Any]) -> None:
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self.path.with_name(f".{self.path.name}.{secrets.token_hex(4)}.tmp")
+        flags = os.O_WRONLY | os.O_CREAT | os.O_TRUNC
+        fd = os.open(tmp, flags, 0o600)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                json.dump(data, handle, indent=2, sort_keys=True)
+        except Exception:
+            with contextlib.suppress(OSError):
+                tmp.unlink()
+            raise
+        tmp.replace(self.path)
+        os.chmod(self.path, 0o600)
+
+    def _lock_file(self, lock_file: Any) -> None:
+        if os.name == "nt":
+            import msvcrt
+
+            msvcrt.locking(lock_file.fileno(), msvcrt.LK_LOCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_EX)
+
+    def _unlock_file(self, lock_file: Any) -> None:
+        if os.name == "nt":
+            import msvcrt
+
+            lock_file.seek(0)
+            msvcrt.locking(lock_file.fileno(), msvcrt.LK_UNLCK, 1)
+        else:
+            import fcntl
+
+            fcntl.flock(lock_file.fileno(), fcntl.LOCK_UN)

--- a/gateway/platforms/email.py
+++ b/gateway/platforms/email.py
@@ -17,7 +17,9 @@ Environment variables:
 
 import asyncio
 import email as email_lib
+import hashlib
 import imaplib
+import json
 import logging
 import os
 import re
@@ -42,6 +44,11 @@ from gateway.platforms.base import (
     cache_image_from_bytes,
 )
 from gateway.config import Platform, PlatformConfig
+from gateway.email_challenge import (
+    DEFAULT_EMAIL_CHALLENGE_TTL_SECONDS,
+    EmailChallengeStore,
+    cleanup_challenge_cached_attachments,
+)
 
 logger = logging.getLogger(__name__)
 # Automated sender patterns — emails from these are silently ignored
@@ -61,6 +68,12 @@ _AUTOMATED_HEADERS = {
 
 # Gmail-safe max length per email body
 MAX_MESSAGE_LENGTH = 50_000
+MAX_EMAIL_CHALLENGE_ATTACHMENTS = 25
+MAX_EMAIL_CHALLENGE_ATTACHMENT_BYTES = 10_000_000
+MAX_EMAIL_CHALLENGE_TOTAL_ATTACHMENT_BYTES = 25_000_000
+MAX_EMAIL_CHALLENGE_EVENT_BYTES = 200_000
+MAX_EMAIL_CONFIRM_CODE_LENGTH = 256
+_CONFIRM_RE = re.compile(r"^\s*/confirm\s+([^\s]+)\s*(?:\r?\n.*)?\Z", re.IGNORECASE | re.DOTALL)
 
 # Supported image extensions for inline detection
 _IMAGE_EXTS = {".jpg", ".jpeg", ".png", ".gif", ".webp"}
@@ -185,6 +198,9 @@ def _extract_email_address(raw: str) -> str:
 def _extract_attachments(
     msg: email_lib.message.Message,
     skip_attachments: bool = False,
+    max_attachment_bytes: Optional[int] = None,
+    max_total_attachment_bytes: Optional[int] = None,
+    max_attachments: Optional[int] = None,
 ) -> List[Dict[str, Any]]:
     """Extract attachment metadata and cache files locally.
 
@@ -195,49 +211,62 @@ def _extract_attachments(
     if not msg.is_multipart():
         return attachments
 
-    for part in msg.walk():
-        disposition = str(part.get("Content-Disposition", ""))
-        if skip_attachments and ("attachment" in disposition or "inline" in disposition):
-            continue
-        if "attachment" not in disposition and "inline" not in disposition:
-            continue
-        # Skip text/plain and text/html body parts
-        content_type = part.get_content_type()
-        if content_type in ("text/plain", "text/html") and "attachment" not in disposition:
-            continue
-
-        filename = part.get_filename()
-        if filename:
-            filename = _decode_header_value(filename)
-        else:
-            ext = part.get_content_subtype() or "bin"
-            filename = f"attachment.{ext}"
-
-        payload = part.get_payload(decode=True)
-        if not payload:
-            continue
-
-        ext = Path(filename).suffix.lower()
-        if ext in _IMAGE_EXTS:
-            try:
-                cached_path = cache_image_from_bytes(payload, ext)
-            except ValueError:
-                logger.debug("Skipping non-image attachment %s (invalid magic bytes)", filename)
+    total_payload_bytes = 0
+    try:
+        for part in msg.walk():
+            disposition = str(part.get("Content-Disposition", ""))
+            if skip_attachments and ("attachment" in disposition or "inline" in disposition):
                 continue
-            attachments.append({
-                "path": cached_path,
-                "filename": filename,
-                "type": "image",
-                "media_type": content_type,
-            })
-        else:
-            cached_path = cache_document_from_bytes(payload, filename)
-            attachments.append({
-                "path": cached_path,
-                "filename": filename,
-                "type": "document",
-                "media_type": content_type,
-            })
+            if "attachment" not in disposition and "inline" not in disposition:
+                continue
+            # Skip text/plain and text/html body parts
+            content_type = part.get_content_type()
+            if content_type in ("text/plain", "text/html") and "attachment" not in disposition:
+                continue
+
+            filename = part.get_filename()
+            if filename:
+                filename = _decode_header_value(filename)
+            else:
+                ext = part.get_content_subtype() or "bin"
+                filename = f"attachment.{ext}"
+
+            payload = part.get_payload(decode=True)
+            if not payload:
+                continue
+            if max_attachments is not None and len(attachments) >= max_attachments:
+                raise ValueError("too many attachments")
+            payload_size = len(payload)
+            if max_attachment_bytes is not None and payload_size > max_attachment_bytes:
+                raise ValueError("attachment payload too large")
+            total_payload_bytes += payload_size
+            if max_total_attachment_bytes is not None and total_payload_bytes > max_total_attachment_bytes:
+                raise ValueError("attachment payload total too large")
+
+            ext = Path(filename).suffix.lower()
+            if ext in _IMAGE_EXTS:
+                try:
+                    cached_path = cache_image_from_bytes(payload, ext)
+                except ValueError:
+                    logger.debug("Skipping non-image attachment %s (invalid magic bytes)", filename)
+                    continue
+                attachments.append({
+                    "path": cached_path,
+                    "filename": filename,
+                    "type": "image",
+                    "media_type": content_type,
+                })
+            else:
+                cached_path = cache_document_from_bytes(payload, filename)
+                attachments.append({
+                    "path": cached_path,
+                    "filename": filename,
+                    "type": "document",
+                    "media_type": content_type,
+                })
+    except Exception:
+        cleanup_challenge_cached_attachments({"attachments": attachments})
+        raise
 
     return attachments
 
@@ -262,6 +291,13 @@ class EmailAdapter(BasePlatformAdapter):
         #       skip_attachments: true
         extra = config.extra or {}
         self._skip_attachments = extra.get("skip_attachments", False)
+        self._auth_mode_config = str(extra.get("auth_mode") or extra.get("email_auth_mode") or "")
+        self._challenge_store_config = str(extra.get("challenge_store") or "")
+        self._challenge_ttl_config = extra.get("challenge_ttl_seconds")
+        self._email_challenge_store_cache = EmailChallengeStore(
+            path=os.getenv("EMAIL_CHALLENGE_STORE", "").strip() or self._challenge_store_config or None,
+            ttl_seconds=self._email_challenge_ttl_seconds(),
+        )
 
         # Track message IDs we've already processed to avoid duplicates
         self._seen_uids: set = set()
@@ -357,6 +393,11 @@ class EmailAdapter(BasePlatformAdapter):
         """Check INBOX for unseen messages and dispatch them."""
         # Run IMAP operations in a thread to avoid blocking the event loop
         loop = asyncio.get_running_loop()
+        if self._email_auth_mode() == "challenge":
+            try:
+                await loop.run_in_executor(None, self._cleanup_expired_email_challenges)
+            except Exception as exc:  # noqa: BLE001 - cleanup must not block polling
+                logger.warning("[Email] Email challenge cleanup failed; continuing inbox poll: %s", exc)
         messages = await loop.run_in_executor(None, self._fetch_new_messages)
         for msg_data in messages:
             await self._dispatch_message(msg_data)
@@ -405,10 +446,51 @@ class EmailAdapter(BasePlatformAdapter):
                     if _is_automated_sender(sender_addr, msg_headers):
                         logger.debug("[Email] Skipping automated sender: %s", sender_addr)
                         continue
-                    body = _extract_text_body(msg)
-                    attachments = _extract_attachments(msg, skip_attachments=self._skip_attachments)
+                    auth_mode = self._email_auth_mode()
+                    if auth_mode == "challenge" and not self._is_email_challenge_authorized(sender_addr):
+                        logger.debug("[Email] Skipping unauthorized challenge sender before body/cache: %s", sender_addr)
+                        continue
+                    direct_pre_auth = "allow"
+                    if auth_mode == "direct":
+                        direct_pre_auth = self._email_direct_pre_auth(sender_addr)
+                    if auth_mode == "direct" and direct_pre_auth == "deny":
+                        logger.debug("[Email] Skipping unauthorized direct sender before body/cache: %s", sender_addr)
+                        continue
 
-                    results.append({
+                    # Challenge mode must parse the text body to detect /confirm
+                    # replies and oversized originals, but attachment caching is
+                    # deferred until after those pre-agent eligibility checks.
+                    body = _extract_text_body(msg)
+                    attachment_error = ""
+                    if auth_mode == "challenge" and (
+                        len(body.strip()) > MAX_MESSAGE_LENGTH or _CONFIRM_RE.match(body.strip())
+                    ):
+                        attachments = []
+                    else:
+                        try:
+                            if auth_mode == "challenge":
+                                attachments = _extract_attachments(
+                                    msg,
+                                    skip_attachments=self._skip_attachments,
+                                    max_attachment_bytes=MAX_EMAIL_CHALLENGE_ATTACHMENT_BYTES,
+                                    max_total_attachment_bytes=MAX_EMAIL_CHALLENGE_TOTAL_ATTACHMENT_BYTES,
+                                    max_attachments=MAX_EMAIL_CHALLENGE_ATTACHMENTS,
+                                )
+                            elif direct_pre_auth == "allow":
+                                attachments = _extract_attachments(msg, skip_attachments=self._skip_attachments)
+                            else:
+                                attachments = []
+                        except ValueError as exc:
+                            if auth_mode != "challenge":
+                                raise
+                            logger.warning("[Email] Rejecting challenge attachment payload for %s: %s", sender_addr, exc)
+                            attachments = []
+                            if str(exc) == "too many attachments":
+                                attachment_error = "too_many"
+                            else:
+                                attachment_error = "too_large"
+
+                    result = {
                         "uid": uid,
                         "sender_addr": sender_addr,
                         "sender_name": sender_name,
@@ -418,7 +500,10 @@ class EmailAdapter(BasePlatformAdapter):
                         "body": body,
                         "attachments": attachments,
                         "date": msg.get("Date", ""),
-                    })
+                    }
+                    if attachment_error:
+                        result["_email_challenge_attachment_error"] = attachment_error
+                    results.append(result)
             finally:
                 try:
                     imap.logout()
@@ -434,28 +519,50 @@ class EmailAdapter(BasePlatformAdapter):
 
         # Skip self-messages
         if sender_addr == self._address.lower():
+            cleanup_challenge_cached_attachments(msg_data)
             return
 
         # Never reply to automated senders
         if _is_automated_sender(sender_addr, {}):
             logger.debug("[Email] Dropping automated sender at dispatch: %s", sender_addr)
+            cleanup_challenge_cached_attachments(msg_data)
             return
 
-        # Skip senders not in EMAIL_ALLOWED_USERS — prevents the adapter
-        # from creating a MessageEvent (and thus thread context) for senders
-        # that the gateway will never authorize.  Without this early guard,
-        # a race between dispatch and authorization can result in the adapter
-        # sending a reply even though the handler returned None.
-        allowed_raw = os.getenv("EMAIL_ALLOWED_USERS", "").strip()
-        if allowed_raw:
-            allowed = {addr.strip().lower() for addr in allowed_raw.split(",") if addr.strip()}
-            if sender_addr.lower() not in allowed:
-                logger.debug("[Email] Dropping non-allowlisted sender at dispatch: %s", sender_addr)
+        # In direct mode, preserve the historical early EMAIL_ALLOWED_USERS
+        # guard. In challenge mode, only challenge senders authorized by env/global
+        # allowlists the central gateway will also accept after confirmation.
+        if self._email_auth_mode() == "challenge":
+            if not self._is_email_challenge_authorized(sender_addr):
+                logger.debug("[Email] Dropping unauthorized challenge sender at dispatch: %s", sender_addr)
+                cleanup_challenge_cached_attachments(msg_data)
                 return
+        else:
+            direct_pre_auth = self._email_direct_pre_auth(sender_addr)
+            if direct_pre_auth == "deny":
+                logger.debug("[Email] Dropping unauthorized direct sender at dispatch: %s", sender_addr)
+                cleanup_challenge_cached_attachments(msg_data)
+                return
+            if direct_pre_auth != "allow":
+                cleanup_challenge_cached_attachments(msg_data)
+                msg_data["attachments"] = []
 
         subject = msg_data["subject"]
         body = msg_data["body"].strip()
         attachments = msg_data["attachments"]
+
+        if (
+            self._email_auth_mode() == "challenge"
+            and not msg_data.get("_email_challenge_confirmed")
+        ):
+            confirm_match = _CONFIRM_RE.match(body)
+            if confirm_match:
+                try:
+                    await self._handle_challenge_confirmation(sender_addr, confirm_match.group(1), msg_data)
+                finally:
+                    cleanup_challenge_cached_attachments(msg_data)
+                return
+            await self._create_email_challenge(sender_addr, subject, body, msg_data)
+            return
 
         # Build message text: include subject as context
         text = body
@@ -499,6 +606,268 @@ class EmailAdapter(BasePlatformAdapter):
 
         logger.info("[Email] New message from %s: %s", sender_addr, subject)
         await self.handle_message(event)
+
+    def _email_auth_mode(self) -> str:
+        raw_mode = os.getenv("EMAIL_AUTH_MODE", "").strip().lower() or self._auth_mode_config.strip().lower()
+        if not raw_mode:
+            return "direct"
+        if raw_mode in {"direct", "challenge"}:
+            return raw_mode
+        logger.warning("[Email] Invalid EMAIL_AUTH_MODE %r; using challenge mode for safety", raw_mode)
+        return "challenge"
+
+    def _email_auth_list_matches(self, raw: Any, sender_addr: str, include_local_part: bool = False) -> bool:
+        if isinstance(raw, (list, tuple, set)):
+            entries = {str(addr).strip() for addr in raw if str(addr).strip()}
+        else:
+            raw_text = str(raw or "").strip()
+            entries = {addr.strip() for addr in raw_text.split(",") if addr.strip()}
+        if not entries:
+            return False
+        check_ids = {sender_addr}
+        if include_local_part and "@" in sender_addr:
+            check_ids.add(sender_addr.split("@", 1)[0])
+        return "*" in entries or bool(check_ids & entries)
+
+    def _is_email_direct_authorized(self, sender_addr: str) -> bool:
+        return self._email_direct_pre_auth(sender_addr) != "deny"
+
+    def _email_direct_pre_auth(self, sender_addr: str) -> str:
+        """Return allow/deny/defer for direct-mode pre-central auth.
+
+        ``allow`` means this adapter can safely cache attachments before the
+        gateway's central authorization. ``defer`` preserves central pairing
+        checks but strips attachments because this adapter cannot verify them.
+        """
+        if os.getenv("EMAIL_ALLOW_ALL_USERS", "").strip().lower() in ("true", "1", "yes"):
+            return "allow"
+
+        email_allowlist = os.getenv("EMAIL_ALLOWED_USERS", "").strip()
+        global_allowlist = os.getenv("GATEWAY_ALLOWED_USERS", "").strip()
+        if not email_allowlist and not global_allowlist:
+            if os.getenv("GATEWAY_ALLOW_ALL_USERS", "").strip().lower() in ("true", "1", "yes"):
+                return "allow"
+            return "defer"
+
+        if email_allowlist:
+            # Preserve direct-mode historical behavior: EMAIL_ALLOWED_USERS is
+            # a case-insensitive literal full-address list, so "*" is not a
+            # wildcard here. GATEWAY_ALLOWED_USERS keeps central wildcard rules.
+            allowed = {addr.strip().lower() for addr in email_allowlist.split(",") if addr.strip()}
+            if sender_addr.lower() in allowed:
+                return "allow"
+
+        if global_allowlist and self._email_auth_list_matches(global_allowlist, sender_addr, include_local_part=True):
+            return "allow"
+        if global_allowlist and not email_allowlist:
+            # Let central gateway auth decide pairing-store approvals. The
+            # adapter cannot see pairing state, so preserve the body-only event
+            # path without caching attachments for non-allowlisted senders.
+            return "defer"
+
+        return "deny"
+
+    def _is_email_challenge_authorized(self, sender_addr: str) -> bool:
+        if os.getenv("EMAIL_ALLOW_ALL_USERS", "").strip().lower() in ("true", "1", "yes"):
+            return True
+
+        if self._email_auth_list_matches(os.getenv("EMAIL_ALLOWED_USERS", ""), sender_addr):
+            return True
+        if self._email_auth_list_matches(os.getenv("GATEWAY_ALLOWED_USERS", ""), sender_addr, include_local_part=True):
+            return True
+
+        configured_allowlists = any([
+            os.getenv("EMAIL_ALLOWED_USERS", "").strip(),
+            os.getenv("GATEWAY_ALLOWED_USERS", "").strip(),
+        ])
+        if not configured_allowlists:
+            return os.getenv("GATEWAY_ALLOW_ALL_USERS", "").strip().lower() in ("true", "1", "yes")
+        return False
+
+    def _email_challenge_ttl_seconds(self) -> int:
+        raw = os.getenv("EMAIL_CHALLENGE_TTL_SECONDS", "").strip()
+        if not raw and self._challenge_ttl_config is not None:
+            raw = str(self._challenge_ttl_config).strip()
+        if not raw:
+            return DEFAULT_EMAIL_CHALLENGE_TTL_SECONDS
+        try:
+            ttl = int(raw)
+        except ValueError:
+            return DEFAULT_EMAIL_CHALLENGE_TTL_SECONDS
+        return ttl if ttl > 0 else DEFAULT_EMAIL_CHALLENGE_TTL_SECONDS
+
+    def _email_challenge_store(self) -> EmailChallengeStore:
+        return self._email_challenge_store_cache
+
+    def _cleanup_expired_email_challenges(self) -> None:
+        if self._email_auth_mode() != "challenge":
+            return
+        self._email_challenge_store().cleanup_expired()
+
+    async def _create_email_challenge(
+        self,
+        sender_addr: str,
+        subject: str,
+        body: str,
+        msg_data: Dict[str, Any],
+    ) -> None:
+        self._thread_context[sender_addr] = {
+            "subject": subject,
+            "message_id": msg_data.get("message_id", ""),
+        }
+        if len(body) > MAX_MESSAGE_LENGTH:
+            cleanup_challenge_cached_attachments(msg_data)
+            await self.send(
+                sender_addr,
+                "Your email request is too large to challenge or process. Please shorten it and resend.",
+                reply_to=msg_data.get("message_id") or None,
+            )
+            return
+        if msg_data.get("_email_challenge_attachment_error") == "too_large":
+            cleanup_challenge_cached_attachments(msg_data)
+            await self._send_email_challenge_notice(
+                sender_addr,
+                "Your email request has an attachment that is too large to challenge or process. Please reduce attachments and resend.",
+                msg_data,
+            )
+            return
+        if msg_data.get("_email_challenge_attachment_error") == "too_many":
+            cleanup_challenge_cached_attachments(msg_data)
+            await self._send_email_challenge_notice(
+                sender_addr,
+                "Your email request has too many attachments to challenge or process. Please reduce the attachments and resend.",
+                msg_data,
+            )
+            return
+        attachments = msg_data.get("attachments", [])
+        if not isinstance(attachments, list):
+            attachments = []
+        if len(attachments) > MAX_EMAIL_CHALLENGE_ATTACHMENTS:
+            cleanup_challenge_cached_attachments(msg_data)
+            await self._send_email_challenge_notice(
+                sender_addr,
+                "Your email request has too many attachments to challenge or process. Please reduce the attachments and resend.",
+                msg_data,
+            )
+            return
+        event_data = {
+            "sender_addr": sender_addr,
+            "sender_name": msg_data.get("sender_name", sender_addr),
+            "subject": subject,
+            "message_id": msg_data.get("message_id", ""),
+            "in_reply_to": msg_data.get("in_reply_to", ""),
+            "body": body,
+            "attachments": attachments,
+            "date": msg_data.get("date", ""),
+            "_email_challenge_confirmed": True,
+        }
+        try:
+            event_size = len(json.dumps(event_data, ensure_ascii=False, sort_keys=True).encode("utf-8"))
+        except (TypeError, ValueError) as exc:
+            logger.warning("[Email] Email challenge metadata could not be serialized for %s: %s", sender_addr, exc)
+            cleanup_challenge_cached_attachments(msg_data)
+            await self._send_email_challenge_notice(
+                sender_addr,
+                "Your email request is temporarily unavailable for confirmation. Please try again later.",
+                msg_data,
+            )
+            return
+        if event_size > MAX_EMAIL_CHALLENGE_EVENT_BYTES:
+            cleanup_challenge_cached_attachments(msg_data)
+            await self._send_email_challenge_notice(
+                sender_addr,
+                "Your email request is too large to challenge or process. Please shorten it and resend.",
+                msg_data,
+            )
+            return
+        store = self._email_challenge_store()
+        try:
+            code = store.create(sender_addr, subject, msg_data.get("message_id", ""), event_data)
+        except Exception as exc:  # noqa: BLE001 - fail closed per message on store I/O errors
+            logger.warning("[Email] Email challenge store create failed for %s: %s", sender_addr, exc)
+            cleanup_challenge_cached_attachments(msg_data)
+            await self._send_email_challenge_notice(
+                sender_addr,
+                "Your email request is temporarily unavailable for confirmation. Please try again later.",
+                msg_data,
+            )
+            return
+        if code is None:
+            logger.warning("[Email] Email challenge not created for %s; pending challenge cap reached", sender_addr)
+            cleanup_challenge_cached_attachments(msg_data)
+            await self.send(
+                sender_addr,
+                "The email challenge queue is busy. Please try again later.",
+                reply_to=msg_data.get("message_id") or None,
+            )
+            return
+        body_hash = hashlib.sha256(body.encode("utf-8", errors="replace")).hexdigest()[:12]
+        ttl = store.ttl_seconds
+        result = await self.send(
+            sender_addr,
+            "Your email request is pending confirmation.\n\n"
+            f"Reply with: /confirm {code}\n\n"
+            f"Original subject: {subject or '(no subject)'}\n"
+            f"Body SHA256 prefix: {body_hash}\n"
+            f"This code expires in {ttl} seconds.",
+            reply_to=msg_data.get("message_id") or None,
+        )
+        if not result.success:
+            logger.warning("[Email] Email challenge delivery failed for %s; removing pending original", sender_addr)
+            try:
+                store.remove(sender_addr, code)
+            except Exception as exc:  # noqa: BLE001 - cleanup must not interrupt polling
+                logger.warning("[Email] Email challenge removal failed for %s after send failure: %s", sender_addr, exc)
+            finally:
+                cleanup_challenge_cached_attachments(msg_data)
+
+    async def _handle_challenge_confirmation(
+        self,
+        sender_addr: str,
+        code: str,
+        msg_data: Dict[str, Any],
+    ) -> None:
+        self._thread_context[sender_addr] = {
+            "subject": msg_data.get("subject", "Hermes Agent"),
+            "message_id": msg_data.get("message_id", ""),
+        }
+        if len(code) > MAX_EMAIL_CONFIRM_CODE_LENGTH:
+            await self.send(
+                sender_addr,
+                "That confirmation code is invalid or already used.",
+                reply_to=msg_data.get("message_id") or None,
+            )
+            return
+        try:
+            status, pending = self._email_challenge_store().confirm(sender_addr, code)
+        except Exception as exc:  # noqa: BLE001 - fail closed per message on store I/O errors
+            logger.warning("[Email] Email challenge confirmation failed for %s: %s", sender_addr, exc)
+            await self._send_email_challenge_notice(
+                sender_addr,
+                "That confirmation code could not be checked temporarily. Please try again later.",
+                msg_data,
+            )
+            return
+        if status == "ok" and pending:
+            await self._dispatch_message(pending)
+            return
+        responses = {
+            "sender_mismatch": "That confirmation code is invalid or already used.",
+            "expired": "That confirmation code has expired. Please resend the original request.",
+            "used": "That confirmation code is invalid or already used.",
+            "not_found": "That confirmation code is invalid or already used.",
+        }
+        await self.send(
+            sender_addr,
+            responses.get(status, "That confirmation code is invalid."),
+            reply_to=msg_data.get("message_id") or None,
+        )
+
+    async def _send_email_challenge_notice(self, sender_addr: str, content: str, msg_data: Dict[str, Any]) -> None:
+        try:
+            await self.send(sender_addr, content, reply_to=msg_data.get("message_id") or None)
+        except Exception as exc:  # noqa: BLE001 - challenge notices are best-effort
+            logger.warning("[Email] Email challenge notice failed for %s: %s", sender_addr, exc)
 
     async def send(
         self,

--- a/tests/gateway/test_email.py
+++ b/tests/gateway/test_email.py
@@ -13,6 +13,11 @@ Covers:
 """
 
 import os
+import json
+import re
+import stat
+import tempfile
+import time
 import unittest
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
@@ -23,6 +28,25 @@ from types import SimpleNamespace
 from unittest.mock import patch, MagicMock, AsyncMock
 
 from gateway.platforms.base import SendResult
+
+
+def _write_cached_test_attachment(kind, filename, data=b"cached test attachment"):
+    from hermes_constants import get_hermes_home
+    from gateway.platforms import base
+
+    # base.py is imported at module import time for SendResult, before the
+    # test autouse fixture redirects HERMES_HOME. Rebind the cache roots here
+    # so cleanup tests do not write to the developer's real ~/.hermes cache.
+    base.DOCUMENT_CACHE_DIR = get_hermes_home() / "cache" / "documents"
+    base.IMAGE_CACHE_DIR = get_hermes_home() / "cache" / "images"
+
+    cache_dir = {
+        "document": base.get_document_cache_dir,
+        "image": base.get_image_cache_dir,
+    }[kind]()
+    path = cache_dir / filename
+    path.write_bytes(data)
+    return path
 
 
 class TestConfigEnvOverrides(unittest.TestCase):
@@ -56,6 +80,24 @@ class TestConfigEnvOverrides(unittest.TestCase):
         home = config.platforms[Platform.EMAIL].home_channel
         self.assertIsNotNone(home)
         self.assertEqual(home.chat_id, "user@test.com")
+
+    @patch.dict(os.environ, {
+        "EMAIL_ADDRESS": "hermes@test.com",
+        "EMAIL_PASSWORD": "secret",
+        "EMAIL_IMAP_HOST": "imap.test.com",
+        "EMAIL_SMTP_HOST": "smtp.test.com",
+        "EMAIL_AUTH_MODE": "challenge",
+        "EMAIL_CHALLENGE_TTL_SECONDS": "300",
+        "EMAIL_CHALLENGE_STORE": "/tmp/email_challenges.json",
+    }, clear=False)
+    def test_email_challenge_config_loaded_from_env(self):
+        from gateway.config import GatewayConfig, Platform, _apply_env_overrides
+        config = GatewayConfig()
+        _apply_env_overrides(config)
+        extra = config.platforms[Platform.EMAIL].extra
+        self.assertEqual(extra["auth_mode"], "challenge")
+        self.assertEqual(extra["challenge_ttl_seconds"], "300")
+        self.assertEqual(extra["challenge_store"], "/tmp/email_challenges.json")
 
     @patch.dict(os.environ, {}, clear=True)
     def test_email_not_loaded_without_env(self):
@@ -234,6 +276,89 @@ class TestExtractAttachments(unittest.TestCase):
         self.assertEqual(result[0]["type"], "image")
         mock_cache.assert_called_once()
 
+    def test_total_attachment_cap_deletes_previously_cached_files(self):
+        """If a later attachment exceeds the total cap, earlier cached files are removed."""
+        from gateway.platforms import base
+        from gateway.platforms.email import _extract_attachments
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base.DOCUMENT_CACHE_DIR = Path(tmpdir) / "cache" / "documents"
+            msg = MIMEMultipart()
+            msg.attach(MIMEText("See attached.", "plain", "utf-8"))
+
+            first = MIMEBase("application", "pdf")
+            first.set_payload(b"small")
+            encoders.encode_base64(first)
+            first.add_header("Content-Disposition", "attachment; filename=first.pdf")
+            msg.attach(first)
+
+            second = MIMEBase("application", "pdf")
+            second.set_payload(b"large payload")
+            encoders.encode_base64(second)
+            second.add_header("Content-Disposition", "attachment; filename=second.pdf")
+            msg.attach(second)
+
+            with self.assertRaises(ValueError):
+                _extract_attachments(
+                    msg,
+                    max_attachment_bytes=100,
+                    max_total_attachment_bytes=10,
+                )
+
+            cache_dir = base.get_document_cache_dir()
+            self.assertEqual(list(cache_dir.iterdir()), [])
+
+    def test_attachment_count_cap_deletes_previously_cached_files(self):
+        """If a later attachment exceeds the count cap, earlier cached files are removed."""
+        from gateway.platforms import base
+        from gateway.platforms.email import _extract_attachments
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base.DOCUMENT_CACHE_DIR = Path(tmpdir) / "cache" / "documents"
+            msg = MIMEMultipart()
+            msg.attach(MIMEText("See attached.", "plain", "utf-8"))
+            for name in ("first.pdf", "second.pdf"):
+                part = MIMEBase("application", "pdf")
+                part.set_payload(b"small")
+                encoders.encode_base64(part)
+                part.add_header("Content-Disposition", f"attachment; filename={name}")
+                msg.attach(part)
+
+            with self.assertRaises(ValueError):
+                _extract_attachments(msg, max_attachments=1)
+
+            cache_dir = base.get_document_cache_dir()
+            self.assertEqual(list(cache_dir.iterdir()), [])
+
+    def test_cache_oserror_deletes_previously_cached_files(self):
+        """If a later cache write fails, earlier cached files are removed."""
+        from gateway.platforms import base
+        from gateway.platforms.email import _extract_attachments
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base.DOCUMENT_CACHE_DIR = Path(tmpdir) / "cache" / "documents"
+            cached_first = base.get_document_cache_dir() / "doc_first.pdf"
+            msg = MIMEMultipart()
+            msg.attach(MIMEText("See attached.", "plain", "utf-8"))
+            for name in ("first.pdf", "second.pdf"):
+                part = MIMEBase("application", "pdf")
+                part.set_payload(b"small")
+                encoders.encode_base64(part)
+                part.add_header("Content-Disposition", f"attachment; filename={name}")
+                msg.attach(part)
+
+            def cache_document(payload, filename):
+                if filename == "first.pdf":
+                    cached_first.write_bytes(payload)
+                    return str(cached_first)
+                raise OSError("disk full")
+
+            with patch("gateway.platforms.email.cache_document_from_bytes", side_effect=cache_document):
+                with self.assertRaises(OSError):
+                    _extract_attachments(msg)
+
+            self.assertFalse(cached_first.exists())
+
 
 class TestDispatchMessage(unittest.TestCase):
     """Test email message dispatch logic."""
@@ -253,6 +378,33 @@ class TestDispatchMessage(unittest.TestCase):
             from gateway.platforms.email import EmailAdapter
             adapter = EmailAdapter(PlatformConfig(enabled=True))
         return adapter
+
+    def _extract_confirmation_code(self, sent_body):
+        match = re.search(r"/confirm\s+(\S+)", sent_body)
+        self.assertIsNotNone(match)
+        return match.group(1)
+
+    def test_email_challenge_store_is_cached_per_adapter_instance(self):
+        """Challenge store path/TTL are resolved once for each adapter."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            first_store = Path(tmpdir) / "first.json"
+            second_store = Path(tmpdir) / "second.json"
+            with patch.dict(os.environ, {
+                "EMAIL_CHALLENGE_STORE": str(first_store),
+                "EMAIL_CHALLENGE_TTL_SECONDS": "123",
+            }, clear=False):
+                adapter = self._make_adapter()
+
+            first = adapter._email_challenge_store()
+            with patch.dict(os.environ, {
+                "EMAIL_CHALLENGE_STORE": str(second_store),
+                "EMAIL_CHALLENGE_TTL_SECONDS": "456",
+            }, clear=False):
+                second = adapter._email_challenge_store()
+
+            self.assertIs(first, second)
+            self.assertEqual(first.path, first_store)
+            self.assertEqual(first.ttl_seconds, 123)
 
     def test_self_message_filtered(self):
         """Messages from the agent's own address should be skipped."""
@@ -274,6 +426,70 @@ class TestDispatchMessage(unittest.TestCase):
 
         asyncio.run(adapter._dispatch_message(msg_data))
         adapter._message_handler.assert_not_called()
+
+    def test_self_message_drop_deletes_cached_attachment(self):
+        """Self-sent messages must not leave challenge-owned cached files behind."""
+        import asyncio
+
+        attachment_path = _write_cached_test_attachment(
+            "document", "doc_self-sent-drop.pdf", b"self-sent attachment"
+        )
+        adapter = self._make_adapter()
+        adapter._message_handler = MagicMock()
+
+        msg_data = {
+            "uid": b"1",
+            "sender_addr": "hermes@test.com",
+            "sender_name": "Hermes",
+            "subject": "Self attachment",
+            "message_id": "<self-attachment@test.com>",
+            "in_reply_to": "",
+            "body": "Self message",
+            "attachments": [{
+                "type": "document",
+                "media_type": "application/pdf",
+                "path": str(attachment_path),
+            }],
+            "date": "",
+        }
+
+        asyncio.run(adapter._dispatch_message(msg_data))
+
+        adapter._message_handler.assert_not_called()
+        self.assertFalse(attachment_path.exists())
+
+    def test_automated_sender_drop_deletes_cached_attachment(self):
+        """Automated dispatch drops must delete cached files before returning."""
+        import asyncio
+
+        attachment_path = _write_cached_test_attachment(
+            "document", "doc_automated-drop.pdf", b"automated attachment"
+        )
+        adapter = self._make_adapter()
+        adapter._message_handler = MagicMock()
+        adapter.send = AsyncMock()
+
+        msg_data = {
+            "uid": b"2",
+            "sender_addr": "no-reply@test.com",
+            "sender_name": "No Reply",
+            "subject": "Automated attachment",
+            "message_id": "<automated-attachment@test.com>",
+            "in_reply_to": "",
+            "body": "Automated message",
+            "attachments": [{
+                "type": "document",
+                "media_type": "application/pdf",
+                "path": str(attachment_path),
+            }],
+            "date": "",
+        }
+
+        asyncio.run(adapter._dispatch_message(msg_data))
+
+        adapter._message_handler.assert_not_called()
+        adapter.send.assert_not_called()
+        self.assertFalse(attachment_path.exists())
 
     def test_subject_included_in_text(self):
         """Subject should be prepended to body for non-reply emails."""
@@ -370,30 +586,33 @@ class TestDispatchMessage(unittest.TestCase):
         """Email with image attachment should set message type to PHOTO."""
         import asyncio
         from gateway.platforms.base import MessageType
-        adapter = self._make_adapter()
-        captured_events = []
+        with patch.dict(os.environ, {"GATEWAY_ALLOW_ALL_USERS": "true"}, clear=False):
+            adapter = self._make_adapter()
+            captured_events = []
 
-        async def capture_handle(event):
-            captured_events.append(event)
+            async def capture_handle(event):
+                captured_events.append(event)
 
-        adapter.handle_message = capture_handle
+            adapter.handle_message = capture_handle
 
-        msg_data = {
-            "uid": b"5",
-            "sender_addr": "user@test.com",
-            "sender_name": "User",
-            "subject": "Re: photo",
-            "message_id": "<msg5@test.com>",
-            "in_reply_to": "",
-            "body": "Check this photo",
-            "attachments": [{"path": "/tmp/img.jpg", "filename": "img.jpg", "type": "image", "media_type": "image/jpeg"}],
-            "date": "",
-        }
+            msg_data = {
+                "uid": b"5",
+                "sender_addr": "user@test.com",
+                "sender_name": "User",
+                "subject": "Re: photo",
+                "message_id": "<msg5@test.com>",
+                "in_reply_to": "",
+                "body": "Check this photo",
+                "attachments": [
+                    {"path": "/tmp/img.jpg", "filename": "img.jpg", "type": "image", "media_type": "image/jpeg"}
+                ],
+                "date": "",
+            }
 
-        asyncio.run(adapter._dispatch_message(msg_data))
-        self.assertEqual(len(captured_events), 1)
-        self.assertEqual(captured_events[0].message_type, MessageType.PHOTO)
-        self.assertEqual(captured_events[0].media_urls, ["/tmp/img.jpg"])
+            asyncio.run(adapter._dispatch_message(msg_data))
+            self.assertEqual(len(captured_events), 1)
+            self.assertEqual(captured_events[0].message_type, MessageType.PHOTO)
+            self.assertEqual(captured_events[0].media_urls, ["/tmp/img.jpg"])
 
     def test_source_built_correctly(self):
         """Session source should have correct chat_id and user info."""
@@ -452,6 +671,77 @@ class TestDispatchMessage(unittest.TestCase):
             # Thread context should NOT be created
             self.assertNotIn("outsider@evil.com", adapter._thread_context)
 
+    def test_direct_mode_star_allowlist_is_literal_not_wildcard(self):
+        """EMAIL_ALLOWED_USERS=* should preserve direct-mode literal matching behavior."""
+        import asyncio
+        with patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "direct",
+            "EMAIL_ALLOWED_USERS": "*",
+        }):
+            adapter = self._make_adapter()
+            adapter._message_handler = MagicMock()
+
+            msg_data = {
+                "uid": b"98",
+                "sender_addr": "outsider@test.com",
+                "sender_name": "Outsider",
+                "subject": "Literal star",
+                "message_id": "<literal-star@test.com>",
+                "in_reply_to": "",
+                "body": "This should not pass direct adapter allowlist",
+                "attachments": [],
+                "date": "",
+            }
+
+            asyncio.run(adapter._dispatch_message(msg_data))
+
+            adapter._message_handler.assert_not_called()
+            self.assertNotIn("outsider@test.com", adapter._thread_context)
+
+    def test_direct_mode_global_allowlist_miss_drops_cached_attachment_before_central_auth(self):
+        """Direct-mode global misses may reach central auth but must not retain cached attachments."""
+        import asyncio
+
+        with patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "direct",
+            "EMAIL_ALLOWED_USERS": "",
+            "GATEWAY_ALLOWED_USERS": "admin@test.com",
+        }):
+            attachment_path = _write_cached_test_attachment(
+                "document", "doc_direct-global-rejected.pdf", b"direct global rejected"
+            )
+            adapter = self._make_adapter()
+            captured_events = []
+
+            async def capture_handle(event):
+                captured_events.append(event)
+
+            adapter.handle_message = capture_handle
+
+            msg_data = {
+                "uid": b"97",
+                "sender_addr": "outsider@test.com",
+                "sender_name": "Outsider",
+                "subject": "Global allowlist miss",
+                "message_id": "<direct-global-miss@test.com>",
+                "in_reply_to": "",
+                "body": "This should not reach the agent",
+                "attachments": [{
+                    "type": "document",
+                    "media_type": "application/pdf",
+                    "path": str(attachment_path),
+                }],
+                "date": "",
+            }
+
+            asyncio.run(adapter._dispatch_message(msg_data))
+
+            self.assertEqual(len(captured_events), 1)
+            self.assertEqual(captured_events[0].source.user_id, "outsider@test.com")
+            self.assertEqual(captured_events[0].media_urls, [])
+            self.assertIn("outsider@test.com", adapter._thread_context)
+            self.assertFalse(attachment_path.exists())
+
     def test_allowlisted_sender_proceeds(self):
         """Senders in EMAIL_ALLOWED_USERS should proceed to dispatch normally."""
         import asyncio
@@ -509,6 +799,1685 @@ class TestDispatchMessage(unittest.TestCase):
             asyncio.run(adapter._dispatch_message(msg_data))
             # Handler should be called when no allowlist is configured
             adapter._message_handler.assert_called()
+
+    def test_challenge_mode_allowlisted_sender_is_challenged_not_dispatched(self):
+        """Challenge mode stores allowlisted email bodies without invoking the agent."""
+        import asyncio
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "challenge",
+            "EMAIL_ALLOWED_USERS": "admin@test.com",
+            "EMAIL_CHALLENGE_STORE": str(Path(tmpdir) / "challenges.json"),
+            "EMAIL_CHALLENGE_TTL_SECONDS": "900",
+        }):
+            adapter = self._make_adapter()
+            adapter.send = AsyncMock(return_value=SendResult(success=True))
+            adapter._message_handler = AsyncMock()
+
+            msg_data = {
+                "uid": b"200",
+                "sender_addr": "admin@test.com",
+                "sender_name": "Admin",
+                "subject": "Run report",
+                "message_id": "<challenge@test.com>",
+                "in_reply_to": "",
+                "body": "Please summarize revenue.",
+                "attachments": [],
+                "date": "",
+            }
+
+            asyncio.run(adapter._dispatch_message(msg_data))
+
+            adapter._message_handler.assert_not_called()
+            adapter.send.assert_awaited_once()
+            sent_body = adapter.send.await_args.args[1]
+            self.assertIn("pending confirmation", sent_body)
+            self.assertIn("/confirm ", sent_body)
+            self.assertIn("Run report", sent_body)
+            self.assertNotIn("Please summarize revenue.", sent_body)
+
+            store_path = Path(os.environ["EMAIL_CHALLENGE_STORE"])
+            stored = json.loads(store_path.read_text())
+            self.assertEqual(len(stored["challenges"]), 1)
+            self.assertEqual(stored["challenges"][0]["sender"], "admin@test.com")
+            self.assertEqual(stored["challenges"][0]["event"]["body"], "Please summarize revenue.")
+            self.assertNotIn("body", stored["challenges"][0])
+            self.assertNotIn(self._extract_confirmation_code(sent_body), store_path.read_text())
+            self.assertEqual(stat.S_IMODE(store_path.stat().st_mode), 0o600)
+
+    def test_challenge_confirm_dispatches_original_once_and_replay_is_rejected(self):
+        """A valid confirmation dispatches the stored original exactly once."""
+        import asyncio
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "challenge",
+            "EMAIL_ALLOWED_USERS": "admin@test.com",
+            "EMAIL_CHALLENGE_STORE": str(Path(tmpdir) / "challenges.json"),
+            "EMAIL_CHALLENGE_TTL_SECONDS": "900",
+        }):
+            adapter = self._make_adapter()
+            adapter.send = AsyncMock(return_value=SendResult(success=True))
+            captured_events = []
+
+            async def capture_handle(event):
+                captured_events.append(event)
+
+            adapter.handle_message = capture_handle
+            original = {
+                "uid": b"201",
+                "sender_addr": "admin@test.com",
+                "sender_name": "Admin",
+                "subject": "Run report",
+                "message_id": "<original@test.com>",
+                "in_reply_to": "",
+                "body": "Please summarize revenue.",
+                "attachments": [],
+                "date": "",
+            }
+            asyncio.run(adapter._dispatch_message(original))
+            code = self._extract_confirmation_code(adapter.send.await_args.args[1])
+
+            confirm = {
+                "uid": b"202",
+                "sender_addr": "admin@test.com",
+                "sender_name": "Admin",
+                "subject": "Re: Run report",
+                "message_id": "<confirm@test.com>",
+                "in_reply_to": "<challenge-reply@test.com>",
+                "body": f"/confirm {code}",
+                "attachments": [],
+                "date": "",
+            }
+
+            asyncio.run(adapter._dispatch_message(confirm))
+            asyncio.run(adapter._dispatch_message(confirm))
+
+            self.assertEqual(len(captured_events), 1)
+            self.assertIn("[Subject: Run report]", captured_events[0].text)
+            self.assertIn("Please summarize revenue.", captured_events[0].text)
+            self.assertEqual(captured_events[0].message_id, "<original@test.com>")
+            self.assertGreaterEqual(adapter.send.await_count, 2)
+            replay_response = adapter.send.await_args.args[1]
+            self.assertIn("invalid or already used", replay_response.lower())
+
+    def test_challenge_confirmed_email_allowed_user_passes_real_gateway_auth(self):
+        """Confirmed originals flow through GatewayRunner's central authorization gate."""
+        import asyncio
+        from gateway.config import GatewayConfig, Platform, PlatformConfig
+        from gateway.run import GatewayRunner
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "challenge",
+            "EMAIL_ALLOWED_USERS": "admin@test.com",
+            "EMAIL_CHALLENGE_STORE": str(Path(tmpdir) / "challenges.json"),
+        }):
+            adapter = self._make_adapter()
+            adapter.send = AsyncMock(return_value=SendResult(success=True))
+
+            runner = object.__new__(GatewayRunner)
+            runner.config = GatewayConfig(platforms={Platform.EMAIL: PlatformConfig(enabled=True)})
+            runner.adapters = {Platform.EMAIL: adapter}
+            runner.pairing_store = MagicMock()
+            runner.pairing_store.is_approved.return_value = False
+            runner.pairing_store._is_rate_limited.return_value = False
+            runner._running_agents = {}
+            runner._running_agents_ts = {}
+            runner._update_prompt_pending = {}
+            runner._draining = False
+            runner._busy_input_mode = "interrupt"
+            runner._handle_message_with_agent = AsyncMock(return_value="agent accepted")
+            adapter.handle_message = runner._handle_message
+
+            original = {
+                "uid": b"234",
+                "sender_addr": "admin@test.com",
+                "sender_name": "Admin",
+                "subject": "Central auth",
+                "message_id": "<central-auth@test.com>",
+                "in_reply_to": "",
+                "body": "This should reach the gateway after confirmation.",
+                "attachments": [],
+                "date": "",
+            }
+            asyncio.run(adapter._dispatch_message(original))
+            code = self._extract_confirmation_code(adapter.send.await_args.args[1])
+
+            asyncio.run(adapter._dispatch_message(dict(
+                original,
+                uid=b"235",
+                subject="Re: Central auth",
+                message_id="<confirm-central-auth@test.com>",
+                body=f"/confirm {code}",
+            )))
+
+            runner.pairing_store.is_approved.assert_called()
+            runner._handle_message_with_agent.assert_awaited_once()
+            event = runner._handle_message_with_agent.await_args.args[0]
+            self.assertEqual(event.source.platform, Platform.EMAIL)
+            self.assertEqual(event.source.user_id, "admin@test.com")
+            self.assertIn("This should reach the gateway", event.text)
+
+    def test_challenge_confirm_from_different_sender_does_not_dispatch(self):
+        """Confirmation codes are bound to the original From sender."""
+        import asyncio
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "challenge",
+            "EMAIL_ALLOWED_USERS": "admin@test.com,other@test.com",
+            "EMAIL_CHALLENGE_STORE": str(Path(tmpdir) / "challenges.json"),
+        }):
+            attachment_path = Path(tmpdir) / "cache" / "documents" / "doc_sensitive-expired.pdf"
+            attachment_path.parent.mkdir(parents=True)
+            attachment_path.write_bytes(b"sensitive document")
+            adapter = self._make_adapter()
+            adapter.send = AsyncMock(return_value=SendResult(success=True))
+            adapter.handle_message = AsyncMock()
+            original = {
+                "uid": b"203",
+                "sender_addr": "admin@test.com",
+                "sender_name": "Admin",
+                "subject": "Sensitive",
+                "message_id": "<sensitive@test.com>",
+                "in_reply_to": "",
+                "body": "Secret task",
+                "attachments": [],
+                "date": "",
+            }
+            asyncio.run(adapter._dispatch_message(original))
+            code = self._extract_confirmation_code(adapter.send.await_args.args[1])
+
+            confirm = dict(
+                original,
+                uid=b"204",
+                sender_addr="other@test.com",
+                sender_name="Other",
+                body=f"/confirm {code}",
+            )
+            asyncio.run(adapter._dispatch_message(confirm))
+
+            adapter.handle_message.assert_not_awaited()
+            self.assertIn("invalid or already used", adapter.send.await_args.args[1].lower())
+            self.assertNotIn("does not match", adapter.send.await_args.args[1].lower())
+
+    def test_expired_challenge_confirm_does_not_dispatch(self):
+        """Expired challenge codes are rejected without invoking the agent."""
+        import asyncio
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "challenge",
+            "EMAIL_ALLOWED_USERS": "admin@test.com",
+            "EMAIL_CHALLENGE_STORE": str(Path(tmpdir) / "challenges.json"),
+            "EMAIL_CHALLENGE_TTL_SECONDS": "1",
+        }):
+            attachment_path = Path(tmpdir) / "cache" / "documents" / "doc_sensitive-expired.pdf"
+            attachment_path.parent.mkdir(parents=True)
+            attachment_path.write_bytes(b"sensitive document")
+            adapter = self._make_adapter()
+            adapter.send = AsyncMock(return_value=SendResult(success=True))
+            adapter.handle_message = AsyncMock()
+            original = {
+                "uid": b"205",
+                "sender_addr": "admin@test.com",
+                "sender_name": "Admin",
+                "subject": "Old task",
+                "message_id": "<old@test.com>",
+                "in_reply_to": "",
+                "body": "Do old thing",
+                "attachments": [],
+                "date": "",
+            }
+            asyncio.run(adapter._dispatch_message(original))
+            store_path = Path(os.environ["EMAIL_CHALLENGE_STORE"])
+            code = self._extract_confirmation_code(adapter.send.await_args.args[1])
+            stored = json.loads(store_path.read_text())
+            stored["challenges"][0]["created_at"] = 0
+            store_path.write_text(json.dumps(stored))
+
+            confirm = dict(
+                original,
+                uid=b"206",
+                subject="Re: Old task",
+                message_id="<confirm-old@test.com>",
+                body=f"/confirm {code}",
+            )
+            asyncio.run(adapter._dispatch_message(confirm))
+
+            adapter.handle_message.assert_not_awaited()
+            self.assertIn("expired", adapter.send.await_args.args[1].lower())
+
+    def test_challenge_confirm_accepts_quoted_reply_body(self):
+        """Confirmation parsing accepts normal replies with quoted original text."""
+        import asyncio
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "challenge",
+            "EMAIL_ALLOWED_USERS": "admin@test.com",
+            "EMAIL_CHALLENGE_STORE": str(Path(tmpdir) / "challenges.json"),
+        }):
+            attachment_path = Path(tmpdir) / "cache" / "images" / "img_sensitive-success.png"
+            attachment_path.parent.mkdir(parents=True)
+            attachment_path.write_bytes(b"sensitive image")
+            adapter = self._make_adapter()
+            adapter.send = AsyncMock(return_value=SendResult(success=True))
+            captured_events = []
+
+            async def capture_handle(event):
+                captured_events.append(event)
+
+            adapter.handle_message = capture_handle
+            original = {
+                "uid": b"208",
+                "sender_addr": "admin@test.com",
+                "sender_name": "Admin",
+                "subject": "Quoted reply",
+                "message_id": "<quoted@test.com>",
+                "in_reply_to": "",
+                "body": "Run this after confirmation",
+                "attachments": [],
+                "date": "",
+            }
+            asyncio.run(adapter._dispatch_message(original))
+            code = self._extract_confirmation_code(adapter.send.await_args.args[1])
+            confirm = dict(
+                original,
+                uid=b"209",
+                subject="Re: Quoted reply",
+                message_id="<confirm-quoted@test.com>",
+                body=f"/confirm {code}\n\nOn Sat, Hermes wrote:\n> Reply with: /confirm {code}",
+            )
+
+            asyncio.run(adapter._dispatch_message(confirm))
+
+            self.assertEqual(len(captured_events), 1)
+            self.assertIn("Run this after confirmation", captured_events[0].text)
+
+    def test_challenge_mode_wildcard_allowlist_is_challenged(self):
+        """Wildcard allowlists work in challenge mode instead of early-dropping senders."""
+        import asyncio
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "challenge",
+            "EMAIL_ALLOWED_USERS": "*",
+            "EMAIL_CHALLENGE_STORE": str(Path(tmpdir) / "challenges.json"),
+        }):
+            adapter = self._make_adapter()
+            adapter.send = AsyncMock(return_value=SendResult(success=True))
+            adapter._message_handler = MagicMock()
+            msg_data = {
+                "uid": b"210",
+                "sender_addr": "anyone@test.com",
+                "sender_name": "Anyone",
+                "subject": "Wildcard",
+                "message_id": "<wildcard@test.com>",
+                "in_reply_to": "",
+                "body": "Please confirm wildcard",
+                "attachments": [],
+                "date": "",
+            }
+
+            asyncio.run(adapter._dispatch_message(msg_data))
+
+            adapter._message_handler.assert_not_called()
+            adapter.send.assert_awaited_once()
+            stored = json.loads(Path(os.environ["EMAIL_CHALLENGE_STORE"]).read_text())
+            self.assertEqual(stored["challenges"][0]["sender"], "anyone@test.com")
+
+    def test_challenge_global_pending_cap_sends_busy_reply_and_deletes_rejected_attachment(self):
+        """A full challenge store tells authorized senders to retry and deletes rejected files."""
+        import asyncio
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "challenge",
+            "EMAIL_ALLOWED_USERS": "*",
+            "EMAIL_CHALLENGE_STORE": str(Path(tmpdir) / "challenges.json"),
+        }), patch("gateway.email_challenge.MAX_PENDING_CHALLENGES_TOTAL", 2):
+            adapter = self._make_adapter()
+            adapter.send = AsyncMock(return_value=SendResult(success=True))
+            adapter._message_handler = MagicMock()
+            rejected_attachment_path = _write_cached_test_attachment(
+                "document", "doc_rejected-cap.pdf", b"rejected cap attachment"
+            )
+
+            for index, sender in enumerate(["one@test.com", "two@test.com", "three@test.com"], start=1):
+                attachments = []
+                if index == 3:
+                    attachments = [{
+                        "type": "document",
+                        "media_type": "application/pdf",
+                        "path": str(rejected_attachment_path),
+                    }]
+                asyncio.run(adapter._dispatch_message({
+                    "uid": str(300 + index).encode(),
+                    "sender_addr": sender,
+                    "sender_name": sender,
+                    "subject": f"Request {index}",
+                    "message_id": f"<request-{index}@test.com>",
+                    "in_reply_to": "",
+                    "body": f"Please run request {index}",
+                    "attachments": attachments,
+                    "date": "",
+                }))
+
+            adapter._message_handler.assert_not_called()
+            self.assertEqual(adapter.send.await_count, 3)
+            self.assertIn("busy", adapter.send.await_args.args[1].lower())
+            self.assertFalse(rejected_attachment_path.exists())
+            stored = json.loads(Path(os.environ["EMAIL_CHALLENGE_STORE"]).read_text())
+            self.assertEqual(len(stored["challenges"]), 2)
+            self.assertEqual({entry["sender"] for entry in stored["challenges"]}, {"one@test.com", "two@test.com"})
+
+    def test_challenge_rejects_oversized_body_without_storing_or_retaining_attachment(self):
+        """Oversized bodies are rejected instead of truncating what the agent would see."""
+        import asyncio
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "challenge",
+            "EMAIL_ALLOWED_USERS": "admin@test.com",
+            "EMAIL_CHALLENGE_STORE": str(Path(tmpdir) / "challenges.json"),
+        }):
+            attachment_path = _write_cached_test_attachment(
+                "document", "doc_too-large.pdf", b"too large attachment"
+            )
+            adapter = self._make_adapter()
+            adapter.send = AsyncMock(return_value=SendResult(success=True))
+            adapter._message_handler = MagicMock()
+
+            asyncio.run(adapter._dispatch_message({
+                "uid": b"312",
+                "sender_addr": "admin@test.com",
+                "sender_name": "Admin",
+                "subject": "Too large",
+                "message_id": "<too-large@test.com>",
+                "in_reply_to": "",
+                "body": "x" * (50_000 + 1),
+                "attachments": [{
+                    "type": "document",
+                    "media_type": "application/pdf",
+                    "path": str(attachment_path),
+                }],
+                "date": "",
+            }))
+
+            adapter._message_handler.assert_not_called()
+            adapter.send.assert_awaited_once()
+            self.assertIn("too large", adapter.send.await_args.args[1].lower())
+            self.assertFalse(Path(os.environ["EMAIL_CHALLENGE_STORE"]).exists())
+            self.assertFalse(attachment_path.exists())
+
+    def test_challenge_rejects_too_many_attachments_without_storing(self):
+        """Challenge storage caps attachment lists and deletes rejected cached files."""
+        import asyncio
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "challenge",
+            "EMAIL_ALLOWED_USERS": "admin@test.com",
+            "EMAIL_CHALLENGE_STORE": str(Path(tmpdir) / "challenges.json"),
+        }), patch("gateway.platforms.email.MAX_EMAIL_CHALLENGE_ATTACHMENTS", 1):
+            first = _write_cached_test_attachment("document", "doc_too-many-1.pdf", b"first")
+            second = _write_cached_test_attachment("document", "doc_too-many-2.pdf", b"second")
+            adapter = self._make_adapter()
+            adapter.send = AsyncMock(return_value=SendResult(success=True))
+            adapter._message_handler = MagicMock()
+
+            asyncio.run(adapter._dispatch_message({
+                "uid": b"313",
+                "sender_addr": "admin@test.com",
+                "sender_name": "Admin",
+                "subject": "Too many attachments",
+                "message_id": "<too-many-attachments@test.com>",
+                "in_reply_to": "",
+                "body": "Please process these attachments",
+                "attachments": [
+                    {"type": "document", "media_type": "application/pdf", "path": str(first)},
+                    {"type": "document", "media_type": "application/pdf", "path": str(second)},
+                ],
+                "date": "",
+            }))
+
+            adapter._message_handler.assert_not_called()
+            adapter.send.assert_awaited_once()
+            self.assertIn("too many attachments", adapter.send.await_args.args[1].lower())
+            self.assertFalse(Path(os.environ["EMAIL_CHALLENGE_STORE"]).exists())
+            self.assertFalse(first.exists())
+            self.assertFalse(second.exists())
+
+    def test_challenge_rejects_oversized_attachment_metadata_without_storing(self):
+        """Challenge storage caps serialized event size, including attachment metadata."""
+        import asyncio
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "challenge",
+            "EMAIL_ALLOWED_USERS": "admin@test.com",
+            "EMAIL_CHALLENGE_STORE": str(Path(tmpdir) / "challenges.json"),
+        }), patch("gateway.platforms.email.MAX_EMAIL_CHALLENGE_EVENT_BYTES", 256):
+            attachment_path = _write_cached_test_attachment(
+                "document", "doc_oversized-metadata.pdf", b"oversized metadata"
+            )
+            adapter = self._make_adapter()
+            adapter.send = AsyncMock(return_value=SendResult(success=True))
+            adapter._message_handler = MagicMock()
+
+            asyncio.run(adapter._dispatch_message({
+                "uid": b"314",
+                "sender_addr": "admin@test.com",
+                "sender_name": "Admin",
+                "subject": "Oversized metadata",
+                "message_id": "<oversized-metadata@test.com>",
+                "in_reply_to": "",
+                "body": "Small body",
+                "attachments": [{
+                    "type": "document",
+                    "media_type": "application/pdf",
+                    "filename": "x" * 2048,
+                    "path": str(attachment_path),
+                }],
+                "date": "",
+            }))
+
+            adapter._message_handler.assert_not_called()
+            adapter.send.assert_awaited_once()
+            self.assertIn("too large", adapter.send.await_args.args[1].lower())
+            self.assertFalse(Path(os.environ["EMAIL_CHALLENGE_STORE"]).exists())
+            self.assertFalse(attachment_path.exists())
+
+    def test_challenge_rejects_oversized_attachment_payload_without_storing(self):
+        """Challenge fetch byte caps reject oversized cached payloads before storage."""
+        import asyncio
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "challenge",
+            "EMAIL_ALLOWED_USERS": "admin@test.com",
+            "EMAIL_CHALLENGE_STORE": str(Path(tmpdir) / "challenges.json"),
+        }):
+            adapter = self._make_adapter()
+            adapter.send = AsyncMock(return_value=SendResult(success=True))
+            adapter._message_handler = MagicMock()
+
+            asyncio.run(adapter._dispatch_message({
+                "uid": b"315",
+                "sender_addr": "admin@test.com",
+                "sender_name": "Admin",
+                "subject": "Oversized attachment payload",
+                "message_id": "<oversized-attachment-payload@test.com>",
+                "in_reply_to": "",
+                "body": "Small body",
+                "attachments": [],
+                "date": "",
+                "_email_challenge_attachment_error": "too_large",
+            }))
+
+            adapter._message_handler.assert_not_called()
+            adapter.send.assert_awaited_once()
+            self.assertIn("attachment", adapter.send.await_args.args[1].lower())
+            self.assertIn("too large", adapter.send.await_args.args[1].lower())
+            self.assertFalse(Path(os.environ["EMAIL_CHALLENGE_STORE"]).exists())
+
+    def test_challenge_global_pending_cap_ignores_expired_entries(self):
+        """Expired challenges are cleaned up before enforcing the global pending cap."""
+        import asyncio
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "challenge",
+            "EMAIL_ALLOWED_USERS": "*",
+            "EMAIL_CHALLENGE_STORE": str(Path(tmpdir) / "challenges.json"),
+            "EMAIL_CHALLENGE_TTL_SECONDS": "1",
+        }), patch("gateway.email_challenge.MAX_PENDING_CHALLENGES_TOTAL", 1):
+            adapter = self._make_adapter()
+            adapter.send = AsyncMock(return_value=SendResult(success=True))
+            store_path = Path(os.environ["EMAIL_CHALLENGE_STORE"])
+
+            asyncio.run(adapter._dispatch_message({
+                "uid": b"310",
+                "sender_addr": "old@test.com",
+                "sender_name": "Old",
+                "subject": "Old",
+                "message_id": "<old-cap@test.com>",
+                "in_reply_to": "",
+                "body": "Old request",
+                "attachments": [],
+                "date": "",
+            }))
+            stored = json.loads(store_path.read_text())
+            stored["challenges"][0]["created_at"] = 0
+            store_path.write_text(json.dumps(stored))
+
+            asyncio.run(adapter._dispatch_message({
+                "uid": b"311",
+                "sender_addr": "new@test.com",
+                "sender_name": "New",
+                "subject": "New",
+                "message_id": "<new-cap@test.com>",
+                "in_reply_to": "",
+                "body": "New request",
+                "attachments": [],
+                "date": "",
+            }))
+
+            self.assertEqual(adapter.send.await_count, 2)
+            stored = json.loads(store_path.read_text())
+            self.assertEqual(len(stored["challenges"]), 1)
+            self.assertEqual(stored["challenges"][0]["sender"], "new@test.com")
+
+    def test_challenge_mode_email_allow_all_still_challenges(self):
+        """Challenge mode must not bypass confirmation when EMAIL_ALLOW_ALL_USERS authorizes sender."""
+        import asyncio
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "challenge",
+            "EMAIL_ALLOW_ALL_USERS": "true",
+            "EMAIL_CHALLENGE_STORE": str(Path(tmpdir) / "challenges.json"),
+        }, clear=False):
+            adapter = self._make_adapter()
+            adapter.send = AsyncMock(return_value=SendResult(success=True))
+            adapter._message_handler = MagicMock()
+            msg_data = {
+                "uid": b"215",
+                "sender_addr": "allowall@test.com",
+                "sender_name": "Allow All",
+                "subject": "Allow all",
+                "message_id": "<allow-all@test.com>",
+                "in_reply_to": "",
+                "body": "This still needs confirmation",
+                "attachments": [],
+                "date": "",
+            }
+
+            asyncio.run(adapter._dispatch_message(msg_data))
+
+            adapter._message_handler.assert_not_called()
+            adapter.send.assert_awaited_once()
+            stored = json.loads(Path(os.environ["EMAIL_CHALLENGE_STORE"]).read_text())
+            self.assertEqual(stored["challenges"][0]["sender"], "allowall@test.com")
+
+    def test_challenge_mode_global_allowlist_still_challenges(self):
+        """Challenge mode must not bypass confirmation for GATEWAY_ALLOWED_USERS-authorized email."""
+        import asyncio
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "challenge",
+            "GATEWAY_ALLOWED_USERS": "global@test.com",
+            "EMAIL_CHALLENGE_STORE": str(Path(tmpdir) / "challenges.json"),
+        }, clear=False):
+            adapter = self._make_adapter()
+            adapter.send = AsyncMock(return_value=SendResult(success=True))
+            adapter._message_handler = MagicMock()
+            msg_data = {
+                "uid": b"216",
+                "sender_addr": "global@test.com",
+                "sender_name": "Global",
+                "subject": "Global allowlist",
+                "message_id": "<global@test.com>",
+                "in_reply_to": "",
+                "body": "This also needs confirmation",
+                "attachments": [],
+                "date": "",
+            }
+
+            asyncio.run(adapter._dispatch_message(msg_data))
+
+            adapter._message_handler.assert_not_called()
+            adapter.send.assert_awaited_once()
+            stored = json.loads(Path(os.environ["EMAIL_CHALLENGE_STORE"]).read_text())
+            self.assertEqual(stored["challenges"][0]["sender"], "global@test.com")
+
+    def test_challenge_mode_config_allow_from_without_env_allowlist_is_not_challenged(self):
+        """Challenge mode does not challenge config-only allow_from senders.
+
+        The adapter challenge gate intentionally mirrors the central gateway auth paths
+        it can validate before storing untrusted bodies. config.yaml allow_from is a
+        direct-mode adapter filter, not a central challenge-mode authorization source.
+        """
+        import asyncio
+        from gateway.config import PlatformConfig
+        from gateway.platforms.email import EmailAdapter
+
+        env = {
+            "EMAIL_AUTH_MODE": "challenge",
+            "EMAIL_CHALLENGE_STORE": "",
+            "EMAIL_ALLOWED_USERS": "",
+            "EMAIL_ALLOW_ALL_USERS": "",
+            "GATEWAY_ALLOWED_USERS": "",
+            "GATEWAY_ALLOW_ALL_USERS": "",
+        }
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(os.environ, env, clear=False):
+            os.environ["EMAIL_CHALLENGE_STORE"] = str(Path(tmpdir) / "challenges.json")
+            adapter = EmailAdapter(PlatformConfig(enabled=True, extra={"allow_from": ["config@test.com"]}))
+            adapter._address = "hermes@test.com"
+            adapter._password = "secret"
+            adapter._imap_host = "imap.test.com"
+            adapter._smtp_host = "smtp.test.com"
+            adapter.send = AsyncMock(return_value=SendResult(success=True))
+            adapter._message_handler = MagicMock()
+            msg_data = {
+                "uid": b"217",
+                "sender_addr": "config@test.com",
+                "sender_name": "Config",
+                "subject": "Config allowlist",
+                "message_id": "<config@test.com>",
+                "in_reply_to": "",
+                "body": "Config-only authorization must not be retained",
+                "attachments": [],
+                "date": "",
+            }
+
+            asyncio.run(adapter._dispatch_message(msg_data))
+
+            adapter._message_handler.assert_not_called()
+            adapter.send.assert_not_awaited()
+            self.assertFalse(Path(os.environ["EMAIL_CHALLENGE_STORE"]).exists())
+
+    def test_challenge_confirm_scrubs_store_but_preserves_original_attachment_file(self):
+        """Successful confirmation scrubs retained metadata without deleting files the agent may read."""
+        import asyncio
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "challenge",
+            "EMAIL_ALLOWED_USERS": "admin@test.com",
+            "EMAIL_CHALLENGE_STORE": str(Path(tmpdir) / "challenges.json"),
+        }):
+            attachment_path = _write_cached_test_attachment(
+                "image", "img_sensitive-success.png", b"sensitive image"
+            )
+            adapter = self._make_adapter()
+            adapter.send = AsyncMock(return_value=SendResult(success=True))
+            captured_events = []
+
+            async def capture_handle(event):
+                captured_events.append(event)
+
+            adapter.handle_message = capture_handle
+            original = {
+                "uid": b"218",
+                "sender_addr": "admin@test.com",
+                "sender_name": "Admin",
+                "subject": "Retain success",
+                "message_id": "<retain-success@test.com>",
+                "in_reply_to": "",
+                "body": "Sensitive success body",
+                "attachments": [{
+                    "type": "image",
+                    "media_type": "image/png",
+                    "path": str(attachment_path),
+                }],
+                "date": "",
+            }
+            asyncio.run(adapter._dispatch_message(original))
+            code = self._extract_confirmation_code(adapter.send.await_args.args[1])
+            confirm_attachment_path = _write_cached_test_attachment(
+                "document", "doc_confirm-success.pdf", b"confirmation attachment"
+            )
+            confirm = dict(
+                original,
+                uid=b"219",
+                message_id="<confirm-retain-success@test.com>",
+                body=f"/confirm {code}",
+                attachments=[{
+                    "type": "document",
+                    "media_type": "application/pdf",
+                    "path": str(confirm_attachment_path),
+                }],
+            )
+
+            asyncio.run(adapter._dispatch_message(confirm))
+
+            self.assertEqual(len(captured_events), 1)
+            self.assertIn("Sensitive success body", captured_events[0].text)
+            self.assertEqual(captured_events[0].media_urls, [str(attachment_path)])
+            self.assertTrue(attachment_path.exists())
+            self.assertFalse(confirm_attachment_path.exists())
+            store_text = Path(os.environ["EMAIL_CHALLENGE_STORE"]).read_text()
+            stored = json.loads(store_text)
+            self.assertEqual(len(stored["challenges"]), 1)
+            self.assertTrue(stored["challenges"][0]["used"])
+            self.assertNotIn("event", stored["challenges"][0])
+            self.assertNotIn("subject", stored["challenges"][0])
+            self.assertNotIn("message_id", stored["challenges"][0])
+            self.assertNotIn("Sensitive success body", store_text)
+            self.assertNotIn("Retain success", store_text)
+            self.assertNotIn("<retain-success@test.com>", store_text)
+            self.assertNotIn("img_sensitive-success.png", store_text)
+
+    def test_challenge_send_failure_removes_pending_original_and_attachment(self):
+        """If the challenge code cannot be delivered, the retained original is removed."""
+        import asyncio
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "challenge",
+            "EMAIL_ALLOWED_USERS": "admin@test.com",
+            "EMAIL_CHALLENGE_STORE": str(Path(tmpdir) / "challenges.json"),
+        }):
+            attachment_path = _write_cached_test_attachment(
+                "document", "doc_send-failure.pdf", b"failed challenge attachment"
+            )
+            adapter = self._make_adapter()
+            adapter.send = AsyncMock(return_value=SendResult(success=False, error="smtp down"))
+            adapter.handle_message = AsyncMock()
+            original = {
+                "uid": b"222",
+                "sender_addr": "admin@test.com",
+                "sender_name": "Admin",
+                "subject": "Undelivered challenge",
+                "message_id": "<send-failure@test.com>",
+                "in_reply_to": "",
+                "body": "Sensitive body without delivered code",
+                "attachments": [{
+                    "type": "document",
+                    "media_type": "application/pdf",
+                    "path": str(attachment_path),
+                }],
+                "date": "",
+            }
+
+            asyncio.run(adapter._dispatch_message(original))
+
+            adapter.handle_message.assert_not_awaited()
+            adapter.send.assert_awaited_once()
+            self.assertFalse(attachment_path.exists())
+            store_text = Path(os.environ["EMAIL_CHALLENGE_STORE"]).read_text()
+            self.assertEqual(json.loads(store_text)["challenges"], [])
+            self.assertNotIn("Sensitive body without delivered code", store_text)
+            self.assertNotIn("doc_send-failure.pdf", store_text)
+
+    def test_challenge_create_store_failure_is_contained_and_deletes_attachment(self):
+        """Create-time store I/O failures fail closed without dispatching the original."""
+        import asyncio
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "challenge",
+            "EMAIL_ALLOWED_USERS": "admin@test.com",
+            "EMAIL_CHALLENGE_STORE": str(Path(tmpdir) / "challenges.json"),
+        }), patch("gateway.platforms.email.EmailChallengeStore.create", side_effect=OSError("store down")):
+            attachment_path = _write_cached_test_attachment(
+                "document", "doc_create-failure.pdf", b"create failure"
+            )
+            adapter = self._make_adapter()
+            adapter.send = AsyncMock(return_value=SendResult(success=True))
+            adapter.handle_message = AsyncMock()
+
+            asyncio.run(adapter._dispatch_message({
+                "uid": b"226",
+                "sender_addr": "admin@test.com",
+                "sender_name": "Admin",
+                "subject": "Create failure",
+                "message_id": "<create-failure@test.com>",
+                "in_reply_to": "",
+                "body": "Sensitive body should not dispatch",
+                "attachments": [{
+                    "type": "document",
+                    "media_type": "application/pdf",
+                    "path": str(attachment_path),
+                }],
+                "date": "",
+            }))
+
+            adapter.handle_message.assert_not_awaited()
+            adapter.send.assert_awaited_once()
+            self.assertIn("temporarily", adapter.send.await_args.args[1].lower())
+            self.assertFalse(attachment_path.exists())
+
+    def test_challenge_confirm_store_failure_is_contained_and_deletes_confirmation_attachment(self):
+        """Confirm-time store I/O failures do not dispatch or retain confirmation files."""
+        import asyncio
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "challenge",
+            "EMAIL_ALLOWED_USERS": "admin@test.com",
+            "EMAIL_CHALLENGE_STORE": str(Path(tmpdir) / "challenges.json"),
+        }), patch("gateway.platforms.email.EmailChallengeStore.confirm", side_effect=OSError("store down")):
+            attachment_path = _write_cached_test_attachment(
+                "image", "img_confirm-store-failure.png", b"confirm failure"
+            )
+            adapter = self._make_adapter()
+            adapter.send = AsyncMock(return_value=SendResult(success=True))
+            adapter.handle_message = AsyncMock()
+
+            asyncio.run(adapter._dispatch_message({
+                "uid": b"227",
+                "sender_addr": "admin@test.com",
+                "sender_name": "Admin",
+                "subject": "Re: Confirm failure",
+                "message_id": "<confirm-store-failure@test.com>",
+                "in_reply_to": "",
+                "body": "/confirm broken-code",
+                "attachments": [{
+                    "type": "image",
+                    "media_type": "image/png",
+                    "path": str(attachment_path),
+                }],
+                "date": "",
+            }))
+
+            adapter.handle_message.assert_not_awaited()
+            adapter.send.assert_awaited_once()
+            self.assertIn("temporarily", adapter.send.await_args.args[1].lower())
+            self.assertFalse(attachment_path.exists())
+
+    def test_challenge_send_failure_remove_error_is_contained_and_deletes_attachment(self):
+        """Remove failures after challenge-send failure are logged and cleaned best-effort."""
+        import asyncio
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "challenge",
+            "EMAIL_ALLOWED_USERS": "admin@test.com",
+            "EMAIL_CHALLENGE_STORE": str(Path(tmpdir) / "challenges.json"),
+        }), patch("gateway.platforms.email.EmailChallengeStore.remove", side_effect=OSError("remove failed")):
+            attachment_path = _write_cached_test_attachment(
+                "document", "doc_remove-failure.pdf", b"remove failure"
+            )
+            adapter = self._make_adapter()
+            adapter.send = AsyncMock(return_value=SendResult(success=False, error="smtp down"))
+            adapter.handle_message = AsyncMock()
+
+            asyncio.run(adapter._dispatch_message({
+                "uid": b"228",
+                "sender_addr": "admin@test.com",
+                "sender_name": "Admin",
+                "subject": "Remove failure",
+                "message_id": "<remove-failure@test.com>",
+                "in_reply_to": "",
+                "body": "Sensitive body with failed send",
+                "attachments": [{
+                    "type": "document",
+                    "media_type": "application/pdf",
+                    "path": str(attachment_path),
+                }],
+                "date": "",
+            }))
+
+            adapter.handle_message.assert_not_awaited()
+            adapter.send.assert_awaited_once()
+            self.assertFalse(attachment_path.exists())
+
+    def test_challenge_send_failure_remove_false_deletes_attachment_fallback(self):
+        """A false remove result after send failure still deletes retained original files."""
+        import asyncio
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "challenge",
+            "EMAIL_ALLOWED_USERS": "admin@test.com",
+            "EMAIL_CHALLENGE_STORE": str(Path(tmpdir) / "challenges.json"),
+        }), patch("gateway.platforms.email.EmailChallengeStore.remove", return_value=False):
+            attachment_path = _write_cached_test_attachment(
+                "document", "doc_remove-false.pdf", b"remove returned false"
+            )
+            adapter = self._make_adapter()
+            adapter.send = AsyncMock(return_value=SendResult(success=False, error="smtp down"))
+            adapter.handle_message = AsyncMock()
+
+            asyncio.run(adapter._dispatch_message({
+                "uid": b"230",
+                "sender_addr": "admin@test.com",
+                "sender_name": "Admin",
+                "subject": "Remove false",
+                "message_id": "<remove-false@test.com>",
+                "in_reply_to": "",
+                "body": "Sensitive body with failed cleanup",
+                "attachments": [{
+                    "type": "document",
+                    "media_type": "application/pdf",
+                    "path": str(attachment_path),
+                }],
+                "date": "",
+            }))
+
+            adapter.handle_message.assert_not_awaited()
+            adapter.send.assert_awaited_once()
+            self.assertFalse(attachment_path.exists())
+
+    def test_invalid_challenge_confirmation_deletes_confirmation_attachment(self):
+        """Attachments cached from invalid /confirm replies are not retained."""
+        import asyncio
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "challenge",
+            "EMAIL_ALLOWED_USERS": "admin@test.com",
+            "EMAIL_CHALLENGE_STORE": str(Path(tmpdir) / "challenges.json"),
+        }):
+            attachment_path = _write_cached_test_attachment(
+                "image", "img_invalid-confirm.png", b"invalid confirm image"
+            )
+            adapter = self._make_adapter()
+            adapter.send = AsyncMock(return_value=SendResult(success=True))
+            adapter.handle_message = AsyncMock()
+            confirm = {
+                "uid": b"223",
+                "sender_addr": "admin@test.com",
+                "sender_name": "Admin",
+                "subject": "Re: Unknown challenge",
+                "message_id": "<invalid-confirm@test.com>",
+                "in_reply_to": "",
+                "body": "/confirm missing-code",
+                "attachments": [{
+                    "type": "image",
+                    "media_type": "image/png",
+                    "path": str(attachment_path),
+                }],
+                "date": "",
+            }
+
+            asyncio.run(adapter._dispatch_message(confirm))
+
+            adapter.handle_message.assert_not_awaited()
+            self.assertIn("invalid", adapter.send.await_args.args[1].lower())
+            self.assertFalse(attachment_path.exists())
+
+    def test_overlong_challenge_confirmation_rejected_without_store_lookup(self):
+        """Very large /confirm tokens are rejected before hashing or store lookup."""
+        import asyncio
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "challenge",
+            "EMAIL_ALLOWED_USERS": "admin@test.com",
+            "EMAIL_CHALLENGE_STORE": str(Path(tmpdir) / "challenges.json"),
+        }), patch("gateway.platforms.email.EmailChallengeStore.confirm") as confirm:
+            adapter = self._make_adapter()
+            adapter.send = AsyncMock(return_value=SendResult(success=True))
+            adapter.handle_message = AsyncMock()
+            msg_data = {
+                "uid": b"231",
+                "sender_addr": "admin@test.com",
+                "sender_name": "Admin",
+                "subject": "Re: Overlong confirm",
+                "message_id": "<overlong-confirm@test.com>",
+                "in_reply_to": "",
+                "body": "/confirm " + ("x" * 4096),
+                "attachments": [],
+                "date": "",
+            }
+
+            asyncio.run(adapter._dispatch_message(msg_data))
+
+            adapter.handle_message.assert_not_awaited()
+            adapter.send.assert_awaited_once()
+            self.assertIn("invalid", adapter.send.await_args.args[1].lower())
+            confirm.assert_not_called()
+
+    def test_expired_challenge_confirm_scrubs_stored_event(self):
+        """Expired confirmation rejects and immediately scrubs retained body/attachments."""
+        import asyncio
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "challenge",
+            "EMAIL_ALLOWED_USERS": "admin@test.com",
+            "EMAIL_CHALLENGE_STORE": str(Path(tmpdir) / "challenges.json"),
+            "EMAIL_CHALLENGE_TTL_SECONDS": "1",
+        }):
+            attachment_path = _write_cached_test_attachment(
+                "document", "doc_sensitive-expired.pdf", b"sensitive document"
+            )
+            adapter = self._make_adapter()
+            adapter.send = AsyncMock(return_value=SendResult(success=True))
+            adapter.handle_message = AsyncMock()
+            original = {
+                "uid": b"220",
+                "sender_addr": "admin@test.com",
+                "sender_name": "Admin",
+                "subject": "Retain expiry",
+                "message_id": "<retain-expiry@test.com>",
+                "in_reply_to": "",
+                "body": "Sensitive expired body",
+                "attachments": [{
+                    "type": "document",
+                    "media_type": "application/pdf",
+                    "path": str(attachment_path),
+                }],
+                "date": "",
+            }
+            self.assertTrue(attachment_path.exists())
+            asyncio.run(adapter._dispatch_message(original))
+            code = self._extract_confirmation_code(adapter.send.await_args.args[1])
+            store_path = Path(os.environ["EMAIL_CHALLENGE_STORE"])
+            stored = json.loads(store_path.read_text())
+            stored["challenges"][0]["created_at"] = 0
+            store_path.write_text(json.dumps(stored))
+            confirm_attachment_path = _write_cached_test_attachment(
+                "image", "img_confirm-expired.png", b"expired confirmation image"
+            )
+            confirm = dict(
+                original,
+                uid=b"221",
+                message_id="<confirm-retain-expiry@test.com>",
+                body=f"/confirm {code}",
+                attachments=[{
+                    "type": "image",
+                    "media_type": "image/png",
+                    "path": str(confirm_attachment_path),
+                }],
+            )
+
+            asyncio.run(adapter._dispatch_message(confirm))
+
+            adapter.handle_message.assert_not_awaited()
+            self.assertIn("expired", adapter.send.await_args.args[1].lower())
+            self.assertFalse(attachment_path.exists())
+            self.assertFalse(confirm_attachment_path.exists())
+            store_text = store_path.read_text()
+            stored = json.loads(store_text)
+            self.assertEqual(len(stored["challenges"]), 1)
+            self.assertTrue(stored["challenges"][0]["used"])
+            self.assertNotIn("event", stored["challenges"][0])
+            self.assertNotIn("subject", stored["challenges"][0])
+            self.assertNotIn("message_id", stored["challenges"][0])
+            self.assertNotIn("Sensitive expired body", store_text)
+            self.assertNotIn("Retain expiry", store_text)
+            self.assertNotIn("<retain-expiry@test.com>", store_text)
+            self.assertNotIn("doc_sensitive-expired.pdf", store_text)
+
+    def test_expired_challenge_confirm_keeps_cleanup_tombstone_after_unlink_failure(self):
+        """Expired confirm scrubs sensitive metadata but keeps retry data when unlink fails."""
+        import asyncio
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "challenge",
+            "EMAIL_ALLOWED_USERS": "admin@test.com",
+            "EMAIL_CHALLENGE_STORE": str(Path(tmpdir) / "challenges.json"),
+            "EMAIL_CHALLENGE_TTL_SECONDS": "1",
+        }):
+            attachment_path = _write_cached_test_attachment(
+                "document", "doc_confirm-unlink-failure.pdf", b"confirm unlink failure"
+            )
+            adapter = self._make_adapter()
+            adapter.send = AsyncMock(return_value=SendResult(success=True))
+            adapter.handle_message = AsyncMock()
+            original = {
+                "uid": b"232",
+                "sender_addr": "admin@test.com",
+                "sender_name": "Admin",
+                "subject": "Confirm unlink failure",
+                "message_id": "<confirm-unlink-failure@test.com>",
+                "in_reply_to": "",
+                "body": "Sensitive body with unlink failure",
+                "attachments": [{
+                    "type": "document",
+                    "media_type": "application/pdf",
+                    "path": str(attachment_path),
+                }],
+                "date": "",
+            }
+            asyncio.run(adapter._dispatch_message(original))
+            code = self._extract_confirmation_code(adapter.send.await_args.args[1])
+            store_path = Path(os.environ["EMAIL_CHALLENGE_STORE"])
+            stored = json.loads(store_path.read_text())
+            stored["challenges"][0]["created_at"] = 0
+            store_path.write_text(json.dumps(stored))
+
+            with patch("pathlib.Path.unlink", side_effect=OSError("permission denied")):
+                asyncio.run(adapter._dispatch_message(dict(original, uid=b"233", body=f"/confirm {code}")))
+
+            self.assertTrue(attachment_path.exists())
+            store_text = store_path.read_text()
+            stored = json.loads(store_text)
+            self.assertEqual(len(stored["challenges"]), 1)
+            self.assertTrue(stored["challenges"][0]["used"])
+            self.assertNotIn("event", stored["challenges"][0])
+            self.assertNotIn("subject", stored["challenges"][0])
+            self.assertNotIn("message_id", stored["challenges"][0])
+            self.assertNotIn("Sensitive body with unlink failure", store_text)
+            self.assertEqual(stored.get("cleanup_pending", [])[0]["attachments"][0]["path"], str(attachment_path))
+
+            adapter._email_challenge_store().cleanup_expired()
+            self.assertFalse(attachment_path.exists())
+            self.assertEqual(json.loads(store_path.read_text()).get("cleanup_pending", []), [])
+
+    def test_challenge_mode_mixed_case_allowlist_does_not_pre_auth_lowercase_sender(self):
+        """Challenge pre-auth mirrors central gateway's case-sensitive allowlist matching."""
+        import asyncio
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "challenge",
+            "EMAIL_ALLOWED_USERS": "Admin@Test.com",
+            "EMAIL_CHALLENGE_STORE": str(Path(tmpdir) / "challenges.json"),
+        }):
+            adapter = self._make_adapter()
+            adapter.send = AsyncMock(return_value=SendResult(success=True))
+            adapter._message_handler = MagicMock()
+            msg_data = {
+                "uid": b"224",
+                "sender_addr": "admin@test.com",
+                "sender_name": "Admin",
+                "subject": "Case mismatch",
+                "message_id": "<case-mismatch@test.com>",
+                "in_reply_to": "",
+                "body": "This should not be retained before central auth would allow it",
+                "attachments": [],
+                "date": "",
+            }
+
+            asyncio.run(adapter._dispatch_message(msg_data))
+
+            adapter._message_handler.assert_not_called()
+            adapter.send.assert_not_awaited()
+            self.assertFalse(Path(os.environ["EMAIL_CHALLENGE_STORE"]).exists())
+
+    def test_challenge_confirmation_preserves_attachments(self):
+        """Confirmed challenge dispatches the original attachment metadata."""
+        import asyncio
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "challenge",
+            "EMAIL_ALLOWED_USERS": "admin@test.com",
+            "EMAIL_CHALLENGE_STORE": str(Path(tmpdir) / "challenges.json"),
+        }):
+            adapter = self._make_adapter()
+            adapter.send = AsyncMock(return_value=SendResult(success=True))
+            captured_events = []
+
+            async def capture_handle(event):
+                captured_events.append(event)
+
+            adapter.handle_message = capture_handle
+            original = {
+                "uid": b"211",
+                "sender_addr": "admin@test.com",
+                "sender_name": "Admin",
+                "subject": "Photo",
+                "message_id": "<photo@test.com>",
+                "in_reply_to": "",
+                "body": "See attached",
+                "attachments": [{
+                    "type": "image",
+                    "media_type": "image/png",
+                    "path": "/tmp/hermes-photo.png",
+                }],
+                "date": "",
+            }
+            asyncio.run(adapter._dispatch_message(original))
+            code = self._extract_confirmation_code(adapter.send.await_args.args[1])
+            confirm = dict(original, uid=b"212", message_id="<confirm-photo@test.com>", body=f"/confirm {code}")
+
+            asyncio.run(adapter._dispatch_message(confirm))
+
+            self.assertEqual(len(captured_events), 1)
+            self.assertEqual(captured_events[0].media_urls, ["/tmp/hermes-photo.png"])
+            self.assertEqual(captured_events[0].media_types, ["image/png"])
+
+    def test_malformed_challenge_created_at_does_not_crash(self):
+        """Malformed store timestamps are rejected instead of crashing dispatch."""
+        import asyncio
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "challenge",
+            "EMAIL_ALLOWED_USERS": "admin@test.com",
+            "EMAIL_CHALLENGE_STORE": str(Path(tmpdir) / "challenges.json"),
+        }):
+            adapter = self._make_adapter()
+            adapter.send = AsyncMock(return_value=SendResult(success=True))
+            adapter.handle_message = AsyncMock()
+            original = {
+                "uid": b"213",
+                "sender_addr": "admin@test.com",
+                "sender_name": "Admin",
+                "subject": "Bad timestamp",
+                "message_id": "<bad-time@test.com>",
+                "in_reply_to": "",
+                "body": "This should not crash",
+                "attachments": [],
+                "date": "",
+            }
+            asyncio.run(adapter._dispatch_message(original))
+            code = self._extract_confirmation_code(adapter.send.await_args.args[1])
+            store_path = Path(os.environ["EMAIL_CHALLENGE_STORE"])
+            stored = json.loads(store_path.read_text())
+            stored["challenges"][0]["created_at"] = "not-a-float"
+            store_path.write_text(json.dumps(stored))
+            confirm = dict(original, uid=b"214", message_id="<confirm-bad-time@test.com>", body=f"/confirm {code}")
+
+            asyncio.run(adapter._dispatch_message(confirm))
+
+            adapter.handle_message.assert_not_awaited()
+            self.assertIn("invalid or already used", adapter.send.await_args.args[1].lower())
+            self.assertEqual(json.loads(store_path.read_text())["challenges"], [])
+
+    def test_challenge_mode_unknown_sender_uses_existing_drop_path(self):
+        """Unknown senders are not challenged as if they were allowlisted."""
+        import asyncio
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "challenge",
+            "EMAIL_ALLOWED_USERS": "admin@test.com",
+            "EMAIL_CHALLENGE_STORE": str(Path(tmpdir) / "challenges.json"),
+        }):
+            adapter = self._make_adapter()
+            adapter.send = AsyncMock(return_value=SendResult(success=True))
+            adapter._message_handler = MagicMock()
+            msg_data = {
+                "uid": b"207",
+                "sender_addr": "outsider@test.com",
+                "sender_name": "Outsider",
+                "subject": "Hello",
+                "message_id": "<outsider@test.com>",
+                "in_reply_to": "",
+                "body": "Let me in",
+                "attachments": [],
+                "date": "",
+            }
+
+            asyncio.run(adapter._dispatch_message(msg_data))
+
+            adapter._message_handler.assert_not_called()
+            adapter.send.assert_not_awaited()
+            self.assertFalse(Path(os.environ["EMAIL_CHALLENGE_STORE"]).exists())
+
+    def test_challenge_email_allowlist_bare_local_part_does_not_match_any_domain(self):
+        """EMAIL_ALLOWED_USERS=admin must not challenge admin@arbitrary-domain."""
+        import asyncio
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "challenge",
+            "EMAIL_ALLOWED_USERS": "admin",
+            "GATEWAY_ALLOWED_USERS": "",
+            "EMAIL_CHALLENGE_STORE": str(Path(tmpdir) / "challenges.json"),
+        }, clear=False):
+            adapter = self._make_adapter()
+            adapter.send = AsyncMock(return_value=SendResult(success=True))
+            adapter._message_handler = MagicMock()
+
+            asyncio.run(adapter._dispatch_message({
+                "uid": b"229",
+                "sender_addr": "admin@evil.example",
+                "sender_name": "Admin Evil",
+                "subject": "Local part bypass",
+                "message_id": "<local-part-bypass@test.com>",
+                "in_reply_to": "",
+                "body": "This must not be retained or challenged.",
+                "attachments": [],
+                "date": "",
+            }))
+
+            adapter._message_handler.assert_not_called()
+            adapter.send.assert_not_awaited()
+            self.assertFalse(Path(os.environ["EMAIL_CHALLENGE_STORE"]).exists())
+
+    def test_invalid_email_auth_mode_fails_closed_to_challenge(self):
+        """Security-sensitive EMAIL_AUTH_MODE typos must not fall back to direct dispatch."""
+        import asyncio
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "challlenge",
+            "EMAIL_ALLOWED_USERS": "admin@test.com",
+            "EMAIL_CHALLENGE_STORE": str(Path(tmpdir) / "challenges.json"),
+        }):
+            adapter = self._make_adapter()
+            adapter.send = AsyncMock(return_value=SendResult(success=True))
+            adapter._message_handler = MagicMock()
+            msg_data = {
+                "uid": b"225",
+                "sender_addr": "admin@test.com",
+                "sender_name": "Admin",
+                "subject": "Typo auth mode",
+                "message_id": "<typo-auth-mode@test.com>",
+                "in_reply_to": "",
+                "body": "This must still require confirmation.",
+                "attachments": [],
+                "date": "",
+            }
+
+            asyncio.run(adapter._dispatch_message(msg_data))
+
+            adapter._message_handler.assert_not_called()
+            adapter.send.assert_awaited_once()
+            self.assertIn("pending confirmation", adapter.send.await_args.args[1])
+            stored = json.loads(Path(os.environ["EMAIL_CHALLENGE_STORE"]).read_text())
+            self.assertEqual(stored["challenges"][0]["sender"], "admin@test.com")
+
+    def test_check_inbox_passively_cleans_expired_challenge_attachments(self):
+        """Polling cleanup removes expired retained challenge data without a new create."""
+        import asyncio
+        from gateway.email_challenge import EmailChallengeStore
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "challenge",
+            "EMAIL_ALLOWED_USERS": "admin@test.com",
+            "EMAIL_CHALLENGE_STORE": str(Path(tmpdir) / "challenges.json"),
+            "EMAIL_CHALLENGE_TTL_SECONDS": "1",
+        }):
+            attachment_path = _write_cached_test_attachment(
+                "image", "img_passive-expiry.png", b"passive expiry image"
+            )
+            store_path = Path(os.environ["EMAIL_CHALLENGE_STORE"])
+            store = EmailChallengeStore(path=str(store_path), ttl_seconds=1)
+            store.create("admin@test.com", "Passive", "<passive@test.com>", {
+                "sender_addr": "admin@test.com",
+                "sender_name": "Admin",
+                "subject": "Passive",
+                "message_id": "<passive@test.com>",
+                "in_reply_to": "",
+                "body": "Sensitive passive body",
+                "attachments": [{
+                    "type": "image",
+                    "media_type": "image/png",
+                    "path": str(attachment_path),
+                }],
+                "date": "",
+                "_email_challenge_confirmed": True,
+            })
+            stored = json.loads(store_path.read_text())
+            stored["challenges"][0]["created_at"] = 0
+            store_path.write_text(json.dumps(stored))
+
+            adapter = self._make_adapter()
+            adapter._fetch_new_messages = MagicMock(return_value=[])
+            awaitable = adapter._check_inbox()
+            asyncio.run(awaitable)
+
+            self.assertFalse(attachment_path.exists())
+            self.assertEqual(json.loads(store_path.read_text())["challenges"], [])
+
+
+class TestEmailChallengeStore(unittest.TestCase):
+    """Focused tests for challenge-store retention cleanup."""
+
+    def test_store_read_oserror_propagates_for_mutating_operations(self):
+        from gateway.email_challenge import EmailChallengeStore
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store_path = Path(tmpdir) / "challenges.json"
+            store_path.write_text('{"challenges": []}', encoding="utf-8")
+            store = EmailChallengeStore(path=str(store_path), ttl_seconds=900)
+
+            with patch("pathlib.Path.read_text", side_effect=OSError("read failed")):
+                with self.assertRaises(OSError):
+                    store.create("admin@test.com", "Subject", "<msg@test.com>", {"attachments": []})
+                with self.assertRaises(OSError):
+                    store.confirm("admin@test.com", "code")
+                with self.assertRaises(OSError):
+                    store.remove("admin@test.com", "code")
+                with self.assertRaises(OSError):
+                    store.cleanup_expired()
+
+    def test_attachment_cleanup_refuses_similar_cache_path_outside_hermes_roots(self):
+        from gateway.email_challenge import cleanup_challenge_cached_attachments
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            outside_attachment = Path(tmpdir) / "cache" / "documents" / "doc_outside-root.pdf"
+            outside_attachment.parent.mkdir(parents=True)
+            outside_attachment.write_bytes(b"outside")
+
+            cleanup_challenge_cached_attachments({
+                "attachments": [{
+                    "type": "document",
+                    "media_type": "application/pdf",
+                    "path": str(outside_attachment),
+                }]
+            })
+
+            self.assertTrue(outside_attachment.exists())
+
+    def test_sender_trim_deletes_trimmed_challenge_attachment(self):
+        from gateway.email_challenge import EmailChallengeStore
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch("gateway.email_challenge.MAX_PENDING_CHALLENGES_PER_SENDER", 1):
+            old_attachment = _write_cached_test_attachment("image", "img_trimmed-old.png", b"old")
+            new_attachment = _write_cached_test_attachment("image", "img_trimmed-new.png", b"new")
+            store = EmailChallengeStore(path=str(Path(tmpdir) / "challenges.json"), ttl_seconds=900)
+
+            store.create("admin@test.com", "Old", "<old@test.com>", {
+                "body": "old body",
+                "attachments": [{"path": str(old_attachment), "type": "image", "media_type": "image/png"}],
+            })
+            store.create("admin@test.com", "New", "<new@test.com>", {
+                "body": "new body",
+                "attachments": [{"path": str(new_attachment), "type": "image", "media_type": "image/png"}],
+            })
+
+            self.assertFalse(old_attachment.exists())
+            self.assertTrue(new_attachment.exists())
+
+    def test_cleanup_expired_does_not_save_when_no_entries_change(self):
+        from gateway.email_challenge import EmailChallengeStore
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = EmailChallengeStore(path=str(Path(tmpdir) / "challenges.json"), ttl_seconds=900)
+            store.create("admin@test.com", "Fresh", "<fresh@test.com>", {
+                "body": "fresh body",
+                "attachments": [],
+            })
+
+            with patch.object(store, "_save", wraps=store._save) as save:
+                store.cleanup_expired()
+
+            save.assert_not_called()
+
+    def test_load_only_confirm_hardens_existing_store_permissions(self):
+        from gateway.email_challenge import EmailChallengeStore
+
+        if os.name == "nt":
+            self.skipTest("POSIX chmod bits are not meaningful on Windows")
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store_path = Path(tmpdir) / "challenges.json"
+            store_path.write_text('{"challenges": []}', encoding="utf-8")
+            os.chmod(store_path, 0o644)
+            store = EmailChallengeStore(path=str(store_path), ttl_seconds=900)
+
+            self.assertEqual(store.confirm("admin@test.com", "missing"), ("not_found", None))
+
+            self.assertEqual(stat.S_IMODE(store_path.stat().st_mode), 0o600)
+
+    def test_pending_cached_attachment_byte_quota_rejects_and_deletes_new_attachment(self):
+        from gateway.email_challenge import EmailChallengeStore
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch(
+            "gateway.email_challenge.MAX_PENDING_CHALLENGE_CACHED_ATTACHMENT_BYTES",
+            10,
+        ):
+            first = _write_cached_test_attachment("document", "doc_quota-first.pdf", b"123456")
+            second = _write_cached_test_attachment("document", "doc_quota-second.pdf", b"abcdef")
+            store = EmailChallengeStore(path=str(Path(tmpdir) / "challenges.json"), ttl_seconds=900)
+
+            first_code = store.create("one@test.com", "First", "<first@test.com>", {
+                "body": "first",
+                "attachments": [{"path": str(first), "type": "document", "media_type": "application/pdf"}],
+            })
+            second_code = store.create("two@test.com", "Second", "<second@test.com>", {
+                "body": "second",
+                "attachments": [{"path": str(second), "type": "document", "media_type": "application/pdf"}],
+            })
+
+            self.assertIsNotNone(first_code)
+            self.assertIsNone(second_code)
+            self.assertTrue(first.exists())
+            self.assertFalse(second.exists())
+            stored = json.loads((Path(tmpdir) / "challenges.json").read_text())
+            self.assertEqual(len(stored["challenges"]), 1)
+            self.assertEqual(stored["challenges"][0]["sender"], "one@test.com")
+
+    def test_cleanup_expired_retries_failed_attachment_unlinks(self):
+        from gateway.email_challenge import EmailChallengeStore
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            attachment_path = _write_cached_test_attachment(
+                "document", "doc_cleanup-retry.pdf", b"cleanup retry"
+            )
+            store_path = Path(tmpdir) / "challenges.json"
+            store = EmailChallengeStore(path=str(store_path), ttl_seconds=1)
+            store.create("admin@test.com", "Cleanup retry", "<cleanup-retry@test.com>", {
+                "body": "sensitive cleanup retry body",
+                "attachments": [{
+                    "path": str(attachment_path),
+                    "type": "document",
+                    "media_type": "application/pdf",
+                }],
+            })
+            stored = json.loads(store_path.read_text())
+            stored["challenges"][0]["created_at"] = 0
+            store_path.write_text(json.dumps(stored))
+
+            with patch("pathlib.Path.unlink", side_effect=OSError("permission denied")):
+                store.cleanup_expired()
+
+            self.assertTrue(attachment_path.exists())
+            stored = json.loads(store_path.read_text())
+            self.assertEqual(stored["challenges"], [])
+            self.assertEqual(stored.get("cleanup_pending", [])[0]["attachments"][0]["path"], str(attachment_path))
+            self.assertNotIn("sensitive cleanup retry body", store_path.read_text())
+
+            store.cleanup_expired()
+            self.assertFalse(attachment_path.exists())
+            self.assertEqual(json.loads(store_path.read_text()).get("cleanup_pending", []), [])
+
+    def test_cleanup_pending_tombstone_removed_when_file_already_gone(self):
+        from gateway.email_challenge import EmailChallengeStore
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            attachment_path = _write_cached_test_attachment(
+                "document", "doc_cleanup-already-gone.pdf", b"already gone"
+            )
+            attachment_path.unlink()
+            store_path = Path(tmpdir) / "challenges.json"
+            store_path.write_text(json.dumps({
+                "challenges": [],
+                "cleanup_pending": [{
+                    "attachments": [{
+                        "path": str(attachment_path),
+                        "type": "document",
+                        "media_type": "application/pdf",
+                    }],
+                }],
+            }))
+            store = EmailChallengeStore(path=str(store_path), ttl_seconds=900)
+
+            store.cleanup_expired()
+
+            self.assertNotIn("cleanup_pending", json.loads(store_path.read_text()))
+
+    def test_corrupt_store_file_is_removed_instead_of_retaining_plaintext(self):
+        from gateway.email_challenge import EmailChallengeStore
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store_path = Path(tmpdir) / "challenges.json"
+            store_path.write_text('{"challenges":[{"body":"secret body"}', encoding="utf-8")
+            store = EmailChallengeStore(path=str(store_path), ttl_seconds=900)
+
+            self.assertEqual(store.confirm("admin@test.com", "missing"), ("not_found", None))
+
+            self.assertFalse(store_path.exists())
+
+    def test_invalid_store_shape_is_removed_instead_of_retaining_plaintext(self):
+        from gateway.email_challenge import EmailChallengeStore
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store_path = Path(tmpdir) / "challenges.json"
+            store_path.write_text('{"body":"secret body","challenges":{}}', encoding="utf-8")
+            store = EmailChallengeStore(path=str(store_path), ttl_seconds=900)
+
+            self.assertEqual(store.confirm("admin@test.com", "missing"), ("not_found", None))
+
+            self.assertFalse(store_path.exists())
+
+    def test_partially_valid_store_with_invalid_challenge_entry_is_sanitized(self):
+        from gateway.email_challenge import EmailChallengeStore
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store_path = Path(tmpdir) / "challenges.json"
+            store_path.write_text('{"challenges":["secret body"]}', encoding="utf-8")
+            store = EmailChallengeStore(path=str(store_path), ttl_seconds=900)
+
+            self.assertEqual(store.confirm("admin@test.com", "missing"), ("not_found", None))
+
+            self.assertNotIn("secret body", store_path.read_text(encoding="utf-8"))
+            self.assertEqual(json.loads(store_path.read_text(encoding="utf-8")), {"challenges": []})
+
+    def test_partially_valid_store_with_extra_sensitive_key_is_sanitized(self):
+        from gateway.email_challenge import EmailChallengeStore
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store_path = Path(tmpdir) / "challenges.json"
+            store_path.write_text(
+                '{"body":"secret body","challenges":[]}',
+                encoding="utf-8",
+            )
+            store = EmailChallengeStore(path=str(store_path), ttl_seconds=900)
+
+            self.assertEqual(store.cleanup_expired(), None)
+
+            self.assertNotIn("secret body", store_path.read_text(encoding="utf-8"))
+            self.assertEqual(json.loads(store_path.read_text(encoding="utf-8")), {"challenges": []})
+
+    def test_fresh_partial_dict_challenge_body_is_sanitized_on_confirm_miss(self):
+        from gateway.email_challenge import EmailChallengeStore
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store_path = Path(tmpdir) / "challenges.json"
+            store_path.write_text(json.dumps({
+                "challenges": [{
+                    "created_at": time.time(),
+                    "used": False,
+                    "body": "secret body",
+                }],
+            }), encoding="utf-8")
+            store = EmailChallengeStore(path=str(store_path), ttl_seconds=900)
+
+            self.assertEqual(store.confirm("admin@test.com", "missing"), ("not_found", None))
+
+            store_text = store_path.read_text(encoding="utf-8")
+            self.assertNotIn("secret body", store_text)
+            self.assertEqual(json.loads(store_text), {"challenges": []})
+
+    def test_fresh_partial_dict_challenge_sensitive_fields_are_sanitized_on_cleanup(self):
+        from gateway.email_challenge import EmailChallengeStore
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store_path = Path(tmpdir) / "challenges.json"
+            store_path.write_text(json.dumps({
+                "challenges": [{
+                    "created_at": time.time(),
+                    "used": False,
+                    "event": {"body": "secret event body"},
+                    "attachments": [{"path": "/tmp/secret.pdf"}],
+                    "subject": "secret subject",
+                    "message_id": "<secret@test.com>",
+                }],
+            }), encoding="utf-8")
+            store = EmailChallengeStore(path=str(store_path), ttl_seconds=900)
+
+            self.assertEqual(store.cleanup_expired(), None)
+
+            store_text = store_path.read_text(encoding="utf-8")
+            self.assertNotIn("secret event body", store_text)
+            self.assertNotIn("secret subject", store_text)
+            self.assertNotIn("<secret@test.com>", store_text)
+            self.assertNotIn("secret.pdf", store_text)
+            self.assertEqual(json.loads(store_text), {"challenges": []})
+
+    def test_valid_created_challenge_still_confirms_after_store_sanitization(self):
+        from gateway.email_challenge import EmailChallengeStore
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store_path = Path(tmpdir) / "challenges.json"
+            store = EmailChallengeStore(path=str(store_path), ttl_seconds=900)
+            code = store.create("admin@test.com", "Valid subject", "<valid@test.com>", {
+                "body": "valid body",
+                "attachments": [],
+            })
+
+            result, event = EmailChallengeStore(path=str(store_path), ttl_seconds=900).confirm(
+                "admin@test.com",
+                code,
+            )
+
+            self.assertEqual(result, "ok")
+            self.assertEqual(event["body"], "valid body")
+
+    def test_missing_created_at_challenge_is_dropped_during_sanitization(self):
+        from gateway.email_challenge import EmailChallengeStore
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store_path = Path(tmpdir) / "challenges.json"
+            store = EmailChallengeStore(path=str(store_path), ttl_seconds=900)
+            code = store.create("admin@test.com", "Missing timestamp", "<missing-time@test.com>", {
+                "body": "sensitive body",
+                "attachments": [],
+            })
+            stored = json.loads(store_path.read_text())
+            stored["challenges"][0].pop("created_at")
+            store_path.write_text(json.dumps(stored), encoding="utf-8")
+
+            self.assertEqual(store.confirm("admin@test.com", code), ("not_found", None))
+
+            store_text = store_path.read_text(encoding="utf-8")
+            self.assertNotIn("sensitive body", store_text)
+            self.assertEqual(json.loads(store_text), {"challenges": []})
 
 
 class TestThreadContext(unittest.TestCase):
@@ -898,6 +2867,326 @@ class TestFetchNewMessages(unittest.TestCase):
         self.assertEqual(results[0]["sender_addr"], "john@test.com")
         self.assertEqual(results[0]["sender_name"], "John Doe")
 
+    def test_challenge_fetch_skips_unauthorized_sender_before_attachment_cache(self):
+        """Challenge-mode unauthorized senders are dropped before caching attachments."""
+        adapter = self._make_adapter()
+        raw_email = MIMEMultipart()
+        raw_email["From"] = "outsider@test.com"
+        raw_email["Subject"] = "Unauthorized attachment"
+        raw_email["Message-ID"] = "<unauthorized-attachment@test.com>"
+        raw_email.attach(MIMEText("Do not retain me", "plain", "utf-8"))
+        part = MIMEBase("application", "pdf")
+        part.set_payload(b"sensitive pdf")
+        encoders.encode_base64(part)
+        part.add_header("Content-Disposition", "attachment; filename=secret.pdf")
+        raw_email.attach(part)
+        mock_imap = MagicMock()
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"1"])
+            if command == "fetch":
+                return ("OK", [(b"1", raw_email.as_bytes())])
+            return ("NO", [])
+
+        mock_imap.uid.side_effect = uid_handler
+        with patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "challenge",
+            "EMAIL_ALLOWED_USERS": "admin@test.com",
+            "GATEWAY_ALLOWED_USERS": "",
+            "EMAIL_ALLOW_ALL_USERS": "",
+            "GATEWAY_ALLOW_ALL_USERS": "",
+        }, clear=False), \
+             patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
+             patch("gateway.platforms.email.cache_document_from_bytes") as mock_cache:
+            results = adapter._fetch_new_messages()
+
+        self.assertEqual(results, [])
+        mock_cache.assert_not_called()
+
+    def test_challenge_fetch_oversized_message_skips_attachment_cache(self):
+        """Oversized challenge-mode messages keep body for rejection but do not cache attachments."""
+        adapter = self._make_adapter()
+        raw_email = MIMEMultipart()
+        raw_email["From"] = "admin@test.com"
+        raw_email["Subject"] = "Oversized attachment"
+        raw_email["Message-ID"] = "<oversized-attachment@test.com>"
+        raw_email.attach(MIMEText("x" * (50_000 + 1), "plain", "utf-8"))
+        part = MIMEBase("application", "pdf")
+        part.set_payload(b"oversized pdf")
+        encoders.encode_base64(part)
+        part.add_header("Content-Disposition", "attachment; filename=oversized.pdf")
+        raw_email.attach(part)
+        mock_imap = MagicMock()
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"1"])
+            if command == "fetch":
+                return ("OK", [(b"1", raw_email.as_bytes())])
+            return ("NO", [])
+
+        mock_imap.uid.side_effect = uid_handler
+        with patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "challenge",
+            "EMAIL_ALLOWED_USERS": "admin@test.com",
+        }, clear=False), \
+             patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
+             patch("gateway.platforms.email.cache_document_from_bytes") as mock_cache:
+            results = adapter._fetch_new_messages()
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["attachments"], [])
+        self.assertGreater(len(results[0]["body"]), 50_000)
+        mock_cache.assert_not_called()
+
+    def test_challenge_fetch_oversized_attachment_payload_skips_cache(self):
+        """Challenge-mode oversized attachment payloads are rejected before caching."""
+        adapter = self._make_adapter()
+        raw_email = MIMEMultipart()
+        raw_email["From"] = "admin@test.com"
+        raw_email["Subject"] = "Oversized attachment payload"
+        raw_email["Message-ID"] = "<oversized-attachment-payload@test.com>"
+        raw_email.attach(MIMEText("Body is small", "plain", "utf-8"))
+        part = MIMEBase("application", "pdf")
+        part.set_payload(b"x" * 64)
+        encoders.encode_base64(part)
+        part.add_header("Content-Disposition", "attachment; filename=oversized-payload.pdf")
+        raw_email.attach(part)
+        mock_imap = MagicMock()
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"1"])
+            if command == "fetch":
+                return ("OK", [(b"1", raw_email.as_bytes())])
+            return ("NO", [])
+
+        mock_imap.uid.side_effect = uid_handler
+        with patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "challenge",
+            "EMAIL_ALLOWED_USERS": "admin@test.com",
+        }, clear=False), \
+             patch("gateway.platforms.email.MAX_EMAIL_CHALLENGE_ATTACHMENT_BYTES", 16), \
+             patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
+             patch("gateway.platforms.email.cache_document_from_bytes") as mock_cache:
+            results = adapter._fetch_new_messages()
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["attachments"], [])
+        self.assertEqual(results[0].get("_email_challenge_attachment_error"), "too_large")
+        mock_cache.assert_not_called()
+
+    def test_challenge_fetch_total_attachment_cap_deletes_partial_cache_and_stores_no_event(self):
+        """Total-byte failures remove earlier cached files and dispatch stores no challenge."""
+        import asyncio
+        from gateway.platforms import base
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "challenge",
+            "EMAIL_ALLOWED_USERS": "admin@test.com",
+            "EMAIL_CHALLENGE_STORE": str(Path(tmpdir) / "challenges.json"),
+        }, clear=False):
+            base.DOCUMENT_CACHE_DIR = Path(tmpdir) / "cache" / "documents"
+            adapter = self._make_adapter()
+            raw_email = MIMEMultipart()
+            raw_email["From"] = "admin@test.com"
+            raw_email["Subject"] = "Partial cache leak"
+            raw_email["Message-ID"] = "<partial-cache-leak@test.com>"
+            raw_email.attach(MIMEText("Body is small", "plain", "utf-8"))
+            first = MIMEBase("application", "pdf")
+            first.set_payload(b"small")
+            encoders.encode_base64(first)
+            first.add_header("Content-Disposition", "attachment; filename=first.pdf")
+            raw_email.attach(first)
+            second = MIMEBase("application", "pdf")
+            second.set_payload(b"large payload")
+            encoders.encode_base64(second)
+            second.add_header("Content-Disposition", "attachment; filename=second.pdf")
+            raw_email.attach(second)
+            mock_imap = MagicMock()
+
+            def uid_handler(command, *args):
+                if command == "search":
+                    return ("OK", [b"1"])
+                if command == "fetch":
+                    return ("OK", [(b"1", raw_email.as_bytes())])
+                return ("NO", [])
+
+            mock_imap.uid.side_effect = uid_handler
+            with patch("gateway.platforms.email.MAX_EMAIL_CHALLENGE_TOTAL_ATTACHMENT_BYTES", 10), \
+                 patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+                results = adapter._fetch_new_messages()
+
+            self.assertEqual(len(results), 1)
+            self.assertEqual(results[0]["attachments"], [])
+            self.assertEqual(results[0].get("_email_challenge_attachment_error"), "too_large")
+            self.assertEqual(list(base.get_document_cache_dir().iterdir()), [])
+
+            adapter.send = AsyncMock(return_value=SendResult(success=True))
+            adapter.handle_message = AsyncMock()
+            asyncio.run(adapter._dispatch_message(results[0]))
+
+            adapter.handle_message.assert_not_awaited()
+            self.assertFalse(Path(os.environ["EMAIL_CHALLENGE_STORE"]).exists())
+
+    def test_challenge_fetch_attachment_count_cap_deletes_partial_cache_and_reports_too_many(self):
+        """Fetch-time count failures remove cached files and use the too-many rejection path."""
+        import asyncio
+        from gateway.platforms import base
+
+        with tempfile.TemporaryDirectory() as tmpdir, patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "challenge",
+            "EMAIL_ALLOWED_USERS": "admin@test.com",
+            "EMAIL_CHALLENGE_STORE": str(Path(tmpdir) / "challenges.json"),
+        }, clear=False):
+            base.DOCUMENT_CACHE_DIR = Path(tmpdir) / "cache" / "documents"
+            adapter = self._make_adapter()
+            raw_email = MIMEMultipart()
+            raw_email["From"] = "admin@test.com"
+            raw_email["Subject"] = "Too many fetch attachments"
+            raw_email["Message-ID"] = "<too-many-fetch-attachments@test.com>"
+            raw_email.attach(MIMEText("Body is small", "plain", "utf-8"))
+            for name in ("first.pdf", "second.pdf"):
+                part = MIMEBase("application", "pdf")
+                part.set_payload(b"small")
+                encoders.encode_base64(part)
+                part.add_header("Content-Disposition", f"attachment; filename={name}")
+                raw_email.attach(part)
+            mock_imap = MagicMock()
+
+            def uid_handler(command, *args):
+                if command == "search":
+                    return ("OK", [b"1"])
+                if command == "fetch":
+                    return ("OK", [(b"1", raw_email.as_bytes())])
+                return ("NO", [])
+
+            mock_imap.uid.side_effect = uid_handler
+            with patch("gateway.platforms.email.MAX_EMAIL_CHALLENGE_ATTACHMENTS", 1), \
+                 patch("imaplib.IMAP4_SSL", return_value=mock_imap):
+                results = adapter._fetch_new_messages()
+
+            self.assertEqual(len(results), 1)
+            self.assertEqual(results[0]["attachments"], [])
+            self.assertEqual(results[0].get("_email_challenge_attachment_error"), "too_many")
+            self.assertEqual(list(base.get_document_cache_dir().iterdir()), [])
+
+            adapter.send = AsyncMock(return_value=SendResult(success=True))
+            adapter.handle_message = AsyncMock()
+            asyncio.run(adapter._dispatch_message(results[0]))
+
+            adapter.handle_message.assert_not_awaited()
+            self.assertIn("too many attachments", adapter.send.await_args.args[1].lower())
+            self.assertFalse(Path(os.environ["EMAIL_CHALLENGE_STORE"]).exists())
+
+    def test_direct_fetch_skips_non_allowlisted_sender_before_attachment_cache(self):
+        """Direct-mode EMAIL_ALLOWED_USERS rejection does not retain cached attachments."""
+        adapter = self._make_adapter()
+        raw_email = MIMEMultipart()
+        raw_email["From"] = "outsider@test.com"
+        raw_email["Subject"] = "Direct unauthorized attachment"
+        raw_email["Message-ID"] = "<direct-unauthorized-attachment@test.com>"
+        raw_email.attach(MIMEText("Do not retain me", "plain", "utf-8"))
+        part = MIMEBase("application", "pdf")
+        part.set_payload(b"direct sensitive pdf")
+        encoders.encode_base64(part)
+        part.add_header("Content-Disposition", "attachment; filename=direct-secret.pdf")
+        raw_email.attach(part)
+        mock_imap = MagicMock()
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"1"])
+            if command == "fetch":
+                return ("OK", [(b"1", raw_email.as_bytes())])
+            return ("NO", [])
+
+        mock_imap.uid.side_effect = uid_handler
+        with patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "direct",
+            "EMAIL_ALLOWED_USERS": "admin@test.com",
+        }, clear=False), \
+             patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
+             patch("gateway.platforms.email.cache_document_from_bytes") as mock_cache:
+            results = adapter._fetch_new_messages()
+
+        self.assertEqual(results, [])
+        mock_cache.assert_not_called()
+
+    def test_direct_fetch_global_allowlist_match_caches_attachment(self):
+        """Direct-mode global allowlist matches can cache attachments for processing."""
+        adapter = self._make_adapter()
+        raw_email = MIMEMultipart()
+        raw_email["From"] = "admin@test.com"
+        raw_email["Subject"] = "Global authorized attachment"
+        raw_email["Message-ID"] = "<global-authorized-attachment@test.com>"
+        raw_email.attach(MIMEText("Retain me", "plain", "utf-8"))
+        part = MIMEBase("application", "pdf")
+        part.set_payload(b"global sensitive pdf")
+        encoders.encode_base64(part)
+        part.add_header("Content-Disposition", "attachment; filename=global-secret.pdf")
+        raw_email.attach(part)
+        mock_imap = MagicMock()
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"1"])
+            if command == "fetch":
+                return ("OK", [(b"1", raw_email.as_bytes())])
+            return ("NO", [])
+
+        mock_imap.uid.side_effect = uid_handler
+        with patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "direct",
+            "EMAIL_ALLOWED_USERS": "",
+            "GATEWAY_ALLOWED_USERS": "admin@test.com",
+        }, clear=False), \
+             patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
+             patch("gateway.platforms.email.cache_document_from_bytes") as mock_cache:
+            results = adapter._fetch_new_messages()
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["sender_addr"], "admin@test.com")
+        mock_cache.assert_called_once()
+
+    def test_direct_fetch_global_allowlist_miss_does_not_cache_attachment(self):
+        """Direct-mode global misses can reach central auth only without retained attachments."""
+        adapter = self._make_adapter()
+        raw_email = MIMEMultipart()
+        raw_email["From"] = "outsider@test.com"
+        raw_email["Subject"] = "Global unauthorized attachment"
+        raw_email["Message-ID"] = "<global-unauthorized-attachment@test.com>"
+        raw_email.attach(MIMEText("Central auth may still decide pairing", "plain", "utf-8"))
+        part = MIMEBase("application", "pdf")
+        part.set_payload(b"global sensitive pdf")
+        encoders.encode_base64(part)
+        part.add_header("Content-Disposition", "attachment; filename=global-secret.pdf")
+        raw_email.attach(part)
+        mock_imap = MagicMock()
+
+        def uid_handler(command, *args):
+            if command == "search":
+                return ("OK", [b"1"])
+            if command == "fetch":
+                return ("OK", [(b"1", raw_email.as_bytes())])
+            return ("NO", [])
+
+        mock_imap.uid.side_effect = uid_handler
+        with patch.dict(os.environ, {
+            "EMAIL_AUTH_MODE": "direct",
+            "EMAIL_ALLOWED_USERS": "",
+            "GATEWAY_ALLOWED_USERS": "admin@test.com",
+        }, clear=False), \
+             patch("imaplib.IMAP4_SSL", return_value=mock_imap), \
+             patch("gateway.platforms.email.cache_document_from_bytes") as mock_cache:
+            results = adapter._fetch_new_messages()
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["sender_addr"], "outsider@test.com")
+        self.assertEqual(results[0]["attachments"], [])
+        mock_cache.assert_not_called()
+
 
 class TestPollLoop(unittest.TestCase):
     """Test the async polling loop."""
@@ -947,6 +3236,18 @@ class TestPollLoop(unittest.TestCase):
 
         self.assertEqual(len(dispatched), 1)
         self.assertEqual(dispatched[0]["subject"], "Inbox Test")
+
+    def test_check_inbox_cleanup_failure_still_fetches_messages(self):
+        """Passive challenge cleanup is best-effort and must not block polling."""
+        import asyncio
+        adapter = self._make_adapter()
+        adapter._cleanup_expired_email_challenges = MagicMock(side_effect=OSError("cleanup failed"))
+        adapter._fetch_new_messages = MagicMock(return_value=[])
+
+        with patch.dict(os.environ, {"EMAIL_AUTH_MODE": "challenge"}, clear=False):
+            asyncio.run(adapter._check_inbox())
+
+        adapter._fetch_new_messages.assert_called_once()
 
 
 class TestSendEmailStandalone(unittest.TestCase):

--- a/website/docs/reference/environment-variables.md
+++ b/website/docs/reference/environment-variables.md
@@ -307,11 +307,14 @@ For cloud sandbox backends, persistence is filesystem-oriented. `TERMINAL_LIFETI
 | `EMAIL_IMAP_PORT` | IMAP port |
 | `EMAIL_SMTP_HOST` | SMTP hostname for the email adapter |
 | `EMAIL_SMTP_PORT` | SMTP port |
-| `EMAIL_ALLOWED_USERS` | Comma-separated email addresses allowed to message the bot |
+| `EMAIL_ALLOWED_USERS` | Comma-separated email addresses allowed to message the bot. Entries are full sender-address matches for email-specific auth; use `EMAIL_ALLOW_ALL_USERS=true` to allow all senders |
 | `EMAIL_HOME_ADDRESS` | Default recipient for proactive email delivery |
 | `EMAIL_HOME_ADDRESS_NAME` | Display name for the email home target |
 | `EMAIL_POLL_INTERVAL` | Email polling interval in seconds |
 | `EMAIL_ALLOW_ALL_USERS` | Allow all inbound email senders |
+| `EMAIL_AUTH_MODE` | Email authorization mode: unset/`direct` preserves normal allowlist/pairing behavior; `challenge` requires senders allowed by explicit env/global allowlists or allow-all settings to confirm before their email reaches the agent. Invalid values fail closed as challenge mode. config-only `allow_from` and pairing-only authorization are not challenge-mode eligibility sources |
+| `EMAIL_CHALLENGE_TTL_SECONDS` | Seconds before an email challenge code expires (default: `900`) |
+| `EMAIL_CHALLENGE_STORE` | Path to the JSON email challenge store (default: `$HERMES_HOME/email_challenges.json`). Email bodies over 50,000 characters, more than 25 attachments, attachment payloads over 10 MB each or 25 MB total, or serialized pending events over about 200 KB are rejected before storage. Pending entries are capped at 25 per sender and 500 total, and cached attachments from rejected/expired/trimmed pending challenges are deleted when trusted metadata is available. Successfully confirmed original attachments follow the normal platform media/cache lifecycle while stored challenge metadata/body is scrubbed immediately. Corrupt/invalid store recovery is best-effort and may leave attachment files for normal cache expiry |
 | `DINGTALK_CLIENT_ID` | DingTalk bot AppKey from developer portal ([open.dingtalk.com](https://open.dingtalk.com)) |
 | `DINGTALK_CLIENT_SECRET` | DingTalk bot AppSecret from developer portal |
 | `DINGTALK_ALLOWED_USERS` | Comma-separated DingTalk user IDs allowed to message the bot |

--- a/website/docs/user-guide/messaging/email.md
+++ b/website/docs/user-guide/messaging/email.md
@@ -145,6 +145,25 @@ Email access follows the same pattern as all other Hermes platforms:
 **Always configure `EMAIL_ALLOWED_USERS`.** Without it, anyone who knows the agent's email address could send commands. The agent has terminal access by default.
 :::
 
+### Challenge-response mode
+
+Set `EMAIL_AUTH_MODE=challenge` to require an authorized sender to prove inbox control before their original email is processed. In this mode:
+
+- authorized senders receive a one-time `/confirm <code>` challenge reply;
+- the original email body and attachments are not sent to the agent until the code is confirmed from the same sender address;
+- confirmation codes expire after `EMAIL_CHALLENGE_TTL_SECONDS` seconds (default: 15 minutes);
+- pending challenge state is stored in `EMAIL_CHALLENGE_STORE` (default: `$HERMES_HOME/email_challenges.json`); codes are stored hashed, not plaintext;
+- pending challenge storage is capped at 25 entries per sender and 500 entries total;
+- email bodies larger than 50,000 characters, more than 25 attachments, attachment payloads over 10 MB each or 25 MB total, or serialized pending events over about 200 KB are rejected instead of stored;
+- cached attachment files owned by rejected, expired, or trimmed pending challenges are deleted during cleanup when trusted metadata is available; after a successful confirmation, the challenge store metadata/body is scrubbed immediately while confirmed original attachments follow the normal platform media/cache lifecycle so downstream processing can read them;
+- if the challenge store is corrupt or invalid, cleanup is best-effort and orphaned attachment files may remain until normal cache expiry;
+- when the global pending cap is full, authorized senders receive a short busy response and can retry later;
+- unauthorized senders are dropped rather than challenged.
+
+Challenge eligibility supports explicit env/global allow settings (`EMAIL_ALLOWED_USERS`, `EMAIL_ALLOW_ALL_USERS`, `GATEWAY_ALLOWED_USERS`, and `GATEWAY_ALLOW_ALL_USERS`). `EMAIL_ALLOWED_USERS` entries are matched as full sender email addresses in challenge mode; use `GATEWAY_ALLOWED_USERS` if you intentionally want the gateway's generic local-part matching. Challenge mode does not support config-only `allow_from` or pairing-only authorization; use an explicit allowlist or allow-all setting for senders that should receive challenges.
+
+In direct mode, `EMAIL_ALLOWED_USERS` uses exact sender-address matching. If only `GATEWAY_ALLOWED_USERS` is configured, non-matching senders are passed to central gateway authorization so previously paired users can still be accepted. Use `EMAIL_ALLOW_ALL_USERS=true` if you intentionally want to accept every sender.
+
 ---
 
 ## Troubleshooting
@@ -188,3 +207,6 @@ Email access follows the same pattern as all other Hermes platforms:
 | `EMAIL_ALLOWED_USERS` | No | — | Comma-separated allowed sender addresses |
 | `EMAIL_HOME_ADDRESS` | No | — | Default delivery target for cron jobs |
 | `EMAIL_ALLOW_ALL_USERS` | No | `false` | Allow all senders (not recommended) |
+| `EMAIL_AUTH_MODE` | No | `direct` | Set to `challenge` to require eligible senders to confirm with a one-time code before their email is dispatched to the agent |
+| `EMAIL_CHALLENGE_TTL_SECONDS` | No | `900` | Seconds before a challenge code expires |
+| `EMAIL_CHALLENGE_STORE` | No | `$HERMES_HOME/email_challenges.json` | JSON file used to persist pending challenges; pending entries, attachment count/bytes, and serialized event size are capped and expired entries are scrubbed during polling/cleanup |


### PR DESCRIPTION
## Summary
- add email challenge-response authentication for the email gateway
- add durable challenge store validation/sanitization and cached store wiring
- document challenge auth environment variables and email flow

## Test Plan
- `scripts/run_tests.sh tests/gateway/test_email.py -k 'challenge or email_challenge' -q` → 56 passed
- `.venv/bin/python -m py_compile gateway/config.py gateway/platforms/email.py gateway/email_challenge.py`
- `git diff --check`
- `git diff origin/main...HEAD --check`

## Review
- OpenCode: no ship blockers
- Claude: no ship blockers; final post-fix review said ship it
- Codex validated Claude's findings; A/B/D fixed, C intentionally left unchanged to preserve existing `GATEWAY_ALLOWED_USERS` semantics
