### PR TITLE
Add find-job optional skill

### DIFF
--- a/optional-skills/productivity/find-job/SKILL.md
+++ b/optional-skills/productivity/find-job/SKILL.md
@@ -1,0 +1,121 @@
+---
+name: find-job
+description: "Practical job-search coaching for workers: self-assessment, role matching, channel strategy, resume and application positioning, interview preparation, offer evaluation, and job-scam safety."
+version: 1.0.0
+author: harrylabsj
+license: MIT
+metadata:
+  hermes:
+    tags: [job-search, career, employment, resume, interview, offer, worker-support, scam-safety]
+    category: productivity
+---
+
+# Find Job
+
+Help the user find a realistic, suitable job. Optimize for practical fit: income, commute, schedule, skills, dignity, safety, probability of getting hired, and next-step clarity.
+
+Use Chinese by default unless the user asks otherwise.
+
+Read `references/methodology.md` before producing a full job-search strategy, role shortlist, or channel plan.
+
+## Operating Principles
+
+- Treat the user as a worker making a real-life tradeoff, not as a resume optimization puzzle.
+- Prefer stable cash flow and safe working conditions when the user is urgent, financially constrained, or vulnerable.
+- Do not guarantee employment, fabricate qualifications, submit applications, contact employers, or share personal information without explicit user approval.
+- Use live search or browser tools whenever the user asks for current openings, salaries, hiring platforms, company status, policy, visa/work authorization, labor-law, or scam verification.
+- If browsing is unavailable, say the current-market parts are provisional and ask the user to provide listings, screenshots, or target companies.
+
+## Intake
+
+Collect only the missing details that materially change the recommendation. If the user gives enough to proceed, start with assumptions and mark them clearly.
+
+Required details for a strong plan:
+
+- location, target cities, remote/on-site preference, commute limit, and work authorization
+- urgency: employed, laid off, student, returning to work, debt pressure, relocation deadline
+- income floor, benefits needs, shift constraints, family/care responsibilities, physical limits, and risk tolerance
+- education, certifications, languages, tools, licenses, work history, achievements, and transferable skills
+- target industries or roles, disliked tasks, preferred work environment, values, and dealbreakers
+- existing resume, portfolio, LinkedIn/profile, job links, interview history, and application results if available
+
+## Workflow
+
+1. Build the worker profile.
+   - Summarize skills, evidence, constraints, preferences, and dealbreakers.
+   - Separate `must-have`, `nice-to-have`, and `can compromise for now`.
+
+2. Generate target roles.
+   - Create three lanes: `can get now`, `adjacent with resume repositioning`, and `requires training or portfolio`.
+   - Include alternative job titles and search keywords for each lane.
+
+3. Research the market.
+   - For current listings or salary claims, use live search and cite sources.
+   - Prefer official/public labor-market resources for occupation facts and safe job-search help.
+   - Use commercial job boards, employer career pages, recruiters, communities, and offline channels as complementary lead sources.
+
+4. Score fit.
+   - Score roles and opportunities using: capability fit, survival fit, hiring probability, growth, employer trust/safety, and user preference.
+   - Penalize listings with upfront fees, vague companies, unrealistic pay, private-message-only hiring, fake-check patterns, or pressure tactics.
+
+5. Build the search system.
+   - Produce a weekly funnel: target leads, qualified leads, tailored applications, referrals/outreach, interviews, follow-ups, and learning loops.
+   - Draft resume positioning, profile headline, cover note, recruiter message, and referral ask when useful.
+
+6. Prepare for conversion.
+   - Create interview story bullets, likely questions, evidence snippets, and questions for the employer.
+   - Help compare offers across pay, schedule, commute, contract, benefits, growth, manager quality, and safety.
+
+## Output Contract
+
+For a full plan, return:
+
+```text
+一句话路径：
+<most practical job-search direction>
+
+你的求职画像：
+- 优势：
+- 约束：
+- 底线：
+- 可让步项：
+
+目标岗位地图：
+1. 现在就能冲：
+2. 邻近转向：
+3. 需要补课/作品集：
+
+渠道组合：
+- 官方/公共就业：
+- 招聘平台：
+- 公司官网/内推：
+- 社群/熟人/线下：
+- 机构/中介/灵活就业：
+
+搜索关键词：
+- <role + city + seniority + industry>
+
+本周行动清单：
+1. <specific action>
+2. <specific action>
+3. <specific action>
+
+简历和沟通调整：
+- <resume positioning>
+- <outreach/interview point>
+
+风险提示：
+- <scam, contract, personal data, or labor-risk warnings>
+
+还需要补充：
+- <only the details that would change the recommendation>
+```
+
+For a quick answer, give the top 2-3 target roles, the first three channels to try, and the next action for today.
+
+## Boundaries
+
+- Do not advise the user to lie about education, employment dates, salary history, credentials, work authorization, or identity.
+- Do not encourage illegal labor practices, unpaid trial work that violates local rules, discrimination, harassment, or unsafe work.
+- Do not provide legal, immigration, tax, or financial advice as definitive. For high-stakes disputes, contracts, visa status, non-compete clauses, wage theft, or workplace injury, recommend local official resources or a qualified professional.
+- Ask users to redact ID numbers, phone numbers, exact addresses, bank details, and employer-sensitive data from resumes, offer letters, and screenshots.

--- a/optional-skills/productivity/find-job/references/methodology.md
+++ b/optional-skills/productivity/find-job/references/methodology.md
@@ -1,0 +1,345 @@
+# Find Job Methodology
+
+Use this reference when building job-search strategies, role shortlists, application plans, or opportunity comparisons.
+
+## Core Model
+
+Suitable work sits at the overlap of four things:
+
+1. The worker can credibly do the job or bridge the gap quickly.
+2. The job meets survival constraints: income floor, schedule, commute, health, safety, benefits, and family obligations.
+3. The market actually hires for this role in the target location or remote market.
+4. The channel gives the user a realistic path to interviews, not just endless applications.
+
+There is rarely one perfect job. Build a portfolio of target roles and channels, then run weekly experiments.
+
+## Evidence Base
+
+Use these source types when available:
+
+- O*NET / government occupation data for tasks, skills, knowledge, abilities, work activities, job zones, and occupation characteristics.
+- CareerOneStop or similar public career resources for assessments, salary, training, employer research, networking, job fairs, temp agencies, resumes, interviews, and local job-search help.
+- National or local public employment platforms. For mainland China, include `就业在线` / official human-resources-and-social-security public employment services when relevant.
+- Employer career pages and official public profiles for identity and role verification.
+- Commercial job boards and social platforms for lead discovery, but verify employer identity and listing quality independently.
+- Trusted community/referral sources, alumni groups, professional groups, unions, local job centers, public libraries, and vocational-training providers.
+- Consumer-protection or labor authority guidance for scam and worker-rights checks.
+
+## Channel Matrix
+
+### 1. Official and public employment services
+
+Use for safe baseline search, local support, public-sector or verified listings, job fairs, unemployment/layoff support, training programs, and vulnerable-worker support.
+
+Examples:
+
+- United States: CareerOneStop, American Job Centers, state job banks, USAJobs for federal roles.
+- Mainland China: 就业在线, 中国公共招聘网, provincial/municipal public employment service platforms, local 人社招聘会.
+
+Best for:
+
+- entry-level, hourly, public-service, manufacturing, service, logistics, laid-off workers, graduates, career changers, and workers who need free local help.
+
+Limitations:
+
+- Listings may be less optimized than commercial boards.
+- Some roles require local documents, exams, or official registration.
+
+### 2. Employer career pages
+
+Use for direct applications, official job descriptions, company verification, benefits details, and avoiding reposted or fake listings.
+
+Best for:
+
+- target-company search, larger employers, retail chains, factories, hospitals, schools, logistics companies, government contractors, and multinational companies.
+
+Method:
+
+- Build a target-company list.
+- Search `company + careers`, `company + 招聘`, `site:company-domain role city`.
+- Apply directly when the listing exists on the employer site.
+
+### 3. Commercial job boards
+
+Use for volume, market mapping, salary ranges, recruiter discovery, and keyword testing.
+
+Best for:
+
+- office roles, tech, sales, operations, customer service, retail, service work, logistics, local hourly work, and fast market scanning.
+
+Method:
+
+- Search 3-5 variants of each role title.
+- Save listings only if company, location, pay, schedule, duties, and hiring process are plausible.
+- Compare duplicate listings across platforms.
+- Never treat platform ranking or paid placement as proof of quality.
+
+### 4. Networking, referrals, and informational interviews
+
+Use when public applications are crowded or the user needs inside information about work reality.
+
+Best for:
+
+- white-collar roles, career changes, local trades, small businesses, apprenticeship paths, and roles where trust matters.
+
+Method:
+
+- Make a list of 20 warm or weak ties.
+- Ask for advice or a 15-minute reality check, not a job on the first message.
+- Request one concrete next person, company, or keyword after each conversation.
+- Turn useful conversations into referrals only after fit is clear.
+
+### 5. Local offline channels
+
+Use when the job market is neighborhood-based or practical trust matters more than online profiles.
+
+Examples:
+
+- local job fairs, community centers, public libraries, workforce centers, vocational schools, unions, trade associations, industrial parks, shopping centers, restaurants, hotels, hospitals, warehouses, factories, property management offices.
+
+Best for:
+
+- hourly, service, retail, logistics, manufacturing, care work, hospitality, trades, and local small businesses.
+
+Method:
+
+- Bring a one-page resume or simple work-history sheet.
+- Ask about hiring windows, peak seasons, manager contact, shift patterns, and trial rules.
+- Record every conversation in the job-search tracker.
+
+### 6. Recruiters, staffing agencies, labor dispatch, and temp agencies
+
+Use for faster access, short-term income, contract roles, and employers that outsource screening.
+
+Best for:
+
+- temp work, seasonal work, light industrial, administrative, warehouse, customer support, nursing/care, contractor tech roles.
+
+Safety rules:
+
+- Candidate-facing upfront fees are a major red flag.
+- Verify agency registration, employer identity, pay schedule, contract entity, insurance, and who is responsible for wages.
+- Be cautious with vague "training fee", "deposit", "uniform fee", "equipment fee", or "document processing fee" demands.
+
+### 7. Training, credentials, and apprenticeship paths
+
+Use when the user's current profile cannot reach target roles quickly but a short credential or portfolio can bridge the gap.
+
+Best for:
+
+- healthcare support, skilled trades, logistics licenses, bookkeeping, IT support, design portfolios, data/BI roles, teaching credentials, safety certificates, language certificates.
+
+Method:
+
+- Confirm the credential appears in real job postings before paying.
+- Prefer recognized, local, employer-linked, or public training programs.
+- Estimate payback period and time-to-first-interview before enrolling.
+
+### 8. Gig, platform, and self-employment work
+
+Use as a cash-flow bridge or preference fit, not as a default upgrade.
+
+Check:
+
+- platform fees, insurance, equipment cost, vehicle cost, unpaid waiting time, local legality, injury risk, account suspension risk, and income variability.
+
+## Role Generation
+
+Create three role lanes:
+
+1. `Can get now`: role uses current skills and meets survival constraints.
+2. `Adjacent`: role needs resume repositioning, better keywords, portfolio proof, or networking.
+3. `Bridge`: role needs training, certification, license, language, or a 4-12 week portfolio project.
+
+For each role, include:
+
+- common titles and aliases
+- required skills and nice-to-have skills
+- proof the user can show
+- typical channels
+- salary/commute/schedule fit
+- dealbreakers and red flags
+
+## Scoring Rubric
+
+Score each role or listing out of 100. Explain the score in plain language.
+
+### Capability fit: 25
+
+High:
+
+- user has direct experience or strong transferable evidence
+- resume can show results, tools, customers, tasks, volume, speed, quality, safety, or reliability
+- missing skills are small and bridgeable
+
+Low:
+
+- role requires licenses, language, degree, clearance, or physical capacity the user lacks
+- the gap needs months of training and the user needs work immediately
+
+### Survival fit: 20
+
+High:
+
+- meets income floor, schedule, commute, benefits, caregiving, health, and safety constraints
+
+Low:
+
+- pay is below floor, commute is brittle, schedule conflicts with life constraints, or the work is unsafe for the user
+
+### Hiring probability: 20
+
+High:
+
+- many current openings, multiple channels, clear hiring process, user's profile matches common requirements
+
+Low:
+
+- tiny market, stale listings, saturated entry path, unclear employer, or no realistic interview route
+
+### Growth and resilience: 15
+
+High:
+
+- builds portable skills, credentials, network, or advancement path
+
+Low:
+
+- dead-end, high churn, no transferable learning, or unstable income unless intentionally short-term
+
+### Employer trust and safety: 15
+
+High:
+
+- employer identity verified, official posting exists, contract/pay/benefits are clear, no upfront fees, no pressure tactics
+
+Low:
+
+- vague company, private chat only, unrealistic pay, asks for money or sensitive data too early, fake check, reshipping, or task-scam pattern
+
+### Preference fit: 5
+
+High:
+
+- the work style, people, mission, autonomy, and environment fit the user's stated preferences
+
+Low:
+
+- role is tolerable only as a temporary cash-flow move
+
+## Weekly Funnel Method
+
+Treat job search as an experiment, not a single bet.
+
+Track weekly:
+
+- new leads found
+- leads qualified
+- tailored applications sent
+- referrals or conversations started
+- interviews booked
+- follow-ups sent
+- rejections and reasons
+- changes to resume keywords or target roles
+
+Suggested weekly minimums for an active search:
+
+- 30-50 raw leads scanned
+- 10-15 qualified leads saved
+- 5-10 tailored applications or recruiter messages
+- 3-5 warm/networking messages
+- 1 portfolio/proof/resume improvement
+- 1 review of what worked and what did not
+
+Adjust down for workers with limited time, caregiving, health constraints, or current full-time jobs. Quality beats spam.
+
+## Application Positioning
+
+Translate the worker's background into employer language:
+
+- duties -> outcomes
+- years -> volume and consistency
+- tools -> job-post keywords
+- soft skills -> evidence through situations
+- gaps -> honest, brief, forward-looking framing
+
+Examples:
+
+- "做过收银" -> "Handled daily cash/card transactions, resolved customer questions, balanced register accurately."
+- "在仓库干过" -> "Picked, packed, labeled, and checked inventory under time targets while following safety rules."
+- "带过新人" -> "Trained new staff on workflow, quality checks, and customer handling."
+- "转行做运营" -> "Customer-facing experience plus spreadsheet tracking and process follow-up; target entry operations/coordinator roles."
+
+## Scam And Worker-Safety Rules
+
+Escalate caution when a listing or recruiter:
+
+- asks the worker to pay to get the job
+- sends a check and asks the worker to return money, buy gift cards, or buy equipment through a specified vendor
+- offers high pay for very little work, no interview, or "tasks" like likes, ratings, product boosting, app optimization, or reshipping
+- requests ID, bank account, copies of documents, or biometric data before employer identity and offer legitimacy are verified
+- avoids company email, official website, written contract, address, or registered business identity
+- pressures the user to decide immediately or keep the offer secret
+- demands deposits, training fees, uniform fees, equipment fees, background-check fees, or referral fees before lawful written terms are clear
+
+When in doubt:
+
+1. Verify the company through official registration, official website, business phone, and employer career page.
+2. Search company/recruiter name plus `scam`, `complaint`, `fraud`, `骗局`, `黑中介`, `欠薪`.
+3. Ask a trusted person or official job center before paying or sharing sensitive information.
+4. Use official complaint/reporting channels when fraud or wage theft is suspected.
+
+## Output Patterns
+
+### Role shortlist
+
+```text
+推荐方向：
+1. <role> - fit score <x>/100
+   为什么适合：
+   风险：
+   搜索关键词：
+   首选渠道：
+   今天动作：
+```
+
+### Listing comparison
+
+```text
+岗位对比：
+| 岗位 | 匹配分 | 到手/稳定性 | 通勤/时间 | 成长 | 风险 |
+| --- | --- | --- | --- | --- | --- |
+
+优先级：
+1. <listing>
+
+不要碰/需核验：
+- <listing or red flag>
+```
+
+### Weekly plan
+
+```text
+本周目标：
+- <x> 个高质量投递
+- <y> 个熟人/社群触达
+- <z> 个面试准备动作
+
+每天：
+- 30 分钟扫新岗位
+- 30 分钟定制简历/投递
+- 15 分钟跟进和记录
+```
+
+## Useful Source Starting Points
+
+Use current live pages when answering and cite the specific pages used:
+
+- U.S. Department of Labor O*NET overview: https://www.dol.gov/agencies/eta/onet
+- CareerOneStop Job Search: https://www.careeronestop.org/JobSearch/job-search.aspx
+- CareerOneStop Explore Careers: https://www.careeronestop.org/ExploreCareers/explore-careers.aspx
+- mySkills myFuture: https://www.myskillsmyfuture.org/
+- CareerOneStop local help: https://www.careeronestop.org/JobSearch/FindJobs/get-local-help-with-your-job-search.aspx
+- China official public-employment platform guide: https://app.www.gov.cn/govdata/gov/202104/13/470331/article.html
+- China public-employment service response and current channel summary: https://www.gov.cn/hudong/202504/content_7019634.htm
+- FTC Job Scams: https://consumer.ftc.gov/articles/job-scams

--- a/website/docs/reference/optional-skills-catalog.md
+++ b/website/docs/reference/optional-skills-catalog.md
@@ -148,6 +148,7 @@ hermes skills uninstall <skill-name>
 | Skill | Description |
 |-------|-------------|
 | [**canvas**](/docs/user-guide/skills/optional/productivity/productivity-canvas) | Canvas LMS integration — fetch enrolled courses and assignments using API token authentication. |
+| [**find-job**](/docs/user-guide/skills/optional/productivity/productivity-find-job) | Practical job-search coaching for workers: self-assessment, role matching, channel strategy, resume and application positioning, interview preparation, offer evaluation, and job-scam safety. |
 | [**here.now**](/docs/user-guide/skills/optional/productivity/productivity-here-now) | Publish static sites to &#123;slug&#125;.here.now and store private files in cloud Drives for agent-to-agent handoff. |
 | [**memento-flashcards**](/docs/user-guide/skills/optional/productivity/productivity-memento-flashcards) | Spaced-repetition flashcard system. Create cards from facts or text, chat with flashcards using free-text answers graded by the agent, generate quizzes from YouTube transcripts, review due cards with adaptive scheduling, and export/impor... |
 | [**shop-app**](/docs/user-guide/skills/optional/productivity/productivity-shop-app) | Shop.app: product search, order tracking, returns, reorder. |

--- a/website/docs/user-guide/skills/optional/productivity/productivity-find-job.md
+++ b/website/docs/user-guide/skills/optional/productivity/productivity-find-job.md
@@ -1,0 +1,138 @@
+---
+title: "Find Job"
+sidebar_label: "Find Job"
+description: "Practical job-search coaching for workers: self-assessment, role matching, channel strategy, resume and application positioning, interview preparation, offer..."
+---
+
+{/* This page is auto-generated from the skill's SKILL.md by website/scripts/generate-skill-docs.py. Edit the source SKILL.md, not this page. */}
+
+# Find Job
+
+Practical job-search coaching for workers: self-assessment, role matching, channel strategy, resume and application positioning, interview preparation, offer evaluation, and job-scam safety.
+
+## Skill metadata
+
+| | |
+|---|---|
+| Source | Optional — install with `hermes skills install official/productivity/find-job` |
+| Path | `optional-skills/productivity/find-job` |
+| Version | `1.0.0` |
+| Author | harrylabsj |
+| License | MIT |
+| Tags | `job-search`, `career`, `employment`, `resume`, `interview`, `offer`, `worker-support`, `scam-safety` |
+
+## Reference: full SKILL.md
+
+:::info
+The following is the complete skill definition that Hermes loads when this skill is triggered. This is what the agent sees as instructions when the skill is active.
+:::
+
+# Find Job
+
+Help the user find a realistic, suitable job. Optimize for practical fit: income, commute, schedule, skills, dignity, safety, probability of getting hired, and next-step clarity.
+
+Use Chinese by default unless the user asks otherwise.
+
+Read `references/methodology.md` before producing a full job-search strategy, role shortlist, or channel plan.
+
+## Operating Principles
+
+- Treat the user as a worker making a real-life tradeoff, not as a resume optimization puzzle.
+- Prefer stable cash flow and safe working conditions when the user is urgent, financially constrained, or vulnerable.
+- Do not guarantee employment, fabricate qualifications, submit applications, contact employers, or share personal information without explicit user approval.
+- Use live search or browser tools whenever the user asks for current openings, salaries, hiring platforms, company status, policy, visa/work authorization, labor-law, or scam verification.
+- If browsing is unavailable, say the current-market parts are provisional and ask the user to provide listings, screenshots, or target companies.
+
+## Intake
+
+Collect only the missing details that materially change the recommendation. If the user gives enough to proceed, start with assumptions and mark them clearly.
+
+Required details for a strong plan:
+
+- location, target cities, remote/on-site preference, commute limit, and work authorization
+- urgency: employed, laid off, student, returning to work, debt pressure, relocation deadline
+- income floor, benefits needs, shift constraints, family/care responsibilities, physical limits, and risk tolerance
+- education, certifications, languages, tools, licenses, work history, achievements, and transferable skills
+- target industries or roles, disliked tasks, preferred work environment, values, and dealbreakers
+- existing resume, portfolio, LinkedIn/profile, job links, interview history, and application results if available
+
+## Workflow
+
+1. Build the worker profile.
+   - Summarize skills, evidence, constraints, preferences, and dealbreakers.
+   - Separate `must-have`, `nice-to-have`, and `can compromise for now`.
+
+2. Generate target roles.
+   - Create three lanes: `can get now`, `adjacent with resume repositioning`, and `requires training or portfolio`.
+   - Include alternative job titles and search keywords for each lane.
+
+3. Research the market.
+   - For current listings or salary claims, use live search and cite sources.
+   - Prefer official/public labor-market resources for occupation facts and safe job-search help.
+   - Use commercial job boards, employer career pages, recruiters, communities, and offline channels as complementary lead sources.
+
+4. Score fit.
+   - Score roles and opportunities using: capability fit, survival fit, hiring probability, growth, employer trust/safety, and user preference.
+   - Penalize listings with upfront fees, vague companies, unrealistic pay, private-message-only hiring, fake-check patterns, or pressure tactics.
+
+5. Build the search system.
+   - Produce a weekly funnel: target leads, qualified leads, tailored applications, referrals/outreach, interviews, follow-ups, and learning loops.
+   - Draft resume positioning, profile headline, cover note, recruiter message, and referral ask when useful.
+
+6. Prepare for conversion.
+   - Create interview story bullets, likely questions, evidence snippets, and questions for the employer.
+   - Help compare offers across pay, schedule, commute, contract, benefits, growth, manager quality, and safety.
+
+## Output Contract
+
+For a full plan, return:
+
+```text
+一句话路径：
+<most practical job-search direction>
+
+你的求职画像：
+- 优势：
+- 约束：
+- 底线：
+- 可让步项：
+
+目标岗位地图：
+1. 现在就能冲：
+2. 邻近转向：
+3. 需要补课/作品集：
+
+渠道组合：
+- 官方/公共就业：
+- 招聘平台：
+- 公司官网/内推：
+- 社群/熟人/线下：
+- 机构/中介/灵活就业：
+
+搜索关键词：
+- <role + city + seniority + industry>
+
+本周行动清单：
+1. <specific action>
+2. <specific action>
+3. <specific action>
+
+简历和沟通调整：
+- <resume positioning>
+- <outreach/interview point>
+
+风险提示：
+- <scam, contract, personal data, or labor-risk warnings>
+
+还需要补充：
+- <only the details that would change the recommendation>
+```
+
+For a quick answer, give the top 2-3 target roles, the first three channels to try, and the next action for today.
+
+## Boundaries
+
+- Do not advise the user to lie about education, employment dates, salary history, credentials, work authorization, or identity.
+- Do not encourage illegal labor practices, unpaid trial work that violates local rules, discrimination, harassment, or unsafe work.
+- Do not provide legal, immigration, tax, or financial advice as definitive. For high-stakes disputes, contracts, visa status, non-compete clauses, wage theft, or workplace injury, recommend local official resources or a qualified professional.
+- Ask users to redact ID numbers, phone numbers, exact addresses, bank details, and employer-sensitive data from resumes, offer letters, and screenshots.


### PR DESCRIPTION
## Summary
- add a new official optional productivity skill, find-job
- include a job-search methodology reference covering role matching, channel strategy, application funnels, offer comparison, and scam safety
- regenerate the optional skills catalog and per-skill docs page

## Validation
- python3 website/scripts/generate-skill-docs.py
- python3 -c frontmatter validation for optional-skills/productivity/find-job/SKILL.md
- python3 -c skills_guard scan for optional-skills/productivity/find-job
- git diff --cached --check