### PR TITLE
fix(gateway): validate user authorization before auto-resume

### DIFF
--- a/gateway/run.py
+++ b/gateway/run.py
@@ -3174,6 +3174,19 @@ class GatewayRunner:
                 )
                 continue
 
+            # Validate that the session owner is still authorized before
+            # auto-resuming. Auth config may have changed between restarts
+            # (e.g. TELEGRAM_ALLOWED_USERS updated) — skip sessions whose
+            # owner is no longer in the allowlist (issue #23778).
+            _user_id = str(getattr(source, "user_id", "") or "")
+            if _user_id and hasattr(adapter, "_is_callback_user_authorized"):
+                if not adapter._is_callback_user_authorized(_user_id):
+                    logger.warning(
+                        "Skipping auto-resume for %s: user %s not authorized",
+                        entry.session_key, _user_id,
+                    )
+                    continue
+
             # Empty-text internal event — the _is_resume_pending branch in
             # _handle_message_with_agent prepends the proper reason-aware
             # system note before the turn runs.


### PR DESCRIPTION
## Problem

Auto-resume of restart-interrupted sessions bypassed auth checks. The session owner was never validated against `TELEGRAM_ALLOWED_USERS` before the synthetic resume event was dispatched. An attacker with an active session before the allowlist was configured could receive a full agent response on gateway restart.

## Fix

Check `_is_callback_user_authorized()` for the session owner before scheduling auto-resume. Unauthorized sessions are skipped with a warning log.

Follows up on #23795 (inbound message auth bypass).

Fixes #23778 (partial - auto-resume auth bypass)