### PR TITLE
fix: read LINE group attachments

### DIFF
--- a/gateway/authz_mixin.py
+++ b/gateway/authz_mixin.py
@@ -346,6 +346,16 @@ class GatewayAuthorizationMixin:
                 Platform.TELEGRAM: "TELEGRAM_GROUP_ALLOWED_CHATS",
                 Platform.QQBOT: "QQ_GROUP_ALLOWED_USERS",
             }.get(source.platform, "")
+            if not chat_allowlist_env:
+                try:
+                    from gateway.platform_registry import platform_registry
+
+                    entry = platform_registry.get(
+                        getattr(source.platform, "value", str(source.platform))
+                    )
+                    chat_allowlist_env = getattr(entry, "group_allowed_chats_env", "")
+                except (ImportError, AttributeError):
+                    chat_allowlist_env = ""
             if chat_allowlist_env:
                 raw_chat_allowlist = os.getenv(chat_allowlist_env, "").strip()
                 if raw_chat_allowlist:

--- a/gateway/platform_registry.py
+++ b/gateway/platform_registry.py
@@ -86,6 +86,9 @@ class PlatformEntry:
     # ── Auth env var names (for _is_user_authorized integration) ──
     # E.g. "IRC_ALLOWED_USERS" — checked for comma-separated user IDs.
     allowed_users_env: str = ""
+    # Optional chat-scoped group allowlist env var. Generic authz consumes
+    # this instead of hardcoding plugin platform names.
+    group_allowed_chats_env: str = ""
     # E.g. "IRC_ALLOW_ALL_USERS" — if truthy, all users authorized.
     allow_all_env: str = ""
 

--- a/plugins/platforms/line/adapter.py
+++ b/plugins/platforms/line/adapter.py
@@ -92,7 +92,9 @@ from gateway.platforms.base import (
     MessageEvent,
     MessageType,
     SendResult,
+    cache_audio_from_bytes,
     cache_image_from_bytes,
+    cache_video_from_bytes,
 )
 from gateway.config import Platform
 
@@ -1062,14 +1064,18 @@ class LineAdapter(BasePlatformAdapter):
         except Exception as exc:
             logger.warning("LINE: failed to fetch %s content for %s: %s", msg_type, message_id, exc)
             return None
-        ext = {
-            "image": ".jpg",
-            "audio": ".m4a",
-            "video": ".mp4",
-            "file": ".bin",
-        }.get(msg_type, ".bin")
+        ext = {"image": ".jpg", "audio": ".m4a", "video": ".mp4", "file": ".bin"}.get(msg_type, ".bin")
         try:
-            return cache_image_from_bytes(data, ext=ext)
+            # LINE audio is a voice note: preserve MessageType.VOICE so the
+            # existing gateway STT path recognizes it. Do not use AUDIO here.
+            if msg_type == "audio":
+                return cache_audio_from_bytes(data, ext=ext)
+            if msg_type == "image":
+                return cache_image_from_bytes(data, ext=ext)
+            if msg_type == "video":
+                return cache_video_from_bytes(data, ext=ext)
+            from gateway.platforms.base import cache_document_from_bytes
+            return cache_document_from_bytes(data, f"line_{message_id}{ext}")
         except Exception as exc:
             logger.warning("LINE: failed to cache %s payload: %s", msg_type, exc)
             return None
@@ -1635,6 +1641,7 @@ def register(ctx) -> None:
         cron_deliver_env_var="LINE_HOME_CHANNEL",
         standalone_sender_fn=_standalone_send,
         allowed_users_env="LINE_ALLOWED_USERS",
+        group_allowed_chats_env="LINE_ALLOWED_GROUPS",
         allow_all_env="LINE_ALLOW_ALL_USERS",
         # LINE per-bubble cap is 5000; smart-chunker uses 4500.
         max_message_length=LINE_SAFE_BUBBLE_CHARS,

--- a/tests/gateway/test_line_plugin.py
+++ b/tests/gateway/test_line_plugin.py
@@ -431,6 +431,7 @@ class TestRegister:
         ctx = self._FakeCtx()
         register(ctx)
         assert ctx.kwargs["allowed_users_env"] == "LINE_ALLOWED_USERS"
+        assert ctx.kwargs["group_allowed_chats_env"] == "LINE_ALLOWED_GROUPS"
         assert ctx.kwargs["allow_all_env"] == "LINE_ALLOW_ALL_USERS"
 
     def test_register_wires_cron_home_channel(self):
@@ -674,3 +675,71 @@ class TestMessageTypeMapping:
     def test_unknown_type_falls_back_to_text(self):
         MessageType = _line.MessageType
         assert _line._LINE_MESSAGE_TYPES.get("flex", MessageType.TEXT) == MessageType.TEXT
+
+
+def test_line_group_allowlist_registry_seam_is_consumed(monkeypatch):
+    from types import SimpleNamespace
+
+    from gateway.authz_mixin import GatewayAuthorizationMixin
+    from gateway.config import Platform
+    from gateway.platform_registry import PlatformEntry, platform_registry
+    from gateway.session import SessionSource
+
+    entry = PlatformEntry(
+        "line-test",
+        "LINE test",
+        lambda cfg: None,
+        lambda: True,
+        group_allowed_chats_env="LINE_TEST_GROUPS",
+    )
+    platform_registry.register(entry)
+    try:
+        monkeypatch.setenv("LINE_TEST_GROUPS", "C-test")
+        runner = object.__new__(GatewayAuthorizationMixin)
+        runner.pairing_store = SimpleNamespace(is_approved=lambda *args: False)
+        source = SessionSource(
+            platform=Platform("line-test"),
+            chat_id="C-test",
+            chat_type="group",
+            user_id=None,
+            user_name="u",
+        )
+        assert runner._is_user_authorized(source) is True
+    finally:
+        platform_registry.unregister("line-test")
+
+
+@pytest.mark.parametrize(
+    ("kind", "expected"),
+    [
+        ("audio", _line.MessageType.VOICE),
+        ("video", _line.MessageType.VIDEO),
+        ("file", _line.MessageType.DOCUMENT),
+    ],
+)
+def test_line_media_types_survive_gateway_event_path(monkeypatch, tmp_path, kind, expected):
+    monkeypatch.setenv("LINE_CHANNEL_ACCESS_TOKEN", "t")
+    monkeypatch.setenv("LINE_CHANNEL_SECRET", "s")
+    monkeypatch.setenv("LINE_ALLOWED_GROUPS", "C1")
+    monkeypatch.setenv("HERMES_HOME", str(tmp_path / ".hermes"))
+    from gateway.config import PlatformConfig
+    ad = LineAdapter(PlatformConfig(enabled=True))
+    ad._client = MagicMock()
+    ad._client.fetch_content = AsyncMock(return_value=b"not-an-image")
+    ad.handle_message = AsyncMock()
+    msg = {"type": kind, "id": "m1"}
+    if kind == "file":
+        msg["fileName"] = "notes.txt"
+    asyncio.run(
+        ad._dispatch_event(
+            {
+                "type": "message",
+                "replyToken": "r",
+                "source": {"type": "group", "groupId": "C1", "userId": "U1"},
+                "message": msg,
+            }
+        )
+    )
+    event = ad.handle_message.await_args.args[0]
+    assert event.message_type is expected
+    assert event.media_urls


### PR DESCRIPTION
## Summary
- Fix LINE inbound dispatch to use the session source builder instead of a missing adapter method.
- Add LINE group authorization to the generic gateway auth gate via `LINE_ALLOWED_GROUPS`.
- Download and cache LINE media/attachments with correct message types, including documents/PDFs instead of forcing non-text payloads through image validation.
- Add regression tests for allowed LINE groups, read-only archive behavior, image/document media caching, and file metadata.
- Carry two current-main CI repair commits needed for this PR branch to pass existing blocking checks: guarded Windows process-kill suppression and hermetic gateway e2e slash-reset tests.

## Test Plan
- `python -m pytest tests/gateway/test_line_group_authorization.py tests/gateway/test_line_plugin.py tests/e2e/test_platform_commands.py -q -o addopts=`
- `python scripts/check-windows-footguns.py --all`