### PR TITLE
fix: use Mattermost thread root as reply anchor in gateway paths

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -83,6 +83,8 @@ def _reply_anchor_for_event(event) -> str | None:
         return None
     if platform == "feishu" and thread_id and getattr(event, "reply_to_message_id", None):
         return getattr(event, "reply_to_message_id", None)
+    if platform == "mattermost" and thread_id:
+        return thread_id
     return getattr(event, "message_id", None)
 
 

--- a/tests/gateway/test_base_platform_reply_anchor.py
+++ b/tests/gateway/test_base_platform_reply_anchor.py
@@ -1,0 +1,62 @@
+from gateway.config import Platform, PlatformConfig
+from gateway.platforms.base import BasePlatformAdapter, MessageEvent, SendResult, _reply_anchor_for_event
+from gateway.session import SessionSource
+
+
+class _StubAdapter(BasePlatformAdapter):
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        self._mark_disconnected()
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None):
+        return SendResult(success=True, message_id="m1")
+
+    async def get_chat_info(self, chat_id: str):
+        return {}
+
+
+def _make_event(*, platform: Platform, message_id: str, thread_id: str | None = None, reply_to_message_id: str | None = None) -> MessageEvent:
+    return MessageEvent(
+        text="hello",
+        source=SessionSource(
+            platform=platform,
+            chat_id="chat-1",
+            user_id="user-1",
+            thread_id=thread_id,
+        ),
+        message_id=message_id,
+        reply_to_message_id=reply_to_message_id,
+    )
+
+
+def test_reply_anchor_uses_mattermost_thread_root():
+    event = _make_event(
+        platform=Platform.MATTERMOST,
+        message_id="post-123",
+        thread_id="root-456",
+    )
+
+    assert _reply_anchor_for_event(event) == "root-456"
+
+
+def test_reply_anchor_preserves_feishu_reply_to_message_id():
+    event = _make_event(
+        platform=Platform.FEISHU,
+        message_id="msg-123",
+        thread_id="thread-456",
+        reply_to_message_id="reply-789",
+    )
+
+    assert _reply_anchor_for_event(event) == "reply-789"
+
+
+def test_reply_anchor_falls_back_to_message_id_for_other_platforms():
+    event = _make_event(
+        platform=Platform.TELEGRAM,
+        message_id="msg-123",
+        thread_id="topic-456",
+    )
+
+    assert _reply_anchor_for_event(event) == "msg-123"


### PR DESCRIPTION
## What does this PR do?

This fixes a Mattermost thread-reply bug in the gateway.

Some gateway reply paths were still anchoring replies on the triggering `event.message_id`. For Mattermost thread replies, the adapter needs the thread root (`event.source.thread_id` / Mattermost `root_id`) so the response stays in the active thread instead of falling back to the top-level DM/channel.

This change updates the shared reply-anchor helper so Mattermost uses the thread root when a threaded inbound event is present, while preserving the existing Feishu behavior.

## Related Issue

Fixes #

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [ ] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- updated `gateway/platforms/base.py` so reply-anchor selection uses the Mattermost thread root for threaded Mattermost events
- kept existing Feishu reply behavior unchanged
- added `tests/gateway/test_base_platform_reply_anchor.py` to cover Mattermost, Feishu, and fallback behavior

## How to Test

1. Run:
   `python -m pytest tests/gateway/test_base_platform_reply_anchor.py -q -o 'addopts='`
2. Verify the tests pass
3. In a Mattermost DM/thread setup, send a threaded message and confirm Hermes replies stay in the same thread instead of posting top-level

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: Ubuntu 24.04

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- Local verification: `python -m pytest tests/gateway/test_base_platform_reply_anchor.py -q -o 'addopts='` -> `3 passed`