### PR TITLE
Reject unsafe curator rollback tar members

### DIFF
--- a/agent/curator_backup.py
+++ b/agent/curator_backup.py
@@ -46,7 +46,7 @@ import tarfile
 import tempfile
 import time
 from datetime import datetime, timezone
-from pathlib import Path
+from pathlib import Path, PurePosixPath, PureWindowsPath
 from typing import Any, Dict, List, Optional, Tuple
 
 from hermes_constants import get_hermes_home
@@ -65,6 +65,53 @@ _EXCLUDE_TOP_LEVEL = {".curator_backups", ".hub"}
 # is portable (Windows-safe). An optional ``-NN`` suffix handles two
 # snapshots landing in the same wallclock second.
 _ID_RE = re.compile(r"^\d{4}-\d{2}-\d{2}T\d{2}-\d{2}-\d{2}Z(-\d{2})?$")
+
+
+def _rollback_archive_member_parts(member_name: str) -> Tuple[str, ...]:
+    """Return safe path parts for a rollback archive member."""
+    normalized_name = member_name.replace("\\", "/")
+    posix_path = PurePosixPath(normalized_name)
+    windows_path = PureWindowsPath(member_name)
+
+    if (
+        not normalized_name
+        or "\\" in member_name
+        or posix_path.is_absolute()
+        or windows_path.is_absolute()
+        or windows_path.drive
+    ):
+        raise tarfile.TarError(f"refusing to extract unsafe path: {member_name!r}")
+
+    parts = tuple(part for part in posix_path.parts if part not in ("", "."))
+    if not parts or any(part == ".." for part in parts):
+        raise tarfile.TarError(f"refusing to extract unsafe path: {member_name!r}")
+    if parts[0] in _EXCLUDE_TOP_LEVEL:
+        raise tarfile.TarError(
+            f"refusing to extract excluded snapshot entry: {member_name!r}"
+        )
+    return parts
+
+
+def _validate_rollback_archive_members(
+    members: List[tarfile.TarInfo],
+    destination: Path,
+) -> None:
+    """Validate snapshot members before extraction."""
+    destination_root = destination.resolve()
+    for member in members:
+        parts = _rollback_archive_member_parts(member.name)
+        target = destination.joinpath(*parts).resolve()
+        try:
+            target.relative_to(destination_root)
+        except ValueError as exc:
+            raise tarfile.TarError(
+                f"refusing to extract unsafe path: {member.name!r}"
+            ) from exc
+
+        if not (member.isdir() or member.isfile()):
+            raise tarfile.TarError(
+                f"refusing to extract unsupported snapshot entry: {member.name!r}"
+            )
 
 
 def _backups_dir() -> Path:
@@ -600,20 +647,13 @@ def rollback(backup_id: Optional[str] = None) -> Tuple[bool, str, Optional[Path]
     # Step 4: extract the snapshot into skills/
     try:
         with tarfile.open(archive, "r:gz") as tf:
-            # Python 3.12+ supports filter='data' for safer extraction.
-            # Fall back to the unfiltered call for older interpreters but
-            # still reject absolute paths and .. components defensively.
-            for member in tf.getmembers():
-                name = member.name
-                if name.startswith("/") or ".." in Path(name).parts:
-                    raise tarfile.TarError(
-                        f"refusing to extract unsafe path: {name!r}"
-                    )
+            members = tf.getmembers()
+            _validate_rollback_archive_members(members, skills)
             try:
-                tf.extractall(str(skills), filter="data")  # type: ignore[call-arg]
+                tf.extractall(str(skills), members=members, filter="data")  # type: ignore[call-arg]
             except TypeError:
                 # Python < 3.12 — no filter kwarg
-                tf.extractall(str(skills))
+                tf.extractall(str(skills), members=members)
     except (OSError, tarfile.TarError) as e:
         # Best-effort recover: move staged contents back
         for orig, dest in moved:

--- a/tests/agent/test_curator_backup.py
+++ b/tests/agent/test_curator_backup.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+import io
 import json
 import os
 import sys
@@ -257,6 +258,68 @@ def test_rollback_rejects_unsafe_tarball(backup_env, monkeypatch):
     ok, msg, _ = cb.rollback()
     assert not ok
     assert "unsafe" in msg.lower() or "refus" in msg.lower() or "extract" in msg.lower()
+
+
+def test_rollback_rejects_tar_symlink_members_on_legacy_extract_fallback(
+    backup_env,
+    monkeypatch,
+    tmp_path,
+):
+    """Python 3.11 fallback extraction must not accept tar links.
+
+    ``filter="data"`` handles this on newer interpreters. The fallback path
+    still needs its own member-type validation before unfiltered extraction.
+    """
+    cb = backup_env["cb"]
+    skills = backup_env["skills"]
+    _write_skill(skills, "alpha")
+    cb.snapshot_skills(reason="legit")
+
+    outside = tmp_path / "outside"
+    outside.mkdir()
+
+    rows = cb.list_backups()
+    snap_dir = Path(rows[0]["path"])
+    mal = snap_dir / "skills.tar.gz"
+    mal.unlink()
+    with tarfile.open(mal, "w:gz") as tf:
+        link = tarfile.TarInfo("link-out")
+        link.type = tarfile.SYMTYPE
+        link.linkname = str(outside)
+        tf.addfile(link)
+
+        data = b"escaped"
+        escaped = tarfile.TarInfo("link-out/escaped.txt")
+        escaped.size = len(data)
+        tf.addfile(escaped, io.BytesIO(data))
+
+    original_extractall = tarfile.TarFile.extractall
+
+    def legacy_extractall(
+        self,
+        path=".",
+        members=None,
+        *,
+        numeric_owner=False,
+        filter=None,
+    ):
+        if filter is not None:
+            raise TypeError("filter argument is not available")
+        return original_extractall(
+            self,
+            path=path,
+            members=members,
+            numeric_owner=numeric_owner,
+        )
+
+    monkeypatch.setattr(tarfile.TarFile, "extractall", legacy_extractall)
+
+    ok, msg, _ = cb.rollback()
+
+    assert not ok
+    assert "unsupported" in msg.lower() or "refus" in msg.lower()
+    assert not (outside / "escaped.txt").exists()
+    assert (skills / "alpha" / "SKILL.md").exists()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes #23794.

Curator rollback already rejected absolute paths and `..` components before extracting `skills.tar.gz`, but the Python 3.11 fallback still passed validated names into unfiltered `tar.extractall()`. A tar link member can make a later regular file write outside the skills directory even when the later file's member name looks safe.

This keeps valid file/directory snapshots working while tightening the extraction preflight:

- normalize and validate every member path before extraction
- reject snapshot entries for live excluded directories (`.hub`, `.curator_backups`)
- reject symlinks, hardlinks, device files, FIFOs, and other non-file/non-directory members
- pass the validated member list into extraction for both filtered and fallback paths

## Test plan

```bash
scripts/run_tests.sh tests/agent/test_curator_backup.py
# 26 passed
```
