### PR TITLE
Fix/gateway redact outbound chat

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2401,6 +2401,32 @@ class BasePlatformAdapter(ABC):
             return response.text, int(ttl or 0)
         return response, 0
 
+    def _redact_outbound(self, content: Optional[str]) -> Optional[str]:
+        """Scrub secrets from an outbound message body before delivery.
+
+        The startup banner promises that "chat responses are scrubbed before
+        delivery" when ``HERMES_REDACT_SECRETS`` is on (#23810).  Logs were
+        already covered via :class:`agent.redact.RedactingFormatter`, but
+        actual outbound message bytes were not — an LLM that echoed a token
+        in its reply would deliver it verbatim to Telegram/Discord/Slack.
+
+        Centralising the call here means every send/edit retry, fallback,
+        and delivery notice in :meth:`_send_with_retry` inherits the same
+        protection.  Honours the global toggle (``HERMES_REDACT_SECRETS`` /
+        ``security.redact_secrets``); a no-op when redaction is disabled or
+        when ``content`` is empty / non-textual.
+        """
+        if not content or not isinstance(content, str):
+            return content
+        try:
+            from agent.redact import redact_sensitive_text
+        except Exception:
+            return content
+        try:
+            return redact_sensitive_text(content)
+        except Exception:
+            return content
+
     async def _send_with_retry(
         self,
         chat_id: str,

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -3274,13 +3274,18 @@ class BasePlatformAdapter(ABC):
                 error_type = type(e).__name__
                 error_detail = str(e)[:300] if str(e) else "no details available"
                 _thread_metadata = _thread_metadata_for_source(event.source, _reply_anchor_for_event(event))
+                # str(e) can carry a secret-shaped substring (e.g. an
+                # auth error from a misconfigured provider) — scrub
+                # before delivery so the radio-silence notice never
+                # becomes the leak channel (#23810).
+                error_body = self._redact_outbound(
+                    f"Sorry, I encountered an error ({error_type}).\n"
+                    f"{error_detail}\n"
+                    "Try again or use /reset to start a fresh session."
+                ) or ""
                 await self.send(
                     chat_id=event.source.chat_id,
-                    content=(
-                        f"Sorry, I encountered an error ({error_type}).\n"
-                        f"{error_detail}\n"
-                        "Try again or use /reset to start a fresh session."
-                    ),
+                    content=error_body,
                     metadata=_thread_metadata,
                 )
             except Exception:

--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -2445,6 +2445,10 @@ class BasePlatformAdapter(ABC):
         know to retry rather than waiting indefinitely.
         """
 
+        # Scrub secrets ONCE up front so every retry, fallback, and notice
+        # below inherits the redacted payload — no second pass needed (#23810).
+        content = self._redact_outbound(content) or ""
+
         result = await self.send(
             chat_id=chat_id,
             content=content,

--- a/tests/gateway/test_outbound_redaction.py
+++ b/tests/gateway/test_outbound_redaction.py
@@ -1,0 +1,297 @@
+"""Regression tests for #23810: outbound chat messages must be scrubbed
+before delivery when ``HERMES_REDACT_SECRETS`` is on.
+
+The gateway startup banner advertises "Secret redaction: ENABLED (tool
+output, logs, and chat responses are scrubbed before delivery)", but
+prior to the fix the outbound path in :class:`BasePlatformAdapter` had
+no call to :func:`agent.redact.redact_sensitive_text`.  Only log records
+(via ``RedactingFormatter``) and tool output (in ``gateway/run.py``)
+were covered — the actual message bytes delivered to
+Telegram/Discord/Slack were not.
+
+These tests pin the contract that:
+
+* :meth:`BasePlatformAdapter._send_with_retry` runs every outbound
+  payload through :meth:`_redact_outbound` before calling
+  :meth:`send`, so all retries and fallbacks inherit the scrubbed text.
+* :meth:`_redact_outbound` honours the global toggle
+  (``HERMES_REDACT_SECRETS`` / ``security.redact_secrets``) and is
+  defensive against import / runtime errors so a redaction bug can
+  never break delivery.
+"""
+
+import pytest
+from unittest.mock import AsyncMock, patch
+
+from gateway.platforms.base import BasePlatformAdapter, SendResult
+from gateway.platforms.base import Platform, PlatformConfig
+
+
+# ---------------------------------------------------------------------------
+# Test fixture: minimal concrete adapter that records every send() call.
+# Mirrors the pattern used by tests/gateway/test_send_retry.py so the two
+# files exercise the same surface without duplicating wiring.
+# ---------------------------------------------------------------------------
+
+
+class _RecordingAdapter(BasePlatformAdapter):
+    def __init__(self):
+        super().__init__(PlatformConfig(), Platform.TELEGRAM)
+        self._send_results: list[SendResult] = []
+        self._send_calls: list[tuple[str, str]] = []
+
+    def _next_result(self) -> SendResult:
+        if self._send_results:
+            return self._send_results.pop(0)
+        return SendResult(success=True, message_id="ok")
+
+    async def send(self, chat_id, content, reply_to=None, metadata=None, **kwargs) -> SendResult:
+        self._send_calls.append((chat_id, content))
+        return self._next_result()
+
+    async def connect(self) -> bool:
+        return True
+
+    async def disconnect(self) -> None:
+        pass
+
+    async def send_typing(self, chat_id, metadata=None) -> None:
+        pass
+
+    async def get_chat_info(self, chat_id):
+        return {"name": "test", "type": "direct", "chat_id": chat_id}
+
+
+@pytest.fixture(autouse=True)
+def _ensure_redaction_enabled(monkeypatch):
+    """Force redaction ON for every test (and make it independent of any
+    HERMES_REDACT_SECRETS that prior tests / CI may have set).
+
+    Mirrors tests/agent/test_redact.py — clears the env var AND patches
+    the module-level snapshot so import-time evaluation doesn't bleed
+    through.
+    """
+    monkeypatch.delenv("HERMES_REDACT_SECRETS", raising=False)
+    monkeypatch.setattr("agent.redact._REDACT_ENABLED", True)
+
+
+# ---------------------------------------------------------------------------
+# _redact_outbound — unit-level contract of the helper.
+# ---------------------------------------------------------------------------
+
+
+class TestRedactOutboundHelper:
+    """The helper used by every outbound path must be safe to call on any input."""
+
+    def test_none_passes_through(self):
+        adapter = _RecordingAdapter()
+        assert adapter._redact_outbound(None) is None
+
+    def test_empty_passes_through(self):
+        adapter = _RecordingAdapter()
+        assert adapter._redact_outbound("") == ""
+
+    def test_non_string_passes_through(self):
+        # _send_with_retry only feeds strings, but defensive: a bogus int
+        # must not raise — silent passthrough keeps delivery working
+        # even if a caller upstream regresses.
+        adapter = _RecordingAdapter()
+        assert adapter._redact_outbound(12345) == 12345  # type: ignore[arg-type]
+
+    def test_clean_text_unchanged(self):
+        adapter = _RecordingAdapter()
+        assert adapter._redact_outbound("hello world") == "hello world"
+
+    def test_sk_token_is_masked(self):
+        adapter = _RecordingAdapter()
+        result = adapter._redact_outbound("api: sk-proj-abc123def456ghi789jkl012")
+        assert "abc123def456" not in result
+        assert "sk-pro" in result  # masking keeps the prefix for diagnostics
+
+    def test_telegram_bot_token_is_masked(self):
+        adapter = _RecordingAdapter()
+        result = adapter._redact_outbound(
+            "Your token is bot1234567890:AAH-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        )
+        assert "AAH-xxxxxxxx" not in result
+        assert ":***" in result
+
+    def test_github_pat_is_masked(self):
+        adapter = _RecordingAdapter()
+        result = adapter._redact_outbound("see ghp_abc123def456ghi789jkl in audit log")
+        assert "abc123def456" not in result
+
+    def test_import_failure_returns_input(self):
+        """If agent.redact ever fails to import (broken venv, partial
+        install, etc.) the gateway must still deliver — silent
+        passthrough is the correct fallback for a security helper that
+        is OPT-IN ON by default, never load-bearing for delivery."""
+        adapter = _RecordingAdapter()
+        secret_text = "key sk-proj-abc123def456"
+        with patch.dict("sys.modules", {"agent.redact": None}):
+            # ImportError surfaces; helper must catch and passthrough.
+            assert adapter._redact_outbound(secret_text) == secret_text
+
+    def test_redaction_disabled_via_env(self, monkeypatch):
+        """When the operator opts out via security.redact_secrets: false
+        (bridged to HERMES_REDACT_SECRETS=false), outbound delivery
+        passes through unchanged.  Honours the same toggle as logs and
+        tool output so the security posture is consistent end-to-end."""
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+        adapter = _RecordingAdapter()
+        text = "OPENAI_API_KEY=sk-proj-abc123def456ghi789jkl012"
+        assert adapter._redact_outbound(text) == text
+
+
+# ---------------------------------------------------------------------------
+# _send_with_retry — end-to-end: secrets must be scrubbed before send().
+# This is the actual bug from #23810: bot replied with token bodies verbatim.
+# ---------------------------------------------------------------------------
+
+
+class TestSendWithRetryRedactsBeforeDelivery:
+    @pytest.mark.asyncio
+    async def test_sk_token_scrubbed_on_first_send(self):
+        """The bug repro from the issue body — an LLM-echoed sk- key
+        must not reach :meth:`send` verbatim."""
+        adapter = _RecordingAdapter()
+        leaky = (
+            "Here is the key you asked about: sk-proj-abc123def456ghi789jkl012"
+        )
+
+        await adapter._send_with_retry(chat_id="123", content=leaky)
+
+        assert len(adapter._send_calls) == 1
+        _, delivered = adapter._send_calls[0]
+        assert "abc123def456" not in delivered
+        assert "sk-pro" in delivered  # masked but identifiable
+
+    @pytest.mark.asyncio
+    async def test_telegram_bot_token_scrubbed(self):
+        adapter = _RecordingAdapter()
+        leaky = "bot1234567890:AAH-xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx ready"
+
+        await adapter._send_with_retry(chat_id="123", content=leaky)
+
+        _, delivered = adapter._send_calls[0]
+        assert "AAH-xxxxxxxx" not in delivered
+
+    @pytest.mark.asyncio
+    async def test_clean_text_unchanged_through_retry(self):
+        """No false positives: a normal agent reply round-trips byte-
+        for-byte."""
+        adapter = _RecordingAdapter()
+        clean = "All good — your file has been saved to /tmp/report.md."
+
+        await adapter._send_with_retry(chat_id="123", content=clean)
+
+        _, delivered = adapter._send_calls[0]
+        assert delivered == clean
+
+    @pytest.mark.asyncio
+    async def test_redaction_happens_once_not_per_retry(self):
+        """Retries must reuse the already-scrubbed payload — re-running
+        the redactor per attempt would be redundant work and, more
+        importantly, would mask the contract that scrubbing is a
+        single canonical step at the top of the delivery pipeline.
+
+        Verified by counting calls to ``redact_sensitive_text`` via
+        the helper: one network failure + retry = one redaction."""
+        adapter = _RecordingAdapter()
+        # First attempt: retryable network failure.
+        # Second attempt: success.
+        adapter._send_results = [
+            SendResult(success=False, error="httpx.ConnectError: dropped", retryable=True),
+            SendResult(success=True, message_id="ok"),
+        ]
+
+        with patch.object(
+            adapter, "_redact_outbound", wraps=adapter._redact_outbound
+        ) as wrapped:
+            # Tight backoff so the test runs fast — the retry path
+            # would otherwise sleep 2s+jitter between attempts.
+            await adapter._send_with_retry(
+                chat_id="123",
+                content="sk-proj-abc123def456ghi789jkl012",
+                base_delay=0.001,
+            )
+
+        assert wrapped.call_count == 1, (
+            "Redaction must run exactly once at the top of _send_with_retry, "
+            "not per attempt"
+        )
+        # Both attempts saw the SAME (already-redacted) content.
+        assert len(adapter._send_calls) == 2
+        first = adapter._send_calls[0][1]
+        second = adapter._send_calls[1][1]
+        assert first == second
+        assert "abc123def456" not in first
+
+    @pytest.mark.asyncio
+    async def test_plain_text_fallback_uses_redacted_content(self):
+        """When the first send fails with a non-retryable formatting
+        error, ``_send_with_retry`` re-sends a plain-text fallback
+        prefixed with a "(Response formatting failed, plain text:)"
+        notice.  That fallback wraps the SAME ``content`` variable that
+        the top-of-function redaction already scrubbed, so the secret
+        must not reappear in the fallback body."""
+        adapter = _RecordingAdapter()
+        adapter._send_results = [
+            SendResult(success=False, error="Bad Request: can't parse entities", retryable=False),
+            SendResult(success=True, message_id="ok"),
+        ]
+        leaky = "Markdown failed sk-proj-abc123def456ghi789jkl012 here."
+
+        result = await adapter._send_with_retry(chat_id="123", content=leaky)
+
+        assert result.success
+        assert len(adapter._send_calls) == 2
+        first = adapter._send_calls[0][1]
+        fallback = adapter._send_calls[1][1]
+        assert "abc123def456" not in first
+        assert "abc123def456" not in fallback
+        assert "plain text" in fallback.lower()
+
+    @pytest.mark.asyncio
+    async def test_disabled_redaction_lets_secrets_through(self, monkeypatch):
+        """Defence in depth shouldn't gate user intent: an operator
+        who explicitly opts out via ``security.redact_secrets: false``
+        (e.g. an internal Slack DM that ships raw provider responses
+        for debugging) must still see verbatim text downstream.
+
+        This is the same end-to-end contract that ``tool output`` and
+        ``logs`` already honour — the three surfaces share one toggle."""
+        monkeypatch.setattr("agent.redact._REDACT_ENABLED", False)
+        adapter = _RecordingAdapter()
+        leaky = "sk-proj-abc123def456ghi789jkl012"
+
+        await adapter._send_with_retry(chat_id="123", content=leaky)
+
+        _, delivered = adapter._send_calls[0]
+        assert delivered == leaky
+
+    @pytest.mark.asyncio
+    async def test_delivery_failure_notice_does_not_leak_original(self):
+        """When all retries are exhausted the adapter sends a separate
+        "delivery failed" notice via :meth:`send`.  That notice is
+        composed by the adapter itself and must not include any
+        scrubbed-but-still-reflected echo of the leaky body — verified
+        by checking that the notice text contains the canonical
+        delivery-failure string and no token fragment."""
+        adapter = _RecordingAdapter()
+        # First attempt + max_retries=2 retries: all retryable network failures.
+        retryable = SendResult(success=False, error="ConnectError: nope", retryable=True)
+        adapter._send_results = [retryable, retryable, retryable, SendResult(success=True, message_id="notice")]
+        leaky = "key sk-proj-abc123def456ghi789jkl012"
+
+        result = await adapter._send_with_retry(
+            chat_id="123", content=leaky, base_delay=0.001
+        )
+
+        # Final result is the LAST failed retry, not the notice.
+        assert not result.success
+        # The notice is the final send call.
+        assert len(adapter._send_calls) == 4
+        notice = adapter._send_calls[-1][1]
+        assert "delivery failed" in notice.lower()
+        assert "abc123def456" not in notice


### PR DESCRIPTION
## What does this PR do?

The gateway startup banner advertises:

```
Secret redaction: ENABLED (tool output, logs, and chat responses are scrubbed before delivery)
```

…but as #23810 shows, the **chat responses** half of that promise was unenforced. Logs were covered via `agent.redact.RedactingFormatter`, and tool output was scrubbed in `gateway/run.py:6508`, but the actual outbound message bytes delivered to Telegram/Discord/Slack/etc. went through `BasePlatformAdapter._send_with_retry` without any redaction call.

Result: an LLM that echoed (or hallucinated) an `sk-…` / `ghp_…` / Telegram-bot-token / JWT-shaped string in its reply leaked the secret verbatim to the user, even when `security.redact_secrets: true`.

This PR closes the gap by:

1. Adding a single helper, `BasePlatformAdapter._redact_outbound(content)`, that wraps `agent.redact.redact_sensitive_text` with defensive fallbacks (None / empty / non-string inputs, import failures).
2. Calling it **once** at the top of `_send_with_retry` so every retry, plain-text fallback, and delivery-failure notice in the same function inherits the scrubbed payload — no second pass needed.
3. Calling it on the error-handler `self.send(...)` in `_process_message_background`, where `str(e)[:300]` can otherwise carry a token-shaped substring from a misconfigured provider into the radio-silence notice.

The helper honours the same toggle the rest of the codebase already uses — `HERMES_REDACT_SECRETS` env / `security.redact_secrets` config (bridged via `hermes_cli/main.py`) — so logs, tool output, and chat responses now share one consistent on/off switch. Opt-in ON by default, with the existing opt-out path for operators who want raw output on internal debug DMs.

## Related Issue

Fixes #23810.

Sibling to #17691 (which made `HERMES_REDACT_SECRETS` default-ON); that issue addressed the *toggle*, this one addresses the *call-site coverage* on the outbound path.

## Type of Change

- [x] 🔒 Security fix
- [x] ✅ Tests (adding or improving test coverage)

## Changes Made

- `gateway/platforms/base.py` — add `_redact_outbound()` helper on `BasePlatformAdapter`; call it once at the top of `_send_with_retry()` so retries / fallbacks / notices all inherit the scrubbed payload; also wrap the error-handler `send()` in `_process_message_background`. (+40 / −5)
- `tests/gateway/test_outbound_redaction.py` — new regression suite: 16 cases covering the helper's defensive contract, the `_send_with_retry` end-to-end behaviour for known token shapes (`sk-…`, `ghp_…`, Telegram bot tokens), single-pass redaction across retries, plain-text fallback, the opt-out toggle, and the delivery-failure notice path. (+297, hermetic — no real network, reuses the `_StubAdapter` pattern from `tests/gateway/test_send_retry.py`)

Total diff: **+337 / −5**.

## How to Test

1. Check out the branch and ensure `.venv` is set up:
   `python3 -m venv .venv && source .venv/bin/activate && pip install -e ".[all,dev]"`
2. Run the new regression suite on its own:
   ```
   scripts/run_tests.sh tests/gateway/test_outbound_redaction.py -v
   ```
   Expected: **16 passed**.
3. Run the redaction-adjacent suites to confirm no cross-file regressions:
   ```
   scripts/run_tests.sh tests/gateway/test_outbound_redaction.py \
     tests/gateway/test_send_retry.py \
     tests/agent/test_redact.py \
     tests/hermes_cli/test_redact_config_bridge.py \
     tests/gateway/test_pii_redaction.py
   ```
   Expected: **146 passed**.
4. To verify the bug repro from the issue body, you can temporarily revert just `gateway/platforms/base.py` and rerun step 2 — **13 of the 16 cases fail on bare main** (the 3 that pass are negative cases that don't depend on the fix: clean-text passthrough, the opt-out toggle, and the hardcoded delivery-failure notice text).

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(gateway): …` and `test(gateway): …`, two focused commits — fix + regression coverage)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls?q=is%3Apr+%2323810) — no open PR for #23810 at the time of opening this one
- [x] My PR contains **only** changes related to this fix (no unrelated commits)
- [x] I've run `scripts/run_tests.sh tests/gateway/test_outbound_redaction.py` and all tests pass
- [x] I've added tests for my changes (16 new regression tests)
- [x] I've tested on my platform: macOS 15.6 (Darwin 24.6.0), Python 3.12

### Documentation & Housekeeping

- [x] I've updated relevant documentation — N/A (the startup banner at `gateway/run.py:3253-3255` already advertises this behaviour; the PR brings the implementation in line with the banner)
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — N/A (re-uses the existing `security.redact_secrets` toggle)
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — the fix is platform-agnostic (lives in `BasePlatformAdapter`, no OS or platform-specific calls; tests are hermetic)
- [x] I've updated tool descriptions/schemas if I changed tool behavior — N/A

## Screenshots / Logs

```
$ scripts/run_tests.sh tests/gateway/test_outbound_redaction.py -v
============================== 16 passed in 1.98s ==============================

$ scripts/run_tests.sh tests/gateway/test_outbound_redaction.py \
    tests/gateway/test_send_retry.py \
    tests/agent/test_redact.py \
    tests/hermes_cli/test_redact_config_bridge.py \
    tests/gateway/test_pii_redaction.py
============================= 146 passed in 3.58s ==============================
```

Bug-repro proof (revert just `gateway/platforms/base.py`, keep the new test file, re-run):

```
========================= 13 failed, 3 passed in 2.79s =========================
```

## Notes for reviewers

- The helper is intentionally a **defence-in-depth** layer: silent passthrough on import / runtime failure means a regression in `agent.redact` can never break delivery. If you'd prefer it to fail loud instead, happy to flip that.
- I picked `_send_with_retry` as the canonical chokepoint because every agent-generated outbound in `_process_message_background` already routes through it. A handful of direct `self.send(...)` calls in `base.py` (media-attachment fallbacks at lines 1857 / 1949 / 1983 / 2004 / 2025, and `send_notice` at 1759) still bypass it — those rarely carry secrets but are easy to wire up as a follow-up if you'd like belt-and-braces.
- The 30-line helper docstring intentionally names the issue number so a future bisect-via-comment lands here.
