### PR TITLE
test(cli): keep systemd refresh unit tests hermetic after preflight (#15187)

### DIFF
--- a/tests/hermes_cli/test_gateway_service.py
+++ b/tests/hermes_cli/test_gateway_service.py
@@ -75,6 +75,7 @@ class TestSystemdServiceRefresh:
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
         monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
 
         gateway_cli.systemd_start()
 
@@ -105,6 +106,7 @@ class TestSystemdServiceRefresh:
             return SimpleNamespace(returncode=0, stdout="", stderr="")
 
         monkeypatch.setattr(gateway_cli.subprocess, "run", fake_run)
+        monkeypatch.setattr(gateway_cli, "_preflight_user_systemd", lambda: None)
 
         gateway_cli.systemd_restart()
 


### PR DESCRIPTION
## Summary
Fixes the unit-test regression in `TestSystemdServiceRefresh` after user D-Bus preflight was added.

- Patch `test_systemd_start_refreshes_outdated_unit` to stub `_preflight_user_systemd`.
- Patch `test_systemd_restart_refreshes_outdated_unit` to stub `_preflight_user_systemd`.

This keeps the tests hermetic and focused on the unit-refresh/systemctl call ordering they are meant to assert.

Closes #15187.

## Root cause
`systemd_start()` and `systemd_restart()` now call `_preflight_user_systemd()` in user scope. These two tests mock `subprocess.run` but did not mock preflight, so they fail early with `UserSystemdUnavailableError` on non-systemd/non-user-DBus environments.

## Validation
Reproduced failing state before fix:

```bash
python -m pytest -q -n 0 \
  tests/hermes_cli/test_gateway_service.py::TestSystemdServiceRefresh::test_systemd_start_refreshes_outdated_unit \
  tests/hermes_cli/test_gateway_service.py::TestSystemdServiceRefresh::test_systemd_restart_refreshes_outdated_unit --tb=short
```

After fix:

```bash
python -m pytest -q -n 0 \
  tests/hermes_cli/test_gateway_service.py::TestSystemdServiceRefresh::test_systemd_start_refreshes_outdated_unit \
  tests/hermes_cli/test_gateway_service.py::TestSystemdServiceRefresh::test_systemd_restart_refreshes_outdated_unit --tb=short
# 2 passed

python -m pytest -q -n 0 \
  tests/hermes_cli/test_gateway_service.py::TestSystemdServiceRefresh --tb=short
# 8 passed
```
