### PR TITLE
feat(gateway): add opt-in AFK follow-up turns

### DIFF
--- a/gateway/afk_followup.py
+++ b/gateway/afk_followup.py
@@ -1,0 +1,168 @@
+"""Gateway-native AFK follow-up helpers.
+
+The gateway owns the idle/scheduling decision. The model owns deciding which
+safe, useful work to do once a virtual turn is injected.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Iterable, Optional, Set
+
+
+DEFAULT_AFK_THRESHOLDS_MINUTES: tuple[int, ...] = (5, 15, 60)
+
+
+@dataclass(frozen=True)
+class AfkFollowupConfig:
+    enabled: bool = False
+    thresholds_minutes: tuple[int, ...] = DEFAULT_AFK_THRESHOLDS_MINUTES
+    interval_seconds: float = 60.0
+
+
+@dataclass(frozen=True)
+class AfkFollowupDecision:
+    session_key: str
+    threshold_minutes: int
+    idle_seconds: float
+    idle_label: str
+
+
+def _as_aware_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def normalize_thresholds(values: Iterable[int] | None) -> tuple[int, ...]:
+    if values is None:
+        return DEFAULT_AFK_THRESHOLDS_MINUTES
+    thresholds: set[int] = set()
+    for value in values:
+        try:
+            threshold = int(value)
+        except (TypeError, ValueError):
+            continue
+        if threshold > 0:
+            thresholds.add(threshold)
+    if not thresholds:
+        return DEFAULT_AFK_THRESHOLDS_MINUTES
+    return tuple(sorted(thresholds))
+
+
+def parse_afk_followup_config(raw) -> AfkFollowupConfig:
+    """Parse ``gateway.afk_followup`` config with safe defaults.
+
+    AFK automation is opt-in. Malformed values are tolerated so a bad config
+    cannot crash gateway startup.
+    """
+    if not isinstance(raw, dict):
+        return AfkFollowupConfig(enabled=False)
+    enabled = bool(raw.get("enabled", False))
+    thresholds = normalize_thresholds(raw.get("thresholds_minutes"))
+    try:
+        interval = float(raw.get("interval_seconds", 60.0))
+    except (TypeError, ValueError):
+        interval = 60.0
+    if interval <= 0:
+        interval = 60.0
+    return AfkFollowupConfig(
+        enabled=enabled,
+        thresholds_minutes=thresholds,
+        interval_seconds=interval,
+    )
+
+
+def format_idle_label(minutes: int) -> str:
+    if minutes >= 60 and minutes % 60 == 0:
+        hours = minutes // 60
+        return f"{hours}h"
+    return f"{minutes}m"
+
+
+def next_afk_followup(
+    entry,
+    *,
+    now: datetime,
+    thresholds_minutes: Iterable[int] = DEFAULT_AFK_THRESHOLDS_MINUTES,
+    fired_thresholds: Set[int] | None = None,
+    running_session_keys: Set[str] | None = None,
+    queued_session_keys: Set[str] | None = None,
+) -> Optional[AfkFollowupDecision]:
+    """Return the next AFK threshold to inject for a session, if any."""
+    session_key = getattr(entry, "session_key", "") or ""
+    if not session_key:
+        return None
+    if getattr(entry, "suspended", False):
+        return None
+    if getattr(entry, "origin", None) is None:
+        return None
+    if session_key in (running_session_keys or set()):
+        return None
+    if session_key in (queued_session_keys or set()):
+        return None
+
+    updated_at = getattr(entry, "updated_at", None)
+    if not isinstance(updated_at, datetime):
+        return None
+
+    now_utc = _as_aware_utc(now)
+    updated_utc = _as_aware_utc(updated_at)
+    idle_seconds = max(0.0, (now_utc - updated_utc).total_seconds())
+    idle_minutes = idle_seconds / 60.0
+    fired = fired_thresholds or set()
+
+    for threshold in normalize_thresholds(thresholds_minutes):
+        if threshold in fired:
+            continue
+        if idle_minutes >= threshold:
+            return AfkFollowupDecision(
+                session_key=session_key,
+                threshold_minutes=threshold,
+                idle_seconds=idle_seconds,
+                idle_label=format_idle_label(threshold),
+            )
+    return None
+
+
+def build_afk_followup_prompt(
+    idle_label: str,
+    *,
+    recent_instruction: str | None = None,
+    cycle_index: int = 1,
+) -> str:
+    instruction_line = ""
+    if recent_instruction:
+        instruction_line = (
+            f"\nRecent user instruction about autonomous follow-ups: {recent_instruction}.\n"
+            "If the user asked you not to work while they are away, ignore this prompt and stay quiet.\n"
+        )
+
+    ordinals = {1: "first", 2: "second", 3: "third"}
+    ordinal = ordinals.get(cycle_index, f"#{cycle_index}")
+
+    if cycle_index <= 1:
+        body = (
+            "Identify the top 3 loose ends or safe follow-up task ideas from the recent conversation "
+            "or your durable task board, in priority order. Work on the first one now and complete it."
+        )
+    else:
+        body = (
+            "You may have identified loose ends in an earlier AFK cycle. Work on the "
+            f"{ordinal} unresolved safe task now. If that task is already resolved, pick the next unresolved one."
+        )
+
+    return (
+        "[Automated AFK follow-up]\n\n"
+        f"The user has been AFK for {idle_label}.\n"
+        f"{instruction_line}\n"
+        f"{body}\n\n"
+        "Safety bounds: do not take destructive, financially risky, credential-changing, "
+        "production-deployment, publishing, message-sending, or irreversible actions unless the user "
+        "already explicitly approved that exact action. Prefer read-only checks, tests, drafts, plans, "
+        "local code edits, and durable task-board updates.\n\n"
+        "When finished, reply to the user with a concise 1-3 sentence summary. "
+        "Use this prefix when applicable: `AFK task completed: <what changed>.` "
+        "If you hit a real blocker, report it concisely."
+    )

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2960,6 +2960,7 @@ class BasePlatformAdapter(ABC):
             # is processed by the pending-message handler below (#8221/#2483).
             if (
                 response
+                and not getattr(event, "internal", False)
                 and interrupt_event.is_set()
                 and session_key in self._pending_messages
             ):

--- a/gateway/run.py
+++ b/gateway/run.py
@@ -638,6 +638,12 @@ from gateway.session import (
     build_session_key,
     is_shared_multi_user_session,
 )
+from gateway.afk_followup import (
+    AfkFollowupConfig,
+    build_afk_followup_prompt,
+    next_afk_followup,
+    parse_afk_followup_config,
+)
 from gateway.delivery import DeliveryRouter
 from gateway.platforms.base import (
     BasePlatformAdapter,
@@ -1178,6 +1184,8 @@ class GatewayRunner:
         self._service_tier = self._load_service_tier()
         self._show_reasoning = self._load_show_reasoning()
         self._busy_input_mode = self._load_busy_input_mode()
+        self._afk_followup_config = self._load_afk_followup_config()
+        self._afk_fired_thresholds: Dict[str, set[int]] = {}
         self._restart_drain_timeout = self._load_restart_drain_timeout()
         self._provider_routing = self._load_provider_routing()
         self._fallback_model = self._load_fallback_model()
@@ -2354,6 +2362,21 @@ class GatewayRunner:
         if mode == "steer":
             return "steer"
         return "interrupt"
+
+    @staticmethod
+    def _load_afk_followup_config() -> AfkFollowupConfig:
+        """Load opt-in gateway AFK follow-up settings from config.yaml."""
+        try:
+            import yaml as _y
+            cfg_path = _hermes_home / "config.yaml"
+            if cfg_path.exists():
+                with open(cfg_path, encoding="utf-8") as _f:
+                    cfg = _y.safe_load(_f) or {}
+                raw = cfg_get(cfg, "gateway", "afk_followup", default={})
+                return parse_afk_followup_config(raw)
+        except Exception as exc:
+            logger.warning("Invalid gateway.afk_followup config; AFK follow-up disabled: %s", exc)
+        return AfkFollowupConfig(enabled=False)
 
     @staticmethod
     def _load_restart_drain_timeout() -> float:
@@ -3662,6 +3685,11 @@ class GatewayRunner:
         # Start background session expiry watcher to finalize expired sessions
         asyncio.create_task(self._session_expiry_watcher())
 
+        # Start optional AFK follow-up watcher. It injects synthetic internal
+        # turns into idle sessions only when explicitly enabled in config.
+        if getattr(self, "_afk_followup_config", AfkFollowupConfig()).enabled:
+            asyncio.create_task(self._afk_followup_watcher())
+
         # Start background kanban notifier — delivers `completed`, `blocked`,
         # `spawn_auto_blocked`, and `crashed` events to gateway subscribers
         # so human-in-the-loop workflows hear back without polling.
@@ -3909,6 +3937,124 @@ class GatewayRunner:
         if not getattr(result, "success", True):
             err = getattr(result, "error", "send returned success=False")
             raise RuntimeError(f"adapter.send failed: {err}")
+
+    async def _afk_followup_watcher(self) -> None:
+        """Inject bounded synthetic follow-up turns for idle gateway sessions."""
+        config = getattr(self, "_afk_followup_config", AfkFollowupConfig())
+        # Let adapters finish connecting and avoid surprising users with an
+        # immediate AFK burst during gateway startup/replacement.
+        await asyncio.sleep(min(max(config.interval_seconds, 1.0), 60.0))
+        while self._running:
+            try:
+                await self._afk_followup_tick()
+            except Exception as exc:
+                logger.debug("AFK follow-up watcher tick failed: %s", exc)
+            sleep_for = max(float(getattr(config, "interval_seconds", 60.0) or 60.0), 1.0)
+            elapsed = 0.0
+            while self._running and elapsed < sleep_for:
+                step = min(1.0, sleep_for - elapsed)
+                await asyncio.sleep(step)
+                elapsed += step
+
+    async def _afk_followup_tick(self) -> None:
+        """Run one AFK scheduling pass.
+
+        Exposed as a small method for tests and for future manual diagnostics.
+        """
+        config = getattr(self, "_afk_followup_config", AfkFollowupConfig())
+        if not config.enabled:
+            return
+
+        session_store = getattr(self, "session_store", None)
+        if session_store is None:
+            return
+        try:
+            session_store._ensure_loaded()
+        except Exception as exc:
+            logger.debug("AFK follow-up: session store unavailable: %s", exc)
+            return
+
+        entries = list(getattr(session_store, "_entries", {}).items())
+        running_session_keys = set(getattr(self, "_running_agents", {}) or {})
+        queued_session_keys = set(getattr(self, "_queued_events", {}) or {})
+        adapters = getattr(self, "adapters", {}) or {}
+        for adapter in adapters.values():
+            pending = getattr(adapter, "_pending_messages", None)
+            if isinstance(pending, dict):
+                queued_session_keys.update(pending.keys())
+        now = datetime.now()
+
+        for session_key, entry in entries:
+            fired_map = getattr(self, "_afk_fired_thresholds", None)
+            if fired_map is None:
+                fired_map = {}
+                self._afk_fired_thresholds = fired_map
+            fired = fired_map.setdefault(session_key, set())
+            decision = next_afk_followup(
+                entry,
+                now=now,
+                thresholds_minutes=config.thresholds_minutes,
+                fired_thresholds=fired,
+                running_session_keys=running_session_keys,
+                queued_session_keys=queued_session_keys,
+            )
+            if decision is None:
+                continue
+
+            origin = getattr(entry, "origin", None)
+            source = self._source_from_afk_origin(origin)
+            if source is None:
+                logger.debug("AFK follow-up: no routable source for %s", session_key)
+                continue
+            adapter = adapters.get(source.platform)
+            if adapter is None:
+                logger.debug("AFK follow-up: no adapter for %s (%s)", session_key, source.platform)
+                continue
+
+            cycle_index = sorted(config.thresholds_minutes).index(decision.threshold_minutes) + 1
+            prompt = build_afk_followup_prompt(decision.idle_label, cycle_index=cycle_index)
+            event = MessageEvent(
+                text=prompt,
+                message_type=MessageType.TEXT,
+                source=source,
+                message_id=f"afk:{decision.threshold_minutes}:{int(time.time())}",
+                internal=True,
+            )
+            logger.info(
+                "AFK follow-up: injecting %s virtual turn for %s",
+                decision.idle_label,
+                session_key,
+            )
+            await adapter.handle_message(event)
+            fired.add(decision.threshold_minutes)
+
+    @staticmethod
+    def _source_from_afk_origin(origin) -> Optional[SessionSource]:
+        if isinstance(origin, SessionSource):
+            return origin
+        if origin is None:
+            return None
+        platform = getattr(origin, "platform", None)
+        if platform is None:
+            return None
+        if not isinstance(platform, Platform):
+            try:
+                platform = Platform(str(platform))
+            except ValueError:
+                return None
+        chat_id = getattr(origin, "chat_id", None)
+        if not chat_id:
+            return None
+        return SessionSource(
+            platform=platform,
+            chat_id=str(chat_id),
+            chat_name=getattr(origin, "chat_name", None),
+            chat_type=getattr(origin, "chat_type", "dm") or "dm",
+            user_id=getattr(origin, "user_id", None),
+            user_name=getattr(origin, "user_name", None),
+            thread_id=getattr(origin, "thread_id", None),
+            chat_topic=getattr(origin, "chat_topic", None),
+        )
 
     async def _session_expiry_watcher(self, interval: int = 300):
         """Background task that finalizes expired sessions.

--- a/tests/gateway/test_afk_followup.py
+++ b/tests/gateway/test_afk_followup.py
@@ -1,0 +1,235 @@
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from gateway.config import GatewayConfig, Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, MessageType, SendResult
+from gateway.run import GatewayRunner
+
+
+def _entry(*, minutes_idle: int, session_key: str = "agent:main:telegram:dm:123"):
+    now = datetime(2026, 5, 5, 12, 0, tzinfo=timezone.utc)
+    return SimpleNamespace(
+        session_key=session_key,
+        session_id="sid-123",
+        updated_at=now - timedelta(minutes=minutes_idle),
+        origin=SimpleNamespace(platform=Platform.TELEGRAM, chat_id="123", thread_id=None),
+        suspended=False,
+        expiry_finalized=False,
+    ), now
+
+
+def test_next_afk_followup_selects_first_unfired_threshold():
+    from gateway.afk_followup import DEFAULT_AFK_THRESHOLDS_MINUTES, next_afk_followup
+
+    entry, now = _entry(minutes_idle=16)
+
+    decision = next_afk_followup(
+        entry,
+        now=now,
+        thresholds_minutes=DEFAULT_AFK_THRESHOLDS_MINUTES,
+        fired_thresholds={5},
+        running_session_keys=set(),
+        queued_session_keys=set(),
+    )
+
+    assert decision is not None
+    assert decision.threshold_minutes == 15
+    assert decision.idle_label == "15m"
+
+
+def test_next_afk_followup_skips_running_or_queued_sessions():
+    from gateway.afk_followup import DEFAULT_AFK_THRESHOLDS_MINUTES, next_afk_followup
+
+    entry, now = _entry(minutes_idle=61)
+
+    assert next_afk_followup(
+        entry,
+        now=now,
+        thresholds_minutes=DEFAULT_AFK_THRESHOLDS_MINUTES,
+        fired_thresholds=set(),
+        running_session_keys={entry.session_key},
+        queued_session_keys=set(),
+    ) is None
+
+    assert next_afk_followup(
+        entry,
+        now=now,
+        thresholds_minutes=DEFAULT_AFK_THRESHOLDS_MINUTES,
+        fired_thresholds=set(),
+        running_session_keys=set(),
+        queued_session_keys={entry.session_key},
+    ) is None
+
+
+def test_build_afk_followup_prompt_is_safety_scoped_and_not_silent():
+    from gateway.afk_followup import build_afk_followup_prompt
+
+    prompt = build_afk_followup_prompt("15m", cycle_index=1)
+
+    assert "[Automated AFK follow-up]" in prompt
+    assert "The user has been AFK for 15m." in prompt
+    assert "top 3 loose ends" in prompt
+    assert "first" in prompt.lower()
+    assert "destructive" in prompt
+    assert "credential" in prompt
+    assert "deployment" in prompt
+    assert "reply" in prompt.lower()
+    assert "Stay silent" not in prompt
+    assert "SILENT" not in prompt
+
+
+@pytest.mark.asyncio
+async def test_afk_followup_tick_injects_internal_virtual_turn_once(monkeypatch):
+    from gateway.afk_followup import AfkFollowupConfig
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    runner._afk_followup_config = AfkFollowupConfig(enabled=True, thresholds_minutes=(5, 15), interval_seconds=1)
+    runner._afk_fired_thresholds = {}
+    runner._running_agents = {}
+    runner._queued_events = {}
+
+    entry, now = _entry(minutes_idle=6)
+    runner.session_store = SimpleNamespace(
+        _ensure_loaded=lambda: None,
+        _entries={entry.session_key: entry},
+    )
+
+    sent_events = []
+
+    class Adapter:
+        def __init__(self):
+            self._pending_messages = {}
+
+        async def handle_message(self, event):
+            sent_events.append(event)
+
+    runner.adapters = {Platform.TELEGRAM: Adapter()}
+    monkeypatch.setattr("gateway.run.datetime", SimpleNamespace(now=lambda tz=None: now))
+
+    await runner._afk_followup_tick()
+    await runner._afk_followup_tick()
+
+    assert len(sent_events) == 1
+    event = sent_events[0]
+    assert event.internal is True
+    assert event.message_type == MessageType.TEXT
+    assert "[Automated AFK follow-up]" in event.text
+    assert "AFK for 5m" in event.text
+    assert event.source.platform == Platform.TELEGRAM
+    assert event.source.chat_id == "123"
+    assert runner._afk_fired_thresholds[entry.session_key] == {5}
+
+
+@pytest.mark.asyncio
+async def test_afk_followup_tick_skips_adapter_pending_message(monkeypatch):
+    from gateway.afk_followup import AfkFollowupConfig
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    runner._afk_followup_config = AfkFollowupConfig(enabled=True, thresholds_minutes=(5,), interval_seconds=1)
+    runner._afk_fired_thresholds = {}
+    runner._running_agents = {}
+    runner._queued_events = {}
+
+    entry, now = _entry(minutes_idle=10)
+    runner.session_store = SimpleNamespace(
+        _ensure_loaded=lambda: None,
+        _entries={entry.session_key: entry},
+    )
+    adapter = SimpleNamespace(
+        _pending_messages={entry.session_key: MessageEvent(text="queued", source=entry.origin)},
+        handle_message=AsyncMock(),
+    )
+    runner.adapters = {Platform.TELEGRAM: adapter}
+    monkeypatch.setattr("gateway.run.datetime", SimpleNamespace(now=lambda tz=None: now))
+
+    await runner._afk_followup_tick()
+
+    adapter.handle_message.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_afk_followup_tick_does_not_inject_when_disabled():
+    from gateway.afk_followup import AfkFollowupConfig
+
+    runner = object.__new__(GatewayRunner)
+    runner._running = True
+    runner._afk_followup_config = AfkFollowupConfig(enabled=False, thresholds_minutes=(5,), interval_seconds=1)
+    runner._afk_fired_thresholds = {}
+    runner._running_agents = {}
+    runner._queued_events = {}
+
+    entry, _now = _entry(minutes_idle=10)
+    runner.session_store = SimpleNamespace(
+        _ensure_loaded=lambda: None,
+        _entries={entry.session_key: entry},
+    )
+    adapter = SimpleNamespace(handle_message=AsyncMock())
+    runner.adapters = {Platform.TELEGRAM: adapter}
+
+    await runner._afk_followup_tick()
+
+    adapter.handle_message.assert_not_called()
+
+
+class _TestAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(
+            PlatformConfig(enabled=True, token="token", extra={}),
+            Platform.TELEGRAM,
+        )
+        self.sent = []
+
+    async def connect(self):
+        return True
+
+    async def disconnect(self):
+        return None
+
+    async def send(self, chat_id, content, **kwargs):
+        self.sent.append((chat_id, content, kwargs))
+        return SendResult(success=True, message_id="sent-1")
+
+    async def get_chat_info(self, chat_id):
+        return {"id": chat_id}
+
+
+@pytest.mark.asyncio
+async def test_internal_afk_response_delivers_even_if_user_message_arrived_mid_run():
+    adapter = _TestAdapter()
+    source = SimpleNamespace(
+        platform=Platform.TELEGRAM,
+        chat_id="123",
+        chat_type="dm",
+        user_id="u1",
+        thread_id=None,
+    )
+    event = MessageEvent(
+        text="[Automated AFK follow-up]",
+        message_type=MessageType.TEXT,
+        source=source,
+        internal=True,
+    )
+    session_key = "agent:main:telegram:dm:123"
+    interrupt = __import__("asyncio").Event()
+    interrupt.set()
+    adapter._active_sessions[session_key] = interrupt
+    adapter._pending_messages[session_key] = MessageEvent(
+        text="user returned",
+        message_type=MessageType.TEXT,
+        source=source,
+    )
+    adapter.set_message_handler(AsyncMock(return_value="AFK task completed: checked logs."))
+
+    await adapter._process_message_background(event, session_key)
+
+    assert adapter.sent[0] == (
+        "123",
+        "AFK task completed: checked logs.",
+        {"reply_to": None, "metadata": {"notify": True}},
+    )
+    assert len(adapter.sent) >= 1


### PR DESCRIPTION
## Summary

- Adds opt-in gateway-native AFK follow-up scheduling via `gateway.afk_followup`.
- Injects AFK prompts as internal virtual `MessageEvent`s at configured idle thresholds.
- Skips sessions that are currently running or have queued/pending user work.
- Fixes internal synthetic response delivery so an AFK summary is not suppressed just because a later user message is pending.

Fixes #23803

## Root cause

`BasePlatformAdapter._process_message_background` suppresses responses when an interrupt event is set and a pending message exists. That is correct for normal stale user-originated responses, but internal synthetic events are different: the internal AFK summary is the response to an already-started virtual turn and should be delivered before the pending user message drains.

Also, AFK follow-up scheduling itself was not wired into upstream `GatewayRunner`, so configs could contain `gateway.afk_followup` while the runtime had no implementation.

## Test plan

```bash
/Users/tylermartin/.hermes/hermes-agent/venv/bin/python -m pytest \
  tests/gateway/test_afk_followup.py \
  tests/gateway/test_pending_drain_race.py \
  tests/gateway/test_session_race_guard.py \
  tests/gateway/test_pending_event_none.py \
  -q
# 33 passed

/Users/tylermartin/.hermes/hermes-agent/venv/bin/python -m py_compile \
  gateway/afk_followup.py \
  gateway/run.py \
  gateway/platforms/base.py
```

## Safety notes

- AFK follow-up is disabled by default.
- The prompt explicitly forbids destructive, credential-changing, deployment, publishing, message-sending, financial, and irreversible actions unless the exact action was already approved.
- Scheduler uses the existing gateway session store and adapter delivery path; it does not create cron jobs or external side effects itself.
