### PR TITLE
docs: add private deliverable public-repo guardrail

### DIFF
--- a/scripts/check_private_deliverable_public_repo.py
+++ b/scripts/check_private_deliverable_public_repo.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+"""Block private/business deliverables from being PR'd to public repositories.
+
+This is intentionally lightweight: it can run as a pre-PR sanity check from an
+agent prompt, a shell script, or CI without importing Hermes internals.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+SENSITIVE_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(pattern, re.IGNORECASE)
+    for pattern in (
+        r"\brevenue\s+lab\b",
+        r"\baligned\s+insights\b",
+        r"\blife\s+church\s+(?:private\s+)?strategy\b",
+        r"\bsample[-\s_]*deliverables?\b",
+        r"\bprivate\s+(?:strategy|business|client|customer)\b",
+        r"\blinear\s+(?:business\s+)?tickets?\b",
+        r"\bRAN-\d+\b",
+    )
+)
+
+TEXT_EXTENSIONS = {
+    ".adoc",
+    ".csv",
+    ".json",
+    ".jsonl",
+    ".md",
+    ".mdx",
+    ".py",
+    ".rst",
+    ".text",
+    ".toml",
+    ".tsv",
+    ".txt",
+    ".yaml",
+    ".yml",
+}
+
+# Files whose purpose is to define or test this guardrail. These may mention the
+# blocked phrases without being private/business deliverables themselves.
+ALLOWLISTED_PATH_PATTERNS: tuple[re.Pattern[str], ...] = tuple(
+    re.compile(pattern)
+    for pattern in (
+        r"^scripts/check_private_deliverable_public_repo\.py$",
+        r"^tests/test_check_private_deliverable_public_repo\.py$",
+        r"^skills/github/github-pr-workflow/SKILL\.md$",
+        r"^skills/productivity/linear/SKILL\.md$",
+        r"^skills/autonomous-ai-agents/codex/SKILL\.md$",
+    )
+)
+
+
+def run(command: list[str], cwd: Path) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(command, cwd=cwd, text=True, capture_output=True, check=False)
+
+
+def git_root() -> Path:
+    result = run(["git", "rev-parse", "--show-toplevel"], Path.cwd())
+    if result.returncode != 0:
+        raise SystemExit("error: must be run inside a git repository")
+    return Path(result.stdout.strip())
+
+
+def owner_repo_from_remote(root: Path) -> str | None:
+    result = run(["git", "remote", "get-url", "origin"], root)
+    if result.returncode != 0:
+        return None
+    remote = result.stdout.strip()
+    match = re.search(r"github\.com[:/]([^/]+)/([^/.]+)(?:\.git)?$", remote)
+    if not match:
+        return None
+    return f"{match.group(1)}/{match.group(2)}"
+
+
+def detect_visibility(root: Path, repo: str | None) -> str | None:
+    if not repo:
+        return None
+    result = run(["gh", "repo", "view", repo, "--json", "visibility", "-q", ".visibility"], root)
+    if result.returncode == 0 and result.stdout.strip():
+        return result.stdout.strip().lower()
+    return None
+
+
+def changed_files(root: Path, base: str) -> list[Path]:
+    result = run(["git", "diff", "--name-only", f"{base}...HEAD"], root)
+    if result.returncode != 0:
+        result = run(["git", "diff", "--name-only", "HEAD"], root)
+    if result.returncode != 0:
+        raise SystemExit(result.stderr.strip() or "error: failed to inspect changed files")
+    return [root / line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def matches_sensitive(text: str) -> str | None:
+    for pattern in SENSITIVE_PATTERNS:
+        match = pattern.search(text)
+        if match:
+            return match.group(0)
+    return None
+
+
+def file_text(path: Path) -> str:
+    if path.suffix.lower() not in TEXT_EXTENSIONS:
+        return ""
+    try:
+        return path.read_text(encoding="utf-8", errors="ignore")[:500_000]
+    except OSError:
+        return ""
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base", default=os.environ.get("PR_BASE", "origin/main"), help="base ref for git diff, default: origin/main")
+    parser.add_argument("--repo", help="GitHub owner/repo; inferred from origin when omitted")
+    parser.add_argument("--visibility", choices=("public", "private", "internal"), help="repo visibility; detected with gh when omitted")
+    parser.add_argument("--text", action="append", default=[], help="additional PR title/body/task text to scan")
+    parser.add_argument("--path", action="append", dest="paths", help="specific file/path to scan instead of git diff")
+    args = parser.parse_args(argv)
+
+    root = git_root()
+    repo = args.repo or owner_repo_from_remote(root)
+    visibility = args.visibility or detect_visibility(root, repo)
+
+    if visibility != "public":
+        print(f"ok: repo {repo or '<unknown>'} visibility is {visibility or 'unknown'}; public-repo private-deliverable guardrail not triggered")
+        return 0
+
+    paths = [root / p for p in args.paths] if args.paths else changed_files(root, args.base)
+    violations: list[str] = []
+
+    for raw in args.text:
+        token = matches_sensitive(raw)
+        if token:
+            violations.append(f"PR text contains private/business marker: {token!r}")
+
+    for path in paths:
+        rel = str(path.relative_to(root)) if path.is_relative_to(root) else str(path)
+        if any(pattern.search(rel) for pattern in ALLOWLISTED_PATH_PATTERNS):
+            continue
+        token = matches_sensitive(rel)
+        if token:
+            violations.append(f"path {rel!r} contains private/business marker: {token!r}")
+            continue
+        token = matches_sensitive(file_text(path)) if path.exists() else None
+        if token:
+            violations.append(f"file {rel!r} contains private/business marker: {token!r}")
+
+    if violations:
+        print("BLOCKED: private/business deliverables must not be opened against a public repository.", file=sys.stderr)
+        print(f"Repository: {repo or '<unknown>'} ({visibility})", file=sys.stderr)
+        print("Route Revenue Lab / Aligned Insights / private strategy work to Ryan's private workspace, local vault, or a dedicated private repo.", file=sys.stderr)
+        for item in violations:
+            print(f"- {item}", file=sys.stderr)
+        return 2
+
+    print(f"ok: no private/business deliverable markers detected for public repo {repo or '<unknown>'}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/skills/autonomous-ai-agents/codex/SKILL.md
+++ b/skills/autonomous-ai-agents/codex/SKILL.md
@@ -97,7 +97,11 @@ terminal(command="codex --yolo exec 'Fix issue #99: <description>. Commit when d
 # Monitor
 process(action="list")
 
-# After completion, push and create PRs
+# After completion, verify the target repo is the right home, then push/create PRs.
+# Do not PR Revenue Lab, Aligned Insights, private strategy, sample deliverables,
+# or private Linear business tickets to public infrastructure repos. In repos that
+# include it, run scripts/check_private_deliverable_public_repo.py before gh pr create.
+terminal(command="cd /tmp/issue-78 && python3 scripts/check_private_deliverable_public_repo.py --text 'fix issue #78' || exit 1")
 terminal(command="cd /tmp/issue-78 && git push -u origin fix/issue-78")
 terminal(command="gh pr create --repo user/repo --head fix/issue-78 --title 'fix: ...' --body '...'")
 

--- a/skills/github/github-pr-workflow/SKILL.md
+++ b/skills/github/github-pr-workflow/SKILL.md
@@ -103,6 +103,21 @@ Types: `feat`, `fix`, `refactor`, `docs`, `test`, `ci`, `chore`, `perf`
 
 ## 3. Pushing and Creating a PR
 
+### Public-repo private-deliverable guardrail
+
+Before opening a PR, confirm the target repository is the right home for the work. Do **not** put Ryan/private business artifacts in public infrastructure repos. Revenue Lab, Aligned Insights, private Life Church strategy, sample deliverables, and private Linear business tickets belong in Ryan's private workspace/local vault or a dedicated private repo, not in public repos such as `NousResearch/hermes-agent`.
+
+Run the bundled pre-PR sanity check from the repo root when the branch may contain business/private deliverables:
+
+```bash
+python3 scripts/check_private_deliverable_public_repo.py \
+  --text "$(git log -1 --pretty=%B)" \
+  --text "${PR_TITLE:-}" \
+  --text "${PR_BODY:-}"
+```
+
+If it blocks, stop and reroute the work instead of creating the PR. The corrected local home for RAN-1381 sample artifacts is `/Users/cogginsryan/Documents/Revenue Lab/sample-deliverables/RAN-1381/`.
+
 ### Push the Branch (same either way)
 
 ```bash

--- a/skills/productivity/linear/SKILL.md
+++ b/skills/productivity/linear/SKILL.md
@@ -72,6 +72,21 @@ Each team has its own named states (e.g., "In Progress" is type `started`). To c
 
 **Priority values:** 0 = None, 1 = Urgent, 2 = High, 3 = Medium, 4 = Low
 
+## Private/business artifact routing guardrail
+
+Linear can describe private business work that should not become a public GitHub PR. Before routing a Linear issue into coding/PR automation, check whether the deliverable mentions Revenue Lab, Aligned Insights, private Life Church strategy, sample deliverables, private business strategy, or private Linear business tickets. Those artifacts must go to Ryan's private workspace/local vault or a dedicated private repo, not public infrastructure/tooling repos such as `NousResearch/hermes-agent`.
+
+If a coding branch may contain those artifacts and the target repo includes the bundled guard script, run this before `gh pr create`:
+
+```bash
+python3 scripts/check_private_deliverable_public_repo.py \
+  --text "$LINEAR_ISSUE_ID $LINEAR_ISSUE_TITLE" \
+  --text "${PR_TITLE:-}" \
+  --text "${PR_BODY:-}"
+```
+
+If the check blocks, stop and reroute the artifact instead of opening the PR. The corrected local home for RAN-1381 sample deliverables is `/Users/cogginsryan/Documents/Revenue Lab/sample-deliverables/RAN-1381/`.
+
 ## Common Queries
 
 ### Get current user

--- a/tests/test_check_private_deliverable_public_repo.py
+++ b/tests/test_check_private_deliverable_public_repo.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).resolve().parents[1] / "scripts" / "check_private_deliverable_public_repo.py"
+spec = importlib.util.spec_from_file_location("check_private_deliverable_public_repo", SCRIPT)
+module = importlib.util.module_from_spec(spec)
+assert spec.loader is not None
+spec.loader.exec_module(module)
+
+
+def test_sensitive_markers_are_detected_in_text() -> None:
+    assert module.matches_sensitive("Revenue Lab sample deliverables for RAN-1381") == "Revenue Lab"
+    assert module.matches_sensitive("Aligned Insights private strategy") == "Aligned Insights"
+
+
+def test_benign_text_is_allowed() -> None:
+    assert module.matches_sensitive("docs: clarify GitHub pull request workflow") is None
+
+
+def test_public_visibility_blocks_sensitive_pr_text(tmp_path, monkeypatch, capsys) -> None:
+    monkeypatch.chdir(tmp_path)
+    assert module.run(["git", "init"], tmp_path).returncode == 0
+    assert module.run(["git", "remote", "add", "origin", "https://github.com/NousResearch/hermes-agent.git"], tmp_path).returncode == 0
+
+    status = module.main([
+        "--visibility",
+        "public",
+        "--text",
+        "Add Revenue Lab sample deliverables",
+        "--path",
+        "README.md",
+    ])
+
+    assert status == 2
+    assert "BLOCKED" in capsys.readouterr().err
+
+
+def test_private_visibility_allows_sensitive_pr_text(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    assert module.run(["git", "init"], tmp_path).returncode == 0
+
+    status = module.main([
+        "--visibility",
+        "private",
+        "--text",
+        "Add Revenue Lab sample deliverables",
+        "--path",
+        "README.md",
+    ])
+
+    assert status == 0


### PR DESCRIPTION
## Summary
- Adds a lightweight pre-PR guard script that blocks private/business artifact markers when the target repo is public.
- Documents the guard in the GitHub PR workflow, Linear workflow, and Codex delegation guidance.
- Adds focused pytest coverage for blocking vs allowed visibility behavior.

## Verification
- `venv/bin/python -m pytest tests/test_check_private_deliverable_public_repo.py -q`
- `python3 scripts/check_private_deliverable_public_repo.py --visibility public --text 'docs: add private deliverable public-repo guardrail'`
