### PR TITLE
fix: pass custom_providers to get_model_context_length in compression feasibility check

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -3142,6 +3142,21 @@ class AIAgent:
             aux_base_url = str(getattr(client, "base_url", ""))
             aux_api_key = str(getattr(client, "api_key", ""))
 
+            # Resolve custom_providers so per-model context_length overrides
+            # (set in config.yaml) are honoured for the compression model.
+            # The main-model resolution path already passes custom_providers
+            # (see __init__ ~line 2222); this path was missing it, causing
+            # correctly-configured custom endpoints to fall back to 256K.
+            _aux_custom_providers = None
+            try:
+                from hermes_cli.config import load_config, get_compatible_custom_providers
+                _cfg = load_config()
+                _aux_custom_providers = get_compatible_custom_providers(_cfg)
+            except Exception:
+                pass
+            if _aux_custom_providers is None:
+                _aux_custom_providers = []
+
             aux_context = get_model_context_length(
                 aux_model,
                 base_url=aux_base_url,
@@ -3151,6 +3166,7 @@ class AIAgent:
                 # provider-specific paths (e.g. Bedrock static table, OpenRouter API)
                 # are invoked for the correct client, not inherited from the main model.
                 provider=(_aux_cfg_provider if _aux_cfg_provider and _aux_cfg_provider != "auto" else getattr(self, "provider", "")),
+                custom_providers=_aux_custom_providers,
             )
 
             # Hard floor: the auxiliary compression model must have at least

--- a/tests/run_agent/test_compression_feasibility.py
+++ b/tests/run_agent/test_compression_feasibility.py
@@ -182,6 +182,7 @@ def test_feasibility_check_passes_config_context_length(mock_get_client, mock_ct
         api_key="sk-custom",
         config_context_length=1_000_000,
         provider="openrouter",
+        custom_providers=[],
     )
 
 
@@ -205,6 +206,7 @@ def test_feasibility_check_ignores_invalid_context_length(mock_get_client, mock_
         api_key="sk-test",
         config_context_length=None,
         provider="openrouter",
+        custom_providers=[],
     )
 
 
@@ -258,6 +260,7 @@ def test_init_feasibility_check_uses_aux_context_override_from_config():
         api_key="sk-custom",
         config_context_length=1_000_000,
         provider="",
+        custom_providers=[],
     )
 
 


### PR DESCRIPTION
## Problem

`_check_compression_model_feasibility()` calls `get_model_context_length()` **without** the `custom_providers` parameter, skipping step 0b of context length resolution. This causes false "256K context" warnings for custom providers that have per-model `context_length` configured in `custom_providers` — the resolution falls through to `DEFAULT_FALLBACK_CONTEXT`.

The main-model init path (~L2222) already passes `custom_providers` and works correctly. This path was missed.

Closes #23779.

## Fix

Resolve `custom_providers` from config inside `_check_compression_model_feasibility()` and pass them to `get_model_context_length()`, matching the main-model pattern.

## Test Plan

- [x] All 16 existing compression feasibility tests pass
- [x] Updated 3 test assertions to expect the new `custom_providers=[]` parameter