### PR TITLE
fix(telegram): make polling conflict retryable with longer backoff

### DIFF
--- a/gateway/platforms/telegram.py
+++ b/gateway/platforms/telegram.py
@@ -823,8 +823,8 @@ class TelegramAdapter(BasePlatformAdapter):
         # giving up, so the old session has time to expire.
         self._polling_conflict_count += 1
 
-        MAX_CONFLICT_RETRIES = 3
-        RETRY_DELAY = 10  # seconds
+        MAX_CONFLICT_RETRIES = 5
+        RETRY_DELAY = 20  # seconds
 
         if self._polling_conflict_count <= MAX_CONFLICT_RETRIES:
             logger.warning(
@@ -864,7 +864,7 @@ class TelegramAdapter(BasePlatformAdapter):
             % MAX_CONFLICT_RETRIES
         )
         logger.error("[%s] %s Original error: %s", self.name, message, error)
-        self._set_fatal_error("telegram_polling_conflict", message, retryable=False)
+        self._set_fatal_error("telegram_polling_conflict", message, retryable=True)
         try:
             if self._app and self._app.updater:
                 await self._app.updater.stop()

--- a/tests/gateway/test_telegram_conflict.py
+++ b/tests/gateway/test_telegram_conflict.py
@@ -191,16 +191,16 @@ async def test_polling_conflict_becomes_fatal_after_retries(monkeypatch):
 
     # Directly call _handle_polling_conflict to avoid event-loop scheduling
     # complexity.  Each call simulates one 409 from Telegram.
-    for i in range(4):
+    for i in range(6):
         await adapter._handle_polling_conflict(
             conflict("Conflict: terminated by other getUpdates request")
         )
 
-    # After 3 failed retries (count 1-3 each enter the retry branch but
-    # start_polling raises), the 4th conflict pushes count to 4 which
-    # exceeds MAX_CONFLICT_RETRIES (3), entering the fatal branch.
+    # After 5 failed retries (count 1-5 each enter the retry branch but
+    # start_polling raises), the 6th conflict pushes count to 6 which
+    # exceeds MAX_CONFLICT_RETRIES (5), entering the fatal branch.
     assert adapter.fatal_error_code == "telegram_polling_conflict", (
-        f"Expected fatal after 4 conflicts, got code={adapter.fatal_error_code}, "
+        f"Expected fatal after 6 conflicts, got code={adapter.fatal_error_code}, "
         f"count={adapter._polling_conflict_count}"
     )
     assert adapter.has_fatal_error is True


### PR DESCRIPTION
Issue: Telegram getUpdates session survives the old gateway process on
the server side for an unknown grace period. During that window every
new getUpdates call gets 409 Conflict. The old code retried 3×10s and
then gave up permanently (retryable=False), requiring manual restart.

Fix: extend retries to 5×20s and mark the error retryable so the
background reconnection loop keeps trying if needed.

Closes #23783