### PR TITLE
fix(compression): pass custom providers to feasibility check

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3141,6 +3141,14 @@ class AIAgent:
 
             aux_base_url = str(getattr(client, "base_url", ""))
             aux_api_key = str(getattr(client, "api_key", ""))
+            _aux_custom_providers = None
+            try:
+                from hermes_cli.config import load_config, get_compatible_custom_providers
+
+                _aux_cfg = load_config()
+                _aux_custom_providers = get_compatible_custom_providers(_aux_cfg)
+            except Exception:
+                _aux_custom_providers = None
 
             aux_context = get_model_context_length(
                 aux_model,
@@ -3151,6 +3159,7 @@ class AIAgent:
                 # provider-specific paths (e.g. Bedrock static table, OpenRouter API)
                 # are invoked for the correct client, not inherited from the main model.
                 provider=(_aux_cfg_provider if _aux_cfg_provider and _aux_cfg_provider != "auto" else getattr(self, "provider", "")),
+                custom_providers=_aux_custom_providers,
             )
 
             # Hard floor: the auxiliary compression model must have at least

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -182,6 +182,39 @@ def test_feasibility_check_passes_config_context_length(mock_get_client, mock_ct
         api_key="sk-custom",
         config_context_length=1_000_000,
         provider="openrouter",
+        custom_providers=[],
+    )
+
+
+@patch("agent.model_metadata.get_model_context_length", return_value=1_000_000)
+@patch("agent.auxiliary_client.get_text_auxiliary_client")
+def test_feasibility_check_passes_custom_providers(mock_get_client, mock_ctx_len):
+    """Compression feasibility should reuse custom_providers context overrides."""
+    agent = _make_agent(main_context=200_000, threshold_percent=0.85)
+    mock_client = MagicMock()
+    mock_client.base_url = "http://custom-endpoint:8080/v1"
+    mock_client.api_key = "sk-custom"
+    mock_get_client.return_value = (mock_client, "custom/big-model")
+    custom_providers = [
+        {
+            "provider": "custom-openai",
+            "base_url": "http://custom-endpoint:8080/v1",
+            "models": [{"name": "custom/big-model", "context_length": 1_000_000}],
+        }
+    ]
+
+    agent._emit_status = lambda msg: None
+    with patch("hermes_cli.config.load_config", return_value={"custom_providers": custom_providers}), \
+         patch("hermes_cli.config.get_compatible_custom_providers", return_value=custom_providers):
+        agent._check_compression_model_feasibility()
+
+    mock_ctx_len.assert_called_once_with(
+        "custom/big-model",
+        base_url="http://custom-endpoint:8080/v1",
+        api_key="sk-custom",
+        config_context_length=None,
+        provider="openrouter",
+        custom_providers=custom_providers,
     )
 
 
@@ -205,6 +238,7 @@ def test_feasibility_check_ignores_invalid_context_length(mock_get_client, mock_
         api_key="sk-test",
         config_context_length=None,
         provider="openrouter",
+        custom_providers=[],
     )
 
 
@@ -258,6 +292,7 @@ def test_init_feasibility_check_uses_aux_context_override_from_config():
         api_key="sk-custom",
         config_context_length=1_000_000,
         provider="",
+        custom_providers=[],
     )
 
 


### PR DESCRIPTION
## What does this PR do?

Passes `custom_providers` through `_check_compression_model_feasibility()` so auxiliary compression models inherit per-model `context_length` overrides the same way the main model path already does. This avoids false 256K startup warnings when the compression model resolves through a custom provider entry with a larger configured context window.

## Related Issue

Fixes #23779

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Forwarded `custom_providers` into `get_model_context_length()` inside `run_agent.py::_check_compression_model_feasibility()`
- Reused live config loading in the feasibility check so auxiliary custom-provider overrides stay aligned with the main-model and switch-model paths
- Added a regression test proving the feasibility check forwards custom provider metadata for the auxiliary compression model
- Updated existing feasibility assertions to match the helper's current empty-list fallback shape

## How to Test

1. Run `uv run --frozen pytest -q -o addopts='' tests/run_agent/test_compression_feasibility.py`
2. Run `uv run --frozen ruff check run_agent.py tests/run_agent/test_compression_feasibility.py`
3. Confirm `test_feasibility_check_passes_custom_providers` asserts the auxiliary feasibility lookup receives the configured `custom_providers` list

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `17 passed in 1.01s` from `tests/run_agent/test_compression_feasibility.py`
- `All checks passed!` from `ruff check run_agent.py tests/run_agent/test_compression_feasibility.py`
