### PR TITLE
fix(tui): show live context pressure in HUD

### DIFF
--- a/agent/context_compressor.py
+++ b/agent/context_compressor.py
@@ -462,6 +462,7 @@ class ContextCompressor(ContextEngine):
         self._context_probed = False  # True after a step-down from context error
 
         self.last_prompt_tokens = 0
+        self.display_prompt_tokens = 0
         self.last_completion_tokens = 0
 
         self.summary_model = summary_model_override or ""
@@ -488,6 +489,7 @@ class ContextCompressor(ContextEngine):
     def update_from_response(self, usage: Dict[str, Any]):
         """Update tracked token usage from API response."""
         self.last_prompt_tokens = usage.get("prompt_tokens", 0)
+        self.display_prompt_tokens = self.last_prompt_tokens
         self.last_completion_tokens = usage.get("completion_tokens", 0)
 
     def should_compress(self, prompt_tokens: int = None) -> bool:

--- a/agent/context_engine.py
+++ b/agent/context_engine.py
@@ -44,6 +44,7 @@ class ContextEngine(ABC):
     # Engines MUST maintain these. run_agent.py reads them directly.
 
     last_prompt_tokens: int = 0
+    display_prompt_tokens: int = 0
     last_completion_tokens: int = 0
     last_total_tokens: int = 0
     threshold_tokens: int = 0
@@ -142,6 +143,7 @@ class ContextEngine(ABC):
         Default resets compression_count and token tracking.
         """
         self.last_prompt_tokens = 0
+        self.display_prompt_tokens = 0
         self.last_completion_tokens = 0
         self.last_total_tokens = 0
         self.compression_count = 0
@@ -177,10 +179,16 @@ class ContextEngine(ABC):
         """
         return {
             "last_prompt_tokens": self.last_prompt_tokens,
+            "display_prompt_tokens": self.display_prompt_tokens,
             "threshold_tokens": self.threshold_tokens,
             "context_length": self.context_length,
             "usage_percent": (
-                min(100, self.last_prompt_tokens / self.context_length * 100)
+                min(
+                    100,
+                    (self.display_prompt_tokens or self.last_prompt_tokens)
+                    / self.context_length
+                    * 100,
+                )
                 if self.context_length else 0
             ),
             "compression_count": self.compression_count,

--- a/run_agent.py
+++ b/run_agent.py
@@ -11725,6 +11725,7 @@ class AIAgent:
                 system_prompt=active_system_prompt or "",
                 tools=self.tools or None,
             )
+            self.context_compressor.display_prompt_tokens = _preflight_tokens
 
             if _preflight_tokens >= self.context_compressor.threshold_tokens:
                 logger.info(
@@ -11771,6 +11772,7 @@ class AIAgent:
                         system_prompt=active_system_prompt or "",
                         tools=self.tools or None,
                     )
+                    self.context_compressor.display_prompt_tokens = _preflight_tokens
                     if _preflight_tokens < self.context_compressor.threshold_tokens:
                         break  # Under threshold
 
@@ -12142,6 +12144,7 @@ class AIAgent:
             # Calculate approximate request size for logging
             total_chars = sum(len(str(msg)) for msg in api_messages)
             approx_tokens = estimate_messages_tokens_rough(api_messages)
+            self.context_compressor.display_prompt_tokens = approx_tokens
             
             # Thinking spinner for quiet mode (animated during API call)
             thinking_spinner = None

--- a/tests/agent/test_context_compressor.py
+++ b/tests/agent/test_context_compressor.py
@@ -47,11 +47,13 @@ class TestUpdateFromResponse:
             "total_tokens": 6000,
         })
         assert compressor.last_prompt_tokens == 5000
+        assert compressor.display_prompt_tokens == 5000
         assert compressor.last_completion_tokens == 1000
 
     def test_missing_fields_default_zero(self, compressor):
         compressor.update_from_response({})
         assert compressor.last_prompt_tokens == 0
+        assert compressor.display_prompt_tokens == 0
 
 
 

--- a/tests/agent/test_context_engine.py
+++ b/tests/agent/test_context_engine.py
@@ -112,12 +112,22 @@ class TestDefaults:
         assert status["threshold_tokens"] == 100000
         assert 0 < status["usage_percent"] <= 100
 
+    def test_default_get_status_prefers_display_prompt_tokens(self):
+        engine = StubEngine()
+        engine.last_prompt_tokens = 109000
+        engine.display_prompt_tokens = 165349
+        status = engine.get_status()
+        assert status["display_prompt_tokens"] == 165349
+        assert status["usage_percent"] == pytest.approx(82.6745)
+
     def test_on_session_reset(self):
         engine = StubEngine()
         engine.last_prompt_tokens = 999
+        engine.display_prompt_tokens = 1234
         engine.compression_count = 3
         engine.on_session_reset()
         assert engine.last_prompt_tokens == 0
+        assert engine.display_prompt_tokens == 0
         assert engine.compression_count == 0
 
     def test_should_compress_preflight_default_false(self):

--- a/tests/test_tui_gateway_server.py
+++ b/tests/test_tui_gateway_server.py
@@ -59,6 +59,34 @@ def test_write_json_returns_false_on_broken_pipe(monkeypatch):
     assert server.write_json({"ok": True}) is False
 
 
+def test_get_usage_prefers_live_display_prompt_tokens():
+    agent = types.SimpleNamespace(
+        model="minimax/MiniMax-M2.7",
+        session_input_tokens=0,
+        session_output_tokens=0,
+        session_cache_read_tokens=0,
+        session_cache_write_tokens=0,
+        session_reasoning_tokens=0,
+        session_prompt_tokens=109_000,
+        session_completion_tokens=0,
+        session_total_tokens=109_000,
+        session_api_calls=7,
+        provider="minimax",
+        base_url="",
+        context_compressor=types.SimpleNamespace(
+            display_prompt_tokens=165_349,
+            last_prompt_tokens=109_000,
+            context_length=204_800,
+            compression_count=1,
+        ),
+    )
+
+    usage = server._get_usage(agent)
+
+    assert usage["context_used"] == 165_349
+    assert usage["context_percent"] == 81
+
+
 def test_dispatch_rejects_non_object_request():
     resp = server.dispatch([])
 

--- a/tui_gateway/server.py
+++ b/tui_gateway/server.py
@@ -1288,7 +1288,12 @@ def _get_usage(agent) -> dict:
     }
     comp = getattr(agent, "context_compressor", None)
     if comp:
-        ctx_used = getattr(comp, "last_prompt_tokens", 0) or usage["total"] or 0
+        ctx_used = (
+            getattr(comp, "display_prompt_tokens", 0)
+            or getattr(comp, "last_prompt_tokens", 0)
+            or usage["total"]
+            or 0
+        )
         ctx_max = getattr(comp, "context_length", 0) or 0
         if ctx_max:
             usage["context_used"] = ctx_used


### PR DESCRIPTION
## Summary
- make HUD usage prefer a live prompt-token estimate instead of stale last-response usage
- carry display_prompt_tokens through context engine/compressor updates and live request sizing
- add focused regressions for status reporting and TUI usage fallback

Fixes #23798

## Verification
- uv run --frozen pytest -q -o addopts="" tests/agent/test_context_engine.py tests/agent/test_context_compressor.py tests/test_tui_gateway_server.py::test_get_usage_prefers_live_display_prompt_tokens
- uv run --frozen ruff check agent/context_engine.py agent/context_compressor.py run_agent.py tui_gateway/server.py tests/test_tui_gateway_server.py tests/agent/test_context_engine.py tests/agent/test_context_compressor.py
- git diff --check