### PR TITLE
fix(gateway): redact outbound replies before delivery

### DIFF
--- a/gateway/platforms/base.py
+++ b/gateway/platforms/base.py
@@ -19,6 +19,7 @@ import uuid
 from abc import ABC, abstractmethod
 from urllib.parse import urlsplit
 
+from agent.redact import redact_sensitive_text
 from utils import normalize_proxy_url
 
 logger = logging.getLogger(__name__)
@@ -2418,10 +2419,11 @@ class BasePlatformAdapter(ABC):
         network errors, sends the user a brief delivery-failure notice so they
         know to retry rather than waiting indefinitely.
         """
+        safe_content = redact_sensitive_text(content)
 
         result = await self.send(
             chat_id=chat_id,
-            content=content,
+            content=safe_content,
             reply_to=reply_to,
             metadata=metadata,
         )
@@ -2448,7 +2450,7 @@ class BasePlatformAdapter(ABC):
                 await asyncio.sleep(delay)
                 result = await self.send(
                     chat_id=chat_id,
-                    content=content,
+                    content=safe_content,
                     reply_to=reply_to,
                     metadata=metadata,
                 )
@@ -2475,7 +2477,7 @@ class BasePlatformAdapter(ABC):
         logger.warning("[%s] Send failed: %s — trying plain-text fallback", self.name, error_str)
         fallback_result = await self.send(
             chat_id=chat_id,
-            content=f"(Response formatting failed, plain text:)\n\n{content[:3500]}",
+            content=f"(Response formatting failed, plain text:)\n\n{safe_content[:3500]}",
             reply_to=reply_to,
             metadata=metadata,
         )

--- a/gateway/stream_consumer.py
+++ b/gateway/stream_consumer.py
@@ -23,6 +23,7 @@ import time
 from dataclasses import dataclass
 from typing import Any, Callable, Optional
 
+from agent.redact import redact_sensitive_text
 from gateway.platforms.base import BasePlatformAdapter as _BasePlatformAdapter
 from gateway.platforms.base import _custom_unit_to_cp
 from gateway.config import (
@@ -617,12 +618,17 @@ class GatewayStreamConsumer:
         # Strip trailing whitespace/newlines but preserve leading content
         return cleaned.rstrip()
 
+    @staticmethod
+    def _prepare_outbound_text(text: str) -> str:
+        """Normalize visible text before delivering it to a platform."""
+        return redact_sensitive_text(GatewayStreamConsumer._clean_for_display(text))
+
     async def _send_new_chunk(self, text: str, reply_to_id: Optional[str]) -> Optional[str]:
         """Send a new message chunk, optionally threaded to a previous message.
 
         Returns the message_id so callers can thread subsequent chunks.
         """
-        text = self._clean_for_display(text)
+        text = self._prepare_outbound_text(text)
         if not text.strip():
             return reply_to_id
         try:
@@ -653,7 +659,7 @@ class GatewayStreamConsumer:
         prefix = self._last_sent_text or ""
         if self.cfg.cursor and prefix.endswith(self.cfg.cursor):
             prefix = prefix[:-len(self.cfg.cursor)]
-        return self._clean_for_display(prefix)
+        return self._prepare_outbound_text(prefix)
 
     def _continuation_text(self, final_text: str) -> str:
         """Return only the part of final_text the user has not already seen."""
@@ -688,7 +694,7 @@ class GatewayStreamConsumer:
 
         Retries each chunk once on flood-control failures with a short delay.
         """
-        final_text = self._clean_for_display(text)
+        final_text = self._prepare_outbound_text(text)
         continuation = self._continuation_text(final_text)
         self._fallback_final_send = False
         if not continuation.strip():
@@ -916,7 +922,7 @@ class GatewayStreamConsumer:
         tail = self._accumulated
         if visible and tail.startswith(visible):
             tail = tail[len(visible):].lstrip()
-        tail = self._clean_for_display(tail)
+        tail = self._prepare_outbound_text(tail)
         if not tail.strip():
             return
         try:
@@ -953,7 +959,7 @@ class GatewayStreamConsumer:
 
     async def _send_commentary(self, text: str) -> bool:
         """Send a completed interim assistant commentary message."""
-        text = self._clean_for_display(text)
+        text = self._prepare_outbound_text(text)
         if not text.strip():
             return False
         try:
@@ -1065,7 +1071,7 @@ class GatewayStreamConsumer:
         # Strip MEDIA: directives so they don't appear as visible text.
         # Media files are delivered as native attachments after the stream
         # finishes (via _deliver_media_from_response in gateway/run.py).
-        text = self._clean_for_display(text)
+        text = self._prepare_outbound_text(text)
         # A bare streaming cursor is not meaningful user-visible content and
         # can render as a stray tofu/white-box message on some clients.
         visible_without_cursor = text

--- a/tests/gateway/test_send_retry.py
+++ b/tests/gateway/test_send_retry.py
@@ -130,6 +130,17 @@ class TestSendWithRetrySuccess:
         result = await adapter._send_with_retry("chat1", "hi")
         assert result.message_id == "abc"
 
+    @pytest.mark.asyncio
+    async def test_redacts_sensitive_text_before_send(self):
+        adapter = _StubAdapter()
+        adapter._send_results = [SendResult(success=True, message_id="123")]
+        secret = "sk-abcdefghijklmnopqrstuvwxyz123456"
+        result = await adapter._send_with_retry("chat1", f"token: {secret}")
+        assert result.success
+        sent_content = adapter._send_calls[0][1]
+        assert secret not in sent_content
+        assert "token:" in sent_content
+
 
 # ---------------------------------------------------------------------------
 # _send_with_retry — network error with successful retry
@@ -282,3 +293,18 @@ class TestSendWithRetryFallback:
             result = await adapter._send_with_retry("chat1", "hello", max_retries=2)
         assert not result.success
         assert len(adapter._send_calls) == 2  # original + fallback only
+
+    @pytest.mark.asyncio
+    async def test_plaintext_fallback_keeps_secret_redacted(self):
+        adapter = _StubAdapter()
+        adapter._send_results = [
+            SendResult(success=False, error="Bad Request: can't parse entities"),
+            SendResult(success=True, message_id="fallback_ok"),
+        ]
+        secret = "ghp_abcdefghijklmnopqrstuvwxyz123456"
+        with patch("asyncio.sleep", new_callable=AsyncMock):
+            result = await adapter._send_with_retry("chat1", f"**{secret}**", max_retries=2, base_delay=0)
+        assert result.success
+        fallback_content = adapter._send_calls[-1][1]
+        assert secret not in fallback_content
+        assert "plain text" in fallback_content.lower()

--- a/tests/gateway/test_stream_consumer.py
+++ b/tests/gateway/test_stream_consumer.py
@@ -84,6 +84,13 @@ class TestCleanForDisplay:
         # But "media:" is lowercase so won't match either
         assert result == text
 
+    def test_prepare_outbound_text_redacts_secrets(self):
+        """Visible streaming text is scrubbed before platform delivery."""
+        text = "token: sk-abcdefghijklmnopqrstuvwxyz123456"
+        result = GatewayStreamConsumer._prepare_outbound_text(text)
+        assert "sk-abcdefghijklmnopqrstuvwxyz123456" not in result
+        assert "token:" in result
+
 
 # ── Integration: _send_or_edit strips MEDIA: ─────────────────────────────
 
@@ -208,6 +215,42 @@ class TestSendOrEditMediaStripping:
         adapter.edit_message.assert_called_once()
         edited_text = adapter.edit_message.call_args[1]["content"]
         assert "MEDIA:" not in edited_text
+
+    @pytest.mark.asyncio
+    async def test_first_send_redacts_secret_tokens(self):
+        """Initial streamed sends redact secrets before hitting the adapter."""
+        adapter = MagicMock()
+        send_result = SimpleNamespace(success=True, message_id="msg_1")
+        adapter.send = AsyncMock(return_value=send_result)
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        consumer = GatewayStreamConsumer(adapter, "chat_123")
+        secret = "ghp_abcdefghijklmnopqrstuvwxyz123456"
+        await consumer._send_or_edit(f"token: {secret}")
+
+        adapter.send.assert_called_once()
+        sent_text = adapter.send.call_args[1]["content"]
+        assert secret not in sent_text
+        assert "token:" in sent_text
+
+    @pytest.mark.asyncio
+    async def test_edit_redacts_secret_tokens(self):
+        """Streaming edits redact secrets before hitting the adapter."""
+        adapter = MagicMock()
+        send_result = SimpleNamespace(success=True, message_id="msg_1")
+        edit_result = SimpleNamespace(success=True)
+        adapter.send = AsyncMock(return_value=send_result)
+        adapter.edit_message = AsyncMock(return_value=edit_result)
+        adapter.MAX_MESSAGE_LENGTH = 4096
+
+        consumer = GatewayStreamConsumer(adapter, "chat_123")
+        await consumer._send_or_edit("hello")
+        secret = "sk-abcdefghijklmnopqrstuvwxyz123456"
+        await consumer._send_or_edit(f"token: {secret}")
+
+        edited_text = adapter.edit_message.call_args[1]["content"]
+        assert secret not in edited_text
+        assert "token:" in edited_text
 
     @pytest.mark.asyncio
     async def test_media_only_skips_send(self):
@@ -1780,4 +1823,3 @@ class TestUtf16OverflowDetection:
         # auto-attr mock. Verified indirectly by all the other tests in
         # this file passing — they all use MagicMock adapters.
         assert consumer is not None
-


### PR DESCRIPTION
## What does this PR do?

Redacts outbound gateway replies before they are delivered to platform adapters, so secret-like values are scrubbed in both the default retry path and the streaming/edit path. This closes a real leak where `redact_sensitive_text` protected transcripts but not the final message sent back to users.

## Related Issue

Fixes #23810

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [x] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- patched `gateway/platforms/base.py` so `_send_with_retry()` redacts outbound content before send, retry, and plaintext fallback delivery
- patched `gateway/stream_consumer.py` so streamed chunks, edits, commentary, and fallback final sends all use a shared outbound-redaction helper
- added regression coverage in `tests/gateway/test_send_retry.py`
- added regression coverage in `tests/gateway/test_stream_consumer.py`

## How to Test

1. Run `uv run --frozen pytest -q -o addopts='' tests/gateway/test_send_retry.py tests/gateway/test_stream_consumer.py`
2. Confirm the new tests prove raw `sk-...` / `ghp_...` style secrets are not forwarded to adapter send/edit calls
3. Run `uv run --frozen ruff check gateway/platforms/base.py gateway/stream_consumer.py tests/gateway/test_send_retry.py tests/gateway/test_stream_consumer.py`

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [ ] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 15.5

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `uv run --frozen pytest -q -o addopts='' tests/gateway/test_send_retry.py tests/gateway/test_stream_consumer.py` -> `129 passed`
- `uv run --frozen ruff check gateway/platforms/base.py gateway/stream_consumer.py tests/gateway/test_send_retry.py tests/gateway/test_stream_consumer.py` -> `All checks passed!`
