### PR TITLE
fix(kanban): prevent column label render crash

### DIFF
--- a/plugins/kanban/dashboard/dist/index.js
+++ b/plugins/kanban/dashboard/dist/index.js
@@ -1898,7 +1898,7 @@
           type: "checkbox",
           className: "hermes-kanban-col-check",
           title: "Select all tasks in this column",
-          "aria-label": `Select all tasks in ${COLUMN_LABEL[props.column.name] || props.column.name}`,
+          "aria-label": `Select all tasks in ${colLabel || props.column.name}`,
           checked: props.column.tasks.length > 0 && props.column.tasks.every(function (t) { return props.selectedIds.has(t.id); }),
           onChange: function (e) {
             e.stopPropagation();


### PR DESCRIPTION
## Summary
- Fixes Kanban dashboard render crash caused by `COLUMN_LABEL` being undefined in the column select-all checkbox aria-label.
- Reuses the already computed localized `colLabel`, matching the visible column heading and preserving the existing fallback to the raw column name.

## Test Plan
- `node --check plugins/kanban/dashboard/dist/index.js`
- Loaded `/kanban` in the local dashboard and verified the board renders without console errors.
- Hermes Kanban CLI still lists boards/tasks.

## Notes
This does not include Richard's local cache-bust manifest change; that was only needed to force his running browser/dashboard to stop using a stale plugin bundle after the local hotfix.
