### PR TITLE
fix(tools): prefer live qqbot adapter sends

### DIFF
--- a/tests/tools/test_send_message_tool.py
+++ b/tests/tools/test_send_message_tool.py
@@ -549,6 +549,55 @@ class TestSendToPlatformChunking:
         helper.assert_not_awaited()
         lightweight.assert_awaited_once()
 
+    def test_qqbot_prefers_live_adapter_path(self):
+        live_send = AsyncMock(return_value={"success": True, "platform": "qqbot", "chat_id": "user-1", "message_id": "live-msg"})
+        rest_send = AsyncMock(return_value={"success": True, "platform": "qqbot", "chat_id": "user-1", "message_id": "rest-msg"})
+
+        with patch("tools.send_message_tool._send_via_adapter", live_send), \
+             patch("tools.send_message_tool._send_qqbot", rest_send):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.QQBOT,
+                    SimpleNamespace(enabled=True, token="tok", extra={}),
+                    "user-1",
+                    "hello from tool",
+                )
+            )
+
+        assert result["success"] is True
+        assert result["message_id"] == "live-msg"
+        live_send.assert_awaited_once()
+        call = live_send.await_args
+        assert call.args[0] == Platform.QQBOT
+        assert call.args[2] == "user-1"
+        assert call.args[3] == "hello from tool"
+        assert call.kwargs["thread_id"] is None
+        assert call.kwargs["media_files"] == []
+        assert call.kwargs["force_document"] is False
+        rest_send.assert_not_awaited()
+
+    def test_qqbot_falls_back_to_rest_when_live_adapter_missing(self):
+        live_send = AsyncMock(return_value={
+            "error": "No live gateway adapter for qqbot and no standalone_sender_fn registered."
+        })
+        rest_send = AsyncMock(return_value={"success": True, "platform": "qqbot", "chat_id": "user-1", "message_id": "rest-msg"})
+
+        with patch("tools.send_message_tool._send_via_adapter", live_send), \
+             patch("tools.send_message_tool._send_qqbot", rest_send):
+            result = asyncio.run(
+                _send_to_platform(
+                    Platform.QQBOT,
+                    SimpleNamespace(enabled=True, token="tok", extra={}),
+                    "user-1",
+                    "hello from tool",
+                )
+            )
+
+        assert result["success"] is True
+        assert result["message_id"] == "rest-msg"
+        live_send.assert_awaited_once()
+        rest_send.assert_awaited_once()
+
     def test_send_matrix_via_adapter_sends_document(self, tmp_path):
         file_path = tmp_path / "report.pdf"
         file_path.write_bytes(b"%PDF-1.4 test")

--- a/tools/send_message_tool.py
+++ b/tools/send_message_tool.py
@@ -723,7 +723,17 @@ async def _send_to_platform(platform, pconfig, chat_id, message, thread_id=None,
         elif platform == Platform.BLUEBUBBLES:
             result = await _send_bluebubbles(pconfig.extra, chat_id, chunk)
         elif platform == Platform.QQBOT:
-            result = await _send_qqbot(pconfig, chat_id, chunk)
+            result = await _send_via_adapter(
+                platform,
+                pconfig,
+                chat_id,
+                chunk,
+                thread_id=thread_id,
+                media_files=media_files,
+                force_document=force_document,
+            )
+            if isinstance(result, dict) and str(result.get("error", "")).startswith("No live gateway adapter"):
+                result = await _send_qqbot(pconfig, chat_id, chunk)
         elif platform == Platform.YUANBAO:
             result = await _send_yuanbao(chat_id, chunk)
         else:


### PR DESCRIPTION
## What does this PR do?

Routes QQBot `send_message` calls through the live gateway adapter when one is available, instead of always forcing the legacy REST token path. This keeps tool-triggered sends aligned with the already-connected QQBot gateway session and avoids the `QQBot: no access_token in response` failure when the adapter is healthy but the standalone token fetch path is not.

## Related Issue

Fixes #23825

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 🔒 Security fix
- [ ] 📝 Documentation update
- [x] ✅ Tests (adding or improving test coverage)
- [ ] ♻️ Refactor (no behavior change)
- [ ] 🎯 New skill (bundled or hub)

## Changes Made

- Updated `tools/send_message_tool.py` so the QQBot branch first attempts `_send_via_adapter(...)`
- Falls back to `_send_qqbot(...)` only when there is no live gateway adapter available
- Added regression tests in `tests/tools/test_send_message_tool.py` covering both the live-adapter path and the REST fallback path

## How to Test

1. Run `uv run --frozen pytest -q -o addopts='' tests/tools/test_send_message_tool.py`
2. Confirm the new QQBot regression tests pass and the full `send_message_tool` suite stays green
3. In a live QQBot gateway session, invoke `send_message` and verify it uses the connected adapter path instead of failing on the standalone access-token fetch

## Checklist

### Code

- [x] I've read the [Contributing Guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md)
- [x] My commit messages follow [Conventional Commits](https://www.conventionalcommits.org/) (`fix(scope):`, `feat(scope):`, etc.)
- [x] I searched for [existing PRs](https://github.com/NousResearch/hermes-agent/pulls) to make sure this isn't a duplicate
- [x] My PR contains **only** changes related to this fix/feature (no unrelated commits)
- [x] I've run `pytest tests/ -q` and all tests pass
- [x] I've added tests for my changes (required for bug fixes, strongly encouraged for features)
- [x] I've tested on my platform: macOS 26.4.1

### Documentation & Housekeeping

- [x] I've updated relevant documentation (README, `docs/`, docstrings) — or N/A
- [x] I've updated `cli-config.yaml.example` if I added/changed config keys — or N/A
- [x] I've updated `CONTRIBUTING.md` or `AGENTS.md` if I changed architecture or workflows — or N/A
- [x] I've considered cross-platform impact (Windows, macOS) per the [compatibility guide](https://github.com/NousResearch/hermes-agent/blob/main/CONTRIBUTING.md#cross-platform-compatibility) — or N/A
- [x] I've updated tool descriptions/schemas if I changed tool behavior — or N/A

## Screenshots / Logs

- `uv run --frozen pytest -q -o addopts='' tests/tools/test_send_message_tool.py` → `113 passed`
- `uv run --frozen ruff check tools/send_message_tool.py tests/tools/test_send_message_tool.py` → passed
