### PR TITLE
fix(agent): stop retrying regressive compression

### DIFF
--- a/run_agent.py
+++ b/run_agent.py
@@ -13808,14 +13808,75 @@ class AIAgent:
                         # messages to the new session, not skipping them.
                         conversation_history = None
 
-                        if len(messages) < original_len or new_ctx and new_ctx < old_ctx:
-                            if len(messages) < original_len:
+                        compressed_tokens = (
+                            getattr(self.context_compressor, "last_prompt_tokens", 0) or
+                            estimate_request_tokens_rough(
+                                messages,
+                                system_prompt=active_system_prompt or "",
+                                tools=self.tools or None,
+                            )
+                        )
+                        compression_reduced_history = len(messages) < original_len
+                        compression_reduced_tokens = (
+                            bool(approx_tokens) and compressed_tokens < approx_tokens
+                        )
+                        compression_stagnated = (
+                            not compression_reduced_history
+                            and bool(approx_tokens)
+                            and compressed_tokens >= approx_tokens
+                        )
+
+                        if (
+                            compression_reduced_history
+                            or compression_reduced_tokens
+                            or (
+                                new_ctx
+                                and new_ctx < old_ctx
+                                and not compression_stagnated
+                            )
+                        ):
+                            if compression_reduced_history:
                                 self._emit_status(f"🗜️ Compressed {original_len} → {len(messages)} messages, retrying...")
+                            elif compression_reduced_tokens:
+                                self._emit_status(
+                                    f"🗜️ Prompt estimate dropped ~{approx_tokens:,} → ~{compressed_tokens:,}, retrying..."
+                                )
                             time.sleep(2)  # Brief pause between compression retries
                             restart_with_compressed_messages = True
                             break
                         else:
                             # Can't compress further and already at minimum tier
+                            if compression_stagnated:
+                                self._vprint(
+                                    f"{self.log_prefix}❌ Compression did not reduce prompt pressure "
+                                    f"(~{approx_tokens:,} → ~{compressed_tokens:,}).",
+                                    force=True,
+                                )
+                                self._vprint(
+                                    f"{self.log_prefix}   💡 Start a fresh session with /new or switch "
+                                    f"back to a higher-context model before retrying.",
+                                    force=True,
+                                )
+                                logging.error(
+                                    "%sCompression regressed or made no progress: approx_tokens=%s compressed_tokens=%s",
+                                    self.log_prefix,
+                                    f"{approx_tokens:,}",
+                                    f"{compressed_tokens:,}",
+                                )
+                                self._persist_session(messages, conversation_history)
+                                return {
+                                    "messages": messages,
+                                    "completed": False,
+                                    "api_calls": api_call_count,
+                                    "error": (
+                                        "Context compression did not reduce prompt size "
+                                        f"(~{approx_tokens:,} -> ~{compressed_tokens:,}). "
+                                        "Start a fresh session with /new."
+                                    ),
+                                    "partial": True,
+                                    "failed": True,
+                                    "compression_exhausted": True,
+                                }
                             self._vprint(f"{self.log_prefix}❌ Context length exceeded and cannot compress further.", force=True)
                             self._vprint(f"{self.log_prefix}   💡 The conversation has accumulated too much content. Try /new to start fresh, or /compress to manually trigger compression.", force=True)
                             logging.error(f"{self.log_prefix}Context length exceeded: {approx_tokens:,} tokens. Cannot compress further.")

--- a/tests/run_agent/test_413_compression.py
+++ b/tests/run_agent/test_413_compression.py
@@ -586,3 +586,44 @@ class TestToolResultPreflightCompression:
 
         mock_compress.assert_called_once()
         assert result["completed"] is True
+
+    def test_context_overflow_stops_when_compression_estimate_grows(self, agent):
+        """If compression returns the same history and the prompt estimate
+        grows, abort instead of looping on a stepped-down context tier."""
+        err_400 = Exception(
+            "Error code: 400 - {'error': {'message': "
+            "'Prompt too long: 65798 tokens exceeds max context window of 65536 tokens'}}"
+        )
+        err_400.status_code = 400
+        calls = {"count": 0}
+
+        def _raise_overflow(*_args, **_kwargs):
+            calls["count"] += 1
+            if calls["count"] > 1:
+                raise AssertionError("run_conversation retried despite regressive compression")
+            raise err_400
+
+        agent.client.chat.completions.create.side_effect = _raise_overflow
+        agent.context_compressor.context_length = 131_072
+
+        prefill = [
+            {"role": "user", "content": "previous question"},
+            {"role": "assistant", "content": "previous answer"},
+        ]
+
+        def _fake_compress(messages, system_message, approx_tokens=0, task_id=None):
+            agent.context_compressor.last_prompt_tokens = approx_tokens + 5_000
+            return list(messages), system_message
+
+        with (
+            patch.object(agent, "_compress_context", side_effect=_fake_compress),
+            patch.object(agent, "_persist_session"),
+            patch.object(agent, "_save_trajectory"),
+            patch.object(agent, "_cleanup_task_resources"),
+        ):
+            result = agent.run_conversation("hello", conversation_history=prefill)
+
+        assert calls["count"] == 1
+        assert result["failed"] is True
+        assert result["compression_exhausted"] is True
+        assert "did not reduce prompt size" in result["error"]


### PR DESCRIPTION
## What does this PR do?

Stops the context-overflow retry loop when a compression pass fails to make any measurable progress.

In the failing path from #23767, Hermes could receive a `Prompt too long` response, run compression, keep the same message history, produce an even larger prompt estimate, and then retry anyway. This change aborts that loop once compression is clearly regressive or stagnant and tells the user to start a fresh session instead.

## Related Issue

Fixes #23767

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- add a compression progress check in `run_agent.py` before retrying after a context overflow
- treat unchanged history plus non-decreasing prompt estimate as compression failure
- return a user-facing error telling the operator to use `/new` instead of looping oversized retries
- add a regression test in `tests/run_agent/test_413_compression.py` covering the regressive-compression case

## How to Test

1. Run `uv run --frozen pytest -q -o addopts='' tests/run_agent/test_413_compression.py`
2. Run `uv run --frozen ruff check run_agent.py tests/run_agent/test_413_compression.py`
3. Confirm the new test `test_context_overflow_stops_when_compression_estimate_grows` passes and the conversation aborts instead of retrying

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.7.4

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Targeted regression tests: `15 passed`
- Focused lint: `ruff check run_agent.py tests/run_agent/test_413_compression.py`
- Repo smoke proof: clean-env `pytest --collect-only` for `tests/run_agent/test_413_compression.py`
