### PR TITLE
fix: suppress guarded process registry Windows footgun

### DIFF
--- a/tools/process_registry.py
+++ b/tools/process_registry.py
@@ -585,7 +585,10 @@ class ProcessRegistry:
             try:
                 if not _IS_WINDOWS:
                     try:
-                        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+                        os.killpg(  # windows-footgun: ok — guarded by not _IS_WINDOWS
+                            os.getpgid(proc.pid),
+                            getattr(signal, "SIGKILL", signal.SIGTERM),
+                        )
                     except (ProcessLookupError, PermissionError, OSError):
                         proc.kill()
                 else:


### PR DESCRIPTION
## Summary
- Fixes the failing Lint (ruff + ty) / Windows footguns blocking job on main.
- Keeps the POSIX process-group kill guarded behind not _IS_WINDOWS.
- Replaces bare signal.SIGKILL with getattr fallback and adds the checker-approved inline suppression for os.killpg.

## Evidence
- Failing upstream run: https://github.com/NousResearch/hermes-agent/actions/runs/25675213695
- Local: python scripts/check-windows-footguns.py --all -> PASS
- Local: python -m py_compile tools/process_registry.py -> PASS

## Notes
- No production runtime change.
- Targeted process_registry pytest currently has unrelated environment/dependency failures in this worktree: psutil missing and live-system guard blocking subprocess cleanup/PID probes.