### PR TITLE
fix: replace deprecated datetime.utcnow() in BlueBubbles adapter

### DIFF
--- a/gateway/platforms/bluebubbles.py
+++ b/gateway/platforms/bluebubbles.py
@@ -14,7 +14,7 @@ import logging
 import os
 import re
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional
 from urllib.parse import quote
 
@@ -380,7 +380,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
         payload = {
             "addresses": [address],
             "message": message,
-            "tempGuid": f"temp-{datetime.utcnow().timestamp()}",
+            "tempGuid": f"temp-{datetime.now(timezone.utc).timestamp()}",
         }
         try:
             res = await self._api_post("/api/v1/chat/new", payload)
@@ -436,7 +436,7 @@ class BlueBubblesAdapter(BasePlatformAdapter):
                 )
             payload: Dict[str, Any] = {
                 "chatGuid": guid,
-                "tempGuid": f"temp-{datetime.utcnow().timestamp()}",
+                "tempGuid": f"temp-{datetime.now(timezone.utc).timestamp()}",
                 "message": chunk,
             }
             if reply_to and self._private_api_enabled and self._helper_connected:


### PR DESCRIPTION
## Problem

`datetime.utcnow()` is deprecated since Python 3.12 and emits `DeprecationWarning`. The BlueBubbles adapter uses it in two places for generating temporary message GUIDs.

## Fix

Replace `datetime.utcnow().timestamp()` with `datetime.now(timezone.utc).timestamp()`:

| Location | Before | After |
|----------|--------|-------|
| `bluebubbles.py:383` | `datetime.utcnow().timestamp()` | `datetime.now(timezone.utc).timestamp()` |
| `bluebubbles.py:439` | `datetime.utcnow().timestamp()` | `datetime.now(timezone.utc).timestamp()` |

Add `timezone` to the existing `from datetime import datetime` import.

## Impact

- Zero functional change — `.timestamp()` works identically on both naive and aware datetimes
- Eliminates deprecation warning on Python 3.12+
- The GUID format `temp-{float}` is preserved