### PR TITLE
fix: include entry-point plugins in CLI list/enable/disable commands

### DIFF
--- a/hermes_cli/plugins_cmd.py
+++ b/hermes_cli/plugins_cmd.py
@@ -704,6 +704,22 @@ def _plugin_exists(name: str) -> bool:
             or (candidate / "plugin.yml").exists()
         ):
             return True
+    # Entry-point / pip plugins
+    try:
+        import importlib.metadata
+        from hermes_cli.plugins import ENTRY_POINTS_GROUP
+        eps = importlib.metadata.entry_points()
+        if hasattr(eps, "select"):
+            group_eps = eps.select(group=ENTRY_POINTS_GROUP)
+        elif isinstance(eps, dict):
+            group_eps = eps.get(ENTRY_POINTS_GROUP, [])
+        else:
+            group_eps = [ep for ep in eps if ep.group == ENTRY_POINTS_GROUP]
+        for ep in group_eps:
+            if ep.name == name:
+                return True
+    except Exception:
+        pass
     return False
 
 
@@ -757,6 +773,24 @@ def _discover_all_plugins() -> list:
             if source == "user" and (d / ".git").exists():
                 src_label = "git"
             seen[name] = (name, version, description, src_label, d)
+
+    # 3. Pip / entry-point plugins
+    try:
+        import importlib.metadata
+        from hermes_cli.plugins import ENTRY_POINTS_GROUP
+        eps = importlib.metadata.entry_points()
+        if hasattr(eps, "select"):
+            group_eps = eps.select(group=ENTRY_POINTS_GROUP)
+        elif isinstance(eps, dict):
+            group_eps = eps.get(ENTRY_POINTS_GROUP, [])
+        else:
+            group_eps = [ep for ep in eps if ep.group == ENTRY_POINTS_GROUP]
+        for ep in group_eps:
+            if ep.name not in seen:
+                seen[ep.name] = (ep.name, "", "", "entrypoint", ep.value)
+    except Exception:
+        pass
+
     return list(seen.values())
 
 


### PR DESCRIPTION
## Problem

`hermes plugins list` and `hermes plugins enable/disable` do not show pip-installed entry-point plugins, even though `PluginManager.discover_and_load()` discovers and loads them correctly at runtime.

Operators who install a Hermes plugin via `pip install <package>` see the plugin's adapters, hooks, and CLI commands work, but the management surfaces behave as if the plugin doesn't exist:
- `hermes plugins list` omits it
- `hermes plugins enable <name>` returns "Plugin '<name>' is not installed or bundled"

## Root Cause

`_discover_all_plugins()` and `_plugin_exists()` in `hermes_cli/plugins_cmd.py` only scan two filesystem directories (bundled + user), while `PluginManager.discover_and_load()` in `plugins.py` has a 4th discovery source: `importlib.metadata.entry_points(group="hermes_agent.plugins")`.

## Fix

Add entry-point scanning to both functions using the same `importlib.metadata` pattern as `PluginManager._scan_entry_points()`:

1. `_plugin_exists()`: check entry-point names before returning False
2. `_discover_all_plugins()`: add entry-point plugins as source="entrypoint" after filesystem scan

## Before vs After

| Command | Before | After |
|---------|--------|-------|
| `hermes plugins list` | Only bundled + user dir plugins | Also shows pip-installed entry-point plugins |
| `hermes plugins enable <ep-plugin>` | "not installed or bundled" | Works correctly |
| `hermes plugins disable <ep-plugin>` | "not installed or bundled" | Works correctly |

## Tests

- Verified syntax with `ast.parse()`
- Entry-point discovery logic matches `PluginManager._scan_entry_points()` exactly
- Wrapped in try/except to match existing defensive pattern (graceful degradation if importlib.metadata unavailable)

Fixes #23802